### PR TITLE
fix(bench): show application-row compile results on the compatibility site

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1505,6 +1505,35 @@ jobs:
           cp bench-pgo-compile-compatibility/project-compatibility-summary.json \
             .target/project-compile-guard/
 
+      # The category:"application" canary rows (umami, excalidraw, ...) are
+      # compiled with full compat by the TRIGGERING CI run's
+      # project-compile-canary matrix (no skip flag), but the PGO compat step
+      # above runs with TSZ_PROJECT_COMPILE_SKIP_APPLICATIONS=1 (to fit its
+      # budget) so it emits no compat line for them. Without an application
+      # compat row the site's compatibilityState() renders them gray
+      # ("missing or incomplete artifact"). Reuse the already-computed canary
+      # compat from the triggering run so they show real status/files/peak.
+      #
+      # Best-effort by design: only the workflow_run (push-to-main) publish
+      # path has a triggering CI run; a missing/old artifact must NEVER block
+      # publishing the timing benchmarks (app rows just fall back to gray).
+      - name: Download application compile compatibility (best-effort)
+        if: github.event_name == 'workflow_run'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CI_RUN_ID: ${{ github.event.workflow_run.id }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          mkdir -p .target/app-compile-compat
+          if [[ -n "${CI_RUN_ID:-}" ]]; then
+            gh run download "$CI_RUN_ID" -n project-compile-canary-logs \
+              -D .target/app-compile-compat \
+              || echo "::warning::could not download project-compile-canary-logs from run ${CI_RUN_ID}; application rows will render gray this run"
+          fi
+          find .target/app-compile-compat -type f -print 2>/dev/null || true
+
       - id: merge
         name: Merge benchmark results
         shell: bash
@@ -1528,10 +1557,21 @@ jobs:
           else
             echo "complete=true" >> "$GITHUB_OUTPUT"
           fi
+          compat_args=( --compat-jsonl "$GITHUB_WORKSPACE/.target/project-compile-guard/project-compatibility.jsonl" )
+          # Add the application-row compat from the triggering CI run if present
+          # (mergeCompatibilityCanaries is idempotent: re-attaching the same
+          # canary compat is harmless and required rows are never overwritten).
+          app_compat="$(find "$GITHUB_WORKSPACE/.target/app-compile-compat" -name 'project-compatibility.jsonl' -type f 2>/dev/null | head -1)"
+          if [[ -n "$app_compat" && -s "$app_compat" ]]; then
+            echo "Including application compile compatibility from triggering CI run: $app_compat"
+            compat_args+=( --compat-jsonl "$app_compat" )
+          else
+            echo "::warning::no application compile compatibility found; application rows will render gray this run"
+          fi
           node scripts/bench/merge-results.mjs \
             "$GITHUB_WORKSPACE/bench-results.json" \
             --require-runner-signature \
-            --compat-jsonl "$GITHUB_WORKSPACE/.target/project-compile-guard/project-compatibility.jsonl" \
+            "${compat_args[@]}" \
             "${json_files[@]}"
 
       - name: Summarize green tsgo winners

--- a/scripts/bench/merge-results.mjs
+++ b/scripts/bench/merge-results.mjs
@@ -3,12 +3,22 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   COMPILE_CANARY_PROJECT_ROWS,
+  PROJECT_ROW_DEFINITIONS,
   REQUIRED_COMPATIBILITY_FIELDS,
   REQUIRED_PROJECT_ROWS,
 } from "./project-rows.mjs";
 import { isGreen } from "./row-utils.mjs";
 
 const REQUIRED_PROJECT_ROW_SET = new Set(REQUIRED_PROJECT_ROWS);
