### PR TITLE
perf(solver): bound the failure-explanation eval storm with a work budget (#13243)

### DIFF
--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -421,6 +421,9 @@ mod constraint_tests;
 #[path = "tests/evaluate_type_param_collection_tests.rs"]
 mod evaluate_type_param_collection_tests;
 #[cfg(test)]
+#[path = "tests/explain_budget_tests.rs"]
+mod explain_budget_tests;
+#[cfg(test)]
 #[path = "../tests/function_comprehensive_tests.rs"]
 mod function_comprehensive_tests;
 #[cfg(test)]

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -342,6 +342,21 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// `ts-morph`) without ever leaking a context-bound verdict to a later
     /// query under a different context. Cleared by [`SubtypeChecker::reset`].
     pub(crate) local_relation_cache: FxHashMap<RelationCacheKey, bool>,
+    /// Configured work budget for one failure-explanation traversal (issue
+    /// #13243). Defaults to [`super::explain::EXPLAIN_EVAL_BUDGET`]; lowered in
+    /// tests via [`Self::with_explain_budget`] to exercise the exhaustion path.
+    /// Loaded into [`Self::explain_eval_fuel`] at the outermost
+    /// [`Self::explain_failure`] entry.
+    pub(crate) explain_budget: u32,
+    /// Remaining work budget for the *current* failure-explanation traversal,
+    /// or `None` outside the explain pass (issue #13243). `Some(_)` doubles as
+    /// the "in explain" marker, so only the failure-explanation traversal —
+    /// never the boolean relation walk — is budgeted.
+    ///
+    /// See [`super::explain::EXPLAIN_EVAL_BUDGET`] for why a separate budget is
+    /// needed and how it preserves byte-identical diagnostics; initialized per
+    /// failure by [`Self::explain_failure`].
+    pub(crate) explain_eval_fuel: Option<u32>,
 }
 
 /// Operation-local cache statistics for [`SubtypeChecker`].
@@ -416,6 +431,8 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             type_param_equivalences: Vec::new(),
             maybe_keys: Vec::new(),
             local_relation_cache: FxHashMap::default(),
+            explain_budget: super::explain::EXPLAIN_EVAL_BUDGET,
+            explain_eval_fuel: None,
         }
     }
 }
@@ -467,6 +484,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             type_param_equivalences: Vec::new(),
             maybe_keys: Vec::new(),
             local_relation_cache: FxHashMap::default(),
+            explain_budget: super::explain::EXPLAIN_EVAL_BUDGET,
+            explain_eval_fuel: None,
         }
     }
 
@@ -508,6 +527,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Configure whether recursive relation cycles should be assumed related.
     pub const fn with_assume_related_on_cycle(mut self, assume: bool) -> Self {
         self.assume_related_on_cycle = assume;
+        self
+    }
+
+    /// Override the failure-explanation work budget (issue #13243).
+    ///
+    /// Lowering the budget bounds the elaboration the explain pass performs
+    /// before collapsing to a coarse `TypeMismatch`; the default
+    /// ([`super::explain::EXPLAIN_EVAL_BUDGET`]) is sized so that legitimate
+    /// diagnostics never reach it. Test seam for exercising the exhaustion path
+    /// deterministically without constructing a pathological generic relation.
+    #[cfg(test)]
+    pub(crate) const fn with_explain_budget(mut self, budget: u32) -> Self {
+        self.explain_budget = budget;
         self
     }
 
@@ -596,6 +628,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.eval_cache.clear();
         self.maybe_keys.clear();
         self.local_relation_cache.clear();
+        self.explain_eval_fuel = None;
     }
 
     /// Return entry and size accounting for this checker's operation-local caches.

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -21,6 +21,18 @@ use crate::visitor::{
     union_list_id,
 };
 
