### PR TITLE
perf(cli): gate the checker pool on the DOM/webworker serialization lock

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -415,6 +415,29 @@ const fn should_use_sequential_fresh_checking(
         || (has_parallel_order_sensitive_global_lib && !force_parallel_order_sensitive_global_lib)
 }
 
+/// Whether the bounded checker pool (`TSZ_CHECKER_POOL`) must be refused
+/// because the program includes a parallel-order-sensitive global lib
+/// (DOM/webworker).
+///
+/// The pool runs `pool_size` long-lived `CheckerState`s in parallel over one
+/// shared `DefinitionStore`, so it is subject to the same schedule-dependent
+/// lib-interface materialization hazard as the fresh-parallel lane gated by
+/// [`should_use_sequential_fresh_checking`]: DOM/SVG element interfaces with
+/// deep heritage are first-demand materialized concurrently, and sibling
+/// workers observe pre-finalize body forms, producing non-deterministic
+/// diagnostics. The pool dispatch is evaluated before that gate, so the
+/// refusal is enforced here independently — DOM programs take the sequential
+/// path whether the pool was reached via an explicit `TSZ_CHECKER_POOL=N` or
+/// a default-on policy. The `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK` diagnosis
+/// override lifts the refusal so forced-parallel byte-diffs can be driven from
+/// the env; non-determinism is never the default.
+const fn pool_refused_for_order_sensitive_global_lib(
+    has_parallel_order_sensitive_global_lib: bool,
+    force_parallel_order_sensitive_global_lib: bool,
+) -> bool {
+    has_parallel_order_sensitive_global_lib && !force_parallel_order_sensitive_global_lib
+}
+
 const fn needs_separate_boxed_prime_checker(
     no_emit: bool,
     emit_declarations: bool,
@@ -1339,7 +1362,28 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
             // than narrowing it.
             let use_file_session_reuse =
                 use_sequential_checking && !extract_type_cache && reuse_requested;
-            if let Some(pool_size) = checker_pool_size().filter(|_| !extract_type_cache) {
+            // The bounded checker pool runs `pool_size` long-lived checkers in
+            // parallel over the *same* shared `DefinitionStore`, so it carries
+            // the identical schedule-dependent lib-interface materialization
+            // hazard as the fresh-parallel lane (DOM/webworker globals; see
+            // `should_use_sequential_fresh_checking`). The pool branch is
+            // evaluated before the `use_sequential_checking` gate, so without
+            // this refusal an explicit `TSZ_CHECKER_POOL=N` — or a future
+            // default-on pool — would route a DOM project onto the pool and
+            // produce non-deterministic diagnostics (proven: `keyof`/indexed
+            // access over DOM element-tag-name maps yields distinct output per
+            // schedule). Refuse the pool for those programs so they take the
+            // deterministic sequential path regardless of how the pool was
+            // requested; the `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK` diagnosis
+            // override lifts the refusal for byte-diff testing only.
+            let pool_size = checker_pool_size().filter(|_| {
+                !extract_type_cache
+                    && !pool_refused_for_order_sensitive_global_lib(
+                        has_parallel_order_sensitive_global_lib,
+                        force_parallel_order_sensitive_global_lib,
+                    )
+            });
+            if let Some(pool_size) = pool_size {
                 // Bounded long-lived checker pool (`TSZ_CHECKER_POOL`): N
                 // round-robin partitions, each a long-lived `CheckerState`
                 // reused via `switch_to_file`, amortising the O(program)

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -788,6 +788,31 @@ fn large_reuse_off_batches_keep_fresh_parallel_eligible() {
     );
 }
 
+#[test]
+fn checker_pool_refuses_order_sensitive_global_lib_by_default() {
+    // The bounded checker pool shares one `DefinitionStore` across parallel
+    // partitions, so it must honor the same DOM/webworker serialization gate
+    // as the fresh-parallel lane — otherwise an explicit `TSZ_CHECKER_POOL=N`
+    // (or a default-on pool) routes a DOM project onto the pool and produces
+    // non-deterministic diagnostics.
+    assert!(
+        pool_refused_for_order_sensitive_global_lib(true, false),
+        "DOM/webworker programs must be refused the pool and take the sequential path"
+    );
+    assert!(
+        !pool_refused_for_order_sensitive_global_lib(false, false),
+        "non-DOM programs stay pool-eligible"
+    );
+    assert!(
+        !pool_refused_for_order_sensitive_global_lib(true, true),
+        "the force-parallel diagnosis override lifts the refusal for byte-diff testing"
+    );
+    assert!(
+        !pool_refused_for_order_sensitive_global_lib(false, true),
+        "the override is a no-op when no order-sensitive global lib is present"
+    );
+}
+
     #[test]
     fn tiny_no_emit_reuse_path_covers_boxed_prime_checker() {
         assert!(


### PR DESCRIPTION
Goal: fast

## Summary

The bounded checker pool (`TSZ_CHECKER_POOL`) runs `pool_size` long-lived `CheckerState`s in parallel over **one shared `DefinitionStore`**, so it carries the same schedule-dependent lib-interface materialization hazard as the fresh-parallel lane. But the pool branch is dispatched **before** the `should_use_sequential_fresh_checking` DOM/webworker gate (`driver/check.rs`), so an explicit `TSZ_CHECKER_POOL=N` — or a future default-on pool (Stage B of #13841) — routed a DOM project onto the pool and produced **non-deterministic diagnostics**.

This refuses the pool for programs that include a parallel-order-sensitive global lib (DOM/webworker) so they take the deterministic sequential path regardless of how the pool was requested. The gate keys on the DOM-specific predicate (`has_parallel_order_sensitive_global_lib`), **not** `use_sequential_checking`, so non-DOM small projects keep the pool. `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK` still lifts the refusal for byte-diff testing only.

## Structural rule

When a program includes the DOM/webworker libs, the shared `DefinitionStore` is mutated schedule-dependently during checking (DOM/SVG element interfaces with deep heritage are first-demand heritage-merge-materialized concurrently; sibling workers read pre-finalize body forms). Therefore **every** parallel checking lane — the fresh-parallel rayon lane AND the bounded checker pool — must fall back to one deterministic worker. Owner: CLI driver dispatch (`driver/check.rs`). Complexity: O(1) predicate at dispatch; no change to per-file work.

## Why this is the right scope (investigation)

The mutation hazard is real, not stale pessimism. Measured forced-parallel vs sequential (sorted-output md5, repeated runs) on a freshly-built binary:

- **ts-toolbelt** (the documented blocker; DOM via default-lib, no DOM-API use): now byte-identical + deterministic under forced-parallel (the landed structural fixes resolved it) — included here only to show the pool gate does **not** regress it: `TSZ_CHECKER_POOL=8` still runs the pool, 4/4 runs == sequential.
- **DOM-API code** that materializes lib-interface heritage/`keyof`/overload bodies (`keyof HTMLElementTagNameMap` + `createElement<K>`; `keyof HTMLElementEventMap`): **non-deterministic** before this change — up to 12 distinct outputs / 12 runs under both the pool and the forced-parallel lane.

The non-determinism appears only where tsz already has DOM relation/overload conformance bugs (the racing diagnostics are themselves false positives). That upstream materialization bug is filed separately as a tracked conformance campaign; this PR is the **correctness floor** that prevents the perf lane from turning those deterministic-but-wrong results into schedule-dependent ones, and lets Stage B default the pool on safely.

## Verification

- New unit test `checker_pool_refuses_order_sensitive_global_lib_by_default` (+ existing `large_reuse_off_batches_keep_fresh_parallel_eligible`): `cargo nextest run -p tsz-cli checker_pool_refuses_order_sensitive_global_lib_by_default large_reuse_off_batches_keep_fresh_parallel_eligible` → 2 passed.
- Existing determinism integration suite unaffected: `cargo nextest run -p tsz-cli --test parallel_sequential_agreement_tests` → 4 passed.
- Byte-identity proof (release binary, sorted-output md5):
  - `domkeyof` `TSZ_CHECKER_POOL=8`: was 12 distinct / 12 runs → now **8/8 == sequential**.
  - `domapp` (`keyof HTMLElementEventMap`) `TSZ_CHECKER_POOL=8`: was 6 distinct → now **8/8 == sequential**.
  - `ts-toolbelt` `TSZ_CHECKER_POOL=8`: **4/4 == sequential**, pool still active (non-DOM unaffected).
  - `TSZ_CHECKER_POOL=8 TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK=1` on `domkeyof`: 3 distinct / 3 runs — confirms the diagnosis override still lifts the refusal; non-determinism is never the default.

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
