### PR TITLE
fix(checker): reduce concrete indexed-access types for assignability diagnostic display

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -944,6 +944,9 @@ path = "tests/enum_equality_narrowing_tests.rs"
 name = "ts2367_comparison_overlap_tests"
 path = "tests/ts2367_comparison_overlap_tests.rs"
 [[test]]
+name = "concrete_indexed_access_display_tests"
+path = "tests/concrete_indexed_access_display_tests.rs"
+[[test]]
 name = "enum_indexed_access_tests"
 path = "tests/enum_indexed_access_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/type_display_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/type_display_policy.rs
@@ -72,6 +72,57 @@ impl<'a> CheckerState<'a> {
         resolved
     }
 
+    /// tsc resolves a *concrete* indexed-access type (`Obj["m"]` where the
+    /// object type and key are fully resolved, with no free type parameters) to
+    /// the member type during type construction (`getIndexedAccessType`), so it
+    /// never renders the `Obj["m"]` form in a diagnostic — it shows the reduced
+    /// member type. tsz keeps the indexed access deferred and rendered the
+    /// unreduced `Obj["m"]` form (e.g. `Property 'bar' is missing in type
+    /// 'Obj["m"]'` where tsc says `... in type '{ foo: string; }'`).
+    ///
+    /// Reduce it here for display, but only when concrete: an indexed access
+    /// that carries a free type parameter is *legitimately* deferred (tsc keeps
+    /// `T["m"]` too), and pre-resolving it risks `TS2589` on deeply-recursive
+    /// generic forms — so those are left opaque. This mirrors the deliberate
+    /// exclusion of [`Self::resolve_indexed_access_alias_for_display`] from the
+    /// assignment roles, but is strictly narrower: only a bare,
+    /// type-parameter-free indexed access with a literal key is touched.
+    pub(in crate::error_reporter) fn resolve_concrete_indexed_access_for_display(
+        &mut self,
+        ty: TypeId,
+    ) -> TypeId {
+        use crate::query_boundaries::common;
+        let db = self.ctx.types.as_type_database();
+        let Some(indexed) = common::get_indexed_access_type(db, ty) else {
+            return ty;
+        };
+        // Only a single string/number literal key reduces to one member;
+        // `keyof`/union keys keep the indexed-access form in tsc too. A literal
+        // key also structurally carries no free type parameters, so only the
+        // object side is checked for deferral below.
+        if !matches!(
+            common::classify_literal_type(db, indexed.index_type),
+            common::LiteralTypeKind::String(_) | common::LiteralTypeKind::Number(_)
+        ) {
+            return ty;
+        }
+        // A free type parameter in the object means the access is legitimately
+        // deferred (tsc renders `T["m"]`); never force-evaluate those.
+        if common::contains_free_type_parameters(db, indexed.object_type) {
+            return ty;
+        }
+        let resolved = self.evaluate_type_with_env(ty);
+        if resolved == ty
+            || crate::query_boundaries::diagnostics::is_unresolved_for_display(
+                self.ctx.types.as_type_database(),
+                resolved,
+            )
+        {
+            return ty;
+        }
+        resolved
+    }
+
     /// Widen literal annotations of `ty` for diagnostic display (#13075),
     /// using the type environment for display-time evaluation when it is
     /// available (so generic applications that evaluate to literals widen
@@ -125,6 +176,13 @@ impl<'a> CheckerState<'a> {
             | DiagnosticTypeDisplayRole::CallParameter { .. }
             | DiagnosticTypeDisplayRole::WeakCallParameter { .. } => {
                 self.resolve_indexed_access_alias_for_display(ty)
+            }
+            // A bare, concrete (type-parameter-free) indexed access is reduced
+            // to its member type, matching tsc's eager `getIndexedAccessType`.
+            // Generic/deferred accesses stay opaque (see the helper's docs).
+            DiagnosticTypeDisplayRole::AssignmentSource { .. }
+            | DiagnosticTypeDisplayRole::AssignmentTarget { .. } => {
+                self.resolve_concrete_indexed_access_for_display(ty)
             }
             _ => ty,
         };

