### PR TITLE
fix(resolver): extensionless package imports target follows PACKAGE_TARGET_RESOLVE

### DIFF
--- a/crates/tsz-cli/src/driver/resolution/exports_imports.rs
+++ b/crates/tsz-cli/src/driver/resolution/exports_imports.rs
@@ -138,20 +138,63 @@ pub(crate) fn resolve_exports_target(
     }
 }
 
-pub(crate) fn resolve_exports_target_candidates(
+/// Resolve a package.json `imports` subpath to ordered `(target, is_types)`
+/// candidates. `is_types` reports whether the matched value passed through a
+/// types-flavored condition (`types`/`types@<range>`); the imports caller uses
+/// it to keep declaration-aware probing of an extensionless target, mirroring
+/// the spec'd `PACKAGE_TARGET_RESOLVE` algorithm shared with the `exports` field.
+pub(crate) fn resolve_imports_subpath_candidates_with_flavor(
+    imports: &serde_json::Value,
+    subpath_key: &str,
+    conditions: &[&str],
+    compiler_version: SemVer,
+) -> Vec<(String, bool)> {
+    let serde_json::Value::Object(map) = imports else {
+        return Vec::new();
+    };
+
+    let has_subpath_keys = map.keys().any(|key| key.starts_with('#'));
+    if !has_subpath_keys {
+        return Vec::new();
+    }
+
+    if let Some(value) = map.get(subpath_key) {
+        return resolve_target_candidates_with_flavor(value, conditions, compiler_version, false);
+    }
+
+    if let Some((wildcard, value)) =
+        find_best_subpath_pattern(map, |key| match_imports_subpath(key, subpath_key))
+    {
+        return resolve_target_candidates_with_flavor(value, conditions, compiler_version, false)
+            .into_iter()
+            .map(|(target, is_types)| (apply_exports_subpath(&target, &wildcard), is_types))
+            .collect();
+    }
+
+    Vec::new()
+}
+
+/// Resolve a value side of an `exports`/`imports` entry to ordered
+/// `(target, is_types)` candidates. Condition keys (including versioned
+/// `<base>@<range>`) are matched against `conditions`; `is_types` is set when
+/// the value was reached through a `types`/`types@<range>` condition, so the
+/// caller can keep declaration-aware probing of an extensionless target.
+fn resolve_target_candidates_with_flavor(
     target: &serde_json::Value,
     conditions: &[&str],
     compiler_version: SemVer,
-) -> Vec<String> {
+    is_types_condition: bool,
+) -> Vec<(String, bool)> {
     match target {
-        serde_json::Value::String(value) => vec![value.clone()],
+        serde_json::Value::String(value) => vec![(value.clone(), is_types_condition)],
         serde_json::Value::Array(list) => {
             let mut candidates = Vec::new();
             for entry in list {
-                candidates.extend(resolve_exports_target_candidates(
+                candidates.extend(resolve_target_candidates_with_flavor(
                     entry,
                     conditions,
                     compiler_version,
+                    is_types_condition,
                 ));
             }
             candidates
@@ -168,20 +211,24 @@ pub(crate) fn resolve_exports_target_candidates(
                         if value.is_null() {
                             return Vec::new();
                         }
-                        candidates.extend(resolve_exports_target_candidates(
+                        let nested_is_types = is_types_condition || base_condition == "types";
+                        candidates.extend(resolve_target_candidates_with_flavor(
                             value,
                             conditions,
                             compiler_version,
+                            nested_is_types,
                         ));
                     }
                 } else if conditions.contains(&key.as_str()) {
                     if value.is_null() {
                         return Vec::new();
                     }
-                    candidates.extend(resolve_exports_target_candidates(
+                    let nested_is_types = is_types_condition || key == "types";
+                    candidates.extend(resolve_target_candidates_with_flavor(
                         value,
                         conditions,
                         compiler_version,
+                        nested_is_types,
                     ));
                 }
             }
@@ -189,37 +236,6 @@ pub(crate) fn resolve_exports_target_candidates(
         }
         _ => Vec::new(),
     }
-}
-
-pub(crate) fn resolve_imports_subpath_candidates(
-    imports: &serde_json::Value,
-    subpath_key: &str,
-    conditions: &[&str],
-    compiler_version: SemVer,
-) -> Vec<String> {
-    let serde_json::Value::Object(map) = imports else {
-        return Vec::new();
-    };
-
-    let has_subpath_keys = map.keys().any(|key| key.starts_with('#'));
-    if !has_subpath_keys {
-        return Vec::new();
-    }
-
-    if let Some(value) = map.get(subpath_key) {
-        return resolve_exports_target_candidates(value, conditions, compiler_version);
-    }
-
-    if let Some((wildcard, value)) =
-        find_best_subpath_pattern(map, |key| match_imports_subpath(key, subpath_key))
-    {
-        return resolve_exports_target_candidates(value, conditions, compiler_version)
-            .into_iter()
-            .map(|target| apply_exports_subpath(&target, &wildcard))
-            .collect();
-    }
-
-    Vec::new()
 }
 
 /// `(prefix_len, suffix_len)` specificity for a package.json `exports` /
@@ -494,13 +510,13 @@ mod tests {
             }),
         ] {
             assert_eq!(
-                resolve_imports_subpath_candidates(
+                resolve_imports_subpath_candidates_with_flavor(
                     &imports,
                     "#abc/abc",
                     &["default"],
                     TEST_VERSION,
                 ),
-                vec!["./by-abc-star.js".to_string()],
+                vec![("./by-abc-star.js".to_string(), false)],
             );
         }
     }

--- a/crates/tsz-cli/src/driver/resolution/package_resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution/package_resolution.rs
@@ -354,7 +354,21 @@ pub(crate) fn resolve_package_imports_specifier(
             && let Some(imports) = package_json.imports.as_ref()
         {
             let package_type = package_type_from_json(Some(&package_json));
-            for target in resolve_imports_subpath_candidates(
+            // Node.js (and tsc) resolve `imports`/`exports` targets via
+            // PACKAGE_TARGET_RESOLVE: the target is taken verbatim, with no
+            // directory-index lookup and no extension invention. tsc only
+            // remaps an explicit `.js`/`.mjs`/`.cjs` target to its `.ts`
+            // sibling. Under the `exports`/`imports`-aware modes
+            // (Node16/NodeNext/Bundler) an EXTENSIONLESS runtime target must
+            // therefore NOT resolve. The legacy `Node`(node10)/`Classic`
+            // modes predate this and keep classic extension/index probing.
+            let strict_extensionless = matches!(
+                options.effective_module_resolution(),
+                ModuleResolutionKind::Node16
+                    | ModuleResolutionKind::NodeNext
+                    | ModuleResolutionKind::Bundler
+            );
+            for (target, is_types_condition) in resolve_imports_subpath_candidates_with_flavor(
                 imports,
                 module_specifier,
                 &conditions,
@@ -368,6 +382,30 @@ pub(crate) fn resolve_package_imports_specifier(
                 } else if !is_valid_bare_imports_target(target) {
                     continue;
                 }
+
+                // An extensionless relative target under a spec'd mode does not
+                // gain a `.ts`/`index.*` lookup — unless the value came through
+                // a types-flavored condition, which keeps declaration-aware
+                // probing (`./types/api` -> `./types/api.d.ts`) exactly like the
+                // `exports` field and `typesVersions`.
+                if strict_extensionless
+                    && target.starts_with("./")
+                    && split_path_extension(Path::new(target)).is_none()
+                {
+                    if is_types_condition
+                        && let Some(resolved) = resolve_declaration_package_entry(
+                            current,
+                            target,
+                            options,
+                            package_type,
+                            resolution_cache,
+                        )
+                    {
+                        return Some(resolved);
+                    }
+                    continue;
+                }
+
                 if let Some(resolved) =
                     resolve_package_entry(current, target, options, package_type, resolution_cache)
                 {

--- a/crates/tsz-cli/tests/driver_tests_parts/part_05.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_05.rs
@@ -353,8 +353,8 @@ fn compile_resolves_package_exports_versioned_condition_respects_compiler_versio
 }
 
 // Regression for issue #4763: package.json `imports` versioned conditions
-// share the same `resolve_exports_target_candidates` plumbing, so the
-// override must reach `imports` as well.
+// share the same target-candidate plumbing (`resolve_target_candidates_with_flavor`)
+// as `exports`, so the override must reach `imports` as well.
 #[test]
 fn compile_resolves_package_imports_versioned_condition_respects_compiler_version_override() {
     let temp = TempDir::new().expect("temp dir");
@@ -407,7 +407,17 @@ fn compile_resolves_package_imports_versioned_condition_respects_compiler_versio
 }
 
 #[test]
-fn compile_resolves_package_imports_wildcard() {
+fn compile_rejects_extensionless_package_imports_wildcard_under_node16() {
+    // tsc parity: under the `exports`/`imports`-aware modes
+    // (Node16/NodeNext/Bundler), a package.json `imports` wildcard target that
+    // is EXTENSIONLESS (`"#utils/*": "./types/*"` imported as `#utils/widget`)
+    // is resolved verbatim via PACKAGE_TARGET_RESOLVE. The runtime does NOT add
+    // a `.ts`/`.d.ts` extension, so even though `types/widget.d.ts` sits on
+    // disk, tsc emits TS2307. (Verified directly against `tsc` 6.x: the trace
+    // reads `Using 'imports' subpath '#utils/*' with target './types/widget'`
+    // then `Module name '#utils/widget' was not resolved.`) Only a target
+    // carrying an explicit `.js`/`.mjs`/`.cjs` extension is remapped to its TS
+    // sibling, and only a types-flavored condition keeps declaration probing.
     let temp = TempDir::new().expect("temp dir");
     let base = &temp.path;
 
@@ -435,19 +445,76 @@ fn compile_resolves_package_imports_wildcard() {
           }
         }"##,
     );
-    write_file(&base.join("types/widget.d.ts"), "export const widget = ;");
+    write_file(
+        &base.join("types/widget.d.ts"),
+        "export declare const widget: number;",
+    );
 
     let args = default_args();
     let result = compile(&args, base).expect("compile should succeed");
 
-    assert!(!result.diagnostics.is_empty());
     assert!(
-        result
-            .diagnostics
-            .iter()
-            .any(|diag| diag.file.contains("types/widget.d.ts"))
+        result.diagnostics.iter().any(|diag| diag.code
+            == diagnostic_codes::CANNOT_FIND_MODULE_OR_ITS_CORRESPONDING_TYPE_DECLARATIONS),
+        "Expected TS2307 for an extensionless imports wildcard target, got diagnostics: {:?}",
+        result.diagnostics
     );
     assert!(!base.join("dist/src/index.js").is_file());
+}
+
+#[test]
+fn compile_resolves_package_imports_wildcard_with_js_extension_to_ts_sibling() {
+    // Companion to the extensionless case: when the `imports` wildcard target
+    // carries an explicit runtime extension (`"#utils/*": "./types/*.js"`), the
+    // substituted target `./types/widget.js` carries `.js`, so tsc strips it
+    // and remaps to its `./types/widget.ts` sibling. (Verified against `tsc`
+    // 6.x: `Using 'imports' subpath '#utils/*' with target './types/widget.js'`
+    // -> `... has a '.js' extension - stripping it` -> resolves `widget.ts`.)
+    // This proves the guard keys on the target's extension, not on the
+    // specifier or a file-name, and that the `.js`->`.ts` substitution path is
+    // preserved.
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {"rootDir": ".",
+            "outDir": "dist",
+            "module": "node16",
+            "moduleResolution": "node16",
+            "noEmit": true
+          },
+          "files": ["src/index.ts"]
+        }"#,
+    );
+    write_file(
+        &base.join("src/index.ts"),
+        "import { widget } from '#utils/widget'; export const n: number = widget;",
+    );
+    write_file(
+        &base.join("package.json"),
+        r##"{
+          "type": "module",
+          "imports": {
+            "#utils/*": "./types/*.js"
+          }
+        }"##,
+    );
+    write_file(
+        &base.join("types/widget.ts"),
+        "export const widget: number = 1;",
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert!(
+        !result.diagnostics.iter().any(|diag| diag.code
+            == diagnostic_codes::CANNOT_FIND_MODULE_OR_ITS_CORRESPONDING_TYPE_DECLARATIONS),
+        "Expected `#utils/widget` (via ./types/*.js) to resolve to types/widget.ts, got diagnostics: {:?}",
+        result.diagnostics
+    );
 }
 
 #[test]

--- a/crates/tsz-core/src/module_resolver/exports_imports.rs
+++ b/crates/tsz-core/src/module_resolver/exports_imports.rs
@@ -119,7 +119,7 @@ impl ModuleResolver {
                 let host_pt =
                     self.target_package_type_from_json(&package_json, importer_package_type);
 
-                for (target, resolved_using_ts_extension) in
+                for (target, resolved_using_ts_extension, is_types_condition) in
                     self.resolve_imports_subpath_candidates(imports, specifier, &conditions)
                 {
                     // Per Node.js PACKAGE_IMPORTS_RESOLVE spec, the resolved
@@ -132,8 +132,27 @@ impl ModuleResolver {
                         else {
                             continue;
                         };
-                        if let Some(resolved) = self.try_file_or_directory(&resolved_path, host_pt)
-                        {
+                        // Imports targets follow the same PACKAGE_TARGET_RESOLVE
+                        // algorithm as exports targets, so route them through the
+                        // shared runtime probe (`try_export_target`) rather than
+                        // the classic `try_file_or_directory`. This makes an
+                        // extensionless imports target (e.g. `"#core/*":
+                        // "./src/core/*"` imported as `#core/sharedOptions`)
+                        // refuse extension/directory-index addition under
+                        // Node16/NodeNext/Bundler, matching tsc, while explicit
+                        // `.js`->`.ts` substitution still applies.
+                        //
+                        // A types-flavored condition (`types`/`types@<range>`)
+                        // keeps declaration-aware probing via `try_types_entry`
+                        // so an extensionless versioned-types target still finds
+                        // its `.d.ts` sibling, mirroring the exports path.
+                        let probed = if is_types_condition {
+                            self.try_types_entry(&resolved_path, host_pt)
+                                .or_else(|| self.try_export_target(&resolved_path, host_pt))
+                        } else {
+                            self.try_export_target(&resolved_path, host_pt)
+                        };
+                        if let Some(resolved) = probed {
                             return Ok(ResolvedModule {
                                 resolved_path: resolved.clone(),
                                 resolved_using_ts_extension,
@@ -186,6 +205,11 @@ impl ModuleResolver {
 
     /// Resolve imports field subpath into ordered target candidates.
     ///
+    /// Each candidate is `(target, resolved_using_ts_extension, is_types)`. The
+    /// `is_types` flag records whether the matched value passed through a
+    /// types-flavored condition (`types`/`types@<range>`); the caller uses it to
+    /// keep declaration-aware probing for extensionless targets.
+    ///
     /// Array targets remain as ordered candidates so filesystem/package
     /// resolution can try later fallbacks when earlier targets are missing.
     fn resolve_imports_subpath_candidates(
@@ -193,7 +217,7 @@ impl ModuleResolver {
         imports: &indexmap::IndexMap<String, PackageExports>,
         specifier: &str,
         conditions: &[String],
-    ) -> Vec<(String, bool)> {
+    ) -> Vec<(String, bool, bool)> {
         // Try exact match first.
         // Keys containing '*' are pattern keys and must not be treated as exact matches.
         if let Some((key, value)) = imports.get_key_value(specifier)
@@ -201,9 +225,9 @@ impl ModuleResolver {
         {
             let resolved_using_ts_extension = key_ends_with_ts_extension(key);
             return self
-                .resolve_export_targets_to_strings(value, conditions)
+                .resolve_export_targets_to_strings(value, conditions, false)
                 .into_iter()
-                .map(|target| (target, resolved_using_ts_extension))
+                .map(|(target, is_types)| (target, resolved_using_ts_extension, is_types))
                 .collect();
         }
 
@@ -216,12 +240,13 @@ impl ModuleResolver {
             let resolved_using_ts_extension = key_ends_with_ts_extension(pattern);
             let is_directory_match = pattern.ends_with('/') && !pattern.contains('*');
             return self
-                .resolve_export_targets_to_strings(value, conditions)
+                .resolve_export_targets_to_strings(value, conditions, false)
                 .into_iter()
-                .map(|target| {
+                .map(|(target, is_types)| {
                     (
                         apply_wildcard_substitution(&target, &wildcard, is_directory_match),
                         resolved_using_ts_extension,
+                        is_types,
                     )
                 })
                 .collect();
@@ -244,29 +269,32 @@ impl ModuleResolver {
         &self,
         value: &PackageExports,
         conditions: &[String],
-    ) -> Vec<String> {
+        is_types_condition: bool,
+    ) -> Vec<(String, bool)> {
         match value {
-            PackageExports::String(s) => vec![s.clone()],
+            PackageExports::String(s) => vec![(s.clone(), is_types_condition)],
             PackageExports::Conditional(cond_entries) => {
                 // Iterate condition map entries in JSON key order.
                 //
-                // Unlike `resolve_package_exports_with_conditions`, the
-                // imports path does not thread `is_types_condition` through
-                // the recursion because [`resolve_package_imports`] resolves
-                // every collected target via `try_file_or_directory`, which
-                // already probes declaration extensions for any target —
-                // types-flavored or not. If a future change tightens the
-                // imports-side probe (analogous to `try_export_target`'s
-                // Node16/NodeNext extensionless-runtime guard), thread the
-                // flavor here so versioned-types branches keep declaration-
-                // aware probing.
+                // The imports path now resolves collected targets through the
+                // spec'd runtime probe (`try_export_target`), which refuses to
+                // add an extension to an extensionless target under
+                // Node16/NodeNext/Bundler. So — exactly like the exports path —
+                // it must thread `is_types_condition` so a versioned-types
+                // branch (`types`/`types@<range>`) keeps declaration-aware
+                // probing for an extensionless target.
                 let mut results = Vec::new();
                 for (key, nested) in cond_entries {
                     if self.condition_key_matches(key, conditions) {
                         if matches!(nested, PackageExports::Null) {
                             return Vec::new();
                         }
-                        results.extend(self.resolve_export_targets_to_strings(nested, conditions));
+                        let nested_is_types = is_types_condition || is_types_condition_key(key);
+                        results.extend(self.resolve_export_targets_to_strings(
+                            nested,
+                            conditions,
+                            nested_is_types,
+                        ));
                     }
                 }
                 results
@@ -276,7 +304,11 @@ impl ModuleResolver {
                 // probe each syntactically applicable target.
                 let mut results = Vec::new();
                 for element in elements {
-                    results.extend(self.resolve_export_targets_to_strings(element, conditions));
+                    results.extend(self.resolve_export_targets_to_strings(
+                        element,
+                        conditions,
+                        is_types_condition,
+                    ));
                 }
                 results
             }

--- a/crates/tsz-core/src/module_resolver/file_probing.rs
+++ b/crates/tsz-core/src/module_resolver/file_probing.rs
@@ -282,18 +282,35 @@ impl ModuleResolver {
             return None;
         }
 
-        // In Node16/NodeNext mode, extensionless export targets (e.g. from
-        // `"./": "./"` directory exports) must NOT probe for extensions.
-        // Node.js resolves exports targets literally — `./other` must exist as a
-        // file with that exact name. tsc mirrors this: it does not add .ts/.d.ts
-        // etc. when the target has no extension. Without this guard,
-        // `import "pkg/other"` would silently resolve to `pkg/other.d.ts`, which
-        // contradicts the ESM requirement for explicit extensions in specifiers.
+        // In the `exports`/`imports`-aware modes (Node16, NodeNext, Bundler),
+        // extensionless runtime targets (e.g. from `"./": "./"` directory
+        // exports or a wildcard `"#core/*": "./src/core/*"` whose specifier
+        // omits the extension) must NOT gain an extension or a directory
+        // `index` lookup. Node.js resolves `exports`/`imports` targets via
+        // PACKAGE_TARGET_RESOLVE, which returns the target verbatim — no
+        // extension substitution, no directory index. tsc mirrors this for
+        // these three modes: it only remaps a target carrying an explicit
+        // `.js`/`.mjs`/`.cjs` extension to its `.ts` sibling (handled above),
+        // and otherwise refuses to invent an extension for an extensionless
+        // target. Without this guard `import "pkg/other"` would silently
+        // resolve to `pkg/other.ts`/`pkg/other/index.ts`, contradicting both
+        // the runtime and tsc.
+        //
+        // The legacy `Node` (node10) and `Classic` modes predate the spec'd
+        // target algorithm and DO apply classic file/directory probing to an
+        // extensionless `exports` target (verified against tsc with
+        // `resolvePackageJsonExports`), so they fall through to the normal
+        // file/directory lookup below.
         let skip_extension_probing = matches!(
             self.resolution_kind,
-            ModuleResolutionKind::Node16 | ModuleResolutionKind::NodeNext
+            ModuleResolutionKind::Node16
+                | ModuleResolutionKind::NodeNext
+                | ModuleResolutionKind::Bundler
         );
-        if !skip_extension_probing && let Some(resolved) = self.try_file(path, package_type) {
+        if skip_extension_probing {
+            return None;
+        }
+        if let Some(resolved) = self.try_file(path, package_type) {
             return Some(resolved);
         }
         if cached_is_dir(path) {


### PR DESCRIPTION
Goal: green

## Summary

msw's `package.json` declares self-referencing subpath imports
`"imports": { "#core": "./src/core", "#core/*": "./src/core/*" }`, and its
sources import them extensionlessly (`import ... from '#core/sharedOptions'`,
`from '#core'`). Under `moduleResolution: bundler` (the msw guard config), `tsc`
resolves a `package.json` `imports`/`exports` map target via Node.js
`PACKAGE_TARGET_RESOLVE`: the target is taken verbatim with no `.ts`/`.d.ts`
extension invention and no directory-`index` lookup, so every `#core/...` import
is reported `TS2307` even though the `.ts` files exist. tsz instead applied
classic extension + index expansion to the extensionless target and resolved
them, then type-checked files `tsc` abandoned at the import — cascading into
dozens of tsz-only false positives (the dominant msw residual cluster).

## Structural rule

When a `package.json` `imports`/`exports` subpath maps to an EXTENSIONLESS
relative target under an `exports`/`imports`-aware module-resolution mode
(`Node16`/`NodeNext`/`Bundler`), `tsc` resolves the target verbatim: no TS
extension substitution and no directory-`index` lookup. Only a target carrying
an explicit `.js`/`.mjs`/`.cjs` extension is remapped to its `.ts` sibling, and
only a `types`/`types@<range>` condition keeps declaration-aware probing. The
legacy `Node` (node10) / `Classic` modes predate the algorithm and keep classic
probing.

tsz now owns this in the resolver layer:
- `tsz-core` `ModuleResolver`: the `imports` probe routes through
  `try_export_target` (symmetric with the `exports` probe); the extensionless
  guard in `try_export_target` gains a `Bundler` arm and now also gates the
  directory-`index` branch; the `imports` candidate resolution threads the
  types-flavor so versioned-`types` branches keep `try_types_entry`.
- CLI driver `resolve_package_imports_specifier`: an extensionless `imports`
  target under a spec'd mode skips the `resolve_package_entry`
  extension/index expansion (types-flavored values still probe declarations via
  `resolve_declaration_package_entry`).

Owner layer: solver-backed module resolver (`tsz-core::module_resolver`) and the
CLI driver resolution path. No checker/solver semantics changed. No
user-name/file-name/printer-string predicates.

Adjacent matrix (verified directly against `node typescript/lib/tsc.js` 6.x):
- extensionless `imports` target, bundler/node16/nodenext -> `TS2307` (fixed).
- extensionless `exports` target (node_modules), bundler/node16/nodenext ->
  `TS2307` (also corrected via the shared `try_export_target` guard).
- `"#utils/*": "./types/*.js"` imported as `#utils/widget` -> remapped to
  `types/widget.ts` (`.js`->`.ts` substitution preserved).
- node10 + `resolvePackageJsonExports` extensionless target -> still resolves
  (legacy probing preserved).
- versioned-`types` branch still threads declaration-aware probing.

## Verification

- msw canary row (`TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_FILTER=msw`,
  diffed against `node typescript/lib/tsc.js`): tsz-only false positives
  **97 -> 88** (net -9; 21 cascade FPs cleared, 12 newly-exposed downstream
  unresolved-import `any`-contagion FPs that belong to the separate D/E +
  #13843/#13813 family). Deterministic across 3 runs (88/88/88).
- Corpus regression scope: scanned every cloned canary fixture's `package.json`;
  only `msw` (`imports`) and `excalidraw` (`exports` of `.css` files) carry
  extensionless map targets. The CLI change is `imports`-only and `excalidraw`'s
  `exports` are CSS, so msw is the sole affected row.
- Conformance (touched families, 0 PASS->FAIL): `moduleResolution` 111/111,
  `nodeModules` 88/88, `packageJson` 11/11, `exports` 22/22, `imports` 6/6,
  `selfName` 2/2, `node/` 94/94, `externalModules` 227/227.
- Unit tests: `tsz-core module_resolver` 242/242; `tsz-cli` resolution + imports
  suites green (renamed `compile_resolves_package_imports_wildcard` to assert
  the tsc-parity `TS2307`, added a `.js`-extension companion).
- `arch_guard.py` passed; `cargo clippy -p tsz-core -p tsz-cli --all-targets`
  clean.

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Project corpus

claude:
- Row: msw
- Bug family: package.json imports extensionless target over-resolution (module resolution / PACKAGE_TARGET_RESOLVE divergence)
