### PR TITLE
perf(cli): bounded long-lived checker pool scheduler (TSZ_CHECKER_POOL) (#13246)

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -50,7 +50,7 @@ mod source_resolution_setup;
 use check_file::{
     CheckFileFlags, CheckFileForParallelContext, CheckFileResult, CheckFilesReuseCtx,
     check_file_for_parallel, check_files_in_parallel_chunks_with_reuse,
-    check_files_sequentially_with_reuse,
+    check_files_round_robin_pool, check_files_sequentially_with_reuse,
 };
 use checker_diagnostics::{
     keep_checker_diagnostic_when_program_has_real_syntax_errors, post_process_checker_diagnostics,
@@ -325,6 +325,27 @@ fn parallel_file_session_reuse_requested() -> bool {
         std::env::var_os("TSZ_DISABLE_FILE_SESSION_REUSE").is_some(),
         std::env::var_os("TSZ_FILE_SESSION_REUSE").is_some(),
     )
+}
+
+/// Bounded long-lived checker-pool width, or `None` when the pool scheduler is
+/// off (the default).
+///
+/// `TSZ_CHECKER_POOL` opts into checking files on a fixed pool of `N`
+/// long-lived `CheckerState`s (round-robin file assignment, each reused via
+/// `switch_to_file`) instead of the default per-file fresh checker. This
+/// amortises the O(program) per-file setup over `files / N` files — the lever
+/// that unblocks large multi-file projects. `=auto` (or `=1`) sizes the pool
+/// to `available_parallelism`; `=N` sets an explicit width; unset / `0` / empty
+/// disables it.
+fn checker_pool_size() -> Option<usize> {
+    let raw = std::env::var("TSZ_CHECKER_POOL").ok()?;
+    match raw.trim() {
+        "" | "0" => None,
+        "auto" | "1" => {
+            Some(std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get))
+        }
+        n => n.parse::<usize>().ok().filter(|&w| w >= 1),
+    }
 }
 
 /// Decide whether fresh per-file checkers run sequentially instead of on the
@@ -1318,7 +1339,41 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
             // than narrowing it.
             let use_file_session_reuse =
                 use_sequential_checking && !extract_type_cache && reuse_requested;
