### PR TITLE
fix(solver): infer type params reachable only through a generic method member

### DIFF
--- a/crates/tsz-checker/src/tests/contextual_return_wrapper_tests.rs
+++ b/crates/tsz-checker/src/tests/contextual_return_wrapper_tests.rs
@@ -351,3 +351,95 @@ use(assign((x) => {
         ts7006.iter().map(|d| &d.message_text).collect::<Vec<_>>()
     );
 }
+
+/// Contextual `new`-expression inference must infer a class type parameter that
+/// occurs **only inside a generic method member** of the contextual interface.
+///
+/// `refine` returns `Builder<DB, TB, O>` and is the only place `DB`/`TB` appear
+/// in `Builder`. When `new BuilderImpl(0)` is checked against the contextual
+/// `Builder<DB, TB, O>`, the constraint walker must descend through the generic
+/// `refine` signature (erasing its own `LRE` type parameter, tsc's
+/// `getErasedSignature`) so its return position `Builder<DB, TB, O>` seeds
+/// `DB`/`TB`. Without erasure the generic target method was skipped, leaving
+/// `DB`/`TB` defaulted to `unknown` and producing a false `TS2322`.
+#[test]
+fn contextual_new_infers_type_params_only_present_in_generic_method_member() {
+    let diags = check_source_diagnostics(
+        r#"
+type AnyColumn<DB, TB extends keyof DB> = { [T in TB]: keyof DB[T] }[TB] & string;
+type RefExpr<DB, TB extends keyof DB> = AnyColumn<DB, TB> | ((db: DB) => TB);
+interface Builder<DB, TB extends keyof DB, O> {
+  get expressionType(): O | undefined;
+  get isBuilder(): true;
+  refine<LRE extends RefExpr<DB, TB>>(lhs: LRE): Builder<DB, TB, O>;
+}
+class BuilderImpl<DB, TB extends keyof DB, O> implements Builder<DB, TB, O> {
+  constructor(x: number) {}
+  get expressionType(): O | undefined { return undefined; }
+  get isBuilder(): true { return true; }
+  refine(lhs: RefExpr<DB, TB>): Builder<DB, TB, O> { return new BuilderImpl(0); }
+}
+"#,
+    );
+
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        0,
+        "Expected no TS2322 — DB/TB must be inferred through the generic `refine` member return, got: {:?}",
+        diagnostic_messages(&ts2322)
+    );
+}
+
+/// Same structural defect, renamed binders and a non-mapped constraint, to lock
+/// the fix to the structural rule rather than the original witness names.
+#[test]
+fn contextual_new_infers_method_only_type_params_with_renamed_binders() {
+    let diags = check_source_diagnostics(
+        r#"
+interface Svc<In, Out> {
+  run(x: In): Out;
+  pipe<Z extends keyof Out>(k: Z): Svc<In, Out>;
+}
+class SvcImpl<In, Out> implements Svc<In, Out> {
+  run(x: In): Out { return undefined as any; }
+  pipe(k: keyof Out): Svc<In, Out> { return new SvcImpl(); }
+}
+"#,
+    );
+
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        0,
+        "Expected no TS2322 — In/Out must be inferred through the generic `pipe` member, got: {:?}",
+        diagnostic_messages(&ts2322)
+    );
+}
+
+/// Negative control: erasing generic target method signatures during inference
+/// must not mask a genuine type mismatch. A `Box<string>` assigned where
+/// `Box<number>` is expected must still report `TS2322`.
+#[test]
+fn generic_method_member_inference_still_reports_genuine_mismatch() {
+    let diags = check_source_diagnostics(
+        r#"
+interface Box<T> {
+  get(): T;
+  map<U>(f: (x: T) => U): Box<U>;
+}
+class BoxImpl<T> implements Box<T> {
+  constructor(private v: T) {}
+  get(): T { return this.v; }
+  map<U>(f: (x: T) => U): Box<U> { return new BoxImpl(f(this.v)); }
+}
+const b: Box<number> = new BoxImpl<string>("x");
+"#,
+    );
+
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        !ts2322.is_empty(),
+        "Expected TS2322 — Box<string> is not assignable to Box<number>"
+    );
+}

--- a/crates/tsz-solver/src/operations/constraints/signatures.rs
+++ b/crates/tsz-solver/src/operations/constraints/signatures.rs
@@ -613,11 +613,19 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         None
     }
 
