### PR TITLE
fix(checker): report @types/node install hint for unresolved node builtins under node16/nodenext

### DIFF
--- a/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_check_body.rs
@@ -11,7 +11,6 @@ use tsz_parser::parser::NodeIndex;
 use super::declaration_helpers::imported_types_package_target;
 use super::declaration_helpers::should_rewrite_module_specifier;
 use super::declaration_helpers::{declaration_file_extension, ts_extension_suffix};
-use crate::query_boundaries::capabilities::is_known_node_module;
 
 impl<'a> CheckerState<'a> {
     /// Shared TS2846/TS5097 module-specifier extension diagnostics.
@@ -398,12 +397,13 @@ impl<'a> CheckerState<'a> {
 
         self.ctx.import_resolution_stack.push(module_name.clone());
 
-        // Node.js built-in modules (e.g. "fs", "path", "node:fs") should not
-        // trigger TS2307/TS2882 when using Node module resolution. TSC resolves
-        // these via @types/node; our single-file checker lacks this, so we
-        // suppress resolution errors for known built-in names.
-        let is_node_builtin =
-            self.ctx.compiler_options.module.is_node_module() && is_known_node_module(module_name);
+        // Node.js built-in specifiers (`"fs"`, `"node:fs"`, …) take the same
+        // not-found path as any other import: `module_not_found_diagnostic`
+        // classifies them via `is_known_node_module` and emits the `@types/node`
+        // install hint (TS2580/TS2591) that `tsc` reports when the builtin is
+        // absent. No module-kind gating here — when `@types/node` is present the
+        // resolver binds the builtin and the import returns before any not-found
+        // path, so a diagnostic only fires on genuine failure.
 
         // Check for specific resolution error from driver (TS2834, TS2835, TS2792, etc.)
         // This must be checked before resolved_modules to catch extensionless import errors
@@ -438,26 +438,6 @@ impl<'a> CheckerState<'a> {
                     self.ctx.import_resolution_stack.pop();
                     return;
                 }
-                // Node.js built-in modules: suppress TS2307/TS2882 entirely,
-                // UNLESS noTypesAndSymbols is set — in that case @types/node
-                // won't be auto-loaded, so tsc emits TS2591 instead.
-                if is_node_builtin {
-                    if self.ctx.compiler_options.no_types_and_symbols {
-                        let (msg, code) = self.module_not_found_diagnostic_for_site(
-                            module_name,
-                            crate::import::core::ModuleNotFoundSite::Import,
-                        );
-                        if !self.ctx.modules_with_ts2307_emitted.contains(&module_key) {
-                            self.ctx
-                                .modules_with_ts2307_emitted
-                                .insert(module_key);
-                            self.error_at_position(spec_start, spec_length, &msg, code);
-                        }
-                    }
-                    self.ctx.import_resolution_stack.pop();
-                    return;
-                }
-
                 // AMD/System/classic-resolution: tsc only emits the secondary
                 // missing-module diagnostic when TS5107 deprecation is silenced
                 // via `ignoreDeprecations` — issue #3077.
@@ -832,23 +812,6 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            self.ctx.import_resolution_stack.pop();
-            return;
-        }
-
-        // Node.js built-in modules: suppress fallback TS2307/TS2882 too,
-        // unless noTypesAndSymbols — emit TS2591 in that case.
-        if is_node_builtin {
-            if self.ctx.compiler_options.no_types_and_symbols {
-                let (msg, code) = self.module_not_found_diagnostic_for_site(
-                    module_name,
-                    crate::import::core::ModuleNotFoundSite::Import,
-                );
-                if !self.ctx.modules_with_ts2307_emitted.contains(&module_key) {
-                    self.ctx.modules_with_ts2307_emitted.insert(module_key);
-                    self.error_at_position(spec_start, spec_length, &msg, code);
-                }
-            }
             self.ctx.import_resolution_stack.pop();
             return;
         }

--- a/crates/tsz-core/tests/module_resolution_tests_parts/part_00.rs
+++ b/crates/tsz-core/tests/module_resolution_tests_parts/part_00.rs
@@ -338,6 +338,92 @@ export const thing = parse();
     );
 }
 
