### PR TITLE
perf(solver): activate collect_properties memo in the intersection-source explain pass

### DIFF
--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -329,6 +329,9 @@ mod integration_tests;
 #[path = "../tests/enum_nominality.rs"]
 mod enum_nominality;
 #[cfg(test)]
+#[path = "../tests/explain_intersection_source_collect_memo_tests.rs"]
+mod explain_intersection_source_collect_memo_tests;
+#[cfg(test)]
 #[path = "../tests/intersection_union_tests.rs"]
 mod intersection_union_tests;
 // lawyer_tests: loaded from relations/lawyer.rs

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -545,10 +545,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             let t_shape_id = object_shape_id(self.interner, resolved_target)
                 .or_else(|| object_with_index_shape_id(self.interner, resolved_target));
             if let Some(t_sid) = t_shape_id {
-                let collected = crate::objects::collect_properties(
+                // Reuse the context-free `collect_properties` memo (#13865) so
+                // the explain pass does not re-walk the source intersection's
+                // full recursive-schema closure that the boolean relation already
+                // collected. Mirrors the relation-side sites (`overlap`/`helpers`/
+                // `core`) which already thread `query_db`; the explain pass was
+                // the remaining bare caller re-collecting from scratch.
+                let collected = crate::objects::collect_properties_cached(
                     resolved_source,
                     self.interner,
                     self.resolver,
+                    self.query_db,
                 );
                 if let crate::objects::PropertyCollectionResult::Properties { properties, .. } =
                     collected
@@ -728,10 +735,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 } else if let Some(s_shape_id) = object_shape_id(self.interner, resolved_source) {
                     self.interner.object_shape(s_shape_id).properties.clone()
                 } else if source_intersection_members.is_some() {
-                    match crate::objects::collect_properties(
+                    // Same memo activation as the intersection-vs-object arm
+                    // above (the callable-target explain path is the other bare
+                    // caller re-collecting the already-walked source closure).
+                    match crate::objects::collect_properties_cached(
                         resolved_source,
                         self.interner,
                         self.resolver,
+                        self.query_db,
                     ) {
                         crate::objects::PropertyCollectionResult::Properties {
                             properties, ..

--- a/crates/tsz-solver/tests/explain_intersection_source_collect_memo_tests.rs
+++ b/crates/tsz-solver/tests/explain_intersection_source_collect_memo_tests.rs
@@ -1,0 +1,142 @@
+//! Regression coverage for the explain-pass `collect_properties` memo
+//! activation (issues #13242 / #13243, workstream B).
+//!
+//! Structural rule: when an assignment from an **intersection source** to an
+//! object/callable target fails, the explain pass collects the source
+//! intersection's merged property closure to report the missing property. That
+//! collection must go through the context-free `collect_properties` memo
+//! (#13865, exposed as `collect_properties_cached`) — the same memo the boolean
+//! relation already threads `query_db` into at every other intersection
+//! collection site (`overlap`/`helpers`/`core`). Before this fix the explain
+//! pass was the remaining bare caller, re-walking the full recursive-schema
+//! closure from scratch on every failing diagnostic.
+//!
+//! The activation is a pure cache surface: it must return a byte-identical
+//! failure reason whether or not a `QueryCache` is supplied. These tests pin
+//! that invariant by explaining the same failing relation twice — once with a
+//! `QueryCache` (`query_db = Some`, the cached path) and once with the bare
+//! interner (`query_db = None`, the legacy path) — and asserting the reason is
+//! structurally identical, naming the genuinely-missing property.
+
+use crate::caches::query_cache::QueryCache;
+use crate::diagnostics::SubtypeFailureReason;
+use crate::intern::TypeInterner;
+use crate::relations::subtype::SubtypeChecker;
+use crate::types::{PropertyInfo, TypeId};
+
+/// `{ a: number } & { b: string }` assigned to `{ a: number; b: string; c: boolean }`
+/// fails because the source closure lacks `c`. The explain pass walks the
+/// intersection-source arm (`collect_properties_cached(resolved_source, …)`).
+#[test]
+fn explain_intersection_source_missing_property_is_identical_cached_and_uncached() {
+    let interner = TypeInterner::new();
+
+    let a = interner.intern_string("a");
+    let b = interner.intern_string("b");
+    let c = interner.intern_string("c");
+
+    let obj_a = interner.object(vec![PropertyInfo::new(a, TypeId::NUMBER)]);
+    let obj_b = interner.object(vec![PropertyInfo::new(b, TypeId::STRING)]);
+    let source = interner.intersection2(obj_a, obj_b);
+
+    let target = interner.object(vec![
+        PropertyInfo::new(a, TypeId::NUMBER),
+        PropertyInfo::new(b, TypeId::STRING),
+        PropertyInfo::new(c, TypeId::BOOLEAN),
+    ]);
+
+    // Sanity: the relation genuinely fails (source has no `c`).
+    let mut probe = SubtypeChecker::new(&interner);
+    assert!(
+        !probe.is_assignable_to(source, target),
+        "intersection source missing `c` must not be assignable to the wider object",
+    );
+
+    // Bare interner: `query_db = None` (the legacy bare-collect path).
+    let uncached = {
+        let mut checker = SubtypeChecker::new(&interner);
+        checker.explain_failure(source, target)
+    };
+
+    // With a `QueryCache`: `query_db = Some` (the memo-activated path the fix
+    // wires up). Explain twice on the same instance so the second call would
+    // hit the populated `collect_properties` memo — the result must not change.
+    let db = QueryCache::new(&interner);
+    let (cached_first, cached_second) = {
+        let mut checker = SubtypeChecker::new(&interner).with_query_db(&db);
+        let first = checker.explain_failure(source, target);
+        let second = checker.explain_failure(source, target);
+        (first, second)
+    };
+
+    for reason in [&uncached, &cached_first, &cached_second] {
+        let names_missing_c = matches!(
+            reason,
+            Some(SubtypeFailureReason::MissingProperty { property_name, .. }) if *property_name == c,
+        ) || matches!(
+            reason,
+            Some(SubtypeFailureReason::MissingProperties { property_names, .. })
+                if property_names.contains(&c),
+        );
+        assert!(
+            names_missing_c,
+            "explain pass must report `c` as the missing property, got {reason:?}",
+        );
+    }
+
+    assert_eq!(
+        uncached, cached_first,
+        "memo activation must be byte-identical to the bare-collect path",
+    );
+    assert_eq!(
+        cached_first, cached_second,
+        "a populated collect-properties memo must serve the same reason",
+    );
+}
+
+/// Same shape with two missing properties (`c` and `d`) to exercise the
+/// `MissingProperties` (TS2739) branch of the same intersection-source arm and
+/// confirm the cached/uncached parity holds for the multi-property reason too.
+#[test]
+fn explain_intersection_source_multiple_missing_properties_parity() {
+    let interner = TypeInterner::new();
+
+    let a = interner.intern_string("a");
+    let c = interner.intern_string("c");
+    let d = interner.intern_string("d");
+
+    let obj_a = interner.object(vec![PropertyInfo::new(a, TypeId::NUMBER)]);
+    // A second member so the source is a genuine intersection (drives the
+    // `intersection_list_id(source).is_some()` arm rather than a plain object).
+    let obj_marker = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("marker"),
+        TypeId::BOOLEAN,
+    )]);
+    let source = interner.intersection2(obj_a, obj_marker);
+
+    let target = interner.object(vec![
+        PropertyInfo::new(a, TypeId::NUMBER),
+        PropertyInfo::new(c, TypeId::STRING),
+        PropertyInfo::new(d, TypeId::BOOLEAN),
+    ]);
+
+    let uncached = {
+        let mut checker = SubtypeChecker::new(&interner);
+        checker.explain_failure(source, target)
+    };
+    let db = QueryCache::new(&interner);
+    let cached = {
+        let mut checker = SubtypeChecker::new(&interner).with_query_db(&db);
+        checker.explain_failure(source, target)
+    };
+
+    assert!(
+        uncached.is_some(),
+        "a failing relation must produce a reason"
+    );
+    assert_eq!(
+        uncached, cached,
+        "intersection-source multi-missing-property explain must be identical \
+         with and without the collect-properties memo",
+    );
+}


### PR DESCRIPTION
Goal: fast

Part of #13242 / #13243 (workstream B — the explain-pass re-evaluation storm).

## Structural rule

When an assignment from an **intersection source** to an object/callable target
fails, the explain pass collects the source intersection's merged property
closure (`collect_properties`) to report the missing property. `tsc` produces
the verdict and the elaboration in one walk; tsz re-collects in the explain
pass. The two intersection-source arms in
`crates/tsz-solver/src/relations/subtype/explain.rs` (`:548` object target,
`:735` callable target) were the **remaining bare `collect_properties` callers**
(`query_db = None`), so they bypassed the context-free `collect_properties` memo
(#13865) and re-walked the full recursive-schema closure from scratch on every
failing diagnostic — the diagnostic re-evaluation storm called out for the
recursive-schema canaries in #13242 / #13243.

> When the explain pass collects an intersection source's property closure, it
> must reuse the same context-free `collect_properties` memo the boolean
> relation already populated, not re-collect from scratch.

## Owner layer / change

Solver relation engine (`SubtypeChecker` explain pass). Both arms now call
`collect_properties_cached(resolved_source, interner, resolver, self.query_db)`,
mirroring the relation-side collection sites (`overlap`/`helpers`/`core`) that
already thread `query_db`, and the merged sibling fix #13871 (which threaded
`query_db` into `intersection_has_incompatible_target_property`).

This is **pure cache activation**: the not-in-flight / own-entry-truncation
guards inside `collect_properties_cached` are unchanged (the #12142
partial-closure pitfall is still respected), so the returned
`PropertyCollectionResult` — and therefore the rendered diagnostic text and
elaboration order — is byte-identical to the bare path. No identifier /
file-name / printer-string predicate is involved (anti-hardcoding gate).

## Adjacent-case matrix

New regression test
(`crates/tsz-solver/tests/explain_intersection_source_collect_memo_tests.rs`)
asserts the explain reason is **identical with and without** a `QueryCache`,
across both arms' reason families:

- intersection source missing one property → `MissingProperty` (TS2339), cached
  == uncached, and a repeat call on a populated memo serves the same reason;
- intersection source missing multiple properties → `MissingProperties` (TS2739)
  parity, cached == uncached.

## Verification

- `cargo test -p tsz-solver --lib explain_intersection_source` — **4 passed**
  (2 new + the 2 existing `relations::compat` intersection-source explain tests).
- `cargo test -p tsz-solver --lib -- compat_tests conditional_comprehensive intersection`
  — **563 passed, 0 failed** (explain / subtype / intersection parity).
- `cargo clippy -p tsz-solver --lib --tests` — clean; `cargo fmt` — clean;
  `python3 scripts/arch/arch_guard.py` — guardrails passed; `git diff --check`
  — clean.
- Broad conformance / emit / fourslash and project-corpus row timing owned by
  ready-review CI per repo policy (byte-identical diagnostics expected by
  construction).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: medium

https://claude.ai/code/session_01XRVBd85Ja2ta53uCkJbetZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRVBd85Ja2ta53uCkJbetZ)_