### PR TITLE
fix(checker): gate sibling-literal expected-type display on bare type-parameter slot (#13956)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -818,6 +818,9 @@ path = "tests/commonjs_module_export_alias_tests.rs"
 name = "conditional_infer_tests"
 path = "tests/conditional_infer_tests.rs"
 [[test]]
+name = "inline_conditional_rest_spread_negative_display_tests"
+path = "tests/inline_conditional_rest_spread_negative_display_tests.rs"
+[[test]]
 name = "inline_conditional_infer_return_tests"
 path = "tests/inline_conditional_infer_return_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -661,6 +661,7 @@ impl<'a> CheckerState<'a> {
                     arg_types: &overload_resolution.arg_types,
                     callee_type: callee_type_for_resolution,
                     callee_has_declared_generic_signature: false,
+                    raw_callee_shape: None,
                     is_super_call: false,
                     is_optional_chain: nullish_cause.is_some(),
                     allow_contextual_mismatch_deferral: false,
@@ -1565,6 +1566,7 @@ impl<'a> CheckerState<'a> {
                             .iter()
                             .any(|sig| !sig.type_params.is_empty())
                     }),
+            raw_callee_shape: original_callee_shape.as_ref(),
             is_super_call,
             is_optional_chain: nullish_cause.is_some(),
             allow_contextual_mismatch_deferral,

--- a/crates/tsz-checker/src/types/computation/call/mod.rs
+++ b/crates/tsz-checker/src/types/computation/call/mod.rs
@@ -1353,6 +1353,17 @@ impl<'a> CheckerState<'a> {
             result = crate::query_boundaries::common::CallResult::Success(fallback_return);
         }
 