+/// Work budget for one failure-explanation traversal; see
+/// [`SubtypeChecker::explain_eval_fuel`] (issue #13243).
+///
+/// Sized well above any legitimate single-diagnostic elaboration — the deepest
+/// `tsc`-parity chains drill at most a few hundred distinct sub-types — and far
+/// below the unbounded breadth of a pathological deeply-generic relation, so it
+/// never alters rendered diagnostics on terminating workloads while still
+/// bounding the explain pass on inputs that would otherwise not terminate. The
+/// magnitude mirrors the proven eval-fuel bound added to the diagnostic display
+/// pass in PR #13176.
+pub(crate) const EXPLAIN_EVAL_BUDGET: u32 = 16_000;
+
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Array element type, transparently peeling a single `readonly` array
     /// wrapper (`readonly T[]` / `ReadonlyArray<T>`).
@@ -195,12 +207,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: TypeId,
         target: TypeId,
     ) -> Option<SubtypeFailureReason> {
-        // Route the public entry through the guarded path so the recursion
-        // guard brackets every elaboration, including the nested branch /
-        // member / constraint explanations that call `explain_failure_guarded`
-        // directly. Bracketing only here would leave those nested paths
-        // unguarded (see `explain_failure_guarded`).
-        self.explain_failure_guarded(source, target)
+        // `explain_failure` is both the public entry *and* the recursion entry
+        // for nested member / element / branch elaborations (explain_function,
+        // explain_tuple, generics_application_helpers all call it). Only the
+        // outermost call initializes the per-failure work budget (#13243) — an
+        // already-active `Some(_)` fuel means a nested call, which shares the
+        // outer budget so the whole elaboration is bounded as one unit rather
+        // than refilling fuel at every level.
+        if self.explain_eval_fuel.is_some() {
+            return self.explain_failure_guarded(source, target);
+        }
+        self.explain_eval_fuel = Some(self.explain_budget);
+        // Route the entry through the guarded path so the recursion guard
+        // brackets every elaboration, including the nested branch / member /
+        // constraint explanations that call `explain_failure_guarded` directly.
+        let result = self.explain_failure_guarded(source, target);
+        self.explain_eval_fuel = None;
+        result
     }
 
     /// Guarded elaboration funnel. Every recursive elaboration path (object
