### PR TITLE
fix(solver): relate same-definition Promise-alias applications via any-arg (zod _parse override TS2416)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -844,66 +844,82 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         .get_application_eval_origin(target)
                         .and_then(|origin| application_id(self.interner, origin))
                 });
-            let variance_result =
-                if let (Some(s_app_id), Some(t_app_id)) = (s_app_id_for_variance, t_app_id) {
-                    self.try_variance_fast_path(s_app_id, t_app_id)
-                } else if let Some(t_app_id) = t_app_id_for_recovered_target {
-                    self.try_same_base_all_any_target_args(source, s_app_id_for_variance, t_app_id)
-                        .or_else(|| {
-                            // Accept-only variance on a provenance-recovered
-                            // same-base pair: tsc relates two instantiations of
-                            // the same generic reference by per-argument
-                            // variance (`relateVariances`) before any
-                            // structural expansion, so an `any` argument
-                            // relates bidirectionally and silences the member
-                            // walk (kysely `ExpressionWrapper<DB, TB, any>` vs
-                            // `ExpressionWrapper<DB, TB, O[K]>`, whose `and`
-                            // member is a deferred conditional that can never
-                            // relate structurally). tsz's checker computes
-                            // class member types in evaluated form, so BOTH
-                            // sides may have lost their `Application` identity
-                            // here; recover each via display provenance and
-                            // honor only a conclusive `True` — rejections from
-                            // display-grade identity are discarded and the
-                            // relation falls through to the structural path.
-                            // The semantic eval-origin map may recover the
-                            // source where display provenance declined to
-                            // record (generic-arg repaint guards); both
-                            // channels are trusted here because this branch
-                            // is accept-only.
-                            let s_app_id = s_app_id_for_variance.or_else(|| {
-                                self.interner
-                                    .get_application_eval_origin(source)
-                                    .and_then(|origin| application_id(self.interner, origin))
-                            })?;
-                            // Identical argument lists prove nothing here:
-                            // the sides are distinct shapes for a
-                            // non-argument reason (context-dependent
-                            // evaluation of the same application, e.g. under
-                            // exactOptionalPropertyTypes), and only the
-                            // structural comparison can judge that.
-                            {
-                                let s_app = self.interner.type_application(s_app_id);
-                                let t_app = self.interner.type_application(t_app_id);
-                                if s_app.args == t_app.args {
-                                    return None;
-                                }
-                            }
-                            let vr = self
-                                .try_same_base_args_identical_or_any(s_app_id, t_app_id)
-                                .or_else(|| self.try_variance_fast_path(s_app_id, t_app_id));
-                            match vr {
-                                Some(SubtypeResult::True) => Some(SubtypeResult::True),
-                                _ => None,
-                            }
-                        })
-                } else if let Some(s_app_id) = s_app_id {
-                    // Source is Application, target might be Union containing an Application.
-                    // This handles optional properties where target is App<X> | undefined.
-                    self.try_variance_against_union_target(source, s_app_id, target)
-                } else {
-                    None
-                };
+            let variance_result = if let (Some(s_app_id), Some(t_app_id)) =
+                (s_app_id_for_variance, t_app_id)
+            {
+                self.try_variance_fast_path(s_app_id, t_app_id)
+            } else if let Some(t_app_id) = t_app_id_for_recovered_target {
+                // Accept-only variance on a provenance-recovered same-base
+                // pair: tsc relates two instantiations of the same generic
+                // reference by per-argument variance (`relateVariances`)
+                // before any structural expansion, so an `any` argument
+                // relates bidirectionally and silences the member walk
+                // (kysely `ExpressionWrapper<DB, TB, any>` vs
+                // `ExpressionWrapper<DB, TB, O[K]>`, whose `and` member is a
+                // deferred conditional that can never relate structurally).
+                // tsz's checker computes class member types in evaluated
+                // form, so BOTH sides may have lost their `Application`
+                // identity here; recover each via display provenance and
+                // honor only a conclusive `True` — rejections from
+                // display-grade identity are discarded and the relation
+                // falls through to the structural path.
+                //
+                // The display-alias and the semantic eval-origin channels
+                // can name DIFFERENT bases for one value: a value typed
+                // through a generic alias over a self-referential generic
+                // (e.g. `Async<T> = Promise<T>`) records the user alias
+                // `Async` as its display provenance but the underlying
+                // `Promise` as its eval origin, while the target only
+                // recovered its underlying base. Try both source candidates
+                // so the one that shares the target's definition
+                // (`Promise<any>` vs `Promise<X>`) is found and its `any`
+                // argument relates the pair before the order-dependent
+                // structural expansion of the recursive `then` member can
+                // spuriously reject it (the false `TS2416` on method
+                // overrides whose return type is a generic alias over
+                // `Promise` — zod's `_parse`).
+                let s_candidates = [
+                    s_app_id_for_variance,
+                    self.interner
+                        .get_application_eval_origin(source)
+                        .and_then(|origin| application_id(self.interner, origin)),
+                ];
+                let mut vr = None;
+                for s_app_id in s_candidates.into_iter().flatten() {
+                    vr = self.try_same_base_all_any_target_args(source, Some(s_app_id), t_app_id);
+                    if matches!(vr, Some(SubtypeResult::True)) {
+                        break;
+                    }
+                    // Identical argument lists prove nothing here: the sides
+                    // are distinct shapes for a non-argument reason
+                    // (context-dependent evaluation of the same application,
+                    // e.g. under exactOptionalPropertyTypes), and only the
+                    // structural comparison can judge that.
+                    {
+                        let s_app = self.interner.type_application(s_app_id);
+                        let t_app = self.interner.type_application(t_app_id);
+                        if s_app.args == t_app.args {
+                            continue;
+                        }
+                    }
+                    vr = self
+                        .try_same_base_args_identical_or_any(s_app_id, t_app_id)
+                        .or_else(|| self.try_variance_fast_path(s_app_id, t_app_id));
+                    if matches!(vr, Some(SubtypeResult::True)) {
+                        break;
+                    }
+                }
+                match vr {
+                    Some(SubtypeResult::True) => Some(SubtypeResult::True),
+                    _ => None,
+                }
+            } else if let Some(s_app_id) = s_app_id {
+                // Source is Application, target might be Union containing an Application.
+                // This handles optional properties where target is App<X> | undefined.
+                self.try_variance_against_union_target(source, s_app_id, target)
+            } else {
+                None
+            };
 
             if let Some(result) = variance_result {
                 if let Some(dp) = def_entered {


### PR DESCRIPTION
Clears the zod `_parse` method-override TS2416 cluster (5 false positives on
`ZodTuple`/`ZodRecord`/`ZodMap`/`ZodSet`/`ZodFunction`). zod is `tsc`-clean.

Goal: green

## Structural rule

When a class method override's return type is a generic type **alias over a
self-referential generic** (zod's `ParseReturnType<T> = SyncParseReturnType<T> |
Promise<SyncParseReturnType<T>>`), the override `_parse(): ParseReturnType<any>`
and the base `_parse(): ParseReturnType<Output>` are compared by the
override/no-erase relation as **evaluated `Promise` object shapes**. The
recursive `then` member returns another `Promise`, so structural expansion of
the differing argument slots is order-dependent and yields a spurious rejection
on the first in-flight evaluation — a false TS2416.

`tsc` relates two instantiations of the same generic reference by per-argument
`relateVariances`: an `any` argument relates **bidirectionally**, regardless of
the measured variance, **before** any structural expansion. tsz already does
this in the provenance-recovery branch of the same-base application relation,
but the **display-alias** and the **semantic eval-origin** provenance channels
can name *different* bases for one value: a value typed through `Async<T> =
Promise<T>` records the user alias `Async` as its display provenance and the
underlying `Promise` as its eval origin, while the target only recovers its
underlying base. The single display-recovered source therefore never shares the
target's definition and the relation falls into the order-dependent structural
path.

Owner layer: solver — `SubtypeChecker` same-base-application provenance recovery
(`crates/tsz-solver/src/relations/subtype/cache.rs`), feeding the existing
accept-only `try_same_base_all_any_target_args` /
`try_same_base_args_identical_or_any` / variance fast path helpers.

Fix: try **both** source provenance candidates (display alias and eval origin)
against the recovered target so the same-definition pair (`Promise<any>` vs
`Promise<X>`) is found and its `any` argument relates the pair before structural
`then`-expansion. The change is accept-only (returns `Some(True)` or falls
through to the unchanged structural path); it cannot reject a relation or change
a `tsc`-clean program's diagnostics.

## Adjacent-case matrix

Minimal repros (each matches `tsc` exactly after the fix):
- Override returns alias-over-`Promise` with `any` vs free-`T` arg: fixed
  (`ParseReturnType<any>` <: `ParseReturnType<{ tup: T }>`).
- Single-level `Async<T> = Promise<T>` alias, `Async<any>` override vs
  `Async<{ tup: T }>` base: fixed.
- `Async<T> = Promise<{ x: T }>` (Promise of object): fixed.
- Mixed alias/expanded (`Async<any>` override vs `Promise<{ tup: T }>` base, and
  vice versa): fixed.
- Control negatives that must keep passing: direct `Promise<any>` vs
  `Promise<X>` (already related via the Application variance fast path);
  non-`Promise` generic aliases (`Array`, `Map`, `Set`, plain covariant box)
  with the same `any`/free-`T` shape; identical-args alias pairs (still fall
  through to the structural path for context-dependent shapes).

## Verification

- zod canary row: TS2416 `_parse` cluster 5 -> 0; total tsz-only diagnostics
  23 -> 18 with no new diagnostics introduced (no TS2416, no TS2344). Measured
  via `TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_FILTER=zod
  scripts/ci/project-compile-guard.sh`.
- Conformance (no PASS->FAIL): `variance` 16/16, `classHeritage` 18/18,
  `abstractClass` 3/3, `genericClass` 17/17, `override` 33/33, `promise` 44/44,
  `awaited` 5/5, `generic` 240/240 — all 100%, 0 known failures.
- `scripts/arch/arch_guard.py`: passed.
- `cargo clippy --lib -p tsz-solver`: clean.
- CI `CI Summary` owns the broad conformance/emit/fourslash and full
  canary+required gates.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
