### PR TITLE
fix(solver): named class/interface without an explicit index is not a string-record subtype

### DIFF
--- a/crates/tsz-checker/tests/control_flow_type_guard_tests/part_01.rs
+++ b/crates/tsz-checker/tests/control_flow_type_guard_tests/part_01.rs
@@ -1533,3 +1533,73 @@ if (f(item, 1)) {
         "both arities resolve to `value is string`; got {diagnostics:#?}"
     );
 }
+
+/// Regression (#10663 F7): a second user-defined type-predicate guard must
+/// *intersect* with — not replace — the type the first guard narrowed to. After
+/// `isBag(v) && isMarker(v)`, `v` keeps the first guard's `{ [k: string]: V }`
+/// index signature *and* gains the named interface's members, matching tsc
+/// (which narrows to `Bag<string, unknown> & Marker`).
+///
+/// Root cause was a subtype-relation defect: a named interface with no explicit
+/// index signature was wrongly judged a subtype of `{ [k: string]: unknown }`,
+/// so the positive predicate narrowing replaced the record with the interface
+/// and dropped the index signature (false `TS7053` on `v['anyKey']`). Binder
+/// names differ from the original kysely witness to keep the fix structural.
+#[test]
+fn successive_type_predicate_guards_intersect_index_signature() {
+    let diagnostics = strict_diagnostics(
+        r#"
+interface Marker { tag(): string }
+type Bag<K extends keyof any, V> = { [P in K]: V };
+declare function isBag(v: unknown): v is Bag<string, unknown>;
+declare function isMarker(v: unknown): v is Marker;
+function probe(v: unknown) {
+    if (isBag(v) && isMarker(v)) {
+        const a = v.tag();
+        const b = v['anyKey'];
+        return [a, b];
+    }
+    return [];
+}
+"#,
+    );
+    let leaked: Vec<_> = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 7053 || *c == 2339)
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "second predicate guard must intersect, preserving the first guard's index signature; got {diagnostics:#?}"
+    );
+}
+
+/// Regression (#10663): a named class/interface without an explicit index
+/// signature is NOT a subtype of `{ [k: string]: unknown }` — it lacks the
+/// required index signature — so a conditional `Named extends Record<…>` takes
+/// the false branch, matching tsc. An anonymous object literal keeps its
+/// implicit index signature and takes the true branch. This guards the subtype
+/// relation directly (the narrowing fix above shares the same defect).
+#[test]
+fn named_type_without_index_is_not_string_record_subtype() {
+    let diagnostics = strict_diagnostics(
+        r#"
+interface Named { run(): number }
+class Klass { run(): number { return 1; } }
+type Rec = { [k: string]: unknown };
+type NamedExtends = Named extends Rec ? 1 : 0;
+type ClassExtends = Klass extends Rec ? 1 : 0;
+type AnonExtends = ({ run(): number }) extends Rec ? 1 : 0;
+declare const ne: NamedExtends;
+declare const ce: ClassExtends;
+declare const ae: AnonExtends;
+const named: 0 = ne;
+const klass: 0 = ce;
+const anon: 1 = ae;
+"#,
+    );
+    let ts2322: Vec<_> = diagnostics.iter().filter(|(c, _)| *c == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "named interface/class must not extend a string-index record, while an anonymous literal must; got {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -26,6 +26,18 @@ pub trait TypeResolver {
         0
     }
 
+    /// Whether this resolver carries no definition/symbol context (the
+    /// [`NoopResolver`] sentinel used by `SubtypeChecker::new`).
+    ///
+    /// Relation rules that need to distinguish "no nominal context is
+    /// available" (treat shapes structurally) from "a real resolver is present
+    /// but a particular symbol/type is simply not mapped here" use this. It
+    /// must stay `false` for every resolver that can answer any
+    /// `symbol_to_def_id`/`def_for_type`/`get_def_kind` query.
+    fn is_noop(&self) -> bool {
+        false
+    }
+
     /// Resolve a symbol reference to its structural type.
     /// Returns None if the symbol cannot be resolved.
     ///
@@ -355,6 +367,10 @@ pub trait TypeResolver {
 pub struct NoopResolver;
 
 impl TypeResolver for NoopResolver {
+    fn is_noop(&self) -> bool {
+        true
+    }
+
     fn resolve_ref(&self, _symbol: SymbolRef, _interner: &dyn TypeDatabase) -> Option<TypeId> {
         None
     }
@@ -367,6 +383,10 @@ impl TypeResolver for NoopResolver {
 impl<T: TypeResolver + ?Sized> TypeResolver for &T {
     fn resolver_generation(&self) -> u64 {
         (**self).resolver_generation()
+    }
+
+    fn is_noop(&self) -> bool {
+        (**self).is_noop()
     }
 
     fn resolve_ref(&self, symbol: SymbolRef, interner: &dyn TypeDatabase) -> Option<TypeId> {

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1646,7 +1646,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     // Class/interface types must have an explicit string index
                     // signature — a number index alone is not enough (see
                     // check_string_index_compatibility for the full rationale).
-                    if self.requires_explicit_declared_index_signature(source_shape) {
+                    if self
+                        .requires_explicit_declared_index_signature_for(source_shape, Some(source))
+                    {
                         return Some(SubtypeFailureReason::MissingIndexSignature {
                             index_kind: "string",
                         });

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -69,6 +69,106 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             .is_some_and(|shape| is_named_non_enum(&shape))
     }
 
+    /// Like [`Self::requires_explicit_declared_index_signature`], but also
+    /// recovers nominal identity from the `receiver`'s type->def registration.
+    ///
+    /// Resolving a `Lazy(DefId)` class/interface to its structural shape (during
+    /// conditional `extends` evaluation, type-predicate narrowing, etc.)
+    /// re-interns a shape whose `symbol` is `None`, even though the type stays
+    /// registered to its `DefId` in the definition store — the same source
+    /// diagnostics use to recover the interface/class *name*. Without this, such
+    /// a resolved class/interface looks anonymous and is wrongly accepted as a
+    /// subtype of a `{ [k: string]: T }` record (it would satisfy the index
+    /// signature structurally), dropping the requirement that a named nominal
+    /// type declare an explicit index signature.
+    ///
+    /// Only `Class`/`Interface` def-kinds trigger the requirement: anonymous
+    /// object literals and object-typed `TypeAlias`es are not registered as
+    /// nominal types (so they keep their implicit-index behaviour, matching
+    /// tsc), and namespace value objects / enums resolve to other def-kinds and
+    /// stay structurally compatible.
+    pub(crate) fn requires_explicit_declared_index_signature_for(
+        &self,
+        shape: &ObjectShape,
+        receiver: Option<TypeId>,
+    ) -> bool {
+        if self.requires_explicit_declared_index_signature(shape) {
+            return true;
+        }
+        if receiver.is_some_and(|receiver| self.receiver_is_named_class_or_interface(receiver)) {
+            return true;
+        }
+
+        // Fallback for a named shape whose nominal `DefId`/`DefKind` is not
+        // mapped in this resolver. When a `Lazy(DefId)` class/interface is
+        // resolved to its structural shape during conditional `extends`
+        // evaluation or type-predicate narrowing, the shape keeps a `symbol`
+        // but neither `symbol_to_def_id` nor the type->def index resolves it in
+        // the relation's resolver view, so the two checks above can't confirm it
+        // is nominal. A `symbol`-bearing, non-enum shape is nevertheless a named
+        // declaration (interface/class/namespace/enum/…); only `Class`/
+        // `Interface` must declare an explicit index signature to satisfy a
+        // `{ [k: string]: T }` target. Treat such a shape as requiring one
+        // unless the resolver positively classifies it as a structurally
+        // index-compatible kind (namespace value object, enum, alias, …).
+        //
+        // Gated on a real resolver (`!is_noop`): with the `NoopResolver`
+        // sentinel there is no nominal context at all, so a symbol-bearing shape
+        // stays an ordinary structural object (preserving the no-resolver
+        // contract relied on by callers that intentionally check structurally).
+        if self.resolver.is_noop() {
+            return false;
+        }
+        let Some(symbol) = shape.symbol else {
+            return false;
+        };
+        if shape.flags.contains(ObjectFlags::ENUM_NAMESPACE) {
+            return false;
+        }
+        match self
+            .resolver
+            .symbol_to_def_id(SymbolRef(symbol.0))
+            .and_then(|def_id| self.resolver.get_def_kind(def_id))
+        {
+            // Positively non-nominal kinds keep their structural index
+            // compatibility (a namespace's exported members / an enum / an
+            // object-typed alias can satisfy the index signature directly).
+            Some(
+                crate::def::DefKind::Namespace
+                | crate::def::DefKind::Enum
+                | crate::def::DefKind::TypeAlias
+                | crate::def::DefKind::Function
+                | crate::def::DefKind::Variable,
+            ) => false,
+            // `Class`/`Interface` (or an unmapped named declaration, which in a
+            // real resolver context is an interface/class whose symbol simply
+            // isn't registered here) require an explicit index signature.
+            _ => true,
+        }
+    }
+
+    /// True when `receiver` (or, for a generic reference, its application base)
+    /// resolves through the definition store to a `Class` or `Interface` `DefId`.
+    /// Used to apply the explicit-index-signature requirement to named nominal
+    /// types whose resolved structural shape no longer carries a `symbol`.
+    fn receiver_is_named_class_or_interface(&self, receiver: TypeId) -> bool {
+        let is_class_or_interface = |candidate: TypeId| {
+            self.resolver.def_for_type(candidate).is_some_and(|def_id| {
+                matches!(
+                    self.resolver.get_def_kind(def_id),
+                    Some(crate::def::DefKind::Class | crate::def::DefKind::Interface)
+                )
+            })
+        };
+        if is_class_or_interface(receiver) {
+            return true;
+        }
+        // For a generic reference `C<…>`, fall back to the application base `C`.
+        application_id(self.interner, receiver)
+            .map(|app_id| self.interner.type_application(app_id).base)
+            .is_some_and(|base| base != receiver && is_class_or_interface(base))
+    }
+
     fn has_compatible_symbol_iterator_methods(
         &mut self,
         source: &PropertyInfo,
@@ -975,7 +1075,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 //
                 // Namespace-like value objects and anonymous types can still
                 // satisfy the target structurally through their exported members.
-                if self.requires_explicit_declared_index_signature(source) {
+                if self.requires_explicit_declared_index_signature_for(source, source_receiver) {
                     return SubtypeResult::False;
                 }
 
@@ -1682,7 +1782,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if target.string_index.as_ref().is_some_and(|idx| {
             idx.key_type != TypeId::SYMBOL
                 && (self.disable_method_bivariance || !idx.value_type.is_any())
-        }) && self.requires_explicit_declared_index_signature(&source_shape)
+        }) && self.requires_explicit_declared_index_signature_for(&source_shape, source_receiver)
         {
             return SubtypeResult::False;
         }


### PR DESCRIPTION
Goal: green

## Summary

Fixes the **F7** facet of #10663: successive user-defined type-predicate guards
(`isObject(x) && isMarker(x)`) were not intersecting — the second guard replaced
the type the first guard narrowed to, dropping the first guard's index
signature and producing a false `TS7053`/`TS2339`.

Root cause is a **subtype-relation defect**, reproducible with no narrowing at
all (a plain conditional type), and `tsc` 6.0.2 disagrees:

```ts
interface I { m(): number }
type Rec = { [k: string]: unknown }
type T = I extends Rec ? "yes" : "no"   // tsc: "no"; tsz (before): "yes"
```

A named class/interface that declares **no** string index signature is **not** a
subtype of `{ [k: string]: T }` (it is missing the index signature) — `tsc` and
tsz's own *assignability* relation both reject it. But once the `Lazy(DefId)`
class/interface is resolved to its structural shape (conditional `extends`
evaluation, type-predicate narrowing, ...), the resolved shape keeps its
`symbol` yet the relation's resolver maps neither that symbol nor the resolved
type back to its `DefId`. So the subtype relation's explicit-index gate
(`requires_explicit_declared_index_signature`) saw an *anonymous* shape and
skipped the requirement, accepting the relation. The narrowing then treated the
named interface as a subtype of the index-signature record and replaced it.

## Structural rule

When the source of an object-vs-`{ [k: string]: T }` subtype check is a named
`Class`/`Interface` (no explicit index signature), `tsc` rejects it; an
anonymous object literal keeps its implicit index signature and is accepted. tsz
must apply the same explicit-index requirement to named nominal types **even
when** the resolved structural shape has lost its `symbol`-based `DefId` mapping.

## Owner layer / fix

Solver subtype relation (`relations/subtype/rules/objects.rs`). The explicit-index
gate now recovers nominal identity through `requires_explicit_declared_index_signature_for`:

1. the existing `symbol`+`DefKind` check, then
2. the receiver's `def_for_type` -> `DefKind` registration (the same identity
   source diagnostics use to print the type name), then
3. when a **real** resolver is present, a `symbol`-bearing non-enum shape whose
   `DefKind` cannot be positively classified as a structurally-index-compatible
   kind (`Namespace`/`Enum`/`TypeAlias`/`Function`/`Variable`) is treated as a
   named class/interface requiring an explicit index signature.

Anonymous object literals (symbol-less) and object-typed aliases keep their
implicit-index behaviour, matching `tsc`. The no-context `NoopResolver` path is
preserved via a new `TypeResolver::is_noop` capability query, so callers that
intentionally check structurally are unaffected. No identifier/file-name/printer
predicates are introduced.

## Adjacent-case matrix (all verified against `tsc` 6.0.2)

| source vs `{ [k: string]: unknown }` | tsc | tsz after |
|---|---|---|
| named `interface` (no index) | not subtype | not subtype |
| named `class` (no index) | not subtype | not subtype |
| anonymous `{ m(): number }` | subtype | subtype |
| object-typed alias `{ a: string }` | subtype | subtype |
| `interface` WITH explicit string index | subtype | subtype |
| classic `Dog extends Animal` predicate narrowing | preserved | preserved |
| namespace value object (structural) | subtype | subtype |

## Verification

- New regression tests (binder names varied from the kysely witness):
  `successive_type_predicate_guards_intersect_index_signature` and
  `named_type_without_index_is_not_string_record_subtype` in
  `crates/tsz-checker/tests/control_flow_type_guard_tests/part_01.rs`.
- `cargo test -p tsz-checker --test control_flow_type_guard_tests` — 87 passed, 0 failed.
- `cargo test -p tsz-solver --lib` — 6764 passed; the only failures are the 4
  pre-existing-on-`main` failures (verified identical via a stashed baseline run;
  the 3 transient regressions an earlier iteration introduced — a namespace
  test + 2 class-context cache tests — are resolved).
- `cargo clippy -p tsz-solver --lib` clean on the changed files.
- CLI parity matrix above checked with the release-equivalent debug binary vs
  `tsc` 6.0.2.
- Broad conformance / emit / project-corpus owned by ready-review CI.

This is one facet of #10663; the row's CPU-termination blocker (#13242/#13250)
and the cross-arena families remain open.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kx3AKogjYkmXY3ugQf5Gf8)_