### PR TITLE
fix(solver): in-narrowing of an existing property keeps optionality and undefined

### DIFF
--- a/crates/tsz-checker/src/tests/in_narrow_apparent_member_tests.rs
+++ b/crates/tsz-checker/src/tests/in_narrow_apparent_member_tests.rs
@@ -161,3 +161,67 @@ function classify(node: { a: 1 } | { b: 2 }) {
         "expected TS2339 for the genuinely-absent property, got: {got:?}"
     );
 }
+
+/// `"p" in x` over a non-union receiver that already declares `p` as an
+/// *optional* own property must not promote `p` to required. tsc's
+/// `narrowTypeByInKeyword` adds no structural information when the property is
+/// already known, so the property stays optional and `delete x.p` remains
+/// legal. Promoting it to required produced a false TS2790 ("operand of a
+/// 'delete' operator must be optional"), the ofetch `delete options.query`
+/// witness. Binder names vary across cases so the behavior is driven by the
+/// optional-own-property shape, not an identifier spelling.
+#[test]
+fn in_narrowing_keeps_optional_own_property_deletable() {
+    let source = r#"
+interface Opts { query?: Record<string, unknown>; headers: number; }
+function configure(opts: Opts) {
+    if ("query" in opts) {
+        delete opts.query;
+    }
+}
+"#;
+    let got = codes(source);
+    assert!(
+        !got.contains(&2790),
+        "expected no TS2790 after `in`-narrowing an optional own property, got: {got:?}"
+    );
+}
+
+/// The negative soundness counterpart: `"p" in x` must *not* exclude `undefined`
+/// from the value type of an already-present optional property. tsc keeps
+/// `x.p` as `T | undefined` after the check, so assigning it to `T` still
+/// reports TS2322. The earlier required-promotion wrongly stripped `undefined`,
+/// silently accepting the unsound assignment.
+#[test]
+fn in_narrowing_preserves_undefined_in_optional_property_value() {
+    let source = r#"
+interface Box { item?: { n: number }; }
+function read(box: Box) {
+    if ("item" in box) {
+        const x: { n: number } = box.item;
+    }
+}
+"#;
+    let got = codes(source);
+    assert!(
+        got.contains(&2322),
+        "expected TS2322 — `in` must not exclude undefined from an optional property, got: {got:?}"
+    );
+}
+
+/// Adjacent: a bare `delete x.p` without any preceding `in`-narrowing already
+/// worked; this pins that the fix did not disturb it.
+#[test]
+fn delete_optional_property_without_in_narrowing_is_legal() {
+    let source = r#"
+interface Config { params?: number[]; name: string; }
+function reset(config: Config) {
+    delete config.params;
+}
+"#;
+    let got = codes(source);
+    assert!(
+        !got.contains(&2790),
+        "expected no TS2790 deleting an optional property, got: {got:?}"
+    );
+}