@@ -217,6 +240,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: TypeId,
         target: TypeId,
     ) -> Option<SubtypeFailureReason> {
+        // Work budget exhausted (#13243): stop drilling and report the coarse
+        // verdict. The boolean relation already decided these types do not
+        // relate, so only elaboration detail is dropped — and only on
+        // pathological traversals that would otherwise not terminate. On
+        // terminating workloads the budget is never reached, so this is inert
+        // and rendered output is byte-identical.
+        if self.explain_eval_fuel == Some(0) {
+            return Some(SubtypeFailureReason::TypeMismatch {
+                source_type: source,
+                target_type: target,
+            });
+        }
         let pair = (source, target);
         match self.guard.enter(pair) {
             crate::recursion::RecursionResult::Entered => {}

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -1981,6 +1981,20 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if let Some(&cached) = self.eval_cache.get(&cache_key) {
             return cached;
         }
+        // Charge the failure-explanation work budget (#13243) for each distinct
+        // (cache-miss) evaluation. Cache hits above are free, so this counts the
+        // sub-types the explain pass actually drills into. Outside the explain
+        // pass the fuel is `None` and this is inert. When the budget is
+        // exhausted, return the type unevaluated and flagged unstable: the
+        // explain traversal then collapses to a coarse `TypeMismatch` (see
+        // `explain_failure_guarded`) instead of driving another combinatorial
+        // `instantiate_and_finalize_application`.
+        if let Some(fuel) = self.explain_eval_fuel.as_mut() {
+            if *fuel == 0 {
+                return (type_id, false);
+            }
+            *fuel -= 1;
+        }
         use crate::evaluation::cross_eval_guard;
         use crate::evaluation::evaluate::TypeEvaluator;
         // Per-query memo + cross-instance cycle break (#11586): the subtype checker

--- a/crates/tsz-solver/src/tests/explain_budget_tests.rs
+++ b/crates/tsz-solver/src/tests/explain_budget_tests.rs
@@ -1,0 +1,126 @@
+//! Tests for the failure-explanation work budget (issue #13243).
+//!
+//! The boolean relation walk short-circuits at the first failing branch, but
+//! the explain pass drills into every property / signature / branch the walk
+//! never visited, each driving a fresh `evaluate_type` → instantiation. On
+//! deeply-generic, diagnostic-heavy relations that breadth is combinatorial and
+//! does not terminate. `SubtypeChecker` caps the number of distinct (cache-miss)
+//! evaluations performed while elaborating one failure; once the budget is
+//! exhausted the remaining elaboration collapses to a coarse `TypeMismatch`,
+//! without changing the relation verdict.
+//!
+//! These tests assert the two ends of that contract:
+//! 1. With the default (generous) budget the explain pass produces its full
+//!    detailed reason — the budget is inert on terminating workloads.
+//! 2. With the budget forced to zero the very first elaboration collapses to
+//!    the coarse verdict — the bound is real and load-bearing.
+//!
+//! Property names are varied between cases so the behavior cannot depend on any
+//! particular binder string.
+
+use crate::PropertyInfo;
+use crate::diagnostics::SubtypeFailureReason;
+use crate::intern::TypeInterner;
+use crate::relations::subtype::SubtypeChecker;
+use crate::types::TypeId;
+
+/// `{ <keep>: string }` is not assignable to `{ <keep>: string; <missing>: number }`
+/// because `<missing>` is absent from the source. Returns `(source, target,
+/// missing_name_atom)`.
+fn missing_property_pair(
+    db: &TypeInterner,
+    keep: &str,
+    missing: &str,
+) -> (TypeId, TypeId, tsz_common::interner::Atom) {
+    let keep_atom = db.intern_string(keep);
+    let missing_atom = db.intern_string(missing);
+
+    let source = db.object(vec![PropertyInfo::new(keep_atom, TypeId::STRING)]);
+    let target = db.object(vec![
+        PropertyInfo::new(keep_atom, TypeId::STRING),
+        PropertyInfo::new(missing_atom, TypeId::NUMBER),
+    ]);
+
+    (source, target, missing_atom)
+}
+
+/// Names the failing property a reason blames, if it carries one. Used to prove
+/// the detailed elaboration survived (it identifies `<missing>` by name) while
+/// the collapsed elaboration does not.
+fn blamed_property(reason: &SubtypeFailureReason) -> Option<tsz_common::interner::Atom> {
+    match reason {
+        SubtypeFailureReason::MissingProperty { property_name, .. } => Some(*property_name),
+        SubtypeFailureReason::MissingProperties { property_names, .. } => {
+            property_names.first().copied()
+        }
+        _ => None,
+    }
+}
+
+#[test]
+fn default_budget_yields_detailed_missing_property_reason() {
+    let interner = TypeInterner::new();
+    let (source, target, missing) = missing_property_pair(&interner, "alpha", "beta");
+
+    let mut checker = SubtypeChecker::new(&interner);
+    let reason = checker
+        .explain_failure(source, target)
+        .expect("incompatible object types must produce a failure reason");
+
+    assert_eq!(
+        blamed_property(&reason),
+        Some(missing),
+        "default budget must keep the detailed missing-property elaboration, got {reason:?}"
+    );
+}
+
+#[test]
+fn exhausted_budget_collapses_to_coarse_type_mismatch() {
+    let interner = TypeInterner::new();
+    let (source, target, _missing) = missing_property_pair(&interner, "alpha", "beta");
+
+    // Budget of zero: the first elaboration node has no fuel and must report the
+    // bare verdict instead of drilling into the missing property.
+    let mut checker = SubtypeChecker::new(&interner).with_explain_budget(0);
+    let reason = checker
+        .explain_failure(source, target)
+        .expect("a failing relation must still produce a reason under an exhausted budget");
+
+    assert!(
+        matches!(
+            reason,
+            SubtypeFailureReason::TypeMismatch {
+                source_type,
+                target_type,
+            } if source_type == source && target_type == target
+        ),
+        "exhausted budget must collapse to the coarse TypeMismatch verdict, got {reason:?}"
+    );
+}
+
+#[test]
+fn budget_behavior_is_independent_of_property_names() {
+    // Same structural shape, different binder names: the detailed-vs-collapsed
+    // contract must not depend on the identifiers chosen.
+    let interner = TypeInterner::new();
+    let (source, target, missing) = missing_property_pair(&interner, "first_key", "second_key");
+
+    let mut detailed = SubtypeChecker::new(&interner);
+    assert_eq!(
+        blamed_property(
+            &detailed
+                .explain_failure(source, target)
+                .expect("must produce a reason")
+        ),
+        Some(missing),
+    );
+
+    let mut collapsed = SubtypeChecker::new(&interner).with_explain_budget(0);
+    let reason = collapsed
+        .explain_failure(source, target)
+        .expect("must produce a reason");
+    assert!(
+        matches!(reason, SubtypeFailureReason::TypeMismatch { .. }),
+        "got {reason:?}"
+    );
+}


### PR DESCRIPTION
Goal: fast

Closes part of #13243 (workstream B / plan item 3).

## Structural rule
When an assignment fails, `tsc`'s `checkTypeRelatedTo` produces the verdict and
the elaboration in one bounded walk. tsz computes the boolean relation (which
short-circuits at the first failing branch), then the failure-explanation
("explain") pass drills into **every** property, signature, and conditional
branch the boolean walk never visited — each driving a fresh `evaluate_type ->
instantiate_and_finalize_application`. On deeply-generic, diagnostic-heavy
relations that breadth is combinatorial and does not terminate (the kysely DNF
documented at the tail of #13243: ~110k–130k `InferSubstitutor::substitute`
frames, 0 diagnostics, 400s timeout).

This PR bounds that traversal: when tsz elaborates a failure reason it now
charges a **work fuel** per distinct (cache-miss) evaluation, owned by the
solver's explain pass.

## Why the existing guards don't catch it (verified at HEAD)
- The shared `eval_cache` does not help: the explain pass evaluates sub-types
  the boolean walk short-circuited **past**, so they are cache misses.
- The shared `RecursionGuard` (depth 100 / 100k iterations) does not trip: it
  counts `(source, target)` explain **pairs**, not the per-pair
  evaluate/instantiate work. A handful of pairs each driving a deep generic
  instantiation stays well under the pair budget while the aggregate runs away.

## Owner layer
Solver, `relations/subtype`. The fuel lives on `SubtypeChecker`:
- `explain_eval_fuel: Option<u32>` — `Some(n)` while the explain pass is active
  (the `Some` doubles as the "in explain" marker, so the boolean relation walk,
  fuel `None`, is never charged), `None` otherwise.
- The outermost `explain_failure` loads `explain_budget` into the fuel; nested
  member/element/branch elaborations (which re-enter `explain_failure`) share
  the one budget rather than refilling it.
- Each cache-miss `evaluate_type_with_stability` during the explain pass charges
  one unit. On exhaustion `evaluate_type` returns the type unevaluated +
  unstable, and `explain_failure_guarded` collapses to the coarse `TypeMismatch`
  verdict — the **same** coarse reason the depth/iteration guards already emit.

The relation verdict is already decided by the boolean walk, so no information
about *whether* the types relate is lost — only elaboration detail, and only on
traversals that would otherwise not terminate.

## Byte-identity / fallback
`EXPLAIN_EVAL_BUDGET = 16_000` is far above any legitimate single-diagnostic
elaboration (the deepest `tsc`-parity chains drill at most a few hundred
distinct sub-types) and well below the unbounded pathological breadth, mirroring
the proven display-pass eval-fuel bound from #13176. On terminating
conformance/fourslash workloads the budget is never reached, so the check is
inert and rendered diagnostics stay byte-identical. The fallback (exhaustion ->
`TypeMismatch`) is the existing coarse-verdict path, not a new message shape.

## Adjacent-case matrix
- Detailed missing-property elaboration preserved under the default budget
  (counter-asserted: full reason still produced).
- Exhausted budget (budget = 0) collapses the very first elaboration node to the
  coarse `TypeMismatch` — the bound is real and load-bearing.
- Same structural shape with different binder/property names: identical
  detailed-vs-collapsed behavior (no name dependence).

## Verification
- `cargo test -p tsz-solver --lib explain_budget` — 3 new tests pass.
- `cargo clippy -p tsz-solver --lib --tests` — clean (no warnings).
- Byte-identical-diagnostics and non-termination bounding are covered by the
  ready-review conformance/fourslash CI gates (broad suites not run locally per
  the repo contract).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01RwuGudHGgVUmU5e23d4w6N)_