### PR TITLE
perf(solver): per-instance memo for context-dependent relation verdicts (#13828)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -294,9 +294,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // Application type-argument comparison at cycle points for TS2403).
         // Types containing ThisType are context-dependent (they depend on which class
         // is currently being checked via the resolver's this_type_stack). Caching them
-        // would poison the cache with results computed outside of any class context
-        // (e.g., during class type construction), causing later legitimate checks
-        // inside class bodies to get the wrong cached result.
+        // in the shared cache would poison it with results computed outside of any
+        // class context (e.g., during class type construction), causing later
+        // legitimate checks inside class bodies to get the wrong cached result. Such
+        // pairs instead use the instance-local fallback memo (issue #13828), which is
+        // valid for the lifetime of this checker — the `this` binding is fixed for one
+        // top-level query — and dropped afterward, so it cannot poison sibling checks.
         //
         // Use contains_this_type (not just is_this_type) because even after
         // substitute_this_type_if_needed the *target* may still be a class instance
@@ -306,35 +309,59 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // Class-symbol classification is also context-dependent: the callback
         // can make the same object shape behave as a named class/interface in
         // one checker and as a plain structural object in another. Since the
-        // relation cache key cannot encode an arbitrary predicate, avoid
-        // sharing those answers across checker instances.
+        // relation cache key cannot encode an arbitrary predicate, those answers
+        // are excluded from the cross-checker shared cache and likewise served by
+        // the instance-local fallback memo, whose `is_class_symbol` closure is fixed
+        // for the checker's lifetime.
         let has_class_check_context = self.is_class_symbol.is_some();
         let can_use_shared_relation_cache = !has_this_type && !has_class_check_context;
         // The `in_callback_param_check` state is encoded in
         // `RelationFlags::IN_CALLBACK_PARAM_CHECK` via `make_cache_key`, so
         // callback-mode results live in a separate cache slot from
         // non-callback-mode results and cannot poison each other.
-        if !self.identity_cycle_check
-            && can_use_shared_relation_cache
-            && let Some(db) = self.query_db
-        {
-            let key = self.make_cache_key(source, target);
-            match db.lookup_subtype_cache_value(key) {
-                Some(RelationCacheValue::True) => return SubtypeResult::True,
-                Some(RelationCacheValue::False) => return SubtypeResult::False,
-                // Budget-conditional assumed-related verdict (tsc
-                // `Ternary.Maybe` parity): honest only when this query's
-                // remaining fuel budget is no larger than the recorded
-                // run's. Under a raised budget, fall through and recompute
-                // (fuel-band cache honesty).
-                Some(RelationCacheValue::LimitTrue { fuel_band })
-                    if limit_result_cache_enabled()
-                        && remaining_global_subtype_fuel() <= fuel_band =>
-                {
-                    tsz_common::perf_counters::record_relation_limit_cache_hit();
-                    return SubtypeResult::DepthExceeded;
+        if !self.identity_cycle_check {
+            if can_use_shared_relation_cache {
+                if let Some(db) = self.query_db {
+                    let key = self.make_cache_key(source, target);
+                    match db.lookup_subtype_cache_value(key) {
+                        Some(RelationCacheValue::True) => return SubtypeResult::True,
+                        Some(RelationCacheValue::False) => return SubtypeResult::False,
+                        // Budget-conditional assumed-related verdict (tsc
+                        // `Ternary.Maybe` parity): honest only when this query's
+                        // remaining fuel budget is no larger than the recorded
+                        // run's. Under a raised budget, fall through and recompute
+                        // (fuel-band cache honesty).
+                        Some(RelationCacheValue::LimitTrue { fuel_band })
+                            if limit_result_cache_enabled()
+                                && remaining_global_subtype_fuel() <= fuel_band =>
+                        {
+                            tsz_common::perf_counters::record_relation_limit_cache_hit();
+                            return SubtypeResult::DepthExceeded;
+                        }
+                        Some(RelationCacheValue::LimitTrue { .. }) | None => {}
+                    }
                 }
-                Some(RelationCacheValue::LimitTrue { .. }) | None => {}
+            } else if !self.local_relation_cache.is_empty() {
+                // Context-dependent pair (polymorphic `this` / class-check
+                // context): excluded from the cross-checker shared cache, but
+                // memoizable for this checker instance's lifetime (issue
+                // #13828). The context — the resolver's `this` binding and the
+                // `is_class_symbol` closure — is fixed for the instance, so a
+                // definitive verdict for this pair holds for every repeat of it
+                // in the same query's recursive structural walk. The memo is
+                // dropped with the checker (and cleared by `reset`), so it can
+                // never serve a verdict to a later query under a different
+                // context. A non-empty memo implies `query_db` was present at
+                // write time (and it never reverts to `None`), so no `query_db`
+                // recheck is needed before building the key below.
+                let key = self.make_cache_key(source, target);
+                if let Some(&related) = self.local_relation_cache.get(&key) {
+                    return if related {
+                        SubtypeResult::True
+                    } else {
+                        SubtypeResult::False
+                    };
+                }
             }
         }
 
@@ -434,45 +461,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         macro_rules! leave_global {
             () => {
                 crate::limits::leave_subtype_frame(global_depth == 0);
-            };
-        }
-
-        // Helper macro to cache a definitive subtype result, but only when the
-        // computation did not depend on a `Lazy` whose body was unresolved
-        // (which would make the result undetermined and poison the cache).
-        //
-        // This is best-effort and intentionally conservative: the snapshots are
-        // process-wide (thread-local), so *any* unresolved-`Lazy` event or
-        // weak-type-sensitivity event anywhere in this top-level call's subtree
-        // — even in a branch whose result did not feed the final answer —
-        // suppresses the write. That only ever skips a cache write
-        // (correctness-preserving: the result is recomputed later), never
-        // produces a wrong answer. Captures `lazy_failures_at_entry` and
-        // `weak_sensitivity_at_entry` from the enclosing scope by name.
-        //
-        // Results computed under `bypass_evaluation` are also never written:
-        // that mode compares raw alias/meta forms without expanding them, so
-        // its answers can differ from full-evaluation answers for the same
-        // pair, and the flag-agnostic `RelationCacheKey` cannot tell the two
-        // modes apart. Persisting a raw-mode `False` (e.g. `unknown` vs an
-        // alias application that evaluates to `unknown`) would poison every
-        // later full-evaluation check of the same pair, from any raw-mode
-        // entry point (`check_return_compat`'s placeholder fallback, the
-        // evaluator's union/intersection simplification). Reads stay shared:
-        // a full-evaluation answer is the more precise result for the same
-        // relation, so serving it to a bypass-mode query is sound.
-        macro_rules! cache_definitive {
-            ($db:expr, $key:expr, $result:expr) => {
-                if !self.bypass_evaluation
-                    && crate::limits::poison_sentinel_counts()
-                        == (lazy_failures_at_entry, weak_sensitivity_at_entry)
-                {
-                    match $result {
-                        SubtypeResult::True => $db.insert_subtype_cache($key, true),
-                        SubtypeResult::False => $db.insert_subtype_cache($key, false),
-                        SubtypeResult::CycleDetected | SubtypeResult::DepthExceeded => {}
-                    }
-                }
             };
         }
 
@@ -926,10 +914,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     self.def_guard.leave(dp);
                 }
                 self.guard.leave(pair);
-                if can_use_shared_relation_cache && let Some(db) = self.query_db {
-                    let key = self.make_cache_key(source, target);
-                    cache_definitive!(db, key, result);
-                }
+                self.record_definitive_verdict(
+                    source,
+                    target,
+                    result,
+                    can_use_shared_relation_cache,
+                    lazy_failures_at_entry,
+                    weak_sensitivity_at_entry,
+                );
                 finish_frame!(result);
                 leave_global!();
                 return result;
@@ -986,10 +978,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 self.def_guard.leave(dp);
             }
             self.guard.leave(pair);
-            if can_use_shared_relation_cache && let Some(db) = self.query_db {
-                let key = self.make_cache_key(source, target);
-                cache_definitive!(db, key, result);
-            }
+            self.record_definitive_verdict(
+                source,
+                target,
+                result,
+                can_use_shared_relation_cache,
+                lazy_failures_at_entry,
+                weak_sensitivity_at_entry,
+            );
             finish_frame!(result);
             leave_global!();
             return result;
@@ -1008,10 +1004,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 self.def_guard.leave(dp);
             }
             self.guard.leave(pair);
-            if can_use_shared_relation_cache && let Some(db) = self.query_db {
-                let key = self.make_cache_key(source, target);
-                cache_definitive!(db, key, result);
-            }
+            self.record_definitive_verdict(
+                source,
+                target,
+                result,
+                can_use_shared_relation_cache,
+                lazy_failures_at_entry,
+                weak_sensitivity_at_entry,
+            );
             finish_frame!(result);
             leave_global!();
             return result;
@@ -1095,12 +1095,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             "check_subtype dispatch result"
         );
 
