### PR TITLE
fix(solver): Array.isArray narrows object-like supertypes of any[] to any[], not never

### DIFF
--- a/crates/tsz-solver/src/narrowing/compound.rs
+++ b/crates/tsz-solver/src/narrowing/compound.rs
@@ -711,7 +711,9 @@ impl<'a> NarrowingContext<'a> {
                     // swallowed by `narrow_to_array`) and `has_any_compat` is
                     // set correctly for the array-like retention pass below.
                     let resolved_member = self.resolve_type(member);
-                    if self.is_any_array_compat(resolved_member) {
+                    if self.is_any_array_compat(resolved_member)
+                        || is_subtype_of(self.db, any_array, resolved_member)
+                    {
                         has_any_compat = true;
                         return Some(any_array);
                     }
@@ -783,9 +785,15 @@ impl<'a> NarrowingContext<'a> {
             return source_type;
         }
 
-        // Non-array source compatible with `any[]`: tsc's predicate narrowing
-        // substitutes the source with `any[]`.
-        if self.is_any_array_compat(source_type) {
+        // Non-array source from which `any[]` can be narrowed: tsc's predicate
+        // narrowing (`mapType(t => isTypeSubtypeOf(any[], t) ? any[] : …)`)
+        // substitutes `any[]` either when the source is structurally array-like
+        // (an `any` string index or any numeric index, via `is_any_array_compat`)
+        // OR when the source is a SUPERTYPE of `any[]` — `object`, `{}`, an empty
+        // interface — i.e. `any[] <: source`. Without the supertype case these
+        // object-like guards narrowed to `never`, producing false TS2339 on every
+        // member access in the true branch.
+        if self.is_any_array_compat(source_type) || is_subtype_of(self.db, any_array, source_type) {
             return any_array;
         }
 


### PR DESCRIPTION
Goal: green

## Summary
`narrow_to_array` (the `Array.isArray(x)` true-branch narrower) substituted the predicate type `any[]` for a non-array source only when the source had an `any`-typed string index or any numeric index (`is_any_array_compat`). An object-like source that is a **supertype** of `any[]` — `object`, `{}`, an empty interface — has no index signature, so it fell through to `never`, and every member access in the true branch became a false `TS2339` (remeda `Array.isArray(data)` on `object`; type-graphql on `{}`).

## Structural Rule
tsc's predicate narrowing for `arg is any[]` is `mapType(t => isTypeSubtypeOf(any[], t) ? any[] : …)` — it substitutes `any[]` whenever `any[] <: source`. tsz now broadens the substitution (both the single-type fall-through and the union per-member path) to also fire when `any[]` is a subtype of the source.

- **Owner layer:** solver — `crates/tsz-solver/src/narrowing/compound.rs` `narrow_to_array` / its union path. Uses the already-imported `is_subtype_of` (no new infrastructure).
- **Fallback:** the false branch (`narrow_excluding_array`) is untouched; a source that `any[]` is *not* assignable to (`{ x: number }`, `string`, …) still narrows to `never`/itself exactly as before.

### Adjacent-case matrix (verified vs `tsc`)
| `Array.isArray(x)` true-branch, x: | tsc | tsz |
|---|---|---|
| `object` | `any[]` | `any[]` (was `never` → TS2339) |
| `{}` | `any[]` | `any[]` (was `never`) |
| `object \| string` | `any[]` (object member) | same (was `never`) |
| `{ x: number }` (not a supertype of any[]) | `never` | `never` (unchanged) |
| `Record<string, any>` / `ArrayLike` (index-sig) | `any[]` | `any[]` (unchanged path) |

## Project Corpus Impact
- **remeda:** 56 → 55 tsz-only FPs.
- **type-graphql:** 16 → 14 tsz-only FPs.
- No new errors introduced.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- Minimal repros (`object`, `{}`, `object|string`, plus a negative `{x:number}` control and the `{x:1}`-not-assignable-to-`number[]` control) diffed against `node typescript/lib/tsc.js --noEmit --strict --target es2022 --lib es2022` — tsz now matches tsc exactly.
- Conformance: **narrowing, typeGuard (86), controlFlow (94), comparable, subtyping, array, union, intersection, members, typeRelationships all 100% pass, zero regressions**.
- remeda/type-graphql measured against a freshly-built clean-main binary; tsz-only delta via `comm` vs the tsc oracle.
- `cargo clippy -p tsz-solver --all-targets -- -D warnings` clean; `cargo fmt` clean.