### PR TITLE
fix(emit): hoist optional-chain temps in ES5 concise-body arrows

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers.rs
@@ -1,4 +1,4 @@
-use super::super::Printer;
+use super::super::{ParamTransformPlan, Printer};
 use crate::transforms::emit_utils;
 use std::sync::Arc;
 use tsz_parser::parser::NodeIndex;
@@ -581,38 +581,77 @@ impl<'a> Printer<'a> {
                 }
             } else if needs_param_prologue {
                 let needs_parens = self.concise_body_needs_parens(func.body);
-                self.write("{");
-                self.write_line();
-                self.increase_indent();
-                self.emit_param_prologue(&param_transforms);
                 let comments_before_return =
                     self.es5_arrow_concise_body_needs_multiline_return(func.body);
-                self.emit_es5_arrow_concise_return(func.body, needs_parens, comments_before_return);
-                self.write_line();
-                self.decrease_indent();
-                self.write("}");
+                self.emit_es5_concise_body_block_hoisting_temps(
+                    func.body,
+                    needs_parens,
+                    comments_before_return,
+                    Some(&param_transforms),
+                );
             } else {
                 // Concise body: (x) => x + 1  →  function (x) { return x + 1; }
                 // If the body is (or resolves to) an object literal, wrap in parens
                 // to disambiguate from a block: () => ({})  →  function () { return ({}); }
+                //
+                // The synthesized `{ return <expr>; }` is not a real block node, so
+                // it bypasses the function-body temp hoisting that `emit_block`
+                // performs. A concise body whose expression downlevels to hoisted
+                // temps (optional chaining `a?.b`, logical assignment, for-of) must
+                // still declare those `var _a, _b;` at the top of this function body
+                // — otherwise the temps are referenced but never declared, which is
+                // a ReferenceError under `"use strict"`. tsc emits them at the body
+                // top; mirror that by splicing the drained prologue before `return`.
                 let needs_parens = self.concise_body_needs_parens(func.body);
                 if self.es5_arrow_concise_body_needs_multiline_return(func.body) {
-                    self.write("{");
-                    self.write_line();
-                    self.increase_indent();
-                    self.emit_es5_arrow_concise_return(func.body, needs_parens, true);
-                    self.write_line();
-                    self.decrease_indent();
-                    self.write("}");
+                    self.emit_es5_concise_body_block_hoisting_temps(
+                        func.body,
+                        needs_parens,
+                        true,
+                        None,
+                    );
                 } else {
                     self.write("{ ");
+                    let var_insert_pos = self.writer.len();
                     self.emit_es5_arrow_concise_return(func.body, needs_parens, false);
+                    let prologue = self.take_single_line_hoisted_temp_prologue();
+                    if !prologue.is_empty() {
+                        self.writer.insert_at(var_insert_pos, &prologue);
+                    }
                     self.write(" }");
                 }
             }
             self.emitting_function_body_block = prev_emitting_function_body_block;
             self.pop_temp_scope();
         }
