### PR TITLE
fix(ci): post 'CI Summary' status for non-compiler PRs (unstick 'Expected' PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1769,3 +1769,28 @@ jobs:
           else:
               print("Draft/light CI passed for all required checks.")
           PY
+
+      - name: Report CI Summary status for non-compiler PRs
+        # Branch protection requires the "CI Summary" status check. For light /
+        # non-compiler PRs the verdict job above reports as "CI Light Summary"
+        # (see the job-name expression), so "CI Summary" is never produced and
+        # the PR sits "Expected — waiting for status to be reported" forever —
+        # it cannot be enqueued and no job is running. Mirror this job's verdict
+        # into a "CI Summary" commit status so non-compiler PRs are mergeable.
+        # Full PRs (required_summary == 'true') already emit "CI Summary" as the
+        # job name, so this guard avoids posting a duplicate context for them.
+        if: always() && github.event_name == 'pull_request' && needs.gate.outputs.required_summary != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          state="failure"
+          if [[ "${{ job.status }}" == "success" ]]; then
+            state="success"
+          fi
+          gh api -X POST "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -f state="$state" \
+            -f context="CI Summary" \
+            -f description="Mirrored from CI Light Summary (non-compiler PR)" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            >/dev/null
+          echo "Posted CI Summary=$state for non-compiler PR head ${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
## Summary
Fixes the long-standing "PR stuck, summary pending, nothing running" bug:
non-compiler PRs (bench scripts, docs, etc.) sit on **`CI Summary — Expected —
Waiting for status to be reported`** forever and can't be merged.

## Root cause
Branch protection (ruleset "Main active") requires the status check named
**`CI Summary`**. But the `ci-summary` job renames itself:
`name: ${{ needs.gate.outputs.required_summary == 'true' && 'CI Summary' || 'CI Light Summary' }}`.
For a light / non-compiler PR the gate sets `required_summary=false`, so the
verdict job reports as **`CI Light Summary`** — which does **not** satisfy the
required `CI Summary`. The job passes, every other job skips, yet `CI Summary`
is never produced → the PR is `Expected` forever and cannot be enqueued. (No
prior-run mirror exists for a fresh light head, so the metadata mirror can't
rescue it either.) `merge_group` always runs full CI and emits the `CI Summary`
**check-run**, so only the PR side is broken.

## Fix
Add a final `ci-summary` step that, for `pull_request` events with
`required_summary != 'true'`, mirrors the job's verdict into a **`CI Summary`
commit status** (success/failure from `job.status`). Full PRs already emit
`CI Summary` as the job name, so the guard prevents a duplicate context. A
failing light run posts `CI Summary: failure` (no false-green), and the edited/
metadata path still runs the failure-propagating mirror, so #9385 (a redundant
event overriding a real failure) stays protected.

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → OK.
- `node scripts/ci/test-pr-ready-state.mjs` → passes (the dual-name + mirror
  assertions are unchanged; this is additive).
- This PR is itself a `ci.yml` change → compiler CI required → reports a real
  `CI Summary`, so it is not subject to the bug it fixes.

Goal: hold

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
