### PR TITLE
fix(solver): drop type-parameter `default` from canonical identity (#13609)

### DIFF
--- a/crates/tsz-solver/src/canonicalize/mod.rs
+++ b/crates/tsz-solver/src/canonicalize/mod.rs
@@ -164,8 +164,22 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
                 TypeData::TypeParameter(info) => {
                     if let Some(index) = self.find_param_index(info.name) {
                         self.interner.bound_parameter(index)
+                    } else if info.default.is_some() {
+                        // Free type-parameter reference carrying a `default`. The
+                        // default is identity-irrelevant (see
+                        // `canonical_type_param`): two references to the same
+                        // parameter that differ only in whether the default was
+                        // captured (`R extends ResponseType = "json"` vs a bare
+                        // `R`) intern to distinct `TypeId`s and would fragment the
+                        // identity fast path. Drop it for the canonical form; the
+                        // interned parameter keeps its default for instantiation.
+                        let normalized = crate::types::TypeParamInfo {
+                            default: None,
+                            ..info
+                        };
+                        self.interner.type_param(normalized)
                     } else {
-                        // Free variable (shouldn't happen in valid code)
+                        // Free variable with no default — already canonical.
                         type_id
                     }
                 }
@@ -275,17 +289,12 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
                         })
                         .collect();
 
-                    // Canonicalize type parameter constraints and defaults
+                    // Canonicalize type parameter constraints (defaults are
+                    // identity-irrelevant; see `canonical_type_param`).
                     let c_type_params: Vec<crate::types::TypeParamInfo> = shape
                         .type_params
                         .iter()
-                        .map(|tp| crate::types::TypeParamInfo {
-                            name: tp.name,
-                            constraint: tp.constraint.map(|c| self.canonicalize(c)),
-                            default: tp.default.map(|d| self.canonicalize(d)),
-                            is_const: tp.is_const,
-                            origin: tp.origin,
-                        })
+                        .map(|&tp| self.canonical_type_param(tp))
                         .collect();
 
                     // Canonicalize type predicate (if it has a type_id)
@@ -348,11 +357,8 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
                     // { [K in T]: K } and { [P in T]: P } hash to the same value.
                     // Since we use De Bruijn indices (BoundParameter) in the body,
                     // this name is never looked up, only used for hashing identity.
-                    let mut c_type_param = mapped.type_param;
+                    let mut c_type_param = self.canonical_type_param(mapped.type_param);
                     c_type_param.name = self.interner.intern_string("");
-                    // Also canonicalize constraint/default inside TypeParamInfo if present
-                    c_type_param.constraint = c_type_param.constraint.map(|c| self.canonicalize(c));
-                    c_type_param.default = c_type_param.default.map(|d| self.canonicalize(d));
 
                     let c_mapped = crate::types::MappedType {
                         type_param: c_type_param,
@@ -644,6 +650,30 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
         self.interner.object_with_index(new_shape)
     }
 
+    /// Canonical (identity) form of a declared type parameter.
+    ///
+    /// The `constraint` is canonicalized recursively, but `default` is dropped:
+    /// `tsc` never distinguishes type parameters by their declared `default` in
+    /// relation/identity (the default is consumed only at instantiation when no
+    /// argument is supplied). Keeping it would let two otherwise-identical
+    /// generic signatures — `<R extends X = "json">` vs `<R extends X>` —
+    /// canonicalize to distinct identities and miss the relation's reflexive
+    /// short-circuit (#13609). Callers that manage an alpha-equivalence scope
+    /// (function/signature/mapped) must push the parameter name before calling
+    /// so the constraint's self/sibling references resolve to bound parameters.
+    fn canonical_type_param(
+        &mut self,
+        tp: crate::types::TypeParamInfo,
+    ) -> crate::types::TypeParamInfo {
+        crate::types::TypeParamInfo {
+            name: tp.name,
+            constraint: tp.constraint.map(|c| self.canonicalize(c)),
+            default: None,
+            is_const: tp.is_const,
+            origin: tp.origin,
+        }
+    }
+
     /// Canonicalize a single call signature with type parameter scope management.
     fn canonicalize_signature(
         &mut self,
@@ -676,18 +706,12 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
             })
             .collect();
 
-        // Canonicalize type parameter constraints and defaults
+        // Canonicalize type parameter constraints (defaults are
+        // identity-irrelevant; see `canonical_type_param`).
         let c_type_params: Vec<crate::types::TypeParamInfo> = sig
             .type_params
             .iter()
