### PR TITLE
fix(checker): contextual-type assignment callbacks through cross-file alias-typed members (jotai)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -803,6 +803,27 @@ impl<'a> CheckerState<'a> {
 
         let js_global_fallback =
             self.is_checked_js_global_element_access_fallback_assignment(left_idx, right_idx);
+        // A cross-file generic-interface member whose declared type is a type-alias
+        // reference (e.g. `interface I<V> { read: Read<V> }`) is left as an
+        // unresolved `Application(Lazy(alias DefId), args)` after the solver
+        // instantiates the interface: the solver-internal evaluator cannot resolve
+        // the alias `DefId`, so the application traverses to `ERROR`. That spurious
+        // error then trips the `!type_contains_error` guard below, which would skip
+        // contextual typing for a function/arrow RHS and emit false TS7006/TS7019.
+        // Resolve the LHS through the `TypeEnvironment` (which owns DefId -> TypeId)
+        // so the member alias collapses to its real signature before the guard.
+        if self.type_contains_error(left_type)
+            && self.ctx.arena.get(right_idx).is_some_and(|node| {
+                node.kind == syntax_kind_ext::ARROW_FUNCTION
+                    || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+            })
+        {
+            let resolved_left = self.evaluate_type_with_env(left_type);
+            if resolved_left != left_type && !self.type_contains_error(resolved_left) {
+                left_type = resolved_left;
+            }
+        }
+
         let contextual_request = if is_destructuring {
             self.destructuring_assignment_initializer_request(left_idx, right_idx)
         } else if left_type != TypeId::ANY


### PR DESCRIPTION
Goal: green

## Summary

Fixes the dominant cluster of the **jotai** canary row's tsz-only false positives: the freezeAtom write-callback `TS7006`/`TS7019` "implicitly any" diagnostics. tsc reports 0 errors on jotai; tsz reported 41. This change clears the freezeAtom assignment-callback cluster (5 FPs) bringing jotai to **41 -> 37** tsz-only FPs.

## Structural rule

When a generic interface is instantiated and one of its members has a declared
type that is a **type-alias reference** (e.g. `interface I<V> { read: Read<V> }`,
`Read<V> = (g, o) => V`), and the interface is imported **cross-file**, the
solver instantiates the member into an unresolved `Application(Lazy(alias DefId), args)`.
The solver-internal evaluator cannot resolve a checker-owned alias `DefId`
(`TypeData::Lazy(DefId)` is resolved by the checker's `TypeEnvironment`, per the
architecture contract), so the application traverses to `TypeId::ERROR`.

When such a member is the LHS of an assignment with a function/arrow RHS
(`anAtom.read = function (get, options) { ... }`), the spurious embedded error
trips the `!type_contains_error(left_type)` guard in
`check_assignment_expression`, which skips building the contextual `TypingRequest`
for the RHS. The function expression is then typed with no contextual signature,
so its parameters fall back to implicit `any` -> false `TS7006`/`TS7019`.

`tsc` resolves the alias and contextually types the callback parameters; `tsz`
must do the same. Owner: checker (`assignment_ops`), reusing the existing
`TypeEnvironment`-backed `evaluate_type_with_env` (DefId -> TypeId) to collapse the
member alias to its real signature **before** the error guard. The guard then
passes, the contextual signature flows to the function expression, and the
callback parameters are typed. Verified that the read path already resolved
correctly via `evaluate_type_with_env`; only the assignment/contextual path was
gated by the spurious error.

Narrowly scoped: the resolution only fires when the LHS already
`type_contains_error`, the RHS is a function/arrow expression, and the
env-resolved type is error-free — it can never degrade an already-clean LHS, and
introduces no identifier/file-name/printer-string checks.

## Adjacent matrix (all match `tsc`)

- Generic alias instantiated over the interface param (`read: Read<Value>`) — fixed.
- Function-expression RHS and arrow-function RHS — both fixed.
- `import type` and value `import` of the interface — both fixed.
- Renamed binders (different interface/alias/param names) — fixed (no hardcoding).
- Single-file (alias + interface co-located) — unchanged, stays clean.
- Negative control: genuinely missing member still reports `TS2339`.
- Non-generic interface with alias member — unchanged.

## Cluster -> root map (jotai residual, post-fix 37)

- **freezeAtom callbacks (TS7006/TS7019, 5)** — FIXED by this PR (assignment-target
  contextual typing through cross-file alias-typed member).
- **atomWithStorage object-literal callbacks (TS7006, 4)** — SAME root, different
  entry point (object-literal property contextual typing, which has its own
  `!type_contains_error` guard in `object_literal_context`). Left for a follow-up;
  higher-risk path.
- **freezeAtom nested-arrow (TS2556, 1, newly surfaced)** — distinct latent bug:
  once `set` is correctly typed as the generic `Setter`, `set(...setArgs)` triggers
  a spread-into-generic-rest-param FP. Reproduces independently of this change.
- **splitAtom / atomWithObservable (TS2349 "not callable", 6)** — deep generic
  inference; separate root.
- **internals `T`->`Atom<unknown>` / `Setter`->`Setter` (TS2345, several)** — generic
  inference / relation drift; separate roots.
- **TS2488 iterable, TS18048 possibly-undefined, TS2394 overload, TS2769, TS2722,
  TS2322, TS7023** — pre-existing separate roots, unchanged.

## Verification

- Minimal 2-file repro (generic interface + type-alias member, cross-file):
  `tsz` was 5 FPs (`TS7006`/`TS7019`), now 0; `tsc` reports 0. Single-file stays 0.
- jotai canary (full project, exact guard tsconfig): **41 -> 37** tsz-only FPs,
  deterministic across 3 runs; `tsc` reports 0.
- Required rows stay green with the patched binary: `rxjs-project`,
  `comlink-project`, `type-fest-project`, `utility-types-project`.
- Adjacent matrix above (arrow/function, type/value import, renamed binders,
  single-file, negative TS2339) all match `tsc`.
- `cargo clippy --profile dist-fast -p tsz-checker`: clean.
- Conformance on touched families: deferred to ready-review CI (hold floor);
  change is gated to the degenerate error-bearing LHS + function RHS only.

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Project corpus

jotai-residual2

AgentName: jotai-residual2
- Row: jotai
- Bug family: contextual-typing TS7006 through cross-file generic-interface alias-typed member