-        // Cache definitive results for cross-checker memoization.
-        // Skip context-dependent results (see lookup guard above).
-        if can_use_shared_relation_cache && let Some(db) = self.query_db {
-            let key = self.make_cache_key(source, target);
-            cache_definitive!(db, key, result);
-        }
+        // Cache definitive results for cross-checker memoization. Context-
+        // dependent pairs route to the instance-local fallback memo instead of
+        // the shared cache (see `record_definitive_verdict` and the lookup
+        // guard above).
+        self.record_definitive_verdict(
+            source,
+            target,
+            result,
+            can_use_shared_relation_cache,
+            lazy_failures_at_entry,
+            weak_sensitivity_at_entry,
+        );
 
         finish_frame!(result);
 
@@ -1109,6 +1115,68 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         crate::limits::leave_subtype_frame(global_depth == 0);
 
         result
+    }
+
+    /// Record a definitive subtype verdict for later reuse.
+    ///
+    /// Context-independent pairs are written to the cross-checker shared
+    /// `QueryCache`. Context-dependent pairs — those carrying a polymorphic
+    /// `this` or checked inside a class-check context, for which
+    /// `can_use_shared_relation_cache` is `false` — are written to the
+    /// instance-local fallback memo instead (issue #13828): their verdict
+    /// depends on the resolver's current `this` binding and on the
+    /// `is_class_symbol` closure, neither of which the flag-agnostic
+    /// [`RelationCacheKey`] encodes, so sharing them across checker instances
+    /// could poison sibling checks. Both inputs are fixed for the lifetime of
+    /// one checker instance, so the local memo safely serves repeats of the
+    /// same pair within one query and is dropped when the instance (or its
+    /// `reset`) ends.
+    ///
+    /// Only definitive `True`/`False` verdicts are recorded; `CycleDetected` /
+    /// `DepthExceeded` are budget-conditional and handled by the maybe-keys
+    /// promotion path.
+    ///
+    /// This mirrors the discipline of the former `cache_definitive!` macro and
+    /// is intentionally conservative: the poison-sentinel snapshots are
+    /// process-wide (thread-local), so *any* unresolved-`Lazy` event or
+    /// weak-type-sensitivity event anywhere in this top-level call's subtree —
+    /// even in a branch whose result did not feed the final answer —
+    /// suppresses the write. That only ever skips a write
+    /// (correctness-preserving: the result is recomputed later), never
+    /// produces a wrong answer. Results computed under `bypass_evaluation` are
+    /// likewise never written: that mode compares raw alias/meta forms without
+    /// expanding them, so its answers can differ from full-evaluation answers
+    /// for the same pair, and the flag-agnostic `RelationCacheKey` cannot tell
+    /// the two modes apart.
+    fn record_definitive_verdict(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        result: SubtypeResult,
+        can_use_shared_relation_cache: bool,
+        lazy_failures_at_entry: u64,
+        weak_sensitivity_at_entry: u64,
+    ) {
+        let related = match result {
+            SubtypeResult::True => true,
+            SubtypeResult::False => false,
+            SubtypeResult::CycleDetected | SubtypeResult::DepthExceeded => return,
+        };
+        if self.bypass_evaluation
+            || crate::limits::poison_sentinel_counts()
+                != (lazy_failures_at_entry, weak_sensitivity_at_entry)
+        {
+            return;
+        }
+        let Some(db) = self.query_db else {
+            return;
+        };
+        let key = self.make_cache_key(source, target);
+        if can_use_shared_relation_cache {
+            db.insert_subtype_cache(key, related);
+        } else {
+            self.local_relation_cache.insert(key, related);
+        }
     }
 
     /// Maybe-stack completion protocol for one `check_subtype` frame