+    }
+
+    /// Emit a concise arrow body as a multi-line ES5 function block,
+    /// `{ <param prologue?> [var _a, _b;] return <expr>; }`, hoisting any
+    /// downlevel temps the body generates (optional chaining, logical
+    /// assignment, for-of) to the top of the body — above the parameter-default
+    /// prologue, matching tsc. Shared by the parameter-prologue and
+    /// comment-forced-multiline concise paths; the anchor is captured before the
+    /// prologue so the temps land first.
+    fn emit_es5_concise_body_block_hoisting_temps(
+        &mut self,
+        body: NodeIndex,
+        needs_parens: bool,
+        comments_before_return: bool,
+        param_transforms: Option<&ParamTransformPlan>,
+    ) {
+        self.write("{");
+        self.write_line();
+        self.increase_indent();
+        let hoist_anchor = self.capture_hoist_anchor();
+        if let Some(transforms) = param_transforms {
+            self.emit_param_prologue(transforms);
+        }
+        self.emit_es5_arrow_concise_return(body, needs_parens, comments_before_return);
+        self.insert_function_body_hoisted_temps_at(hoist_anchor);
+        self.write_line();
+        self.decrease_indent();
+        self.write("}");
     }
 
     fn es5_arrow_concise_body_needs_multiline_return(&self, body: NodeIndex) -> bool {

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -791,6 +791,16 @@ impl<'a> Printer<'a> {
         &mut self,
         anchor: HoistAnchor,
     ) {
+        // Common path: most function bodies hoist no temps. Skip the indent
+        // string allocation and the buffer-shifting insert when there is
+        // nothing to declare.
+        if self.hoisted_assignment_temps.is_empty()
+            && self.hoisted_for_of_temps.is_empty()
+            && self.hoisted_assignment_value_temps.is_empty()
+        {
+            return;
+        }
+
         let indent = self.writer.indent_string_at(anchor.indent_level);
         let mut ref_vars = Vec::new();
         ref_vars.extend(self.hoisted_assignment_temps.iter().cloned());

--- a/crates/tsz-emitter/tests/printer/basic_downlevel.rs
+++ b/crates/tsz-emitter/tests/printer/basic_downlevel.rs
@@ -118,6 +118,54 @@ fn arrow_default_optional_chain_temp_is_scoped_to_es5_body() {
 }
 
 #[test]
+fn arrow_concise_body_optional_chain_temp_declared_in_es5_body() {
+    // A concise-body arrow whose expression downlevels to hoisted temps
+    // (`node?.parent?.id`) must declare `var _a, _b;` at the top of the
+    // synthesized ES5 function body. The synthesized `{ return <expr>; }` is not
+    // a real block, so it bypasses `emit_block`'s function-body temp hoisting;
+    // without the splice the temps are referenced but never declared, a
+    // ReferenceError under `"use strict"`.
+    let source = "const readNode = (node?: { parent?: { id?: number } }) => node?.parent?.id ?? 0;";
+    let output = parse_lower_print(source, PrintOptions::es5());
+
+    assert!(
+        output.contains("function (node) { var _a, _b; return (_b = (_a = node === null || node === void 0 ? void 0 : node.parent) === null || _a === void 0 ? void 0 : _a.id) !== null && _b !== void 0 ? _b : 0; }"),
+        "Concise-body optional-chain temps must be declared inside the ES5 function body.\nOutput:\n{output}"
+    );
+    // The temps must not leak to the enclosing (module) scope.
+    assert!(
+        !output.trim_start().starts_with("var _a"),
+        "Concise-body temps must not be hoisted to the enclosing scope.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn arrow_concise_body_optional_chain_temp_is_name_agnostic() {
+    // Same shape, different binder spellings: the hoist follows the optional
+    // chain's structure, not any particular identifier.
+    let source = "const pick = (cfg?: { opts?: { port?: number } }) => cfg?.opts?.port;";
+    let output = parse_lower_print(source, PrintOptions::es5());
+
+    assert!(
+        output.contains("function (cfg) { var _a; return (_a = cfg === null || cfg === void 0 ? void 0 : cfg.opts) === null || _a === void 0 ? void 0 : _a.port; }"),
+        "Renamed binders must still get the body-scoped optional-chain temp.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn arrow_concise_body_optional_chain_temp_above_param_default_prologue() {
+    // Concise body with a parameter default: tsc declares the body's hoisted
+    // `var _a;` above the parameter-default prologue (`if (entry === void 0)`).
+    let source = "const withFallback = (entry = { meta: undefined as undefined | { tag?: string } }) => entry?.meta?.tag;";
+    let output = parse_lower_print(source, PrintOptions::es5());
+
+    assert!(
+        output.contains("function (entry) {\n    var _a;\n    if (entry === void 0) { entry = { meta: undefined }; }\n    return (_a = entry === null || entry === void 0 ? void 0 : entry.meta) === null || _a === void 0 ? void 0 : _a.tag;\n}"),
+        "Body optional-chain temp must be declared above the parameter-default prologue.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn optional_parameter_missing_initializer_skips_question_after_trivia() {
     let source = "function f(a ? = ) {}\n";
     let output = parse_lower_print(source, PrintOptions::es6());


### PR DESCRIPTION
Goal: hold

Fixes #13986.

## Summary

A concise-body arrow downleveled to ES5 (`(a) => a?.b?.c` → `function (a) { return <expr>; }`) synthesizes a function body that is **not a real block node**, so it bypassed the function-body temp hoisting `emit_block` performs. When the body lowered to hoisted temps (optional chaining, nullish coalescing, …), the temps were emitted as `_a`/`_b` references but **declared nowhere** — discarded with the arrow's temp scope at `pop_temp_scope`. Under `"use strict"` (always set for emitted modules) the output threw **`ReferenceError: _a is not defined`** at runtime; it was broken code, not merely a parity diff.

```ts
export const opt = (a?: { b?: { c?: number } }) => a?.b?.c ?? 0;
```
```
tsc  --target es5  →  var opt = function (a) { var _a, _b; return (...); };
tsz  --target es5  →  var opt = function (a) {            return (...); };   // _a/_b undeclared → ReferenceError
```

Block-body arrows, function expressions/declarations, and IIFEs were already correct — only the concise-body shape was affected, and it was entirely uncovered by tests.

## Structural rule

When an arrow with a concise body is downleveled to the ES5 `function (a) { return <expr>; }` form and `<expr>` lowers to hoisted temps, `tsc` declares `var _a, _b;` at the top of the synthesized body (above the parameter-default prologue). tsz must do the same through the emitter's ES5 concise-arrow lowering instead of discarding the temps with the arrow's temp scope.

## Owner layer / fix

Emitter only (`crates/tsz-emitter/src/emitter/es5/helpers.rs`, `emit_arrow_function_es5`). No checker/solver/semantic change; no output surgery beyond the sanctioned hoisted-`var` splice.

- Single-line concise body: inline `take_single_line_hoisted_temp_prologue()` + `writer.insert_at()` (the same pattern the native path and `emit_single_line_block` already use).
- Multi-line and parameter-default concise bodies: a shared `emit_es5_concise_body_block_hoisting_temps` helper that captures a hoist anchor **before** the parameter-default prologue and splices the `var` line there (matching tsc, which emits `var _a;` above `if (a === void 0)`).
- The drain is **shape-agnostic** — it declares whatever temps the body actually generated — so it covers every temp-generating concise body (optional chaining, nullish, etc.) rather than enumerating syntactic cases.
- Also adds an early-return guard to the shared `insert_function_body_hoisted_temps_at` so the no-temp common path skips the indent-string allocation and buffer-shift.

## Anti-hardcoding

No identifier/file-name/printer-string predicates drive behavior; the hoist follows the body's actual temp generation. Regression tests vary binder names (`node`/`parent`/`id`, `cfg`/`opts`/`port`, `entry`/`meta`/`tag`).

## Adjacent-case matrix (verified byte-identical to `tsc` 6.0.2)

| shape | result |
|---|---|
| `(a) => a?.b?.c ?? 0` (two temps) | `function (a) { var _a, _b; return …; }` ✓ |
| `(cfg) => cfg?.opts?.port` (one temp, renamed) | `var _a;` in body ✓ |
| `(entry = {…}) => entry?.meta?.tag` (param default) | `var _a;` **above** `if (entry === void 0)` ✓ |
| `(o) => o?.["k"]?.v` (element access) | hoisted ✓ |
| `(o) => o?.f?.()` (optional call, **es5**) | hoisted ✓ |
| block-body / function-expr / IIFE / decl | unchanged, still correct ✓ |

Runtime: the previously-`ReferenceError` outputs now execute correctly.

## Known related follow-up (out of scope)

At es2015–es2019 the **native** arrow path (`param_initializer_generates_hoisted_temp`) has a narrower variant of the same family: its concise-body prologue detection misses the optional-**call** shape `o?.f?.()`, so that temp still leaks at those targets. That is a separate detection bug in a different code path; noted in #13986 for follow-up.

## Verification

- `cargo test -p tsz-emitter --lib` → 3757 passed, 0 failed (incl. 3 new name-agnostic regression tests in `tests/printer/basic_downlevel.rs`).
- Integration targets `optional_chaining_tests`, `arrow_parameter_prologue_tests`, `async_arrow_default_param_3758_tests`, `cjs_hoisted_var_position_tests`, `function_parameter_native_prologue_tests`, `using_function_body_hoisted_temps_indent_tests` → all pass.
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --lib` → clean.
- Differential vs `tsc` across es5/es2015/es2017/es2019/es2020/esnext on the matrix above → ES5 byte-identical; runtime no longer throws.
- Broad emit/conformance/fourslash owned by ready-review CI per repo policy.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01K4PquPQHFwtkWLuNryfCty

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4PquPQHFwtkWLuNryfCty)_