### PR TITLE
fix(checker): truthy condition read proves definite assignment in positive branch

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/var_utils.rs
+++ b/crates/tsz-checker/src/flow/control_flow/var_utils.rs
@@ -498,17 +498,37 @@ impl<'a> FlowAnalyzer<'a> {
             return false;
         }
 
-        self.expr_proves_assignment(flow.node, is_true_condition, is_false_condition, reference)
+        // At the condition root a bare truthy reference's truthiness decides the
+        // branch outright, so it may prove assignment. Short-circuit operand
+        // positions (`||` either sense, `&&` false sense) demote this.
+        self.expr_proves_assignment(
+            flow.node,
+            is_true_condition,
+            is_false_condition,
+            reference,
+            true,
+        )
     }
 
     /// Check if an expression node (possibly compound via `&&`/`||`) proves
     /// that `reference` has been assigned a value.
+    ///
+    /// `bare_ref_decisive` tracks whether, at this position, a bare truthy
+    /// reference is *guaranteed evaluated and truthy* on the branch. It holds at
+    /// the condition root, through `!`/parentheses, and through `&&` operands in
+    /// the true sense (both are guaranteed evaluated and truthy). It is cleared
+    /// for `||` operands (either sense) and `&&` operands in the false sense,
+    /// because short-circuiting means the operand may not be evaluated and its
+    /// truthiness does not decide the branch. Without this gate a bare reference
+    /// inside such a position would falsely "prove" assignment (the unassigned
+    /// marker survives those branches).
     fn expr_proves_assignment(
         &self,
         condition: NodeIndex,
         is_true_condition: bool,
         is_false_condition: bool,
         reference: NodeIndex,
+        bare_ref_decisive: bool,
     ) -> bool {
         let Some(node_data) = self.arena.get(condition) else {
             return false;
@@ -521,11 +541,14 @@ impl<'a> FlowAnalyzer<'a> {
             if let Some(unary) = self.arena.get_unary_expr(node_data)
                 && unary.operator == SyntaxKind::ExclamationToken as u16
             {
+                // Negation only flips the sense; the operand remains as
+                // decisive for a bare reference as the negated whole was.
                 return self.expr_proves_assignment(
                     unary.operand,
                     is_false_condition, // flip: outer false = inner true
                     is_true_condition,  // flip: outer true = inner false
                     reference,
+                    bare_ref_decisive,
                 );
             }
             return false;
@@ -539,6 +562,7 @@ impl<'a> FlowAnalyzer<'a> {
                     is_true_condition,
                     is_false_condition,
                     reference,
+                    bare_ref_decisive,
                 );
             }
             return false;
@@ -568,7 +592,16 @@ impl<'a> FlowAnalyzer<'a> {
         // sentinel — so it does NOT prove assignment. This mirrors tsc, which
         // suppresses the downstream truthy-branch TS2454 (the condition read
         // itself still reports) even when the variable was never assigned.
-        if is_true_condition && self.is_matching_reference(condition, reference) {
+        //
+        // `bare_ref_decisive` guards against short-circuit positions: in
+        // `(typeof x === 'boolean' && !x) || typeof x === 'string'`, the right
+        // `||` operand runs with the left `&&` in its false sense, where `!x`
+        // is not guaranteed evaluated and `x`'s truthiness does not decide the
+        // branch — the unassigned marker survives, so tsc still reports.
+        if is_true_condition
+            && bare_ref_decisive
+            && self.is_matching_reference(condition, reference)
+        {
             return true;
         }
 
@@ -580,32 +613,50 @@ impl<'a> FlowAnalyzer<'a> {
             return false;
         };
 
-        // `&&`: TRUE_CONDITION means both operands are true, so either
-        // proving assignment is sufficient.
+        // `&&`: TRUE_CONDITION means both operands are true (and both evaluated),
+        // so either proving assignment is sufficient. Both operands are
+        // guaranteed evaluated and truthy here, so a bare reference stays
+        // decisive.
         if bin.operator_token == SyntaxKind::AmpersandAmpersandToken as u16 && is_true_condition {
-            return self.expr_proves_assignment(bin.left, true, false, reference)
-                || self.expr_proves_assignment(bin.right, true, false, reference);
+            return self.expr_proves_assignment(
+                bin.left,
+                true,
+                false,
+                reference,
+                bare_ref_decisive,
+            ) || self.expr_proves_assignment(
+                bin.right,
+                true,
+                false,
+                reference,
+                bare_ref_decisive,
+            );
         }
 
         // `&&`: FALSE_CONDITION means at least one operand is false (!A || !B),
         // so either side proving assignment in the negative sense is sufficient.
+        // The operands are not guaranteed truthy (and the right is not even
+        // guaranteed evaluated), so a bare reference is no longer decisive.
         if bin.operator_token == SyntaxKind::AmpersandAmpersandToken as u16 && is_false_condition {
-            return self.expr_proves_assignment(bin.left, false, true, reference)
-                || self.expr_proves_assignment(bin.right, false, true, reference);
+            return self.expr_proves_assignment(bin.left, false, true, reference, false)
+                || self.expr_proves_assignment(bin.right, false, true, reference, false);
         }
 
         // `||`: TRUE_CONDITION means at least one operand is true, so either
-        // side proving assignment in the positive sense is sufficient.
+        // side proving assignment in the positive sense is sufficient. Short
+        // circuiting means neither operand is guaranteed truthy, so a bare
+        // reference is no longer decisive.
         if bin.operator_token == SyntaxKind::BarBarToken as u16 && is_true_condition {
-            return self.expr_proves_assignment(bin.left, true, false, reference)
-                || self.expr_proves_assignment(bin.right, true, false, reference);
+            return self.expr_proves_assignment(bin.left, true, false, reference, false)
+                || self.expr_proves_assignment(bin.right, true, false, reference, false);
         }
 
         // `||`: FALSE_CONDITION means both operands are false, so either
-        // proving assignment (in negative sense) is sufficient.
+        // proving assignment (in negative sense) is sufficient. Both operands
+        // are falsy here, so a bare reference is not decisive.
         if bin.operator_token == SyntaxKind::BarBarToken as u16 && is_false_condition {
-            return self.expr_proves_assignment(bin.left, false, true, reference)
-                || self.expr_proves_assignment(bin.right, false, true, reference);
+            return self.expr_proves_assignment(bin.left, false, true, reference, false)
+                || self.expr_proves_assignment(bin.right, false, true, reference, false);
         }
 
         // instanceof: `x instanceof C` → TRUE_CONDITION proves assignment

--- a/crates/tsz-checker/src/flow/control_flow/var_utils.rs
+++ b/crates/tsz-checker/src/flow/control_flow/var_utils.rs
@@ -560,6 +560,18 @@ impl<'a> FlowAnalyzer<'a> {
             return false;
         }
 
+        // Bare truthiness reference: `if (ref)` / `if (!ref)`.
+        // In the positive (truthy) sense, the variable is narrowed to its truthy
+        // members; tsc removes the falsy "unassigned" marker on that branch, so
+        // the reference is treated as definitely assigned there. The negative
+        // (falsy) sense keeps the marker — falsy values include the unassigned
+        // sentinel — so it does NOT prove assignment. This mirrors tsc, which
+        // suppresses the downstream truthy-branch TS2454 (the condition read
+        // itself still reports) even when the variable was never assigned.
+        if is_true_condition && self.is_matching_reference(condition, reference) {
+            return true;
+        }
+
         if node_data.kind != syntax_kind_ext::BINARY_EXPRESSION {
             return false;
         }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -223,6 +223,9 @@ mod flow_inferred_predicate_boundary_tests;
 #[path = "tests/flow_promise_identity_tests.rs"]
 mod flow_promise_identity_tests;
 #[cfg(test)]
+#[path = "tests/flow_truthy_proves_assignment_tests.rs"]
+mod flow_truthy_proves_assignment_tests;
+#[cfg(test)]
 #[path = "tests/flow_usage_relation_routing_arch_tests.rs"]
 mod flow_usage_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/flow_truthy_proves_assignment_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_truthy_proves_assignment_tests.rs
@@ -100,6 +100,73 @@ if (y) { } else { y.toFixed(); }
 }
 
 #[test]
+fn short_circuit_operand_does_not_falsely_prove_assignment() {
+    // Regression guard for the narrowed bare-ref rule: a bare reference reached
+    // through a short-circuit operand position (here `!x` as the right operand
+    // of `&&`, evaluated in the `&&`'s false sense because it sits under the
+    // `||`'s true branch) is NOT guaranteed evaluated/truthy, so the unassigned
+    // marker survives and tsc still reports the truthy-branch read.
+    //
+    // `(typeof x === 'boolean' && !x) || typeof x === 'string'`: tsc reports
+    // TS2454 at the first `typeof x` (col 13) and the `||`-right `typeof x`
+    // (col 62), but NOT at the `&&`-right `!x`. Two condition reads in total.
+    let codes = check_strict(
+        r#"
+let strOrBool: string | boolean;
+if ((typeof strOrBool === 'boolean' && !strOrBool) || typeof strOrBool === 'string') {
+}
+"#,
+    );
+
+    assert_eq!(
+        count(&codes, 2454),
+        2,
+        "both guaranteed condition reads must report; the short-circuit `!x` operand must not falsely prove assignment, got codes: {codes:?}"
+    );
+}
+
+#[test]
+fn or_true_branch_does_not_prove_assignment() {
+    // `if (x || foo()) { x }` — the truthy branch of `||` does not narrow the
+    // unassigned marker away from `x` (it could be the `foo()` path), so the
+    // body read still reports. Two TS2454 total (condition read + body read).
+    let codes = check_strict(
+        r#"
+declare function foo(): boolean;
+let x: number;
+if (x || foo()) { x.toFixed(); }
+"#,
+    );
+
+    assert_eq!(
+        count(&codes, 2454),
+        2,
+        "the `||` true branch must not prove assignment for a bare reference, got codes: {codes:?}"
+    );
+}
+
+#[test]
+fn and_true_branch_still_proves_assignment() {
+    // `if (x && foo()) { x }` — the truthy branch of `&&` DOES narrow `x` to
+    // truthy (x is always evaluated and must be truthy), so the body read is
+    // suppressed. Exactly one TS2454 at the condition read. This keeps the
+    // zustand-style suppression intact for guaranteed-truthy operands.
+    let codes = check_strict(
+        r#"
+declare function foo(): boolean;
+let x: number;
+if (x && foo()) { x.toFixed(); }
+"#,
+    );
+
+    assert_eq!(
+        count(&codes, 2454),
+        1,
+        "the `&&` true branch must still prove assignment for the guaranteed-truthy left operand, got codes: {codes:?}"
+    );
+}
+
+#[test]
 fn plain_reads_without_condition_still_report_each_use() {
     // Negative control: without an intervening condition, every read of a
     // possibly-unassigned variable reports TS2454 (tsc does not dedup here).

--- a/crates/tsz-checker/src/tests/flow_truthy_proves_assignment_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_truthy_proves_assignment_tests.rs
@@ -1,0 +1,121 @@
+//! Definite-assignment (TS2454) parity for bare truthiness conditions.
+//!
+//! Structural rule: when a possibly-unassigned reference is read in a
+//! truthiness condition (`if (ref)` / `if (!ref)`), tsc reports TS2454 once at
+//! the condition read, then narrows the falsy "unassigned" marker away on the
+//! positive (truthy) branch. Subsequent uses on that branch are treated as
+//! definitely assigned, so no further TS2454 (and no cascading TS2339) fires.
+//! The negative (falsy) branch keeps the marker and still reports.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+#[test]
+fn truthy_branch_of_negated_condition_is_assigned() {
+    // `if (!ec) {} else { ec.foo() }` — the else branch is the truthy sense.
+    // tsc reports TS2454 once (at the condition read) and treats `ec` as
+    // assigned with its narrowed type in the else branch, so `ec.foo()` is OK.
+    let codes = check_strict(
+        r#"
+declare const enabled: boolean;
+let ec: { foo(): void } | false;
+try { ec = enabled && (window as any).__X__; } catch {}
+if (!ec) { } else { ec.foo(); }
+"#,
+    );
+
+    assert_eq!(
+        count(&codes, 2454),
+        1,
+        "expected exactly one TS2454 at the condition read, got codes: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2339),
+        "truthy-branch use must not cascade into TS2339, got codes: {codes:?}"
+    );
+}
+
+#[test]
+fn truthy_branch_of_plain_condition_is_assigned() {
+    // `if (ec) { ec.foo() }` — the then branch is the truthy sense.
+    let codes = check_strict(
+        r#"
+declare const enabled: boolean;
+let ec: { foo(): void } | false;
+try { ec = enabled && (window as any).__X__; } catch {}
+if (ec) { ec.foo(); } else { }
+"#,
+    );
+
+    assert_eq!(
+        count(&codes, 2454),
+        1,
+        "expected exactly one TS2454 at the condition read, got codes: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2339),
+        "truthy-branch use must not cascade into TS2339, got codes: {codes:?}"
+    );
+}
+
+#[test]
+fn truthy_branch_suppresses_even_when_never_assigned() {
+    // Negative control matching tsc: a variable that is genuinely never
+    // assigned still reports TS2454 only at the condition read; the truthy
+    // branch use is suppressed (tsc behaviour, verified against tsc 6.0.3).
+    let codes = check_strict(
+        r#"
+let y: number;
+if (y) { y.toFixed(); }
+"#,
+    );
+
+    assert_eq!(
+        count(&codes, 2454),
+        1,
+        "expected exactly one TS2454 at the condition read, got codes: {codes:?}"
+    );
+}
+
+#[test]
+fn falsy_branch_still_reports_use_before_assignment() {
+    // Negative control: the falsy (else of `if (ec)`) branch keeps the
+    // unassigned marker, so a use there must STILL report TS2454. This guards
+    // against over-suppression.
+    let codes = check_strict(
+        r#"
+let y: number;
+if (y) { } else { y.toFixed(); }
+"#,
+    );
+
+    assert_eq!(
+        count(&codes, 2454),
+        2,
+        "expected TS2454 at both the condition read and the falsy-branch use, got codes: {codes:?}"
+    );
+}
+
+#[test]
+fn plain_reads_without_condition_still_report_each_use() {
+    // Negative control: without an intervening condition, every read of a
+    // possibly-unassigned variable reports TS2454 (tsc does not dedup here).
+    let codes = check_strict(
+        r#"
+declare const enabled: boolean;
+let ec: number;
+try { ec = enabled ? 1 : 2; } catch {}
+ec;
+let z: number = ec;
+"#,
+    );
+
+    assert_eq!(
+        count(&codes, 2454),
+        2,
+        "expected TS2454 at each plain read, got codes: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary

A possibly-unassigned `let` read in a truthiness condition (`if (ref)` / `if (!ref)`) was re-flagged TS2454 in the positive (truthy) branch, with a cascading TS2339 because the reference kept its unnarrowed declared type. tsc reports TS2454 **once** at the condition read, then narrows the falsy "unassigned" marker away on the truthy branch and treats the reference as definitely assigned there.

This caused ~7 zustand false positives in devtools/persist, where an errored RHS sub-expression (e.g. `import.meta.env?.MODE`, a TS2339 both compilers emit and the gate subtracts) sits in a `try`-guarded assignment and the variable is later truthiness-checked.

Goal: green

## Structural rule

When a possibly-unassigned reference is read in a truthiness condition, tsc reports TS2454 at the condition read, then on the **positive (truthy) branch** narrows away the falsy unassigned marker so the reference is definitely assigned (its narrowed declared type). The **negative (falsy) branch** keeps the marker and still reports. Owner: checker `FlowAnalyzer::expr_proves_assignment` (`crates/tsz-checker/src/flow/control_flow/var_utils.rs`).

tsz already modeled this for `typeof` / `instanceof` / equality / property-access / call conditions but not for a bare truthiness reference, which fell through to `false` — so the truthy branch re-emitted TS2454 + cascaded TS2339. Fix: a bare reference in the positive sense proves assignment.

No hardcoding: pure structural polarity on the condition flow node (`is_true_condition`) and `is_matching_reference`; no identifier/file-name/printer-string checks.

## Adjacent matrix (all match tsc 6.0.3)

- `if (!ec) {} else { ec.foo() }` (truthy else): TS2454 once at read, no TS2339 — FIXED.
- `if (ec) { ec.foo() } else {}` (truthy then): TS2454 once, no TS2339 — FIXED.
- `let y: number; if (y) { y.toFixed() }` never-assigned, truthy use: TS2454 once (matches tsc; tsc also suppresses the truthy-branch re-report).
- `let y: number; if (y) {} else { y.toFixed() }` falsy branch: TS2454 at both sites — negative control, unchanged.
- Plain reads with no intervening condition: TS2454 at each read — negative control, unchanged.
- `if (ec === undefined) {} else { ec.toFixed() }`, `if (typeof ec === "number") { ... }`: unchanged (already correct).

## Verification

- Repro `if (!ec) {} else { ec.foo() }` now matches tsc 6.0.3 (single TS2454 at the condition read; no spurious downstream TS2454/TS2339).
- Negative controls vs tsc 6.0.3: falsy-branch use still reports; plain reads still report each use; never-assigned truthy use reports once (no over-suppression).
- `scripts/conformance/conformance.sh run --filter` (tsc cache 6.0.3): definiteAssignment 4/4, UsedBefore 10/10, controlFlow 94/94, tryCatch 2/2, narrowing 29/29, truthiness 6/6, assigned 8/8, assignmentCompat 128/128, conditionalTypes 5/5, ifStatement/whileStatement/forStatement all pass. 0 PASS->FAIL.
- `scripts/arch/arch_guard.py`: PASS.
- `cargo clippy --profile dist-fast -p tsz-checker --lib`: clean.
- Added focused regression coverage: `crates/tsz-checker/src/tests/flow_truthy_proves_assignment_tests.rs` (truthy-branch suppression + falsy/plain-read/never-assigned negative controls).

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high
