### PR TITLE
perf(ci): skip useless cargo-target-deps restore on PR dist-binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,6 +630,13 @@ jobs:
       # dist-fast build is short enough without sccache, and all harness suites
       # are blocked until this artifact uploads.
       TSZ_CI_DISABLE_SCCACHE: "1"
+      # On PR (non-refresh) dist runs the cargo-target-deps exact key always
+      # misses and falls back to a markerless warm blob, so cargo rebuilds the
+      # workspace regardless — the ~200s restore is pure overhead on the
+      # critical path (dist-binaries gates every harness suite). Skip it on
+      # non-refresh runs; keep it on trusted refresh runs that legitimately
+      # restore a fresher incremental base before re-publishing the cache.
+      TSZ_CI_SKIP_DIST_RESTORE: ${{ needs.gate.outputs.rust_cache_refresh == 'true' && '0' || '1' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
Goal: fast

Skip the markerless `cargo-target-deps` warm-blob restore on PR `dist-binaries` runs. This is lever **Q1** of the CI-performance plan (highest ROI / lowest risk).

## Why
`dist-binaries` gates every harness suite (conformance/emit/fourslash/unit), so it sits on the critical path to **CI Summary**. CI-perf evidence across recent PR + `merge_group` runs shows it is ~71% of green-light latency, of which ~200s is the `cargo-target-deps` restore. On PR (non-refresh) runs the exact cache key always misses and falls back to a **markerless warm blob** (pre-#13747), so cargo rebuilds the full workspace anyway — the restore buys nothing.

## Change
Set `TSZ_CI_SKIP_DIST_RESTORE` on the `dist-binaries` job, conditional on the gate `rust_cache_refresh` output:
- PR / non-refresh runs → `1` → skip the useless restore (honored at `scripts/ci/gcp-cache.sh:627`).
- Trusted refresh runs → `0` → keep the restore (legitimately seeds a fresher incremental base before re-publishing the shared cache key). No change to `main`.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `python3 -c "yaml.safe_load(...)"` confirms `ci.yml` parses; gate already exposes `rust_cache_refresh` (`ci.yml:38`), used by the existing `TSZ_CI_CACHE_SAVE_CARGO_TARGETS` env.
- Diff is +7 lines, purely additive (one env var + rationale comment); no logic moved.
- Success metric (verify on this PR before landing): `dist-binaries` wall-clock drops ~200s vs recent PR baseline with compile time unchanged, and the restore step is absent from the log.