### PR TITLE
fix(checker): recover contextual literal surface in object-literal excess-property check (#13212)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs
+++ b/crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs
@@ -294,6 +294,32 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // Literal-surface recovery (#13212 F1): the caller's `source_prop_type`
+        // can be the *widened* primitive of a contextually-typed literal property
+        // (e.g. `kind: 'schema'` in an object literal contextually typed by a
+        // cross-arena generic interface gets widened to `string` in the source
+        // shape used for excess-property checking). When the widened source fails
+        // against a literal target but the property's actual literal surface is
+        // assignable, tsc keeps the contextual literal and reports nothing; the
+        // diagnostic display role then re-renders the widened source by its
+        // literal surface, producing a display-identical false positive
+        // (`'schema' ≰ 'schema'`, `false ≰ false`). Recover the literal from the
+        // initializer and suppress when it relates. Structural — keyed on the
+        // widened-primitive-vs-literal-target shape, not on any name.
+        if !self
+            .call_arg_relation_outcome(source_prop_type, target_prop_type)
+            .related
+            && let Some((_, value_idx)) =
+                self.object_literal_property_name_and_value(obj_literal_idx, prop_name)
+            && let Some(literal_type) = self.literal_type_from_initializer(value_idx)
+            && literal_type != source_prop_type
+            && self
+                .call_arg_relation_outcome(literal_type, target_prop_type)
+                .related
+        {
+            return;
+        }
+
         let target_prop_type_for_message =
             self.object_literal_property_value_diagnostic_target_type(target_prop_type);
         let report_idx = self


### PR DESCRIPTION
Goal: green

Targets the #13212 F1 "display-identical false positive" family on the
valibot benchmark row (and the io-ts / runtypes residual attributed to the
same root): `Type '"schema"' is not assignable to type '"schema"'`,
`Type 'false' is not assignable to type 'false'`, etc.

## Structural rule

When an object literal is contextually typed by a cross-arena generic
interface (valibot's `BooleanSchema`/`ArraySchema extends BaseSchema<…>`),
its literal-annotated inherited members — `kind: 'schema'`, `async: false`,
`type: 'array'` — are present in the object literal but the **source object
shape used by the excess-property checker carries the *widened* primitive**
(`string` / `boolean`), not the contextual literal. In
`check_object_literal_named_property_value`
(`crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs`) the
widened source fails the per-property relation against the literal target,
and the assignment-source diagnostic display role re-renders the widened
`string` source **by its literal surface** `"schema"`. The result is a
display-identical false positive `'"schema"' ≰ '"schema"'` whose two
endpoints are genuinely different `TypeId`s (`Intrinsic(String)` vs
`Literal(String("schema"))`), confirmed by tracing the emission at
`error_type_not_assignable_at_with_display_types` (source `#Intrinsic(String)`,
target `#Literal("schema")`, both rendering `"schema"`).

`tsc` keeps the contextual literal for the property, so `'schema' ≤ 'schema'`
passes and nothing is reported. tsz must do the same: when the widened source
fails but the property's literal surface (from the initializer) IS assignable
to the literal target, suppress the per-property emission.

Owner layer: checker object-literal excess-property elaboration
(`check_object_literal_named_property_value`). This is **not** a non-canonical
solver-interning defect — the per-property *target* is the canonical literal
`TypeId` and `evaluate_type_with_env` materializes the cross-arena interface
body to the same canonical members; the defect is source-side literal
widening surfacing through the display role. (Prior investigations that
framed this as opaque/non-canonical instantiation are corrected here: traced
the exact emission path `check_return_statement` →
`try_elaborate_assignment_source_error` →
`try_elaborate_object_literal_properties_with_source` →
`check_object_literal_excess_properties` →
`check_object_literal_named_property_value` →
`error_type_not_assignable_at_with_display_types`, and dumped the source/target
`TypeId`s at the emission. The defect reproduces only in release/dist-fast,
not debug — debug aborts on the #13086 env-divergence assertion before the
graph-scale path emits — which is why it never minimized synthetically.)

The guard is keyed purely on the widened-primitive-source vs literal-target
shape, recovered from the AST initializer; it does not read any identifier,
property, or file-name string. Real literal mismatches (where neither the
widened nor the literal form relates to the target) still error.

## Verification

dist-fast binary, valibot fixture `fabian-hiller/valibot@e7bcacb`
(`library/src`, guard tsconfig, `skipLibCheck`), tsc 5.9.3 baseline 1513
(TS5097×1260 + TS2307×253, config-shaped). Measured **to completion**:

| metric | before | after |
|---|---|---|
| valibot total `error TS` | 2653 | **2467** (−186) |
| **display-identical TS2322** (`Type X ≰ type X`) | **184** | **0** |
| TS2322 (all) | 256 | 70 |
| TS5097 / TS2307 (config-shaped) | match tsc | unchanged, match tsc |
| TS2344 / TS2345 / TS2536 / TS2339 / TS2430 | unchanged | unchanged |

Isolated witnesses (`schemas/array/array.ts`, `schemas/boolean/boolean.ts`
+ full transitive `.ts` import closure, 556 files, tsc-clean): the 4–5
per-property display-identical TS2322 each drop to 0 (the lone residual is
the genuine top-level object→`ArraySchema` mismatch on the conditional
`'~run'`/`'~types'` members — a separate deeper family, not display-identical).

Determinism: 3× full-row runs → 2467 / 2467 / 2467 (identical).

Negative / over-suppression guard (vs tsc, both byte-identical):
`{ kind: 'validation', n: 6 }` → `Want{kind:'schema';n:5}` still emits both
`'validation' ≰ 'schema'` and `6 ≰ 5`; `{ tag: 'a' }` → `{ tag: 'a'|'b' }`
clean.

Conformance (`scripts/conformance.sh run --filter`, dist-fast), all 0
PASS→FAIL on a broad sweep:
- objectLiteral 52/52, object 233/233, excessProperty 11/11,
  excessProperties 1/1, weakType 3/3, propertyAssignment 8/8,
  assignmentCompat 128/128, contextualTyping 83/83, literalType 8/8,
  unionType 30/30, discriminated 8/8
- typeRelationships 265/265, intersection 44/44, mappedType 55/55,
  conditionalType 17/17, recursiveType 23/23, genericInterface 4/4,
  instantiation 3/3, instantiationExpression 3/3,
  tsxLibraryManagedAttributes 1/1, heritage 1/1
- `deeplyNested`: 6/7 — the lone FAIL (`deeplyNestedMappedTypes.ts`, plus
  `propTypeValidatorInference.ts` elsewhere) is **pre-existing main drift**
  (committed `conformance-baseline.txt` dated 2026-06-03; main HEAD
  2026-06-17), fingerprint-only (error codes match tsc, only type-display
  text differs), on recursive mapped-type shapes my guard cannot fire on;
  both fail identically with the change stashed.

clippy: clean on `-p tsz-checker --lib`. (The 9 architecture_contract /
relation_routing arch tests that fail in this worktree also fail with the
change stashed — pre-existing on this base, environment/submodule-related;
ready-review CI owns the arch gate in its proper environment.)

io-ts / runtypes rows: attributed to the same F1 root in #13212 comments;
their on-demand fixtures are not cached in this workspace so were not
re-measured here. Expected to benefit from the same source-literal recovery.

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

AgentName: MacOpusF1Canon
- Row: valibot
- Row: io-ts
- Row: runtypes
- Bug family: F1-canonical-interning

Refs #13212.
