### PR TITLE
perf(solver): cache collect_properties by subtree-context-free truncation (#13242)

### DIFF
--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -1784,6 +1784,36 @@ pub trait QueryDatabase: TypeDatabase + TypeResolver {
     /// is not eligible for merging (contains callables, non-objects, etc.).
     fn insert_intersection_merge(&self, _intersection_id: TypeId, _result: Option<TypeId>) {}
 
+    /// Look up a previously memoized `collect_properties` result.
+    ///
+    /// The key carries the resolver generation so that a result computed under
+    /// an older resolver view (fewer lazy `DefId`s resolvable) is never reused
+    /// after the resolver advances. Callers MUST only consult/populate this
+    /// cache for a *context-free* collection — one that began with an empty
+    /// `COLLECT_PROPERTIES_STACK` (entry depth 0) — so that the recursion-guard
+    /// truncation baked into the stored result is the type's own intrinsic
+    /// cycle, identical on every standalone collection, and never an
+    /// outer-frame artifact. See `collect_properties_cached`. Default
+    /// implementation always misses.
+    fn lookup_collect_properties(
+        &self,
+        _type_id: TypeId,
+        _resolver_generation: u64,
+    ) -> Option<crate::objects::PropertyCollectionResult> {
+        None
+    }
+
+    /// Memoize a context-free `collect_properties` result. See
+    /// [`Self::lookup_collect_properties`] for the safety contract. Default
+    /// implementation is a no-op.
+    fn insert_collect_properties(
+        &self,
+        _type_id: TypeId,
+        _resolver_generation: u64,
+        _result: crate::objects::PropertyCollectionResult,
+    ) {
+    }
+
     /// Look up a cached assignability result for the given key.
     /// Returns `None` if the result is not cached.
     /// Default implementation returns `None` (no caching).

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -239,6 +239,17 @@ pub struct QueryCache<'a> {
     /// across multiple `SubtypeChecker` instances (common in constraint checking).
     /// `Some(type_id)` = successfully merged, `None` = not eligible for merging.
     intersection_merge_cache: RefCell<FxHashMap<TypeId, Option<TypeId>>>,
+    /// Cache for context-free `collect_properties` results, keyed by
+    /// `(TypeId, resolver_generation)`. Only populated for collections that
+    /// began at `COLLECT_PROPERTIES_STACK` depth 0 (see the safety contract on
+    /// [`crate::caches::db::QueryDatabase::lookup_collect_properties`]), so a
+    /// truncated/partial closure produced by an outer-frame recursion guard is
+    /// never stored or served out of context (the #12142 pitfall). Collapses
+    /// the repeated full-property materialization the recursive-schema canary
+    /// rows (typebox/kysely/ts-morph) perform per relation/member-access touch.
+    collect_properties_cache:
+        RefCell<FxHashMap<(TypeId, u64), crate::objects::PropertyCollectionResult>>,
+    collect_properties_cache_stats: CacheCounter,
     /// Cross-call cache for `instantiate_type` results, keyed by
     /// `(TypeId, CanonicalSubst, mode_bits, Option<this_type>)`.
     ///
@@ -303,6 +314,8 @@ impl<'a> QueryCache<'a> {
             variance_cache: RefCell::new(FxHashMap::default()),
             canonical_cache: RefCell::new(FxHashMap::default()),
             intersection_merge_cache: RefCell::new(FxHashMap::default()),
+            collect_properties_cache: RefCell::new(FxHashMap::default()),
+            collect_properties_cache_stats: CacheCounter::new(),
             instantiation_cache: InstantiationCache::new(),
             subtype_reduction_cache: SubtypeReductionCache::new(),
             application_eval_cache_stats: SharedCacheCounter::new(),
@@ -330,6 +343,7 @@ impl<'a> QueryCache<'a> {
         self.variance_cache.borrow_mut().clear();
         self.canonical_cache.borrow_mut().clear();
         self.intersection_merge_cache.borrow_mut().clear();
+        self.collect_properties_cache.borrow_mut().clear();
         self.instantiation_cache.clear();
         self.subtype_reduction_cache.clear();
         self.reset_relation_cache_stats();
@@ -389,6 +403,7 @@ impl<'a> QueryCache<'a> {
         self.subtype_cache_stats.reset();
         self.assignability_cache_stats.reset();
         self.intersection_merge_cache_stats.reset();
+        self.collect_properties_cache_stats.reset();
         self.instantiation_cache_stats.reset();
         self.subtype_reduction_cache_stats.reset();
     }
@@ -1681,6 +1696,35 @@ impl QueryDatabase for QueryCache<'_> {
         self.intersection_merge_cache
             .borrow_mut()
             .insert(intersection_id, result);
+    }
+
+    fn lookup_collect_properties(
+        &self,
+        type_id: TypeId,
+        resolver_generation: u64,
+    ) -> Option<crate::objects::PropertyCollectionResult> {
+        let result = self
+            .collect_properties_cache
+            .borrow()
+            .get(&(type_id, resolver_generation))
+            .cloned();
+        if result.is_some() {
+            self.collect_properties_cache_stats.record_hit();
+        } else {
+            self.collect_properties_cache_stats.record_miss();
+        }
+        result
+    }
+
+    fn insert_collect_properties(
+        &self,
+        type_id: TypeId,
+        resolver_generation: u64,
+        result: crate::objects::PropertyCollectionResult,
+    ) {
+        self.collect_properties_cache
+            .borrow_mut()
+            .insert((type_id, resolver_generation), result);
     }
 
     fn get_index_signatures(&self, type_id: TypeId) -> IndexInfo {

--- a/crates/tsz-solver/src/objects/collect.rs
+++ b/crates/tsz-solver/src/objects/collect.rs
@@ -43,6 +43,19 @@ impl CollectPropertiesDepthGuard {
     }
 }
 
+/// Current depth of the active cross-collector property stack.
+///
+/// A depth of `0` means no `collect_properties` call is in flight up the stack,
+/// so a collection that begins here can only ever be truncated by the type's
+/// *own* intrinsic cycle (a `TypeId` that reappears inside its own structure) —
+/// never by a `TypeId` an outer collector already pushed. That makes its result
+/// a context-free function of the resolved `TypeId`, safe to memoize and reuse.
+/// At any non-zero depth the result may be a partial closure (the #12142
+/// pitfall) and must NOT be cached. See `collect_properties_cached`.
+fn collect_properties_stack_depth() -> usize {
+    COLLECT_PROPERTIES_STACK.with_borrow(Vec::len)
+}
+
 impl Drop for CollectPropertiesDepthGuard {
     fn drop(&mut self) {
         COLLECT_PROPERTIES_STACK.with_borrow_mut(|stack| {
@@ -126,6 +139,39 @@ pub fn collect_properties_cached<'a, R>(
 where
     R: TypeResolver,
 {
+    // Context-free result memo (issue #13242, workstream B). A collection that
+    // begins at `COLLECT_PROPERTIES_STACK` depth 0 cannot have any member
+    // truncated by an *outer* collector's recursion guard, so its result is a
+    // pure function of `(resolved TypeId, resolver_generation)` and is safe to
+    // reuse. Recursive-schema canary rows (typebox/kysely/ts-morph) re-collect
+    // the same generic-application/intersection shapes thousands of times across
+    // relation and member-access touches; without this memo each touch re-walks
+    // and re-instantiates the entire property closure. Nested (depth > 0)
+    // collections deliberately bypass the cache: their result may be a partial
+    // closure that the guard truncated against an outer frame (the #12142
+    // pitfall — a truncated closure served out of context yields wrong types).
+    //
+    // The generation is taken from the *resolver actually used to resolve the
+    // members* (`resolver`), not the `query_db`: when the two differ (e.g. a
+    // `NOOP` resolver paired with a real query database) the lazy members
+    // resolve through `resolver`, so the result is a function of its generation.
+    // Both production resolvers (`TypeEnvironment`) bump on every write that can
+    // change a resolution outcome; `NOOP` is generation-0 and stable, and a
+    // generation-0 result is only ever served back to another generation-0
+    // (same `NOOP`) collection.
+    let cacheable = query_db.is_some() && collect_properties_stack_depth() == 0;
+    let generation = if cacheable {
+        resolver.resolver_generation()
+    } else {
+        0
+    };
+    if cacheable
+        && let Some(db) = query_db
+        && let Some(cached) = db.lookup_collect_properties(type_id, generation)
+    {
+        return cached;
+    }
+
     let mut collector = PropertyCollector {
         interner,
         resolver,
@@ -139,27 +185,32 @@ where
     };
     collector.collect(type_id);
 
-    // If we encountered Any at any point, the result is Any (commutative)
-    if collector.found_any {
-        return PropertyCollectionResult::Any;
-    }
-
-    // If no properties were collected, return NonObject
-    if collector.properties.is_empty()
+    let result = if collector.found_any {
+        // If we encountered Any at any point, the result is Any (commutative)
+        PropertyCollectionResult::Any
+    } else if collector.properties.is_empty()
         && collector.string_index.is_none()
         && collector.number_index.is_none()
     {
-        return PropertyCollectionResult::NonObject;
+        // If no properties were collected, return NonObject
+        PropertyCollectionResult::NonObject
+    } else {
+        // Sort properties by name to maintain interner invariants
+        collector.properties.sort_by_key(|p| p.name.0);
+        PropertyCollectionResult::Properties {
+            properties: collector.properties,
+            string_index: collector.string_index,
+            number_index: collector.number_index,
+        }
+    };
+
+    // Store only the depth-0 (context-free) result; see the cache contract at
+    // the top of this function.
+    if cacheable && let Some(db) = query_db {
+        db.insert_collect_properties(type_id, generation, result.clone());
     }
 
-    // Sort properties by name to maintain interner invariants
-    collector.properties.sort_by_key(|p| p.name.0);
-
-    PropertyCollectionResult::Properties {
-        properties: collector.properties,
-        string_index: collector.string_index,
-        number_index: collector.number_index,
-    }
+    result
 }
 
 /// Helper function to resolve Lazy types via DefId

--- a/crates/tsz-solver/src/objects/collect.rs
+++ b/crates/tsz-solver/src/objects/collect.rs
@@ -19,6 +19,16 @@ use std::cell::RefCell;
 
 thread_local! {
     static COLLECT_PROPERTIES_STACK: RefCell<Vec<TypeId>> = const { RefCell::new(Vec::new()) };
+    /// Lowest cross-collector stack index at which the active subtree truncated
+    /// a member against a type that was *already* in flight (a `stack.contains`
+    /// hit in [`CollectPropertiesDepthGuard::enter`]). Initialized to
+    /// `usize::MAX` ("no outer-frame truncation seen"). Used by
+    /// `collect_properties_cached` to decide whether a result is context-free:
+    /// see its cache contract. Each invocation scopes this to its own subtree
+    /// (save/restore + merge into the parent) so sibling subtrees never
+    /// over-taint each other.
+    static COLLECT_PROPERTIES_MIN_TRUNCATION: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(usize::MAX) };
 }
 
 // Nested public collect_properties calls can reset TypeEvaluator-local guards while
@@ -34,7 +44,20 @@ struct CollectPropertiesDepthGuard {
 impl CollectPropertiesDepthGuard {
     fn enter(type_id: TypeId) -> Option<Self> {
         COLLECT_PROPERTIES_STACK.with_borrow_mut(|stack| {
-            if stack.len() >= MAX_COLLECT_PROPERTIES_DEPTH || stack.contains(&type_id) {
+            if stack.len() >= MAX_COLLECT_PROPERTIES_DEPTH {
+                return None;
+            }
+            // A `stack.contains` hit means `type_id` is already being collected
+            // by *some* frame up the chain. Record the position so the owning
+            // `collect_properties_cached` invocation(s) can tell whether the
+            // truncation was against one of their *own* in-flight entries (would
+            // also happen on a standalone collection, result still context-free)
+            // or against an *outer ancestor* frame (context-dependent, partial
+            // closure — must not be cached; the #12142 pitfall). Any active
+            // invocation whose entry floor is strictly greater than `pos`
+            // experienced an ancestor truncation.
+            if let Some(pos) = stack.iter().position(|&active| active == type_id) {
+                COLLECT_PROPERTIES_MIN_TRUNCATION.with(|min| min.set(min.get().min(pos)));
                 return None;
             }
             stack.push(type_id);
@@ -44,16 +67,13 @@ impl CollectPropertiesDepthGuard {
 }
 
 /// Current depth of the active cross-collector property stack.
-///
-/// A depth of `0` means no `collect_properties` call is in flight up the stack,
-/// so a collection that begins here can only ever be truncated by the type's
-/// *own* intrinsic cycle (a `TypeId` that reappears inside its own structure) —
-/// never by a `TypeId` an outer collector already pushed. That makes its result
-/// a context-free function of the resolved `TypeId`, safe to memoize and reuse.
-/// At any non-zero depth the result may be a partial closure (the #12142
-/// pitfall) and must NOT be cached. See `collect_properties_cached`.
 fn collect_properties_stack_depth() -> usize {
     COLLECT_PROPERTIES_STACK.with_borrow(Vec::len)
+}
+
+/// Whether `type_id` is already in flight on an ancestor collector frame.
+fn collect_properties_stack_contains(type_id: TypeId) -> bool {
+    COLLECT_PROPERTIES_STACK.with_borrow(|stack| stack.contains(&type_id))
 }
 
 impl Drop for CollectPropertiesDepthGuard {
@@ -139,17 +159,33 @@ pub fn collect_properties_cached<'a, R>(
 where
     R: TypeResolver,
 {
-    // Context-free result memo (issue #13242, workstream B). A collection that
-    // begins at `COLLECT_PROPERTIES_STACK` depth 0 cannot have any member
-    // truncated by an *outer* collector's recursion guard, so its result is a
-    // pure function of `(resolved TypeId, resolver_generation)` and is safe to
-    // reuse. Recursive-schema canary rows (typebox/kysely/ts-morph) re-collect
-    // the same generic-application/intersection shapes thousands of times across
-    // relation and member-access touches; without this memo each touch re-walks
-    // and re-instantiates the entire property closure. Nested (depth > 0)
-    // collections deliberately bypass the cache: their result may be a partial
-    // closure that the guard truncated against an outer frame (the #12142
-    // pitfall — a truncated closure served out of context yields wrong types).
+    // Context-free result memo (issue #13242, workstream B).
+    //
+    // A `collect_properties` result is a pure function of `(resolved TypeId,
+    // resolver_generation)` — and therefore safe to reuse — exactly when the
+    // collection's recursion truncation depended only on the type's *own*
+    // structure, not on which outer frames happened to be in flight. The
+    // cross-collector `COLLECT_PROPERTIES_STACK` lets a *nested* collection
+    // (e.g. a union member re-collected by `collect_union_common`) be truncated
+    // against an *ancestor* frame's in-flight type. Such a result is a partial
+    // closure and must NOT be cached (the #12142 pitfall — a truncated closure
+    // served out of context yields wrong types).
+    //
+    // We detect this precisely instead of conservatively gating on depth 0:
+    // `entry_floor` is this invocation's stack length at entry; the subtree it
+    // runs records, in `COLLECT_PROPERTIES_MIN_TRUNCATION`, the *lowest* stack
+    // index at which any member truncated against an already-in-flight type. If
+    // that lowest index is below `entry_floor`, the truncation was against an
+    // outer ancestor (context-dependent) and the result is not cacheable;
+    // otherwise every truncation was against one of this collection's own
+    // in-flight entries — identical to what a standalone (depth-0) collection
+    // would produce — so the result is context-free. Depth 0 is just the
+    // special case `entry_floor == 0`, where no ancestor exists and `>= 0`
+    // always holds. Recursive-schema canary rows (typebox/kysely/ts-morph)
+    // re-collect the same generic-application/intersection shapes thousands of
+    // times across relation and member-access touches; this lets the cache
+    // absorb the deeply *nested* re-collections (the dominant frame), not only
+    // top-level ones.
     //
     // The generation is taken from the *resolver actually used to resolve the
     // members* (`resolver`), not the `query_db`: when the two differ (e.g. a
@@ -159,18 +195,37 @@ where
     // change a resolution outcome; `NOOP` is generation-0 and stable, and a
     // generation-0 result is only ever served back to another generation-0
     // (same `NOOP`) collection.
-    let cacheable = query_db.is_some() && collect_properties_stack_depth() == 0;
-    let generation = if cacheable {
+    let entry_floor = collect_properties_stack_depth();
+    let generation = if query_db.is_some() {
         resolver.resolver_generation()
     } else {
         0
     };
-    if cacheable
-        && let Some(db) = query_db
+    // Only serve the cache when this `type_id` is not itself already in flight on
+    // an ancestor frame. The stored result is the type's full (context-free)
+    // closure; in the not-in-flight case it can only *replace* a fresh standalone
+    // computation, so behavior is unchanged. Were `type_id` already on the stack,
+    // the legacy path would truncate it to break the recursion, and returning the
+    // full closure there would change that frame's merge — so we skip the cache
+    // and let the existing cross-collector guard truncate as before.
+    if let Some(db) = query_db
+        && !collect_properties_stack_contains(type_id)
         && let Some(cached) = db.lookup_collect_properties(type_id, generation)
     {
         return cached;
     }
+
+    // Scope the truncation observation to this invocation's subtree: save the
+    // parent's running minimum, start fresh at `usize::MAX`, then on the way out
+    // decide cacheability from our own subtree and merge our minimum back into
+    // the parent (so an ancestor truncation we observed still taints the
+    // ancestors that own it). Sibling subtrees therefore never over-taint each
+    // other.
+    let saved_min = COLLECT_PROPERTIES_MIN_TRUNCATION.with(|min| {
+        let prev = min.get();
+        min.set(usize::MAX);
+        prev
+    });
 
     let mut collector = PropertyCollector {
         interner,
@@ -184,6 +239,18 @@ where
         found_any: false,
     };
     collector.collect(type_id);
+
+    let subtree_min = COLLECT_PROPERTIES_MIN_TRUNCATION.with(|min| {
+        let subtree = min.get();
+        // Merge our subtree's minimum into the parent for any ancestor-level
+        // truncation we witnessed (positions below our own floor concern frames
+        // above us).
+        min.set(saved_min.min(subtree));
+        subtree
+    });
+    // Cacheable iff every truncation this subtree saw was against one of our own
+    // in-flight entries (>= our entry floor), never an outer ancestor.
+    let cacheable = query_db.is_some() && subtree_min >= entry_floor;
 
     let result = if collector.found_any {
         // If we encountered Any at any point, the result is Any (commutative)
@@ -204,8 +271,8 @@ where
         }
     };
 
-    // Store only the depth-0 (context-free) result; see the cache contract at
-    // the top of this function.
+    // Store only context-free results (no outer-ancestor truncation); see the
+    // cache contract at the top of this function.
     if cacheable && let Some(db) = query_db {
         db.insert_collect_properties(type_id, generation, result.clone());
     }


### PR DESCRIPTION
Goal: fast

Generalizes the #13242 workstream-B `collect_properties` result memo so the cache absorbs the deeply *nested* re-collections that dominate recursive-schema canary rows, not just top-level (depth-0) collections.

## Structural rule
When `collect_properties` collects a type whose recursion truncation depended only on the type's *own* in-flight entries (never an outer ancestor frame on the cross-collector `COLLECT_PROPERTIES_STACK`), the result is a pure function of `(resolved TypeId, resolver_generation)` and is safe to memoize at any nesting depth; tsz now decides cacheability per-subtree via a `COLLECT_PROPERTIES_MIN_TRUNCATION` marker (lowest stack index hit by the guard) instead of the conservative depth-0-only gate. The owner is the solver `objects::collect` module. The cache is served only when `type_id` is not itself in flight, so it can only replace a fresh standalone computation and never short-circuits a recursion the legacy guard would have truncated (the #12142 partial-closure pitfall). Depth-0 is the special case `entry_floor == 0`.

## Profile (why this site)
macOS `sample` of the `typebox` canary (dist-fast binary):
- Before: `collect_properties_cached` self-recursion (via `collect_union_common`) was the dominant call-tree spine (834 self + a deep self-recursive chain), only the depth-0 entry was cached.
- After: that deep self-recursion is eliminated; the dominant frame shifts to the narrowing/subtype machinery (`narrow_type` -> `check_subtype` -> `intersection_has_incompatible_target_property`). The `collect_properties` recursion is no longer the bottleneck.

## Verification
- `collect_properties` recursion eliminated as dominant frame (sample profile, typebox).
- Broad conformance sweep (`scripts/conformance/conformance.sh run --filter ...`, dist-fast): objectType 127/127, propertyAccess 26/26, recursiveType 23/23, mappedType 55/55, conditionalType 17/17, intersection 44/44, genericInterface 4/4, instantiation 3/3, indexedAccess 13/13, heritage 1/1, circularType 5/5, typeRelationships 265/265, deeplyNested 6/7. The single deeplyNested miss (`deeplyNestedMappedTypes.ts`) is a pre-existing accepted regression identical on `main` (verified by rebuilding the merge-base) — 0 new PASS->FAIL.
- Canary no-regress: `kysely` and `comlink` diagnostics byte-identical between `main` and this change (rebuilt both, `diff` clean). kysely terminates 7-8s on both.
- Determinism: kysely diagnostics sha256 identical across 3 runs.
- clippy `-p tsz-solver` clean; `arch_guard_rust.py` + `arch_guard_counts.py` exit 0; `collect.rs` 739 lines (< 2000 ceiling).

## Known blocker (does not regress, not fixed here)
`typebox` still does NOT terminate (>150s, CI budget 90s). The remaining non-termination is dominated by a narrowing/subtype-checking explosion in call-argument type computation, outside the `collect_properties` scope of this workstream. Documented on #13242.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Corpus
AgentName: claude-code

- Row: typebox
- Bug family: collect-properties-eager-materialization
- Row: kysely
- Bug family: collect-properties-eager-materialization

Refs #13242.
