### PR TITLE
hold(bench): resolve library-canary deps to cut false TS2307 noise

### DIFF
--- a/scripts/bench/lib/project-fixture-stubs.sh
+++ b/scripts/bench/lib/project-fixture-stubs.sh
@@ -1163,3 +1163,23 @@ interface ErrorConstructor {
 }
 TYPES
 }
+
+tsz_write_io_ts_external_stubs() {
+  # io-ts's `src/` imports the `fp-ts` peer dependency through deep `/lib/*`
+  # subpaths (`fp-ts/lib/Either`, `fp-ts/lib/HKT`, `fp-ts/lib/function`, …). The
+  # fixture clone runs no npm install and the bench baseline pins `"types": []`,
+  # so without a stub tsc emits a wall of spurious TS2307 "Cannot find module
+  # 'fp-ts/lib/…'", each of which degrades the imported symbol to `error` and
+  # seeds a downstream TS2304/TS2315 cascade through io-ts's HKT-parameterized
+  # codec definitions. Mirror the drizzle-orm `*` convention: a single
+  # `export = any` module plus a `paths` entry that maps every `fp-ts/lib/*`
+  # specifier onto it, so fp-ts-typed positions resolve to `any` exactly as a
+  # bare-`any` install would, while io-ts's own `./` source stays real-checked.
+  local output="$1"
+  local fixture_dir
+  fixture_dir="$(dirname "$output")"
+  cat > "$fixture_dir/tsz-bench-external-module.d.ts" <<'TYPES'
+declare const tszBenchExternalModule: any;
+export = tszBenchExternalModule;
+TYPES
+}

--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -759,6 +759,8 @@ ${extra_compiler_options}    "resolveJsonModule": true
   "exclude": [
     "**/*.test.ts",
     "**/*.test.tsx",
+    "**/*.test-d.ts",
+    "**/*.test-d.tsx",
     "**/*.spec.ts",
     "**/*.spec.tsx",
     "**/__tests__/**",
@@ -876,7 +878,17 @@ tsz_write_fp_ts_config() {
   tsz_write_basic_external_project_config "$1" "src"
 }
 tsz_write_io_ts_config() {
-  tsz_write_basic_external_project_config "$1" "src"
+  # io-ts imports the `fp-ts` peer dependency via deep `/lib/*` subpaths that the
+  # clone-only fixture (no npm install) cannot resolve; map them onto a single
+  # `any` external-module stub so fp-ts-typed positions resolve like a bare-`any`
+  # install would, matching what tsc sees instead of a spurious TS2307 wall.
+  tsz_write_io_ts_external_stubs "$1"
+  tsz_write_basic_external_project_config "$1" "src" \
+    '    "baseUrl": ".",
+    "paths": {
+      "fp-ts/lib/*": ["tsz-bench-external-module.d.ts"]
+    },
+'
 }
 tsz_write_immer_config() {
   # immer imports sibling modules with explicit `.ts` extensions; its real


### PR DESCRIPTION
Goal: hold

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Summary

Harness-quality fix for the library-canary portion of #13826. The clone-only
library canary fixtures install no dependencies and the canary run's tsc oracle
does not execute (`oracle_classification: unknown`), so imports of a library's
own external/test-only deps surface as raw TS2307 + cascade that inflate the
recorded diagnostic-mismatch count. Two minimal, convention-matching changes:

- **remeda** — exclude `**/*.test-d.ts` (and `.tsx`) from the shared basic
  external config. These are vitest type-test files (`import { expectTypeOf }
  from "vitest"`, `type-fest`) — not shippable source. remeda's own `src/*.ts`
  has zero external imports, so narrowing to real source removes the entire
  TS2307(`vitest`/`type-fest`) wave. Generalizes safely to any basic-config row
  using the `.test-d.ts` convention.
- **io-ts** — map the `fp-ts/lib/*` peer-dependency subpaths onto the existing
  `tsz-bench-external-module.d.ts` `export = any` stub via `paths`, mirroring
  the drizzle-orm / ofetch / trpc stub convention. io-ts's own `./` source binds
  on the filesystem; fp-ts-typed positions resolve to `any` exactly as a bare
  install would, dropping the `fp-ts/lib/*` TS2307 wall and its TS2304/TS2315
  cascade.

**msw and tanstack-router are intentionally NOT touched.** Their TS2307 mixes
harness-absent deps with the genuine tsz resolver bugs #13826 tracks
(`node:` builtins, package `exports`/subpath, monorepo self-imports like
`@tanstack/history` / `@tanstack/router-core/isServer` / msw `#core/*`).
Stubbing them in the harness would mask the resolver bugs that issue exists to
fix, so they stay as real signal for the `module_resolver` work.

## Verification
- Row-sync enforcers green: `node scripts/bench/test-project-rows.mjs`,
  `node scripts/bench/test-validate-project-metadata.mjs`,
  `python3 scripts/arch/arch_guard_project.py`,
  `node scripts/bench/project-row-summary.mjs` (60 rows consistent),
  `node scripts/ci/test-project-tsc-oracle.mjs`,
  `node scripts/bench/test-fixture-provenance.mjs`,
  `node scripts/ci/test-project-compile-guard-fingerprint.mjs`.
  `bash -n` + `shellcheck -S error` clean on both edited shell files; generated
  io-ts `tsconfig.tsz-guard.json` validated as parseable JSON.
- Rows changed and before/after on false TS2307:
  - **remeda**: before — `.test-d.ts` files emit TS2307 `Cannot find module
    'vitest'` / `'type-fest'` across the type-test suite; after — those files
    are excluded, leaving only remeda's real source (no external imports), so
    the false TS2307 wave drops to 0.
  - **io-ts**: before — ~20 distinct `fp-ts/lib/*` imports each emit TS2307
    plus downstream TS2304/TS2315; after — all `fp-ts/lib/*` resolve to the
    `any` stub, dropping the TS2307 wall and its cascade.
