### PR TITLE
fix(bench): unfreeze benchmark publish (skip app rows + readiness excludes unmeasured rows)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1438,8 +1438,15 @@ jobs:
           test -x .target-bench/dist/tsz
           test -f .target-bench/dist/.bench-pgo-optimized
 
+          # Skip category:"application" canary rows here: they clone+install real
+          # apps (minutes each) and are excluded from the benchmark corpus, so
+          # they produce no PGO timing data but would blow this job's 30m budget
+          # (observed 2026-06-17: bench-publish timed out for ~14h, freezing the
+          # published benchmarks). Application *compatibility* is still tracked by
+          # the CI project-compile-canary shards, which do not set this flag.
           TSZ_BIN="$GITHUB_WORKSPACE/.target-bench/dist/tsz" \
           TSZ_PROJECT_COMPILE_SET=canary \
+          TSZ_PROJECT_COMPILE_SKIP_APPLICATIONS=1 \
           TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 \
           scripts/ci/project-compile-guard.sh
 

--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -28,11 +28,23 @@ import {
   REQUIRED_PROJECT_ROWS,
   PROJECT_ROWS_BY_NAME,
 } from "./project-rows.mjs";
+import { BENCH_RUNNER_EXCLUDED_ROWS } from "./project-row-summary.mjs";
 import {
   hasCompletePhaseMetadata,
   isGreen,
 } from "./row-utils.mjs";
 import { measurementProfileStatus } from "./measurement-profile.mjs";
+
+// The bench artifact readiness gate must not demand rows that are intentionally
+// excluded from the bench runner (BENCH_RUNNER_EXCLUDED_ROWS): those rows are
+// never measured, so they can never appear in the merged artifact. Requiring
+// them fails every publish on a permanently-missing row — e.g.
+// type-challenges-solutions-project, a required compile-guard row that is
+// excluded from timing (#13549). Only rows that are both required AND actually
+// measured belong in the readiness required-set.
+const REQUIRED_MEASURED_ROWS = REQUIRED_PROJECT_ROWS.filter(
+  (name) => !BENCH_RUNNER_EXCLUDED_ROWS.has(name),
+);
 
 const args = process.argv.slice(2);
 
@@ -234,7 +246,7 @@ function analyzeArtifact(artifact, expectedCommit) {
     }
   }
 
