### PR TITLE
perf(checker,solver): tsc-faithful shallow false-branch predicate exclusion (#13242)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -338,8 +338,20 @@ pub(crate) fn narrow_call_predicate_guard(
     {
         let positive = narrowing.narrow_type(type_id, guard, GuardSense::Positive);
         if positive != type_id && positive != TypeId::NEVER {
-            let excluded = narrowing.narrow_excluding_type(type_id, positive);
-            if excluded != type_id {
+            // tsc's false-branch predicate exclusion is a shallow
+            // `filterType(type, t => !isTypeSubsetOf(t, trueType))` over the
+            // top-level union members (identity/containment only). The general
+            // `narrow_excluding_type` recurses into every intersection/union
+            // member with a deep `is_assignable_to` and explodes on
+            // recursive-schema unions (typebox / ts-morph `value is T`, where
+            // each nested schema is a distinct `TypeId` so the
+            // `(source, excluded)` memo never hits). Take tsc's cheap shallow
+            // path; when it cannot reduce the source, fall through to the
+            // structural top-level-member pass below (tsc's
+            // `directlyRelated`/intersection step) rather than the deep recursion.
+            if let Some(excluded) = narrowing.narrow_excluding_positive_subset(type_id, positive)
+                && excluded != type_id
+            {
                 return excluded;
             }
         }

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -12,7 +12,7 @@ use crate::visitor::{
     lazy_def_id, literal_value, object_shape_id, object_with_index_shape_id, template_literal_id,
     type_param_info, union_list_id,
 };
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use std::cell::RefCell;
 use std::sync::Arc;
 use tracing::{Level, span, trace};
@@ -478,56 +478,50 @@ pub(crate) struct NarrowExcludingKey {
 impl NarrowingCache {
     pub fn new() -> Self {
         Self {
-            resolve_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
-                1024,
-                Default::default(),
-            )),
+            resolve_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(1024, FxBuildHasher)),
             resolve_visiting: RefCell::new(FxHashSet::default()),
-            property_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
-                512,
-                Default::default(),
-            )),
+            property_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(512, FxBuildHasher)),
             required_property_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
                 256,
-                Default::default(),
+                FxBuildHasher,
             )),
             split_nullish_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
                 512,
-                Default::default(),
+                FxBuildHasher,
             )),
             contains_type_parameters_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
                 1024,
-                Default::default(),
+                FxBuildHasher,
             )),
             optional_chain_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
                 512,
-                Default::default(),
+                FxBuildHasher,
             )),
             optional_property_chain_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
                 512,
-                Default::default(),
+                FxBuildHasher,
             )),
             contextual_resolve_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
                 256,
-                Default::default(),
+                FxBuildHasher,
             )),
             discriminant_index: RefCell::new(FxHashMap::default()),
             narrow_type_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
                 1024,
-                Default::default(),
+                FxBuildHasher,
             )),
             narrow_excluding_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
                 256,
-                Default::default(),
+                FxBuildHasher,
             )),
             narrow_excluding_visiting: RefCell::new(FxHashSet::default()),
             narrow_assignable_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
                 512,
-                Default::default(),
+                FxBuildHasher,
             )),
             narrow_subtype_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
                 512,
-                Default::default(),
+                FxBuildHasher,
             )),
         }
     }

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -1411,6 +1411,86 @@ impl<'a> NarrowingContext<'a> {
         self.narrow_to_type(literal, target) != TypeId::NEVER
     }
 
