### PR TITLE
fix(checker): object-spread initializer declares spread-source properties (TS2565 definite assignment)

### DIFF
--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -453,6 +453,17 @@ impl<'a> CheckerState<'a> {
                 return false;
             };
 
+            // A spread element (`{ ...src }`) contributes every property carried by
+            // the spread source's type to the variable's semantic shape. The
+            // initializer therefore already declares `property_name` when the spread
+            // source structurally has it; a later `obj.prop = ...` write is a
+            // re-assignment of an existing property, not an expando forward-read.
+            if elem_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT
+                || elem_node.kind == syntax_kind_ext::SPREAD_ELEMENT
+            {
+                return self.spread_source_type_declares_property(elem_node, property_name);
+            }
+
             let elem_prop_name = match elem_node.kind {
                 syntax_kind_ext::PROPERTY_ASSIGNMENT => self
                     .ctx
@@ -479,6 +490,72 @@ impl<'a> CheckerState<'a> {
 
             elem_prop_name.is_some_and(|name| name == property_name)
         })
+    }
+
+    /// Whether a spread element's source type structurally declares `property_name`.
+    ///
+    /// The spread source expression is typed when the enclosing object literal is
+    /// computed (node-type cache); for a plain identifier source the resolved
+    /// symbol type is the fallback. The structural `type_has_property` query covers
+    /// named members, index signatures, and members introduced through nested
+    /// spreads.
+    fn spread_source_type_declares_property(
+        &self,
+        spread_elem_node: &tsz_parser::parser::node::Node,
+        property_name: &str,
+    ) -> bool {
+        let Some(spread) = self.ctx.arena.get_spread(spread_elem_node) else {
+            return false;
+        };
+        let spread_type = self
+            .ctx
+            .node_types
+            .get(&spread.expression.0)
+            .copied()
+            .or_else(|| {
+                self.resolve_identifier_symbol(spread.expression)
+                    .and_then(|sym_id| self.ctx.symbol_types.get(&sym_id).copied())
+            });
+        let Some(spread_type) = spread_type else {
+            return false;
+        };
+        let prop_atom = self.ctx.types.intern_string(property_name);
+        self.resolved_type_has_property(spread_type, prop_atom)
+    }
+
+    /// Structural `type_has_property` that first resolves a `Lazy(DefId)` source
+    /// reference (type alias / interface) through the checker-owned `DefId`
+    /// resolver. The solver's environment-free finite-name query cannot enumerate
+    /// members of an unresolved lazy reference, so a spread of an interface-typed
+    /// value (`{ ...state }` where `state: QueryState`) would otherwise report no
+    /// properties.
+    fn resolved_type_has_property(
+        &self,
+        type_id: tsz_solver::TypeId,
+        prop_atom: tsz_common::Atom,
+    ) -> bool {
+        use crate::query_boundaries::definition_identity::lazy_def_id;
+        use crate::query_boundaries::property_access::type_has_property;
+        use crate::query_boundaries::type_checking_utilities::application_base;
+        use tsz_solver::relations::subtype::TypeResolver;
+
+        if type_has_property(self.ctx.types, type_id, prop_atom) {
+            return true;
+        }
+        // The property *name* set of an interface/alias is independent of its type
+        // arguments, so peel a generic application (`QueryState<T, E>`) to its base
+        // before resolving the lazy reference. Resolving the `DefId` body yields the
+        // interface's structural members, which the environment-free finite-name
+        // query cannot enumerate from an unresolved `Lazy` reference alone.
+        let base = application_base(self.ctx.types, type_id).unwrap_or(type_id);
+        if let Some(def_id) = lazy_def_id(self.ctx.types, base)
+            && let Some(body) = self.ctx.resolve_lazy(def_id, self.ctx.types)
+            && body != type_id
+            && body != base
+        {
+            return type_has_property(self.ctx.types, body, prop_atom);
+        }
+        false
     }
 
     pub(in crate::types_domain) fn union_has_explicit_property_member(


### PR DESCRIPTION
Fixes a bounded flow/definite-assignment false positive: an object-spread-initialized `let`/`const` read after a conditional property write falsely reported TS2565 "Property 'X' is used before being assigned." Witnessed in tanstack-query (`queryObserver.ts`: `let newState = { ...state }; if (...) { newState.fetchStatus = 'idle' } ... newState.fetchStatus`).

Goal: green

## Structural rule
When an object-literal variable initializer contains a spread element `...src` and the spread source's type structurally declares property `P`, the variable's semantic shape already declares `P`; a later `obj.P = ...` write is a re-assignment of an existing property, not an expando forward-read. tsc treats it as definitely assigned.

Owner layer: checker property-access expando gate (`crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs`, `object_literal_root_declares_property`). The gate previously matched only syntactic object-literal members (property/shorthand/method/accessor); spread elements (`SPREAD_ASSIGNMENT`/`SPREAD_ELEMENT`) were not recognized, so a spread-introduced property was treated as a fresh expando whose first/only write was the conditional one, tripping the expando-forward-read TS2565 path in `types/property_access_type/resolve.rs`.

Fix: resolve the spread source's type (node-type cache, then resolved symbol type), peel a generic application to its base, and resolve a `Lazy(DefId)` interface/alias reference through the checker-owned DefId resolver (`resolve_lazy`) before the structural `type_has_property` query. The environment-free finite-name query cannot enumerate members of an unresolved lazy reference, which is why a spread of an interface-typed value (`{ ...state }` where `state: QueryState`) previously reported no properties. Routed through narrow boundaries (`definition_identity::lazy_def_id`, `type_checking_utilities::application_base`, `tsz_solver::relations::subtype::TypeResolver`) so the `query_boundaries::common` quarantine count (#8225) does not grow.

No hardcoding: decision is structural (spread element whose source type has the property); no identifier/file-name/printer-output checks.

Same definite-assignment family as #13788 (truthy-condition-read proves assignment).

## Adjacent matrix
- spread of param + conditional property write + read -> OK (was the bug)
- spread + extra explicit props -> OK
- spread-reassign chain (`s = { ...s, ...fn() }`) then read -> OK
- array spread (`[...arr]`) -> unaffected (object-literal-only gate)
- generic spread source (`QueryState<T, E>`) -> OK (application base peeled, lazy resolved)
- NEGATIVE: genuine expando (property NOT in spread source) -> behavior unchanged (still flagged as a non-declared property; orthogonal pre-existing TS2339/TS2565 cascade, not introduced here)

## Verification
- Repro matrix matches tsc 6.0.3 (all spread-declared reads clean; `tsc --strict --noEmit` clean on every variant).
- tanstack-query (`packages/query-core/src`, tsz-guard config): TS2565 8 -> 0. Total diagnostics 86 -> 78 (net -8, exactly the removed false TS2565; no new diagnostics). 3x deterministic (total=78, ts2565=0 each run).
- Local canary smoke (tsz-guard configs): fp-ts (2058 err), valibot (2653 err), trpc (171), ts-pattern (18), immer (5) — all 0 TS2565, no crashes. immer is a spread/draft-heavy library.
- Conformance `scripts/conformance/conformance.sh --filter`: definiteAssignment 4/4, UsedBefore 10/10, controlFlow 94/94, assigned 8/8, narrowing 29/29, objectSpread 11/11, expando 13/13, objectLiteral 52/52, propertyAccess 26/26 — all 100%. `spread` (12585 tests) 12583/12585; the 2 FAILs (deeplyNestedMappedTypes.ts, propTypeValidatorInference.ts) are pre-existing accepted regressions (mapped-type TS2322, orthogonal). 0 PASS->FAIL from this change.
- `scripts/arch/arch_guard.py`: passed (no growth of #8225 common-quarantine count).
- `cargo clippy -p tsz-checker`: clean.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Project corpus
AgentName: claude-code
- Row: tanstack-query
- Bug family: spread-definite-assignment