+// Regression (#13826 sub-root #1, opposite-polarity parity gap): a static
+// `import` of an unresolved Node builtin must report the `@types/node` install
+// hint (TS2580) regardless of the `module` emit target. Node16/18/20/NodeNext
+// previously suppressed it silently, while every other module kind (and `tsc`)
+// reports TS2580/TS2591.
+#[test]
+fn test_node_module_kind_static_import_of_node_builtin_emits_ts2580() {
+    for module in [
+        crate::common::ModuleKind::Node16,
+        crate::common::ModuleKind::Node18,
+        crate::common::ModuleKind::Node20,
+        crate::common::ModuleKind::NodeNext,
+    ] {
+        let diags = check_with_module_not_found_errors(
+            r#"import { parse } from "url";
+export const thing = () => parse();
+"#,
+            "usage.ts",
+            vec![],
+            vec!["url"],
+            CheckerOptions {
+                module,
+                ..CheckerOptions::default()
+            },
+        );
+        assert!(
+            has_error_code(&diags, TS2580),
+            "{module:?} static import of unresolved Node builtin should emit TS2580 (not be silently suppressed), got: {diags:?}"
+        );
+        assert!(
+            no_error_code(&diags, TS2307),
+            "{module:?} Node builtin should use the TS2580 install hint, not TS2307, got: {diags:?}"
+        );
+    }
+}
+
+// The witnessed trpc specifier shape: a `node:`-scheme subpath builtin under
+// NodeNext that fails to resolve must surface the install hint rather than
+// staying silent.
+#[test]
+fn test_nodenext_node_scheme_subpath_builtin_emits_install_hint() {
+    let diags = check_with_module_not_found_errors(
+        r#"import { pipeline } from "node:stream/promises";
+export const run = () => pipeline;
+"#,
+        "usage.ts",
+        vec![],
+        vec!["node:stream/promises"],
+        CheckerOptions {
+            module: crate::common::ModuleKind::NodeNext,
+            ..CheckerOptions::default()
+        },
+    );
+    assert!(
+        has_error_code(&diags, TS2580),
+        "NodeNext static import of unresolved node:stream/promises should emit the @types/node install hint, got: {diags:?}"
+    );
+}
+
+// Guard: removing the suppression must not over-report. A genuine non-builtin
+// bare package that fails to resolve under NodeNext must keep the plain
+// module-not-found path (TS2307), never the @types/node install hint.
+#[test]
+fn test_nodenext_non_builtin_bare_package_keeps_ts2307() {
+    let diags = check_with_module_not_found_errors(
+        r#"import { thing } from "definitely-not-a-node-builtin";
+export const use = () => thing;
+"#,
+        "usage.ts",
+        vec![],
+        vec!["definitely-not-a-node-builtin"],
+        CheckerOptions {
+            module: crate::common::ModuleKind::NodeNext,
+            ..CheckerOptions::default()
+        },
+    );
+    assert!(
+        has_module_not_found(&diags),
+        "NodeNext non-builtin bare package should keep a module-not-found error, got: {diags:?}"
+    );
+    assert!(
+        no_error_code(&diags, TS2580) && no_error_code(&diags, TS2591),
+        "NodeNext non-builtin bare package must not take the @types/node install-hint path, got: {diags:?}"
+    );
+}
+
 #[test]
 fn test_es_default_import_resolved() {
     let source = r#"import utils from "./utils";"#;


### PR DESCRIPTION
Goal: hold

Addresses the opposite-polarity parity gap flagged in #13826's discussion (the
sub-root #1 follow-up the investigation comments recommended splitting into its
own scoped PR). Does not close the #13826 umbrella (the canary `node:` misses
bottom out in fixture `@types/node` loading, which needs a project-scale
witness); this lands the standalone, unit-verifiable diagnostic-parity fix.

## Summary

A static `import` of a Node.js built-in module (`fs`, `node:fs`,
`node:stream/promises`, …) that fails to resolve was **silently suppressed**
under `module: node16 | node18 | node20 | nodenext`, while every other module
kind — and `tsc` — report the `@types/node` install hint (TS2580/TS2591).

The suppression lived as a `module.is_node_module()`-gated special case at the
import-check call site (`declaration_check_body.rs`), duplicated across the
resolution-error path and the fallback path. For all other module kinds, node
builtins already flow through the shared `module_not_found_diagnostic` helper,
which classifies them via `is_known_node_module` and emits TS2580/TS2591. This
removes the two bespoke suppression blocks so node builtins route through that
single helper uniformly, independent of the `module` emit target.

When `@types/node` is present the resolver binds the builtin (ambient/resolved)
and the import returns before any not-found path, so a diagnostic only fires on
genuine failure — matching `tsc` and the require-like / dynamic-import paths
(which never had the module-kind gate).

## Structural rule

When a Node.js built-in module specifier fails to resolve, `tsc` reports the
`@types/node` install hint (TS2580 for import/export sites, TS2591 for
require-like / import-type / JS / `noTypesAndSymbols`) regardless of the
`module` emit target. tsz now does the same through the shared
`module_not_found_diagnostic` / `module_not_found_diagnostic_for_site` query
boundary, instead of a `module.is_node_module()`-gated suppression that left
node16/node18/node20/nodenext silent.

## Owner layer

Checker import-declaration diagnostics. No solver/resolver/emit change. The
single source of truth for "is this a Node builtin?" stays
`query_boundaries::capabilities::is_known_node_module`; the call site no longer
re-derives or special-cases it.

## Anti-hardcoding

No identifier/file-name/printer-string predicates. Builtin classification is the
existing structural `is_known_node_module` set; the guard test confirms a
non-builtin bare package keeps the plain TS2307 path (no over-reporting).

## Adjacent-case matrix

- `module: node16|node18|node20|nodenext`, static `import { parse } from "url"`,
  unresolved → TS2580 (was: silent). Renamed binder (`parse`) — no name
  predicate involved.
- `module: nodenext`, `import { pipeline } from "node:stream/promises"`
  (the witnessed trpc `node:` subpath shape), unresolved → install hint.
- `module: nodenext`, non-builtin bare package, unresolved → TS2307 (guard:
  not the install-hint path).
- Unchanged: `module: commonjs` static import → TS2580; `noTypesAndSymbols` +
  any module → TS2591; require-like / dynamic-import / import-type → TS2591.

## Verification

- `cargo test -p tsz-core --lib -- module_resolution_tests::` — 93 pass,
  including 3 new regression tests
  (`test_node_module_kind_static_import_of_node_builtin_emits_ts2580`,
  `test_nodenext_node_scheme_subpath_builtin_emits_install_hint`,
  `test_nodenext_non_builtin_bare_package_keeps_ts2307`) and the pre-existing
  node-builtin suite (`test_ts_import_of_node_builtin_uses_ts2580`,
  `test_no_types_and_symbols_*`, `test_require_like_*`, `test_dynamic_import_*`).
- `cargo test -p tsz-checker --lib -- module_resolution_guard_tests::` — 9 pass
  (incl. `import_declaration_prefers_driver_resolution_error_over_ambient_match`).
- `cargo fmt --check -p tsz-checker -p tsz-core` clean; `cargo check -p tsz-checker` clean.
- Broad conformance / emit / fourslash owned by ready-review CI per repo policy.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jtt7ABPJxf2VdTEh2QtCti)_