+    /// Exclude the positive (true-branch) narrowing from a source for the
+    /// false branch of a type-predicate guard, mirroring tsc's
+    /// `getNarrowedTypeWorker(assumeTrue=false)`:
+    /// `filterType(type, t => !isTypeSubsetOf(t, trueType))`.
+    ///
+    /// tsc's `filterType` is a *shallow* pass over the source union's top-level
+    /// members, and `isTypeSubsetOf` is a pure identity/containment test (no
+    /// structural subtype walk, no descent into a member's intersection
+    /// sub-structure). The general [`Self::narrow_excluding_type`] instead
+    /// recurses into every intersection/union member and runs a deep
+    /// `is_assignable_to` per member; over a recursive-schema union (typebox /
+    /// ts-morph `value is T` guards, where each nested schema instantiates to a
+    /// distinct `TypeId` so the `(source, excluded)` memo never hits) that
+    /// recursion is exponential and was the dominant non-termination frame.
+    ///
+    /// This boundary keeps the false-branch predicate exclusion on tsc's cheap
+    /// O(N) shallow path. It returns `None` when the shallow filter cannot
+    /// reduce the source (every member survives `isTypeSubsetOf`), so the caller
+    /// can fall back to its structural-assignability member pass for the cases
+    /// tsc covers through `directlyRelated`/intersection construction.
+    pub fn narrow_excluding_positive_subset(
+        &self,
+        source_type: TypeId,
+        positive_type: TypeId,
+    ) -> Option<TypeId> {
+        // `any`/`unknown` are never reduced by exclusion (tsc returns the source
+        // unchanged), so there is nothing for the shallow filter to do.
+        if source_type == TypeId::ANY || source_type == TypeId::UNKNOWN {
+            return None;
+        }
+
+        let resolved_source = self.resolve_type(source_type);
+        let Some(members) = union_list_id(self.db, resolved_source) else {
+            // A non-union source is dropped to `never` iff it is a subset of the
+            // positive type; otherwise it is unrelated and kept. tsc:
+            // `type.flags & Never || f(type) ? type : neverType`.
+            return self
+                .is_type_subset_of(resolved_source, positive_type)
+                .then_some(TypeId::NEVER);
+        };
+
+        let members = self.db.type_list(members);
+        let remaining: Vec<TypeId> = members
+            .iter()
+            .copied()
+            .filter(|&member| !self.is_type_subset_of(member, positive_type))
+            .collect();
+
+        if remaining.len() == members.len() {
+            // Nothing filtered — let the caller try its structural fallback.
+            return None;
+        }
+        Some(match remaining.as_slice() {
+            [] => TypeId::NEVER,
+            [single] => *single,
+            _ => self.db.union(remaining),
+        })
+    }
+
+    /// tsc's `isTypeSubsetOf`: a pure identity/containment relation used by
+    /// false-branch predicate exclusion. `source` is a subset of `target` when
+    /// it is identical, is `never`, or — when `target` is a union — every
+    /// constituent of `source` is one of `target`'s constituents. No structural
+    /// subtype walk is performed (that is the divergence this avoids).
+    fn is_type_subset_of(&self, source: TypeId, target: TypeId) -> bool {
+        if source == target || source == TypeId::NEVER {
+            return true;
+        }
+        let Some(target_members) = union_list_id(self.db, target) else {
+            return false;
+        };
+        let target_members = self.db.type_list(target_members);
+        if let Some(source_members) = union_list_id(self.db, source) {
+            let source_members = self.db.type_list(source_members);
+            source_members.iter().all(|s| target_members.contains(s))
+        } else {
+            target_members.contains(&source)
+        }
+    }
+
     /// Narrow a type to exclude members assignable to target.
     ///
     /// Memoizing entry point. The recursive body (`narrow_excluding_type_uncached`)
@@ -2124,6 +2204,35 @@ impl<'a> NarrowingContext<'a> {
                             let resolved_source = self.resolve_for_exclusion_narrowing(source_type);
                             let resolved_target =
                                 self.resolve_for_exclusion_narrowing(*target_type);
+
+                            // tsc's `getNarrowedTypeWorker(assumeTrue=false)` first
+                            // computes the true-branch type, then shallow-filters the
+                            // source: `filterType(type, t => !isTypeSubsetOf(t,
+                            // trueType))`. `filterType`/`isTypeSubsetOf` are a pure
+                            // identity/containment pass over the source union's
+                            // top-level members — no descent into a member's
+                            // intersection sub-structure and no structural subtype
+                            // walk. Take that cheap path when it reduces the source:
+                            // the general `narrow_excluding_type` recurses into every
+                            // member with a deep `is_assignable_to`, which explodes on
+                            // recursive-schema unions (typebox / ts-morph `value is T`,
+                            // where each nested schema instantiates to a distinct
+                            // `TypeId` so the `(source, excluded)` memo never hits).
+                            // The positive (true-branch) type is the union members of
+                            // the source that overlap the target, so filtering members
+                            // that are subsets of it matches tsc. When the shallow
+                            // filter cannot reduce the source (no member is a clean
+                            // subset — e.g. type-parameter / single-intersection
+                            // sources tsc handles via its intersection step), fall back
+                            // to the existing structural exclusion.
+                            let positive = self.narrow_to_type(resolved_source, resolved_target);
+                            if positive != TypeId::NEVER
+                                && positive != resolved_source
+                                && let Some(excluded) =
+                                    self.narrow_excluding_positive_subset(resolved_source, positive)
+                            {
+                                return excluded;
+                            }
                             self.narrow_excluding_type(resolved_source, resolved_target)
                         }
                     }

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -342,6 +342,7 @@ pub struct NarrowingCacheStatistics {
     pub narrow_type_cache_entries: usize,
     pub narrow_excluding_cache_entries: usize,
     pub narrow_assignable_cache_entries: usize,
+    pub narrow_subtype_cache_entries: usize,
     pub estimated_size_bytes: usize,
 }
 
