### PR TITLE
test(checker): synthetic witness for #13232 resolver-less deferred-conditional relation

### DIFF
--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
@@ -596,3 +596,136 @@ function viaArrayGeneric(xs: Array<typeof Alpha.resolved>): Beta[] { return xs; 
         );
     }
 
+    // ------------------------------------------------------------------
+    // #13232 (line-16 facet): resolver-less evaluation must not distribute a
+    // still-generic conditional during relation pre-evaluation / flow read.
+    //
+    // A generic async function expression contextually typed by an interface
+    // member signature whose return type embeds a still-generic conditional
+    // alias (`MappedResponseType<R, T>` with `R`/`T` free type parameters) must
+    // NOT false-fail TS2322. tsc keeps `R extends keyof ResponseMap ? ... : ...`
+    // deferred while `R` is generic, so the flow-narrowed `context.response`
+    // (source) and the contextual return element (target) are the *same*
+    // deferred type and relate by identity.
+    //
+    // tsz degrades the source: the flow-narrowed read evaluates the conditional
+    // through a relation-internal evaluator whose resolver cannot expand the
+    // cross-file `Lazy(def)` (`resolver_generation() == 0`), so it evaluates the
+    // operands — `keyof ResponseMap` -> the key-literal union and the true
+    // branch `ResponseMap[R]` -> the value-type union — instead of keeping them
+    // as the deferred alias the target carries. The two structurally-identical
+    // `FetchResponse<MappedResponseType<R, T>>` types then fail to relate, so a
+    // self-assignment reports the canonical false
+    //   `'FetchResponse<MappedResponseType<R, T>>' is not assignable to
+    //    'FetchResponse<MappedResponseType<R, T>>'`.
+    //
+    // Binder names vary from the original ofetch witness so the behavior follows
+    // the type shape, not a spelling. Both returns and the flow narrowing are
+    // required: a single direct return passes (the issue's "both returns are
+    // needed" note).
+    //
+    // The durable fix is the #13232 resolver-threading work (thread the
+    // checker's def-resolving resolver into the relation-internal evaluator so
+    // the cross-file `keyof`/alias expands, OR refuse to serve resolver-less
+    // results so a resolved pass recomputes them). That is architectural and
+    // validated by the full conformance/canary suite, so this is committed as an
+    // `#[ignore]`d synthetic witness that pins the bug deterministically in ~1s
+    // (the prior reproductions were project-corpus-only). Un-ignore when the
+    // resolver-less deferred-conditional relation is fixed.
+    // ------------------------------------------------------------------
+    #[test]
+    #[ignore = "#13232 line-16: resolver-less relation distributes a still-generic \
+                deferred conditional; un-ignore when resolver threading lands"]
+    fn program_mode_generic_conditional_in_contextual_return_stays_deferred() {
+        let lib_files = tsz::checker::test_utils::load_lib_files(&[
+            "es5.d.ts",
+            "es2015.d.ts",
+            "es2015.promise.d.ts",
+            "es2015.iterable.d.ts",
+            "dom.d.ts",
+        ]);
+        assert!(
+            lib_files.len() >= 3,
+            "es5.d.ts + es2015 + dom.d.ts must be available (Promise, Response, fetch)"
+        );
+        let options = project_mode_es2015_strict_options();
+        let diagnostics = collect_test_diagnostics_with_lib_files_and_options(
+            &[
+                (
+                    "/p/types.ts",
+                    r#"
+export interface ResponseMap {
+  blob: Blob;
+  text: string;
+  arrayBuffer: ArrayBuffer;
+  stream: ReadableStream;
+}
+export type ResponseType = keyof ResponseMap | "json";
+export type MappedResponseType<
+  R extends ResponseType,
+  JsonType = any,
+> = R extends keyof ResponseMap ? ResponseMap[R] : JsonType;
+export interface FetchResponse<T> extends Response {
+  _data?: T;
+}
+export interface FetchContext<T = any, R extends ResponseType = ResponseType> {
+  request: string;
+  options: unknown;
+  response?: FetchResponse<MappedResponseType<R, T>>;
+  error?: Error;
+}
+export interface $Fetch {
+  raw<T = any, R extends ResponseType = "json">(
+    request: string,
+    options?: unknown,
+  ): Promise<FetchResponse<MappedResponseType<R, T>>>;
+}
+"#,
+                ),
+                (
+                    "/p/main.ts",
+                    r#"
+import type {
+  FetchResponse,
+  ResponseType,
+  MappedResponseType,
+  FetchContext,
+  $Fetch,
+} from "./types";
+
+async function onError<T, R extends ResponseType>(
+  context: FetchContext<T, R>,
+): Promise<FetchResponse<MappedResponseType<R, T>>> {
+  throw new Error("x");
+}
+
+export const $fetchRaw: $Fetch["raw"] = async function $fetchRaw<
+  T = any,
+  R extends ResponseType = "json",
+>(_request: string, _options: unknown = {}) {
+  const context: FetchContext<T, R> = undefined as any;
+  context.response = (await fetch(context.request)) as FetchResponse<
+    MappedResponseType<R, T>
+  >;
+  if (context.response.status >= 400) {
+    return await onError(context);
+  }
+  return context.response;
+};
+"#,
+                ),
+            ],
+            &lib_files,
+            &options,
+        );
+        let bogus: Vec<_> = diagnostics
+            .iter()
+            .filter(|diag| diag.code == 2322)
+            .collect();
+        assert!(
+            bogus.is_empty(),
+            "a still-generic conditional alias in the contextual return type must \
+             stay deferred (no false TS2322): {bogus:?}; all: {diagnostics:?}"
+        );
+    }
+


