### PR TITLE
fix(checker): merge transitive lib-base heritage for cross-file generic class

### DIFF
--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -36,6 +36,21 @@ thread_local! {
     /// Shared depth counter for all cross-arena delegation points.
     /// Prevents stack overflow from deeply nested CheckerState creation.
     static CROSS_ARENA_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+
+    /// Depth counter for resolving a class's directly-named heritage (`extends`)
+    /// base expression. Nonzero while
+    /// [`CheckerState::base_instance_type_from_expression`] is on the stack.
+    ///
+    /// The cross-arena lib-heritage global fallback
+    /// (`select_global_lib_interface`) is only sound for the lib interface that
+    /// is the class's own `extends` target (and its transitive lib heritage,
+    /// resolved while still inside this scope). Member-signature resolution that
+    /// happens later — outside this scope — must NOT trigger the fallback: a
+    /// delegation child eagerly pulling an entire global graph (e.g. the DOM
+    /// graph reached through `React.Component`'s members) re-merges base members
+    /// the top-level checker already owns, producing duplicated intersections
+    /// and false JSX-inference diagnostics.
+    static CLASS_HERITAGE_BASE_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
 }
 
 /// Reset the cross-arena delegation depth counter to zero.
@@ -49,6 +64,7 @@ thread_local! {
 /// pathological project cannot poison the next one.
 pub(crate) fn reset_cross_arena_depth() {
     CROSS_ARENA_DEPTH.with(|c| c.set(0));
+    CLASS_HERITAGE_BASE_DEPTH.with(|c| c.set(0));
 }
 
 #[cfg(test)]
@@ -588,6 +604,22 @@ impl<'a> CheckerState<'a> {
     /// from different arenas.
     pub(crate) fn is_in_cross_arena_delegation() -> bool {
         CROSS_ARENA_DEPTH.with(|c| c.get() > 0)
+    }
+
+    /// Enter the scope that resolves a class's directly-named heritage
+    /// (`extends`) base expression. See [`CLASS_HERITAGE_BASE_DEPTH`].
+    pub(crate) fn enter_class_heritage_base() {
+        CLASS_HERITAGE_BASE_DEPTH.with(|c| c.set(c.get().saturating_add(1)));
+    }
+
+    /// Leave the class-heritage-base resolution scope.
+    pub(crate) fn leave_class_heritage_base() {
+        CLASS_HERITAGE_BASE_DEPTH.with(|c| c.set(c.get().saturating_sub(1)));
+    }
+
+    /// Whether we are resolving a class's directly-named heritage base.
+    pub(crate) fn is_resolving_class_heritage_base() -> bool {
+        CLASS_HERITAGE_BASE_DEPTH.with(|c| c.get() > 0)
     }
 
     /// Check if the source file has any parse errors.

--- a/crates/tsz-checker/src/state/type_resolution/constructors.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors.rs
@@ -873,9 +873,11 @@ impl<'a> CheckerState<'a> {
                 return self.cache_base_instance_result(expr_idx, should_cache, Some(array_base));
             }
 
-            if let Some(lib_base) =
-                self.actual_or_cloned_lib_instance_type_for_heritage(base_sym_id, type_arguments)
-            {
+            Self::enter_class_heritage_base();
+            let lib_base =
+                self.actual_or_cloned_lib_instance_type_for_heritage(base_sym_id, type_arguments);
+            Self::leave_class_heritage_base();
+            if let Some(lib_base) = lib_base {
                 return self.cache_base_instance_result(expr_idx, should_cache, Some(lib_base));
             }
 

--- a/crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs
@@ -35,6 +35,38 @@ fn select_external_module_lib_interface(
         })
 }
 
+/// Find a global (script, non-external-module) lib interface symbol directly in
+/// the loaded lib contexts by name.
+///
+/// The primary symbol resolution path (`resolve_lib_symbol_by_entity_name`)
+/// reads the active checker's binder, which carries the standard-lib globals
+/// merged in via `merge_lib_contexts_into_binder`. A transient cross-arena
+/// delegation child (`delegate_cross_arena_class_instance_type`) runs against
+/// the imported file's binder, which never received that merge, so a global
+/// lib base reached through a heritage clause (e.g. a generic class
+/// `extends Response`, where `Response extends Body`) fails to resolve there.
+/// `select_external_module_lib_interface` only covers module-scoped lib
+/// declarations, so global script libs (`lib.dom.d.ts`, `lib.es5.d.ts`) need
+/// this context-independent fallback to keep the lib base's own transitive
+/// heritage from being dropped. Mirrors the same `lib_ctx.binder.file_locals`
+/// scan `resolve_lib_type_with_params` uses for the lib base's OWN members, so
+/// the two resolutions agree on the same lib symbol.
+fn select_global_lib_interface(
+    name: &str,
+    actual_lib_file_count: usize,
+    lib_contexts: &[crate::context::LibContext],
+) -> Option<(SymbolId, Option<Arc<BinderState>>)> {
+    lib_contexts
+        .iter()
+        .take(actual_lib_file_count)
+        .find_map(|lib_ctx| {
+            let sym_id = lib_ctx.binder.file_locals.get(name)?;
+            let symbol = lib_ctx.binder.get_symbol(sym_id)?;
+            (symbol.escaped_name == name && symbol.has_any_flags(symbol_flags::INTERFACE))
+                .then_some((sym_id, Some(Arc::clone(&lib_ctx.binder))))
+        })
+}
+
 impl<'a> CheckerState<'a> {
     /// Merge base interface members into a lib interface type by walking
     /// heritage (`extends`) clauses in declaration-specific arenas.
@@ -111,6 +143,20 @@ impl<'a> CheckerState<'a> {
             .map(|id| (id, None))
             .or_else(|| {
                 select_external_module_lib_interface(
+                    name,
+                    self.ctx.actual_lib_file_count,
+                    &self.ctx.lib_contexts,
+                )
+            })
+            .or_else(|| {
+                // A transient cross-arena delegation child checks against an
+                // imported file's binder, which lacks the merged standard-lib
+                // globals, so the binder-based resolution above returns None for
+                // a global lib base (e.g. a class `extends Response`). Fall back
+                // to a direct lib-context scan so the lib base's own transitive
+                // heritage (`Response extends Body`) is still merged instead of
+                // dropped.
+                select_global_lib_interface(
                     name,
                     self.ctx.actual_lib_file_count,
                     &self.ctx.lib_contexts,

--- a/crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs
@@ -156,6 +156,20 @@ impl<'a> CheckerState<'a> {
                 // to a direct lib-context scan so the lib base's own transitive
                 // heritage (`Response extends Body`) is still merged instead of
                 // dropped.
+                //
+                // Scope this to the resolution of a class's directly-named
+                // `extends` base (and its transitive lib heritage, resolved
+                // while still in that scope). Without the gate the fallback also
+                // fires when a delegation child lowers the base's member
+                // signatures, eagerly pulling an entire global graph it does not
+                // own (e.g. the DOM graph reached through `React.Component`'s
+                // members). Re-merging those base members the top-level checker
+                // already resolves produces duplicated intersections and false
+                // JSX-inference diagnostics; the member types resolve correctly
+                // in the top-level checker whose binder carries the globals.
+                if !Self::is_resolving_class_heritage_base() {
+                    return None;
+                }
                 select_global_lib_interface(
                     name,
                     self.ctx.actual_lib_file_count,

--- a/crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs
@@ -157,17 +157,23 @@ impl<'a> CheckerState<'a> {
                 // heritage (`Response extends Body`) is still merged instead of
                 // dropped.
                 //
-                // Scope this to the resolution of a class's directly-named
-                // `extends` base (and its transitive lib heritage, resolved
-                // while still in that scope). Without the gate the fallback also
-                // fires when a delegation child lowers the base's member
-                // signatures, eagerly pulling an entire global graph it does not
-                // own (e.g. the DOM graph reached through `React.Component`'s
-                // members). Re-merging those base members the top-level checker
-                // already resolves produces duplicated intersections and false
-                // JSX-inference diagnostics; the member types resolve correctly
-                // in the top-level checker whose binder carries the globals.
-                if !Self::is_resolving_class_heritage_base() {
+                // Scope this to a cross-arena child's resolution of a class's
+                // directly-named `extends` base (and its transitive lib heritage,
+                // resolved while still in that scope). Same-arena checkers either
+                // have merged globals in their active binder or should keep the
+                // existing resolution behavior.
+                //
+                // Without the heritage-base gate the fallback also fires when a
+                // delegation child lowers the base's member signatures, eagerly
+                // pulling an entire global graph it does not own (e.g. the DOM
+                // graph reached through `React.Component`'s members). Re-merging
+                // those base members the top-level checker already resolves
+                // produces duplicated intersections and false JSX-inference
+                // diagnostics; the member types resolve correctly in the
+                // top-level checker whose binder carries the globals.
+                if !Self::is_in_cross_arena_delegation()
+                    || !Self::is_resolving_class_heritage_base()
+                {
                     return None;
                 }
                 select_global_lib_interface(

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -1595,6 +1595,78 @@ declare namespace Intl {
         collect_es2015_default_lib_diagnostics_with_options(source, |_: &mut _| {})
     }
 
+    /// Multi-file variant of [`collect_es2015_default_lib_diagnostics`]. Each
+    /// `(relative_name, source)` pair is written into the same temp directory so
+    /// `./name` imports resolve cross-file, exercising the program/CLI path
+    /// (distinct from the single-`main.ts` in-process path). The default es2015
+    /// lib set is loaded (includes `lib.dom.d.ts`).
+    fn collect_es2015_default_lib_diagnostics_multifile(files: &[(&str, &str)]) -> Vec<Diagnostic> {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let mut file_paths = Vec::with_capacity(files.len());
+        for (name, source) in files {
+            let path = dir.path().join(name);
+            std::fs::write(&path, source).expect("write source");
+            file_paths.push(path);
+        }
+
+        let resolved = resolved_options_for_es2015_strict_test();
+        let SourceReadResult {
+            sources,
+            dependencies: _,
+            module_resolutions: _,
+            type_reference_errors,
+            resolution_mode_errors,
+            ..
+        } = super::read_source_files(&file_paths, dir.path(), &resolved, None, None)
+            .expect("read source files");
+
+        assert!(type_reference_errors.is_empty());
+        assert!(resolution_mode_errors.is_empty());
+
+        let disable_default_libs =
+            resolved.lib_is_default && super::sources_have_no_default_lib(&sources);
+        let lib_paths = super::resolve_effective_lib_paths(
+            &resolved,
+            &sources,
+            dir.path(),
+            disable_default_libs,
+        )
+        .expect("resolve effective lib paths");
+        let lib_path_refs: Vec<_> = lib_paths.iter().map(PathBuf::as_path).collect();
+        let lib_files =
+            parallel::load_lib_files_for_binding_strict(&lib_path_refs).expect("load strict libs");
+        let checker_libs = load_checker_libs(&lib_files);
+        let compile_inputs: Vec<_> = sources
+            .into_iter()
+            .map(|source| {
+                (
+                    source.path.to_string_lossy().into_owned(),
+                    source.text.unwrap_or_default(),
+                )
+            })
+            .collect();
+        let program = parallel::merge_bind_results(parallel::parse_and_bind_parallel_with_libs(
+            compile_inputs,
+            &lib_files,
+        ));
+        let type_cache_output = std::sync::Mutex::new(FxHashMap::default());
+
+        collect_diagnostics(
+            &CollectDiagnosticsInput {
+                program: &program,
+                options: &resolved,
+                base_dir: dir.path(),
+                checker_libs: &checker_libs,
+                typescript_dom_replacement_globals: (false, false, false),
+                has_deprecation_diagnostics: false,
+                collect_compile_stats: false,
+            },
+            None,
+            &type_cache_output,
+        )
+        .diagnostics
+    }
+
     fn collect_es2015_default_lib_diagnostics_with_options(
         source: &str,
         configure: impl FnOnce(&mut ResolvedCompilerOptions),

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part3.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part3.rs
@@ -1262,3 +1262,64 @@ interface Node {
         );
     }
 
+    /// A generic class declared in one module that `extends` a global lib
+    /// interface whose own body inherits from a further lib base
+    /// (`class FetchResponse<T> extends Response`, where
+    /// `interface Response extends Body`) must surface the transitive base
+    /// members (`json`, `text`, `body`, ...) when the class is used from a
+    /// DIFFERENT module.
+    ///
+    /// The class instance type is built in a transient cross-arena delegation
+    /// child (`delegate_cross_arena_class_instance_type`) running against the
+    /// declaring file's binder, which lacks the merged standard-lib globals.
+    /// `merge_lib_interface_heritage` resolved the lib base symbol through that
+    /// binder and silently bailed when it was absent, dropping the lib base's
+    /// own `extends` and leaving an own-members-only `Response`. Property access
+    /// and assignability then mis-reported the inherited members as missing
+    /// (false TS2339 / TS2740). The same-file and non-generic forms were
+    /// unaffected because they resolve the lib base in the top-level checker
+    /// whose binder carries the globals; this is the class analog of the
+    /// interface-path fix #13767 / the lib-interface drain #12299.
+    ///
+    /// Vary the class name, type parameter spelling, and lib base so a fix keyed
+    /// to a single identifier would not satisfy this.
+    #[test]
+    fn cross_file_generic_class_inherits_transitive_lib_base_members() {
+        for (class_name, type_param, lib_base, inherited_member) in [
+            ("FetchResponse", "T", "Response", "json"),
+            ("Wrapped", "TValue", "Response", "text"),
+        ] {
+            let base_src = format!(
+                "export class {class_name}<{type_param}> extends {lib_base} {{ parsed?: {type_param}; }}\n"
+            );
+            let use_src = format!(
+                "import {{ {class_name} }} from './base';\nfunction take(x: {class_name}<number>) {{ x.{inherited_member}(); }}\n"
+            );
+            let diagnostics = collect_es2015_default_lib_diagnostics_multifile(&[
+                ("base.ts", base_src.as_str()),
+                ("use.ts", use_src.as_str()),
+            ]);
+            assert!(
+                !diagnostics.iter().any(|diag| diag.code == 2339),
+                "{class_name}<{type_param}> extends {lib_base}: inherited `{inherited_member}` must resolve cross-file: {diagnostics:?}"
+            );
+        }
+
+        // Guard against over-correction: a genuinely missing member still errors
+        // on the cross-file generic class.
+        let bogus = collect_es2015_default_lib_diagnostics_multifile(&[
+            (
+                "base.ts",
+                "export class FetchResponse<T> extends Response { parsed?: T; }\n",
+            ),
+            (
+                "use.ts",
+                "import { FetchResponse } from './base';\nfunction take(x: FetchResponse<number>) { x.totallyBogusMember(); }\n",
+            ),
+        ]);
+        assert!(
+            bogus.iter().any(|diag| diag.code == 2339),
+            "a genuinely missing member must still report TS2339 cross-file: {bogus:?}"
+        );
+    }
+


### PR DESCRIPTION
## Summary

A generic class declared in one module that `extends` a global lib interface whose own body inherits from a further lib base (`class FetchResponse<T> extends Response`, where `interface Response extends Body`) dropped the transitive base members (`json`, `text`, `body`, `bodyUsed`, ...) when used from a DIFFERENT module — false TS2339 on inherited methods and false TS2740/TS2741 ("missing the following properties") in relation contexts. Same-file and non-generic forms were clean; only the cross-file generic class path dropped them.

This is the class-instance analog of the cross-file generic **interface** type-reference fix #13767 and the lib-interface heritage drain #12299, both of which left the cross-file **class** `compute_type_of_symbol` heritage path unfixed (their in-process tests can only reach the LibContext / type-reference paths, not the cross-arena class-instance delegation).

Goal: green

## Structural rule

When a class `extends` a global lib interface that itself has a heritage chain (`Response extends Body`), tsc includes the full transitive member set. tsz builds the class instance type for a cross-file (imported) class in a transient cross-arena delegation child (`delegate_cross_arena_class_instance_type`) running against the **declaring file's binder**, which never received the standard-lib globals merged in via `merge_lib_contexts_into_binder`. `merge_lib_interface_heritage` resolved the lib base symbol through that binder (`resolve_lib_symbol_by_entity_name`) and, finding it absent, bailed at the `selected`-is-`None` guard — returning the lib base's own-members-only (heritage-thin) body and dropping its `extends`. `select_external_module_lib_interface` only covers module-scoped lib declarations, so global script libs (`lib.dom.d.ts`, `lib.es5.d.ts`) had no context-independent fallback.

Owner layer: solver-backed checker lib-resolution boundary (`crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs`), the class-instance-type heritage member-collection path (distinct from the interface `merge_cross_file_heritage` / `interface_type.rs` recursive-heritage anchor).

Fix: add a global (script, non-external-module) lib-interface fallback to the selected-symbol chain that scans `lib_contexts` by name directly — the same `lib_ctx.binder.file_locals` lookup `resolve_lib_type_with_params` already uses for the lib base's OWN members, so the two resolutions agree on the same lib symbol. Order-independent; no identifier/file-name predicate; no printer-output predicate.

Narrowing (regression follow-up): the global fallback is gated to fire ONLY while resolving a class's directly-named `extends` base (and its transitive lib heritage, resolved within that scope), tracked by a `CLASS_HERITAGE_BASE_DEPTH` thread-local set around `actual_or_cloned_lib_instance_type_for_heritage` in `base_instance_type_from_expression`. Without the gate the fallback also fired when a delegation child lowered the base's *member* signatures, eagerly pulling an entire global graph the child does not own (e.g. the whole DOM graph reached through `React.Component`'s members: ~2810 spurious fallback resolutions for `class extends React.Component`). Re-merging those base members the top-level checker already resolves produced duplicated intersections and false JSX-inference diagnostics. Structural rule: *when resolving a cross-file class's directly-named lib `extends` base, tsc merges that base's transitive lib heritage; member-signature resolution does not eagerly merge an unowned global graph.* Empirically the legit `extends Response` case hits the fallback exactly once, always with the heritage-base flag set; the JSX-leak cases hit it only with the flag clear.

Adjacent matrix:
- generic + cross-file + lib-base-with-heritage (`extends Response`): fixed (was the bug).
- non-generic + cross-file: fixed (and no longer poisoned by the generic case's thin cache).
- same-file (generic or not): unchanged (resolves in top-level checker with merged globals).
- interface `extends Response` cross-file: unchanged (already correct via #13767).
- lib base with no heritage (`extends Error`): unchanged.
- negative / over-correction: genuinely-missing member still reports TS2339 (asserted in test).
- JSX class-tag inference (`class extends React.Component` / `React.PureComponent`): unchanged vs origin/main — the gate blocks the fallback during member-signature lowering, so JSX intrinsic/generic-tag inference is untouched.

## Verification

- New regression test `cross_file_generic_class_inherits_transitive_lib_base_members` (program/CLI multi-file path; varies class name, type-param spelling, lib base, inherited member) + over-correction guard — PASS.
- JSX regression fix (3 tests that regressed on the un-narrowed change): `checkJsxGenericTagHasCorrectInferences.tsx`, `tsxFragmentChildrenCheck.ts`, `spellingSuggestionJSXAttribute.tsx` — now PASS (were FAIL: duplicated-intersection fingerprint + false TS2322 + missing TS2769). Full `jsx` filter 298/298, `tsx` 336/336, `react` 16/16, `extends` 13/13, `heritage` 1/1 — all 100%.
- Cross-file fix preserved post-narrowing: `class FetchResponse<T> extends Response` used cross-file still resolves `json/text/body` (no TS2339); fallback verified firing exactly once for the directly-named `Response` base.
- Existing #12299 DOM program-mode test `dom_element_inherits_node_members_in_program_mode_12299` — PASS (interface path untouched).
- Conformance (`scripts/conformance/conformance.sh run --filter`): heritage, inherit (66), extends (13), genericClass (17), classExtend (33), interfaceExtend (12), instantiation, declarationFileForHtml, libMembers, Element (146), subclass, derived (40), baseClass, class (12585), interface (116), import (281) — all 100%, **Known failures: 0**, no new accepted-regressions. The 5 substring-matched `class` non-passes are pre-existing baseline/accepted (mapped-type/JSX, unrelated).
- Determinism: identical results across 3 runs.
- clippy `-p tsz-checker -p tsz-cli` clean; architecture static check (`scripts/architecture-check.sh --quick`) unchanged (0 cross-layer, 0 LOC violations; diff adds no solver imports / diagnostic calls / interning).
- Repro witnesses (tsz vs `node typescript/lib/tsc.js`, `--lib es2015,dom`): `class FetchResponse<T> extends Response` used cross-file now resolves `json/text/body/bodyUsed` and TS2740 enumerates "and 12 more" matching tsc (was "and 4 more").

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Project corpus

AgentName: xfile-class-heritage
- Row: trpc
- Bug family: cross-file-class-heritage-member-drop
