### PR TITLE
fix(emit): retain transitive deps of non-exported classes/variables in .d.ts

### DIFF
--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -132,6 +132,10 @@ name = "declaration_type_walk_boundary_dts_emit_tests"
 path = "tests/declaration_type_walk_boundary_dts_emit_tests.rs"
 
 [[test]]
+name = "non_exported_dependency_transitive_dts_emit_tests"
+path = "tests/non_exported_dependency_transitive_dts_emit_tests.rs"
+
+[[test]]
 name = "lib_target_suggestion_ts2550_tests"
 path = "tests/lib_target_suggestion_ts2550_tests.rs"
 

--- a/crates/tsz-cli/tests/non_exported_dependency_transitive_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/non_exported_dependency_transitive_dts_emit_tests.rs
@@ -119,7 +119,7 @@ declare class Worker {
 }
 export declare function spawn(): Worker;
 export {};"#,
-    );
+    )
 }
 
 /// A non-exported class is the base of an exported class. The base's member
@@ -143,7 +143,7 @@ declare class Foundation {
 export declare class Surface extends Foundation {
 }
 export {};"#,
-    );
+    )
 }
 
 /// Transitive chain: an exported function returns a non-exported class whose
@@ -173,7 +173,7 @@ declare class Middle {
 }
 export declare function entry(): Middle;
 export {};"#,
-    );
+    )
 }
 
 /// A non-exported `const` surfaced through `typeof` names a local type in its
@@ -194,5 +194,5 @@ declare const registry: {
 };
 export type Snapshot = typeof registry;
 export {};"#,
-    );
+    )
 }