--- a/crates/tsz-solver/src/narrowing/property.rs
+++ b/crates/tsz-solver/src/narrowing/property.rs
@@ -229,51 +229,24 @@ impl<'a> NarrowingContext<'a> {
         if present {
             // Positive: "prop" in x
             //
-            // `has_property` is apparent-type aware (so arrays/functions/
-            // primitives are recognised), but the structural property the
-            // promotion logic below needs only exists for object shapes. When
-            // the member is contributed purely by the apparent type (e.g.
-            // `push` on `T[]`, `call` on a function type) there is no own slot
-            // to promote, and tsc leaves the receiver unchanged — so return it
-            // as-is rather than synthesising a bogus `{ prop: unknown }` slot.
-            let has_own_property = self
-                .get_property_type(resolved_type, property_name)
-                .is_some();
-            if has_property && !has_own_property {
-                return source_type;
-            }
+            // `has_property` is apparent-type aware, so this covers both an
+            // apparent-only member (e.g. `push` on `T[]`) and a declared own
+            // property. In either case the property is already part of the
+            // non-union receiver's type, so the `in` check adds nothing.
             if has_property {
-                // Property exists: promote to required. For exact-optional
-                // slots the write type excludes the synthetic missing-property
-                // `undefined`, so use it for the presence filter.
-                let prop_info = self.get_property_info(resolved_type, property_name);
-                let prop_type = prop_info
-                    .as_ref()
-                    .map(|prop| {
-                        if prop.optional {
-                            prop.write_type
-                        } else {
-                            prop.type_id
-                        }
-                    })
-                    .or_else(|| self.get_property_type(resolved_type, property_name));
-                let required_prop = PropertyInfo {
-                    name: property_name,
-                    type_id: prop_type.unwrap_or(TypeId::UNKNOWN),
-                    write_type: prop_type.unwrap_or(TypeId::UNKNOWN),
-                    optional: false,
-                    readonly: prop_info.as_ref().is_some_and(|prop| prop.readonly),
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: None,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                };
-                let filter_obj = self.db.object(vec![required_prop]);
-                self.db.intersection2(source_type, filter_obj)
+                // The property is already declared on the (non-union) source
+                // type — whether contributed by the apparent type (no own slot)
+                // or by an own property slot. tsc's `narrowTypeByInKeyword`
+                // adds no structural information in this case: the property is
+                // already known, so the receiver is returned unchanged. In
+                // particular an *optional* own property keeps its optionality
+                // (so `delete x.p` after `"p" in x` stays legal) and its
+                // declared type keeps `undefined` (so `"p" in x` does not
+                // discriminate the property's value type). Synthesising a
+                // required-property intersection wrongly stripped both, causing
+                // false TS2790 on `delete` and unsoundly excluding `undefined`
+                // from the property's type (ofetch `delete options.query`).
+                source_type
             } else {
                 // Property not found on a non-union type.
                 // TypeScript narrows to `source_type & Record<prop, unknown>` for


### PR DESCRIPTION
## Summary

`narrow_by_property_presence` (the `"k" in x` positive branch) synthesized a
**required**-property intersection (`source & { p: T }`, `optional: false`)
whenever a non-union receiver already declared the property. That over-narrowed
an existing **optional** own property in two tsc-divergent ways:

1. It stripped the property's optionality, so `delete x.p` after `"p" in x`
   reported a false **TS2790** ("operand of a 'delete' operator must be
   optional").
2. It excluded `undefined` from the property's value type, **unsoundly**
   accepting `const y: T = x.p` where tsc keeps `x.p: T | undefined`.

tsc's `narrowTypeByInKeyword` adds no structural information when the property
is already declared on the receiver — the union branch already kept members
as-is for present narrowing. The fix returns the receiver unchanged in that
case; the `Record<prop, unknown>` synthesis stays scoped to the
genuinely-absent-property case (unchanged).

Goal: hold

## Structural rule

When `"p" in x` is checked and `p` is already a member of the (non-union)
receiver type `x` (own property or apparent-type member), tsc adds no
structural information: the receiver type is unchanged, so an optional `p`
stays optional (its value type keeps `undefined`). tsz now returns the
receiver unchanged in that case through `solver narrowing::narrow_by_property_presence`,
matching the union-branch policy that already kept present members as-is. The
absent-property case still narrows to `x & Record<p, unknown>`.

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- New solver-narrowing parity tests (`tsz-checker` `in_narrow_apparent_member_tests`):
  `in_narrowing_keeps_optional_own_property_deletable`,
  `in_narrowing_preserves_undefined_in_optional_property_value`,
  `delete_optional_property_without_in_narrowing_is_legal`,
  plus the existing apparent-member and object-union cases — 5/5 PASS.
- Conformance, 0 PASS→FAIL on touched/adjacent families:
  `delete` 13/13, `inOperator` 5/5, `inKeyword` 4/4, `narrowing` 29/29,
  `controlFlow` 94/94, `typeGuard` 86/86, `discriminated` 8/8.
- Corpus no-regression (canary, dist-fast baseline vs patched):
  kysely 118→118, msw 97→97, tanstack-router 234→234, ofetch 12→12.
- Determinism: 3× identical diagnostics on the witness repros.
- clippy clean (`tsz-solver`, `tsz-checker`).

Note: this is a correctness/parity fix (witnessed by ofetch
`delete options.query`). It does **not** by itself change ofetch's tsz-only
count (12→12); the ofetch `delete`-site TS2790 is a separate, entangled root
(truthy-narrow + `Omit<RequestInit>`-heritage member resolution + generic
instantiation of `ResolvedFetchOptions<ResponseType>`) that this change does
not address.