@@ -360,6 +361,7 @@ impl NarrowingCacheStatistics {
             + self.narrow_type_cache_entries
             + self.narrow_excluding_cache_entries
             + self.narrow_assignable_cache_entries
+            + self.narrow_subtype_cache_entries
     }
 }
 
@@ -447,6 +449,16 @@ pub struct NarrowingCache {
     /// over one recursive `TSchema`, so memoizing the boolean collapses the
     /// repeated deep materialization (issue #13242 / #13250).
     pub(crate) narrow_assignable_cache: RefCell<FxHashMap<NarrowExcludingKey, bool>>,
+    /// Memo for the narrowing-boundary subtype check
+    /// ([`NarrowingContext::is_subtype_for_narrowing`]) keyed by
+    /// `(source, target, resolver_generation)`.
+    ///
+    /// This is the single chokepoint that constructs a fresh `SubtypeChecker`
+    /// for narrowing; both the positive type-predicate branch and
+    /// `is_assignable_to` funnel here, so it is the deepest point at which the
+    /// recursive-schema `collect_properties_cached` walk can be cached once per
+    /// `(source, target)` pair (issue #13242 / #13250).
+    pub(crate) narrow_subtype_cache: RefCell<FxHashMap<NarrowExcludingKey, bool>>,
 }
 
 /// Cache key for [`NarrowingContext::narrow_excluding_type`] and
@@ -513,6 +525,10 @@ impl NarrowingCache {
                 512,
                 Default::default(),
             )),
+            narrow_subtype_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
+                512,
+                Default::default(),
+            )),
         }
     }
 
@@ -537,6 +553,7 @@ impl NarrowingCache {
             narrow_type_cache_entries: self.narrow_type_cache.borrow().len(),
             narrow_excluding_cache_entries: self.narrow_excluding_cache.borrow().len(),
             narrow_assignable_cache_entries: self.narrow_assignable_cache.borrow().len(),
+            narrow_subtype_cache_entries: self.narrow_subtype_cache.borrow().len(),
             estimated_size_bytes: self.estimated_size_bytes(),
         }
     }
