### PR TITLE
perf(checker): canonical cycle-guard key collapses import-alias fan-out

### DIFF
--- a/crates/tsz-checker/src/context/canonical_app_key.rs
+++ b/crates/tsz-checker/src/context/canonical_app_key.rs
@@ -1,0 +1,48 @@
+//! Canonical key for the `type_resolution_visiting` cycle guard.
+
+use tsz_solver::TypeId;
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::def::{DefId, DefinitionStore};
+
+use crate::query_boundaries::state::type_environment as query;
+
+/// Canonical key for the `type_resolution_visiting` cycle guard.
+///
+/// For `Application(Lazy(def), args)` types the key is
+/// [`CanonicalAppKey::App`] carrying the *canonical* `DefId` (resolved through
+/// the import-alias forwarding chain at check time) plus the argument vector,
+/// so that all import-alias variants of the same logical generic definition
+/// collapse onto one key. For every other shape the key is
+/// [`CanonicalAppKey::Raw`] over the raw `TypeId`, preserving the prior
+/// per-`TypeId` behavior exactly.
+///
+/// The canonical `DefId` is recomputed each time the key is built (it is never
+/// stored on an interned `TypeId`), which keeps the guard order-independent and
+/// always consistent with the current resolver generation.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum CanonicalAppKey {
+    /// `Application(Lazy(canonical_def), args)`.
+    App(DefId, Box<[TypeId]>),
+    /// Any non-`Application(Lazy, _)` type, keyed by its raw `TypeId`.
+    Raw(TypeId),
+}
+
+impl CanonicalAppKey {
+    /// Build the cycle-guard key for `type_id`. The canonical `DefId` is
+    /// resolved through the import-alias forwarding chain at call time (never
+    /// stored on the interned `TypeId`), keeping the key order-independent.
+    /// Decomposition uses the query-boundary helpers, not raw `TypeData`.
+    pub fn build(
+        db: &dyn TypeDatabase,
+        definition_store: &DefinitionStore,
+        type_id: TypeId,
+    ) -> Self {
+        if let Some((base, args)) = query::application_info(db, type_id)
+            && let Some(def_id) = query::lazy_def_id(db, base)
+        {
+            let canonical = definition_store.canonical_def_id(def_id);
+            return Self::App(canonical, args.into_boxed_slice());
+        }
+        Self::Raw(type_id)
+    }
+}

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -6,6 +6,7 @@
 mod aliases;
 mod cache_statistics;
 mod caches;
+mod canonical_app_key;
 mod compiler_options;
 mod cross_file_delegation_cache;
 mod cross_file_type_params_cache;
@@ -16,6 +17,7 @@ pub use caches::{
     NarrowableIdentifierCache, NodeTypeCache, SharedConstraintProofCache, SymbolTypeCache,
     TypeNodeSurfaceCaches, TypeReferenceValidationCaches,
 };
+pub use canonical_app_key::CanonicalAppKey;
 pub(crate) use compiler_options::is_declaration_file_name;
 pub(crate) use compiler_options::is_js_file_name;
 pub(crate) use compiler_options::should_resolve_jsdoc_for_file;
@@ -921,12 +923,11 @@ pub struct CheckerContext<'a> {
     /// Recursion guard for mapped type evaluation with resolution.
     pub mapped_eval_set: FxHashSet<TypeId>,
 
