### PR TITLE
fix(solver): source index signatures must not satisfy/reject target named members

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -63,6 +63,14 @@ impl<'a> CheckerState<'a> {
                             .cloned()
                     })
             })
+            .or_else(|| {
+                crate::query_boundaries::diagnostics::intersection_members(self.ctx.types, ty)
+                    .and_then(|members| {
+                        members
+                            .iter()
+                            .find_map(|member| self.property_info_for_display(*member, name))
+                    })
+            })
     }
 
     fn should_suppress_outer_callback_return_assignability(

--- a/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure_missing_property.rs
@@ -713,6 +713,39 @@ impl<'a> CheckerState<'a> {
         diag.push_elaboration_in_span(start, length, message, code, 0);
     }
 
+    fn type_or_display_alias_is_intersection(&self, type_id: TypeId) -> bool {
+        crate::query_boundaries::diagnostics::is_intersection_type(self.ctx.types, type_id)
+            || self
+                .ctx
+                .types
+                .get_display_alias(type_id)
+                .is_some_and(|alias| {
+                    crate::query_boundaries::diagnostics::is_intersection_type(
+                        self.ctx.types,
+                        alias,
+                    )
+                })
+    }
+
+    fn common_missing_property_declaring_type_name(
+        &self,
+        target_type: TypeId,
+        property_names: &[tsz_common::interner::Atom],
+    ) -> Option<String> {
+        let mut common_parent = None;
+        for property_name in property_names {
+            let parent = self
+                .property_info_for_display(target_type, *property_name)?
+                .parent_id?;
+            if common_parent.is_some_and(|common| common != parent) {
+                return None;
+            }
+            common_parent = Some(parent);
+        }
+        let symbol = self.ctx.binder.get_symbol(common_parent?)?;
+        Some(symbol.escaped_name.clone())
+    }
+
     /// For TS2739 source display, unfold wrapper aliases like
     /// `type B = A<X>` to the body application `A<X>`. Other shapes keep
     /// normal formatting.
@@ -1395,14 +1428,28 @@ impl<'a> CheckerState<'a> {
             let (src, _) = self.format_type_pair_diagnostic(widened_source, target_type);
             src
         };
+        let ordered_names =
+            self.sort_missing_property_names_for_display(target_type, &filtered_names);
         let tgt_str = if depth == 0 {
             self.checked_js_global_element_access_fallback_target_display(idx)
-                .unwrap_or_else(|| self.format_assignability_type_for_message(target, source))
+                .unwrap_or_else(|| {
+                    if self.type_or_display_alias_is_intersection(target_type)
+                        || self.type_or_display_alias_is_intersection(target)
+                    {
+                        self.common_missing_property_declaring_type_name(
+                            target_type,
+                            &ordered_names,
+                        )
+                        .unwrap_or_else(|| {
+                            self.format_assignability_type_for_message(target, source)
+                        })
+                    } else {
+                        self.format_assignability_type_for_message(target, source)
+                    }
+                })
         } else {
             self.format_type_diagnostic(target_type)
         };
-        let ordered_names =
-            self.sort_missing_property_names_for_display(target_type, &filtered_names);
         let (props_joined, more) = self.truncated_missing_property_list(&ordered_names);
         if let Some(more_count) = more {
             let more_count = more_count.to_string();

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1748,178 +1748,20 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source_shape_id: ObjectShapeId,
         target_props: &[PropertyInfo],
     ) -> Option<SubtypeFailureReason> {
-        for t_prop in target_props {
-            if let Some(sp) =
-                self.lookup_property(&source_shape.properties, Some(source_shape_id), t_prop.name)
-            {
-                // Check nominal identity for private/protected properties.
-                // `private` requires the same declaration; `protected` is
-                // hierarchical (a derived class may widen it to public) —
-                // decided by the shared `nominal_member_origin_ok`.
-                if t_prop.visibility != Visibility::Public {
-                    if !self.nominal_member_origin_ok(
-                        t_prop.name,
-                        sp.parent_id,
-                        t_prop.parent_id,
-                        t_prop.visibility,
-                    ) {
-                        return Some(SubtypeFailureReason::PropertyNominalMismatch {
-                            property_name: t_prop.name,
-                        });
-                    }
-                }
-                // Cannot assign private/protected source to public target
-                else if sp.visibility != Visibility::Public {
-                    return Some(SubtypeFailureReason::PropertyVisibilityMismatch {
-                        property_name: t_prop.name,
-                        source_visibility: sp.visibility,
-                        target_visibility: t_prop.visibility,
-                    });
-                }
-
-                // NOTE: TypeScript allows readonly source to satisfy mutable target
-                // (readonly is a constraint on the reference, not structural compatibility)
-
-                // Check property type compatibility before the optional/required
-                // mismatch: TS2327 ("Property 'x' is optional ... but required ...")
-                // only applies when the read types are compatible and optionality is
-                // the sole failure. An incompatible read type must surface the
-                // "Types of property 'x' are incompatible." chain instead.
-                let source_type = self.optional_property_type(sp);
-                let target_type = self.optional_property_type(t_prop);
-                let allow_bivariant = sp.is_method || t_prop.is_method;
-                if !self
-                    .check_subtype_with_method_variance(source_type, target_type, allow_bivariant)
-                    .is_true()
-                {
-                    let nested = self.explain_failure_with_method_variance(
-                        source_type,
-                        target_type,
-                        allow_bivariant,
-                    );
-                    return Some(SubtypeFailureReason::PropertyTypeMismatch {
-                        property_name: t_prop.name,
-                        source_property_type: source_type,
-                        target_property_type: target_type,
-                        nested_reason: nested.map(Box::new),
-                    });
-                }
-
-                if sp.optional && !t_prop.optional {
-                    return Some(SubtypeFailureReason::OptionalPropertyRequired {
-                        property_name: t_prop.name,
-                    });
-                }
-                // Sound Mode only: tsc never relates split-accessor write
-                // types (mirrors the gate in check_property_types).
-                if self.check_split_accessor_writes
-                    && !t_prop.readonly
-                    && !sp.readonly
-                    && (sp.has_split_accessor() || t_prop.has_split_accessor())
-                {
-                    let source_write = self.optional_property_write_type(sp);
-                    let target_write = self.optional_property_write_type(t_prop);
-                    if !self
-                        .check_subtype_with_method_variance(
-                            target_write,
-                            source_write,
-                            allow_bivariant,
-                        )
-                        .is_true()
-                    {
-                        let nested = self.explain_failure_with_method_variance(
-                            target_write,
-                            source_write,
-                            allow_bivariant,
-                        );
-                        return Some(SubtypeFailureReason::PropertyTypeMismatch {
-                            property_name: t_prop.name,
-                            source_property_type: source_write,
-                            target_property_type: target_write,
-                            nested_reason: nested.map(Box::new),
-                        });
-                    }
-                }
-                continue;
-            }
-
-            let mut checked = false;
-            let target_type = self.optional_property_type(t_prop);
-
-            if utils::is_numeric_property_name(self.interner, t_prop.name)
-                && let Some(number_idx) = &source_shape.number_index
-            {
-                checked = true;
-                if number_idx.readonly && !t_prop.readonly {
-                    return Some(SubtypeFailureReason::ReadonlyPropertyMismatch {
-                        property_name: t_prop.name,
-                    });
-                }
-                if !self
-                    .check_subtype_with_method_variance(
-                        number_idx.value_type,
-                        target_type,
-                        t_prop.is_method,
-                    )
-                    .is_true()
-                {
-                    let nested_reason = self
-                        .explain_failure_with_method_variance(
-                            number_idx.value_type,
-                            target_type,
-                            t_prop.is_method,
-                        )
-                        .map(Box::new);
-                    return Some(SubtypeFailureReason::IndexSignatureMismatch {
-                        index_kind: "number",
-                        source_value_type: number_idx.value_type,
-                        target_value_type: target_type,
-                        nested_reason,
-                    });
-                }
-            }
-
-            if let Some(string_idx) = &source_shape.string_index {
-                checked = true;
-                if string_idx.readonly && !t_prop.readonly {
-                    return Some(SubtypeFailureReason::ReadonlyPropertyMismatch {
-                        property_name: t_prop.name,
-                    });
-                }
-                if !self
-                    .check_subtype_with_method_variance(
-                        string_idx.value_type,
-                        target_type,
-                        t_prop.is_method,
-                    )
-                    .is_true()
-                {
-                    let nested_reason = self
-                        .explain_failure_with_method_variance(
-                            string_idx.value_type,
-                            target_type,
-                            t_prop.is_method,
-                        )
-                        .map(Box::new);
-                    return Some(SubtypeFailureReason::IndexSignatureMismatch {
-                        index_kind: "string",
-                        source_value_type: string_idx.value_type,
-                        target_value_type: target_type,
-                        nested_reason,
-                    });
-                }
-            }
-
-            if !checked && !t_prop.optional {
-                return Some(SubtypeFailureReason::MissingProperty {
-                    property_name: t_prop.name,
-                    source_type: source,
-                    target_type: target,
-                });
-            }
-        }
-
-        None
+        // The source's index signatures never participate in satisfying the
+        // target's *named* members (`tsc`'s `getPropertyOfType` does not
+        // synthesize a member from an index signature), and a plain object
+        // target declares no index signature for the source index to relate
+        // against. Every failure on this path is therefore a named-member
+        // failure — explained exactly as for a plain object source, which also
+        // yields the correct `TS2739`/`TS2741`/property-mismatch selection.
+        self.explain_object_failure(
+            source,
+            target,
+            &source_shape.properties,
+            Some(source_shape_id),
+            target_props,
+        )
     }
 
     fn explain_properties_against_index_signatures(

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -277,6 +277,54 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             .cloned()
     }
 
+    /// Decide whether a target property that is *absent* from the source's named
+    /// properties is nevertheless satisfied.
+    ///
+    /// This is the single rule shared by every object-subtype path (plain
+    /// objects, the merge-scan fast path, and objects carrying index
+    /// signatures). The source's index signatures play **no** role here:
+    /// `tsc`'s `getPropertyOfType` never synthesizes a named member from an
+    /// index signature, so `getUnmatchedProperty` reports a required named
+    /// member as missing (`TS2741`/`TS2739`/`TS2740`) even when the source
+    /// declares a `[k: string]: …` / `[n: number]: …` signature, and an
+    /// *optional* named member imposes no constraint at all. A source index
+    /// signature participates only in index-to-index relations
+    /// (`check_string_index_compatibility` / `check_number_index_compatibility`).
+    ///
+    /// An absent target member is therefore satisfied iff it is:
+    /// - optional and public (no constraint); or
+    /// - required and public but supplied — compatibly — by the implicit
+    ///   `Object.prototype` members every object type carries.
+    ///
+    /// A private/protected member can never be satisfied while absent, so any
+    /// non-public member returns `False`.
+    fn check_absent_target_property(
+        &mut self,
+        target_prop: &PropertyInfo,
+        source_receiver: Option<TypeId>,
+        target_receiver: Option<TypeId>,
+    ) -> SubtypeResult {
+        // Private/Protected properties cannot be satisfied while absent.
+        if target_prop.visibility != Visibility::Public {
+            return SubtypeResult::False;
+        }
+        if target_prop.optional {
+            return SubtypeResult::True;
+        }
+        // `Object.prototype` fallback: TypeScript treats every object type as
+        // implicitly carrying the global `Object` members.
+        if let Some(obj_prop) = self.get_object_base_property(target_prop.name) {
+            self.check_property_compatibility(
+                &obj_prop,
+                target_prop,
+                source_receiver,
+                target_receiver,
+            )
+        } else {
+            SubtypeResult::False
+        }
+    }
+
     /// Check object subtyping (structural with nominal optimization).
     ///
     /// Validates that source object is a subtype of target object by checking:
@@ -395,30 +443,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 Some(sp) => {
                     self.check_property_compatibility(sp, t_prop, source_receiver, target_receiver)
                 }
-                None => {
-                    // Private/Protected properties cannot be missing, even if optional
-                    if t_prop.visibility != Visibility::Public {
-                        return SubtypeResult::False;
-                    }
-
-                    // Property missing - only OK if target property is optional
-                    if t_prop.optional {
-                        SubtypeResult::True
-                    } else {
-                        // Object.prototype fallback: TypeScript treats all object interface
-                        // types as implicitly having Object.prototype methods.
-                        if let Some(obj_prop) = self.get_object_base_property(t_prop.name) {
-                            self.check_property_compatibility(
-                                &obj_prop,
-                                t_prop,
-                                source_receiver,
-                                target_receiver,
-                            )
-                        } else {
-                            SubtypeResult::False
-                        }
-                    }
-                }
+                None => self.check_absent_target_property(t_prop, source_receiver, target_receiver),
             };
 
             if !result.is_true() {
@@ -463,25 +488,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 continue;
             }
 
