### PR TITLE
fix(checker): poison indexed-access over unresolved-import object to any

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -502,6 +502,21 @@ impl<'a> CheckerState<'a> {
             return self.get_type_from_type_reference(idx);
         }
 
+        // Poison an indexed access whose object is an unresolved-module import
+        // to `any`. `tsc` resolves a reference to a generic interface from a
+        // module it could not find (TS2307) to `any`, so `T[K]` collapses to
+        // `any[K] = any` instead of a deferred `Application(UnresolvedTypeName,
+        // …)[K]`. Keeping it deferred false-fails an arrow initializer with
+        // TS2322 and suppresses the implicit-`any` parameter diagnostics that
+        // `tsc` reports. The object root is detected structurally via
+        // `is_unresolved_import_symbol_id` (#13755/#13780), not by name.
+        if let Some(node) = self.ctx.arena.get(idx)
+            && node.kind == syntax_kind_ext::INDEXED_ACCESS_TYPE
+            && self.indexed_access_object_is_unresolved_import(node)
+        {
+            return TypeId::ANY;
+        }
+
         // Pre-warm namespace-qualified interface types before entering the &self lowering pass.
         // When `import * as L` is used only in type positions, `symbol_types[L.Foo]` stays unset;
         // `ensure_type_alias_resolved_inner` then bails at the TYPE_ALIAS guard for interfaces,

--- a/crates/tsz-checker/src/state/variable_checking/core/annotation_context.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core/annotation_context.rs
@@ -13,7 +13,11 @@ impl<'a> CheckerState<'a> {
             return false;
         };
         if node.kind == syntax_kind_ext::INDEXED_ACCESS_TYPE {
-            return true;
+            // An indexed access whose object is an unresolved-module import is
+            // poisoned to `any` (see `get_type_from_type_node`); it cannot
+            // supply contextual parameter types, so `tsc` reports the
+            // implicit-`any` parameter diagnostics rather than deferring them.
+            return !self.indexed_access_object_is_unresolved_import(node);
         }
         if node.kind == syntax_kind_ext::TYPE_REFERENCE
             && let Some(type_ref) = self.ctx.arena.get_type_ref(node)

--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -1628,6 +1628,17 @@ impl<'a> CheckerState<'a> {
             })
             .or_else(|| self.resolve_global_augmentation_root_symbol(root_name, &lib_binders))?;
 
