### PR TITLE
test(cli): make #13255 parallel-determinism guards exercise the real par_iter path

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -430,6 +430,16 @@ const fn resolve_checker_pool_size(
 /// global-lib gate so forced-parallel rows can be byte-compared against the
 /// sequential baseline without also changing tiny-batch policy.
 ///
+/// `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK_TINY` is a second diagnosis-only escape
+/// hatch (`force_tiny_batch_parallel`) that *additionally* bypasses the
+/// tiny-batch floor, forcing the genuine rayon `par_iter` fresh-checker path
+/// even for a handful of files. The schedule-determinism regression guards in
+/// `parallel_sequential_agreement_tests` rely on it: their distilled witnesses
+/// are far below the [`FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES`] floor, so
+/// `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK` alone left them on the sequential arm
+/// (sequential-vs-sequential, a silent no-op). This flag never changes the
+/// production default — tiny batches still run sequentially unless it is set.
+///
 /// Large wildcard barrels are still detected and tested separately, but they
 /// no longer force the entire project onto one core: the mutation-isolation
 /// and cold-start cache work that landed before #13244 made the whole-project
@@ -478,8 +488,9 @@ const fn should_use_sequential_fresh_checking(
     work_item_count: usize,
     has_parallel_order_sensitive_global_lib: bool,
     force_parallel_order_sensitive_global_lib: bool,
+    force_tiny_batch_parallel: bool,
 ) -> bool {
-    work_item_count <= FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES
+    (work_item_count <= FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES && !force_tiny_batch_parallel)
         || (has_parallel_order_sensitive_global_lib && !force_parallel_order_sensitive_global_lib)
 }
 
@@ -1401,10 +1412,16 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
             // env without also bypassing tiny-batch policy.
             let force_parallel_order_sensitive_global_lib =
                 std::env::var_os("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK").is_some();
+            // Diagnosis-only: also bypass the tiny-batch floor so the
+            // schedule-determinism regression guards exercise the genuine
+            // `par_iter` fresh-checker path on their small distilled witnesses.
+            let force_tiny_batch_parallel =
+                std::env::var_os("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK_TINY").is_some();
             let use_sequential_checking = should_use_sequential_fresh_checking(
                 work_items.len(),
                 has_parallel_order_sensitive_global_lib,
                 force_parallel_order_sensitive_global_lib,
+                force_tiny_batch_parallel,
             );
             // T2.1.B (`PERFORMANCE_PLAN.md` §6 PR table): the sequential
             // no-emit path *can* construct one `CheckerState` and re-target

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -767,24 +767,40 @@ fn large_reuse_off_batches_keep_fresh_parallel_eligible() {
     let large_project = FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES + 1;
 
     assert!(
-        !should_use_sequential_fresh_checking(large_project, false, false),
+        !should_use_sequential_fresh_checking(large_project, false, false, false),
         "large fresh-checker batches should stay parallel-eligible even when session reuse is off"
     );
     assert!(
-        should_use_sequential_fresh_checking(10, false, false),
+        should_use_sequential_fresh_checking(10, false, false, false),
         "tiny batches stay sequential for deterministic cross-file behavior"
     );
     assert!(
-        should_use_sequential_fresh_checking(10, true, true),
+        should_use_sequential_fresh_checking(10, true, true, false),
         "the force-parallel experiment must not bypass tiny-batch policy"
     );
     assert!(
-        should_use_sequential_fresh_checking(large_project, true, false),
+        should_use_sequential_fresh_checking(large_project, true, false, false),
         "order-sensitive global libraries stay on the deterministic sequential fallback"
     );
     assert!(
-        !should_use_sequential_fresh_checking(large_project, true, true),
+        !should_use_sequential_fresh_checking(large_project, true, true, false),
         "the force-parallel experiment should bypass only the order-sensitive global-lib gate"
+    );
+    // The dedicated tiny-batch override forces the genuine `par_iter`
+    // fresh-checker path even below the small-project floor, so the
+    // schedule-determinism regression guards stop silently degrading to
+    // sequential-vs-sequential no-ops.
+    assert!(
+        !should_use_sequential_fresh_checking(10, false, false, true),
+        "TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK_TINY must force tiny batches onto the parallel path"
+    );
+    assert!(
+        should_use_sequential_fresh_checking(10, true, false, true),
+        "the tiny-batch override must still respect the order-sensitive global-lib gate"
+    );
+    assert!(
+        !should_use_sequential_fresh_checking(10, true, true, true),
+        "both force overrides together must reach the parallel path"
     );
 }
 

--- a/crates/tsz-cli/tests/parallel_sequential_agreement_tests.rs
+++ b/crates/tsz-cli/tests/parallel_sequential_agreement_tests.rs
@@ -16,6 +16,16 @@
 //! validation this failed deterministically: the parallel output disagreed
 //! with the sequential output on elaboration identity and carried extra
 //! false diagnostics.
+//!
+//! Floor caveat: `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK` only lifts the
+//! order-sensitive global-lib (DOM) gate; it deliberately keeps the tiny-batch
+//! policy, so a witness below the small-project floor
+//! (`FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES`, 32 files) runs sequentially
+//! in *both* arms of the `forced_parallel_*_matches_sequential` tests — a
+//! sequential-vs-sequential comparison that cannot witness a schedule race.
+//! `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK_TINY` additionally bypasses that floor
+//! and forces the genuine per-file `par_iter` path; `genuine_parallel_*` tests
+//! use it so a small distilled witness is actually checked concurrently.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -207,24 +217,55 @@ const SCOPE_REGISTRY_FIXTURE_FILES: &[(&str, &str)] = &[
 const SCOPE_REGISTRY_FIXTURE_TSCONFIG: &str =
     include_str!("fixtures/parallel_agreement_scope_registry/tsconfig.json");
 
-fn run_project(tsz_bin: &Path, project_dir: &Path, force_parallel: bool) -> String {
+/// Run the project, clearing both force-parallel experiment flags first and
+/// then setting exactly `envs` (so a leaked env from the caller's process can
+/// never perturb which checking path is taken).
+fn run_tsz(tsz_bin: &Path, project_dir: &Path, envs: &[(&str, &str)]) -> String {
     let mut cmd = Command::new(tsz_bin);
     cmd.args(["-p", "tsconfig.json", "--pretty", "false"])
-        .current_dir(project_dir);
-    if force_parallel {
-        cmd.env("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK", "1");
-    } else {
-        cmd.env_remove("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK");
+        .current_dir(project_dir)
+        .env_remove("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK")
+        .env_remove("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK_TINY");
+    for (key, value) in envs {
+        cmd.env(key, value);
     }
     let output = cmd.output().expect("run tsz on agreement fixture");
     String::from_utf8_lossy(&output.stdout).into_owned()
 }
 
-fn assert_parallel_matches_sequential(
+fn run_project(tsz_bin: &Path, project_dir: &Path, force_parallel: bool) -> String {
+    let envs: &[(&str, &str)] = if force_parallel {
+        &[("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK", "1")]
+    } else {
+        &[]
+    };
+    run_tsz(tsz_bin, project_dir, envs)
+}
+
+/// Run the project on the *genuine* rayon `par_iter` fresh-checker path.
+///
+/// `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK` alone only lifts the DOM gate, not the
+/// tiny-batch floor (see module docs), so a sub-floor witness needs
+/// `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK_TINY` too to actually run concurrently.
+fn run_project_tiny_parallel(tsz_bin: &Path, project_dir: &Path) -> String {
+    run_tsz(
+        tsz_bin,
+        project_dir,
+        &[
+            ("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK", "1"),
+            ("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK_TINY", "1"),
+        ],
+    )
+}
+
+/// Stage a witness project and assert its sequential baseline is byte-identical
+/// to `run_parallel`'s output across `attempts` schedules.
+fn assert_matches_sequential(
     name: &str,
     files: &[(&str, &str)],
     tsconfig: &str,
     attempts: usize,
+    run_parallel: impl Fn(&Path, &Path) -> String,
 ) {
     let Some(tsz_bin) = find_tsz_binary() else {
         println!("skipping parallel agreement test: tsz binary not found");
@@ -242,14 +283,36 @@ fn assert_parallel_matches_sequential(
         !sequential.is_empty() || run_project(&tsz_bin, &temp.path, false) == sequential,
         "sequential run should be reproducible"
     );
-
     for attempt in 0..attempts {
-        let parallel = run_project(&tsz_bin, &temp.path, true);
+        let parallel = run_parallel(&tsz_bin, &temp.path);
         assert_eq!(
             parallel, sequential,
-            "forced-parallel diagnostics diverged from sequential on attempt {attempt}"
+            "parallel diagnostics diverged from sequential on attempt {attempt}"
         );
     }
+}
+
+fn assert_parallel_matches_sequential(
+    name: &str,
+    files: &[(&str, &str)],
+    tsconfig: &str,
+    attempts: usize,
+) {
+    assert_matches_sequential(name, files, tsconfig, attempts, |bin, dir| {
+        run_project(bin, dir, true)
+    });
+}
+
+/// Genuine-`par_iter` variant of [`assert_parallel_matches_sequential`]: drives
+/// the real concurrent path (via [`run_project_tiny_parallel`]) so a sub-floor
+/// witness can actually observe an in-flight shared-state schedule race.
+fn assert_tiny_parallel_matches_sequential(
+    name: &str,
+    files: &[(&str, &str)],
+    tsconfig: &str,
+    attempts: usize,
+) {
+    assert_matches_sequential(name, files, tsconfig, attempts, run_project_tiny_parallel);
 }
 
 /// Forced-parallel fresh checking must produce byte-identical diagnostics to
@@ -400,5 +463,21 @@ fn dom_element_heritage_clean_sequential() {
         !output.contains("error TS"),
         "DOM element interfaces must be recognized as Node under the fresh per-file \
          checker pool (default sequential schedule); got diagnostics:\n{output}"
+    );
+}
+
+/// Genuine-`par_iter` guard for the cross-arena delegation witness (#13255):
+/// unlike the `forced_parallel_*` tests (which a sub-floor witness runs
+/// sequentially in both arms — see module docs), this drives the real
+/// concurrent path, so the delegation derivation (#13391: lib-origin global
+/// resolution + def-identity recovery for symbol-less structural bases) is
+/// proven schedule-independent rather than merely sequentially reproducible.
+#[test]
+fn genuine_parallel_disposable_delegation_matches_sequential() {
+    assert_tiny_parallel_matches_sequential(
+        "disposable_tiny",
+        DISPOSABLE_FIXTURE_FILES,
+        DISPOSABLE_FIXTURE_TSCONFIG,
+        8,
     );
 }


### PR DESCRIPTION
Goal: fast

## Summary

The parallel-vs-sequential agreement guards for #13255
(`crates/tsz-cli/tests/parallel_sequential_agreement_tests.rs`) pass
`TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK`, but **every distilled witness in that
file is far below the small-project floor**
(`FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES`, 32 files; the witnesses are
4–9 files). That flag deliberately only lifts the order-sensitive global-lib
(DOM) gate and **keeps the tiny-batch policy**, so
`should_use_sequential_fresh_checking` still returns `true` for these
fixtures — both arms run sequentially. The guards had silently degraded to
**sequential-vs-sequential no-ops** that cannot observe a schedule race.

Confirmed empirically by reading the gate
(`work_item_count <= 32 || (dom && !force)` → always `true` here) and by
running the binary: forcing the *genuine* `par_iter` path reproduces live
#13255 flaps on witnesses the no-op guards reported green —
`parallel_agreement` drops `pipeline.ts(130,42)` in ~2/12 runs, and
`lib_iter` drops a 12-line TS2322 cluster in ~1/12 runs.

## Structural rule

When a fresh-per-file-checker witness is below the tiny-batch floor, the
existing `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK` flag cannot drive the rayon
`par_iter` path, so a schedule-determinism guard built on it proves nothing.
This adds a second, orthogonal diagnosis-only escape hatch,
`TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK_TINY` (`force_tiny_batch_parallel`), that
*additionally* bypasses the tiny-batch floor and forces the genuine per-file
`par_iter` fresh-checker path. It is:

- **orthogonal** to the existing flag, which keeps its documented (and
  unit-tested) "must not bypass tiny-batch policy" contract — the two flags
  gate two independent axes (DOM gate vs. file-count floor);
- **default-off** and never changes the production schedule (owner:
  `tsz_cli::driver::check::should_use_sequential_fresh_checking`).

It is wired into a new
`genuine_parallel_disposable_delegation_matches_sequential` guard that drives
the cross-arena delegation witness (#13391: lib-origin global resolution +
def-identity recovery for symbol-less structural bases) on the **real
concurrent path across 8 schedules** — the first guard on this issue that can
actually observe an in-flight shared-state race on a small distilled fixture.
This witness is byte-stable on the genuine parallel path (verified 50/50
locally); the remaining witnesses (`parallel_agreement`, `lib_iter`,
`scope_registry`) still flap on the genuine path and stay on their current
`forced_parallel_*` (sequential-arm) assertions until the documented
mutation-isolation / interner-ordering channel lands — captured for the next
slice in the issue thread.

The run/assert helpers were deduplicated while adding this (`run_tsz` single
runner that clears both flags before setting exactly what it needs;
`assert_matches_sequential` parameterized on the parallel runner).

## Verification

- `cargo test -p tsz-cli --test parallel_sequential_agreement_tests` → 6/6
  pass, including the new `genuine_parallel_disposable_delegation_matches_sequential`
  (8 genuine-`par_iter` schedules byte-identical to sequential).
- `cargo test -p tsz-cli --lib large_reuse_off_batches_keep_fresh_parallel_eligible`
  → pass (extended to cover the new `force_tiny_batch_parallel` axis incl. the
  DOM-gate-still-respected and both-overrides cases).
- `cargo fmt -p tsz-cli --check` clean; `cargo clippy -p tsz-cli --tests` clean.
- Manual repro of the no-op gap: with both flags set, the genuine path drops
  `pipeline.ts(130,42)` ~2/12 and a `lib_iter` TS2322 cluster ~1/12, vs. 0
  divergence the old `FORCE_PARALLEL_CHECK`-only runs could ever surface.
- Production behavior unchanged (new flag default-off; tiny batches still
  sequential).

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01JRyftbfSFxm7mrZUdYvp6E

---
_Generated by [Claude Code](https://claude.ai/code/session_01JRyftbfSFxm7mrZUdYvp6E)_