-            // Property missing - only OK if target property is optional and public
-            if t_prop.visibility != Visibility::Public {
-                return SubtypeResult::False;
-            }
-            if !t_prop.optional {
-                // Object.prototype fallback: TypeScript treats all object interface
-                // types as implicitly having Object.prototype methods.
-                if let Some(obj_prop) = self.get_object_base_property(t_prop.name) {
-                    let compat = self.check_property_compatibility(
-                        &obj_prop,
-                        t_prop,
-                        source_receiver,
-                        target_receiver,
-                    );
-                    if compat.is_true() {
-                        continue;
-                    }
-                }
-                return SubtypeResult::False;
+            // Property missing - resolved by the shared absent-member rule
+            // (optional, or provided by Object.prototype; source index
+            // signatures are irrelevant to target named members).
+            let result =
+                self.check_absent_target_property(t_prop, source_receiver, target_receiver);
+            if !result.is_true() {
+                return result;
             }
         }
 
@@ -1444,107 +1457,21 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         return SubtypeResult::False;
                     }
                 }
-            } else if !self
-                .check_missing_property_against_index_signatures(
-                    source,
-                    source_receiver,
-                    t_prop,
-                    target_receiver,
-                )
-                .is_true()
-            {
-                return SubtypeResult::False;
+            } else {
+                // Property absent from the source's named members. The source's
+                // index signatures never supply a target *named* member (they
+                // only participate in index-to-index relations), so this is
+                // resolved by the shared absent-member rule exactly as for a
+                // plain object source.
+                let result =
+                    self.check_absent_target_property(t_prop, source_receiver, target_receiver);
+                if !result.is_true() {
+                    return result;
+                }
             }
         }
 
         SubtypeResult::True
