### PR TITLE
fix(checker): monotone lib-interface body publication so deep DOM heritage survives the fresh per-file checker pool

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -39,6 +39,14 @@ filter = 'test(fuel_drained_earlier_statements_keep_select_callback_context) | t
 slow-timeout = { period = "120s", terminate-after = 2 }
 threads-required = "num-test-threads"
 
+# DOM lib-heritage publication witnesses intentionally build enough files to
+# exercise the fresh per-file checker pool. Run them alone with the longer
+# timeout used by other heavy checker regression tests.
+[[profile.default.overrides]]
+filter = 'test(dom_element_heritage_clean_sequential) | test(forced_parallel_lib_iterator_heritage_matches_sequential)'
+slow-timeout = { period = "120s", terminate-after = 2 }
+threads-required = "num-test-threads"
+
 [profile.default.junit]
 path = "target/nextest/default/junit.xml"
 
@@ -64,6 +72,13 @@ threads-required = "num-test-threads"
 # Issue #10677 / #10683 regression — see the matching default-profile override.
 [[profile.ci.overrides]]
 filter = 'test(fuel_drained_earlier_statements_keep_select_callback_context) | test(fuel_drained_inside_function_body_keeps_select_callback_context)'
+slow-timeout = { period = "120s", terminate-after = 2 }
+threads-required = "num-test-threads"
+
+# DOM lib-heritage publication witnesses — see the matching default-profile
+# override.
+[[profile.ci.overrides]]
+filter = 'test(dom_element_heritage_clean_sequential) | test(forced_parallel_lib_iterator_heritage_matches_sequential)'
 slow-timeout = { period = "120s", terminate-after = 2 }
 threads-required = "num-test-threads"
 

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -332,14 +332,24 @@ impl<'a> CheckerState<'a> {
             _ => None,
         };
 
+        let mut heritage_incomplete = false;
         if let Some(ty) = lib_type_id {
-            lib_type_id = Some(self.merge_lib_interface_heritage(ty, name).0);
+            let (merged, incomplete) = self.merge_lib_interface_heritage(ty, name);
+            lib_type_id = Some(merged);
+            heritage_incomplete = incomplete;
         }
 
         // Merge global augmentations (declare global { interface X { ... } }).
         if let Some(merged) = self.merge_global_augmentations(name, lib_type_id, &lib_contexts) {
             lib_type_id = Some(merged);
-            self.register_augmented_lib_body(name, merged);
+            // Only publish (and, via the monotone gate, pin) the finalized body
+            // when heritage is complete: an augmented body built on a
+            // heritage-incomplete (base-dropped) form is still missing inherited
+            // members, and pinning it would freeze the thin form in the shared
+            // store (#13862 / #12299).
+            if !heritage_incomplete {
+                self.register_augmented_lib_body(name, merged);
+            }
         }
 
         // Mirror into shared cache when safe (no local augmentations).

