### PR TITLE
fix(solver): accept extends-ReadonlyArray shapes against readonly array targets

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -286,6 +286,9 @@ path = "tests/array_generic_shorthand_canonical_tests.rs"
 name = "array_subclass_inheritance_tests"
 path = "tests/array_subclass_inheritance_tests.rs"
 [[test]]
+name = "extends_readonly_array_assignability_tests"
+path = "tests/extends_readonly_array_assignability_tests.rs"
+[[test]]
 name = "tuple_infer_mapped_recursive_tests"
 path = "tests/tuple_infer_mapped_recursive_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/extends_readonly_array_assignability_tests.rs
+++ b/crates/tsz-checker/tests/extends_readonly_array_assignability_tests.rs
@@ -1,0 +1,129 @@
+//! An interface/class that declares `extends Array<T>` or `extends
+//! ReadonlyArray<T>` is a heritage-flattened object shape, not a `TypeData::Array`.
+//! The solver subtype dispatch accepts such a source against a *mutable* array
+//! target via a covariant element check (PR #13928). These tests cover the
+//! symmetric `readonly U[]` / `ReadonlyArray<U>` target side and guard the
+//! readonly-direction discipline (mutable source -> readonly target ok; readonly
+//! source -> mutable target rejected).
+
+use tsz_checker::context::CheckerOptions;
+
+fn strict_diagnostics(source: &str) -> Vec<(u32, String)> {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn assignment_codes(diags: &[(u32, String)]) -> Vec<u32> {
+    diags
+        .iter()
+        .filter(|(code, _)| matches!(*code, 2322 | 2345 | 2740 | 2741))
+        .map(|(code, _)| *code)
+        .collect()
+}
+
+#[test]
+fn readonly_nonempty_array_assignable_to_readonly_array_target() {
+    let diagnostics = strict_diagnostics(
+        r#"
+interface ReadonlyNonEmptyArray<A> extends ReadonlyArray<A> {
+  readonly 0: A;
+}
+declare const r: ReadonlyNonEmptyArray<string>;
+const a: readonly string[] = r;
+const b: ReadonlyArray<string> = r;
+"#,
+    );
+    let codes = assignment_codes(&diagnostics);
+    assert!(
+        codes.is_empty(),
+        "extends-ReadonlyArray source should satisfy a readonly array target, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn mutable_nonempty_array_assignable_to_readonly_array_target() {
+    // A mutable `extends Array` source is assignable to a readonly target
+    // (mutable -> readonly is allowed).
+    let diagnostics = strict_diagnostics(
+        r#"
+interface NonEmptyArray<A> extends Array<A> {
+  0: A;
+}
+declare const n: NonEmptyArray<number>;
+const a: readonly number[] = n;
+const b: ReadonlyArray<number> = n;
+"#,
+    );
+    let codes = assignment_codes(&diagnostics);
+    assert!(
+        codes.is_empty(),
+        "extends-Array source should satisfy a readonly array target, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn readonly_nonempty_array_covariant_widening_to_readonly_target() {
+    let diagnostics = strict_diagnostics(
+        r#"
+interface ReadonlyNonEmptyArray<A> extends ReadonlyArray<A> {
+  readonly 0: A;
+}
+declare const r: ReadonlyNonEmptyArray<string>;
+const a: readonly (string | number)[] = r;
+"#,
+    );
+    let codes = assignment_codes(&diagnostics);
+    assert!(
+        codes.is_empty(),
+        "covariant widening to a readonly target should be accepted, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn readonly_source_rejected_against_mutable_array_target() {
+    // A `ReadonlyArray`-derived source must NOT be assignable to a *mutable*
+    // array target: readonly -> mutable loses the readonly guarantee.
+    let diagnostics = strict_diagnostics(
+        r#"
+interface ReadonlyNonEmptyArray<A> extends ReadonlyArray<A> {
+  readonly 0: A;
+}
+declare const r: ReadonlyNonEmptyArray<string>;
+const a: string[] = r;
+"#,
+    );
+    let codes = assignment_codes(&diagnostics);
+    assert!(
+        !codes.is_empty(),
+        "readonly-derived source must be rejected against a mutable array target, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn readonly_target_covariant_element_mismatch_rejected() {
+    let diagnostics = strict_diagnostics(
+        r#"
+interface ReadonlyNonEmptyArray<A> extends ReadonlyArray<A> {
+  readonly 0: A;
+}
+declare const r: ReadonlyNonEmptyArray<string | number>;
+const a: readonly string[] = r;
+"#,
+    );
+    let codes = assignment_codes(&diagnostics);
+    assert!(
+        !codes.is_empty(),
+        "element-type mismatch must still be rejected on a readonly target, got: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/extends_readonly_array_assignability_tests.rs
+++ b/crates/tsz-checker/tests/extends_readonly_array_assignability_tests.rs
@@ -1,5 +1,5 @@
 //! An interface/class that declares `extends Array<T>` or `extends
-//! ReadonlyArray<T>` is a heritage-flattened object shape, not a `TypeData::Array`.
+//! ReadonlyArray<T>` is a heritage-flattened object shape, not a syntactic array.
 //! The solver subtype dispatch accepts such a source against a *mutable* array
 //! target via a covariant element check (PR #13928). These tests cover the
 //! symmetric `readonly U[]` / `ReadonlyArray<U>` target side and guard the

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -19,7 +19,7 @@ pub use super::property_readonly::{
 
 // Child module: resolution helpers (mapped types, primitives, arrays, applications, etc.)
 #[path = "property_helpers.rs"]
-mod property_helpers;
+pub(crate) mod property_helpers;
 
 // =============================================================================
 // Property Access Resolution

--- a/crates/tsz-solver/src/operations/property_helpers.rs
+++ b/crates/tsz-solver/src/operations/property_helpers.rs
@@ -13,7 +13,15 @@ use crate::types::{
     TypeParamInfo,
 };
 
-fn is_array_mutating_method(prop_name: &str) -> bool {
+/// The `Array<T>` members that `ReadonlyArray<T>` does not declare.
+///
+/// These are exactly the mutating methods stripped from the readonly array
+/// surface, so this predicate is the canonical structural difference between the
+/// mutable and readonly array member sets. Property access on `readonly T[]` uses
+/// it to reject mutating-method access; the subtype dispatch uses it to recognize
+/// a heritage-flattened `extends ReadonlyArray<T>` source (which carries the
+/// non-mutating subset) against a readonly-array target.
+pub(crate) fn is_array_mutating_method(prop_name: &str) -> bool {
     matches!(
         prop_name,
         "copyWithin"

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -1013,46 +1013,72 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             );
         }
 
-        // Object-like source vs (mutable) array target. An interface/class that
-        // declares `extends Array<T>` (e.g. `interface NonEmptyArray<A> extends
-        // Array<A>`) is assignable to `T[]`. Arrays are `TypeData::Array`, not
-        // object shapes, so none of the structural object branches above fire and
-        // the pair would otherwise fall through to failure.
+        // Object-like source vs array / readonly-array target. An interface or
+        // class that declares `extends Array<T>` (e.g. `interface NonEmptyArray<A>
+        // extends Array<A>`) or `extends ReadonlyArray<T>` is a heritage-flattened
+        // object shape, not a `TypeData::Array`, so none of the structural object
+        // branches above fire and the pair would otherwise fall through to failure.
         //
-        // `tsc` treats array assignability covariantly, so `S <: T[]` reduces to
-        // the element relation on the numeric element type. We therefore:
-        //   1. require the source to carry a non-`readonly` numeric index
-        //      signature — `Array<T>` declares `[n: number]: T`, and a `readonly`
-        //      source (a `ReadonlyArray`-derived shape) is not assignable to a
-        //      mutable array, matching `tsc`;
-        //   2. confirm the source genuinely provides the whole `Array` member
-        //      surface by name, distinguishing a heritage-flattened
-        //      `extends Array` shape (its inherited members are present as named
-        //      properties) from a bare `Record<number, T>` that merely shares a
-        //      numeric index. The scan walks the source's own named properties
-        //      directly rather than going through `lookup_property`, so a
-        //      `[key: string]` index signature cannot spoof every member name; and
-        //   3. decide the relation by the covariant element check.
+        // `tsc` treats array assignability covariantly, so `S <: U[]` /
+        // `S <: readonly U[]` reduces to the element relation on the numeric
+        // element type. We therefore:
+        //   1. recognize both the mutable (`U[]`) and the readonly
+        //      (`readonly U[]` / `ReadonlyArray<U>`, in either the
+        //      `ReadonlyType(Array)` syntax form or the generic-application form)
+        //      target shapes and extract the target element type;
+        //   2. gate readonly direction. A `readonly` source numeric index (a
+        //      `ReadonlyArray`-derived shape) is assignable to a readonly target
+        //      but NOT to a mutable one, while a mutable source is assignable to
+        //      either; this matches `tsc`;
+        //   3. confirm the source genuinely provides the array member surface by
+        //      name. The scan walks the registered mutable `Array<T>` base (always
+        //      available) and the source's own named properties directly rather
+        //      than going through `lookup_property`, distinguishing a
+        //      heritage-flattened shape from a bare `Record<number, T>` and
+        //      preventing a `[key: string]` index from spoofing every member name.
+        //      For a readonly target the mutable-only members (`push`/`pop`/...)
+        //      are not required: `ReadonlyArray<T>`'s surface is exactly `Array<T>`
+        //      minus those mutating methods, so a `ReadonlyArray`-derived source
+        //      legitimately omits them; and
+        //   4. decide the relation by the covariant element check.
         //
-        // This deliberately avoids materializing the instantiated `Array<T>`
-        // interface and running a full structural comparison: doing that in this
-        // hot dispatch path (a) re-enters instantiation/evaluation with observable
+        // This deliberately avoids materializing the instantiated array interface
+        // and running a full structural comparison: doing that in this hot
+        // dispatch path (a) re-enters instantiation/evaluation with observable
         // cache side effects and (b) can exhaust the relation depth limit on deep
         // generic sources, which is treated as `true` and silently over-accepts
-        // unrelated types.
-        if let Some(t_elem) = array_element_type(self.interner, target)
-            && let Some(s_shape_id) = object_with_index_shape_id(self.interner, source)
+        // unrelated types. The readonly-target arm runs *before* the readonly-peel
+        // below (which strips the target to a mutable array and would otherwise
+        // reject a legitimately readonly source). The cheap source discriminator
+        // (`object_with_index_shape_id`) is checked first so the readonly-array
+        // target extraction only runs for object-with-index sources.
+        if let Some(s_shape_id) = object_with_index_shape_id(self.interner, source)
             && let Some(array_base) = self.resolver.get_array_base_type()
             && let Some(array_shape_id) = object_shape_id(self.interner, array_base)
                 .or_else(|| object_with_index_shape_id(self.interner, array_base))
+            && let Some((t_elem, target_readonly)) = array_element_type(self.interner, target)
+                .map(|elem| (elem, false))
+                .or_else(|| {
+                    self.readonly_array_syntax_element(target)
+                        .or_else(|| self.readonly_array_application_element(target))
+                        .map(|elem| (elem, true))
+                })
         {
             let s_shape = self.interner.object_shape(s_shape_id);
+            // A `readonly` source numeric index (a `ReadonlyArray`-derived shape)
+            // is assignable to a readonly target but NOT to a mutable one; a
+            // mutable source is assignable to either.
             if let Some(num_idx) = s_shape.number_index
-                && !num_idx.readonly
+                && (target_readonly || !num_idx.readonly)
             {
                 let array_shape = self.interner.object_shape(array_shape_id);
                 let source_has_full_array_surface = array_shape.properties.iter().all(|member| {
-                    member.optional || s_shape.properties.iter().any(|p| p.name == member.name)
+                    member.optional
+                        || s_shape.properties.iter().any(|p| p.name == member.name)
+                        || (target_readonly
+                            && crate::operations::property::property_helpers::is_array_mutating_method(
+                                self.interner.resolve_atom_ref(member.name).as_ref(),
+                            ))
                 });
                 if source_has_full_array_surface {
                     return self.check_subtype(num_idx.value_type, t_elem);


### PR DESCRIPTION
Goal: green

Closes #13932. Follow-up to #13928.

## Structural rule
When the source is a heritage-flattened object shape declaring `extends ReadonlyArray<T>` (or mutable `extends Array<T>`) and the target is a readonly array (`readonly U[]` syntax form `ReadonlyType(Array)`, or the `ReadonlyArray<U>` generic-application form), `tsc` accepts the assignment covariantly when `T <: U`. tsz now decides this through the solver subtype dispatch (`relations/subtype/core_dispatch.rs`), the same branch #13928 added for mutable array targets.

`tsc` treats array assignability covariantly, so `S <: readonly U[]` reduces to the element relation on the source's numeric-index value type. PR #13928 handled only mutable `U[]` targets, because the trigger used `array_element_type`, which matches `TypeData::Array` and therefore neither readonly form. The readonly forms fell through to failure (`TS2322`).

## Owner layer
Solver — `crates/tsz-solver/src/relations/subtype/core_dispatch.rs`, the object-source-vs-array branch.

- Recognize readonly array targets via the existing `readonly_array_syntax_element` / `readonly_array_application_element` extractors and carry a `target_readonly` flag.
- Gate the readonly direction: a `readonly` source numeric index (a `ReadonlyArray`-derived shape) satisfies a readonly target but **not** a mutable one; a mutable source satisfies either. The mutable-target path is byte-for-byte unchanged.
- The member-surface gate scans the **always-registered mutable `Array<T>` base**, skipping the mutating methods for a readonly target. `ReadonlyArray<T>`'s surface is exactly `Array<T>` minus the mutating methods, so the gate reuses the canonical `is_array_mutating_method` predicate (now `pub(crate)`, documented as the structural difference between the two member sets) rather than registering a separate `ReadonlyArray` base — an attempt to register that global broke property-access resolution, whose consumers (`property_helpers`, narrowing) expect the `Lazy`/application base form.
- The readonly arm runs **before** the readonly-peel below it, so a legitimately readonly source is not stripped to a mutable comparison and then rejected by the mutable-direction guard.

This deliberately avoids materializing the instantiated array interface for a full structural comparison, which would re-enter instantiation/evaluation in the hot dispatch path and can exhaust the relation depth limit on deep generic sources.

## Adjacent-case matrix (new regression tests, `extends_readonly_array_assignability_tests.rs`)
| Case | Expected | Status |
|---|---|---|
| `extends ReadonlyArray<string>` source → `readonly string[]` / `ReadonlyArray<string>` | accept | was `TS2322` |
| mutable `extends Array<number>` source → `readonly number[]` (mutable → readonly) | accept | was `TS2322` |
| `extends ReadonlyArray<string>` → `readonly (string \| number)[]` (covariant widen) | accept | was `TS2322` |
| `extends ReadonlyArray<string>` source → mutable `string[]` (readonly → mutable) | reject | unchanged (correct) |
| `extends ReadonlyArray<string \| number>` → `readonly string[]` (element mismatch) | reject | unchanged (correct) |

A bare `{ [n: number]: T }` (`Record<number, T>`) still fails the member-surface gate against a readonly target (it lacks `map`/`filter`/…), so it is rejected, matching `tsc`.

## Verification
- `cargo test -p tsz-checker --test extends_readonly_array_assignability_tests` — 5/5 pass (the matrix above).
- `cargo test -p tsz-checker --test ts2339_readonly_array_mutating_methods_tests --test array_subclass_inheritance_tests` — pass (readonly mutating-method rejection and array-subclass inheritance unaffected).
- Broader readonly/array checker suites pass; the only 2 failures (`ts2540_readonly_tests::test_deep_readonly_function_branch_all_levels_error`, `test_nested_readonly_survives_prior_receiver_assignment`) are pre-existing on `main` (verified via `git stash`) and unrelated (`DeepReadonly` recursive mapped types).
- `cargo clippy -p tsz-solver --lib` clean; `cargo fmt` clean.
- Broad conformance (`readonly` / `array` / `assignmentCompatibility`) and the fp-ts canary are owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xe88Ti1bPtdHoY3StQoj56)_