### PR TITLE
fix(ci): stop bench-gate deferring to wedged active runs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,6 +36,13 @@ env:
   BENCH_REQUIRE_PGO: "1"
   HYPERFINE_VER: "1.18.0"
   BENCH_MAX_TARGET_AGE_HOURS: "48"
+  # A healthy Bench run whose slowest shard times out at 105m can legitimately
+  # stay in_progress for ~2h, so bench-catch-up-after-active already treats a
+  # still-active run as stale after 180m. Mirror that bound in the gate: past
+  # this age an "active" run is presumed wedged (e.g. an orphaned Cloud Build
+  # left running after its GH run was cancelled), so we stop deferring fresh
+  # runs to it instead of freezing published benchmark data indefinitely.
+  BENCH_STALE_ACTIVE_RUN_MINUTES: "180"
   BENCH_CATCH_UP_MIN_INTERVAL_HOURS: "4"
   GITHUB_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
   BENCH_TARGET_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
@@ -135,11 +142,11 @@ jobs:
             list_other_active_runs() {
               {
                 gh run list --repo "${{ github.repository }}" --workflow bench.yml --branch main --status in_progress --limit 20 \
-                  --json databaseId,headSha,url \
-                  --jq '.[] | select(.databaseId != ${{ github.run_id }}) | [.databaseId, .headSha, .url] | @tsv'
+                  --json databaseId,headSha,url,createdAt \
+                  --jq '.[] | select(.databaseId != ${{ github.run_id }}) | [.databaseId, .headSha, .url, .createdAt] | @tsv'
                 gh run list --repo "${{ github.repository }}" --workflow bench.yml --branch main --status queued --limit 20 \
-                  --json databaseId,headSha,url \
-                  --jq '.[] | select(.databaseId != ${{ github.run_id }}) | [.databaseId, .headSha, .url] | @tsv'
+                  --json databaseId,headSha,url,createdAt \
+                  --jq '.[] | select(.databaseId != ${{ github.run_id }}) | [.databaseId, .headSha, .url, .createdAt] | @tsv'
               } | sort -u
             }
             if ! active_runs_raw="$(gh_retry list_other_active_runs)"; then
@@ -147,9 +154,21 @@ jobs:
               should_run=false
               active_runs_raw=""
             fi
+            stale_active_minutes="${BENCH_STALE_ACTIVE_RUN_MINUTES:-180}"
+            if ! [[ "$stale_active_minutes" =~ ^[0-9]+$ ]]; then
+              stale_active_minutes=180
+            fi
+            stale_active_seconds=$((stale_active_minutes * 60))
+            now_epoch="$(date -u +%s)"
             active_runs=""
-            while IFS=$'\t' read -r run_id run_sha run_url; do
+            while IFS=$'\t' read -r run_id run_sha run_url run_created; do
               [[ -n "${run_id:-}" ]] || continue
+              run_created_epoch="$(date -u -d "${run_created}" +%s 2>/dev/null || true)"
+              if [[ "$run_created_epoch" =~ ^[0-9]+$ &&
+                    $((now_epoch - run_created_epoch)) -ge "$stale_active_seconds" ]]; then
+                echo "Ignoring active Bench run ${run_id} (${run_url}); it started ${run_created} (>= ${stale_active_minutes}m ago) and is presumed wedged, so it will not block this run."
+                continue
+              fi
               active_runs+="${run_id}"$'\t'"${run_sha}"$'\t'"${run_url}"$'\n'
             done <<< "$active_runs_raw"
             if [[ -n "$active_runs" ]]; then


### PR DESCRIPTION
## Summary
The website's published benchmarks went ~11.8h stale (`2026-06-16T21:24:39Z`).
Root cause was not capacity (the `tsz-cloud-run` pool had 43/43 runners idle):
a Bench run for an older main SHA hung on its `solver-stress` and
`project-hotspots` Cloud Build shards (105m shard timeout each). Cancelling
the *GitHub* run does **not** cancel its fire-and-forget `gcloud builds submit`
Cloud Builds, so those shards kept running for over an hour.

`bench-gate` then deferred **every** fresh `workflow_run` bench to that wedged
run via the active-run check — with no age bound — so a single stuck run froze
published benchmark data indefinitely. `bench-catch-up-after-active` already
treats a still-active run as stale after `max_active_minutes=180`; the gate did
not mirror that bound, leaving the asymmetry that caused the freeze.

## Change
- Add `BENCH_STALE_ACTIVE_RUN_MINUTES` (default `180`, matching the existing
  catch-up staleness bound).
- `bench-gate`'s `list_other_active_runs` now also fetches `createdAt`; the
  deferral loop skips any active run older than the threshold, logging
  `Ignoring active Bench run … presumed wedged`. A healthy run (slowest shard
  ~105m) still defers normally; only a genuinely wedged run stops blocking.

This is plumbing only — no benchmark methodology, target selection, or
publish logic changes.

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/bench.yml'))"` → OK.
- Manual incident remediation (out of band): cancelled the wedged GH run +
  its three orphaned `6fb09a0a` Cloud Builds (`solver-stress`, `projects`,
  `large-ts-repo`), dispatched a fresh Bench run at current main
  (`db1782e0`, includes #13820 solver perf fix) which passed `bench-gate`
  with `should_run=true` and is measuring.
- Merge-queue `merge_group` runs the full Bench validation.

Goal: fast

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