--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -1213,7 +1213,23 @@ impl<'a> CheckerState<'a> {
         // Finalize after heritage merge — `merge_lib_interface_heritage`
         // above may have produced a new TypeId; helper rewires type→def
         // and the DefId body so literal and annotation paths agree.
-        if let Some(ty) = lib_type_id {
+        //
+        // Gate on `!heritage_incomplete`: publishing a heritage-incomplete
+        // (base-dropped) body through `register_finalized_lib_body` writes it
+        // into the program-shared `DefinitionStore`, which sibling fresh
+        // per-file checkers read via `Lazy(DefId)` resolution. The store is
+        // last-writer-wins without the opt-in freeze, so a heritage-thin form
+        // (own members only, inherited members missing) published during the
+        // DOM `Node`/`Element`/`HTMLElement` cycle (#12299) can be observed by
+        // another checker's relation — producing false TS2345/TS2740/TS2322
+        // where a derived element interface is not recognized as its
+        // transitive base (e.g. `HTMLDivElement` not assignable to `Node`).
+        // The depth-0 drain below re-resolves the name once the dropped base
+        // has completed and publishes the full body, so skipping the publish
+        // here removes only the poisoned intermediate, never the final form.
+        if let Some(ty) = lib_type_id
+            && !heritage_incomplete
+        {
             self.register_finalized_lib_body(name, ty);
             // Update the symbol_types cache for the INTERFACE type position.
             // compute_type_of_symbol may have cached a DIFFERENT TypeId
@@ -1251,9 +1267,10 @@ impl<'a> CheckerState<'a> {
             // `lib_type_id` is missing inherited members. Mark `name` incomplete
             // and do NOT persist the type: remove the local slot and skip the
             // shared cache so the next request recomputes once the base has
-            // completed. The def body / `symbol_types` entries written above are
-            // overwritten by that recompute (`register_finalized_lib_body`
-            // rewires the body and clears eval caches). See #12299.
+            // completed. The finalized def-body / `symbol_types` publication is
+            // skipped above while incomplete, so the shared store never carries
+            // the heritage-thin form; the depth-0 drain's recompute publishes
+            // the full body once the dropped base resolves. See #12299.
             set_lib_resolution_mark(name, LibResolutionMark::Incomplete);
             self.ctx.lib_type_resolution_caches.types.remove(name);
             return lib_type_id;

--- a/crates/tsz-cli/tests/parallel_sequential_agreement_tests.rs
+++ b/crates/tsz-cli/tests/parallel_sequential_agreement_tests.rs
@@ -300,3 +300,105 @@ fn forced_parallel_scope_registry_alias_republication_matches_sequential() {
         7,
     );
 }
+
+/// Fifth witness family (#13862): deep-heritage DOM lib interfaces materialized
+/// by the fresh per-file checker pool. A derived element interface
+/// (`HTMLxElement extends HTMLElement extends Element extends Node`) is a valid
+/// `Node`, but the shared `DefinitionStore` was last-writer-wins, so a
+/// heritage-thin body re-derived by a sibling checker could clobber the
+/// heritage-merged form mid-`Node`/`Element`/`HTMLElement` diamond resolution
+/// (#12299) and a reader's relation saw the thin one — false `TS2345`/`TS2740`
+/// where the element was "missing the following properties from type 'Node'".
+///
+/// The pool path only engages above the small-project session-reuse ceiling
+/// (`FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES`, 32), so this drives a 40-file
+/// project. Each file names a *distinct* DOM element interface (varied binders
+/// per the anti-hardcoding test discipline) and asserts assignability to `Node`.
+///
+/// This pins the default (DOM-gated sequential) schedule users actually hit:
+/// DOM projects keep `should_use_sequential_fresh_checking` on
+/// (`has_parallel_order_sensitive_global_lib`), so the program must type-check
+/// clean here. Pre-fix this emitted a deterministic cluster of false
+/// diagnostics. Lifting the DOM serialization gate so the *forced-parallel*
+/// schedule is also clean/byte-identical is the separate materialization
+/// campaign tracked in #13862 / #13861.
+const DOM_ELEMENT_NAMES: &[&str] = &[
+    "Div",
+    "Span",
+    "Heading",
+    "Paragraph",
+    "Pre",
+    "Body",
+    "Style",
+    "Script",
+    "Meta",
+    "Link",
+    "Source",
+    "Map",
+    "Meter",
+    "Option",
+    "Label",
+    "Legend",
+    "Dialog",
+    "Details",
+    "DataList",
+    "Data",
+    "Base",
+    "Audio",
+    "Table",
+    "Form",
+    "Input",
+    "Select",
+    "Button",
+    "Anchor",
+    "Area",
+    "Canvas",
+    "Object",
+    "Output",
+    "Embed",
+    "FieldSet",
+    "Image",
+    "Progress",
+    "Quote",
+    "Title",
+    "Time",
+    "Track",
+];
+
+const DOM_HERITAGE_TSCONFIG: &str = r#"{
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["dom", "es2020"],
+    "strict": true,
+    "skipLibCheck": true,
+    "module": "es2020",
+    "target": "es2020"
+  },
+  "include": ["*.ts"]
+}"#;
+
+/// Deep-heritage DOM element interfaces must type-check clean (assignable to
+/// `Node`) when the program is large enough to engage the fresh per-file
+/// checker pool on the default DOM-gated sequential schedule.
+#[test]
+fn dom_element_heritage_clean_sequential() {
+    let Some(tsz_bin) = find_tsz_binary() else {
+        println!("skipping DOM heritage test: tsz binary not found");
+        return;
+    };
+    let temp = TempDir::new("dom_heritage").expect("temp dir");
+    for (i, elem) in DOM_ELEMENT_NAMES.iter().enumerate() {
+        let contents = format!(
+            "export function use_{elem}(node: HTML{elem}Element): Node {{\n    return node;\n}}\n"
+        );
+        std::fs::write(temp.path.join(format!("f{i}.ts")), contents).expect("write fixture file");
+    }
+    std::fs::write(temp.path.join("tsconfig.json"), DOM_HERITAGE_TSCONFIG).expect("write tsconfig");
+
+    let output = run_project(&tsz_bin, &temp.path, false);
+    assert!(
+        !output.contains("error TS"),
+        "DOM element interfaces must be recognized as Node under the fresh per-file \
+         checker pool (default sequential schedule); got diagnostics:\n{output}"
+    );
+}

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -45,6 +45,19 @@ use tsz_common::interner::Atom;
 /// Used for debugging `DefId` collision issues.
 static NEXT_INSTANCE_ID: AtomicU64 = AtomicU64::new(1);
 
+/// Whether monotone lib-interface body publication (#13862) is active.
+///
+/// Default-on; `TSZ_DISABLE_LIB_DEF_MONOTONE=1` is the kill switch. When on, a
+/// def whose finalized lib-interface body has been published rejects later
+/// non-finalize different-body overwrites (heritage-thin re-derivations from
+/// sibling fresh per-file checkers), so the shared store keeps the
+/// heritage-complete form. See `set_body_with_params_impl`.
+fn lib_def_monotone_publish_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| !std::env::var("TSZ_DISABLE_LIB_DEF_MONOTONE").is_ok_and(|v| v == "1"))
+}
+
 type CrossFileQueryCacheKey = (u8, u32, u32, u32, u64);
 type CrossFileQueryCacheValue = (TypeId, Arc<Vec<TypeParamInfo>>);
 type DefDashMap<K, V> = DashMap<K, V, FxBuildHasher>;
