### PR TITLE
fix(checker): classify node:-scheme-only builtins distinctly from their npm package names

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/capabilities.rs
+++ b/crates/tsz-checker/src/query_boundaries/capabilities.rs
@@ -285,17 +285,39 @@ pub(crate) fn is_known_node_global(name: &str) -> bool {
 /// instead of TS2307 ("Cannot find module 'X'").
 ///
 /// This is the single source of truth for "is this a Node.js builtin module
-/// specifier?". The list mirrors `@types/node`'s ambient `declare module`
+/// specifier?". The set mirrors `@types/node`'s ambient `declare module`
 /// surface and includes the documented subpath builtins (`fs/promises`,
 /// `stream/promises`, `path/posix`, …). tsc classifies a subpath builtin
 /// exactly like its base module, so they must share one set — otherwise the
 /// same import shape produces TS2591 for `fs` but TS2307 for `fs/promises`.
-/// The `node:`-prefixed spelling names the same builtin, so it is stripped
-/// before matching. Adding a name here means tsz no longer treats it as a
-/// resolvable user package on resolution failure.
+///
+/// Node builtins come in two spelling classes, and conflating them
+/// misclassifies real npm packages:
+/// - *Dual-spelled* builtins (`fs`, `fs/promises`, …) are reachable as both
+///   the bare name and the `node:`-prefixed name; `@types/node` declares both
+///   `declare module "fs"` and `declare module "node:fs"`.
+/// - *`node:`-scheme-only* builtins (`node:test`, `node:sqlite`, `node:sea`)
+///   are only reachable through the `node:` scheme; `@types/node` declares only
+///   the `node:`-prefixed form. The bare names (`test`, `sqlite`, `sea`) are
+///   valid, published npm packages, so they must keep the user-package TS2307
+///   path — an unconditional `node:` strip would wrongly classify
+///   `import "test"` as a Node builtin.
+///
+/// Adding a name here means tsz no longer treats it as a resolvable user
+/// package on resolution failure.
 pub(crate) fn is_known_node_module(specifier: &str) -> bool {
-    // Handle `node:` prefix (e.g., `node:fs`, `node:path`)
-    let name = specifier.strip_prefix("node:").unwrap_or(specifier);
+    match specifier.strip_prefix("node:") {
+        // `node:`-prefixed specifiers may name either class of builtin.
+        Some(name) => is_dual_spelled_node_builtin(name) || is_node_scheme_only_builtin(name),
+        // Bare specifiers only name a builtin if it is dual-spelled; the bare
+        // forms of the `node:`-only builtins are real npm packages.
+        None => is_dual_spelled_node_builtin(specifier),
+    }
+}
+
+/// Builtins `@types/node` declares under both the bare and `node:`-prefixed
+/// spellings (`fs`/`node:fs`, `fs/promises`/`node:fs/promises`, …).
+fn is_dual_spelled_node_builtin(name: &str) -> bool {
     matches!(
         name,
         "assert"
@@ -353,6 +375,13 @@ pub(crate) fn is_known_node_module(specifier: &str) -> bool {
             | "worker_threads"
             | "zlib"
     )
+}
+
+/// Builtins reachable only through the `node:` scheme. `@types/node` declares
+/// only the `node:`-prefixed form for these; their bare names are published
+/// npm packages, so they must not be matched without the scheme.
+fn is_node_scheme_only_builtin(name: &str) -> bool {
+    matches!(name, "test" | "test/reporters" | "sea" | "sqlite")
 }
 
 /// Check if a name is a known DOM/ScriptHost global that requires 'dom' lib (TS2584).
@@ -516,6 +545,26 @@ mod tests {
             assert!(
                 !is_known_node_module(other),
                 "expected non-builtin {other} to NOT be recognized"
+            );
+        }
+    }
+
+    #[test]
+    fn test_node_scheme_only_builtins_require_prefix() {
+        // `node:test`, `node:sqlite`, `node:sea` are builtins reachable only
+        // through the `node:` scheme; `@types/node` declares only the prefixed
+        // form. They must be recognized when prefixed...
+        for scheme_only in ["test", "test/reporters", "sea", "sqlite"] {
+            assert!(
+                is_known_node_module(&format!("node:{scheme_only}")),
+                "expected node:{scheme_only} to be recognized"
+            );
+            // ...and must NOT be recognized bare: `test`, `sea`, and `sqlite`
+            // are real, published npm packages. Treating the bare name as a
+            // builtin would steal the user-package TS2307 path.
+            assert!(
+                !is_known_node_module(scheme_only),
+                "expected bare {scheme_only} (an npm package) to NOT be recognized"
             );
         }
     }

--- a/crates/tsz-core/tests/module_resolution_tests_parts/part_00.rs
+++ b/crates/tsz-core/tests/module_resolution_tests_parts/part_00.rs
@@ -238,6 +238,58 @@ fn test_dynamic_import_of_node_builtin_uses_ts2591_with_no_types_and_symbols() {
 }
 
 #[test]
+fn test_dynamic_import_of_node_scheme_only_builtin_uses_ts2591() {
+    // `node:test`/`node:sqlite`/`node:sea` are builtins reachable only through
+    // the `node:` scheme, so they must classify exactly like `node:path`: the
+    // "install @types/node" family, never a raw TS2307.
+    let diags = check_with_module_not_found_errors(
+        r#"import("node:test");"#,
+        "no.ts",
+        vec![],
+        vec!["node:test"],
+        CheckerOptions {
+            module: crate::common::ModuleKind::Preserve,
+            no_types_and_symbols: true,
+            ..CheckerOptions::default()
+        },
+    );
+    assert!(
+        has_error_code(&diags, TS2591),
+        "Dynamic import of unresolved node:-only builtin should emit TS2591, got: {diags:?}"
+    );
+    assert!(
+        no_error_code(&diags, TS2307),
+        "Dynamic import of unresolved node:-only builtin should not emit TS2307, got: {diags:?}"
+    );
+}
+
+#[test]
+fn test_bare_test_package_is_not_a_node_builtin() {
+    // `test` (without the `node:` scheme) is a real, published npm package, not
+    // a builtin. It must keep the user-package module-not-found path rather than
+    // the "install @types/node" family that the `node:test` builtin uses.
+    let diags = check_with_module_not_found_errors(
+        r#"import("test");"#,
+        "no.ts",
+        vec![],
+        vec!["test"],
+        CheckerOptions {
+            module: crate::common::ModuleKind::Preserve,
+            no_types_and_symbols: true,
+            ..CheckerOptions::default()
+        },
+    );
+    assert!(
+        has_module_not_found(&diags),
+        "Bare `test` npm package should emit a module-not-found error, got: {diags:?}"
+    );
+    assert!(
+        no_error_code(&diags, TS2591),
+        "Bare `test` npm package must not take the @types/node TS2591 path, got: {diags:?}"
+    );
+}
+
+#[test]
 fn test_no_types_and_symbols_keeps_ts2591_for_node_builtin_imports() {
     let diags = check_with_module_not_found_errors(
         r#"import { parse } from "url";


### PR DESCRIPTION
Goal: hold

Refs #13826.

## Summary
`is_known_node_module` (the single classifier that decides whether an unresolved
module specifier takes the install-`@types/node` diagnostic family — TS2580/
TS2591 — instead of a raw TS2307) **unconditionally stripped the `node:` scheme**
before matching one builtin set. That conflated two structurally distinct classes
of Node builtin, and the single-set design could express neither correctly.

## Structural rule
`@types/node` declares Node builtins under two spelling regimes, mirroring the
Node runtime:

- **Dual-spelled builtins** (`fs`, `fs/promises`, `stream/promises`, …) are
  reachable as both the bare name and the `node:`-prefixed name; `@types/node`
  ships both `declare module "fs"` and `declare module "node:fs"`.
- **`node:`-scheme-only builtins** (`node:test`, `node:test/reporters`,
  `node:sqlite`, `node:sea`) are reachable **only** through the `node:` scheme;
  `@types/node` declares only the `node:`-prefixed form. Their bare names
  (`test`, `sqlite`, `sea`) are real, published **npm packages**.

`tsc` classifies a `node:`-only builtin exactly like any other builtin, and
classifies the bare npm package as a user package. tsz must match each.

## The bug
With the unconditional strip + one set:
- `node:test` was **unrecognized** — it fell through to a raw `TS2307` instead of
  the `@types/node` family when the types were absent (it should behave exactly
  like `node:path`).
- It could not be fixed by simply adding `test`/`sqlite`/`sea` to the set: that
  would strip `node:` off nothing and match the **bare** npm packages, stealing
  their user-package `TS2307` path.

## Fix
Split the predicate into the two classes (owner layer: checker query-boundary
classifier, `query_boundaries/capabilities.rs`):

- `node:`-prefixed specifiers match **either** the dual-spelled set **or** the
  `node:`-scheme-only set;
- bare specifiers match **only** the dual-spelled set.

No new identifier/file-name/printer-string predicate — this is true-builtin
enumeration only (permitted by the contract), and it *removes* a
class-conflation rather than adding a special case.

## Adjacent-case matrix
- `node:test`, `node:test/reporters`, `node:sqlite`, `node:sea` → recognized
  (now classify like `node:path`).
- bare `test`, `sqlite`, `sea` (npm packages) → **not** recognized; keep the
  user-package module-not-found path.
- dual-spelled `fs`, `fs/promises`, `node:fs/promises`, … → unchanged.
- lookalike user packages (`express`, `fs-extra`, `fsx`, `node:does-not-exist`)
  → unchanged (not recognized).

## Verification
- `cargo test -p tsz-checker --lib query_boundaries::capabilities::tests` — 11
  passed (incl. new `test_node_scheme_only_builtins_require_prefix`).
- `cargo test -p tsz-core --lib module_resolution_tests::` — 90 passed (incl. new
  end-to-end `test_dynamic_import_of_node_scheme_only_builtin_uses_ts2591` and
  `test_bare_test_package_is_not_a_node_builtin`).
- `cargo clippy -p tsz-checker --lib` — clean.
- `cargo fmt -p tsz-checker -p tsz-core -- --check` — clean.
- Broad conformance/emit/fourslash owned by ready-review CI per repo policy.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01H8w5K3WKHHJ3sGKBmsSxum

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8w5K3WKHHJ3sGKBmsSxum)_