### PR TITLE
fix(checker): unary arithmetic on any yields number, not bigint

### DIFF
--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -471,7 +471,17 @@ impl<'a> CheckerState<'a> {
                     let evaluator =
                         crate::query_boundaries::common::new_binary_op_evaluator(self.ctx.types);
                     let resolved = self.evaluate_type_with_env(operand_type);
-                    if evaluator.is_bigint_like(resolved) {
+                    // `is_bigint_like` reports `true` for `any` (and the error
+                    // sentinel), but a unary arithmetic operator (`+`/`-`/`~`/`++`/
+                    // `--`) on an `any` operand yields `number` in tsc, not `bigint`
+                    // — only a genuinely bigint-typed operand produces `bigint`.
+                    // Without this guard `--x`/`+x` on `any` became `bigint`, which
+                    // then poisoned downstream comparisons (false TS2367) and
+                    // arithmetic (false TS2365).
+                    if resolved != TypeId::ANY
+                        && resolved != TypeId::ERROR
+                        && evaluator.is_bigint_like(resolved)
+                    {
                         TypeId::BIGINT
                     } else {
                         TypeId::NUMBER
@@ -510,7 +520,17 @@ impl<'a> CheckerState<'a> {
                     let evaluator =
                         crate::query_boundaries::common::new_binary_op_evaluator(self.ctx.types);
                     let resolved = self.evaluate_type_with_env(operand_type);
-                    if evaluator.is_bigint_like(resolved) {
+                    // `is_bigint_like` reports `true` for `any` (and the error
+                    // sentinel), but a unary arithmetic operator (`+`/`-`/`~`/`++`/
+                    // `--`) on an `any` operand yields `number` in tsc, not `bigint`
+                    // — only a genuinely bigint-typed operand produces `bigint`.
+                    // Without this guard `--x`/`+x` on `any` became `bigint`, which
+                    // then poisoned downstream comparisons (false TS2367) and
+                    // arithmetic (false TS2365).
+                    if resolved != TypeId::ANY
+                        && resolved != TypeId::ERROR
+                        && evaluator.is_bigint_like(resolved)
+                    {
                         TypeId::BIGINT
                     } else {
                         TypeId::NUMBER
@@ -585,7 +605,17 @@ impl<'a> CheckerState<'a> {
                     let evaluator =
                         crate::query_boundaries::common::new_binary_op_evaluator(self.ctx.types);
                     let resolved = self.evaluate_type_with_env(operand_type);
-                    if evaluator.is_bigint_like(resolved) {
+                    // `is_bigint_like` reports `true` for `any` (and the error
+                    // sentinel), but a unary arithmetic operator (`+`/`-`/`~`/`++`/
+                    // `--`) on an `any` operand yields `number` in tsc, not `bigint`
+                    // — only a genuinely bigint-typed operand produces `bigint`.
+                    // Without this guard `--x`/`+x` on `any` became `bigint`, which
+                    // then poisoned downstream comparisons (false TS2367) and
+                    // arithmetic (false TS2365).
+                    if resolved != TypeId::ANY
+                        && resolved != TypeId::ERROR
+                        && evaluator.is_bigint_like(resolved)
+                    {
                         TypeId::BIGINT
                     } else {
                         TypeId::NUMBER


### PR DESCRIPTION
Goal: green

## Summary
`get_type_of_prefix_unary_with_request` typed `+x`/`-x`/`~x`/`++x`/`--x` as `bigint` whenever `is_bigint_like(operand)` held — but that predicate reports `true` for `any` (and the error sentinel). tsc types a unary arithmetic operator on an `any` operand as `number`; only a genuinely bigint-typed operand yields `bigint`. The spurious `bigint` then poisoned downstream code: `--g === 0` (g: any) produced a false `TS2367` ("bigint and number have no overlap"), and `1 / +b` a false `TS2365`.

## Structural Rule
A prefix unary arithmetic operator (`+`, `-`, `~`, `++`, `--`) yields `bigint` only when its operand is *genuinely* bigint-typed; an `any` operand yields `number`. tsz now guards the three bigint result branches to exclude `ANY`/`ERROR`.

- **Owner layer:** checker — `crates/tsz-checker/src/types/computation/helpers.rs`, the PlusToken/MinusToken, TildeToken, and PlusPlus/MinusMinus result branches.
- **Fallback:** genuine bigint operands still produce `bigint` (verified `-bg` with `bg: bigint`); all non-bigint, non-any operands continue to yield `number`.

### Adjacent-case matrix (verified vs `tsc`)
| operand | `+`/`-`/`~`/`++`/`--` result | tsc | tsz |
|---|---|---|---|
| `any` | `number` | number | number (was `bigint`) |
| `bigint` | `bigint` | bigint | bigint (unchanged) |
| `number` | `number` | number | number (unchanged) |

## Project Corpus Impact
- **mobx:** 106 → 103 tsz-only FPs (the `--global.__mobxInstanceCount === 0` TS2367 and `1/+a` TS2365 roots).
- No new errors introduced.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- Minimal repros (`--g===0`, `1/+b`, `+/~/-` on any assigned to `number`, plus a `bigint` negative control) diffed against `node typescript/lib/tsc.js --noEmit --strict --target es2022 --lib es2022` — tsz now matches tsc.
- Conformance: **bigint (10), Operator (278), arithmetic (12), unaryOperator (60), comparison (29), expressions (377), narrowing, typeRelationships all 100% pass, zero regressions**.
- mobx measured against a freshly-built clean-main binary; tsz-only delta via `comm` vs the tsc oracle.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean; `cargo fmt` clean.