@@ -639,6 +656,13 @@ impl NarrowingCache {
         }
         {
             let map = self.narrow_assignable_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<NarrowExcludingKey>()
+                    + std::mem::size_of::<bool>());
+        }
+        {
+            let map = self.narrow_subtype_cache.borrow();
             size += map.capacity()
                 * (BUCKET_OVERHEAD
                     + std::mem::size_of::<NarrowExcludingKey>()

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -340,6 +340,8 @@ pub struct NarrowingCacheStatistics {
     pub contextual_resolve_cache_entries: usize,
     pub discriminant_index_entries: usize,
     pub narrow_type_cache_entries: usize,
+    pub narrow_excluding_cache_entries: usize,
+    pub narrow_assignable_cache_entries: usize,
     pub estimated_size_bytes: usize,
 }
 
@@ -356,6 +358,8 @@ impl NarrowingCacheStatistics {
             + self.contextual_resolve_cache_entries
             + self.discriminant_index_entries
             + self.narrow_type_cache_entries
+            + self.narrow_excluding_cache_entries
+            + self.narrow_assignable_cache_entries
     }
 }
 
@@ -412,6 +416,51 @@ pub struct NarrowingCache {
     /// paths because their results depend on structural lookups that are already
     /// cached at narrower query boundaries.
     pub(crate) narrow_type_cache: RefCell<FxHashMap<NarrowTypeCacheKey, TypeId>>,
+    /// Memo for [`NarrowingContext::narrow_excluding_type`] keyed by
+    /// `(source, excluded, resolver_generation)`.
+    ///
+    /// False-branch type-predicate narrowing over a recursive-schema union
+    /// (typebox / ts-morph `value is T` guards) drives `narrow_excluding_type`
+    /// into an exponential self-recursion: every intersection / type-parameter
+    /// member re-enters the function on `(member, excluded)`, and the recursive
+    /// alias members expand the same `(source, excluded)` subtree at each depth.
+    /// Memoizing collapses that re-expansion to linear; combined with
+    /// `narrow_excluding_visiting` it is the structural fix for the
+    /// non-terminating typebox row (issue #13242 / #13250).
+    pub(crate) narrow_excluding_cache: RefCell<FxHashMap<NarrowExcludingKey, TypeId>>,
+    /// In-progress `(source, excluded, resolver_generation)` set for
+    /// `narrow_excluding_type`. A recursive-alias member whose resolution
+    /// re-enters the same `(source, excluded)` pair is a cycle; returning the
+    /// source unchanged on re-entry mirrors tsc, which does not exhaustively
+    /// re-expand a recursive union during exclusion narrowing.
+    pub(crate) narrow_excluding_visiting: RefCell<FxHashSet<NarrowExcludingKey>>,
+    /// Memo for the narrowing-boundary assignability check
+    /// ([`NarrowingContext::is_assignable_to`]) keyed by
+    /// `(source, target, resolver_generation)`.
+    ///
+    /// Positive-branch type-predicate narrowing (`narrow_to_type`) filters each
+    /// union member with `is_assignable_to(member, target)`, which falls into a
+    /// full `SubtypeChecker` whose structural comparison of recursive-schema
+    /// interfaces re-materializes the recursive property closure via
+    /// `collect_properties_cached` at each depth. The same `(member, target)`
+    /// pair recurs across the many `IsXxx(s)` guards a typebox/ts-morph file runs
+    /// over one recursive `TSchema`, so memoizing the boolean collapses the
+    /// repeated deep materialization (issue #13242 / #13250).
+    pub(crate) narrow_assignable_cache: RefCell<FxHashMap<NarrowExcludingKey, bool>>,
+}
+
+/// Cache key for [`NarrowingContext::narrow_excluding_type`] and
+/// [`NarrowingContext::is_assignable_to`].
+///
+/// A `(source, target, resolver_generation)` triple. `resolver_generation` is
+/// folded in so a later resolver that resolves a Lazy alias differently cannot
+/// reuse a stale result, matching the keying discipline of
+/// [`NarrowTypeCacheKey`].
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]
+pub(crate) struct NarrowExcludingKey {
+    source: TypeId,
+    excluded: TypeId,
+    resolver_generation: u64,
 }
 
 impl NarrowingCache {
@@ -455,6 +504,15 @@ impl NarrowingCache {
                 1024,
                 Default::default(),
             )),
+            narrow_excluding_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
+                256,
+                Default::default(),
+            )),
+            narrow_excluding_visiting: RefCell::new(FxHashSet::default()),
+            narrow_assignable_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
+                512,
+                Default::default(),
+            )),
         }
     }
 
@@ -477,6 +535,8 @@ impl NarrowingCache {
             contextual_resolve_cache_entries: self.contextual_resolve_cache.borrow().len(),
             discriminant_index_entries: self.discriminant_index.borrow().len(),
             narrow_type_cache_entries: self.narrow_type_cache.borrow().len(),
+            narrow_excluding_cache_entries: self.narrow_excluding_cache.borrow().len(),
+            narrow_assignable_cache_entries: self.narrow_assignable_cache.borrow().len(),
             estimated_size_bytes: self.estimated_size_bytes(),
         }
     }
@@ -565,6 +625,24 @@ impl NarrowingCache {
                 * (BUCKET_OVERHEAD
                     + std::mem::size_of::<NarrowTypeCacheKey>()
                     + std::mem::size_of::<TypeId>());
+        }
+        {
+            let map = self.narrow_excluding_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<NarrowExcludingKey>()
+                    + std::mem::size_of::<TypeId>());
+        }
+        {
+            let set = self.narrow_excluding_visiting.borrow();
+            size += set.capacity() * (BUCKET_OVERHEAD + std::mem::size_of::<NarrowExcludingKey>());
+        }
+        {
+            let map = self.narrow_assignable_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<NarrowExcludingKey>()
+                    + std::mem::size_of::<bool>());
         }
 
         size
