### PR TITLE
fix(checker): validate nested deferred-conditional indexed access via apparent type

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -499,6 +499,9 @@ mod ts2469_symbol_operator_tests;
 #[path = "../tests/ts2498_tests.rs"]
 mod ts2498_tests;
 #[cfg(test)]
+#[path = "tests/ts2536_deferred_conditional_indexed_access_tests.rs"]
+mod ts2536_deferred_conditional_indexed_access_tests;
+#[cfg(test)]
 #[path = "../tests/ts2540_readonly_tests.rs"]
 mod ts2540_readonly_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/ts2536_deferred_conditional_indexed_access_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2536_deferred_conditional_indexed_access_tests.rs
@@ -1,0 +1,103 @@
+//! Regression coverage for TS2536 on *nested* indexed accesses into a deferred
+//! conditional type: `Cond<T>[k1][k2]`.
+//!
+//! The inner `Cond<T>[k1]` is a generic indexed access whose apparent type is
+//! the conditional's branch-union constraint indexed by `k1` (tsc's
+//! `getConstraintOfIndexedAccessType`). That apparent type carries a concrete
+//! key space even while the access stays deferred, so the outer literal key `k2`
+//! is validated against it: keys present in the apparent type (e.g. `length`,
+//! numeric indices, array methods on a tuple-valued part) are accepted while a
+//! genuinely-missing key still emits TS2536. Mirrors tsc, which keeps the access
+//! deferred but never collapses the apparent key space to empty.
+//!
+//! Binder names vary across cases so no fixture/identifier string drives the
+//! decision.
+
+use crate::test_utils::check_source_codes;
+
+/// `Cond<T>["required"]["length"]` — `length` is in the tuple apparent type of
+/// the `required` part, so no TS2536. Matches tsc.
+#[test]
+fn nested_deferred_conditional_length_index_does_not_emit_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Parts<T extends ReadonlyArray<unknown>, Prefix extends unknown[] = []> =
+  T extends readonly [infer Head, ...infer Tail]
+    ? Parts<Tail, [...Prefix, Head]>
+    : { required: Prefix; optional: []; suffix: [] };
+type Len<T extends ReadonlyArray<unknown>> = Parts<T>["required"]["length"];
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "TS2536 should not fire for `Parts<T>[\"required\"][\"length\"]`: {codes:?}"
+    );
+}
+
+/// Numeric index into the tuple apparent type — also valid.
+#[test]
+fn nested_deferred_conditional_numeric_index_does_not_emit_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Cond<U extends ReadonlyArray<unknown>> = U extends readonly []
+  ? { head: [1] }
+  : { head: [2] };
+type First<U extends ReadonlyArray<unknown>> = Cond<U>["head"][0];
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "TS2536 should not fire for numeric index `Cond<U>[\"head\"][0]`: {codes:?}"
+    );
+}
+
+/// Inline deferred conditional (no alias indirection) — same acceptance for an
+/// array method key.
+#[test]
+fn inline_nested_deferred_conditional_method_index_does_not_emit_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type M<V> = (V extends string ? { a: [1] } : { a: [2] })["a"]["map"];
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "TS2536 should not fire for `(...)[\"a\"][\"map\"]` array-method index: {codes:?}"
+    );
+}
+
+/// Negative: a key absent from the apparent type STILL emits TS2536 — the
+/// suppression must not be a blanket defer.
+#[test]
+fn nested_deferred_conditional_bogus_key_emits_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Cond<W extends ReadonlyArray<unknown>> = W extends readonly []
+  ? { part: [1] }
+  : { part: [2] };
+type Bad<W extends ReadonlyArray<unknown>> = Cond<W>["part"]["nope"];
+"#,
+    );
+    assert!(
+        codes.contains(&2536),
+        "TS2536 expected for missing key `Cond<W>[\"part\"][\"nope\"]`: {codes:?}"
+    );
+}
+
+/// Negative: a first-level key absent from every branch still emits TS2536
+/// (unchanged behavior — guards the inner access too).
+#[test]
+fn deferred_conditional_first_level_missing_key_emits_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Cond<X extends ReadonlyArray<unknown>> = X extends readonly []
+  ? { only: [1] }
+  : { only: [2] };
+type Bad<X extends ReadonlyArray<unknown>> = Cond<X>["missing"];
+"#,
+    );
+    assert!(
+        codes.contains(&2536),
+        "TS2536 expected for first-level missing key `Cond<X>[\"missing\"]`: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/ts2574_rest_tuple_element_type_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2574_rest_tuple_element_type_tests.rs
@@ -299,3 +299,62 @@ declare function f<S extends SelTuple>(...args: [...selectors: S, last: Sel]): v
         "TS2574 should not fire for `[...S]` with `S extends SelTuple` (array alias): {codes:?}"
     );
 }
