### PR TITLE
perf(solver): eval-materialization probe de-risks #13250 deferred-materialization lever

### DIFF
--- a/crates/tsz-cli/src/bin/tsz/diagnostics_report.rs
+++ b/crates/tsz-cli/src/bin/tsz/diagnostics_report.rs
@@ -234,7 +234,7 @@ fn build_diagnostics_report(
     // when `TSZ_PERF_COUNTERS` is set (both helpers return "" otherwise).
     report
         .perf_counter_dump
-        .push_str(&tsz_solver::eval_materialization_probe_report());
+        .push_str(&tsz_solver::observability::eval_materialization_probe_report());
 
     report
 }

--- a/crates/tsz-cli/src/bin/tsz/diagnostics_report.rs
+++ b/crates/tsz-cli/src/bin/tsz/diagnostics_report.rs
@@ -229,6 +229,12 @@ fn build_diagnostics_report(
     }
 
     report.perf_counter_dump = tsz_common::perf_counters::PerfCounters::dump_string();
+    // Measurement-only eval-materialization probe (#13250). Appended to the
+    // same field so it renders directly under the perf-counter dump and only
+    // when `TSZ_PERF_COUNTERS` is set (both helpers return "" otherwise).
+    report
+        .perf_counter_dump
+        .push_str(&tsz_solver::evaluation::eval_materialization_probe::dump_report());
 
     report
 }

--- a/crates/tsz-cli/src/bin/tsz/diagnostics_report.rs
+++ b/crates/tsz-cli/src/bin/tsz/diagnostics_report.rs
@@ -234,7 +234,7 @@ fn build_diagnostics_report(
     // when `TSZ_PERF_COUNTERS` is set (both helpers return "" otherwise).
     report
         .perf_counter_dump
-        .push_str(&tsz_solver::evaluation::eval_materialization_probe::dump_report());
+        .push_str(&tsz_solver::eval_materialization_probe_report());
 
     report
 }

