### PR TITLE
fix(solver): decompose boolean union member in literal-equality exclusion narrowing (mobx 96->89)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -604,6 +604,9 @@ mod assertion_type_predicate_diagnostics_tests;
 #[path = "../tests/bigint_target_ts2737_tests.rs"]
 mod bigint_target_ts2737_tests;
 #[cfg(test)]
+#[path = "tests/boolean_literal_union_narrowing_tests.rs"]
+mod boolean_literal_union_narrowing_tests;
+#[cfg(test)]
 #[path = "tests/builtin_iterator_implements_tests.rs"]
 mod builtin_iterator_implements_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/boolean_literal_union_narrowing_tests.rs
+++ b/crates/tsz-checker/src/tests/boolean_literal_union_narrowing_tests.rs
@@ -1,0 +1,166 @@
+//! Narrowing a union member of type `boolean` by a boolean-literal equality
+//! guard must decompose the member into `true | false` and drop the excluded
+//! literal, matching tsc's `narrowTypeByEquality` over the implicit
+//! `true | false` representation of `boolean`.
+//!
+//! Regression for the mobx `make_(annotation: Annotation | boolean)` family,
+//! where `if (a === true)` / `if (a === false)` must leave the object facet
+//! (false TS2339 `Property ... does not exist on type 'boolean | Annotation'`).
+//! Binder names are varied across cases per the anti-hardcoding gate.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(diagnostics: &[Diagnostic]) -> Vec<u32> {
+    diagnostics.iter().map(|d| d.code).collect()
+}
+
+/// `=== true` false-branch drops `true` from a `boolean` union member,
+/// leaving the object facet plus `false`.
+#[test]
+fn eq_true_false_branch_keeps_object_and_false() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+type Marker = { tag_: string };
+function classify(entry: Marker | boolean): void {
+    if (entry === true) {
+        return;
+    }
+    const rest: Marker | false = entry;
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "expected `entry` to narrow to `Marker | false`, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// Excluding both `true` and `false` removes `boolean` entirely, leaving the
+/// object facet so member access on it is valid (the mobx `make_` shape).
+#[test]
+fn eq_true_and_eq_false_leave_only_object_facet() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+type Setting = { kind_: string; apply_(): number };
+function handle(opt: Setting | boolean): void {
+    if (opt === true) {
+        return;
+    }
+    if (opt === false) {
+        return;
+    }
+    const name = opt.kind_;
+    opt.apply_();
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "expected `opt` to narrow to `Setting` after excluding both boolean literals, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// Assignment-narrowing in the `=== true` branch followed by `=== false`
+/// exclusion, exactly mirroring mobx's `make_` (reassign `true` to a default
+/// object, then drop `false`).
+#[test]
+fn reassign_true_branch_then_exclude_false() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+type Rule = { code_: string; run_(): number };
+declare const fallback: Rule;
+function evaluate(rule: Rule | boolean): void {
+    if (rule === true) {
+        rule = fallback;
+    }
+    if (rule === false) {
+        return;
+    }
+    const id = rule.code_;
+    rule.run_();
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "expected `rule` to narrow to `Rule`, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// The same decomposition applies when the boolean facet is spelled as an
+/// explicit `true | false` union rather than the `boolean` keyword.
+#[test]
+fn explicit_true_false_union_member_decomposes() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+type Token = { text_: string };
+function read(piece: Token | true | false): void {
+    if (piece === false) {
+        return;
+    }
+    if (piece === true) {
+        return;
+    }
+    const value = piece.text_;
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "expected `piece` to narrow to `Token`, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// Negative control: the positive branch of `=== true` still narrows to the
+/// `true` literal (no regression to the equality side of the guard).
+#[test]
+fn eq_true_positive_branch_narrows_to_true() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+type Flagged = { note_: string };
+function inspect(flag: Flagged | boolean): void {
+    if (flag === true) {
+        const exact: true = flag;
+    }
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "expected positive branch to narrow `flag` to `true`, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// Negative control: a non-boolean literal guard over the same union must not
+/// be affected by the boolean-decomposition path.
+#[test]
+fn non_boolean_member_exclusion_unaffected() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+type Holder = { item_: string };
+function pick(slot: Holder | 0 | 1): void {
+    if (slot === 0) {
+        return;
+    }
+    const rest: Holder | 1 = slot;
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "expected numeric-literal exclusion to leave `Holder | 1`, got {:?}",
+        codes(&diagnostics)
+    );
+}

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -1416,6 +1416,20 @@ impl<'a> NarrowingContext<'a> {
                     {
                         return narrowed.non_never();
                     }
+                    // A `boolean` (or `true`/`false`) union member is the implicit
+                    // `true | false` union; excluding one boolean literal must leave
+                    // the other rather than keeping the whole member. The top-level
+                    // boolean special-case below only fires when the source is exactly
+                    // boolean, so recurse here so `Ann | boolean` minus `true` yields
+                    // `Ann | false` (mirrors tsc's `boolean` literal decomposition).
+                    if matches!(
+                        member,
+                        TypeId::BOOLEAN | TypeId::BOOLEAN_TRUE | TypeId::BOOLEAN_FALSE
+                    ) {
+                        return self
+                            .narrow_excluding_type(member, excluded_type)
+                            .non_never();
+                    }
                     if self.is_assignable_to(member, excluded_type) {
                         None
                     } else {


### PR DESCRIPTION
Goal: green

## Summary
mobx canary residual after the cross-module enum fix (#13805) and inline empty-array fix (#13814). Post-enum baseline measured at **96 tsz-only** diagnostics (board's ~98). This clears the largest coherent genuine-extra cluster.

**mobx: 96 -> 89 tsz-only** (deterministic across 4 isolated runs).

## Structural rule
When narrowing a union by a boolean-literal inequality guard (the false branch of `x === true` / `x === false`), tsc treats a `boolean` (and `true`/`false`) union member as the implicit `true | false` union and drops only the excluded literal. tsz does X through the solver narrowing engine: `narrow_excluding_type` had a top-level boolean special-case (`boolean` minus `true` -> `false`) but it only fired when the *whole source* was exactly `boolean`. For a union source (`Annotation | boolean`), the per-member filter fell through to `is_assignable_to(boolean, true)` which is false, so the entire `boolean` member was kept. The fix recurses boolean-family union members back through `narrow_excluding_type` so the decomposition applies, matching tsc's `narrowTypeByEquality`.

Owner layer: `crates/tsz-solver/src/narrowing/core.rs` (`narrow_excluding_type_uncached`, union-member filter).

## Adjacent matrix
- `=== true` false-branch -> `T | false` (positive: object facet + `false` survive)
- exclude both `true` and `false` -> object facet only (the mobx `make_` shape)
- assignment-narrow in `=== true` branch then `=== false` exclusion (faithful mobx repro)
- explicit `T | true | false` union member (not the `boolean` keyword)
- positive branch `=== true` still narrows to `true` (no regression on equality side)
- non-boolean literal exclusion (`T | 0 | 1` minus `0`) unaffected (fallback)
- binder names varied across all six cases

## Verification
- `cargo nextest run -p tsz-checker boolean_literal_union_narrowing` — 6/6 pass
- Conformance (`scripts/conformance/conformance.sh run --filter`): narrowing 29/29, boolean 12/12, typeGuard 86/86, discriminant 16/16, controlFlow 94/94, switchCase 7/7, truthiness 6/6 — 250 tests, 0 PASS->FAIL on touched families
- `cargo clippy -p tsz-solver -p tsz-checker --profile dist-fast` — clean
- `python3 scripts/arch/arch_guard.py` — passed
- Corpus gate: mobx 96 (baseline, confirmed independently on a clean origin/main build) -> 89 (fixed); required rows all green (EXIT 0, 0 tsz-only); determinism 89x4

## Residual cluster -> root map (for the remaining 89, not fixed here)
- 7x TS2304 `ReadonlySetLike` (observableset.ts): diagnostic-suggestion-cap *ordering* parity (tsc emits TS2552 at same loc); global suggestionCount-vs-checking-order divergence, not type correctness — risky global fix, documented not attempted.
- tojs.ts (10), observable-collection TS2322 family: user-predicate-narrowing-of-`any` (`forEach` on `never`) — maps to the in-flight `green/any-userpredicate-narrowing` root (#13805 sibling), not a new bounded cluster.
- remainder: diffuse long tail across 18 codes (index-access, assignability, implicit-any) with no single dominant new bounded cluster.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Project corpus
AgentName: mobx-residual2
- Row: mobx
- Bug family: boolean-literal-union-exclusion-narrowing
