### PR TITLE
perf(cli): default bounded checker pool on for large non-DOM parallel lane

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -327,31 +327,49 @@ fn parallel_file_session_reuse_requested() -> bool {
     )
 }
 
-/// Explicit bounded-checker-pool width requested via the `TSZ_CHECKER_POOL`
-/// env var, or `None` when the var is unset / `0` / empty / invalid.
+/// The user's explicit `TSZ_CHECKER_POOL` request, parsed once.
 ///
-/// `TSZ_CHECKER_POOL` checks files on a fixed pool of `N` long-lived
+/// The bounded checker pool checks files on a fixed pool of `N` long-lived
 /// `CheckerState`s (cost-balanced file assignment, each reused via
 /// `switch_to_file`) instead of the per-file fresh checker. This amortises the
 /// O(program) per-file setup over `files / N` files — the lever that unblocks
-/// large multi-file projects. `=auto` (or `=1`) sizes the pool to
-/// `available_parallelism`; `=N` sets an explicit width; unset / `0` / empty
-/// leaves the decision to [`resolve_checker_pool_size`] (which defaults the
-/// pool ON for the large non-DOM parallel lane).
-fn checker_pool_size() -> Option<usize> {
-    let raw = std::env::var("TSZ_CHECKER_POOL").ok()?;
+/// large multi-file projects.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum CheckerPoolEnv {
+    /// `TSZ_CHECKER_POOL` unset or invalid: defer to the lane default.
+    Unset,
+    /// `TSZ_CHECKER_POOL=0` or empty: force the pool off on every lane,
+    /// overriding the large-lane default.
+    ForceOff,
+    /// `TSZ_CHECKER_POOL=N` explicit width (`auto`/`1` -> available
+    /// parallelism): use this width on any lane.
+    Width(usize),
+}
+
+/// Parse the explicit `TSZ_CHECKER_POOL` request. `=auto` (or `=1`) sizes the
+/// pool to `available_parallelism`; `=N` sets an explicit width; `0` / empty
+/// forces it off; unset / invalid defers to [`resolve_checker_pool_size`]
+/// (which defaults the pool ON for the large non-DOM parallel lane).
+fn checker_pool_env() -> CheckerPoolEnv {
+    let Ok(raw) = std::env::var("TSZ_CHECKER_POOL") else {
+        return CheckerPoolEnv::Unset;
+    };
     match raw.trim() {
-        "" | "0" => None,
-        "auto" | "1" => {
-            Some(std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get))
-        }
-        n => n.parse::<usize>().ok().filter(|&w| w >= 1),
+        "" | "0" => CheckerPoolEnv::ForceOff,
+        "auto" | "1" => CheckerPoolEnv::Width(
+            std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get),
+        ),
+        n => n
+            .parse::<usize>()
+            .ok()
+            .filter(|&w| w >= 1)
+            .map_or(CheckerPoolEnv::Unset, CheckerPoolEnv::Width),
     }
 }
 
 /// Whether the bounded checker pool is force-disabled via the
 /// `TSZ_DISABLE_CHECKER_POOL` kill switch. An explicit `TSZ_CHECKER_POOL=<n>`
