### PR TITLE
perf(ci): build dist-binaries at -j8 (measured RSS-safe on 32 GiB)

### DIFF
--- a/scripts/ci/ci-resources.sh
+++ b/scripts/ci/ci-resources.sh
@@ -74,11 +74,22 @@ default_cargo_build_jobs() {
       ;;
     dist-binaries)
       # sccache is disabled for dist-binaries (TSZ_CI_DISABLE_SCCACHE=1 in
-      # GitHub CI) so every codegen unit compiles from scratch. Keep the
-      # default 7168 MiB/job budget so the 8 vCPU x 32 GiB Cloud Run runner can
-      # build at -j4; -j3 has repeatedly finished cargo just after the runner's
-      # external cancellation window and before artifact upload.
-      mem_per_job_mb="${TSZ_CI_DIST_CARGO_MB_PER_JOB:-7168}"
+      # GitHub CI) so every codegen unit compiles from scratch.
+      #
+      # The old 7168 MiB/job budget (→ -j4 on a 32 GiB runner) assumed each
+      # parallel rustc holds ~7 GiB simultaneously. Direct measurement on a
+      # 16 vCPU / 128 GiB box (dist-fast workspace recompile, warm deps —
+      # i.e. CI's post-restore state) refutes that: system-wide peak RSS is
+      # ~7.9 GiB at -j4, -j8, AND -j16 (flat). The peak is one big crate
+      # (tsz-core/tsz-checker) at link time, NOT N parallel rustc each at
+      # 7 GiB. Wall time: -j4 423s → -j8 335s (-88s, -21%); peak unchanged.
+      # The documented SIGKILL history is the `unit` lib-test compile
+      # (>16 GiB/rustc), never dist. So budget for -j8 on the 8 vCPU runner
+      # (3584 MiB/job → min(8 cpu, ~8 mem) = 8). safe-run.sh --limit 88%
+      # remains the backstop: if real peak (incl. any tmpfs target dir) ever
+      # approaches the limit it kills cargo gracefully rather than letting the
+      # kernel OOM-kill the runner.
+      mem_per_job_mb="${TSZ_CI_DIST_CARGO_MB_PER_JOB:-3584}"
       ;;
     *)
       mem_per_job_mb="${TSZ_CI_CARGO_MB_PER_JOB:-7168}"

--- a/scripts/ci/test_ci_resources.py
+++ b/scripts/ci/test_ci_resources.py
@@ -121,7 +121,11 @@ class DefaultCargoBuildJobsTests(unittest.TestCase):
         )
         self.assertEqual(result_int(r), 1)
 
-    def test_dist_suite_cloud_run_shape_gets_four_jobs(self):
+    def test_dist_suite_cloud_run_shape_gets_eight_jobs(self):
+        # dist-binaries on the 8 vCPU / 32 GiB Cloud Run shape builds at -j8.
+        # The dist budget is 3584 MiB/job: floor(32097 / 3584) = 8, capped by
+        # the 8 host CPUs. Measurement (dist-fast workspace recompile) showed
+        # peak RSS ~7.9 GiB flat across -j4/-j8/-j16, so -j8 is RSS-safe here.
         env = os.environ.copy()
         env["HOST_CPUS"] = "8"
         env["TSZ_CI_SUITE"] = "dist-binaries"
@@ -137,7 +141,7 @@ class DefaultCargoBuildJobsTests(unittest.TestCase):
             env=env,
             check=False,
         )
-        self.assertEqual(result_int(r), 4)
+        self.assertEqual(result_int(r), 8)
 
     def test_does_not_exceed_host_cpus(self):
         r = call_function("default_cargo_build_jobs", host_cpus=4,


### PR DESCRIPTION
Goal: fast

The real, measured replacement for the original plan's S2 ("move dist to a bigger box"). **No bigger box needed** — measurement shows dist fits `-j8` on the existing 32 GiB runner.

## What I measured
Spun up a 16 vCPU / 128 GiB GCE box and re-timed the `dist-fast` **workspace** compile with **warm deps** (= CI's state after the `cargo-target-deps` restore), sampling system-wide peak RSS:

| jobs | wall | peak RSS |
|---|---|---|
| 4 | 423s | 7.9 GiB |
| 8 | **335s** | **7.9 GiB** |
| 16 (cold, +deps) | 386s | 8.1 GiB |

Peak RSS is **flat (~8 GiB) across -j4/-j8/-j16** — the peak is one big crate (`tsz-core`/`tsz-checker`) at link time, **not** N parallel rustc each at 7 GiB as the old `7168 MiB/job` budget assumed.

## Why it was capped at -j4 (and why that was wrong for dist)
`ci-resources.sh` budgeted 7168 MiB/job → `min(8 cpu, 4 mem) = -j4`. That figure (and the SIGKILL history behind it) is the **`unit` lib-test** compile (>16 GiB/rustc), **not** dist. dist's real whole-build peak is ~8 GiB.

## Change
One line: dist `mem_per_job` 7168 → **3584** → `min(8 cpu, ~8 mem) = -j8`. `safe-run.sh --limit 88%` stays the backstop — if real peak (incl. any tmpfs target dir on the Cloud Run runner) ever approaches the cap it kills cargo gracefully instead of a runner OOM death.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Measurement above (e2-highmem-16, torn down after).
- **Verify on THIS PR's own `dist-binaries` run before landing**: (a) it does not OOM/SIGKILL (safe-run guards anyway), (b) wall-clock drops vs ~454s baseline, (c) log shows `CARGO_BUILD_JOBS=8`. If it OOMs or does not improve, revert (single-line, reversible).