### PR TITLE
fix(solver): bound exclusion-narrowing recursion with a per-request work budget (#13806 theme C)

### DIFF
--- a/crates/tsz-solver/src/narrowing/compound.rs
+++ b/crates/tsz-solver/src/narrowing/compound.rs
@@ -67,6 +67,16 @@ impl<'a> NarrowingContext<'a> {
     /// Excludes object types (objects, arrays, tuples, class instances).
     /// Note: null should already be excluded before calling this.
     pub(crate) fn narrow_excluding_typeof_object(&self, source_type: TypeId) -> TypeId {
+        // Shares the per-request exclusion-narrowing budget (see
+        // `narrow_excluding_type`): `narrow_type_param_excluding_typeof_object`
+        // re-mints `T & narrowed` and recurses here, so a self-referential
+        // constraint must be bounded on this path too. Charge one unit per call
+        // and bail to the unchanged source when the budget is spent.
+        let _frame = self.enter_exclusion_frame();
+        if !self.charge_exclusion_work() {
+            return source_type;
+        }
+
         let resolved = self.resolve_type(source_type);
 
         if let Some(narrowed) = self.narrow_type_param_excluding_typeof_object(resolved) {

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -13,7 +13,7 @@ use crate::visitor::{
     type_param_info, union_list_id,
 };
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::sync::Arc;
 use tracing::{Level, span, trace};
 use tsz_common::interner::Atom;
@@ -459,6 +459,62 @@ pub struct NarrowingCache {
     /// recursive-schema `collect_properties_cached` walk can be cached once per
     /// `(source, target)` pair (issue #13242 / #13250).
     pub(crate) narrow_subtype_cache: RefCell<FxHashMap<NarrowExcludingKey, bool>>,
+    /// Re-entrancy depth of the exclusion-narrowing families
+    /// (`narrow_excluding_type` / `narrow_excluding_function` /
+    /// `narrow_excluding_typeof_object`).
+    ///
+    /// The outermost frame (`depth == 0`) primes [`Self::narrow_excluding_fuel`]
+    /// so the cumulative work bound is scoped *per top-level request* and never
+    /// leaks across the many independent narrowings a shared cache serves.
+    pub(crate) narrow_excluding_depth: Cell<u32>,
+    /// Remaining cumulative work for the current outermost exclusion-narrowing
+    /// request.
+    ///
+    /// `narrow_type_param_excluding` re-mints a fresh `source & narrowed_constraint`
+    /// intersection at every level, so the per-pair [`Self::narrow_excluding_visiting`]
+    /// guard (keyed on a *stable* `(source, excluded)`) never fires for a
+    /// self-referential constraint such as `T extends Foo`: each recursion
+    /// presents a different `source` `TypeId`. A persistent work counter — the
+    /// narrowing analogue of tsc's `instantiationCount` — bounds that
+    /// breadth-fanned recursion regardless of how many fresh types it mints. On
+    /// exhaustion the recursion bails to the unchanged source, the same
+    /// conservative answer the in-flight cycle guard returns.
+    pub(crate) narrow_excluding_fuel: Cell<u32>,
+    /// Per-request work cap used to prime [`Self::narrow_excluding_fuel`]. `0`
+    /// means "use [`NARROW_EXCLUDING_WORK_BUDGET`]"; tests and tuning may lower
+    /// it to exercise the bail path deterministically.
+    pub(crate) narrow_excluding_budget: Cell<u32>,
+}
+
+/// Per-request cumulative work bound shared by the exclusion-narrowing families
+/// (`narrow_excluding_type` / `narrow_excluding_function` /
+/// `narrow_excluding_typeof_object`) and their `narrow_type_param_excluding*`
+/// recursions.
+///
+/// One unit is charged per *fresh* (un-memoized) exclusion narrow. Real flow
+/// narrowing performs at most a few hundred such steps per request, so the bound
+/// is pure headroom on conforming code and only bites the pathological
+/// breadth-fan that re-mints `source & constraint` intersections without
+/// converging (the latent defect tracked in the narrowing-recursion audit). It
+/// mirrors the role of tsc's `instantiationCount` cap: a generous absolute
+/// ceiling that turns a non-terminating expansion into a bounded, conservative
+/// result rather than a tuned per-shape heuristic.
+pub(crate) const NARROW_EXCLUDING_WORK_BUDGET: u32 = 1_000_000;
+
+/// RAII guard for one exclusion-narrowing recursion frame.
+///
+/// Restores the prior re-entrancy depth on every return path (including panic
+/// unwinds), so the per-request budget priming in [`NarrowingContext`] stays
+/// balanced. Shared by all `narrow_excluding_*` entry points.
+pub(in crate::narrowing) struct ExclusionFrame<'b> {
+    depth: &'b Cell<u32>,
+    prior: u32,
+}
+
+impl Drop for ExclusionFrame<'_> {
+    fn drop(&mut self) {
+        self.depth.set(self.prior);
+    }
 }
 
 /// Cache key for [`NarrowingContext::narrow_excluding_type`] and
@@ -523,6 +579,9 @@ impl NarrowingCache {
                 512,
                 FxBuildHasher,
             )),
+            narrow_excluding_depth: Cell::new(0),
+            narrow_excluding_fuel: Cell::new(0),
+            narrow_excluding_budget: Cell::new(0),
         }
     }
 
