### PR TITLE
fix(cli,resolver): reset path-existence caches at the batch boundary (#13368)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -302,6 +302,14 @@ fn clear_batch_iteration_state() {
     tsz_solver::construction::clear_thread_local_cache();
     tsz_solver::relations::subtype::reset_subtype_thread_local_state();
     tsz::checker::clear_all_thread_local_state();
+    // Drop the resolver's thread-local filesystem-existence caches too. They
+    // live in a `thread_local!` (not on the resolver instance), so a fresh
+    // resolver per compilation never clears them; without this a later
+    // compilation on the reused worker could read a stale `is_file`/`is_dir`
+    // answer for a path whose on-disk state changed between compilations
+    // (emit-then-recheck, watch rebuild, reused temp path). Same worker-reuse
+    // isolation contract as the three resets above (#13368 / #13255 family).
+    tsz::module_resolver::reset_path_existence_caches();
 }
 
 fn write_batch_residency_report(

--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -1197,5 +1197,31 @@ fn is_arbitrary_extension_declaration(specifier: &str, resolved_path: &std::path
     resolved_name.ends_with(&expected_suffix)
 }
 
+/// Reset the resolver's thread-local filesystem-existence caches
+/// (`FILE_EXISTS` / `DIR_EXISTS`) for the current thread.
+///
+/// These caches memoize `is_file` / `is_dir` for the duration of one
+/// compilation (the filesystem is assumed stable while a single `tsz`
+/// invocation runs, mirroring tsc's `ModuleResolutionHost` memoization). They
+/// live in a `thread_local!`, not on the [`ModuleResolver`] instance, so a
+/// fresh resolver per compilation does *not* clear them: only
+/// [`ModuleResolver::clear_cache`] does, and the batch/merge-group worker
+/// reuses one thread across many compilations without constructing-and-clearing
+/// a long-lived resolver.
+///
+/// This free-function entry point lets the per-compilation boundary reset
+/// (`clear_batch_iteration_state`) drop the existence caches alongside the
+/// interner, solver-limit, and checker thread-locals, so a later compilation on
+/// a reused worker never reads a stale existence answer for a path whose
+/// on-disk state changed between compilations (emit-then-recheck, a watch
+/// rebuild, or a reused temporary path). It is the module-resolver sibling of
+/// `clear_thread_local_cache` (interner) and `clear_all_thread_local_state`
+/// (checker), completing the worker-reuse isolation contract that keeps batch
+/// results byte-identical to a fresh process regardless of what ran before on
+/// the thread (#13368 / #13255 isolation family).
+pub fn reset_path_existence_caches() {
+    crate::resolution::helpers::clear_path_existence_caches();
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -19,6 +19,7 @@ mod module_extension;
 mod node16_modes;
 mod package_exports_imports;
 mod package_json_data;
+mod path_existence_reset;
 mod path_mapping;
 mod pattern_matching;
 mod resolution_failure;

--- a/crates/tsz-core/src/module_resolver/tests/path_existence_reset.rs
+++ b/crates/tsz-core/src/module_resolver/tests/path_existence_reset.rs
@@ -1,0 +1,54 @@
+//! Public `reset_path_existence_caches` boundary contract.
+//!
+//! The resolver memoizes `is_file` / `is_dir` in a `thread_local!` for the
+//! duration of one compilation. A long-lived batch/merge-group worker reuses
+//! one thread across many compilations, so the per-compilation boundary reset
+//! (`clear_batch_iteration_state`) must drop these existence caches through the
+//! public [`reset_path_existence_caches`] entry point — otherwise a later
+//! compilation reads a stale existence answer for a path whose on-disk state
+//! changed between compilations (#13368 / #13255 worker-reuse isolation).
+
+use super::super::reset_path_existence_caches;
+use super::fixtures::TempFixture;
+use crate::resolution::helpers::{cached_is_dir, cached_is_file};
+
+#[test]
+fn public_reset_drops_stale_file_and_dir_existence_after_fs_change() {
+    // Start from a clean slate on this test thread.
+    reset_path_existence_caches();
+
+    let fixture = TempFixture::new();
+    let file = fixture.write("present.ts", "export {};");
+    let dir = fixture.join("present-dir");
+    std::fs::create_dir(&dir).expect("create probed directory");
+
+    // First probes record both as present and seed the thread-local caches.
+    assert!(cached_is_file(&file), "file should be observed present");
+    assert!(cached_is_dir(&dir), "directory should be observed present");
+
+    // Remove both on disk. Within one compilation the filesystem is assumed
+    // stable, so the cached answers are intentionally reused even though the
+    // paths are now gone — this is what collapses repeated `stat()` syscalls.
+    std::fs::remove_file(&file).expect("remove probed file");
+    std::fs::remove_dir(&dir).expect("remove probed directory");
+    assert!(
+        cached_is_file(&file),
+        "cache is stable until the boundary reset"
+    );
+    assert!(
+        cached_is_dir(&dir),
+        "cache is stable until the boundary reset"
+    );
+
+    // The public boundary reset (called from `clear_batch_iteration_state`)
+    // drops both caches, so the next compilation re-reads the real filesystem.
+    reset_path_existence_caches();
+    assert!(
+        !cached_is_file(&file),
+        "post-reset re-read must observe the file is gone"
+    );
+    assert!(
+        !cached_is_dir(&dir),
+        "post-reset re-read must observe the directory is gone"
+    );
+}

--- a/crates/tsz-core/src/resolution/helpers.rs
+++ b/crates/tsz-core/src/resolution/helpers.rs
@@ -65,6 +65,13 @@ pub(crate) fn cached_is_dir(path: &Path) -> bool {
 /// Long-lived hosts should use `ModuleResolver::clear_cache` between
 /// compilation cycles. That public reset path calls this helper for the
 /// current thread; rayon worker threads keep their own cache entries.
+///
+/// The batch/merge-group worker reuses one thread across many compilations
+/// without a long-lived resolver to clear, so the per-compilation boundary
+/// reset calls this through the public
+/// [`crate::module_resolver::reset_path_existence_caches`] entry point —
+/// keeping the existence caches inside the same worker-reuse isolation contract
+/// as the interner, solver-limit, and checker thread-locals.
 pub(crate) fn clear_path_existence_caches() {
     FILE_EXISTS.with(|cache| cache.borrow_mut().clear());
     DIR_EXISTS.with(|cache| cache.borrow_mut().clear());


### PR DESCRIPTION
## Summary

Closes the last module-resolver thread-local that escaped the per-compilation
worker-reuse isolation contract behind the #13255 / #13368 schedule-sensitivity
family.

The batch / merge-group worker reuses one OS thread across many compilations.
`clear_batch_iteration_state` resets the interner cache, the solver-limit
budgets, and the checker thread-locals between compilations — but **not** the
module resolver's thread-local filesystem-existence caches
(`FILE_EXISTS` / `DIR_EXISTS` in `crates/tsz-core/src/resolution/helpers.rs`).
Those caches live in a `thread_local!`, not on the `ModuleResolver` instance,
and `driver::compile` constructs a **fresh** resolver per compilation without
ever calling `ModuleResolver::clear_cache` (the only existing path-cache reset).
So a later compilation on the reused worker can read a **stale** `is_file` /
`is_dir` answer for a path whose on-disk state changed between compilations.

## Structural rule

When a compilation memoizes filesystem existence in a thread-local for the
"filesystem is stable within one compilation" optimization, and a long-lived
worker reuses that thread across compilations, the per-compilation boundary
reset must drop the memo — otherwise a path created/removed between
compilations (emit-then-recheck, a watch rebuild, or a reused temporary path)
reads the previous compilation's answer, producing the worker-reuse,
order-dependent, single-file-deterministic divergence the #13255 / #13368
family describes. tsc/tsgo resolution is schedule-independent; tsz must be too.

## Owner layer

Module resolver (`tsz-core`) existence caches + the CLI per-compilation boundary
reset. This is the module-resolver sibling of `clear_thread_local_cache`
(interner) and `clear_all_thread_local_state` (checker), and follows the same
isolation-completion precedent as #13615 and #13673.

## Change

- Add a public free-function entry point
  `module_resolver::reset_path_existence_caches()` (delegates to the existing
  `pub(crate)` helper), so the boundary reset can drop the existence caches
  without a resolver instance.
- Call it from `clear_batch_iteration_state` alongside its three siblings.
- Document the contract on both the helper and the new entry point.

No behavior change on a stable filesystem: the `--noEmit` conformance batch runs
over a stable corpus, so every existence answer is identical with or without the
reset → conformance baselines are unaffected. The reset only **adds** correctness
when the filesystem changes between compilations on a reused worker. The fix is
name-agnostic and structural (no identifier / file-name / printer-string
predicates), satisfying the anti-hardcoding gate.

## Adjacent matrix

- Public-reset regression test
  (`crates/tsz-core/src/module_resolver/tests/path_existence_reset.rs`): seed
  the file and directory existence caches, remove both on disk, confirm the
  cached answers are reused until the boundary reset, then confirm
  `reset_path_existence_caches()` drops **both** caches so a post-reset probe
  re-reads the real filesystem.
- Existing `path_existence_caches_are_stable_until_reset_for_files_and_directories`
  continues to cover the helper-level reset.

## Verification

- `cargo nextest run -p tsz-core module_resolver::tests::path_existence_reset` — pass (new test).
- `cargo nextest run -p tsz-core module_resolver::tests::package_exports` — 24/24 pass (no resolver regression).
- `cargo nextest run -p tsz-cli batch` — 6/6 pass (batch boundary intact).
- `cargo check -p tsz-cli --bin tsz` — clean (public path resolves).
- `cargo clippy -p tsz-core --tests` — clean.
- CI owns `conformance-5` (temporal's shard), `conformance-aggregate`, `forced-parallel-determinism`, `fourslash-aggregate`.

Note: per the #13368 removal condition, this closes a confirmed isolation
channel but does not close the issue — `temporal.ts` stability remains empirical
across 3 consecutive merge-group batches.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude
Effort: high

https://claude.ai/code/session_01RoaFjVefNy6ws6AWucHDhS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoaFjVefNy6ws6AWucHDhS)_