### PR TITLE
fix(checker): preserve primitive-literal right operand of contextual ||/??

### DIFF
--- a/crates/tsz-checker/src/types/computation/binary.rs
+++ b/crates/tsz-checker/src/types/computation/binary.rs
@@ -319,7 +319,22 @@ impl<'a> CheckerState<'a> {
                     } else {
                         TypingRequest::NONE
                     };
+                    // Preserve literal types for a primitive-literal right operand,
+                    // symmetrically with the left operand above. Without this, a
+                    // literal RHS in a contextual position (`const r: Strategy =
+                    // v || 'warn'`) is checked with no contextual type (literals are
+                    // not context-sensitive forms, so `right_request` is NONE) and
+                    // widens to its base primitive (`'warn'` → `string`); the logical
+                    // result then becomes `string`, failing assignability to the
+                    // literal-union target. The `logical_operand_is_primitive_literal`
+                    // gate excludes array/object literals, so element widening is
+                    // unaffected.
+                    let prev_preserve_right = self.ctx.preserve_literal_types;
+                    if self.logical_operand_is_primitive_literal(right_idx) {
+                        self.ctx.preserve_literal_types = true;
+                    }
                     let right_type = self.get_type_of_node_with_request(right_idx, &right_request);
+                    self.ctx.preserve_literal_types = prev_preserve_right;
                     let right_type = self.preserve_logical_operand_literal(right_idx, right_type);
 
                     let should_check_contextual_right =


### PR DESCRIPTION
Goal: green

## Summary
The `||`/`??` result branch set `preserve_literal_types` for a primitive-literal **left** operand but not the **right**. In a contextual position a literal right operand is not a context-sensitive form, so `right_request` is `NONE`, it received no contextual type, and widened to its base primitive: `const r: Strategy = v || 'warn'` typed `'warn'` as `string`, so the logical result became `string` and produced a false `TS2322` against the literal-union target.

## Structural Rule
Both operands of `||`/`??` whose syntactic form is a primitive literal must keep their literal type when forming the logical result. tsz already did this for the left operand; this applies the same treatment to the right operand, symmetrically.

- **Owner layer:** checker — `crates/tsz-checker/src/types/computation/binary.rs`, the `BarBarToken`/`QuestionQuestionToken` result branch.
- **Fallback:** the `logical_operand_is_primitive_literal` gate excludes array/object literals (element widening unaffected), and a literal genuinely outside the target union still errors — `const r: Strategy = v || 'zzz'` reports the identical `TS2322` ('S | "zzz"' not assignable to 'S') as tsc.

### Adjacent-case matrix (verified vs `tsc`)
| expression (target `Strategy = 'a'|'b'|'c'`) | tsc | tsz |
|---|---|---|
| `const r: S = v \|\| 'b'` | ok | ok (was TS2322) |
| `const r: S = v ?? 'b'` | ok | ok (was TS2322) |
| `const r: S = v \|\| 'zzz'` | TS2322 | TS2322 (identical) |
| `['true','false'].includes(x) && 1` (array literal) | ok | ok (unaffected) |

## Project Corpus Impact
- **msw:** 86 → 84 tsz-only FPs.
- No new errors introduced.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- Minimal repros (`v || 'warn'`, `v ?? 'warn'`, the `'zzz'` negative, and an array-literal control) diffed against `node typescript/lib/tsc.js --noEmit --strict --target es2022 --lib es2022` — tsz matches tsc exactly.
- Conformance: **contextualTyping (83), expressions (377), narrowing, typeGuard (86), literal (55), controlFlow (94), comparable, union, typeRelationships, members all 100% pass, zero regressions**.
- msw measured against a freshly-built clean-main binary; tsz-only delta via `comm` vs the tsc oracle.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean; `cargo fmt` clean.