### PR TITLE
perf(checker): memoize the pass-through chase's assignment-relevance classification (#13311)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1680,6 +1680,9 @@ path = "tests/flow_call_divert_memoization_tests.rs"
 [[test]]
 name = "flow_captured_let_memoization_tests"
 path = "tests/flow_captured_let_memoization_tests.rs"
+[[test]]
+name = "flow_passthrough_run_narrowing_tests"
+path = "tests/flow_passthrough_run_narrowing_tests.rs"
 
 [[test]]
 name = "public_package_unique_symbol_emit_tests"

--- a/crates/tsz-checker/src/flow/control_flow/core/defer_classification.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/defer_classification.rs
@@ -16,20 +16,35 @@
 
 use super::FlowAnalyzer;
 use rustc_hash::FxHashMap;
-use tsz_binder::{FlowNode, FlowNodeId};
+use tsz_binder::{FlowNode, FlowNodeId, SymbolId};
+use tsz_parser::parser::NodeIndex;
 
 /// Per-walk classification memos shared by the linear-passthrough chase and the
-/// defer classifier. Both decisions are pure functions of a flow node within a
+/// defer classifier. Every decision is a pure function of a flow node within a
 /// single backward walk (`reference`/`symbol_id` are fixed and the type / type-
 /// predicate caches are immutable mid-walk), so each is computed at most once per
 /// node per walk. Bundling them keeps the chase within its argument budget while
-/// the recursion in `antecedent_requires_defer` reuses both tables.
+/// the recursion in `antecedent_requires_defer` reuses the tables.
+///
+/// INVARIANT: an instance is created fresh at the start of a single `check_flow`
+/// walk and never reused across walks. That is what makes keying purely by
+/// `FlowNodeId` sound — the `reference`/`symbol_id` a result depends on are
+/// constant for the instance's lifetime, so they need not enter the key. A future
+/// change that hoisted/shared a `FlowDeferMemos` across walks would silently serve
+/// stale verdicts for a different reference and must re-key by reference instead.
 #[derive(Default)]
 pub(crate) struct FlowDeferMemos {
     /// `antecedent_requires_defer` result keyed by flow-node id.
     pub(crate) defer: FxHashMap<FlowNodeId, bool>,
     /// `call_node_may_narrow_or_divert` result keyed by flow-node id.
     pub(crate) call_divert: FxHashMap<FlowNodeId, bool>,
+    /// `assignment_relevant_to_reference` result keyed by flow-node id — whether a
+    /// pure ASSIGNMENT flow node targets or affects the queried reference, the
+    /// gate the linear-passthrough chase uses to decide whether it may splice the
+    /// node. Pure per walk (`reference`/`symbol_id` are fixed), recomputed on every
+    /// chase re-scan of an overlapping assignment run, so memoized like the two
+    /// classifications above.
+    pub(crate) assignment_relevant: FxHashMap<FlowNodeId, bool>,
 }
 
 impl FlowAnalyzer<'_> {
@@ -54,6 +69,65 @@ impl FlowAnalyzer<'_> {
             return cached;
         }
         let result = self.call_node_may_narrow_or_divert(ant_flow);