--- a/crates/tsz-cli/tests/non_exported_dependency_transitive_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/non_exported_dependency_transitive_dts_emit_tests.rs
@@ -1,0 +1,198 @@
+//! DTS emit: transitive retention of non-exported declarations pulled into the
+//! public-API surface through a non-exported **class** or **variable**.
+//!
+//! Structural rule: when a declaration enters the emitted `.d.ts` surface only
+//! because an exported declaration references it (an exported function returns
+//! a non-exported class, a non-exported class is the base of an exported class,
+//! or a non-exported `const` is surfaced through `typeof`), `tsc` also emits —
+//! transitively — every local type those member/value signatures name. The
+//! declaration emitter's usage analyzer walks the bodies of transitively
+//! referenced type aliases, interfaces, functions and modules, but previously
+//! skipped class and variable declarations, so a `declare class` (or `declare
+//! const`) survived while the local types it referenced were elided, leaving
+//! the `.d.ts` with dangling references. The analyzer now walks class bodies
+//! and variable types reached transitively, matching `tsc`.
+//!
+//! Binder names vary per case so the coverage follows the structural shape, not
+//! a spelling (anti-hardcoding).
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_non_exported_dep_dts_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+/// Compile `source` with declaration emit and return the generated `.d.ts`
+/// text. Returns `None` when the tsz binary is unavailable (lets the test
+/// self-skip in environments that do not build the binary).
+fn emit_dts(name: &str, source: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let src_path = temp.path.join("repro.ts");
+    std::fs::write(&src_path, source).expect("write repro file");
+
+    let _ = Command::new(tsz_bin)
+        .args([
+            "repro.ts",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--target",
+            "es2015",
+            "--lib",
+            "es6",
+            "--pretty",
+            "false",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz declaration emit");
+
+    Some(std::fs::read_to_string(temp.path.join("repro.d.ts")).unwrap_or_default())
+}
+
+#[track_caller]
+fn assert_dts(name: &str, source: &str, expected: &str) {
+    let Some(dts) = emit_dts(name, source) else {
+        println!("skipping: tsz binary unavailable");
+        return;
+    };
+    assert_eq!(dts.trim_end(), expected.trim_end(), "fixture: {name}");
+}
+
+/// An exported function returns a non-exported class. The class's method
+/// parameter and return types are local aliases that must survive elision.
+#[test]
+fn exported_function_returns_non_exported_class_retains_member_types() {
+    assert_dts(
+        "exported_fn_returns_local_class",
+        r#"type Payload = { id: string };
+type Outcome = { ok: boolean };
+class Worker {
+  run(input: Payload): Outcome { return { ok: true }; }
+}
+export function spawn(): Worker {
+  return new Worker();
+}
+"#,
+        r#"type Payload = {
+    id: string;
+};
+type Outcome = {
+    ok: boolean;
+};
+declare class Worker {
+    run(input: Payload): Outcome;
+}
+export declare function spawn(): Worker;
+export {};"#,
+    );
+}
+
+/// A non-exported class is the base of an exported class. The base's member
+/// type (a local interface) must survive — `tsc` emits `interface Spec`.
+#[test]
+fn non_exported_base_class_retains_member_types() {
+    assert_dts(
+        "local_base_of_exported_class",
+        r#"interface Spec { tag: number }
+class Foundation {
+  describe(): Spec { return { tag: 1 }; }
+}
+export class Surface extends Foundation {}
+"#,
+        r#"interface Spec {
+    tag: number;
+}
+declare class Foundation {
+    describe(): Spec;
+}
+export declare class Surface extends Foundation {
+}
+export {};"#,
+    );
+}
+
+/// Transitive chain: an exported function returns a non-exported class whose
+/// member returns another non-exported class whose member returns a local
+/// alias. Every link must be retained.
+#[test]
+fn transitive_chain_of_non_exported_classes_retains_every_link() {
+    assert_dts(
+        "chain_local_classes",
+        r#"type Leaf = { v: number };
+class Inner {
+  leaf(): Leaf { return { v: 0 }; }
+}
+class Middle {
+  inner(): Inner { return new Inner(); }
+}
+export function entry(): Middle { return new Middle(); }
+"#,
+        r#"type Leaf = {
+    v: number;
+};
+declare class Inner {
+    leaf(): Leaf;
+}
+declare class Middle {
+    inner(): Inner;
+}
+export declare function entry(): Middle;
+export {};"#,
+    );
+}
+
+/// A non-exported `const` surfaced through `typeof` names a local type in its
+/// annotation; the alias must survive (the symmetric variable-declaration gap).
+#[test]
+fn non_exported_variable_typeof_retains_referenced_types() {
+    assert_dts(
+        "typeof_local_const",
+        r#"type Internal = { z: boolean };
+const registry: { read(): Internal } = { read: () => ({ z: true }) };
+export type Snapshot = typeof registry;
+"#,
+        r#"type Internal = {
+    z: boolean;
+};
+declare const registry: {
+    read(): Internal;
+};
+export type Snapshot = typeof registry;
+export {};"#,
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/symbol_references.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/symbol_references.rs
@@ -397,6 +397,22 @@ impl UsageAnalyzer<'_> {
                 k if k == syntax_kind_ext::FUNCTION_DECLARATION => {
                     self.analyze_function_declaration(decl_idx)
                 }
+                // A non-exported class can enter the public-API surface by being
+                // referenced from an exported declaration (e.g. an exported
+                // function returns it, or it is the base of an exported class).
+                // tsc then emits the class and, transitively, every local type
+                // its members name. Without walking the class body here, those
+                // member-type dependencies are dropped and the emitted
+                // `declare class` references types whose declarations are gone.
+                k if k == syntax_kind_ext::CLASS_DECLARATION => {
+                    self.analyze_class_declaration(decl_idx)
+                }
+                // Symmetric gap for a non-exported variable pulled in via
+                // `typeof x`: its annotated/inferred type can name local types
+                // that must survive elision.
+                k if k == syntax_kind_ext::VARIABLE_DECLARATION => {
+                    self.analyze_variable_declaration(decl_idx)
+                }
                 k if k == syntax_kind_ext::MODULE_DECLARATION => {
                     self.analyze_module_declaration(decl_idx)
                 }

--- a/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/symbol_references.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/symbol_references.rs
@@ -389,13 +389,13 @@ impl UsageAnalyzer<'_> {
             };
             match decl_node.kind {
                 k if k == syntax_kind_ext::TYPE_ALIAS_DECLARATION => {
-                    self.analyze_type_alias_declaration(decl_idx)
+                    self.analyze_type_alias_declaration(decl_idx);
                 }
                 k if k == syntax_kind_ext::INTERFACE_DECLARATION => {
-                    self.analyze_interface_declaration(decl_idx)
+                    self.analyze_interface_declaration(decl_idx);
                 }
                 k if k == syntax_kind_ext::FUNCTION_DECLARATION => {
-                    self.analyze_function_declaration(decl_idx)
+                    self.analyze_function_declaration(decl_idx);
                 }
                 // A non-exported class can enter the public-API surface by being
                 // referenced from an exported declaration (e.g. an exported
@@ -405,16 +405,16 @@ impl UsageAnalyzer<'_> {
                 // member-type dependencies are dropped and the emitted
                 // `declare class` references types whose declarations are gone.
                 k if k == syntax_kind_ext::CLASS_DECLARATION => {
-                    self.analyze_class_declaration(decl_idx)
+                    self.analyze_class_declaration(decl_idx);
                 }
                 // Symmetric gap for a non-exported variable pulled in via
                 // `typeof x`: its annotated/inferred type can name local types
                 // that must survive elision.
                 k if k == syntax_kind_ext::VARIABLE_DECLARATION => {
-                    self.analyze_variable_declaration(decl_idx)
+                    self.analyze_variable_declaration(decl_idx);
                 }
                 k if k == syntax_kind_ext::MODULE_DECLARATION => {
-                    self.analyze_module_declaration(decl_idx)
+                    self.analyze_module_declaration(decl_idx);
                 }
                 _ => {}
             }