-    }
-
-    /// Check if a missing target property can be satisfied by source index signatures.
-    ///
-    /// When a target property doesn't exist in the source object, the source's index
-    /// signatures can potentially satisfy it:
-    /// - If property name is numeric, check against number index signature
-    /// - Always check against string index signature (since numbers convert to strings)
-    pub(crate) fn check_missing_property_against_index_signatures(
-        &mut self,
-        source: &ObjectShape,
-        source_receiver: Option<TypeId>,
-        target_prop: &PropertyInfo,
-        target_receiver: Option<TypeId>,
-    ) -> SubtypeResult {
-        // Required properties cannot be satisfied by index signatures (soundness).
-        // An index signature { [k: string]: V } admits the empty object {},
-        // but a required property means the target does NOT admit {}.
-        // This is a fundamental set-theoretic mismatch, not just a TS compatibility rule.
-        if !target_prop.optional {
-            return SubtypeResult::False;
-        }
-
-        // Private/Protected properties cannot be satisfied by index signatures.
-        // They must be explicitly present in the source and match nominally.
-        if target_prop.visibility != Visibility::Public {
-            return SubtypeResult::False;
-        }
-
-        // Check if property name matches index signatures
-        // Numeric property names can match number index signatures
-        // All property names can match string index signatures (numbers convert to strings)
-        let target_type = self
-            .bind_property_receiver_this(target_receiver, self.optional_property_type(target_prop));
-
-        if utils::is_numeric_property_name(self.interner, target_prop.name)
-            && let Some(number_idx) = &source.number_index
-        {
-            if number_idx.readonly && !target_prop.readonly {
-                return SubtypeResult::False;
-            }
-            let source_value =
-                self.bind_property_receiver_this(source_receiver, number_idx.value_type);
-            if !self
-                .check_subtype_with_method_variance(
-                    source_value,
-                    target_type,
-                    target_prop.is_method,
-                )
-                .is_true()
-            {
-                return SubtypeResult::False;
-            }
-            return SubtypeResult::True;
-        }
-
-        if let Some(string_idx) = source
-            .string_index
-            .as_ref()
-            .filter(|idx| idx.key_type != TypeId::SYMBOL)
-        {
-            if string_idx.readonly && !target_prop.readonly {
-                return SubtypeResult::False;
-            }
-            let source_value =
-                self.bind_property_receiver_this(source_receiver, string_idx.value_type);
-            if !self
-                .check_subtype_with_method_variance(
-                    source_value,
-                    target_type,
-                    target_prop.is_method,
-                )
-                .is_true()
-            {
-                return SubtypeResult::False;
-            }
-            return SubtypeResult::True;
-        }
-
-        // No matching index signature
-        // For optional properties, this is OK
-        // For required properties, this is an error
-        if !target_prop.optional {
-            SubtypeResult::False
-        } else {
-            SubtypeResult::True
-        }
     }
 
     fn is_symbol_named_property(&self, name: Atom) -> bool {

--- a/crates/tsz-solver/tests/index_signature_tests.rs
+++ b/crates/tsz-solver/tests/index_signature_tests.rs
@@ -884,3 +884,138 @@ fn test_anonymous_plain_object_still_assignable_to_string_indexed_target_when_co
         "Anonymous object with compatible props should still satisfy {{ [k: string]: number }}"
     );
 }
