### PR TITLE
ci: reduce project-compile-canary shards 6 -> 3 (relieve unit starvation wedging the queue, #13771)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -730,7 +730,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5]
+        shard: [0, 1, 2]
     env:
       npm_config_cache: ${{ github.workspace }}/.ci-cache/npm-project-compile-canary
       TSZ_CI_CACHE_SAVE: "0"
@@ -738,7 +738,7 @@ jobs:
       TSZ_PROJECT_COMPILE_ALLOW_FAILURES: "1"
       TSZ_PROJECT_COMPILE_INCLUDE_GENERATED_APPS: "0"
       _TSZ_CI_CANARY_SHARD_INDEX: ${{ matrix.shard }}
-      _TSZ_CI_CANARY_SHARD_COUNT: 6
+      _TSZ_CI_CANARY_SHARD_COUNT: 3
     steps:
       - uses: actions/checkout@v4
         with:
@@ -802,11 +802,11 @@ jobs:
       TSZ_PROJECT_COMPILE_SET: canary
       TSZ_PROJECT_COMPILE_ALLOW_FAILURES: "1"
       # Expected canary shard count (mirrors the project-compile-canary matrix
-      # `shard: [0..5]` / `_TSZ_CI_CANARY_SHARD_COUNT: 6`). The aggregate script
+      # `shard: [0..2]` / `_TSZ_CI_CANARY_SHARD_COUNT: 3`). The aggregate script
       # records shards_seen vs this expected count and emits a distinct
       # CANARY_SHARDS_INCOMPLETE signal when a shard is missing, so a dead runner
       # cannot produce a silently-green required check over a partial set.
-      TSZ_CANARY_SHARDS_EXPECTED: "6"
+      TSZ_CANARY_SHARDS_EXPECTED: "3"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -817,7 +817,7 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          EXPECTED=6
+          EXPECTED=3
           MAX_WAIT=180
           INTERVAL=10
           elapsed=0


### PR DESCRIPTION
## Summary
Reduce `project-compile-canary` shards **6 → 3**, reverting #13735's 3→6 doubling. Per the #13771 bisect, `main` post-merge CI has been red on the `unit` job since `cc81bb47` (#13735), and the increased self-hosted fan-out (6 canary runners instead of 3) is the suspected contention source.

## Evidence
- #13771 bisect: last green `b143f919`; first red `cc81bb47` (#13735, canary 3→6, 19:50Z); `unit` failed on 10/10 subsequent `main` pushes.
- The `unit` failures manifest as load-correlated **emitter test panics** (`source_map_tests_4::*` at `crates/tsz-emitter/src/transforms/async_es5_ir_control.rs:289` + `declaration_emitter` tests) — they pass in lower-load `merge_group` runs but fail on the busier `push` path, the signature of parallel-pressure/runner-contention (the #13255 schedule-sensitivity family), not a deterministic code regression.
- Doubling canary to 6 added 3 concurrent self-hosted runners to the dist→harness wave, raising fleet contention while `unit` (a single OOM-/contention-prone 21k-test job) runs alongside.

## Change
The same 3 canary-shard literals #13735 touched, reverted in lockstep, plus the `TSZ_CANARY_SHARDS_EXPECTED` env added by #13764:
- matrix `shard: [0..5] → [0, 1, 2]`
- `_TSZ_CI_CANARY_SHARD_COUNT: 6 → 3`
- aggregate poller `EXPECTED=6 → 3` and `TSZ_CANARY_SHARDS_EXPECTED: "6" → "3"`

`canary_row_in_shard` round-robin (`index % count`) and the aggregate recombiner are count-agnostic; `project-compile-canary-aggregate` (the CI Summary input) keys on the aggregate name, so coverage and the required gate are unaffected. fourslash (6) and conformance (4) untouched.

## Why this is the right lever
Canary shard count is a **capacity/cost knob, not wall-clock** (#13665): canary runs under the `unit`/`dist` poles, so trading a slightly longer canary tail for 3 freed self-hosted slots relieves the contention starving `unit`. Pairs with #13745 (canary-aggregate moved to ubuntu-latest, already freeing a slot).

## Risk / Validation
Low risk — symmetric revert of #13735. `python3 yaml.safe_load` on ci.yml OK; `node scripts/ci/test-pr-ready-state.mjs` passes; fourslash/conformance shard counts confirmed unchanged. If contention is not the sole cause, the residual emitter-test flake (#13255 family) remains for separate investigation, but this removes the load amplifier #13771 bisected to.

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — OK
- `node scripts/ci/test-pr-ready-state.mjs` — pass
- diff: ci.yml only, 5 insertions / 5 deletions

Goal: hold

## Provenance
Machine: MacBookPro.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

— AgentName: M1FableArchitect