+        // Raw (uninstantiated) callee signature, used only for the literal-display
+        // heuristic in `handle_call_result` to inspect declared parameter slots.
+        let raw_callee_shape_owned = is_generic_call
+            .then(|| {
+                call_checker::get_contextual_signature_for_arity(
+                    self.ctx.types,
+                    callee_type_for_resolution,
+                    args.len(),
+                )
+            })
+            .flatten();
         let call_context = super::call_result::CallResultContext {
             callee_expr,
             call_idx: idx,
@@ -1360,6 +1371,7 @@ impl<'a> CheckerState<'a> {
             arg_types: &arg_types,
             callee_type: callee_type_for_call,
             callee_has_declared_generic_signature: is_generic_call,
+            raw_callee_shape: raw_callee_shape_owned.as_ref(),
             is_super_call,
             is_optional_chain,
             allow_contextual_mismatch_deferral,

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -13,7 +13,7 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{ParamInfo, TupleElement, TypeId};
+use tsz_solver::{FunctionShape, ParamInfo, TupleElement, TypeId};
 
 pub(super) struct CallResultContext<'a> {
     pub(super) callee_expr: NodeIndex,
@@ -22,6 +22,10 @@ pub(super) struct CallResultContext<'a> {
     pub(super) arg_types: &'a [TypeId],
     pub(super) callee_type: TypeId,
     pub(super) callee_has_declared_generic_signature: bool,
+    /// Uninstantiated callee signature (with `type_params` and raw parameter
+    /// types) used for structural display decisions that must inspect the
+    /// *declared* parameter slot rather than its post-inference instantiation.
+    pub(super) raw_callee_shape: Option<&'a FunctionShape>,
     pub(super) is_super_call: bool,
     pub(super) is_optional_chain: bool,
     pub(super) allow_contextual_mismatch_deferral: bool,
@@ -671,6 +675,7 @@ impl<'a> CheckerState<'a> {
     fn preferred_literal_expected_for_mismatch(
         &self,
         callee_has_declared_generic_signature: bool,
+        raw_callee_shape: Option<&FunctionShape>,
         arg_types: &[TypeId],
         args: &[NodeIndex],
         actual: TypeId,
@@ -713,6 +718,18 @@ impl<'a> CheckerState<'a> {
         if !callee_has_declared_generic_signature {
             return expected;
         }
+        // Repaint the widened-primitive `expected` with a sibling argument's
+        // literal type *only* when the declared parameter slot at `mismatch_index`
+        // is the bare type parameter that the sibling pinned (e.g. `f<T>(a: T, b: T)`
+        // called as `f("x", 1)` reports `"x"`). When the slot is a structural type
+        // that merely *evaluates* to the primitive — such as a conditional/indexed
+        // rest element `...[key: K, ...(Handlers[K] extends void ? [] : [value:
+        // Handlers[K]])]` whose `value` slot resolves to `string` — the widened
+        // `expected` is the genuine target, and a coincidental sibling literal
+        // (the `key`) must not replace it (#13956).
+        if !self.mismatch_param_slot_is_bare_type_parameter(raw_callee_shape, mismatch_index) {
+            return expected;
+        }
         arg_types
             .iter()
             .enumerate()
@@ -733,6 +750,48 @@ impl<'a> CheckerState<'a> {
                     })
             })
             .unwrap_or(expected)
+    }
+
+    /// Whether the declared parameter slot consumed by argument `arg_index` is a
+    /// bare type parameter (`T`) in the callee's *uninstantiated* signature.
+    ///
+    /// Inspects the raw (pre-inference) signature so a slot whose declared type
+    /// is itself `TypeData::TypeParameter` (e.g. `b: T`) is distinguished from a
+    /// structural type that merely *evaluates* to a primitive after inference
+    /// (e.g. `value: Handlers[K]`). Tuple rest parameters (`...args: [a: T,
+    /// ...Rest]`) are flattened into their per-position slots first (mirroring
+    /// the accept path). Name-agnostic: keys on type structure, not on
+    /// identifier or file-name strings.
+    fn mismatch_param_slot_is_bare_type_parameter(
+        &self,
+        raw_callee_shape: Option<&FunctionShape>,
+        arg_index: usize,
+    ) -> bool {
+        let Some(shape) = raw_callee_shape else {
+            return false;
+        };
+        let unpacked: Vec<ParamInfo> = shape
+            .params
+            .iter()
+            .flat_map(|param| common::unpack_tuple_rest_parameter(self.ctx.types, param))
+            .collect();
+        unpacked
+            .get(arg_index)
+            .or_else(|| unpacked.last().filter(|param| param.rest))
+            .is_some_and(|param| {
+                // When the consumed slot is itself a trailing rest (array-backed)
+                // element, the declared element is the array's element type.
+                let slot_type = if param.rest {
+                    common::array_element_type(self.ctx.types, param.type_id)
+                        .unwrap_or(param.type_id)
+                } else {
+                    param.type_id
+                };
+                crate::query_boundaries::checkers::call::is_type_parameter_type(
+                    self.ctx.types,
+                    slot_type,
+                )
+            })
     }
 
     fn is_generic_callable_against_nongeneric_target(
@@ -832,6 +891,7 @@ impl<'a> CheckerState<'a> {
             arg_types,
             callee_type,
             callee_has_declared_generic_signature,
+            raw_callee_shape,
             is_super_call,
             is_optional_chain,
             allow_contextual_mismatch_deferral,
@@ -1100,6 +1160,7 @@ impl<'a> CheckerState<'a> {
                         .unwrap_or(expected);
                     self.preferred_literal_expected_for_mismatch(
                         callee_has_declared_generic_signature,
+                        raw_callee_shape,
                         arg_types,
                         args,
                         reported_actual,

--- a/crates/tsz-checker/src/types/computation/tagged_template.rs
+++ b/crates/tsz-checker/src/types/computation/tagged_template.rs
@@ -521,6 +521,10 @@ impl<'a> CheckerState<'a> {
                                 .iter()
                                 .any(|sig| !sig.type_params.is_empty())
                         }),
+                // Tagged-template arguments map positionally to the tag's
+                // declared parameters; the literal-display heuristic that
+                // consumes `raw_callee_shape` does not apply here.
+                raw_callee_shape: None,
                 is_super_call: false,
                 is_optional_chain: false,
                 allow_contextual_mismatch_deferral: true,

--- a/crates/tsz-checker/tests/inline_conditional_rest_spread_negative_display_tests.rs
+++ b/crates/tsz-checker/tests/inline_conditional_rest_spread_negative_display_tests.rs
@@ -1,0 +1,131 @@
+//! Negative-case display parity for inline-`Conditional` rest-spread call
+//! parameters (residual of #6475, tracked by #13956).
+//!
+//! When an argument to a call whose rest parameter is an *inline* conditional
+//! tuple element — `...[key: K, ...(M[K] extends void ? [] : [value: M[K]])]` —
+//! has the wrong type, tsc reports the payload argument against the evaluated
+//! `value` element (`string`), not against the `key` element (`"log"`):
+//!
+//! ```text
+//! TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+//! ```
+//!
+//! The accept path already flattens the inline conditional rest element, so the
+//! relation result was correct; only the *displayed* expected type diverged.
+//! The defect was the literal-display heuristic in `handle_call_result`: it
+//! repainted the widened-primitive `expected` (`string`) with a sibling
+//! argument's literal whenever that literal widened to the same primitive —
+//! here the `key` literal `"log"` — even though the mismatched parameter slot
+//! (`value: M[K]`) is a structural type, not the bare type parameter the
+//! sibling pinned.
+//!
+//! The tests vary interface / type-parameter / function / property names to
+//! prove the rule is structural and name-agnostic (see `.claude/CLAUDE.md`).
+
+use tsz_checker::test_utils::check_source_code_messages as diagnostics;
+
+fn ts2345_messages(source: &str) -> Vec<String> {
+    diagnostics(source)
+        .into_iter()
+        .filter_map(|(code, msg)| (code == 2345).then_some(msg))
+        .collect()
+}
+
+// The #13956 witness: the payload `123` is reported against the evaluated
+// `value` element (`string`), not the `key` element (`"log"`).
+#[test]
+fn inline_conditional_rest_payload_reports_value_element_not_key() {
+    let source = r#"
+interface Handlers { log: string; stop: void; }
+declare function run<K extends keyof Handlers>(
+    ...args: [key: K, ...(Handlers[K] extends void ? [] : [value: Handlers[K]])]
+): void;
+run("log", 123);
+"#;
+    let msgs = ts2345_messages(source);
+    assert_eq!(msgs.len(), 1, "expected one TS2345, got: {msgs:#?}");
+    assert!(
+        msgs[0].contains("Argument of type 'number'")
+            && msgs[0].contains("parameter of type 'string'"),
+        "inline conditional rest payload must report the value element, got: {msgs:#?}"
+    );
+}
+
+// Renaming every binder (interface, type parameter, function, members) must not
+// change the result — the rule is structural, not bound to `Handlers`/`K`/etc.
+#[test]
+fn inline_conditional_rest_payload_display_is_structural_under_renaming() {
+    let source = r#"
+interface EventMap { click: number; ready: void; }
+declare function dispatch<E extends keyof EventMap>(
+    ...parts: [name: E, ...(EventMap[E] extends void ? [] : [payload: EventMap[E]])]
+): void;
+dispatch("click", "oops");
+"#;
+    let msgs = ts2345_messages(source);
+    assert_eq!(msgs.len(), 1, "expected one TS2345, got: {msgs:#?}");
+    assert!(
+        msgs[0].contains("Argument of type 'string'")
+            && msgs[0].contains("parameter of type 'number'"),
+        "renamed binders must still report the value element, got: {msgs:#?}"
+    );
+}
+
+// Method form: the same signature on a class method routes through the same
+// display path and must report the value element.
+#[test]
+fn inline_conditional_rest_payload_method_form_reports_value_element() {
+    let source = r#"
+interface Signals { warn: string; idle: void; }
+class Bus {
+    emit<S extends keyof Signals>(
+        ...args: [signal: S, ...(Signals[S] extends void ? [] : [value: Signals[S]])]
+    ): void {}
+}
+new Bus().emit("warn", 42);
+"#;
+    let msgs = ts2345_messages(source);
+    assert_eq!(msgs.len(), 1, "expected one TS2345, got: {msgs:#?}");
+    assert!(
+        msgs[0].contains("Argument of type 'number'")
+            && msgs[0].contains("parameter of type 'string'"),
+        "method-form inline conditional rest must report the value element, got: {msgs:#?}"
+    );
+}
+
+// Structured (object-typed) payload: the value element is an object type, so the
+// reported expected type must be that object, never the `key` literal.
+#[test]
+fn inline_conditional_rest_structured_payload_reports_value_element() {
+    let source = r#"
+interface Routes { open: { id: string }; close: void; }
+declare function navigate<R extends keyof Routes>(
+    ...args: [route: R, ...(Routes[R] extends void ? [] : [params: Routes[R]])]
+): void;
+navigate("open", 7);
+"#;
+    let msgs = ts2345_messages(source);
+    assert_eq!(msgs.len(), 1, "expected one TS2345, got: {msgs:#?}");
+    assert!(
+        msgs[0].contains("Argument of type 'number'")
+            && msgs[0].contains("parameter of type '{ id: string; }'"),
+        "structured payload must report the value (object) element, got: {msgs:#?}"
+    );
+}
+
+// Positive control: the sibling-literal display heuristic must STILL fire when
+// the mismatched parameter slot is genuinely the bare type parameter the
+// sibling pinned (`f<T>(a: T, b: T)`), so this fix is narrow.
+#[test]
+fn bare_type_parameter_sibling_literal_display_is_preserved() {
+    let source = r#"
+declare function couple<T>(first: T, second: T): T;
+couple(1, "");
+"#;
+    let msgs = ts2345_messages(source);
+    assert_eq!(msgs.len(), 1, "expected one TS2345, got: {msgs:#?}");
+    assert!(
+        msgs[0].contains("Argument of type '\"\"'") && msgs[0].contains("parameter of type '1'"),
+        "bare type-parameter sibling literal display must be preserved, got: {msgs:#?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Fixes #13956. Residual of the closed #6475.

## Summary
A wrong-typed payload argument to a call whose rest parameter is an **inline**
conditional tuple element was reported against the **`key`** element instead of
the evaluated **`value`** element:

```ts
interface Handlers { log: string; stop: void; }
declare function run<K extends keyof Handlers>(
    ...args: [key: K, ...(Handlers[K] extends void ? [] : [value: Handlers[K]])]
): void;
run("log", 123);
```

- **tsz (before):** `TS2345: Argument of type '123' is not assignable to parameter of type '"log"'.`
- **tsc 5.x:** `TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.`

The accept path already flattens the inline conditional rest element, and the
solver returned the **correct** `expected` (`string`); only the diagnostic
*display* diverged.

## Root cause / structural rule
The defect was the literal-display heuristic in
`preferred_literal_expected_for_mismatch` (`handle_call_result`). For a generic
call whose mismatch `expected` is a widened primitive (`string`), it repainted
`expected` with a **sibling** argument's literal whenever that literal widened
to the same primitive — here `"log"` (the `key` arg) — even though the
mismatched parameter slot (`value: Handlers[K]`) is a *structural* type, not the
bare type parameter the sibling pinned.

`When the mismatched parameter slot's declared type is the bare type parameter a
sibling argument pinned (f<T>(a: T, b: T) called f("x", 1) reports "x"), tsc
shows that sibling literal; when the slot is a structural type that merely
evaluates to a primitive (value: Handlers[K] -> string), tsc shows the widened
primitive.` tsz now matches both, through the checker call-result display layer.

## Owner layer
Checker diagnostic display — `call_result::preferred_literal_expected_for_mismatch`.
The sibling-literal substitution is gated on a new
`mismatch_param_slot_is_bare_type_parameter`, which inspects the **raw
(uninstantiated)** callee signature, flattens tuple rest parameters into their
per-position slots (mirroring the accept path's `unpack_tuple_rest_parameter`),
and only allows the repaint when the declared slot is a `TypeData::TypeParameter`.
The raw signature is threaded through `CallResultContext` (reusing the
already-computed `original_callee_shape` on the primary path; the secondary
finalize/tagged-template/overload sites pass it where available or `None`, which
conservatively disables the heuristic). The primary `Application`-display path
(`generic_application_literal_expected_for_mismatch`) is untouched.

## Anti-hardcoding
No identifier/file-name/printer-string predicates: the gate keys purely on the
declared slot's type structure (`is_type_parameter_type`). The regression suite
varies interface / type-parameter / function / property names.

## Adjacent-case matrix (new `inline_conditional_rest_spread_negative_display_tests`)
- inline-conditional payload reports the `value` element (`string`) — the witness;
- structural under renamed binders (`EventMap`/`E`/`dispatch`/`payload`);
- method form (class method with the rest-spread signature);
- structured (object) payload renders `{ id: string; }`, never the `key` literal;
- positive control: bare-`T` sibling-literal display (`couple<T>(a:T,b:T)`,
  `couple(1, "")` -> `'""'` / `'1'`) is preserved, proving the fix is narrow.

The existing `generic_call_primitive_widening_display_tests` (10 cases, incl. the
unconstrained `bar<T>(a:T,b:T)` literal-candidate path and the
constrained-primitive widening paths) stay green, as does
`generic_conflicting_argument_type_display_tests`.

## Scope note (follow-up)
A deeper alternative — encoding "declared slot is a bare type parameter" as a
field on the solver's `CallResult::ArgumentTypeMismatch` instead of
reconstructing it at display time — would remove the raw-shape threading, but it
touches every solver-side `ArgumentTypeMismatch` construction site and is left
out of scope to keep this fix low-regression-risk.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New `cargo test -p tsz-checker --test inline_conditional_rest_spread_negative_display_tests` — 5/5 pass.
- `cargo test -p tsz-checker --test generic_call_primitive_widening_display_tests` — 10/10 (incl. the previously-at-risk `unconstrained_type_param_preserves_literal_displays`); `--test generic_conflicting_argument_type_display_tests` — 1/1.
- No regressions across sampled display/argument suites: `tuple_argument_mismatch_elaboration_tests`, `variadic_tuple_arity_inference_tests`, `variadic_tuple_rest_param_suffix_inference_tests`, `spread_rest_tests` (78 pass; the 1 failure `test_array_like_rest_rejects_aggregate_rest_arguments` is **pre-existing on `main`**, verified via `git stash`), `spread_rest_diagnostics_tests`, `keyof_call_parameter_display_tests`, `overload_inference_literal_preservation_tests`, `literal_widening_display_tests`, `recursive_generic_interface_application_display_tests`, `satisfies_generic_inference_literal_widening_tests`, `block_body_callback_literal_widening_tests`, and others.
- CLI on the witness + adjacent cases matches `tsc` exactly.
- `cargo fmt -p tsz-checker -- --check` clean; `cargo clippy -p tsz-checker --lib` clean.
- `scripts/arch/check-checker-boundaries.sh` — Architecture guardrails passed (`call_result.rs` 1969 lines, under the 2000 ceiling; field-count guard 251).
- Broad conformance/emit/fourslash owned by ready-review CI per repo policy.

https://claude.ai/code/session_013EBiSUeifW68zPNws4LKDF

---
_Generated by [Claude Code](https://claude.ai/code/session_013EBiSUeifW68zPNws4LKDF)_