### PR TITLE
fix(solver): classify readonly T[] wrapper as element-indexable by its inner type

### DIFF
--- a/crates/tsz-solver/src/type_queries/extended.rs
+++ b/crates/tsz-solver/src/type_queries/extended.rs
@@ -1156,6 +1156,16 @@ pub fn classify_element_indexable_with_resolver<R: crate::relations::subtype::Ty
     match db.lookup(evaluated) {
         Some(TypeData::Array(_)) => ElementIndexableKind::Array,
         Some(TypeData::Tuple(_)) => ElementIndexableKind::Tuple,
+        // `readonly T[]` / `readonly [A, B]` (and any other `readonly` wrapper)
+        // is exactly as element-indexable as the type it wraps — the `readonly`
+        // modifier constrains assignment, not indexing. Classify by the inner
+        // type. Without this the wrapper falls through to `Other`, so a
+        // `ReadonlyType` member of an intersection (e.g. the `readonly A[]` half of
+        // a `ReadonlyNonEmptyArray = readonly A[] & { readonly 0: A }`) is treated
+        // as non-indexable, producing a false TS7053 on `x[n]`.
+        Some(TypeData::ReadonlyType(inner)) => {
+            classify_element_indexable_with_resolver(db, resolver, inner)
+        }
         Some(TypeData::ObjectWithIndex(shape_id)) => {
             let shape = db.object_shape(shape_id);
             let has_late_bound = shape


### PR DESCRIPTION
Goal: green

## Summary
`classify_element_indexable` (the shared element-indexability query for `TS7053`/indexed-access) had no arm for `TypeData::ReadonlyType`, so a `readonly` wrapper fell through to `Other` (not element-indexable). A standalone `readonly T[]` indexes fine via the dedicated array-element path, but **as a member of an intersection** it routes through this classifier — so `ReadonlyNonEmptyArray<A> = readonly A[] & { readonly 0: A }` was classified as non-numeric-indexable and `x[n]` produced a false `TS7053`.

## Structural Rule
`readonly` constrains assignment, not indexing, so a `ReadonlyType(inner)` is exactly as element-indexable as `inner`. When `classify_element_indexable_with_resolver` sees `TypeData::ReadonlyType(inner)`, classify by recursing on `inner` (`crates/tsz-solver/src/type_queries/extended.rs`).

- **Owner layer:** solver — `type_queries` element-indexability classifier; both consumers (`access_helpers.rs`, `element_indexable.rs`) share it, so one arm fixes both.
- **Fallback:** a non-indexable inner (e.g. `readonly { a: number }` indexed by number) recurses to `ObjectWithIndex { has_number: false }` and still correctly reports `TS7053`. The change is monotonic — it can only turn a previously-`Other` readonly wrapper into its inner classification, never suppress a genuine error.

### Adjacent-case matrix (verified)
| Source → index | Expected | tsz |
|---|---|---|
| `readonly number[] & { readonly 0: number }` `[1]` | ok | ok |
| `number[] & { x: 1 }` `[0]` (mutable, control) | ok | ok |
| `Array<string> & { brand: 1 }` `[0]` (named, control) | ok | ok |
| `readonly number[]` `[0]` (standalone, control) | ok | ok |
| `g<A>(xs: readonly A[] & { readonly 0: A })` → `xs[2]` | ok | ok |
| `readonly { a: number }` `[n]` (non-indexable inner) | error | error (preserved) |

## Project Corpus Impact
- **fp-ts:** −28 false positives (all remaining `TS7053`, → 0; the `ReadonlyNonEmptyArray` indexing pattern), no new errors.
- **immer / tanstack-query:** unchanged (7 / 79).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- Minimal repros (`readonly A[] & { readonly 0: A }` indexing, generic + concrete + non-indexable-inner) diffed against `node typescript/lib/tsc.js` — tsz now matches tsc.
- Conformance `scripts/conformance/conformance.sh run --filter <fam>`: **15 families 100% pass, zero regressions** — indexedAccess, array, tuple, readonly, intersection, members, mappedType, typeRelationships, subtyping, comparable, generics, narrowing, keyof, indexSignature, genericObjectRest.
- fp-ts/immer/tanstack-query measured against a freshly-built clean-main binary.
- `cargo clippy -p tsz-solver --all-targets -- -D warnings` clean (no new `#[allow]`); `cargo fmt` clean.