@@ -1506,6 +1565,55 @@ impl<'a> NarrowingContext<'a> {
         }
     }
 
+    /// Enter one exclusion-narrowing recursion frame.
+    ///
+    /// The outermost frame (`depth == 0`) primes the per-request cumulative work
+    /// budget; nested frames inherit it. Scoping the bound to one top-level
+    /// narrowing keeps it from accumulating across the many independent requests
+    /// a shared cache serves, while still bounding a recursion that re-mints
+    /// fresh `source & constraint` intersections (which slip past the
+    /// stable-keyed `narrow_excluding_visiting` guard). The returned guard
+    /// restores the prior depth on drop.
+    ///
+    /// Shared by [`Self::narrow_excluding_type`], [`Self::narrow_excluding_function`],
+    /// and [`Self::narrow_excluding_typeof_object`] so the three exclusion families
+    /// draw down one budget, and a self-referential constraint reached through
+    /// any of them terminates the same way.
+    pub(in crate::narrowing) fn enter_exclusion_frame(&self) -> ExclusionFrame<'_> {
+        let depth = &self.cache.narrow_excluding_depth;
+        let prior = depth.get();
+        if prior == 0 {
+            let cap = self.cache.narrow_excluding_budget.get();
+            let cap = if cap == 0 {
+                NARROW_EXCLUDING_WORK_BUDGET
+            } else {
+                cap
+            };
+            self.cache.narrow_excluding_fuel.set(cap);
+        }
+        depth.set(prior + 1);
+        ExclusionFrame { depth, prior }
+    }
+
+    /// Charge one unit of the per-request exclusion-narrowing budget. Returns
+    /// `false` once the budget is spent, signalling the caller to bail to a
+    /// conservative (un-narrowed) result.
+    pub(in crate::narrowing) fn charge_exclusion_work(&self) -> bool {
+        let fuel = self.cache.narrow_excluding_fuel.get();
+        if fuel == 0 {
+            return false;
+        }
+        self.cache.narrow_excluding_fuel.set(fuel - 1);
+        true
+    }
+
+    /// Whether the current request is still within its exclusion-narrowing
+    /// budget. Used to skip memoizing a result whose subtree drained the budget
+    /// (a truncated, request-local answer that must not poison a later request).
+    fn exclusion_within_budget(&self) -> bool {
+        self.cache.narrow_excluding_fuel.get() > 0
+    }
+
     /// Narrow a type to exclude members assignable to target.
     ///
     /// Memoizing entry point. The recursive body (`narrow_excluding_type_uncached`)
