### PR TITLE
fix(checker): preserve source-order redeclaration diagnostics

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -1811,26 +1811,38 @@ impl<'a> CheckerState<'a> {
                     // variable (let/const) at the same scope, tsc uses TS2300.
                     false
                 } else if has_block_scoped_conflict {
-                    // Same-file mixed case (var + let/const, no function):
-                    // tsc uses TS2451 if the first conflicting declaration (by
-                    // source position) is block-scoped (let/const), TS2300 if
-                    // the first conflicting declaration is non-block-scoped (var).
-                    let first_conflict = declarations
-                        .iter()
-                        .filter(|(decl_idx, _, is_local, _, _)| {
-                            *is_local && conflicts.contains(decl_idx)
-                        })
-                        .min_by_key(|(decl_idx, _, _, _, _)| {
-                            self.ctx
-                                .arena
-                                .get(*decl_idx)
-                                .map_or(u32::MAX, |node| node.pos)
-                        });
-                    first_conflict
-                        .map(|(_, flags, _, _, _)| {
-                            (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0
-                        })
-                        .unwrap_or(true)
+                    // Pure variable redeclaration (var + let/const in the same
+                    // scope, no function/class/other-kind declaration in the
+                    // conflict set): a block-scoped variable can never be
+                    // redeclared, so tsc reports TS2451 on every declaration
+                    // regardless of source order. `var foo; let foo;` and
+                    // `let foo; var foo;` both produce two TS2451s.
+                    //
+                    // Only the mixed case where a non-variable declaration also
+                    // conflicts (for example a `class` sharing the name) falls
+                    // back to the source-position heuristic: tsc uses TS2451 when
+                    // the first conflicting declaration is block-scoped, TS2300
+                    // when it is non-block-scoped.
+                    if !has_non_variable_conflict {
+                        true
+                    } else {
+                        let first_conflict = declarations
+                            .iter()
+                            .filter(|(decl_idx, _, is_local, _, _)| {
+                                *is_local && conflicts.contains(decl_idx)
+                            })
+                            .min_by_key(|(decl_idx, _, _, _, _)| {
+                                self.ctx
+                                    .arena
+                                    .get(*decl_idx)
+                                    .map_or(u32::MAX, |node| node.pos)
+                            });
+                        first_conflict
+                            .map(|(_, flags, _, _, _)| {
+                                (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0
+                            })
+                            .unwrap_or(true)
+                    }
                 } else if has_remote_declaration {
                     false
                 } else {

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -1811,38 +1811,26 @@ impl<'a> CheckerState<'a> {
                     // variable (let/const) at the same scope, tsc uses TS2300.
                     false
                 } else if has_block_scoped_conflict {
-                    // Pure variable redeclaration (var + let/const in the same
-                    // scope, no function/class/other-kind declaration in the
-                    // conflict set): a block-scoped variable can never be
-                    // redeclared, so tsc reports TS2451 on every declaration
-                    // regardless of source order. `var foo; let foo;` and
-                    // `let foo; var foo;` both produce two TS2451s.
-                    //
-                    // Only the mixed case where a non-variable declaration also
-                    // conflicts (for example a `class` sharing the name) falls
-                    // back to the source-position heuristic: tsc uses TS2451 when
-                    // the first conflicting declaration is block-scoped, TS2300
-                    // when it is non-block-scoped.
-                    if has_non_variable_conflict {
-                        let first_conflict = declarations
-                            .iter()
-                            .filter(|(decl_idx, _, is_local, _, _)| {
-                                *is_local && conflicts.contains(decl_idx)
-                            })
-                            .min_by_key(|(decl_idx, _, _, _, _)| {
-                                self.ctx
-                                    .arena
-                                    .get(*decl_idx)
-                                    .map_or(u32::MAX, |node| node.pos)
-                            });
-                        first_conflict
-                            .map(|(_, flags, _, _, _)| {
-                                (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0
-                            })
-                            .unwrap_or(true)
-                    } else {
-                        true
-                    }
+                    // Same-file mixed case (`var` + `let`/`const`, optionally
+                    // plus other conflict kinds): tsc uses TS2451 if the first
+                    // conflicting declaration by source position is block-scoped,
+                    // and TS2300 if the first is non-block-scoped (`var`).
+                    let first_conflict = declarations
+                        .iter()
+                        .filter(|(decl_idx, _, is_local, _, _)| {
+                            *is_local && conflicts.contains(decl_idx)
+                        })
+                        .min_by_key(|(decl_idx, _, _, _, _)| {
+                            self.ctx
+                                .arena
+                                .get(*decl_idx)
+                                .map_or(u32::MAX, |node| node.pos)
+                        });
+                    first_conflict
+                        .map(|(_, flags, _, _, _)| {
+                            (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0
+                        })
+                        .unwrap_or(true)
                 } else if has_remote_declaration {
                     false
                 } else {

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -1823,9 +1823,7 @@ impl<'a> CheckerState<'a> {
                     // back to the source-position heuristic: tsc uses TS2451 when
                     // the first conflicting declaration is block-scoped, TS2300
                     // when it is non-block-scoped.
-                    if !has_non_variable_conflict {
-                        true
-                    } else {
+                    if has_non_variable_conflict {
                         let first_conflict = declarations
                             .iter()
                             .filter(|(decl_idx, _, is_local, _, _)| {
@@ -1842,6 +1840,8 @@ impl<'a> CheckerState<'a> {
                                 (flags & symbol_flags::BLOCK_SCOPED_VARIABLE) != 0
                             })
                             .unwrap_or(true)
+                    } else {
+                        true
                     }
                 } else if has_remote_declaration {
                     false

--- a/crates/tsz-checker/tests/conformance_issues/modules/declare_global.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/declare_global.rs
@@ -401,10 +401,8 @@ import { nonExistent } from "./thisModule";
 }
 
 /// A `let`+`var` redeclaration for the same name emits TS2451 ("Cannot
-/// redeclare block-scoped variable") on both declarations, not TS2300
-/// ("Duplicate identifier"): a block-scoped variable can never be redeclared.
-/// Order-independent — see `test_ts2451_var_before_let_emits_block_scoped_error`
-/// for the mirror case.
+/// redeclare block-scoped variable") on both declarations because the first
+/// conflicting declaration is block-scoped.
 #[test]
 fn test_ts2451_let_before_var_emits_block_scoped_error() {
     let diagnostics = compile_and_get_diagnostics(
@@ -432,12 +430,11 @@ var x = 2;
     );
 }
 
-/// A `var`+`let` redeclaration is a block-scoped redeclaration regardless of
-/// which declaration is written first: tsc emits TS2451 on both. The verdict is
-/// a property of the merged symbol (does it have a block-scoped declaration?),
-/// not source order. Confirmed against `letAndVarRedeclaration.ts`.
+/// A `var`+`let` redeclaration in the same file emits TS2300 ("Duplicate
+/// identifier") when the first conflicting declaration is the `var`. This is
+/// the source-order split in `letDeclarations-scopes-duplicates.ts`.
 #[test]
-fn test_ts2451_var_before_let_emits_block_scoped_error() {
+fn test_ts2300_var_before_let_emits_duplicate_identifier() {
     let diagnostics = compile_and_get_diagnostics(
         r"
 var x = 1;
@@ -451,11 +448,10 @@ let x = 2;
         .filter(|(code, _)| *code == 2451 || *code == 2300)
         .map(|(code, _)| *code)
         .collect();
-    // Both declarations get TS2451 (block-scoped redeclaration), same as the
-    // `let`-before-`var` ordering.
+    // Both declarations get TS2300 in the var-before-let ordering.
     assert!(
-        codes.iter().all(|&c| c == 2451),
-        "Expected all TS2451 (var-first + let conflict), got codes: {codes:?}"
+        codes.iter().all(|&c| c == 2300),
+        "Expected all TS2300 (var-first + let conflict), got codes: {codes:?}"
     );
     assert!(
         codes.len() == 2,

--- a/crates/tsz-checker/tests/conformance_issues/modules/declare_global.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/declare_global.rs
@@ -400,12 +400,11 @@ import { nonExistent } from "./thisModule";
     }
 }
 
-/// TS2451 vs TS2300: when `let` appears before `var` for the same name, tsc emits TS2451
-/// ("Cannot redeclare block-scoped variable") rather than TS2300 ("Duplicate identifier").
-/// The distinction depends on which declaration appears first in source order.
-///
-/// Regression test: the binder's declaration vector can be reordered by var hoisting,
-/// so we must use source position to determine the first declaration.
+/// A `let`+`var` redeclaration for the same name emits TS2451 ("Cannot
+/// redeclare block-scoped variable") on both declarations, not TS2300
+/// ("Duplicate identifier"): a block-scoped variable can never be redeclared.
+/// Order-independent — see `test_ts2451_var_before_let_emits_block_scoped_error`
+/// for the mirror case.
 #[test]
 fn test_ts2451_let_before_var_emits_block_scoped_error() {
     let diagnostics = compile_and_get_diagnostics(
@@ -433,11 +432,12 @@ var x = 2;
     );
 }
 
-/// When `var` appears before `let` for the same name, tsc emits TS2300
-/// ("Duplicate identifier") because the first declaration is non-block-scoped.
-/// When `let` appears before `var`, tsc emits TS2451 instead.
+/// A `var`+`let` redeclaration is a block-scoped redeclaration regardless of
+/// which declaration is written first: tsc emits TS2451 on both. The verdict is
+/// a property of the merged symbol (does it have a block-scoped declaration?),
+/// not source order. Confirmed against `letAndVarRedeclaration.ts`.
 #[test]
-fn test_ts2300_var_before_let_emits_duplicate_identifier() {
+fn test_ts2451_var_before_let_emits_block_scoped_error() {
     let diagnostics = compile_and_get_diagnostics(
         r"
 var x = 1;
@@ -451,10 +451,11 @@ let x = 2;
         .filter(|(code, _)| *code == 2451 || *code == 2300)
         .map(|(code, _)| *code)
         .collect();
-    // tsc uses TS2300 when the first declaration is non-block-scoped (var).
+    // Both declarations get TS2451 (block-scoped redeclaration), same as the
+    // `let`-before-`var` ordering.
     assert!(
-        codes.iter().all(|&c| c == 2300),
-        "Expected all TS2300 (var-first + let conflict), got codes: {codes:?}"
+        codes.iter().all(|&c| c == 2451),
+        "Expected all TS2451 (var-first + let conflict), got codes: {codes:?}"
     );
     assert!(
         codes.len() == 2,

--- a/crates/tsz-checker/tests/ts2300_tests.rs
+++ b/crates/tsz-checker/tests/ts2300_tests.rs
@@ -1096,9 +1096,9 @@ export interface foo {}
     );
 }
 
-/// When a const conflicts with a var, tsc uses TS2451 ("Cannot redeclare
-/// block-scoped variable") on both: a block-scoped variable can never be
-/// redeclared, and the verdict does not depend on declaration order.
+/// When a const conflicts with a later var, tsc uses TS2451 ("Cannot redeclare
+/// block-scoped variable") on both because the first conflicting declaration is
+/// block-scoped.
 #[test]
 fn const_var_conflict_emits_ts2451() {
     // const before var in pure 2-way variable conflict → TS2451
@@ -1185,25 +1185,22 @@ fn let_var_function_same_scope_ts2300() {
     assert_eq!(ts2300, 3, "All three should be TS2300 at same scope");
 }
 
-/// A `var` redeclared alongside a `let`/`const` in the same scope is a
-/// block-scoped redeclaration: tsc reports TS2451 on every declaration
-/// regardless of source order (the verdict is a property of the merged symbol's
-/// declarations, not which one is written first). `var x; let x;` and
-/// `let x; var x;` both produce two TS2451s. Confirmed against
-/// `letAndVarRedeclaration.ts` (`x`/`x11`: `let` then `var` → TS2451).
+/// Same-file `var` + `let`/`const` follows tsc's source-position split:
+/// `var` first reports TS2300, while `let`/`const` first reports TS2451. This
+/// matches `letDeclarations-scopes-duplicates.ts` (`var5` versus `var6`).
 #[test]
-fn var_before_let_same_scope_ts2451() {
+fn var_before_let_same_scope_ts2300() {
     let diagnostics = verify_errors(
         "var x = 0;\nlet x = 0;",
         &[
-            (1, 5, "Cannot redeclare block-scoped variable 'x'."),
-            (2, 5, "Cannot redeclare block-scoped variable 'x'."),
+            (1, 5, "Duplicate identifier 'x'."),
+            (2, 5, "Duplicate identifier 'x'."),
         ],
     );
     let ts2451 = diagnostics.iter().filter(|d| d.code == 2451).count();
     let ts2300 = diagnostics.iter().filter(|d| d.code == 2300).count();
-    assert_eq!(ts2451, 2, "var-before-let should be TS2451");
-    assert_eq!(ts2300, 0, "var-before-let should not emit TS2300");
+    assert_eq!(ts2451, 0, "var-before-let should not emit TS2451");
+    assert_eq!(ts2300, 2, "var-before-let should be TS2300");
 }
 
 /// When an interface default export conflicts with a non-function/non-class

--- a/crates/tsz-checker/tests/ts2300_tests.rs
+++ b/crates/tsz-checker/tests/ts2300_tests.rs
@@ -1096,8 +1096,9 @@ export interface foo {}
     );
 }
 
-/// When a const conflicts with a var, tsc uses TS2300 ("Duplicate identifier")
-/// because it's a mix of block-scoped and function-scoped declarations.
+/// When a const conflicts with a var, tsc uses TS2451 ("Cannot redeclare
+/// block-scoped variable") on both: a block-scoped variable can never be
+/// redeclared, and the verdict does not depend on declaration order.
 #[test]
 fn const_var_conflict_emits_ts2451() {
     // const before var in pure 2-way variable conflict → TS2451
@@ -1166,11 +1167,10 @@ fn var_type_alias_conflict_emits_ts2300() {
     );
 }
 
-/// Test that let+var+function at the same top-level scope get duplicate errors.
-///
-/// TODO: tsc emits TS2300 ("Duplicate identifier") here. We currently emit
-/// TS2451 ("Cannot redeclare block-scoped variable"). Update once classification
-/// is refined.
+/// `let`+`var`+`function` sharing a name at the same scope: once a function
+/// declaration joins the conflict, tsc reports TS2300 ("Duplicate identifier")
+/// on every declaration rather than the block-scoped-redeclaration TS2451.
+/// Matches `letAndVarRedeclaration.ts` (`e0`).
 #[test]
 fn let_var_function_same_scope_ts2300() {
     let diagnostics = verify_errors(
@@ -1185,20 +1185,25 @@ fn let_var_function_same_scope_ts2300() {
     assert_eq!(ts2300, 3, "All three should be TS2300 at same scope");
 }
 
-/// Test that var-before-let at the same scope level gets TS2451.
-/// When var comes first and let/const comes second, tsc uses TS2300 (not TS2451).
-/// When let/const comes first and var comes second, tsc uses TS2451.
+/// A `var` redeclared alongside a `let`/`const` in the same scope is a
+/// block-scoped redeclaration: tsc reports TS2451 on every declaration
+/// regardless of source order (the verdict is a property of the merged symbol's
+/// declarations, not which one is written first). `var x; let x;` and
+/// `let x; var x;` both produce two TS2451s. Confirmed against
+/// `letAndVarRedeclaration.ts` (`x`/`x11`: `let` then `var` → TS2451).
 #[test]
-fn var_before_let_same_scope_ts2300() {
+fn var_before_let_same_scope_ts2451() {
     let diagnostics = verify_errors(
         "var x = 0;\nlet x = 0;",
         &[
-            (1, 5, "Duplicate identifier 'x'."),
-            (2, 5, "Duplicate identifier 'x'."),
+            (1, 5, "Cannot redeclare block-scoped variable 'x'."),
+            (2, 5, "Cannot redeclare block-scoped variable 'x'."),
         ],
     );
+    let ts2451 = diagnostics.iter().filter(|d| d.code == 2451).count();
     let ts2300 = diagnostics.iter().filter(|d| d.code == 2300).count();
-    assert_eq!(ts2300, 2, "var-before-let should be TS2300");
+    assert_eq!(ts2451, 2, "var-before-let should be TS2451");
+    assert_eq!(ts2300, 0, "var-before-let should not emit TS2300");
 }
 
 /// When an interface default export conflicts with a non-function/non-class

--- a/crates/tsz-core/tests/checker_state_tests_parts/part_00.rs
+++ b/crates/tsz-core/tests/checker_state_tests_parts/part_00.rs
@@ -1452,14 +1452,20 @@ function foo() {}
 }
 
 #[test]
-#[ignore = "Pre-existing failure from recent merges"]
 fn test_duplicate_identifier_var_let_2300() {
-    use crate::checker::diagnostics::diagnostic_codes;
+    // tsc emits TS2451 (Cannot redeclare block-scoped variable) for var/let
+    // conflicts: the `let` declaration introduces block-scoping, so neither
+    // declaration may redeclare it.
+    let (ts2451, ts2300) = count_redeclaration_diagnostics("var foo = 1;\nlet foo = 2;\n");
+    assert_eq!(ts2451, 2, "Expected 2 TS2451 for var followed by let");
+    assert_eq!(ts2300, 0, "Expected no TS2300 for pure var/let redeclaration");
+}
 
-    let source = r#"
-var foo = 1;
-let foo = 2;
-"#;
+/// Compile `source` and return `(ts2451_count, ts2300_count)` for the
+/// block-scoped-redeclaration / duplicate-identifier diagnostics. Shared by the
+/// var/let redeclaration adjacent-case matrix below.
+fn count_redeclaration_diagnostics(source: &str) -> (usize, usize) {
+    use crate::checker::diagnostics::diagnostic_codes;
 
     let (parser, root) = parse_test_source(source);
     assert!(
@@ -1483,19 +1489,74 @@ let foo = 2;
     setup_lib_contexts(&mut checker);
     checker.check_source_file(root);
 
-    // tsc emits TS2451 (Cannot redeclare block-scoped variable) for var/let conflicts.
-    // The `let` declaration introduces block-scoping, making both declarations conflict.
-    let ts2451_count = checker
+    let ts2451 = checker
         .ctx
         .diagnostics
         .iter()
         .filter(|d| d.code == diagnostic_codes::CANNOT_REDECLARE_BLOCK_SCOPED_VARIABLE)
         .count();
-    assert_eq!(
-        ts2451_count, 2,
-        "Expected 2 TS2451 for var followed by let, got: {:?}",
-        checker.ctx.diagnostics
-    );
+    let ts2300 = checker
+        .ctx
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::DUPLICATE_IDENTIFIER)
+        .count();
+    (ts2451, ts2300)
+}
+
+#[test]
+fn test_duplicate_identifier_let_var_2451() {
+    // Reverse order of the var/let case: a block-scoped variable can never be
+    // redeclared, so order does not matter — tsc emits two TS2451 here too.
+    let (ts2451, ts2300) = count_redeclaration_diagnostics("let foo = 1;\nvar foo = 2;\n");
+    assert_eq!(ts2451, 2, "Expected 2 TS2451 for let followed by var");
+    assert_eq!(ts2300, 0, "Expected no TS2300 for pure let/var redeclaration");
+}
+
+#[test]
+fn test_duplicate_identifier_var_const_2451() {
+    let (ts2451, ts2300) = count_redeclaration_diagnostics("var bar = 1;\nconst bar = 2;\n");
+    assert_eq!(ts2451, 2, "Expected 2 TS2451 for var followed by const");
+    assert_eq!(ts2300, 0, "Expected no TS2300 for pure var/const redeclaration");
+}
+
+#[test]
+fn test_duplicate_identifier_const_var_2451() {
+    let (ts2451, ts2300) = count_redeclaration_diagnostics("const baz = 1;\nvar baz = 2;\n");
+    assert_eq!(ts2451, 2, "Expected 2 TS2451 for const followed by var");
+    assert_eq!(ts2300, 0, "Expected no TS2300 for pure const/var redeclaration");
+}
+
+#[test]
+fn test_duplicate_identifier_three_way_var_let_var_2451() {
+    // Three pure-variable declarations (one block-scoped) → TS2451 on each.
+    let (ts2451, _ts2300) =
+        count_redeclaration_diagnostics("var q = 1;\nlet q = 2;\nvar q = 3;\n");
+    assert_eq!(ts2451, 3, "Expected 3 TS2451 for var/let/var redeclaration");
+}
+
+#[test]
+fn test_duplicate_identifier_let_var_function_stays_2300() {
+    // When a function declaration also participates in the conflict, tsc switches
+    // to TS2300 (Duplicate identifier) — the pure-variable TS2451 rule must not
+    // swallow this mixed case. Mirrors `letAndVarRedeclaration.ts` (`e0`).
+    let (ts2451, ts2300) =
+        count_redeclaration_diagnostics("let e0 = 1;\nvar e0 = 2;\nfunction e0() {}\n");
+    assert_eq!(ts2451, 0, "Expected no TS2451 once a function joins the conflict");
+    assert_eq!(ts2300, 3, "Expected 3 TS2300 for let/var/function redeclaration");
+}
+
+#[test]
+fn test_var_catch_clause_collision_does_not_emit_2451() {
+    // A `var` hoisted past a catch block collides with the (block-scoped)
+    // catch-clause variable across scopes. tsc treats this as a duplicate
+    // identifier (TS2300 family), never the same-scope block-scoped
+    // redeclaration TS2451. Guard that the pure-variable TS2451 rule stays
+    // scoped to genuine same-scope `var`+`let`/`const` conflicts and does not
+    // leak into the catch-clause-variable case.
+    let (ts2451, _ts2300) =
+        count_redeclaration_diagnostics("try {} catch (w) {\n    var w = 1;\n}\n");
+    assert_eq!(ts2451, 0, "Expected no TS2451 for a var/catch-clause-variable collision");
 }
 
 #[test]

--- a/crates/tsz-core/tests/checker_state_tests_parts/part_00.rs
+++ b/crates/tsz-core/tests/checker_state_tests_parts/part_00.rs
@@ -1453,12 +1453,11 @@ function foo() {}
 
 #[test]
 fn test_duplicate_identifier_var_let_2300() {
-    // tsc emits TS2451 (Cannot redeclare block-scoped variable) for var/let
-    // conflicts: the `let` declaration introduces block-scoping, so neither
-    // declaration may redeclare it.
+    // Same-file `var` before `let` follows tsc's source-position split and
+    // emits TS2300, matching `letDeclarations-scopes-duplicates.ts` (`var5`).
     let (ts2451, ts2300) = count_redeclaration_diagnostics("var foo = 1;\nlet foo = 2;\n");
-    assert_eq!(ts2451, 2, "Expected 2 TS2451 for var followed by let");
-    assert_eq!(ts2300, 0, "Expected no TS2300 for pure var/let redeclaration");
+    assert_eq!(ts2451, 0, "Expected no TS2451 for var followed by let");
+    assert_eq!(ts2300, 2, "Expected 2 TS2300 for var followed by let");
 }
 
 /// Compile `source` and return `(ts2451_count, ts2300_count)` for the
@@ -1506,18 +1505,18 @@ fn count_redeclaration_diagnostics(source: &str) -> (usize, usize) {
 
 #[test]
 fn test_duplicate_identifier_let_var_2451() {
-    // Reverse order of the var/let case: a block-scoped variable can never be
-    // redeclared, so order does not matter — tsc emits two TS2451 here too.
+    // Reverse order of the var/let case: the first conflicting declaration is
+    // block-scoped, so tsc emits TS2451.
     let (ts2451, ts2300) = count_redeclaration_diagnostics("let foo = 1;\nvar foo = 2;\n");
     assert_eq!(ts2451, 2, "Expected 2 TS2451 for let followed by var");
     assert_eq!(ts2300, 0, "Expected no TS2300 for pure let/var redeclaration");
 }
 
 #[test]
-fn test_duplicate_identifier_var_const_2451() {
+fn test_duplicate_identifier_var_const_2300() {
     let (ts2451, ts2300) = count_redeclaration_diagnostics("var bar = 1;\nconst bar = 2;\n");
-    assert_eq!(ts2451, 2, "Expected 2 TS2451 for var followed by const");
-    assert_eq!(ts2300, 0, "Expected no TS2300 for pure var/const redeclaration");
+    assert_eq!(ts2451, 0, "Expected no TS2451 for var followed by const");
+    assert_eq!(ts2300, 2, "Expected 2 TS2300 for var followed by const");
 }
 
 #[test]
@@ -1528,11 +1527,13 @@ fn test_duplicate_identifier_const_var_2451() {
 }
 
 #[test]
-fn test_duplicate_identifier_three_way_var_let_var_2451() {
-    // Three pure-variable declarations (one block-scoped) → TS2451 on each.
-    let (ts2451, _ts2300) =
+fn test_duplicate_identifier_three_way_var_let_var_2300() {
+    // The first conflicting declaration is `var`, so tsc reports TS2300 on
+    // each declaration in this same-file mixed set.
+    let (ts2451, ts2300) =
         count_redeclaration_diagnostics("var q = 1;\nlet q = 2;\nvar q = 3;\n");
-    assert_eq!(ts2451, 3, "Expected 3 TS2451 for var/let/var redeclaration");
+    assert_eq!(ts2451, 0, "Expected no TS2451 for var/let/var redeclaration");
+    assert_eq!(ts2300, 3, "Expected 3 TS2300 for var/let/var redeclaration");
 }
 
 #[test]
@@ -1830,4 +1831,3 @@ f(true);
         "Expected TS2345 or TS2769 for overload call mismatch, got: {codes:?}"
     );
 }
-


### PR DESCRIPTION
Goal: hold

## Summary

Same-file `var` plus `let`/`const` redeclaration diagnostics are source-order sensitive in `tsc`. When the first conflicting declaration is block-scoped, `tsc` emits TS2451 (Cannot redeclare block-scoped variable). When the first conflicting declaration is a `var`, `tsc` emits TS2300 (Duplicate identifier). PR CI caught that the earlier order-independent TS2451 rule regressed conformance fixtures such as `letDeclarations-scopes-duplicates.ts`, `letAsIdentifier.ts`, and reserved-word cases.

This keeps the duplicate-identifier classifier on the source-position rule, removes the ignored in-repo witness, and expands adjacent tests for `var`/`let`, `let`/`var`, `var`/`const`, `const`/`var`, three-way `var`/`let`/`var`, function-present conflicts, and catch-clause collisions.

## Structural rule

When a same-file redeclaration set contains `var` plus `let`/`const`, `tsc` chooses TS2451 or TS2300 from the first conflicting declaration by source position. tsz owns this in the checker duplicate-identifier classifier at `crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs`; binder declaration order must not substitute for source position.

Owner layer: checker diagnostic classification only. No solver, relation, inference, or emit behavior is touched.

## CI evidence

Run `27787345120` on head `be30676ea5a08952e8d4d4db49ca3112fba83193` failed `conformance-aggregate` at `12579/12585` with unlisted regressions in:

- `TypeScript/tests/cases/compiler/letAsIdentifier.ts`
- `TypeScript/tests/cases/compiler/letAsIdentifierInStrictMode.ts`
- `TypeScript/tests/cases/compiler/letDeclarations-scopes-duplicates.ts`
- `TypeScript/tests/cases/compiler/strictModeReservedWord.ts`

The other two failures in that aggregate, `propTypeValidatorInference.ts` and `deeplyNestedMappedTypes.ts`, were already accepted-regression ledger entries. Follow-up commit `0ce6958d381944ec1aa32d5a68ee58c325b0a9af` restores the source-order split.

## Verification

- `cargo fmt`
- `./scripts/safe-run.sh cargo nextest run -p tsz-core -E ...` - 7 passed
- `./scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts2300_tests -E ...` - 4 passed
- `./scripts/safe-run.sh cargo nextest run -p tsz-checker --test conformance_issues_modules -E ...` - 2 passed
- Exact-head CI run `27788849592` is running for head `0ce6958d381944ec1aa32d5a68ee58c325b0a9af`.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high