### PR TITLE
fix(solver): canonicalize free type-parameter constraints so identity ignores resolution state (#13609)

### DIFF
--- a/crates/tsz-solver/src/canonicalize/mod.rs
+++ b/crates/tsz-solver/src/canonicalize/mod.rs
@@ -164,23 +164,23 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
                 TypeData::TypeParameter(info) => {
                     if let Some(index) = self.find_param_index(info.name) {
                         self.interner.bound_parameter(index)
-                    } else if info.default.is_some() {
-                        // Free type-parameter reference carrying a `default`. The
-                        // default is identity-irrelevant (see
-                        // `canonical_type_param`): two references to the same
-                        // parameter that differ only in whether the default was
-                        // captured (`R extends ResponseType = "json"` vs a bare
-                        // `R`) intern to distinct `TypeId`s and would fragment the
-                        // identity fast path. Drop it for the canonical form; the
-                        // interned parameter keeps its default for instantiation.
-                        let normalized = crate::types::TypeParamInfo {
-                            default: None,
-                            ..info
-                        };
-                        self.interner.type_param(normalized)
                     } else {
-                        // Free variable with no default — already canonical.
-                        type_id
+                        // Free type-parameter reference. Its identity is the
+                        // parameter itself — its name and the *shape* of its
+                        // constraint — never how the optional `default` was
+                        // captured nor what *resolution state* the constraint
+                        // snapshot happened to be in. Two references to the same
+                        // parameter whose constraint differs only because one
+                        // captured a resolved form (`keyof ResponseMap | "json"`)
+                        // and the other its still-`Lazy` pre-resolution alias must
+                        // canonicalize to one identity, or the relation's
+                        // reflexive/identity fast path fragments (#13609). Reuse
+                        // `canonical_type_param` so a free reference and a declared
+                        // parameter (function/signature/mapped) reduce identically:
+                        // canonicalize the constraint, drop the default. The
+                        // interned parameter keeps its default for instantiation.
+                        let normalized = self.canonical_type_param(info);
+                        self.interner.type_param(normalized)
                     }
                 }
 

--- a/crates/tsz-solver/tests/canonicalize_tests.rs
+++ b/crates/tsz-solver/tests/canonicalize_tests.rs
@@ -1257,3 +1257,143 @@ fn canonicalize_function_type_param_list_ignores_default() {
         "type-parameter default in a signature list must not fragment identity"
     );
 }
