### PR TITLE
fix(checker): fold enum bitwise/shift via ECMAScript ToInt32/ToUint32 (#13919)

### DIFF
--- a/crates/tsz-checker/src/types/utilities/const_enum_eval.rs
+++ b/crates/tsz-checker/src/types/utilities/const_enum_eval.rs
@@ -13,6 +13,7 @@
 //! nested but non-cyclic expression trees.
 
 use super::cycle_guard::{self, CycleSetId};
+use tsz_common::numeric::{to_int32, to_uint32};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
@@ -103,7 +104,7 @@ pub(crate) fn evaluate_const_enum_initializer(
             match unary.operator {
                 op if op == SyntaxKind::MinusToken as u16 => Some(-operand),
                 op if op == SyntaxKind::PlusToken as u16 => Some(operand),
-                op if op == SyntaxKind::TildeToken as u16 => Some(!(operand as i32) as f64),
+                op if op == SyntaxKind::TildeToken as u16 => Some(f64::from(!to_int32(operand))),
                 _ => None,
             }
         }
@@ -120,22 +121,22 @@ pub(crate) fn evaluate_const_enum_initializer(
                 op if op == SyntaxKind::SlashToken as u16 => Some(left / right),
                 op if op == SyntaxKind::PercentToken as u16 => Some(left % right),
                 op if op == SyntaxKind::BarToken as u16 => {
-                    Some((left as i32 | right as i32) as f64)
+                    Some(f64::from(to_int32(left) | to_int32(right)))
                 }
                 op if op == SyntaxKind::AmpersandToken as u16 => {
-                    Some((left as i32 & right as i32) as f64)
+                    Some(f64::from(to_int32(left) & to_int32(right)))
                 }
                 op if op == SyntaxKind::CaretToken as u16 => {
-                    Some((left as i32 ^ right as i32) as f64)
+                    Some(f64::from(to_int32(left) ^ to_int32(right)))
                 }
                 op if op == SyntaxKind::LessThanLessThanToken as u16 => {
-                    Some(((left as i32) << (right as u32 & 0x1f)) as f64)
+                    Some(f64::from(to_int32(left) << (to_uint32(right) & 0x1f)))
                 }
                 op if op == SyntaxKind::GreaterThanGreaterThanToken as u16 => {
-                    Some(((left as i32) >> (right as u32 & 0x1f)) as f64)
+                    Some(f64::from(to_int32(left) >> (to_uint32(right) & 0x1f)))
                 }
                 op if op == SyntaxKind::GreaterThanGreaterThanGreaterThanToken as u16 => {
-                    Some(((left as u32) >> (right as u32 & 0x1f)) as f64)
+                    Some(f64::from(to_uint32(left) >> (to_uint32(right) & 0x1f)))
                 }
                 op if op == SyntaxKind::AsteriskAsteriskToken as u16 => Some(left.powf(right)),
                 _ => None,
@@ -461,4 +462,108 @@ fn enum_member_index(
             .and_then(|m_data| arena.get_identifier_text(m_data.name))
             .is_some_and(|m_name| m_name == member_name)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsz_parser::parser::ParserState;
+
+    /// Parse `source`, find the first enum declaration, and evaluate the
+    /// initializer of its first member through [`evaluate_const_enum_initializer`].
+    ///
+    /// Literal-only initializers (the bitwise/shift witnesses below) need no
+    /// binder, so this exercises the evaluator in isolation and deterministically.
+    fn first_member_value(source: &str) -> Option<f64> {
+        let mut parser = ParserState::new("t.ts".to_string(), source.to_string());
+        let root = parser.parse_source_file();
+        let arena = parser.get_arena();
+
+        let mut stack = vec![root];
+        while let Some(idx) = stack.pop() {
+            if let Some(enum_data) = arena.get_enum_at(idx) {
+                let m_idx = enum_data.members.nodes[0];
+                let m_node = arena.get(m_idx)?;
+                let m_data = arena.get_enum_member(m_node)?;
+                let enum_name = arena.get_identifier_text(enum_data.name);
+                return evaluate_const_enum_initializer(
+                    arena,
+                    m_data.initializer,
+                    enum_data,
+                    enum_name,
+                    0,
+                );
+            }
+            for child in arena.get_children(idx) {
+                stack.push(child);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn bitwise_or_wraps_like_ecmascript_toint32() {
+        // `0x80000000` is 2_147_483_648. ECMAScript `ToInt32` wraps it to
+        // -2_147_483_648 before `| 0`; the old saturating `as i32` cast produced
+        // i32::MAX (2_147_483_647), diverging from tsc.
+        assert_eq!(
+            first_member_value("const enum E { A = 0x80000000 | 0 }"),
+            Some(-2_147_483_648.0)
+        );
+        // Renamed binder: behavior follows the value, not the enum/member name.
+        assert_eq!(
+            first_member_value("const enum Flags { Mask = 0x80000000 | 0 }"),
+            Some(-2_147_483_648.0)
+        );
+    }
+
+    #[test]
+    fn bitwise_and_xor_not_wrap() {
+        // 0xFFFFFFFF -> ToInt32 -> -1.
+        assert_eq!(
+            first_member_value("const enum E { A = 0xFFFFFFFF & 0xFFFFFFFF }"),
+            Some(-1.0)
+        );
+        assert_eq!(
+            first_member_value("const enum E { A = 0xFFFFFFFF ^ 0 }"),
+            Some(-1.0)
+        );
+        // ~0 == -1, and ~0x7FFFFFFF == -2147483648.
+        assert_eq!(first_member_value("const enum E { A = ~0 }"), Some(-1.0));
+        assert_eq!(
+            first_member_value("const enum E { A = ~0x7FFFFFFF }"),
+            Some(-2_147_483_648.0)
+        );
+    }
+
+    #[test]
+    fn shifts_use_toint32_touint32_operands() {
+        // 1 << 31 -> i32::MIN (signed left shift), matching JS.
+        assert_eq!(
+            first_member_value("const enum E { A = 1 << 31 }"),
+            Some(-2_147_483_648.0)
+        );
+        // Signed `>>` sign-extends: -2147483648 >> 31 == -1.
+        assert_eq!(
+            first_member_value("const enum E { A = (0x80000000 | 0) >> 31 }"),
+            Some(-1.0)
+        );
+        // Unsigned `>>>` zero-fills the ToUint32 operand: 0x80000000 >>> 31 == 1.
+        assert_eq!(
+            first_member_value("const enum E { A = 0x80000000 >>> 31 }"),
+            Some(1.0)
+        );
+    }
+
+    #[test]
+    fn small_values_are_unaffected() {
+        // Regression: ordinary in-range constants keep their value.
+        assert_eq!(
+            first_member_value("const enum E { A = 1 << 4 }"),
+            Some(16.0)
+        );
+        assert_eq!(first_member_value("const enum E { A = 6 & 3 }"), Some(2.0));
+        assert_eq!(first_member_value("const enum E { A = 5 | 2 }"), Some(7.0));
+        assert_eq!(first_member_value("const enum E { A = 255 }"), Some(255.0));
+    }
 }

--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -5,6 +5,7 @@ use crate::query_boundaries::type_checking_utilities as query;
 use crate::state::{CheckerState, EnumKind, MemberAccessLevel};
 use rustc_hash::FxHashMap;
 use tsz_binder::{SymbolId, symbol_flags};
+use tsz_common::numeric::{to_int32, to_uint32};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
@@ -378,7 +379,9 @@ impl<'a> CheckerState<'a> {
                 match unary.operator {
                     op if op == SyntaxKind::MinusToken as u16 => Some(-operand),
                     op if op == SyntaxKind::PlusToken as u16 => Some(operand),
-                    op if op == SyntaxKind::TildeToken as u16 => Some(!(operand as i32) as f64),
+                    op if op == SyntaxKind::TildeToken as u16 => {
+                        Some(f64::from(!to_int32(operand)))
+                    }
                     _ => None,
                 }
             }
@@ -393,22 +396,22 @@ impl<'a> CheckerState<'a> {
                     op if op == SyntaxKind::SlashToken as u16 => Some(left / right),
                     op if op == SyntaxKind::PercentToken as u16 => Some(left % right),
                     op if op == SyntaxKind::BarToken as u16 => {
-                        Some((left as i32 | right as i32) as f64)
+                        Some(f64::from(to_int32(left) | to_int32(right)))
                     }
                     op if op == SyntaxKind::AmpersandToken as u16 => {
-                        Some((left as i32 & right as i32) as f64)
+                        Some(f64::from(to_int32(left) & to_int32(right)))
                     }
                     op if op == SyntaxKind::CaretToken as u16 => {
-                        Some((left as i32 ^ right as i32) as f64)
+                        Some(f64::from(to_int32(left) ^ to_int32(right)))
                     }
                     op if op == SyntaxKind::LessThanLessThanToken as u16 => {
-                        Some(((left as i32) << (right as u32 & 0x1f)) as f64)
+                        Some(f64::from(to_int32(left) << (to_uint32(right) & 0x1f)))
                     }
                     op if op == SyntaxKind::GreaterThanGreaterThanToken as u16 => {
-                        Some(((left as i32) >> (right as u32 & 0x1f)) as f64)
+                        Some(f64::from(to_int32(left) >> (to_uint32(right) & 0x1f)))
                     }
                     op if op == SyntaxKind::GreaterThanGreaterThanGreaterThanToken as u16 => {
-                        Some(((left as u32) >> (right as u32 & 0x1f)) as f64)
+                        Some(f64::from(to_uint32(left) >> (to_uint32(right) & 0x1f)))
                     }
                     op if op == SyntaxKind::AsteriskAsteriskToken as u16 => Some(left.powf(right)),
                     _ => None,

--- a/crates/tsz-common/src/primitives/numeric.rs
+++ b/crates/tsz-common/src/primitives/numeric.rs
@@ -32,6 +32,52 @@ pub fn parse_numeric_literal_value(text: &str) -> Option<f64> {
     text.parse::<f64>().ok()
 }
 
+/// Number of distinct 32-bit integer values (`2^32`), the modulus used by the
+/// ECMAScript `ToInt32` / `ToUint32` abstract operations.
+const TWO_POW_32: f64 = 4_294_967_296.0;
+
+/// ECMAScript `ToUint32` (<https://tc39.es/ecma262/#sec-touint32>).
+///
+/// Truncates `value` toward zero and reduces it modulo `2^32` into the
+/// unsigned 32-bit range `[0, 2^32)`. `NaN`, `±0`, and `±∞` map to `0`.
+///
+/// This is the conversion JavaScript/TypeScript applies to the operands of the
+/// bitwise (`&`, `|`, `^`, `~`) and shift (`<<`, `>>`, `>>>`) operators, so any
+/// constant-expression evaluator that mirrors those operators on `f64` values
+/// must route through it. A plain `value as u32` cast is **not** equivalent:
+/// Rust's float-to-int cast *saturates* (`3e9_f64 as u32 == u32::MAX`,
+/// `-1.0_f64 as u32 == 0`), whereas ECMAScript *wraps* (`ToUint32(3e9) ==
+/// 3000000000`, `ToUint32(-1) == 4294967295`).
+#[inline]
+#[must_use]
+pub fn to_uint32(value: f64) -> u32 {
+    if !value.is_finite() || value == 0.0 {
+        return 0;
+    }
+    // `trunc()` is the spec's truncate-toward-zero; `rem_euclid` yields a
+    // non-negative remainder in `[0, 2^32)`, so the subsequent cast never
+    // saturates. For integer-valued inputs within `2^53` the arithmetic is
+    // exact, matching the double-precision result JS engines produce.
+    let modulo = value.trunc().rem_euclid(TWO_POW_32);
+    modulo as u32
+}
+
+/// ECMAScript `ToInt32` (<https://tc39.es/ecma262/#sec-toint32>).
+///
+/// Like [`to_uint32`] but reinterprets the wrapped value into the signed 32-bit
+/// range `[-2^31, 2^31)`. `ToInt32(2^31) == -2^31`, `ToInt32(-1) == -1`.
+///
+/// Use this — never `value as i32` — when folding the operands of JavaScript
+/// bitwise/shift operators: the saturating `as i32` cast turns
+/// `0x80000000 | 0` into `i32::MAX` instead of the correct `-2147483648`.
+#[inline]
+#[must_use]
+pub fn to_int32(value: f64) -> i32 {
+    // `u32 as i32` is a bit-pattern reinterpretation (wrapping), which is
+    // exactly the signed view of the `ToUint32` result.
+    to_uint32(value) as i32
+}
+
 /// Parse a digit sequence in the given base (2/8/10/16) as `f64`.
 ///
 /// Hex digits are case-insensitive. Underscores (numeric separators) are
@@ -133,6 +179,47 @@ mod tests {
         assert_eq!(parse_numeric_literal_value("0xDE_AD"), Some(57005.0));
         assert_eq!(parse_numeric_literal_value("0b1010_1111"), Some(175.0));
         assert_eq!(parse_numeric_literal_value("0o7_7"), Some(63.0));
+    }
+
+    #[test]
+    fn to_uint32_wraps_modulo_two_pow_32() {
+        // Small values are unchanged.
+        assert_eq!(to_uint32(0.0), 0);
+        assert_eq!(to_uint32(255.0), 255);
+        // `2^31` stays in unsigned range; `2^32` wraps to 0.
+        assert_eq!(to_uint32(2_147_483_648.0), 2_147_483_648);
+        assert_eq!(to_uint32(4_294_967_296.0), 0);
+        // Negative and out-of-range values wrap rather than saturate
+        // (a plain `as u32` cast would yield 0 and u32::MAX respectively).
+        assert_eq!(to_uint32(-1.0), 4_294_967_295);
+        assert_eq!(to_uint32(3_000_000_000.0), 3_000_000_000);
+        assert_eq!(to_uint32(4_294_967_297.0), 1);
+        // Truncation is toward zero before the modulo.
+        assert_eq!(to_uint32(5.9), 5);
+        assert_eq!(to_uint32(-5.9), 4_294_967_291);
+    }
+
+    #[test]
+    fn to_uint32_maps_non_finite_to_zero() {
+        assert_eq!(to_uint32(f64::NAN), 0);
+        assert_eq!(to_uint32(f64::INFINITY), 0);
+        assert_eq!(to_uint32(f64::NEG_INFINITY), 0);
+        assert_eq!(to_uint32(-0.0), 0);
+    }
+
+    #[test]
+    fn to_int32_wraps_into_signed_range() {
+        assert_eq!(to_int32(0.0), 0);
+        assert_eq!(to_int32(255.0), 255);
+        // `0x80000000` is the canonical witness: saturating `as i32` would give
+        // i32::MAX (2147483647); ECMAScript ToInt32 wraps to -2147483648.
+        assert_eq!(to_int32(2_147_483_648.0), -2_147_483_648);
+        assert_ne!(to_int32(2_147_483_648.0), i32::MAX);
+        assert_eq!(to_int32(4_294_967_295.0), -1);
+        assert_eq!(to_int32(-1.0), -1);
+        assert_eq!(to_int32(3_000_000_000.0), -1_294_967_296);
+        assert_eq!(to_int32(4_294_967_296.0), 0);
+        assert_eq!(to_int32(f64::NAN), 0);
     }
 
     #[test]


### PR DESCRIPTION
Goal: hold

Closes #13919.

## Summary

The checker's two `f64`-based constant-expression evaluators for enum member
initializers coerced the operands of the JavaScript bitwise (`&` `|` `^` `~`)
and shift (`<<` `>>` `>>>`) operators with Rust's `value as i32` / `value as u32`
casts. Since Rust 1.45 those float→int casts **saturate**, whereas ECMAScript
`ToInt32`/`ToUint32` — the coercion JS/TS bitwise operators apply — **wrap
modulo 2^32**. So `tsz` diverged from `tsc` for any operand `>= 2^31`:

```ts
const enum E { A = 0x80000000 | 0 }
//  tsc: -2147483648 ;  tsz before: 2147483647 (0x80000000 saturated to i32::MAX)
```

The emitter (`crates/tsz-emitter/src/transforms/enum_es5.rs`) already folds the
same operators in `i64` with wrapping semantics, so before this fix the checker
computed a literal type that disagreed with the value `tsz` actually emits.

## Structural rule

> When folding a constant enum-member initializer that applies a JavaScript
> bitwise/shift operator, `tsc` coerces each operand via `ToInt32`/`ToUint32`
> (truncate toward zero, reduce modulo 2^32 into the signed/unsigned 32-bit
> range). `tsz` must too — a saturating `f64 as i32`/`as u32` cast is not
> `ToInt32`/`ToUint32`.

## Owner layer / change

Checker constant-expression evaluation. New shared, spec-faithful helpers
`to_int32` / `to_uint32` live in `tsz_common::numeric` (one home any future
const-folding site can reuse), and both evaluators route through them:

- `crates/tsz-checker/src/types/utilities/enum_utils.rs`
  (`evaluate_constant_expression` — numeric / non-const enums)
- `crates/tsz-checker/src/types/utilities/const_enum_eval.rs`
  (`evaluate_const_enum_initializer` — const enums)

Pure numeric semantics — no identifier / file-name / printer-string predicates
(anti-hardcoding gate). Non-bitwise arithmetic (`+ - * / % **`) and small
in-range values are unchanged.

## Adjacent-case matrix

- `0x80000000 | 0` → `-2147483648` (the witness); renamed binder
  (`enum Flags { Mask = ... }`) gives the same result (behavior follows value,
  not name).
- `&` / `^` / `~` wrap: `0xFFFFFFFF & 0xFFFFFFFF == -1`, `~0 == -1`,
  `~0x7FFFFFFF == -2147483648`.
- shifts use ToInt32/ToUint32 operands: `1 << 31 == -2147483648`,
  `(0x80000000|0) >> 31 == -1` (sign-extend), `0x80000000 >>> 31 == 1`
  (zero-fill).
- regression: `1 << 4 == 16`, `6 & 3 == 2`, `5 | 2 == 7`, `255 == 255`.
- helper units: wrap vs saturate, `±0` / `NaN` / `±∞ → 0`, negative and
  out-of-range inputs.

## Verification

- `cargo test -p tsz-common numeric` — 13 passed (incl. 3 new `to_int32`/`to_uint32` tests).
- `cargo test -p tsz-checker --lib const_enum_eval` — 4 passed (new evaluator tests).
- `cargo clippy -p tsz-common --lib` and `cargo clippy -p tsz-checker --lib` — clean.
- `cargo fmt` — clean.
- Pre-existing `--lib` enum-display failures (`mapped_*_enum_*_member_display`,
  `mapped_enum_discriminant_application_exposes_member_property`) reproduce
  identically with the change stashed — not introduced here.
- Ready-review CI owns the broad conformance / emit / fourslash floor (the `hold` gate).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_013vsaMmPTqrHmL36uZwyvUs)_