### PR TITLE
fix(solver): resolver-aware subtype in enum discriminant narrowing

### DIFF
--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -762,7 +762,11 @@ impl<'a> NarrowingContext<'a> {
         self.is_structurally_assignable_to_object(resolved_source, resolved_target)
     }
 
-    pub(super) fn is_subtype_for_narrowing(&self, source: TypeId, target: TypeId) -> bool {
+    pub(in crate::narrowing) fn is_subtype_for_narrowing(
+        &self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
         if let Some(resolver) = self.resolver {
             let mut checker = SubtypeChecker::with_resolver(self.db.as_type_database(), &resolver)
                 .with_query_db(self.db);

--- a/crates/tsz-solver/src/narrowing/discriminants.rs
+++ b/crates/tsz-solver/src/narrowing/discriminants.rs
@@ -16,7 +16,6 @@ use rustc_hash::FxHashMap;
 
 use super::{CachedPropertyType, DiscriminantInfo, NarrowingContext, union_or_single_preserve};
 use crate::operations::property::{PropertyAccessEvaluator, PropertyAccessResult};
-use crate::relations::subtype::is_subtype_of;
 use crate::type_queries::{
     LiteralValueKind, TypeParameterConstraintKind, UnionMembersKind, classify_for_literal_value,
     classify_for_type_parameter_constraint, classify_for_union_members,
@@ -462,7 +461,7 @@ impl<'a> NarrowingContext<'a> {
                     true
                 } else {
                     self.literal_subtype_fast(prop_type, literal_value)
-                        .unwrap_or_else(|| is_subtype_of(self.db, prop_type, literal_value))
+                        .unwrap_or_else(|| self.is_subtype_for_narrowing(prop_type, literal_value))
                 };
                 if is_excluded {
                     if excluded_idx.is_some() {
@@ -513,20 +512,22 @@ impl<'a> NarrowingContext<'a> {
                             crate::type_queries::contains_generic_type_parameters_db(self.db, part)
                                 || self
                                     .literal_subtype_fast(literal_value, part)
-                                    .unwrap_or_else(|| is_subtype_of(self.db, literal_value, part))
+                                    .unwrap_or_else(|| {
+                                        self.is_subtype_for_narrowing(literal_value, part)
+                                    })
                         })
                     } else {
                         true
                     }
                 } else {
                     self.literal_subtype_fast(literal_value, prop_type)
-                        .unwrap_or_else(|| is_subtype_of(self.db, literal_value, prop_type))
+                        .unwrap_or_else(|| self.is_subtype_for_narrowing(literal_value, prop_type))
                 }
             } else {
                 // false branch: exclude members where property_type <: excluded_literal
                 !self
                     .literal_subtype_fast(prop_type, literal_value)
-                    .unwrap_or_else(|| is_subtype_of(self.db, prop_type, literal_value))
+                    .unwrap_or_else(|| self.is_subtype_for_narrowing(prop_type, literal_value))
             };
 
             if should_keep {
@@ -957,6 +958,14 @@ impl<'a> NarrowingContext<'a> {
         // narrow `obj` to `never` when the property doesn't exist.
         let mut any_member_has_property = false;
 
+        // Resolver-aware subtype check. The bare `is_subtype_of` builds a
+        // `SubtypeChecker` with no resolver, so the nominal enum-member-to-
+        // whole-enum rule (`E.B <: E`, which needs
+        // `resolver.get_enum_parent_def_id`) cannot fire and silently returns
+        // `false`. For a discriminant property typed as a whole enum that makes
+        // every member fail the match and collapses the receiver to `never`
+        // (false TS2339). Route through the narrowing context's resolver-aware
+        // subtype helper so enum-typed discriminant properties relate correctly.
         let literal_matches_property_type = |prop_type: TypeId| -> bool {
             if let Some(parts_id) = intersection_list_id(self.db, prop_type) {
                 return self.db.type_list(parts_id).iter().all(|&part| {
@@ -964,7 +973,7 @@ impl<'a> NarrowingContext<'a> {
                     crate::type_queries::contains_generic_type_parameters_db(
                         self.db,
                         normalized_part,
-                    ) || is_subtype_of(self.db, literal_value, normalized_part)
+                    ) || self.is_subtype_for_narrowing(literal_value, normalized_part)
                 });
             }
 
@@ -973,7 +982,7 @@ impl<'a> NarrowingContext<'a> {
                 self.db,
                 normalized_prop_type,
             ) {
-                return is_subtype_of(self.db, literal_value, normalized_prop_type);
+                return self.is_subtype_for_narrowing(literal_value, normalized_prop_type);
             }
 
             let Some(parts_id) = intersection_list_id(self.db, normalized_prop_type) else {
@@ -982,7 +991,7 @@ impl<'a> NarrowingContext<'a> {
             self.db.type_list(parts_id).iter().all(|&part| {
                 let normalized_part = normalize_constructor_property_type(part);
                 crate::type_queries::contains_generic_type_parameters_db(self.db, normalized_part)
-                    || is_subtype_of(self.db, literal_value, normalized_part)
+                    || self.is_subtype_for_narrowing(literal_value, normalized_part)
             })
         };
 
@@ -1235,8 +1244,10 @@ impl<'a> NarrowingContext<'a> {
 
                 // Exclude member ONLY if property type is subtype of excluded value
                 // This means the property is ALWAYS the excluded value
-                // REVERSE of narrow_by_discriminant logic
-                let should_exclude = is_subtype_of(self.db, resolved_prop_type, excluded_value);
+                // REVERSE of narrow_by_discriminant logic. Resolver-aware so
+                // nominal enum relations (`E.A <: E`) resolve correctly.
+                let should_exclude =
+                    self.is_subtype_for_narrowing(resolved_prop_type, excluded_value);
 
                 if should_exclude {
                     trace!(
@@ -1277,7 +1288,7 @@ impl<'a> NarrowingContext<'a> {
                     if normalized_prop_type == TypeId::ANY {
                         true
                     } else {
-                        !is_subtype_of(self.db, normalized_prop_type, excluded_value)
+                        !self.is_subtype_for_narrowing(normalized_prop_type, excluded_value)
                     }
                 } else {
                     let effective_type = self.db.intersection(prop_types);
@@ -1286,7 +1297,7 @@ impl<'a> NarrowingContext<'a> {
                     if normalized_effective_type == TypeId::ANY {
                         true
                     } else {
-                        !is_subtype_of(self.db, normalized_effective_type, excluded_value)
+                        !self.is_subtype_for_narrowing(normalized_effective_type, excluded_value)
                     }
                 }
             } else {
@@ -1509,9 +1520,10 @@ impl<'a> NarrowingContext<'a> {
                     return false; // Exclude
                 }
 
-                // Subtype check for each excluded value
+                // Subtype check for each excluded value. Resolver-aware so
+                // nominal enum relations (`E.A <: E`) resolve correctly.
                 for &excluded in excluded_values {
-                    if is_subtype_of(self.db, resolved_prop_type, excluded) {
+                    if self.is_subtype_for_narrowing(resolved_prop_type, excluded) {
                         return false; // Exclude
                     }
                 }


### PR DESCRIPTION
Goal: green

## Summary
Single (non-union) receivers whose discriminant property is typed as a
**whole enum** were mis-narrowed to `never` by `=== EnumMember` /
`switch`/`!==` guards, producing false `TS2339` ("Property X does not
exist on type 'never'"). The discriminant narrower compared the literal
enum member against the property's declared enum with the bare
`crate::relations::subtype::is_subtype_of`, which constructs a
`SubtypeChecker` with **no resolver**. The nominal enum-member-to-whole-
enum subtype rule (`E.B <: E`) requires `resolver.get_enum_parent_def_id`,
so without a resolver it silently returns `false`; the single member then
fails the match and the whole receiver collapses to `never`.

Fix: route the discriminant subtype checks through the narrowing
context's existing resolver-aware `is_subtype_for_narrowing` helper (the
same one the rest of narrowing uses), in `narrow_by_discriminant`, the
fast top-level path, and both exclusion paths. Visibility of the helper
widened from `pub(super)` to `pub(in crate::narrowing)` so sibling
`discriminants.rs` can call it.

## Structural rule
When narrowing a single (non-union) receiver `obj` by a guard on an
enum-typed property (`obj.p === E.B`, `switch (obj.p)`, `obj.p !== E.B`),
`tsc` narrows the property to the matching member and keeps `obj`; the
enum member `E.B` is a subtype of the whole enum `E`. tsz now resolves
that nominal `E.B <: E` relation during narrowing via the solver's
resolver-aware subtype path (`NarrowingContext::is_subtype_for_narrowing`
-> `SubtypeChecker::with_resolver` -> `get_enum_parent_def_id`), instead
of the resolver-less `is_subtype_of` that could not see the enum parent.

## Adjacent matrix (all verified)
- `===` member, `!==`+else, `switch`/`case`, `==` loose: all fixed.
- Numeric / const / string enums: all fixed.
- Interface property and class property receivers: both fixed.
- Negative: enum members stay nominally distinct (`E.B` not assignable to
  `E.A` still errors, matching tsc).
- Non-regression: literal-union-typed properties (`0|1|2`) and
  member-literal-discriminated unions (`IA{s:E.A}|IB{s:E.B}`) already
  worked and still do.

## Known residual (out of scope, deeper root)
The **cross-module** enum variant (enum imported across files, e.g.
mobx's `IDerivationState_`) is a separate, deeper root: the solver-side
`TypeEnvironment.enum_parents` map is `FileLocalReset`, so an enum
registered while its home file is checked is dropped at the file-session
boundary and the consuming file's flow-analyzer env reads an empty map
(`get_enum_parent` -> `None`). That requires program-wide enum-parent
residency (e.g. backing it with the shared `DefinitionStore`) and is
tracked separately; this PR fixes the bounded single-file root only.

## Verification
- Repros (single-file enum-property narrowing): all CLEAN; tsc oracle
  clean; deterministic across 3 runs.
- Conformance (resolver-aware narrowing-adjacent families), all 100%, 0
  regressions:
  - `--filter enum` 81/81
  - `--filter narrowing` 29/29
  - `--filter discriminat` 16/16
  - `--filter switch` 15/15
  - `--filter typeGuard` 86/86
  - `--filter controlFlow` 94/94
- `arch_guard_rust.py`: pass.
- `cargo clippy -p tsz-solver --profile dist-fast`: clean.
- Project rows (raw tsz diagnostic counts, base e86a6d70 binary -> fix):
  - mobx 348 -> 344 (TS2339 25 -> 19); tsz-only oracle delta 146 -> 142.
  - xstate 244 -> 241 (-3, helped).
  - zod 18 -> 18 (unchanged, no regression).

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

AgentName: ClaudeOpus-MobxRemeasure
- Row: mobx
- Bug family: enum discriminant narrowing collapses receiver to never (false TS2339)
- Row: xstate
- Bug family: enum discriminant narrowing collapses receiver to never (false TS2339)
