### PR TITLE
fix(solver): typeof-function narrowing unwraps generic alias-union members

### DIFF
--- a/crates/tsz-checker/tests/discriminant_narrow_function_lazy_preserved_tests.rs
+++ b/crates/tsz-checker/tests/discriminant_narrow_function_lazy_preserved_tests.rs
@@ -78,3 +78,68 @@ function f(instance: Function | string) {
         "Expected no TS2339 with Function | string, got: {diags:#?}"
     );
 }
+
+/// Regression: `typeof x === 'function'` narrowing over a *generic type-alias
+/// instantiation* whose alias resolves to a union containing a call signature.
+/// `narrow_to_function` inspected the raw `Application`/`Lazy` wrapper, which
+/// `union_list_id` does not recognize as a union, so the call-signature member
+/// was dropped and the result was no longer callable (spurious TS2349) and the
+/// non-function member rendered as a lost-member union (spurious TS2322).
+///
+/// Mirrors `tanstack-query`'s `resolveStaleTime`/`resolveQueryBoolean`:
+/// `typeof option === 'function' ? option(query) : option` over
+/// `option: undefined | Fn<T>`.
+#[test]
+fn typeof_function_narrows_generic_alias_union_member() {
+    let source = r#"
+type Fn<T> = number | ((x: T) => number)
+function resolve<T>(option: undefined | Fn<T>, x: T): number | undefined {
+    return typeof option === 'function' ? option(x) : option
+}
+"#;
+    let diags = check_source(source, "test.ts", CheckerOptions::default());
+    assert!(
+        diags.is_empty(),
+        "Expected no diagnostics narrowing a generic-alias union, got: {diags:#?}"
+    );
+}
+
+/// Adjacent: the same alias-union reached *directly* (not behind an outer
+/// `undefined`), narrowed in an `if` block rather than a ternary, with the
+/// negative (`else`) branch keeping only the non-function members.
+#[test]
+fn typeof_function_narrows_generic_alias_if_and_else_branches() {
+    let source = r#"
+type Fn<T> = number | ((x: T) => number)
+function resolve<T>(option: Fn<T>, x: T): number {
+    if (typeof option === 'function') {
+        return option(x)
+    }
+    return option
+}
+"#;
+    let diags = check_source(source, "test.ts", CheckerOptions::default());
+    assert!(
+        diags.is_empty(),
+        "Expected no diagnostics on if/else alias-union narrowing, got: {diags:#?}"
+    );
+}
+
+/// Adjacent: a concrete instantiation `Fn<string>` (no free type parameter)
+/// must narrow identically to the generic form — the bug was in the wrapper
+/// handling, not the type parameter.
+#[test]
+fn typeof_function_narrows_concrete_alias_instantiation() {
+    let source = r#"
+type Fn<T> = number | ((x: T) => number)
+function resolve(option: Fn<string>, x: string): number {
+    if (typeof option === 'function') { return option(x) }
+    return option
+}
+"#;
+    let diags = check_source(source, "test.ts", CheckerOptions::default());
+    assert!(
+        diags.is_empty(),
+        "Expected no diagnostics on concrete alias instantiation, got: {diags:#?}"
+    );
+}

