### PR TITLE
fix(solver): accept extends-Array interfaces as T[] via covariant element check

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -1013,6 +1013,53 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             );
         }
 
+        // Object-like source vs (mutable) array target. An interface/class that
+        // declares `extends Array<T>` (e.g. `interface NonEmptyArray<A> extends
+        // Array<A>`) is assignable to `T[]`. Arrays are `TypeData::Array`, not
+        // object shapes, so none of the structural object branches above fire and
+        // the pair would otherwise fall through to failure.
+        //
+        // `tsc` treats array assignability covariantly, so `S <: T[]` reduces to
+        // the element relation on the numeric element type. We therefore:
+        //   1. require the source to carry a non-`readonly` numeric index
+        //      signature — `Array<T>` declares `[n: number]: T`, and a `readonly`
+        //      source (a `ReadonlyArray`-derived shape) is not assignable to a
+        //      mutable array, matching `tsc`;
+        //   2. confirm the source genuinely provides the whole `Array` member
+        //      surface by name, distinguishing a heritage-flattened
+        //      `extends Array` shape (its inherited members are present as named
+        //      properties) from a bare `Record<number, T>` that merely shares a
+        //      numeric index. The scan walks the source's own named properties
+        //      directly rather than going through `lookup_property`, so a
+        //      `[key: string]` index signature cannot spoof every member name; and
+        //   3. decide the relation by the covariant element check.
+        //
+        // This deliberately avoids materializing the instantiated `Array<T>`
+        // interface and running a full structural comparison: doing that in this
+        // hot dispatch path (a) re-enters instantiation/evaluation with observable
+        // cache side effects and (b) can exhaust the relation depth limit on deep
+        // generic sources, which is treated as `true` and silently over-accepts
+        // unrelated types.
+        if let Some(t_elem) = array_element_type(self.interner, target)
+            && let Some(s_shape_id) = object_with_index_shape_id(self.interner, source)
+            && let Some(array_base) = self.resolver.get_array_base_type()
+            && let Some(array_shape_id) = object_shape_id(self.interner, array_base)
+                .or_else(|| object_with_index_shape_id(self.interner, array_base))
+        {
+            let s_shape = self.interner.object_shape(s_shape_id);
+            if let Some(num_idx) = s_shape.number_index
+                && !num_idx.readonly
+            {
+                let array_shape = self.interner.object_shape(array_shape_id);
+                let source_has_full_array_surface = array_shape.properties.iter().all(|member| {
+                    member.optional || s_shape.properties.iter().any(|p| p.name == member.name)
+                });
+                if source_has_full_array_surface {
+                    return self.check_subtype(num_idx.value_type, t_elem);
+                }
+            }
+        }
+
         if let (Some(s_fn_id), Some(t_fn_id)) = (
             function_shape_id(self.interner, source),
             function_shape_id(self.interner, target),


### PR DESCRIPTION
Goal: green

## Summary
An interface/class declaring `extends Array<T>` (e.g. `interface NonEmptyArray<A> extends Array<A>`) is assignable to `T[]` in `tsc`. tsz's subtype dispatch (`check_subtype_inner_impl`) had no branch for an object-shaped source against a bare `Array` target — arrays are `TypeData::Array`, not object shapes — so the pair fell through to failure (`TS2322`/`TS2345`). This adds a covariant element branch.

## Structural Rule
When the **target** is a mutable array `U[]` and the **source** is an object shape carrying a **non-`readonly` numeric index signature** whose **named-property surface covers the whole `Array` member set**, `tsc` accepts iff the element relation `T <: U` holds (arrays are covariant). tsz now decides this in the solver subtype dispatch (`crates/tsz-solver/src/relations/subtype/core_dispatch.rs`) via the covariant element check `E <: t_elem`.

- **Owner layer:** solver — `relations/subtype` dispatch. No checker/printer involvement.
- **Why covariant element, not full structural compare:** materializing the instantiated `Array<T>` interface and running `check_object_subtype` in this hot path (a) re-enters instantiation/evaluation with observable cache side effects and (b) can exhaust the relation depth limit on deep generic sources, which is treated as `true` (`DepthExceeded` ⇒ Maybe) and silently over-accepts unrelated types. The covariant element check is both cheaper and a closer match to tsc's intentional array variance (which ignores method-parameter contravariance).
- **Member-surface gate:** a direct scan of the source's own named properties (not `lookup_property`) so a `Record<number, T>` (numeric index, no array members) and a `[key: string]` index cannot spoof the surface; such sources fall through to the prior structural rejection, unchanged.

### Adjacent-case matrix (all verified)
| Case | Source → Target | Expected | tsz |
|---|---|---|---|
| direct | `NEA<string>` → `string[]` | OK | OK |
| generic | `g<A>(as: NEA<A>)` → `A[]` | OK | OK |
| union | `NEA<number> \| number[]` → `number[]` | OK | OK |
| nested | `NEA<NEA<string>>` → `string[][]` | OK | OK |
| covariant accept | `NEA<Dog>` → `Animal[]` | OK | OK |
| covariant reject | `NEA<Animal>` → `Dog[]` | error | error |
| readonly src → mutable | `RNEA<string>` (readonly) → `string[]` | error | error |
| mutable src → readonly | `NEA<string>` → `readonly string[]` | OK | OK |
| Record fallback | `Record<number,string>` → `string[]` | error | error |
| plain object fallback | `{x:1}` → `number[]` | error | error |
| partial array-like fallback | `{[n:number]:string; length; push}` → `string[]` | error | error |

**Fallback:** any source lacking the full Array named-member surface, or with a readonly numeric index against a mutable target, falls through to the prior structural failure path with no behavior change.

## Project Corpus Impact
- **fp-ts:** -25 distinct false-positive error locations (1741 → 1716); **zero** new erroring locations. (Net error lines 1963 → 1935; the 3 line-level "new" entries are message churn on locations that already errored on clean main — the remaining failures are the known HKT/`Kind2`/`Kind3` inference families, tracked separately.)
- **tanstack-query / tanstack-router:** unchanged vs clean-main baseline (79 / 339 both before and after — note the checked-in `.result-cache` baselines are stale from an older commit).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo build --profile dist-fast -p tsz-cli` (clean) + repros `/tmp/nea3.ts`, `/tmp/nea_bool.ts` → 0 errors.
- Conformance (`scripts/conformance/conformance.sh run --filter <fam>`), **26 families 100% pass, zero regressions**: assignmentCompatibility, array, thisType, interface, class, tuple, typeRelationships, members, mappedType, comparable, recursiveType, circular, union, intersection, subtyping, generics, variance, readonly, indexedAccess, indexSignature, spread, genericObjectRest, override, iterators, forOf, destructuring.
- Adversarial soundness panel (10 probes): **0 false-accepts**; the matrix above. The one `[key:string]: any` spoof case is a pre-existing, array-independent gap (a non-array `{a:string}` target also rejects it) — out of scope, filed separately.
- `cargo clippy -p tsz-solver --all-targets -- -D warnings` clean (no new `#[allow]`); `cargo fmt` clean.
- fp-ts / tanstack-query / tanstack-router measured against a freshly-built clean-`main` binary (the checked-in result-cache baselines were stale).