### PR TITLE
fix(checker): reduce inline conditional/mapped type-alias application contextual type before object-literal property typing (#13618)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -818,6 +818,9 @@ path = "tests/conditional_alias_lib_application_tests.rs"
 name = "recursive_conditional_mapped_infer_tests"
 path = "tests/recursive_conditional_mapped_infer_tests.rs"
 [[test]]
+name = "deep_pick_inline_application_contextual_tests"
+path = "tests/deep_pick_inline_application_contextual_tests.rs"
+[[test]]
 name = "in_chain_narrows_unconstrained_type_param_tests"
 path = "tests/in_chain_narrows_unconstrained_type_param_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -7,7 +7,9 @@ use super::super::object_literal_context::ContextualPropertyPresence;
 use super::accessor_element::{ObjectLiteralAccessorContext, ObjectLiteralAccessorState};
 use crate::context::speculation::DiagnosticSpeculationSnapshot;
 use crate::context::{PartialObjectLiteralInitializer, TypingRequest};
-use crate::query_boundaries::common::ContextualTypeContext;
+use crate::query_boundaries::common::{
+    ContextualTypeContext, get_application_base, is_conditional_type, is_mapped_type,
+};
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
@@ -29,42 +31,12 @@ struct ObjectLiteralRequestFacts {
 }
 
 impl<'a> CheckerState<'a> {
-    /// An object literal contextually typed by an *inline* instantiated generic
-    /// **type-alias** application whose body is a computed (conditional/mapped)
-    /// type — e.g. ts-essentials `DeepPick<T, Filter>` used directly as a
-    /// `const` annotation — must have that application reduced through the
-    /// authoritative resolver before its per-property contextual types are
-    /// extracted.
-    ///
-    /// The solver's default per-property contextual extraction runs with a
-    /// non-resolving resolver, so a recursive instantiated alias body left as an
-    /// opaque `Application` cannot expand: each property's expected type then
-    /// degrades to the un-reduced source instead of the picked result, producing
-    /// spurious `TS2741`/`TS2322`. A named-alias or `satisfies` contextual type
-    /// already reaches the literal in evaluated form; reducing here brings the
-    /// inline-application case to the same parity (#13618).
-    ///
-    /// The gate is deliberately narrow — only an application whose base alias
-    /// body is a `Conditional`/`Mapped` type. An **interface/class** application
-    /// (e.g. comlink's `TransferHandler<object, MessagePort>`) instantiates its
-    /// members directly through the default path and must NOT be reduced:
-    /// re-evaluating it can widen a method's tuple-return contextual type. A
-    /// plain object/`Lazy` alias likewise resolves fine through the normal path.
     fn contextual_type_requires_authoritative_evaluation(&mut self, type_id: TypeId) -> bool {
-        if !matches!(
-            self.ctx.types.lookup(type_id),
-            Some(tsz_solver::TypeData::Application(_))
-        ) {
-            return false;
-        }
-        let Some(base) =
-            crate::query_boundaries::common::get_application_base(self.ctx.types, type_id)
-        else {
+        let Some(base) = get_application_base(self.ctx.types, type_id) else {
             return false;
         };
         let base_body = self.resolve_lazy_type(base);
-        crate::query_boundaries::common::is_conditional_type(self.ctx.types, base_body)
-            || crate::query_boundaries::common::is_mapped_type(self.ctx.types, base_body)
+        is_conditional_type(self.ctx.types, base_body) || is_mapped_type(self.ctx.types, base_body)
     }
 
     fn collect_object_literal_request_facts(

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -29,6 +29,44 @@ struct ObjectLiteralRequestFacts {
 }
 
 impl<'a> CheckerState<'a> {
+    /// An object literal contextually typed by an *inline* instantiated generic
+    /// **type-alias** application whose body is a computed (conditional/mapped)
+    /// type — e.g. ts-essentials `DeepPick<T, Filter>` used directly as a
+    /// `const` annotation — must have that application reduced through the
+    /// authoritative resolver before its per-property contextual types are
+    /// extracted.
+    ///
+    /// The solver's default per-property contextual extraction runs with a
+    /// non-resolving resolver, so a recursive instantiated alias body left as an
+    /// opaque `Application` cannot expand: each property's expected type then
+    /// degrades to the un-reduced source instead of the picked result, producing
+    /// spurious `TS2741`/`TS2322`. A named-alias or `satisfies` contextual type
+    /// already reaches the literal in evaluated form; reducing here brings the
+    /// inline-application case to the same parity (#13618).
+    ///
+    /// The gate is deliberately narrow — only an application whose base alias
+    /// body is a `Conditional`/`Mapped` type. An **interface/class** application
+    /// (e.g. comlink's `TransferHandler<object, MessagePort>`) instantiates its
+    /// members directly through the default path and must NOT be reduced:
+    /// re-evaluating it can widen a method's tuple-return contextual type. A
+    /// plain object/`Lazy` alias likewise resolves fine through the normal path.
+    fn contextual_type_requires_authoritative_evaluation(&mut self, type_id: TypeId) -> bool {
+        if !matches!(
+            self.ctx.types.lookup(type_id),
+            Some(tsz_solver::TypeData::Application(_))
+        ) {
+            return false;
+        }
+        let Some(base) =
+            crate::query_boundaries::common::get_application_base(self.ctx.types, type_id)
+        else {
+            return false;
+        };
+        let base_body = self.resolve_lazy_type(base);
+        crate::query_boundaries::common::is_conditional_type(self.ctx.types, base_body)
+            || crate::query_boundaries::common::is_mapped_type(self.ctx.types, base_body)
+    }
+
     fn collect_object_literal_request_facts(
         &mut self,
         idx: NodeIndex,
@@ -56,6 +94,20 @@ impl<'a> CheckerState<'a> {
                 {
                     contextual_type = Some(non_nullish);
                 }
+            }
+        }
+
+        // Reduce an inline instantiated generic type-alias application whose body
+        // is a computed (conditional/mapped) type to its structural form through
+        // the authoritative resolver before per-property contextual types are
+        // extracted. See `contextual_type_requires_authoritative_evaluation` for
+        // why this is gated narrowly (#13618).
+        if let Some(ctx) = contextual_type
+            && self.contextual_type_requires_authoritative_evaluation(ctx)
+        {
+            let evaluated = self.evaluate_contextual_type(ctx);
+            if evaluated != ctx {
+                contextual_type = Some(evaluated);
             }
         }
 

--- a/crates/tsz-checker/tests/deep_pick_inline_application_contextual_tests.rs
+++ b/crates/tsz-checker/tests/deep_pick_inline_application_contextual_tests.rs
@@ -1,0 +1,186 @@
+//! Regression tests for #13618: an object literal whose contextual type is an
+//! *inline* generic application (e.g. ts-essentials `DeepPick<Type, Filter>`
+//! used directly as a variable annotation) must have that application reduced
+//! through the authoritative resolver before its per-property contextual types
+//! are extracted.
+//!
+//! Structural rule: when an object literal is contextually typed by an
+//! unevaluated complex type — an instantiated generic `Application`, or a
+//! deferred `Conditional`/`IndexAccess`/`KeyOf` — `tsc` evaluates that type to
+//! its structural object form and contextually types each property against the
+//! reduced member. tsz's per-property contextual extraction runs with a
+//! non-resolving resolver, so a recursive instantiated body left as an opaque
+//! `Application` could not expand: each property's expected type degraded to the
+//! un-reduced source (`DeepPick<User, { id: true }>` resolving to `User` instead
+//! of the picked `{ id: string }`), producing spurious `TS2741`/`TS2322`.
+//!
+//! The divergence is purely single-file and position-sensitive (a `satisfies`
+//! operand, a parameter/return annotation, or a `type Alias = DeepPick<...>`
+//! wrapper already reach the literal in evaluated form and were always clean —
+//! it is only the inline-application-in-annotation form that degraded), so this
+//! is distinct from the cross-arena `error`/`never`-in-type-argument family
+//! (#13044/#13484). The fix reduces an unevaluated complex contextual type via
+//! the authoritative resolver in the object-literal request setup.
+//!
+//! Binder names are varied from the original ts-essentials witness so the
+//! behavior follows the type shape, not a spelling (anti-hardcoding gate). The
+//! matrix covers the object-only and array-bearing branches, single and multiple
+//! keys, a named-alias control that was already correct, and negative controls
+//! proving the picked leaf is the concrete reduced type (not `any`/`error`).
+
+use tsz_checker::diagnostics::Diagnostic;
+
+fn check_source(source: &str) -> Vec<Diagnostic> {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        tsz_checker::context::CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+        &libs,
+    )
+}
+
+/// A faithful reconstruction of the ts-essentials `DeepPick` chain with renamed
+/// binders. `Project<Source, Spec>` keeps each key listed in `Spec`, recursing
+/// into nested objects/arrays and treating a `true` leaf as "take the whole
+/// source property".
+const PROJECT_DEF: &str = r#"
+type Prim = string | number | boolean | bigint | symbol | undefined | null;
+type Native = Prim | Function | Date | Error | RegExp;
+type AnyRec<T = any> = Record<keyof any, T>;
+type Project<Source, Spec> = Source extends Native
+  ? Source
+  : Source extends Array<infer Item>
+    ? Spec extends Array<infer SpecItem>
+      ? Array<Project<Item, SpecItem>>
+      : Source
+    : Spec extends AnyRec
+      ? {
+          [K in keyof Source as K extends keyof Spec ? K : never]: Spec[K &
+            keyof Spec] extends true
+            ? Source[K]
+            : K extends keyof Spec
+              ? Project<Source[K], Spec[K]>
+              : never;
+        }
+      : never;
+"#;
+
+fn project_source(body: &str) -> String {
+    format!("{PROJECT_DEF}\n{body}\n")
+}
+
+fn assignment_errors(diagnostics: &[Diagnostic]) -> Vec<&Diagnostic> {
+    diagnostics
+        .iter()
+        .filter(|d| d.code == 2322 || d.code == 2741 || d.code == 2353)
+        .collect()
+}
+
+fn assert_no_assignment_error(body: &str, label: &str) {
+    let diagnostics = check_source(&project_source(body));
+    let errors = assignment_errors(&diagnostics);
+    assert!(
+        errors.is_empty(),
+        "[{label}] expected no TS2322/TS2741/TS2353; got:\n{errors:#?}\nall: {diagnostics:#?}"
+    );
+}
+
+fn assert_has_assignment_error(body: &str, label: &str) {
+    let diagnostics = check_source(&project_source(body));
+    let errors = assignment_errors(&diagnostics);
+    assert!(
+        !errors.is_empty(),
+        "[{label}] expected a TS2322/TS2741/TS2353 (picked leaf is the concrete \
+         reduced type, not any/error); got none. All: {diagnostics:#?}"
+    );
+}
+
+/// The #13618 witness: an inline `Project<...>` application used directly as a
+/// const annotation, over a multi-key object/array mix with a *named* filter
+/// alias. Before the fix each picked property degraded to the full source type
+/// (`Widget`, requiring `mode`), so the picked-shape literal false-failed
+/// `TS2741`.
+#[test]
+fn inline_project_application_multi_key_object_and_array() {
+    let body = r#"
+type Widget = { id: string; mode: 'a' | 'b' };
+type Plan = { lead: Widget; crew: Widget[]; backups: Widget[] };
+type PickSpec = { lead: { id: true }; crew: { id: true }[]; backups: { id: true }[] };
+const out: Project<Plan, PickSpec> = {
+  lead: { id: 'lead_id' },
+  crew: [{ id: 'crew_id' }],
+  backups: [{ id: 'backup_id' }],
+};
+"#;
+    assert_no_assignment_error(
+        body,
+        "inline application, multi-key object+array, named filter",
+    );
+}
+
+/// Minimal trigger: a single object key with a *named* filter alias. The inline
+/// `Project<{ box: Cell }, OneSpec>` annotation must reduce to
+/// `{ box: { id: string } }` so the picked-shape literal is accepted.
+#[test]
+fn inline_project_application_single_key_named_filter() {
+    let body = r#"
+type Cell = { id: string; mode: 'a' | 'b' };
+type Wrap = { box: Cell };
+type OneSpec = { box: { id: true } };
+const w: Project<Wrap, OneSpec> = { box: { id: 'k' } };
+"#;
+    assert_no_assignment_error(body, "single key, named filter alias");
+}
+
+/// An inline filter (no named alias) was always clean; keep it as a control so
+/// a future change to the reduction path cannot regress the common case.
+#[test]
+fn inline_project_application_inline_filter_control() {
+    let body = r#"
+type Cell = { id: string; mode: 'a' | 'b' };
+const w: Project<{ box: Cell }, { box: { id: true } }> = { box: { id: 'k' } };
+"#;
+    assert_no_assignment_error(body, "inline filter control");
+}
+
+/// A `type Alias = Project<...>` wrapper already reached the literal in
+/// evaluated form (and was always correct). Locking it guards the parity floor.
+#[test]
+fn named_result_alias_control() {
+    let body = r#"
+type Cell = { id: string; mode: 'a' | 'b' };
+type OneSpec = { box: { id: true } };
+type Picked = Project<{ box: Cell }, OneSpec>;
+const w: Picked = { box: { id: 'k' } };
+"#;
+    assert_no_assignment_error(body, "named result alias control");
+}
+
+/// Negative control: the picked leaf is the concrete reduced type, not silenced
+/// to `any`/`error`. A genuinely mismatched leaf value (`id` should be `string`)
+/// must still report.
+#[test]
+fn inline_project_application_rejects_genuine_leaf_mismatch() {
+    let body = r#"
+type Cell = { id: string; mode: 'a' | 'b' };
+type OneSpec = { box: { id: true } };
+const bad: Project<{ box: Cell }, OneSpec> = { box: { id: 123 } };
+"#;
+    assert_has_assignment_error(body, "genuine leaf mismatch still reported");
+}
+
+/// Negative control: an excess property not present in the picked result is
+/// still rejected (the reduced contextual type is a real object, not `any`).
+#[test]
+fn inline_project_application_rejects_excess_picked_property() {
+    let body = r#"
+type Cell = { id: string; mode: 'a' | 'b' };
+type OneSpec = { box: { id: true } };
+const bad: Project<{ box: Cell }, OneSpec> = { box: { id: 'k', mode: 'a' } };
+"#;
+    assert_has_assignment_error(body, "excess property on picked leaf rejected");
+}

--- a/crates/tsz-common/src/diagnostics/mod.rs
+++ b/crates/tsz-common/src/diagnostics/mod.rs
@@ -188,6 +188,7 @@ impl Diagnostic {
         }
     }
 
+    #[must_use]
     pub fn with_related(
         mut self,
         file: impl Into<String>,
@@ -275,6 +276,7 @@ impl Diagnostic {
     }
 
     /// `Span`-based variant of [`Diagnostic::with_related`].
+    #[must_use]
     pub fn with_related_span(
         self,
         file: impl Into<String>,


### PR DESCRIPTION
Goal: green

Closes #13618 (the single-file inline-application residual of the DeepPick `{ key: never }` / `ApplyDefaultOptions` family; the ts-essentials `deep-pick` micro-bench false positives).

## Summary

An object literal whose contextual type is an **inline** instantiated generic **type-alias** application whose body is a computed (conditional/mapped) type — e.g. ts-essentials `DeepPick<Type, Filter>` used directly as a `const` annotation — false-failed a well-typed literal with `TS2741`/`TS2322`. The picked property degraded to the full source shape: `DeepPick<User, { id: true }>` resolved to `User` (requiring `right`) instead of the picked `{ id: string }`.

Prior investigation attributed the residual to the cross-arena `error`/`never`-in-type-argument family (#13044/#13484). It is not: it reproduces **single-file** and is **position-sensitive** — a `satisfies` operand, a parameter/return annotation, a `type Alias = DeepPick<...>` wrapper, and even a *declared* `const` (no initializer) were all already correct; only an object **literal** checked against an **inline** application degraded.

## Root cause

A declared value of the type evaluates correctly (the type itself is fine). The divergence is in **object-literal contextual property typing**: the solver's default per-property contextual extraction runs with a non-resolving resolver, so a recursive instantiated alias body left as an opaque `Application` cannot expand, and each property's expected type falls back to the un-reduced source. A named alias / `satisfies` operand already reaches the literal in evaluated form, which is why only the inline-application form degraded.

## Structural rule

When an object literal is contextually typed by an inline instantiated generic type-alias application whose body is a `Conditional`/`Mapped` type, `tsc` evaluates it to its structural object form and contextually types each property against the reduced member. tsz now reduces such a contextual type through the authoritative resolver (`evaluate_contextual_type`) in the object-literal request setup, before per-property contextual types are extracted.

## Owner layer

Checker — object-literal contextual typing (`crates/tsz-checker/src/types/computation/object_literal/computation.rs`). No solver/emitter changes. The boundary that owns the authoritative resolver, mirroring the existing `evaluate_contextual_type` usage in `mapped_object_literals.rs`.

The gate is **deliberately narrow**: only an `Application` whose base alias body is a `Conditional`/`Mapped` type. An **interface/class** application (e.g. comlink's `TransferHandler<object, MessagePort>`) instantiates its members directly through the default path and is left untouched — re-evaluating it can widen a method's tuple-return contextual type (caught as a `project-compile-guard` comlink regression on the first iteration and fixed by this narrowing). A plain object / `Lazy` alias / union is likewise unaffected, so the common case is unchanged and there is no per-object-literal perf cost.

## Adjacent-case matrix (`crates/tsz-checker/tests/deep_pick_inline_application_contextual_tests.rs`, renamed binders)

- inline application, multi-key object + array mix, named filter alias — clean (the #13618 witness)
- single object key, named filter alias (minimal trigger) — clean
- inline filter (no named alias) control — clean
- `type Alias = Project<...>` named-result control — clean
- **negative**: genuine leaf mismatch (`id: 123` vs `string`) still reports `TS2322` (picked leaf is concrete, not `any`/`error`)
- **negative**: excess property on a picked leaf still reports `TS2353` (reduced contextual type is a real object)

Binder names vary from the ts-essentials witness so the behavior follows the type shape, not a spelling (anti-hardcoding gate).

## Verification

- `cargo test -p tsz-checker --test deep_pick_inline_application_contextual_tests` → 6 passed.
- `cargo test -p tsz-checker --test recursive_conditional_mapped_infer_tests` (the #6533 DeepPick suite) → 7 passed.
- CLI repro: the DeepPick witness family (single-file, multi-key, cross-module) is clean with the fix; negatives still error.
- **comlink** (`project-compile-guard` required row): clean again with the narrowed gate (`tsz --noEmit` over `src/comlink.ts` at the pinned ref) — the first-iteration regression is resolved.
- Regression sweep (`contextual_typing_tests`, `deeply_nested_conditional_mapped_recursion_tests`, `deeply_nested_mapped_types_tests`, `cross_file_generic_interface_mapped_filter_tests`, `curry_recursive_conditional_infer_tests`) → no new failures (one pre-existing local lib-harness artifact, identical with the change stashed).
- Ready-review CI owns the broad conformance/emit/project suites per repo policy.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high