### PR TITLE
fix(binder): merge user namespace exports into same-named lib namespace

### DIFF
--- a/crates/tsz-core/src/parallel/core/bind_result_reducer.rs
+++ b/crates/tsz-core/src/parallel/core/bind_result_reducer.rs
@@ -597,6 +597,15 @@ impl BindResultReducer {
                 }
                 // Copy symbols from this file to global arena, getting new IDs
                 let mut id_remap: FxHashMap<SymbolId, SymbolId> = FxHashMap::default();
+                // A user file may augment a lib symbol with its own exports (e.g.
+                // `declare namespace Reflect { function getMetadata(...) }` merges
+                // into the lib `Reflect` namespace during the per-file lib merge).
+                // The lib-symbol fast path below reuses the Phase 1 global id and
+                // propagates flags/declarations, but the user-contributed export
+                // entries reference this file's local SymbolIds, so they can only be
+                // remapped once `id_remap` is fully built. Defer them here as
+                // `(global_id, this-file lib SymbolId)` pairs.
+                let mut deferred_lib_export_merges: Vec<(SymbolId, SymbolId)> = Vec::new();
                 for i in 0..result.symbols.len() {
                     let old_id = SymbolId(i as u32);
                     if let Some(sym) = result.symbols.get(old_id) {
@@ -631,6 +640,15 @@ impl BindResultReducer {
                                 }
                             }
                             if let Some(global_id) = resolved_global_id {
+                                // Capture the lib symbol's ORIGINAL flags before the
+                                // user augmentation below folds in extra flags. The
+                                // namespace-merge gate must judge what the lib actually
+                                // declared (a pure namespace vs a `var`/`interface`),
+                                // not the post-merge union.
+                                let lib_original_flags = self
+                                    .global_symbols
+                                    .get(global_id)
+                                    .map_or(0, |g| g.flags);
                                 // The user binder may have merged additional flags and declarations
                                 // into this lib symbol (e.g., user `interface Event<T>` augments
                                 // lib's non-generic `Event`, or user `type Proxy<T>` adds TYPE_ALIAS
@@ -650,6 +668,40 @@ impl BindResultReducer {
                                         &mut global_sym.declarations,
                                         &sym.declarations,
                                     );
+                                }
+                                // The user file may have merged its own exports into
+                                // this lib symbol (e.g. a user `declare namespace
+                                // Reflect { ... }` augmenting the lib `Reflect`).
+                                // Defer the export/member merge until `id_remap` is
+                                // complete so the user export SymbolIds remap correctly.
+                                //
+                                // Restrict to the genuine namespace/namespace merge:
+                                // both the user symbol and the LIB-ORIGINAL symbol must
+                                // be PURE namespaces — `MODULE`
+                                // (`VALUE_MODULE | NAMESPACE_MODULE`) set and no
+                                // conflicting value/type meaning. A user
+                                // `declare namespace Object` colliding with the lib's
+                                // `var Object` / `interface Object` is a genuine
+                                // duplicate-identifier conflict (`TS2300`); its members
+                                // must not be silently merged in.
+                                use crate::binder::symbol_flags;
+                                let conflicting =
+                                    symbol_flags::VARIABLE
+                                        | symbol_flags::FUNCTION
+                                        | symbol_flags::CLASS
+                                        | symbol_flags::INTERFACE
+                                        | symbol_flags::TYPE_ALIAS
+                                        | symbol_flags::ENUM;
+                                let user_is_pure_namespace = sym.flags & symbol_flags::MODULE != 0
+                                    && sym.flags & conflicting == 0;
+                                let lib_is_pure_namespace =
+                                    lib_original_flags & symbol_flags::MODULE != 0
+                                        && lib_original_flags & conflicting == 0;
+                                if user_is_pure_namespace
+                                    && lib_is_pure_namespace
+                                    && (sym.exports.is_some() || sym.members.is_some())
+                                {
+                                    deferred_lib_export_merges.push((global_id, old_id));
                                 }
                                 id_remap.insert(old_id, global_id);
                                 continue;
@@ -726,6 +778,44 @@ impl BindResultReducer {
                             new_id
                         };
                         id_remap.insert(old_id, new_id);
+                    }
+                }
+
+                // Merge user-contributed exports/members into lib symbols that this
+                // file augmented (deferred from the lib-symbol fast path so the user
+                // export SymbolIds can be remapped via the now-complete `id_remap`).
+                // Only ADD names missing from the global symbol — lib-origin entries
+                // were already remapped in Phase 1.5; this recovers user members such
+                // as `Reflect.getMetadata` that would otherwise be dropped, matching
+                // tsc's merge of a user namespace into a same-named lib namespace.
+                for &(global_id, this_file_lib_id) in &deferred_lib_export_merges {
+                    let (src_exports, src_members) = match result.symbols.get(this_file_lib_id) {
+                        Some(src) => (src.exports.clone(), src.members.clone()),
+                        None => continue,
+                    };
+                    if let Some(src_exports) = src_exports
+                        && let Some(global_sym) = self.global_symbols.get_mut(global_id)
+                    {
+                        let target = global_sym.exports.get_or_insert_with(Default::default);
+                        for (name, export_id) in src_exports.iter() {
+                            if !target.has(name)
+                                && let Some(&remapped) = id_remap.get(export_id)
+                            {
+                                target.set(name.clone(), remapped);
+                            }
+                        }
+                    }
+                    if let Some(src_members) = src_members
+                        && let Some(global_sym) = self.global_symbols.get_mut(global_id)
+                    {
+                        let target = global_sym.members.get_or_insert_with(Default::default);
+                        for (name, member_id) in src_members.iter() {
+                            if !target.has(name)
+                                && let Some(&remapped) = id_remap.get(member_id)
+                            {
+                                target.set(name.clone(), remapped);
+                            }
+                        }
                     }
                 }
 

