### PR TITLE
fix(emitter): ES5 async if-lowering panic + DTS alias tuple labels + TS2883 dedup tests — unwedge unit (#13255)

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
@@ -17,10 +17,6 @@ impl<'a> DeclarationEmitter<'a> {
             .or_else(|| {
                 self.super_method_call_return_type_text(expr_idx)
                     .or_else(|| self.generic_call_reverse_mapped_handler_type_text(expr_idx))
-                    .or_else(|| {
-                        self.call_expression_source_return_type_text(expr_idx)
-                            .filter(|text| text.trim_start().starts_with('['))
-                    })
                     .or_else(|| self.generic_mapped_tuple_rest_call_return_type_text(expr_idx))
                     .or_else(|| self.generic_call_literal_type_text(expr_idx))
                     .or_else(|| self.generic_call_pick_mapped_type_text(expr_idx))
@@ -31,6 +27,15 @@ impl<'a> DeclarationEmitter<'a> {
                     .or_else(|| self.call_expression_local_overload_return_type_text(expr_idx))
                     .or_else(|| self.generic_rest_identity_parameters_tuple_type_text(expr_idx))
                     .or_else(|| self.call_expression_parameters_return_tuple_type_text(expr_idx))
+                    // A call whose source return annotation already resolves to a
+                    // tuple (`[...]`) is emitted verbatim — but only AFTER the
+                    // label-preserving rest-identity/parameters paths above, so an
+                    // alias-wrapped `Parameters<...>` (e.g. `type A<F> = Parameters<F>`)
+                    // keeps its element labels instead of collapsing to `[object, ...]`.
+                    .or_else(|| {
+                        self.call_expression_source_return_type_text(expr_idx)
+                            .filter(|text| text.trim_start().starts_with('['))
+                    })
                     .or_else(|| self.generic_spread_array_call_return_type_text(expr_idx))
                     .or_else(|| {
                         self.explicit_type_argument_indexed_member_return_type_text(expr_idx)

--- a/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
@@ -957,32 +957,35 @@ fn probe_parenthesized_conditional_extends_type_remains_grouped() {
     );
 }
 
+// `take_diagnostics`/`normalize_portability_diagnostics` performs EXACT dedup
+// only. #13155 fixed the TS2883 argument order at every checker emission site
+// (`{0}=name, {1}=from_path, {2}=type_name`) and removed the prior message-text
+// "swapped argument" canonicalization (`parse_ts2883_named_reference_message` /
+// `canonical_ts2883_named_reference_message` / `looks_like_module_path`) because
+// driving dedup off rendered diagnostic text violated the anti-hardcoding
+// contract. Emission can no longer produce a swapped-order TS2883, so the only
+// dedup the emitter owes is collapsing byte-identical duplicates. These tests
+// pin that contract (the obsolete swapped-canonicalization tests were retired
+// alongside the logic they exercised).
 #[test]
-fn take_diagnostics_drops_swapped_ts2883_when_canonical_exists() {
+fn take_diagnostics_dedupes_identical_ts2883() {
     use tsz_common::diagnostics::Diagnostic;
 
     let (parser, _root) = parse_test_source("");
     let mut emitter = DeclarationEmitter::new(&parser.arena);
-    emitter.diagnostics.push(Diagnostic::from_code(
-        2883,
-        "src/index.ts",
-        10,
-        3,
-        &["foo", "Other", "../node_modules/some-dep/dist/inner"],
-    ));
-    emitter.diagnostics.push(Diagnostic::from_code(
-        2883,
-        "src/index.ts",
-        10,
-        3,
-        &["foo", "../node_modules/some-dep/dist/inner", "SomeType"],
-    ));
+    let args = ["foo", "../node_modules/some-dep/dist/inner", "SomeType"];
+    emitter
+        .diagnostics
+        .push(Diagnostic::from_code(2883, "src/index.ts", 10, 3, &args));
+    emitter
+        .diagnostics
+        .push(Diagnostic::from_code(2883, "src/index.ts", 10, 3, &args));
 
     let diagnostics = emitter.take_diagnostics();
     assert_eq!(
         diagnostics.len(),
         1,
-        "expected swapped TS2883 to be removed"
+        "byte-identical TS2883 diagnostics at the same site must collapse to one"
     );
     assert_eq!(
         diagnostics[0].message_text,
@@ -991,11 +994,13 @@ fn take_diagnostics_drops_swapped_ts2883_when_canonical_exists() {
 }
 
 #[test]
-fn take_diagnostics_keeps_ts2883_when_swapped_seen_before_canonical_duplicate() {
+fn take_diagnostics_keeps_distinct_ts2883_at_same_site() {
     use tsz_common::diagnostics::Diagnostic;
 
     let (parser, _root) = parse_test_source("");
     let mut emitter = DeclarationEmitter::new(&parser.arena);
+    // Two genuinely different non-portable references at the same location
+    // (distinct referenced type names) are NOT duplicates and both survive.
     emitter.diagnostics.push(Diagnostic::from_code(
         2883,
         "src/index.ts",
@@ -1008,18 +1013,14 @@ fn take_diagnostics_keeps_ts2883_when_swapped_seen_before_canonical_duplicate() 
         "src/index.ts",
         10,
         3,
-        &["foo", "SomeType", "../node_modules/some-dep/dist/inner"],
+        &["foo", "../node_modules/some-dep/dist/inner", "OtherType"],
     ));
 
     let diagnostics = emitter.take_diagnostics();
     assert_eq!(
         diagnostics.len(),
-        1,
-        "expected one surviving canonical TS2883 diagnostic"
-    );
-    assert_eq!(
-        diagnostics[0].message_text,
-        "The inferred type of 'foo' cannot be named without a reference to 'SomeType' from '../node_modules/some-dep/dist/inner'. This is likely not portable. A type annotation is necessary."
+        2,
+        "distinct TS2883 references at the same site must both be preserved"
     );
 }
 

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_control.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_control.rs
@@ -128,21 +128,21 @@ impl<'a> AsyncES5Transformer<'a> {
         let else_placeholder = delayed_else_label.then(|| self.next_loop_exit_placeholder());
         let end_placeholder = delayed_end_label.then(|| self.next_loop_exit_placeholder());
 
-        let mut else_label: Option<u32> = if delayed_else_label {
-            None
-        } else {
+        let mut else_label: Option<u32> = if has_else && !delayed_else_label {
             Some(self.state.next_label())
+        } else {
+            // No else branch (no separate else label is needed), or the else label
+            // must be delayed until the suspending then branch allocates its
+            // resume labels.
+            None
         };
         let mut end_label: Option<u32> = if delayed_end_label {
             None
         } else {
-            // No branch suspends: both else_label and end_label are safe to allocate now.
-            if has_else {
-                Some(self.state.next_label())
-            } else {
-                // No else: end_label == else_label (the next case after the then block)
-                else_label
-            }
+            // No branch suspends: end_label is safe to allocate now. With an else
+            // branch the else label was just allocated above; without one this is
+            // simply the next case after the then block.
+            Some(self.state.next_label())
         };
 
         // Emit: if (!(condition)) return [3 /*break*/, else_or_end_placeholder];
@@ -278,7 +278,42 @@ impl<'a> AsyncES5Transformer<'a> {
             }
             *current_label = end_l;
         } else {
-            // No else branch.
+            // No else branch. When the then branch suspended, `end_label` was
+            // delayed (see `delayed_end_label`) so the then branch's yield-resume
+            // labels are allocated first. Resolve it now and patch the placeholder
+            // that the initial `if (!cond) break` skip target referenced.
+            if let Some(end_ph) = end_placeholder {
+                let patched_end_label = self.state.next_label();
+                Self::patch_if_break_target(cases, end_ph, patched_end_label);
+                Self::patch_if_break_target_in_statements(
+                    current_statements,
+                    end_ph,
+                    patched_end_label,
+                );
+                end_label = Some(patched_end_label);
+            }
+            let end_l = end_label.expect("end label must be available after if lowering");
+
+            // Emit `_a.label = end_label` so the state machine falls through to the
+            // merge point on re-entry, mirroring the else-branch path above. The
+            // then branch suspended, so its yield-resume statements (`_a.sent()`)
+            // are the last case; without the hint a re-entry would not advance.
+            if !current_statements.is_empty()
+                && !matches!(
+                    current_statements.last(),
+                    Some(
+                        IRNode::ReturnStatement(_)
+                            | IRNode::ThrowStatement(_)
+                            | IRNode::BreakStatement(_)
+                    )
+                )
+            {
+                current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+                    IRNode::GeneratorLabel,
+                    IRNode::number(end_l.to_string()),
+                ))));
+            }
+
             // Flush current case and start end label
             if !current_statements.is_empty() {
                 cases.push(IRGeneratorCase {
@@ -286,7 +321,7 @@ impl<'a> AsyncES5Transformer<'a> {
                     statements: std::mem::take(current_statements),
                 });
             }
-            *current_label = end_label.expect("end label must be available after if lowering");
+            *current_label = end_l;
         }
     }
 

--- a/crates/tsz-emitter/tests/es5_transforms_e2e_parts/part_01.rs
+++ b/crates/tsz-emitter/tests/es5_transforms_e2e_parts/part_01.rs
@@ -496,3 +496,33 @@ fn class_property_initializer_no_rename_when_no_shadow() {
         "Unshadowed let reference must remain unchanged.\nOutput:\n{output}"
     );
 }
+
+
+/// Regression (#13255): an `if` whose then-branch suspends (`yield`/`await`) and
+/// which has NO else branch must resolve its delayed merge ("end") label after
+/// the then branch consumes its yield-resume labels. Previously the end label was
+/// left unallocated, panicking with "end label must be available after if lowering"
+/// in `process_if_statement_in_async`. The lowered state machine must skip to the
+/// merge case on a false condition, suspend in the then case, and rejoin via
+/// `_a.label = <end>` so re-entry advances correctly — matching tsc.
+#[test]
+fn generator_if_then_yield_without_else_resolves_merge_label() {
+    let output = emit_es5("function* g() { if (cond()) { yield 1; } return 2; }\n");
+
+    assert!(
+        output.contains("if (!cond()) return [3 /*break*/, 2];"),
+        "false condition must break to the merge label.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return [4 /*yield*/, 1];"),
+        "then-branch yield must suspend.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a.label = 2;"),
+        "resume case must hint the merge label for re-entry (tsc parity).\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("case 2: return [2 /*return*/, 2];"),
+        "merge case must hold the post-if continuation.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Goal: hold

One PR carrying every emitter fix the `unit` job needs so the SINGLE PR goes green and can merge through the wedged queue. Fixes three independent emitter bugs.

## 1. ES5 async if-lowering panic (#13255 / #13368)

Deterministic logic bug (NOT a thread-local/isolation leak) in
`process_if_statement_in_async` (`async_es5_ir_control.rs:289`). When an `if`
then-branch suspends (`await`/`yield`) and has **no else branch**, the delayed
merge ("end") label was never resolved → `end_label = None` → panic
(`end label must be available after if lowering`). Reproduces single-threaded,
single-test (`source_map_tests_4::test_source_map_generator_transform_es5_comprehensive`).

Fix: allocate+patch the end label after the suspending then branch (mirroring
the has-else path), drop the unused else-label allocation, and emit the
`_a.label = <end>` re-entry hint — verified exact tsc parity on the lowered
generator state machine. Regression test added.

## 2. DTS labeled-tuple labels dropped on alias-wrapped `Parameters<...>` (#13276)

`fix_generic_rest_identity_preserves_parameters_tuple_labels` regressed at
`75e09a6d0d` (#13276, bisected). #13276 inserted a "source return already
resolves to a tuple" shortcut near the front of `call_expression_reused_type_text`'s
fallback chain; for `f(...g(x))` where `g` returns an alias-wrapped `Parameters<F>`
(`type A<F> = Parameters<F>`) it fired before the label-preserving
`generic_rest_identity_parameters_tuple_type_text` and collapsed
`[elem: object, index: number]` → `[object, number]`.

Fix: move that tuple-source shortcut **after** the label-preserving
rest-identity/parameters-return tuple paths. Minimal reorder; the shortcut still
outranks the spread/variadic/bind/source-return fallbacks it was added for.

## 3. Obsolete swapped-TS2883 dedup tests (#13155 follow-up)

Two `declaration_emitter` tests asserted the message-text swapped-argument
canonicalization that #13155 deliberately **removed** as an anti-hardcoding
violation (rendered diagnostic text must not drive dedup; TS2883 arg order was
fixed at the emission sites instead). They have failed since #13155.
`normalize_portability_diagnostics` now does exact dedup only.

Fix: rewrite the two tests to pin the current contract (identical TS2883 →
collapsed; distinct references at the same site → both kept). No production
logic changed; the anti-hardcoding violation is NOT reintroduced.

## Verification

- `cargo nextest run -p tsz-emitter` → **4304 pass, 0 fail** (3× multi-threaded `--test-threads=16`, stable).
- `cargo nextest run -p tsz-core --lib source_map_tests_4::test_source_map_generator` → 16/16 (was panicking).
- New/updated regression tests: `generator_if_then_yield_without_else_resolves_merge_label`, `take_diagnostics_dedupes_identical_ts2883`, `take_diagnostics_keeps_distinct_ts2883_at_same_site`.
- `cargo clippy -p tsz-emitter --tests` → clean.

## Provenance

Machine: MacBookPro.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

— AgentName: M1FableArchitect
