### PR TITLE
perf(solver): share eval support relation query cache

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -93,16 +93,21 @@ impl<'a> CheckerState<'a> {
                 return true;
             }
             let raw_branch = branch;
+            if self.indexed_object_map_branch_satisfies_constraint(raw_branch, constraint) {
+                return true;
+            }
             let resolved_branch = self.resolve_lazy_type(raw_branch);
+            if resolved_branch != raw_branch
+                && self.indexed_object_map_branch_satisfies_constraint(resolved_branch, constraint)
+            {
+                return true;
+            }
             let branch_evaluated = self.evaluate_type_for_assignability(resolved_branch);
-            self.indexed_object_map_branch_satisfies_constraint(raw_branch, constraint)
-                || self
-                    .conditional_constraint_component_relation_outcome(resolved_branch, constraint)
-                    .related
+            self.conditional_constraint_component_relation_outcome(resolved_branch, constraint)
+                .related
                 || self
                     .conditional_constraint_component_relation_outcome(branch_evaluated, constraint)
                     .related
-                || self.indexed_object_map_branch_satisfies_constraint(resolved_branch, constraint)
                 || (raw_branch == true_type
                     && raw_branch == check_type
                     && self.conditional_extends_type_satisfies_constraint(extends_type, constraint))
@@ -499,11 +504,13 @@ impl<'a> CheckerState<'a> {
                 }
 
                 let true_resolved = self.resolve_lazy_type(true_type);
-                if self
-                    .conditional_constraint_component_relation_outcome(true_resolved, constraint)
-                    .related
+                if self.indexed_object_map_branch_satisfies_constraint(true_resolved, constraint)
                     || self
-                        .indexed_object_map_branch_satisfies_constraint(true_resolved, constraint)
+                        .conditional_constraint_component_relation_outcome(
+                            true_resolved,
+                            constraint,
+                        )
+                        .related
                 {
                     return true;
                 }