@@ -830,6 +843,29 @@ impl DefinitionStore {
             }
             if suppressed || deferred {
                 return;
+            }
+
+            // Monotone lib-interface publication (#13862): the program-shared
+            // `DefinitionStore` is read by sibling fresh per-file checkers via
+            // `Lazy(DefId)` resolution. Without isolation it is last-writer-wins,
+            // so a heritage-thin body re-derived by a cross-arena lowering path
+            // (`resolver.rs` `insert_def_with_params`, the cross-file delegation
+            // helpers) can clobber the heritage-merged body another checker
+            // already finalized — the DOM `Node`/`Element`/`HTMLElement` diamond
+            // (#12299) then oscillates between forms and a reader's relation sees
+            // the thin one (false TS2345/TS2740/TS2322 where a derived element
+            // interface is not recognized as its transitive base). Once a
+            // *finalized* interface body is published (only
+            // `register_finalized_lib_body` reaches the finalize entry point, and
+            // only on heritage-complete resolution — see `lib_resolution`), mark
+            // the def deferred so later non-finalize different-body overwrites are
+            // dropped. Marking at the finalize point (rather than blanket
+            // up-front, the opt-in `mark_non_program_interface_defs_deferred`
+            // path) keeps the load-bearing pre-finalize forms for augmented names
+            // intact — finalize re-publications (which carry the augmentation)
+            // still win. Kill switch: `TSZ_DISABLE_LIB_DEF_MONOTONE=1`.
+            if finalize && entry.kind == DefKind::Interface && lib_def_monotone_publish_enabled() {
+                self.state_flags.mark_deferred_publish(id);
             }
 
             // Identical republication is a no-op: nothing a reader can


### PR DESCRIPTION
Goal: green

Fixes a deterministic, sequentially-reproducible sub-root of #13862: the deep-heritage DOM **element-interface subtype** cluster (the `appendChild(HTMLHeadingElement)` → false `TS2345` witness). This is distinct from the concurrent raw-`SymbolId` cross-lib-binder collision sub-root (`HTMLElementTagNameMap["div"]` → `FileSystemEntry`, the `createElement` cluster) being landed separately — different files/functions, different witnesses; the two are complementary.

## Symptom

