### PR TITLE
fix(ci): bound dist-binaries cache-save memory to unblock workspace-rlib refresh (#13733)

### DIFF
--- a/scripts/ci/gcp-cache.sh
+++ b/scripts/ci/gcp-cache.sh
@@ -201,22 +201,68 @@ tmp_archive() {
   printf '/tmp/tsz-cache-%s-%s.tar.gz\n' "$label" "$$"
 }
 
+# Emit a tar.gz byte stream of <base>/<path...> on stdout.
+#
+# Shared producer for both the staged-file (create_archive) and the
+# stream-to-GCS (stream_archive_to_uri) save paths. Keeping a single
+# producer guarantees both paths pack BYTE-IDENTICAL blobs — same `tar`
+# selection/flags, same `gzip -n` (no timestamp/name header) at the same
+# level — so switching staging strategy never changes blob contents or the
+# downstream cache hit.
+#
+# Cut the in-process compression peak at tar time. The default tar `-z`
+# uses gzip level 6, whose deflate path keeps large hash chains/window
+# buffers; gzip levels 1-3 use the lighter `deflate_fast` algorithm with
+# smaller tables and far less CPU. Since the save-path tar runs at
+# post-build memory peak (#13733/#13748), pipe tar -> gzip with an explicit,
+# tunable level so the compressor never inflates RSS at the worst moment.
+# TSZ_CI_CACHE_GZIP_LEVEL tunes the size/speed tradeoff (default 1; raise it
+# to trade CPU/RSS for a smaller blob). Note: this only lowers the
+# compression level — it does NOT switch codecs (zstd is tracked separately
+# in #13605 item 4).
+emit_archive_stream() {
+  local base="$1"
+  shift
+  local level="${TSZ_CI_CACHE_GZIP_LEVEL:-1}"
+  COPYFILE_DISABLE=1 tar --exclude='._*' -cf - -C "$base" "$@" \
+    | gzip -n -"${level}"
+}
+
 create_archive() {
   local archive="$1" base="$2"
   shift 2
-  # Cut the in-process compression peak at tar time. The default tar `-z`
-  # uses gzip level 6, whose deflate path keeps large hash chains/window
-  # buffers; gzip levels 1-3 use the lighter `deflate_fast` algorithm with
-  # smaller tables and far less CPU. Since the save-path tar runs at
-  # post-build memory peak (#13733/#13748), pipe tar -> gzip with an explicit,
-  # tunable level so the compressor never inflates RSS at the worst moment.
-  # TSZ_CI_CACHE_GZIP_LEVEL tunes the size/speed tradeoff (default 1; raise it
-  # to trade CPU/RSS for a smaller blob). Note: this only lowers the
-  # compression level — it does NOT switch codecs (zstd is tracked separately
-  # in #13605 item 4).
-  local level="${TSZ_CI_CACHE_GZIP_LEVEL:-1}"
-  COPYFILE_DISABLE=1 tar --exclude='._*' -cf - -C "$base" "$@" \
-    | gzip -n -"${level}" > "$archive"
+  emit_archive_stream "$base" "$@" > "$archive"
+}
+
+# Stream tar -> gzip -> gsutil cp - DIRECTLY to GCS, never staging the full
+# blob on the local filesystem (#13733/#13748).
+#
+# Why this is the real OOM lever: dist-binaries runs on Cloud Run, whose
+# `/tmp` (and the rest of the writable tree) is a RAM-backed tmpfs that
+# counts against the container memory limit. The previous save_archive
+# staged a multi-GB `.target/dist-fast` tar.gz under /tmp via create_archive
+# and only then ran `gsutil cp <file>`, so the whole compressed blob became
+# resident at the post-build memory peak — exactly when MemAvailable is
+# lowest — and the kernel OOM-killer SIGKILL'd the container (exit 137),
+# wedging the merge queue. Streaming the producer straight into
+# `gsutil cp -` keeps only the pipe buffers (a few MiB) resident regardless
+# of blob size, which is what lets the bounded #13747 workspace-rlib refresh
+# run on every green main build without re-triggering the OOM.
+#
+# Correctness: byte-identical to the staged path (same emit_archive_stream
+# producer, same destination URI/key). `gsutil cp -` performs a single
+# resumable streaming upload whose object only becomes visible after the
+# stream completes, so a mid-pipe failure (caught by `pipefail`) leaves no
+# partial object — same atomicity the staged path had via a complete temp
+# file. Upload size logging becomes a best-effort post-upload `gsutil du`
+# (diagnostic only; never gates the save).
+stream_archive_to_uri() {
+  local uri="$1" base="$2"
+  shift 2
+  if emit_archive_stream "$base" "$@" | gsutil -q cp - "$uri"; then
+    return 0
+  fi
+  return 1
 }
 
 validate_typescript_cache_tree() {
@@ -390,22 +436,21 @@ save_archive() {
     return 0
   fi
 
-  local archive
-  archive="$(tmp_archive "$label")"
+  # Stream pack+upload directly to GCS — never stage the blob on the local
+  # (Cloud Run tmpfs / RAM-backed) filesystem, which is the residual OOM hog
+  # at post-build memory peak (#13733/#13748). See stream_archive_to_uri.
   local t0=$SECONDS
-  create_archive "$archive" "$base" "${existing[@]}"
-  local pack_secs=$((SECONDS - t0))
-  local size_h
-  size_h="$(du -h "$archive" 2>/dev/null | awk '{print $1}')"
-
-  local t1=$SECONDS
-  if gsutil -q cp "$archive" "$uri"; then
-    local upload_secs=$((SECONDS - t1))
-    echo "Cache saved: ${label} (size=${size_h:-?}, pack=${pack_secs}s, upload=${upload_secs}s)"
+  if stream_archive_to_uri "$uri" "$base" "${existing[@]}"; then
+    local total_secs=$((SECONDS - t0))
+    # Best-effort, post-upload size for diagnostics only. `gsutil du` reads
+    # the object's stored size from GCS metadata (no local re-read), so it
+    # adds no memory pressure to the save path.
+    local size_h
+    size_h="$(gsutil du -h "$uri" 2>/dev/null | awk '{print $1 $2}')"
+    echo "Cache saved: ${label} (size=${size_h:-?}, pack+upload=${total_secs}s, streamed)"
   else
-    echo "warning: failed to upload cache ${label}" >&2
+    echo "warning: failed to pack/upload cache ${label}" >&2
   fi
-  rm -f "$archive"
 }
 
 suite_needs_rust_compile() {


### PR DESCRIPTION
## Summary
The dist-binaries cache-save staged a multi-GB `.target/dist-fast` tar.gz to a
local temp file (`tmp_archive` under `/tmp`) via `create_archive`, then ran
`gsutil cp <file> gs://...`. dist-binaries runs on Cloud Run, whose `/tmp` (and
writable tree) is a RAM-backed tmpfs counting against the container memory
limit, so the entire compressed blob became resident at the post-build memory
peak — exactly when MemAvailable is lowest — and the kernel OOM-killer
SIGKILL'd the container (exit 137), wedging the merge queue (#13733). This is
the residual OOM that keeps the bounded #13747 workspace-rlib refresh
(`TSZ_CI_REFRESH_WORKSPACE_RLIBS`) default-off.

## Root cause (file:line)
- `scripts/ci/gcp-cache.sh` `save_archive`: `create_archive "$archive" ...` wrote
  the full blob to `tmp_archive()` (`/tmp/tsz-cache-*.tar.gz`) before
  `gsutil cp "$archive" "$uri"`. The pre-existing peak-cutting (gzip -1 stream,
  #13748) reduced the compressor's working set but NOT the staged blob residency
  on tmpfs.

## Fix
- Add `emit_archive_stream` (shared producer) and `stream_archive_to_uri`, and
  switch `save_archive` to pipe `tar -> gzip -> gsutil cp -` directly to GCS.
  Only pipe buffers (a few MiB) stay resident regardless of blob size, so the
  cache-save no longer inflates RSS by the full blob at the memory peak. This is
  what lets the bounded #13747 refresh run on every green main build safely.
- `create_archive` is refactored onto the same producer (used only by the
  TypeScript source repopulate path, which runs at cache-warm time, not the
  post-build peak), so blob bytes there are unchanged too.

## Bounded / behavior-preserving
- Default-off repo variable behavior is unchanged — `TSZ_CI_REFRESH_WORKSPACE_RLIBS`
  still defaults to `0`; this PR only makes the SAVE not OOM so the variable CAN
  later be flipped.
- Byte-identical blob: both paths use the single `emit_archive_stream` producer
  (same `tar` selection/flags, same `gzip -n -level`), and the same destination
  URI/cache key. Verified locally that the staged vs streamed producer emit
  byte-identical archives.
- Atomicity preserved: `gsutil cp -` performs a single resumable streaming
  upload whose object only becomes visible after the stream completes, and
  `pipefail` catches a mid-pipe failure, so a failed save leaves no partial
  object (same atomicity the staged temp file gave).
- The MemAvailable preflight (`ci_cache_save_memory_ok`, #13748) stays as
  defense-in-depth.

Goal: hold

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- bash -n on edited scripts
- The memory reduction removes the multi-GB tmpfs-resident staged blob by
  streaming tar->gzip->gsutil cp - instead of staging to /tmp then uploading;
  the blob contents and cache key are preserved because both paths share one
  `emit_archive_stream` producer (same tar flags + gzip -n -level) and the same
  destination URI, verified byte-identical locally.

Refs #13733 #13747 #13748