@@ -1310,7 +1388,58 @@ impl<'a> NarrowingContext<'a> {
     }
 
     /// Narrow a type to exclude members assignable to target.
+    ///
+    /// Memoizing entry point. The recursive body (`narrow_excluding_type_uncached`)
+    /// re-enters on every intersection / type-parameter / union-intersection
+    /// member, so a recursive-schema union (typebox / ts-morph `value is T`
+    /// false-branch guards) expands the same `(source, excluded)` subtree
+    /// exponentially. The memo collapses that to linear and the visiting set
+    /// breaks the `Lazy`-alias resolution cycle — returning the source unchanged
+    /// on re-entry, which matches tsc's non-exhaustive exclusion over a recursive
+    /// union (issue #13242 / #13250).
     pub fn narrow_excluding_type(&self, source_type: TypeId, excluded_type: TypeId) -> TypeId {
+        // Intrinsics and identity pairs are answered without recursion; skip the
+        // memo bookkeeping for them so the common shallow path stays allocation-
+        // and borrow-free.
+        if source_type == TypeId::ANY {
+            return TypeId::ANY;
+        }
+        if source_type.is_intrinsic() && excluded_type.is_intrinsic() {
+            return self.narrow_excluding_type_uncached(source_type, excluded_type);
+        }
+
+        let key = NarrowExcludingKey {
+            source: source_type,
+            excluded: excluded_type,
+            resolver_generation: self.resolver_generation(),
+        };
+        if let Some(&cached) = self.cache.narrow_excluding_cache.borrow().get(&key) {
+            return cached;
+        }
+        // Re-entry on the same `(source, excluded)` pair is a recursive-alias
+        // cycle: leave the source unchanged so the in-flight outer frame owns the
+        // result, mirroring tsc's bounded exclusion over a recursive union.
+        if !self
+            .cache
+            .narrow_excluding_visiting
+            .borrow_mut()
+            .insert(key)
+        {
+            return source_type;
+        }
+        let result = self.narrow_excluding_type_uncached(source_type, excluded_type);
+        self.cache
+            .narrow_excluding_visiting
+            .borrow_mut()
+            .remove(&key);
+        self.cache
+            .narrow_excluding_cache
+            .borrow_mut()
+            .insert(key, result);
+        result
+    }
+
+    fn narrow_excluding_type_uncached(&self, source_type: TypeId, excluded_type: TypeId) -> TypeId {
         // `any` cannot be narrowed by exclusion — it remains `any` in all branches.
         // Without this guard, the `is_assignable_to(any, X)` check below would always
         // succeed (any is assignable to everything), incorrectly producing `never`.

--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -921,13 +921,36 @@ impl<'a> NarrowingContext<'a> {
         source: TypeId,
         target: TypeId,
     ) -> bool {
-        if let Some(resolver) = self.resolver {
+        // Memoize at this chokepoint: every narrowing subtype query (positive
+        // predicate branch and `is_assignable_to` alike) constructs a fresh
+        // `SubtypeChecker` here, and on a recursive-schema interface that walk
+        // re-materializes the property closure via `collect_properties_cached`.
+        // Caching the boolean by `(source, target, resolver_generation)` lets the
+        // same `(source, target)` pair — recurring across the many predicate
+        // guards over one `TSchema` — reuse the first walk (issue #13242 / #13250).
+        if source == target {
+            return true;
+        }
+        let key = NarrowExcludingKey {
+            source,
+            excluded: target,
+            resolver_generation: self.resolver_generation(),
+        };
+        if let Some(&cached) = self.cache.narrow_subtype_cache.borrow().get(&key) {
+            return cached;
+        }
+        let result = if let Some(resolver) = self.resolver {
             let mut checker = SubtypeChecker::with_resolver(self.db.as_type_database(), &resolver)
                 .with_query_db(self.db);
             checker.is_subtype_of(source, target)
         } else {
             crate::relations::subtype::is_subtype_of_with_db(self.db, source, target)
-        }
+        };
+        self.cache
+            .narrow_subtype_cache
+            .borrow_mut()
+            .insert(key, result);
+        result
     }
 
     fn is_class_subtype_for_narrowing(&self, source: TypeId, target: TypeId) -> bool {

--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -768,7 +768,44 @@ impl<'a> NarrowingContext<'a> {
     }
 
     /// Simple assignability check for narrowing purposes.
+    ///
+    /// Memoizing entry point. The structural fallback
+    /// ([`Self::is_subtype_for_narrowing`]) compares recursive-schema interfaces
+    /// by re-materializing their property closure via `collect_properties_cached`
+    /// at each depth, so the same `(source, target)` pair — recurring across the
+    /// many predicate guards a typebox/ts-morph file runs over one recursive
+    /// `TSchema` — would redo that deep walk every time. The shared memo (keyed
+    /// by `(source, target, resolver_generation)`) collapses it to one walk
+    /// (issue #13242 / #13250).
     pub(in crate::narrowing) fn is_assignable_to(&self, source: TypeId, target: TypeId) -> bool {
+        // Trivial answers are cheaper than a memo probe; keep them inline so the
+        // common shallow path stays borrow-free.
+        if source == target || source == TypeId::NEVER || target.is_any_or_unknown() {
+            return true;
+        }
+        // Only memoize non-intrinsic pairs: intrinsic vs intrinsic is resolved by
+        // the fast-path arms below without any recursive structural walk.
+        if source.is_intrinsic() && target.is_intrinsic() {
+            return self.is_assignable_to_uncached(source, target);
+        }
+
+        let key = NarrowExcludingKey {
+            source,
+            excluded: target,
+            resolver_generation: self.resolver_generation(),
+        };
+        if let Some(&cached) = self.cache.narrow_assignable_cache.borrow().get(&key) {
+            return cached;
+        }
+        let result = self.is_assignable_to_uncached(source, target);
+        self.cache
+            .narrow_assignable_cache
+            .borrow_mut()
+            .insert(key, result);
+        result
+    }
+
+    fn is_assignable_to_uncached(&self, source: TypeId, target: TypeId) -> bool {
         if source == target {
             return true;
         }

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs
@@ -1016,6 +1016,67 @@ fn test_narrow_excluding_type() {
 }
 
 #[test]
+fn test_narrow_excluding_positive_subset_filters_union_members() {
+    // tsc's false-branch predicate exclusion: filterType(type, t =>
+    // !isTypeSubsetOf(t, trueType)). Members that are subsets of (here equal to,
+    // or contained in) the positive type are dropped; the rest survive — a
+    // shallow identity/containment pass, no structural subtype walk.
+    let interner = TypeInterner::new();
+    let ctx = NarrowingContext::new(&interner);
+
+    let union = interner.union(vec![TypeId::STRING, TypeId::NUMBER, TypeId::BOOLEAN]);
+
+    // Exclude the positive `string` -> number | boolean.
+    let excluded = ctx
+        .narrow_excluding_positive_subset(union, TypeId::STRING)
+        .expect("a reducible member exists");
+    let expected = interner.union(vec![TypeId::NUMBER, TypeId::BOOLEAN]);
+    assert_eq!(excluded, expected);
+
+    // Exclude a positive `string | number` -> boolean (multi-member positive).
+    let positive = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    let excluded = ctx
+        .narrow_excluding_positive_subset(union, positive)
+        .expect("two members are subsets of the positive");
+    assert_eq!(excluded, TypeId::BOOLEAN);
+}
+
+#[test]
+fn test_narrow_excluding_positive_subset_no_reduction_returns_none() {
+    // When no source member is a subset of the positive type, the shallow filter
+    // cannot reduce the source and returns None so the caller can fall back to
+    // the structural exclusion path.
+    let interner = TypeInterner::new();
+    let ctx = NarrowingContext::new(&interner);
+
+    let union = interner.union(vec![TypeId::NUMBER, TypeId::BOOLEAN]);
+    // `string` is not a member of the source, so nothing is filtered.
+    assert_eq!(
+        ctx.narrow_excluding_positive_subset(union, TypeId::STRING),
+        None
+    );
+}
+
+#[test]
+fn test_narrow_excluding_positive_subset_non_union_source() {
+    // A non-union source collapses to `never` iff it is a subset of the positive
+    // type, mirroring tsc's `type.flags & Never || f(type) ? type : neverType`.
+    let interner = TypeInterner::new();
+    let ctx = NarrowingContext::new(&interner);
+
+    // `string` is a subset of positive `string` -> never.
+    assert_eq!(
+        ctx.narrow_excluding_positive_subset(TypeId::STRING, TypeId::STRING),
+        Some(TypeId::NEVER)
+    );
+    // `string` is unrelated to positive `number` -> not reduced (None).
+    assert_eq!(
+        ctx.narrow_excluding_positive_subset(TypeId::STRING, TypeId::NUMBER),
+        None
+    );
+}
+
+#[test]
 fn test_narrow_excluding_type_param_with_union_constraint() {
     let interner = TypeInterner::new();
     let ctx = NarrowingContext::new(&interner);


### PR DESCRIPTION
Goal: fast

Stacked on #13822 (`green/defmat-narrow`); base is that branch so the diff shows only this commit. References #13242 / #13250 (workstream B — stop doing work tsc never does).

## Structural rule

When a user **type-predicate guard's false branch** narrows a recursive-schema
union (typebox / ts-morph `value is T`), tsc computes the true-branch type once
and then runs a **shallow** `filterType(type, t => !isTypeSubsetOf(t, trueType))`
over the source union's top-level members. `filterType`/`isTypeSubsetOf`
(`checker.ts:28526` / `:28491`, called from `getNarrowedTypeWorker(assumeTrue=false)`
`checker.ts:30070-30071`) are a pure identity/containment pass: no descent into a
member's intersection sub-structure and no structural subtype walk.

tsz instead routed the false branch through the general `narrow_excluding_type`,
which recurses into every intersection/union member and runs a deep
`is_assignable_to` per member. Because each nested schema instantiates to a
**distinct `TypeId`**, the `(source, excluded)` memo (added by #13822) never hits
on the descent, so the recursion was exponential — the dominant non-termination
frame on typebox (profiled at ~100% of the predicate-guard subtree; gone post-fix,
0 frames).

Owner layer: solver narrowing (`crates/tsz-solver/src/narrowing/core.rs`) owns the
tsc-faithful shallow filter; the checker flow boundary
(`crates/tsz-checker/src/query_boundaries/flow_analysis.rs`) routes the predicate
false branch through it.

## What changed

- `NarrowingContext::narrow_excluding_positive_subset` — tsc's
  `filterType(source, |t| !isTypeSubsetOf(t, positive))` over top-level union
  members, plus `is_type_subset_of` (identity / union-containment; no structural
  walk). Returns `None` when it cannot reduce the source so callers fall back to
  the existing structural member pass (tsc's `directlyRelated`/intersection step),
  never the deep recursion.
- `narrow_type` regular-guard false branch and the `narrow_call_predicate_guard`
  fallback now take the shallow path first.

## Adjacent matrix / fallback

- Positive and negative branches (synthetic recursive-schema `value is T`:
  false branch correctly excludes the guarded member -> `s.items` trips TS2339).
- Union vs non-union source; multi-member positive; no-reduction -> `None` ->
  structural fallback preserved (unit tests). Renamed binders are irrelevant
  (no name/identifier checks — pure TypeId/structural logic).

## Verification

- typebox profile (fresh dist-fast, `sample`): `narrow_excluding_type_uncached`
  drops from the dominant predicate-guard frame to **0 frames**. Remaining cost
  is the separate eager-evaluation / `collect_properties` materialization lever
  (#13242 section 2) — typebox does NOT yet fully terminate from this slice alone
  (still EXIT 124 at 900s, eager-eval-bound; RSS stable ~56MB = terminating-class,
  not memory blowup). This slice removes the narrowing hotspot only.
- Recursive-schema predicate synthetic: ~0.14s warm, exit 0, correct narrowing.
- Conformance (dist-fast, `conformance.sh --filter`), **0 PASS->FAIL**: narrow
  56/56, typeGuard 86/86, mappedType 55/55, conditionalType 17/17, recursiveType
  23/23, unionType 30/30, tsxLibraryManagedAttributes 1/1, deeplyNested 6/7
  (the 1 is a pre-existing accepted fingerprint-only diff in
  `deeplyNestedMappedTypes.ts`, which uses no type predicates).
- `cargo nextest -p tsz-solver` narrowing/exclusion/predicate: 369/369; 3 new
  unit tests pass.
- clippy clean (tsz-solver, tsz-checker); `arch_guard.py` passes.
- Determinism: synthetics + narrowing conformance identical across 3 runs.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

AgentName: M1Opus
- Row: typebox
- Bug family: deferred-materialization-narrowing