### PR TITLE
fix(binder,checker): don't trip the stack-overflow guard when headroom is unmeasurable (#13815)

### DIFF
--- a/crates/tsz-binder/src/binding/stack_guard.rs
+++ b/crates/tsz-binder/src/binding/stack_guard.rs
@@ -58,6 +58,28 @@ pub(crate) fn trip_stack_overflow() {
     BINDER_STACK_STATE.set(BINDER_STACK_STATE.get() | BINDER_STACK_TRIPPED_BIT);
 }
 
+/// Decide whether measured stack headroom is below `min_bytes`.
+///
+/// Split out as a pure function of the measurement so the `None` case can be
+/// unit-tested without controlling the real stack: `stacker::remaining_stack()`
+/// returns `None` on targets whose stack bounds are unknown (notably `wasm32`).
+/// Treating that unknown as "critically low" (an `unwrap_or(0)`) would trip the
+/// breaker on the first probe and abort the recursive walk mid-input, silently
+/// dropping every node bound after the trip point. With no measurement there is
+/// no evidence of exhaustion, so we report "not low" and let the walk proceed.
+#[inline]
+#[must_use]
+pub(crate) const fn measured_headroom_below(remaining: Option<usize>, min_bytes: usize) -> bool {
+    matches!(remaining, Some(r) if r < min_bytes)
+}
+
+/// `true` only when the remaining stack can be measured AND is below `min_bytes`.
+#[inline]
+#[must_use]
+pub(crate) fn headroom_below(min_bytes: usize) -> bool {
+    measured_headroom_below(stacker::remaining_stack(), min_bytes)
+}
+
 /// Reset the stack overflow breaker for this thread.
 ///
 /// Must be called at the start of each file's `bind_source_file` so that a
