### PR TITLE
fix(checker): keep member-property assignment narrowing across an if-join (#13232)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -392,6 +392,7 @@ impl<'a> FlowAnalyzer<'a> {
                         //     the declared type instead of the assignment-narrowed type)
                         let ant_needs_defer = self.condition_antecedent_requires_defer_cached(
                             ant,
+                            reference,
                             symbol_id,
                             &mut condition_antecedent_defer_memo,
                         );
@@ -1557,13 +1558,14 @@ impl<'a> FlowAnalyzer<'a> {
     fn condition_antecedent_requires_defer_cached(
         &self,
         antecedent: FlowNodeId,
+        reference: NodeIndex,
         symbol_id: Option<SymbolId>,
         memo: &mut FxHashMap<FlowNodeId, bool>,
     ) -> bool {
         if let Some(&cached) = memo.get(&antecedent) {
             return cached;
         }
-        let result = self.condition_antecedent_requires_defer(antecedent, symbol_id);
+        let result = self.condition_antecedent_requires_defer(antecedent, reference, symbol_id);
         memo.insert(antecedent, result);
         result
     }
@@ -1571,6 +1573,7 @@ impl<'a> FlowAnalyzer<'a> {
     fn condition_antecedent_requires_defer(
         &self,
         antecedent: FlowNodeId,
+        reference: NodeIndex,
         symbol_id: Option<SymbolId>,
     ) -> bool {
         let Some(ant_flow) = self.binder.flow_nodes.get(antecedent) else {
@@ -1579,11 +1582,24 @@ impl<'a> FlowAnalyzer<'a> {
         let ant_flags = ant_flow.flags;
         let ant_is_assignment = (ant_flags & flow_flags::ASSIGNMENT) != 0;
         // Check if the antecedent ASSIGNMENT targets our reference.
-        let ant_is_targeting_assignment = ant_is_assignment && {
-            // Quick symbol check: does this assignment target our ref?
-            let assignment_sym = self.reference_symbol(ant_flow.node);
-            assignment_sym.is_some() && symbol_id.is_some() && assignment_sym == symbol_id
-        };
+        //
+        // The symbol-equality shortcut only works for plain-identifier references,
+        // whose `symbol_id` is the binder symbol the assignment also resolves to.
+        // Member-access references (`c.r`, `o[k]`) carry no `symbol_id`, so a
+        // symbol-only test silently misses an assignment that DOES target them
+        // (`c.r = …` before an `if`), and the CONDITION join then drops the
+        // assignment's narrowing. Fall back to the same structural targeting
+        // predicate the worklist's ASSIGNMENT branch and the sibling
+        // `antecedent_requires_defer` classifier use, gated by the O(1) root
+        // pre-filter so unrelated assignments stay cheap to reject.
+        let ant_is_targeting_assignment = ant_is_assignment
+            && ant_flow.node.is_some()
+            && self.assignment_root_symbols_may_overlap(ant_flow.node, reference, symbol_id)
+            && (symbol_id
+                .zip(self.reference_symbol(ant_flow.node))
+                .is_some_and(|(target, assignment)| target == assignment)
+                || self.assignment_targets_reference_node(ant_flow.node, reference)
+                || self.assignment_affects_reference_node(ant_flow.node, reference));
         // Also defer to non-targeting ASSIGNMENT antecedents when
         // their own antecedent chain contains a deferrable node.
         // This covers the pattern: `x = 10; var b = x; typeof x`

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
@@ -597,45 +597,37 @@ function viaArrayGeneric(xs: Array<typeof Alpha.resolved>): Beta[] { return xs; 
     }
 
     // ------------------------------------------------------------------
-    // #13232 (line-16 facet): resolver-less evaluation must not distribute a
-    // still-generic conditional during relation pre-evaluation / flow read.
+    // #13232: a member-access (`context.response`) write before an `if` must
+    // keep its assignment narrowing across the `if`-join.
     //
     // A generic async function expression contextually typed by an interface
-    // member signature whose return type embeds a still-generic conditional
-    // alias (`MappedResponseType<R, T>` with `R`/`T` free type parameters) must
-    // NOT false-fail TS2322. tsc keeps `R extends keyof ResponseMap ? ... : ...`
-    // deferred while `R` is generic, so the flow-narrowed `context.response`
-    // (source) and the contextual return element (target) are the *same*
-    // deferred type and relate by identity.
+    // member signature returns `context.response` after `context.response = …`
+    // and an `if` statement. tsc narrows the optional `response?` property to
+    // non-`undefined` at the assignment and carries that across the merge, so the
+    // return type relates to the declared element type and reports no TS2322.
     //
-    // tsz degrades the source: the flow-narrowed read evaluates the conditional
-    // through a relation-internal evaluator whose resolver cannot expand the
-    // cross-file `Lazy(def)` (`resolver_generation() == 0`), so it evaluates the
-    // operands — `keyof ResponseMap` -> the key-literal union and the true
-    // branch `ResponseMap[R]` -> the value-type union — instead of keeping them
-    // as the deferred alias the target carries. The two structurally-identical
-    // `FetchResponse<MappedResponseType<R, T>>` types then fail to relate, so a
-    // self-assignment reports the canonical false
-    //   `'FetchResponse<MappedResponseType<R, T>>' is not assignable to
-    //    'FetchResponse<MappedResponseType<R, T>>'`.
+    // The earlier "resolver-less still-generic conditional distribution" framing
+    // was a red herring: the source and target `FetchResponse<MappedResponseType<
+    // R, T>>` relate fine. The real failure is that `context.response` stays
+    // `… | undefined` at the `return`. The flow walk reaches the `if`'s CONDITION
+    // node whose antecedent is the property-write ASSIGNMENT; the CONDITION
+    // defer-classifier (`condition_antecedent_requires_defer`) decided whether to
+    // process that antecedent using a symbol-equality shortcut that only matches
+    // plain-identifier references. A member-access reference carries no
+    // `symbol_id`, so the targeting assignment was missed, the CONDITION finalized
+    // on the un-narrowed declared type, and the assignment narrowing was dropped
+    // at the join. The fix makes that classifier fall back to the same structural
+    // `assignment_targets_reference_node` / `assignment_affects_reference_node`
+    // predicate the worklist's ASSIGNMENT branch and the sibling
+    // `antecedent_requires_defer` classifier already use.
     //
     // Binder names vary from the original ofetch witness so the behavior follows
     // the type shape, not a spelling. Both returns and the flow narrowing are
     // required: a single direct return passes (the issue's "both returns are
-    // needed" note).
-    //
-    // The durable fix is the #13232 resolver-threading work (thread the
-    // checker's def-resolving resolver into the relation-internal evaluator so
-    // the cross-file `keyof`/alias expands, OR refuse to serve resolver-less
-    // results so a resolved pass recomputes them). That is architectural and
-    // validated by the full conformance/canary suite, so this is committed as an
-    // `#[ignore]`d synthetic witness that pins the bug deterministically in ~1s
-    // (the prior reproductions were project-corpus-only). Un-ignore when the
-    // resolver-less deferred-conditional relation is fixed.
+    // needed" note). The focused minimal witness for the flow fix itself lives in
+    // `member_property_write_narrowing_survives_if_join` below.
     // ------------------------------------------------------------------
     #[test]
-    #[ignore = "#13232 line-16: resolver-less relation distributes a still-generic \
-                deferred conditional; un-ignore when resolver threading lands"]
     fn program_mode_generic_conditional_in_contextual_return_stays_deferred() {
         let lib_files = tsz::checker::test_utils::load_lib_files(&[
             "es5.d.ts",
@@ -726,6 +718,96 @@ export const $fetchRaw: $Fetch["raw"] = async function $fetchRaw<
             bogus.is_empty(),
             "a still-generic conditional alias in the contextual return type must \
              stay deferred (no false TS2322): {bogus:?}; all: {diagnostics:?}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // #13232 (minimal flow witness): assignment narrowing of an optional
+    // *property* reference must survive a CONDITION (`if`) join.
+    //
+    // `c.r = { s: 1 }` narrows the optional `r?: Inner` to non-`undefined`. With a
+    // following `if` statement the flow walk for the `return c.r` read reaches the
+    // `if`'s CONDITION node whose antecedent is the property-write ASSIGNMENT. The
+    // CONDITION's defer classifier must process (defer to) that antecedent so the
+    // narrowing reaches the merge; previously it used a symbol-equality shortcut
+    // that only matched plain-identifier references and silently skipped the
+    // member-access write, dropping the narrowing and reporting a false TS2322.
+    //
+    // Adjacency is asserted in one pass: a plain-identifier local (`local`) and an
+    // element-access write (`elem`) must also narrow; base reassignment (`reassign`)
+    // and an `undefined` overwrite on one branch (`overwrite`) must still keep
+    // `undefined` and report TS2322. Binder names differ across the cases so the
+    // behavior tracks the reference shape, not a spelling.
+    // ------------------------------------------------------------------
+    #[test]
+    fn member_property_write_narrowing_survives_if_join() {
+        let options = project_mode_es2015_strict_options();
+        let base = std::path::Path::new("/");
+
+        // Positive: property write before an `if` narrows the optional away.
+        let positive = collect_test_diagnostics_with_options(
+            &[(
+                "/p/a.ts",
+                r#"
+interface Inner { s: number }
+interface C { r?: Inner }
+export function f(c: C, flag: boolean): Inner {
+  c.r = { s: 1 };
+  if (flag) {}
+  return c.r;
+}
+export function viaElement(obj: C, flag: boolean): Inner {
+  obj["r"] = { s: 1 };
+  if (flag) {}
+  return obj["r"];
+}
+export function viaLocal(flag: boolean): Inner {
+  let r: Inner | undefined;
+  r = { s: 1 };
+  if (flag) {}
+  return r;
+}
+"#,
+            )],
+            &options,
+            base,
+        );
+        let positive_2322: Vec<_> = positive.iter().filter(|d| d.code == 2322).collect();
+        assert!(
+            positive_2322.is_empty(),
+            "property/element/local write before an `if` must keep its narrowing \
+             across the join (no false TS2322): {positive_2322:?}; all: {positive:?}"
+        );
+
+        // Negative: a branch that reassigns the base or writes `undefined` must
+        // re-introduce `undefined` at the merge and still report TS2322.
+        let negative = collect_test_diagnostics_with_options(
+            &[(
+                "/p/b.ts",
+                r#"
+interface Inner { s: number }
+interface C { r?: Inner }
+export function reassign(c: C, other: C, flag: boolean): Inner {
+  c.r = { s: 1 };
+  if (flag) { c = other; }
+  return c.r;
+}
+export function overwrite(c: C, flag: boolean): Inner {
+  c.r = { s: 1 };
+  if (flag) { c.r = undefined; }
+  return c.r;
+}
+"#,
+            )],
+            &options,
+            base,
+        );
+        let negative_2322 = negative.iter().filter(|d| d.code == 2322).count();
+        assert_eq!(
+            negative_2322, 2,
+            "base reassignment and `undefined` overwrite on one branch must keep \
+             `undefined` at the merge (TS2322 at both returns); got {negative_2322} \
+             from {negative:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #13232. A property/element write before an `if` statement lost its flow
narrowing at the merge, producing a false `TS2322`:

```ts
interface Inner { s: number }
interface C { r?: Inner }
export function f(c: C, flag: boolean): Inner {
  c.r = { s: 1 };
  if (flag) {}
  return c.r;   // tsz: false TS2322 'Inner | undefined' ≰ 'Inner'; tsc: clean
}
```

This is the **line-16** facet the issue tracked. The earlier "resolver-less
still-generic conditional distribution" framing was a red herring: the source
and target `FetchResponse<MappedResponseType<R, T>>` relate fine. The real
failure is that `context.response` stayed `… | undefined` at the `return`
because the property-write narrowing was dropped at the `if`-join.

## Wrong operation

Flow narrowing — `condition_antecedent_requires_defer` (the CONDITION flow
node's antecedent defer classifier).

## Structural rule

When a CONDITION flow node's antecedent is an ASSIGNMENT that targets or affects
the reference being narrowed, the CONDITION must defer to that antecedent so the
assignment's narrowing reaches the join — tsz does this through the flow
worklist in `crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs`.

The classifier decided this with a symbol-equality shortcut
(`assignment_sym == symbol_id`) that only matches **plain-identifier**
references. A member-access reference (`c.r`, `o[k]`, `this.x`) carries no
`symbol_id` (the flow query resolves member-like references to `None`), so the
targeting assignment was missed, the CONDITION finalized on the un-narrowed
declared type, and the branch-label union re-introduced `undefined`. Without the
`if` (no CONDITION node) the walk reaches the assignment directly and narrows
correctly, which is why the single-statement form passed.

## Fix

Fall back to the same structural `assignment_targets_reference_node` /
`assignment_affects_reference_node` predicate the worklist's ASSIGNMENT branch
and the sibling `antecedent_requires_defer` classifier (in `core.rs`) already
use, gated by the O(1) `assignment_root_symbols_may_overlap` root pre-filter so
unrelated assignments stay cheap to reject. The two defer classifiers now agree
on what "targeting assignment" means. No name/file-string checks; the decision
is purely structural over the flow graph and reference shape.

## Owner layer

Checker flow narrowing (`flow/control_flow`). No solver/relation change.

## Adjacent-case matrix (all match tsc)

| case | shape | result |
|---|---|---|
| property write `c.r = …` + `if` | member | narrows ✓ |
| element write `o["r"] = …` + `if` | member | narrows ✓ |
| nested `t.mid.leaf = …` + `if` | member | narrows ✓ |
| local `let r; r = …` + `if` | identifier | narrows ✓ (unchanged) |
| `if/else` both arms | member | narrows ✓ |
| base reassigned on a branch `c = other` | member | keeps `undefined` → TS2322 ✓ |
| `c.r = undefined` on a branch | member | keeps `undefined` → TS2322 ✓ |

## Verification

- New focused test `member_property_write_narrowing_survives_if_join`
  (positive: property/element/local; negative: base-reassign, undefined-overwrite).
- Un-ignored the synthetic ofetch witness
  `program_mode_generic_conditional_in_contextual_return_stays_deferred` (#13831),
  now passing.
- Original 2-file ofetch witness: clean (exit 0).
- `cargo test -p tsz-cli --lib` (the two targeted tests): pass.
- Source-assertion tests in `flow_dp_memoization_tests.rs` unaffected (the
  asserted strings are unchanged).
- Broad flow/conformance/canary suites: owned by ready-review CI.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_014zXku3Tatstbbc1BnfJ6iC)_