### PR TITLE
fix(solver): cross-module enum-parent residency + identity in discriminant narrowing

### DIFF
--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -402,6 +402,20 @@ pub struct DefinitionStore {
     /// `DefId` on demand during type checking.
     class_to_constructor: DefDashMap<DefId, DefId>,
 
+    /// Program-wide enum member `DefId` -> parent enum `DefId` map.
+    ///
+    /// `TypeEnvironment::enum_parents` is reset per file (it lives in the
+    /// file-local evaluator/flow-analyzer env). Cross-file enum discriminant
+    /// narrowing reads the member→parent edge through the *consuming* file's
+    /// flow-analyzer env, by which point the producing file's local
+    /// registration has been wiped. This shared map survives the per-file
+    /// reset (it lives on the program-wide `DefinitionStore`), so
+    /// `TypeEnvironment::get_enum_parent` can fall back to it and resolve the
+    /// nominal `E.B <: E` relation at narrowing time regardless of which file
+    /// declared the enum. Populated by write-through from
+    /// `TypeEnvironment::register_enum_parent`.
+    enum_member_to_parent: DefDashMap<DefId, DefId>,
+
     /// Shared cross-file instance-type cache for class `DefId`s.
     ///
     /// A class has two `TypeId`s: the constructor (value side, written into
@@ -493,6 +507,7 @@ impl DefinitionStore {
                 id_capacity / 2,
                 Default::default(),
             ),
+            enum_member_to_parent: DefDashMap::default(),
             name_to_defs: DefDashMap::with_capacity_and_hasher(id_capacity, Default::default()),
             cross_file_cache: CrossFileQueryCache::default(),
             fully_populated: std::sync::atomic::AtomicBool::new(false),
@@ -1138,6 +1153,7 @@ impl DefinitionStore {
         self.file_to_defs.clear();
         self.class_to_constructor.clear();
         self.class_to_instance.clear();
+        self.enum_member_to_parent.clear();
         self.name_to_defs.clear();
         self.next_id.store(DefId::FIRST_VALID, Ordering::SeqCst);
         self.bump_generation();
@@ -1274,6 +1290,31 @@ impl DefinitionStore {
     /// finished building the class yet.
     pub fn get_class_instance_type(&self, class_def: DefId) -> Option<TypeId> {
         self.class_to_instance.get(&class_def).map(|r| *r)
+    }
+
+    /// Publish an enum member `DefId` -> parent enum `DefId` edge into the
+    /// shared, program-wide map (see the `enum_member_to_parent` field doc).
+    ///
+    /// Write-through target for `TypeEnvironment::register_enum_parent`. The
+    /// producing file's local `enum_parents` map is wiped on its file-session
+    /// reset; this shared copy persists so a consuming file's flow-analyzer env
+    /// can still resolve the member's parent during cross-file enum
+    /// discriminant narrowing.
+    pub fn register_enum_parent(&self, member_def: DefId, parent_def: DefId) {
+        if self
+            .enum_member_to_parent
+            .insert(member_def, parent_def)
+            .is_none()
+        {
+            self.bump_generation();
+        }
+    }
+
+    /// Look up the parent enum `DefId` for an enum member `DefId` in the shared
+    /// program-wide map. Returns `None` when no checker has registered the edge
+    /// (e.g. a non-enum-member `DefId`).
+    pub fn get_enum_parent(&self, member_def: DefId) -> Option<DefId> {
+        self.enum_member_to_parent.get(&member_def).map(|r| *r)
     }
 
     /// Get exports for a namespace/module `DefId`.

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -1239,12 +1239,33 @@ impl TypeEnvironment {
                 .or_default()
                 .push(member_def_id);
         }
+        // Write through to the program-wide shared store. The per-file env reset
+        // wipes `self.enum_parents` before a consuming file narrows on a
+        // cross-file enum discriminant; the shared store survives that reset so
+        // `get_enum_parent` can recover the member->parent edge at narrowing
+        // time (see `DefinitionStore::enum_member_to_parent`).
+        if let Some(store) = self.definition_store.as_ref() {
+            store.register_enum_parent(member_def_id, parent_def_id);
+        }
         self.bump_generation();
     }
 
     /// Get the parent enum `DefId` for an enum member `DefId`.
+    ///
+    /// Falls back to the shared program-wide `DefinitionStore` when the
+    /// file-local `enum_parents` map lacks the entry. The local map is reset per
+    /// file, so a consuming file's flow-analyzer env (which drives cross-file
+    /// enum discriminant narrowing) would otherwise see `None` for a member
+    /// declared in another file, collapsing the narrowed receiver to `never`.
     pub fn get_enum_parent(&self, member_def_id: DefId) -> Option<DefId> {
-        self.enum_parents.get(&member_def_id.0).copied()
+        self.enum_parents
+            .get(&member_def_id.0)
+            .copied()
+            .or_else(|| {
+                self.definition_store
+                    .as_ref()
+                    .and_then(|store| store.get_enum_parent(member_def_id))
+            })
     }
 
     /// Get the registered member `DefIds` for a parent enum `DefId` (in
@@ -1467,10 +1488,14 @@ impl TypeResolver for TypeEnvironment {
     fn is_enum_type(&self, type_id: TypeId, interner: &dyn TypeDatabase) -> bool {
         use crate::visitors::visitor_extract::enum_components;
         if let Some((def_id, _)) = enum_components(interner, type_id) {
-            // A full enum type's DefId is NOT registered as a member (key) in enum_parents.
-            // Member DefIds ARE keys in enum_parents (mapping to their parent DefId).
-            // So if the DefId is NOT a member, it's the parent enum type.
-            !self.enum_parents.contains_key(&def_id.0)
+            // A full enum type's DefId is NOT registered as a member (key) in
+            // enum_parents. Member DefIds ARE keys (mapping to their parent
+            // DefId). So if the DefId has no parent, it's the parent enum type.
+            // Use the store-fallback-aware `get_enum_parent` so a member
+            // declared in another file (absent from the per-file `enum_parents`
+            // map after the file-session reset) is not misclassified as a whole
+            // enum type.
+            Self::get_enum_parent(self, def_id).is_none()
         } else {
             false
         }
@@ -1766,6 +1791,56 @@ mod tests {
             Some(instance_type),
             "shared slot must be visible to any checker holding the store"
         );
+    }
+
+    /// Pins the cross-module enum-parent residency fix: a producing env's
+    /// `register_enum_parent` write-through publishes the member->parent edge to
+    /// the shared `DefinitionStore`, so a *fresh* consumer env (modeling the
+    /// per-file `TypeEnvironment::new()` session reset) recovers the parent via
+    /// the store fallback even though its local `enum_parents` map is empty.
+    ///
+    /// Without the fallback, cross-file enum discriminant narrowing reads the
+    /// consuming file's reset env, gets `None`, and collapses the receiver to
+    /// `never` (false TS2339 in mobx's `IDerivationState_` cascade).
+    #[test]
+    fn enum_parent_survives_file_reset_via_shared_store() {
+        let store = Arc::new(DefinitionStore::new());
+        let member_def = DefId(501);
+        let parent_def = DefId(500);
+
+        // Producing file's env registers the member->parent edge and, because
+        // it holds the shared store, writes through to it.
+        let mut producer_env = TypeEnvironment::new();
+        producer_env.set_definition_store(Arc::clone(&store));
+        producer_env.register_enum_parent(member_def, parent_def);
+        assert_eq!(
+            store.get_enum_parent(member_def),
+            Some(parent_def),
+            "register_enum_parent must write through to the shared store"
+        );
+
+        // Consuming file's env is fresh (its local enum_parents is empty, as
+        // after a file-session reset) but shares the same store.
+        let mut consumer_env = TypeEnvironment::new();
+        consumer_env.set_definition_store(Arc::clone(&store));
+        assert!(
+            !consumer_env.enum_parents.contains_key(&member_def.0),
+            "consumer's local enum_parents must be cold"
+        );
+        assert_eq!(
+            consumer_env.get_enum_parent(member_def),
+            Some(parent_def),
+            "consumer must recover the parent via the shared-store fallback"
+        );
+        assert_eq!(
+            TypeResolver::get_enum_parent_def_id(&consumer_env, member_def),
+            Some(parent_def),
+            "resolver-trait accessor must use the same fallback path"
+        );
+
+        // An env with no store still returns None (no panic, no false edge).
+        let bare_env = TypeEnvironment::new();
+        assert_eq!(bare_env.get_enum_parent(member_def), None);
     }
 
     /// Pins the `get_def_kind` store-fallback path:

--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -762,7 +762,11 @@ impl<'a> NarrowingContext<'a> {
         self.is_structurally_assignable_to_object(resolved_source, resolved_target)
     }
 
-    pub(super) fn is_subtype_for_narrowing(&self, source: TypeId, target: TypeId) -> bool {
+    pub(in crate::narrowing) fn is_subtype_for_narrowing(
+        &self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
         if let Some(resolver) = self.resolver {
             let mut checker = SubtypeChecker::with_resolver(self.db.as_type_database(), &resolver)
                 .with_query_db(self.db);

--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -170,7 +170,10 @@ impl<'a> NarrowingContext<'a> {
             return false;
         };
 
-        left_parent == right_parent
+        // Cross-module import barrels can give the same enum two `DefId`s;
+        // compare parents through `defs_are_equivalent` (alias-forward /
+        // `SymbolId` aware) rather than raw equality.
+        resolver.defs_are_equivalent(left_parent, right_parent)
             && self.literal_values_equivalent_for_narrowing(left_inner, right_inner)
     }
 

--- a/crates/tsz-solver/src/narrowing/discriminants.rs
+++ b/crates/tsz-solver/src/narrowing/discriminants.rs
@@ -16,7 +16,6 @@ use rustc_hash::FxHashMap;
 
 use super::{CachedPropertyType, DiscriminantInfo, NarrowingContext, union_or_single_preserve};
 use crate::operations::property::{PropertyAccessEvaluator, PropertyAccessResult};
-use crate::relations::subtype::is_subtype_of;
 use crate::type_queries::{
     LiteralValueKind, TypeParameterConstraintKind, UnionMembersKind, classify_for_literal_value,
     classify_for_type_parameter_constraint, classify_for_union_members,
@@ -462,7 +461,7 @@ impl<'a> NarrowingContext<'a> {
                     true
                 } else {
                     self.literal_subtype_fast(prop_type, literal_value)
-                        .unwrap_or_else(|| is_subtype_of(self.db, prop_type, literal_value))
+                        .unwrap_or_else(|| self.is_subtype_for_narrowing(prop_type, literal_value))
                 };
                 if is_excluded {
                     if excluded_idx.is_some() {
@@ -513,20 +512,22 @@ impl<'a> NarrowingContext<'a> {
                             crate::type_queries::contains_generic_type_parameters_db(self.db, part)
                                 || self
                                     .literal_subtype_fast(literal_value, part)
-                                    .unwrap_or_else(|| is_subtype_of(self.db, literal_value, part))
+                                    .unwrap_or_else(|| {
+                                        self.is_subtype_for_narrowing(literal_value, part)
+                                    })
                         })
                     } else {
                         true
                     }
                 } else {
                     self.literal_subtype_fast(literal_value, prop_type)
-                        .unwrap_or_else(|| is_subtype_of(self.db, literal_value, prop_type))
+                        .unwrap_or_else(|| self.is_subtype_for_narrowing(literal_value, prop_type))
                 }
             } else {
                 // false branch: exclude members where property_type <: excluded_literal
                 !self
                     .literal_subtype_fast(prop_type, literal_value)
-                    .unwrap_or_else(|| is_subtype_of(self.db, prop_type, literal_value))
+                    .unwrap_or_else(|| self.is_subtype_for_narrowing(prop_type, literal_value))
             };
 
             if should_keep {
@@ -957,6 +958,14 @@ impl<'a> NarrowingContext<'a> {
         // narrow `obj` to `never` when the property doesn't exist.
         let mut any_member_has_property = false;
 
+        // Resolver-aware subtype check. The bare `is_subtype_of` builds a
+        // `SubtypeChecker` with no resolver, so the nominal enum-member-to-
+        // whole-enum rule (`E.B <: E`, which needs
+        // `resolver.get_enum_parent_def_id`) cannot fire and silently returns
+        // `false`. For a discriminant property typed as a whole enum that makes
+        // every member fail the match and collapses the receiver to `never`
+        // (false TS2339). Route through the narrowing context's resolver-aware
+        // subtype helper so enum-typed discriminant properties relate correctly.
         let literal_matches_property_type = |prop_type: TypeId| -> bool {
             if let Some(parts_id) = intersection_list_id(self.db, prop_type) {
                 return self.db.type_list(parts_id).iter().all(|&part| {
@@ -964,7 +973,7 @@ impl<'a> NarrowingContext<'a> {
                     crate::type_queries::contains_generic_type_parameters_db(
                         self.db,
                         normalized_part,
-                    ) || is_subtype_of(self.db, literal_value, normalized_part)
+                    ) || self.is_subtype_for_narrowing(literal_value, normalized_part)
                 });
             }
 
@@ -973,7 +982,7 @@ impl<'a> NarrowingContext<'a> {
                 self.db,
                 normalized_prop_type,
             ) {
-                return is_subtype_of(self.db, literal_value, normalized_prop_type);
+                return self.is_subtype_for_narrowing(literal_value, normalized_prop_type);
             }
 
             let Some(parts_id) = intersection_list_id(self.db, normalized_prop_type) else {
@@ -982,7 +991,7 @@ impl<'a> NarrowingContext<'a> {
             self.db.type_list(parts_id).iter().all(|&part| {
                 let normalized_part = normalize_constructor_property_type(part);
                 crate::type_queries::contains_generic_type_parameters_db(self.db, normalized_part)
-                    || is_subtype_of(self.db, literal_value, normalized_part)
+                    || self.is_subtype_for_narrowing(literal_value, normalized_part)
             })
         };
 
@@ -1235,8 +1244,10 @@ impl<'a> NarrowingContext<'a> {
 
                 // Exclude member ONLY if property type is subtype of excluded value
                 // This means the property is ALWAYS the excluded value
-                // REVERSE of narrow_by_discriminant logic
-                let should_exclude = is_subtype_of(self.db, resolved_prop_type, excluded_value);
+                // REVERSE of narrow_by_discriminant logic. Resolver-aware so
+                // nominal enum relations (`E.A <: E`) resolve correctly.
+                let should_exclude =
+                    self.is_subtype_for_narrowing(resolved_prop_type, excluded_value);
 
                 if should_exclude {
                     trace!(
@@ -1277,7 +1288,7 @@ impl<'a> NarrowingContext<'a> {
                     if normalized_prop_type == TypeId::ANY {
                         true
                     } else {
-                        !is_subtype_of(self.db, normalized_prop_type, excluded_value)
+                        !self.is_subtype_for_narrowing(normalized_prop_type, excluded_value)
                     }
                 } else {
                     let effective_type = self.db.intersection(prop_types);
@@ -1286,7 +1297,7 @@ impl<'a> NarrowingContext<'a> {
                     if normalized_effective_type == TypeId::ANY {
                         true
                     } else {
-                        !is_subtype_of(self.db, normalized_effective_type, excluded_value)
+                        !self.is_subtype_for_narrowing(normalized_effective_type, excluded_value)
                     }
                 }
             } else {
@@ -1509,9 +1520,10 @@ impl<'a> NarrowingContext<'a> {
                     return false; // Exclude
                 }
 
-                // Subtype check for each excluded value
+                // Subtype check for each excluded value. Resolver-aware so
+                // nominal enum relations (`E.A <: E`) resolve correctly.
                 for &excluded in excluded_values {
-                    if is_subtype_of(self.db, resolved_prop_type, excluded) {
+                    if self.is_subtype_for_narrowing(resolved_prop_type, excluded) {
                         return false; // Exclude
                     }
                 }

--- a/crates/tsz-solver/src/relations/compat_overrides.rs
+++ b/crates/tsz-solver/src/relations/compat_overrides.rs
@@ -369,8 +369,17 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             // Case 1: Both are enums (or enum members or Union-based enums)
             // Note: Same-DefId, different-TypeId case is now handled above before get_enum_def_id
             (Some(s_def), Some(t_def)) => {
-                if s_def == t_def {
-                    // Same DefId: Same type (E.A -> E.A or E -> E)
+                // Cross-module import barrels can give the same enum declaration
+                // two distinct `DefId`s (the declaring file's key and an
+                // import-alias key reached through a re-export). They denote the
+                // same nominal enum, so compare through `defs_are_equivalent`
+                // (which canonicalizes alias-forwarding and falls back to
+                // `SymbolId`) rather than raw `DefId` equality. Raw `==` here
+                // collapses `E.X <: E` to a nominal mismatch whenever the field
+                // type and the member's parent were reached through different
+                // module paths (mobx `IDerivationState_` cascade).
+                if self.subtype.resolver.defs_are_equivalent(s_def, t_def) {
+                    // Same definition: Same type (E.A -> E.A or E -> E)
                     return Some(true);
                 }
 
@@ -380,7 +389,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
                 let t_parent = self.subtype.resolver.get_enum_parent_def_id(t_def);
 
                 match (s_parent, t_parent) {
-                    (Some(sp), Some(tp)) if sp == tp => {
+                    (Some(sp), Some(tp)) if self.subtype.resolver.defs_are_equivalent(sp, tp) => {
                         // Same parent enum
                         if self.same_parent_enum_members_share_value(source, target) {
                             return Some(true);
@@ -395,8 +404,9 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
                     }
                     (Some(sp), None) => {
                         // Source is a member, target doesn't have a parent (target is not a member)
-                        // Check if target is the parent enum type
-                        if t_def == sp {
+                        // Check if target is the parent enum type (cross-module
+                        // identity via `defs_are_equivalent`, see above).
+                        if self.subtype.resolver.defs_are_equivalent(t_def, sp) {
                             // Target is the parent enum of source member
                             // Allow member to parent enum assignment (E.A -> E)
                             return Some(true);
@@ -496,7 +506,9 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return false;
         };
 
-        source_parent == target_parent
+        self.subtype
+            .resolver
+            .defs_are_equivalent(source_parent, target_parent)
             && matches!(
                 (
                     crate::visitor::literal_value(self.interner, source_inner),

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -1264,7 +1264,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             enum_components(self.interner, source),
             enum_components(self.interner, target),
         ) {
-            if s_def_id == t_def_id
+            // Cross-module import barrels can give the same enum (or member)
+            // declaration two distinct `DefId`s (the declaring file's key and an
+            // import-alias key reached via a re-export). They denote the same
+            // nominal enum, so compare through `defs_are_equivalent` (which
+            // canonicalizes alias-forwarding and falls back to `SymbolId`)
+            // instead of raw `DefId` equality. Raw `==` here makes the narrowing
+            // subtype check (`E.MEMBER <: E`) fail whenever the discriminant
+            // property type and the literal member were reached through
+            // different module paths, collapsing the receiver to `never` (the
+            // mobx `IDerivationState_` cross-file enum cascade).
+            let same_def = self.resolver.defs_are_equivalent(s_def_id, t_def_id);
+
+            if same_def
                 && source != target
                 && crate::type_queries::is_literal_enum_member(self.interner, source)
                 && crate::type_queries::is_literal_enum_member(self.interner, target)
@@ -1272,14 +1284,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 return SubtypeResult::False;
             }
 
-            // Enum to Enum: Nominal check - DefIds must match
-            if s_def_id == t_def_id {
+            // Enum to Enum: Nominal check - definitions must match
+            if same_def {
                 return SubtypeResult::True;
             }
 
             // Check for member-to-parent relationship (e.g., E.A -> E)
             // If source is a member of the target enum, it is a subtype
-            if self.resolver.get_enum_parent_def_id(s_def_id) == Some(t_def_id) {
+            if self
+                .resolver
+                .get_enum_parent_def_id(s_def_id)
+                .is_some_and(|parent| self.resolver.defs_are_equivalent(parent, t_def_id))
+            {
                 // Source is a member of target enum
                 // Only allow if target is the full enum type (not a different member)
                 if self.resolver.is_enum_type(target, self.interner) {


### PR DESCRIPTION
Cross-module enum discriminant narrowing collapsed the narrowed receiver to `never` (false `TS2339`/`TS2367`/`TS2719`/`TS2678`/`TS2322`/`TS2416`) whenever the enum was declared in another file or reached through a re-export barrel. This stacks on #13798 (single-file enum discriminant narrowing) and extends it to the cross-module case behind mobx's enum cascade. Refs #13512, #13798.

Goal: green

## Structural rule
When an enum member and its parent enum are reached through different module paths (cross-file declaration, `export *` barrel, circular barrel), `tsc` treats them as the same nominal enum and the `E.MEMBER <: E` relation holds; `tsz` now does too.

Two structural causes, both in the solver:

1. **Residency.** `TypeEnvironment.enum_parents` is reset per file (file-session reset at `file_session_reset.rs`). A consuming file's flow-analyzer env reads the member→parent edge at narrowing time, by which point the producing file's local registration was already wiped, so `get_enum_parent` returned `None` → `E.B <: E` failed → receiver collapsed to `never`. Fix: a program-wide `DefinitionStore::enum_member_to_parent` map that survives the per-file reset, written through from `TypeEnvironment::register_enum_parent` and read as a fallback in `get_enum_parent` (same write-through/fallback pattern as `class_to_instance`).

2. **Identity.** Cross-module import barrels give the same enum two distinct `DefId`s (declaring key vs import-alias key). The bare `SubtypeChecker` enum path (`core_dispatch.rs`) and the compat-override enum path (`compat_overrides.rs`) compared `DefId`s with raw `==`, so `E.MEMBER <: E` failed when the discriminant property type and the literal member were reached through different module paths. Fix: route those enum same-def / member→parent comparisons through `defs_are_equivalent` (alias-forward / `SymbolId` aware). Nominal distinctness (`E.A != E.B`, same `DefId`) is preserved by the retained `source != target` guard and confirmed by `test_literal_enum_members_with_same_def_id_are_distinct_subtypes`.

Owner layer: solver (relations + narrowing + def store). No hardcoding — resolution is structural (binder-backed `SymbolId`/alias-forward identity + structural member→parent map); no identifier/file-name/printer-text checks.

## Adjacent-case matrix
- minimal cross-file enum (`import { E }`, `if (s.kind === E.B)`) — fixed
- aliased import (`import { Color as C }`) + `switch` — fixed
- cross-file `const enum` — fixed
- simple `export *` barrel — fixed
- circular barrel (declaring file imports back through the barrel, mobx shape) — now byte-identical to `tsc`
- same-file (the #13798 case) — unchanged
- negative: `E.A != E.B` and unrelated-enum comparison still reject nominally (`TS2367`)

## Verification
- **mobx (canary row), measured to completion before/after:** 344 → 300 diagnostics. Enum cluster: `TS2719` 5→0, `TS2678` 4→0, `TS2367` 10→2, `TS2339` 19→13, `TS2345` 18→8, `TS2322` 29→23, `TS2416` 5→1 (~44 cross-module enum diagnostics dropped). Remaining 300 are unrelated families (e.g. `TS7006` implicit-any params, 119).
- **Repros vs tsc:** minimal cross-file, simple barrel, and circular barrel all match `tsc` exactly (circular barrel: tsz and tsc both emit the single legitimate `TS2367`).
- **Conformance** (`scripts/conformance/conformance.sh --filter`): `narrowing` 29/29, `discriminant` 9/9, `switch` 15/15, `controlFlow` 94/94, `typeGuard` 86/86, `constEnum` 30/30, `crossFile` 11/11, broad `enum` 12583/12585 — 0 PASS→FAIL; the 1 fingerprint-only diff (`deeplyNestedMappedTypes.ts`) is a pre-existing accepted regression unrelated to enums.
- **Canary no-regression:** xstate net −2 (no file went clean→red; churn is within already-red `createActor.ts`, an existing `Actor<TLogic>` FP unmasked by removing the enum poison). Full canary set ran to completion with no new panics/crashes/stack-overflows (effect/drizzle timeouts are pre-existing). Enum-heavy rows (ts-pattern, trpc, zod, runtypes, io-ts, class-transformer) checked for new false positives.
- **Unit tests:** new `enum_parent_survives_file_reset_via_shared_store` pins the store-fallback path; 87 solver enum subtype tests pass; adjacent `overlay_missing_from` / `shared_class_to_instance` pass.
- **arch_guard** quick: 0 LOC violations, 0 cross-layer imports (the 1 diagnostic-leak / 1 TODO are pre-existing, not in this diff). **clippy** clean on tsz-solver + tsz-checker. **Determinism:** mobx 300/300/300 and circular-barrel 1/1/1 across 3 runs.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Project corpus
AgentName: enum-parent-residency
- Row: mobx
- Bug family: cross-module enum-parent residency
