### PR TITLE
perf(solver): classify application eval cache eligibility

### DIFF
--- a/crates/tsz-solver/src/evaluation/eval_materialization_probe.rs
+++ b/crates/tsz-solver/src/evaluation/eval_materialization_probe.rs
@@ -125,6 +125,7 @@ struct ProbeState {
     /// Structural-hash -> first distinct result `TypeId` of that hash, per
     /// kind. Detects the hash-cons gap in #2 above.
     result_structural_hash: [DashMap<u64, u32, FxBuildHasher>; PROBE_KIND_COUNT],
+    application_cache: ApplicationCacheTotals,
 }
 
 fn new_dashset() -> DashSet<u32, FxBuildHasher> {
@@ -145,7 +146,161 @@ fn state() -> &'static ProbeState {
         eager_conditional_inputs: new_dashset(),
         eager_conditional_computes: AtomicU64::new(0),
         result_structural_hash: [new_dashmap(), new_dashmap(), new_dashmap()],
+        application_cache: ApplicationCacheTotals::new(),
     })
+}
+
+struct ApplicationCacheTotals {
+    entries_with_def_id: AtomicU64,
+    entries_without_def_id: AtomicU64,
+    entries_without_query_db: AtomicU64,
+    raw_lookup_hits: AtomicU64,
+    raw_lookup_misses: AtomicU64,
+    expanded_lookup_hits: AtomicU64,
+    expanded_lookup_misses: AtomicU64,
+    body_known_params: AtomicU64,
+    body_extracted_params: AtomicU64,
+    body_value_call_return: AtomicU64,
+    body_typeof_specialized: AtomicU64,
+    body_opaque_unresolved_no_body: AtomicU64,
+    body_opaque_resolved_unknown: AtomicU64,
+    body_opaque_self_lazy: AtomicU64,
+    body_opaque_typequery_callable: AtomicU64,
+    body_opaque_extracted_mismatch: AtomicU64,
+    body_opaque_no_registered_body: AtomicU64,
+    cache_insert_eligible: AtomicU64,
+    cache_insert_skipped_limit: AtomicU64,
+    cache_insert_skipped_no_query_db: AtomicU64,
+}
+
+impl ApplicationCacheTotals {
+    const fn new() -> Self {
+        Self {
+            entries_with_def_id: AtomicU64::new(0),
+            entries_without_def_id: AtomicU64::new(0),
+            entries_without_query_db: AtomicU64::new(0),
+            raw_lookup_hits: AtomicU64::new(0),
+            raw_lookup_misses: AtomicU64::new(0),
+            expanded_lookup_hits: AtomicU64::new(0),
+            expanded_lookup_misses: AtomicU64::new(0),
+            body_known_params: AtomicU64::new(0),
+            body_extracted_params: AtomicU64::new(0),
+            body_value_call_return: AtomicU64::new(0),
+            body_typeof_specialized: AtomicU64::new(0),
+            body_opaque_unresolved_no_body: AtomicU64::new(0),
+            body_opaque_resolved_unknown: AtomicU64::new(0),
+            body_opaque_self_lazy: AtomicU64::new(0),
+            body_opaque_typequery_callable: AtomicU64::new(0),
+            body_opaque_extracted_mismatch: AtomicU64::new(0),
+            body_opaque_no_registered_body: AtomicU64::new(0),
+            cache_insert_eligible: AtomicU64::new(0),
+            cache_insert_skipped_limit: AtomicU64::new(0),
+            cache_insert_skipped_no_query_db: AtomicU64::new(0),
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub(crate) enum ApplicationLookupSite {
+    RawArgs,
+    ExpandedArgs,
+}
+
+#[derive(Copy, Clone)]
+pub(crate) enum ApplicationBodyPath {
+    KnownParams,
+    ExtractedParams,
+    ValueCallReturn,
+    TypeofSpecialized,
+    OpaqueUnresolvedNoBody,
+    OpaqueResolvedUnknown,
+    OpaqueSelfLazy,
+    OpaqueTypeQueryCallable,
+    OpaqueExtractedMismatch,
+    OpaqueNoRegisteredBody,
+}
+
+/// Record whether an application input has a `DefId` cache key and whether
+/// this evaluator may consult the authoritative query cache.
+#[inline]
+pub(crate) fn record_application_entry(has_def_id: bool, has_query_db: bool) {
+    if !gate_enabled() {
+        return;
+    }
+    let totals = &state().application_cache;
+    if has_def_id {
+        totals.entries_with_def_id.fetch_add(1, Ordering::Relaxed);
+        if !has_query_db {
+            totals
+                .entries_without_query_db
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    } else {
+        totals
+            .entries_without_def_id
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Record one `application_eval_cache` lookup and whether it short-circuited.
+#[inline]
+pub(crate) fn record_application_cache_lookup(site: ApplicationLookupSite, hit: bool) {
+    if !gate_enabled() {
+        return;
+    }
+    let totals = &state().application_cache;
+    let counter = match (site, hit) {
+        (ApplicationLookupSite::RawArgs, true) => &totals.raw_lookup_hits,
+        (ApplicationLookupSite::RawArgs, false) => &totals.raw_lookup_misses,
+        (ApplicationLookupSite::ExpandedArgs, true) => &totals.expanded_lookup_hits,
+        (ApplicationLookupSite::ExpandedArgs, false) => &totals.expanded_lookup_misses,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record which application body path the evaluator dispatched to after the
+/// raw-args lookup. Body-specific expanded-args lookups may still short-circuit
+/// inside the known/extracted path.
+#[inline]
+pub(crate) fn record_application_body_path(path: ApplicationBodyPath) {
+    if !gate_enabled() {
+        return;
+    }
+    let totals = &state().application_cache;
+    let counter = match path {
+        ApplicationBodyPath::KnownParams => &totals.body_known_params,
+        ApplicationBodyPath::ExtractedParams => &totals.body_extracted_params,
+        ApplicationBodyPath::ValueCallReturn => &totals.body_value_call_return,
+        ApplicationBodyPath::TypeofSpecialized => &totals.body_typeof_specialized,
+        ApplicationBodyPath::OpaqueUnresolvedNoBody => &totals.body_opaque_unresolved_no_body,
+        ApplicationBodyPath::OpaqueResolvedUnknown => &totals.body_opaque_resolved_unknown,
+        ApplicationBodyPath::OpaqueSelfLazy => &totals.body_opaque_self_lazy,
+        ApplicationBodyPath::OpaqueTypeQueryCallable => &totals.body_opaque_typequery_callable,
+        ApplicationBodyPath::OpaqueExtractedMismatch => &totals.body_opaque_extracted_mismatch,
+        ApplicationBodyPath::OpaqueNoRegisteredBody => &totals.body_opaque_no_registered_body,
+    };
+    counter.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record whether a computed application result was eligible to be written to
+/// the `(DefId, expanded_args, options)` cache.
+#[inline]
+pub(crate) fn record_application_cache_insert(cacheable: bool, has_query_db: bool) {
+    if !gate_enabled() {
+        return;
+    }
+    let totals = &state().application_cache;
+    if !cacheable {
+        totals
+            .cache_insert_skipped_limit
+            .fetch_add(1, Ordering::Relaxed);
+    } else if !has_query_db {
+        totals
+            .cache_insert_skipped_no_query_db
+            .fetch_add(1, Ordering::Relaxed);
+    } else {
+        totals.cache_insert_eligible.fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 /// Classify an input `TypeData` into the eval-engine kind the lever targets.
@@ -243,6 +398,58 @@ fn snapshot_kind(idx: usize) -> KindRow {
     }
 }
 
+#[derive(Default)]
+struct ApplicationCacheRow {
+    entries_with_def_id: u64,
+    entries_without_def_id: u64,
+    entries_without_query_db: u64,
+    raw_lookup_hits: u64,
+    raw_lookup_misses: u64,
+    expanded_lookup_hits: u64,
+    expanded_lookup_misses: u64,
+    body_known_params: u64,
+    body_extracted_params: u64,
+    body_value_call_return: u64,
+    body_typeof_specialized: u64,
+    body_opaque_unresolved_no_body: u64,
+    body_opaque_resolved_unknown: u64,
+    body_opaque_self_lazy: u64,
+    body_opaque_typequery_callable: u64,
+    body_opaque_extracted_mismatch: u64,
+    body_opaque_no_registered_body: u64,
+    cache_insert_eligible: u64,
+    cache_insert_skipped_limit: u64,
+    cache_insert_skipped_no_query_db: u64,
+}
+
+fn snapshot_application_cache() -> ApplicationCacheRow {
+    let t = &state().application_cache;
+    ApplicationCacheRow {
+        entries_with_def_id: t.entries_with_def_id.load(Ordering::Relaxed),
+        entries_without_def_id: t.entries_without_def_id.load(Ordering::Relaxed),
+        entries_without_query_db: t.entries_without_query_db.load(Ordering::Relaxed),
+        raw_lookup_hits: t.raw_lookup_hits.load(Ordering::Relaxed),
+        raw_lookup_misses: t.raw_lookup_misses.load(Ordering::Relaxed),
+        expanded_lookup_hits: t.expanded_lookup_hits.load(Ordering::Relaxed),
+        expanded_lookup_misses: t.expanded_lookup_misses.load(Ordering::Relaxed),
+        body_known_params: t.body_known_params.load(Ordering::Relaxed),
+        body_extracted_params: t.body_extracted_params.load(Ordering::Relaxed),
+        body_value_call_return: t.body_value_call_return.load(Ordering::Relaxed),
+        body_typeof_specialized: t.body_typeof_specialized.load(Ordering::Relaxed),
+        body_opaque_unresolved_no_body: t.body_opaque_unresolved_no_body.load(Ordering::Relaxed),
+        body_opaque_resolved_unknown: t.body_opaque_resolved_unknown.load(Ordering::Relaxed),
+        body_opaque_self_lazy: t.body_opaque_self_lazy.load(Ordering::Relaxed),
+        body_opaque_typequery_callable: t.body_opaque_typequery_callable.load(Ordering::Relaxed),
+        body_opaque_extracted_mismatch: t.body_opaque_extracted_mismatch.load(Ordering::Relaxed),
+        body_opaque_no_registered_body: t.body_opaque_no_registered_body.load(Ordering::Relaxed),
+        cache_insert_eligible: t.cache_insert_eligible.load(Ordering::Relaxed),
+        cache_insert_skipped_limit: t.cache_insert_skipped_limit.load(Ordering::Relaxed),
+        cache_insert_skipped_no_query_db: t
+            .cache_insert_skipped_no_query_db
+            .load(Ordering::Relaxed),
+    }
+}
+
 /// Format the probe measurements as a multi-line report. Returns an empty
 /// string when counters are disabled, so callers can append it
 /// unconditionally next to the perf-counter dump.
@@ -312,6 +519,96 @@ pub fn dump_report() -> String {
         "  eager recompute headroom {eager_recompute:>12}  ({eager_pct:.1}% of eager computes)"
     );
 
+    let app_kind = snapshot_kind(ProbeKind::Application as usize);
+    let app_cache = snapshot_application_cache();
+    let app_recompute = app_kind.computes.saturating_sub(app_kind.distinct_inputs);
+    let app_cache_hits = app_cache.raw_lookup_hits + app_cache.expanded_lookup_hits;
+    let not_explained_by_def_args = app_recompute.saturating_sub(app_cache_hits);
+    let opaque_body_paths = app_cache.body_opaque_unresolved_no_body
+        + app_cache.body_opaque_resolved_unknown
+        + app_cache.body_opaque_self_lazy
+        + app_cache.body_opaque_typequery_callable
+        + app_cache.body_opaque_extracted_mismatch
+        + app_cache.body_opaque_no_registered_body;
+    let _ = writeln!(out, "[application cache eligibility]");
+    let _ = writeln!(out, "  application input recomputes {app_recompute:>12}");
+    let _ = writeln!(
+        out,
+        "  `(DefId,args)` cache hits     {app_cache_hits:>12}  (raw {}, expanded {})",
+        app_cache.raw_lookup_hits, app_cache.expanded_lookup_hits
+    );
+    let _ = writeln!(
+        out,
+        "  recomputes beyond cache hits {not_explained_by_def_args:>12}  (lower bound)"
+    );
+    let _ = writeln!(
+        out,
+        "  entries with DefId           {:>12}",
+        app_cache.entries_with_def_id
+    );
+    let _ = writeln!(
+        out,
+        "  entries without DefId        {:>12}",
+        app_cache.entries_without_def_id
+    );
+    let _ = writeln!(
+        out,
+        "  DefId entries without DB     {:>12}",
+        app_cache.entries_without_query_db
+    );
+    let _ = writeln!(
+        out,
+        "  raw lookups hit/miss         {:>12}/{:<12}",
+        app_cache.raw_lookup_hits, app_cache.raw_lookup_misses
+    );
+    let _ = writeln!(
+        out,
+        "  expanded lookups hit/miss    {:>12}/{:<12}",
+        app_cache.expanded_lookup_hits, app_cache.expanded_lookup_misses
+    );
+    let _ = writeln!(
+        out,
+        "  dispatch known/extracted     {:>12}/{:<12}",
+        app_cache.body_known_params, app_cache.body_extracted_params
+    );
+    let _ = writeln!(
+        out,
+        "  uncached special paths       {:>12}  (value-call {}, typeof {})",
+        app_cache.body_value_call_return + app_cache.body_typeof_specialized,
+        app_cache.body_value_call_return,
+        app_cache.body_typeof_specialized
+    );
+    let _ = writeln!(
+        out,
+        "  opaque body paths            {opaque_body_paths:>12}"
+    );
+    let _ = writeln!(
+        out,
+        "    unresolved/unknown/self    {:>12}/{:<12}/{:<12}",
+        app_cache.body_opaque_unresolved_no_body,
+        app_cache.body_opaque_resolved_unknown,
+        app_cache.body_opaque_self_lazy
+    );
+    let _ = writeln!(
+        out,
+        "    typequery/mismatch/nobody  {:>12}/{:<12}/{:<12}",
+        app_cache.body_opaque_typequery_callable,
+        app_cache.body_opaque_extracted_mismatch,
+        app_cache.body_opaque_no_registered_body
+    );
+    let _ = writeln!(
+        out,
+        "  cache inserts eligible       {:>12}",
+        app_cache.cache_insert_eligible
+    );
+    let _ = writeln!(
+        out,
+        "  cache inserts skipped        {:>12}  (limit {}, no-db {})",
+        app_cache.cache_insert_skipped_limit + app_cache.cache_insert_skipped_no_query_db,
+        app_cache.cache_insert_skipped_limit,
+        app_cache.cache_insert_skipped_no_query_db
+    );
+
     let overall_fanout = pct(
         total_computes.saturating_sub(total_distinct_results),
         total_computes.max(1),
@@ -345,6 +642,11 @@ fn kind_snapshot_for_tests(idx: usize) -> (u64, u64, u64, u64) {
         r.distinct_results,
         r.deferred_results,
     )
+}
+
+#[cfg(test)]
+fn application_cache_snapshot_for_tests() -> ApplicationCacheRow {
+    snapshot_application_cache()
 }
 
 #[cfg(test)]
@@ -434,6 +736,11 @@ mod tests {
         FORCE_PROBE_FOR_TESTS.store(true, Ordering::Relaxed);
         let app = TypeData::Application(TypeApplicationId(11));
         record_compute(TypeId(900), &app, TypeId(901), None);
+        record_application_entry(true, true);
+        record_application_cache_lookup(ApplicationLookupSite::RawArgs, false);
+        record_application_cache_lookup(ApplicationLookupSite::ExpandedArgs, true);
+        record_application_body_path(ApplicationBodyPath::KnownParams);
+        record_application_cache_insert(true, true);
         let report = dump_report();
         assert!(
             report.contains("eval-materialization probe"),
@@ -442,6 +749,62 @@ mod tests {
         assert!(
             report.contains("recompute headroom"),
             "report should expose recompute headroom"
+        );
+        assert!(
+            report.contains("application cache eligibility"),
+            "report should expose the application cache eligibility split"
+        );
+    }
+
+    /// Application cache counters split `(DefId,args)` eligibility from opaque
+    /// and tainted paths so #13250 follow-ups can tell whether the existing
+    /// application-eval cache key is the right reuse layer.
+    #[test]
+    fn application_cache_eligibility_counters_record_deltas() {
+        FORCE_PROBE_FOR_TESTS.store(true, Ordering::Relaxed);
+        let before = application_cache_snapshot_for_tests();
+
+        record_application_entry(true, false);
+        record_application_entry(false, false);
+        record_application_cache_lookup(ApplicationLookupSite::RawArgs, false);
+        record_application_cache_lookup(ApplicationLookupSite::ExpandedArgs, true);
+        record_application_body_path(ApplicationBodyPath::OpaqueResolvedUnknown);
+        record_application_body_path(ApplicationBodyPath::ExtractedParams);
+        record_application_cache_insert(false, true);
+        record_application_cache_insert(true, false);
+        record_application_cache_insert(true, true);
+
+        let after = application_cache_snapshot_for_tests();
+        assert_eq!(after.entries_with_def_id - before.entries_with_def_id, 1);
+        assert_eq!(
+            after.entries_without_def_id - before.entries_without_def_id,
+            1
+        );
+        assert_eq!(
+            after.entries_without_query_db - before.entries_without_query_db,
+            1
+        );
+        assert_eq!(after.raw_lookup_misses - before.raw_lookup_misses, 1);
+        assert_eq!(after.expanded_lookup_hits - before.expanded_lookup_hits, 1);
+        assert_eq!(
+            after.body_opaque_resolved_unknown - before.body_opaque_resolved_unknown,
+            1
+        );
+        assert_eq!(
+            after.body_extracted_params - before.body_extracted_params,
+            1
+        );
+        assert_eq!(
+            after.cache_insert_skipped_limit - before.cache_insert_skipped_limit,
+            1
+        );
+        assert_eq!(
+            after.cache_insert_skipped_no_query_db - before.cache_insert_skipped_no_query_db,
+            1
+        );
+        assert_eq!(
+            after.cache_insert_eligible - before.cache_insert_eligible,
+            1
         );
     }
 }

--- a/crates/tsz-solver/src/evaluation/evaluate/application.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/application.rs
@@ -46,8 +46,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // defining `DefId` stay opaque so later passes with a richer
         // resolver can expand them.
         let Some(def_id) = self.resolve_application_def_id(app.base) else {
+            crate::evaluation::eval_materialization_probe::record_application_entry(false, false);
             return self.evaluate_application_no_def_id(app_id, original_type_id);
         };
+        crate::evaluation::eval_materialization_probe::record_application_entry(
+            true,
+            self.query_db.is_some(),
+        );
 
         tracing::trace!(
             base = app.base.0,
@@ -90,8 +95,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // skip the fallback behavior that preserves recursive/inference parity.
         if let Some(db) = self.query_db {
             let no_unchecked = self.no_unchecked_indexed_access;
-            if let Some(cached) = db.lookup_application_eval_cache(def_id, &app.args, no_unchecked)
-            {
+            let cached = db.lookup_application_eval_cache(def_id, &app.args, no_unchecked);
+            crate::evaluation::eval_materialization_probe::record_application_cache_lookup(
+                crate::evaluation::eval_materialization_probe::ApplicationLookupSite::RawArgs,
+                cached.is_some(),
+            );
+            if let Some(cached) = cached {
                 self.decrement_def_depth(def_id);
                 return cached;
             }
@@ -292,12 +301,18 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             && let Some(resolved) = ctx.resolved
             && let Some(call_return) = self.value_call_return_application(def_id, resolved, args)
         {
+            crate::evaluation::eval_materialization_probe::record_application_body_path(
+                crate::evaluation::eval_materialization_probe::ApplicationBodyPath::ValueCallReturn,
+            );
             return ApplicationEvalOutcome::Computed(call_return);
         }
 
         // `typeof f<Args>` instantiation expression: specialize per-signature
         // (consume, not shadow, the callable's type params) — see helper (#10933).
         if let Some(specialized) = self.try_specialize_typeof_instantiation_expression(ctx, args) {
+            crate::evaluation::eval_materialization_probe::record_application_body_path(
+                crate::evaluation::eval_materialization_probe::ApplicationBodyPath::TypeofSpecialized,
+            );
             return ApplicationEvalOutcome::Computed(specialized);
         }
 
@@ -308,6 +323,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // published it yet). The opaque result is a registration-window
                 // artifact — keep it out of the persistent caches.
                 self.mark_unresolved_def_seen();
+                crate::evaluation::eval_materialization_probe::record_application_body_path(
+                    crate::evaluation::eval_materialization_probe::ApplicationBodyPath::OpaqueUnresolvedNoBody,
+                );
                 return ApplicationEvalOutcome::Computed(original_type_id);
             };
             // When the resolver returns `unknown` for the alias body, the
@@ -320,6 +338,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // expand it correctly.
             if resolved == TypeId::UNKNOWN {
                 self.mark_unresolved_def_seen();
+                crate::evaluation::eval_materialization_probe::record_application_body_path(
+                    crate::evaluation::eval_materialization_probe::ApplicationBodyPath::OpaqueResolvedUnknown,
+                );
                 return ApplicationEvalOutcome::Computed(original_type_id);
             }
 
@@ -348,8 +369,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 )
             {
                 self.mark_unresolved_def_seen();
+                crate::evaluation::eval_materialization_probe::record_application_body_path(
+                    crate::evaluation::eval_materialization_probe::ApplicationBodyPath::OpaqueSelfLazy,
+                );
                 return ApplicationEvalOutcome::Computed(original_type_id);
             }
+            crate::evaluation::eval_materialization_probe::record_application_body_path(
+                crate::evaluation::eval_materialization_probe::ApplicationBodyPath::KnownParams,
+            );
             self.evaluate_application_with_known_params(
                 def_id,
                 original_type_id,
@@ -370,6 +397,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 && matches!(self.interner.lookup(resolved), Some(TypeData::Callable(_)))
                 && !args.is_empty()
             {
+                crate::evaluation::eval_materialization_probe::record_application_body_path(
+                    crate::evaluation::eval_materialization_probe::ApplicationBodyPath::OpaqueTypeQueryCallable,
+                );
                 return ApplicationEvalOutcome::Computed(original_type_id);
             }
             // Class-instance extraction must apply on this path too: when a
@@ -381,6 +411,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             let resolved = self.extract_class_instance_body(def_id, resolved);
             let extracted_params = self.extract_type_params_from_type(resolved);
             if !extracted_params.is_empty() && extracted_params.len() == args.len() {
+                crate::evaluation::eval_materialization_probe::record_application_body_path(
+                    crate::evaluation::eval_materialization_probe::ApplicationBodyPath::ExtractedParams,
+                );
                 self.evaluate_application_with_extracted_params(
                     def_id,
                     original_type_id,
@@ -390,6 +423,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     ctx.prefer_application_display_alias,
                 )
             } else {
+                crate::evaluation::eval_materialization_probe::record_application_body_path(
+                    crate::evaluation::eval_materialization_probe::ApplicationBodyPath::OpaqueExtractedMismatch,
+                );
                 ApplicationEvalOutcome::Computed(original_type_id)
             }
         } else {
@@ -398,6 +434,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // its target, or a def evaluated before its declaring file
             // published anything). Same registration-window taint as above.
             self.mark_unresolved_def_seen();
+            crate::evaluation::eval_materialization_probe::record_application_body_path(
+                crate::evaluation::eval_materialization_probe::ApplicationBodyPath::OpaqueNoRegisteredBody,
+            );
             ApplicationEvalOutcome::Computed(original_type_id)
         }
     }
@@ -419,14 +458,19 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let expanded_args = self.prepare_expanded_args_for_body(resolved, args);
         let no_unchecked_indexed_access = self.no_unchecked_indexed_access;
 
-        if let Some(db) = self.query_db
-            && let Some(cached) = db.lookup_application_eval_cache(
+        if let Some(db) = self.query_db {
+            let cached = db.lookup_application_eval_cache(
                 def_id,
                 &expanded_args,
                 no_unchecked_indexed_access,
-            )
-        {
-            return ApplicationEvalOutcome::ShortCircuit(cached);
+            );
+            crate::evaluation::eval_materialization_probe::record_application_cache_lookup(
+                crate::evaluation::eval_materialization_probe::ApplicationLookupSite::ExpandedArgs,
+                cached.is_some(),
+            );
+            if let Some(cached) = cached {
+                return ApplicationEvalOutcome::ShortCircuit(cached);
+            }
         }
 
         // Homomorphic mapped-type passthrough for non-object arguments.
@@ -509,14 +553,19 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let expanded_args = self.expand_type_args(args);
         let no_unchecked_indexed_access = self.no_unchecked_indexed_access;
 
-        if let Some(db) = self.query_db
-            && let Some(cached) = db.lookup_application_eval_cache(
+        if let Some(db) = self.query_db {
+            let cached = db.lookup_application_eval_cache(
                 def_id,
                 &expanded_args,
                 no_unchecked_indexed_access,
-            )
-        {
-            return ApplicationEvalOutcome::ShortCircuit(cached);
+            );
+            crate::evaluation::eval_materialization_probe::record_application_cache_lookup(
+                crate::evaluation::eval_materialization_probe::ApplicationLookupSite::ExpandedArgs,
+                cached.is_some(),
+            );
+            if let Some(cached) = cached {
+                return ApplicationEvalOutcome::ShortCircuit(cached);
+            }
         }
 
         let evaluated = self.instantiate_and_finalize_application(
@@ -804,7 +853,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         no_unchecked_indexed_access: bool,
         evaluated: TypeId,
     ) {
-        if !self.application_eval_result_cacheable() {
+        let cacheable = self.application_eval_result_cacheable();
+        crate::evaluation::eval_materialization_probe::record_application_cache_insert(
+            cacheable,
+            self.query_db.is_some(),
+        );
+        if !cacheable {
             return;
         }
         // A limited-resolver (first-pass `TypeEnvironment`) evaluator must never


### PR DESCRIPTION
Goal: fast

## Summary
- Extend the merged eval-materialization probe from #13842 with `TSZ_PERF_COUNTERS`-only application eval cache eligibility counters.
- Split application recompute headroom into DefId presence, query DB availability, raw/expanded `(DefId,args)` lookup hits, dispatch paths, and cache insert skip reasons.
- Keep compiler behavior unchanged; this is solver/evaluation measurement only.

## Findings
- Original ts-toolbelt attribution showed 70,566 application recompute-headroom events, but existing `(DefId,args)` cache hits accounted for only 4,039 of them; lower-bound recomputes beyond cache hits were 66,527.
- Enabling `TSZ_SHARE_INSTANTIATION_CACHES=1` added only 22 shared application eval hits on that ts-toolbelt run, so simply leaning harder on the current `(DefId,args)` cache did not explain the slowdown.
- Focused type-fest consumers showed the same shape: 1,518,702 application recompute-headroom events, 480 `(DefId,args)` cache hits, and 1,518,222 lower-bound recomputes beyond cache hits.
- Post-#13886 scratch attribution still pointed at query-DB availability/read-vs-write semantics, especially first-pass `TypeEnvironment` and object/relation evaluator callers, rather than a wider unconditional application-eval cache.

## Coordination
- #13842 has merged, so the original stacked-probe blocker is resolved.
- This PR is a one-commit, measurement-only solver instrumentation change on current `main`; later implementation PRs may use the data but do not need to be bundled into this PR.
- The branch was rebased onto `origin/main` at `6542cf0a2e6e530a0b0c1605d124e899688d6e13`; refreshed head is `16c9cdfdab674d5a327f45ea48c4c9f1c716cbef`.

## Verification
- Previous head `98bf92f75a41dd3a03b88599f33c9bc694d849db`: `cargo fmt --check`
- Previous head `98bf92f75a41dd3a03b88599f33c9bc694d849db`: `git diff --check origin/main...HEAD`
- Previous head `98bf92f75a41dd3a03b88599f33c9bc694d849db`: `python3 scripts/arch/arch_guard.py`
- Previous head `98bf92f75a41dd3a03b88599f33c9bc694d849db`: `scripts/safe-run.sh cargo nextest run -p tsz-solver eval_materialization_probe` (4/4 passed)
- Previous head `98bf92f75a41dd3a03b88599f33c9bc694d849db`: `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- Previous head `98bf92f75a41dd3a03b88599f33c9bc694d849db`: exact-head `CI Summary`, conformance, emit, fourslash, and project-compile canaries succeeded.
- Stale-base head `5146985fa4ddd4a0a806b1c17ab65f8f91e5d00b`: exact-head run `27749562857` completed successfully, including `CI Summary`, conformance, emit, fourslash, and project-compile guard/canaries.
- Refresh head `16c9cdfdab674d5a327f45ea48c4c9f1c716cbef`: `git range-diff ebd2af719f229bf7c1a72a4ea279f33212ab4df3..5146985fa4ddd4a0a806b1c17ab65f8f91e5d00b origin/main..HEAD`
- Refresh head `16c9cdfdab674d5a327f45ea48c4c9f1c716cbef`: `git diff --check origin/main...HEAD`
- Fresh PR-head CI is expected after the rebase/push.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high