-    /// Recursion guard for `evaluate_type_with_resolution`.
-    /// Prevents infinite mutual recursion through
-    /// `evaluate_type_with_resolution → prune_impossible_object_union_members_with_env
-    /// → object_member_has_impossible_required_property_with_env → evaluate_type_with_resolution`
-    /// on recursive type aliases.
-    pub type_resolution_visiting: FxHashSet<TypeId>,
+    /// Recursion guard for `evaluate_type_with_resolution`, preventing infinite
+    /// mutual recursion (evaluate → prune → impossible-property → evaluate) on
+    /// recursive type aliases. Keyed by [`CanonicalAppKey`] (not raw [`TypeId`])
+    /// to collapse import-alias variants; see that type for the rationale.
+    pub type_resolution_visiting: FxHashSet<CanonicalAppKey>,
     /// Reentrancy guard for `prune_impossible_object_union_members_with_env`.
     /// Prevents infinite mutual recursion: evaluate → prune → evaluate → prune.
     pub pruning_union_members: bool,

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -415,18 +415,22 @@ impl<'a> CheckerState<'a> {
     /// Wrapped with `stacker::maybe_grow()` to prevent stack overflow when resolving
     /// long Lazy alias chains (e.g., a chain of re-exported type aliases across modules).
     pub(crate) fn evaluate_type_with_resolution(&mut self, type_id: TypeId) -> TypeId {
-        // Cycle guard: evaluate_type_with_resolution → prune_impossible_object_union_members_with_env
-        // → object_member_has_impossible_required_property_with_env → evaluate_type_with_resolution
-        // can form an infinite mutual recursion on recursive type aliases like
-        // `type Box2 = Box<Box2 | number>`. Track types currently being resolved and
-        // bail out if we re-enter with the same type.
-        if !self.ctx.type_resolution_visiting.insert(type_id) {
+        // Cycle guard against infinite mutual recursion (evaluate → prune →
+        // impossible-property → evaluate) on recursive type aliases like
+        // `type Box2 = Box<Box2 | number>`. Track types currently being resolved
+        // (keyed by `CanonicalAppKey` to collapse import-alias variants).
+        let key = crate::context::CanonicalAppKey::build(
+            self.ctx.types.as_type_database(),
+            &self.ctx.definition_store,
+            type_id,
+        );
+        if !self.ctx.type_resolution_visiting.insert(key.clone()) {
             return type_id;
         }
         let result = stacker::maybe_grow(256 * 1024, 2 * 1024 * 1024, || {
             self.evaluate_type_with_resolution_inner(type_id)
         });
-        self.ctx.type_resolution_visiting.remove(&type_id);
+        self.ctx.type_resolution_visiting.remove(&key);
         result
     }
 


### PR DESCRIPTION
Goal: fast

## Summary

Changes the `type_resolution_visiting` cycle guard from `FxHashSet<TypeId>` to
`FxHashSet<CanonicalAppKey>`. For `Application(Lazy(def), args)` the key carries
the **canonical** `DefId` (resolved through the import-alias forwarding chain)
plus the argument vector, so all import-alias variants of one logical generic
definition collapse onto a single guard key. Every other shape keeps its prior
per-`TypeId` identity via `CanonicalAppKey::Raw`.

This is the standalone, behavior-neutral dedup prerequisite for the
recursive-heritage canonical-materialization work (STAGE 0 of #13212/#13242). It
removes the alias-fan-out multiplication factor that lets a recursive heritage
cycle re-walk the guard once per import-alias variant; the anchor-materialization
stages build on top of it.

## Structural rule

When `evaluate_type_with_resolution` re-enters with an `Application(Lazy(def), args)`
whose base `DefId` is an import-alias of an already-in-progress canonical
definition, `tsc` treats it as the same logical reference; `tsz` now collapses
both onto one `CanonicalAppKey::App(canonical_def_id(def), args)` guard key
(owner: checker `type_resolution_visiting` guard in
`state/type_environment/lazy.rs`), instead of seeing a fresh per-`TypeId` key and
re-walking the cycle per alias variant.

The canonical `DefId` is recomputed at guard-check time and never baked into an
interned `TypeId`, keeping the guard order-independent and consistent with the
current resolver generation (avoids the symbolid-order / neverthrow
order-determinism trap). Decomposition goes through the existing
`query_boundaries` helpers (`query::application_info` + `query::lazy_def_id`),
not raw `TypeData` inspection, so the checker boundary is respected.

## Verification

- arch_guard: PASS (query-boundary decomposition, no raw `lookup()`/`TypeData`
  inspection; `CanonicalAppKey` split into its own `context::canonical_app_key`
  submodule to stay under the 2000-LOC checker file ceiling).
- clippy: clean (`-p tsz-checker`).
- Conformance gate (the recursive/heritage families that exercise the guard) is
  **0 PASS->FAIL vs the branch parent** — verified by reverting STAGE 0 and
  rebuilding: every family produces identical counts on parent and on STAGE 0:
  - heritage 12583/12585 (the 2 failures `deeplyNestedMappedTypes.ts` /
    `propTypeValidatorInference.ts` are **pre-existing** main regressions vs the
    committed baseline snapshot — they fail identically on the parent commit and
    are not caused by this change)
  - conditionalType 17/17, mappedType 55/55, recursiveType 23/23,
    intersection 44/44, circularType 5/5, genericInterface 4/4,
    typeRelationships 265/265, instantiation 3/3,
    tsxLibraryManagedAttributes 1/1, deeplyNested 6/7 (same pre-existing failure)
- Determinism: 3x identical results (heritage 12583/12585 x3, conditionalType
  17/17 x3) — proves the canonical-key collapse is order-independent.

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high