+
+// ── Deferred conditional indexed-access bases ────────────────────────────────
+// A spread of `Cond<T>[k]` where `Cond<T>` is a deferred conditional indexes the
+// conditional's branch-union constraint by `k` (tsc's
+// `getConstraintOfIndexedAccessType`) and classifies array-like-ness from that
+// apparent type — tuple-valued branches are accepted, non-array branches still
+// flag. The binder names vary so no fixture name drives the decision.
+
+/// `[...Cond<T>["suffix"]]` where both branches give a tuple at `suffix` — the
+/// apparent type (`[] | [string]`) is array-like, so no TS2574. Matches tsc.
+#[test]
+fn rest_deferred_conditional_indexed_tuple_branch_does_not_emit_ts2574() {
+    let codes = check_source_codes(
+        r#"
+type Shape<T extends ReadonlyArray<unknown>> = T extends readonly []
+  ? { suffix: [] }
+  : { suffix: [string] };
+type Spread<T extends ReadonlyArray<unknown>> = [...Shape<T>["suffix"]];
+"#,
+    );
+    assert!(
+        !codes.contains(&2574),
+        "TS2574 should not fire for `[...Shape<T>[\"suffix\"]]` with tuple branches: {codes:?}"
+    );
+}
+
+/// Inline deferred conditional (no alias indirection) — same acceptance.
+#[test]
+fn rest_inline_deferred_conditional_indexed_tuple_does_not_emit_ts2574() {
+    let codes = check_source_codes(
+        r#"
+type Spread<U extends ReadonlyArray<unknown>> =
+  [...(U extends readonly [] ? { rest: [1] } : { rest: [2] })["rest"]];
+"#,
+    );
+    assert!(
+        !codes.contains(&2574),
+        "TS2574 should not fire for inline deferred conditional indexed tuple spread: {codes:?}"
+    );
+}
+
+/// Negative: `[...Cond<T>[k]]` where the indexed branch is a *non-array* (string
+/// literals) must STILL flag TS2574 (the apparent type `"x" | "y"` is not
+/// array-like). Guards against over-suppression.
+#[test]
+fn rest_deferred_conditional_indexed_nonarray_branch_emits_ts2574() {
+    let codes = check_source_codes(
+        r#"
+type Shape<T extends ReadonlyArray<unknown>> = T extends readonly []
+  ? { val: "x" }
+  : { val: "y" };
+type Spread<T extends ReadonlyArray<unknown>> = [...Shape<T>["val"]];
+"#,
+    );
+    assert!(
+        codes.contains(&2574),
+        "TS2574 expected for `[...Shape<T>[\"val\"]]` with string-literal branches: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -1315,6 +1315,21 @@ impl<'a> CheckerState<'a> {
             {
                 return;
             }
+            // A nested deferred indexed access `Cond<T>[k1][k2]`: the inner
+            // `Cond<T>[k1]` is a generic indexed access whose apparent type (the
+            // conditional's branch-union constraint indexed by `k1`) carries a
+            // concrete key space. Validate the outer literal key `k2` against it,
+            // matching tsc's `getConstraintOfIndexedAccessType` — `length`/`0`/
+            // array methods are accepted, a missing key still emits TS2536.
+            if !foreign_keyof_indexed_constraint
+                && self.deferred_indexed_access_conditional_key_is_valid(
+                    object_type,
+                    object_type_for_check,
+                    index_type_for_check,
+                )
+            {
+                return;
+            }
             if self.index_has_keyof_constraint_from_declaration(
                 data.index_type,
                 data.object_type,

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/deferred_conditional_index.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/deferred_conditional_index.rs
@@ -75,4 +75,115 @@ impl<'a> CheckerState<'a> {
         self.indexed_access_key_space_relation_outcome(index_type_for_check, keyof_constraint)
             .related
     }
+
+    /// Apparent type of a *deferred* indexed access `B[K1]` whose base `B` is a
+    /// deferred conditional (e.g. `Cond<T>['required']`). tsc resolves such a
+    /// generic indexed access through `getConstraintOfIndexedAccessType`: it
+    /// indexes `B`'s base constraint — the union of the conditional's branch
+    /// results — with `K1`. That apparent type carries a concrete key space even
+    /// while the access itself stays deferred, so a later access
+    /// `B[K1][K2]` (or a spread `[...B[K1]]`) validates `K2`/array-likeness
+    /// against it instead of failing as if `B[K1]` had no members.
+    ///
+    /// Returns the evaluated apparent type, or `None` when `object_type` is not
+    /// such a deferred indexed access, the inner key is not a usable literal, the
+    /// conditional has no resolvable branch-union constraint, or the apparent
+    /// type cannot be reduced to a concrete (non-deferred) form.
+    pub(super) fn deferred_indexed_access_conditional_apparent_type(
+        &mut self,
+        object_type: TypeId,
+    ) -> Option<TypeId> {
+        use crate::query_boundaries::common as q;
+        // Resolve a generic `Application` (e.g. an alias `Drop<T>`) whose body is
+        // an indexed access into that indexed access first, so both the direct and
+        // alias-wrapped forms are covered.
+        let resolve_index_access = |this: &mut Self, ty: TypeId| -> Option<(TypeId, TypeId)> {
+            if let Some(parts) = q::index_access_types(this.ctx.types, ty) {
+                return Some(parts);
+            }
+            if q::is_generic_application(this.ctx.types, ty) {
+                let expanded = this.evaluate_application_type(ty);
+                if let Some(parts) = q::index_access_types(this.ctx.types, expanded) {
+                    return Some(parts);
+                }
+            }
+            None
+        };
+        let (inner_base, inner_index) = resolve_index_access(self, object_type)?;
+
+        // The inner base must resolve to a deferred conditional; otherwise the
+        // existing concrete/type-parameter paths already own validation.
+        let resolve_conditional = |this: &mut Self, ty: TypeId| -> Option<TypeId> {
+            if q::is_conditional_type(this.ctx.types, ty) {
+                return Some(ty);
+            }
+            if q::is_generic_application(this.ctx.types, ty) {
+                let expanded = this.evaluate_application_type(ty);
+                if q::is_conditional_type(this.ctx.types, expanded) {
+                    return Some(expanded);
+                }
+            }
+            None
+        };
+        let conditional = match resolve_conditional(self, inner_base) {
+            Some(c) => c,
+            None => {
+                let evaluated_base = self.evaluate_type_with_env(inner_base);
+                resolve_conditional(self, evaluated_base)?
+            }
+        };
+
+        let base_constraint = q::conditional_branch_union_constraint(self.ctx.types, conditional)?;
+        // The branch-union must have resolved to a concrete shape; a constraint
+        // that is itself still deferred has no computable apparent type.
+        if q::is_conditional_type(self.ctx.types, base_constraint)
+            || q::is_index_access_type(self.ctx.types, base_constraint)
+        {
+            return None;
+        }
+
+        // The inner key drives `apparent = base_constraint[inner_index]`. Evaluate
+        // it; an apparent type that is still deferred (e.g. the inner key was
+        // itself generic) gives no concrete key space, so bail.
+        let apparent = self.evaluate_type_with_env(
+            self.ctx
+                .types
+                .factory()
+                .index_access(base_constraint, inner_index),
+        );
+        if apparent == TypeId::ERROR
+            || apparent == TypeId::ANY
+            || q::is_index_access_type(self.ctx.types, apparent)
+            || q::is_conditional_type(self.ctx.types, apparent)
+        {
+            return None;
+        }
+        Some(apparent)
+    }
+
+    /// Index-key validation for `B[K1][K2]` where `B[K1]` is a deferred indexed
+    /// access into a deferred conditional. Validates the outer literal key `K2`
+    /// against the key space of the apparent type of `B[K1]` (see
+    /// [`Self::deferred_indexed_access_conditional_apparent_type`]). tsc accepts
+    /// `Cond<T>['required']['length']` (length ∈ keyof of the tuple apparent
+    /// type) but still rejects `Cond<T>['required']['nope']`.
+    pub(super) fn deferred_indexed_access_conditional_key_is_valid(
+        &mut self,
+        object_type: TypeId,
+        object_type_for_check: TypeId,
+        index_type_for_check: TypeId,
+    ) -> bool {
+        let Some(apparent) = self
+            .deferred_indexed_access_conditional_apparent_type(object_type_for_check)
+            .or_else(|| self.deferred_indexed_access_conditional_apparent_type(object_type))
+        else {
+            return false;
+        };
+        let keyof_apparent = self.ctx.types.evaluate_keyof(apparent);
+        if crate::query_boundaries::common::is_keyof_type(self.ctx.types, keyof_apparent) {
+            return false;
+        }
+        self.indexed_access_key_space_relation_outcome(index_type_for_check, keyof_apparent)
+            .related
+    }
 }

--- a/crates/tsz-checker/src/types/type_node_helpers.rs
+++ b/crates/tsz-checker/src/types/type_node_helpers.rs
@@ -837,12 +837,76 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             // (e.g. `number extends infer U ? U : never` from `Cond<number>`)
             // so it is classified by its reduced shape rather than left opaque.
             let next = self.ctx.types.evaluate_type(next);
+            // A *deferred* indexed access into a deferred conditional
+            // (`Cond<T>['suffix']`) stays opaque here, but tsc classifies its
+            // array-like-ness from its apparent type: the conditional's
+            // branch-union constraint indexed by the inner key. Reduce to that
+            // apparent type so a tuple-valued branch (`{ suffix: [] }`) is
+            // accepted while a non-array branch (`{ s: string }`) still fires
+            // TS2574. Mirrors `getConstraintOfIndexedAccessType`.
+            let next = self
+                .deferred_indexed_access_apparent_array_like_type(next)
+                .unwrap_or(next);
             if next == current {
                 break;
             }
             current = next;
         }
         current
+    }
+
+    /// Apparent type of a deferred indexed access `B[K1]` whose base `B` is a
+    /// deferred conditional, for the TS2574 rest-element array-like check. Indexes
+    /// the conditional's branch-union constraint with `K1` (tsc's
+    /// `getConstraintOfIndexedAccessType`) and returns the evaluated result.
+    /// Returns `None` when `type_id` is not such a deferred indexed access or the
+    /// apparent type cannot be reduced concretely, leaving the caller to treat the
+    /// type as indeterminate (legal).
+    fn deferred_indexed_access_apparent_array_like_type(
+        &self,
+        type_id: tsz_solver::TypeId,
+    ) -> Option<tsz_solver::TypeId> {
+        use crate::query_boundaries::common as q;
+        let (base, index) = q::index_access_types(self.ctx.types, type_id)?;
+        // Only handle a still-generic conditional base; concrete indexed accesses
+        // already reduce through `evaluate_type` above. An alias-wrapped base
+        // (`Application(Lazy(Cond), [T])`) is expanded to its conditional first so
+        // both `Cond<T>[k]` and inline `(T extends ... ? ... : ...)[k]` are
+        // covered.
+        let conditional = if q::is_conditional_type(self.ctx.types, base) {
+            base
+        } else if q::is_generic_application(self.ctx.types, base) {
+            let env = self.ctx.type_environment.borrow();
+            let expanded = crate::query_boundaries::flow_analysis::evaluate_application_type(
+                self.ctx.types,
+                &env,
+                base,
+            );
+            if q::is_conditional_type(self.ctx.types, expanded) {
+                expanded
+            } else {
+                return None;
+            }
+        } else {
+            return None;
+        };
+        let base_constraint = q::conditional_branch_union_constraint(self.ctx.types, conditional)?;
+        if q::is_conditional_type(self.ctx.types, base_constraint)
+            || q::is_index_access_type(self.ctx.types, base_constraint)
+        {
+            return None;
+        }
+        let apparent = self
+            .ctx
+            .types
+            .evaluate_type(self.ctx.types.index_access(base_constraint, index));
+        if apparent == tsz_solver::TypeId::ERROR
+            || q::is_index_access_type(self.ctx.types, apparent)
+            || q::is_conditional_type(self.ctx.types, apparent)
+        {
+            return None;
+        }
+        Some(apparent)
     }
 
     pub(super) fn fixed_tuple_spread_elements(

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1434,7 +1434,17 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # `is_generic_application`, `is_index_access_type`) already called from
         # `common` in the very same expressions — no new quarantine entry.
         # Removal condition remains #8225 narrowing this quarantine.
-        3072,
+        #
+        # Bumped by 1 for the nested deferred-conditional indexed-access parity
+        # fix (#13792): the new `indexed_access/deferred_conditional_index.rs`
+        # module resolves a deferred `B[K1]` apparent type through the existing
+        # `query_boundaries::common` structural predicates (`is_conditional_type`,
+        # `is_generic_application`, `is_index_access_type`, `is_keyof_type`,
+        # `conditional_branch_union_constraint`). These join the sibling
+        # predicates already routed through `common`; the net live count rises by
+        # one over current main — no new quarantine entry.
+        # Removal condition remains #8225 narrowing this quarantine.
+        3073,
     ),
 ]
 


