### PR TITLE
fix(checker,solver): contextual free-type-param erasure root (zustand/superstruct/mobx)

### DIFF
--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -722,6 +722,22 @@ impl<'a> CheckerState<'a> {
                 )
                 .or_else(|| ctx_helper.get_parameter_type_for_call(i, args.len()))
                 .map(|param_type| self.normalize_contextual_call_param_type(param_type))
+                .filter(|&param_type| {
+                    // A call argument whose contextual type is a bare free type
+                    // parameter from an enclosing generic signature — e.g.
+                    // `set((p) => ...)` where `set: (p: T) => void` and `T` is free
+                    // in the enclosing `<T>(...)` middleware — must NOT be
+                    // contextually typed by that type parameter. `tsc` treats such a
+                    // `T` as "could be instantiated with an arbitrary type": it does
+                    // not flow into the argument, so a callback argument's own
+                    // parameters stay implicitly `any` (TS7006) and the argument is
+                    // checked against `T` directly (TS2345). This only applies when
+                    // the callee is non-generic; a genuine generic callee's own type
+                    // parameters are inferred from these arguments and must keep their
+                    // contextual seed. Mirrors the bare type-parameter filter on
+                    // contextual *return* types in `return_expression_type`.
+                    is_generic_call || !is_type_parameter_type(self.ctx.types, param_type)
+                })
             })
             .collect();
         // For union callees, skip excess property checking during argument collection.

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -457,8 +457,21 @@ impl<'a> CheckerState<'a> {
             found
         })
         .unwrap_or_else(|| {
+            // A contextually sensitive body (e.g. a nested arrow/closure) can still
+            // receive useful parameter context from an `expected_return_type` that
+            // mentions free type parameters from an enclosing generic signature.
+            // tsc applies the expected return type to such a body so the inner
+            // closure's own parameters acquire their declared shapes (e.g. `set`
+            // gets `(p: T) => void` rather than `any`). Only genuine `infer`
+            // placeholders — which carry no usable shape yet — must block the
+            // contextual body. Free type parameters do not, so gate on
+            // `contains_infer_types` rather than the broader inference-hole check
+            // (which also trips on any `contains_type_parameters`).
             let can_apply_contextual_body =
-                !self.type_has_unresolved_inference_holes(expected_return_type);
+                !crate::query_boundaries::state::type_environment::contains_infer_types(
+                    self.ctx.types,
+                    expected_return_type,
+                );
             let literal_sensitive_return = crate::query_boundaries::common::literal_value(
                 self.ctx.types,
                 expected_return_type,

--- a/crates/tsz-solver/src/contextual/extractors.rs
+++ b/crates/tsz-solver/src/contextual/extractors.rs
@@ -903,8 +903,15 @@ pub(crate) fn extract_rest_param_type_at(
             // Return the rest param's type directly (it's already a tuple or array type).
             return Some(normalized.type_id);
         }
-        // Past the end with no rest param — no contextual type.
-        return None;
+        // The callback declares a rest parameter (`...args`) at a position past the
+        // end of a fixed-arity contextual signature that has no rest parameter. The
+        // contextual type for that rest is the empty tuple `[]`: there are no
+        // further parameters for it to capture. Typing it as `[]` (rather than
+        // leaving it un-contextual, which defaults to `any[]`) matches `tsc` and
+        // lets the rest be spread back into another fixed-arity callee without a
+        // spurious TS2556 (`A spread argument must either have a tuple type or be
+        // passed to a rest parameter`).
+        return Some(db.tuple(vec![]));
     }
 
     // The callback rest param starts before the contextual function's rest param.

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -1626,6 +1626,32 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 .match_infer_pattern_union_members(&members, pattern, bindings, visited, checker);
         }
 
+        // Intersection sources match the pattern through whichever constituent
+        // structurally matches it: e.g. `((g: () => T) => U) & { z?: 1 }` matched
+        // against `(...args: any) => infer R` extracts `R = U` from the callable
+        // member. Without this, `ReturnType<X>`/`Parameters<X>` over an
+        // intersection-of-callable carrying a free type parameter fails to reduce
+        // and the conditional stays deferred (a false `ReturnType<...>` residue).
+        // Mirrors how `tsc` evaluates conditional `infer` extraction against an
+        // intersection by inspecting each constituent. Try members in declaration
+        // order and accept the first that binds the pattern; later members that do
+        // not match the pattern shape (e.g. the `{ z?: 1 }` brand) are simply not
+        // the constituent the pattern targets.
+        if let Some(TypeData::Intersection(members)) = self.interner().lookup(source) {
+            let members = self.interner().type_list(members);
+            for &member in members.iter() {
+                if member == source {
+                    continue;
+                }
+                let mut local = bindings.clone();
+                if self.match_infer_pattern(member, pattern, &mut local, visited, checker) {
+                    *bindings = local;
+                    return true;
+                }
+            }
+            return false;
+        }
+
         let Some(pattern_key) = self.interner().lookup(pattern) else {
             return false;
         };


### PR DESCRIPTION
Fixes the contextual free-type-parameter erasure root shared by the
zustand/superstruct/mobx middleware family: a generic signature
`<T>(init) => StateCreator<T>` whose body is a nested arrow had its inner
closure params (`set`/`get`/`store`) erased to `any`.

Goal: green

## Structural rule
When an arrow's expression body is a contextually-sensitive nested closure and
the expected return type mentions free type parameters from an enclosing
generic signature (but no `infer` placeholders), `tsc` applies that expected
return type to the body so the inner closure's own parameters acquire their
declared shapes; tsz now does the same through
`check_expression_body_return_type` (gating on `contains_infer_types`, not the
broader inference-hole check). Three companion rules keep parity once the inner
params are typed:
- A call argument whose contextual type is a *bare* free enclosing-signature
  type parameter is not contextually typed by it (TS7006 + TS2345), mirroring
  the bare type-param filter on contextual return types in
  `return_expression_type`. Owner: `computation/call/inner`.
- `ReturnType<X>`/`Parameters<X>` over an intersection-of-callable reduces by
  matching the callable constituent (no deferred `ReturnType<StateCreator<…>>`
  residue). Owner: `evaluation/evaluate_rules/infer_pattern`.
- A callback `...rest` past a fixed-arity contextual signature is typed `[]`,
  not `any[]`, so it spreads into another fixed-arity callee without TS2556.
  Owner: `contextual/extractors`.

Owner layers: checker (`function_type_helpers`, `computation/call/inner`),
solver (`evaluation/evaluate_rules/infer_pattern`, `contextual/extractors`).

## Adjacent-case matrix
- Positive: `set` typed `(p:T)=>void` -> `const probe: number = set` -> TS2322
  (was missed; tsz `set` was `any`).
- Negative/fallback: `set((p)=>config(p))` -> TS7006 + TS2345 (free `T` does
  not contextually type the argument).
- No-regression: `arr.map((x)=>x)` and `g((x)=>{const probe:T=x})` (a free `T`
  reachable only through a contextual *function* param) stay clean.
- `ReturnType` over intersection-of-callable with free `T` reduces to the
  return type both standalone and nested through `Omit`/indexed-access.
- Callback `...rest` past a fixed-arity overloaded callee spreads cleanly.

## Verification
- zustand corpus (canary, to completion, oracle off, 90s+ no timeout):
  origin/main binary = 22 tsz-only diagnostics; this binary = 18. Net -4
  (strictly fewer). 5 FPs removed: devtools.ts(262) TS2488, devtools.ts(323)
  TS2345 + TS2352, persist.ts(214) TS2488, persist.ts(238) TS2488.
- 7-witness check (tsc reports none): immer.ts:82 TS2556 CLEARED,
  persist.ts:224 TS2322 CLEARED, subscribeWithSelector.ts:50 TS2352 CLEARED.
  Residual: devtools.ts(217,5) TS2322 — one new line at a site that already
  carried 3 baseline FPs (217,20 TS2352 + 217,22/29 TS7006, all pre-existing).
  Root is a deeper nested `ReturnType<typeof fn>` (inside an index-signature
  value flowing through `Omit`/`Write`/`StoreDevtools` `infer` capture) that
  still does not reduce; tracked as follow-up. Net corpus count still strictly
  drops.
- 3x determinism on zustand (cache cleared each run): 18 / 18 / 18.
- superstruct corpus: 28 -> 28 (neutral). mobx corpus: 142 -> 142 (neutral).
- 9 minimal repros match tsc (core TS2322; witness TS7006+TS2345; map/callback
  generics clean; ReturnType-intersection reduces; rest-spread clean).
- Conformance `scripts/conformance/conformance.sh run --filter` (0 PASS->FAIL):
  contextualTyping 83/83, genericFunction 16/16, arrowFunction 67/67,
  typeParameter 101/101, genericInference 4/4, inference 23/23, implicitAny
  22/22, noImplicitAny 37/37, generic 240/240. Plus solver-safety sweep:
  conditionalTypes 5/5, mappedTypes 10/10, infer 87/87, returnType 7/7, spread
  71/71, restParameter 22/22, recursiveConditionalTypes 2/2, intersection
  44/44, types 858/858, functions 39/39, classes 464/464. All 100%, 0 known
  failures/crashes/timeouts.
- arch_guard: #8225 `query_boundaries::common` checker count unchanged
  (3072 -> 3072); both checker additions route through narrower boundaries.
- clippy: clean on tsz-checker + tsz-solver.

Mohsen:
- Row: zustand
- Bug family: contextual free-type-param erasure

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high