@@ -65,4 +87,24 @@ pub(crate) fn trip_stack_overflow() {
 /// subsequent files processed on the same thread.
 pub(crate) fn reset_stack_overflow_flag() {
     BINDER_STACK_STATE.set(BINDER_STACK_STATE.get() & !BINDER_STACK_TRIPPED_BIT);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::measured_headroom_below;
+
+    #[test]
+    fn unmeasurable_headroom_never_trips() {
+        // `wasm32` reports `None`; that must not count as critically low, or the
+        // binder aborts mid-file and drops later declarations (issue #13815).
+        assert!(!measured_headroom_below(None, 1024 * 1024));
+        assert!(!measured_headroom_below(None, usize::MAX));
+    }
+
+    #[test]
+    fn measured_headroom_compares_against_threshold() {
+        assert!(measured_headroom_below(Some(512 * 1024), 1024 * 1024));
+        assert!(!measured_headroom_below(Some(2 * 1024 * 1024), 1024 * 1024));
+        assert!(!measured_headroom_below(Some(1024 * 1024), 1024 * 1024));
+    }
 }

--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -632,7 +632,7 @@ impl BinderState {
             return;
         }
         if crate::binding::stack_guard::should_probe_stack()
-            && stacker::remaining_stack().unwrap_or(0) < 1024 * 1024
+            && crate::binding::stack_guard::headroom_below(1024 * 1024)
         {
             crate::binding::stack_guard::trip_stack_overflow();
             return;

--- a/crates/tsz-checker/src/checkers/mod.rs
+++ b/crates/tsz-checker/src/checkers/mod.rs
@@ -53,6 +53,29 @@ pub fn should_probe_stack() -> bool {
     c & STACK_COUNTER_MASK == 0
 }
 
+/// Decide whether measured stack headroom is below `min_bytes`.
+///
+/// Pure function of the measurement so the `None` case is unit-testable without
+/// controlling the real stack. `stacker::remaining_stack()` returns `None` on
+/// targets whose stack bounds cannot be determined (notably `wasm32`). Treating
+/// that unknown as "critically low" (the old `unwrap_or(0)` form) trips the
+/// breaker on the very first probe, aborting the recursive walk mid-input and
+/// silently dropping every node after the trip point. With no measurement there
+/// is no evidence of exhaustion, so we report "not low" and let the walk
+/// proceed; `stacker::maybe_grow` still handles genuine growth.
+#[inline]
+#[must_use]
+pub const fn measured_headroom_below(remaining: Option<usize>, min_bytes: usize) -> bool {
+    matches!(remaining, Some(r) if r < min_bytes)
+}
+
+/// `true` only when the remaining stack can be measured AND is below `min_bytes`.
+#[inline]
+#[must_use]
+pub fn headroom_below(min_bytes: usize) -> bool {
+    measured_headroom_below(stacker::remaining_stack(), min_bytes)
+}
+
 /// Trip the stack overflow breaker.  Called from guards in `dispatch.rs` and
 /// `state/type_analysis/core.rs` when `stacker::remaining_stack()` reports
 /// < 256 KB remaining.
@@ -168,6 +191,22 @@ mod tests {
     fn stack_overflow_tripped_starts_false() {
         reset();
         assert!(!stack_overflow_tripped());
+    }
+
+    #[test]
+    fn unmeasurable_headroom_never_trips() {
+        // `wasm32` reports `None`; that must not count as critically low, or the
+        // checker bails to `TypeId::ERROR` mid-recursion on every guarded entry
+        // point (issue #13815 family).
+        assert!(!measured_headroom_below(None, 1024 * 1024));
+        assert!(!measured_headroom_below(None, usize::MAX));
+    }
+
+    #[test]
+    fn measured_headroom_compares_against_threshold() {
+        assert!(measured_headroom_below(Some(256 * 1024), 1024 * 1024));
+        assert!(!measured_headroom_below(Some(4 * 1024 * 1024), 1024 * 1024));
+        assert!(!measured_headroom_below(Some(1024 * 1024), 1024 * 1024));
     }
 
     #[test]

--- a/crates/tsz-checker/src/dispatch/mod.rs
+++ b/crates/tsz-checker/src/dispatch/mod.rs
@@ -65,7 +65,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
         // This prevents unbounded stack growth from stacker::maybe_grow
         // which would eventually hit the OS stack limit and crash.
         if crate::checkers_domain::should_probe_stack()
-            && stacker::remaining_stack().unwrap_or(0) < 1024 * 1024
+            && crate::checkers_domain::headroom_below(1024 * 1024)
         {
             crate::checkers_domain::trip_stack_overflow();
             return TypeId::ERROR;

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1088,7 +1088,7 @@ impl<'a> CheckerState<'a> {
         }
         // Periodically probe remaining stack and trip the breaker if low.
         if crate::checkers_domain::should_probe_stack()
-            && stacker::remaining_stack().unwrap_or(0) < 1024 * 1024
+            && crate::checkers_domain::headroom_below(1024 * 1024)
         {
             crate::checkers_domain::trip_stack_overflow();
             self.ctx.symbol_types.insert(sym_id, TypeId::ERROR);

--- a/crates/tsz-checker/src/types/queries/lib_aliases.rs
+++ b/crates/tsz-checker/src/types/queries/lib_aliases.rs
@@ -40,7 +40,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         if crate::checkers_domain::should_probe_stack()
-            && stacker::remaining_stack().unwrap_or(usize::MAX) < 512 * 1024
+            && crate::checkers_domain::headroom_below(512 * 1024)
         {
             crate::checkers_domain::trip_stack_overflow();
             return None;

--- a/crates/tsz-wasm/src/wasm_tests.rs
+++ b/crates/tsz-wasm/src/wasm_tests.rs
@@ -1047,3 +1047,38 @@ fn test_wasm_language_service_primitive_excludes_constructor() {
         );
     }
 }
+
+/// A `TsProgram` built from the real lib `.d.ts` assets must resolve a lib
+/// interface (`Error`) as a *type*, with its value-space and type-space
+/// declarations merged.
+///
+/// This is the playground/wasm scenario from issue #13815. On `wasm32` the
+/// binder's stack guard used to trip after the first probe (because
+/// `stacker::remaining_stack()` is `None` there and `unwrap_or(0)` read as
+/// zero headroom), aborting the es5 statement pass so `interface Error` was
+/// never bound — only the hoisted `var Error` survived, yielding a false
+/// `TS2749`. The fix makes an unmeasurable headroom never trip the guard
+/// (see `headroom_below` / `measured_headroom_below`). On native the headroom
+/// is always measurable, so this asserts the always-correct path stays green.
+#[test]
+fn lib_interface_used_as_type_resolves_13815() {
+    use std::fs;
+    let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../tsz-core/src/lib-assets");
+    let libs = ["es5", "es2015.core", "es2015.iterable", "dom"];
+    let mut p = TsProgram::new();
+    p.set_compiler_options("{\"strict\":true}").unwrap();
+    for l in libs {
+        let path = format!("{dir}/{l}.d.ts");
+        let src = fs::read_to_string(&path).unwrap();
+        p.add_lib_file(format!("lib.{l}.d.ts"), src);
+    }
+    p.add_source_file(
+        "input.ts".to_string(),
+        "type LogLine = string | Error;\nlet e: Error = new Error('x');".to_string(),
+    );
+    let diags = p.get_semantic_diagnostics_json(None);
+    assert!(
+        !diags.contains("2749") && !diags.contains("2304"),
+        "Error must resolve as a type, got diagnostics: {diags}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Fixes #13815.

## Summary

On the **wasm build only** (e.g. the tsz.dev playground), some global lib
**type-space** registrations were dropped, so a lib interface used as a type
failed to resolve while its value-space declaration still worked
(`type LogLine = string | Error` → false `TS2749` / `error[]`). Native and
`tsc` were clean.

## Structural rule

When the binder/checker probe stack headroom, the breaker must only trip on a
*measurement* that is below the threshold; an **unmeasurable** headroom is not
evidence of exhaustion and must not trip the breaker. `tsc`-parity behaviour:
binding/checking runs to completion regardless of whether `stacker` can read
the stack bounds.

## Root cause (pinned with a wasm build + native ground-truth)

`stacker::remaining_stack()` returns `None` on `wasm32` (stack bounds are
unknowable there). The binder and checker stack-overflow guards read that as
zero headroom via `stacker::remaining_stack().unwrap_or(0) < THRESHOLD`, so the
breaker tripped on the **first probe** (every 64th node) and the recursive walk
returned early for the rest of the input.

Concretely, during `lib.es5.d.ts` binding: the hoisted `var Error` was bound in
the hoist pass (before the trip), but the later `interface Error` *statement*
was skipped once the guard tripped — so the merged global `Error` symbol kept
only its value-space declaration (`flags=0x1`, 1 decl) instead of the
interface+var merge (`flags=0x41`, 2 decls). Captured native-vs-wasm with a
temporary `TsProgram` debug accessor + `declare_symbol`/`bind_interface` event
trace, then removed. This is **not** an `FxHashMap` iteration-order bug (the
issue's original hypothesis); it is deterministic per target. The "which type
drops varies / scale-dependent" symptom follows from where the 64th-probe trip
lands.

## Owner layer / fix

Binder `binding/stack_guard.rs` and checker `checkers/mod.rs` (the guard
helpers). "Is headroom critically low?" is now a function of the measurement
that returns `false` when unmeasurable:

```rust
const fn measured_headroom_below(remaining: Option<usize>, min_bytes: usize) -> bool {
    matches!(remaining, Some(r) if r < min_bytes)
}
fn headroom_below(min_bytes: usize) -> bool {
    measured_headroom_below(stacker::remaining_stack(), min_bytes)
}
```

This is the **established intent** — `types/queries/lib_aliases.rs` already used
the non-tripping `unwrap_or(usize::MAX)` form. The broad fix routes all four
guard sites through the helper:

- `tsz-binder` `bind_node` (`unwrap_or(0)` → fixed)
- `tsz-checker` `dispatch_type_computation_with_request` (`unwrap_or(0)` → fixed)
- `tsz-checker` `get_type_of_symbol` (`unwrap_or(0)` → fixed)
- `tsz-checker` `lib_aliases` (already correct; aligned to the helper)

The other two checker sites had the same wasm-hostile `unwrap_or(0)`, so they
would spuriously bail to `TypeId::ERROR` on wasm too — fixing the family, not
just the one repro.

## Verification

- **wasm repro now clean**: rebuilt `wasm-pack build --target nodejs` and ran
  the issue's exact Node repro (`addLibFile` es5+es2015+dom + `Array<LogLine>`):
  `getSemanticDiagnosticsJson()` → `[]` (was `TS2749` + `TS2339 'error[]'`).
- **native parity test** `tsz-wasm` `lib_interface_used_as_type_resolves_13815`:
  builds a `TsProgram` from the real lib assets and asserts `Error` resolves as
  a type (no TS2749/TS2304).
- **pure-function unit tests** in both crates:
  `unmeasurable_headroom_never_trips` (the `None` case) and
  `measured_headroom_compares_against_threshold`.
- `cargo clippy -p tsz-binder -p tsz-checker --lib` clean; broad
  conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

https://claude.ai/code/session_01YZooSRfQZu2oQwFyyhd534

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZooSRfQZu2oQwFyyhd534)_