-/// still wins over this switch; the switch only suppresses the default-on
+/// width still wins over this switch; the switch only suppresses the default-on
 /// behavior on the large non-DOM parallel lane.
 fn checker_pool_disabled() -> bool {
     std::env::var_os("TSZ_DISABLE_CHECKER_POOL").is_some()
@@ -362,7 +380,8 @@ fn checker_pool_disabled() -> bool {
 ///
 /// Precedence, highest first:
 ///   1. an explicit `TSZ_CHECKER_POOL=<n|auto>` width always wins, on any lane;
-///   2. the `TSZ_DISABLE_CHECKER_POOL` kill switch forces the pool off;
+///   2. an explicit `TSZ_CHECKER_POOL=0` / empty, or the
+///      `TSZ_DISABLE_CHECKER_POOL` kill switch, forces the pool off;
 ///   3. on the large non-DOM parallel lane (`default_eligible`) the pool
 ///      defaults ON, sized to `available_parallelism`;
 ///   4. otherwise the pool stays off and checking falls through to the
@@ -375,21 +394,25 @@ fn checker_pool_disabled() -> bool {
 /// diagnostics stay byte-identical to the fresh-checker arm regardless of
 /// partitioning.
 const fn resolve_checker_pool_size(
-    explicit: Option<usize>,
-    disabled: bool,
+    env: CheckerPoolEnv,
+    kill_switch: bool,
     default_eligible: bool,
     available_parallelism: usize,
 ) -> Option<usize> {
-    if let Some(width) = explicit {
-        return Some(width);
-    }
-    if disabled {
-        return None;
-    }
-    if default_eligible {
-        Some(available_parallelism)
-    } else {
-        None
+    match env {
+        // Explicit positive width wins on any lane, even over the kill switch.
+        CheckerPoolEnv::Width(width) => Some(width),
+        // Explicit `0`/empty forces off, overriding the large-lane default.
+        CheckerPoolEnv::ForceOff => None,
+        CheckerPoolEnv::Unset => {
+            if kill_switch {
+                None
+            } else if default_eligible {
+                Some(available_parallelism)
+            } else {
+                None
+            }
+        }
     }
 }
 
@@ -1424,7 +1447,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
                 && !has_parallel_order_sensitive_global_lib
                 && !parallel_reuse_requested;
             let checker_pool_size = resolve_checker_pool_size(
-                checker_pool_size(),
+                checker_pool_env(),
                 checker_pool_disabled(),
                 checker_pool_default_eligible,
                 std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get),

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -330,7 +330,7 @@ fn parallel_file_session_reuse_requested() -> bool {
 /// The user's explicit `TSZ_CHECKER_POOL` request, parsed once.
 ///
 /// The bounded checker pool checks files on a fixed pool of `N` long-lived
-/// `CheckerState`s (cost-balanced file assignment, each reused via
+/// `CheckerState`s (round-robin file assignment, each reused via
 /// `switch_to_file`) instead of the per-file fresh checker. This amortises the
 /// O(program) per-file setup over `files / N` files — the lever that unblocks
 /// large multi-file projects.

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -327,16 +327,17 @@ fn parallel_file_session_reuse_requested() -> bool {
     )
 }
 
-/// Bounded long-lived checker-pool width, or `None` when the pool scheduler is
-/// off (the default).
+/// Explicit bounded-checker-pool width requested via the `TSZ_CHECKER_POOL`
+/// env var, or `None` when the var is unset / `0` / empty / invalid.
 ///
-/// `TSZ_CHECKER_POOL` opts into checking files on a fixed pool of `N`
-/// long-lived `CheckerState`s (round-robin file assignment, each reused via
-/// `switch_to_file`) instead of the default per-file fresh checker. This
-/// amortises the O(program) per-file setup over `files / N` files — the lever
-/// that unblocks large multi-file projects. `=auto` (or `=1`) sizes the pool
-/// to `available_parallelism`; `=N` sets an explicit width; unset / `0` / empty
-/// disables it.
+/// `TSZ_CHECKER_POOL` checks files on a fixed pool of `N` long-lived
+/// `CheckerState`s (cost-balanced file assignment, each reused via
+/// `switch_to_file`) instead of the per-file fresh checker. This amortises the
+/// O(program) per-file setup over `files / N` files — the lever that unblocks
+/// large multi-file projects. `=auto` (or `=1`) sizes the pool to
+/// `available_parallelism`; `=N` sets an explicit width; unset / `0` / empty
+/// leaves the decision to [`resolve_checker_pool_size`] (which defaults the
+/// pool ON for the large non-DOM parallel lane).
 fn checker_pool_size() -> Option<usize> {
     let raw = std::env::var("TSZ_CHECKER_POOL").ok()?;
     match raw.trim() {
@@ -345,6 +346,50 @@ fn checker_pool_size() -> Option<usize> {
             Some(std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get))
         }
         n => n.parse::<usize>().ok().filter(|&w| w >= 1),
+    }
+}
+
+/// Whether the bounded checker pool is force-disabled via the
+/// `TSZ_DISABLE_CHECKER_POOL` kill switch. An explicit `TSZ_CHECKER_POOL=<n>`
+/// still wins over this switch; the switch only suppresses the default-on
+/// behavior on the large non-DOM parallel lane.
+fn checker_pool_disabled() -> bool {
+    std::env::var_os("TSZ_DISABLE_CHECKER_POOL").is_some()
+}
+
+/// Resolve the effective bounded-checker-pool width, folding the explicit env
+/// request, the kill switch, and the default-on lane policy into one decision.
+///
+/// Precedence, highest first:
+///   1. an explicit `TSZ_CHECKER_POOL=<n|auto>` width always wins, on any lane;
+///   2. the `TSZ_DISABLE_CHECKER_POOL` kill switch forces the pool off;
+///   3. on the large non-DOM parallel lane (`default_eligible`) the pool
+///      defaults ON, sized to `available_parallelism`;
+///   4. otherwise the pool stays off and checking falls through to the
+///      fresh-checker / sequential-reuse arms.
+///
+/// `default_eligible` is the large non-DOM parallel lane: more files than the
+/// small-project boundary, no order-sensitive global lib (DOM/webworker), and
+/// no explicit `TSZ_FILE_SESSION_REUSE` opt-in (which selects its own reuse
+/// arm). The per-partition body is the proven sequential-reuse path, so
+/// diagnostics stay byte-identical to the fresh-checker arm regardless of
+/// partitioning.
+const fn resolve_checker_pool_size(
+    explicit: Option<usize>,
+    disabled: bool,
+    default_eligible: bool,
+    available_parallelism: usize,
+) -> Option<usize> {
+    if let Some(width) = explicit {
+        return Some(width);
+    }
+    if disabled {
+        return None;
+    }
+    if default_eligible {
+        Some(available_parallelism)
+    } else {
+        None
     }
 }
 
@@ -1362,35 +1407,44 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
             // than narrowing it.
             let use_file_session_reuse =
                 use_sequential_checking && !extract_type_cache && reuse_requested;
-            // The bounded checker pool runs `pool_size` long-lived checkers in
-            // parallel over the *same* shared `DefinitionStore`, so it carries
-            // the identical schedule-dependent lib-interface materialization
-            // hazard as the fresh-parallel lane (DOM/webworker globals; see
-            // `should_use_sequential_fresh_checking`). The pool branch is
-            // evaluated before the `use_sequential_checking` gate, so without
-            // this refusal an explicit `TSZ_CHECKER_POOL=N` — or a future
-            // default-on pool — would route a DOM project onto the pool and
-            // produce non-deterministic diagnostics (proven: `keyof`/indexed
-            // access over DOM element-tag-name maps yields distinct output per
-            // schedule). Refuse the pool for those programs so they take the
-            // deterministic sequential path regardless of how the pool was
-            // requested; the `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK` diagnosis
-            // override lifts the refusal for byte-diff testing only.
-            let pool_size = checker_pool_size().filter(|_| {
+            // Default the bounded pool ON for the large non-DOM parallel lane:
+            // more files than the small-project boundary, no order-sensitive
+            // global lib (DOM/webworker keep their deterministic sequential
+            // gate — lifted separately), and no explicit
+            // `TSZ_FILE_SESSION_REUSE` opt-in (which selects its own reuse
+            // arm). This is exactly the lane that otherwise falls through to
+            // the fresh-checker `else` arm below, so default-on swaps one
+            // `CheckerState` per file for a bounded pool without changing which
+            // files run in parallel. An explicit `TSZ_CHECKER_POOL=<n>` still
+            // wins inside the resolver; the DOM/webworker refusal below is a
+            // separate correctness gate. `TSZ_DISABLE_CHECKER_POOL` forces the
+            // default off.
+            let checker_pool_default_eligible = work_items.len()
+                > FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES
+                && !has_parallel_order_sensitive_global_lib
+                && !parallel_reuse_requested;
+            let checker_pool_size = resolve_checker_pool_size(
+                checker_pool_size(),
+                checker_pool_disabled(),
+                checker_pool_default_eligible,
+                std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get),
+            )
+            .filter(|_| {
                 !extract_type_cache
                     && !pool_refused_for_order_sensitive_global_lib(
                         has_parallel_order_sensitive_global_lib,
                         force_parallel_order_sensitive_global_lib,
                     )
             });
-            if let Some(pool_size) = pool_size {
-                // Bounded long-lived checker pool (`TSZ_CHECKER_POOL`): N
-                // round-robin partitions, each a long-lived `CheckerState`
-                // reused via `switch_to_file`, amortising the O(program)
-                // per-file setup over `files / N` files — the lever that
-                // unblocks large multi-file projects. Gated default-off; the
-                // per-partition body is the proven sequential-reuse path, so
-                // diagnostics are byte-identical to the fresh-checker arm.
+            if let Some(pool_size) = checker_pool_size {
+                // Bounded long-lived checker pool: N round-robin partitions,
+                // each a long-lived `CheckerState` reused via `switch_to_file`,
+                // amortising the O(program) per-file setup over `files / N`
+                // files — the lever that unblocks large multi-file projects.
+                // DOM/webworker programs are refused above so they keep the
+                // deterministic sequential gate. The per-partition body is the
+                // proven sequential-reuse path, so diagnostics are
+                // byte-identical to the fresh-checker arm.
                 tsz::parallel::ensure_rayon_global_pool();
                 let reuse_ctx = CheckFilesReuseCtx {
                     program,

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -815,14 +815,16 @@ fn checker_pool_refuses_order_sensitive_global_lib_by_default() {
 
 /// Asserts the Stage-B default-on policy for the bounded checker pool: the
 /// pool turns ON by default for the large non-DOM parallel lane, while the
-/// explicit env width and the kill switch keep their precedence.
+/// explicit env width, the explicit `=0`/empty off, and the kill switch keep
+/// their precedence.
 #[test]
 fn checker_pool_defaults_on_for_large_non_dom_parallel_lane() {
     const AP: usize = 8;
+    use CheckerPoolEnv::{ForceOff, Unset, Width};
 
     // Default-on: large non-DOM parallel lane (eligible) with no env knobs.
     assert_eq!(
-        resolve_checker_pool_size(None, false, true, AP),
+        resolve_checker_pool_size(Unset, false, true, AP),
         Some(AP),
         "large non-DOM parallel lane must default the pool on, sized to available parallelism"
     );
@@ -830,26 +832,33 @@ fn checker_pool_defaults_on_for_large_non_dom_parallel_lane() {
     // Ineligible lanes (small project / DOM / explicit file-session reuse)
     // keep the pool off by default.
     assert_eq!(
-        resolve_checker_pool_size(None, false, false, AP),
+        resolve_checker_pool_size(Unset, false, false, AP),
         None,
         "ineligible lanes (small/DOM/reuse-opt-in) keep the pool off by default"
     );
 
     // Explicit width wins on any lane, eligible or not.
     assert_eq!(
-        resolve_checker_pool_size(Some(4), false, false, AP),
+        resolve_checker_pool_size(Width(4), false, false, AP),
         Some(4),
         "explicit TSZ_CHECKER_POOL=<n> must win even on an ineligible lane"
     );
     assert_eq!(
-        resolve_checker_pool_size(Some(4), true, true, AP),
+        resolve_checker_pool_size(Width(4), true, true, AP),
         Some(4),
         "explicit TSZ_CHECKER_POOL=<n> must win over the kill switch and the default"
     );
 
+    // Explicit `=0`/empty forces off, overriding the eligible-lane default.
+    assert_eq!(
+        resolve_checker_pool_size(ForceOff, false, true, AP),
+        None,
+        "explicit TSZ_CHECKER_POOL=0 must override the eligible-lane default"
+    );
+
     // Kill switch suppresses the default-on behavior.
     assert_eq!(
-        resolve_checker_pool_size(None, true, true, AP),
+        resolve_checker_pool_size(Unset, true, true, AP),
         None,
         "TSZ_DISABLE_CHECKER_POOL must override the eligible-lane default"
     );

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -813,6 +813,48 @@ fn checker_pool_refuses_order_sensitive_global_lib_by_default() {
     );
 }
 
+/// Asserts the Stage-B default-on policy for the bounded checker pool: the
+/// pool turns ON by default for the large non-DOM parallel lane, while the
+/// explicit env width and the kill switch keep their precedence.
+#[test]
+fn checker_pool_defaults_on_for_large_non_dom_parallel_lane() {
+    const AP: usize = 8;
+
+    // Default-on: large non-DOM parallel lane (eligible) with no env knobs.
+    assert_eq!(
+        resolve_checker_pool_size(None, false, true, AP),
+        Some(AP),
+        "large non-DOM parallel lane must default the pool on, sized to available parallelism"
+    );
+
+    // Ineligible lanes (small project / DOM / explicit file-session reuse)
+    // keep the pool off by default.
+    assert_eq!(
+        resolve_checker_pool_size(None, false, false, AP),
+        None,
+        "ineligible lanes (small/DOM/reuse-opt-in) keep the pool off by default"
+    );
+
+    // Explicit width wins on any lane, eligible or not.
+    assert_eq!(
+        resolve_checker_pool_size(Some(4), false, false, AP),
+        Some(4),
+        "explicit TSZ_CHECKER_POOL=<n> must win even on an ineligible lane"
+    );
+    assert_eq!(
+        resolve_checker_pool_size(Some(4), true, true, AP),
+        Some(4),
+        "explicit TSZ_CHECKER_POOL=<n> must win over the kill switch and the default"
+    );
+
+    // Kill switch suppresses the default-on behavior.
+    assert_eq!(
+        resolve_checker_pool_size(None, true, true, AP),
+        None,
+        "TSZ_DISABLE_CHECKER_POOL must override the eligible-lane default"
+    );
+}
+
     #[test]
     fn tiny_no_emit_reuse_path_covers_boxed_prime_checker() {
         assert!(


### PR DESCRIPTION
Goal: fast

## Summary

Stage B of #13841: make the bounded checker pool (the `TSZ_CHECKER_POOL`
scheduler) default-on for the large non-DOM parallel lane, so large multi-file
projects amortize O(program) per-file checker setup without needing an env var.

This head is rebased onto `origin/main@4f34e5c974` and composes Stage B with the
already-merged #13861 DOM/webworker refusal. The large non-DOM lane defaults to
the pool; DOM/webworker projects, including explicit `TSZ_CHECKER_POOL=<n>`
requests, are refused from the pool and keep the deterministic sequential gate
unless `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK` is set for diagnosis.

## Structural Rule

When a parallel non-DOM program is on the large-project lane (more files than
`FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES`, no order-sensitive DOM/webworker
global lib, and no explicit `TSZ_FILE_SESSION_REUSE` opt-in), `tsc` checks files
over a bounded worker set. tsz now does the same by default through the bounded
checker pool owned by `tsz-cli` driver dispatch (`driver/check.rs`), instead of
constructing one `CheckerState` per file.

The pool reuses the existing round-robin `check_files_round_robin_pool` path:
each partition runs `check_files_sequentially_with_reuse`, retargets its
long-lived checker via `switch_to_file`, and reassembles diagnostics by original
file position. Complexity changes from per-file O(program) `apply_to` setup
across `files` fresh checker constructions to `pool_size` constructions, with
`pool_size` defaulting to `available_parallelism` on the eligible lane.

## Lane Gate And Precedence

`default_eligible = files > FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES`
`&& !has_parallel_order_sensitive_global_lib(checker_libs)`
`&& !parallel_reuse_requested`

These are structural facts already computed by the driver; the lane adds no new
file-count constant and does not key on filenames or rendered diagnostics.
`has_parallel_order_sensitive_global_lib` is the DOM/webworker structural lib
predicate.

`resolve_checker_pool_size` folds env policy into one pure resolver:

1. explicit `TSZ_CHECKER_POOL=<n|auto>` selects that width in the resolver;
2. explicit `TSZ_CHECKER_POOL=0`/empty, or `TSZ_DISABLE_CHECKER_POOL`, forces
   the default off;
3. unset env on the eligible lane defaults to `available_parallelism`;
4. otherwise the pool stays off and checking falls through to the existing
   fresh-checker / sequential-reuse arms.

After resolution, the independent #13861 DOM/webworker refusal filters the pool
for order-sensitive global libs. That refusal covers both default-on and
explicit pool requests; only `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK` lifts it for
byte-diff diagnosis. Emit/declaration runs (`extract_type_cache`) keep the pool
off because cache extraction consumes per-file checker state.

## Performance And Parity Notes

Prior same-binary Stage-B evidence on the scale-cliff fixtures showed the pool
engages by default on non-DOM monorepo-006 (5,251 files): `CheckerState::new`
falls from 5,251 to about available parallelism (17 on that machine). The
bounded pool was byte-identical to the old fresh-checker path across
monorepo-001..006 (101 / 1,010 / 5,099 / 5,151 / 5,202 / 5,251 files).

Drift-controlled alternating A(pool-on)/B(pool-off) on monorepo-006, 7 rounds,
measured CHECK median 5.60s vs 11.34s (-50.6%) and TOTAL median 13.81s vs
17.68s (-21.9%). These are setup-amortization numbers for a non-DOM row; they
are not claimed for DOM/webworker rows, which remain sequential by default.

DOM-specific validation from #13861 now applies to this head after rebase:
DOM/webworker programs are refused from the pool even for explicit widths, so
the old explicit DOM pool hole is not a remaining follow-up in this PR.

## Verification

Exact-head local verification after rebase/push to
`4e71596ade322181e50d7f92f4ad650f783e70b0`:

- `git diff --check` PASS.
- `cargo fmt -p tsz-cli --check` PASS.
- `scripts/safe-run.sh cargo nextest run -p tsz-cli checker_pool_defaults_on_for_large_non_dom_parallel_lane checker_pool_refuses_order_sensitive_global_lib_by_default` PASS (2/2).
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "inferentialTypingWithFunctionTypeZip" --verbose` PASS (1/1; no known failures, crashes, timeouts, or fingerprint-only drift).

Ready-review CI owns broad conformance/emit/unit coverage for the exact head.

## Provenance

Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