@@ -1139,7 +1207,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ///   `LimitTrue` — or discarded on failure. Promotion is additionally
     ///   gated on the unresolved-`Lazy` / weak-type-sensitivity counters
     ///   having been stable across the whole outermost window, the same
-    ///   discipline `cache_definitive!` applies to definitive writes.
+    ///   discipline `record_definitive_verdict` applies to definitive writes.
     fn finish_relation_frame(
         &mut self,
         result: SubtypeResult,

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -21,8 +21,8 @@ use crate::operations::AssignabilityChecker;
 #[cfg(test)]
 use crate::types::*;
 use crate::types::{
-    IntrinsicKind, LiteralValue, ObjectFlags, ObjectShape, PropertyInfo, SymbolRef, TemplateSpan,
-    TypeData, TypeId, TypeListId,
+    IntrinsicKind, LiteralValue, ObjectFlags, ObjectShape, PropertyInfo, RelationCacheKey,
+    SymbolRef, TemplateSpan, TypeData, TypeId, TypeListId,
 };
 use crate::visitor::{
     TypeVisitor, application_id, array_element_type, callable_shape_id, conditional_type_id,
@@ -321,6 +321,27 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// parity, issue #13241). See `cache::MaybeRelationEntry` and
     /// `finish_relation_frame` in the `cache` module.
     pub(crate) maybe_keys: Vec<super::cache::MaybeRelationEntry>,
+    /// Instance-local fallback memo for definitive relation verdicts that the
+    /// cross-checker shared cache must skip (issue #13828).
+    ///
+    /// A pair whose source/target carries a polymorphic `this`, or that is
+    /// checked inside a class-check context (`is_class_symbol` set), is
+    /// context-dependent: its verdict depends on the resolver's current `this`
+    /// binding (`resolve_this_type`) and on the class-symbol classification
+    /// callback. Those inputs cannot be encoded in the flag-agnostic
+    /// [`RelationCacheKey`], so such verdicts are excluded from the shared
+    /// `QueryCache` to avoid cross-checker poisoning.
+    ///
+    /// They are, however, stable for the lifetime of one [`SubtypeChecker`]
+    /// instance: a fresh checker is built per top-level relation query, the
+    /// resolver is borrowed immutably for that whole lifetime (so the
+    /// `this` binding cannot shift mid-query), and the `is_class_symbol`
+    /// closure is fixed at construction. Memoizing them here therefore serves
+    /// the repeated comparisons of the same pair inside one query's recursive
+    /// structural walk (the dominant redundancy on class-heavy code such as
+    /// `ts-morph`) without ever leaking a context-bound verdict to a later
+    /// query under a different context. Cleared by [`SubtypeChecker::reset`].
+    pub(crate) local_relation_cache: FxHashMap<RelationCacheKey, bool>,
 }
 
 /// Operation-local cache statistics for [`SubtypeChecker`].
@@ -394,6 +415,7 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             apparent_primitive_shapes: std::array::from_fn(|_| None),
             type_param_equivalences: Vec::new(),
             maybe_keys: Vec::new(),
+            local_relation_cache: FxHashMap::default(),
         }
     }
 }
