### PR TITLE
fix(checker): treat indexing an unresolved-import alias as permissive error type (#13512)

### DIFF
--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -36,6 +36,7 @@ pub use lifetime_shells::{FileSession, LspPersistentCache, SpeculationScope, Wor
 mod def_mapping;
 mod def_mapping_formatters;
 mod deferred_flow_env_write;
+mod unresolved_import;
 pub use deferred_flow_env_write::DeferredFlowEnvWrite;
 mod file_format_lookup;
 pub(crate) use file_format_lookup::{lookup_file_is_esm_in_map, lookup_is_external_module_in_map};

--- a/crates/tsz-checker/src/context/unresolved_import.rs
+++ b/crates/tsz-checker/src/context/unresolved_import.rs
@@ -14,7 +14,7 @@ use tsz_solver::TypeId;
 
 use crate::context::CheckerContext;
 
-impl<'a> CheckerContext<'a> {
+impl CheckerContext<'_> {
     /// Whether `type_id` (recursively) references an *unresolved imported alias*:
     /// a `Lazy(DefId)`/`UnresolvedTypeName` whose backing symbol is an `import`
     /// from a module that failed to resolve. Covers the

--- a/crates/tsz-checker/src/context/unresolved_import.rs
+++ b/crates/tsz-checker/src/context/unresolved_import.rs
@@ -1,0 +1,94 @@
+//! Context-level detection of references to *unresolved imported aliases*.
+//!
+//! When an `import { X } from "missing"` cannot resolve its module (its
+//! `TS2307` was already reported), `tsc` types `X` — and anything reached
+//! through it — as the permissive `error` type. Checker passes that would
+//! otherwise cascade spurious structural diagnostics (`TS2536`/`TS2574`/…) off
+//! the resulting poisoned shape consult these helpers to honor that contagion.
+//!
+//! Lives on `CheckerContext` (not `CheckerState`) so both the full state
+//! surface and the type-node grammar checker — which holds only a
+//! `CheckerContext` — share a single detector.
+
+use tsz_solver::TypeId;
+
+use crate::context::CheckerContext;
+
+impl<'a> CheckerContext<'a> {
+    /// Whether `type_id` (recursively) references an *unresolved imported alias*:
+    /// a `Lazy(DefId)`/`UnresolvedTypeName` whose backing symbol is an `import`
+    /// from a module that failed to resolve. Covers the
+    /// `import { X } from "missing"` alias case via the symbol's `import_module`;
+    /// the entity-name `import X = E.Member` variant is handled by the
+    /// `CheckerState` resolver path and not needed here.
+    pub fn type_references_unresolved_import(&self, type_id: TypeId) -> bool {
+        crate::query_boundaries::common::collect_all_types(self.types, type_id)
+            .into_iter()
+            .any(|ty| {
+                crate::query_boundaries::common::lazy_def_id(self.types, ty)
+                    .and_then(|def_id| self.def_to_symbol_id(def_id))
+                    .is_some_and(|sym_id| self.is_unresolved_import_alias_symbol(sym_id))
+                    || crate::query_boundaries::spread::unresolved_type_name_atom(self.types, ty)
+                        .is_some()
+            })
+    }
+
+    /// Whether `sym_id` is an `import` alias whose module cannot be resolved
+    /// through any known channel (`module_exports`, ambient/shorthand modules,
+    /// CLI-resolved modules, or package resolution). The module-spec import case
+    /// of `CheckerState::is_unresolved_import_symbol_id`, lifted to the context
+    /// so it is reachable without the full state surface.
+    fn is_unresolved_import_alias_symbol(&self, sym_id: tsz_binder::SymbolId) -> bool {
+        use tsz_binder::symbol_flags;
+        let Some(symbol) = self.binder.get_symbol(sym_id) else {
+            return false;
+        };
+        if !symbol.has_any_flags(symbol_flags::ALIAS) {
+            return false;
+        }
+        let Some(module_name) = symbol.import_module() else {
+            return false;
+        };
+        if self.module_exports_contains_module(self.binder, module_name) {
+            return false;
+        }
+        if self.context_has_ambient_module(module_name) {
+            // A shorthand ambient module (no exports) is treated as unresolved
+            // (`any`); a declared ambient module with a body is resolved.
+            return self.binder.shorthand_ambient_modules.contains(module_name)
+                && !self.declared_modules_contains(self.binder, module_name);
+        }
+        if let Some(ref resolved) = self.resolved_modules
+            && resolved.contains(module_name)
+        {
+            return false;
+        }
+        if self.resolve_import_target(module_name).is_some() {
+            return false;
+        }
+        true
+    }
+
+    /// Whether `module_name` is declared as an ambient module in the current
+    /// binder, the project-wide declared-module index, or any sibling binder.
+    fn context_has_ambient_module(&self, module_name: &str) -> bool {
+        let binder_ambient = |binder: &tsz_binder::BinderState| {
+            binder.declared_modules.contains(module_name)
+                || binder.shorthand_ambient_modules.contains(module_name)
+        };
+        if binder_ambient(self.binder) {
+            return true;
+        }
+        if let Some(declared) = &self.global_declared_modules {
+            let normalized = module_name.trim().trim_matches('"').trim_matches('\'');
+            if declared.exact.contains(normalized) {
+                return true;
+            }
+            return declared.matches_wildcard(module_name);
+        }
+        if let Some(binders) = &self.all_binders {
+            return binders.iter().any(|binder| binder_ambient(binder));
+        }
+        false
+    }
+}

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -502,6 +502,9 @@ mod ts2498_tests;
 #[path = "tests/ts2536_deferred_conditional_indexed_access_tests.rs"]
 mod ts2536_deferred_conditional_indexed_access_tests;
 #[cfg(test)]
+#[path = "tests/ts2536_error_type_contagion_tests.rs"]
+mod ts2536_error_type_contagion_tests;
+#[cfg(test)]
 #[path = "../tests/ts2540_readonly_tests.rs"]
 mod ts2540_readonly_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -499,6 +499,9 @@ mod ts2469_symbol_operator_tests;
 #[path = "../tests/ts2498_tests.rs"]
 mod ts2498_tests;
 #[cfg(test)]
+#[path = "tests/ts2536_deferred_conditional_indexed_access_tests.rs"]
+mod ts2536_deferred_conditional_indexed_access_tests;
+#[cfg(test)]
 #[path = "../tests/ts2540_readonly_tests.rs"]
 mod ts2540_readonly_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/ts2536_deferred_conditional_indexed_access_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2536_deferred_conditional_indexed_access_tests.rs
@@ -1,0 +1,103 @@
+//! Regression coverage for TS2536 on *nested* indexed accesses into a deferred
+//! conditional type: `Cond<T>[k1][k2]`.
+//!
+//! The inner `Cond<T>[k1]` is a generic indexed access whose apparent type is
+//! the conditional's branch-union constraint indexed by `k1` (tsc's
+//! `getConstraintOfIndexedAccessType`). That apparent type carries a concrete
+//! key space even while the access stays deferred, so the outer literal key `k2`
+//! is validated against it: keys present in the apparent type (e.g. `length`,
+//! numeric indices, array methods on a tuple-valued part) are accepted while a
+//! genuinely-missing key still emits TS2536. Mirrors tsc, which keeps the access
+//! deferred but never collapses the apparent key space to empty.
+//!
+//! Binder names vary across cases so no fixture/identifier string drives the
+//! decision.
+
+use crate::test_utils::check_source_codes;
+
+/// `Cond<T>["required"]["length"]` — `length` is in the tuple apparent type of
+/// the `required` part, so no TS2536. Matches tsc.
+#[test]
+fn nested_deferred_conditional_length_index_does_not_emit_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Parts<T extends ReadonlyArray<unknown>, Prefix extends unknown[] = []> =
+  T extends readonly [infer Head, ...infer Tail]
+    ? Parts<Tail, [...Prefix, Head]>
+    : { required: Prefix; optional: []; suffix: [] };
+type Len<T extends ReadonlyArray<unknown>> = Parts<T>["required"]["length"];
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "TS2536 should not fire for `Parts<T>[\"required\"][\"length\"]`: {codes:?}"
+    );
+}
+
+/// Numeric index into the tuple apparent type — also valid.
+#[test]
+fn nested_deferred_conditional_numeric_index_does_not_emit_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Cond<U extends ReadonlyArray<unknown>> = U extends readonly []
+  ? { head: [1] }
+  : { head: [2] };
+type First<U extends ReadonlyArray<unknown>> = Cond<U>["head"][0];
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "TS2536 should not fire for numeric index `Cond<U>[\"head\"][0]`: {codes:?}"
+    );
+}
+
+/// Inline deferred conditional (no alias indirection) — same acceptance for an
+/// array method key.
+#[test]
+fn inline_nested_deferred_conditional_method_index_does_not_emit_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type M<V> = (V extends string ? { a: [1] } : { a: [2] })["a"]["map"];
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "TS2536 should not fire for `(...)[\"a\"][\"map\"]` array-method index: {codes:?}"
+    );
+}
+
+/// Negative: a key absent from the apparent type STILL emits TS2536 — the
+/// suppression must not be a blanket defer.
+#[test]
+fn nested_deferred_conditional_bogus_key_emits_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Cond<W extends ReadonlyArray<unknown>> = W extends readonly []
+  ? { part: [1] }
+  : { part: [2] };
+type Bad<W extends ReadonlyArray<unknown>> = Cond<W>["part"]["nope"];
+"#,
+    );
+    assert!(
+        codes.contains(&2536),
+        "TS2536 expected for missing key `Cond<W>[\"part\"][\"nope\"]`: {codes:?}"
+    );
+}
+
+/// Negative: a first-level key absent from every branch still emits TS2536
+/// (unchanged behavior — guards the inner access too).
+#[test]
+fn deferred_conditional_first_level_missing_key_emits_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Cond<X extends ReadonlyArray<unknown>> = X extends readonly []
+  ? { only: [1] }
+  : { only: [2] };
+type Bad<X extends ReadonlyArray<unknown>> = Cond<X>["missing"];
+"#,
+    );
+    assert!(
+        codes.contains(&2536),
+        "TS2536 expected for first-level missing key `Cond<X>[\"missing\"]`: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/ts2536_error_type_contagion_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2536_error_type_contagion_tests.rs
@@ -1,0 +1,86 @@
+//! Regression guard for the remeda error-type-contagion fix (#13512).
+//!
+//! The fix suppresses spurious TS2536/TS2574 when an indexed-access object is
+//! rooted at the application of an *unresolved imported alias* (e.g. `Simplify<…>`
+//! / `TupleParts<…>` from a module that failed to resolve — TS2307), which `tsc`
+//! gives the permissive `error` apparent type. That import-failure precondition
+//! requires the full module-resolution pipeline and is validated end-to-end by
+//! the CLI repros and the `remeda` project-compile delta (TS2536 cluster 54→0),
+//! not reproducible through the single-file checker unit harness (which does not
+//! run module resolution, so a missing-module import is not flagged unresolved
+//! here).
+//!
+//! What this file *does* guard is the gating that keeps the fix from
+//! over-suppressing: a *well-formed* conditional (no unresolved import) must keep
+//! its per-branch key-space restriction — a key shared by both branches is
+//! accepted, a key present in only one branch still emits TS2536. The fix routes
+//! these cases through the unchanged strict path, so they must stay correct.
+//! Binder names vary per case so no identifier string drives the decision.
+
+use crate::test_utils::check_source_codes;
+
+/// A key shared by both well-formed branches is accepted (no TS2536). The
+/// branch-union keyof is `keyof A ∩ keyof B`, which keeps shared keys; the
+/// error-contagion path must not fire for a conditional with no unresolved
+/// import.
+#[test]
+fn shared_key_across_well_formed_conditional_branches_is_accepted() {
+    let codes = check_source_codes(
+        r#"
+type Wf<T> = T extends number ? { p: 1; q: 2 } : { p: 3; r: 4 };
+type Shared<T> = Wf<T>["p"];
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "a key shared by both well-formed branches must be accepted: {codes:?}"
+    );
+}
+
+/// A key present in only one well-formed branch still emits TS2536 — the
+/// per-branch restriction must survive. This is the adjacency the prototype
+/// regressed and the fix is gated to preserve.
+#[test]
+fn solo_branch_key_in_well_formed_conditional_still_emits_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Wf<U> = U extends number ? { p: 1; q: 2 } : { p: 3; r: 4 };
+type Solo<U> = Wf<U>["q"];
+"#,
+    );
+    assert!(
+        codes.contains(&2536),
+        "a key present in only one well-formed branch must still emit TS2536: {codes:?}"
+    );
+}
+
+/// A renamed-binder variant of the shared-key case: acceptance must be
+/// structural, not keyed to any identifier.
+#[test]
+fn shared_key_across_well_formed_conditional_branches_renamed_binders() {
+    let codes = check_source_codes(
+        r#"
+type Cond<Elem> = Elem extends string ? { key: 1; only_true: 2 } : { key: 3; only_false: 4 };
+type Access<Elem> = Cond<Elem>["key"];
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "shared-key acceptance must be structural across renamed binders: {codes:?}"
+    );
+}
+
+/// A missing key (in neither well-formed branch) still emits TS2536.
+#[test]
+fn missing_key_in_well_formed_conditional_still_emits_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Cond<X> = X extends string ? { a: 1 } : { a: 2 };
+type Bad<X> = Cond<X>["zzz"];
+"#,
+    );
+    assert!(
+        codes.contains(&2536),
+        "a key absent from both branches must still emit TS2536: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/ts2574_rest_tuple_element_type_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2574_rest_tuple_element_type_tests.rs
@@ -299,3 +299,62 @@ declare function f<S extends SelTuple>(...args: [...selectors: S, last: Sel]): v
         "TS2574 should not fire for `[...S]` with `S extends SelTuple` (array alias): {codes:?}"
     );
 }