--- a/crates/tsz-core/src/parallel/core/bind_result_reducer.rs
+++ b/crates/tsz-core/src/parallel/core/bind_result_reducer.rs
@@ -684,18 +684,18 @@ impl BindResultReducer {
                                 // `var Object` / `interface Object` is a genuine
                                 // duplicate-identifier conflict (`TS2300`); its members
                                 // must not be silently merged in.
-                                use crate::binder::symbol_flags;
                                 let conflicting =
-                                    symbol_flags::VARIABLE
-                                        | symbol_flags::FUNCTION
-                                        | symbol_flags::CLASS
-                                        | symbol_flags::INTERFACE
-                                        | symbol_flags::TYPE_ALIAS
-                                        | symbol_flags::ENUM;
-                                let user_is_pure_namespace = sym.flags & symbol_flags::MODULE != 0
-                                    && sym.flags & conflicting == 0;
+                                    crate::binder::symbol_flags::VARIABLE
+                                        | crate::binder::symbol_flags::FUNCTION
+                                        | crate::binder::symbol_flags::CLASS
+                                        | crate::binder::symbol_flags::INTERFACE
+                                        | crate::binder::symbol_flags::TYPE_ALIAS
+                                        | crate::binder::symbol_flags::ENUM;
+                                let user_is_pure_namespace =
+                                    sym.flags & crate::binder::symbol_flags::MODULE != 0
+                                        && sym.flags & conflicting == 0;
                                 let lib_is_pure_namespace =
-                                    lib_original_flags & symbol_flags::MODULE != 0
+                                    lib_original_flags & crate::binder::symbol_flags::MODULE != 0
                                         && lib_original_flags & conflicting == 0;
                                 if user_is_pure_namespace
                                     && lib_is_pure_namespace


### PR DESCRIPTION
Goal: green

## Summary
Fixes a clean, tsc-confirmed false positive: a user `declare namespace Reflect { function getMetadata(...): any }` plus a separate `Reflect.getMetadata(...)` usage emitted a false `TS2339` (the namespace-as-value resolved to an unrelated global function such as DOM `alert` / `eval`), while `tsc` accepts it (rc=0).

## Structural rule
When a user namespace declaration shares its name with a lib namespace (`Reflect`, `Intl`, ...), `tsc` merges both declaration sets into one global namespace object (user members **plus** lib members). tsz drops the user members through the binder bind-result reducer.

Root cause (`crates/tsz-core/src/parallel/core/bind_result_reducer.rs`, `merge_user_files`): the per-file lib merge (`merge_lib_contexts_into_binder`) folds the user namespace's exports into the file's lib-merged `Reflect` symbol, marking it lib-origin. In `merge_user_files`, the lib-symbol fast path reuses the Phase 1 global id and propagates only `flags`/`declarations` — it never merges the user-contributed `exports`/`members`. So any file that does not itself declare the namespace resolves the lib-only symbol, missing the user's `getMetadata`, and emits false `TS2339`. (The displayed `(message?: any) => void` was an incidental cross-arena `NodeIndex` collision in the diagnostic's value-position type; the real defect is the dropped export.)

