### PR TITLE
test(checker): guard deferred HOF application against false TS2344 on unknown[] constraint (#13908)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -626,6 +626,9 @@ path = "tests/deferred_conditional_identity_extends_tests.rs"
 name = "deferred_conditional_indexed_access_tests"
 path = "tests/deferred_conditional_indexed_access_tests.rs"
 [[test]]
+name = "deferred_hof_application_unknown_array_constraint_tests"
+path = "tests/deferred_hof_application_unknown_array_constraint_tests.rs"
+[[test]]
 name = "ts2322_property_decl_annotation_tests"
 path = "tests/ts2322_property_decl_annotation_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/deferred_hof_application_unknown_array_constraint_tests.rs
+++ b/crates/tsz-checker/tests/deferred_hof_application_unknown_array_constraint_tests.rs
@@ -1,0 +1,227 @@
+//! Regression guard: TS2344 must be deferred — not eagerly emitted — for a
+//! deferred higher-order-function (HOF) application that is indexed by
+//! `[number]` and threaded through an `infer X extends unknown[]` argument
+//! channel, the shape used pervasively by `hotscript` (`grow` canary row).
+//!
+//! Structural rule: when a type argument is a generic *application* that still
+//! contains free type parameters (here, `this`-relative HOF lambda bodies such
+//! as `Invoke<Each<...>, this["second"]>`) and the target parameter constraint
+//! is an array/tuple type (`unknown[]`), `tsc` defers the constraint check to
+//! instantiation time. The deferred application's base constraint is `unknown`,
+//! which is not assignable to `unknown[]`, so eagerly checking it fabricates a
+//! spurious `TS2344 … does not satisfy the constraint 'unknown[]'`. tsz must
+//! defer it through the generic-application path in
+//! `validate_type_args_against_params` (the application-with-type-parameters
+//! branch), exactly as `tsc` does.
+//!
+//! The witness is `hotscript`'s `Tuples.EveryFn`:
+//!
+//! ```ts
+//! interface EveryFn extends Fn {
+//!   return: false extends Call<
+//!     Tuples.Map<Extract<this["arg0"], Fn>>,
+//!     this["arg1"]
+//!   >[number]
+//!     ? false
+//!     : true;
+//! }
+//! ```
+//!
+//! `Call`/`Apply`/`PartialApply` all route their argument tuple through
+//! `infer args extends unknown[]` and re-apply it via an `unknown[]`-constrained
+//! parameter (`Apply<fn, args extends unknown[]>`). A single-file reduction of
+//! any one helper evaluates eagerly and stays clean; the deferral only matters
+//! once the full HOF graph keeps the application deferred. The two positive
+//! cases below reproduce that graph with disjoint binder names (the deferral is
+//! structural, never name-driven), and the negative controls prove the deferral
+//! is not vacuous: a *concrete* non-array argument still earns its `TS2344`.
+//!
+//! Issue: tsz-org/tsz#13908.
+
+use tsz_checker::test_utils::check_source_codes;
+
+/// Minimal `--noLib` prelude: the global interfaces the structural-type machinery
+/// references plus a local `Extract`, so the HOF graph below is self-contained.
+const PRELUDE: &str = r#"
+interface Array<T> { length: number; [n: number]: T; }
+interface ReadonlyArray<T> { length: number; readonly [n: number]: T; }
+interface Boolean {}
+interface Function {}
+interface CallableFunction {}
+interface NewableFunction {}
+interface IArguments {}
+interface Number {}
+interface Object {}
+interface RegExp {}
+interface String {}
+interface Symbol {}
+type Extract<T, U> = T extends U ? T : never;
+"#;
+
+/// hotscript-shaped deferred HOF graph (binder set "A"): `Lambda`/`Invoke`/
+/// `ApplyAll`/`Curry`/`Each`/`All`. The `AllFn` body indexes a deferred
+/// `Invoke<Each<...>, this["second"]>` by `[number]`, which is the exact
+/// `EveryFn` witness. No `TS2344` may be emitted.
+#[test]
+fn test_deferred_hof_application_indexed_by_number_defers_unknown_array_constraint() {
+    let source = format!(
+        "{PRELUDE}{}",
+        r#"
+declare const rawArgs: unique symbol;
+type rawArgs = typeof rawArgs;
+
+interface Lambda {
+  [rawArgs]: unknown;
+  arguments: this[rawArgs] extends infer a extends unknown[] ? a : never;
+  first: this[rawArgs] extends [infer x, ...any] ? x : never;
+  second: this[rawArgs] extends [any, infer x, ...any] ? x : never;
+}
+
+declare const blank: unique symbol;
+type blank = typeof blank;
+
+type Drop<xs, out extends any[] = []> = xs extends [infer h, ...infer t]
+  ? [h] extends [blank] ? Drop<t, out> : Drop<t, [...out, h]>
+  : out;
+
+type Invoke<lam extends Lambda, p0 = blank, p1 = blank> = (lam & {
+  [rawArgs]: Drop<[p0, p1]>;
+})["return"];
+
+type ApplyAll<lam extends Lambda, items extends unknown[]> =
+  (lam & { [rawArgs]: items })["return"];
+
+interface Curry<lam extends Lambda, held extends unknown[]> extends Lambda {
+  return: this["arguments"] extends infer joined extends unknown[]
+    ? ApplyAll<lam, [...held, ...joined]>
+    : never;
+}
+
+interface EachFn extends Lambda {
+  return: this["arguments"] extends [infer lam extends Lambda, infer seq extends unknown[]]
+    ? { [k in keyof seq]: Invoke<lam, seq[k]> }
+    : never;
+}
+type Each<lam extends Lambda | blank = blank, seq extends readonly any[] | blank = blank> =
+  Curry<EachFn, [lam, seq]>;
+
+interface AllFn extends Lambda {
+  return: false extends Invoke<Each<Extract<this["first"], Lambda>>, this["second"]>[number]
+    ? false
+    : true;
+}
+type All<lam extends Lambda, seq = blank> = Curry<AllFn, [lam, seq]>;
+
+interface IsNum<T> extends Lambda { return: this["first"] extends T ? true : false; }
+type Positive = Invoke<All<IsNum<number>>, [1, 2, 3]>;
+"#
+    );
+    let diagnostics = check_source_codes(&source);
+    assert!(
+        !diagnostics.contains(&2344),
+        "deferred HOF application must not emit TS2344; got: {diagnostics:?}"
+    );
+}
+
+/// Same structural graph as above with a disjoint binder set ("B":
+/// `Thunk`/`Run`/`Spread`/`Bind`/`OverEach`/`Whole`). The deferral is a
+/// structural property of the application/constraint shapes, never of the
+/// chosen identifiers, so this must also emit no `TS2344`.
+#[test]
+fn test_deferred_hof_application_renamed_binders_still_defers() {
+    let source = format!(
+        "{PRELUDE}{}",
+        r#"
+declare const packed: unique symbol;
+type packed = typeof packed;
+
+interface Thunk {
+  [packed]: unknown;
+  inputs: this[packed] extends infer a extends unknown[] ? a : never;
+  head: this[packed] extends [infer x, ...any] ? x : never;
+  next: this[packed] extends [any, infer x, ...any] ? x : never;
+}
+
+declare const hole: unique symbol;
+type hole = typeof hole;
+
+type Strip<xs, acc extends any[] = []> = xs extends [infer h, ...infer t]
+  ? [h] extends [hole] ? Strip<t, acc> : Strip<t, [...acc, h]>
+  : acc;
+
+type Run<th extends Thunk, q0 = hole, q1 = hole> = (th & {
+  [packed]: Strip<[q0, q1]>;
+})["return"];
+
+type Spread<th extends Thunk, cells extends unknown[]> =
+  (th & { [packed]: cells })["return"];
+
+interface Bind<th extends Thunk, saved extends unknown[]> extends Thunk {
+  return: this["inputs"] extends infer merged extends unknown[]
+    ? Spread<th, [...saved, ...merged]>
+    : never;
+}
+
+interface OverEachFn extends Thunk {
+  return: this["inputs"] extends [infer th extends Thunk, infer row extends unknown[]]
+    ? { [k in keyof row]: Run<th, row[k]> }
+    : never;
+}
+type OverEach<th extends Thunk | hole = hole, row extends readonly any[] | hole = hole> =
+  Bind<OverEachFn, [th, row]>;
+
+interface WholeFn extends Thunk {
+  return: false extends Run<OverEach<Extract<this["head"], Thunk>>, this["next"]>[number]
+    ? false
+    : true;
+}
+type Whole<th extends Thunk, row = hole> = Bind<WholeFn, [th, row]>;
+
+interface IsStr<T> extends Thunk { return: this["head"] extends T ? true : false; }
+type Result = Run<Whole<IsStr<string>>, ["a", "b"]>;
+"#
+    );
+    let diagnostics = check_source_codes(&source);
+    assert!(
+        !diagnostics.contains(&2344),
+        "renamed-binder deferred HOF application must not emit TS2344; got: {diagnostics:?}"
+    );
+}
+
+/// Negative control: a *concrete* non-array argument passed to an
+/// `unknown[]`-constrained parameter must still earn its `TS2344`. This proves
+/// the deferral above is structural (deferred-application-only), not a blanket
+/// suppression of array-constraint checks.
+#[test]
+fn test_concrete_non_array_into_unknown_array_constraint_still_emits_ts2344() {
+    let source = format!(
+        "{PRELUDE}{}",
+        r#"
+type Vec<X extends unknown[]> = { items: X };
+type Bad = Vec<string>;
+"#
+    );
+    let diagnostics = check_source_codes(&source);
+    assert!(
+        diagnostics.contains(&2344),
+        "concrete non-array argument must emit TS2344; got: {diagnostics:?}"
+    );
+}
+
+/// Negative control: a concrete array argument satisfies `unknown[]` and must
+/// not emit `TS2344` (guards against over-correcting into a false negative).
+#[test]
+fn test_concrete_array_into_unknown_array_constraint_is_accepted() {
+    let source = format!(
+        "{PRELUDE}{}",
+        r#"
+type Vec<X extends unknown[]> = { items: X };
+type Ok = Vec<number[]>;
+"#
+    );
+    let diagnostics = check_source_codes(&source);
+    assert!(
+        !diagnostics.contains(&2344),
+        "concrete array argument must not emit TS2344; got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
Goal: grow

Closes #13908.

## Summary

Issue #13908 reported a single residual hotscript (`grow` canary) false positive:
`TS2344 … does not satisfy the constraint 'unknown[]'` at `Tuples.ts` on the
deferred `Call<Tuples.Map<…>, this["arg1"]>[number]` shape in `EveryFn`.

I could not reproduce the diagnostic on current `main`. The hotscript witness
now compiles with **0 errors**, matching `tsc` — so the row is green. Rather
than land a no-op, this PR converts that accidental/implicit greenness into an
explicit, name-independent regression guard at the fast checker-unit layer (the
acceptance lever the issue itself names: "a faithful checker/solver unit test
that forces the deferred-application constraint path").

## Structural rule

When a type argument is a generic *application* that still contains free type
parameters (here, `this`-relative HOF lambda bodies such as
`Invoke<Each<…>, this["second"]>`) and the target parameter constraint is an
array/tuple type (`unknown[]`), `tsc` defers the type-argument constraint check
to instantiation time. The deferred application's base constraint is `unknown`,
which is not assignable to `unknown[]`, so eagerly checking it would fabricate a
spurious `TS2344`. tsz already defers this through the
application-with-type-parameters branch of
`CheckerState::validate_type_args_against_params`
(`crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs`);
this PR adds the missing coverage so a future edit to that deferral logic cannot
silently reintroduce the FP.

## Owner layer

Checker — type-argument-against-constraint validation (TS2344). No solver/emitter
changes; behavior is unchanged.

## Adjacent-case matrix

- **Positive (binder set A)** — hotscript `Lambda`/`Invoke`/`ApplyAll`/`Curry`/
  `Each`/`All` graph; `AllFn` indexes a deferred `Invoke<Each<…>, this["second"]>`
  by `[number]` (the exact `EveryFn` witness): no `TS2344`.
- **Positive (binder set B)** — structurally identical graph with disjoint
  identifiers (`Thunk`/`Run`/`Spread`/`Bind`/`OverEach`/`Whole`): no `TS2344`
  (proves the deferral is structural, never name-driven; anti-hardcoding gate).
- **Negative control (fallback)** — concrete non-array `Vec<string>` into an
  `unknown[]`-constrained parameter: `TS2344` is still emitted (deferral is not a
  blanket suppression).
- **Negative control** — concrete `Vec<number[]>`: accepted, no `TS2344` (no
  over-correction into a false negative).

## Reproduction evidence (why this is a guard, not a behavior change)

Built `dist-fast` and `debug` from current HEAD, ran the canonical
`tsz_write_hotscript_config` guard config (es2022 + dom/dom.iterable, strict,
bundler) against hotscript pinned at `0bc205286bd5…`:

- `src`-only guard: **0 errors** (multiple runs; default, `RAYON_NUM_THREADS=1`,
  and `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK=1` ×5 — all 0).
- Also 0 errors at the commit *before* #13903, and on a faithful single-file
  reconstruction — consistent with the issue's note that minimal reductions are
  clean.

## Verification

- `cargo test -p tsz-checker --test deferred_hof_application_unknown_array_constraint_tests`
  → `4 passed; 0 failed`.
- `cargo fmt -p tsz-checker` clean; `cargo clippy -p tsz-checker --test deferred_hof_application_unknown_array_constraint_tests` clean.
- Rebased on `origin/main`; no conflicts.
- Ready-review CI (unit / lint) owns broad validation.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhKPstdVDjUQXBtQvVuJEe)_