-  const rows = REQUIRED_PROJECT_ROWS.map((name) => {
+  const rows = REQUIRED_MEASURED_ROWS.map((name) => {
     const row = byName.get(name) ?? null;
     const duplicateCount = duplicateCounts.get(name) ?? (row ? 1 : 0);
     const duplicate = duplicateCount > 1;
@@ -301,7 +313,7 @@ function uniqueRowsByName(rows) {
 }
 
 function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, validationWarnings, sourceFreshness, rows, successfulProjectTimingPairs, missing, red, yellow, gray, green, duplicates }) {
-  const missingNames = missing?.map((r) => r.name) ?? REQUIRED_PROJECT_ROWS;
+  const missingNames = missing?.map((r) => r.name) ?? REQUIRED_MEASURED_ROWS;
   const metadataWarningsList = metadataWarnings(measurementProfile, validationWarnings);
   const nonGreenRows = rows
     ? uniqueRowsByName([
@@ -332,7 +344,7 @@ function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, v
     },
     metadata_clean: metadataWarningsList.length === 0,
     metadata_warnings_total: metadataWarningsList.length,
-    required_row_count: rows?.length ?? REQUIRED_PROJECT_ROWS.length,
+    required_row_count: rows?.length ?? REQUIRED_MEASURED_ROWS.length,
     successful_project_timing_pairs: successfulProjectTimingPairs?.length ?? 0,
     required_project_timing_pairs: requiredProjectTimingPairs,
     green: green?.length ?? 0,

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -6,8 +6,16 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import {
-  REQUIRED_PROJECT_ROWS,
+  REQUIRED_PROJECT_ROWS as ALL_REQUIRED_PROJECT_ROWS,
 } from "./project-rows.mjs";
+import { BENCH_RUNNER_EXCLUDED_ROWS } from "./project-row-summary.mjs";
+
+// The readiness gate checks only required rows that are actually measured (it
+// subtracts BENCH_RUNNER_EXCLUDED_ROWS). Mirror that here so the synthesized
+// artifacts and row counts match the gate's effective required-set.
+const REQUIRED_PROJECT_ROWS = ALL_REQUIRED_PROJECT_ROWS.filter(
+  (name) => !BENCH_RUNNER_EXCLUDED_ROWS.has(name),
+);
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(SCRIPT_DIR, "..", "..");

--- a/scripts/ci/project-compile-guard.sh
+++ b/scripts/ci/project-compile-guard.sh
@@ -9,6 +9,12 @@ TSZ_BIN="${TSZ_BIN:-$DEFAULT_TARGET_DIR/dist-fast/tsz}"
 FIXTURE_ROOT="${TSZ_PROJECT_COMPILE_FIXTURE_ROOT:-$ROOT_DIR/.target/project-compile-guard}"
 PROJECT_TIMEOUT="${TSZ_PROJECT_COMPILE_TIMEOUT:-90}"
 INCLUDE_GENERATED_APPS="${TSZ_PROJECT_COMPILE_INCLUDE_GENERATED_APPS:-1}"
+# Skip category:"application" canary rows. These clone+install real apps (deps
+# can take minutes each) and are compatibility canaries excluded from the
+# benchmark corpus, so latency-sensitive callers (e.g. bench-publish's PGO
+# timing step, capped at 30m) set this to 1 to avoid blowing their job budget
+# on rows that produce no benchmark data.
+SKIP_APPLICATIONS="${TSZ_PROJECT_COMPILE_SKIP_APPLICATIONS:-0}"
 PROJECT_FILTER="${TSZ_PROJECT_COMPILE_FILTER:-}"
 PROJECT_SET="${TSZ_PROJECT_COMPILE_SET:-required}"
 ALLOW_FAILURES="${TSZ_PROJECT_COMPILE_ALLOW_FAILURES:-0}"
@@ -424,6 +430,10 @@ install_application_deps() {
 #   name fixture_dir repo ref install_cmd install_root app_tsconfig src_dir
 run_application_row() {
   local name="$1" fdir="$2" repo="$3" ref="$4" install_cmd="$5" install_root="$6" app_tsconfig="$7" src_rel="$8"
+  if [[ "$SKIP_APPLICATIONS" == "1" ]]; then
+    echo "Skipping application row $name (TSZ_PROJECT_COMPILE_SKIP_APPLICATIONS=1)"
+    return 0
+  fi
   local root="$FIXTURE_ROOT/$fdir"
   ensure_git_fixture "$fdir" "$repo" "$ref" "$root"
   install_application_deps "$root/$install_root" "$install_cmd"


### PR DESCRIPTION
## Summary
Fixes the two compounding blockers that have frozen tsz.dev benchmarks at
`2026-06-16T21:24:39Z` (~18h). Supersedes #13848 (which carried only the first
fix). Both blockers were masked in sequence: bench-publish always died at the
timeout *before* reaching the readiness gate, so the second blocker only
surfaced once the first was fixed.

### Blocker 1 — bench-publish timeout (the original 14h freeze)
`bench-publish`'s "Run PGO compile canaries" step runs `project-compile-guard.sh`
(`TSZ_PROJECT_COMPILE_SET=canary`) under a 30m job timeout. Since #13740 added 20
`category:"application"` canary rows, that step clones+installs+compiles 20 real
apps (minutes each; several hit the 90s per-project wall) — far exceeding 30m, so
the job was cancelled before publishing on every run. Timing: #13740 merged
`20:47:49Z`; last good publish `21:24:39Z`.
- Add `TSZ_PROJECT_COMPILE_SKIP_APPLICATIONS` (guards the single
  `run_application_row` chokepoint) and set it in bench-publish's PGO step. App
  *compatibility* is still tracked by the CI `project-compile-canary` shards.

### Blocker 2 — readiness gate requires a never-measured row
With the timeout gone, runs reached `check-artifact-readiness`, which built its
required-set from `REQUIRED_PROJECT_ROWS` (`benchmark_set==required`) **without
subtracting `BENCH_RUNNER_EXCLUDED_ROWS`**. `type-challenges-solutions-project`
is `benchmark_set:required` (a required *compile-guard* row, #13549) yet excluded
from the bench runner — so it is never measured, never in the artifact, and the
gate failed every publish on a permanently-missing required row.
- Subtract `BENCH_RUNNER_EXCLUDED_ROWS` from the gate's required-set (only rows
  that are both required AND measured). Test mirrors the same exclusion.

## Verification
- `node --check` + `bash -n` on changed scripts → OK; `bench.yml` YAML parses.
- `node scripts/bench/test-check-artifact-readiness.mjs` → all pass (gate now
  checks 12 measured required rows, not 13).
- `node scripts/bench/validate-project-metadata.mjs`, `test-ci-health-benchmark-readiness`,
  `test-gh-pages-benchmark-artifact-gate`, `test-bench-readiness-banner` → pass.
- End-to-end: dispatched Bench from this branch (run 27700570695); it measures
  with apps skipped (no timeout) and the readiness gate no longer demands the
  excluded row, so it publishes fresh data.

Goal: fast

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
