### PR TITLE
perf(ci): move conformance-aggregate to ubuntu-latest (#13745)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1206,7 +1206,13 @@ jobs:
     name: conformance-aggregate
     needs: [gate, conformance]
     if: needs.gate.outputs.full_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true' && !cancelled() && needs.conformance.result != 'skipped' && needs.conformance.result != 'cancelled'
-    runs-on: [self-hosted, tsz-cloud-run]
+    # Pure-IO aggregate: consumes ONLY the downloaded conformance-shard-*
+    # artifacts (github-suite.sh conformance-aggregate concatenates them and
+    # reads no dist binary); the GCS env below is best-effort CI cache that
+    # gracefully no-ops when gsutil is absent. A free ubuntu-latest runner is
+    # sufficient and frees a scarce Cloud Run slot (mirrors
+    # project-compile-canary-aggregate, #13745).
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       SCCACHE_GCS_KEY_JSON: ${{ secrets.SCCACHE_GCS_KEY_JSON }}


### PR DESCRIPTION
Moves the `conformance-aggregate` job off the scarce `[self-hosted, tsz-cloud-run]` pool to a free `ubuntu-latest` runner. The job is pure IO — it waits for, downloads (`actions/download-artifact` pattern `conformance-shard-*`), and concatenates the shard results via `github-suite.sh conformance-aggregate`. It uses no dist binary; its `SCCACHE_GCS_KEY_JSON`/cache env is best-effort CI cache that gracefully no-ops when `gsutil` is absent (`TSZ_CI_CACHE_SAVE: "0"`). Freeing the Cloud Run slot mirrors the already-merged `project-compile-canary-aggregate` migration.

Partially resolves #13745. Scope kept to one job:
- `fourslash-aggregate` left self-hosted — it hands shard data off over GCS (no `download-artifact` step) and would need `gsutil`/auth on `ubuntu-latest`; separate change.
- `emit-aggregate` deferred pending the same GCS-vs-artifact verification.

Goal: hold

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → YAML OK.
- The change is a single `runs-on:` swap (+ explanatory comment); job steps unchanged, so the migration is validated by this PR's own `conformance-aggregate` run completing green on `ubuntu-latest`. Do not merge until that job is green on the PR head.
- Pattern precedent: `project-compile-canary-aggregate` already runs this identical download-artifact + concatenate flow on `ubuntu-latest` on main.
