### PR TITLE
perf(ci): make cargo-target-deps staleness measurable on the shallow dist-binaries runner (#13747)

### DIFF
--- a/scripts/ci/gcp-cache.sh
+++ b/scripts/ci/gcp-cache.sh
@@ -377,6 +377,27 @@ refresh_rust_source_mtimes_after_target_restore() {
   echo "Refreshed Rust source mtimes after Cargo target cache restore"
 }
 
+# Render a whole-second duration as a compact human age (e.g. "2d 3h", "4h 18m",
+# "37m"). Used by the staleness report so a wall-clock age is readable at a
+# glance in the dist-binaries job summary.
+format_duration() {
+  local secs="$1" days hours mins
+  if [[ ! "$secs" =~ ^[0-9]+$ ]]; then
+    printf 'unknown\n'
+    return 0
+  fi
+  days=$(( secs / 86400 )); secs=$(( secs % 86400 ))
+  hours=$(( secs / 3600 )); secs=$(( secs % 3600 ))
+  mins=$(( secs / 60 ))
+  if (( days > 0 )); then
+    printf '%dd %dh\n' "$days" "$hours"
+  elif (( hours > 0 )); then
+    printf '%dh %dm\n' "$hours" "$mins"
+  else
+    printf '%dm\n' "$mins"
+  fi
+}
+
 # Observability for #13747: how stale is the restored workspace-rlib baseline?
 #
 # The cargo-target-deps (dist-fast) blob is the only cross-commit reuse the
@@ -384,24 +405,51 @@ refresh_rust_source_mtimes_after_target_restore() {
 # rust_cache_refresh (Cargo.lock/Cargo.toml/.cargo/config.toml changes only),
 # so on a long run of source-only main pushes the workspace .rlibs inside it
 # drift many commits behind HEAD and Cargo recompiles the hot crates against an
-# old baseline every PR. We pack a tiny `.tsz-cache-commit` marker into the
-# blob at save time (no extra GCS object) and read it back here so the staleness
-# is measurable before we decide whether to broaden the save trigger.
+# old baseline every PR. The blob carries two markers (no extra GCS object):
+# `.tsz-cache-commit` (the build commit) and `.tsz-cache-built-at` (epoch
+# seconds), read back here so the staleness gating the #13747 rollout is
+# measurable before we decide whether to broaden the save trigger.
 #
-# Best-effort: never fails the build. dist-binaries checks out fetch-depth:1, so
-# `git rev-list` usually cannot resolve the blob commit — in that case we still
-# log both SHAs and report distance as unknown.
+# dist-binaries checks out fetch-depth:1, so `git rev-list` usually cannot
+# resolve the blob commit and the commit-distance reports "unknown" on the real
+# runner. The wall-clock age derived from `.tsz-cache-built-at` is depth-
+# independent, so it is always available — that is the number the measured
+# rollout decision actually needs. The line is echoed and, when running inside a
+# job, appended to GITHUB_STEP_SUMMARY so it is visible without log-diving.
+# Best-effort throughout: never fails the build.
 log_cargo_target_deps_staleness() {
-  local marker=".target/dist-fast/.tsz-cache-commit"
-  if [[ ! -f "$marker" ]]; then
-    echo "cargo-target-deps staleness: no commit marker in restored blob (pre-#13747 blob or cache miss)"
+  local commit_marker=".target/dist-fast/.tsz-cache-commit"
+  local built_at_marker=".target/dist-fast/.tsz-cache-built-at"
+  if [[ ! -f "$commit_marker" && ! -f "$built_at_marker" ]]; then
+    echo "cargo-target-deps staleness: no marker in restored blob (pre-#13747 blob or cache miss)"
     return 0
   fi
-  local blob_commit head_commit distance
-  blob_commit="$(tr -d '[:space:]' < "$marker" 2>/dev/null || true)"
+
+  local head_commit blob_commit="" distance="unknown" age="unknown"
   head_commit="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
-  distance="$(git rev-list --count "${blob_commit}..HEAD" 2>/dev/null || echo unknown)"
-  echo "cargo-target-deps staleness: blob built at ${blob_commit:-unknown}; HEAD ${head_commit}; workspace-rlib baseline is ${distance} commit(s) behind (#13747)"
+
+  if [[ -f "$commit_marker" ]]; then
+    blob_commit="$(tr -d '[:space:]' < "$commit_marker" 2>/dev/null || true)"
+    if [[ -n "$blob_commit" ]]; then
+      distance="$(git rev-list --count "${blob_commit}..HEAD" 2>/dev/null || echo unknown)"
+    fi
+  fi
+
+  if [[ -f "$built_at_marker" ]]; then
+    local built_at now
+    built_at="$(tr -cd '0-9' < "$built_at_marker" 2>/dev/null || true)"
+    now="$(date -u +%s 2>/dev/null || true)"
+    if [[ -n "$built_at" && -n "$now" && "$now" -ge "$built_at" ]]; then
+      age="$(format_duration "$(( now - built_at ))")"
+    fi
+  fi
+
+  local line
+  line="cargo-target-deps staleness: blob built at ${blob_commit:-unknown} (age ${age}); HEAD ${head_commit}; workspace-rlib baseline is ${distance} commit(s) behind (#13747)"
+  echo "$line"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    printf '%s\n' "$line" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+  fi
 }
 
 # save_archive <label> <gs://...> <base> <path...>
@@ -709,8 +757,16 @@ save_caches() {
     if [[ "$save_cargo_targets" == "1" || "$refresh_workspace_rlibs" == "1" ]]; then
       # Pack a tiny provenance marker into the blob so the next restore can
       # measure how stale this workspace-rlib baseline is (#13747). Best-effort.
+      #
+      # Two markers, because the consumer (dist-binaries) checks out with
+      # fetch-depth:1: `git rev-list blob..HEAD` almost never resolves the blob
+      # commit there, so a commit-distance alone reports "unknown" on the real
+      # runner. The epoch-seconds build time lets the restore report staleness as
+      # a wall-clock age regardless of clone depth, which is the signal the
+      # measured #13747 rollout decision actually needs.
       if [[ -d .target/dist-fast ]]; then
         printf '%s\n' "$commit" > .target/dist-fast/.tsz-cache-commit 2>/dev/null || true
+        date -u +%s > .target/dist-fast/.tsz-cache-built-at 2>/dev/null || true
       fi
       save_archive \
         "cargo-target-deps-${cargo_target_key}" \
@@ -800,4 +856,9 @@ main() {
   esac
 }
 
-main "$@"
+# Only dispatch when executed directly. Sourcing (e.g. from
+# test-gcp-cache-staleness.mjs) loads the helpers without running auth/IO so the
+# staleness reporting can be unit-tested in isolation.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -440,6 +440,8 @@ run_lint() {
   node scripts/ci/test-check-ci-job-timing.mjs || return $?
   node scripts/ci/test-check-main-red.mjs || return $?
   node scripts/ci/test-cloudbuild-config-paths.mjs || return $?
+  node scripts/ci/test-gcp-cache-auth.mjs || return $?
+  node scripts/ci/test-gcp-cache-staleness.mjs || return $?
   node scripts/ci/test-wip-state-comments.mjs || return $?
   node scripts/ci/test-project-compatibility.mjs || return $?
   node scripts/ci/test-type-challenges-solutions-manifest.mjs || return $?

--- a/scripts/ci/test-gcp-cache-staleness.mjs
+++ b/scripts/ci/test-gcp-cache-staleness.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Guards the #13747 cargo-target-deps staleness reporting in gcp-cache.sh.
+//
+// The measured #13747 rollout (republish the workspace-rlib blob on every green
+// main build) is gated on reading how stale the restored blob is. The consumer
+// (dist-binaries) checks out fetch-depth:1, so a `git rev-list blob..HEAD`
+// commit-distance reports "unknown" on the real runner. The wall-clock age
+// derived from the `.tsz-cache-built-at` marker is depth-independent and is the
+// number the rollout decision actually needs, so this verifies it resolves even
+// when the commit-distance cannot.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+const CACHE_SCRIPT = path.join(ROOT, "scripts", "ci", "gcp-cache.sh");
+const cacheScript = fs.readFileSync(CACHE_SCRIPT, "utf8");
+
+// --- Static guards: the markers + summary plumbing must stay wired. ----------
+assert.match(
+  cacheScript,
+  /date -u \+%s > \.target\/dist-fast\/\.tsz-cache-built-at/,
+  "save must write the epoch build-time marker alongside the commit marker",
+);
+assert.match(
+  cacheScript,
+  /\.tsz-cache-built-at/,
+  "reader must consult the build-time marker",
+);
+assert.match(
+  cacheScript,
+  /GITHUB_STEP_SUMMARY/,
+  "staleness must surface to the job summary, not only stdout logs",
+);
+assert.match(
+  cacheScript,
+  /if \[\[ "\$\{BASH_SOURCE\[0\]\}" == "\$\{0\}" \]\]; then\n\s*main "\$@"/,
+  "main must be guarded so the script can be sourced for testing",
+);
+
+// --- Functional: drive the real bash helpers in isolation. -------------------
+const work = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-stale-"));
+const stubBin = path.join(work, "bin");
+fs.mkdirSync(stubBin, { recursive: true });
+// `git` stub: rev-parse always resolves HEAD; rev-list either fails (shallow
+// clone — blob commit absent) or echoes a count, controlled via env.
+fs.writeFileSync(
+  path.join(stubBin, "git"),
+  [
+    "#!/usr/bin/env bash",
+    'case "$1" in',
+    '  rev-parse) echo "${STUB_HEAD:-headsha0000}" ;;',
+    '  rev-list) if [[ -n "${STUB_REVLIST_COUNT:-}" ]]; then echo "$STUB_REVLIST_COUNT"; else exit 1; fi ;;',
+    "  *) exit 0 ;;",
+    "esac",
+    "",
+  ].join("\n"),
+  { mode: 0o755 },
+);
+
+// One bash invocation exercises both clone shapes (the git stub's rev-list is
+// toggled mid-run) plus the formatter, so the script is sourced only once.
+const harness = `
+set -uo pipefail
+export _TSZ_CI_CACHE_BUCKET="gs://example/tsz-test-cache"
+export PATH="${stubBin}:$PATH"
+source "${CACHE_SCRIPT}"
+hash -r
+work="${work}"
+cd "$work"
+mkdir -p .target/dist-fast
+echo "blobsha1111" > .target/dist-fast/.tsz-cache-commit
+echo "$(( $(date -u +%s) - 7200 ))" > .target/dist-fast/.tsz-cache-built-at
+export GITHUB_STEP_SUMMARY="$work/summary.md"
+: > "$work/summary.md"
+echo "===SHALLOW==="          # rev-list fails: blob commit absent under fetch-depth:1
+unset STUB_REVLIST_COUNT
+log_cargo_target_deps_staleness
+echo "===DEEP==="             # rev-list resolves: full history available
+export STUB_REVLIST_COUNT=5
+log_cargo_target_deps_staleness
+echo "===FMT==="
+format_duration 90061
+format_duration 3661
+format_duration 600
+format_duration notanumber
+`;
+
+const out = execFileSync("bash", ["-c", harness], {
+  cwd: ROOT,
+  env: process.env,
+  encoding: "utf8",
+});
+
+function staleLine(section) {
+  const header = `===${section}===`;
+  const start = out.indexOf(header);
+  return out
+    .slice(start + header.length, out.indexOf("===", start + header.length))
+    .split("\n")
+    .find((l) => l.startsWith("cargo-target-deps staleness:"));
+}
+
+// Shallow clone — rev-list fails, age still resolves from built-at.
+const shallowLine = staleLine("SHALLOW");
+assert.ok(shallowLine, "staleness line must be printed");
+assert.match(shallowLine, /blob built at blobsha1111/, "blob commit reported");
+assert.match(shallowLine, /age 2h 0m/, "wall-clock age resolves under shallow clone");
+assert.match(
+  shallowLine,
+  /is unknown commit\(s\) behind/,
+  "commit-distance is unknown when rev-list cannot resolve the blob commit",
+);
+
+// Full history — rev-list resolves, distance reported alongside the age.
+const deepLine = staleLine("DEEP");
+assert.match(deepLine, /is 5 commit\(s\) behind/, "commit-distance reported when available");
+assert.match(deepLine, /age 2h 0m/, "age still reported alongside distance");
+
+const summary = fs.readFileSync(path.join(work, "summary.md"), "utf8");
+assert.match(summary, /cargo-target-deps staleness:/, "staleness appended to job summary");
+
+// format_duration shapes.
+const fmt = out.slice(out.indexOf("===FMT===")).split("\n");
+assert.equal(fmt[1], "1d 1h", "format_duration days");
+assert.equal(fmt[2], "1h 1m", "format_duration hours");
+assert.equal(fmt[3], "10m", "format_duration minutes");
+assert.equal(fmt[4], "unknown", "format_duration rejects non-numeric");
+
+fs.rmSync(work, { recursive: true, force: true });
+console.log("test-gcp-cache-staleness: ok");


### PR DESCRIPTION
Goal: fast

Partially addresses #13747 (the measurement leg that gates its rollout).

## Summary

The #13747 mechanism that republishes the workspace-rlib (`cargo-target-deps`)
blob on every green main build is already implemented and bounded
(`stream_archive_to_uri` + MemAvailable preflight, scoped to the dist-fast blob),
but it ships **default-off behind the `TSZ_CI_REFRESH_WORKSPACE_RLIBS` repo
variable** so it can be flipped *after reading how stale the restored blob is*.
That gating measurement was broken on the real runner:

- Staleness was computed only as a `git rev-list <blob_commit>..HEAD`
  commit-distance, but `dist-binaries` checks out with `fetch-depth: 1`
  (`ci.yml:636`). The blob commit is almost never in that shallow history, so
  `git rev-list` fails and the distance reports **`unknown` on essentially every
  run** — the exact number the measured rollout depends on was never available.
- The staleness line was only `echo`'d into the multi-thousand-line dist-binaries
  log, so even when present it required log-diving to read.

## Structural rule

When the cargo-target-deps blob is restored, its staleness must be reportable
**independent of checkout depth**, because the consumer runs at `fetch-depth: 1`.
A commit-distance cannot satisfy that; a wall-clock build age can. So the blob
now carries a build *timestamp* in addition to the build *commit*, and the
restore reports an age that is always available, surfaced where an operator can
read it.

## Owner layer

CI cache scripting (`scripts/ci/gcp-cache.sh`). No change to compiler/solver/emit
behavior and no change to the cache save trigger.

- `save_caches`: write a second tiny marker `.tsz-cache-built-at` (epoch seconds)
  into the blob alongside the existing `.tsz-cache-commit` (no extra GCS object;
  best-effort). The pre-existing commit marker is left untouched so blobs already
  published to GCS stay readable.
- `log_cargo_target_deps_staleness`: report a depth-independent wall-clock age
  from `.tsz-cache-built-at`, keep the commit-distance when history allows it
  (else `unknown`), and append the line to `GITHUB_STEP_SUMMARY` so it is visible
  without log-diving. Reads each marker independently and degrades gracefully.
- `format_duration`: compact age renderer (`2d 3h` / `4h 18m` / `37m`).
- Guard `main` behind `BASH_SOURCE` so the helpers can be sourced for unit
  testing without running auth/IO.

The broader-refresh path stays **default-off** behind the existing
`TSZ_CI_REFRESH_WORKSPACE_RLIBS` repo variable — this PR fixes the measurement the
flip depends on, it does not flip it.

## Anti-hardcoding

No identifier/file-name/printer-string predicates; this is CI glue, not a
compiler decision. The marker contract is generic (commit + epoch), not keyed on
any project/fixture name.

## Verification

- `node scripts/ci/test-gcp-cache-staleness.mjs` — new functional test: sources
  the script with a stubbed `git`, exercises both clone shapes (shallow →
  `rev-list` fails, age still resolves; deep → distance reported), asserts the
  `GITHUB_STEP_SUMMARY` append, and covers `format_duration` shapes.
- `node scripts/ci/test-gcp-cache-auth.mjs` — previously orphaned (invoked
  nowhere); now wired into `run_lint` alongside the new test.
- `bash -n scripts/ci/gcp-cache.sh` / `scripts/ci/gcp-full-ci.sh` — syntax clean.
- Direct dispatch unchanged: `gcp-cache.sh bogusarg` still prints usage, exits 2.
- Both node tests run in CI via `run_lint` in `scripts/ci/gcp-full-ci.sh`.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01K6GXQ19XvasDC3QDB8omiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6GXQ19XvasDC3QDB8omiF)_