-            if use_file_session_reuse {
+            if let Some(pool_size) = checker_pool_size().filter(|_| !extract_type_cache) {
+                // Bounded long-lived checker pool (`TSZ_CHECKER_POOL`): N
+                // round-robin partitions, each a long-lived `CheckerState`
+                // reused via `switch_to_file`, amortising the O(program)
+                // per-file setup over `files / N` files — the lever that
+                // unblocks large multi-file projects. Gated default-off; the
+                // per-partition body is the proven sequential-reuse path, so
+                // diagnostics are byte-identical to the fresh-checker arm.
+                tsz::parallel::ensure_rayon_global_pool();
+                let reuse_ctx = CheckFilesReuseCtx {
+                    program,
+                    compiler_options: &compiler_options,
+                    program_context: &program_context,
+                    resolved_modules_per_file: &resolved_modules_per_file,
+                    shared_lib_cache: Arc::clone(&shared_lib_cache),
+                    shared_constraint_proofs: Arc::clone(&shared_constraint_proofs),
+                    shared_query_cache: shared_query_cache.as_ref(),
+                };
+                let reuse_flags = CheckFileFlags {
+                    no_check,
+                    check_js,
+                    explicit_check_js_false,
+                    skip_lib_check,
+                    program_has_real_syntax_errors,
+                    program_has_unsupported_js_root,
+                    extract_type_cache,
+                };
+                check_files_round_robin_pool(
+                    &work_items,
+                    &reuse_ctx,
+                    &reuse_flags,
+                    pool_size,
+                    &build_checker_binder,
+                )
+            } else if use_file_session_reuse {
                 let reuse_ctx = CheckFilesReuseCtx {
                     program,
                     compiler_options: &compiler_options,

--- a/crates/tsz-cli/src/driver/check_file.rs
+++ b/crates/tsz-cli/src/driver/check_file.rs
@@ -691,3 +691,82 @@ where
         .flatten()
         .collect()
 }
+
+/// Check all `work_items` on a **bounded pool of `pool_size` long-lived
+/// checkers** (the `TSZ_CHECKER_POOL` scheduler mode).
+///
+/// Unlike [`check_files_in_parallel_chunks_with_reuse`], which splits the work
+/// into `ceil(files / chunk_size)` contiguous chunks — and therefore builds
+/// `ceil(files / chunk_size)` `CheckerState`s — this distributes files
+/// **round-robin** into exactly `pool_size` partitions. Each partition is one
+/// long-lived `CheckerState` (built once via `apply_to`, re-targeted per file
+/// via `switch_to_file`), so the expensive O(program) per-file setup is
+/// amortised over `files / pool_size` files instead of `chunk_size`. Round-robin
+/// (vs contiguous) also spreads heavy files (deep `delegate_cross_arena`
+/// cascades) across partitions instead of clustering them in one chunk.
+///
+/// Results are reassembled into the original `work_items` order (downstream
+/// diagnostic aggregation is order-sensitive). The per-partition body is
+/// [`check_files_sequentially_with_reuse`] verbatim, so the reset contract
+/// (`CheckerContext::switch_to_file`) and stats accounting are unchanged.
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) fn check_files_round_robin_pool<F>(
+    work_items: &[usize],
+    ctx: &CheckFilesReuseCtx<'_>,
+    flags: &CheckFileFlags,
+    pool_size: usize,
+    build_checker_binder: &F,
+) -> Vec<CheckFileResult>
+where
+    F: Fn(usize) -> tsz_binder::BinderState + Sync,
+{
+    use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+    debug_assert!(!flags.extract_type_cache);
+    let pool_size = pool_size.max(1).min(work_items.len().max(1));
+
+    // Distribute round-robin, carrying each file's original position so the
+    // partitions' results can be stitched back into `work_items` order.
+    let mut partitions: Vec<Vec<(usize, usize)>> = vec![Vec::new(); pool_size];
+    for (pos, &file_idx) in work_items.iter().enumerate() {
+        partitions[pos % pool_size].push((pos, file_idx));
+    }
+
+    // Each partition runs on its own long-lived checker, in parallel. Bounding
+    // to `pool_size` partitions bounds the number of live `CheckerState`s (and
+    // their O(program) `apply_to` setups) to `pool_size`.
+    let partition_results: Vec<Vec<(usize, CheckFileResult)>> = partitions
+        .into_par_iter()
+        .map(|partition| {
+            let partition_ctx = CheckFilesReuseCtx {
+                program: ctx.program,
+                compiler_options: ctx.compiler_options,
+                program_context: ctx.program_context,
+                resolved_modules_per_file: ctx.resolved_modules_per_file,
+                shared_lib_cache: Arc::clone(&ctx.shared_lib_cache),
+                shared_constraint_proofs: Arc::clone(&ctx.shared_constraint_proofs),
+                shared_query_cache: ctx.shared_query_cache,
+            };
+            let (positions, file_list): (Vec<usize>, Vec<usize>) = partition.into_iter().unzip();
+            let results = check_files_sequentially_with_reuse(
+                &file_list,
+                &partition_ctx,
+                flags,
+                build_checker_binder,
+            );
+            positions.into_iter().zip(results).collect::<Vec<_>>()
+        })
+        .collect();
+
+    // Reassemble into original order. Every position is filled exactly once.
+    let mut ordered: Vec<Option<CheckFileResult>> = (0..work_items.len()).map(|_| None).collect();
+    for partition in partition_results {
+        for (pos, result) in partition {
+            ordered[pos] = Some(result);
+        }
+    }
+    ordered
+        .into_iter()
+        .map(|slot| slot.expect("round-robin pool filled every work-item position"))
+        .collect()
+}


### PR DESCRIPTION
## Summary

Large multi-file projects pay **O(program) checker setup per file**: the default parallel path constructs one `CheckerState` per file, and each construction runs `apply_to` (shared def-store install, def-id pre-population, cross-batch heritage resolution, arena indexing, boxed-type priming). So `checker_state_new ≈ file_count`, and at scale this per-file setup dominates — the root of the large-project cliff (large-ts-repo DNFs at the 1500s ceiling; monorepos run multiples slower).

This adds a **gated bounded-checker-partition scheduler** (`TSZ_CHECKER_POOL`, default off): distribute files **round-robin into N partitions** (N = `available_parallelism`), each a single **long-lived `CheckerState`** reused across its files via the existing `switch_to_file` reset contract. This bounds live checkers to N and amortises the O(program) per-file setup from **O(files) → O(cores)**.

## Structural rule

When checking M files, `tsc`/`tsgo` pay program-level checker setup ~once over a fixed checker pool, not once per file. tsz now matches that under `TSZ_CHECKER_POOL`: N long-lived checkers over one immutable `MergedProgram` + shared `DefinitionStore`, each reset between files via the unchanged `switch_to_file` contract. Owner: `tsz-cli` driver scheduler (`check.rs` dispatch + `check_file.rs` distributor).

## Change (~120 LOC, 2 files, default-off)

- `check_file.rs`: `check_files_round_robin_pool` — round-robin partitioning carrying original position, `into_par_iter` over partitions, each running `check_files_sequentially_with_reuse` **verbatim** (so the reset contract + stats accounting are unchanged), results reassembled into original work-item order.
- `check.rs`: `checker_pool_size()` policy (`auto`/`N`/off) + a **`None`-guarded** dispatch arm as the first branch. With `TSZ_CHECKER_POOL` unset, every existing arm runs exactly as before — **zero default-behavior change**.

Round-robin (vs the existing contiguous `par_chunks(8)` reuse) also spreads heavy cross-arena-delegation files across partitions instead of clustering them.

## Verification (scale-cliff harness, same binary, flag on vs off)

| fixture | files | `checker_state_new` off→on | `check_s` off→on | total off→on | diagnostics |
|---|---|---|---|---|---|
| monorepo-002 | 1,010 | 1,011 → 17 | 0.54 → 0.46 | 1.25 → 1.05 | identical ✓ |
| monorepo-003 | 5,099 | **5,100 → 17** | 5.98 → **3.53 (−41%)** | 10.59 → 7.80 | identical ✓ |
| monorepo-004 | 5,151 | 5,152 → 17 | 5.73 → 3.32 (−42%) | 10.13 → 7.40 | identical ✓ |
| monorepo-005 | 5,202 | 5,202 → 17 | 5.79 → 3.77 | 10.17 → 7.73 | identical ✓ |
| monorepo-006 (cross-pkg) | 5,251 | 5,251 → 17 | 6.30 → 3.81 (−40%) | 10.59 → 8.10 | identical ✓ |

- `checker_state_new` collapses from **one-per-file to N (=cores)** — the bounded pool.
- Type-check phase **−40%** at 5k files; total **−22–24%**; user CPU **−47%**. Win grows with project size.
- **Byte-identical diagnostics** on all 6 fixtures (101…5,251 files).
- `scripts/bench/scale-cliff/run-cliff.sh --compare-against`: **0 ratio regressions** (24 stable). `compute_type_of_symbol_calls` / `resolver_lookup_calls` **unchanged** — pure setup amortisation, no behavior change.

Commands: `scripts/bench/scale-cliff/generate-fixtures.sh` then `run-cliff.sh --tsz <bin> --json-file off.json` vs `TSZ_CHECKER_POOL=auto … --json-file on.json --compare-against off.json`. Full conformance/emit/fourslash parity is owned by ready-review CI; this change is gated default-off so the default path is untouched.

## Follow-ups (staged)

- **Stage B**: flip the default for the large, non-DOM parallel lane once CI conformance with `TSZ_CHECKER_POOL` forced on confirms corpus-wide byte-identical parity (the canary). This is what actually *unblocks* large projects by default.
- Crash-isolation (reconstruct a partition's checker on per-file panic — currently parity with the existing chunked-reuse path) and a `debug_assert_eq!(cross_arena_depth(), 0)` per-file guard.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: max

Goal: fast