Owner layer: binder cross-file merge (solver/checker untouched).

Fix: defer the user export/member merge until `id_remap` is complete, then add the missing names to the lib global symbol. Gate strictly on the namespace/namespace case — both the user symbol and the **lib-original** symbol must be pure namespaces (`MODULE` set, no conflicting `VARIABLE|FUNCTION|CLASS|INTERFACE|TYPE_ALIAS|ENUM` meaning). This keeps a user `declare namespace Object` colliding with the lib's `var Object` / `interface Object` a genuine duplicate-identifier conflict. Structural (by symbol kind), no name/file-string checks.

## Adjacent matrix (tsz vs tsc, all parity)
- `Reflect` cross-file (primary): tsz rc=0, tsc rc=0
- user `getMetadata` + lib `has` together: both resolve
- same-file declaration + usage: rc=0
- lib-only member (`Reflect.has`): still rc=0
- without DOM lib (`--lib es2015`): rc=0
- `Intl` namespace augmentation (another lib namespace): tsz rc=0, tsc rc=0
- `Atomics`/`Object` (lib `var`/`interface`, NOT namespace): correctly NOT merged (genuine conflict), tsz matches its prior behavior; tsc emits TS2300
- non-global name `MyReflect`, two-user-file `MyReflect`, interface augmentation (`Array`): unchanged, rc=0

## Verification
- Conformance (`scripts/conformance/conformance.sh run --filter`, 0 PASS->FAIL): `namespace` 17/17, `moduleResolution` 111/111, `globalThis` 16/16, `mergedDeclarations` 7/7, `exportImport` 7/7, `identifier` 3/3, `declarationMerging` 28/28, `crossFile` 11/11, `augmentation` 4/4, `decorator` 139/139, `globalMerge` 2/2 — all 100%.
- Project corpus (`project-compile-guard`, my binary vs origin/main binary):
  - type-graphql: 29 -> 21 tsz-only diagnostics (8 fewer; removed errors include `Property 'getMetadata' does not exist on type 'typeof Reflect'` and `... on type '(message?: any) => void'`), zero new.
  - class-transformer: 85 -> 81 (net -4); the 2 newly surfaced errors (`TS2345`, `TS2532`) are TRUE positives that `tsc` also emits (previously masked by garbage `any`).
- Architecture: static report 0 LOC violations, 0 cross-layer imports. Change is tsz-core-only; the two failing solver-import contract tests audit tsz-checker/tsz-emitter (pre-existing baseline drift, untouched by this PR).
- clippy clean (`tsz-core`, `tsz-cli`); 3x determinism confirmed on primary + same-file repro.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

AgentName: namespace-value-xfile
- Row: type-graphql
- Row: class-transformer
- Bug family: namespace-as-value-cross-file-resolution
