### PR TITLE
fix(solver): resolve cross-file generic alias-of-callable call targets (#13947)

### DIFF
--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -74,36 +74,21 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 let shape = self.interner.callable_shape(c_id);
                 self.resolve_callable_call(shape.as_ref(), arg_types)
             }
-            TypeData::Union(list_id) => {
-                // Handle union types: if all members are callable with compatible signatures,
-                // the union is callable
-                self.resolve_union_call(func_type, list_id, arg_types)
-            }
+            TypeData::Union(list_id) => self.resolve_union_call(func_type, list_id, arg_types),
             TypeData::Intersection(list_id) => {
                 // Handle intersection types: if any member is callable, use that
                 // This handles cases like: Function & { prop: number }
                 self.resolve_intersection_call(func_type, list_id, arg_types)
             }
             TypeData::Application(_app_id) => {
-                // Handle Application types (e.g., GenericCallable<string>)
-                // Evaluate the application type to properly instantiate its base type with arguments
                 let evaluated = self.checker.evaluate_type(func_type);
                 if evaluated != func_type {
                     return self.resolve_call(evaluated, arg_types);
                 }
-                // `evaluate_type` cannot expand a *cross-file* generic alias/interface
-                // application whose base carries no `SymbolId` in the calling file's
-                // context (the resolver-less case: the base survives lowering as a bare
-                // `Lazy(DefId)`/`TypeQuery`/`UnresolvedTypeName`). The constraint walker
-                // and generic-call inference already recover this through
-                // `expand_type_alias_application`, which resolves the base via its
-                // declaring `DefId` and instantiates the open body. The call boundary
-                // did not, so a callable generic alias/interface reached as a call
-                // target (e.g. an imported `type Create<R> = Sig<R>` where `Sig` is a
-                // callable interface) collapsed to a spurious `NotCallable` — the
-                // untyped-call / not-callable family tracked in #13947. Expand the alias
-                // application and retry; callability is still decided structurally, so a
-                // genuinely non-callable application stays `NotCallable`.
+                // Resolver-less cross-file generic aliases can survive as
+                // unexpanded applications. Retry through the same alias
+                // expansion used by constraints and generic-call inference;
+                // callability is still decided structurally after expansion.
                 if let Some(expanded) = self.checker.expand_type_alias_application(func_type)
                     && expanded != func_type
                 {
@@ -1398,16 +1383,10 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     ) -> CallResult {
         let members = self.interner.type_list(list_id);
 
-        // For intersection types: if ANY member is callable, the intersection is callable
-        // This is different from unions where ALL members must be callable
-        // We try each member in order and use the first callable one
         for &member in members.iter() {
             let result = self.resolve_call(member, arg_types);
             match result {
-                CallResult::Success(return_type) => {
-                    // Found a callable member - use its return type
-                    return CallResult::Success(return_type);
-                }
+                CallResult::Success(return_type) => return CallResult::Success(return_type),
                 CallResult::NotCallable { .. } => {
                     // This member is not callable, try the next one
                     continue;

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -89,10 +89,27 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 // Evaluate the application type to properly instantiate its base type with arguments
                 let evaluated = self.checker.evaluate_type(func_type);
                 if evaluated != func_type {
-                    self.resolve_call(evaluated, arg_types)
-                } else {
-                    CallResult::NotCallable { type_id: func_type }
+                    return self.resolve_call(evaluated, arg_types);
                 }
+                // `evaluate_type` cannot expand a *cross-file* generic alias/interface
+                // application whose base carries no `SymbolId` in the calling file's
+                // context (the resolver-less case: the base survives lowering as a bare
+                // `Lazy(DefId)`/`TypeQuery`/`UnresolvedTypeName`). The constraint walker
+                // and generic-call inference already recover this through
+                // `expand_type_alias_application`, which resolves the base via its
+                // declaring `DefId` and instantiates the open body. The call boundary
+                // did not, so a callable generic alias/interface reached as a call
+                // target (e.g. an imported `type Create<R> = Sig<R>` where `Sig` is a
+                // callable interface) collapsed to a spurious `NotCallable` — the
+                // untyped-call / not-callable family tracked in #13947. Expand the alias
+                // application and retry; callability is still decided structurally, so a
+                // genuinely non-callable application stays `NotCallable`.
+                if let Some(expanded) = self.checker.expand_type_alias_application(func_type)
+                    && expanded != func_type
+                {
+                    return self.resolve_call(expanded, arg_types);
+                }
+                CallResult::NotCallable { type_id: func_type }
             }
             TypeData::TypeParameter(param_info) => {
                 // For type parameters with callable constraints (e.g., T extends { (): string }),

--- a/crates/tsz-solver/src/operations/core/call_resolution_tests.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution_tests.rs
@@ -1,0 +1,100 @@
+//! Unit tests for `resolve_call`'s `Application` arm cross-file alias-of-callable
+//! recovery (refs #13947).
+
+use super::call_evaluator::{AssignabilityChecker, CallEvaluator, CallResult};
+use crate::TypeInterner;
+use crate::def::DefId;
+use crate::types::{FunctionShape, TypeId};
+
+/// Mock checker modelling the resolver-less cross-file case: `evaluate_type`
+/// cannot reduce the application (the trait default returns it unchanged), but
+/// `expand_type_alias_application` recovers the open body for the tracked
+/// application `TypeId` — exactly what the real checker's DefId-keyed expansion
+/// does for an imported `type Create<R> = Sig<R>` whose `Sig` base carries no
+/// `SymbolId` in the calling file's context.
+struct AliasExpandChecker {
+    app: TypeId,
+    expanded: Option<TypeId>,
+}
+
+impl AssignabilityChecker for AliasExpandChecker {
+    fn is_assignable_to(&mut self, _source: TypeId, _target: TypeId) -> bool {
+        true
+    }
+
+    fn expand_type_alias_application(&mut self, type_id: TypeId) -> Option<TypeId> {
+        if type_id == self.app {
+            self.expanded
+        } else {
+            None
+        }
+    }
+}
+
+/// A generic application `Base<string>` whose base is a bare `Lazy(DefId)` that
+/// the (default) evaluator cannot resolve — the resolver-less call-target shape.
+fn resolver_less_application(interner: &TypeInterner) -> TypeId {
+    let base = interner.lazy(DefId(1));
+    interner.application(base, vec![TypeId::STRING])
+}
+
+#[test]
+fn application_call_target_falls_back_to_alias_expansion() {
+    let interner = TypeInterner::new();
+    let app = resolver_less_application(&interner);
+    // The alias body is a callable `() => number`.
+    let callable = interner.function(FunctionShape::new(vec![], TypeId::NUMBER));
+
+    let mut checker = AliasExpandChecker {
+        app,
+        expanded: Some(callable),
+    };
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+    let result = evaluator.resolve_call(app, &[]);
+
+    assert!(
+        matches!(result, CallResult::Success(ret) if ret == TypeId::NUMBER),
+        "a resolver-less alias-of-callable application used as a call target must \
+         resolve through expand_type_alias_application rather than collapsing to \
+         NotCallable, got {result:?}"
+    );
+}
+
+#[test]
+fn application_call_target_without_expansion_stays_not_callable() {
+    let interner = TypeInterner::new();
+    let app = resolver_less_application(&interner);
+
+    // The checker cannot expand the application (genuinely opaque / non-callable):
+    // the fallback must not invent callability.
+    let mut checker = AliasExpandChecker {
+        app,
+        expanded: None,
+    };
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+    let result = evaluator.resolve_call(app, &[]);
+
+    assert!(
+        matches!(result, CallResult::NotCallable { .. }),
+        "an application the checker cannot expand stays NotCallable, got {result:?}"
+    );
+}
+
+#[test]
+fn application_call_target_prefers_evaluation_when_available() {
+    let interner = TypeInterner::new();
+    let app = resolver_less_application(&interner);
+    // If expansion yields the same type (no progress), the call stays NotCallable
+    // rather than recursing forever.
+    let mut checker = AliasExpandChecker {
+        app,
+        expanded: Some(app),
+    };
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+    let result = evaluator.resolve_call(app, &[]);
+
+    assert!(
+        matches!(result, CallResult::NotCallable { .. }),
+        "a non-progressing expansion must not loop or fabricate callability, got {result:?}"
+    );
+}

--- a/crates/tsz-solver/src/operations/core/mod.rs
+++ b/crates/tsz-solver/src/operations/core/mod.rs
@@ -9,6 +9,8 @@
 pub(crate) mod call_evaluator;
 mod call_inference_shape;
 mod call_resolution;
+#[cfg(test)]
+mod call_resolution_tests;
 
 pub(crate) use call_evaluator::MAX_CONSTRAINT_STEPS;
 pub use call_evaluator::*;


### PR DESCRIPTION
Goal: green

Incremental progress on #13947 (runtypes canary: cross-file generic call-signature loss → untyped/not-callable cascade).

## Structural rule

When a call target is a generic type `Application` whose base is a **cross-file** alias/interface with no `SymbolId` in the calling file's context — the resolver-less case, where the base survives lowering as a bare `Lazy(DefId)` / `TypeQuery` / `UnresolvedTypeName` — `evaluate_type` cannot expand it. `resolve_call`'s `Application` arm then returned a spurious `NotCallable`, so a callable generic alias/interface reached as a call target (e.g. an imported `type Create<R> = Sig<R>` where `Sig` is a callable interface) collapsed to the not-callable / untyped-call family tracked in #13947.

`tsc` resolves such a call target through its declaring symbol's body. The constraint walker and generic-call inference paths already recover the resolver-less form via `expand_type_alias_application`, which resolves the base through its declaring `DefId` and instantiates the open body. This PR wires that same recovery into the call boundary: when `evaluate_type` makes no progress on an `Application` call target, expand the alias application and retry the call. This is the exact fix direction noted in #13947 ("`resolve_call` `Application` arm falling back to `expand_type_alias_application`").

Owner layer: solver call resolution (`crates/tsz-solver/src/operations/core/call_resolution.rs`, `resolve_call`).

## Safety / non-regression

- Callability is still decided **structurally** after expansion: a genuinely non-callable application (alias body without a call signature) stays `NotCallable`.
- A non-progressing expansion (`expanded == func_type`) does not recurse, so no loop is introduced.
- Name-agnostic and structural — no identifier/file-name/printer-string predicate drives the decision.

## Scope note

This hardens the call-resolution boundary for **all** cross-file generic alias-of-callable call targets (structural, not fixture-specific). The full runtypes canary failure is emergent from that project's complete type web (class+namespace merge, default export, self-referential `R extends Runtype`) and is **not** retired here; this lands as independent, verified correctness progress on #13947.

The fix fits under the `call_resolution.rs` 2000-line cap (1962 lines); unit tests live in a sibling `call_resolution_tests.rs` module, so no file split was required.

## Adjacent-case matrix

- Resolver-less `Application` call target whose alias body is callable → resolves to the body's call signature (`application_call_target_falls_back_to_alias_expansion`); fails without the gate, passes with it.
- Application the checker cannot expand → stays `NotCallable` (`application_call_target_without_expansion_stays_not_callable`).
- Non-progressing expansion (`expanded == target`) → stays `NotCallable`, no loop (`application_call_target_prefers_evaluation_when_available`).

## Verification

- `cargo test -p tsz-solver --lib operations::core::call_resolution_tests` — 3/3 pass; the assignment-arm test fails on `main` (returns `NotCallable`) and passes with the gate (verified by toggling the gate off/on).
- `cargo test -p tsz-solver --lib` — 6794 passed; the only 3 failures are pre-existing on `main` HEAD (identical with this change reverted: `test_conditional_infer_optional_property_present_distributive`, `literal_mask_preserves_object_vs_literal_reduction`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`) and unrelated to this diff.
- `cargo fmt -p tsz-solver --check` and `cargo clippy -p tsz-solver --lib` — clean.
- Conformance / emit / fourslash parity floor: owned by ready-review CI per repo policy.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Qb5767HVuZCHHMd4xX4ity

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb5767HVuZCHHMd4xX4ity)_