@@ -444,6 +466,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             apparent_primitive_shapes: std::array::from_fn(|_| None),
             type_param_equivalences: Vec::new(),
             maybe_keys: Vec::new(),
+            local_relation_cache: FxHashMap::default(),
         }
     }
 
@@ -572,14 +595,20 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.sym_visiting.clear();
         self.eval_cache.clear();
         self.maybe_keys.clear();
+        self.local_relation_cache.clear();
     }
 
     /// Return entry and size accounting for this checker's operation-local caches.
     #[must_use]
     pub fn cache_statistics(&self) -> SubtypeCheckerCacheStatistics {
         let eval_entries = self.eval_cache.len();
-        let estimated_size_bytes =
-            eval_entries.saturating_mul(std::mem::size_of::<((TypeId, bool), (TypeId, bool))>());
+        let estimated_size_bytes = eval_entries
+            .saturating_mul(std::mem::size_of::<((TypeId, bool), (TypeId, bool))>())
+            .saturating_add(
+                self.local_relation_cache
+                    .len()
+                    .saturating_mul(std::mem::size_of::<(RelationCacheKey, bool)>()),
+            );
         SubtypeCheckerCacheStatistics {
             eval_entries,
             estimated_size_bytes,

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/class_context_partitioning.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/class_context_partitioning.rs
@@ -74,6 +74,76 @@ fn subtype_cache_skips_class_check_context() {
 }
 
 #[test]
+fn class_check_context_verdict_uses_instance_local_memo_not_shared_cache() {
+    use tsz_binder::SymbolId;
+
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let source_symbol = SymbolId(44);
+    let class_ref = crate::SymbolRef(source_symbol.0);
+    let is_class = |symbol: crate::SymbolRef| symbol == class_ref;
+
+    let source = interner.object_with_flags_and_symbol(
+        vec![
+            PropertyInfo::new(interner.intern_string("a"), TypeId::NUMBER),
+            PropertyInfo::new(interner.intern_string("b"), TypeId::NUMBER),
+        ],
+        ObjectFlags::empty(),
+        Some(source_symbol),
+    );
+    let target = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+
+    let mut checker = SubtypeChecker::new(&interner)
+        .with_query_db(&db)
+        .with_class_check(&is_class);
+    let key = checker.debug_cache_key_for(source, target);
+
+    // A class-context verdict is excluded from the cross-checker shared cache
+    // (it depends on the `is_class_symbol` closure), so the first check
+    // populates the instance-local fallback memo instead (issue #13828).
+    assert!(!checker.is_subtype_of(source, target));
+    assert_eq!(
+        db.lookup_subtype_cache(key),
+        None,
+        "class-context verdict must not populate the shared class-agnostic slot",
+    );
+    assert_eq!(
+        checker.local_relation_cache.get(&key),
+        Some(&false),
+        "class-context verdict must be memoized in the instance-local fallback",
+    );
+
+    // A repeat comparison on the same instance is served from the local memo
+    // and preserves the verdict.
+    assert!(!checker.is_subtype_of(source, target));
+
+    // `reset` clears the instance-local memo so a reused checker never carries a
+    // context-bound verdict into a fresh context.
+    checker.reset();
+    assert!(
+        checker.local_relation_cache.is_empty(),
+        "reset must clear the instance-local relation memo",
+    );
+
+    // A separate structural checker (no class context) computes the ordinary
+    // structural answer, unaffected by the per-instance memo — the verdict is
+    // never shared across instances.
+    let mut structural = SubtypeChecker::new(&interner).with_query_db(&db);
+    assert!(structural.is_subtype_of(source, target));
+}
+
+#[test]
 fn assignability_relation_context_propagates_class_check_without_shared_cache() {
     use tsz_binder::SymbolId;
 


### PR DESCRIPTION
Goal: fast

Fixes the redundant structural-subtype recompute behind the `ts-morph` project-compile timeout (#13828), and the same lever plausibly helps the `typebox` eval-side residual.

## Structural rule

`When a relation verdict is context-dependent — its source/target carries a polymorphic `this`, or it is checked inside a class-check context — tsc still reuses that verdict within the current comparison; tsz now does too, through an instance-local fallback memo owned by the solver's `SubtypeChecker`.`

The cross-checker shared relation cache (`cache.rs:312`, `can_use_shared_relation_cache`) is bypassed for those pairs because their verdict depends on the resolver's current `this` binding (`resolve_this_type`) and on the `is_class_symbol` closure — neither of which the flag-agnostic `RelationCacheKey` can encode. Class-heavy code (`ts-morph` over the TypeScript compiler API; `typebox`) hits that bypass on a large fraction of its checks, so the same generic-signature comparisons are re-instantiated and re-compared from scratch in every branch of a diamond-shaped type graph instead of being served from cache (the profile's `subtype::cache` ≈ `functions::checking` frame-line ratio = low served-from-cache rate).

## Why this is sound (and why not the global-key change)

A fresh `SubtypeChecker`/`CompatChecker` is built per top-level relation query (`relation_queries.rs:589`). The resolver is borrowed immutably (via a `RefCell` `Ref`) for that whole lifetime, so the `this` binding cannot shift mid-query, and the `is_class_symbol` closure is fixed at construction. The full context is therefore constant for one instance, so a definitive verdict for a `(source, target)` pair holds for every repeat of that pair in the same query's recursive structural walk. The memo is dropped with the checker and cleared by `reset()`, so it can never serve a context-bound verdict to a later query under a different context — no cross-checker poisoning, which is exactly the risk that makes encoding the context into the shared `RelationCacheKey` (the abandoned-PR direction) unsafe.

## Owner layer

Solver, relations layer. Both the shared-cache write and the local-memo write now route through one `record_definitive_verdict` helper (replacing the inline `cache_definitive!` macro), preserving the existing poison-sentinel (`unresolved-Lazy` / weak-type-sensitivity) and `bypass_evaluation` write discipline for both tiers. Only definitive `True`/`False` are memoized; `CycleDetected`/`DepthExceeded` stay on the budget-conditional maybe-keys promotion path. No checker/emitter changes; no `RelationCacheKey`/cache-key surface change.

## Adjacent-case matrix

- Class-context pair (named class source vs string-index target): verdict excluded from the shared slot, written to the instance-local memo, served on repeat, and `reset()` clears it — covered by the new `class_check_context_verdict_uses_instance_local_memo_not_shared_cache` test (varied binder symbol id, so no name-based logic).
- Structural pair without class context on a fresh checker: still computes the ordinary structural answer, unaffected by the per-instance memo (asserted in the same test) — confirms no cross-instance sharing.
- Existing `subtype_cache_skips_class_check_context` / assignability-context partitioning tests still pass: context-dependent verdicts remain absent from the shared class-agnostic cache.

## Verification

- `cargo test -p tsz-solver --lib class_context_partitioning` — 3 pass (incl. new test).
- `cargo test -p tsz-solver --lib relation` — 1494 pass; `architecture` guards — 34 pass.
- `cargo clippy -p tsz-solver --lib` — clean.
- Ready-review CI owns the broad conformance / emit / fourslash parity floor for this relations-layer change (the `hold` gate).

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01HfrpJwRJx4vGgTJkPW3QKc

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfrpJwRJx4vGgTJkPW3QKc)_