### PR TITLE
fix(checker): substitute type args for namespace-qualified generic interface refs

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -39,6 +39,9 @@ path = "tests/reexport_generic_typeref_instantiation_tests.rs"
 name = "cross_file_recursive_alias_intersection_tests"
 path = "tests/cross_file_recursive_alias_intersection_tests.rs"
 [[test]]
+name = "qualified_namespace_generic_substitution_tests"
+path = "tests/qualified_namespace_generic_substitution_tests.rs"
+[[test]]
 name = "heritage_reexport_generic_type_params_tests"
 path = "tests/heritage_reexport_generic_type_params_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -391,6 +391,56 @@ impl<'a> CheckerState<'a> {
                         return TypeId::ERROR;
                     }
                 }
+                // Namespace-qualified generic interface reference
+                // (`ns.Generic<Arg>`): build the application off the resolved
+                // member's primed `DefId` directly, mirroring the bare-name path
+                // (`ensure_def_ready_for_lowering` + `Application(Lazy(def),
+                // args)`). The generic `TypeLowering` path used below keys the
+                // application base to a *different* `DefId` than the one
+                // `ensure_def_ready_for_lowering` primes with the declared type
+                // parameters, so a qualified reference reached relation time with
+                // an empty `type_params` list on its base def and left every type
+                // parameter unsubstituted (a free `T`) — a false TS2322 on every
+                // `ns.Generic<...>` assignment.
+                //
+                // Scoped to a generic interface: its body resolves on demand
+                // from `Lazy(def)`, whereas classes carry a constructor/instance
+                // split and type aliases a distinct alias-body lowering path —
+                // both already handled by the existing path below. Gated on the
+                // member actually being generic (non-empty primed params) so
+                // non-generic qualified references keep their existing path and
+                // TS2315 arity diagnostics.
+                if has_type_args
+                    && let Some(args) = type_ref.type_arguments.as_ref()
+                    // Cheap `DefKind` gate (the def's kind is fixed at mint time)
+                    // before the more expensive param priming and qualified-name
+                    // build, so non-interface qualified references pay nothing.
+                    // `ensure_def_ready_for_lowering` returns this same `DefId`.
+                    && matches!(
+                        self.ctx
+                            .definition_store
+                            .get_kind(self.ctx.get_or_create_def_id(sym_id)),
+                        Some(tsz_solver::def::DefKind::Interface)
+                    )
+                {
+                    let qualified_name = self
+                        .entity_name_text(type_name_idx)
+                        .unwrap_or_else(|| "<unknown>".to_string());
+                    let def_id = self.ensure_def_ready_for_lowering(sym_id, &qualified_name);
+                    if self
+                        .ctx
+                        .get_def_type_params(def_id)
+                        .is_some_and(|params| !params.is_empty())
+                    {
+                        let type_args: Vec<TypeId> = args
+                            .nodes
+                            .iter()
+                            .map(|&arg_idx| self.get_type_from_type_node(arg_idx))
+                            .collect();
+                        let base = self.ctx.types.factory().lazy(def_id);
+                        return self.ctx.types.factory().application(base, type_args);
+                    }
+                }
                 let type_param_bindings = self.get_type_param_bindings();
                 let type_resolver =
                     |node_idx: NodeIndex| self.resolve_type_symbol_for_lowering(node_idx);