+
+// =============================================================================
+// Source index signatures vs target NAMED members (tsc parity)
+// -----------------------------------------------------------------------------
+// A source index signature is related only against a target's *index*
+// signatures, never against the target's named members. `tsc`'s
+// `getPropertyOfType` does not synthesize a named member from an index
+// signature, so:
+//   - a required target member absent from the source's named members is
+//     missing (TS2741/TS2739) even when the source declares an index, and
+//   - an optional target member imposes no constraint at all, regardless of
+//     the source index value type.
+// =============================================================================
+
+/// A `{ [k: string]: string }` source must NOT satisfy a required named member
+/// `{ a: string }` — even though the index value type would be compatible. tsc
+/// reports `a` as missing (TS2741).
+#[test]
+fn test_string_index_source_does_not_supply_required_named_member() {
+    let interner = TypeInterner::new();
+
+    let source = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::STRING,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+    let target = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+
+    assert!(
+        !is_subtype_of(&interner, source, target),
+        "string index source must not supply required named member 'a'"
+    );
+}
+
+/// A `{ [k: string]: string }` source IS assignable to `{ a?: number }`: the
+/// optional member imposes no constraint, and the source index value type
+/// (`string`) is irrelevant to target named members. Previously tsz wrongly
+/// related the index value against the optional member and rejected (false
+/// TS2322).
+#[test]
+fn test_string_index_source_satisfies_optional_named_member_regardless_of_value() {
+    let interner = TypeInterner::new();
+
+    let source = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::STRING,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+    let target = interner.object(vec![PropertyInfo::opt(
+        interner.intern_string("a"),
+        TypeId::NUMBER,
+    )]);
+
+    assert!(
+        is_subtype_of(&interner, source, target),
+        "string index source should satisfy optional member 'a?: number' (index value is irrelevant)"
+    );
+}
+
+/// A `{ [n: number]: string }` source IS assignable to `{ 0?: number }`: the
+/// numeric optional member imposes no constraint, and the number index value
+/// type is irrelevant to target named members.
+#[test]
+fn test_number_index_source_satisfies_optional_numeric_member_regardless_of_value() {
+    let interner = TypeInterner::new();
+
+    let source = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: None,
+        number_index: Some(IndexSignature {
+            key_type: TypeId::NUMBER,
+            value_type: TypeId::STRING,
+            readonly: false,
+            param_name: None,
+        }),
+    });
+    let target = interner.object(vec![PropertyInfo::opt(
+        interner.intern_string("0"),
+        TypeId::NUMBER,
+    )]);
+
+    assert!(
+        is_subtype_of(&interner, source, target),
+        "number index source should satisfy optional numeric member '0?: number'"
+    );
+}
+
+/// Regression guard: a `{ [k: string]: string }` source still satisfies a
+/// matching optional member `{ a?: string }` (this case was already accepted,
+/// but only incidentally because the index value matched).
+#[test]
+fn test_string_index_source_satisfies_matching_optional_named_member() {
+    let interner = TypeInterner::new();
+
+    let source = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::STRING,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+    let target = interner.object(vec![PropertyInfo::opt(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+
+    assert!(
+        is_subtype_of(&interner, source, target),
+        "string index source should satisfy matching optional member 'a?: string'"
+    );
+}


### PR DESCRIPTION
Goal: hold

Fixes #13931.

## Structural rule
When a target *named* member is absent from the source's named properties, `tsc` does X; tsz now does X through the solver subtype object path.

A source object's index signatures are related **only** against a target's own index signatures (`indexSignaturesRelatedTo`), never against the target's *named* members. `tsc`'s `getPropertyOfType` does not synthesize a named member from an index signature, so `getUnmatchedProperty` reports a **required** named member as missing (`TS2741`/`TS2739`/`TS2740`) even when the source declares an index signature, and an **optional** named member imposes no constraint at all. A source index signature value type is irrelevant to target named members.

## The bug (note on the issue)
The issue as filed claims `tsc` *accepts* a `[k: string]: any` source against a target with a **required** named member. That premise is false: `tsc` 5.4 -> 6.0.3 all reject required-member cases with `TS2741`/`TS2740`, and tsz already matched that verdict. The *real* divergence — confirmed against `tsc` 6.0.3 (the pinned submodule version) — is that tsz's source-with-index -> plain-object path related the source's index **value** type against target named members, producing:

- **False positives (over-rejection):** `{ [k: string]: string }` was rejected against `{ a?: number }` (any optional member whose type the index value did not satisfy), and `Object.prototype` members (`toString`, `hasOwnProperty`) on an index-typed source were rejected. `tsc` accepts all of these.
- **Wrong diagnostic code:** a required member missing from an index-typed source was reported as `TS2322` ("index signatures are incompatible") instead of `tsc`'s `TS2741`/`TS2739` ("property is missing").

## Owner layer
Solver — `relations/subtype` object property check; follow-up display repair in checker diagnostics.

- Introduced a single shared `check_absent_target_property` rule (optional -> ok; else `Object.prototype` fallback; else missing) and routed all three object-subtype paths (`check_object_subtype`, `check_object_subtype_merge_scan`, `check_object_with_index_to_object`) through it.
- Deleted the buggy `check_missing_property_against_index_signatures`.
- The explain counterpart `explain_object_with_index_to_object_failure` now delegates to the plain-object `explain_object_failure` (every failure on this path is a named-member failure), matching the existing `explain_indexed_object_failure` pattern.
- Follow-up: depth-0 `TS2739` rendering now uses the common declaring type for missing members when an evaluated/display-alias intersection surface would otherwise leak into the target text (`D`, not `D & C`).

## Adjacent-case matrix (tsz output now identical to `tsc` 6.0.3)
- Optional named member, value mismatch vs source index -> **accept** (was false `TS2322`).
- Optional named member, value match -> accept (unchanged).
- Numeric optional member vs number-index source -> accept (was false `TS2322`).
- `Object.prototype` member (`toString`/`hasOwnProperty`) on index source -> accept (was false `TS2322`).
- Required named member missing -> `TS2741` single / `TS2739` multiple (was `TS2322` on the value-mismatch sub-case).
- `any`-valued string index vs required member -> `TS2741` missing (not satisfied by index).
- Genuine index-to-index incompatibility (target declares its own index) -> `TS2322` (unchanged, still correct).
- Array target (`string[]`) from index source -> `TS2740` (unchanged).
- Evaluated/display-alias intersection target with missing nominal class members -> `TS2739` mentions the declaring target (`D`), matching the pinned conformance fingerprint.

## Fallback / hot path
The deleted code eagerly computed `bind_property_receiver_this` and ran index-value relations for every missing required member; the new helper early-returns on optional members and only does the `Object.prototype` lookup for required ones — a small net reduction of work on the relation hot path. No fixture-name or printer-output predicates introduced.

## Verification
- `cargo fmt --check`.
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test this_type_tests test_this_type_relationship_assignment_diagnostics_use_nominal_class_names` — passed.
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter 'types/thisType/typeRelationships.ts' --verbose` — `1/1 passed`, `Fingerprint-only: 0`.
- Existing solver regression coverage in `crates/tsz-solver/tests/index_signature_tests.rs` covers required-missing rejection, optional satisfaction regardless of index value, numeric optional satisfaction, and matching optional satisfaction.
- Broad conformance/emit/fourslash/project rows owned by ready-review CI.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
