### PR TITLE
fix(config): unresolved tsconfig `extends` emits TS6053 and continues instead of aborting

### DIFF
--- a/crates/tsz-core/src/config/extends.rs
+++ b/crates/tsz-core/src/config/extends.rs
@@ -21,66 +21,84 @@ use crate::module_resolver_helpers::{
 
 use super::{CompilerOptions, TsConfig};
 
-/// Resolve `extends` to an absolute path on disk.
+/// Resolve a tsconfig `extends` specifier to the config file it names on disk.
 ///
-/// Handles four cases in order:
-/// 1. relative or absolute paths (`./base.json`, `/abs/base.json`);
-/// 2. package specifiers whose `package.json` exports map points to a
-///    config file (`pkg/tsconfig.json` -> `node_modules/pkg/configs/...`);
-/// 3. package-name extends that walk `node_modules` upward;
-/// 4. a final fallback that treats the value as a relative path.
-pub(super) fn resolve_extends_path(current_path: &Path, extends: &str) -> Result<PathBuf> {
+/// Returns `Ok(Some(path))` for a successfully located, existing config file,
+/// `Ok(None)` when the specifier cannot be resolved to an existing file (the
+/// caller then reports TS6053 and continues, matching `tsc`'s
+/// `getExtendsConfigPath`), and `Err` only for a malformed `current_path`.
+///
+/// Resolution mirrors `tsc`:
+/// - **Relative / absolute** specifiers (`./base`, `../base.json`, `/abs`)
+///   resolve against the declaring config's directory, appending `.json` when
+///   the specifier carries no extension. No directory lookup is attempted (a
+///   relative `extends` must name a file, like `tsc`).
+/// - **Non-relative** specifiers go through Node module resolution: first the
+///   package's `package.json` `"exports"` map, then a `node_modules` walk that
+///   honors an explicit file subpath (`pkg/base.json`), an extensionless
+///   subpath (`pkg/recommended` -> `recommended.json`), and a bare package
+///   whose root holds a `tsconfig.json`.
+pub(super) fn resolve_extends_path(current_path: &Path, extends: &str) -> Result<Option<PathBuf>> {
     let base_dir = current_path
         .parent()
         .ok_or_else(|| anyhow!("tsconfig has no parent directory"))?;
 
-    // Check if this is a relative or absolute path
+    // Relative or absolute path: resolve against the declaring config's dir.
     if extends.starts_with('.') || extends.starts_with('/') {
-        let mut candidate = PathBuf::from(extends);
-        if candidate.extension().is_none() {
-            candidate.set_extension("json");
-        }
-
-        if candidate.is_absolute() {
-            return Ok(candidate);
-        }
-        return Ok(base_dir.join(candidate));
+        let candidate = if Path::new(extends).is_absolute() {
+            PathBuf::from(extends)
+        } else {
+            base_dir.join(extends)
+        };
+        return Ok(probe_extends_candidate(&candidate, false));
     }
 
+    // Non-relative: Node module resolution. `package.json` exports first.
     if let Some(resolved) = resolve_package_extends_path(current_path, extends) {
-        return Ok(resolved);
+        return Ok(Some(resolved));
     }
 
-    // Package-name extends (e.g. "@tsconfig/node20/tsconfig.json")
-    // Resolve through node_modules, walking up directory ancestors.
+    // Package-name extends (e.g. "@tsconfig/node20/tsconfig.json").
+    // Walk `node_modules` upward through directory ancestors.
     let mut search_dir = base_dir.to_path_buf();
     loop {
-        let mut candidate = search_dir.join("node_modules").join(extends);
-        if candidate.extension().is_none() {
-            candidate.set_extension("json");
-        }
-        if candidate.exists() {
-            return Ok(candidate);
-        }
-        // Also try the package's tsconfig.json if extends points to a directory
-        let dir_candidate = search_dir.join("node_modules").join(extends);
-        if dir_candidate.is_dir() {
-            let tsconfig_in_dir = dir_candidate.join("tsconfig.json");
-            if tsconfig_in_dir.exists() {
-                return Ok(tsconfig_in_dir);
-            }
+        let candidate = search_dir.join("node_modules").join(extends);
+        if let Some(resolved) = probe_extends_candidate(&candidate, true) {
+            return Ok(Some(resolved));
         }
         if !search_dir.pop() {
             break;
         }
     }
 
-    // Fallback: treat as relative path (original behavior)
-    let mut candidate = PathBuf::from(extends);
-    if candidate.extension().is_none() {
-        candidate.set_extension("json");
+    Ok(None)
+}
+
+/// Probe a single candidate path for an `extends` target, returning the
+/// existing config file it names or `None`.
+///
+/// Tries, in order: the candidate as written, the candidate with a `.json`
+/// extension appended when it has none, and — only when `allow_dir_tsconfig`
+/// is set (the `node_modules` package-root case) — a `tsconfig.json` inside the
+/// candidate directory. Existence is checked at every step so a miss is
+/// reported as `None` rather than a path that does not exist.
+fn probe_extends_candidate(candidate: &Path, allow_dir_tsconfig: bool) -> Option<PathBuf> {
+    if candidate.is_file() {
+        return Some(candidate.to_path_buf());
     }
-    Ok(base_dir.join(candidate))
+    if candidate.extension().is_none() {
+        let with_json = candidate.with_extension("json");
+        if with_json.is_file() {
+            return Some(with_json);
+        }
+    }
+    if allow_dir_tsconfig && candidate.is_dir() {
+        let nested = candidate.join("tsconfig.json");
+        if nested.is_file() {
+            return Some(nested);
+        }
+    }
+    None
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -230,23 +248,11 @@ fn resolve_package_extends_export_value(
 
 #[cfg(not(target_arch = "wasm32"))]
 fn resolve_config_export_target(package_dir: &Path, target: &str) -> Option<PathBuf> {
+    // A package `"exports"` target names a package-relative path; probe it the
+    // same way as a `node_modules` extends candidate (exact file, `.json`
+    // append, or directory `tsconfig.json`).
     let resolved = package_dir.join(target.trim_start_matches("./"));
-    if resolved.is_file() {
-        return Some(resolved);
-    }
-    if resolved.extension().is_none() {
-        let json_path = resolved.with_extension("json");
-        if json_path.is_file() {
-            return Some(json_path);
-        }
-    }
-    if resolved.is_dir() {
-        let tsconfig_path = resolved.join("tsconfig.json");
-        if tsconfig_path.is_file() {
-            return Some(tsconfig_path);
-        }
-    }
-    None
+    probe_extends_candidate(&resolved, true)
 }
 
 /// Anchor relative path-like compiler options at the directory of the
@@ -968,22 +974,38 @@ mod tests {
         let temp = tempdir().unwrap();
         let project = temp.path().join("p");
         std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(project.join("base.json"), "{}").unwrap();
         let child = project.join("tsconfig.json");
 
+        // Extensionless relative specifier resolves by appending `.json`.
         let resolved = resolve_extends_path(&child, "./base").unwrap();
-        assert_eq!(resolved, project.join("base.json"));
+        assert_eq!(resolved, Some(project.join("base.json")));
+    }
+
+    #[test]
+    fn resolve_extends_path_relative_missing_is_none() {
+        let temp = tempdir().unwrap();
+        let project = temp.path().join("p");
+        std::fs::create_dir_all(&project).unwrap();
+        let child = project.join("tsconfig.json");
+
+        // A relative specifier that names no existing file is reported as a
+        // miss (the caller then emits TS6053) rather than a bogus path.
+        let resolved = resolve_extends_path(&child, "./missing").unwrap();
+        assert_eq!(resolved, None);
     }
 
     #[test]
     fn resolve_extends_path_absolute() {
         let temp = tempdir().unwrap();
         let abs = temp.path().join("abs.json");
+        std::fs::write(&abs, "{}").unwrap();
         let project = temp.path().join("p");
         std::fs::create_dir_all(&project).unwrap();
         let child = project.join("tsconfig.json");
 
         let resolved = resolve_extends_path(&child, abs.to_string_lossy().as_ref()).unwrap();
-        assert_eq!(resolved, abs);
+        assert_eq!(resolved, Some(abs));
     }
 
     #[test]
@@ -997,7 +1019,7 @@ mod tests {
         let child = project.join("tsconfig.json");
 
         let resolved = resolve_extends_path(&child, "@scope/pkg/recommended").unwrap();
-        assert_eq!(resolved, base);
+        assert_eq!(resolved, Some(base));
     }
 
     #[test]
@@ -1011,6 +1033,53 @@ mod tests {
         let child = project.join("tsconfig.json");
 
         let resolved = resolve_extends_path(&child, "@scope/pkg/tsconfig.base.json").unwrap();
-        assert_eq!(resolved, base);
+        assert_eq!(resolved, Some(base));
+    }
+
+    #[test]
+    fn resolve_extends_path_node_modules_walk_from_nested_dir() {
+        // The package config lives in the workspace-root `node_modules`, while
+        // the consuming config is several directories down (the directus /
+        // rocketchat / cal-com monorepo shape). The walk must climb ancestors.
+        let temp = tempdir().unwrap();
+        let root = temp.path().join("repo");
+        let pkg = root.join("node_modules").join("@scope").join("tsconfig");
+        std::fs::create_dir_all(&pkg).unwrap();
+        let base = pkg.join("node22.json");
+        std::fs::write(&base, "{}").unwrap();
+        let nested = root.join("apps").join("web");
+        std::fs::create_dir_all(&nested).unwrap();
+        let child = nested.join("tsconfig.json");
+
+        let resolved = resolve_extends_path(&child, "@scope/tsconfig/node22.json").unwrap();
+        assert_eq!(resolved, Some(base));
+    }
+
+    #[test]
+    fn resolve_extends_path_bare_package_uses_root_tsconfig() {
+        // A bare package specifier resolves to the package root's tsconfig.json.
+        let temp = tempdir().unwrap();
+        let project = temp.path().join("project");
+        let pkg = project.join("node_modules").join("shared-config");
+        std::fs::create_dir_all(&pkg).unwrap();
+        let base = pkg.join("tsconfig.json");
+        std::fs::write(&base, "{}").unwrap();
+        let child = project.join("tsconfig.json");
+
+        let resolved = resolve_extends_path(&child, "shared-config").unwrap();
+        assert_eq!(resolved, Some(base));
+    }
+
+    #[test]
+    fn resolve_extends_path_missing_package_is_none() {
+        // A non-relative specifier whose package is not installed resolves to a
+        // miss (caller emits TS6053), never to a literal config-dir path-join.
+        let temp = tempdir().unwrap();
+        let project = temp.path().join("project");
+        std::fs::create_dir_all(&project).unwrap();
+        let child = project.join("tsconfig.json");
+
+        let resolved = resolve_extends_path(&child, "@scope/pkg/file.json").unwrap();
+        assert_eq!(resolved, None);
     }
 }

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -575,6 +575,27 @@ fn find_top_level_value_offset_in_source(source: &str, key: &str) -> u32 {
     }
 }
 
+/// Locate the source span of an `extends` specifier string (including its
+/// surrounding quotes) for anchoring TS6053 on an unresolved base config.
+///
+/// The search starts at the top-level `extends` key so an array element is
+/// anchored at its own position; when the literal cannot be located (e.g. the
+/// value was rewritten by JSONC stripping) it falls back to the `extends`
+/// value start with the specifier's quoted width, matching `tsc`'s anchor on
+/// the `extends` value.
+fn find_extends_specifier_span(source: &str, specifier: &str) -> (u32, u32) {
+    let quoted = format!("\"{specifier}\"");
+    let extends_pos = source.find("\"extends\"").unwrap_or(0);
+    if let Some(rel) = source[extends_pos..].find(&quoted) {
+        ((extends_pos + rel) as u32, quoted.len() as u32)
+    } else {
+        (
+            find_top_level_value_offset_in_source(source, "extends"),
+            specifier.len() as u32 + 2,
+        )
+    }
+}
+
 fn validate_top_level_array_option(
     obj: &mut serde_json::Map<String, serde_json::Value>,
     diagnostics: &mut Vec<Diagnostic>,
@@ -1248,7 +1269,13 @@ fn load_tsconfig_inner(
         // Each base is merged into the accumulated config.
         let mut accumulated: Option<TsConfig> = None;
         for extends_path_str in &extends_paths {
-            let base_path = resolve_extends_path(path, extends_path_str)?;
+            // An unresolved `extends` is a recoverable condition (tsc reports
+            // TS6053 and continues with the local config). This diagnostic-free
+            // loader simply degrades: skip the missing base rather than aborting
+            // the whole config load.
+            let Some(base_path) = resolve_extends_path(path, extends_path_str)? else {
+                continue;
+            };
             let base_config = load_tsconfig_inner(&base_path, visited, true, config_dir)?;
             accumulated = Some(match accumulated {
                 Some(acc) => merge_configs(acc, base_config),
@@ -1296,8 +1323,25 @@ fn load_tsconfig_inner_with_diagnostics(
         };
         let mut accumulated: Option<TsConfig> = None;
         let mut base_removed_options: Vec<String> = Vec::new();
+        let stripped = strip_jsonc(&source);
         for extends_path_str in &extends_paths {
-            let base_path = resolve_extends_path(path, extends_path_str)?;
+            // An `extends` specifier that names no existing config file is a
+            // recoverable error: tsc emits TS6053 anchored at the specifier and
+            // continues with the remaining (local) options. Emit the same and
+            // skip this base instead of failing the whole config load.
+            let Some(base_path) = resolve_extends_path(path, extends_path_str)? else {
+                let (start, length) = find_extends_specifier_span(&stripped, extends_path_str);
+                let message =
+                    format_message(diagnostic_messages::FILE_NOT_FOUND, &[extends_path_str]);
+                parsed.diagnostics.push(Diagnostic::error(
+                    &file_display,
+                    start,
+                    length,
+                    message,
+                    diagnostic_codes::FILE_NOT_FOUND,
+                ));
+                continue;
+            };
             // Collect removed options from base configs for TS5102 diagnostics.
             // TSC checks the merged result and emits TS5102 at the child's key position
             // when removed options come from base configs via extends.
@@ -1413,7 +1457,7 @@ fn collect_removed_options_from_config(path: &Path, removed: &mut Vec<String>) {
         .as_object()
         .and_then(|o| o.get("extends"))
         .and_then(|v| v.as_str())
-        && let Ok(base_path) = resolve_extends_path(path, extends)
+        && let Ok(Some(base_path)) = resolve_extends_path(path, extends)
     {
         collect_removed_options_from_config(&base_path, removed);
     }

--- a/crates/tsz-core/src/config/tests/module_resolution.rs
+++ b/crates/tsz-core/src/config/tests/module_resolution.rs
@@ -1427,7 +1427,141 @@ fn test_resolve_extends_path_uses_package_exports_mapping() {
     let resolved =
         resolve_extends_path(&project_dir.join("tsconfig.json"), "pkg/tsconfig.json").unwrap();
 
-    assert_eq!(resolved, expected);
+    assert_eq!(resolved, Some(expected));
+}
+
+#[test]
+fn extends_scoped_package_config_resolved_via_node_modules_from_nested_dir() {
+    // A workspace-internal config (the directus / rocketchat / cal-com shape):
+    // a nested app config `extends` a package-provided tsconfig that lives in
+    // the repo-root `node_modules`. The base must be loaded through Node module
+    // resolution (walking ancestors), not path-joined onto the config dir.
+    let temp = tempdir().expect("create temp dir");
+    let root = temp.path().join("repo");
+    let pkg = root.join("node_modules").join("@scope").join("tsconfig");
+    std::fs::create_dir_all(&pkg).expect("create package dir");
+    std::fs::write(
+        pkg.join("node22.json"),
+        r#"{ "compilerOptions": { "strict": true, "target": "ES2022" } }"#,
+    )
+    .expect("write base");
+
+    let app = root.join("apps").join("web");
+    std::fs::create_dir_all(&app).expect("create app dir");
+    let child_path = app.join("tsconfig.json");
+    std::fs::write(
+        &child_path,
+        r#"{ "extends": "@scope/tsconfig/node22.json", "compilerOptions": { "strict": false } }"#,
+    )
+    .expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load child");
+    assert!(
+        !parsed.diagnostics.iter().any(|d| d.code == 6053),
+        "an installed package config must resolve, no TS6053: {:?}",
+        parsed.diagnostics
+    );
+    let opts = parsed.config.compiler_options.expect("merged options");
+    assert_eq!(
+        opts.strict,
+        Some(false),
+        "child overrides the base's strict value"
+    );
+    assert_eq!(
+        opts.target.as_deref(),
+        Some("ES2022"),
+        "the base config's options must be inherited"
+    );
+}
+
+#[test]
+fn extends_unresolved_package_emits_ts6053_and_keeps_local_options() {
+    // The package providing the base config is not installed (the canary
+    // clone-without-deps shape). tsc emits TS6053 anchored at the `extends`
+    // specifier and keeps compiling with the local options; tsz must not abort
+    // the whole config load.
+    let temp = tempdir().expect("create temp dir");
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    let child_path = project.join("tsconfig.json");
+    let child_source =
+        r#"{ "extends": "@scope/pkg/file.json", "compilerOptions": { "strict": true } }"#;
+    std::fs::write(&child_path, child_source).expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed, not abort");
+
+    let ts6053: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 6053)
+        .collect();
+    assert_eq!(
+        ts6053.len(),
+        1,
+        "exactly one TS6053 for the unresolved extends: {:?}",
+        parsed.diagnostics
+    );
+    assert!(
+        ts6053[0].message_text.contains("@scope/pkg/file.json"),
+        "TS6053 names the unresolved specifier: {}",
+        ts6053[0].message_text
+    );
+    let expected_start = child_source
+        .find("\"@scope/pkg/file.json\"")
+        .expect("specifier present in source") as u32;
+    assert_eq!(
+        ts6053[0].start, expected_start,
+        "TS6053 anchors at the extends specifier literal"
+    );
+
+    let opts = parsed
+        .config
+        .compiler_options
+        .expect("local options retained");
+    assert_eq!(
+        opts.strict,
+        Some(true),
+        "local options survive an unresolved extends"
+    );
+}
+
+#[test]
+fn extends_array_reports_each_unresolved_entry() {
+    // Array `extends` (TS 5.0): every entry that cannot be resolved gets its
+    // own TS6053, and resolvable entries still merge.
+    let temp = tempdir().expect("create temp dir");
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    std::fs::write(
+        project.join("present.json"),
+        r#"{ "compilerOptions": { "target": "ES2021" } }"#,
+    )
+    .expect("write present base");
+    let child_path = project.join("tsconfig.json");
+    std::fs::write(
+        &child_path,
+        r#"{ "extends": ["./present.json", "./missing-a.json", "./missing-b.json"] }"#,
+    )
+    .expect("write child");
+
+    let parsed = load_tsconfig_with_diagnostics(&child_path).expect("load must succeed");
+    let ts6053: Vec<&Diagnostic> = parsed
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 6053)
+        .collect();
+    assert_eq!(
+        ts6053.len(),
+        2,
+        "one TS6053 per unresolved array entry: {:?}",
+        parsed.diagnostics
+    );
+    let opts = parsed.config.compiler_options.expect("present base merged");
+    assert_eq!(
+        opts.target.as_deref(),
+        Some("ES2021"),
+        "the resolvable array entry is still applied"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Goal: hold

Fixes #13825.

## Summary

A non-relative tsconfig `extends` already resolves through Node module resolution
(`config/extends.rs::resolve_extends_path`, with existing coverage for
`@scope/pkg/file.json`, extensionless subpaths, and bare-package roots) — that
works when the package is installed. The real, harness-independent defect is the
**failure mode**: when the base config cannot be located, `resolve_extends_path`
returned a **bogus literal path** (config dir + specifier); the loader then
`read_to_string`'d it, hit `ENOENT`, and propagated an error that **aborted the
entire config load**:

```
tsz: Error: failed to read tsconfig: /@scope/pkg/file.json
tsz: Caused by:
tsz:     No such file or directory (os error 2)
```

The project then never reads *any* of its options. `tsc` instead emits
**TS6053 `File '{0}' not found.`** anchored at the `extends` specifier and keeps
compiling with the remaining (local) options.

## Structural rule

When a tsconfig `extends` value (single string or array element) cannot be
resolved to an existing config file — relative, absolute, or via Node module
resolution — `tsc` reports TS6053 at the specifier and continues with the
remaining options. tsz now does the same instead of aborting config loading.

## Change (owner: `tsz-core` config loader)

- `resolve_extends_path` now returns `Result<Option<PathBuf>>` — `Some(existing
  file)` or `None` (a genuine miss) — via a shared `probe_extends_candidate`
  helper (exact file → `.json` append → package-root `tsconfig.json`). The
  literal path-join fallback is removed. The package `"exports"` target probe
  (`resolve_config_export_target`) now reuses the same helper.
- Both loaders (`load_tsconfig_inner`, `load_tsconfig_inner_with_diagnostics`)
  treat `None` as recoverable: the diagnostic loader emits TS6053 anchored at the
  specifier (one per unresolved array entry) and continues; the diagnostic-free
  loader degrades silently. Local options survive; resolvable bases still merge.

## Anti-hardcoding

No identifier/file-name/printer-string predicates; resolution stays structural
(filesystem existence + Node module walk). No single-fixture suppression.

## Verification

- `cargo test -p tsz-core --lib config::` — 226 pass, including new coverage:
  - `resolve_extends_path_node_modules_walk_from_nested_dir` (monorepo ancestor walk)
  - `resolve_extends_path_bare_package_uses_root_tsconfig`
  - `resolve_extends_path_relative_missing_is_none`, `resolve_extends_path_missing_package_is_none`
  - `extends_scoped_package_config_resolved_via_node_modules_from_nested_dir` (base options inherited, no TS6053)
  - `extends_unresolved_package_emits_ts6053_and_keeps_local_options` (TS6053 anchored at specifier; local `strict` retained; no abort)
  - `extends_array_reports_each_unresolved_entry` (one TS6053 per missing entry; resolvable entry still merges)
- `cargo clippy -p tsz-core --lib` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_019EtfyMBqujQKsaZ7Qov3YP

---
_Generated by [Claude Code](https://claude.ai/code/session_019EtfyMBqujQKsaZ7Qov3YP)_