### PR TITLE
perf(checker): skip pass-2 recompute for conflict-free symbols in duplicate-identifier check

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -59,6 +59,17 @@ impl<'a> CheckerState<'a> {
         // One entry per distinct symbol name; bounded by the symbol set (#11617).
         let mut global_scope_conflict_cache: FxHashMap<String, DuplicateDeclList> =
             FxHashMap::with_capacity_and_hasher(symbol_ids.len(), Default::default());
+        // Symbols that survive pass 1's conflict-free skip (declarations <= 1 with
+        // no cross-file / augmentation / global-scope / jsx-runtime / default-import
+        // / module-block conflicts). Pass 2 re-derives the same per-symbol conflict
+        // helpers + declaration scan; for a typical file ~all symbols are
+        // conflict-free, so re-running pass 2 over the full set only to re-hit the
+        // identical skip is pure duplicate work (two identical hot scans in the
+        // profile). Recording the survivors here lets pass 2 iterate just them.
+        // `symbol_ids` is an `FxHashSet`; pass 1 (`iter`) and pass 2 (`into_iter`)
+        // visit it in the same internal-table order, so pushing in pass-1 order
+        // preserves pass 2's original relative order — byte-identical diagnostics.
+        let mut pass2_symbol_ids: Vec<tsz_binder::SymbolId> = Vec::with_capacity(symbol_ids.len());
         let may_have_default_import_alias_conflicts = !is_external_module
             && self.ctx.all_arenas.is_some()
             && self.current_file_has_named_default_export_identifier();
@@ -123,6 +134,10 @@ impl<'a> CheckerState<'a> {
                     continue;
                 }
             }
+
+            // Survived the conflict-free skip: pass 2 must re-examine this symbol.
+            // Record it so pass 2 iterates only survivors instead of the full set.
+            pass2_symbol_ids.push(sym_id);
 
             let mut has_local = false;
             let mut has_remote = false;
@@ -230,7 +245,7 @@ impl<'a> CheckerState<'a> {
             );
         }
 
-        for sym_id in symbol_ids {
+        for sym_id in pass2_symbol_ids {
             let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
                 continue;
             };


### PR DESCRIPTION
## Summary

`check_duplicate_identifiers` runs **two passes** over the current file's symbol
set. Pass 1 must visit every symbol because it builds the program-wide
`cross_file_conflicts` list that drives the TS6200 (`>= 8` conflicting
definitions) decision. Pass 2 then re-derives the six per-symbol
conflict-declaration helpers (`module_augmentation`, `script_scope`,
`global_scope`, `jsx_runtime`, `default_import_alias`, `module_block_scoped`)
**plus** the `declaration_arenas` / `declaration_symbol_flags` scan for **every**
symbol — only to re-hit the identical conflict-free skip for ~all of them and
emit nothing.

Profiling (samply, monorepo-006) shows `check_duplicate_identifiers` self-time as
the single largest checker lever, and the disassembly shows **two
structurally-identical hot scan loops** — one per pass. This PR removes the
second loop's work for conflict-free single-declaration symbols.

## Structural rule

When a symbol has `declarations.len() <= 1`, no cross-file declaration alias, and
all six conflict-declaration helpers return empty, tsc emits no duplicate
diagnostic for it — so neither does tsz. Pass 1 already computes exactly this
predicate (its early-`continue`). We record the **survivors** (symbols that did
*not* hit pass 1's skip) into a list and have pass 2 iterate only those instead
of the full symbol set.

Correctness: the survivor set (`declarations > 1` OR any conflict) is a
**superset** of every symbol pass 2 can emit a diagnostic for — TS2300/TS2451
fire only on conflicts/duplicates, TS6200 only on `>= 8` declarations, and the
overload checks (TS2383/TS2384/TS2385) only on `declarations > 1`. So skipping
conflict-free single-declaration symbols cannot drop or add any diagnostic.
`symbol_ids` is an `FxHashSet`; pass 1 (`iter`) and pass 2 (`into_iter`) visit it
in the same internal-table order, so survivors are visited in pass 2 in the same
relative order as before — order-sensitive TS6200/TS2300/TS2451 output is
byte-identical.

Owner layer: checker (`tsz_checker::types_domain::type_checking::duplicate_identifiers`).

## Complexity

Pass 2 goes from `O(symbols x per-symbol-helper-cost)` to
`O(survivors x per-symbol-helper-cost)` where `survivors ~= conflicting symbols`
(typically near zero for a clean file). Pass 1 is unchanged. No cache, no
invalidation, no fixture-name fast path — pure structural skip of redundant
recomputation.

Goal: fast

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- **Byte-identical diagnostics** (default and `TSZ_CHECKER_POOL=auto` paths),
  empty diff vs base@main:
  - A multi-file fixture emitting the affected codes (TS2300 x4, TS2451 x4,
    TS2383, TS2385, TS2391): identical.
  - scale-cliff `monorepo-006` (5251 files): identical.
- **A/B (CPU time, alternating base@main vs patched, 15 rounds), monorepo-006
  default path:** base median 21.84s / min 19.66s; patched median 20.63s / min
  18.75s -> **-5.5% median, -4.6% min CPU**. Pool path: neutral (median +1.6%
  noise, min -5.1%), no regression.
- `cargo nextest run -p tsz-checker duplicate` (duplicate-identifier unit suite).
- Broad conformance/emit owned by ready-review CI.