+        // Bare reference to an import alias from an unresolved module: same
+        // poison-to-`any` rule as the `NodeIndex` path above (qualified members
+        // like `E.URI` fail in the segment walk below and return `None` there).
+        if segments.clone().next().is_none() && self.is_unresolved_import_symbol_id(current_sym) {
+            self.ctx
+                .lowering_entity_name_resolution_cache
+                .borrow_mut()
+                .insert(name.to_string(), None);
+            return None;
+        }
+
         for segment in segments {
             let mut visited_aliases = AliasCycleTracker::new();
             current_sym = self
@@ -1791,6 +1802,16 @@ impl<'a> CheckerState<'a> {
                 && let TypeSymbolResolution::Type(sym_id) =
                     self.resolve_identifier_symbol_in_type_position(idx)
             {
+                // An import alias from a module that never resolved (TS2307
+                // already emitted) must not bind to a stable `DefId`: lowering
+                // would build `Application(Lazy(alias_def), args)`, a non-error
+                // shape that keeps its type arguments for structural comparison
+                // (so two instantiations differing only in an argument fail to
+                // relate). tsc poisons it to `any`; `None` routes lowering to the
+                // error-like `UnresolvedTypeName`. See `is_unresolved_import_symbol_id`.
+                if self.is_unresolved_import_symbol_id(sym_id) {
+                    return None;
+                }
                 let lib_binders = self.get_lib_binders();
                 if let Some(alias_symbol) =
                     self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)

--- a/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
@@ -652,6 +652,69 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// For an indexed-access type annotation `T[K]`, return `true` when the
+    /// object operand `T` is a type reference rooted in an unresolved module
+    /// import (TS2307 already emitted).
+    ///
+    /// `tsc` poisons a reference to a generic interface from an unresolved
+    /// module to `any`, so the indexed access `T[K]` collapses to `any[K] =
+    /// any` rather than a deferred `T[K]`. Without this signal the lowering
+    /// keeps the access stuck on `Application(UnresolvedTypeName, …)`, which
+    /// (1) false-fails assignability (`TS2322`) against an arrow initializer
+    /// and (2) is treated as a valid contextual type that wrongly suppresses
+    /// the implicit-`any` parameter diagnostics (`TS7006`) `tsc` reports.
+    ///
+    /// The root identifier is resolved structurally via
+    /// `is_unresolved_import_symbol_id` (the same helper #13755/#13780 use);
+    /// no identifier/file-name string is inspected. Qualified object names
+    /// (`ns.Iface[K]`) walk to the leftmost identifier before the check.
+    pub(crate) fn indexed_access_object_is_unresolved_import(
+        &self,
+        indexed_access_node: &Node,
+    ) -> bool {
+        let Some(indexed) = self.ctx.arena.get_indexed_access_type(indexed_access_node) else {
+            return false;
+        };
+        let Some(object_node) = self.ctx.arena.get(indexed.object_type) else {
+            return false;
+        };
+        if object_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return false;
+        }
+        let Some(type_ref) = self.ctx.arena.get_type_ref(object_node) else {
+            return false;
+        };
+        self.type_reference_root_is_unresolved_import(type_ref.type_name)
+    }
+
+    /// Walk an entity name (`E`, `E.M`, `E.M.N`, …) to its leftmost identifier
+    /// and report whether that root resolves to an unresolved module import.
+    /// Shared root-walk for the indexed-access poison check above.
+    fn type_reference_root_is_unresolved_import(&self, entity_name_idx: NodeIndex) -> bool {
+        let mut current = entity_name_idx;
+        for _ in 0..MAX_TREE_WALK_ITERATIONS {
+            let Some(node) = self.ctx.arena.get(current) else {
+                return false;
+            };
+            if node.kind == syntax_kind_ext::QUALIFIED_NAME {
+                let Some(qn) = self.ctx.arena.get_qualified_name(node) else {
+                    return false;
+                };
+                current = qn.left;
+                continue;
+            }
+            if node.kind == SyntaxKind::Identifier as u16 {
+                return matches!(
+                    self.resolve_identifier_symbol_in_type_position_without_tracking(current),
+                    crate::symbol_resolver::TypeSymbolResolution::Type(sym_id)
+                        if self.is_unresolved_import_symbol_id(sym_id)
+                );
+            }
+            return false;
+        }
+        false
+    }
+
     /// Check if a module specifier matches a declared or shorthand ambient module pattern.
     ///
     /// Supports simple wildcard patterns using `*` (e.g., "foo*baz", "*!text").

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -409,6 +409,40 @@ impl<'a> CheckerState<'a> {
                     return array_type;
                 }
 
+                // A reference whose name resolves to an import alias from a module
+                // that never resolved (TS2307 already emitted) must not bind to a
+                // stable `Lazy(DefId)` base here. `resolve_symbol_as_lazy_type_named`
+                // would yield `Application(Lazy(alias_def), args)`, a non-error shape
+                // that retains its type arguments for structural comparison; two
+                // instantiations differing only in an argument then fail to relate.
+                // tsc poisons such a reference to `any`, so the application relates
+                // freely. Route to `UnresolvedTypeName` (error-like for any args,
+                // display-preserving) to match tsc and prevent self-assignability
+                // cascades through generic interfaces parameterized by members of
+                // unresolved imports (e.g. `interface Decoder<I,A> extends
+                // K.Kleisli<E.URI, I, E, A>` where `E`/`Kind2` are unresolved).
+                if type_param.is_none() && self.is_unresolved_import_symbol(type_name_idx) {
+                    let lowered_args: Vec<TypeId> = type_ref
+                        .type_arguments
+                        .as_ref()
+                        .map(|args| {
+                            args.nodes
+                                .iter()
+                                .map(|&arg_idx| {
+                                    self.get_type_from_type_node_in_type_literal(arg_idx)
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let atom = self.ctx.types.intern_string(name);
+                    let base = self.ctx.types.unresolved_type_name(atom);
+                    return if lowered_args.is_empty() {
+                        base
+                    } else {
+                        self.ctx.types.application(base, lowered_args)
+                    };
+                }
+
                 // Validate type arguments against constraints (TS2344)
                 // This mirrors the check in get_type_from_type_reference for the
                 // normal type resolution path. Without this, type references inside


### PR DESCRIPTION
## Summary

An indexed-access type annotation `T[K]` whose object `T` references a generic interface imported from an **unresolved module** (TS2307 already emitted) was left as a stuck `Application(UnresolvedTypeName, …)[K]`. `tsc` resolves the unresolved import to `any`, so `T[K]` collapses to `any[K] = any`. The stuck access:
1. false-failed an arrow initializer with a spurious **TS2322**, and
2. was treated as a valid contextual type, which wrongly **suppressed the TS7006** implicit-`any` parameter diagnostics `tsc` reports.

This extends the unresolved-import poison family landed in #13755 / #13780 (which poisoned entity-name import-equals and type-position member uses, but not the indexed-access **object**).

## Structural rule

When an indexed-access type annotation `T[K]` has an object `T` that is a type reference whose leftmost identifier resolves to an unresolved module import, `tsc` poisons `T` to `any` (so `any[K] = any`) and reports the arrow's implicit-`any` parameters; tsz now does the same through `CheckerState`:
- `get_type_from_type_node` short-circuits such an `INDEXED_ACCESS_TYPE` to `TypeId::ANY`.
- `explicit_annotation_can_defer_implicit_any_context` stops deferring the implicit-`any` check for it.

Detection is structural via the existing `is_unresolved_import_symbol_id` helper (no identifier / file-name string checks). Qualified object names (`ns.Iface[K]`) walk to the leftmost identifier first. Owner layer: checker `CheckerState` (the layer that already owns the unresolved-import poison decision in `resolve_type_symbol_for_lowering`).

## Adjacent-case matrix (all match `tsc`)

| Case | Object | tsz before | tsz after / tsc |
| --- | --- | --- | --- |
| `Functor2<URI>['map'] = (fa,f)=>…` (unresolved import) | unresolved | TS2322, no TS7006 | TS2307 + 2×TS7006 |
| `M.Category2<'X'>['compose']` (unresolved `import * as M`, qualified) | unresolved | TS2322 | TS2307 + 2×TS7006 |
| local `interface Functor2<F>{…}; Functor2<URI>['map']=(fa,f)=>…` | resolved | clean | clean (no TS7006) |
| `Box['get'] = (k)=>1` (resolved) | resolved | clean | clean |
| `const x: Functor2<URI>['map'] = 42` (non-fn init, unresolved) | unresolved | TS2322 | only TS2307 |
| fp-ts `Monad1<URI>['map']`, `Filterable1<URI>['filter']` (resolved interfaces) | resolved | 0 TS7006 | 0 TS7006 (no over-fire) |

## Verification

Repro (`/tmp/iots-repro/idx.ts`): a module importing a non-existent module's generic interface, then `const map_: Functor2<URI>['map'] = (fa, f) => fa`.

Before:
```
idx.ts(1,26): error TS2307: Cannot find module 'nonexistent/Functor' …
idx.ts(3,7):  error TS2322: Type '(fa: any, f: any) => any' is not assignable to type 'Functor2<"X">["map"]'.
```
After (matches `node typescript/lib/tsc.js --strict --noEmit`):
```
idx.ts(1,26): error TS2307: Cannot find module 'nonexistent/Functor' …
idx.ts(3,37): error TS7006: Parameter 'fa' implicitly has an 'any' type.
idx.ts(3,41): error TS7006: Parameter 'f' implicitly has an 'any' type.
```

io-ts (`TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_FILTER=io-ts`): the indexed-access TS2322 cluster is eliminated — all 7 cluster lines now emit `TS7006` matching `tsc` exactly:
- `Decoder.ts:391/393/395` (`Functor2['map']`, `Alt2['alt']`, `Category2['compose']`)
- `TaskDecoder.ts:398/400/402` (same trio)
- `Codec.ts:328` (`Invariant3['imap']`)

`tsc` reports 0 TS2322 in io-ts; the remaining 12 tsz TS2322 are unrelated families (Codec/Encoder/Eq/Guard/Schema/Kleisli mapped-type & HKT assignability) — no new FPs introduced. No-regression confirmed on **fp-ts** (resolved interfaces): both tsz and tsc emit 0 TS7006, i.e. the poison does not over-fire on resolved indexed accesses.

Conformance (`scripts/conformance/conformance.sh run --filter …`, 0 PASS→FAIL):
- `indexedAccess` 13/13, `implicitAny` 22/22, `anyType` 2/2, `importType` 17/17, `moduleResolution` 111/111, `unresolved` 1/1, `import` 281/281.

Other gates: `cargo clippy -p tsz-checker` clean; `scripts/architecture-check.sh --quick` clean (no new boundary/cross-layer/diagnostic-leak entries); 3× determinism stable.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

AgentName: iots-indexed-access-poison
- Row: io-ts
- Bug family: indexed-access unresolved-import poison

Goal: green