--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -331,9 +331,48 @@ impl<'a> CheckerState<'a> {
                 // assignable to `string`.
                 let type_arg_contains_type_parameters =
                     query::contains_type_parameters(self.ctx.types, type_arg);
-                if type_arg_contains_type_parameters
-                    && query::is_application_type(self.ctx.types.as_type_database(), type_arg)
-                {
+                let type_arg_is_application =
+                    query::is_application_type(self.ctx.types.as_type_database(), type_arg);
+                if type_arg_contains_type_parameters && type_arg_is_application {
+                    // Application type arguments that still contain type parameters
+                    // are generally deferred to instantiation time. Check the cheap
+                    // callable/indexed-access exception before proving positive
+                    // conditional/object-map cases, since those proofs can expand
+                    // recursive helper aliases for libraries like ts-toolbelt.
+                    let constraint_resolved = self.resolve_lazy_type(constraint);
+                    let constraint_is_callable = query::is_callable_type(
+                        self.ctx.types.as_type_database(),
+                        constraint_resolved,
+                    ) || query::constraint_expands_to_callable_union(
+                        self.ctx.types.as_type_database(),
+                        constraint_resolved,
+                    ) || self
+                        .is_function_constraint(param.constraint.unwrap_or(TypeId::NEVER));
+                    let constraint_is_object_like = constraint_resolved == TypeId::OBJECT
+                        || query::get_object_shape(
+                            self.ctx.types.as_type_database(),
+                            constraint_resolved,
+                        )
+                        .is_some();
+                    let generic_indexed_type_arg = self.generic_indexed_access_subject(type_arg);
+                    let keep_eager_check = constraint_is_callable
+                        && generic_indexed_type_arg.is_some()
+                        && !self.indexed_access_resolves_to_callable(
+                            generic_indexed_type_arg.unwrap_or(type_arg),
+                        );
+                    let is_infer_result_conditional_application = self
+                        .type_arg_evaluates_to_infer_result_conditional(type_arg)
+                        || self
+                            .type_alias_application_infer_result_conditional_components(type_arg)
+                            .is_some();
+                    if !constraint_is_object_like
+                        && !keep_eager_check
+                        && !is_infer_result_conditional_application
+                    {
+                        continue;
+                    }
+                }
+                if type_arg_contains_type_parameters && type_arg_is_application {
                     let constraint_resolved = self.resolve_lazy_type(constraint);
                     let inst_constraint = self
                         .instantiate_constraint_with_subst(constraint_resolved, &type_arg_subst);
@@ -341,6 +380,13 @@ impl<'a> CheckerState<'a> {
                         type_arg,
                         inst_constraint,
                     ) {
+                        continue;
+                    }
+                    if self
+                        .conditional_result_branches_satisfy_constraint(type_arg, inst_constraint)
+                        || self
+                            .type_alias_application_filters_to_constraint(type_arg, inst_constraint)
+                    {
                         continue;
                     }
                     let evaluated_arg = self.evaluate_type_for_assignability(type_arg);
@@ -380,39 +426,6 @@ impl<'a> CheckerState<'a> {
                                 arg_idx,
                             );
                         }
-                        continue;
-                    }
-                }
-                if type_arg_contains_type_parameters
-                    && !query::is_bare_type_parameter(self.ctx.types.as_type_database(), type_arg)
-                    && query::is_application_type(self.ctx.types.as_type_database(), type_arg)
-                {
-                    // Application type arguments that still contain type parameters
-                    // are generally deferred to instantiation time. Check the cheap
-                    // callable/indexed-access exception before computing a base
-                    // constraint, since base-constraint evaluation can expand the
-                    // alias body recursively for helper-heavy libraries.
-                    let constraint_resolved = self.resolve_lazy_type(constraint);
-                    let constraint_is_callable = query::is_callable_type(
-                        self.ctx.types.as_type_database(),
-                        constraint_resolved,
-                    ) || query::constraint_expands_to_callable_union(
-                        self.ctx.types.as_type_database(),
-                        constraint_resolved,
-                    ) || self
-                        .is_function_constraint(param.constraint.unwrap_or(TypeId::NEVER));
-                    let generic_indexed_type_arg = self.generic_indexed_access_subject(type_arg);
-                    let keep_eager_check = constraint_is_callable
-                        && generic_indexed_type_arg.is_some()
-                        && !self.indexed_access_resolves_to_callable(
-                            generic_indexed_type_arg.unwrap_or(type_arg),
-                        );
-                    let is_infer_result_conditional_application = self
-                        .type_arg_evaluates_to_infer_result_conditional(type_arg)
-                        || self
-                            .type_alias_application_infer_result_conditional_components(type_arg)
-                            .is_some();
-                    if !keep_eager_check && !is_infer_result_conditional_application {
                         continue;
                     }
                 }

--- a/crates/tsz-checker/tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs
+++ b/crates/tsz-checker/tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs
@@ -415,3 +415,52 @@ type Use<A> = Box<ExecText<A>>;
         "Nested conditional filters should satisfy string constraints through their extends branch. Got: {diagnostics:?}"
     );
 }
