### PR TITLE
fix(checker): globalThis.X resolves lib global over module-local import-type shadow

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -227,11 +227,10 @@ impl<'a> CheckerState<'a> {
                         )
                     {
                         // Route through wrong-meaning boundary: primitive keyword type-only
-                        use crate::query_boundaries::name_resolution::NameLookupKind;
                         self.report_wrong_meaning_diagnostic(
                             &name,
                             type_ref.type_name,
-                            NameLookupKind::Type,
+                            crate::query_boundaries::name_resolution::NameLookupKind::Type,
                         );
                         self.ctx.node_types.insert(idx.0, TypeId::ERROR);
                         return TypeId::ERROR;
@@ -444,11 +443,10 @@ impl<'a> CheckerState<'a> {
                             };
                             if let Some(keyword_name) = keyword_name {
                                 // Route through wrong-meaning boundary: keyword type-only
-                                use crate::query_boundaries::name_resolution::NameLookupKind;
                                 self.report_wrong_meaning_diagnostic(
                                     keyword_name,
                                     array_type.element_type,
-                                    NameLookupKind::Type,
+                                    crate::query_boundaries::name_resolution::NameLookupKind::Type,
                                 );
                                 self.ctx.node_types.insert(idx.0, TypeId::ERROR);
                                 return TypeId::ERROR;
@@ -1069,8 +1067,11 @@ impl<'a> CheckerState<'a> {
                     return vt;
                 }
                 // Route through wrong-meaning boundary: alias resolves to type-only
-                use crate::query_boundaries::name_resolution::NameLookupKind;
-                self.report_wrong_meaning_diagnostic(name, error_node, NameLookupKind::Type);
+                self.report_wrong_meaning_diagnostic(
+                    name,
+                    error_node,
+                    crate::query_boundaries::name_resolution::NameLookupKind::Type,
+                );
                 return TypeId::ERROR;
             }
             if let Some(symbol) = self.ctx.binder.get_symbol(sym_id) {
@@ -1082,8 +1083,11 @@ impl<'a> CheckerState<'a> {
                         return vt;
                     }
                     // Route through wrong-meaning boundary: symbol has no value meaning
-                    use crate::query_boundaries::name_resolution::NameLookupKind;
-                    self.report_wrong_meaning_diagnostic(name, error_node, NameLookupKind::Type);
+                    self.report_wrong_meaning_diagnostic(
+                        name,
+                        error_node,
+                        crate::query_boundaries::name_resolution::NameLookupKind::Type,
+                    );
                     return TypeId::ERROR;
                 }
                 // In TypeScript, `typeof globalThis` only exposes `var`-declared

--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -1009,6 +1009,32 @@ impl<'a> CheckerState<'a> {
         self.ctx.types.factory().callable(callable_shape)
     }
 
+    /// Resolve `name` to a lib-declared global value (`declare var`/`function`/
+    /// `class`) and return its value type, if any. Used as the recovery path
+    /// for `globalThis.<name>` accesses when the in-scope `<name>` is a
+    /// module-local binding that does not contribute a global value (a
+    /// block-scoped `const`/`let`, a type-only `import type` alias, or a symbol
+    /// without value meaning). `globalThis` exposes only the ambient global
+    /// scope, so such module-local bindings must never shadow a real lib global.
+    fn resolve_lib_global_var_value_type(&mut self, name: &str) -> Option<TypeId> {
+        let lib_sym_id = self.resolve_lib_global_var_symbol(name)?;
+        let lib_sym = self.ctx.binder.get_symbol(lib_sym_id).cloned()?;
+        for &decl_idx in &lib_sym.declarations {
+            if decl_idx.is_none() {
+                continue;
+            }
+            let vt = self.type_of_value_declaration_for_symbol(lib_sym_id, decl_idx);
+            if vt != TypeId::UNKNOWN && vt != TypeId::ERROR {
+                return Some(self.augment_js_global_value_type_with_expandos(name, lib_sym_id, vt));
+            }
+        }
+        let vt = self.get_type_of_symbol(lib_sym_id);
+        if vt != TypeId::UNKNOWN && vt != TypeId::ERROR {
+            return Some(self.augment_js_global_value_type_with_expandos(name, lib_sym_id, vt));
+        }
+        None
+    }
+
     pub(crate) fn resolve_global_this_property_type(
         &mut self,
         name: &str,
@@ -1035,6 +1061,13 @@ impl<'a> CheckerState<'a> {
 
         if let Some(sym_id) = self.resolve_global_value_symbol(name) {
             if self.alias_resolves_to_type_only(sym_id) {
+                // A module-local `import type X` binding never shadows `globalThis.X`:
+                // `globalThis` exposes only the ambient global scope. Prefer the lib
+                // global `var`/`function`/`class` of the same name if one exists.
+                // E.g. `import type Symbol from "./Symbol"` then `globalThis.Symbol()`.
+                if let Some(vt) = self.resolve_lib_global_var_value_type(name) {
+                    return vt;
+                }
                 // Route through wrong-meaning boundary: alias resolves to type-only
                 use crate::query_boundaries::name_resolution::NameLookupKind;
                 self.report_wrong_meaning_diagnostic(name, error_node, NameLookupKind::Type);
@@ -1042,6 +1075,12 @@ impl<'a> CheckerState<'a> {
             }
             if let Some(symbol) = self.ctx.binder.get_symbol(sym_id) {
                 if !symbol.has_any_flags(symbol_flags::VALUE) {
+                    // A type-only module-local binding (e.g. an interface or a
+                    // type-only import) does not contribute a global value. Prefer
+                    // the lib global value of the same name before erroring.
+                    if let Some(vt) = self.resolve_lib_global_var_value_type(name) {
+                        return vt;
+                    }
                     // Route through wrong-meaning boundary: symbol has no value meaning
                     use crate::query_boundaries::name_resolution::NameLookupKind;
                     self.report_wrong_meaning_diagnostic(name, error_node, NameLookupKind::Type);
@@ -1057,26 +1096,8 @@ impl<'a> CheckerState<'a> {
                     // E.g. `const Symbol = globalThis.Symbol` — the local const shadows
                     // the lib `declare var Symbol: SymbolConstructor`, but globalThis
                     // should still resolve to the lib var.
-                    if let Some(lib_sym_id) = self.resolve_lib_global_var_symbol(name)
-                        && let Some(lib_sym) = self.ctx.binder.get_symbol(lib_sym_id).cloned()
-                    {
-                        for &decl_idx in &lib_sym.declarations {
-                            if decl_idx.is_none() {
-                                continue;
-                            }
-                            let vt =
-                                self.type_of_value_declaration_for_symbol(lib_sym_id, decl_idx);
-                            if vt != TypeId::UNKNOWN && vt != TypeId::ERROR {
-                                return self.augment_js_global_value_type_with_expandos(
-                                    name, lib_sym_id, vt,
-                                );
-                            }
-                        }
-                        let vt = self.get_type_of_symbol(lib_sym_id);
-                        if vt != TypeId::UNKNOWN && vt != TypeId::ERROR {
-                            return self
-                                .augment_js_global_value_type_with_expandos(name, lib_sym_id, vt);
-                        }
+                    if let Some(vt) = self.resolve_lib_global_var_value_type(name) {
+                        return vt;
                     }
                     self.error_property_not_exist_on_global_this(name, error_node, base_display);
                     return TypeId::ERROR;


### PR DESCRIPTION
## Summary

`globalThis.X` property access must resolve `X` against the ambient global
scope, never against a module-local binding. tsz was consulting the in-scope
`X` first, so a module-local `import type X` (or any local type-only binding)
shadowed the lib global of the same name, producing spurious TS2585
(`'Symbol' only refers to a type`) and TS1361 (`'Object' cannot be used as a
value because it was imported using 'import type'`).

Witnessed by the **runtypes** canary row: `Runtype.ts` does
`import type Symbol from "./Symbol.ts"` / `import type Object from "./Object.ts"`
(to use those names as types) and then calls `globalThis.Symbol(...)`,
`globalThis.Object.assign(...)`, etc. for the runtime values. tsc resolves
these to the lib `SymbolConstructor` / `ObjectConstructor`; tsz reported
TS2585/TS1361.

The existing block-scoped-const fallback (`const Symbol = globalThis.Symbol`)
already recovered the lib global var. This change extracts that fallback into a
shared helper (`resolve_lib_global_var_value_type`) and applies it to the two
remaining error paths in `resolve_global_this_property_type`:
the type-only import alias path and the no-value-meaning symbol path.

## Structural rule

When resolving a `globalThis.<Name>` (or `(typeof globalThis)['<Name>']`)
property access, if the in-scope `<Name>` is a module-local binding that does
not contribute a global value (a block-scoped `const`/`let`, a type-only
`import type` alias, or a symbol without value meaning), and the lib declares a
global `var`/`function`/`class <Name>`, tsc resolves to the lib global value;
tsz now does the same through the checker's
`resolve_global_this_property_type` -> `resolve_lib_global_var_value_type`
(owner: checker global-scope symbol resolution). Negative case preserved:
`globalThis.NotAGlobal` (no lib global of that name) still reports TS7017,
matching tsc.

Adjacent matrix (all tsc-clean, tsz now matches):
- `import type Symbol` + `globalThis.Symbol()` -> lib `SymbolConstructor` (was TS2585).
- `import type Object` + `globalThis.Object.assign(...)` -> lib `ObjectConstructor` (was TS1361).
- value+type merged default export imported as `import type` -> lib global value.
- `const Symbol = globalThis.Symbol` (block-scoped shadow) -> still resolves (unchanged).
- `globalThis.NotAGlobal` (genuine non-global) -> still TS7017 (negative case).

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- Minimal repro (`import type Symbol/Object` + `globalThis.Symbol/Object`):
  tsc clean, tsz clean after fix; `globalThis.NotAGlobal` still TS7017 on both.
- Conformance (touched families, dist-fast, 0 regressions):
  `globalThis` 16/16, `importType` 17/17, `symbolType` 20/20,
  `typeOnly` 68/68, `uniqueSymbol` 12/12 = 133/133 PASS.
- Corpus (canary): runtypes-project **237 -> 222 tsz-only** diagnostics
  (`TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_FILTER=runtypes`);
  deterministic across 3 binary runs (222 each).
- Corpus (required rows): all required rows compile successfully (no regression).
- Clippy `-p tsz-checker --profile dist-fast`: clean.
- `architecture-check.sh --quick`: identical counts to baseline (0 new
  boundary bypasses / diagnostic leaks / cross-layer imports); touched file 941 LOC.

The remaining runtypes residual (the dominant TS2347 `Runtype.create` untyped
cascade + TS2740 static-member-in-instance leak) is the known non-canonical
instantiation mega-root (#13212, class-heritage flavor) and is out of scope for
this bounded fix; documented as a witness on #13212.

Goal: green

## Project corpus

AgentName: runtypes-residual

- Row: runtypes
- Bug family: globalThis member access shadowed by module-local import-type binding (TS2585/TS1361 false positives)