--- a/crates/tsz-checker/tests/qualified_namespace_generic_substitution_tests.rs
+++ b/crates/tsz-checker/tests/qualified_namespace_generic_substitution_tests.rs
@@ -1,0 +1,174 @@
+//! Regression tests: a namespace-qualified generic **interface** reference
+//! (`ns.Interface<Arg>`) must substitute its type arguments, exactly like the
+//! bare-name form (`Interface<Arg>`).
+//!
+//! Structural rule: when a type reference is a qualified name whose resolved
+//! member is a generic interface, `tsc` instantiates the interface with the
+//! supplied type arguments. tsz built the qualified application through the
+//! generic `TypeLowering` path, which keyed the application base to a different
+//! `DefId` than the one primed with the interface's declared type parameters —
+//! so the application reached relation time with an empty `type_params` list and
+//! left every type parameter **unsubstituted** (a free `T`), producing a false
+//! `TS2322` (`Type 'T' is not assignable to type 'number'`) on assignment. The
+//! qualified path now primes the resolved member's `DefId`
+//! (`ensure_def_ready_for_lowering`) and builds `Application(Lazy(def), args)`
+//! off it — the same shape the bare-name path produces — when the primed def is
+//! a generic interface.
+//!
+//! Scoped to interface members: classes carry a constructor/instance split and
+//! type aliases a distinct alias-body lowering path, both already handled by the
+//! existing qualified path. Refs #13212 (cross-arena type-parameter
+//! substitution family).
+
+use tsz_checker::test_utils::{check_multi_file_with_global_index, check_source_code_messages};
+use tsz_common::CheckerOptions;
+
+fn strict_opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        module: tsz_common::common::ModuleKind::CommonJS,
+        ..Default::default()
+    }
+}
+
+fn codes_multi(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    check_multi_file_with_global_index(files, entry, strict_opts())
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+const BOX: &str = "export interface Box<T> { value: T; }\n";
+
+/// Witness: `import * as ns; const x: ns.Box<number>` substitutes `T = number`,
+/// so a matching object literal is assignable and the member reads as `number`.
+#[test]
+fn qualified_namespace_generic_interface_substitutes_type_arg() {
+    let codes = codes_multi(
+        &[
+            ("base.ts", BOX),
+            (
+                "use.ts",
+                "import * as B from './base';\n\
+                 const x: B.Box<number> = { value: 1 };\n\
+                 const y: number = x.value;\n",
+            ),
+        ],
+        "use.ts",
+    );
+    assert!(
+        !codes.contains(&2322),
+        "qualified ns.Box<number> must substitute T=number (no false TS2322); got: {codes:?}"
+    );
+}
+
+/// Multiple type parameters are substituted positionally.
+#[test]
+fn qualified_namespace_generic_interface_multiple_type_params() {
+    let codes = codes_multi(
+        &[
+            ("base.ts", "export interface Pair<A, B> { a: A; b: B; }\n"),
+            (
+                "use.ts",
+                "import * as M from './base';\n\
+                 const p: M.Pair<number, string> = { a: 1, b: 'x' };\n\
+                 const a: number = p.a;\n\
+                 const b: string = p.b;\n",
+            ),
+        ],
+        "use.ts",
+    );
+    assert!(
+        !codes.contains(&2322),
+        "qualified ns.Pair<number, string> must substitute both params; got: {codes:?}"
+    );
+}
+
+/// Anti-hardcoding: a renamed namespace alias and renamed binders behave
+/// identically — the result is not keyed on any particular identifier text.
+#[test]
+fn qualified_namespace_generic_interface_renamed_binders() {
+    let codes = codes_multi(
+        &[
+            (
+                "schema.ts",
+                "export interface Wrapper<Payload> { contents: Payload; }\n",
+            ),
+            (
+                "consumer.ts",
+                "import * as Schemas from './schema';\n\
+                 const entry: Schemas.Wrapper<string> = { contents: 'ok' };\n\
+                 const read: string = entry.contents;\n",
+            ),
+        ],
+        "consumer.ts",
+    );
+    assert!(
+        !codes.contains(&2322),
+        "renamed qualified ns.Wrapper<string> must substitute; got: {codes:?}"
+    );
+}
+
+/// Same-file namespace member: `namespace N { interface Box<T> }` then
+/// `N.Box<number>` substitutes too (single-arena path).
+#[test]
+fn same_file_namespace_generic_interface_substitutes() {
+    let codes = check_source_code_messages(
+        "namespace N { export interface Box<T> { value: T; } }\n\
+         const x: N.Box<number> = { value: 1 };\n\
+         const y: number = x.value;\n",
+    )
+    .into_iter()
+    .map(|(code, _)| code)
+    .collect::<Vec<_>>();
+    assert!(
+        !codes.contains(&2322),
+        "same-file N.Box<number> must substitute T=number; got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls — substitution must not paper over real errors.
+// ---------------------------------------------------------------------------
+
+/// A genuine member mismatch must still surface `TS2322` (the substitution is
+/// real, not a blanket suppression).
+#[test]
+fn qualified_namespace_generic_interface_keeps_real_mismatch() {
+    let codes = codes_multi(
+        &[
+            ("base.ts", BOX),
+            (
+                "use.ts",
+                "import * as B from './base';\n\
+                 const x: B.Box<number> = { value: 'oops' };\n",
+            ),
+        ],
+        "use.ts",
+    );
+    assert!(
+        codes.contains(&2322),
+        "string value assigned to ns.Box<number> must still emit TS2322; got: {codes:?}"
+    );
+}
+
+/// A non-generic qualified interface used with type arguments must still emit
+/// `TS2315` — the fast path is gated on the member actually being generic.
+#[test]
+fn qualified_namespace_non_generic_interface_still_ts2315() {
+    let codes = codes_multi(
+        &[
+            ("base.ts", "export interface Plain { x: number; }\n"),
+            (
+                "use.ts",
+                "import * as B from './base';\n\
+                 type D = B.Plain<number>;\n",
+            ),
+        ],
+        "use.ts",
+    );
+    assert!(
+        codes.contains(&2315),
+        "non-generic ns.Plain<number> must still emit TS2315; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

Refs #13212 (cross-arena type-parameter substitution family).

## Summary
A namespace-qualified generic **interface** reference (`ns.Interface<Arg>`) left
its type parameters **unsubstituted**, producing a false `TS2322`. Minimal,
deterministic repro (production path; `tsc` accepts it):

```ts
// base.ts
export interface Box<T> { value: T; }
// use.ts
import * as B from './base';
const x: B.Box<number> = { value: 1 };   // tsz: TS2322 "Type 'T' is not assignable to type 'number'"
const y: number = x.value;               // tsz: x.value typed as the free 'T'
```

The bare-name form (`Box<number>`) is already correct; only the qualified form
diverged. Same-file namespace members (`namespace N { interface Box<T> }` →
`N.Box<number>`) hit the same bug.

## Structural rule
When a type reference is a qualified name whose resolved member is a generic
interface, `tsc` instantiates the interface with the supplied type arguments.
tsz built the qualified application through the generic `TypeLowering` path,
which keyed the application base to a **different** `DefId` than the one
`ensure_def_ready_for_lowering` primes with the interface's declared type
parameters. The application therefore reached relation time with an empty
`type_params` list on its base def and left every type parameter unsubstituted
(a free `T`).

## Owner layer
Checker — type-reference lowering (`state/type_resolution/core.rs`,
`get_type_from_type_reference`, qualified-name branch). The qualified branch now
mirrors the bare-name path: it primes the resolved member's `DefId`
(`ensure_def_ready_for_lowering`) and builds `Application(Lazy(def), args)` off
that same def. Scoped via the primed def's `DefKind` to generic **interface**
members — classes carry a constructor/instance split and type aliases a distinct
alias-body lowering path, both already handled by the existing path — and gated
on the member actually being generic, so non-generic qualified references keep
their existing path and `TS2315` arity diagnostics. The cheap `DefKind` gate
runs before the param priming and qualified-name string build, so non-interface
qualified references pay nothing extra.

## Anti-hardcoding
No identifier/file-name/printer-string predicates: the decision is driven purely
by the resolved member's `DefKind` and declared type-parameter count. The new
regression test varies binder names (`Wrapper`/`Payload`, `Schemas`) to prove
the result is not keyed on any identifier text.

## Adjacent-case matrix (new `qualified_namespace_generic_substitution_tests`, 6 tests)
- cross-module `import * as B; const x: B.Box<number>` substitutes (the witness);
- multiple type parameters (`M.Pair<number, string>`) substitute positionally;
- renamed namespace alias + renamed binders (anti-hardcoding);
- same-file `namespace N { interface Box<T> }` → `N.Box<number>` substitutes;
- **negative:** a genuine member mismatch still emits `TS2322` (substitution is
  real, not a blanket suppression);
- **negative:** a non-generic qualified interface used with type args still emits
  `TS2315`.

## Verification
- `cargo test -p tsz-checker --test qualified_namespace_generic_substitution_tests` — 6/6.
- No new regressions: broad sweep of namespace/module/cross-file/generic/enum
  integration suites and `--lib architecture_contract` checked against clean
  `main` — every failure present is **byte-identical to `main`** (the pre-existing
  set, #13961); this change introduces zero new failures.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib`
  clean; `scripts/arch/arch_guard.py` — guardrails passed; `core.rs` under the
  2000-line ceiling.
- Broad conformance / emit / fourslash owned by ready-review CI per repo policy.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01KWV6vUdevPh3fpYFoceEJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWV6vUdevPh3fpYFoceEJa)_