### PR TITLE
checker: add targeted per-TypeId env_eval_cache invalidation

### DIFF
--- a/crates/tsz-checker/src/context/env_eval_cache.rs
+++ b/crates/tsz-checker/src/context/env_eval_cache.rs
@@ -163,6 +163,60 @@ impl<'a> CheckerContext<'a> {
         self.env_eval_cache.borrow_mut().clear();
     }
 
+    /// Drop the single top-level `env_eval_cache` entry keyed by `type_id`, if
+    /// present. Returns whether an entry was actually removed.
+    ///
+    /// This is the minimal targeted counterpart to [`Self::clear_env_eval_cache`]
+    /// (global flush) and [`Self::clear_type_evaluation_caches_for_def`]
+    /// (per-`DefId` sweep): it invalidates exactly one evaluation result without
+    /// disturbing any other entry or paying an `O(cache)` structural scan. Use it
+    /// when a specific `type_id` must be re-evaluated — e.g. re-resolving a type
+    /// under a different resolution mode after a speculative (bounded) verdict —
+    /// so the next [`Self::lookup_env_eval_cache`] recomputes rather than
+    /// short-circuiting to the stale entry.
+    pub(crate) fn invalidate_env_eval_for(&self, type_id: TypeId) -> bool {
+        self.env_eval_cache.borrow_mut().remove(&type_id).is_some()
+    }
+
+    /// Drop every `env_eval_cache` entry structurally reachable from `type_id`:
+    /// the entry for `type_id` itself plus every entry whose key **or** cached
+    /// result is a structural sub-term of `type_id`. Returns the number of
+    /// entries removed.
+    ///
+    /// Re-evaluating a type under a different resolution mode is not enough to
+    /// invalidate just its top-level result: the first (e.g. shallow/bounded)
+    /// pass also cached results for the sub-terms it walked, and a later full
+    /// pass would short-circuit to those stale sub-results. This transitive
+    /// variant clears the type's reachable sub-evaluations in one pass so the
+    /// re-evaluation recomputes the whole reachable closure.
+    ///
+    /// The reachable set is collected once (`collect_referenced_types`, which
+    /// includes the root) and entries are tested by O(1) membership, so the
+    /// sweep is `O(reachable(type_id)) + O(cache)` rather than re-walking per
+    /// entry. The result side is matched with the same key-and-result discipline
+    /// as [`Self::clear_type_evaluation_caches_for_def`]: an entry whose result
+    /// embeds a reachable sub-term holds that sub-term's pre-re-evaluation form,
+    /// so it is dropped too. Over-matching only forces a deterministic recompute;
+    /// it never changes a result.
+    ///
+    /// Scope is the `env_eval_cache` only. Unlike the per-`DefId` sweep, this
+    /// does not touch the narrowing `resolve_cache`/`contextual_resolve_cache`:
+    /// those are invalidated through the def-keyed path and are not part of a
+    /// per-type evaluation closure.
+    pub(crate) fn invalidate_env_eval_reachable_from(&self, type_id: TypeId) -> usize {
+        let mut cache = self.env_eval_cache.borrow_mut();
+        if cache.is_empty() {
+            // Nothing to drop: skip the structural walk entirely (mirrors the
+            // empty-cache early-out in `env_eval_cache_seed_entries`).
+            return 0;
+        }
+        let reachable =
+            crate::query_boundaries::common::collect_referenced_types(self.types, type_id);
+        let before = cache.len();
+        cache.retain(|&key, value| !reachable.contains(&key) && !reachable.contains(&value.result));
+        before - cache.len()
+    }
+
     pub(crate) fn clear_type_evaluation_caches_for_def(&self, def_id: tsz_solver::DefId) {
         self.env_eval_cache.borrow_mut().retain(|&key, value| {
             !self.type_mentions_def(key, def_id) && !self.type_mentions_def(value.result, def_id)

--- a/crates/tsz-checker/src/context/env_eval_cache.rs
+++ b/crates/tsz-checker/src/context/env_eval_cache.rs
@@ -210,8 +210,9 @@ impl<'a> CheckerContext<'a> {
             // empty-cache early-out in `env_eval_cache_seed_entries`).
             return 0;
         }
-        let reachable =
-            crate::query_boundaries::common::collect_referenced_types(self.types, type_id);
+        let reachable = crate::query_boundaries::type_computation::core::collect_referenced_types(
+            self.types, type_id,
+        );
         let before = cache.len();
         cache.retain(|&key, value| !reachable.contains(&key) && !reachable.contains(&value.result));
         before - cache.len()

--- a/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
@@ -42,6 +42,13 @@ pub(crate) fn contains_application_unknown_arg(db: &dyn TypeDatabase, type_id: T
     tsz_solver::type_queries::contains_application_unknown_arg(db, type_id)
 }
 
+pub(crate) fn collect_referenced_types(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> rustc_hash::FxHashSet<TypeId> {
+    tsz_solver::visitor::collect_referenced_types(db, type_id)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WriteTargetLogicalOperator {
     LogicalOr,

--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
@@ -597,6 +597,87 @@ fn test_env_eval_cache_def_invalidation_is_targeted() {
 }
 
 #[test]
+fn test_invalidate_env_eval_for_targets_single_entry() {
+    let arena = NodeArena::new();
+    let binder = BinderState::new();
+    let types = TypeInterner::new();
+    let ctx = CheckerContext::new(
+        &arena,
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    let target = types.lazy(DefId(11_001));
+    let neighbor = types.lazy(DefId(11_002));
+
+    ctx.cache_env_eval_result(target, TypeId::STRING, false);
+    ctx.cache_env_eval_result(neighbor, TypeId::NUMBER, false);
+
+    // Removing the targeted key drops only that entry and reports the removal.
+    assert!(ctx.invalidate_env_eval_for(target));
+    assert!(ctx.lookup_env_eval_cache(target).is_none());
+    assert_eq!(
+        ctx.lookup_env_eval_cache(neighbor)
+            .map(|entry| entry.result),
+        Some(TypeId::NUMBER),
+        "unrelated entries must survive a targeted single-key invalidation",
+    );
+
+    // A second invalidation of the now-absent key is a no-op and reports false.
+    assert!(!ctx.invalidate_env_eval_for(target));
+}
+
+#[test]
+fn test_invalidate_env_eval_reachable_from_clears_structural_closure() {
+    let arena = NodeArena::new();
+    let binder = BinderState::new();
+    let types = TypeInterner::new();
+    let ctx = CheckerContext::new(
+        &arena,
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    // `composite` structurally reaches `member_a` and `member_b`; `outsider`
+    // and the `keep_*` lazies are not part of its reachable closure.
+    let member_a = types.lazy(DefId(12_001));
+    let member_b = types.lazy(DefId(12_002));
+    let composite = types.union(vec![member_a, member_b]);
+    let outsider = types.lazy(DefId(12_003));
+    let keep_key = types.lazy(DefId(12_004));
+    let keep_result = types.lazy(DefId(12_005));
+
+    // Root entry (key == composite) and a sub-term entry (key reachable).
+    ctx.cache_env_eval_result(composite, TypeId::STRING, false);
+    ctx.cache_env_eval_result(member_a, TypeId::NUMBER, false);
+    // Result-side staleness: an unrelated key whose cached result embeds a
+    // reachable sub-term must also be dropped.
+    ctx.cache_env_eval_result(outsider, member_b, false);
+    // Wholly unrelated entry: neither key nor result is reachable.
+    ctx.cache_env_eval_result(keep_key, keep_result, false);
+
+    let removed = ctx.invalidate_env_eval_reachable_from(composite);
+    assert_eq!(
+        removed, 3,
+        "root, reachable sub-term key, and result-side mention should be cleared",
+    );
+
+    assert!(ctx.lookup_env_eval_cache(composite).is_none());
+    assert!(ctx.lookup_env_eval_cache(member_a).is_none());
+    assert!(ctx.lookup_env_eval_cache(outsider).is_none());
+    assert_eq!(
+        ctx.lookup_env_eval_cache(keep_key)
+            .map(|entry| entry.result),
+        Some(keep_result),
+        "entries outside the reachable closure must survive",
+    );
+}
+
+#[test]
 fn test_register_def_in_envs_skips_invalidation_for_unchanged_body() {
     let arena = NodeArena::new();
     let binder = BinderState::new();


### PR DESCRIPTION
## Summary

`env_eval_cache` (`crates/tsz-checker/src/context/env_eval_cache.rs`) previously
exposed only two invalidation scopes:

- **global** — `clear_env_eval_cache` / file-session reset, and
- **per-`DefId`** — `clear_type_evaluation_caches_for_def`.

There was no way to invalidate a **single type's** cached evaluation. Any scheme
that wants to re-evaluate a specific type under a different resolution mode
(e.g. a speculative bounded verdict that must fall back to a full re-resolve)
short-circuits to the stale shallow entry, because the first evaluation is
cached and the second lookup hits it. This closes #13981.

## Structural rule

When a single `TypeId` (and its reachable sub-evaluations) must be re-evaluated
without flushing the whole file's env-eval memo, `tsc`'s equivalent staged
evaluation recomputes that type's closure on demand; tsz now does the same
through two targeted `CheckerContext` helpers in the cache's owning layer
(`context/env_eval_cache.rs`), keeping the algorithm out of the checker body.

## What changed

Two new `CheckerContext` helpers, alongside the existing `clear_*` surface:

- `invalidate_env_eval_for(type_id) -> bool` — O(1) removal of the single
  top-level entry keyed by `type_id`; reports whether one was removed.
- `invalidate_env_eval_reachable_from(type_id) -> usize` — transitive variant:
  drops `type_id`'s own entry plus every entry whose **key or cached result** is
  a structural sub-term of `type_id`, so the shallow sub-evaluations cached
  during the first pass are cleared together with the top-level result. The
  reachable set is collected once (`collect_referenced_types`) and entries are
  tested by O(1) membership (`O(reachable(type_id)) + O(cache)`); an empty cache
  skips the structural walk. Result-side matching mirrors the key-and-result
  discipline of `clear_type_evaluation_caches_for_def`; over-matching only forces
  a deterministic recompute, never a different result.

Scope is the env-eval cache only — the narrowing
`resolve_cache`/`contextual_resolve_cache` stay on the def-keyed path, as
documented on the method. This is a reusable enabler for resolution-mode-sensitive
re-evaluation (the comlink Fast-goal approach in #13979), not a one-off.

## Adjacent cases

- Exact targeting: only the named key is dropped; neighbors survive; a second
  invalidation of the now-absent key is a no-op returning `false`.
- Transitive closure: root entry, a reachable sub-term key, and a result-side
  mention are all cleared while a wholly unrelated entry survives.
- Empty cache: early-out skips the reachable-set walk.

Goal: hold

## Verification

- `cargo test -p tsz-checker --lib invalidate_env_eval` — both new
  architecture-contract tests pass (`test_invalidate_env_eval_for_targets_single_entry`,
  `test_invalidate_env_eval_reachable_from_clears_structural_closure`).
- `cargo clippy -p tsz-checker --lib` — clean (workspace `style`/`perf`/`complexity`/`correctness` deny gates).
- Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_015kfCtg1CXACnbQmYLhsf7j)_