### PR TITLE
perf(checker): cut ts-toolbelt conditional and lib cache work

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -479,6 +479,15 @@ impl<'a> CheckerState<'a> {
 
                 if true_type == check {
                     let extends_resolved = self.resolve_lazy_type(extends_type);
+                    if self
+                        .conditional_constraint_component_relation_outcome(
+                            extends_resolved,
+                            constraint,
+                        )
+                        .related
+                    {
+                        return true;
+                    }
                     let extends_evaluated = self.evaluate_type_for_assignability(extends_resolved);
                     let constraint_evaluated = self.evaluate_type_for_assignability(constraint);
                     return self
@@ -486,16 +495,18 @@ impl<'a> CheckerState<'a> {
                             extends_evaluated,
                             constraint_evaluated,
                         )
-                        .related
-                        || self
-                            .conditional_constraint_component_relation_outcome(
-                                extends_resolved,
-                                constraint,
-                            )
-                            .related;
+                        .related;
                 }
 
                 let true_resolved = self.resolve_lazy_type(true_type);
+                if self
+                    .conditional_constraint_component_relation_outcome(true_resolved, constraint)
+                    .related
+                    || self
+                        .indexed_object_map_branch_satisfies_constraint(true_resolved, constraint)
+                {
+                    return true;
+                }
                 let true_evaluated = self.evaluate_type_for_assignability(true_resolved);
                 let constraint_evaluated = self.evaluate_type_for_assignability(constraint);
                 if self
@@ -504,14 +515,6 @@ impl<'a> CheckerState<'a> {
                         constraint_evaluated,
                     )
                     .related
-                    || self
-                        .conditional_constraint_component_relation_outcome(
-                            true_resolved,
-                            constraint,
-                        )
-                        .related
-                    || self
-                        .indexed_object_map_branch_satisfies_constraint(true_resolved, constraint)
                 {
                     return true;
                 }

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_shared_cache.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_shared_cache.rs
@@ -9,6 +9,15 @@ fn shared_actual_lib_delegation_cache_key(name: &str) -> String {
     format!("\0actual-lib-delegation:{name}")
 }
 
+fn shared_actual_lib_value_declaration_cache_key(
+    name: &str,
+    file_name: &str,
+    decl_idx: tsz_parser::NodeIndex,
+    mode: u8,
+) -> String {
+    format!("\0actual-lib-value-declaration:{file_name}:{decl_idx:?}:{mode}:{name}")
+}
+
 impl<'a> CheckerState<'a> {
     /// Compute the shared-cache name for a builtin lib CLASS symbol, scoping the
     /// `symbol_arenas` borrow inside this `&self` method so the caller can then
@@ -87,6 +96,64 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn cache_shared_actual_lib_delegation(&self, shared_name: &str, result: TypeId) {
         self.insert_to_shared_lib_cache(
             shared_actual_lib_delegation_cache_key(shared_name),
+            result,
+        );
+    }
+
+    pub(crate) fn shared_actual_lib_value_declaration_name(
+        &self,
+        sym_id: SymbolId,
+        decl_arena: &tsz_parser::NodeArena,
+    ) -> Option<String> {
+        if !is_builtin_lib_declaration_arena(decl_arena) {
+            return None;
+        }
+        let symbol = self.get_cross_file_symbol(sym_id)?;
+        let name = symbol.escaped_name.clone();
+        if self.lib_name_locally_augmented(&name) || self.any_program_file_augments_lib_name(&name)
+        {
+            return None;
+        }
+        Some(name)
+    }
+
+    pub(crate) fn cached_shared_actual_lib_value_declaration(
+        &mut self,
+        shared_name: &str,
+        decl_arena: &tsz_parser::NodeArena,
+        decl_idx: tsz_parser::NodeIndex,
+        mode: u8,
+    ) -> Option<TypeId> {
+        let file_name = decl_arena.source_files.first()?.file_name.as_str();
+        let cached_type = self.lookup_shared_lib_type(
+            &shared_actual_lib_value_declaration_cache_key(shared_name, file_name, decl_idx, mode),
+        )?;
+        self.ctx.lib_delegation_cache.insert_declaration_node_type(
+            decl_arena,
+            decl_idx,
+            mode,
+            cached_type,
+        );
+        Some(cached_type)
+    }
+
+    pub(crate) fn cache_shared_actual_lib_value_declaration(
+        &self,
+        shared_name: &str,
+        decl_arena: &tsz_parser::NodeArena,
+        decl_idx: tsz_parser::NodeIndex,
+        mode: u8,
+        result: TypeId,
+    ) {
+        let Some(file_name) = decl_arena
+            .source_files
+            .first()
+            .map(|source_file| source_file.file_name.as_str())
+        else {
+            return;
+        };
+        self.insert_to_shared_lib_cache(
+            shared_actual_lib_value_declaration_cache_key(shared_name, file_name, decl_idx, mode),
             result,
         );
     }
@@ -311,6 +378,122 @@ mod tests {
             state.shared_actual_lib_delegation_name(sym_id, Some(arena.as_ref()), false),
             None,
             "only built-in TypeScript libs may use the shared actual-lib name cache",
+        );
+    }
+
+    #[test]
+    fn shared_actual_lib_value_declaration_cache_roundtrip_warms_local_cache() {
+        let lib_files = load_lib_files(&["dom.d.ts"]);
+        let mut parser = ParserState::new("fixture.ts".to_string(), "let x: Window;".to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file_with_libs(parser.get_arena(), root, &lib_files);
+        let arena = Arc::new(parser.get_arena().clone());
+        let binder = Arc::new(binder);
+        let types = TypeInterner::new();
+        let ctx = CheckerContext::new(
+            arena.as_ref(),
+            binder.as_ref(),
+            &types,
+            "fixture.ts".to_string(),
+            CheckerOptions::default(),
+        );
+        let mut state = CheckerState { ctx };
+        state
+            .ctx
+            .set_all_binders(Arc::new(vec![Arc::clone(&binder)]));
+        let shared: Arc<dashmap::DashMap<String, Option<tsz_solver::TypeId>>> =
+            Arc::new(dashmap::DashMap::new());
+        state.ctx.shared_lib_type_cache = Some(shared);
+
+        let dom_arena = lib_files[0].arena.as_ref();
+        let sym_id = state
+            .ctx
+            .binder
+            .file_locals
+            .get("Window")
+            .expect("Window should be a DOM lib symbol");
+        let decl_idx = state
+            .get_cross_file_symbol(sym_id)
+            .expect("Window symbol should be visible")
+            .value_declaration;
+        let shared_name = state
+            .shared_actual_lib_value_declaration_name(sym_id, dom_arena)
+            .expect("DOM value declarations should be shared-cache eligible");
+
+        assert!(
+            state
+                .cached_shared_actual_lib_value_declaration(&shared_name, dom_arena, decl_idx, 1)
+                .is_none(),
+            "cache should be empty before the first write"
+        );
+
+        state.cache_shared_actual_lib_value_declaration(
+            &shared_name,
+            dom_arena,
+            decl_idx,
+            1,
+            tsz_solver::TypeId::STRING,
+        );
+
+        assert_eq!(
+            state.cached_shared_actual_lib_value_declaration(&shared_name, dom_arena, decl_idx, 1),
+            Some(tsz_solver::TypeId::STRING)
+        );
+        assert_eq!(
+            state
+                .ctx
+                .lib_delegation_cache
+                .declaration_node_type(dom_arena, decl_idx, 1),
+            Some(tsz_solver::TypeId::STRING),
+            "shared hits should warm the file-local declaration-node cache"
+        );
+    }
+
+    #[test]
+    fn shared_actual_lib_value_declaration_name_rejects_program_augmentations() {
+        let lib_files = load_lib_files(&["dom.d.ts"]);
+        let mut parser = ParserState::new("fixture.ts".to_string(), "let x: Window;".to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file_with_libs(parser.get_arena(), root, &lib_files);
+        let arena = Arc::new(parser.get_arena().clone());
+        let binder = Arc::new(binder);
+
+        let mut augment_parser = ParserState::new(
+            "augment.ts".to_string(),
+            "export {}; declare global { interface Window { tszAugment: string; } }".to_string(),
+        );
+        let augment_root = augment_parser.parse_source_file();
+        let mut augment_binder = BinderState::new();
+        augment_binder.bind_source_file(augment_parser.get_arena(), augment_root);
+        let augment_binder = Arc::new(augment_binder);
+
+        let types = TypeInterner::new();
+        let ctx = CheckerContext::new(
+            arena.as_ref(),
+            binder.as_ref(),
+            &types,
+            "fixture.ts".to_string(),
+            CheckerOptions::default(),
+        );
+        let mut state = CheckerState { ctx };
+        state
+            .ctx
+            .set_all_binders(Arc::new(vec![Arc::clone(&binder), augment_binder]));
+
+        let dom_arena = lib_files[0].arena.as_ref();
+        let sym_id = state
+            .ctx
+            .binder
+            .file_locals
+            .get("Window")
+            .expect("Window should be a DOM lib symbol");
+
+        assert_eq!(
+            state.shared_actual_lib_value_declaration_name(sym_id, dom_arena),
+            None,
+            "program-wide global augmentations must keep value declarations out of the shared cache",
         );
     }
 

--- a/crates/tsz-checker/src/types/computation/call_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/call_helpers.rs
@@ -953,11 +953,26 @@ impl<'a> CheckerState<'a> {
             return cached_type;
         }
 
+        let declaration_cache_mode = if apply_module_augmentations { 1 } else { 2 };
         if let Some(cached) = self.ctx.lib_delegation_cache.declaration_node_type(
             decl_arena.as_ref(),
             decl_idx,
-            if apply_module_augmentations { 1 } else { 2 },
+            declaration_cache_mode,
         ) {
+            return cached;
+        }
+
+        let shared_actual_lib_value_name = apply_module_augmentations
+            .then(|| self.shared_actual_lib_value_declaration_name(sym_id, decl_arena.as_ref()))
+            .flatten();
+        if let Some(shared_name) = shared_actual_lib_value_name.as_deref()
+            && let Some(cached) = self.cached_shared_actual_lib_value_declaration(
+                shared_name,
+                decl_arena.as_ref(),
+                decl_idx,
+                declaration_cache_mode,
+            )
+        {
             return cached;
         }
 
@@ -1038,9 +1053,18 @@ impl<'a> CheckerState<'a> {
             self.ctx.lib_delegation_cache.insert_declaration_node_type(
                 decl_arena.as_ref(),
                 decl_idx,
-                if apply_module_augmentations { 1 } else { 2 },
+                declaration_cache_mode,
                 result,
             );
+            if let Some(shared_name) = shared_actual_lib_value_name.as_deref() {
+                self.cache_shared_actual_lib_value_declaration(
+                    shared_name,
+                    decl_arena.as_ref(),
+                    decl_idx,
+                    declaration_cache_mode,
+                    result,
+                );
+            }
         }
         result
     }


### PR DESCRIPTION
Goal: fast

## Summary
- Try raw conditional constraint component proofs before forcing assignability evaluation in `type_alias_application_filters_to_constraint`.
- Share completed builtin-lib value-declaration types across per-file checkers when the lib name is not locally or program-wide augmented, warming the existing file-local declaration-node cache on shared hits.
- This addresses the `ts-toolbelt-project` slowdown by cutting both repeated conditional-filter expansion and repeated child-checker construction for embedded-lib value declarations reached by `BuiltIn`-dependent aliases.

## Structural Rule
When a conditional filter has `false` branch `never` and the raw true/extends component already satisfies the required constraint through the conditional-constraint relation boundary, `tsz` can accept that proof without first normalizing both sides through assignability evaluation. The owner layer is the checker TS2344 conditional-constraint helper; semantic comparison still goes through the solver-backed `conditional_constraint_component_relation_outcome` gateway.

When a value declaration belongs to a builtin lib arena, is resolved in canonical augmentation-applied mode, and no file in the program augments that lib name, the declaration's computed `TypeId` is program-stable. `tsz` can store that result in the existing shared-lib cache keyed by lib file, declaration node, mode, and escaped symbol name, then warm the per-checker `lib_delegation_cache` on hit. Augmented names, external package declarations, sentinel results, and noncanonical modes keep the existing local-only path.

## Adjacent Matrix
- Conditional `true_type == check`: prove `extends_type <: constraint` raw first, then fall back to the evaluated relation.
- General conditional true branch: prove `true_type <: constraint` or indexed-object-map branch raw first, then fall back to the evaluated relation.
- Conditional negative/fallback behavior is unchanged: non-`never` false branches, direct `infer` true branches, and failed raw proofs still use the existing evaluated path.
- Shared value-declaration cache accepts builtin lib declarations with no program-wide augmentation and rejects external package declarations or augmented lib names.
- Shared value-declaration hits warm the file-local declaration-node cache; misses and uncacheable results still construct the child checker through the existing `CallHelpers` path.

## Performance Evidence
- Starting local baseline on the original `origin/main` for this investigation (`69ac17f555`): `ts-toolbelt-project` `tsz 1.002s +/- 0.014`, `tsgo 108.1ms +/- 1.7`, ratio `9.27x`.
- Rebased raw-conditional-only commit on `origin/main` (`8fd11d83f3`): `tsz 826.22ms`, `tsgo 105.74ms`, ratio `7.81x`, green compatibility (`/tmp/ts-toolbelt-raw-first-pgo-rebased2-20260618.json`).
- Current head rebased onto `origin/main` (`d2cd7937ce`): `tsz 480.00ms`, `tsgo 106.20ms`, ratio `4.52x`, green compatibility (`/tmp/ts-toolbelt-value-decl-cache-rebased-main-pgo-20260618.json`).
- Current rebased-head perf counters: Check `0.48s`, Total `0.69s`, diagnostics `0`; `with_parent_cache` `475`, `CallHelpers` `309`, evaluator constructions `29157` (`/tmp/ts-toolbelt-value-decl-cache-rebased-main-perf-20260618.json`).
- Remaining headroom is now dominated by `Function/AutoPath.ts` and `List/Extract.ts` body validation plus recursive type-evaluation pressure, not the original 8x gate failure.

## History Notes
- Relevant cache lineage reviewed: `767780d1f6` shared actual-lib delegation results, `9870fe7713` shared DOM lib delegation cache, `c1a606b4bb` builtin lib class-instance cache, and `c17a19b98a` delegation-tree memo for cross-arena sentinel results.
- This patch follows that lineage by sharing only program-stable builtin-lib answers and preserving file-local cache warming instead of broadening source-file or external package sharing.
- Overlap checked: #13842/#13881 own eval-materialization probe/counter split; #13856 owns checker-pool defaulting and remains draft/blocked. This PR is the current row-gate mitigation and does not default the checker pool.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-cli`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib shared_actual_lib --no-fail-fast`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib conditional_constraint_relation_routing_arch_tests --no-fail-fast`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts2344_infer_result_application_constraint_tests --no-fail-fast`
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter inferentialTypingWithFunctionTypeZip --workers 1 --profile dist-fast --force --test-dir /Users/mohsen/code/tsz/TypeScript/tests/cases`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 RAYON_NUM_THREADS=1 scripts/safe-run.sh cargo run -q --profile dist-fast -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json /tmp/ts-toolbelt-value-decl-cache-rebased-main-perf-20260618.json --noEmit -p .target-bench/external/ts-toolbelt/tsconfig.flat.json`
- `scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --filter '^ts-toolbelt-project$' --json-file /tmp/ts-toolbelt-value-decl-cache-rebased-main-pgo-20260618.json`

## Provenance
Machine: Mac
Assistant: codex
Model: gpt-5
Effort: high
