### PR TITLE
fix(checker): type object-literal method `this` as the complete object literal (#13970)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -262,6 +262,9 @@ path = "tests/async_return_promise_identity_tests.rs"
 name = "object_literal_getter_widening_tests"
 path = "tests/object_literal_getter_widening_tests.rs"
 [[test]]
+name = "object_literal_method_this_member_order_tests"
+path = "tests/object_literal_method_this_member_order_tests.rs"
+[[test]]
 name = "object_union_assignability_fast_path_tests"
 path = "tests/object_union_assignability_fast_path_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -15,6 +15,10 @@ pub(super) struct ObjectLiteralAccessorContext<'b> {
     pub(super) marker_this_type: Option<TypeId>,
     pub(super) skip_duplicate_check: bool,
     pub(super) partial_initializer_stack_index: Option<usize>,
+    /// Non-method members declared after this accessor; spliced into the
+    /// accessor's synthetic `this` so `this.<laterMember>` resolves like the
+    /// full object literal (see `object_literal_trailing_member_props`).
+    pub(super) trailing_member_props: &'b FxHashMap<Atom, PropertyInfo>,
 }
 
 pub(super) struct ObjectLiteralAccessorState<'b> {
@@ -41,6 +45,7 @@ impl<'a> CheckerState<'a> {
             marker_this_type,
             skip_duplicate_check,
             partial_initializer_stack_index,
+            trailing_member_props,
         } = context;
         let properties = state.properties;
         let setter_names = state.setter_names;
