### PR TITLE
fix(emit): map ES5-lowered generator/async body source positions

### DIFF
--- a/crates/tsz-core/tests/source_map_tests_1_parts/part_06.rs
+++ b/crates/tsz-core/tests/source_map_tests_1_parts/part_06.rs
@@ -363,7 +363,6 @@ fn test_source_map_es5_transform_async_for_of_destructuring_mapping() {
 }
 
 #[test]
-#[ignore = "regressed after remote changes: yield expression source map mappings no longer generated"]
 fn test_source_map_es5_transform_generator_yield_mapping() {
     let source = "function* gen() { yield first(); yield second(); }";
     let (parser, root) = parse_test_source(source);
@@ -426,6 +425,49 @@ fn test_source_map_es5_transform_generator_yield_mapping() {
         has_yield1_mapping || has_yield2_mapping,
         "expected at least one mapping for yield expressions. mappings: {mappings}"
     );
+}
+
+/// Anti-hardcoding companion: renamed binders and a multi-line body, asserting
+/// the mapping lands exactly on the yield operand's token start (not merely
+/// within a tolerance window). The generator body is otherwise position-less
+/// after lowering, so this exercises the `Positioned` IR tagging end-to-end.
+#[test]
+fn test_source_map_es5_generator_yield_operand_token_start() {
+    let source = "function* produce() {\n    yield alpha();\n    yield beta();\n}";
+    let (parser, root) = parse_test_source(source);
+
+    let options = PrinterOptions {
+        target: ScriptTarget::ES5,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+
+    let mut printer = Printer::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_target_es5(ctx.target_es5);
+    printer.set_source_map_text(parser.get_source_text());
+    printer.enable_source_map("test.js", "test.ts");
+    printer.emit(root);
+
+    let map_json = printer.generate_source_map_json().expect("source map");
+    let map_value: Value = serde_json::from_str(&map_json).expect("parse source map");
+    let mappings = map_value
+        .get("mappings")
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+    let decoded = decode_mappings(mappings);
+
+    // Each yielded call expression must map back to the start of its operand
+    // token (`alpha` / `beta`), the position tsc emits a mapping for.
+    for operand in ["alpha(", "beta("] {
+        let (op_line, op_col) = find_line_col(source, operand);
+        assert!(
+            decoded
+                .iter()
+                .any(|entry| entry.original_line == op_line && entry.original_column == op_col),
+            "expected a mapping at the `{operand}` operand ({op_line}:{op_col}). mappings: {mappings}"
+        );
+    }
 }
 
 #[test]

--- a/crates/tsz-emitter/src/emitter/es5/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers.rs
@@ -932,6 +932,7 @@ impl<'a> Printer<'a> {
         async_emitter.set_indent_level(self.writer.indent_level() + 1);
         if let Some(text) = self.source_text_for_map() {
             async_emitter.set_source_map_context(text, self.writer.current_source_index());
+            async_emitter.set_capture_mappings(self.writer.has_source_map());
         }
         if let Some(generator_this_arg) = &self.async_arrow_generator_this_arg {
             async_emitter.set_generator_this_arg(generator_this_arg.clone());

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -230,6 +230,7 @@ impl<'a> Printer<'a> {
             async_emitter.set_indent_level(self.writer.indent_level() + 1);
             if let Some(text) = self.source_text_for_map() {
                 async_emitter.set_source_map_context(text, self.writer.current_source_index());
+                async_emitter.set_capture_mappings(self.writer.has_source_map());
             }
             async_emitter.set_lexical_this(this_expr != "this");
             if self.ctx.options.import_helpers && self.ctx.is_effectively_commonjs() {
@@ -282,7 +283,8 @@ impl<'a> Printer<'a> {
                 for generated_name in async_emitter.take_generated_disposable_env_names() {
                     self.generated_temp_names.insert(generated_name);
                 }
-                self.write(&rendered);
+                let mappings = async_emitter.take_mappings();
+                self.write_with_offset_mappings(&rendered, &mappings);
                 self.write_line();
                 self.decrease_indent();
                 self.write("}");
@@ -629,7 +631,9 @@ impl<'a> Printer<'a> {
         }
         let mut printer = IRPrinter::with_arena(self.arena);
         printer.set_transforms(self.transforms.clone());
-        if let Some(text) = self.source_text {
+        // Use the source-map text (falling back to source text) so a downleveled
+        // generator body can be mapped; the two are identical in normal emit.
+        if let Some(text) = self.source_text_for_map() {
             printer.set_source_text(text);
         }
         printer.set_indent_level(self.writer.indent_level());
@@ -637,8 +641,14 @@ impl<'a> Printer<'a> {
             printer.set_tslib_prefix(true);
             printer.set_tslib_import_binding(self.commonjs_tslib_import_binding.clone());
         }
+        if self.writer.has_source_map() {
+            printer.enable_mapping_capture();
+            printer.set_source_map_source_index(self.writer.current_source_index());
+        }
         printer.emit(&ir);
-        self.write(&printer.take_output());
+        let mappings = printer.take_mappings();
+        let output = printer.take_output();
+        self.write_with_offset_mappings(&output, &mappings);
         if let Some(node) = self.arena.get(function_node) {
             while self.comment_emit_idx < self.all_comments.len()
                 && self.all_comments[self.comment_emit_idx].end <= node.end

--- a/crates/tsz-emitter/src/transforms/async_es5.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5.rs
@@ -89,6 +89,10 @@ pub struct AsyncES5Emitter<'a> {
     source_text: Option<&'a str>,
     source_index: u32,
     mappings: Vec<Mapping>,
+    /// When true, the inner `IRPrinter` records source mappings for re-emitted
+    /// `ASTRef` nodes so the downleveled body is mapped. Set by the caller only
+    /// when a source map is being generated.
+    capture_mappings: bool,
     this_capture_depth: u32,
     class_name: Option<String>,
     /// Outer names (e.g. a class-expression alias) that must not be chosen as
@@ -111,6 +115,7 @@ impl<'a> AsyncES5Emitter<'a> {
             source_text: None,
             source_index: 0,
             mappings: Vec::new(),
+            capture_mappings: false,
             this_capture_depth: 0,
             class_name: None,
             outer_reserved_for_generator_state: Vec::new(),
@@ -224,6 +229,21 @@ impl<'a> AsyncES5Emitter<'a> {
         self.transformer.set_source_text(source_text);
     }
 
+    /// Enable source-map capture for the downleveled body. Callers set this only
+    /// when a source map is being generated, since the inner `IRPrinter` then
+    /// scans its output to position each mapping.
+    pub const fn set_capture_mappings(&mut self, capture: bool) {
+        self.capture_mappings = capture;
+    }
+
+    /// Forward this emitter's source-map capture state to an inner `IRPrinter`.
+    fn configure_printer_capture(&self, printer: &mut IRPrinter<'a>) {
+        if self.capture_mappings {
+            printer.enable_mapping_capture();
+            printer.set_source_map_source_index(self.source_index);
+        }
+    }
+
     pub fn take_mappings(&mut self) -> Vec<Mapping> {
         std::mem::take(&mut self.mappings)
     }
@@ -332,6 +352,7 @@ impl<'a> AsyncES5Emitter<'a> {
         if let Some(text) = self.source_text {
             printer.set_source_text(text);
         }
+        self.configure_printer_capture(&mut printer);
         printer.set_indent_level(self.indent_level);
         printer.set_tslib_prefix(self.tslib_helpers.prefix());
         printer.set_tslib_import_binding(self.tslib_helpers.binding().to_string());
@@ -354,6 +375,7 @@ impl<'a> AsyncES5Emitter<'a> {
         };
         printer.set_generator_state_name(state_name);
         printer.emit(&ir);
+        self.mappings.extend(printer.take_mappings());
         (
             printer.take_output(),
             hoisted,
@@ -400,6 +422,7 @@ impl<'a> AsyncES5Emitter<'a> {
         if let Some(text) = self.source_text {
             printer.set_source_text(text);
         }
+        self.configure_printer_capture(&mut printer);
         printer.set_indent_level(self.indent_level);
         printer.set_tslib_prefix(self.tslib_helpers.prefix());
         printer.set_tslib_import_binding(self.tslib_helpers.binding().to_string());
@@ -410,6 +433,7 @@ impl<'a> AsyncES5Emitter<'a> {
             self.outer_reserved_for_generator_state.clone(),
         );
         printer.emit(&awaiter_call);
+        self.mappings.extend(printer.take_mappings());
         printer.take_output()
     }
 

--- a/crates/tsz-emitter/src/transforms/async_es5.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5.rs
@@ -237,7 +237,7 @@ impl<'a> AsyncES5Emitter<'a> {
     }
 
     /// Forward this emitter's source-map capture state to an inner `IRPrinter`.
-    fn configure_printer_capture(&self, printer: &mut IRPrinter<'a>) {
+    const fn configure_printer_capture(&self, printer: &mut IRPrinter<'a>) {
         if self.capture_mappings {
             printer.enable_mapping_capture();
             printer.set_source_map_source_index(self.source_index);

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_statement_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_statement_helpers.rs
@@ -176,7 +176,13 @@ impl<'a> AsyncES5Transformer<'a> {
     pub(super) fn generator_yield_operand_to_ir(&self, idx: NodeIndex) -> IRNode {
         let operand = self.expression_to_ir(idx);
         let Some(comment) = self.yield_operand_line_comment(idx) else {
-            return operand;
+            // Tag the decomposed operand with its source position so the lowered
+            // `[4 /*yield*/, <operand>]` carries a source-map mapping; without
+            // this the entire generator/async body emits with no body mappings.
+            return IRNode::Positioned {
+                source: idx,
+                inner: Box::new(operand),
+            };
         };
         let operand_text = crate::transforms::ir_printer::IRPrinter::emit_to_string(&operand);
         IRNode::Raw(format!("\n                {comment}\n                {operand_text}").into())

--- a/crates/tsz-emitter/src/transforms/ir.rs
+++ b/crates/tsz-emitter/src/transforms/ir.rs
@@ -441,6 +441,13 @@ pub enum IRNode {
         comment: Option<Cow<'static, str>>,
     },
 
+    /// A child node tagged with the source `NodeIndex` it was lowered from, so
+    /// the printer can emit a source-map mapping at the start of its output.
+    /// Transparent: it emits exactly `inner` and forwards all traversal to it.
+    /// Used to preserve source positions across the lowering of generator/async
+    /// bodies, where expressions are otherwise decomposed into position-less IR.
+    Positioned { source: NodeIndex, inner: Box<Self> },
+
     /// _`a.sent()` - get the sent value in generator
     GeneratorSent,
 
@@ -1154,6 +1161,7 @@ impl IRNode {
             Self::GeneratorOp { value, .. } => value
                 .as_ref()
                 .is_some_and(|value| value.contains_identifier(name)),
+            Self::Positioned { inner, .. } => inner.contains_identifier(name),
             Self::IfBreak { condition, .. } => condition.contains_identifier(name),
             Self::PrivateFieldSet {
                 receiver, value, ..
@@ -1387,6 +1395,7 @@ impl IRNode {
             Self::WeakMapSet { key, value, .. } => {
                 key.contains_captured_this_reference() || value.contains_captured_this_reference()
             }
+            Self::Positioned { inner, .. } => inner.contains_captured_this_reference(),
             _ => false,
         }
     }

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -39,12 +39,14 @@ use ir_printer_namespace::NamespaceIifeContext;
 
 use crate::context::transform::TransformContext;
 use crate::emitter::{Printer as AstPrinter, PrinterOptions};
+use crate::output::source_writer::compute_line_col;
 use crate::transforms::ClassES5Emitter;
 use crate::transforms::ir::{
     EnumMember, EnumMemberValue, IRMethodName, IRNode, IRParam, IRProperty, IRPropertyKey,
     IRPropertyKind, IRSwitchCase,
 };
 use crate::transforms::tslib_helper_naming::TslibHelperNaming;
+use tsz_common::source_map::Mapping;
 use tsz_parser::parser::base::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
 
@@ -95,6 +97,17 @@ pub struct IRPrinter<'a> {
     block_scope_shadowed_names: Vec<String>,
     block_scope_reserved_names: Vec<String>,
     pending_commonjs_class_export_name: Option<(String, Vec<String>)>,
+    /// Source-map mappings recorded for re-emitted `ASTRef` nodes while
+    /// `capture_mappings` is set. Generated positions are relative to the start
+    /// of this printer's own output, so a caller splices them with a base
+    /// offset via `Printer::write_with_offset_mappings`.
+    mappings: Vec<Mapping>,
+    /// Source index recorded on captured mappings.
+    source_index: u32,
+    /// When true, record a source mapping at the start of each re-emitted
+    /// `ASTRef` node. Off by default so emits without source maps pay no
+    /// position-scan cost.
+    capture_mappings: bool,
 }
 
 impl<'a> IRPrinter<'a> {
@@ -272,6 +285,9 @@ impl<'a> IRPrinter<'a> {
             block_scope_shadowed_names: Vec::new(),
             block_scope_reserved_names: Vec::new(),
             pending_commonjs_class_export_name: None,
+            mappings: Vec::new(),
+            source_index: 0,
+            capture_mappings: false,
         }
     }
 
@@ -304,6 +320,9 @@ impl<'a> IRPrinter<'a> {
             block_scope_shadowed_names: Vec::new(),
             block_scope_reserved_names: Vec::new(),
             pending_commonjs_class_export_name: None,
+            mappings: Vec::new(),
+            source_index: 0,
+            capture_mappings: false,
         }
     }
 
@@ -336,6 +355,9 @@ impl<'a> IRPrinter<'a> {
             block_scope_shadowed_names: Vec::new(),
             block_scope_reserved_names: Vec::new(),
             pending_commonjs_class_export_name: None,
+            mappings: Vec::new(),
+            source_index: 0,
+            capture_mappings: false,
         }
     }
 
@@ -457,6 +479,52 @@ impl<'a> IRPrinter<'a> {
     /// Set the source text for `ASTRef` emission
     pub const fn set_source_text(&mut self, text: &'a str) {
         self.source_text = Some(text);
+    }
+
+    /// Enable recording of source-map mappings for re-emitted `ASTRef` nodes.
+    /// Callers enable this only when a source map is being generated.
+    pub const fn enable_mapping_capture(&mut self) {
+        self.capture_mappings = true;
+    }
+
+    /// Set the source index recorded on captured mappings.
+    pub const fn set_source_map_source_index(&mut self, index: u32) {
+        self.source_index = index;
+    }
+
+    /// Take the source-map mappings recorded during emission. Generated
+    /// positions are relative to the start of this printer's output.
+    pub fn take_mappings(&mut self) -> Vec<Mapping> {
+        std::mem::take(&mut self.mappings)
+    }
+
+    /// Record a source mapping from the current generated output position to the
+    /// token start of `idx` in the original source. Mirrors `tsc`, which emits a
+    /// mapping at the start of each node re-emitted into a lowered generator or
+    /// async body; without this the entire downleveled body has no mappings.
+    pub(super) fn record_ast_ref_mapping(&mut self, idx: NodeIndex) {
+        if !self.capture_mappings {
+            return;
+        }
+        let (Some(arena), Some(text)) = (self.arena, self.source_text) else {
+            return;
+        };
+        let Some(node) = arena.get(idx) else {
+            return;
+        };
+        let token_start =
+            crate::transforms::emit_utils::skip_trivia_forward(Some(text), node.pos, node.end);
+        let (original_line, original_column) = compute_line_col(text, token_start);
+        let (generated_line, generated_column) =
+            compute_line_col(&self.output, self.output.len() as u32);
+        self.mappings.push(Mapping {
+            generated_line,
+            generated_column,
+            source_index: self.source_index,
+            original_line,
+            original_column,
+            name_index: None,
+        });
     }
 
     /// Set the indentation level
@@ -1635,6 +1703,13 @@ impl<'a> IRPrinter<'a> {
                 self.emit_node(body);
             }
             IRNode::ASTRef(_) => self.emit_ast_ref_node(node),
+
+            IRNode::Positioned { source, inner } => {
+                // Record a mapping at the start of the lowered node's output,
+                // then emit it transparently.
+                self.record_ast_ref_mapping(*source);
+                self.emit_node(inner);
+            }
 
             IRNode::ASTRefWithGeneratorThis {
                 node,

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -35,11 +35,12 @@ mod ir_printer_namespace;
 mod ir_printer_node_predicates;
 #[path = "ir_printer_recovery.rs"]
 mod ir_printer_recovery;
+#[path = "ir_printer_source_map.rs"]
+mod ir_printer_source_map;
 use ir_printer_namespace::NamespaceIifeContext;
 
 use crate::context::transform::TransformContext;
 use crate::emitter::{Printer as AstPrinter, PrinterOptions};
-use crate::output::source_writer::compute_line_col;
 use crate::transforms::ClassES5Emitter;
 use crate::transforms::ir::{
     EnumMember, EnumMemberValue, IRMethodName, IRNode, IRParam, IRProperty, IRPropertyKey,
@@ -479,52 +480,6 @@ impl<'a> IRPrinter<'a> {
     /// Set the source text for `ASTRef` emission
     pub const fn set_source_text(&mut self, text: &'a str) {
         self.source_text = Some(text);
-    }
-
-    /// Enable recording of source-map mappings for re-emitted `ASTRef` nodes.
-    /// Callers enable this only when a source map is being generated.
-    pub const fn enable_mapping_capture(&mut self) {
-        self.capture_mappings = true;
-    }
-
-    /// Set the source index recorded on captured mappings.
-    pub const fn set_source_map_source_index(&mut self, index: u32) {
-        self.source_index = index;
-    }
-
-    /// Take the source-map mappings recorded during emission. Generated
-    /// positions are relative to the start of this printer's output.
-    pub fn take_mappings(&mut self) -> Vec<Mapping> {
-        std::mem::take(&mut self.mappings)
-    }
-
-    /// Record a source mapping from the current generated output position to the
-    /// token start of `idx` in the original source. Mirrors `tsc`, which emits a
-    /// mapping at the start of each node re-emitted into a lowered generator or
-    /// async body; without this the entire downleveled body has no mappings.
-    pub(super) fn record_ast_ref_mapping(&mut self, idx: NodeIndex) {
-        if !self.capture_mappings {
-            return;
-        }
-        let (Some(arena), Some(text)) = (self.arena, self.source_text) else {
-            return;
-        };
-        let Some(node) = arena.get(idx) else {
-            return;
-        };
-        let token_start =
-            crate::transforms::emit_utils::skip_trivia_forward(Some(text), node.pos, node.end);
-        let (original_line, original_column) = compute_line_col(text, token_start);
-        let (generated_line, generated_column) =
-            compute_line_col(&self.output, self.output.len() as u32);
-        self.mappings.push(Mapping {
-            generated_line,
-            generated_column,
-            source_index: self.source_index,
-            original_line,
-            original_column,
-            name_index: None,
-        });
     }
 
     /// Set the indentation level

--- a/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
@@ -651,6 +651,10 @@ impl<'a> IRPrinter<'a> {
         let IRNode::ASTRef(idx) = node else {
             return;
         };
+        // Map the re-emitted node back to its original source position so a
+        // downleveled generator/async body carries source mappings (tsc emits a
+        // mapping at the start of each such node). No-op unless capture is on.
+        self.record_ast_ref_mapping(*idx);
         // Check if this node has a transform directive that we should apply
         if let Some(arena) = self.arena
             && let Some(node) = arena.get(*idx)

--- a/crates/tsz-emitter/src/transforms/ir_printer_source_map.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_source_map.rs
@@ -1,0 +1,52 @@
+//! Source-map capture helpers for [`IRPrinter`].
+//!
+//! Extracted from `ir_printer.rs` to keep file sizes manageable.
+
+use super::IRPrinter;
+use crate::output::source_writer::compute_line_col;
+use crate::transforms::emit_utils::skip_trivia_forward;
+use tsz_common::source_map::Mapping;
+use tsz_parser::parser::base::NodeIndex;
+
+impl<'a> IRPrinter<'a> {
+    /// Enable source-map mappings for re-emitted `ASTRef` nodes.
+    pub const fn enable_mapping_capture(&mut self) {
+        self.capture_mappings = true;
+    }
+
+    pub const fn set_source_map_source_index(&mut self, index: u32) {
+        self.source_index = index;
+    }
+
+    /// Take mappings recorded during emission. Generated positions are relative
+    /// to the start of this printer's output.
+    pub fn take_mappings(&mut self) -> Vec<Mapping> {
+        std::mem::take(&mut self.mappings)
+    }
+
+    /// Record a mapping from the current generated output position to the token
+    /// start of `idx` in the original source.
+    pub(super) fn record_ast_ref_mapping(&mut self, idx: NodeIndex) {
+        if !self.capture_mappings {
+            return;
+        }
+        let (Some(arena), Some(text)) = (self.arena, self.source_text) else {
+            return;
+        };
+        let Some(node) = arena.get(idx) else {
+            return;
+        };
+        let token_start = skip_trivia_forward(Some(text), node.pos, node.end);
+        let (original_line, original_column) = compute_line_col(text, token_start);
+        let (generated_line, generated_column) =
+            compute_line_col(&self.output, self.output.len() as u32);
+        self.mappings.push(Mapping {
+            generated_line,
+            generated_column,
+            source_index: self.source_index,
+            original_line,
+            original_column,
+            name_index: None,
+        });
+    }
+}

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir_const_enum.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir_const_enum.rs
@@ -274,6 +274,9 @@ impl<'a> NamespaceES5Transformer<'a> {
                     self.rewrite_const_enum_accesses_in_node(value, namespace_path);
                 }
             }
+            IRNode::Positioned { inner, .. } => {
+                self.rewrite_const_enum_accesses_in_node(inner, namespace_path);
+            }
             IRNode::IfBreak { condition, .. } => {
                 self.rewrite_const_enum_accesses_in_node(condition, namespace_path);
             }


### PR DESCRIPTION
Goal: hold

## Summary
ES5-downleveled generator and async function bodies emitted **no source-map
mappings** for their content. The `__generator` / `__awaiter` lowering
decomposes every body expression into structured, position-less IR nodes
(`Identifier`, `CallExpr`, …) in `IRNode`, so a yielded/awaited operand lost its
link back to the original source. The entire body mapped only its `function`
header and closing brace:

```ts
// tsc --target ES5
function* gen() { yield first(); yield second(); }
```
`mappings` before: `"AAAA;;;;;;;;;;;;;;;;;;;;;;;;;;;AAAA"` — every body line empty.
After: the yielded `first()` / `second()` operands map back to their source.

This is the regression behind the `#[ignore]`d
`test_source_map_es5_transform_generator_yield_mapping`
("regressed after remote changes: yield expression source map mappings no longer
generated").

## Structural rule
When `tsc` downlevels a generator/async body, it emits a source-map mapping at
the start of each node it re-emits into the `__generator`/`__awaiter` switch.
tsz lowered those nodes into position-less IR and never recorded the mappings.
`When a generator/async body is downleveled to ES5, tsc maps each re-emitted
operand back to its source position; tsz now does the same through the emitter's
IR printer.`

## Owner layer
Emitter — generator/async IR lowering + IR printer.
- `transforms/ir.rs`: new transparent `IRNode::Positioned { source, inner }` that
  tags a lowered child with the source `NodeIndex` it came from.
- `transforms/async_es5_ir_statement_helpers.rs`: `generator_yield_operand_to_ir`
  wraps the operand in `Positioned` (the one place the operand's `NodeIndex` is
  still known).
- `transforms/ir_printer.rs`: `record_ast_ref_mapping` records a mapping at the
  current generated position → the operand's token start (via the existing
  `skip_trivia_forward` + `compute_line_col`); gated on `capture_mappings` so
  non-source-map emits pay no position-scan cost.
- `emitter/es5/helpers.rs`, `helpers_async.rs`, `transforms/async_es5.rs`: the
  bare-generator, async-function, and async-arrow paths enable capture (only when
  `writer.has_source_map()`) and splice the printer's mappings through the
  existing `write_with_offset_mappings` offset path.

`Positioned` is transparent: every `IRNode` traversal that descends into a
yield/await operand (`contains_identifier`, `contains_captured_this_reference`,
const-enum rewrite, and emit) forwards through `inner`. Verified that these are
the only traversals which recurse into `GeneratorOp.value`; the
namespace/constructor rewrites never descended into operands, so behavior there
is unchanged.

## Anti-hardcoding
No identifier/file-name/printer-string predicates — mapping positions are driven
purely by the operand's source `NodeIndex` (token start via trivia skip). The
new companion test varies binder names (`produce`/`alpha`/`beta`) and asserts the
mapping lands exactly on the operand token start.

## Verification
- `cargo test -p tsz-core --lib generator_yield` — 5/5 pass, including the
  un-ignored `test_source_map_es5_transform_generator_yield_mapping` and the new
  renamed-binder `test_source_map_es5_generator_yield_operand_token_start`.
- `cargo test -p tsz-emitter` — full suite green (3752 lib + all integration
  targets, 0 failed) before and after the `Positioned` change, confirming no
  emit-output change.
- The 4 pre-existing `source_map` parity-ratchet failures
  (`parity_statements` 322/321, `parity_functions` 13/10,
  `parity_return_throw_break_continue` 2/0, `names_array`) are **unrelated** to
  this change — confirmed identical on clean `main` via `git stash` (they involve
  no generators/async). This PR leaves them untouched and fixes one ignored test.
- `cargo fmt -p tsz-emitter -p tsz-core --check` clean; `cargo clippy -p
  tsz-emitter --lib` clean.
- Broad conformance/emit/fourslash owned by ready-review CI per repo policy.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfXY492JNMFy9fTZ4pcgmv)_