### PR DESCRIPTION
Goal: green

## Structural rule

When the object of an indexed access is a deferred indexed access `B[K1]` whose
base `B` is a deferred conditional (e.g. `Cond<T>["required"]`), `tsc` validates
a further literal key — `B[K1][K2]` — and the rest-element array-like check —
`[...B[K1]]` — against the **apparent type** of `B[K1]`: the conditional's
branch-union constraint indexed by `K1` (`getConstraintOfIndexedAccessType`).
That apparent type carries a concrete key space even while the access stays
deferred. `tsz` previously treated `B[K1]` as having an empty/unresolved key
space and emitted spurious **TS2536** (nested literal index) and **TS2574**
(rest spread) for keys that are in the apparent key space (`length`, numeric
indices, array methods on a tuple-valued part).

Owner layer: checker indexed-access validation (`check_indexed_access_type`) and
the rest-element array-like classifier (`rest_element_type_is_array_like`), using
existing solver query-boundary structural helpers
(`conditional_branch_union_constraint`, `index_access_types`, `evaluate_keyof`,
`factory().index_access`). No `keyof`/relation semantics changed; a missing key
still emits TS2536 and a non-array branch still emits TS2574.

Adjacent matrix (all covered by new unit tests, binder names varied):
- nested literal index `Cond<T>["required"]["length"]` — accept
- numeric index `Cond<U>["head"][0]` — accept
- array-method index `(...)["a"]["map"]` — accept
- inline conditional (no alias) and alias-wrapped `Cond<T>` — both accept
- rest spread `[...Cond<T>["suffix"]]` over tuple branches — accept
- negative: missing outer key `...["nope"]` — still TS2536
- negative: first-level missing key `Cond<X>["missing"]` — still TS2536
- negative: non-array indexed branch `[...Cond<T>["val"]]` (string literals) —
  still TS2574