--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -231,14 +231,47 @@ impl<'a> NarrowingContext<'a> {
 
     /// Narrow to function types only.
     pub(super) fn narrow_to_function(&self, source_type: TypeId) -> TypeId {
+        // A Lazy/Application wrapper that aliases a union (e.g. a generic
+        // type-alias instantiation `Fn<T> = number | ((x: T) => number)`) is
+        // opaque to `union_list_id`, so without resolving it the call-signature
+        // member is dropped and the narrowed type is no longer callable. Other
+        // typeof targets reach `narrow_to_type`, which resolves the source
+        // itself; the "function" branch needs the same unwrapping. We only do
+        // this when the wrapper resolves to a *union* — resolving an object-like
+        // wrapper (e.g. the global `Function` interface) to its shape and
+        // recursing would wrongly collapse it to `never`, so those keep the
+        // direct structural handling below. Identity of `source_type` is
+        // preserved when narrowing is a no-op.
+        if union_list_id(self.db, source_type).is_none() {
+            let resolved = self.resolve_type(source_type);
+            if resolved != source_type
+                && resolved != TypeId::ERROR
+                && union_list_id(self.db, resolved).is_some()
+            {
+                let narrowed = self.narrow_to_function(resolved);
+                return if narrowed == resolved {
+                    source_type
+                } else {
+                    narrowed
+                };
+            }
+        }
         if let Some(members) = union_list_id(self.db, source_type) {
             let members = self.db.type_list(members);
             let mut functions: Option<Vec<TypeId>> = None;
             for (index, &member) in members.iter().enumerate() {
                 let narrowed = if let Some(narrowed) = self.narrow_type_param_to_function(member) {
                     narrowed.non_never()
+                } else if self.is_function_type(member) {
+                    Some(member)
+                } else if let Some(resolved_member) = self.resolve_alias_union_member(member) {
+                    // A union member may itself be a Lazy/Application wrapper
+                    // aliasing a union with a call signature. Resolve and recurse
+                    // so the call-signature members inside the wrapper survive
+                    // instead of being dropped from the function-narrowed result.
+                    self.narrow_to_function(resolved_member).non_never()
                 } else {
-                    self.is_function_type(member).then_some(member)
+                    None
                 };
 
                 match (narrowed, &mut functions) {
@@ -307,8 +340,48 @@ impl<'a> NarrowingContext<'a> {
         is_function_type_through_type_constraints(self.db, type_id)
     }
 
+    /// Resolve a union member that is a Lazy/Application wrapper aliasing a
+    /// *union* (e.g. a generic type-alias instantiation
+    /// `Fn<T> = number | ((x: T) => number)`). Returns the resolved union when
+    /// the member is such a wrapper, otherwise `None`. Members that resolve to a
+    /// non-union (object shapes like the global `Function` interface, type
+    /// params, intrinsics) are left to the direct structural handling so they
+    /// are not collapsed.
+    fn resolve_alias_union_member(&self, member: TypeId) -> Option<TypeId> {
+        if union_list_id(self.db, member).is_some() {
+            return None;
+        }
+        let resolved = self.resolve_type(member);
+        if resolved != member
+            && resolved != TypeId::ERROR
+            && union_list_id(self.db, resolved).is_some()
+        {
+            Some(resolved)
+        } else {
+            None
+        }
+    }
+
     /// Narrow a type to exclude function-like members (typeof !== "function").
     pub fn narrow_excluding_function(&self, source_type: TypeId) -> TypeId {
+        // Mirror `narrow_to_function`: resolve a Lazy/Application wrapper that
+        // aliases a union (such as a generic type-alias instantiation) so the
+        // function members inside it are excluded rather than surviving whole.
+        // The positive/negative typeof branches must partition the same union.
+        if union_list_id(self.db, source_type).is_none() {
+            let resolved = self.resolve_type(source_type);
+            if resolved != source_type
+                && resolved != TypeId::ERROR
+                && union_list_id(self.db, resolved).is_some()
+            {
+                let narrowed = self.narrow_excluding_function(resolved);
+                return if narrowed == resolved {
+                    source_type
+                } else {
+                    narrowed
+                };
+            }
+        }
         if let Some(members) = union_list_id(self.db, source_type) {
             let members = self.db.type_list(members);
             let mut remaining: Option<Vec<TypeId>> = None;
@@ -318,6 +391,12 @@ impl<'a> NarrowingContext<'a> {
                         narrowed.non_never()
                     } else if self.is_function_type(member) {
                         None
+                    } else if let Some(resolved_member) = self.resolve_alias_union_member(member) {
+                        // A union member may itself be a Lazy/Application
+                        // wrapper aliasing a union with a call signature.
+                        // Resolve and recurse so its function members are
+                        // excluded instead of kept whole.
+                        self.narrow_excluding_function(resolved_member).non_never()
                     } else {
                         Some(member)
                     };


### PR DESCRIPTION
Goal: green

## Summary
ramda is not a project row; per the task, I picked the nearest UNATTACKED canary
row. The functional-utility analogs (fp-ts, arktype, typebox, ts-morph) all
CPU-bound time out (deferred-materialization, #13242/#13250). Among canary rows
that compile to completion and produce FPs, **tanstack-query-project** is the
nearest runtime-utility analog, so that is the row characterized and fixed here.

This is a genuinely NEW, bounded, structurally-localizable narrowing root (not
one of the shared deep trackers).

## Structural rule
When `typeof x === 'function'` narrows a union member that is a **generic
type-alias instantiation** (a `Lazy`/`Application` wrapper aliasing a union with
a call signature, e.g. `Fn<T> = number | ((x: T) => number)`), tsc keeps the
call-signature member; tsz dropped it. `narrow_to_function` /
`narrow_excluding_function` inspected the raw source through `union_list_id`,
which does not see through the wrapper, so the callable member was lost: the
narrowed value was no longer callable (spurious TS2349) and the non-function
part rendered as a lost-member union `| undefined` (spurious TS2322).

Owner layer: solver narrowing
(`crates/tsz-solver/src/narrowing/core/helpers.rs`).

Fix: resolve the wrapper before structural inspection — mirroring
`narrow_to_type`, which already resolves its source — but only when it resolves
to a *union*. Gating on "resolves to a union" preserves the object-like
`Function`-interface path (`typeof x === 'function'` over `Function | object`
must stay `Function`, not collapse to `never`). The positive and negative
typeof branches both get the unwrapping so they partition the same union.

## Adjacent matrix (all pass, tsc-clean)
- leading-bar `| undefined | Fn<T>` and no-bar `undefined | Fn<T>`
- alias-first `Fn<T> | undefined` vs undefined-first
- generic `Fn<T>`, concrete `Fn<string>`, non-generic alias `Fn` (control)
- inline nested union (no alias, control), `typeof === 'object'` over generic
  alias (control)
- if-block and ternary; positive and negative (`else`) branches
- regression guard: `Function | object` narrowing stays `Function`

## Verification
- Row: tanstack-query-project measured to COMPLETION (not timeout) before->after:
  95 -> 90 tsz-only FPs; 5 cleared (resolveStaleTime/resolveQueryBoolean
  utils.ts 126/140 + queryObserver.ts 784), 0 new FPs.
- Regression check: tanstack-router-project 260 -> 260, 0 new FPs.
- Conformance (`scripts/conformance/conformance.sh run --filter`), all 100%:
  typeGuard 86/86 (was 85/86 mid-fix, restored), typeof 33/33, narrowing 29/29,
  discriminate 15/15, controlFlow 94/94, function 284/284, unionType 30/30,
  conditional 51/51, instanceof 14/14, callExpression 2/2, overload 62/62,
  generic 240/240.
- New unit tests: 3 added to
  `discriminant_narrow_function_lazy_preserved_tests.rs` (6/6 pass).
- tsz-solver narrowing unit tests: 313/313 pass.
- clippy -p tsz-solver: clean. arch_guard: pass. 3x determinism on repros: stable.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Project corpus
AgentName: claude-code
- Row: tanstack-query-project
- Bug family: typeof-function narrowing drops call-signature member of a generic type-alias-instantiation union