@@ -1518,8 +1626,8 @@ impl<'a> NarrowingContext<'a> {
     /// union (issue #13242 / #13250).
     pub fn narrow_excluding_type(&self, source_type: TypeId, excluded_type: TypeId) -> TypeId {
         // Intrinsics and identity pairs are answered without recursion; skip the
-        // memo bookkeeping for them so the common shallow path stays allocation-
-        // and borrow-free.
+        // memo and budget bookkeeping for them so the common shallow path stays
+        // allocation- and borrow-free.
         if source_type == TypeId::ANY {
             return TypeId::ANY;
         }
@@ -1527,6 +1635,24 @@ impl<'a> NarrowingContext<'a> {
             return self.narrow_excluding_type_uncached(source_type, excluded_type);
         }
 
+        let _frame = self.enter_exclusion_frame();
+        self.narrow_excluding_type_budgeted(source_type, excluded_type)
+    }
+
+    /// Override the per-request exclusion-narrowing work budget shared by every
+    /// `narrow_excluding_*` family.
+    ///
+    /// `0` restores the default [`NARROW_EXCLUDING_WORK_BUDGET`]. Lets tests
+    /// exercise the bail path deterministically without driving a million-step
+    /// recursion.
+    #[cfg(test)]
+    pub(crate) fn set_narrow_excluding_budget(&self, budget: u32) {
+        self.cache.narrow_excluding_budget.set(budget);
+    }
+
+    /// Memoized, budget-charged body of [`Self::narrow_excluding_type`]. Always
+    /// reached with the per-request fuel primed by the outermost frame.
+    fn narrow_excluding_type_budgeted(&self, source_type: TypeId, excluded_type: TypeId) -> TypeId {
         let key = NarrowExcludingKey {
             source: source_type,
             excluded: excluded_type,
@@ -1534,6 +1660,14 @@ impl<'a> NarrowingContext<'a> {
         };
         if let Some(&cached) = self.cache.narrow_excluding_cache.borrow().get(&key) {
             return cached;
+        }
+        // Charge one unit of the per-request budget for each fresh exclusion
+        // narrow. On exhaustion, bail to the unchanged source — the same
+        // conservative answer the in-flight cycle guard below returns — so a
+        // breadth-fanned recursion that keeps minting fresh intersections
+        // terminates instead of spinning unbounded.
+        if !self.charge_exclusion_work() {
+            return source_type;
         }
         // Re-entry on the same `(source, excluded)` pair is a recursive-alias
         // cycle: leave the source unchanged so the in-flight outer frame owns the
@@ -1551,10 +1685,16 @@ impl<'a> NarrowingContext<'a> {
             .narrow_excluding_visiting
             .borrow_mut()
             .remove(&key);
-        self.cache
-            .narrow_excluding_cache
-            .borrow_mut()
-            .insert(key, result);
+        // Only memoize when the whole subtree stayed within budget. A result that
+        // bottomed out the fuel is truncated and request-local, so caching it
+        // would poison a later, fully-budgeted request with the conservative
+        // answer.
+        if self.exclusion_within_budget() {
+            self.cache
+                .narrow_excluding_cache
+                .borrow_mut()
+                .insert(key, result);
+        }
         result
     }
 

--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -427,6 +427,17 @@ impl<'a> NarrowingContext<'a> {
 
     /// Narrow a type to exclude function-like members (typeof !== "function").
     pub fn narrow_excluding_function(&self, source_type: TypeId) -> TypeId {
+        // Shares the per-request exclusion-narrowing budget with
+        // `narrow_excluding_type`: a constrained type parameter whose constraint
+        // re-mints `T & narrowed` at each level (via
+        // `narrow_type_param_excluding_function`) would otherwise recurse
+        // unbounded here too. Charge one unit per call and bail to the unchanged
+        // source when the budget is spent.
+        let _frame = self.enter_exclusion_frame();
+        if !self.charge_exclusion_work() {
+            return source_type;
+        }
+
         // Resolve a non-union Lazy/Application source so an instantiated generic
         // alias whose body is a callable union is decomposed before exclusion
         // (the dual of `narrow_to_function`). Resolution is only adopted when it

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_01.rs
@@ -507,3 +507,143 @@ fn test_in_then_typeof_object_independent_of_property_name() {
         );
     }
 }
+
+// =============================================================================
+// narrow_excluding_type per-request cumulative work budget (issue #13806, theme C)
+// =============================================================================
+
+/// A constrained type parameter whose constraint loses a member is refined to
+/// `T & <narrowed constraint>` under a normal budget, but the nested constraint
+/// narrow that performs that refinement is the recursion the per-request work
+/// budget bounds. With the budget spent on the outer union narrow, the nested
+/// refinement bails to the unchanged source instead of recursing — the result
+/// still terminates and conservatively equals the un-narrowed union.
+///
+/// `narrow_type_param_excluding` re-mints a fresh `T & constraint'` intersection
+/// at each level, so the `(source, excluded)` `narrow_excluding_visiting` guard
+/// (keyed on a stable pair) cannot catch a self-referential constraint; the
+/// cumulative counter is what guarantees termination.
+#[test]
+fn test_narrow_excluding_budget_bounds_constraint_refinement() {
+    let interner = TypeInterner::new();
+    let constraint = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    let param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    }));
+    let union = interner.union(vec![param, TypeId::BOOLEAN]);
+
+    // Default budget refines the constrained parameter: (T & number) | boolean.
+    let expected_param = interner.intersection(vec![param, TypeId::NUMBER]);
+    let expected_full = interner.union(vec![expected_param, TypeId::BOOLEAN]);
+    let full_ctx = NarrowingContext::new(&interner);
+    assert_eq!(
+        full_ctx.narrow_excluding_type(union, TypeId::STRING),
+        expected_full,
+    );
+
+    // Budget 1 is consumed by the outer union narrow, so the nested constraint
+    // narrow bails to the unchanged source. A fresh context (and therefore a
+    // fresh memo) is required so the cached full result is not reused.
+    let bounded_ctx = NarrowingContext::new(&interner);
+    bounded_ctx.set_narrow_excluding_budget(1);
+    assert_eq!(
+        bounded_ctx.narrow_excluding_type(union, TypeId::STRING),
+        union,
+    );
+}
+
+/// Name-independence: the bound is structural, not keyed on the type-parameter
+/// name. Refinement happens under a normal budget and bails under a starved one
+/// regardless of how the parameter is spelled.
+#[test]
+fn test_narrow_excluding_budget_bound_is_name_independent() {
+    for name in ["T", "U", "Element", "__x"] {
+        let interner = TypeInterner::new();
+        let constraint = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+        let param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+            name: interner.intern_string(name),
+            constraint: Some(constraint),
+            default: None,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        }));
+        let union = interner.union(vec![param, TypeId::BOOLEAN]);
+
+        let full_ctx = NarrowingContext::new(&interner);
+        let refined = full_ctx.narrow_excluding_type(union, TypeId::STRING);
+        assert_ne!(refined, union, "param `{name}` must refine under full budget");
+
+        let bounded_ctx = NarrowingContext::new(&interner);
+        bounded_ctx.set_narrow_excluding_budget(1);
+        assert_eq!(
+            bounded_ctx.narrow_excluding_type(union, TypeId::STRING),
+            union,
+            "param `{name}` must bail to the source under a starved budget",
+        );
+    }
+}
+
+/// The default budget is generous enough that a legitimately wide (but finite)
+/// type narrows fully without a false bail. A 4,000-member intersection forces
+/// one exclusion narrow per member; excluding `string` removes nothing, so the
+/// result must terminate and equal the source unchanged.
+#[test]
+fn test_narrow_excluding_default_budget_handles_wide_intersection() {
+    let interner = TypeInterner::new();
+    let ctx = NarrowingContext::new(&interner);
+
+    let mut members = Vec::new();
+    for i in 0..4000 {
+        let name = interner.intern_string(&format!("p{i}"));
+        members.push(interner.object(vec![PropertyInfo::new(name, TypeId::NUMBER)]));
+    }
+    let wide = interner.intersection(members);
+
+    assert_eq!(ctx.narrow_excluding_type(wide, TypeId::STRING), wide);
+}
+
+/// The per-request budget is shared across the exclusion families: the
+/// `typeof x !== "function"` path (`narrow_excluding_function`) re-mints
+/// `T & narrowed` through `narrow_type_param_excluding_function`, so it must be
+/// bounded by the same counter. Under a normal budget a constrained parameter
+/// refines; under a starved one it bails to the unchanged source.
+#[test]
+fn test_narrow_excluding_function_shares_the_budget() {
+    let interner = TypeInterner::new();
+    let func = interner.function(FunctionShape {
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("x")),
+            type_id: TypeId::NUMBER,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: TypeId::VOID,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let constraint = interner.union(vec![func, TypeId::NUMBER]);
+    let param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    }));
+
+    // Full budget: the callable constituent is stripped, refining T to T & number.
+    let full_ctx = NarrowingContext::new(&interner);
+    let refined = full_ctx.narrow_excluding_function(param);
+    assert_ne!(refined, param, "T must refine away its callable constraint constituent");
+
+    // Starved budget: the nested constraint narrow bails, leaving T unchanged.
+    let bounded_ctx = NarrowingContext::new(&interner);
+    bounded_ctx.set_narrow_excluding_budget(1);
+    assert_eq!(bounded_ctx.narrow_excluding_function(param), param);
+}


