### PR TITLE
perf(checker): memoize type-position identifier resolution

### DIFF
--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -64,6 +64,7 @@ daa_error_nodes = { lifetime = "SpeculationScoped", capability = "SpeculationSta
 deferred_ts2454_errors = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
 flow_narrowed_nodes = { lifetime = "SpeculationScoped", capability = "SpeculationState", reason = "snapshot/rollback-sensitive state mutated during speculative checking; also reset at file-session boundary" }
 refs_resolved = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
+type_position_resolution_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "memo of type-position identifier resolution keyed on this file's arena node idx; reset at file-session boundary" }
 application_symbols_resolved = { lifetime = "FileLocalReset", capability = "RelationSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 application_symbols_resolution_set = { lifetime = "FileLocalReset", capability = "RelationSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 namespace_module_names = { lifetime = "FileLocalReset", capability = "EmitSummaryState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -299,6 +299,7 @@ impl<'a> CheckerContext<'a> {
                 FxHashSet::with_capacity_and_hasher(256, Default::default()),
             ),
             refs_resolved: FxHashSet::default(),
+            type_position_resolution_cache: RefCell::new(FxHashMap::default()),
             application_symbols_resolved: FxHashSet::default(),
             application_symbols_resolution_set: FxHashSet::default(),
             namespace_module_names: FxHashMap::default(),

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -307,6 +307,7 @@ impl<'a> CheckerContext<'a> {
         self.jsdoc_generic_typedef_resolving.borrow_mut().clear();
         self.resolving_jsdoc_typedefs.borrow_mut().clear();
         self.refs_resolved.clear();
+        self.type_position_resolution_cache.borrow_mut().clear();
         self.application_symbols_resolved.clear();
         self.application_symbols_resolution_set.clear();
         self.namespace_module_names.clear();

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -65,6 +65,7 @@ pub mod typing_request;
 use crate::control_flow::FlowGraph;
 use crate::diagnostics::Diagnostic;
 use crate::query_boundaries::common::{QueryDatabase, TypeEnvironment};
+use crate::symbol_resolver::TypeSymbolResolution;
 pub use aliases::*;
 pub(crate) use diagnostic_indices::DiagnosticIndices;
 pub use request_cache::{RequestCacheCounters, RequestCacheKey};
@@ -963,6 +964,16 @@ pub struct CheckerContext<'a> {
     /// `TypeIds` whose lazy/type-query refs have been walked and resolved.
     /// This avoids repeated deep traversals in `ensure_refs_resolved`.
     pub refs_resolved: FxHashSet<TypeId>,
+
+    /// Memo of type-position identifier resolution keyed on node idx
+    /// (`NodeIndex::0`). A type-position identifier's resolution is fixed by
+    /// its lexical position and the binder/lib symbol tables, both immutable
+    /// for the context's lifetime, so the resolved symbol is stable across
+    /// every call for a given node. Recursive type evaluation re-resolves the
+    /// same alias/type-parameter identifier nodes once per recursion level
+    /// (`resolve_identifier_symbol_in_type_position`), and the by-name scope
+    /// walk dominates those repeats; the memo collapses them to one lookup.
+    pub type_position_resolution_cache: RefCell<FxHashMap<u32, TypeSymbolResolution>>,
 
     /// `TypeIds` whose application/lazy symbol references are fully resolved in `type_env`.
     /// This avoids repeated deep traversals in assignability hot paths.

--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -888,6 +888,36 @@ impl<'a> CheckerState<'a> {
         &self,
         idx: NodeIndex,
     ) -> TypeSymbolResolution {
+        // A type-position identifier's resolution is determined by its lexical
+        // position (enclosing type-parameter scopes walked via `arena`) and the
+        // binder/lib symbol tables — all immutable for the context's lifetime —
+        // so the result is stable across every call for a given node. Memoize
+        // on node idx to collapse the repeated by-name scope walks that
+        // dominate recursive type evaluation (a recursive alias re-resolves the
+        // same body identifiers once per recursion level). The underlying
+        // `_uncached` resolver is side-effect free (its only mutation is a
+        // function-local `Cell`), so a cache hit is behavior-identical.
+        if let Some(cached) = self
+            .ctx
+            .type_position_resolution_cache
+            .borrow()
+            .get(&idx.0)
+            .copied()
+        {
+            return cached;
+        }
+        let resolved = self.resolve_identifier_symbol_in_type_position_uncached(idx);
+        self.ctx
+            .type_position_resolution_cache
+            .borrow_mut()
+            .insert(idx.0, resolved);
+        resolved
+    }
+
+    fn resolve_identifier_symbol_in_type_position_uncached(
+        &self,
+        idx: NodeIndex,
+    ) -> TypeSymbolResolution {
         let node = match self.ctx.arena.get(idx) {
             Some(node) => node,
             None => return TypeSymbolResolution::NotFound,

--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_03.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_03.rs
@@ -178,6 +178,19 @@ fn test_env_eval_threads_seed_persist_to_cache_entry_collection() {
     );
 }
 
+/// File-session invariant: type-position identifier resolution is cached by
+/// file-local `NodeIndex`, so it must be reset before checking the next file.
+#[test]
+fn test_type_position_resolution_cache_clears_at_file_boundary() {
+    let reset_source = fs::read_to_string("src/context/file_session_reset.rs")
+        .expect("failed to read file_session_reset.rs");
+    assert!(
+        reset_source.contains("type_position_resolution_cache")
+            && reset_source.contains("type_position_resolution_cache.borrow_mut().clear()"),
+        "type-position node-index cache must clear at the file-session boundary"
+    );
+}
+
 /// Boundary invariant: every `evaluate_type_with_cache` call must pass the
 /// explicit cache-entry collection flag. This keeps the speed-only drain gate
 /// visible at call sites instead of relying on a hidden default.

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -94,10 +94,10 @@ active campaigns.
   test out of the shard failure set.
 - Output-surgery audit stays at zero unallowlisted calls and zero allowlist
   entries.
-- CheckerContext field-count guard is ratcheted at `251` fields after adding
-  a recursion guard for cross-file omitted-default constraint expansion. Future
-  work should reduce this through capability extraction rather than silently
-  adding checker-global state.
+- CheckerContext field-count guard is ratcheted at `252` fields after adding
+  `type_position_resolution_cache` (a per-file memo of type-position identifier
+  resolution; #13987). Future work should reduce this through capability
+  extraction rather than silently adding checker-global state.
 
 ## How To Pick Work
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1034,7 +1034,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        251,
+        252,
     ),
 ]
 


### PR DESCRIPTION
Goal: fast

Refs #13987.

## Summary
Recursive type evaluation re-resolves the same alias / type-parameter body
identifiers once per recursion level, and the by-name scope walk in
`resolve_identifier_symbol_in_type_position` dominates those repeats
(profiled at 75.6% inclusive on a `DeepReadonly` recompute repro, 46.4% on
`typeof globalThis`). This memoizes that resolution on node idx.

## Structural rule
When the checker resolves a **type-position identifier**, `tsc`/tsz pick the
symbol from the identifier's lexical position (enclosing type-parameter scopes,
walked through the `arena`) and the binder/lib symbol tables. All of those
inputs are **immutable for the checker context's lifetime** — type-position
resolution runs during checking, after lib loading/merge completes — so the
resolved symbol is **stable across every call for a given node**. The repeated
by-name scope walk is therefore pure recomputation.

## Owner layer
Checker symbol resolution
(`symbols/symbol_resolver.rs`). `resolve_identifier_symbol_in_type_position_inner`
now consults a per-`CheckerContext` memo keyed on `NodeIndex::0`
(`type_position_resolution_cache`) before delegating to the renamed
`_uncached` body. The underlying resolver is side-effect free (its only
mutation is a function-local `Cell`), so a cache hit is behavior-identical.
- **Cache key:** node idx (within the context's arena).
- **Invalidation:** none needed — the resolution inputs are immutable for the
  context lifetime; the memo is `FileLocalReset` (per-file arena), reset at the
  file-session boundary like `refs_resolved`.
- **Residency:** one `FxHashMap` entry per distinct type-position identifier
  node touched, bounded by the file's type-position identifier count.

## Soundness (why a node-keyed memo is safe)
- `resolve_enclosing_type_parameter_symbol` is purely lexical (walks
  `arena.parent_of`, returns `binder.get_node_symbol`); it carries no dynamic
  substitution context. Type-parameter *shadowing* resolves by symbol per the
  identifier's lexical node, which is fixed.
- A behavior-neutral **shadow probe** (recompute on every call, compare to a
  shadow cache, return the fresh value) logged **zero** unstable resolutions
  across the full **6752-test** `tsz-checker` unit suite.
- The real memo produces a unit-suite failing set **identical** to clean
  `main` (74 passed-delta-zero). The 74 baseline failures are a pre-existing
  `cargo test --lib`-vs-`nextest` lib-fixture harness artifact (e.g. "Cannot
  find name 'Promise'"), present on untouched `main`; this change adds **zero**
  regressions and changes **zero** outcomes.

## Performance (release, `--noEmit --extendedDiagnostics`, min of 5–7 runs)
| repro | cache off | cache on | speedup |
|---|--:|--:|--:|
| `DeepReadonly` depth-12 (binary-nested) | 0.16s | 0.07s | **2.3×** |
| deeply-nested recursive mapped (p-deep12) | 0.10s | 0.05s | **2.0×** |
| `DeepReadonly` depth-10 | 0.05s | 0.03s | 1.7× |
| `typeof globalThis` | 0.06s | 0.05s | ~1.2× |
Total-time figures include fixed lib-load overhead, so the eval-portion
speedup is larger. Interned-type counts are unchanged (this is recompute, not
materialization).

## Anti-hardcoding
No identifier/file-name/printer-string predicates: the memo key is the raw node
index and the cached value is the resolver's own `TypeSymbolResolution`. No
behavior branch is added — the cache is a transparent memo of the existing
resolver.

## Architecture
`CheckerContext` field-count guard ratcheted 251→252 for the new field
(`scripts/arch/arch_guard_shared.py`), with the `checker_context_lifetimes.toml`
inventory entry and the ROADMAP metric-1 note updated in the same diff.

## Verification
- `cargo build -p tsz-checker --lib`, `cargo clippy -p tsz-checker --lib`,
  `cargo fmt -p tsz-checker --check` — clean.
- `python3 scripts/arch/arch_guard.py` — passes (field-count + lifetime
  inventory).
- Full `cargo test -p tsz-checker --lib` failing set diffed against clean
  `origin/main`: **identical** (zero regressions); shadow-probe stability sweep:
  zero unstable resolutions across 6752 tests.
- Broad conformance / emit / fourslash / project-canary owned by ready-review CI.

## Provenance
Machine: MacBookPro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high