-    /// Constrain `source_sig` against `target_sig`, erasing any source type
-    /// parameters first (using defaults/constraints). Shared helper for the
-    /// four overload-matching branches below, which all need to erase
-    /// source-side type params before constraining.
-    fn constrain_signature_erasing_source_type_params(
+    /// Constrain `source_sig` against `target_sig`, erasing the type parameters
+    /// of **both** signatures first (using defaults/constraints). Shared helper
+    /// for the overload-matching branches below.
+    ///
+    /// Erasing the target signature's own type parameters mirrors tsc's
+    /// `getErasedSignature` in `inferFromSignatures`: a generic target signature
+    /// (e.g. an interface method `refine<L extends …>(x: L): Builder<DB, TB, O>`)
+    /// still contributes inference from its parameter and return positions, with
+    /// its method-level type parameters replaced by their constraints/defaults.
+    /// Without this, type parameters that appear only inside a generic method
+    /// member (`DB`/`TB` above, reached only through `refine`'s return type) would
+    /// never receive a candidate and silently default to `unknown`.
+    fn constrain_signature_erasing_type_params(
         &mut self,
         ctx: &mut InferenceContext,
         var_map: &FxHashMap<TypeId, crate::inference::infer::InferenceVar>,
@@ -626,22 +634,25 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         priority: crate::types::InferencePriority,
         is_constructor: bool,
     ) {
+        // `erase_signature_type_params` is a no-op clone when the signature has
+        // no type parameters, so this is cheap for the common non-generic case.
+        let erased_target = self.erase_signature_type_params(target_sig);
         if source_sig.type_params.is_empty() {
             self.constrain_call_signature_to_call_signature(
                 ctx,
                 var_map,
                 source_sig,
-                target_sig,
+                &erased_target,
                 priority,
                 is_constructor,
             );
         } else {
-            let erased = self.erase_signature_type_params(source_sig);
+            let erased_source = self.erase_signature_type_params(source_sig);
             self.constrain_call_signature_to_call_signature(
                 ctx,
                 var_map,
-                &erased,
-                target_sig,
+                &erased_source,
+                &erased_target,
                 priority,
                 is_constructor,
             );
@@ -664,10 +675,117 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         if source_signatures.len() == 1 && target_signatures.len() == 1 {
             let source_sig = &source_signatures[0];
             let target_sig = &target_signatures[0];
-            if target_sig.type_params.is_empty() {
-                // Source may carry type params (e.g. generic class construct sig)
-                // while target does not; the helper erases them first when needed.
-                self.constrain_signature_erasing_source_type_params(
+            // Either side may carry type params (e.g. a generic class construct
+            // sig, or a generic interface method); the helper erases both first.
+            self.constrain_signature_erasing_type_params(
+                ctx,
+                var_map,
+                source_sig,
+                target_sig,
+                priority,
+                is_constructor,
+            );
+            return;
+        }
+
+        if target_signatures.len() == 1 {
+            // Erase the (possibly generic) target signature's own type parameters
+            // up front so both overload selection and the final constraint operate
+            // on tsc's `getErasedSignature` form. A non-generic target erases to an
+            // identical clone, preserving existing behavior.
+            let erased_target = self.erase_signature_type_params(&target_signatures[0]);
+            let target_sig = &erased_target;
+            let source_idx = if source_signatures.len() == 1 {
+                Some(0)
+            } else {
+                let target_fn = self.function_type_from_signature(target_sig, is_constructor);
+                let selected = self.select_signature_for_target(
+                    source_signatures,
+                    target_fn,
+                    var_map,
+                    is_constructor,
+                );
+                // Fallback: tsc's `inferFromSignaturesOfType` does NOT gate
+                // inference on assignability — it just pairs signatures by
+                // index from the end of each list (with `len = min(srcLen, tgtLen)`).
+                // When the target has 1 signature, that pairing picks the last
+                // source signature regardless of whether any source signature
+                // is "assignable" to the placeholder-erased target.
+                //
+                // The strict pre-check in `select_signature_for_target` is too
+                // restrictive for the common case where inheritance-merged
+                // callable overloads (e.g. `ArrayIterator<T>` adds a
+                // `[Symbol.iterator]` overload returning `ArrayIterator<T>`
+                // on top of the inherited `IteratorObject<T,…>` signature)
+                // disagree on the apparent return type while still being
+                // structurally compatible. Without this fallback, inference
+                // silently drops, the placeholder receives no candidate from
+                // the argument, and the call later fails with a spurious
+                // TS2769 (e.g. `Array.from(arr.values())`).
+                //
+                // Two guards prevent over-eager inference from the wrong
+                // overload:
+                //
+                // 1. `arity_compatible`: the chosen source signature's
+                //    parameter count must align with the target signature's
+                //    arity. This is the primary discriminator that lets us
+                //    pair `[Symbol.iterator](): ArrayIterator<A>` (arity 0)
+                //    with `[Symbol.iterator](): Iterator<T,…>` (arity 0)
+                //    while rejecting cross-arity pairings like a 2-arg
+                //    overload paired against a 1-arg target.
+                //
+                // 2. `all_same_arity`: every non-generic source overload
+                //    must share the same parameter count. Inheritance-merged
+                //    overload sets (the case this fallback exists to
+                //    rescue) always satisfy this — the derived interface's
+                //    override is a return-type refinement of the inherited
+                //    signature. By contrast, semantically split overload
+                //    sets such as `Array.from`'s `(arrayLike)` plus
+                //    `(arrayLike, mapfn, thisArg?)` represent distinct
+                //    calling conventions and must still rely on the strict
+                //    assignability discriminator.
+                selected.or_else(|| {
+                    let last_idx = source_signatures
+                        .iter()
+                        .rposition(|sig| sig.type_params.is_empty())?;
+                    let target_arity = target_sig.params.len();
+                    let last_arity = source_signatures[last_idx].params.len();
+                    let arity_compatible = last_arity == target_arity
+                        || source_signatures[last_idx]
+                            .params
+                            .last()
+                            .is_some_and(|p| p.rest);
+                    let all_same_arity = source_signatures
+                        .iter()
+                        .filter(|sig| sig.type_params.is_empty())
+                        .all(|sig| sig.params.len() == last_arity);
+                    if all_same_arity && arity_compatible {
+                        Some(last_idx)
+                    } else {
+                        None
+                    }
+                })
+            };
+            if let Some(idx) = source_idx {
+                self.constrain_signature_erasing_type_params(
+                    ctx,
+                    var_map,
+                    &source_signatures[idx],
+                    target_sig,
+                    priority,
+                    is_constructor,
+                );
+            }
+            return;
+        }
+
+        if source_signatures.len() == 1 {
+            let source_sig = &source_signatures[0];
+            for target_sig in target_signatures {
+                // Erase both sides (the helper is a no-op clone for non-generic
+                // signatures) so a generic target overload still contributes
+                // inference from its parameter and return positions.
+                self.constrain_signature_erasing_type_params(
                     ctx,
                     var_map,
                     source_sig,
@@ -679,136 +797,21 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return;
         }
 
-        if target_signatures.len() == 1 {
-            let target_sig = &target_signatures[0];
-            if target_sig.type_params.is_empty() {
-                let source_idx = if source_signatures.len() == 1 {
-                    Some(0)
-                } else {
-                    let target_fn = self.function_type_from_signature(target_sig, is_constructor);
-                    let selected = self.select_signature_for_target(
-                        source_signatures,
-                        target_fn,
-                        var_map,
-                        is_constructor,
-                    );
-                    // Fallback: tsc's `inferFromSignaturesOfType` does NOT gate
-                    // inference on assignability — it just pairs signatures by
-                    // index from the end of each list (with `len = min(srcLen, tgtLen)`).
-                    // When the target has 1 signature, that pairing picks the last
-                    // source signature regardless of whether any source signature
-                    // is "assignable" to the placeholder-erased target.
-                    //
-                    // The strict pre-check in `select_signature_for_target` is too
-                    // restrictive for the common case where inheritance-merged
-                    // callable overloads (e.g. `ArrayIterator<T>` adds a
-                    // `[Symbol.iterator]` overload returning `ArrayIterator<T>`
-                    // on top of the inherited `IteratorObject<T,…>` signature)
-                    // disagree on the apparent return type while still being
-                    // structurally compatible. Without this fallback, inference
-                    // silently drops, the placeholder receives no candidate from
-                    // the argument, and the call later fails with a spurious
-                    // TS2769 (e.g. `Array.from(arr.values())`).
-                    //
-                    // Two guards prevent over-eager inference from the wrong
-                    // overload:
-                    //
-                    // 1. `arity_compatible`: the chosen source signature's
-                    //    parameter count must align with the target signature's
-                    //    arity. This is the primary discriminator that lets us
-                    //    pair `[Symbol.iterator](): ArrayIterator<A>` (arity 0)
-                    //    with `[Symbol.iterator](): Iterator<T,…>` (arity 0)
-                    //    while rejecting cross-arity pairings like a 2-arg
-                    //    overload paired against a 1-arg target.
-                    //
-                    // 2. `all_same_arity`: every non-generic source overload
-                    //    must share the same parameter count. Inheritance-merged
-                    //    overload sets (the case this fallback exists to
-                    //    rescue) always satisfy this — the derived interface's
-                    //    override is a return-type refinement of the inherited
-                    //    signature. By contrast, semantically split overload
-                    //    sets such as `Array.from`'s `(arrayLike)` plus
-                    //    `(arrayLike, mapfn, thisArg?)` represent distinct
-                    //    calling conventions and must still rely on the strict
-                    //    assignability discriminator.
-                    selected.or_else(|| {
-                        let last_idx = source_signatures
-                            .iter()
-                            .rposition(|sig| sig.type_params.is_empty())?;
-                        let target_arity = target_sig.params.len();
-                        let last_arity = source_signatures[last_idx].params.len();
-                        let arity_compatible = last_arity == target_arity
-                            || source_signatures[last_idx]
-                                .params
-                                .last()
-                                .is_some_and(|p| p.rest);
-                        let all_same_arity = source_signatures
-                            .iter()
-                            .filter(|sig| sig.type_params.is_empty())
-                            .all(|sig| sig.params.len() == last_arity);
-                        if all_same_arity && arity_compatible {
-                            Some(last_idx)
-                        } else {
-                            None
-                        }
-                    })
-                };
-                if let Some(idx) = source_idx {
-                    self.constrain_signature_erasing_source_type_params(
-                        ctx,
-                        var_map,
-                        &source_signatures[idx],
-                        target_sig,
-                        priority,
-                        is_constructor,
-                    );
-                }
-            }
-            return;
-        }
-
-        if source_signatures.len() == 1 {
-            let source_sig = &source_signatures[0];
-            let erased_sig;
-            let effective_sig = if source_sig.type_params.is_empty() {
-                source_sig
-            } else {
-                erased_sig = self.erase_signature_type_params(source_sig);
-                &erased_sig
-            };
-            for target_sig in target_signatures {
-                if target_sig.type_params.is_empty() {
-                    self.constrain_call_signature_to_call_signature(
-                        ctx,
-                        var_map,
-                        effective_sig,
-                        target_sig,
-                        priority,
-                        is_constructor,
-                    );
-                }
-            }
-            return;
-        }
-
-        // Match tsc's `inferFromSignatures`: filter target signatures down to
-        // the non-generic ones, then pair overloads from the bottom up with
-        // `len = min(sourceLen, filteredTargetLen)`. Excess leading entries on
-        // either side are skipped — tsc does not reuse the first source for
-        // unmatched leading targets.
-        let filtered_targets: Vec<&CallSignature> = target_signatures
-            .iter()
-            .filter(|sig| sig.type_params.is_empty())
-            .collect();
+        // Match tsc's `inferFromSignatures`: pair signatures from the bottom up
+        // with `len = min(sourceLen, targetLen)`, applying `getErasedSignature`
+        // to each target (and `getBaseSignature` to each source) rather than
+        // dropping generic target overloads. Excess leading entries on either
+        // side are skipped — tsc does not reuse the first source for unmatched
+        // leading targets.
         let source_len = source_signatures.len();
-        let filtered_target_len = filtered_targets.len();
-        let len = source_len.min(filtered_target_len);
+        let target_len = target_signatures.len();
+        let len = source_len.min(target_len);
         let source_skip = source_len - len;
-        let target_skip = filtered_target_len - len;
+        let target_skip = target_len - len;
         for i in 0..len {
             let source_sig = &source_signatures[source_skip + i];
-            let target_sig = filtered_targets[target_skip + i];
-            self.constrain_signature_erasing_source_type_params(
+            let target_sig = &target_signatures[target_skip + i];
+            self.constrain_signature_erasing_type_params(
                 ctx,
                 var_map,
                 source_sig,


### PR DESCRIPTION
## Summary

Contextual `new`-expression inference left a class type parameter that appears
**only inside a generic interface method** unconstrained, so it silently
defaulted to `unknown` and produced a false `TS2322` when the constructed
instance was checked against the contextual interface type.

Minimal witness (tsc 6.x clean; tsz emitted `TS2322` before this change):

```ts
type AnyColumn<DB, TB extends keyof DB> = { [T in TB]: keyof DB[T] }[TB] & string;
type RefExpr<DB, TB extends keyof DB> = AnyColumn<DB, TB> | ((db: DB) => TB);
interface Builder<DB, TB extends keyof DB, O> {
  get expressionType(): O | undefined;
  refine<LRE extends RefExpr<DB, TB>>(lhs: LRE): Builder<DB, TB, O>;
}
class BuilderImpl<DB, TB extends keyof DB, O> implements Builder<DB, TB, O> {
  constructor(x: number) {}
  get expressionType(): O | undefined { return undefined; }
  refine(lhs: RefExpr<DB, TB>): Builder<DB, TB, O> { return new BuilderImpl(0); } // was false TS2322
}
```

`O` (present in the `expressionType` property) was inferred, but `DB`/`TB` —
reachable only through the generic `refine` member — were not, so the result
type defaulted to `BuilderImpl<unknown, unknown, O>` and failed the relation.

## Structural rule

When `new C(args)` is checked against a contextual type `I<…>` and a class type
parameter of `C` occurs only inside a generic (type-parameter-bearing) method
member, `tsc` still infers it: `inferFromSignatures` applies `getErasedSignature`
to the target method signature (its own method-level type parameters erased) and
infers from the signature's parameter and return positions. tsz's constraint
walker instead **skipped/filtered every target call or construct signature that
carried its own type parameters**, so inference never descended into such a
member — leaving the type parameters reachable only there unbound.

## Fix (owner layer: solver constraint collection)

`crates/tsz-solver/src/operations/constraints/signatures.rs`,
`constrain_matching_signatures` + its shared helper:

- The shared helper (renamed `constrain_signature_erasing_type_params`) now
  erases the type parameters of **both** sides — `getBaseSignature` on the
  source (unchanged) and `getErasedSignature` on the target (new) — via the
  existing `erase_signature_type_params` (a no-op clone for non-generic sigs).
- All four overload-pairing branches route a generic target through erasure
  instead of skipping it; the N×N branch now pairs the full signature lists
  from the end (matching tsc) rather than pre-filtering generic targets out.

No fixture-name/source-text/printer predicates; the fix keys purely on
signature structure.

## Adjacent-case matrix (all verified)

- positive: original witness + renamed binders (`Svc`/`SvcImpl`, `In`/`Out`) +
  non-mapped constraint → clean
- explicit type args (`new BuilderImpl<DB,TB,O>(0)`) → already clean, still clean
- negative control: `Box<string>` assigned where `Box<number>` expected → still
  reports genuine `TS2322` (erasure does not mask real mismatches)

## Verification

- New regression tests in
  `crates/tsz-checker/src/tests/contextual_return_wrapper_tests.rs`
  (`contextual_new_infers_type_params_only_present_in_generic_method_member`,
  `..._with_renamed_binders`, `generic_method_member_inference_still_reports_genuine_mismatch`):
  `cargo nextest run -p tsz-checker --lib contextual_return_wrapper_tests` → 12 passed.
- `cargo nextest run -p tsz-solver` → net-neutral vs `origin/main` (same 4
  pre-existing env failures before and after).
- `cargo nextest run -p tsz-checker --lib` → **zero new failures**; this change
  additionally **fixes** the previously-red
  `zod_type_query_regression_tests::generic_promise_then_flattens_promise_return_from_callback`
  (same class: contextual inference through a callback/method signature).
- `cargo clippy -p tsz-solver --lib` → clean.
- Broad conformance/emit/project-compile gates are owned by ready-review CI.

Refs #10663 (kysely F1(a) contextual-`new` inference facet; one component of the
row, which remains separately blocked by the CPU-timeout family).

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01LmgJKSBPAiBXWn2je2YUNB

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmgJKSBPAiBXWn2je2YUNB)_