### PR TITLE
feat(website): relative-time + commit link in benchmark runner info

### DIFF
--- a/crates/tsz-website/scripts/benchmark-data-smoke.mjs
+++ b/crates/tsz-website/scripts/benchmark-data-smoke.mjs
@@ -357,7 +357,13 @@ try {
     getBenchmarkPages,
     getProjectCompatibilityDashboard,
   } = await import("../src/_data/benchmark_data.js");
-  assert.match(getBenchmarkEnvironmentSummary(), /sha 0123456789ab/);
+  const envSummary = getBenchmarkEnvironmentSummary();
+  // sha links to its GitHub commit; the generated timestamp is a <relative-time>.
+  assert.match(
+    envSummary,
+    /sha <a href="https:\/\/github\.com\/tsz-org\/tsz\/commit\/0123456789ab[0-9a-f]*"[^>]*><code>0123456789ab<\/code><\/a>/,
+  );
+  assert.match(envSummary, /Generated <relative-time datetime="[^"]+"[^>]*>/);
   const pages = getBenchmarkPages();
   const fixturePage = pages.find((page) => page.name === "conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable.ts");
   assert.ok(fixturePage, "expected TypeScript fixture benchmark page");

--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -58,14 +58,32 @@ function measurementProfileSummary(data) {
   return `tsz ${mode}`;
 }
 
+// Builds the "show runner info" line as an HTML string. Each part is either a
+// pre-escaped text fragment or intentional markup: the generated timestamp is a
+// GitHub <relative-time> web component (relative display, absolute ISO as
+// fallback text + title), and the source sha links to its GitHub commit. The
+// caller embeds this without further escaping, so every dynamic text value is
+// escaped here.
+const TSZ_COMMIT_URL_BASE = "https://github.com/tsz-org/tsz/commit/";
+
 function runnerEnvironmentSummary(data) {
   const parts = [];
   const generatedAt = formatUtcTimestamp(data?.generated_at);
-  if (generatedAt) parts.push(`Generated ${generatedAt}`);
+  if (generatedAt) {
+    const iso = escapeHtml(generatedAt);
+    parts.push(
+      `Generated <relative-time datetime="${iso}" tense="past" format="relative" title="${iso}">${iso}</relative-time>`,
+    );
+  }
   const sourceCommit = normalizedCommit(data?.source_commit);
-  if (sourceCommit) parts.push(`sha ${sourceCommit.slice(0, 12)}`);
+  if (sourceCommit) {
+    const href = escapeHtml(`${TSZ_COMMIT_URL_BASE}${sourceCommit}`);
+    parts.push(
+      `sha <a href="${href}" target="_blank" rel="noreferrer noopener"><code>${escapeHtml(sourceCommit.slice(0, 12))}</code></a>`,
+    );
+  }
   const measurement = measurementProfileSummary(data);
-  if (measurement) parts.push(measurement);
+  if (measurement) parts.push(escapeHtml(measurement));
 
   const env = data?.runner_environment;
   if (!env || typeof env !== "object") {
@@ -73,24 +91,24 @@ function runnerEnvironmentSummary(data) {
   }
 
   const platform = [env.platform, env.arch].filter(Boolean).join("/");
-  if (platform) parts.push(platform);
+  if (platform) parts.push(escapeHtml(platform));
   if (env.cpu_count) {
     const cpuModel = env.cpu_model ? ` ${env.cpu_model}` : "";
-    parts.push(`${env.cpu_count} CPU${env.cpu_count === 1 ? "" : "s"}${cpuModel}`);
+    parts.push(escapeHtml(`${env.cpu_count} CPU${env.cpu_count === 1 ? "" : "s"}${cpuModel}`));
   }
   const memory = formatMemory(env.total_memory_bytes);
-  if (memory) parts.push(memory);
+  if (memory) parts.push(escapeHtml(memory));
   if (env.github_actions?.runner_os || env.github_actions?.runner_arch) {
     const runner = [
       env.github_actions.runner_os,
       env.github_actions.runner_arch,
     ].filter(Boolean).join("/");
-    parts.push(`GitHub Actions ${runner}`);
+    parts.push(escapeHtml(`GitHub Actions ${runner}`));
   } else if (env.ci) {
-    parts.push("CI runner");
+    parts.push(escapeHtml("CI runner"));
   }
   if (env.cloud_build?.machine_type) {
-    parts.push(`Cloud Build ${env.cloud_build.machine_type}`);
+    parts.push(escapeHtml(`Cloud Build ${env.cloud_build.machine_type}`));
   }
 
   return parts.join(" · ");
@@ -1639,9 +1657,11 @@ export function getBenchmarkMicroCharts() {
 export function getBenchmarkEnvironmentSummary() {
   const summary = runnerEnvironmentSummary(loadBenchmarks());
   if (!summary) return "";
+  // summary is already HTML-safe (text fragments escaped; the timestamp and sha
+  // carry intentional <relative-time>/<a> markup), so it is embedded raw here.
   return `<details class="bench-runner-details">
   <summary>show runner info</summary>
-  <p class="bench-runner-meta">${escapeHtml(summary)}</p>
+  <p class="bench-runner-meta">${summary}</p>
 </details>`;
 }
 

--- a/crates/tsz-website/src/_includes/layouts/base.njk
+++ b/crates/tsz-website/src/_includes/layouts/base.njk
@@ -27,6 +27,9 @@
   {% if build.sha %}<meta name="tsz-build-sha" content="{{ build.sha }}">{% endif %}
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/style.css">
+  <!-- GitHub <relative-time> web component: renders timestamps as relative time.
+       Degrades gracefully to the absolute ISO fallback text if it fails to load. -->
+  <script type="module">import "https://cdn.jsdelivr.net/npm/@github/relative-time-element@4/+esm";</script>
   {{ extra_head | safe }}
 </head>
 <body>


### PR DESCRIPTION
Goal: hold

The website "show runner info" line rendered the generated timestamp as a raw UTC string and the source sha as plain text:
> Generated 2026-06-16T21:24:39Z · sha b143f919bb20 · tsz release-pgo … · CI runner · Cloud Build e2-highcpu-32

Now:
- **Timestamp → GitHub `<relative-time>` web component** (relative display, e.g. "2 hours ago"), with the absolute ISO kept as the element’s fallback text + `title` so it **degrades gracefully** to the exact UTC string if the component script fails to load.
- **sha → link** to its GitHub commit (`https://github.com/tsz-org/tsz/commit/<sha>`), shown as `<code>`.

## Implementation
- `runnerEnvironmentSummary` now returns an **HTML string**: every dynamic text fragment is individually `escapeHtml`’d, and only the timestamp/sha carry intentional `<relative-time>`/`<a>` markup. `getBenchmarkEnvironmentSummary` embeds it raw (previously it `escapeHtml`’d the whole line, which is why the elements could not be added before).
- The `<relative-time>` element (`@github/relative-time-element`) is loaded via a pinned CDN module script in `base.njk`. No-JS / load-failure path still shows the absolute time (the element’s text content).

## Verification
- `node crates/tsz-website/scripts/benchmark-data-smoke.mjs` — passes; updated to assert the commit-link markup (`sha <a href=".../commit/…"><code>…</code></a>`) and the `<relative-time datetime="…">` element.

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: max