-            .map(|tp| crate::types::TypeParamInfo {
-                name: tp.name,
-                constraint: tp.constraint.map(|c| self.canonicalize(c)),
-                default: tp.default.map(|d| self.canonicalize(d)),
-                // Preserve other fields as-is
-                is_const: tp.is_const,
-                origin: tp.origin,
-            })
+            .map(|&tp| self.canonical_type_param(tp))
             .collect();
 
         // Canonicalize type predicate (if it has a type_id)

--- a/crates/tsz-solver/tests/canonicalize_tests.rs
+++ b/crates/tsz-solver/tests/canonicalize_tests.rs
@@ -1084,3 +1084,176 @@ fn canonicalize_object_with_index_signature() {
         panic!("Expected object type with index");
     }
 }
+
+// ===================================================================
+// Type-parameter `default` must not fragment canonical identity (#13609)
+// ===================================================================
+
+// `tsc` never distinguishes type parameters by their declared `default` in
+// relation/identity; the default is metadata consumed only at instantiation
+// when no argument is supplied. tsz interns type parameters structurally and
+// hashes the `default` field, so two references to the same parameter that
+// differ only in whether the (optional) default was captured intern to
+// distinct `TypeId`s. Those must still canonicalize to one identity so the
+// relation's reflexive/identity fast path is not lost.
+#[test]
+fn canonicalize_type_param_ignores_optional_default() {
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let name = interner.intern_string("R");
+    let constraint = Some(TypeId::STRING);
+
+    // Same parameter, one with a captured default, one without.
+    let r_with_default = interner.type_param(TypeParamInfo {
+        name,
+        constraint,
+        default: Some(TypeId::NUMBER),
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    let r_no_default = interner.type_param(TypeParamInfo {
+        name,
+        constraint,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+
+    // Distinct interned identities (the structural hash includes `default`)...
+    assert_ne!(
+        r_with_default, r_no_default,
+        "precondition: interning keeps the default distinct"
+    );
+
+    // ...but they canonicalize to the same identity.
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(r_with_default),
+        c2.canonicalize(r_no_default),
+        "type-parameter default must not fragment canonical identity"
+    );
+
+    // Two *different* defaults on the same parameter also collapse.
+    let r_other_default = interner.type_param(TypeParamInfo {
+        name,
+        constraint,
+        default: Some(TypeId::BOOLEAN),
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    let mut c3 = Canonicalizer::new(&interner, &env);
+    let mut c4 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c3.canonicalize(r_with_default),
+        c4.canonicalize(r_other_default),
+        "differing defaults on the same parameter canonicalize identically"
+    );
+}
+
+// A genuinely different parameter (different name/constraint) must stay
+// distinct — the normalization only drops `default`, it does not erase the
+// parameter's identity.
+#[test]
+fn canonicalize_type_param_default_drop_preserves_real_distinctions() {
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let r = interner.type_param(TypeParamInfo {
+        name: interner.intern_string("R"),
+        constraint: None,
+        default: Some(TypeId::NUMBER),
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    // Different name.
+    let s = interner.type_param(TypeParamInfo {
+        name: interner.intern_string("S"),
+        constraint: None,
+        default: Some(TypeId::NUMBER),
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    // Different constraint.
+    let r_constrained = interner.type_param(TypeParamInfo {
+        name: interner.intern_string("R"),
+        constraint: Some(TypeId::STRING),
+        default: Some(TypeId::NUMBER),
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    let mut c3 = Canonicalizer::new(&interner, &env);
+    let mut c4 = Canonicalizer::new(&interner, &env);
+    assert_ne!(
+        c1.canonicalize(r),
+        c2.canonicalize(s),
+        "distinct parameter names stay distinct after dropping default"
+    );
+    assert_ne!(
+        c3.canonicalize(r),
+        c4.canonicalize(r_constrained),
+        "distinct constraints stay distinct after dropping default"
+    );
+}
+
+// The same identity rule applies when the type parameter is declared in a
+// signature's type-parameter list: two generic function types that differ only
+// in a type parameter's `default` must canonicalize to one identity, so the
+// relation's reflexive short-circuit holds for `<R extends X = "json">() => R`
+// against `<R extends X>() => R` (#13609).
+#[test]
+fn canonicalize_function_type_param_list_ignores_default() {
+    use crate::types::{FunctionShape, ParamInfo};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let r = interner.intern_string("R");
+    let make = |default: Option<TypeId>| {
+        let body = interner.type_param(TypeParamInfo {
+            name: r,
+            constraint: Some(TypeId::STRING),
+            default,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        });
+        interner.function(FunctionShape {
+            type_params: vec![TypeParamInfo {
+                name: r,
+                constraint: Some(TypeId::STRING),
+                default,
+                is_const: false,
+                origin: crate::types::TypeParamOrigin::User,
+            }],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("x")),
+                type_id: body,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: body,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+
+    let with_default = make(Some(TypeId::NUMBER));
+    let without_default = make(None);
+    assert_ne!(
+        with_default, without_default,
+        "precondition: interning keeps the default distinct"
+    );
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(with_default),
+        c2.canonicalize(without_default),
+        "type-parameter default in a signature list must not fragment identity"
+    );
+}


### PR DESCRIPTION
## Summary

A type parameter's optional `default` is metadata that `tsc` consumes only at
instantiation (when no type argument is supplied); it never distinguishes type
parameters in relation/identity. tsz interns type parameters structurally and
hashes the `default` field, so two references to the **same** parameter that
differ only in whether the default annotation was captured — e.g. a signature
that resolved `R extends ResponseType = "json"` vs a bare `R` — intern to
distinct `TypeId`s.

The `Canonicalizer` reduces structural identity to `TypeId` equality and backs
`canonical_id`, which the subtype relation uses for its reflexive/identity fast
path (`relations/subtype/cache.rs`). It treated `default` **inconsistently**:
the free-`TypeParameter` branch kept the whole `TypeParamInfo`, while the
function / call-signature / mapped type-parameter lists canonicalized-and-kept
the default. Either way a type could stop being identity-equal to itself across
two signatures, lose the reflexive short-circuit, and fall into a structural
walk that can degrade — the fragmentation documented in #13609 (false
TS2344/TS2322 on the type-fest / ofetch families).

## Wrong operation

Solver structural identity / canonicalization (`crates/tsz-solver/src/canonicalize/mod.rs`).

## Structural rule

When two types differ only in a type parameter's declared `default`, `tsc`
treats them as identical in relation/identity (defaults are not part of
`compareSignaturesIdentical`/type identity). tsz must canonicalize them to one
identity so the relation's reflexive short-circuit holds.

## Fix

Make the rule uniform via a new `canonical_type_param` helper that canonicalizes
the `constraint` and drops `default`. It is used at every site that builds a
canonical `TypeParamInfo` — function shape, call signature, and mapped type —
and the free-`TypeParameter` branch drops the default too. Interning is
unchanged, so each parameter keeps its `default` for instantiation; only the
identity (canonical) form drops it.

Dropping `default` from the identity form is a **pure widening** of identity —
it can only add reflexive short-circuits (more `source_canon == target_canon`
hits), never remove a real mismatch — and it matches `tsc`. The decision is
purely structural over `TypeParamInfo`; no name/file-string predicates
(anti-hardcoding gate honored).

## Owner layer

Solver canonicalization, surfaced through the subtype relation's identity fast
path. No checker/emitter change.

## Adjacent-case matrix

| case | shape | canonical identity |
|---|---|---|
| free `R = json` vs free `R` (same name/constraint) | free type-param ref | identical ✓ |
| `R = json` vs `R = number` (same name/constraint) | free type-param ref | identical ✓ |
| `<R extends X = json>() => R` vs `<R extends X>() => R` | signature type-param list | identical ✓ |
| `R` vs `S` (different name) | free type-param ref | distinct ✓ |
| `R` vs `R extends string` (different constraint) | free type-param ref | distinct ✓ |
| default-bearing param at instantiation with no arg | interning unchanged | default still applied ✓ |

## Verification

- New focused solver unit tests in `crates/tsz-solver/tests/canonicalize_tests.rs`:
  - `canonicalize_type_param_ignores_optional_default` (default-present vs absent, and two differing defaults, canonicalize identically; precondition asserts interning keeps them distinct).
  - `canonicalize_type_param_default_drop_preserves_real_distinctions` (different name / constraint stay distinct).
  - `canonicalize_function_type_param_list_ignores_default` (the signature-list site).
- `cargo test -p tsz-solver --lib canonicalize::tests` — all pass.
- Full `cargo test -p tsz-solver --lib` — only 4 failures, all **pre-existing on the merge base** (`test_conditional_infer_optional_property_present_distributive`, `literal_mask_preserves_object_vs_literal_reduction`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`, `solver_file_size_ceiling_tests`); verified identical on a clean tree, so no new regressions.
- `cargo check --workspace` and `cargo clippy -p tsz-solver --lib` clean.
- Broad conformance / emit / fourslash / corpus suites: owned by ready-review CI.

Note: the specific committed witness in #13609
(`program_mode_generic_conditional_in_contextual_return_stays_deferred`) is a
flow-narrowing facet owned by #13872; this PR addresses the distinct
type-parameter-identity fragmentation called out in the same issue's analysis,
in a different layer (solver canonicalization vs checker flow), so the two do
not conflict.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01TDaGVGTZyFy3DYKjZNgcFA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDaGVGTZyFy3DYKjZNgcFA)_