### PR TITLE
test(checker): type-interner count guards for lib-heritage laziness (#13937)

### DIFF
--- a/crates/tsz-checker/src/test_utils.rs
+++ b/crates/tsz-checker/src/test_utils.rs
@@ -1019,7 +1019,27 @@ pub fn check_source_with_libs(
             checker.ctx.diagnostics.clone()
         });
     }
+    with_checked_source_with_libs(source, file_name, options, lib_files, |checker, _types| {
+        checker.ctx.diagnostics.clone()
+    })
+}
 
+/// Run the canonical parse → bind → check pipeline **with `lib_files` wired
+/// in**, handing the post-check `CheckerState` and the live [`TypeInterner`]
+/// to `extract`. Shared body for the libs-based public helpers so any change
+/// to lib-context setup applies to all of them, and so callers that need the
+/// interner (e.g. type-count probes) don't have to copy the pipeline.
+///
+/// Callers that want the no-libs fast path should special-case
+/// `lib_files.is_empty()` and route to [`with_checked_source`]; this helper
+/// always installs lib contexts (an empty list when `lib_files` is empty).
+fn with_checked_source_with_libs<R>(
+    source: &str,
+    file_name: &str,
+    options: CheckerOptions,
+    lib_files: &[Arc<LibFile>],
+    extract: impl FnOnce(&CheckerState<'_>, &TypeInterner) -> R,
+) -> R {
     let mut parser = ParserState::new(file_name.to_string(), source.to_string());
     let source_file = parser.parse_source_file();
 
@@ -1047,7 +1067,32 @@ pub fn check_source_with_libs(
     checker.ctx.set_actual_lib_file_count(lib_files.len());
 
     checker.check_source_file(source_file);
-    checker.ctx.diagnostics.clone()
+    extract(&checker, &types)
+}
+
+/// Parse, bind, and type-check `source` with `lib_files`, returning the
+/// diagnostics alongside the number of types interned during the check
+/// ([`TypeInterner::len`]).
+///
+/// This is the in-process analogue of `tsz --extendedDiagnostics`'s
+/// "Types" counter: it exposes how much of the lib-type graph a check
+/// materialized. Lazy lib-interface heritage/member work (#12101, #13933,
+/// #13935, #13936) is measured exactly by this count — a regression that
+/// re-eagerly materializes a receiver's transitive `extends` closure shows
+/// up here as a multi-thousand-type jump even when diagnostics stay
+/// byte-identical. The absolute value depends on the bundled stripped lib
+/// assets (so it differs from the `dist` binary's full-lib numbers), but it
+/// is deterministic for a fixed lib set, which is what a regression guard
+/// needs.
+pub fn check_source_with_libs_type_count(
+    source: &str,
+    file_name: &str,
+    options: CheckerOptions,
+    lib_files: &[Arc<LibFile>],
+) -> (Vec<Diagnostic>, usize) {
+    with_checked_source_with_libs(source, file_name, options, lib_files, |checker, types| {
+        (checker.ctx.diagnostics.clone(), types.len())
+    })
 }
 
 /// `(code, message_text)` projection of [`check_source_with_libs`].

--- a/crates/tsz-checker/src/tests/lazy_lib_heritage_guard_tests.rs
+++ b/crates/tsz-checker/src/tests/lazy_lib_heritage_guard_tests.rs
@@ -119,6 +119,165 @@ fn messageport_onmessage_event_clean() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Type-interner count harness (the perf side of #13937).
+//
+// `merge_lib_interface_heritage` over-materializing a lib-interface receiver's
+// transitive `extends` closure is invisible to a diagnostic-only guard: the
+// extra thousands of interned types are dropped after a single member lookup,
+// so diagnostics stay byte-identical while `tsz --extendedDiagnostics`'s "Types"
+// counter balloons. These guards make that count observable and bounded so the
+// lazy-heritage rework (#13933 producer / #13935 consumer / #13936
+// relation-input) can iterate locally on the actual lever instead of only the
+// diagnostic surface.
+//
+// Counts are the in-process analogue of `--extendedDiagnostics`; their absolute
+// value depends on the bundled stripped lib assets (smaller than the `dist`
+// binary's full-lib numbers), but is deterministic for a fixed lib set, so the
+// margins below are expressed relative to the trivial-file baseline rather than
+// hardcoded totals.
+// ---------------------------------------------------------------------------
+
+/// Trivial source whose interned-type count is the per-lib-set baseline floor
+/// every other count is measured against.
+const TRIVIAL_SOURCE: &str = "const c = 1; export {};";
+
+/// Max types a **lazy** lib-interface receiver may intern above the trivial
+/// baseline. Today (default bundle) `Document`/`HTMLElement`/`Node`
+/// annotations add ≤ ~440 over the floor, while the eager (un-deferred)
+/// heritage path adds ≥ ~`4_600`; `2_000` sits cleanly between, so a regression
+/// that re-materializes a lazy receiver's `extends` closure trips this bound
+/// long before it reaches the eager cost.
+const LAZY_RECEIVER_MARGIN: usize = 2_000;
+
+/// Ceiling (above baseline) for the interfaces that **currently** over-
+/// materialize — the lazy-heritage rework's target. Today the worst case
+/// (`Worker` + member access) adds ~`7_800` over the floor; this only guards
+/// against the count getting *worse*. When #13933/#13935/#13936 land and drop
+/// these under [`LAZY_RECEIVER_MARGIN`], move the affected cases into the
+/// lazy-floor guards above and tighten this ratchet.
+const EAGER_RECEIVER_CEILING: usize = 10_000;
+
+/// Interned-type count for `source` under the default lib bundle (strict),
+/// asserting no lazy-heritage hazard diagnostic surfaced first (a dropped base
+/// would corrupt both the count and the diagnostics).
+fn type_count(source: &str) -> usize {
+    use crate::test_utils::check_source_with_libs_type_count;
+    let libs = load_default_lib_files();
+    let (diagnostics, count) = check_source_with_libs_type_count(
+        source,
+        "guard.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    );
+    let hazards: Vec<u32> = diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.code)
+        .filter(|code| HERITAGE_HAZARD_CODES.contains(code))
+        .collect();
+    assert!(
+        hazards.is_empty(),
+        "type_count({source:?}) surfaced lazy-heritage hazard diagnostics {hazards:?}",
+    );
+    count
+}
+
+fn assert_lazy_receiver(label: &str, source: &str) {
+    let base = type_count(TRIVIAL_SOURCE);
+    let count = type_count(source);
+    assert!(
+        count <= base + LAZY_RECEIVER_MARGIN,
+        "{label}: interned {count} types (baseline {base}), exceeding the lazy ceiling \
+         {} — a lib-interface receiver that should resolve lazily is materializing its \
+         full heritage closure (#12101/#13933 regression)",
+        base + LAZY_RECEIVER_MARGIN,
+    );
+}
+
+/// The trivial-file baseline must not silently balloon (a regression there
+/// would mask every relative bound below).
+#[test]
+fn trivial_baseline_is_bounded() {
+    let base = type_count(TRIVIAL_SOURCE);
+    assert!(
+        base <= 1_500,
+        "trivial file interned {base} types; the baseline floor regressed",
+    );
+}
+
+/// `Document` (the shipped #12101 lazy-receiver win) stays at the lazy floor
+/// for both a bare annotation and a property read — member access must not
+/// force the receiver's heritage closure.
+#[test]
+fn document_receiver_stays_lazy() {
+    assert_lazy_receiver("Document annotation", "declare const d: Document; void d;");
+    assert_lazy_receiver(
+        "Document.title read",
+        "declare const d: Document; const t = d.title; void t;",
+    );
+}
+
+/// Property access on a lazy receiver must add no materialization over the bare
+/// annotation — the invariant that makes `document.title` cheap.
+#[test]
+fn property_access_adds_no_materialization() {
+    let annotation = type_count("declare const d: Document; void d;");
+    let property = type_count("declare const d: Document; const t = d.title; void t;");
+    assert!(
+        property <= annotation,
+        "Document.title interned {property} types vs {annotation} for the bare annotation; \
+         member access is forcing receiver materialization (#12101 regression)",
+    );
+}
+
+/// `HTMLElement` and `Node` resolve lazily today and must stay that way; the
+/// heritage rework must not regress the receivers that already win.
+#[test]
+fn htmlelement_and_node_receivers_stay_lazy() {
+    assert_lazy_receiver(
+        "HTMLElement annotation",
+        "declare const e: HTMLElement; void e;",
+    );
+    assert_lazy_receiver("Node annotation", "declare const n: Node; void n;");
+}
+
+/// Ratchet for the campaign-target interfaces (messaging / deep heritage) that
+/// over-materialize today. They sit above the lazy margin now; this only fails
+/// if the count grows past [`EAGER_RECEIVER_CEILING`]. The rework drives them
+/// under [`LAZY_RECEIVER_MARGIN`], at which point they graduate to the
+/// lazy-floor guards above.
+#[test]
+fn eager_receivers_stay_below_ratchet() {
+    let base = type_count(TRIVIAL_SOURCE);
+    let ceiling = base + EAGER_RECEIVER_CEILING;
+    for (label, source) in [
+        ("Worker annotation", "declare const w: Worker; void w;"),
+        (
+            "Worker.addEventListener",
+            "declare const w: Worker; w.addEventListener(\"message\", (e) => { void e.data; });",
+        ),
+        (
+            "MessagePort annotation",
+            "declare const p: MessagePort; void p;",
+        ),
+        (
+            "HTMLDivElement annotation",
+            "declare const e: HTMLDivElement; void e;",
+        ),
+    ] {
+        let count = type_count(source);
+        assert!(
+            count <= ceiling,
+            "{label}: interned {count} types (baseline {base}), exceeding the over-\
+             materialization ratchet {ceiling}; lib-interface heritage materialization \
+             regressed further (#13933/#13935/#13936)",
+        );
+    }
+}
+
 /// Floor sanity (#12158): an already-lazy own property read stays clean — the
 /// heritage rework must not regress the member-access laziness already shipped.
 #[test]


### PR DESCRIPTION
Completes the **perf-side deliverable of #13937** — the `--extendedDiagnostics` type-count assertion harness — left undone by the diagnostic-only guard suite that already landed in #13948.

## Structural rule
When a property access or relation touches a `Lazy(DefId)` lib-interface receiver, `tsc`/`tsgo` resolve only the touched member; `tsz` must not materialize the receiver's full structural shape + transitive `extends` closure (the #12101/#13933/#13935/#13936 lever). That over-materialization is **invisible to a diagnostic-only guard**: `merge_lib_interface_heritage` lowers the whole closure, then drops it after a single member lookup, so diagnostics stay byte-identical while the interned-type count balloons by thousands. This PR makes that count observable and bounded in fast local tests so the lazy-heritage rework can iterate on the actual lever before a CI round-trip.

## What landed (test-only, behavior unchanged)
- **`check_source_with_libs_type_count`** (`test_utils`): returns diagnostics plus `TypeInterner::len()`, the in-process analogue of `--extendedDiagnostics`'s "Types" counter.
- **Owner-layer cleanup**: factored the libs pipeline into a shared `with_checked_source_with_libs` closure helper so `check_source_with_libs` and the new probe no longer duplicate ~30 lines of setup (drift hazard), and future tests can read any post-check state without copying the pipeline.
- **Guards** (`lazy_lib_heritage_guard_tests`):
  - *Lazy-floor lock-in* for the shipped #12101 receivers — `Document`/`HTMLElement`/`Node` annotations stay within a small margin of the trivial-file baseline, and `document.title` adds no materialization over the bare annotation.
  - *Ratchet ceiling* for the campaign-target interfaces (`Worker`/`MessagePort`/`HTMLDivElement`) that over-materialize today; it fails only if the count grows worse, and graduates cases to the lazy-floor guards once the rework drops them under the lazy margin.

Bounds are expressed **relative to the trivial-file baseline**, not hardcoded totals, so they survive lib-asset churn. Assertions are shape-driven, not name-keyed; the helper also asserts no lazy-heritage hazard diagnostic (`TS2339/2740/2488/2345/2322`) surfaced, so a dropped heritage base trips both the count and the diagnostic.

## Adjacent matrix
Lazy (must stay cheap): `Document` annotation + `.title` read, `HTMLElement`, `Node`. Eager (ratchet): `Worker` annotation + `.addEventListener`, `MessagePort`, `HTMLDivElement`. Plus the trivial-baseline floor sanity.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-checker --lib lazy_lib_heritage_guard` → 12 passed (7 existing diagnostic guards + 5 new count guards).
- `cargo test -p tsz-checker --lib test_utils::tests` → 41 passed (confirms the `check_source_with_libs` refactor is behavior-preserving).
- `cargo clippy -p tsz-checker --tests` → clean.
- `cargo fmt -p tsz-checker --check` → clean.
- Rebased on `origin/main` (post #13953); guard ceilings still hold.

https://claude.ai/code/session_01PgfjFJXtMtX6tkfnrhN6ZW

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgfjFJXtMtX6tkfnrhN6ZW)_