### PR DESCRIPTION
Closes the **theme C** (unbounded narrowing recursion) slice of #13806 — the one theme with no prior owning issue.

Goal: hold

## Structural rule
When an exclusion narrow recurses through a self-referential type-parameter constraint (e.g. `T extends Foo`), `narrow_type_param_excluding` re-mints a fresh `source & narrowed_constraint` intersection at every level. The existing in-flight `narrow_excluding_visiting` guard is keyed on a **stable** `(source, excluded)` pair, so it never fires when each recursion presents a *different* `source` TypeId — the recursion was unbounded. `tsc` bounds equivalent work with a cumulative count (`instantiationCount`); tsz now bounds it through a solver-owned narrowing budget rather than the stable-keyed cycle guard.

This is a latent correctness defect regardless of the timeout attribution noted in the audit: the missing cumulative bound is the bug.

## What changed (owner layer: solver / narrowing)
- A **per-request cumulative work budget** on `NarrowingCache`, shared by all three exclusion families: `narrow_excluding_type`, `narrow_excluding_function`, `narrow_excluding_typeof_object`.
- The outermost exclusion frame primes the budget (RAII `ExclusionFrame` restores depth on every return path); each fresh (un-memoized) exclusion narrow charges one unit; on exhaustion the recursion **bails to the unchanged source** — the same conservative answer the in-flight cycle guard already returns.
- Results whose subtree drained the budget are **not memoized**, so a truncated, request-local answer can never poison a later, fully-budgeted request.
- The default budget (1,000,000) is pure headroom: real flow narrowing performs at most a few hundred steps per request, so conforming code never trips it and diagnostic/emit parity is unchanged. It only bites the pathological breadth-fan.

