### PR TITLE
perf(bench): overlap PGO canaries with benchmark shards

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1404,10 +1404,70 @@ jobs:
           if-no-files-found: warn
           compression-level: 1
 
+  pgo-compile-canaries:
+    name: bench-pgo-compile-canaries
+    needs: bench-prep-artifact
+    if: always() && needs.bench-prep-artifact.result == 'success'
+    runs-on: [self-hosted, tsz-cloud-run]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ env.BENCH_TARGET_SHA }}
+          fetch-depth: 1
+
+      - name: Download benchmark prep artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bench-prep-ready
+          path: .
+
+      - name: Run PGO compile canaries
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tar -xf bench-prep.tar
+          test -x .target-bench/dist/tsz
+          test -f .target-bench/dist/.bench-pgo-optimized
+
+          # Skip category:"application" canary rows here: they clone+install real
+          # apps (minutes each) and are excluded from the benchmark corpus, so
+          # they produce no PGO timing data. Application compatibility is still
+          # tracked by the CI project-compile-canary shards, which do not set
+          # this flag.
+          TSZ_BIN="$GITHUB_WORKSPACE/.target-bench/dist/tsz" \
+          TSZ_PROJECT_COMPILE_SET=canary \
+          TSZ_PROJECT_COMPILE_SKIP_APPLICATIONS=1 \
+          TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 \
+          scripts/ci/project-compile-guard.sh
+
+      - name: Stage PGO compile compatibility artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p bench-pgo-compile-compatibility
+          cp .target/project-compile-guard/project-compatibility.jsonl \
+            bench-pgo-compile-compatibility/
+          cp .target/project-compile-guard/project-compatibility-summary.json \
+            bench-pgo-compile-compatibility/
+
+      - name: Upload PGO compile compatibility artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bench-pgo-compile-compatibility
+          path: bench-pgo-compile-compatibility
+          retention-days: 7
+          if-no-files-found: error
+          compression-level: 1
+
   publish:
     name: bench-publish
-    needs: bench
-    if: always() && (needs.bench.result == 'success' || needs.bench.result == 'failure' || needs.bench.result == 'cancelled')
+    needs: [bench, pgo-compile-canaries]
+    if: >-
+      always() &&
+      (needs.bench.result == 'success' || needs.bench.result == 'failure' || needs.bench.result == 'cancelled') &&
+      needs.pgo-compile-canaries.result == 'success'
     runs-on: [self-hosted, tsz-cloud-run]
     timeout-minutes: 30
     steps:
@@ -1429,26 +1489,21 @@ jobs:
           name: bench-prep-ready
           path: .
 
-      - name: Run PGO compile canaries
+      - name: Download PGO compile compatibility artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bench-pgo-compile-compatibility
+          path: bench-pgo-compile-compatibility
+
+      - name: Restore PGO compile compatibility artifact
         shell: bash
         run: |
           set -euo pipefail
-
-          tar -xf bench-prep.tar
-          test -x .target-bench/dist/tsz
-          test -f .target-bench/dist/.bench-pgo-optimized
-
-          # Skip category:"application" canary rows here: they clone+install real
-          # apps (minutes each) and are excluded from the benchmark corpus, so
-          # they produce no PGO timing data but would blow this job's 30m budget
-          # (observed 2026-06-17: bench-publish timed out for ~14h, freezing the
-          # published benchmarks). Application *compatibility* is still tracked by
-          # the CI project-compile-canary shards, which do not set this flag.
-          TSZ_BIN="$GITHUB_WORKSPACE/.target-bench/dist/tsz" \
-          TSZ_PROJECT_COMPILE_SET=canary \
-          TSZ_PROJECT_COMPILE_SKIP_APPLICATIONS=1 \
-          TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 \
-          scripts/ci/project-compile-guard.sh
+          mkdir -p .target/project-compile-guard
+          cp bench-pgo-compile-compatibility/project-compatibility.jsonl \
+            .target/project-compile-guard/
+          cp bench-pgo-compile-compatibility/project-compatibility-summary.json \
+            .target/project-compile-guard/
 
       - id: merge
         name: Merge benchmark results

