### PR TITLE
fix(checker): unwrap rest-element array type when iterating a tuple in for-of

### DIFF
--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -677,7 +677,23 @@ impl<'a> CheckerState<'a> {
         match classify_for_of_element_type(self.ctx.types, type_id) {
             ForOfElementKind::Array(elem) => elem,
             ForOfElementKind::Tuple(elements) => {
-                let member_types: Vec<TypeId> = elements.iter().map(|e| e.type_id).collect();
+                // A rest element (`...T[]`) contributes the iterated ELEMENT type of
+                // its array, not the array type itself; fixed (non-rest) elements
+                // contribute their own type. Iterating `[Base, ...Base[]]` yields
+                // `Base`, not `Base | Base[]`. Computing the rest's element type via
+                // the same iterable element-type query keeps it a solver-backed
+                // decision and resolves concrete arrays, readonly arrays, and generic
+                // `T extends U[]` rests uniformly.
+                let member_types: Vec<TypeId> = elements
+                    .iter()
+                    .map(|e| {
+                        if e.rest {
+                            self.for_of_element_type_classified(e.type_id, depth + 1)
+                        } else {
+                            e.type_id
+                        }
+                    })
+                    .collect();
                 tsz_solver::utils::union_or_single(self.ctx.types, member_types)
             }
             ForOfElementKind::Union(members) => {


### PR DESCRIPTION
Goal: green

## Summary
`for_of_element_type_classified`'s `ForOfElementKind::Tuple` arm computed the iterated element union from each `TupleElement.type_id` directly, **ignoring the `rest` flag**. For a tuple with a rest element — `[Base, ...Base[]]`, or the generic `[A, ...B]` where `B extends AnyStruct[]` — the rest element's type is the *array* (`Base[]` / `B`), so the iteration element type became `Base | Base[]` and member access in the loop body produced a false `TS2339`.

## Structural Rule
When iterating (`for-of`) a tuple, a **rest** element (`...T[]`) contributes the iterated *element* type of its array, not the array type itself; fixed (non-rest) elements contribute their own type. tsz now computes the rest's element type through the same iterable element-type query (recursing `for_of_element_type_classified` on the rest type).

- **Owner layer:** checker — `crates/tsz-checker/src/checkers/iterable_checker.rs`, the `ForOfElementKind::Tuple` arm. The array-element extraction stays a solver-backed decision (the recursive query resolves `TypeData::Array`, readonly arrays, and generic `T extends U[]` rests uniformly), per the architecture contract.
- **Fallback:** non-rest elements are untouched; a rest type that isn't array-like falls through the recursion as before.

### Adjacent-case matrix (verified vs `tsc`)
| Tuple → for-of element | tsc | tsz |
|---|---|---|
| `[Base, ...Base[]]` (concrete rest) | `Base` | `Base` (was `Base \| Base[]` → TS2339) |
| `[A, ...B]`, `B extends AnyStruct[]` (generic rest) | `A \| <elem of B>` | same (was `A \| B` → TS2339) |
| `[A, B]` (no rest) | `A \| B` | `A \| B` (unchanged) |

## Project Corpus Impact
- **zod:** 19 → 18 tsz-only FPs.
- **superstruct:** 19 → 16 tsz-only FPs.
- No new errors introduced.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- Minimal repros (concrete `[Base, ...Base[]]` and generic `[A, ...B]`) diffed against `node typescript/lib/tsc.js --noEmit --strict --target es2022 --lib es2022` — tsz now matches tsc (both clean).
- Conformance `scripts/conformance/conformance.sh run --filter <fam>`: **forOf, iterators, tuple, array, spread, destructuring, generics, members, typeRelationships, subtyping all 100% pass, zero regressions**.
- zod/superstruct measured against a freshly-built clean-main binary; tsz-only delta computed via `comm` against the tsc oracle.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean; `cargo fmt` clean.