+
+#[test]
+fn indexed_object_map_filtering_to_string_satisfies_string_constraint() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type Box<T extends string> = T;
+type PickMatching<U, M> =
+  U extends unknown
+    ? { 1: U & M, 0: never }[U extends M ? 1 : 0]
+    : never;
+type NextText<OP> = PickMatching<OP, string>;
+type Routed<A> = NextText<string | { payload: A }>;
+
+type Use<A> = Box<Routed<A>>;
+"#,
+    );
+
+    assert!(
+        diagnostics.iter().all(|(code, _)| *code != 2344),
+        "Indexed object-map filters whose values include `string` should satisfy string constraints. Got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn indexed_object_map_filtering_to_number_does_not_satisfy_string_constraint() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type Box<T extends string> = T;
+type PickMatching<U, M> =
+  U extends unknown
+    ? { 1: U & M, 0: never }[U extends M ? 1 : 0]
+    : never;
+type NextNumber<OP> = PickMatching<OP, number>;
+type Routed<A> = NextNumber<number | { payload: A }>;
+
+type Use<A> = Box<Routed<A>>;
+"#,
+    );
+
+    let ts2344: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2344)
+        .collect();
+    assert_eq!(
+        ts2344.len(),
+        1,
+        "Expected one TS2344 when the object-map filter is bounded by number, not string. Got: {diagnostics:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -799,6 +799,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         use crate::relations::subtype::{MAX_SUBTYPE_DEPTH, SubtypeChecker};
         let mut checker = SubtypeChecker::with_resolver(self.interner, self.resolver);
+        if let Some(query_db) = self.query_db {
+            checker = checker.with_query_db(query_db);
+        }
         checker.bypass_evaluation = true;
         checker.max_depth = MAX_SUBTYPE_DEPTH;
         checker.no_unchecked_indexed_access = self.no_unchecked_indexed_access;

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -9,6 +9,7 @@
 //! - Deep recursive substitution through nested types
 //! - Handling of constraints and defaults
 
+use crate::caches::db::QueryDatabase;
 use crate::construction::TypeDatabase;
 #[cfg(test)]
 use crate::types::*;
@@ -31,6 +32,7 @@ const MAX_TUPLE_SPREAD_FLATTEN_ELEMENTS: usize = 8192;
 /// Instantiator for applying type substitutions.
 pub struct TypeInstantiator<'a> {
     interner: &'a dyn TypeDatabase,
+    query_db: Option<&'a dyn QueryDatabase>,
     substitution: &'a TypeSubstitution,
     /// Track visited types to handle cycles
     visiting: FxHashMap<TypeId, TypeId>,
@@ -86,6 +88,7 @@ impl<'a> TypeInstantiator<'a> {
             });
         TypeInstantiator {
             interner,
+            query_db: None,
             substitution,
             visiting: FxHashMap::default(),
             shadowed: Vec::new(),
@@ -105,6 +108,42 @@ impl<'a> TypeInstantiator<'a> {
 
     fn is_shadowed(&self, name: Atom) -> bool {
         self.shadowed.contains(&name)
+    }
+
+    pub(crate) const fn with_query_db(mut self, query_db: Option<&'a dyn QueryDatabase>) -> Self {
+        self.query_db = query_db;
+        self
+    }
+
+    #[inline]
+    pub(super) fn evaluate_type(&self, type_id: TypeId) -> TypeId {
+        if let Some(db) = self.query_db {
+            db.evaluate_type(type_id)
+        } else {
+            crate::evaluation::evaluate::evaluate_type(self.interner, type_id)
+        }
+    }
+
+    #[inline]
+    pub(super) fn evaluate_index_access(&self, object_type: TypeId, index_type: TypeId) -> TypeId {
+        if let Some(db) = self.query_db {
+            db.evaluate_index_access(object_type, index_type)
+        } else {
+            crate::evaluation::evaluate::evaluate_index_access(
+                self.interner,
+                object_type,
+                index_type,
+            )
+        }
+    }
+
+    #[inline]
+    pub(super) fn evaluate_keyof(&self, operand: TypeId) -> TypeId {
+        if let Some(db) = self.query_db {
+            db.evaluate_keyof(operand)
+        } else {
+            crate::evaluation::evaluate::evaluate_keyof(self.interner, operand)
+        }
     }
 
     /// Pre-trip the sticky depth-exceeded guard so the very next
@@ -166,7 +205,7 @@ impl<'a> TypeInstantiator<'a> {
         // would change `T[P]` (the union of all key values) into a per-key
         // `T[Q]`, so it is intentionally excluded.
         let substituted = self.substitution.get(p_name)?;
-        let resolved = crate::evaluation::evaluate::evaluate_type(self.interner, substituted);
+        let resolved = self.evaluate_type(substituted);
         if !crate::type_queries::is_type_usable_as_property_name(self.interner, resolved) {
             return None;
         }

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -766,7 +766,7 @@ pub(crate) fn instantiate_with_request_cached(
             db.insert_instantiation_cache(key, restored);
             return InstantiationResult::ok(restored);
         }
-        let result = run_instantiator(interner, request);
+        let result = run_instantiator(interner, query_db, request);
         if !result.depth_exceeded() {
             db.insert_instantiation_cache(key, result.type_id());
             if let Some(alpha_key) = alpha_key
@@ -781,7 +781,7 @@ pub(crate) fn instantiate_with_request_cached(
         }
         return result;
     }
-    run_instantiator(interner, request)
+    run_instantiator(interner, query_db, request)
 }
 
 fn alpha_canonicalize_cached_result(
@@ -814,10 +814,12 @@ fn alpha_canonicalize_cached_result(
 /// touching any cache.
 fn run_instantiator(
     interner: &dyn TypeDatabase,
+    query_db: Option<&dyn QueryDatabase>,
     request: InstantiationRequest<'_>,
 ) -> InstantiationResult {
     let options = request.options();
-    let mut instantiator = TypeInstantiator::new(interner, request.substitution());
+    let mut instantiator =
+        TypeInstantiator::new(interner, request.substitution()).with_query_db(query_db);
     instantiator.substitute_infer = options.substitute_infer();
     instantiator.preserve_meta_types = options.preserve_meta_types();
     instantiator.preserve_unsubstituted_type_params = options.preserve_unsubstituted_type_params();
@@ -866,8 +868,9 @@ pub fn instantiate_type_with_request(
 /// constraints reference substituted outer type parameters, so a fresh local
 /// binding such as a mapped type's iteration variable cannot be rewritten
 /// into its constraint by the forward-reference fallback in `instantiate_key`.
-pub(crate) fn instantiate_type_with_shadowed(
+pub(crate) fn instantiate_type_with_shadowed_cached(
     interner: &dyn TypeDatabase,
+    query_db: Option<&dyn QueryDatabase>,
     type_id: TypeId,
     substitution: &TypeSubstitution,
     shadowed_params: &[Atom],
@@ -878,7 +881,7 @@ pub(crate) fn instantiate_type_with_shadowed(
     if substitution.is_empty() {
         return type_id;
     }
-    let mut instantiator = TypeInstantiator::new(interner, substitution);
+    let mut instantiator = TypeInstantiator::new(interner, substitution).with_query_db(query_db);
     instantiator.shadowed.extend_from_slice(shadowed_params);
     // The walk returns a relation-preserving value on a depth/frame bail (it
     // never surfaces a substitution-bound free type parameter), so keep it

--- a/crates/tsz-solver/src/instantiation/instantiate/conditional.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/conditional.rs
@@ -4,7 +4,7 @@
 
 use crate::types::{ConditionalType, ConditionalTypeId, TypeData, TypeId};
 
-use super::{TypeInstantiator, instantiate_type, instantiate_type_preserving};
+use super::{TypeInstantiator, instantiate_type_cached, instantiate_type_preserving_cached};
 
 impl<'a> TypeInstantiator<'a> {
     /// Instantiate a conditional type: instantiate all parts.
@@ -36,16 +36,25 @@ impl<'a> TypeInstantiator<'a> {
                     let mut member_subst = self.substitution.clone();
                     member_subst.insert(info.name, member);
                     let instantiated = if self.preserve_unsubstituted_type_params {
-                        instantiate_type_preserving(self.interner, cond_type, &member_subst)
+                        instantiate_type_preserving_cached(
+                            self.interner,
+                            self.query_db,
+                            cond_type,
+                            &member_subst,
+                        )
                     } else {
-                        instantiate_type(self.interner, cond_type, &member_subst)
+                        instantiate_type_cached(
+                            self.interner,
+                            self.query_db,
+                            cond_type,
+                            &member_subst,
+                        )
                     };
                     if instantiated == TypeId::ERROR {
                         self.depth_exceeded = true;
                         return TypeId::ERROR;
                     }
-                    let evaluated =
-                        crate::evaluation::evaluate::evaluate_type(self.interner, instantiated);
+                    let evaluated = self.evaluate_type(instantiated);
                     if evaluated == TypeId::ERROR {
                         self.depth_exceeded = true;
                         return TypeId::ERROR;
@@ -56,7 +65,7 @@ impl<'a> TypeInstantiator<'a> {
             }
             let distribution_source = match self.interner.lookup(substituted) {
                 Some(TypeData::Union(_)) => substituted,
-                _ => crate::evaluation::evaluate::evaluate_type(self.interner, substituted),
+                _ => self.evaluate_type(substituted),
             };
             if let Some(TypeData::Union(members)) = self.interner.lookup(distribution_source) {
                 let members = self.interner.type_list(members);
@@ -85,9 +94,19 @@ impl<'a> TypeInstantiator<'a> {
                     }
                     member_subst.insert(info.name, member);
                     let instantiated = if self.preserve_unsubstituted_type_params {
-                        instantiate_type_preserving(self.interner, cond_type, &member_subst)
+                        instantiate_type_preserving_cached(
+                            self.interner,
+                            self.query_db,
+                            cond_type,
+                            &member_subst,
+                        )
                     } else {
-                        instantiate_type(self.interner, cond_type, &member_subst)
+                        instantiate_type_cached(
+                            self.interner,
+                            self.query_db,
+                            cond_type,
+                            &member_subst,
+                        )
                     };
                     // Check if instantiation hit depth limit
                     if instantiated == TypeId::ERROR {

--- a/crates/tsz-solver/src/instantiation/instantiate/homomorphic.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/homomorphic.rs
@@ -52,7 +52,7 @@ impl<'a> TypeInstantiator<'a> {
             readonly_modifier: mapped.readonly_modifier,
             optional_modifier: mapped.optional_modifier,
         });
-        let evaluated = crate::evaluation::evaluate::evaluate_type(self.interner, expanded);
+        let evaluated = self.evaluate_type(expanded);
         if evaluated == TypeId::ERROR
             || matches!(self.interner.lookup(evaluated), Some(TypeData::Mapped(_)))
         {

--- a/crates/tsz-solver/src/instantiation/instantiate/indexed.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/indexed.rs
@@ -50,7 +50,7 @@ impl<'a> TypeInstantiator<'a> {
             return self.interner.index_access(inst_obj, inst_idx);
         }
         // Evaluate immediately to achieve O(1) equality
-        crate::evaluation::evaluate::evaluate_index_access(self.interner, inst_obj, inst_idx)
+        self.evaluate_index_access(inst_obj, inst_idx)
     }
 
     /// Instantiate a `keyof`: instantiate the operand and evaluate immediately.
@@ -115,7 +115,7 @@ impl<'a> TypeInstantiator<'a> {
             return self.interner.keyof(inst_operand);
         }
         // Evaluate immediately to expand keyof { a: 1 } -> "a"
-        let result = crate::evaluation::evaluate::evaluate_keyof(self.interner, inst_operand);
+        let result = self.evaluate_keyof(inst_operand);
 
         // Store display alias so the formatter shows "keyof Shape" instead
         // of the expanded union. Only store when the result is non-trivial
@@ -173,7 +173,7 @@ impl<'a> TypeInstantiator<'a> {
         // If we detected types that can be evaluated, trigger evaluation
         // to potentially expand the template literal to a union of string literals
         if needs_evaluation {
-            crate::evaluation::evaluate::evaluate_type(self.interner, template_type)
+            self.evaluate_type(template_type)
         } else {
             template_type
         }
@@ -198,7 +198,7 @@ impl<'a> TypeInstantiator<'a> {
                 | TypeData::Literal(LiteralValue::String(_))
                 | TypeData::TemplateLiteral(_)
                 | TypeData::Intrinsic(IntrinsicKind::String) => {
-                    crate::evaluation::evaluate::evaluate_type(self.interner, string_intrinsic)
+                    self.evaluate_type(string_intrinsic)
                 }
                 _ => string_intrinsic,
             }

--- a/crates/tsz-solver/src/instantiation/instantiate/mapped.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/mapped.rs
@@ -11,9 +11,10 @@ use rustc_hash::FxHashMap;
 use crate::types::{MappedType, MappedTypeId, TypeData, TypeId, TypeParamInfo};
 
 use super::{
-    TypeInstantiator, TypeSubstitution, conditional_condition_needs_resolver, instantiate_type,
-    instantiate_type_with_shadowed, mapped_constraint_needs_resolver,
-    template_has_lazy_application_in_composite, type_contains_lazy_application,
+    TypeInstantiator, TypeSubstitution, conditional_condition_needs_resolver,
+    instantiate_type_cached, instantiate_type_with_shadowed_cached,
+    mapped_constraint_needs_resolver, template_has_lazy_application_in_composite,
+    type_contains_lazy_application,
 };
 
 impl<'a> TypeInstantiator<'a> {
@@ -46,7 +47,7 @@ impl<'a> TypeInstantiator<'a> {
             && !self.is_shadowed(tp_info.name)
             && let Some(substituted) = self.substitution.get(tp_info.name)
         {
-            let resolved = crate::evaluation::evaluate::evaluate_type(self.interner, substituted);
+            let resolved = self.evaluate_type(substituted);
             if let Some(TypeData::Union(list_id)) = self.interner.lookup(resolved)
                 && !Self::is_array_or_tuple_like(self.interner, resolved)
             {
@@ -74,8 +75,9 @@ impl<'a> TypeInstantiator<'a> {
                     }
                     member_subst.insert(tp_info.name, member);
                     let inst = |t| {
-                        instantiate_type_with_shadowed(
+                        instantiate_type_with_shadowed_cached(
                             self.interner,
+                            self.query_db,
                             t,
                             &member_subst,
                             &iter_var_shadow,
@@ -116,9 +118,9 @@ impl<'a> TypeInstantiator<'a> {
                 keyof_source,
                 mapped.type_param.name,
             )
-            && crate::evaluation::evaluate::evaluate_type(self.interner, substituted) == TypeId::ANY
+            && self.evaluate_type(substituted) == TypeId::ANY
             && tp_info.constraint.is_some_and(|c| {
-                let ec = crate::evaluation::evaluate::evaluate_type(self.interner, c);
+                let ec = self.evaluate_type(c);
                 Self::is_array_or_tuple_like(self.interner, ec)
             })
         {
@@ -128,10 +130,12 @@ impl<'a> TypeInstantiator<'a> {
             self.exit_shadowing_scope(shadowed_len, saved_visiting);
 
             let subst = TypeSubstitution::single(mapped.type_param.name, TypeId::NUMBER);
-            let mapped_element = crate::evaluation::evaluate::evaluate_type(
+            let mapped_element = self.evaluate_type(instantiate_type_cached(
                 self.interner,
-                instantiate_type(self.interner, new_template, &subst),
-            );
+                self.query_db,
+                new_template,
+                &subst,
+            ));
 
             let final_element = if matches!(
                 mapped.optional_modifier,
@@ -166,7 +170,7 @@ impl<'a> TypeInstantiator<'a> {
                 keyof_source,
                 mapped.type_param.name,
             );
-            let resolved = crate::evaluation::evaluate::evaluate_type(self.interner, substituted);
+            let resolved = self.evaluate_type(substituted);
 
             // tsc: When a homomorphic mapped type's source type parameter
             // is instantiated with `any`, the result depends on the type
@@ -178,7 +182,7 @@ impl<'a> TypeInstantiator<'a> {
             // makes `Objectish<any>` assignable to `any[]`, which is wrong.
             if resolved == TypeId::ANY {
                 let constraint_is_array_like = tp_info.constraint.is_some_and(|c| {
-                    let ec = crate::evaluation::evaluate::evaluate_type(self.interner, c);
+                    let ec = self.evaluate_type(c);
                     Self::is_array_or_tuple_like(self.interner, ec)
                 });
 
@@ -189,10 +193,12 @@ impl<'a> TypeInstantiator<'a> {
                     self.exit_shadowing_scope(shadowed_len, saved_visiting);
 
                     let subst = TypeSubstitution::single(mapped.type_param.name, TypeId::NUMBER);
-                    let mapped_element = crate::evaluation::evaluate::evaluate_type(
+                    let mapped_element = self.evaluate_type(instantiate_type_cached(
                         self.interner,
-                        instantiate_type(self.interner, new_template, &subst),
-                    );
+                        self.query_db,
+                        new_template,
+                        &subst,
+                    ));
 
                     let final_element = if matches!(
                         mapped.optional_modifier,
@@ -244,7 +250,7 @@ impl<'a> TypeInstantiator<'a> {
                 match self.interner.lookup(resolved) {
                     Some(TypeData::Tuple(tid)) => Some((tid, false)),
                     Some(TypeData::ReadonlyType(inner)) => {
-                        let ir = crate::evaluation::evaluate::evaluate_type(self.interner, inner);
+                        let ir = self.evaluate_type(inner);
                         if ir.is_intrinsic() {
                             None
                         } else {
@@ -348,10 +354,12 @@ impl<'a> TypeInstantiator<'a> {
                     };
 
                     let subst = TypeSubstitution::single(mapped.type_param.name, key_type);
-                    let mapped_type = crate::evaluation::evaluate::evaluate_type(
+                    let mapped_type = self.evaluate_type(instantiate_type_cached(
                         self.interner,
-                        instantiate_type(self.interner, rebound_template, &subst),
-                    );
+                        self.query_db,
+                        rebound_template,
+                        &subst,
+                    ));
 
                     // Re-wrap a `...E[]` rest in `Array<>`; absorb
                     // `Add ?` on a rest as `T | undefined` (a rest can
@@ -399,14 +407,12 @@ impl<'a> TypeInstantiator<'a> {
                 self.exit_shadowing_scope(shadowed_len, saved_visiting);
 
                 let subst = TypeSubstitution::single(mapped.type_param.name, TypeId::NUMBER);
-                let mapped_element = crate::evaluation::evaluate::evaluate_type(
+                let mapped_element = self.evaluate_type(instantiate_type_cached(
                     self.interner,
-                    crate::instantiation::instantiate::instantiate_type(
-                        self.interner,
-                        new_template,
-                        &subst,
-                    ),
-                );
+                    self.query_db,
+                    new_template,
+                    &subst,
+                ));
 
                 // Apply mapped type modifiers
                 let final_element = if matches!(
@@ -549,7 +555,7 @@ impl<'a> TypeInstantiator<'a> {
             // the mapped type after inference resolves the type parameters.
             mapped_type
         } else {
-            crate::evaluation::evaluate::evaluate_type(self.interner, mapped_type)
+            self.evaluate_type(mapped_type)
         }
     }
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Rebased onto current #13886 (`dd36bc2c353142b1e4682bfef1a164424501d0a4`) after #13886 moved to `origin/main@2c471f8a4a`.
- Thread the evaluator's existing query cache into the subtype checker used by `remove_redundant_members` during union/intersection simplification.
- This lets relation work spawned from query-backed evaluation reuse application/instantiation caches instead of falling back to a no-query-DB subtype checker.
- The former #13891 read-only first-pass cache draft is closed as superseded by #13889's `EvaluateTypeWithCacheOptions` / `with_limited_resolver` model.

## Structural Rule
When evaluation simplifies union/intersection members with the same resolver and compiler options as its parent `TypeEvaluator`, subtype checks should share the parent evaluator's query cache. `tsz` owns this in solver evaluation support by forwarding `query_db` into the local `SubtypeChecker` while preserving `bypass_evaluation`, depth, and `no_unchecked_indexed_access` settings.

Owner layer: solver evaluation support. No checker-local semantic shortcut, fixture-name gate, source-text gate, rendered-type predicate, or user identifier gate is used.

## Performance
- Actual filtered benchmark on this stack: `/tmp/ts-toolbelt-13890-bench-045171ca-20260618.json` PASS; `tsz` 391.8ms +- 11.1, `tsgo` 115.0ms +- 2.0, ratio 3.41x (<8x threshold).
- Baseline #13886 artifact: `/tmp/ts-toolbelt-13886-dd36bc2c-20260618.json`.
- Current artifact: `/tmp/ts-toolbelt-support-querydb-045171ca-20260618.json`.
- Diagnostics: 0 -> 0.
- Check time: 0.27s -> 0.27s; total time: 0.49s -> 0.48s. These are perf-counter attribution runs, not benchmark-row timing claims.
- Application eval cache hits: 59 -> 78; misses 1592 -> 1596.
- Instantiation cache hits: 1194 -> 1225; misses 598 -> 599.
- Application computes: 1399 -> 1080.
- Conditional computes: 877 -> 756.
- Mapped computes: 573 -> 525.
- Total eval computes: 2849 -> 2361.
- Application recompute headroom: 1196 -> 877.
- Evaluator memo constructions: 22547 -> 22150; lost recomputes: 4910 -> 4163; dropped memo entries: 26434 -> 25187.
- Slowest alias phase improves on `List/Diff.ts` body validation: 3.80ms -> 2.83ms.
- #13863 (`fffd4e2318`) does not move the actual `ts-toolbelt-project` benchmark row: 13.69x slower than `tsgo` locally, versus 13.66x on `origin/main@2c471f8a4a`. The row includes DOM lib, so the bounded checker pool is refused by the DOM/webworker safety gate unless using the unsafe diagnostic escape hatch; even that only measured ~10% faster locally.

## Verification
- Current PR head: `045171cad071078b99523ee818d4fa6cd4fb3914`; PR base: #13886 at `dd36bc2c353142b1e4682bfef1a164424501d0a4`.
- `git range-diff 7ff2dc467ec198c26fb69b49fbd1a9f1167133ae..17c1421e4743f28cb353cd0dedd23ea60b25f8a7 origin/codex/instantiation-query-eval-20260618..HEAD` PASS: `1:  17c1421e47 = 1:  045171cad0 perf(solver): share eval support relation query cache`.
- `cargo fmt --check` PASS.
- `git diff --check origin/main..HEAD && git diff --cached --check` PASS.
- `scripts/safe-run.sh cargo check -p tsz-cli` PASS.
- `scripts/safe-run.sh cargo nextest run -p tsz-solver union_simplification_generic_member_tests --no-fail-fast` PASS (3/3).
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --rebuild --filter "ts-toolbelt-project" --json-file /tmp/ts-toolbelt-13890-bench-045171ca-20260618.json` PASS: `tsz` 391.8ms +- 11.1, `tsgo` 115.0ms +- 2.0, ratio 3.41x.
- Baseline perf smoke on #13886: `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 RAYON_NUM_THREADS=1 scripts/safe-run.sh cargo run -q --profile dist-fast -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json /tmp/ts-toolbelt-13886-dd36bc2c-20260618.json --noEmit -p /Users/mohsen/code/tsz-instantiation-query-eval/.target-bench/external/ts-toolbelt/tsconfig.flat.json`.
- Current perf smoke on this branch: `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 RAYON_NUM_THREADS=1 scripts/safe-run.sh cargo run -q --profile dist-fast -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json /tmp/ts-toolbelt-support-querydb-045171ca-20260618.json --noEmit -p /Users/mohsen/code/tsz-instantiation-query-eval/.target-bench/external/ts-toolbelt/tsconfig.flat.json`.
- Earlier base verification from #13886 remains relevant for the lower stack commit: TS2344 focused checker tests and solver instantiation tests passed there.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: max