--- a/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
@@ -67,8 +67,8 @@ assert.match(
 
 assert.match(
   workflow,
-  /publish:[\s\S]+needs: bench[\s\S]+if: always\(\) && \(needs\.bench\.result == 'success' \|\| needs\.bench\.result == 'failure' \|\| needs\.bench\.result == 'cancelled'\)[\s\S]+Merge benchmark results/,
-  "bench publish should run after failed or timed-out/cancelled shard jobs so uploaded complete shard artifacts can still be merged instead of pinning the website to stale data",
+  /publish:[\s\S]+needs: \[bench, pgo-compile-canaries\][\s\S]+if: >-[\s\S]+always\(\) &&[\s\S]+\(needs\.bench\.result == 'success' \|\| needs\.bench\.result == 'failure' \|\| needs\.bench\.result == 'cancelled'\) &&[\s\S]+needs\.pgo-compile-canaries\.result == 'success'[\s\S]+Merge benchmark results/,
+  "bench publish should run after failed or timed-out/cancelled shard jobs once the overlapping PGO canary prerequisite succeeds, so uploaded complete shard artifacts can still be merged instead of pinning the website to stale data",
 );
 
 assert.doesNotMatch(


### PR DESCRIPTION
Goal: fast

## Summary
- Move the PGO compile-canary pass out of `bench-publish` into a separate `bench-pgo-compile-canaries` job.
- Start that job as soon as `bench-prep-artifact` is ready, so it runs in parallel with the benchmark shard matrix instead of after every shard completes.
- Publish now downloads the canary compatibility JSONL/summary artifact and restores it before `merge-results.mjs`, preserving the existing merged-artifact inputs.

## Evidence
- Previous completed run 27739740535 reached all benchmark shards, then spent `bench-publish` time in `Run PGO compile canaries` before the workflow was cancelled at the 30m publish timeout.
- Current main run 27747653571 shows the shard matrix constrained by `max-parallel: 4`, with four shards in progress and five queued after prep; this change adds useful independent work without raising Cloud Build shard submission pressure.
- Schedule run 27749517441 is release-only and completes quickly; workflow_run 27749472003 is currently in catch-up-after-active, so the long critical path remains the main benchmark run shape.

## Verification
- Lint guard fix head `b5e5dfc4cd`: `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs` passed.
- Lint guard fix head `b5e5dfc4cd`: `git diff --check` passed.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/bench.yml"); puts "yaml ok"'`
- `actionlint -ignore 'label "tsz-cloud-run" is unknown' -ignore 'SC2129' -ignore 'SC2140' .github/workflows/bench.yml`
- `node --check scripts/bench/merge-results.mjs && node --check scripts/ci/project-compatibility.mjs`
- `git diff --check`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high


- Refresh head `8d73304865`: rebased conflict-free onto `8a65a60555` after #13856 landed.
- Refresh head `8d73304865`: `git range-diff b5e5dfc4cd32d030593325d7a4386cfac39df6c3~2..b5e5dfc4cd32d030593325d7a4386cfac39df6c3 origin/main...HEAD` shows both commits equivalent.
- Refresh head `8d73304865`: `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs` passed.
- Refresh head `8d73304865`: `git diff --check origin/main...HEAD` passed.


- Refresh head `153d51dda3`: rebased conflict-free onto `2c471f8a4a` after #13887 landed.
- Refresh head `153d51dda3`: `git range-diff 8d73304865203b8b7d87b5664763d7f146464ac3~2..8d73304865203b8b7d87b5664763d7f146464ac3 origin/main...HEAD` shows both commits equivalent.
- Refresh head `153d51dda3`: `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs` passed.
- Refresh head `153d51dda3`: `git diff --check origin/main...HEAD` passed.
