### PR TITLE
fix(bench): skip application canary rows in bench-publish PGO step

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1419,8 +1419,15 @@ jobs:
           test -x .target-bench/dist/tsz
           test -f .target-bench/dist/.bench-pgo-optimized
 
+          # Skip category:"application" canary rows here: they clone+install real
+          # apps (minutes each) and are excluded from the benchmark corpus, so
+          # they produce no PGO timing data but would blow this job's 30m budget
+          # (observed 2026-06-17: bench-publish timed out for ~14h, freezing the
+          # published benchmarks). Application *compatibility* is still tracked by
+          # the CI project-compile-canary shards, which do not set this flag.
           TSZ_BIN="$GITHUB_WORKSPACE/.target-bench/dist/tsz" \
           TSZ_PROJECT_COMPILE_SET=canary \
+          TSZ_PROJECT_COMPILE_SKIP_APPLICATIONS=1 \
           TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 \
           scripts/ci/project-compile-guard.sh
 

--- a/scripts/ci/project-compile-guard.sh
+++ b/scripts/ci/project-compile-guard.sh
@@ -9,6 +9,12 @@ TSZ_BIN="${TSZ_BIN:-$DEFAULT_TARGET_DIR/dist-fast/tsz}"
 FIXTURE_ROOT="${TSZ_PROJECT_COMPILE_FIXTURE_ROOT:-$ROOT_DIR/.target/project-compile-guard}"
 PROJECT_TIMEOUT="${TSZ_PROJECT_COMPILE_TIMEOUT:-90}"
 INCLUDE_GENERATED_APPS="${TSZ_PROJECT_COMPILE_INCLUDE_GENERATED_APPS:-1}"
+# Skip category:"application" canary rows. These clone+install real apps (deps
+# can take minutes each) and are compatibility canaries excluded from the
+# benchmark corpus, so latency-sensitive callers (e.g. bench-publish's PGO
+# timing step, capped at 30m) set this to 1 to avoid blowing their job budget
+# on rows that produce no benchmark data.
+SKIP_APPLICATIONS="${TSZ_PROJECT_COMPILE_SKIP_APPLICATIONS:-0}"
 PROJECT_FILTER="${TSZ_PROJECT_COMPILE_FILTER:-}"
 PROJECT_SET="${TSZ_PROJECT_COMPILE_SET:-required}"
 ALLOW_FAILURES="${TSZ_PROJECT_COMPILE_ALLOW_FAILURES:-0}"
@@ -424,6 +430,10 @@ install_application_deps() {
 #   name fixture_dir repo ref install_cmd install_root app_tsconfig src_dir
 run_application_row() {
   local name="$1" fdir="$2" repo="$3" ref="$4" install_cmd="$5" install_root="$6" app_tsconfig="$7" src_rel="$8"
+  if [[ "$SKIP_APPLICATIONS" == "1" ]]; then
+    echo "Skipping application row $name (TSZ_PROJECT_COMPILE_SKIP_APPLICATIONS=1)"
+    return 0
+  fi
   local root="$FIXTURE_ROOT/$fdir"
   ensure_git_fixture "$fdir" "$repo" "$ref" "$root"
   install_application_deps "$root/$install_root" "$install_cmd"


### PR DESCRIPTION
## Summary
This is the true root cause of the ~14h benchmark staleness on tsz.dev (the
gate/catch-up deadlock fixes #13833/#13836 were real but secondary — they
unblock *measurement*; this fixes *publishing*).

`bench-publish` runs `scripts/ci/project-compile-guard.sh` with
`TSZ_PROJECT_COMPILE_SET=canary` in its "Run PGO compile canaries" step, under
a **30-minute job timeout** (`timeout-minutes: 30`). Since **#13740** added 20
`category:"application"` canary rows, that step now clones + installs + compiles
20 real applications. From the live log of the stuck run:
- dep installs run per app (`pnpm`/`npm ci`/`yarn`, minutes each; several fail
  outright — the runner's Node is too old for `pnpm`);
- multiple app compiles hit the **90s per-project wall timeout** (lobe-chat,
  payload, medusa are CPU-bound).

20 apps × ~90–120s ≫ 30m, so `bench-publish` was **cancelled on the timeout
before publishing — every run**. Timing confirms it: #13740 merged
`2026-06-16T20:47:49Z`; the last successful publish was `2026-06-16T21:24:39Z`;
the site stayed frozen there for ~14h.

## Fix
Application rows are compatibility canaries, **excluded from the benchmark
corpus** (`arch_guard_project.py`), and produce no PGO timing data — they don't
belong in the latency-capped publish step. Add
`TSZ_PROJECT_COMPILE_SKIP_APPLICATIONS` (default `0`) guarding the single
`run_application_row` chokepoint, and set it `=1` in `bench-publish`'s PGO step.
The step now compiles only the library canaries (well under 30m). Application
**compatibility** is unchanged — the CI `project-compile-canary` shards still
run the apps (they don't set the flag).

## Verification
- `bash -n scripts/ci/project-compile-guard.sh` → OK
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/bench.yml'))"` → OK
- Single-chokepoint skip: every `category:"application"` row dispatches through
  `run_application_row`, so the guard covers all 20 apps; library/required rows
  and the CI canary shards are unaffected.
- merge_group runs full Bench validation.

Goal: fast

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