+        memo.insert(flow_id, result);
+        result
+    }
+
+    /// Whether a pure ASSIGNMENT flow node *targets* or *affects* `reference` — the
+    /// relevance gate the linear-passthrough chase uses to decide whether the node
+    /// is a pure pass-through it may splice. Mirrors the worklist's own ASSIGNMENT
+    /// pre-filter: the #13404 O(1) root-symbol overlap probe rejects unrelated
+    /// assignments cheaply, and only on a possible overlap does it fall back to the
+    /// deep `assignment_targets_reference_node` / `assignment_affects_reference_node`
+    /// AST predicates. The result is a pure function of
+    /// `(assignment_node, reference, symbol_id)`.
+    fn assignment_relevant_to_reference(
+        &self,
+        assignment_node: NodeIndex,
+        reference: NodeIndex,
+        symbol_id: Option<SymbolId>,
+    ) -> bool {
+        if !self.assignment_root_symbols_may_overlap(assignment_node, reference, symbol_id) {
+            false
+        } else if let Some(target_sym) = symbol_id {
+            let assignment_sym = self.reference_symbol(assignment_node);
+            if assignment_sym.is_some() && assignment_sym != Some(target_sym) {
+                // Different binder symbol: cannot target the reference. It may still
+                // *affect* a property/element path of the reference.
+                self.assignment_affects_reference_node(assignment_node, reference)
+            } else {
+                self.assignment_targets_reference_node(assignment_node, reference)
+                    || self.assignment_affects_reference_node(assignment_node, reference)
+            }
+        } else {
+            self.assignment_targets_reference_node(assignment_node, reference)
+                || self.assignment_affects_reference_node(assignment_node, reference)
+        }
+    }
+
+    /// Per-walk memoized wrapper around [`Self::assignment_relevant_to_reference`].
+    ///
+    /// The relevance decision is a pure function of the ASSIGNMENT flow node within
+    /// a single backward walk (`reference`/`symbol_id` are fixed and the binder
+    /// symbol / AST shapes are immutable mid-walk). The linear-passthrough chase
+    /// re-derives it for the same node on every overlapping re-scan — each interior
+    /// node a surviving merge re-schedules re-runs the chase over the run ahead of
+    /// it — so without a memo an assignment-dense scope pays the full root-overlap
+    /// probe plus targeting/affecting AST comparison many times per reference read.
+    /// Caching by flow-node id collapses that to one classification per node per
+    /// walk with no change in value.
+    pub(crate) fn assignment_relevant_to_reference_cached(
+        &self,
+        flow_id: FlowNodeId,
+        assignment_node: NodeIndex,
+        reference: NodeIndex,
+        symbol_id: Option<SymbolId>,
+        memo: &mut FxHashMap<FlowNodeId, bool>,
+    ) -> bool {
+        if let Some(&cached) = memo.get(&flow_id) {
+            return cached;
+        }
+        let result = self.assignment_relevant_to_reference(assignment_node, reference, symbol_id);
         memo.insert(flow_id, result);
         result
     }

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -1422,25 +1422,17 @@ impl<'a> FlowAnalyzer<'a> {
             // when the assignment's root symbol is provably disjoint from the
             // reference's, it is irrelevant and skippable. Only fall back to the
             // deep AST predicates (which the worklist's ASSIGNMENT branch also runs)
-            // when the roots may overlap.
-            let relevant =
-                if !self.assignment_root_symbols_may_overlap(flow.node, reference, symbol_id) {
-                    false
-                } else if let Some(target_sym) = symbol_id {
-                    let assignment_sym = self.reference_symbol(flow.node);
-                    if assignment_sym.is_some() && assignment_sym != Some(target_sym) {
-                        // Different binder symbol: cannot target the reference. It may
-                        // still *affect* a property/element path of the reference.
-                        self.assignment_affects_reference_node(flow.node, reference)
-                    } else {
-                        self.assignment_targets_reference_node(flow.node, reference)
-                            || self.assignment_affects_reference_node(flow.node, reference)
-                    }
-                } else {
-                    self.assignment_targets_reference_node(flow.node, reference)
-                        || self.assignment_affects_reference_node(flow.node, reference)
-                };
-            if relevant {
+            // when the roots may overlap. The classification is a per-walk-pure
+            // function of the node, re-derived on every overlapping chase re-scan,
+            // so it is memoized by flow-node id alongside the defer / call-divert
+            // memos — one classification per node per walk, byte-identical in value.
+            if self.assignment_relevant_to_reference_cached(
+                current,
+                flow.node,
+                reference,
+                symbol_id,
+                &mut memos.assignment_relevant,
+            ) {
                 return current;
             }
 

--- a/crates/tsz-checker/tests/flow_passthrough_run_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/flow_passthrough_run_narrowing_tests.rs
@@ -1,0 +1,159 @@
+//! Witness matrix for the linear-pass-through chase's ASSIGNMENT *relevance*
+//! classification (`chase_linear_passthrough` in
+//! `crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs`), now
+//! memoized per walk by flow-node id (issue #13311 `fast` slice, completing the
+//! chase-classification memoization started in #13683).
+//!
+//! Structural rule:
+//!
+//! > When a backward flow walk crosses a straight-line run of ASSIGNMENT flow
+//! > nodes that neither *target* nor *affect* the queried reference, each node's
+//! > flow type equals its antecedent's, so the chase splices the run and the
+//! > narrowing established before it is preserved unchanged. A node that DOES
+//! > target or affect the reference (a killing definition or a base/property
+//! > reassignment) stops the chase and re-establishes the assignment-narrowed
+//! > type. Memoizing the relevance decision by flow-node id is a per-walk-pure
+//! > transform: `reference`/`symbol_id` are fixed within a walk, so the cached
+//! > verdict is byte-identical to recomputing it on every chase re-scan.
+//!
+//! Each case below uses distinct binder / parameter / property names so the
+//! behavior follows the structural shape, not any identifier spelling
+//! (CLAUDE.md anti-hardcoding gate). Both the plain-identifier reference path
+//! (`symbol_id` present) and the member-access path (`symbol_id` absent) are
+//! covered, in both the narrowing-preserved and narrowing-cleared directions,
+//! and with a branch merge that re-schedules interior run nodes so the chase
+//! re-scans the run (the case the memo is meant to collapse).
+
+use tsz_checker::test_utils::check_source_codes;
+
+const TS2322_ASSIGNMENT: u32 = 2322;
+
+/// The guard read after the pass-through run is still narrowed, so the trailing
+/// return is assignable to the `string` result and emits no TS2322.
+fn assert_narrowing_preserved(source: &str) {
+    let diags = check_source_codes(source);
+    assert!(
+        !diags.contains(&TS2322_ASSIGNMENT),
+        "narrowing must survive the pass-through run; got: {diags:?}",
+    );
+}
+
+/// A relevant assignment inside the run re-establishes the assignment-narrowed
+/// type, so the trailing return is no longer assignable and TS2322 fires. If the
+/// relevance memo wrongly served "irrelevant" the chase would splice past the
+/// assignment and the error would vanish.
+fn assert_narrowing_cleared(source: &str) {
+    let diags = check_source_codes(source);
+    assert!(
+        diags.contains(&TS2322_ASSIGNMENT),
+        "a relevant assignment in the run must clear narrowing (expected TS2322); got: {diags:?}",
+    );
+}
+
+// =========================================================================
+// Narrowing is PRESERVED across an irrelevant pass-through assignment run.
+// =========================================================================
+
+/// A long run of independent `const` declarations sits between a `typeof`
+/// guard and a later read of the narrowed identifier. None of the `const`s
+/// target or affect `value`, so the chase splices them and `value` stays
+/// narrowed to `string` — `return value` is assignable to the `string`
+/// result and emits no TS2322.
+#[test]
+fn identifier_narrowing_survives_long_const_run() {
+    assert_narrowing_preserved(
+        r#"
+function widenFirst(value: string | number): string {
+    if (typeof value !== "string") return "";
+    const p0 = 0; const p1 = 1; const p2 = 2; const p3 = 3; const p4 = 4;
+    const p5 = 5; const p6 = 6; const p7 = 7; const p8 = 8; const p9 = 9;
+    return value;
+}
+"#,
+    );
+}
+
+/// Same shape but with an `if (flag) { ... }` block in the middle of the run.
+/// Its `BRANCH_LABEL` merge re-schedules the interior run nodes, so the chase
+/// re-scans the run on more than one worklist pop — the exact repetition the
+/// relevance memo collapses. Narrowing must still be byte-identical (no
+/// TS2322).
+#[test]
+fn identifier_narrowing_survives_run_with_branch_merge() {
+    assert_narrowing_preserved(
+        r#"
+function widenSecond(token: string | number, flag: boolean): string {
+    if (typeof token !== "string") return "";
+    const b0 = 0; const b1 = 1; const b2 = 2; const b3 = 3; const b4 = 4;
+    if (flag) {
+        const c0 = 0; const c1 = 1;
+    }
+    const d0 = 0; const d1 = 1; const d2 = 2;
+    return token;
+}
+"#,
+    );
+}
+
+/// Member-access reference (`holder.payload`) carries no `symbol_id`, so the
+/// relevance classifier takes its `else` arm. The `const`s do not affect the
+/// `holder.payload` path, so it stays narrowed to `string`.
+#[test]
+fn member_narrowing_survives_long_const_run() {
+    assert_narrowing_preserved(
+        r#"
+function readMember(holder: { payload: string | number }): string {
+    if (typeof holder.payload !== "string") return "";
+    const e0 = 0; const e1 = 1; const e2 = 2; const e3 = 3; const e4 = 4;
+    return holder.payload;
+}
+"#,
+    );
+}
+
+// =========================================================================
+// A RELEVANT assignment in the run still stops the chase and clears narrowing.
+// =========================================================================
+
+/// A killing definition (`subject = 42`) in the middle of the run targets the
+/// reference, so the chase must NOT splice past it: `subject` is re-narrowed to
+/// `number` and the trailing `return subject` is no longer assignable to the
+/// `string` result, emitting TS2322. If the relevance memo wrongly classified
+/// the targeting assignment as irrelevant, the chase would skip it and the
+/// error would vanish.
+#[test]
+fn identifier_targeting_assignment_in_run_clears_narrowing() {
+    assert_narrowing_cleared(
+        r#"
+function reassignFirst(subject: string | number): string {
+    if (typeof subject === "string") {
+        const g0 = 0; const g1 = 1; const g2 = 2; const g3 = 3; const g4 = 4;
+        subject = 42;
+        const h0 = 0; const h1 = 1;
+        return subject;
+    }
+    return "";
+}
+"#,
+    );
+}
+
+/// A property reassignment (`record.field = count`) affects the member
+/// reference, so the chase stops at it and `record.field` is re-narrowed to
+/// `number`, producing TS2322 on the trailing return. Exercises the
+/// member-reference `affects` arm of the relevance classifier.
+#[test]
+fn member_affecting_assignment_in_run_clears_narrowing() {
+    assert_narrowing_cleared(
+        r#"
+function reassignMember(record: { field: string | number }, count: number): string {
+    if (typeof record.field === "string") {
+        const j0 = 0; const j1 = 1; const j2 = 2;
+        record.field = count;
+        return record.field;
+    }
+    return "";
+}
+"#,
+    );
+}


### PR DESCRIPTION
Goal: fast

Part of #13311 (single-large-function flow-analysis blowup). Completes the chase-classification memoization started in #13683.

## Structural rule

> When a backward flow walk crosses a straight-line run of ASSIGNMENT flow nodes that neither *target* nor *affect* the queried reference, each node's flow type equals its antecedent's, so `chase_linear_passthrough` splices the run. Deciding whether a node is relevant is a pure function of `(flow node, reference, symbol_id)` — all fixed within one `check_flow` walk — so it must be classified at most once per node per walk, never recomputed on every re-scan.

## Owner loop + complexity

`chase_linear_passthrough` (`crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs`) re-scans overlapping pass-through runs on every worklist pop / interior-node re-schedule. Cost is `O(distinct reference paths * scope statements)`. #13683 memoized the per-walk-pure CALL narrow/divert (`call_divert`) and defer (`defer`) classifications it derives in that loop, but the **sibling ASSIGNMENT relevance classification** — the `assignment_root_symbols_may_overlap` O(1) root pre-filter plus the deep `assignment_targets_reference_node` / `assignment_affects_reference_node` AST predicates — was still recomputed on every re-scan of an assignment-dense run. Same repetition, just for `const`/assignment nodes instead of call nodes.

## What changed (owner layer: checker flow analysis)

- Extend `FlowDeferMemos` (`core/defer_classification.rs`) with a third per-walk memo, `assignment_relevant`, keyed by `FlowNodeId`, alongside the existing `defer` / `call_divert` memos.
- Extract the chase's inline relevance logic into `assignment_relevant_to_reference` (a verbatim move — the targeting/affecting short-circuit is preserved) and route the chase through `assignment_relevant_to_reference_cached`, mirroring `call_node_may_narrow_or_divert_cached`.
- The verdict is **byte-identical** to recomputing it: `reference`/`symbol_id` are constant for the memo instance's lifetime, so node-id-only keying is sound. Documented the per-walk-fresh `FlowDeferMemos` invariant that makes that keying sound (a future change that shared a memos instance across walks would have to re-key by reference).

No identifier / file-name / printer-string predicate drives the decision (anti-hardcoding gate); it is the same structural AST/binder-symbol probe the worklist's own ASSIGNMENT branch uses.

## Adjacent-case matrix (witness tests, binder names varied per case)

`crates/tsz-checker/tests/flow_passthrough_run_narrowing_tests.rs`:

| case | reference shape | expectation |
|---|---|---|
| narrowing across a long independent-`const` run | plain identifier (`symbol_id` present) | preserved (no TS2322) |
| same run split by an `if (flag) {}` branch merge (re-schedules interior nodes → chase re-scans, the exact repetition the memo collapses) | plain identifier | preserved |
| narrowing across a `const` run for a member access | `holder.payload` (`symbol_id` absent, `else` arm) | preserved |
| killing definition (`subject = 42`) inside the run | plain identifier (targeting → relevant `true`) | cleared (TS2322) |
| property reassignment (`record.field = count`) inside the run | member access (affecting → relevant `true`) | cleared (TS2322) |

The preserved/cleared pairs assert the memo serves the correct verdict in both directions (it must not over-splice a relevant assignment into silence, nor stop at an irrelevant one).

## Verification

- `cargo test -p tsz-checker --test flow_passthrough_run_narrowing_tests` — 5 passed (new witness matrix).
- `cargo test -p tsz-checker --lib control_flow` — 210 passed.
- `cargo test -p tsz-checker --test flow_call_divert_memoization_tests --test flow_captured_let_memoization_tests --test flow_dp_memoization_tests --test flow_narrowing_finalization_tests --test nested_discriminant_narrowing_tests --test assignment_branch_merge_narrowing_tests --test control_flow_type_guard_tests --test this_rooted_discriminant_narrowing_tests --test closure_boundary_property_narrowing_tests --test discriminant_literal_reference_narrowing_tests --test unique_symbol_discriminant_narrowing_tests` — all green (byte-identical narrowing).
- `cargo clippy -p tsz-checker --lib --tests` — clean. `cargo fmt` — clean. `python3 scripts/arch/arch_guard.py` — guardrails passed.
- Constant-factor cost reduction is validated by the project benchmark / ready-review CI, not an absolute-time assertion here. Broad conformance / emit / fourslash floor owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01QpkWHWGGVcdjFeWKn2Qg8U

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpkWHWGGVcdjFeWKn2Qg8U)_