@@ -141,6 +146,9 @@ impl<'a> CheckerState<'a> {
             let mut pushed_synthetic_this = false;
             if marker_this_type.is_none() {
                 let mut this_props: Vec<PropertyInfo> = properties.values().cloned().collect();
+                // Splice in members declared after this accessor so that
+                // `this.<laterMember>` resolves like the complete object literal.
+                Self::merge_trailing_member_props(&mut this_props, trailing_member_props);
                 let name_atom = self.ctx.types.intern_string(&name);
                 if !this_props.iter().any(|p| p.name == name_atom) {
                     // Getter-only accessors are readonly in the object type

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -286,6 +286,11 @@ impl<'a> CheckerState<'a> {
         let mut spread_display_order_base = SPREAD_DISPLAY_ORDER_OFFSET;
 
         let obj_all_method_names = self.object_literal_callable_member_names(&obj.elements.nodes);
+        // Non-method members declared after the first `this`-capturing callable.
+        // These are missing from the incrementally-built `properties` map when an
+        // earlier method/accessor body is checked, so they are spliced into the
+        // synthetic `this` type to match tsc (which sees the full object literal).
+        let trailing_member_props = self.object_literal_trailing_member_props(&obj.elements.nodes);
         let circular_return_method_sites =
             self.object_literal_circular_return_method_sites(&obj_all_method_names);
 
@@ -576,6 +581,7 @@ impl<'a> CheckerState<'a> {
                                     .build_object_literal_fn_property_synthetic_this_type(
                                         &properties,
                                         &obj_all_method_names,
+                                        &trailing_member_props,
                                         &name,
                                     );
                                 self.ctx.this_type_stack.push(synthetic_this_type);
@@ -1484,6 +1490,7 @@ impl<'a> CheckerState<'a> {
                                 .build_object_literal_method_synthetic_this_type(
                                     &properties,
                                     &obj_all_method_names,
+                                    &trailing_member_props,
                                     elem_idx,
                                     &name,
                                     None,
@@ -1613,6 +1620,7 @@ impl<'a> CheckerState<'a> {
                             .build_object_literal_method_synthetic_this_type(
                                 &properties,
                                 &obj_all_method_names,
+                                &trailing_member_props,
                                 elem_idx,
                                 &name,
                                 Some(refined_method_type),
@@ -1878,6 +1886,7 @@ impl<'a> CheckerState<'a> {
                     marker_this_type,
                     skip_duplicate_check,
                     partial_initializer_stack_index,
+                    trailing_member_props: &trailing_member_props,
                 },
                 ObjectLiteralAccessorState {
                     properties: &mut properties,

--- a/crates/tsz-checker/src/types/computation/object_literal/symbol_key_routing.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/symbol_key_routing.rs
@@ -100,7 +100,7 @@ impl<'a> CheckerState<'a> {
         (is_string_named, is_symbol_named, single_quoted_name)
     }
 
-    pub(super) fn object_literal_computed_key_is_wide_symbol(
+    pub(crate) fn object_literal_computed_key_is_wide_symbol(
         &mut self,
         name_idx: NodeIndex,
     ) -> bool {

--- a/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
@@ -8,6 +8,212 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::{CallSignature, CallableShape, TypeId, Visibility};
 
 impl<'a> CheckerState<'a> {
+    /// Whether an object-literal member, when its body is checked, binds the
+    /// synthetic object-literal `this` type — i.e. a member whose `this` refers
+    /// to the surrounding object literal rather than the enclosing scope.
+    ///
+    /// Methods, get/set accessors, and `function`-expression property
+    /// initializers all capture the object as `this`. Arrow-function property
+    /// initializers do NOT: an arrow inherits `this` lexically from the
+    /// enclosing scope, so a data member declared after an arrow is irrelevant
+    /// to that arrow's `this`.
+    fn object_literal_member_captures_synthetic_this(&self, elem_idx: NodeIndex) -> bool {
+        let Some(elem_node) = self.ctx.arena.get(elem_idx) else {
+            return false;
+        };
+        if elem_node.kind == syntax_kind_ext::METHOD_DECLARATION
+            || elem_node.kind == syntax_kind_ext::GET_ACCESSOR
+            || elem_node.kind == syntax_kind_ext::SET_ACCESSOR
+        {
+            return true;
+        }
+        let Some(prop) = self.ctx.arena.get_property_assignment(elem_node) else {
+            return false;
+        };
+        let initializer = self
+            .ctx
+            .arena
+            .skip_parenthesized_and_assertions(prop.initializer);
+        self.ctx
+            .arena
+            .get(initializer)
+            .is_some_and(|init_node| init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION)
+    }
+
+    /// Best-effort `PropertyInfo` entries for the object literal's non-method
+    /// members (data properties, shorthands, and accessors) declared *after* the
+    /// first `this`-capturing callable member.
+    ///
+    /// `tsc` types `this` inside an object-literal method/accessor/function
+    /// property as the *complete* object literal type. tsz instead builds the
+    /// synthetic `this` incrementally, so a member declared after the callable
+    /// is invisible to it, producing spurious `TS2339` (and the consequent
+    /// `TS7023` circular-return diagnostic) on `this.<laterMember>`. Members
+    /// declared *before* the first callable are already present in the
+    /// incremental `properties` map by the time the callable body is checked,
+    /// and method / `function` / arrow-function members are already represented
+    /// in `obj_all_method_names`, so only the trailing non-method members need a
+    /// prescan.
+    ///
+    /// The prescan is deliberately free of expression-checker side effects: it
+    /// never invokes `get_type_of_node` (which would populate `node_types` and
+    /// suppress the main loop's diagnostics on the subsequent authoritative
+    /// pass). Trailing data properties with a literal initializer get their
+    /// precise widened type via `literal_type_from_initializer`; every other
+    /// trailing member is recorded as `any`, which is enough to make the member
+    /// *exist* on `this` (clearing the spurious error) without ever introducing
+    /// a new diagnostic.
+    pub(super) fn object_literal_trailing_member_props(
+        &mut self,
+        elements: &[NodeIndex],
+    ) -> FxHashMap<Atom, tsz_solver::PropertyInfo> {
+        let mut result: FxHashMap<Atom, tsz_solver::PropertyInfo> = FxHashMap::default();
+        let Some(first_callable_pos) = elements
+            .iter()
+            .position(|&elem_idx| self.object_literal_member_captures_synthetic_this(elem_idx))
+        else {
+            return result;
+        };
+        // Common arrangement ("data first, methods last"): nothing is declared
+        // after the only/last callable, so the incremental `properties` map is
+        // already complete and no prescan work is needed.
+        if first_callable_pos + 1 >= elements.len() {
+            return result;
+        }
+
+        // Names declared with a `set` accessor anywhere in the literal — a
+        // trailing get-accessor is only `readonly` when it has no paired setter.
+        let setter_names: FxHashSet<Atom> = elements
+            .iter()
+            .filter_map(|&elem_idx| {
+                let elem_node = self.ctx.arena.get(elem_idx)?;
+                if elem_node.kind != syntax_kind_ext::SET_ACCESSOR {
+                    return None;
+                }
+                let accessor = self.ctx.arena.get_accessor(elem_node)?;
+                self.get_property_name_resolved(accessor.name)
+                    .map(|name| self.ctx.types.intern_string(&name))
+            })
+            .collect();
+
+        let in_const = self.ctx.in_const_assertion;
+        for (pos, &elem_idx) in elements.iter().enumerate().skip(first_callable_pos + 1) {
+            let Some((name_atom, type_id, readonly)) =
+                self.object_literal_trailing_member_prop_entry(elem_idx, &setter_names)
+            else {
+                continue;
+            };
+            result.insert(
+                name_atom,
+                tsz_solver::PropertyInfo {
+                    name: name_atom,
+                    type_id,
+                    write_type: type_id,
+                    optional: false,
+                    readonly: readonly || in_const,
+                    is_method: false,
+                    is_class_prototype: false,
+                    visibility: Visibility::Public,
+                    parent_id: None,
+                    declaration_order: (pos + 1) as u32,
+                    is_string_named: false,
+                    is_symbol_named: false,
+                    single_quoted_name: false,
+                },
+            );
+        }
+        result
+    }
+
+    /// Compute `(name, read_type, readonly)` for a single trailing non-method
+    /// member, or `None` when the member is already represented elsewhere
+    /// (methods / `function` / arrow properties) or carries no statically
+    /// resolvable name.
+    fn object_literal_trailing_member_prop_entry(
+        &mut self,
+        elem_idx: NodeIndex,
+        setter_names: &FxHashSet<Atom>,
+    ) -> Option<(Atom, TypeId, bool)> {
+        let elem_node = self.ctx.arena.get(elem_idx)?;
+
+        // Accessors contribute a data-shaped property read through `this`.
+        if elem_node.kind == syntax_kind_ext::GET_ACCESSOR
+            || elem_node.kind == syntax_kind_ext::SET_ACCESSOR
+        {
+            let accessor_name = self.ctx.arena.get_accessor(elem_node)?.name;
+            if self.object_literal_computed_key_is_wide_symbol(accessor_name) {
+                return None;
+            }
+            let name = self.get_property_name_resolved(accessor_name)?;
+            let name_atom = self.ctx.types.intern_string(&name);
+            // Read type is left as `any`: the member only needs to *exist* on
+            // the synthetic `this` to clear the spurious error, and inferring an
+            // un-annotated accessor body here would re-run the checker.
+            let readonly = elem_node.kind == syntax_kind_ext::GET_ACCESSOR
+                && !setter_names.contains(&name_atom);
+            return Some((name_atom, TypeId::ANY, readonly));
+        }
+
+        // Shorthand property: { x } — the value is an outer binding; record the
+        // member as existing without resolving its symbol (which would touch the
+        // node cache / flow diagnostics).
+        if elem_node.kind == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT {
+            let shorthand = self.ctx.arena.get_shorthand_property(elem_node)?;
+            let ident = self
+                .ctx
+                .arena
+                .get(shorthand.name)
+                .and_then(|name_node| self.ctx.arena.get_identifier(name_node))?;
+            let name_atom = self.ctx.types.intern_string(&ident.escaped_text);
+            return Some((name_atom, TypeId::ANY, false));
+        }
+
+        // Data property assignment. `function`/arrow initializers are already
+        // represented in `obj_all_method_names`, so they are skipped here.
+        let prop = self.ctx.arena.get_property_assignment(elem_node)?;
+        let initializer = self
+            .ctx
+            .arena
+            .skip_parenthesized_and_assertions(prop.initializer);
+        if self.ctx.arena.get(initializer).is_some_and(|init_node| {
+            init_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                || init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+        }) {
+            return None;
+        }
+        if self.object_literal_computed_key_is_wide_symbol(prop.name) {
+            return None;
+        }
+        let name = self.get_property_name_resolved(prop.name)?;
+        let name_atom = self.ctx.types.intern_string(&name);
+        // A literal initializer has a statically known type; an object-literal
+        // data property widens it (e.g. `v: 1` → `number`). Anything else stays
+        // `any` (member exists, no spurious error). `as const` / type-assertion
+        // initializers are non-widening, but `literal_type_from_initializer`
+        // does not descend into assertion nodes, so those fall through to `any`.
+        let type_id = match self.literal_type_from_initializer(prop.initializer) {
+            Some(literal) => self.widen_literal_type(literal),
+            None => TypeId::ANY,
+        };
+        Some((name_atom, type_id, false))
+    }
+
+    /// Merge trailing-member entries into a synthetic-`this` property vector,
+    /// skipping any name already present (earlier members and methods take
+    /// precedence). The entries already carry their final `readonly` flag (the
+    /// `const`-assertion case is baked in by `object_literal_trailing_member_props`).
+    pub(crate) fn merge_trailing_member_props(
+        this_props: &mut Vec<tsz_solver::PropertyInfo>,
+        trailing_member_props: &FxHashMap<Atom, tsz_solver::PropertyInfo>,
+    ) {
+        for (&name_atom, info) in trailing_member_props {
+            if this_props.iter().any(|p| p.name == name_atom) {
+                continue;
+            }
+            this_props.push(info.clone());
+        }
+    }
+
     pub(super) fn object_literal_callable_member_names(
         &mut self,
         elements: &[NodeIndex],
@@ -412,6 +618,10 @@ impl<'a> CheckerState<'a> {
         &mut self,
         properties: &rustc_hash::FxHashMap<tsz_common::interner::Atom, tsz_solver::PropertyInfo>,
         obj_all_method_names: &rustc_hash::FxHashMap<tsz_common::interner::Atom, (NodeIndex, u32)>,
+        trailing_member_props: &rustc_hash::FxHashMap<
+            tsz_common::interner::Atom,
+            tsz_solver::PropertyInfo,
+        >,
         current_method_idx: NodeIndex,
         current_method_name: &str,
         current_method_type_override: Option<TypeId>,
@@ -423,6 +633,10 @@ impl<'a> CheckerState<'a> {
                 prop.readonly = true;
             }
         }
+
+        // Members declared after the current method are not yet in `properties`;
+        // splice them in so `this.<laterMember>` resolves like the full object.
+        Self::merge_trailing_member_props(&mut this_props, trailing_member_props);
 
         let current_method_name_atom = self.ctx.types.intern_string(current_method_name);
         for (&method_name_atom, &(other_elem_idx, decl_order)) in obj_all_method_names {
@@ -600,6 +814,10 @@ impl<'a> CheckerState<'a> {
         &mut self,
         properties: &rustc_hash::FxHashMap<tsz_common::interner::Atom, tsz_solver::PropertyInfo>,
         obj_all_method_names: &rustc_hash::FxHashMap<tsz_common::interner::Atom, (NodeIndex, u32)>,
+        trailing_member_props: &rustc_hash::FxHashMap<
+            tsz_common::interner::Atom,
+            tsz_solver::PropertyInfo,
+        >,
         _current_property_name: &str,
     ) -> TypeId {
         let mut this_props: Vec<tsz_solver::PropertyInfo> = properties.values().cloned().collect();
@@ -609,6 +827,10 @@ impl<'a> CheckerState<'a> {
                 prop.readonly = true;
             }
         }
+
+        // Members declared after this function-expression property are not yet
+        // in `properties`; splice them in so `this.<laterMember>` resolves.
+        Self::merge_trailing_member_props(&mut this_props, trailing_member_props);
 
         // Add placeholder callable types for pre-scanned method declarations
         for (&method_name_atom, &(other_elem_idx, decl_order)) in obj_all_method_names {

--- a/crates/tsz-checker/tests/object_literal_method_this_member_order_tests.rs
+++ b/crates/tsz-checker/tests/object_literal_method_this_member_order_tests.rs
@@ -1,0 +1,143 @@
+//! `this` inside an object-literal method/accessor/`function`-property must be
+//! typed as the *complete* object literal, independent of member declaration
+//! order.
+//!
+//! tsz builds the object-literal type incrementally, so a member declared
+//! *after* a method was invisible to that method's synthetic `this`:
+//!
+//! ```ts
+//! const obj = { method() { return this.value; }, value: 42 };
+//! //                            ^^^^^^^^^^ TS2339 + TS7023 (tsz, before fix)
+//! ```
+//!
+//! `tsc` resolves `this.value` to `number` because `this` is the whole object.
+//! The fix prescans the non-method members declared after the first
+//! `this`-capturing callable and splices them into the synthetic `this`. The
+//! prescan is side-effect-free, so it never perturbs the authoritative
+//! diagnostics emitted when each member is actually checked.
+
+use tsz_checker::test_utils::check_source_code_messages as get_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut c: Vec<u32> = get_diagnostics(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect();
+    c.sort_unstable();
+    c
+}
+
+/// The reported witness: a method reading a data property declared after it.
+#[test]
+fn method_reads_later_data_property_no_spurious_error() {
+    let source = r#"
+const obj = { method() { return this.value; }, value: 42 };
+const n: number = obj.method();
+"#;
+    assert_eq!(
+        codes(source),
+        Vec::<u32>::new(),
+        "method reading a later data property must not emit TS2339/TS7023"
+    );
+}
+
+/// Same shape, but the binder names are different to prove the fix is structural
+/// (no name-based fast path).
+#[test]
+fn method_reads_later_data_property_renamed_binders() {
+    let source = r#"
+const widget = { render() { return this.label + this.count; }, label: "x", count: 3 };
+const text: string = widget.render();
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}
+
+/// The precise (widened) type of the later property must still flow through, so
+/// a genuine mismatch in the method body is still reported.
+#[test]
+fn method_reads_later_data_property_keeps_precise_type() {
+    // `this.value` is `number`; assigning it to `string` must still be TS2322.
+    let source = r#"
+const obj = { method() { const s: string = this.value; return s; }, value: 42 };
+"#;
+    assert_eq!(
+        codes(source),
+        vec![2322u32],
+        "the later property's precise type must still catch real mismatches"
+    );
+}
+
+/// A genuinely-missing member is still TS2339 — the prescan only adds declared
+/// members, never invents them.
+#[test]
+fn method_reads_genuinely_missing_property_still_errors() {
+    let source = r#"
+const obj = { method() { return this.typo; }, value: 42 };
+"#;
+    let c = codes(source);
+    assert!(
+        c.contains(&2339u32),
+        "reading an undeclared member must still emit TS2339, got: {c:?}"
+    );
+}
+
+/// Writes through `this` to a later property must type-check against it.
+#[test]
+fn method_writes_later_data_property() {
+    let source = r#"
+const counter = { increment() { this.value++; }, reset() { this.value = 0; }, value: 0 };
+counter.increment();
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}
+
+/// A `function`-expression property (which binds the object as `this`, unlike an
+/// arrow) can read a later data property.
+#[test]
+fn function_property_reads_later_data_property() {
+    let source = r#"
+const handler = { run: function () { return this.payload; }, payload: { id: 1 } };
+const id: number = handler.run().id;
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}
+
+/// A getter can read a later data property.
+#[test]
+fn getter_reads_later_data_property() {
+    let source = r#"
+const point = { get magnitude() { return this.x + this.y; }, x: 3, y: 4 };
+const m: number = point.magnitude;
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}
+
+/// `return this` exposes later members on the returned receiver type.
+#[test]
+fn method_returns_this_exposes_later_members() {
+    let source = r#"
+const builder = { self() { return this; }, name: "b" };
+const name: string = builder.self().name;
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}
+
+/// The pre-existing "earlier member" ordering must remain correct.
+#[test]
+fn method_reads_earlier_data_property_unchanged() {
+    let source = r#"
+const obj = { value: 42, method() { return this.value; } };
+const n: number = obj.method();
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}
+
+/// Nested access through a later member resolves end-to-end.
+#[test]
+fn method_reads_later_nested_member() {
+    let source = r#"
+const config = { read() { return this.nested.deep; }, nested: { deep: 7 } };
+const n: number = config.read();
+"#;
+    assert_eq!(codes(source), Vec::<u32>::new());
+}


### PR DESCRIPTION
Fixes #13970.

Goal: hold

## Problem

`tsc` types `this` inside an object-literal method / accessor / `function`-expression
property as the **complete** object literal type, independent of member declaration
order. tsz built the synthetic `this` incrementally, so a data property or accessor
declared **after** a method was invisible to that method's `this`:

```ts
const obj = { method() { return this.value; }, value: 42 };
const n: number = obj.method();
```

- `tsc`: no error.
- tsz (before): `TS2339: Property 'value' does not exist on type '{ method(): any; }'`
  plus the consequent `TS7023` circular-return diagnostic.

Later **methods**/`function`/arrow properties were already represented (via the
callable-member pre-scan); only trailing **data properties and accessors** were missing.

## Structural rule

> When `this.<member>` appears inside an object-literal method / accessor /
> `function`-expression property, `<member>` resolves against the **complete** object
> literal type — every data property, accessor, and method — regardless of whether it
> is declared before or after the enclosing member.

Owner layer: checker — object-literal type computation / synthetic-`this`
construction (`crates/tsz-checker/src/types/computation/object_literal*`).

## Approach

Prescan the non-method members (data properties, shorthands, accessors) declared
**after the first `this`-capturing callable** and splice them into the synthetic `this`
built by the two method/function builders and the inline accessor path. Key properties:

- **Side-effect-free**: the prescan never invokes the expression checker
  (`get_type_of_node` would populate `node_types` and suppress the main loop's
  authoritative diagnostics on the subsequent pass). Trailing data properties with a
  literal initializer keep their precise widened type via `literal_type_from_initializer`
  so real mismatches still surface `TS2322`; every other trailing member is recorded as
  `any`, enough to make the member *exist* on `this` without introducing any new
  diagnostic.
- **No fixture/name fast paths** — purely structural (member kind + position).
- **Cheap on the hot path**: the common "data first, methods last" arrangement
  early-returns with zero extra work (no trailing members after the last callable).

## Adjacent-case matrix (verified vs `tsc` 6.0.2 + unit tests)

renamed binders · `this.x` read / `this.x =` write / `return this` · nested access
(`this.a.b`) · getter reading later data · `function`-expression property · precise
type preserved (real `this.value` mismatch still `TS2322`) · genuinely missing member
still `TS2339` · earlier-member ordering unchanged · `as const` trailing member.

## Verification

- New: `crates/tsz-checker/tests/object_literal_method_this_member_order_tests.rs`
  (10 cases — positive, precise-type, negative, regression).
- Full `tsz-checker` lib unit suite: **identical** failing-test set before vs after
  (zero regressions; the pre-existing failures are unrelated env/lib rows).
- Differential battery vs `tsc` 6.0.2: all object-literal/`this` cases match.
- `cargo clippy -p tsz-checker`: clean.
- CI gates: conformance / JS emit / DTS / fourslash floors.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01MV7qq2cv3paDeinkpv4a5S

---
_Generated by [Claude Code](https://claude.ai/code/session_01MV7qq2cv3paDeinkpv4a5S)_