### PR TITLE
fix(ci): stop required CI Summary from blocking on the advisory canary suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1539,7 +1539,13 @@ jobs:
       - dist-binaries
       - lsp-e2e
       - project-compile-guard
-      - project-compile-canary-aggregate
+      # project-compile-canary-aggregate is intentionally NOT a dependency here.
+      # It is an advisory, continue-on-error suite (ALLOW_FAILURES=1) that now
+      # installs deps for ~20 real applications, so it runs for tens of minutes
+      # and queues on a busy pool. Keeping it in `needs` made the required
+      # CI Summary wait on it indefinitely ("expected — waiting for status to be
+      # reported") even though it never gates correctness. It still runs and
+      # records results out of band.
       - wasm
       - node-harness-prep
       - unit
@@ -1701,7 +1707,9 @@ jobs:
           if full_run and compiler_checks_required:
               required.update({
                   "project-compile-guard",
-                  "project-compile-canary-aggregate",
+                  # project-compile-canary-aggregate is advisory (continue-on-error,
+                  # ALLOW_FAILURES=1) and no longer a CI Summary dependency, so it is
+                  # not required to pass; it must not block/delay the merge gate.
                   "conformance-snapshot-gate",
               })
               required.update({

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -195,10 +195,16 @@ assert.doesNotMatch(
   "CI Summary must not treat cancelled required jobs as a neutral protected check",
 );
 
-assert.match(
+// The project-compile-canary suite is advisory (continue-on-error + ALLOW_FAILURES)
+// and now installs dependencies for ~20 real applications, so it runs for tens of
+// minutes and queues on a busy pool. It must NOT be a dependency of, or required by,
+// the CI Summary gate — otherwise the required CI Summary stalls "expected — waiting
+// for status to be reported" on a suite that never gates correctness. It still runs
+// and records its compatibility results out of band.
+assert.doesNotMatch(
   ciWorkflow,
-  /\n\s{2}ci-summary:\n[\s\S]+?needs:[\s\S]+?- project-compile-guard\s*\n\s+- project-compile-canary-aggregate[\s\S]+?"project-compile-guard",\s*\n\s+"project-compile-canary-aggregate",/,
-  "CI Summary must wait for the project compile canary aggregate (the shard recombiner) before reporting required full-run success",
+  /^\s+- project-compile-canary-aggregate\s*$/m,
+  "CI Summary must NOT list project-compile-canary-aggregate in needs: the advisory canary must not block/delay the required gate",
 );
 
 for (const job of ["lint", "cargo-shear", "cargo-deny"]) {


### PR DESCRIPTION
Goal: hold

**Investigation result for the recurring "CI Summary — expected, waiting for status to be reported, nothing moving" stuck PRs.**

## Root cause
The required `ci-summary` job had **`project-compile-canary-aggregate` in both its `needs:` and its required-to-pass set**. That aggregate transitively waits on the `project-compile-canary` shards — which now **install dependencies for ~20 real applications** and run for tens of minutes (and *queue* when the self-hosted pool is busy; #13804 already cut shards 6→3 to relieve this). So the **required** CI Summary both *waited on* and *required success from* an **advisory** suite that never gates correctness — it is `continue-on-error` with `ALLOW_FAILURES=1`, so per-row crashes/timeouts are *recorded, not failed*. When the canary shards queued or hit the 45-min timeout, CI Summary sat `expected` indefinitely → PR stuck.

(The library corpus made this rare; the 20 heavy **application** canaries I added turned it into a recurring blocker.)

## Fix
Remove `project-compile-canary-aggregate` from the `ci-summary` `needs:` list and from the `required` job set. The canary suite still runs and records its compatibility results out of band — it just no longer **blocks or delays** the merge gate. CI Summary now resolves as soon as the genuinely-required suites finish (lint, dist-binaries, unit, conformance/emit/fourslash aggregates, project-compile-guard, wasm, lsp-e2e).

This is correct by design: an advisory `continue-on-error` suite must not be a blocking dependency of the required merge gate.

## Follow-up (not here)
To relieve runner-pool *saturation* (canary shards competing with the required suites for runners), consider running the heavy application canary rows on `merge_group` only rather than every PR push.

## Verification
- `actionlint` clean; canary-aggregate now appears only in its own job + comments, not in any `needs:`/required set.
- After merge, in-flight PRs that were stuck on CI Summary will resolve once their required suites pass (this PR also gets pushed into open PRs to re-trigger them).

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: max