+
+// ── Deferred conditional indexed-access bases ────────────────────────────────
+// A spread of `Cond<T>[k]` where `Cond<T>` is a deferred conditional indexes the
+// conditional's branch-union constraint by `k` (tsc's
+// `getConstraintOfIndexedAccessType`) and classifies array-like-ness from that
+// apparent type — tuple-valued branches are accepted, non-array branches still
+// flag. The binder names vary so no fixture name drives the decision.
+
+/// `[...Cond<T>["suffix"]]` where both branches give a tuple at `suffix` — the
+/// apparent type (`[] | [string]`) is array-like, so no TS2574. Matches tsc.
+#[test]
+fn rest_deferred_conditional_indexed_tuple_branch_does_not_emit_ts2574() {
+    let codes = check_source_codes(
+        r#"
+type Shape<T extends ReadonlyArray<unknown>> = T extends readonly []
+  ? { suffix: [] }
+  : { suffix: [string] };
+type Spread<T extends ReadonlyArray<unknown>> = [...Shape<T>["suffix"]];
+"#,
+    );
+    assert!(
+        !codes.contains(&2574),
+        "TS2574 should not fire for `[...Shape<T>[\"suffix\"]]` with tuple branches: {codes:?}"
+    );
+}
+
+/// Inline deferred conditional (no alias indirection) — same acceptance.
+#[test]
+fn rest_inline_deferred_conditional_indexed_tuple_does_not_emit_ts2574() {
+    let codes = check_source_codes(
+        r#"
+type Spread<U extends ReadonlyArray<unknown>> =
+  [...(U extends readonly [] ? { rest: [1] } : { rest: [2] })["rest"]];
+"#,
+    );
+    assert!(
+        !codes.contains(&2574),
+        "TS2574 should not fire for inline deferred conditional indexed tuple spread: {codes:?}"
+    );
+}
+
+/// Negative: `[...Cond<T>[k]]` where the indexed branch is a *non-array* (string
+/// literals) must STILL flag TS2574 (the apparent type `"x" | "y"` is not
+/// array-like). Guards against over-suppression.
+#[test]
+fn rest_deferred_conditional_indexed_nonarray_branch_emits_ts2574() {
+    let codes = check_source_codes(
+        r#"
+type Shape<T extends ReadonlyArray<unknown>> = T extends readonly []
+  ? { val: "x" }
+  : { val: "y" };
+type Spread<T extends ReadonlyArray<unknown>> = [...Shape<T>["val"]];
+"#,
+    );
+    assert!(
+        codes.contains(&2574),
+        "TS2574 expected for `[...Shape<T>[\"val\"]]` with string-literal branches: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -489,14 +489,8 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn type_references_unresolved_import(&self, type_id: TypeId) -> bool {
-        crate::query_boundaries::common::collect_all_types(self.ctx.types, type_id)
-            .into_iter()
-            .any(|ty| {
-                crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty)
-                    .and_then(|def_id| self.ctx.def_to_symbol_id(def_id))
-                    .is_some_and(|sym_id| self.is_unresolved_import_symbol_id(sym_id))
-            })
+    pub(crate) fn type_references_unresolved_import(&self, type_id: TypeId) -> bool {
+        self.ctx.type_references_unresolved_import(type_id)
     }
 
     fn should_report_primitive_to_generic_indexed_conditional_return(

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -5,6 +5,7 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 mod deferred_conditional_index;
+mod error_contagion;
 mod indexed_access_helpers;
 mod infer_node_walk;
 mod mapped_key_check;
@@ -817,6 +818,18 @@ impl<'a> CheckerState<'a> {
             data.object_type,
             index_type_for_check,
         ) {
+            return;
+        }
+        // Error-type contagion: when the indexed-access object type references an
+        // *unresolved imported alias* (e.g. `TupleParts<T>["required"]` where
+        // `TupleParts` comes from a module that failed to resolve — already
+        // flagged TS2307), tsc gives the object the permissive `error` apparent
+        // type, whose key space is universal, so the access accepts any key (and a
+        // further `[K2]` / `[...spread]` over it is also accepted). Suppress
+        // TS2536 here to match — the import-failure diagnostic is the only error
+        // tsc reports for these positions.
+        if self.indexed_access_object_is_unresolved_import_error(object_type, object_type_for_check)
+        {
             return;
         }
         // A deferred conditional object base has no key space of its own; tsc

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -1315,6 +1315,21 @@ impl<'a> CheckerState<'a> {
             {
                 return;
             }
+            // A nested deferred indexed access `Cond<T>[k1][k2]`: the inner
+            // `Cond<T>[k1]` is a generic indexed access whose apparent type (the
+            // conditional's branch-union constraint indexed by `k1`) carries a
+            // concrete key space. Validate the outer literal key `k2` against it,
+            // matching tsc's `getConstraintOfIndexedAccessType` — `length`/`0`/
+            // array methods are accepted, a missing key still emits TS2536.
+            if !foreign_keyof_indexed_constraint
+                && self.deferred_indexed_access_conditional_key_is_valid(
+                    object_type,
+                    object_type_for_check,
+                    index_type_for_check,
+                )
+            {
+                return;
+            }
             if self.index_has_keyof_constraint_from_declaration(
                 data.index_type,
                 data.object_type,

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/deferred_conditional_index.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/deferred_conditional_index.rs
@@ -75,4 +75,115 @@ impl<'a> CheckerState<'a> {
         self.indexed_access_key_space_relation_outcome(index_type_for_check, keyof_constraint)
             .related
     }
+
+    /// Apparent type of a *deferred* indexed access `B[K1]` whose base `B` is a
+    /// deferred conditional (e.g. `Cond<T>['required']`). tsc resolves such a
+    /// generic indexed access through `getConstraintOfIndexedAccessType`: it
+    /// indexes `B`'s base constraint — the union of the conditional's branch
+    /// results — with `K1`. That apparent type carries a concrete key space even
+    /// while the access itself stays deferred, so a later access
+    /// `B[K1][K2]` (or a spread `[...B[K1]]`) validates `K2`/array-likeness
+    /// against it instead of failing as if `B[K1]` had no members.
+    ///
+    /// Returns the evaluated apparent type, or `None` when `object_type` is not
+    /// such a deferred indexed access, the inner key is not a usable literal, the
+    /// conditional has no resolvable branch-union constraint, or the apparent
+    /// type cannot be reduced to a concrete (non-deferred) form.
+    pub(super) fn deferred_indexed_access_conditional_apparent_type(
+        &mut self,
+        object_type: TypeId,
+    ) -> Option<TypeId> {
+        use crate::query_boundaries::common as q;
+        // Resolve a generic `Application` (e.g. an alias `Drop<T>`) whose body is
+        // an indexed access into that indexed access first, so both the direct and
+        // alias-wrapped forms are covered.
+        let resolve_index_access = |this: &mut Self, ty: TypeId| -> Option<(TypeId, TypeId)> {
+            if let Some(parts) = q::index_access_types(this.ctx.types, ty) {
+                return Some(parts);
+            }
+            if q::is_generic_application(this.ctx.types, ty) {
+                let expanded = this.evaluate_application_type(ty);
+                if let Some(parts) = q::index_access_types(this.ctx.types, expanded) {
+                    return Some(parts);
+                }
+            }
+            None
+        };
+        let (inner_base, inner_index) = resolve_index_access(self, object_type)?;
+
+        // The inner base must resolve to a deferred conditional; otherwise the
+        // existing concrete/type-parameter paths already own validation.
+        let resolve_conditional = |this: &mut Self, ty: TypeId| -> Option<TypeId> {
+            if q::is_conditional_type(this.ctx.types, ty) {
+                return Some(ty);
+            }
+            if q::is_generic_application(this.ctx.types, ty) {
+                let expanded = this.evaluate_application_type(ty);
+                if q::is_conditional_type(this.ctx.types, expanded) {
+                    return Some(expanded);
+                }
+            }
+            None
+        };
+        let conditional = match resolve_conditional(self, inner_base) {
+            Some(c) => c,
+            None => {
+                let evaluated_base = self.evaluate_type_with_env(inner_base);
+                resolve_conditional(self, evaluated_base)?
+            }
+        };
+
+        let base_constraint = q::conditional_branch_union_constraint(self.ctx.types, conditional)?;
+        // The branch-union must have resolved to a concrete shape; a constraint
+        // that is itself still deferred has no computable apparent type.
+        if q::is_conditional_type(self.ctx.types, base_constraint)
+            || q::is_index_access_type(self.ctx.types, base_constraint)
+        {
+            return None;
+        }
+
+        // The inner key drives `apparent = base_constraint[inner_index]`. Evaluate
+        // it; an apparent type that is still deferred (e.g. the inner key was
+        // itself generic) gives no concrete key space, so bail.
+        let apparent = self.evaluate_type_with_env(
+            self.ctx
+                .types
+                .factory()
+                .index_access(base_constraint, inner_index),
+        );
+        if apparent == TypeId::ERROR
+            || apparent == TypeId::ANY
+            || q::is_index_access_type(self.ctx.types, apparent)
+            || q::is_conditional_type(self.ctx.types, apparent)
+        {
+            return None;
+        }
+        Some(apparent)
+    }
+
+    /// Index-key validation for `B[K1][K2]` where `B[K1]` is a deferred indexed
+    /// access into a deferred conditional. Validates the outer literal key `K2`
+    /// against the key space of the apparent type of `B[K1]` (see
+    /// [`Self::deferred_indexed_access_conditional_apparent_type`]). tsc accepts
+    /// `Cond<T>['required']['length']` (length ∈ keyof of the tuple apparent
+    /// type) but still rejects `Cond<T>['required']['nope']`.
+    pub(super) fn deferred_indexed_access_conditional_key_is_valid(
+        &mut self,
+        object_type: TypeId,
+        object_type_for_check: TypeId,
+        index_type_for_check: TypeId,
+    ) -> bool {
+        let Some(apparent) = self
+            .deferred_indexed_access_conditional_apparent_type(object_type_for_check)
+            .or_else(|| self.deferred_indexed_access_conditional_apparent_type(object_type))
+        else {
+            return false;
+        };
+        let keyof_apparent = self.ctx.types.evaluate_keyof(apparent);
+        if crate::query_boundaries::common::is_keyof_type(self.ctx.types, keyof_apparent) {
+            return false;
+        }
+        self.indexed_access_key_space_relation_outcome(index_type_for_check, keyof_apparent)
+            .related
+    }
 }

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/deferred_conditional_index.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/deferred_conditional_index.rs
@@ -5,7 +5,7 @@
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
-impl<'a> CheckerState<'a> {
+impl CheckerState<'_> {
     /// When the indexed-access object base is a *deferred* conditional, validate
     /// the index key against the conditional's base constraint — the union of
     /// its two branch results (tsc's `getBaseConstraintOfType` of a conditional).

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/error_contagion.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/error_contagion.rs
@@ -15,7 +15,7 @@
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
-impl<'a> CheckerState<'a> {
+impl CheckerState<'_> {
     /// Whether `object_type` is a deferred conditional whose apparent type (tsc's
     /// `getDefaultConstraintOfConditionalType` — the union of branch results) has
     /// a concrete key space that admits the index key. Mirrors tsc's
@@ -263,8 +263,10 @@ impl<'a> CheckerState<'a> {
         // union shape, else fall back to the raw constraint.
         let members: Vec<TypeId> = q::union_members(self.ctx.types, evaluated_constraint)
             .or_else(|| q::union_members(self.ctx.types, constraint))
-            .map(|list| list.iter().copied().collect())
-            .unwrap_or_else(|| vec![evaluated_constraint, constraint]);
+            .map_or_else(
+                || vec![evaluated_constraint, constraint],
+                |list| list.iter().copied().collect(),
+            );
         if !members.iter().any(|&m| is_error_contagious(self, m)) {
             return None;
         }

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/error_contagion.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/error_contagion.rs
@@ -1,0 +1,294 @@
+//! Error-type contagion for indexed access whose object is rooted at an
+//! *unresolved imported alias* (e.g. `Simplify<…>`/`TupleParts<…>` from a
+//! module that failed to resolve — already flagged `TS2307`).
+//!
+//! `tsc` gives such references the permissive `error` apparent type, whose key
+//! space is the universal `string | number | symbol`, so indexing them — and
+//! chaining further indices / spreads over the result — accepts any key. This
+//! module centralizes the structural detection and the index-key-space
+//! re-derivation that mirror that behavior, suppressing the spurious
+//! `TS2536`/`TS2574` those positions would otherwise produce while keeping the
+//! concrete-branch key-space restriction for well-formed conditionals. Split out
+//! of `indexed_access_helpers.rs` to keep that file under the per-file LOC
+//! ceiling; behavior is unchanged.
+
+use crate::state::CheckerState;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Whether `object_type` is a deferred conditional whose apparent type (tsc's
+    /// `getDefaultConstraintOfConditionalType` — the union of branch results) has
+    /// a concrete key space that admits the index key. Mirrors tsc's
+    /// `getApparentType` resolution in `checkIndexedAccessIndexType`. Returns
+    /// `false` (so normal validation/error paths proceed) when the object is not
+    /// a deferred conditional, the constraint is unresolved, or the key is not in
+    /// the constraint's key space.
+    pub(crate) fn deferred_conditional_index_is_in_key_space(
+        &mut self,
+        object_type: TypeId,
+        index_type_for_check: TypeId,
+        index_type: TypeId,
+    ) -> bool {
+        let Some(constraint) = crate::query_boundaries::common::conditional_default_constraint(
+            self.ctx.types,
+            object_type,
+        ) else {
+            return false;
+        };
+        let evaluated_constraint = self.evaluate_type_with_env(constraint);
+        // Error-type contagion: a branch of the conditional may be the application
+        // of an *unresolved* imported alias (e.g. `Simplify<…>` when `type-fest`
+        // is absent — already flagged TS2307). tsc resolves the access through
+        // that branch's permissive `error` apparent type, whose key space is the
+        // universal `string | number | symbol`, so the access accepts any key. For
+        // a union of branches `keyof` distributes to the *intersection* of the
+        // per-branch key spaces, and the error branch's universal key space is the
+        // identity element, so only the concrete branches restrict the valid keys
+        // (`universal ∩ concrete = concrete`). Handle that before the strict
+        // ERROR/ANY/unresolved-keyof bails below would fall through to a spurious
+        // TS2536.
+        if let Some(result) = self.error_contagious_conditional_index_in_key_space(
+            constraint,
+            evaluated_constraint,
+            index_type_for_check,
+            index_type,
+        ) {
+            return result;
+        }
+        if evaluated_constraint == TypeId::ERROR || evaluated_constraint == TypeId::ANY {
+            return false;
+        }
+        let keyof = self.ctx.types.evaluate_keyof(evaluated_constraint);
+        if !self.indexed_access_key_space_is_resolved(keyof) {
+            return false;
+        }
+        self.indexed_access_key_space_relation_outcome(index_type_for_check, keyof)
+            .related
+            || self
+                .indexed_access_key_space_relation_outcome(index_type, keyof)
+                .related
+    }
+
+    /// Whether the indexed-access object type is (or is rooted at) an *unresolved
+    /// imported alias* — e.g. `TupleParts<T>` or `TupleParts<T>["required"]`
+    /// where `TupleParts` comes from a module that failed to resolve (already
+    /// flagged TS2307). tsc gives such a type the permissive `error` apparent
+    /// type, whose key space is universal, so indexing it — and chaining further
+    /// indices / spreads over the result — accepts any key. Used to suppress the
+    /// spurious TS2536 those positions would otherwise produce.
+    ///
+    /// The detection walks the object type's *base spine* (peeling generic
+    /// `Application`s and `IndexAccess` objects) so a deferred nested access whose
+    /// root is an unresolved import is recognized, but a normal concrete object
+    /// that merely contains an unresolved-import value somewhere is not — only the
+    /// object actually being indexed must be error-typed.
+    pub(crate) fn indexed_access_object_is_unresolved_import_error(
+        &mut self,
+        object_type: TypeId,
+        object_type_for_check: TypeId,
+    ) -> bool {
+        self.index_object_base_spine_references_unresolved_import(object_type)
+            || self.index_object_base_spine_references_unresolved_import(object_type_for_check)
+    }
+
+    /// Whether a conditional's branch-union (default) constraint is error-typed
+    /// from contagion: it collapsed to `error`/`any`, or it (recursively)
+    /// references an unresolved imported alias. Both forms mean a deferred index
+    /// into the conditional has the permissive `error` apparent type, so chaining
+    /// a further index over it accepts any key.
+    fn constraint_is_error_contagious(&mut self, constraint: TypeId) -> bool {
+        if constraint == TypeId::ERROR || constraint == TypeId::ANY {
+            return true;
+        }
+        if self.type_references_unresolved_import(constraint) {
+            return true;
+        }
+        let evaluated = self.evaluate_type_with_env(constraint);
+        evaluated == TypeId::ERROR
+            || evaluated == TypeId::ANY
+            || self.type_references_unresolved_import(evaluated)
+    }
+
+    /// Walk the base spine of an indexed-access object type, peeling generic
+    /// `Application`s and `IndexAccess` bases, and report whether the *root* of
+    /// the spine is itself an unresolved-import reference / application.
+    ///
+    /// Crucially this only fires when the spine root is *directly* the unresolved
+    /// alias (e.g. `TupleParts<T>` or `TupleParts<T>["required"]`). A conditional
+    /// object — even one with an error-typed branch (`Cond<T> = … : Simplify<…>`)
+    /// — is *not* treated as error here: those are owned by
+    /// [`Self::deferred_conditional_index_is_in_key_space`], which keeps the
+    /// concrete branches' key-space restriction (so `Cond<T>["missing"]` still
+    /// emits TS2536). Bounded against pathological nesting.
+    fn index_object_base_spine_references_unresolved_import(&mut self, ty: TypeId) -> bool {
+        use crate::query_boundaries::common as q;
+        let mut current = ty;
+        // Whether we have already peeled at least one *indexed-access* layer. A
+        // top-level conditional object (`Cond<T>[k]`) is owned by the per-branch
+        // key-space path, so it must NOT be blanket-suppressed here. But once an
+        // inner index has been applied (`Cond<T>[k1][k2]`), the inner
+        // `Cond<T>[k1]` selected the conditional's branch union — and if that
+        // union is error-contagious its apparent type is `error`, so the outer
+        // `[k2]` accesses an error type and accepts any key.
+        let mut peeled_index = false;
+        for _ in 0..64 {
+            if q::is_conditional_type(self.ctx.types, current) {
+                // Only treat a conditional as error-typed when reached *through* an
+                // inner index and its branch union references an unresolved import.
+                if !peeled_index {
+                    return false;
+                }
+                let Some(constraint) =
+                    crate::query_boundaries::common::conditional_default_constraint(
+                        self.ctx.types,
+                        current,
+                    )
+                else {
+                    return false;
+                };
+                return self.constraint_is_error_contagious(constraint);
+            }
+            if let Some((base, _args)) = q::application_info(self.ctx.types, current) {
+                // The application is error-typed when its *base* (the alias being
+                // applied) is the unresolved import — not when an *argument*
+                // merely carries one.
+                if self.spine_node_is_unresolved_import_reference(base) {
+                    return true;
+                }
+                // A generic application of a *conditional* alias (e.g.
+                // `TupleParts<T, []>`) whose branch union is error-contagious has
+                // an `error` apparent type once an inner index has been applied.
+                // Its branch union is reachable through the conditional default
+                // constraint of the application itself (the alias body is resolved
+                // internally), so check that before giving up on a non-reducing
+                // generic application.
+                if peeled_index
+                    && let Some(constraint) =
+                        crate::query_boundaries::common::conditional_default_constraint(
+                            self.ctx.types,
+                            current,
+                        )
+                    && self.constraint_is_error_contagious(constraint)
+                {
+                    return true;
+                }
+                // Peel a generic application whose body reduces to a further
+                // indexed access / application / conditional (alias wrappers); a
+                // concrete body stops the walk.
+                let expanded = self.evaluate_application_type(current);
+                if expanded != current
+                    && (q::is_index_access_type(self.ctx.types, expanded)
+                        || q::is_generic_application(self.ctx.types, expanded)
+                        || q::is_conditional_type(self.ctx.types, expanded))
+                {
+                    current = expanded;
+                    continue;
+                }
+                return false;
+            }
+            if let Some((inner_base, _index)) = q::index_access_types(self.ctx.types, current) {
+                peeled_index = true;
+                current = inner_base;
+                continue;
+            }
+            // Spine bottoms out: a bare unresolved-import reference
+            // (Lazy/UnresolvedTypeName) is error-typed.
+            return self.spine_node_is_unresolved_import_reference(current);
+        }
+        false
+    }
+
+    /// Whether a single spine node is *itself* an unresolved-import reference: a
+    /// `Lazy(DefId)`/`UnresolvedTypeName` (optionally wrapped in an application
+    /// whose base is one) bound to an `import` from an unresolvable module. Unlike
+    /// the recursive [`CheckerState::type_references_unresolved_import`], this does
+    /// NOT descend into a composite shape (union/conditional/object), so a
+    /// concrete type that merely *contains* an unresolved import deeper inside is
+    /// not misclassified as error-typed.
+    fn spine_node_is_unresolved_import_reference(&self, node: TypeId) -> bool {
+        use crate::query_boundaries::common as q;
+        let candidate = match q::application_info(self.ctx.types, node) {
+            Some((base, _)) => base,
+            None => node,
+        };
+        if crate::query_boundaries::spread::unresolved_type_name_atom(self.ctx.types, candidate)
+            .is_some()
+        {
+            return true;
+        }
+        q::lazy_def_id(self.ctx.types, candidate)
+            .and_then(|def_id| self.ctx.def_to_symbol_id(def_id))
+            .is_some_and(|sym_id| self.is_unresolved_import_symbol_id(sym_id))
+    }
+
+    /// Error-type contagion handling for
+    /// [`Self::deferred_conditional_index_is_in_key_space`].
+    ///
+    /// When a deferred conditional's default-constraint (branch union) carries an
+    /// *unresolved-alias application* member, tsc treats that branch's apparent
+    /// type as the permissive `error` type whose key space is universal. This
+    /// re-derives the validation key space as the intersection of the *concrete*
+    /// branches' key spaces only (the error branches contribute the universal
+    /// identity), exactly matching tsc's `keyof (error | concrete) = concrete`.
+    ///
+    /// Returns:
+    /// - `None` when no branch is error-contagious — the caller keeps its strict
+    ///   path, so well-formed conditionals (including the
+    ///   `keyof(A | B) = keyof A ∩ keyof B` shared-key case) are unaffected;
+    /// - `Some(true)` when every branch is error-contagious (the whole branch
+    ///   union collapsed to `error`/an unresolved application): any key is
+    ///   accepted, matching `keyof error = string | number | symbol`;
+    /// - `Some(true | false)` from validating the index against the intersection
+    ///   of the concrete branches' key spaces otherwise. When that key space is
+    ///   still not concrete, returns `None` to defer to the caller.
+    fn error_contagious_conditional_index_in_key_space(
+        &mut self,
+        constraint: TypeId,
+        evaluated_constraint: TypeId,
+        index_type_for_check: TypeId,
+        index_type: TypeId,
+    ) -> Option<bool> {
+        use crate::query_boundaries::common as q;
+        // A branch is error-contagious when it (recursively) references an
+        // unresolved imported alias — an `Application`/reference whose base is a
+        // `Lazy(DefId)` mapping to an unresolved-import symbol, or an
+        // `UnresolvedTypeName`. tsc gives such a branch the permissive `error`
+        // apparent type. (`TypeId::ERROR` itself is also treated as error here.)
+        let is_error_contagious = |this: &Self, ty: TypeId| -> bool {
+            ty == TypeId::ERROR || this.type_references_unresolved_import(ty)
+        };
+        // Decompose both the raw and evaluated branch unions; the unresolved-alias
+        // application survives in one or the other depending on how far evaluation
+        // reduced the branches. Prefer the evaluated form when it still carries the
+        // union shape, else fall back to the raw constraint.
+        let members: Vec<TypeId> = q::union_members(self.ctx.types, evaluated_constraint)
+            .or_else(|| q::union_members(self.ctx.types, constraint))
+            .map(|list| list.iter().copied().collect())
+            .unwrap_or_else(|| vec![evaluated_constraint, constraint]);
+        if !members.iter().any(|&m| is_error_contagious(self, m)) {
+            return None;
+        }
+        let concrete: Vec<TypeId> = members
+            .into_iter()
+            .filter(|&m| !is_error_contagious(self, m))
+            .collect();
+        if concrete.is_empty() {
+            // Every branch is error-typed -> universal key space -> any key valid.
+            return Some(true);
+        }
+        // `evaluate_keyof` over the union of the concrete branches already computes
+        // their key-space intersection.
+        let concrete_union = self.ctx.types.union(concrete);
+        let keyof_concrete = self.ctx.types.evaluate_keyof(concrete_union);
+        if !self.indexed_access_key_space_is_resolved(keyof_concrete) {
+            return None;
+        }
+        Some(
+            self.indexed_access_key_space_relation_outcome(index_type_for_check, keyof_concrete)
+                .related
+                || self
+                    .indexed_access_key_space_relation_outcome(index_type, keyof_concrete)
+                    .related,
+        )
+    }
+}

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -179,44 +179,10 @@ impl<'a> CheckerState<'a> {
     /// has a usable key space for indexed-access validation. `evaluate_keyof` only
     /// leaves a deferred operator (its `Conditional` arm re-wraps as `KeyOf`, never
     /// a bare conditional/application), so guarding `ERROR`/`ANY`/`KeyOf` suffices.
-    fn indexed_access_key_space_is_resolved(&self, keyof_result: TypeId) -> bool {
+    pub(super) fn indexed_access_key_space_is_resolved(&self, keyof_result: TypeId) -> bool {
         !(keyof_result == TypeId::ERROR
             || keyof_result == TypeId::ANY
             || crate::query_boundaries::common::is_keyof_type(self.ctx.types, keyof_result))
-    }
-
-    /// Whether `object_type` is a deferred conditional whose apparent type (tsc's
-    /// `getDefaultConstraintOfConditionalType` — the union of branch results) has
-    /// a concrete key space that admits the index key. Mirrors tsc's
-    /// `getApparentType` resolution in `checkIndexedAccessIndexType`. Returns
-    /// `false` (so normal validation/error paths proceed) when the object is not
-    /// a deferred conditional, the constraint is unresolved, or the key is not in
-    /// the constraint's key space.
-    pub(crate) fn deferred_conditional_index_is_in_key_space(
-        &mut self,
-        object_type: TypeId,
-        index_type_for_check: TypeId,
-        index_type: TypeId,
-    ) -> bool {
-        let Some(constraint) = crate::query_boundaries::common::conditional_default_constraint(
-            self.ctx.types,
-            object_type,
-        ) else {
-            return false;
-        };
-        let evaluated_constraint = self.evaluate_type_with_env(constraint);
-        if evaluated_constraint == TypeId::ERROR || evaluated_constraint == TypeId::ANY {
-            return false;
-        }
-        let keyof = self.ctx.types.evaluate_keyof(evaluated_constraint);
-        if !self.indexed_access_key_space_is_resolved(keyof) {
-            return false;
-        }
-        self.indexed_access_key_space_relation_outcome(index_type_for_check, keyof)
-            .related
-            || self
-                .indexed_access_key_space_relation_outcome(index_type, keyof)
-                .related
     }
 
     /// TS4105: Emit "Private or protected member '{name}' cannot be accessed on

--- a/crates/tsz-checker/src/types/type_node_helpers.rs
+++ b/crates/tsz-checker/src/types/type_node_helpers.rs
@@ -739,6 +739,15 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         if matches!(t, TypeId::ANY | TypeId::NEVER | TypeId::ERROR) {
             return false;
         }
+        // Error-type contagion: a rest element rooted at an *unresolved imported
+        // alias* (e.g. `[...TupleParts<T>["suffix"]]` where `TupleParts` comes
+        // from a module that failed to resolve — already flagged TS2307) has the
+        // permissive `error` apparent type in tsc, which is assignable to
+        // `readonly any[]`, so the spread is legal. Treat it as array-like
+        // (indeterminate) rather than emitting a spurious TS2574.
+        if self.ctx.type_references_unresolved_import(t) {
+            return false;
+        }
         // tsc's nullable guard: bare `null`/`undefined` are rejected.
         if q::is_nullish_type(self.ctx.types, t) {
             return true;

--- a/crates/tsz-checker/src/types/type_node_helpers.rs
+++ b/crates/tsz-checker/src/types/type_node_helpers.rs
@@ -837,12 +837,76 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             // (e.g. `number extends infer U ? U : never` from `Cond<number>`)
             // so it is classified by its reduced shape rather than left opaque.
             let next = self.ctx.types.evaluate_type(next);
+            // A *deferred* indexed access into a deferred conditional
+            // (`Cond<T>['suffix']`) stays opaque here, but tsc classifies its
+            // array-like-ness from its apparent type: the conditional's
+            // branch-union constraint indexed by the inner key. Reduce to that
+            // apparent type so a tuple-valued branch (`{ suffix: [] }`) is
+            // accepted while a non-array branch (`{ s: string }`) still fires
+            // TS2574. Mirrors `getConstraintOfIndexedAccessType`.
+            let next = self
+                .deferred_indexed_access_apparent_array_like_type(next)
+                .unwrap_or(next);
             if next == current {
                 break;
             }
             current = next;
         }
         current
+    }
+
+    /// Apparent type of a deferred indexed access `B[K1]` whose base `B` is a
+    /// deferred conditional, for the TS2574 rest-element array-like check. Indexes
+    /// the conditional's branch-union constraint with `K1` (tsc's
+    /// `getConstraintOfIndexedAccessType`) and returns the evaluated result.
+    /// Returns `None` when `type_id` is not such a deferred indexed access or the
+    /// apparent type cannot be reduced concretely, leaving the caller to treat the
+    /// type as indeterminate (legal).
+    fn deferred_indexed_access_apparent_array_like_type(
+        &self,
+        type_id: tsz_solver::TypeId,
+    ) -> Option<tsz_solver::TypeId> {
+        use crate::query_boundaries::common as q;
+        let (base, index) = q::index_access_types(self.ctx.types, type_id)?;
+        // Only handle a still-generic conditional base; concrete indexed accesses
+        // already reduce through `evaluate_type` above. An alias-wrapped base
+        // (`Application(Lazy(Cond), [T])`) is expanded to its conditional first so
+        // both `Cond<T>[k]` and inline `(T extends ... ? ... : ...)[k]` are
+        // covered.
+        let conditional = if q::is_conditional_type(self.ctx.types, base) {
+            base
+        } else if q::is_generic_application(self.ctx.types, base) {
+            let env = self.ctx.type_environment.borrow();
+            let expanded = crate::query_boundaries::flow_analysis::evaluate_application_type(
+                self.ctx.types,
+                &env,
+                base,
+            );
+            if q::is_conditional_type(self.ctx.types, expanded) {
+                expanded
+            } else {
+                return None;
+            }
+        } else {
+            return None;
+        };
+        let base_constraint = q::conditional_branch_union_constraint(self.ctx.types, conditional)?;
+        if q::is_conditional_type(self.ctx.types, base_constraint)
+            || q::is_index_access_type(self.ctx.types, base_constraint)
+        {
+            return None;
+        }
+        let apparent = self
+            .ctx
+            .types
+            .evaluate_type(self.ctx.types.index_access(base_constraint, index));
+        if apparent == tsz_solver::TypeId::ERROR
+            || q::is_index_access_type(self.ctx.types, apparent)
+            || q::is_conditional_type(self.ctx.types, apparent)
+        {
+            return None;
+        }
+        Some(apparent)
     }
 
     pub(super) fn fixed_tuple_spread_elements(

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1434,7 +1434,16 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # `is_generic_application`, `is_index_access_type`) already called from
         # `common` in the very same expressions — no new quarantine entry.
         # Removal condition remains #8225 narrowing this quarantine.
-        3072,
+        #
+        # Bumped 3072→3076 for the remeda error-type-contagion fix (#13512):
+        # the `indexed_access/error_contagion.rs` spine walk adds an
+        # `application_info` + `index_access_types` peel and the
+        # `context/unresolved_import.rs` detector adds a `lazy_def_id` lookup,
+        # all through the existing `query_boundaries::common` gateway joining the
+        # sibling structural predicates already used in the same expressions —
+        # no new quarantine entry. (+2 from the layered #13792 base whose own
+        # ratchet lands with it.) Removal condition remains #8225.
+        3076,
     ),
 ]
 


### PR DESCRIPTION
Goal: green

Fixes the dominant remeda canary FP cluster (#13512): the **error-type
contagion** root underneath the deferred-conditional indexed-access slice
(sibling PR #13792, which this branch is layered on).

## Structural rule

When the object of an indexed access is rooted at an **unresolved imported
alias** — a `Lazy(DefId)`/`UnresolvedTypeName` whose binder symbol is an
`import` from a module that failed to resolve (already flagged `TS2307`), e.g.
`Simplify<…>`/`TupleParts<…>` when `type-fest` is absent — `tsc` resolves the
access through that reference's permissive **`error` apparent type**, whose key
space is the universal `string | number | symbol`. So the access, and any
further `[K2]` / `[...spread]` over its result, accepts any key; the only
diagnostic `tsc` reports is the import failure.

`tsz` previously kept such accesses deferred and poisoned the key space,
cascading spurious `TS2536` (×54) / `TS2574`. This change mirrors `tsc`:

- A deferred **conditional** whose branch union carries an error-contagious
  branch: re-derive the validation key space as `keyof` of the *concrete*
  branches only — the error branch contributes the universal identity, so
  `keyof (error | concrete) = keyof concrete`. When every branch is error-typed,
  any key is accepted.
- An indexed-access object **rooted directly** at the unresolved-import
  application (`TupleParts<T>["required"]`), or a *nested* access through a
  conditional whose branch union collapsed to `error`/an unresolved import
  (`TupleParts<T>["required"]["length"]`): the apparent type is `error`, so the
  outer index accepts any key.
- A rest element rooted at such an access (`[...TupleParts<T>["suffix"]]`): the
  `error` apparent type is assignable to `readonly any[]`, so no `TS2574`.

**Gating (no over-suppression):** only the error-typed branch contributes the
universal key space. A *well-formed* conditional keeps its per-branch key-space
restriction (`keyof(A | B) = keyof A ∩ keyof B`): a key shared by both branches
is accepted while a key present in only one branch — or in neither — still emits
`TS2536`. This is the adjacency a prior prototype regressed; it is preserved
here and covered by unit tests.

Owner layer: checker indexed-access validation (`check_indexed_access_type` →
`indexed_access/error_contagion.rs`) and the rest-element array-like classifier
(`type_node_helpers.rs`), using a shared `CheckerContext`
unresolved-import detector (`context/unresolved_import.rs`) and existing
`query_boundaries` structural helpers. No relation/keyof semantics changed for
well-formed types; detection is structural (binder import-symbol flag + type
shape), not name/file string matching.

## Adjacent matrix

- All branches error (`Rec<T> = … : Simplify<{a}>`), `Rec<T>["a"]` — accept.
- Mixed concrete + error (`Mix<T> = … ? {a} : Simplify<{a}>`): `["a"]` accept,
  `["b"]` still `TS2536`.
- Nested through error-contagious conditional (`TupleParts<T>["required"]
  ["length"]`, `["optional"][number]`) — accept.
- Rest spread `[...TupleParts<T>["suffix"]]` — accept (no `TS2574`).
- Renamed binders — structural, unaffected.
- Negative (no unresolved import): shared key accepted, solo/missing key still
  `TS2536` (per-branch restriction preserved).

## Verification

- **remeda canary** (pinned fixture `53d22a60`, shared external config, oracle =
  `tsc`): `TS2536` tsz-only cluster **54 → 0**; `TS2574` 8 → 1; total tsz-only
  delta **304 → 243**. The residual 243 are the separate overload/assignability
  cascades (`TS2578`/`TS2345`/`TS2769`/`TS2554`) — a distinct architectural
  surface tracked in #13512's decomposition step 3, not the indexed-access root.
  Measured to completion (exit 0, nonempty), **stable across 3 runs**.
- **CLI repros vs `tsc`** (exact match): all-error branch, mixed concrete+error
  (`"a"` accept / `"b"` TS2536), nested `TupleParts` `["length"]`/`[number]`,
  rest spread, and the **shared-key negative** (`Wf<T>["p"]` clean,
  `Wf<T>["q"]` TS2536).
- **Conformance** (`scripts/conformance.sh --filter`, 0 PASS→FAIL): conditionalType
  17/17, indexedAccess 13/13, keyof 14/14, mappedType 55/55, intersection 44/44,
  distributiveConditional 3/3, indexType 2/2, errorType 1/1, unresolvedType 1/1,
  restElement 14/14, restTuple 2/2, tupleType 3/3, moduleResolution 111/111,
  importType 17/17.
- **Unit tests**: `tests/ts2536_error_type_contagion_tests.rs` (4 tests, regression
  guard for the well-formed per-branch key-space property; the import-failure
  precondition needs the module-resolution pipeline and is validated by the CLI
  repros + remeda delta above).
- `arch_guard.py` PASS (quarantine cap bumped 3072→3076 for the +2 new
  `query_boundaries::common` structural-query references, documented inline);
  clippy clean on `tsz-checker`; new files split to stay under the 2000-LOC
  ceiling.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Project corpus

AgentName: claude-code
- Row: remeda-project
- Bug family: error-type-contagion deferred-conditional-index
