### PR TITLE
perf(solver): key union-normalize memo by canonical member multiset (#13240)

### DIFF
--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -780,18 +780,67 @@ impl TypeInterner {
     /// interning) is deterministic in the flattened input list over immutable
     /// interned types, and evaluation hot paths rebuild the same unions
     /// constantly (the interner sees ~97% repeat hits on type-level-heavy
-    /// projects). Key is the exact pre-normalization member list, so repeats
-    /// skip straight to the previously interned result.
+    /// projects).
+    ///
+    /// Two key spellings share one memo:
+    /// - The **raw** pre-normalization member list is the fast path, taken
+    ///   first at zero canonicalization cost, and serves exact repeats.
+    /// - For non-order-preserving unions the normalized result is a pure
+    ///   function of the member *multiset* (the pipeline sorts+dedups
+    ///   internally before doing any reduction), so on a raw miss the
+    ///   **canonical** (sorted, deduped) member list is consulted too. Generic
+    ///   instantiation and conditional distribution rebuild the same multiset
+    ///   with members in varying orders; canonical keying lets those
+    ///   order-permuted reconstructions share one entry instead of each
+    ///   re-running the O(N²) `reduce_union_subtypes` sweep (issue #13240 /
+    ///   #12271 / #13250).
+    ///
+    /// `should_preserve_callable_union_order` is a function of the member set,
+    /// so a given multiset is deterministically order-preserving or not: an
+    /// order-preserving callable union (whose result *is* order-dependent)
+    /// keeps raw-only keying, and its raw key can never alias another union's
+    /// canonical key.
     pub(super) fn normalize_union(&self, flat: TypeListBuffer) -> TypeId {
         if flat.len() > Self::UNION_NORMALIZE_CACHE_MAX_LEN {
             return self.normalize_union_uncached(flat);
         }
+        // Fast path: an exact repeat of a previously-seen member list. This is
+        // the dominant case and pays only one hash lookup.
         if let Some(hit) = self.union_normalize_cache.get(flat.as_slice()) {
             return *hit;
         }
-        let key: Box<[TypeId]> = flat.as_slice().into();
+
+        // Order-preserving callable unions retain their input member order, so
+        // their normalized result is order-dependent — only the raw spelling
+        // is a valid key.
+        if self.should_preserve_callable_union_order(&flat) {
+            let key: Box<[TypeId]> = flat.as_slice().into();
+            let result = self.normalize_union_uncached(flat);
+            self.union_normalize_cache.insert(key, result);
+            return result;
+        }
+
+        // Canonical key: catches order-permuted reconstructions of the same
+        // multiset that the raw key just missed.
+        let mut canonical = flat.clone();
+        self.sort_union_members(&mut canonical);
+        canonical.dedup();
+        let canonical_key: Box<[TypeId]> = canonical.as_slice().into();
+        if let Some(hit) = self.union_normalize_cache.get(&canonical_key) {
+            let shared = *hit;
+            // Record the raw spelling so a later exact repeat takes the fast
+            // path above without recomputing the canonical key.
+            self.union_normalize_cache
+                .insert(flat.as_slice().into(), shared);
+            return shared;
+        }
+
+        let raw_key: Box<[TypeId]> = flat.as_slice().into();
         let result = self.normalize_union_uncached(flat);
-        self.union_normalize_cache.insert(key, result);
+        // Store under both spellings: the raw key serves exact repeats from the
+        // fast path; the canonical key serves future order-permuted repeats.
+        self.union_normalize_cache.insert(canonical_key, result);
+        self.union_normalize_cache.insert(raw_key, result);
         result
     }
 

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -773,6 +773,14 @@ impl TypeInterner {
         max_len
     };
 
+    /// Minimum input length for the canonical union-normalize memo spelling.
+    ///
+    /// Canonical lookup sorts and dedups the raw miss before the full normalize
+    /// pipeline runs. That extra O(N log N) work is only worth paying when it
+    /// can avoid a meaningful O(N²) subtype-reduction repeat; small unions stay
+    /// on the raw-only memo path that serves exact repeats without extra work.
+    const UNION_NORMALIZE_CANONICAL_CACHE_MIN_LEN: usize = TYPE_LIST_INLINE + 1;
+
     /// Memoized union normalization.
     ///
     /// The full pipeline (callable-order probe, semantic sort, dedup, literal
@@ -782,18 +790,19 @@ impl TypeInterner {
     /// constantly (the interner sees ~97% repeat hits on type-level-heavy
     /// projects).
     ///
-    /// Two key spellings share one memo:
+    /// Large non-order-preserving inputs may share two memo spellings:
     /// - The **raw** pre-normalization member list is the fast path, taken
     ///   first at zero canonicalization cost, and serves exact repeats.
-    /// - For non-order-preserving unions the normalized result is a pure
-    ///   function of the member *multiset* (the pipeline sorts+dedups
-    ///   internally before doing any reduction), so on a raw miss the
-    ///   **canonical** (sorted, deduped) member list is consulted too. Generic
-    ///   instantiation and conditional distribution rebuild the same multiset
-    ///   with members in varying orders; canonical keying lets those
+    /// - For sufficiently large non-order-preserving unions the normalized
+    ///   result is a pure function of the member *multiset* (the pipeline
+    ///   sorts+dedups internally before doing any reduction), so on a raw miss
+    ///   the **canonical** (sorted, deduped) member list is consulted too.
+    ///   Generic instantiation and conditional distribution rebuild the same
+    ///   multiset with members in varying orders; canonical keying lets those
     ///   order-permuted reconstructions share one entry instead of each
     ///   re-running the O(N²) `reduce_union_subtypes` sweep (issue #13240 /
-    ///   #12271 / #13250).
+    ///   #12271 / #13250). Small raw misses stay raw-only because the extra
+    ///   canonical sort costs more than the pairwise work it could skip.
     ///
     /// `should_preserve_callable_union_order` is a function of the member set,
     /// so a given multiset is deterministically order-preserving or not: an
@@ -808,6 +817,13 @@ impl TypeInterner {
         // the dominant case and pays only one hash lookup.
         if let Some(hit) = self.union_normalize_cache.get(flat.as_slice()) {
             return *hit;
+        }
+
+        if flat.len() < Self::UNION_NORMALIZE_CANONICAL_CACHE_MIN_LEN {
+            let key: Box<[TypeId]> = flat.as_slice().into();
+            let result = self.normalize_union_uncached(flat);
+            self.union_normalize_cache.insert(key, result);
+            return result;
         }
 
         // Order-preserving callable unions retain their input member order, so

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -91,6 +91,42 @@ fn type_predicate_cache_statistics_reports_union_normalize_entries() {
 }
 
 #[test]
+fn union_normalize_memo_shares_order_permuted_member_lists() {
+    // A non-order-preserving union's normalized result is a pure function of
+    // its member multiset, so rebuilding the same multiset with members in a
+    // different order must reuse the memo instead of re-running the O(N^2)
+    // `reduce_union_subtypes` sweep (issue #13240). Three disjoint primitives
+    // are non-reducible against each other, so the union keeps all members and
+    // its identity is stable across orderings.
+    tsz_common::perf_counters::force_enable_perf_counters_for_tests();
+
+    let interner = TypeInterner::new();
+
+    let first_order = interner.union_from_slice(&[TypeId::BOOLEAN, TypeId::NUMBER, TypeId::STRING]);
+
+    // After the first build the canonical (sorted) key is memoized. A rebuild
+    // in a different member order must hit that entry without recomputing.
+    let before = tsz_common::perf_counters::PerfCounters::snapshot()
+        .solver_materialization
+        .union_subtype_reduction_calls;
+    let permuted_order =
+        interner.union_from_slice(&[TypeId::STRING, TypeId::BOOLEAN, TypeId::NUMBER]);
+    let after = tsz_common::perf_counters::PerfCounters::snapshot()
+        .solver_materialization
+        .union_subtype_reduction_calls;
+
+    assert_eq!(
+        first_order, permuted_order,
+        "union member order must not change the interned result"
+    );
+    assert_eq!(
+        after, before,
+        "an order-permuted rebuild of the same multiset must be served from the \
+         memo, not re-run through reduce_union_subtypes"
+    );
+}
+
+#[test]
 fn boxed_def_id_registration_is_idempotent() {
     let interner = TypeInterner::new();
     let def_id = DefId(7);

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -95,22 +95,26 @@ fn union_normalize_memo_shares_order_permuted_member_lists() {
     // A non-order-preserving union's normalized result is a pure function of
     // its member multiset, so rebuilding the same multiset with members in a
     // different order must reuse the memo instead of re-running the O(N^2)
-    // `reduce_union_subtypes` sweep (issue #13240). Three disjoint primitives
-    // are non-reducible against each other, so the union keeps all members and
-    // its identity is stable across orderings.
+    // `reduce_union_subtypes` sweep (issue #13240). The canonical-key path is
+    // limited to unions large enough to make that O(N²) avoidance worthwhile,
+    // so use enough disjoint literal members to exercise that path.
     tsz_common::perf_counters::force_enable_perf_counters_for_tests();
 
     let interner = TypeInterner::new();
+    let members: Vec<TypeId> = (0..9)
+        .map(|idx| interner.literal_string(&format!("member_{idx}")))
+        .collect();
+    let mut permuted_members = members.clone();
+    permuted_members.reverse();
 
-    let first_order = interner.union_from_slice(&[TypeId::BOOLEAN, TypeId::NUMBER, TypeId::STRING]);
+    let first_order = interner.union_from_slice(&members);
 
     // After the first build the canonical (sorted) key is memoized. A rebuild
     // in a different member order must hit that entry without recomputing.
     let before = tsz_common::perf_counters::PerfCounters::snapshot()
         .solver_materialization
         .union_subtype_reduction_calls;
-    let permuted_order =
-        interner.union_from_slice(&[TypeId::STRING, TypeId::BOOLEAN, TypeId::NUMBER]);
+    let permuted_order = interner.union_from_slice(&permuted_members);
     let after = tsz_common::perf_counters::PerfCounters::snapshot()
         .solver_materialization
         .union_subtype_reduction_calls;


### PR DESCRIPTION
Goal: fast

Closes a narrow, not-yet-attempted slice of #13240 (workstream C of #13250).

## Structural rule

When N reconstructions of a union present the same member multiset in different orders, `tsc`/tsz must compute one normalized result. The interner's `union_normalize_cache` keyed by the **exact raw pre-normalization member list** (`crates/tsz-solver/src/intern/core/constructors.rs`), so a non-order-preserving union rebuilt with its members in a different order missed the memo and re-ran the full normalize pipeline — including the O(N²) `reduce_union_subtypes` pairwise sweep. The 2026-06-15 large-ts-repo profile on this issue named `reduce_union_subtypes` the steady-state DNF dominator ("the solver constructs many intermediate unions whose member multiset is content-identical to one already reduced … each construction re-runs the O(n²) pairwise reduction from scratch"); generic instantiation and conditional distribution are exactly the producers of order-permuted-but-content-identical unions.

tsz now keys the memo by the **canonical (sorted, deduped) member list** for non-order-preserving unions, so order-permuted reconstructions share one entry.

## Owner layer / change

Solver interner union construction (`intern/core/constructors.rs::normalize_union`). Two key spellings now share one memo:

- The **raw** member list stays the fast path, consulted first at zero canonicalization cost — the dominant exact-repeat case (~97% hit) is unchanged.
- On a raw miss for a non-order-preserving union, the **canonical** (sorted+deduped) member list is consulted and stored too. The normalized result of such a union is a pure function of its member multiset (the pipeline sorts+dedups before any reduction), so this is sound.

## Soundness (no staleness, no false-sharing, no flag-swallowing)

- `should_preserve_callable_union_order` is a function of the member **set** (it ignores order), so a given multiset is deterministically order-preserving or not. Order-preserving callable unions (whose result *is* order-dependent) keep raw-only keying, and their raw key can never alias another union's canonical key.
- The result for a non-order-preserving multiset is order-independent already (`normalize_union_uncached` sorts+dedups first), so canonical sharing returns the byte-identical interned `TypeId`.
- The `UNION_NORMALIZE_CACHE_MAX_LEN` = 1000 bound is untouched: every cached input has `pairwise < UNION_SUBTYPE_PAIRWISE_LIMIT`, so no cache entry can set or swallow the sticky TS2590 `union_too_complex` flag.

## Adjacent-case matrix

- Order-permuted rebuild of the same multiset → identical interned result, served from the memo without re-running `reduce_union_subtypes` (new unit test, counter-asserted).
- Order-preserving callable union → raw-only keying preserved (covered by existing callable-union-order tests).
- Duplicate-collapsing inputs (`[A,A,B]` vs `[A,B]`) → canonicalization dedups to the same key, which is the correct shared result.
- Diagnostic-neutral: no change to any rendered diagnostic or emit; the change is a cache-key refinement only.

## Verification

- `scripts/safe-run.sh cargo nextest run -p tsz-solver union_normalize_memo_shares_order_permuted_member_lists` - 1 passed after limiting canonical memo lookup to larger raw misses.
- `cargo fmt -p tsz-solver` - clean.
- `git diff --check` - clean.
- `python3 scripts/arch/arch_guard.py` - passed.
- Fresh broad conformance / emit / fourslash and project-corpus checks owned by exact-head CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_0163hKMYoD5mQeZ36sX8yYjn

---
_Generated by [Claude Code](https://claude.ai/code/session_0163hKMYoD5mQeZ36sX8yYjn)_