+
+// ===================================================================
+// A free type-parameter reference's constraint must canonicalize, so its
+// identity does not fragment on the constraint's *resolution state* (#13609)
+// ===================================================================
+
+/// Resolver where `DefId(1)` is a type alias whose body is `string | number`.
+/// Models a cross-module constraint reference that one signature captured as a
+/// still-`Lazy` alias and another captured already expanded to its union body.
+struct AliasConstraintResolver {
+    body: TypeId,
+}
+
+impl TypeResolver for AliasConstraintResolver {
+    fn resolve_ref(&self, _symbol: SymbolRef, _interner: &dyn TypeDatabase) -> Option<TypeId> {
+        None
+    }
+
+    fn resolve_lazy(&self, def_id: DefId, _interner: &dyn TypeDatabase) -> Option<TypeId> {
+        (def_id == DefId(1)).then_some(self.body)
+    }
+
+    fn get_def_kind(&self, def_id: DefId) -> Option<DefKind> {
+        (def_id == DefId(1)).then_some(DefKind::TypeAlias)
+    }
+}
+
+// `tsc` identifies a type parameter by the parameter itself, never by what
+// resolution state its constraint snapshot was in. tsz interns a free
+// type-parameter reference structurally, hashing the constraint `TypeId`, so the
+// *same* parameter `R` referenced with constraint `Lazy(Alias)` in one signature
+// and the alias's expanded `string | number` body in another interns to distinct
+// `TypeId`s. Both must canonicalize to one identity (the #13609 `507`/`516`
+// constraint-snapshot fragmentation), restoring the relation's reflexive
+// short-circuit.
+#[test]
+fn canonicalize_free_type_param_constraint_resolution_state_converges() {
+    let interner = TypeInterner::new();
+    let union_body = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    let resolver = AliasConstraintResolver { body: union_body };
+
+    let r = interner.intern_string("R");
+    // Same parameter, constraint captured as the still-`Lazy` alias...
+    let r_lazy_constraint = interner.type_param(TypeParamInfo {
+        name: r,
+        constraint: Some(interner.lazy(DefId(1))),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    // ...vs the same constraint already resolved to the alias body.
+    let r_resolved_constraint = interner.type_param(TypeParamInfo {
+        name: r,
+        constraint: Some(union_body),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+
+    assert_ne!(
+        r_lazy_constraint, r_resolved_constraint,
+        "precondition: interning keeps the two constraint snapshots distinct"
+    );
+
+    let mut c1 = Canonicalizer::new(&interner, &resolver);
+    let mut c2 = Canonicalizer::new(&interner, &resolver);
+    assert_eq!(
+        c1.canonicalize(r_lazy_constraint),
+        c2.canonicalize(r_resolved_constraint),
+        "a free type parameter's constraint resolution state must not fragment identity"
+    );
+
+    // The default is still irrelevant on top of the constraint convergence.
+    let r_lazy_with_default = interner.type_param(TypeParamInfo {
+        name: r,
+        constraint: Some(interner.lazy(DefId(1))),
+        default: Some(TypeId::BOOLEAN),
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    let mut c3 = Canonicalizer::new(&interner, &resolver);
+    let mut c4 = Canonicalizer::new(&interner, &resolver);
+    assert_eq!(
+        c3.canonicalize(r_lazy_with_default),
+        c4.canonicalize(r_resolved_constraint),
+        "constraint convergence holds regardless of the captured default"
+    );
+}
+
+// The convergence is structural, not name-driven: renaming the binder leaves the
+// identity rule intact (anti-hardcoding gate), and a *genuinely* different
+// constraint shape still stays distinct (the fix only collapses resolution-state
+// differences, it does not erase real constraint distinctions).
+#[test]
+fn canonicalize_free_type_param_constraint_convergence_is_name_agnostic() {
+    let interner = TypeInterner::new();
+    let union_body = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    let resolver = AliasConstraintResolver { body: union_body };
+
+    // Renamed binder `Element` instead of `R`.
+    let elem = interner.intern_string("Element");
+    let lazy_constraint = interner.type_param(TypeParamInfo {
+        name: elem,
+        constraint: Some(interner.lazy(DefId(1))),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    let resolved_constraint = interner.type_param(TypeParamInfo {
+        name: elem,
+        constraint: Some(union_body),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    let mut c1 = Canonicalizer::new(&interner, &resolver);
+    let mut c2 = Canonicalizer::new(&interner, &resolver);
+    assert_eq!(
+        c1.canonicalize(lazy_constraint),
+        c2.canonicalize(resolved_constraint),
+        "constraint resolution-state convergence is independent of the binder name"
+    );
+
+    // Negative control: a genuinely different constraint shape (`string` only,
+    // not the `string | number` the alias expands to) must stay distinct.
+    let other_constraint = interner.type_param(TypeParamInfo {
+        name: elem,
+        constraint: Some(TypeId::STRING),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    let mut c3 = Canonicalizer::new(&interner, &resolver);
+    let mut c4 = Canonicalizer::new(&interner, &resolver);
+    assert_ne!(
+        c3.canonicalize(resolved_constraint),
+        c4.canonicalize(other_constraint),
+        "a genuinely different constraint shape must not be merged by canonicalization"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary

A type parameter's identity in `tsc` is the parameter itself — its name and the
shape of its constraint — never how the optional `default` was captured nor what
*resolution state* the constraint snapshot happened to be in. #13888 fixed the
`default` axis by adding `canonical_type_param` (canonicalize the constraint,
drop the default) and applying it at the function, call-signature, and mapped
type-parameter sites. The **free-`TypeParameter` reference branch** of the
canonicalizer was left inconsistent: it only dropped the `default` and kept the
constraint **raw**, and when no default was present it returned the type
unchanged entirely.

So two references to the *same* parameter whose constraint differs only by
**resolution state** — one capturing a still-`Lazy` cross-module alias
(`Lazy(ResponseType)`) and the other its already-expanded body
(`keyof ResponseMap | "json"`) — interned to distinct `TypeId`s and canonicalized
to distinct identities, defeating the subtype relation's reflexive/identity fast
path. That is the documented `507`/`516` constraint-snapshot fragmentation
residual of #13609 (see the 2026-06-18 01:23Z analysis: *"even setting aside
`ERROR`, the constraint snapshot itself fragments (507 vs 516)"*).

## Structural rule

> When a free type-parameter reference `R` is canonicalized, `tsc` reduces its
> identity to the parameter (name + constraint **shape**), independent of whether
> the constraint snapshot was captured as a `Lazy` alias or its resolved body, and
> independent of any captured `default`. tsz must canonicalize the constraint and
> drop the default at the free-reference site too, exactly as it already does for
> declared parameters (function/signature/mapped) via `canonical_type_param`.

## Owner layer / fix

Solver structural-identity layer (`crates/tsz-solver/src/canonicalize/mod.rs`).
The free-`TypeParameter` branch now reuses the shared `canonical_type_param`
helper instead of inline `default`-only normalization, so a free reference and a
declared parameter reduce **identically**: the constraint is canonicalized
(reducing both the `Lazy` alias and its expanded body to one structural form) and
the default is dropped. Interning is unchanged — each parameter keeps its default
for instantiation. Dropping resolution-state and default differences from the
*identity* form is a pure widening of identity (it only adds reflexive
short-circuits) and matches `tsc`; the change is name-agnostic. A genuinely
different constraint **shape** still stays distinct.

This unifies all four type-parameter canonicalization sites (function,
call-signature, mapped, free reference) under one helper — a generalization, not
a new special case.

## Adjacent-case matrix (regression tests, name-agnostic)

| case | canonical identity |
|---|---|
| same `R`, constraint `Lazy(Alias)` vs alias's expanded `string \| number` body | **converge** (was distinct) |
| same convergence with a captured `default` on top | converge |
| renamed binder (`Element`) — same alias/expanded pair | converge (structural, not name-driven) |
| genuinely different constraint shape (`string` only) | stays distinct (negative control) |
| existing `default`-only fragmentation (#13888) | still converge |
| different name / different constraint (#13888 negatives) | still distinct |

## Verification

- `cargo test -p tsz-solver --lib canonicalize` → **49 passed, 0 failed**
  (the 2 new tests + the full #13888 default-identity suite + the relation
  reflexivity/identity fast-path tests).
- `cargo test -p tsz-solver --lib` → **6770 passed, 4 failed**; the 4 failures are
  **pre-existing on `main`** (verified byte-identical: the same 4 fail with this
  change stashed — `test_conditional_infer_optional_property_present_distributive`,
  `literal_mask_preserves_object_vs_literal_reduction`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`,
  `test_solver_oversized_file_size_ceilings`). **Zero new failures.**
- `cargo clippy -p tsz-solver --lib` — clean.
- `cargo fmt -p tsz-solver` — clean.
- Broad conformance / emit / project-corpus owned by ready-review CI per repo
  policy.

Refs #13609. This closes the constraint-snapshot (`507`/`516`) fragmentation axis
of the identity-fragmentation root; the residual `ERROR`/dropped-constraint forms
of the committed witness come from the deeper #13232 resolver-availability family
and remain out of scope.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_012fYYiq6RpHVDgVxNA4C6uz)_