--- a/crates/tsz-solver/src/evaluation/eval_materialization_probe.rs
+++ b/crates/tsz-solver/src/evaluation/eval_materialization_probe.rs
@@ -1,0 +1,447 @@
+//! Measurement-only probe of recursive type-evaluator materialization
+//! (issue #13250, ts-toolbelt / type-fest `AutoPath`/`MetaPath` lever).
+//!
+//! The recursive `TypeEvaluator` eagerly interns full conditional / mapped /
+//! application expansions, materializing many distinct intermediate shapes.
+//! Before committing to the large (4-8 week, high-conformance-risk) deferred /
+//! lazy-materialization change, this probe quantifies the *headroom* of three
+//! candidate sub-strategies so the campaign can be redirected on evidence:
+//!
+//! 1. **Distinct intermediate shapes** — how many distinct result `TypeId`s the
+//!    eval engine materializes for conditional / mapped / application inputs.
+//! 2. **Structural-dedup headroom (hash-cons)** — the central `TypeInterner`
+//!    *already* hash-conses: structurally identical `TypeData` collapses to one
+//!    `TypeId` (see `crates/tsz-solver/src/types.rs` `TypeData` doc and
+//!    `intern()` in `intern/core/interner.rs`). So additional hash-consing of
+//!    the *result* buys nothing unless two distinct result `TypeId`s carry
+//!    structurally equal `TypeData` (a hash-cons *gap*). We count those gaps;
+//!    an ~0 count is the finding that interner-level dedup is already complete,
+//!    redirecting the headroom question to *recomputation* (below).
+//! 3. **Recompute headroom (defer / memo)** — `computes - distinct_inputs`:
+//!    how many computes re-derive a result for an input `TypeId` already
+//!    computed earlier. This is the work a deferred-materialization or a
+//!    longer-lived eval memo would skip (the interner dedups the *output* but
+//!    the recursion still *runs* to produce it).
+//! 4. **Defer headroom (conditionals)** — of conditional computes, how many
+//!    resolve eagerly to a concrete branch vs stay deferred (result is still a
+//!    `Conditional`). `tsc` keeps more conditionals deferred; eager computes
+//!    whose input repeats are the redundant-eager-eval headroom.
+//! 5. **Fan-out** — distinct intermediate result shapes vs distinct inputs, and
+//!    total computes vs distinct results: the "wasted" intermediate
+//!    materialization the lever would collapse.
+//!
+//! Everything is gated on `TSZ_PERF_COUNTERS` via
+//! [`tsz_common::perf_counters::enabled_fast`]. In a normal run every hook is a
+//! single predictable branch and the global maps are never touched. The probe
+//! never feeds back into evaluation: it only accumulates measurement state and
+//! is read once at end-of-run via [`dump_report`]. Default behavior is
+//! unchanged.
+//!
+//! State is process-wide (the evaluator runs across rayon worker threads), so
+//! distinct-shape sets use [`DashSet`] and the scalar totals a small
+//! [`Mutex`]-guarded struct, matching the existing perf-counter conventions.
+
+use crate::types::{TypeData, TypeId};
+use dashmap::{DashMap, DashSet};
+use rustc_hash::FxBuildHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tsz_common::perf_counters;
+
+/// Test-only force flag so the probe's own unit tests can drive the recorder
+/// without relying on `tsz_common`'s `debug_assertions`-gated force hook (which
+/// is not compiled when the dependency is built `--release`). Compiled only in
+/// the probe's own `cfg(test)` builds; production builds keep the single
+/// `enabled_fast` gate.
+#[cfg(test)]
+static FORCE_PROBE_FOR_TESTS: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// The probe gate: process-wide `TSZ_PERF_COUNTERS` (via `enabled_fast`), plus
+/// a `cfg(test)`-only force flag. One predictable branch on the hot path in a
+/// production build (the `cfg(test)` arm does not exist there).
+#[inline(always)]
+fn gate_enabled() -> bool {
+    #[cfg(test)]
+    if FORCE_PROBE_FOR_TESTS.load(Ordering::Relaxed) {
+        return true;
+    }
+    perf_counters::enabled_fast()
+}
+
+/// Eval-engine kinds the lever targets. Index into [`ProbeState`] arrays.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(usize)]
+enum ProbeKind {
+    Conditional = 0,
+    Mapped = 1,
+    Application = 2,
+}
+
+const PROBE_KIND_COUNT: usize = 3;
+const PROBE_KIND_NAMES: [&str; PROBE_KIND_COUNT] = ["conditional", "mapped", "application"];
+
+/// Per-kind scalar totals. Distinct-shape membership lives in the sibling
+/// [`DashSet`]s on [`ProbeState`]; these atomics carry the running counts.
+struct KindTotals {
+    /// Nodes of this kind computed (passed every memo/cache layer).
+    computes: AtomicU64,
+    /// Computes whose result stayed the *same* kind as the input — for
+    /// conditionals/mapped this is "deferred" (re-interned, not resolved).
+    deferred_results: AtomicU64,
+    /// Distinct result-`TypeId`s that carried `TypeData` structurally equal to
+    /// an *earlier* distinct result-`TypeId` of this kind: a genuine
+    /// interner-level hash-cons gap (expected ~0 because `intern()` already
+    /// hash-conses). Non-zero here would be true additional dedup headroom.
+    hash_cons_gap_results: AtomicU64,
+}
+
+impl KindTotals {
+    const fn new() -> Self {
+        Self {
+            computes: AtomicU64::new(0),
+            deferred_results: AtomicU64::new(0),
+            hash_cons_gap_results: AtomicU64::new(0),
+        }
+    }
+}
+
+struct ProbeState {
+    totals: [KindTotals; PROBE_KIND_COUNT],
+    /// Distinct input `TypeId`s computed, per kind. Size =
+    /// `distinct_inputs`; `computes - distinct_inputs` = recompute headroom.
+    distinct_inputs: [DashSet<u32, FxBuildHasher>; PROBE_KIND_COUNT],
+    /// Distinct result `TypeId`s materialized, per kind. Size =
+    /// `distinct_results` (the interner already collapses structurally equal
+    /// results into one id, so this is the realized distinct-shape count).
+    distinct_results: [DashSet<u32, FxBuildHasher>; PROBE_KIND_COUNT],
+    /// Distinct input `TypeId`s whose conditional resolved *eagerly* to a
+    /// concrete branch. Index 0 only meaningful for `Conditional`.
+    eager_conditional_inputs: DashSet<u32, FxBuildHasher>,
+    /// Total eager conditional computes (result is not a `Conditional`).
+    eager_conditional_computes: AtomicU64,
+    /// Structural-hash -> first distinct result `TypeId` of that hash, per
+    /// kind. Detects the hash-cons gap in #2 above.
+    result_structural_hash: [DashMap<u64, u32, FxBuildHasher>; PROBE_KIND_COUNT],
+}
+
+fn new_dashset() -> DashSet<u32, FxBuildHasher> {
+    DashSet::with_hasher(FxBuildHasher)
+}
+
+fn new_dashmap() -> DashMap<u64, u32, FxBuildHasher> {
+    DashMap::with_hasher(FxBuildHasher)
+}
+
+static STATE: OnceLock<ProbeState> = OnceLock::new();
+
+fn state() -> &'static ProbeState {
+    STATE.get_or_init(|| ProbeState {
+        totals: [KindTotals::new(), KindTotals::new(), KindTotals::new()],
+        distinct_inputs: [new_dashset(), new_dashset(), new_dashset()],
+        distinct_results: [new_dashset(), new_dashset(), new_dashset()],
+        eager_conditional_inputs: new_dashset(),
+        eager_conditional_computes: AtomicU64::new(0),
+        result_structural_hash: [new_dashmap(), new_dashmap(), new_dashmap()],
+    })
+}
+
+/// Classify an input `TypeData` into the eval-engine kind the lever targets.
+#[inline]
+const fn probe_kind(key: &TypeData) -> Option<ProbeKind> {
+    match key {
+        TypeData::Conditional(_) => Some(ProbeKind::Conditional),
+        TypeData::Mapped(_) => Some(ProbeKind::Mapped),
+        TypeData::Application(_) => Some(ProbeKind::Application),
+        _ => None,
+    }
+}
+
+/// Record one computed eval node. Called from `evaluate_guarded_inner` after
+/// `visit_type_key` produces `result` for input `type_id` whose `TypeData` is
+/// `key`. `result_key` is `interner.lookup(result)` (the result's `TypeData`,
+/// if interned) so the probe can classify deferred-vs-eager and detect
+/// hash-cons gaps without re-borrowing the interner.
+///
+/// No-op (single branch) unless `TSZ_PERF_COUNTERS` is set.
+#[inline]
+pub(crate) fn record_compute(
+    type_id: TypeId,
+    key: &TypeData,
+    result: TypeId,
+    result_key: Option<&TypeData>,
+) {
+    if !gate_enabled() {
+        return;
+    }
+    let Some(kind) = probe_kind(key) else {
+        return;
+    };
+    let s = state();
+    let idx = kind as usize;
+    let t = &s.totals[idx];
+
+    t.computes.fetch_add(1, Ordering::Relaxed);
+    s.distinct_inputs[idx].insert(type_id.0);
+
+    // First time we see this distinct result id, fold it into the structural
+    // hash-cons-gap detector. A *different* result id whose `TypeData` hashes
+    // (and compares) equal to an earlier one is dedup the interner missed.
+    if s.distinct_results[idx].insert(result.0)
+        && let Some(rk) = result_key
+    {
+        let mut hasher = rustc_hash::FxHasher::default();
+        rk.hash(&mut hasher);
+        let h = hasher.finish();
+        // Distinct ids colliding on structural hash: the cheap signal. We
+        // cannot re-`lookup` the previous id's `TypeData` here without the
+        // interner, so we treat a hash collision between two distinct result
+        // ids as a (rare) candidate gap. Equal `TypeData` would have collapsed
+        // to the same id at `intern()`, so a true gap is essentially
+        // impossible — a non-zero count is the headroom signal worth probing.
+        if let Some(prev) = s.result_structural_hash[idx].insert(h, result.0)
+            && prev != result.0
+        {
+            t.hash_cons_gap_results.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    // Deferred-vs-eager: result kind same as input kind => deferred
+    // (re-interned), otherwise the recursion resolved it to a concrete shape.
+    let result_is_same_kind = result_key.and_then(probe_kind) == Some(kind);
+    if result_is_same_kind {
+        t.deferred_results.fetch_add(1, Ordering::Relaxed);
+    } else if matches!(kind, ProbeKind::Conditional) {
+        // Conditional that resolved eagerly to a concrete branch.
+        s.eager_conditional_computes.fetch_add(1, Ordering::Relaxed);
+        s.eager_conditional_inputs.insert(type_id.0);
+    }
+}
+
+/// Per-kind snapshot row for the dump.
+struct KindRow {
+    name: &'static str,
+    computes: u64,
+    distinct_inputs: u64,
+    distinct_results: u64,
+    deferred_results: u64,
+    hash_cons_gap_results: u64,
+}
+
+fn snapshot_kind(idx: usize) -> KindRow {
+    let s = state();
+    let t = &s.totals[idx];
+    KindRow {
+        name: PROBE_KIND_NAMES[idx],
+        computes: t.computes.load(Ordering::Relaxed),
+        distinct_inputs: s.distinct_inputs[idx].len() as u64,
+        distinct_results: s.distinct_results[idx].len() as u64,
+        deferred_results: t.deferred_results.load(Ordering::Relaxed),
+        hash_cons_gap_results: t.hash_cons_gap_results.load(Ordering::Relaxed),
+    }
+}
+
+/// Format the probe measurements as a multi-line report. Returns an empty
+/// string when counters are disabled, so callers can append it
+/// unconditionally next to the perf-counter dump.
+///
+/// The report exposes, per eval-engine kind, the four de-risking numbers:
+/// recompute headroom (`computes - distinct_inputs`), defer/eager split,
+/// hash-cons gap, and fan-out (`distinct_results` vs `distinct_inputs`).
+pub fn dump_report() -> String {
+    if !gate_enabled() {
+        return String::new();
+    }
+    // No computes recorded => nothing materialized; keep the dump quiet.
+    let any = (0..PROBE_KIND_COUNT).any(|i| state().totals[i].computes.load(Ordering::Relaxed) > 0);
+    if !any {
+        return String::new();
+    }
+
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(out, "\n=== TSZ eval-materialization probe (#13250) ===");
+    let _ = writeln!(
+        out,
+        "Per eval-engine kind: computes, distinct inputs, distinct results,\n\
+         recompute headroom (computes - distinct inputs), defer/eager, hash-cons gap.\n"
+    );
+
+    let mut total_computes = 0u64;
+    let mut total_distinct_results = 0u64;
+    for idx in 0..PROBE_KIND_COUNT {
+        let r = snapshot_kind(idx);
+        total_computes += r.computes;
+        total_distinct_results += r.distinct_results;
+        let name = r.name;
+        let computes = r.computes;
+        let distinct_inputs = r.distinct_inputs;
+        let distinct_results = r.distinct_results;
+        let deferred_results = r.deferred_results;
+        let hash_cons_gap = r.hash_cons_gap_results;
+        let recompute_headroom = computes.saturating_sub(distinct_inputs);
+        let recompute_pct = pct(recompute_headroom, computes);
+        let fanout_pct = pct(
+            distinct_results.saturating_sub(distinct_inputs),
+            distinct_results.max(1),
+        );
+        let _ = writeln!(out, "[{name}]");
+        let _ = writeln!(out, "  computes                 {computes:>12}");
+        let _ = writeln!(out, "  distinct inputs          {distinct_inputs:>12}");
+        let _ = writeln!(out, "  distinct results         {distinct_results:>12}");
+        let _ = writeln!(
+            out,
+            "  recompute headroom       {recompute_headroom:>12}  ({recompute_pct:.1}% of computes)"
+        );
+        let _ = writeln!(out, "  deferred results         {deferred_results:>12}");
+        let _ = writeln!(out, "  hash-cons gap (results)  {hash_cons_gap:>12}");
+        let _ = writeln!(out, "  fan-out (results>inputs) {fanout_pct:>12.1}%");
+    }
+
+    let s = state();
+    let eager_computes = s.eager_conditional_computes.load(Ordering::Relaxed);
+    let eager_distinct = s.eager_conditional_inputs.len() as u64;
+    let eager_recompute = eager_computes.saturating_sub(eager_distinct);
+    let eager_pct = pct(eager_recompute, eager_computes);
+    let _ = writeln!(out, "[conditional defer headroom]");
+    let _ = writeln!(out, "  eager computes           {eager_computes:>12}");
+    let _ = writeln!(out, "  eager distinct inputs    {eager_distinct:>12}");
+    let _ = writeln!(
+        out,
+        "  eager recompute headroom {eager_recompute:>12}  ({eager_pct:.1}% of eager computes)"
+    );
+
+    let overall_fanout = pct(
+        total_computes.saturating_sub(total_distinct_results),
+        total_computes.max(1),
+    );
+    let _ = writeln!(
+        out,
+        "[totals] computes {total_computes} -> distinct results {total_distinct_results} \
+         (overall fan-out {overall_fanout:.1}%)"
+    );
+    out
+}
+
+#[inline]
+fn pct(num: u64, den: u64) -> f64 {
+    if den == 0 {
+        0.0
+    } else {
+        (num as f64) * 100.0 / (den as f64)
+    }
+}
+
+/// Test-only read of the `(computes, distinct_inputs, distinct_results,
+/// deferred_results)` totals for one kind index. Used to assert recorder
+/// semantics on deltas (the global state is process-wide via `OnceLock`).
+#[cfg(test)]
+fn kind_snapshot_for_tests(idx: usize) -> (u64, u64, u64, u64) {
+    let r = snapshot_kind(idx);
+    (
+        r.computes,
+        r.distinct_inputs,
+        r.distinct_results,
+        r.deferred_results,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ConditionalTypeId, MappedTypeId, TypeApplicationId};
+
+    /// `record_compute` distinguishes distinct inputs from recomputes and
+    /// distinct results from collapsed ones, and classifies deferred-vs-eager.
+    /// Asserts on deltas because the probe state is process-wide.
+    #[test]
+    fn record_compute_counts_distinct_and_recompute_deltas() {
+        FORCE_PROBE_FOR_TESTS.store(true, Ordering::Relaxed);
+        let idx = ProbeKind::Conditional as usize;
+        let before = kind_snapshot_for_tests(idx);
+
+        let cond = TypeData::Conditional(ConditionalTypeId(7));
+        // Eager: input conditional resolves to a non-conditional concrete
+        // result. Same input twice => one distinct input, two computes
+        // (the second is a recompute). Two distinct concrete results.
+        let concrete_a = TypeData::Intrinsic(crate::types::IntrinsicKind::Number);
+        let concrete_b = TypeData::Intrinsic(crate::types::IntrinsicKind::String);
+        record_compute(TypeId(100), &cond, TypeId(200), Some(&concrete_a));
+        record_compute(TypeId(100), &cond, TypeId(201), Some(&concrete_b));
+        // Deferred: result stays a conditional (re-interned, not resolved).
+        let deferred_cond = TypeData::Conditional(ConditionalTypeId(9));
+        record_compute(TypeId(101), &cond, TypeId(202), Some(&deferred_cond));
+
+        let after = kind_snapshot_for_tests(idx);
+        let d_computes = after.0 - before.0;
+        let d_inputs = after.1 - before.1;
+        let d_results = after.2 - before.2;
+        let d_deferred = after.3 - before.3;
+
+        assert_eq!(d_computes, 3, "three computes recorded");
+        assert_eq!(d_inputs, 2, "two distinct input TypeIds (100, 101)");
+        assert_eq!(
+            d_results, 3,
+            "three distinct result TypeIds (200, 201, 202)"
+        );
+        assert_eq!(d_deferred, 1, "one result stayed a conditional (deferred)");
+        // recompute headroom = computes - distinct_inputs = 3 - 2 = 1.
+        assert_eq!(
+            d_computes - d_inputs,
+            1,
+            "one recompute of an existing input"
+        );
+    }
+
+    /// Non eval-engine kinds are ignored; mapped/application route to their
+    /// own buckets.
+    #[test]
+    fn record_compute_ignores_non_lever_kinds_and_routes_per_kind() {
+        FORCE_PROBE_FOR_TESTS.store(true, Ordering::Relaxed);
+        let m_idx = ProbeKind::Mapped as usize;
+        let a_idx = ProbeKind::Application as usize;
+        let m_before = kind_snapshot_for_tests(m_idx);
+        let a_before = kind_snapshot_for_tests(a_idx);
+
+        // An object input is not a lever kind: must be ignored entirely.
+        let object = TypeData::Array(TypeId(1));
+        record_compute(TypeId(300), &object, TypeId(301), None);
+
+        let mapped = TypeData::Mapped(MappedTypeId(3));
+        let app = TypeData::Application(TypeApplicationId(4));
+        record_compute(TypeId(400), &mapped, TypeId(401), None);
+        record_compute(TypeId(500), &app, TypeId(501), None);
+
+        let m_after = kind_snapshot_for_tests(m_idx);
+        let a_after = kind_snapshot_for_tests(a_idx);
+        // `>` (not `==`): under a shared-process test runner a sibling test
+        // may record into the application bucket concurrently. The object
+        // input must contribute nothing to either lever bucket, which the
+        // mapped-bucket delta (no sibling writes mapped) pins exactly.
+        assert_eq!(
+            m_after.0 - m_before.0,
+            1,
+            "one mapped compute, object ignored"
+        );
+        assert!(a_after.0 > a_before.0, "at least our application compute");
+    }
+
+    /// The report is empty when counters are disabled and the gate is the
+    /// only check (default-behavior-unchanged contract).
+    #[test]
+    fn dump_report_nonempty_only_under_gate() {
+        FORCE_PROBE_FOR_TESTS.store(true, Ordering::Relaxed);
+        let app = TypeData::Application(TypeApplicationId(11));
+        record_compute(TypeId(900), &app, TypeId(901), None);
+        let report = dump_report();
+        assert!(
+            report.contains("eval-materialization probe"),
+            "report should render under the gate"
+        );
+        assert!(
+            report.contains("recompute headroom"),
+            "report should expose recompute headroom"
+        );
+    }
+}

--- a/crates/tsz-solver/src/evaluation/eval_materialization_probe.rs
+++ b/crates/tsz-solver/src/evaluation/eval_materialization_probe.rs
@@ -44,6 +44,7 @@
 use crate::types::{TypeData, TypeId};
 use dashmap::{DashMap, DashSet};
 use rustc_hash::FxBuildHasher;
+use std::fmt::Write as _;
 use std::hash::{Hash, Hasher};
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -61,7 +62,7 @@ static FORCE_PROBE_FOR_TESTS: std::sync::atomic::AtomicBool =
 /// The probe gate: process-wide `TSZ_PERF_COUNTERS` (via `enabled_fast`), plus
 /// a `cfg(test)`-only force flag. One predictable branch on the hot path in a
 /// production build (the `cfg(test)` arm does not exist there).
-#[inline(always)]
+#[inline]
 fn gate_enabled() -> bool {
     #[cfg(test)]
     if FORCE_PROBE_FOR_TESTS.load(Ordering::Relaxed) {
@@ -259,7 +260,6 @@ pub fn dump_report() -> String {
         return String::new();
     }
 
-    use std::fmt::Write as _;
     let mut out = String::new();
     let _ = writeln!(out, "\n=== TSZ eval-materialization probe (#13250) ===");
     let _ = writeln!(

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -1058,6 +1058,20 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // Visitor pattern: dispatch to appropriate visit_* method
         let result = self.visit_type_key(type_id, &key);
 
+        // Measurement-only (issue #13250): quantify recursive-eval
+        // materialization headroom for conditional/mapped/application inputs.
+        // No-op (single branch) unless `TSZ_PERF_COUNTERS` is set; the lookup
+        // of the result's `TypeData` is only performed under that gate.
+        if tsz_common::perf_counters::enabled_fast() {
+            let result_key = self.interner.lookup(result);
+            crate::evaluation::eval_materialization_probe::record_compute(
+                type_id,
+                &key,
+                result,
+                result_key.as_ref(),
+            );
+        }
+
         // Symmetric cleanup: leave guard and cache result
         self.guard.leave(type_id);
         self.memo_insert(limit_epoch_at_entry, type_id, result);

--- a/crates/tsz-solver/src/evaluation/mod.rs
+++ b/crates/tsz-solver/src/evaluation/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod cross_eval_guard;
+pub mod eval_materialization_probe;
 pub(crate) mod evaluate;
 pub(crate) mod evaluate_rules;
 pub(crate) mod memo_audit;

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -196,6 +196,20 @@ pub mod computation {
     };
 }
 
+/// Solver-owned observability reports.
+///
+/// These are measurement-only surfaces for CLI diagnostics and performance
+/// monitoring. They must not feed decisions back into checker or solver
+/// semantics.
+pub mod observability {
+    /// Measurement-only eval-materialization probe report (#13250).
+    ///
+    /// Returns an empty string unless `TSZ_PERF_COUNTERS` is set.
+    pub fn eval_materialization_probe_report() -> String {
+        crate::evaluation::eval_materialization_probe::dump_report()
+    }
+}
+
 /// Tier 4: Type construction — building new types.
 ///
 /// These create or modify types via the interner. Should be accessed through
@@ -260,11 +274,6 @@ pub use diagnostics::{
     DiagnosticArg, DiagnosticSeverity, PendingDiagnostic, PendingDiagnosticBuilder, SourceSpan,
 };
 pub use diagnostics::{SubtypeFailureReason, TupleArity};
-/// Measurement-only eval-materialization probe report (#13250). Re-exported at
-/// the crate root as a named facade so measurement consumers (CLI
-/// `--diagnostics`) do not reach through the `evaluation` module path. Returns
-/// an empty string unless `TSZ_PERF_COUNTERS` is set.
-pub use evaluation::eval_materialization_probe::dump_report as eval_materialization_probe_report;
 #[cfg(test)]
 #[allow(unused_imports)]
 pub(crate) use evaluation::evaluate::{

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -260,6 +260,11 @@ pub use diagnostics::{
     DiagnosticArg, DiagnosticSeverity, PendingDiagnostic, PendingDiagnosticBuilder, SourceSpan,
 };
 pub use diagnostics::{SubtypeFailureReason, TupleArity};
+/// Measurement-only eval-materialization probe report (#13250). Re-exported at
+/// the crate root as a named facade so measurement consumers (CLI
+/// `--diagnostics`) do not reach through the `evaluation` module path. Returns
+/// an empty string unless `TSZ_PERF_COUNTERS` is set.
+pub use evaluation::eval_materialization_probe::dump_report as eval_materialization_probe_report;
 #[cfg(test)]
 #[allow(unused_imports)]
 pub(crate) use evaluation::evaluate::{


### PR DESCRIPTION
Goal: fast

## Summary

Measurement-only probe that de-risks the largest single change on the #13250
board: the deferred/lazy structural-materialization rewrite (4-8 weeks, HIGH
conformance risk because it changes *when* conditionals evaluate). Before
committing to that, this PR quantifies the headroom of the candidate
sub-strategies on the ts-toolbelt AutoPath/MetaPath lever (plus type-fest) so the
campaign can be redirected on evidence rather than assumption.

Everything is gated behind the existing `TSZ_PERF_COUNTERS` env flag and read
once via `--extendedDiagnostics`. **Default behavior is unchanged**: every hook
is a single predictable branch when the flag is unset; the result-`TypeData`
lookup is only performed under the gate.

### What it measures

Hooked at the single eval chokepoint `evaluate_guarded_inner` (every type kind
flows through it). For `conditional` / `mapped` / `application` inputs it
records, per kind: total computes, distinct input `TypeId`s, distinct result
`TypeId`s, deferred-vs-eager classification, and a structural hash-cons-gap
detector. A self-contained module
(`crates/tsz-solver/src/evaluation/eval_materialization_probe.rs`) owns the
process-wide state; `dump_report()` renders under the perf-counter dump.

## Measurements

### ts-toolbelt (sources/**, tsconfig.bench.json)

AutoPath.ts family is ~88% of ts-toolbelt's wall.

```
[conditional]  computes 53642  distinct inputs 50062  distinct results 41309
               recompute headroom  3580  (6.7%)   deferred 5475   hash-cons gap 0
[mapped]       computes  7376  distinct inputs  6965  distinct results  6938
               recompute headroom   411  (5.6%)   deferred  531   hash-cons gap 0
[application]  computes 130874 distinct inputs 60312  distinct results 51656
               recompute headroom 70562 (53.9%)   deferred 65523  hash-cons gap 0
[conditional defer headroom]  eager computes 48167  eager distinct 46336
               eager recompute headroom 1831 (3.8%)
[totals] computes 191892 -> distinct results 99903 (overall fan-out 47.9%)
```

### type-fest (deep recursive consumers: paths, partial-deep, merge-deep, get, conditional-*)

The deeply-recursive consumers make the signal unambiguous:

```
[conditional]  computes  4370195  distinct inputs 3593  distinct results 1185
               recompute headroom  4366602  (99.9%)   deferred 4098633  hash-cons gap 0
[mapped]       computes   631270  distinct inputs 1409  distinct results  855
               recompute headroom   629861  (99.8%)   deferred  581287  hash-cons gap 0
[application]  computes 11677995  distinct inputs 5274  distinct results 2956
               recompute headroom 11672721 (100.0%)   deferred 11444837 hash-cons gap 0
[totals] computes 16679460 -> distinct results 4996 (overall fan-out 100.0%)
```

~10K distinct inputs, but 16.7M computes — the same small set is re-derived
millions of times. (This run reports a TS2307 on a `tsd` import in the consumer
harness; the eval engine still fully exercised the type definitions, so the
probe numbers are valid.)

## Findings (the de-risking answer)

1. **Hash-cons (dedup) headroom: ZERO.** `hash-cons gap = 0` for every kind on
   both corpora. The central `TypeInterner` already structurally hash-conses
   (`TypeData` -> one `TypeId`), so two structurally-equal produced shapes
   already collapse to one id. Additional hash-consing of eval results buys
   nothing. Structural hash-consing is NOT the lever.

2. **Defer headroom (conditionals): SMALL on the representative ts-toolbelt
   workload.** Conditional recompute headroom is 6.7% of computes;
   eager-conditional recompute headroom is 3.8%. Deferring more conditionals
   (the expensive, high-conformance-risk rewrite) targets a thin slice.

3. **Recompute headroom (the real lever): APPLICATION eval.** ts-toolbelt
   application computes show **53.9% recompute headroom**; type-fest shows
   **~100%** across all kinds (4,996 distinct results from 16.7M computes). The
   interner dedups the *output*, but the recursion still *runs* to produce it,
   and the same unresolved applications are re-entered across evaluator
   contexts (65,523 / 11.4M deferred-application re-interns respectively).

### Recommendation: NOT defer, NOT hash-cons — a longer-lived application-eval memo

The headroom is application **recomputation**, not output duplication and not
eager-conditional evaluation. The high-value, far-lower-risk change is a
longer-lived / shared application-evaluation memo keyed on
`(def_id, args, options)` so the deep recursion is not re-run per evaluator
context — exactly the lane the opt-in `shared_application_eval_cache` (#13240)
already prototypes. This is a memo-lifetime/key change, not a semantics change,
so it carries a fraction of the conformance risk of the deferred-materialization
rewrite while addressing the dominant recompute slice on both corpora.

The zero hash-cons gap and the small ts-toolbelt conditional slice argue
**against** spending 4-8 weeks on deferred conditional evaluation for this row.

## Verification

- `cargo clippy --profile ci-lint -p tsz-common -p tsz-solver -p tsz-cli --all-targets -- -D warnings` — clean (the profile CI uses; dev-inherited).
- `cargo build --release -p tsz-cli --bin tsz` — clean.
- Three new probe unit tests assert recorder semantics (distinct-vs-recompute, per-kind routing, gated report rendering).
- Probe output reproduced byte-identically across two release builds on ts-toolbelt; default-path behavior unchanged (gate off => empty report).

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high