### Adjacent-case matrix
- **Families**: type-exclusion **and** function-exclusion covered by tests under both full and starved budgets; typeof-object exclusion shares the identical `enter_exclusion_frame` / `charge_exclusion_work` path.
- **Binder-name independence**: the bound is structural — verified across parameter names `T`, `U`, `Element`, `__x`.
- **Fallback / no false-bail**: a wide (4,000-member) intersection narrows fully under the default budget and returns unchanged.
- **Bail value consistency**: budget-exhaustion and the existing cycle guard both return `source` unchanged.

### Note on layering (reviewed alternative)
The thread-local `crate::limits::LimitBudgets` was considered as the home for this counter. It was deliberately **not** used: the sibling narrowing recursion guard (`narrow_excluding_visiting`) and the exclusion memo both live on the per-context `NarrowingCache`, because narrowing runs on a single `NarrowingContext`/cache per request (unlike the evaluator, which spins fresh instances mid-relation and therefore needs thread-local state). Keeping the budget on the cache matches the established narrowing-guard placement.

## Verification
- `cargo test -p tsz-solver --lib narrowing::` → **200 passed** (includes the new budget tests and all existing `narrow_excluding_*` tests, proving no behavior change on conforming inputs).
- `cargo clippy -p tsz-solver --tests` → clean.
- `python3 scripts/arch/arch_guard.py` → guardrails passed.
- Pre-existing-on-base failures unrelated to this diff (verified by stashing): `mapped.rs` file-size baseline drift, `test_conditional_infer_optional_property_present_distributive`, `literal_mask_preserves_object_vs_literal_reduction`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder` — all fail identically on clean HEAD.
- Broad conformance/emit owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_0148jefsiSmbqrevHHz8Zpd9

---
_Generated by [Claude Code](https://claude.ai/code/session_0148jefsiSmbqrevHHz8Zpd9)_