--- a/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
+++ b/crates/tsz-checker/tests/concrete_indexed_access_display_tests.rs
@@ -1,0 +1,98 @@
+//! Display parity for concrete indexed-access types in assignability
+//! diagnostics.
+//!
+//! `tsc` resolves a *concrete* indexed-access type (`Obj["m"]` whose object and
+//! key are fully resolved, with no free type parameters) to its member type
+//! during type construction (`getIndexedAccessType`), so the type is never an
+//! indexed access by the time a diagnostic renders it — `tsc` shows the reduced
+//! member shape. tsz kept the access deferred and rendered the unreduced
+//! `Obj["m"]` surface in `TS2741`/`TS2322` assignability messages.
+//!
+//! The display policy now reduces a bare, type-parameter-free indexed access
+//! with a literal key to its member type for the assignment source/target
+//! roles, matching `tsc`. Generic/deferred accesses (a free type parameter in
+//! the object or key) stay opaque — `tsc` renders `T["m"]` there too — and are
+//! guarded by the existing `deferred_keyof_index_access_assignability_tests` /
+//! `deferred_conditional_indexed_access_tests` suites.
+
+use tsz_checker::test_utils::check_source_strict_messages;
+
+fn ts2741_messages(source: &str) -> Vec<String> {
+    check_source_strict_messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2741)
+        .map(|(_, message)| message)
+        .collect()
+}
+
+fn assert_reduced_member(message: &str, expected_member: &str) {
+    assert!(
+        message.contains(expected_member),
+        "source must render the reduced member shape `{expected_member}`: {message}"
+    );
+    assert!(
+        !message.contains("[\"") && !message.contains("['"),
+        "source must not render the unreduced indexed-access surface: {message}"
+    );
+}
+
+/// String-literal key: `Obj["m"]` renders as its member object, not `Obj["m"]`.
+#[test]
+fn concrete_string_indexed_access_source_renders_reduced_member() {
+    let messages = ts2741_messages(
+        r#"
+interface Obj { m: { foo: string } }
+declare function get(): Obj["m"];
+const bad: { foo: string; bar: string } = get();
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ foo: string; }");
+}
+
+/// Anti-hardcoding: the reduction keys on the structural concrete-indexed-access
+/// condition, not on the identifiers `Obj`/`m`. Renamed binders behave the same.
+#[test]
+fn concrete_indexed_access_source_reduction_is_binder_name_independent() {
+    let messages = ts2741_messages(
+        r#"
+interface Container { payload: { alpha: string } }
+declare function fetchPayload(): Container["payload"];
+const bad: { alpha: string; beta: string } = fetchPayload();
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ alpha: string; }");
+}
+
+/// Numeric-literal key: `Wrap[0]` reduces the same way.
+#[test]
+fn concrete_numeric_indexed_access_source_renders_reduced_member() {
+    let messages = ts2741_messages(
+        r#"
+interface Wrap { 0: { a: number } }
+declare function g(): Wrap[0];
+const bad: { a: number; b: number } = g();
+"#,
+    );
+    assert_eq!(messages.len(), 1, "exactly one TS2741: {messages:?}");
+    assert_reduced_member(&messages[0], "{ a: number; }");
+}
+
+/// The reduced member must still be related structurally, so a target that the
+/// member *does* satisfy stays clean — the reduction is display-only and never
+/// fabricates or suppresses a mismatch.
+#[test]
+fn concrete_indexed_access_assignable_target_stays_clean() {
+    let messages = ts2741_messages(
+        r#"
+interface Obj { m: { foo: string } }
+declare function get(): Obj["m"];
+const ok: { foo: string } = get();
+"#,
+    );
+    assert!(
+        messages.is_empty(),
+        "an assignable indexed-access member must not error: {messages:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

## Summary
A bare, fully-concrete indexed-access type (`Obj["m"]` whose object and key are
resolved with **no free type parameters**) was rendered **unreduced** in
`TS2741`/`TS2322` assignability messages, e.g.:

```
Property 'bar' is missing in type 'Obj["m"]' but required in type '{ foo: string; bar: string; }'
```

where `tsc` shows the reduced member shape:

```
Property 'bar' is missing in type '{ foo: string; }' but required in type '{ foo: string; bar: string; }'
```

`tsc` resolves a concrete indexed access to its member type at type
construction (`getIndexedAccessType`), so the type is never an indexed access
by the time a diagnostic renders. tsz deliberately keeps concrete accesses
deferred (lazy on-demand evaluation, needed for generic instantiation), so the
unreduced `Obj["m"]` surface leaked into the message. This is display-only —
the relation result was already correct; only the rendered source/target text
diverged.

## Structural rule
When the source/target of a `TS2322`/`TS2741` is a bare indexed-access type
`Obj[K]` where the object carries no free type parameters and `K` is a string
or number **literal**, `tsc` renders the resolved member type. tsz must match.
A free type parameter in the object (`T["m"]`) is *legitimately* deferred —
`tsc` renders `T["m"]` too — so those stay opaque.

## Owner layer
Checker diagnostic display — `error_reporter::type_display_policy`. New
`resolve_concrete_indexed_access_for_display` is applied only for the
`AssignmentSource`/`AssignmentTarget` display roles. It mirrors the existing
`resolve_indexed_access_alias_for_display` (which is deliberately **excluded**
from the assignment roles to avoid `TS2589` on deferred generic aliases) but is
strictly narrower: only a type-parameter-free indexed access with a literal key
is touched, and the evaluated result is dropped back to the original type when
it stays unresolved (`is_unresolved_for_display`). So the policy can never trip
`TS2589`, fabricate, or suppress a relation result. The printer asks the solver
to evaluate the type and then reads it — semantics stay in the solver.

## Anti-hardcoding
No identifier/file-name/printer-string predicates. The reduction keys purely on
the structural condition (concrete indexed access + literal key + no free type
parameters). The regression suite varies binder names.

## Adjacent-case matrix (new `concrete_indexed_access_display_tests.rs`)
- string-literal key `Obj["m"]` → reduced member object (the witness);
- renamed binders (`Container["payload"]`, anti-hardcoding) → reduced;
- numeric-literal key `Wrap[0]` → reduced;
- assignable target stays clean (reduction is display-only, never fabricates a
  mismatch).

Negative/deferred cases (a free type parameter keeps `T["m"]` opaque) remain
covered by the existing `deferred_keyof_index_access_assignability_tests` and
`deferred_conditional_indexed_access_tests` suites, which stay green.

## Scope note
This is the concrete-indexed-access facet of the broader assignability
display-reduction family that the `deeplyNestedMappedTypes.ts` accepted
regression also touches (`...["params"]`/`Static<...>` unreduced forms, #8432).
The identifier-source "as-written annotation" repaint path and reducible
type-alias applications are out of scope here and remain on their existing
display policy.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New `cargo test -p tsz-checker --test concrete_indexed_access_display_tests` — 4 passed (string/numeric/renamed-binder reductions + assignable-target-stays-clean).
- No regressions across the assignability/indexed-access/source-display families (run locally): `error_reporter` lib (187), `deeply_nested_mapped_types_tests`, `deferred_keyof_index_access_assignability_tests`, `deferred_conditional_indexed_access_tests`, `enum_indexed_access_tests`, `homomorphic_indexed_access_edge_cases`, `bare_alias_display_tests`, `conditional_alias_source_display_tests`, `union_source_missing_property_elaboration_tests`, `union_index_annotation_missing_key_tests`, `class_field_mapped_type_indexed_access_tests`, `typeof_chained_indexed_access_alias_tests`, `assertion_source_literal_display_tests`, and ~10 more — all green. (`generic_property_mismatch_display_tests`'s 9 failures are pre-existing on `main`, verified by `git stash`.)
- `cargo clippy -p tsz-checker --lib` clean; `cargo fmt` clean.
- `scripts/arch/check-checker-boundaries.sh` — Architecture guardrails passed (file 276 lines, under the 2000 ceiling).
- Broad conformance/emit/fourslash owned by ready-review CI per repo policy.

https://claude.ai/code/session_01SyTrZG6c28EB8yKQDsqQcK

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyTrZG6c28EB8yKQDsqQcK)_