### PR TITLE
fix(checker): resolve cross-arena import-alias application body for in-narrowed receivers

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -286,6 +286,29 @@ impl<'a> CheckerState<'a> {
         // TypeEnvironment to get a concrete key union (e.g., "a" | "b").
         let object_type = self.resolve_mapped_constraint_for_property_access(object_type);
 
+        // An `Application(UnresolvedTypeName(name), args)` receiver — produced
+        // when a `"prop" in x` narrowing captures a receiver typed through an
+        // import alias — is opaque to both `resolve_lazy_type` (which only
+        // resolves bare `Lazy(DefId)`) and the boundary's noop resolver, so its
+        // member lookup reports false `TS2339`. Route it through
+        // `evaluate_type_with_env`, whose `CheckerContext` resolver recovers the
+        // declaring `DefId` by name and (via `resolve_unresolved_application_bodies`)
+        // cross-arena registers the interface body, so the application
+        // instantiates its heritage and own members before lookup.
+        let object_type = if crate::query_boundaries::spread::contains_unresolved_application(
+            self.ctx.types,
+            object_type,
+        ) {
+            let evaluated = self.evaluate_type_with_env(object_type);
+            if evaluated != TypeId::ERROR && evaluated != TypeId::UNKNOWN {
+                evaluated
+            } else {
+                object_type
+            }
+        } else {
+            object_type
+        };
+
         // Route through QueryDatabase so repeated property lookups hit QueryCache.
         // This is especially important for hot paths like repeated `string[].push`
         // checks in class-heavy files.

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -228,12 +228,28 @@ impl<'a> CheckerState<'a> {
         // redundant pass dominated their type-check time. The second pass still
         // runs when first-pass progress was made (`result != type_id`), since
         // the more powerful resolver may then lower sub-terms further.
-        let first_pass_made_no_progress = first_pass_silent_bailed && result == type_id;
-        let first_pass_unresolved_application = result != type_id
-            && crate::query_boundaries::spread::contains_unresolved_application(
+        // An unchanged `Application(UnresolvedTypeName(name), args)` residue is
+        // the exception to the silent-bail no-progress short-circuit: the
+        // `TypeEnvironment` resolver only resolves such names from a lazily-seeded
+        // map and returns `None` for an import-alias name it has not seen, so the
+        // first pass *cannot* make progress regardless of depth. The residue
+        // arises when a `"prop" in x` narrowing captures a receiver typed through
+        // an import alias. Two things must still happen: (1) cross-arena delegate
+        // the declaring def's body even when `result == type_id` (the no-progress
+        // case the old `result != type_id` gate skipped) — without it
+        // `resolve_lazy(def)` stays `None` because the foreign interface body was
+        // never registered into this importing checker's envs; (2) run the
+        // `CheckerContext` resolver pass, which recovers the def by name and
+        // expands the now-registered body. Without both, property access reports
+        // false `TS2339` on inherited (and own) members.
+        let result_has_unresolved_application =
+            crate::query_boundaries::spread::contains_unresolved_application(
                 self.ctx.types,
                 result,
             );
+        let first_pass_made_no_progress =
+            first_pass_silent_bailed && result == type_id && !result_has_unresolved_application;
+        let first_pass_unresolved_application = result_has_unresolved_application;
         if first_pass_unresolved_application {
             self.resolve_unresolved_application_bodies(result);
         }
@@ -256,10 +272,7 @@ impl<'a> CheckerState<'a> {
                 // resolver. CheckerContext can walk the merged binder graph
                 // via `resolve_unresolved_type_name`, recover the alias's
                 // `DefId`, and let the application expand normally.
-                || crate::query_boundaries::spread::contains_unresolved_application(
-                    self.ctx.types,
-                    result,
-                )
+                || result_has_unresolved_application
                 // `result != type_id` guards against re-running the second pass
                 // when the first pass deferred a generic conditional unchanged
                 // (type params present); we only retry when the first pass


### PR DESCRIPTION
Goal: green

## Summary

Fixes the cross-arena import-alias application body-resolution gap behind ofetch's TS2339 cascade. When a `"prop" in x` narrowing captures a receiver typed through an import alias, the narrowed intersection re-evaluates the receiver as `Application(UnresolvedTypeName(name), args)`. The first-pass `TypeEnvironment` evaluator resolves such names only from a lazily-seeded map, so for an import-alias name it returns `None` and the application stays opaque; the declaring interface body was also never cross-arena registered into the importing checker's envs. Property access on the opaque application reported false `TS2339` on inherited (and own) members — e.g. ofetch's `ResolvedFetchOptions<R>.body` / `.method` / `.headers`.

References #13755 / #13780 / #13790 and the body-forwarding seam documented at `crates/tsz-checker/src/state/type_resolution/heritage_publication.rs:253-284` (`register_alias_def_forwarding`). Root precisely re-pinned by tracing: the production path is `evaluate_type_with_env`'s no-progress short-circuit + `resolve_property_access_with_env`'s opaque receiver, not `register_alias_def_forwarding` (which is bypassed for these cases). The receiver carries its type parameters; the missing piece is the cross-arena interface **body** registration for the unresolved-name application.

## Structural rule

When a property access targets a receiver of the form `Application(UnresolvedTypeName(name), args)` (produced by `"prop" in x` narrowing of an import-aliased generic interface), tsc resolves the alias's declaring interface and instantiates its heritage; tsz must (1) cross-arena delegate and register the declaring def's body even when the first env-evaluation pass made no progress, (2) run the `CheckerContext` resolver pass that recovers the def by name, and (3) evaluate the receiver through `evaluate_type_with_env` before member lookup. Owner layer: checker `evaluate_type_with_env` + `resolve_property_access_with_env` (both consume solver/query-boundary structural helpers; no name/file string checks).

Previously the body delegation was gated on `result != type_id`, which skipped exactly the no-progress narrowing case; the opaque receiver was never re-evaluated before lookup.

## Verification

Minimal repro (matches tsc clean after fix; false TS2339 before):
- module A `export interface Base<R>{baseProp:R}` + `export interface Opts<R> extends Base<R>{body:R}`; module B `import type { Opts }`, `const c: Opts<string>; if ("x" in c){ c.body; c.baseProp }`.
- A faithful ofetch-shaped repro (`Ctx.options: Resolved<R>` where `Resolved<R> extends Base<R>`, narrowed by `"query" in ctx.options`) goes from 3 false TS2339 to clean.

Corpus deltas (dist-fast baseline `origin/main` vs fixed binary, per-row diagnostic-line `comm`):

| Row | baseline | fixed | added FP | removed |
|-----|----------|-------|----------|---------|
| ofetch | 40 | 12 | 1 | 29 |
| io-ts | 257 | 257 | 0 | 0 |
| msw | 209 | 209 | 0 | 0 |
| kysely | 156 | 156 | 0 | 0 |

- ofetch: the entire import-alias `ResolvedFetchOptions` TS2339 cascade (28 lines) is gone. The 1 "added" line is a pre-existing latent `TS2790` (`delete` on an optional property the truthy narrowing wrongly promotes) that was previously masked by the opaque receiver — a separate bug family, not introduced by this change; ofetch net FPs still drop 40 -> 12.
- **msw and kysely: zero diagnostic-line change** (the known +20 / +4 regression vectors do not regress).
- io-ts unchanged: its TS2322/TS2339 clusters are a different root (mapped-type indexed-access `InputOf<P[K]>`, fp-ts re-exports), not the `in`-narrowing import-alias path; no regression.

Conformance (broad `scripts/conformance/conformance.sh run --filter`, all 100% pass, 0 PASS->FAIL):
- importType 17/17, moduleResolution 111/111, heritage 1/1, genericInterface 4/4, propertyAccess 26/26, narrowing 29/29, inOperator 5/5, intersection 44/44, reexport 14/14.

Other gates: `arch_guard.py` PASS (lazy.rs kept under 2000 LOC); `cargo clippy -p tsz-checker -p tsz-solver` clean; ofetch deterministic across 3 runs (identical diagnostic set); both repros clean 3x.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

ofetch-import-alias-fwd:
- Row: ofetch
- Row: io-ts
- Bug family: import-alias body-forwarding type-params
