### PR TITLE
fix(checker): no TS2454/TS2448 for computed property names in type positions

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -590,6 +590,9 @@ path = "tests/tuple_index_access_tests.rs"
 name = "control_flow_type_guard_tests"
 path = "tests/control_flow_type_guard_tests.rs"
 [[test]]
+name = "computed_property_name_type_position_no_ts2454_tests"
+path = "tests/computed_property_name_type_position_no_ts2454_tests.rs"
+[[test]]
 name = "array_isarray_mutual_subtype_narrowing_tests"
 path = "tests/array_isarray_mutual_subtype_narrowing_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
@@ -9,6 +9,37 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 
 impl<'a> CheckerState<'a> {
+    /// Whether the computed property name node `computed_name_idx` is a member
+    /// of a type-only element — an `interface` declaration or a type literal
+    /// (`{ [sym]: T }`). The container is the name's grandparent
+    /// (`name -> member -> container`), which uniformly covers property / method
+    /// / accessor / index signatures without enumerating each member kind.
+    ///
+    /// Computed names on type-only elements are type-level: the key they compute
+    /// has no runtime control-flow node, so a value referenced inside the name
+    /// (e.g. a `unique symbol` const) must not be subjected to definite-assignment
+    /// (TS2454) or temporal-dead-zone (TS2448) analysis. Value-position computed
+    /// names (object literals, class fields) have a real control-flow container
+    /// and stay flow-checked.
+    pub(crate) fn computed_property_name_has_type_only_container(
+        &self,
+        computed_name_idx: NodeIndex,
+    ) -> bool {
+        let Some(member_idx) = self.ctx.arena.parent_of(computed_name_idx) else {
+            return false;
+        };
+        let Some(container_idx) = self.ctx.arena.parent_of(member_idx) else {
+            return false;
+        };
+        let Some(container) = self.ctx.arena.get(container_idx) else {
+            return false;
+        };
+        matches!(
+            container.kind,
+            syntax_kind_ext::INTERFACE_DECLARATION | syntax_kind_ext::TYPE_LITERAL
+        )
+    }
+
     /// Check if a variable is used before its declaration in a static block.
     ///
     /// This detects Temporal Dead Zone (TDZ) violations where a block-scoped variable
@@ -175,8 +206,13 @@ impl<'a> CheckerState<'a> {
         // 5. Check if usage is inside a computed property name.
         // Skip TDZ in ambient/type-only contexts (interfaces, type aliases,
         // declare class, .d.ts files) — these don't have runtime TDZ semantics.
-        if self.find_enclosing_computed_property(usage_idx).is_some()
+        // A computed name on an `interface` / type-literal member is type-level:
+        // its key has no runtime control-flow node, so `tsc` raises no TS2448 for
+        // a forward reference there (only value-position computed names — object
+        // literals, class fields — keep runtime TDZ).
+        if let Some(computed_name_idx) = self.find_enclosing_computed_property(usage_idx)
             && !self.ctx.arena.is_in_ambient_context(usage_idx)
+            && !self.computed_property_name_has_type_only_container(computed_name_idx)
         {
             return true;
         }

--- a/crates/tsz-checker/src/flow/flow_analysis/usage.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/usage.rs
@@ -12,6 +12,27 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// Whether `idx` is a value reference nested inside a computed property name
+    /// (`[expr]`) of a type-only element — a member of an `interface` declaration
+    /// or a type literal (`{ [sym]: T }`).
+    ///
+    /// Such computed names are type-level: the property key they compute has no
+    /// runtime control-flow node, so `tsc` does not subject a value referenced in
+    /// the name (e.g. a `unique symbol` const) to definite-assignment (TS2454)
+    /// analysis. Computed names in value positions (object literals, class fields)
+    /// have a real container in the control-flow graph and stay flow-checked.
+    ///
+    /// Reuses `find_enclosing_computed_property` (which climbs to the enclosing
+    /// `COMPUTED_PROPERTY_NAME`, handling nested expressions such as `[ns.sym]`
+    /// and stopping at function boundaries) plus the shared container classifier
+    /// `computed_property_name_has_type_only_container`.
+    pub(crate) fn reference_in_type_position_computed_name(&self, idx: NodeIndex) -> bool {
+        self.find_enclosing_computed_property(idx)
+            .is_some_and(|computed_name_idx| {
+                self.computed_property_name_has_type_only_container(computed_name_idx)
+            })
+    }
+
     /// Check flow-aware usage of a variable (definite assignment + type narrowing).
     ///
     /// This is the main entry point for flow analysis when variables are used.
@@ -162,7 +183,16 @@ impl<'a> CheckerState<'a> {
         // narrowed type). The definite assignment analysis itself handles typeof/
         // instanceof true branches — those are treated as proof that the variable
         // has a value, so TS2454 is suppressed in those branches.
-        if should_report_variable_use_before_assignment(self, idx, declared_type, sym_id) {
+        // A reference inside a computed property name on a type-only element
+        // (interface / type-literal member) names a type-level property key with
+        // no runtime control-flow node, so `tsc` does not raise TS2454 for it.
+        // Narrowing above still runs (so a literal-typed key keeps its literal
+        // type); only the definite-assignment diagnostic is suppressed here.
+        // Value-position computed names (object literals, class fields) stay
+        // flow-checked.
+        if should_report_variable_use_before_assignment(self, idx, declared_type, sym_id)
+            && !self.reference_in_type_position_computed_name(idx)
+        {
             // Report TS2454 error: Variable used before assignment
             self.emit_definite_assignment_error(idx, sym_id);
             // Mark this node so `get_type_of_node` won't re-narrow via the second

--- a/crates/tsz-checker/tests/computed_property_name_type_position_no_ts2454_tests.rs
+++ b/crates/tsz-checker/tests/computed_property_name_type_position_no_ts2454_tests.rs
@@ -1,0 +1,174 @@
+//! A computed property name (`[expr]`) on a type-only element — a member of an
+//! `interface` declaration or a type literal — is a type-level reference: the
+//! property key it computes has no runtime control-flow node. `tsc` therefore
+//! does NOT run definite-assignment (TS2454) or temporal-dead-zone (TS2448)
+//! analysis on a value referenced in the name (e.g. a `unique symbol` const).
+//!
+//! tsz used to flow-check those references and emit a false TS2454 for the
+//! `[sym]` member of `interface I { [sym]: T }` (witness: the prop-types
+//! `nominalTypeHack` pattern from `propTypeValidatorInference.ts`). The fix
+//! classifies the reference by the container of its enclosing computed name
+//! (`name -> member -> container`): interface / type literal => type position
+//! (suppress TS2454/TS2448); object literal / class => value position (keep the
+//! flow check). Narrowing still runs in both, so literal-typed keys keep their
+//! literal type.
+//!
+//! Owner layer: checker flow analysis
+//! (`flow/flow_analysis/usage.rs::reference_in_type_position_computed_name`).
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+// ---------------------------------------------------------------------------
+// Type positions: no TS2454 / TS2448 (binder names varied per case).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unique_symbol_computed_key_in_interface_no_ts2454() {
+    let codes = check_source_codes(
+        r#"
+export const sym: unique symbol;
+export interface Box<T> { [sym]?: T; }
+export {};
+"#,
+    );
+    assert_eq!(count(&codes, 2454), 0, "got: {codes:?}");
+    assert_eq!(count(&codes, 2448), 0, "got: {codes:?}");
+}
+
+/// Renamed binder (anti-hardcoding): the const is not named `sym`.
+#[test]
+fn unique_symbol_computed_key_in_interface_renamed_binder() {
+    let codes = check_source_codes(
+        r#"
+export const brandMarker: unique symbol;
+export interface Schema<V> { [brandMarker]?: V; }
+export {};
+"#,
+    );
+    assert_eq!(count(&codes, 2454), 0, "got: {codes:?}");
+}
+
+#[test]
+fn unique_symbol_computed_key_in_type_literal_alias_no_ts2454() {
+    let codes = check_source_codes(
+        r#"
+export const tag: unique symbol;
+export type Tagged = { [tag]: number };
+export {};
+"#,
+    );
+    assert_eq!(count(&codes, 2454), 0, "got: {codes:?}");
+}
+
+/// Declaration order: interface references the const before it is declared.
+/// The type-level key still must not trigger TS2454/TS2448.
+#[test]
+fn computed_key_before_const_declaration_no_flow_error() {
+    let codes = check_source_codes(
+        r#"
+export interface Wrapper<T> { [marker]?: T; }
+export const marker: unique symbol;
+export {};
+"#,
+    );
+    assert_eq!(count(&codes, 2454), 0, "got: {codes:?}");
+    assert_eq!(count(&codes, 2448), 0, "got: {codes:?}");
+}
+
+/// Nested type literal in a method-signature return position.
+#[test]
+fn nested_type_literal_computed_key_no_ts2454() {
+    let codes = check_source_codes(
+        r#"
+export const inner: unique symbol;
+export interface Outer<T> { make(): { [inner]: T }; }
+export {};
+"#,
+    );
+    assert_eq!(count(&codes, 2454), 0, "got: {codes:?}");
+}
+
+/// Method signature (not a property signature) computed name.
+#[test]
+fn method_signature_computed_name_no_ts2454() {
+    let codes = check_source_codes(
+        r#"
+export const callKey: unique symbol;
+export interface Callable { [callKey](): void; }
+export {};
+"#,
+    );
+    assert_eq!(count(&codes, 2454), 0, "got: {codes:?}");
+}
+
+/// Qualified-name computed key (`[Ns.member]`): the inner identifier must also
+/// escape flow analysis.
+#[test]
+fn qualified_name_computed_key_in_interface_no_ts2454() {
+    let codes = check_source_codes(
+        r#"
+declare namespace Keys { const id: unique symbol; }
+export interface Holder { [Keys.id]: string; }
+export {};
+"#,
+    );
+    assert_eq!(count(&codes, 2454), 0, "got: {codes:?}");
+}
+
+/// A literal-typed `as const` key must keep its literal type through the
+/// suppressed flow path — narrowing is preserved, only the diagnostic is gated.
+#[test]
+fn literal_const_computed_key_keeps_literal_type() {
+    let codes = check_source_codes(
+        r#"
+const key = "feature" as const;
+interface Flags { [key]: boolean; }
+declare let k: keyof Flags;
+const lit: "feature" = k;
+"#,
+    );
+    assert_eq!(count(&codes, 2454), 0, "got: {codes:?}");
+    // keyof Flags must still be the literal "feature": no TS2322 on the assignment.
+    assert_eq!(count(&codes, 2322), 0, "got: {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Value positions: TS2454 must STILL fire (negative controls).
+// ---------------------------------------------------------------------------
+
+/// An object-literal computed key is a runtime value reference: a `let` used
+/// before assignment in that position must still report TS2454, matching `tsc`.
+#[test]
+fn object_literal_computed_key_still_reports_ts2454() {
+    let codes = check_source_codes(
+        r#"
+let runtimeKey: symbol;
+const obj = { [runtimeKey]: 1 };
+runtimeKey = Symbol();
+"#,
+    );
+    assert!(
+        count(&codes, 2454) >= 1,
+        "value-position computed key must keep TS2454; got: {codes:?}"
+    );
+}
+
+/// A plain use-before-assignment elsewhere in the file must be unaffected.
+#[test]
+fn plain_use_before_assignment_still_reports_ts2454() {
+    let codes = check_source_codes(
+        r#"
+let value: number;
+const echoed = value;
+value = 1;
+"#,
+    );
+    assert!(
+        count(&codes, 2454) >= 1,
+        "ordinary use-before-assignment must keep TS2454; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

## Summary
A computed property name `[expr]` on a **type-only element** — a member of an
`interface` declaration or a type literal `{ [sym]: T }` — is a *type-level*
reference: the property key it computes has no runtime control-flow node. `tsc`
therefore does **not** run definite-assignment (TS2454) or temporal-dead-zone
(TS2448) analysis on a value referenced inside such a name. tsz did, producing a
false `TS2454 "Variable used before being assigned"` for the `[nominalTypeHack]`
member pattern.

Minimal witness (clean in `tsc`, false TS2454 in tsz before this change):
```ts
export const sym: unique symbol;
export interface I<T> { [sym]?: T; }   // tsz: false TS2454 at [sym]
```
This is the divergence behind the `propTypeValidatorInference.ts` accepted
regression (the `prop-types` `nominalTypeHack` shape).

## Structural rule
When a computed property name's container (reached as `name -> member ->
container`) is an `interface` declaration or a type literal, `tsc` performs no
definite-assignment / TDZ flow analysis on values referenced in the name; tsz now
matches. Object-literal and class-field computed names have a real control-flow
container and stay flow-checked (TS2454 still fires there, as in `tsc`).

Narrowing is unchanged in both positions, so a literal-typed key keeps its literal
type (`keyof { [k]: V }` with `const k = "x" as const` stays `"x"`).

Owner layer: checker flow analysis (`flow/flow_analysis/{usage,tdz}.rs`).

## Implementation
- `computed_property_name_has_type_only_container` (tdz.rs): shared classifier by
  container kind, uniformly covering property / method / accessor / index
  signatures without enumerating each member kind.
- TS2454: gate added at the definite-assignment emission site, short-circuited
  behind the existing `should_report_variable_use_before_assignment` predicate —
  no per-identifier cost (the container walk runs only when an error would
  otherwise be emitted).
- TS2448: gate added inside the existing computed-property TDZ branch (which only
  runs in computed-name contexts), beside the existing ambient-context exclusion.
- The type-position check reuses `find_enclosing_computed_property` (climbs to the
  enclosing computed name, handles nested expressions like `[ns.sym]`, stops at
  function boundaries).

No user-name / file-name string checks; classification is purely structural by
AST container kind.

## Adjacent-case matrix (new test target `computed_property_name_type_position_no_ts2454_tests`)
Type positions — no TS2454/TS2448 (binder names varied per case): interface
property signature, renamed binder, type-literal alias, declaration-order
(reference before const), nested type literal in a method-signature return,
method signature, qualified name `[Keys.id]`, and a literal-`as const` key whose
`keyof` literal type is preserved. Value positions — TS2454 still fires
(negative controls): object-literal computed key, plain use-before-assignment.

## Verification
- `cargo test -p tsz-checker --test computed_property_name_type_position_no_ts2454_tests` — 10/10 pass.
- Regression sweeps (clean): `cargo test -p tsz-checker --lib definite_assignment` (74), `--lib tdz` (5); integration `decorator_method_tdz_tests`, `ts2449_parameter_decorator_no_tdz_tests`, `static_readonly_unique_symbol_tests`, `keyof_class_unique_symbol_key_tests`, `control_flow_type_guard_tests`, `merged_unique_symbol_factory_value_identity_tests`, `unique_symbol_discriminant_narrowing_tests`. (The handful of pre-existing `--lib` failures — e.g. `keyof_keeps_computed_unique_like_string_property_as_string_key`, relation-flags boundary tests — fail identically on the un-patched base and are unrelated to this change.)
- `cargo clippy -p tsz-checker` — clean.
- CLI vs `tsc 6.0.2` on the witness `[sym]` family across interface / type-literal / type-alias / nested / qualified-name / decl-order forms, with object-literal and class value-position controls — all match.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAig3bHZtXXkNzUkfwaxK1)_