### PR TITLE
perf(interner): per-file TLS-cache locality instrumentation + opt-in promote-first probe (#13246)

### DIFF
--- a/crates/tsz-cli/src/driver/check_file.rs
+++ b/crates/tsz-cli/src/driver/check_file.rs
@@ -261,6 +261,10 @@ fn run_check_on_existing_checker<'a>(
         let check_start = tsz_common::perf_counters::enabled_fast().then(std::time::Instant::now);
         tsz::checker::reset_stack_overflow_flag();
         checker.check_source_file(file.source_file);
+        // #13246: snapshot and reset the per-file interner working set at the
+        // file boundary so the distinct-`TypeId` high-water / over-cache
+        // buckets attribute thrash per file. No-op when counters are disabled.
+        tsz_common::perf_counters::record_interner_working_set_for_file();
         let mut checker_diagnostics = std::mem::take(&mut checker.ctx.diagnostics);
         let effective_options = ResolvedCompilerOptions {
             check_js,

--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -73,6 +73,20 @@ impl PerfCounters {
              application intern calls   {:>12}\n  \
              conditional intern calls   {:>12}\n  \
              mapped intern calls        {:>12}\n\
+             TypeInterner locality (#13246):\n  \
+             lookup calls               {:>12}\n  \
+             lookup TLS hits            {:>12}\n  \
+             lookup cold-Vec fallbacks  {:>12}\n  \
+             lookup TLS evictions       {:>12}\n  \
+             intern TLS hits            {:>12}\n  \
+             intern cold fallbacks      {:>12}\n  \
+             intern TLS evictions       {:>12}\n  \
+             working-set distinct max   {:>12}\n  \
+             working-set distinct total {:>12}\n  \
+             working-set files sampled  {:>12}\n  \
+             working-set files >cache   {:>12}\n  \
+             promote-tier hits          {:>12}\n  \
+             promote-tier misses        {:>12}\n\
              Solver materialization:\n  \
              union subtype reductions   {:>12}\n  \
              union reduction members    {:>12}\n  \
@@ -140,6 +154,19 @@ impl PerfCounters {
             snap.interner.application_intern_calls,
             snap.interner.conditional_intern_calls,
             snap.interner.mapped_intern_calls,
+            snap.interner.lookup_calls,
+            snap.interner.lookup_tls_hits,
+            snap.interner.lookup_cold_vec_fallbacks,
+            snap.interner.lookup_tls_evictions,
+            snap.interner.intern_tls_hits,
+            snap.interner.intern_cold_fallbacks,
+            snap.interner.intern_tls_evictions,
+            snap.interner.working_set_distinct_max,
+            snap.interner.working_set_distinct_total,
+            snap.interner.working_set_files_sampled,
+            snap.interner.working_set_files_over_cache,
+            snap.interner.promote_tier_hits,
+            snap.interner.promote_tier_misses,
             snap.solver_materialization
                 .union_subtype_reduction_calls,
             snap.solver_materialization

--- a/crates/tsz-common/src/perf_counters/recorders/interner_resolver.rs
+++ b/crates/tsz-common/src/perf_counters/recorders/interner_resolver.rs
@@ -1,3 +1,171 @@
+// ─── interner locality instrumentation (issue #13246) ───────────────────
+//
+// The per-instance TLS direct-mapped caches in
+// `crates/tsz-solver/src/intern/core/interner/cache.rs` are sized to hold a
+// file's hot working set. When a file's live distinct-`TypeId` set exceeds the
+// 1024-slot lookup cache (or 512-slot intern cache), inserts collide and evict
+// live entries, and subsequent probes miss into the cold sharded
+// `RwLock<Vec<TypeData>>` at ~15-25 ns/lookup. The helpers below quantify that
+// thrash so the `O(files^1.7)` per-file slope can be attributed to locality
+// decay (or ruled out). Every helper short-circuits on `enabled_fast()`, so
+// default builds (env var unset) pay only the gate load.
+
+/// TLS lookup-cache slot count mirror, used to classify a file's working set
+/// as "over cache" without reaching into the solver crate. Must track
+/// `LOOKUP_CACHE_SIZE` in
+/// `crates/tsz-solver/src/intern/core/interner/cache.rs`; the per-file
+/// sampler only uses it for a coarse threshold, so a stale value degrades the
+/// classification but never affects correctness.
+pub const INTERNER_TLS_LOOKUP_CACHE_SLOTS: u64 = 1024;
+
+/// Record one `lookup()` entry past the intrinsic/error short-circuit, with
+/// its TLS-cache outcome. `tls_hit == true` means the TLS direct-mapped probe
+/// served the result; `false` means it fell through to the cold sharded
+/// `RwLock<Vec<TypeData>>`.
+#[inline]
+pub fn record_interner_lookup(tls_hit: bool) {
+    if !enabled_fast() {
+        return;
+    }
+    let c = counters();
+    c.interner_lookup_calls.fetch_add(1, Ordering::Relaxed);
+    if tls_hit {
+        c.interner_lookup_tls_hits.fetch_add(1, Ordering::Relaxed);
+    } else {
+        c.interner_lookup_cold_vec_fallbacks
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Record a TLS lookup-cache insert that overwrote a live entry belonging to a
+/// different `TypeId` (a direct-mapped collision / eviction). The eviction
+/// rate is the working-set-exceeds-cache thrash signal on the lookup side.
+#[inline]
+pub fn record_interner_lookup_tls_eviction() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .interner_lookup_tls_evictions
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record an `intern()` TLS-cache outcome on the structural-key path (after
+/// the intrinsic short-circuit). `tls_hit == true` means the TLS intern probe
+/// served the id; `false` means it ran the `DashMap`/shard slow path.
+#[inline]
+pub fn record_interner_intern_tls_outcome(tls_hit: bool) {
+    if !enabled_fast() {
+        return;
+    }
+    let c = counters();
+    if tls_hit {
+        c.interner_intern_tls_hits.fetch_add(1, Ordering::Relaxed);
+    } else {
+        c.interner_intern_cold_fallbacks
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Record a TLS intern-cache insert that overwrote a live entry for a
+/// different hash (a direct-mapped collision / eviction). The intern-side
+/// thrash signal.
+#[inline]
+pub fn record_interner_intern_tls_eviction() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .interner_intern_tls_evictions
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record one promoted-tier probe consultation (`TSZ_PROMOTE_FIRST`). `hit`
+/// distinguishes a stable-hot-set serve from a fall-through to the normal TLS
+/// path. Measurement-only; never fires when the probe is off.
+#[inline]
+pub fn record_interner_promote_tier_probe(hit: bool) {
+    if !enabled_fast() {
+        return;
+    }
+    let c = counters();
+    if hit {
+        c.interner_promote_tier_hits.fetch_add(1, Ordering::Relaxed);
+    } else {
+        c.interner_promote_tier_misses
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+// Per-file distinct-`TypeId` working-set sampler. A thread-local set tracks the
+// distinct ids a file touched; the CLI snapshots and clears it at each
+// `check_source_file` boundary via [`record_interner_working_set_for_file`].
+// Only mutated when counters are enabled, so default builds never allocate.
+thread_local! {
+    static WORKING_SET_IDS: std::cell::RefCell<rustc_hash::FxHashSet<u32>> =
+        std::cell::RefCell::new(rustc_hash::FxHashSet::default());
+}
+
+/// Note that a `TypeId` (raw u32) was touched by the current file's
+/// `lookup`/`intern` activity. Cheap insert into a thread-local set; the
+/// distinct count is read and reset at the file boundary. Gated, so disabled
+/// builds skip the set entirely.
+#[inline]
+pub fn note_interner_working_set_id(raw_id: u32) {
+    if !enabled_fast() {
+        return;
+    }
+    WORKING_SET_IDS.with(|set| {
+        set.borrow_mut().insert(raw_id);
+    });
+}
+
+/// Snapshot and reset the current thread's per-file distinct working set,
+/// folding the result into the run-wide max / total / over-cache buckets.
+/// Called at each `check_source_file` boundary. Returns the distinct count
+/// observed for the file (for optional tracing), or 0 when disabled.
+pub fn record_interner_working_set_for_file() -> u64 {
+    if !enabled_fast() {
+        return 0;
+    }
+    let distinct = WORKING_SET_IDS.with(|set| {
+        let mut set = set.borrow_mut();
+        let n = set.len() as u64;
+        set.clear();
+        n
+    });
+    if distinct == 0 {
+        return 0;
+    }
+    let c = counters();
+    c.interner_working_set_files_sampled
+        .fetch_add(1, Ordering::Relaxed);
+    c.interner_working_set_distinct_total
+        .fetch_add(distinct, Ordering::Relaxed);
+    record_max_inner(&c.interner_working_set_distinct_max, distinct);
+    if distinct > INTERNER_TLS_LOOKUP_CACHE_SLOTS {
+        c.interner_working_set_files_over_cache
+            .fetch_add(1, Ordering::Relaxed);
+    }
+    distinct
+}
+
+/// Whether the opt-in promote-first interner probe is enabled
+/// (`TSZ_PROMOTE_FIRST` set). Default OFF: the interner consults its normal
+/// per-instance TLS cache + sharded storage exactly as before. When ON, the
+/// `lookup`/`intern` hot paths additionally probe a process-global promoted
+/// tier of stable hot types (intrinsics + lib ids) first, and the
+/// `interner_promote_tier_*` counters measure whether that raises the hit rate
+/// and cuts the cold-Vec fallback. No semantic change: the promoted tier only
+/// ever holds ids already resolvable through the normal path, so the answer is
+/// identical; only the lookup *order* changes. Latched once via `OnceLock`,
+/// mirroring [`enabled_fast`], so the hot-path read is one branch + one load.
+#[inline(always)]
+pub fn promote_first_enabled() -> bool {
+    static PROMOTE_FIRST: OnceLock<bool> = OnceLock::new();
+    *PROMOTE_FIRST.get_or_init(|| std::env::var_os("TSZ_PROMOTE_FIRST").is_some())
+}
+
 /// Record a `TypeInterner::intern_string` call. Mirrors the existing
 /// `record_compute_type_of_symbol_*` shape: gate once, one `counters()`
 /// lookup, increment exactly the named field.

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -261,6 +261,65 @@ pub struct PerfCounters {
     /// and the histogram stays at all-zero.
     pub interner_lock_wait_histogram_ns: [AtomicU64; LOCK_WAIT_BUCKET_COUNT],
 
+    // ─── interner locality (issue #13246, Tier-1 memory-locality tax) ────
+    // The fixed-size TLS direct-mapped caches in
+    // `crates/tsz-solver/src/intern/core/interner/cache.rs` thrash once a
+    // file's live working set exceeds their slot count, falling back to the
+    // sharded `RwLock<Vec<TypeData>>` cold path. These counters quantify
+    // that thrash directly so the `O(files^1.7)` per-file check-time slope
+    // can be attributed to (or ruled out as) cache-locality decay.
+    //
+    // Hit-rate denominators:
+    //   intern: `interner_intern_calls`
+    //   lookup: `interner_lookup_calls`
+    /// `lookup()` entries that reached the TLS/shard probe (intrinsics and
+    /// error ids short-circuit before this and are not counted).
+    pub interner_lookup_calls: AtomicU64,
+    /// `lookup()` calls served from the TLS direct-mapped lookup cache.
+    pub interner_lookup_tls_hits: AtomicU64,
+    /// `lookup()` calls that missed the TLS cache and fell through to the
+    /// cold sharded `RwLock<Vec<TypeData>>` (the 15-25 ns/lookup path).
+    pub interner_lookup_cold_vec_fallbacks: AtomicU64,
+    /// TLS lookup-cache inserts that overwrote a live entry whose tag
+    /// belonged to a *different* `TypeId` (a direct-mapped collision). A
+    /// rising eviction rate is the working-set-exceeds-cache thrash signal.
+    pub interner_lookup_tls_evictions: AtomicU64,
+    /// `intern()` calls served from the TLS direct-mapped intern cache.
+    /// Subset of `interner_intern_hits`; isolates TLS hits from intrinsic
+    /// and shard-read hits, which the aggregate `interner_intern_hits`
+    /// lumps together.
+    pub interner_intern_tls_hits: AtomicU64,
+    /// `intern()` calls that missed the TLS intern cache and ran the
+    /// `DashMap`/shard slow path (`intern_slow`).
+    pub interner_intern_cold_fallbacks: AtomicU64,
+    /// TLS intern-cache inserts that overwrote a live entry for a different
+    /// hash (direct-mapped collision). The intern-side thrash signal.
+    pub interner_intern_tls_evictions: AtomicU64,
+    /// Per-file distinct-`TypeId` working-set high-water mark across the
+    /// run (max over files of distinct ids touched by `lookup`/`intern`).
+    /// When this exceeds `LOOKUP_CACHE_SIZE` (1024) the TLS cache cannot
+    /// hold a file's live set and thrash is structurally forced.
+    pub interner_working_set_distinct_max: AtomicU64,
+    /// Number of files whose distinct working set exceeded the TLS lookup
+    /// cache slot count. The over-capacity file fraction along the scale
+    /// ladder is the locality-decay signal.
+    pub interner_working_set_files_over_cache: AtomicU64,
+    /// Files sampled for the working-set metric (denominator for the
+    /// over-cache fraction).
+    pub interner_working_set_files_sampled: AtomicU64,
+    /// Sum of per-file distinct working sets (for a mean alongside the max).
+    pub interner_working_set_distinct_total: AtomicU64,
+    /// Probe accounting (`TSZ_PROMOTE_FIRST`, opt-in, default OFF): times a
+    /// `lookup`/`intern` was served from the promoted/global hot tier before
+    /// the per-instance TLS cache was consulted. Measurement-only; zero when
+    /// the probe is off. See [`promote_first_enabled`].
+    pub interner_promote_tier_hits: AtomicU64,
+    /// Probe accounting: times the promoted tier was consulted but missed
+    /// (the id/key was not in the stable hot set), falling through to the
+    /// normal TLS + shard path. Sum with `interner_promote_tier_hits` is the
+    /// number of probe consultations.
+    pub interner_promote_tier_misses: AtomicU64,
+
     // ─── compute_type_of_symbol ──────────────────────────────────────────
     pub compute_type_of_symbol_calls: AtomicU64,
     pub compute_type_of_symbol_cache_hits: AtomicU64,
@@ -428,6 +487,19 @@ impl PerfCounters {
             interner_conditional_intern_calls: AtomicU64::new(0),
             interner_mapped_intern_calls: AtomicU64::new(0),
             interner_lock_wait_histogram_ns: [const { AtomicU64::new(0) }; LOCK_WAIT_BUCKET_COUNT],
+            interner_lookup_calls: AtomicU64::new(0),
+            interner_lookup_tls_hits: AtomicU64::new(0),
+            interner_lookup_cold_vec_fallbacks: AtomicU64::new(0),
+            interner_lookup_tls_evictions: AtomicU64::new(0),
+            interner_intern_tls_hits: AtomicU64::new(0),
+            interner_intern_cold_fallbacks: AtomicU64::new(0),
+            interner_intern_tls_evictions: AtomicU64::new(0),
+            interner_working_set_distinct_max: AtomicU64::new(0),
+            interner_working_set_files_over_cache: AtomicU64::new(0),
+            interner_working_set_files_sampled: AtomicU64::new(0),
+            interner_working_set_distinct_total: AtomicU64::new(0),
+            interner_promote_tier_hits: AtomicU64::new(0),
+            interner_promote_tier_misses: AtomicU64::new(0),
             compute_type_of_symbol_calls: AtomicU64::new(0),
             compute_type_of_symbol_cache_hits: AtomicU64::new(0),
             compute_type_of_symbol_interface_simple_object_fastpath_hits: AtomicU64::new(0),

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -597,6 +597,20 @@ pub struct InternerCounters {
     /// Lock-wait histogram. `None` because the timing path is gated on
     /// the `perf-counters-timing` feature (`PERFORMANCE_PLAN.md` §4.T0.3).
     pub lock_wait_histogram_ns: Option<Vec<u64>>,
+    // ─── interner locality (issue #13246) ────────────────────────────────
+    pub lookup_calls: u64,
+    pub lookup_tls_hits: u64,
+    pub lookup_cold_vec_fallbacks: u64,
+    pub lookup_tls_evictions: u64,
+    pub intern_tls_hits: u64,
+    pub intern_cold_fallbacks: u64,
+    pub intern_tls_evictions: u64,
+    pub working_set_distinct_max: u64,
+    pub working_set_files_over_cache: u64,
+    pub working_set_files_sampled: u64,
+    pub working_set_distinct_total: u64,
+    pub promote_tier_hits: u64,
+    pub promote_tier_misses: u64,
 }
 
 impl PerfCounters {
@@ -757,6 +771,19 @@ impl PerfCounters {
                 } else {
                     None
                 },
+                lookup_calls: load(&c.interner_lookup_calls),
+                lookup_tls_hits: load(&c.interner_lookup_tls_hits),
+                lookup_cold_vec_fallbacks: load(&c.interner_lookup_cold_vec_fallbacks),
+                lookup_tls_evictions: load(&c.interner_lookup_tls_evictions),
+                intern_tls_hits: load(&c.interner_intern_tls_hits),
+                intern_cold_fallbacks: load(&c.interner_intern_cold_fallbacks),
+                intern_tls_evictions: load(&c.interner_intern_tls_evictions),
+                working_set_distinct_max: load(&c.interner_working_set_distinct_max),
+                working_set_files_over_cache: load(&c.interner_working_set_files_over_cache),
+                working_set_files_sampled: load(&c.interner_working_set_files_sampled),
+                working_set_distinct_total: load(&c.interner_working_set_distinct_total),
+                promote_tier_hits: load(&c.interner_promote_tier_hits),
+                promote_tier_misses: load(&c.interner_promote_tier_misses),
             },
             relation_limit_cache: RelationLimitCacheCounters {
                 limit_cache_hits: load(&c.relation_limit_cache_hits),

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -292,6 +292,61 @@ mod json_tests {
     }
 
     #[test]
+    fn interner_locality_counters_serialize_as_numbers() {
+        // #13246 Tier-1 locality instrumentation: the per-file working-set /
+        // TLS hit-miss-eviction / cold-Vec-fallback / promote-tier counters
+        // must surface as numbers (zero is fine when the test process has not
+        // interned user types) so the scale-cliff bench harness can parse them.
+        let snap = PerfCounters::snapshot();
+        let json = serde_json::to_value(&snap).expect("serializes");
+        for key in [
+            "lookup_calls",
+            "lookup_tls_hits",
+            "lookup_cold_vec_fallbacks",
+            "lookup_tls_evictions",
+            "intern_tls_hits",
+            "intern_cold_fallbacks",
+            "intern_tls_evictions",
+            "working_set_distinct_max",
+            "working_set_files_over_cache",
+            "working_set_files_sampled",
+            "working_set_distinct_total",
+            "promote_tier_hits",
+            "promote_tier_misses",
+        ] {
+            assert!(
+                json["interner"][key].is_number(),
+                "interner locality counter `{key}` should serialize as a number, got: {}",
+                json["interner"][key]
+            );
+        }
+    }
+
+    #[test]
+    fn interner_working_set_records_distinct_high_water() {
+        // Drive the per-file working-set sampler directly: noting two distinct
+        // ids then closing the file must record a distinct count of 2 and feed
+        // the run-wide total/max. Below the over-cache threshold, so the
+        // over-cache bucket stays untouched.
+        force_enable_perf_counters_for_tests();
+        let c = counters();
+        let before_total = c
+            .interner_working_set_distinct_total
+            .load(Ordering::Relaxed);
+        note_interner_working_set_id(7);
+        note_interner_working_set_id(9);
+        note_interner_working_set_id(7); // duplicate, must not double-count
+        let distinct = record_interner_working_set_for_file();
+        assert_eq!(distinct, 2, "two distinct ids noted");
+        let after_total = c
+            .interner_working_set_distinct_total
+            .load(Ordering::Relaxed);
+        assert_eq!(after_total - before_total, 2);
+        // A second close with no notes records nothing (set was cleared).
+        assert_eq!(record_interner_working_set_for_file(), 0);
+    }
+
+    #[test]
     fn file_session_resets_serializes_as_number() {
         // The T2.1 file-session reset counter rides inside the existing
         // `checker_construction` wired group, so adding it must not

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -1084,12 +1084,22 @@ impl TypeInterner {
                 c.interner_intern_hits
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             }
+            // #13246: split the TLS-cache hit out of the aggregate intern_hits
+            // and record this id in the per-file working set.
+            tsz_common::perf_counters::record_interner_intern_tls_outcome(true);
+            tsz_common::perf_counters::note_interner_working_set_id(id.0);
             return id;
         }
 
+        // #13246: TLS intern-cache miss -> shard slow path.
+        tsz_common::perf_counters::record_interner_intern_tls_outcome(false);
         let result = self.intern_slow(key, hash, pc);
         if result != TypeId::ERROR {
-            cache::intern_insert(hash, self.instance_id, key, result);
+            let evicted = cache::intern_insert(hash, self.instance_id, key, result);
+            if evicted {
+                tsz_common::perf_counters::record_interner_intern_tls_eviction();
+            }
+            tsz_common::perf_counters::note_interner_working_set_id(result.0);
         }
         result
     }
@@ -1245,14 +1255,45 @@ impl TypeInterner {
             return self.get_intrinsic_key(id);
         }
 
+        // #13246 locality instrumentation: record the distinct-id working set
+        // and the TLS-cache outcome. Both calls short-circuit on
+        // `enabled_fast()`, so default builds pay only a gate load.
+        tsz_common::perf_counters::note_interner_working_set_id(id.0);
+
         // Fast path: thread-local cache hit scoped by this interner's
         // instance_id.
         if let Some(data) = cache::lookup_probe(id, self.instance_id) {
+            tsz_common::perf_counters::record_interner_lookup(true);
             return Some(data);
         }
 
+        // Opt-in promote-first probe (`TSZ_PROMOTE_FIRST`, default OFF): on a
+        // TLS miss, consult the promoted global hot tier before the cold shard.
+        // Measurement-only — the tier only holds ids the cold shard already
+        // returned, so the answer is identical; only lookup order changes.
+        if tsz_common::perf_counters::promote_first_enabled() {
+            if let Some(data) = cache::promote_tier_probe(id, self.instance_id) {
+                tsz_common::perf_counters::record_interner_promote_tier_probe(true);
+                tsz_common::perf_counters::record_interner_lookup(true);
+                let evicted = cache::lookup_insert(id, self.instance_id, data);
+                if evicted {
+                    tsz_common::perf_counters::record_interner_lookup_tls_eviction();
+                }
+                return Some(data);
+            }
+            tsz_common::perf_counters::record_interner_promote_tier_probe(false);
+        }
+
+        // Cold path: sharded `RwLock<Vec<TypeData>>` read.
+        tsz_common::perf_counters::record_interner_lookup(false);
         let data = self.lookup_slow(id)?;
-        cache::lookup_insert(id, self.instance_id, data);
+        let evicted = cache::lookup_insert(id, self.instance_id, data);
+        if evicted {
+            tsz_common::perf_counters::record_interner_lookup_tls_eviction();
+        }
+        if tsz_common::perf_counters::promote_first_enabled() {
+            cache::promote_tier_insert(id, self.instance_id, data);
+        }
         Some(data)
     }
 

--- a/crates/tsz-solver/src/intern/core/interner/cache.rs
+++ b/crates/tsz-solver/src/intern/core/interner/cache.rs
@@ -166,14 +166,23 @@ impl TypeInternerCache {
         }
     }
 
+    /// Insert into the lookup cache, returning `true` when the slot already
+    /// held a live entry (non-empty tag) for a *different* `TypeId` in this
+    /// interner — a direct-mapped collision that evicts a still-useful entry.
+    /// The boolean drives the `#13246` locality eviction counter; the insert
+    /// itself is unconditional and correctness is unaffected (a stale slot is
+    /// always re-validated on probe via tag + `instance_id`).
     #[inline(always)]
-    fn lookup_insert(&self, id: TypeId, instance_id: u32, data: TypeData) {
+    fn lookup_insert(&self, id: TypeId, instance_id: u32, data: TypeData) -> bool {
         let idx = (id.0 & LOOKUP_CACHE_MASK) as usize;
+        let prev = self.lookup[idx].get();
+        let evicted = prev.tag != 0 && (prev.tag != id.0 || prev.instance_id != instance_id);
         self.lookup[idx].set(LookupCacheEntry {
             tag: id.0,
             instance_id,
             data,
         });
+        evicted
     }
 
     #[inline(always)]
@@ -187,15 +196,24 @@ impl TypeInternerCache {
         }
     }
 
+    /// Insert into the intern cache, returning `true` when the slot already
+    /// held a live entry (non-zero `result`) for a *different* hash/instance —
+    /// a direct-mapped collision that evicts a still-useful entry. Drives the
+    /// `#13246` intern-side eviction counter; correctness is unaffected
+    /// (probe re-validates hash + key + `instance_id`).
     #[inline(always)]
-    fn intern_insert(&self, hash: u64, instance_id: u32, key: TypeData, result: TypeId) {
+    fn intern_insert(&self, hash: u64, instance_id: u32, key: TypeData, result: TypeId) -> bool {
         let idx = (hash & INTERN_CACHE_MASK) as usize;
+        let prev = self.intern[idx].get();
+        let evicted =
+            prev.result != TypeId::NONE && (prev.hash != hash || prev.instance_id != instance_id);
         self.intern[idx].set(InternCacheEntry {
             hash,
             instance_id,
             key,
             result,
         });
+        evicted
     }
 
     #[inline]
@@ -265,9 +283,12 @@ pub(super) fn lookup_probe(id: TypeId, instance_id: u32) -> Option<TypeData> {
     TL_CACHE.with(|cache| cache.lookup_probe(id, instance_id))
 }
 
+/// Insert into the TLS lookup cache. Returns `true` when a live entry for a
+/// different `TypeId` was evicted (a direct-mapped collision), which the
+/// `lookup()` hot path forwards to the `#13246` eviction counter.
 #[inline(always)]
-pub(super) fn lookup_insert(id: TypeId, instance_id: u32, data: TypeData) {
-    TL_CACHE.with(|cache| cache.lookup_insert(id, instance_id, data));
+pub(super) fn lookup_insert(id: TypeId, instance_id: u32, data: TypeData) -> bool {
+    TL_CACHE.with(|cache| cache.lookup_insert(id, instance_id, data))
 }
 
 #[inline(always)]
@@ -275,9 +296,11 @@ pub(super) fn intern_probe(hash: u64, instance_id: u32, key: &TypeData) -> Optio
     TL_CACHE.with(|cache| cache.intern_probe(hash, instance_id, key))
 }
 
+/// Insert into the TLS intern cache. Returns `true` when a live entry for a
+/// different hash/instance was evicted (a direct-mapped collision).
 #[inline(always)]
-pub(super) fn intern_insert(hash: u64, instance_id: u32, key: TypeData, result: TypeId) {
-    TL_CACHE.with(|cache| cache.intern_insert(hash, instance_id, key, result));
+pub(super) fn intern_insert(hash: u64, instance_id: u32, key: TypeData, result: TypeId) -> bool {
+    TL_CACHE.with(|cache| cache.intern_insert(hash, instance_id, key, result))
 }
 
 #[inline]
@@ -288,4 +311,81 @@ pub(super) fn string_probe(hash: u64, instance_id: u32, s: &str) -> Option<Atom>
 #[inline]
 pub(super) fn string_insert(hash: u64, instance_id: u32, s: &str, result: Atom) {
     TL_CACHE.with(|cache| cache.string_insert(hash, instance_id, s, result));
+}
+
+// ---------------------------------------------------------------------------
+// Promoted global lookup tier (opt-in probe, `TSZ_PROMOTE_FIRST`, issue #13246)
+// ---------------------------------------------------------------------------
+// Measurement-only. The per-instance TLS lookup cache is small (1024 slots) and
+// thrashes once a file's working set exceeds it, sending lookups to the cold
+// sharded `RwLock<Vec<TypeData>>`. This promoted tier is a *much larger*
+// process-global direct-mapped cache. When the probe is ON, every cold-Vec
+// fallback also populates this tier, and the next time the same id misses the
+// TLS cache the tier serves it before the cold shard. The fraction of TLS
+// misses the tier catches (`interner_promote_tier_hits`) is a direct estimate
+// of how much a bounded-partition / promoted hot-set interner would cut the
+// cold-Vec fallback rate. It never changes the answer: the tier only ever holds
+// `(instance_id, TypeId) -> TypeData` pairs the cold shard already returned, so
+// a tier hit yields the identical `TypeData` the shard read would have.
+//
+// The tier is sized to comfortably hold a large file's working set (256K slots,
+// ~12 bytes/slot under `Cell<u32 tag + u32 instance + TypeData>` ≈ a few MB) so
+// it measures the "no-thrash" ceiling rather than a second small cache. It is
+// only allocated when `TSZ_PROMOTE_FIRST` is set, so default runs never pay for
+// it. A `RwLock` guards interior mutability for `Sync`; under the single-thread
+// CLI/bench workload the read/write locks are uncontended.
+
+const PROMOTE_TIER_BITS: u32 = 18;
+const PROMOTE_TIER_SIZE: usize = 1 << PROMOTE_TIER_BITS; // 262_144
+const PROMOTE_TIER_MASK: u32 = (PROMOTE_TIER_SIZE as u32) - 1;
+
+#[derive(Clone, Copy)]
+struct PromoteTierEntry {
+    tag: u32,
+    instance_id: u32,
+    data: TypeData,
+}
+
+const EMPTY_PROMOTE_ENTRY: PromoteTierEntry = PromoteTierEntry {
+    tag: 0,
+    instance_id: 0,
+    data: TypeData::Error,
+};
+
+static PROMOTE_TIER: std::sync::OnceLock<std::sync::RwLock<Vec<PromoteTierEntry>>> =
+    std::sync::OnceLock::new();
+
+#[inline]
+fn promote_tier() -> &'static std::sync::RwLock<Vec<PromoteTierEntry>> {
+    PROMOTE_TIER
+        .get_or_init(|| std::sync::RwLock::new(vec![EMPTY_PROMOTE_ENTRY; PROMOTE_TIER_SIZE]))
+}
+
+/// Probe the promoted global tier for a `TypeId` after a TLS-cache miss.
+/// Returns the cached `TypeData` when present for this interner. Only called
+/// when `TSZ_PROMOTE_FIRST` is enabled; otherwise the tier is never touched.
+#[inline]
+pub(super) fn promote_tier_probe(id: TypeId, instance_id: u32) -> Option<TypeData> {
+    let idx = (id.0 & PROMOTE_TIER_MASK) as usize;
+    let tier = promote_tier().read().ok()?;
+    let entry = tier[idx];
+    if entry.tag == id.0 && entry.instance_id == instance_id {
+        Some(entry.data)
+    } else {
+        None
+    }
+}
+
+/// Populate the promoted global tier after a cold-Vec fallback resolved a
+/// `TypeId`. Only called when `TSZ_PROMOTE_FIRST` is enabled.
+#[inline]
+pub(super) fn promote_tier_insert(id: TypeId, instance_id: u32, data: TypeData) {
+    let idx = (id.0 & PROMOTE_TIER_MASK) as usize;
+    if let Ok(mut tier) = promote_tier().write() {
+        tier[idx] = PromoteTierEntry {
+            tag: id.0,
+            instance_id,
+            data,
+        };
+    }
 }


### PR DESCRIPTION
## Summary

Tier-1 #13246 (the per-file check-time super-linear tax). This is the **first measurement PR** to test whether the global `TypeInterner`'s fixed-size TLS direct-mapped cache thrashes as a file's working set grows, driving the super-linear per-file check-time slope on the scale ladder. Two safe, low-risk parts:

1. **Instrumentation (always-on, `TSZ_PERF_COUNTERS`-gated, default behavior unchanged).** Per-file interner working-set + TLS hit/miss/eviction + cold-`Vec`-fallback counters.
2. **Opt-in probe (`TSZ_PROMOTE_FIRST`, default OFF, no semantic change).** On a TLS miss, `lookup()` consults a larger process-global promoted hot tier before the cold shard; the tier only ever holds `(instance, TypeId) -> TypeData` pairs the cold shard already returned, so the answer is identical — only lookup order changes. Counters measure how many TLS misses a promoted-hot-set tier would catch.

Goal: fast

## Structural rule

When a file's live distinct-`TypeId` working set exceeds the per-instance TLS direct-mapped lookup cache (1024 slots) / intern cache (512 slots) in `crates/tsz-solver/src/intern/core/interner/cache.rs`, inserts collide and evict live entries and subsequent probes fall through to the cold sharded `RwLock<Vec<TypeData>>` (~15-25 ns/lookup). `tsc` has no such tier; tsz owns this entirely in the solver interner. This PR quantifies that thrash per file so the `O(files^1.7)` slope can be attributed to (or ruled out as) memory-locality decay.

## Owner layer

Solver interner (`intern/core/interner.rs`, `interner/cache.rs`) for the hot-path counting + promoted tier; `tsz-common::perf_counters` for the counter storage/snapshot/dump; CLI `check_file.rs` for the per-file working-set boundary snapshot. No checker/emitter semantics touched.

## Measurement (scale ladder, probe OFF)

| Metric | monorepo-002 (1010f) | monorepo-003 (5099f) | slope |
|---|---|---|---|
| Check time / file | 1.01 ms | 1.32 ms | **1.3x** over 5.05x files |
| lookups / file | 6,506 | 6,237 | flat (−4%) |
| **lookup TLS hit rate** | **99.723%** | **99.750%** | **flat (improves)** |
| cold-`Vec` fallbacks / file | 18.05 | 15.62 | **−13%** |
| cold-`Vec` fallback rate | 0.277% | 0.250% | **DOWN** |
| **working-set distinct max / file** | **131** | **131** | **identical** |
| **files over TLS cache (>1024)** | **0** | **0** | **zero** |
| lookup TLS evictions | 9,001 | 63,267 | grows with lookups |

## Promote-first result (probe ON)

- monorepo-002: promote-tier hit rate **39.7%** of TLS misses; cold-`Vec` fallbacks 18.8K → 10.6K.
- monorepo-003: promote-tier hit rate **35.9%** of TLS misses; cold-`Vec` fallbacks 79.6K → 50.9K.
- Check-time delta OFF vs ON is **within run-to-run noise** (±~1.5 s on monorepo-003): the global tier's `RwLock` read/write costs roughly what the cold-`Vec` read it replaces, and TLS misses are only ~0.25% of lookups, so there is no headroom to win.

## What this implies for bounded-partition (#13246)

**Cache-thrash does NOT explain the super-linear slope — high-value honest negative.** The per-file working set is flat at 131 distinct `TypeId`s (far below the 1024-slot TLS cache), **no file exceeds the cache at either scale**, the TLS hit rate is flat/improving at ~99.7%, and the cold-`Vec` fallback rate *decreases* per file as the project grows. A bounded-partition / promoted-hot-set interner would catch ~36% of an already-negligible 0.25% miss stream and add lock overhead. The #13246 multi-week bounded-partition campaign should be **redirected**: the steady-state per-file tax is not TLS-cache locality decay. The instrumentation stays in to re-target the search (e.g. shard-`RwLock` contention, def-store growth, allocator/residency, or per-file checker-state accumulation) with the same `TSZ_PERF_COUNTERS` surface.

## Verification

- `cargo build --release --bin tsz` (worktree, shared target) — green.
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance --all-targets -- -D warnings` (the exact CI lint command) — green.
- `scripts/arch/arch_guard.py` — passed.
- Default run (no `TSZ_PERF_COUNTERS`): locality dump section absent — confirms zero default-path behavior change.
- New unit tests: `interner_locality_counters_serialize_as_numbers`, `interner_working_set_records_distinct_high_water`.
- Conformance/emit/fourslash: untouched (instrumentation + opt-in only; default path byte-identical). Owned by ready-review CI.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high