+// Application rows (real apps cloned + installed) are NEVER timed by the
+// vs-tsgo benchmark, so the project-compile-guard / canary compatibility JSONL
+// is their ONLY source of a `compatibility` object. Track them so the
+// canary-compat merge attaches compat to application rows even when they are
+// promoted to benchmark_set:"required" (e.g. infisical-project) — without it
+// the required-row guard skips them and the site renders them gray forever.
+const APPLICATION_ROW_SET = new Set(
+  PROJECT_ROW_DEFINITIONS.filter((row) => row.category === "application").map((row) => row.name),
+);
 const PROJECT_COMPATIBILITY_ROW_SET = new Set([
   ...REQUIRED_PROJECT_ROWS,
   ...COMPILE_CANARY_PROJECT_ROWS,
@@ -66,7 +76,10 @@ function readJsonl(file) {
 function mergeCompatibilityCanaries(results, compatibilityJsonlFiles) {
   if (compatibilityJsonlFiles.length === 0) return results;
 
-  const canaryNames = new Set(COMPILE_CANARY_PROJECT_ROWS);
+  // Attach compat for compile-canary rows AND application rows. Application
+  // rows are never timed, so this JSONL is their only compatibility source —
+  // including the ones promoted to benchmark_set:"required" (infisical-project).
+  const compatNames = new Set([...COMPILE_CANARY_PROJECT_ROWS, ...APPLICATION_ROW_SET]);
   const byName = new Map();
   const merged = results.map((row) => {
     if (row?.name) byName.set(row.name, row);
@@ -76,10 +89,13 @@ function mergeCompatibilityCanaries(results, compatibilityJsonlFiles) {
   for (const file of compatibilityJsonlFiles) {
     for (const compatibility of readJsonl(file)) {
       const name = compatibility?.name;
-      if (!canaryNames.has(name)) continue;
+      if (!compatNames.has(name)) continue;
       const existing = byName.get(name);
       if (existing) {
-        if (REQUIRED_PROJECT_ROW_SET.has(name)) {
+        // Required NON-application rows get their compatibility from the timing
+        // run; don't let the canary JSONL clobber it. Application rows are not
+        // timed, so they DO need the canary compat attached even when required.
+        if (REQUIRED_PROJECT_ROW_SET.has(name) && !APPLICATION_ROW_SET.has(name)) {
           continue;
         }
         existing.compatibility = compatibility;


### PR DESCRIPTION
Goal: grow

The 20 `category:"application"` corpus rows (umami, excalidraw, dub, …) render **gray** ("missing or incomplete artifact") on [tsz.dev/compatibility](https://tsz.dev/compatibility/). This makes the grow-corpus app rows meaningless on the site. This fix surfaces their real compile results (status / files / peak RSS).

## Root cause (traced end-to-end)
The site's `compatibilityState()` (`crates/tsz-website/src/_data/benchmark_data.js`) renders a row gray whenever its result has **no `compatibility` object**. The published `bench-results.json` has none for application rows because the **only** bench-publish producer of the compat JSONL is `bench-pgo-compile-canaries`, which runs the guard with `TSZ_PROJECT_COMPILE_SKIP_APPLICATIONS=1` (added in #13848 to avoid the 30m publish timeout). The app rows **are** compiled with full compat by the **triggering CI run's** `project-compile-canary` matrix (no skip flag) — that data just never reached publish.

## Fix (no recompute, no install cost, never blocks publish)
1. **`bench.yml` publish**: best-effort download of the triggering `workflow_run`'s `project-compile-canary-logs` artifact (already has application compat) → pass it as a **second, idempotent `--compat-jsonl`** to `merge-results`. Guarded by `github.event_name == workflow_run` + `continue-on-error` + a file-exists check, so schedule/dispatch runs or a missing artifact fall back to today's gray rather than failing the publish.
2. **`merge-results.mjs`**: attach canary compat to application rows even when `benchmark_set:"required"` (`infisical-project`). Apps are never timed, so this JSONL is their only compat source; the required-row guard previously skipped them (`mergeCompatibilityCanaries` keyed only `COMPILE_CANARY_PROJECT_ROWS` and `continue`d on required rows), leaving infisical gray regardless.

Why not the obvious "run the apps in a new bench job": that re-installs+recompiles 20 real apps (the 360s/app installs that caused the original timeout). Reusing the already-computed canary data is free.

## Why timing/publish are unaffected
App rows keep `tsz_ms/tsgo_ms = null`, and `check-artifact-readiness.mjs:47-50` already excludes `category:"application"` from the timing requirement (its comment names infisical/payload/medusa). So this never re-enters the perf bench or blocks publishing.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Functional: crafted a bench shard + canary compat JSONL; merge attaches `compatibility` to **umami** (canary) AND **infisical** (required-app); a non-app required row without compat stays untouched.
- `node scripts/bench/test-merge-results.mjs` → exit 0 (no regression).
- `python3 -c yaml.safe_load` → `bench.yml` valid.
- Confirmed all 20 application rows are reachable: 19 ∈ `COMPILE_CANARY_PROJECT_ROWS`, infisical ∈ required-application (now handled).
- Post-merge, verify on a real bench publish that `bench-runs/latest.json` application rows carry `compatibility` and the site renders them non-gray.