### PR TITLE
fix(emitter): preserve alias-resolved Parameters tuple labels + TS2883 dedup order (#13867)

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
@@ -17,6 +17,17 @@ impl<'a> DeclarationEmitter<'a> {
             .or_else(|| {
                 self.super_method_call_return_type_text(expr_idx)
                     .or_else(|| self.generic_call_reverse_mapped_handler_type_text(expr_idx))
+                    // A tuple-shaped source return (`[...]`) is a high-priority
+                    // structural reconstruction, but it does not carry tuple
+                    // element labels. The rest-identity and Parameters-return
+                    // paths below recover labeled tuples for
+                    // `f(...g(...)): Parameters<...>` shapes (including ones
+                    // routed through a generic type-alias such as
+                    // `type ArgsOf<Fn> = Parameters<Fn>`). Try those labeled
+                    // paths first so an alias-resolved labeled tuple is not
+                    // clobbered by the unlabeled source-return tuple.
+                    .or_else(|| self.generic_rest_identity_parameters_tuple_type_text(expr_idx))
+                    .or_else(|| self.call_expression_parameters_return_tuple_type_text(expr_idx))
                     .or_else(|| {
                         self.call_expression_source_return_type_text(expr_idx)
                             .filter(|text| text.trim_start().starts_with('['))
@@ -29,8 +40,6 @@ impl<'a> DeclarationEmitter<'a> {
                     .or_else(|| self.call_expression_function_variable_return_type_text(expr_idx))
                     .or_else(|| self.generic_call_returned_identity_callback_type_text(expr_idx))
                     .or_else(|| self.call_expression_local_overload_return_type_text(expr_idx))
-                    .or_else(|| self.generic_rest_identity_parameters_tuple_type_text(expr_idx))
-                    .or_else(|| self.call_expression_parameters_return_tuple_type_text(expr_idx))
                     .or_else(|| self.generic_spread_array_call_return_type_text(expr_idx))
                     .or_else(|| {
                         self.explicit_type_argument_indexed_member_return_type_text(expr_idx)

--- a/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
@@ -957,70 +957,91 @@ fn probe_parenthesized_conditional_extends_type_remains_grouped() {
     );
 }
 
+// TS2883 argument canonicalization is owned by the structured emission site
+// `emit_non_portable_named_reference_diagnostic`, which classifies the two name
+// arguments by *path shape* (a structured-value decision) and always seats the
+// module path in the `from` slot before rendering. `take_diagnostics` then only
+// needs exact-key dedup. This replaces the former
+// `parse_ts2883_named_reference_message` string-parsing canonicalizer that PR
+// #13155 removed as an anti-hardcoding violation (a rendered diagnostic string
+// must not drive semantic decisions). These two tests therefore exercise the
+// structured canonicalizer rather than re-rendered message text.
+const TS2883_CANONICAL_FOO_MESSAGE: &str = "The inferred type of 'foo' cannot be named without a reference to 'SomeType' from '../node_modules/some-dep/dist/inner'. This is likely not portable. A type annotation is necessary.";
+
 #[test]
 fn take_diagnostics_drops_swapped_ts2883_when_canonical_exists() {
-    use tsz_common::diagnostics::Diagnostic;
-
     let (parser, _root) = parse_test_source("");
     let mut emitter = DeclarationEmitter::new(&parser.arena);
-    emitter.diagnostics.push(Diagnostic::from_code(
-        2883,
+
+    // Swapped structured form: the module path is supplied in the `type_name`
+    // slot and the type name in the `from_path` slot. The structured emitter
+    // restores canonical order from the path shape before rendering.
+    emitter.emit_non_portable_named_reference_diagnostic(
+        "foo",
         "src/index.ts",
         10,
         3,
-        &["foo", "Other", "../node_modules/some-dep/dist/inner"],
-    ));
-    emitter.diagnostics.push(Diagnostic::from_code(
-        2883,
+        "SomeType",
+        "../node_modules/some-dep/dist/inner",
+    );
+    // Canonical structured form for the same site.
+    emitter.emit_non_portable_named_reference_diagnostic(
+        "foo",
         "src/index.ts",
         10,
         3,
-        &["foo", "../node_modules/some-dep/dist/inner", "SomeType"],
-    ));
+        "../node_modules/some-dep/dist/inner",
+        "SomeType",
+    );
 
     let diagnostics = emitter.take_diagnostics();
     assert_eq!(
         diagnostics.len(),
         1,
-        "expected swapped TS2883 to be removed"
+        "expected swapped TS2883 to canonicalize and dedup away: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| d.message_text.as_str())
+            .collect::<Vec<_>>()
     );
-    assert_eq!(
-        diagnostics[0].message_text,
-        "The inferred type of 'foo' cannot be named without a reference to 'SomeType' from '../node_modules/some-dep/dist/inner'. This is likely not portable. A type annotation is necessary."
-    );
+    assert_eq!(diagnostics[0].message_text, TS2883_CANONICAL_FOO_MESSAGE);
 }
 
 #[test]
 fn take_diagnostics_keeps_ts2883_when_swapped_seen_before_canonical_duplicate() {
-    use tsz_common::diagnostics::Diagnostic;
-
     let (parser, _root) = parse_test_source("");
     let mut emitter = DeclarationEmitter::new(&parser.arena);
-    emitter.diagnostics.push(Diagnostic::from_code(
-        2883,
+
+    // Swapped form first, canonical form second: both canonicalize to the same
+    // message, so exactly one survives regardless of arrival order.
+    emitter.emit_non_portable_named_reference_diagnostic(
+        "foo",
         "src/index.ts",
         10,
         3,
-        &["foo", "../node_modules/some-dep/dist/inner", "SomeType"],
-    ));
-    emitter.diagnostics.push(Diagnostic::from_code(
-        2883,
+        "SomeType",
+        "../node_modules/some-dep/dist/inner",
+    );
+    emitter.emit_non_portable_named_reference_diagnostic(
+        "foo",
         "src/index.ts",
         10,
         3,
-        &["foo", "SomeType", "../node_modules/some-dep/dist/inner"],
-    ));
+        "../node_modules/some-dep/dist/inner",
+        "SomeType",
+    );
 
     let diagnostics = emitter.take_diagnostics();
     assert_eq!(
         diagnostics.len(),
         1,
-        "expected one surviving canonical TS2883 diagnostic"
+        "expected one surviving canonical TS2883 diagnostic: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| d.message_text.as_str())
+            .collect::<Vec<_>>()
     );
-    assert_eq!(
-        diagnostics[0].message_text,
-        "The inferred type of 'foo' cannot be named without a reference to 'SomeType' from '../node_modules/some-dep/dist/inner'. This is likely not portable. A type annotation is necessary."
-    );
+    assert_eq!(diagnostics[0].message_text, TS2883_CANONICAL_FOO_MESSAGE);
 }
 
 // ── Private class namespace emission ────────────────────────────────


### PR DESCRIPTION
Fixes the three deterministic `declaration_emitter` unit tests that wedge the merge queue (#13867).

Goal: hold

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- cargo nextest run -p tsz-emitter declaration_emitter --test-threads=1 → all pass (1496/1496). Previously-failing now green: `fix_verification_returned::fix_generic_rest_identity_preserves_parameters_tuple_labels`, `enum_template_and_advanced::take_diagnostics_drops_swapped_ts2883_when_canonical_exists`, `enum_template_and_advanced::take_diagnostics_keeps_ts2883_when_swapped_seen_before_canonical_duplicate`. The two tests #13276 added stay green: `class_features::test_js_async_class_method_emits_promise_return`, `generics_and_ambient::test_full_emit_unannotated_this_indexed_access_return_preserves_key_param`.
- cargo nextest run -p tsz-emitter --lib --test-threads=1 → 3751/3751 pass.
- Structural rule (Symptom A): when a DTS const initializer's inferred type is a generic rest-identity call whose callee returns a generic type-alias application that resolves to a labeled `Parameters<...>` tuple (e.g. `type ArgsOf<Fn> = Parameters<Fn>; getArgsAlias(x): ArgsOf<Fn>`), tsc preserves the tuple element labels; tsz dropped them because PR #13276's new high-priority `call_expression_source_return_type_text` (`[`-leading) branch in `call_expression_reused_type_text` (owner: `declaration_emitter/helpers/generic_call_literal.rs`) ran before the labeled rest-identity/Parameters-return paths and emitted the unlabeled `[object, number]`. Fixed by running the labeled-tuple paths (`generic_rest_identity_parameters_tuple_type_text`, `call_expression_parameters_return_tuple_type_text`) before the unlabeled source-return tuple branch. Direct `Parameters<Fn>` forms were already correct (their source-return path returns None).
- Structural rule (Symptom B): the swapped-vs-canonical TS2883 dedup the two `take_diagnostics` tests asserted was a rendered-message string parser (`parse_ts2883_named_reference_message`/`looks_like_module_path`) that PR #13155 removed as an anti-hardcoding violation (rendered diagnostic text must not drive decisions). Production now canonicalizes TS2883 argument order at the structured emission site `emit_non_portable_named_reference_diagnostic` (owner: `declaration_emitter/helpers/portability_resolve.rs`) by classifying the two name arguments by path shape, so `take_diagnostics` only needs exact-key dedup. The two tests were rewritten to drive through that structured canonicalizer instead of re-rendered message text; swapped and canonical structured forms collapse to one canonical diagnostic regardless of arrival order. No string-parsing of rendered output is reintroduced and no test is ignored.

Note: bisect in the issue attributed Symptom B to #13276, but the `normalize_portability_diagnostics` dedup is byte-identical between #13276's parent and HEAD; the canonicalizer was removed earlier by #13155 (an ancestor of the issue's bisect-good commit). Symptom B is therefore fixed forward at the structured layer rather than by reintroducing the removed string parser.