### PR DESCRIPTION
## Summary

Adds a **self-contained, deterministic `check_tests` reproduction** of the
#13232 line-16 facet (resolver-less evaluation mis-distributing a still-generic
conditional). Every prior reproduction of this facet was **project-corpus-only**
(ofetch / kysely / zod); this pins the defect synthetically in ~1s using only
the `es5`/`es2015`/`dom` libs, so the architectural fix can be iterated on
without the corpus.

The witness is committed `#[ignore]`d (asserting the *correct* post-fix state,
no false `TS2322`); un-ignore it when the resolver-threading fix lands.

## Structural rule

When a generic async function expression is contextually typed by an interface
member whose return type embeds a still-generic conditional alias
(`MappedResponseType<R, T> = R extends keyof ResponseMap ? ResponseMap[R] : T`),
`tsc` keeps the conditional deferred while `R`/`T` are free, so the
flow-narrowed `context.response` (source) and the contextual return element
(target) are the **same** deferred type and relate by identity.

tsz degrades the source: the flow-narrowed read evaluates the conditional
operands — `keyof ResponseMap` → the key-literal union and the true branch
`ResponseMap[R]` → the value-type union — through a relation-internal evaluator
whose resolver cannot expand the cross-file `Lazy(def)`
(`resolver_generation() == 0`), while the target keeps the deferred alias. The
two structurally-identical `FetchResponse<MappedResponseType<R, T>>` types then
fail to relate, producing the canonical false self-assignment:

```
TS2322: Type 'FetchResponse<MappedResponseType<R, T>>' is not assignable to
        type 'FetchResponse<MappedResponseType<R, T>>'.
```

Owner layer: **solver relation-internal evaluation** (the resolver-less
`SubtypeChecker`/`TypeEvaluator` built during the diagnostic relation),
surfaced through the checker's `prepare_assignability_inputs` →
`evaluate_type_for_assignability` return-statement path.

## Why a witness, not the fix

The durable fix is the #13232 resolver-threading work (thread the checker's
def-resolving resolver into the relation-internal evaluator so the cross-file
`keyof`/alias expands, or refuse to serve `resolver_generation() == 0` results
so a resolved pass recomputes them). That is high-blast-radius and must be
validated against the full conformance/canary suite; this PR de-risks it by
turning a corpus-only repro into a 1s synthetic one. Root-cause detail and
ablations are recorded on #13232.

Adjacent matrix captured in the witness comment: both returns + flow narrowing
are required (a single direct return passes — the issue's "both returns needed"
note); the defect persists with the indexed-access true branch replaced by a
fixed type (so it is the conditional, not the indexed access) and with `R`
constrained exactly to `keyof ResponseMap` (so it is not the lossy-distribution
constraint-shape gate).

## Verification

- `cargo test -p tsz-cli --lib program_mode_generic_conditional_in_contextual_return_stays_deferred` — skipped by default (`#[ignore]`), CI stays green.
- `cargo test -p tsz-cli --lib program_mode_generic_conditional_in_contextual_return_stays_deferred -- --ignored` — reproduces the false `TS2322` deterministically.
- No CI job runs `--include-ignored`; the witness is inert for ready-review CI.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

https://claude.ai/code/session_01U8gHvvVX37PBquaNVnerBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8gHvvVX37PBquaNVnerBE)_