### PR TITLE
fix(checker): inline-exported empty-array const is fixed never[], not evolving (mobx noImplicitAny FP)

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -1009,9 +1009,19 @@ impl<'a> CheckerState<'a> {
                     }
                 }
             }
+            // An inline-exported variable (`export const/let/var x = []`) is not an
+            // evolving array: tsc fixes its declared type to the array literal's own
+            // type (`never[]`) because the type must be observable to consuming
+            // modules, so it never enters the control-flow evolving-array path and
+            // never reports TS7034/TS7005. A variable exported via a separate
+            // `export { x }` statement keeps the normal evolving-array behavior
+            // (matching tsc), which is why this gates on the inline export modifier
+            // (`is_declaration_exported`) rather than on whether the symbol is
+            // referenced by any export.
             let direct_empty_array_implicit_any = self.ctx.no_implicit_any()
                 && !self.ctx.has_real_syntax_errors
                 && !sym_already_cached
+                && !is_exported
                 && var_decl.type_annotation.is_none()
                 && var_decl.initializer.is_some()
                 && self


### PR DESCRIPTION
Goal: green

## Summary
Characterized mobx's non-enum noImplicitAny / this-any residual and fixed the
one structurally-localizable sub-cluster.

Key characterization finding (corrects the assumed scope): after the per-row
**tsc oracle subtraction** (the gate subtracts tsc's own noImplicitAny errors
because the mobx fixture compiles with `noImplicitAny` and mobx's source is
heavily untyped), the noImplicitAny/this-any clusters are overwhelmingly
**tsc-parity, not tsz-only**:

| code | tsz raw | tsc (oracle) | tsz-only |
|------|--------:|-------------:|---------:|
| TS7006 (implicit-any param) | 119 | 118 | 8 |
| TS2683 (this-any) | 20 | 23 | **0** (tsz emits fewer) |
| TS7010 | 11 | 11 | 0 |
| TS7053 (implicit-any index) | 29 | 37 | 2 |
| TS7005/7034/7052 | 10 | 9 | 4 |

The dominant tsz-only residual is the **cross-module enum / type-duplication
cascade** (TS2322/TS2339/TS2367/TS2719/TS2416/TS2345 ~= 86 lines, the
`IDerivationState_` / `IDerivation` "two different types with this name exist"
family) — the deep cross-module enum-parent residency root that PR #13798
documents as out of scope. The scattered TS7006/TS7053 FPs are downstream of
that cascade poisoning receiver types (`IObservableArray<any>.forEach`,
`ownKeys(...).forEach`); they are not reproducible in isolation (verified with
barrel/guard-chain repros) and are not separately localizable.

The one isolable, structurally-clean sub-cluster fixed here: the
**inline-exported empty-array evolving-array FP** (`utils/utils.ts`
`export const EMPTY_ARRAY = []`), which emitted a false TS7034 + TS7005 pair.

## Structural rule
When a variable is declared with an **inline `export` modifier** and an empty
array literal initializer (`export const|let|var x = []`), `tsc` fixes the
declared type to the array literal's own type (`never[]`) — the type must be
observable to consuming modules, so the variable never enters the control-flow
evolving-array path and never reports TS7034/TS7005. A variable exported via a
separate `export { x }` statement keeps normal evolving-array behavior. tsz now
skips the evolving-array implicit-any registration
(`pending_implicit_any_vars` `EvolvingArray`) for inline-exported declarations
in `state/variable_checking/core.rs`, gating on the existing
`is_declaration_exported` (inline export modifier), not on whether any export
references the symbol.

## Adjacent matrix (all verified tsz == tsc after fix)
- `export const x = []; Object.freeze(x)` -> clean (was false TS7034/7005).
- `export let x = []` / `export var x = []` -> clean (broadened correctly).
- `const x = []; export { x }` (separate export) -> still TS7034/7005 (parity).
- `const x = []` (no export) -> still TS7034/7005 (parity).
- `const x = []; const y = x` (fresh-value read) -> still TS7034/7005 (parity).
- No binder-name dependence: rule keys on the export modifier, not identifiers.

## Verification
- mobx row (tsz-only oracle delta), measured to completion, no result cache:
  **146 -> 144** (TS7034 1->0, TS7005 2->1; the `EMPTY_ARRAY` pair removed,
  the unrelated `when.ts` `abort` control-flow TS7005 correctly preserved).
  Raw tsz lines 347 -> 345. Zero new FPs.
- Required project rows (parity floor): all 9 compile successfully, 0 failures.
- Conformance (relevant + adjacent families), all 100%, 0 known failures, 0
  crashes:
  - `noImplicitAny` 37/37, `implicitAny` 22/22, `contextualTyping` 83/83,
    `thisType` 32/32, `inference` 23/23, `parameter` 38/38,
    `indexSignature` 24/24, `arrayLiteral` 19/19, `evolvingArray` 2/2,
    `strictNullChecks` 1/1, `export` 286/286.
- `arch_guard_rust.py`: pass.
- `cargo clippy --profile dist-fast -p tsz-checker`: clean.
- Determinism: 3x identical on the repro matrix.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

AgentName: ClaudeOpus-MobxImplicitAny
- Row: mobx
- Bug family: noImplicitAny