## Verification

- New unit tests:
  `crates/tsz-checker/src/tests/ts2536_deferred_conditional_indexed_access_tests.rs`
  and additions to
  `crates/tsz-checker/src/tests/ts2574_rest_tuple_element_type_tests.rs`.
- CLI parity vs `tsc` oracle on isolated repros (positive + negative): exact
  match (TS2536/TS2574 emitted iff `tsc` emits).
- Conformance (no regressions, families touched):
  `indexedAccess` 13/13, `conditionalType` 17/17, `restElement` 14/14,
  `restTuple` 2/2, `tupleType` 3/3, `keyof` 14/14, `mappedType` 55/55.
- `arch_guard.py` PASS; clippy clean on `tsz-checker`/`tsz-solver`;
  3x determinism stable.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Project corpus

This change targets the deferred-conditional indexed-access FP family. It does
NOT move the `remeda` canary delta: every remeda TS2536/TS2574 is gated by a
distinct broad-architectural root (error-type-as-`any` propagation from the
unresolved `type-fest`/`vitest` imports), which is filed for a dedicated PR.

AgentName: claude-code
- Row: remeda-project
- Bug family: deferred-conditional indexed-access TS2536/TS2574 (adjacent family; remeda residual root is import-failure any-propagation, deferred to a dedicated PR)