### PR DESCRIPTION
Goal: hold

## Summary
The declaration emitter's usage analyzer keeps non-exported declarations alive
when they enter the public-API surface, and walks their bodies transitively so
the *local types those bodies name* also survive elision. That transitive walk
(`analyze_referenced_declaration_body`) handled type aliases, interfaces,
functions and modules — but **not classes or variables**. So a non-exported
class pulled into the surface had its member-type dependencies dropped, emitting
a `declare class` whose parameter/return types referenced declarations that were
no longer in the file — **invalid `.d.ts` that `tsc` never produces**.

### Repro (before this change)
```ts
type LocalRet = { x: number };
type LocalParam = { y: string };
class Helper { m(p: LocalParam): LocalRet { return { x: 1 }; } }
export function make(): Helper { return new Helper(); }
```
tsz emitted (note the dangling `LocalParam`/`LocalRet`):
```ts
declare class Helper { m(p: LocalParam): LocalRet; }   // LocalParam/LocalRet declarations missing
export declare function make(): Helper;
export {};
```
After this change tsz emits the local aliases at their source positions, matching `tsc`:
```ts
type LocalRet = { x: number; };
type LocalParam = { y: string; };
declare class Helper { m(p: LocalParam): LocalRet; }
export declare function make(): Helper;
export {};
```

## Structural rule
`When a declaration enters the emitted .d.ts surface only because an exported
declaration references it (an exported function returns a non-exported class, a
non-exported class is the base of an exported class, or a non-exported const is
surfaced through typeof), tsc also emits — transitively — every local type those
member/value signatures name; tsz now walks class and variable bodies in the
usage analyzer's transitive closure, like the other declaration kinds.`

## Owner layer
Emitter — declaration usage analysis
(`usage_analyzer::analyze_referenced_declaration_body`). Add `CLASS_DECLARATION`
→ `analyze_class_declaration` and `VARIABLE_DECLARATION` →
`analyze_variable_declaration` arms alongside the existing alias/interface/
function/module arms. The `mark_symbol_used` `is_new || usage_expanded` guard
already prevents re-walking, so transitive chains (class → class → alias)
terminate and resolve in one pass.

## Anti-hardcoding
No identifier/file-name/printer-string predicates — dispatch is purely on the
declaration's AST node kind, reusing the existing per-kind analyzers. Retention
is additive (it can only keep declarations that `tsc` also keeps), never a
source-text or message predicate. The regression fixtures vary every binder
name so coverage follows the structural shape, not a spelling.

## Adjacent-case matrix (new `non_exported_dependency_transitive_dts_emit_tests`, 4/4)
- exported function returns a non-exported class; method param + return are
  local aliases (the witness);
- non-exported class as the **base** of an exported class (heritage path);
- transitive **chain** of non-exported classes (`entry → Middle → Inner → Leaf`)
  — every link retained;
- non-exported `const` surfaced via `typeof` naming a local type (the symmetric
  variable-declaration gap).

## Verification
- New `cargo test -p tsz-cli --test non_exported_dependency_transitive_dts_emit_tests` — 4 passed (registered as a `[[test]]` target so ready-review CI runs it).
- `cargo test -p tsz-emitter --lib` — 3752 passed, 0 failed (no emitter regressions).
- All existing declared DTS-emit CLI targets pass unchanged:
  `declaration_type_walk_boundary` (10), `recursive_const_arrow` (4),
  `inferred_object_index_signature` (6), `generic_call_bare_type_param` (6),
  `parenthesized_type` (4), `import_equals_alias` (7),
  `inferred_const_literal_union` (6), `overload_call_node_type_cache` (5),
  `generator_yield_star` (10), `sound_declaration_projection` (2).
- CLI repro confirmed: dropped local aliases now emit at source position,
  byte-matching `tsc`.
- `cargo fmt -p tsz-emitter -p tsz-cli -- --check` clean; `cargo clippy -p tsz-emitter --lib` clean.
- Broad conformance / emit / fourslash owned by ready-review CI per repo policy.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Ga4F2GV1RaCDQbvVbACjAB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ga4F2GV1RaCDQbvVbACjAB)_