A program large enough to engage the **fresh per-file checker pool** (more than `FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES` = 32 files) emits a deterministic cluster of false positives where a derived DOM element interface is not recognized as its transitive base:

```
TS2345: Argument of type 'HTMLDivElement' is not assignable to parameter of type 'Node'.
  Type 'HTMLDivElement' is missing the following properties from type 'Node': baseURI, childNodes, firstChild, isConnected, and 46 more.
```

(also `TS2740`/`TS2322` of the same family). Single-file / ≤32-file projects (session-reuse path) are clean. `tsc` accepts all of these — every `HTML*Element` is a `Node` (`HTML*Element → HTMLElement → Element → Node`).

## Root cause

Sibling fresh per-file checkers share one program `DefinitionStore`, which the relation reads via `Lazy(DefId)` resolution. The store was **last-writer-wins**, so a heritage-thin body (own members only, inherited members missing) re-derived by a cross-arena lowering path (`resolver.rs` `insert_def_with_params`, the cross-file delegation helpers) could clobber the heritage-merged body another checker already finalized. During the DOM `Node`/`Element`/`HTMLElement` diamond (#12299) the def body oscillates between forms (`TSZ_DEF_PUBLICATION_CENSUS` shows 3–5 distinct bodies for `Element`/`HTMLElement`) and a reader's relation observes the thin one.

Structural rule: when a generic-free lib interface with a heritage chain is materialized by more than one fresh per-file checker, `tsc` always relates the full transitive member set; tsz let a later checker publish a less-complete body into the shared store, so a reader saw the incomplete form.

## Fix

Two parts, both behind the existing finalize/deferred-publication machinery:

1. `lib_resolution` / `lib`: do **not** publish a heritage-incomplete (base-dropped) body through `register_finalized_lib_body`. The depth-0 heritage drain (#12299) re-resolves the name once the dropped base completes and publishes the full body — so the shared store never carries the heritage-thin form. Preserves the finalize entry point's invariant *finalized ⇒ heritage-complete*.

2. `def` store (`set_body_with_params_impl`): once a **finalized** lib-interface body is published, mark the def deferred so later **non-finalize** different-body overwrites are dropped (monotone publication). Marking at the finalize point — rather than the blanket up-front `mark_non_program_interface_defs_deferred` (the opt-in path that regressed the augmentation class) — keeps load-bearing pre-finalize forms for augmented names intact: finalize re-publications (which carry the augmentation) still win, so `declare global { interface Window/ImportMeta { … } }` augmentations remain visible. Kill switch: `TSZ_DISABLE_LIB_DEF_MONOTONE=1`.

Scope note: this fixes the **default DOM-gated sequential** schedule users hit. Making the *forced-parallel* schedule byte-identical (lifting `should_use_sequential_fresh_checking`) is the separate materialization campaign in #13862 / #13861 and is intentionally out of scope.

## Anti-hardcoding

No user-name / file-name / printer-string predicates. The gate is purely structural: completeness of heritage resolution (`heritage_incomplete`) and the def-store finalize/publication state. The regression test varies the element binder across 40 distinct DOM interfaces.

## Verification

- New regression test `dom_element_heritage_clean_sequential` (40 files, varied element binders) — fails pre-fix, passes post-fix.
- `cargo test -p tsz-cli --test parallel_sequential_agreement_tests` — 5/5 pass (4 pre-existing agreement tests unaffected).
- `cargo test -p tsz-solver --lib def::` — 98/98 pass.
- `cargo test -p tsz-checker --test lib_resolution_identity_tests` — 169/169 pass.
- `cargo clippy -p tsz-solver -p tsz-checker -p tsz-cli --all-targets` — clean; `cargo fmt --check` — clean.
- Manual: 33/36/50-file DOM repros go from 19/23/82 false positives → 0 heritage-`Node` errors (the lone residual in the 50-file mixed repro is the *other* sub-root, `AudioData` served for `HTMLAnchorElement`). Augmentation repro: augmented `window`/`import.meta` members stay visible; a genuinely-missing member still errors `TS2339`. Kill switch `TSZ_DISABLE_LIB_DEF_MONOTONE=1` restores the bug.
- Full conformance / DOM corpus parity: deferred to ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_015Tix61G689W2LFpPS7YRjD)_