### PR TITLE
fix(checker): match tsc's syntactic ?? operand nullishness for TS2869/TS2871

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -416,6 +416,9 @@ path = "tests/ts1207_decorated_accessor_tests.rs"
 name = "ts2802_downlevel_iteration_tests"
 path = "tests/ts2802_downlevel_iteration_tests.rs"
 [[test]]
+name = "ts2869_syntactic_never_nullish_tests"
+path = "tests/ts2869_syntactic_never_nullish_tests.rs"
+[[test]]
 name = "ts2871_always_nullish_tests"
 path = "tests/ts2871_always_nullish_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/binary.rs
+++ b/crates/tsz-checker/src/types/computation/binary.rs
@@ -548,21 +548,15 @@ impl<'a> CheckerState<'a> {
                 // stored as an Application needs to be expanded so that the nullish split
                 // can see through the alias to extract the non-nullable component.
                 let evaluated_left = self.evaluate_type_with_env(left_type);
-                let (non_nullish, cause) = self.split_nullish_type(evaluated_left);
-                let left_is_top_type =
-                    evaluated_left == TypeId::UNKNOWN || evaluated_left == TypeId::ANY;
-                let diagnostics = self.nullish_coalescing_left_diagnostics(
-                    left_idx,
-                    non_nullish,
-                    cause,
-                    left_is_top_type,
-                );
+                let (non_nullish, _cause) = self.split_nullish_type(evaluated_left);
+                let diagnostics = self.nullish_coalescing_left_diagnostics(left_idx);
 
                 if let Some(diag_idx) = diagnostics.never_nullish_diag {
                     use crate::diagnostics::diagnostic_codes;
-                    // tsc points the error at the left operand (the never-nullish expression),
-                    // skipping through any parentheses to reach the inner expression.
-                    // e.g., `(expr) ?? ""` → error anchored at `expr`, not `(expr)`.
+                    // tsc anchors at `skipOuterExpressions(left, All)` — the inner
+                    // expression reached through parentheses, type assertions,
+                    // `satisfies`, and non-null assertions. e.g. `(1 as any) ?? ""`
+                    // → error anchored at `1`, not `(1 as any)`.
                     self.error_at_node(
                         diag_idx,
                         "Right operand of ?? is unreachable because the left operand is never nullish.",
@@ -570,15 +564,12 @@ impl<'a> CheckerState<'a> {
                     );
                     type_stack.push(left_type);
                 } else if let Some(diag_idx) = diagnostics.always_nullish_diag {
-                    // TS2871: complementary to TS2869. When the left operand of
-                    // `??` is syntactically a nullish-coalescing chain or a
-                    // bare nullish literal and its evaluated type contains
-                    // only nullish constituents (split yields no non-nullish
-                    // part), tsc emits TS2871 — the left expression is
-                    // *always* nullish, so the `??` itself is redundant.
-                    //
-                    // Same anchor strategy as TS2869: point at the left
-                    // operand, skipping through parentheses.
+                    // TS2871: complementary to TS2869. When the `??` left operand,
+                    // looked through outer expressions, is syntactically always
+                    // nullish (the `null` keyword, the `undefined` identifier, or a
+                    // `??`/comma/conditional that resolves to one), tsc emits TS2871
+                    // — the left expression is *always* nullish, so the `??` itself
+                    // is redundant. Same anchor as TS2869.
                     use crate::diagnostics::diagnostic_codes;
                     self.error_at_node(
                         diag_idx,

--- a/crates/tsz-checker/src/types/computation/binary_support.rs
+++ b/crates/tsz-checker/src/types/computation/binary_support.rs
@@ -17,10 +17,8 @@ use tsz_solver::TypeId;
 /// Result of syntactic nullishness analysis, mirroring tsc's `PredicateSemantics`.
 /// This is a purely syntactic check -- it does NOT look at types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
-enum SyntacticNullishness {
+pub(super) enum SyntacticNullishness {
     /// The expression is always nullish (e.g., `null`, `undefined`).
-    #[allow(dead_code)]
     Always,
     /// The expression may or may not be nullish (e.g., identifiers, calls, property accesses).
     Sometimes,
@@ -341,33 +339,17 @@ impl CheckerState<'_> {
     /// that determines whether an expression can ever be nullish, WITHOUT consulting the
     /// type system. For example, a variable `foo: string` returns `Sometimes` (it could
     /// theoretically be reassigned at runtime), while a literal `"hello"` returns `Never`.
-    #[allow(dead_code)]
-    fn get_syntactic_nullishness(&self, idx: NodeIndex) -> SyntacticNullishness {
+    ///
+    /// Outer expressions (parentheses, `as`/`satisfies`/`<T>` assertions, and non-null
+    /// `!`) are looked *through* — exactly like tsc's `skipOuterExpressions(node, All)` —
+    /// so `(1 as any) ?? x` classifies on the literal `1` and `null! ?? x` on `null`.
+    pub(super) fn get_syntactic_nullishness(&self, idx: NodeIndex) -> SyntacticNullishness {
+        let idx = self.ctx.arena.skip_parenthesized_and_assertions(idx);
         let Some(node) = self.ctx.arena.get(idx) else {
             return SyntacticNullishness::Sometimes;
         };
 
         let kind = node.kind;
-
-        // Skip parenthesized expressions (tsc's skipOuterExpressions)
-        if kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
-            && let Some(paren) = self.ctx.arena.get_parenthesized(node)
-        {
-            return self.get_syntactic_nullishness(paren.expression);
-        }
-
-        // Non-null assertions (!): always Never
-        if kind == syntax_kind_ext::NON_NULL_EXPRESSION {
-            return SyntacticNullishness::Never;
-        }
-
-        // Type assertions (as/satisfies/<T>x): tsc skips these via skipOuterExpressions
-        if kind == syntax_kind_ext::AS_EXPRESSION
-            || kind == syntax_kind_ext::SATISFIES_EXPRESSION
-            || kind == syntax_kind_ext::TYPE_ASSERTION
-        {
-            return SyntacticNullishness::Sometimes;
-        }
 
         // Expressions that may produce null/undefined at runtime
         if kind == syntax_kind_ext::AWAIT_EXPRESSION
@@ -446,47 +428,6 @@ impl CheckerState<'_> {
         // object literal, array literal, function expression, arrow function, class expression,
         // etc.) are never nullish.
         SyntacticNullishness::Never
-    }
-    /// Check if an AST node is a nullish coalescing expression (`??`) or a
-    /// literal value (string, number, boolean, bigint, template), unwrapping
-    /// parentheses. TSC only emits TS2869 for these syntactic forms; general
-    /// non-nullable expressions (identifiers, property access, `&&` chains)
-    /// do not trigger TS2869 even when their type is never nullish.
-    pub(super) fn is_nullish_coalescing_or_literal(
-        arena: &tsz_parser::parser::NodeArena,
-        node_idx: NodeIndex,
-    ) -> bool {
-        use tsz_scanner::SyntaxKind;
-
-        let Some(node) = arena.get(node_idx) else {
-            return false;
-        };
-
-        // Unwrap parentheses: (expr) -> expr
-        if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION {
-            if let Some(paren) = arena.get_parenthesized(node) {
-                return Self::is_nullish_coalescing_or_literal(arena, paren.expression);
-            }
-            return false;
-        }
-
-        // Binary expression: check if it's a `??`
-        if node.kind == syntax_kind_ext::BINARY_EXPRESSION {
-            if let Some(binary) = arena.get_binary_expr(node) {
-                return binary.operator_token == SyntaxKind::QuestionQuestionToken as u16;
-            }
-            return false;
-        }
-
-        // Literal values: string, number, bigint, template, true, false
-        let kind = node.kind;
-        kind == SyntaxKind::StringLiteral as u16
-            || kind == SyntaxKind::NumericLiteral as u16
-            || kind == SyntaxKind::BigIntLiteral as u16
-            || kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
-            || kind == SyntaxKind::TrueKeyword as u16
-            || kind == SyntaxKind::FalseKeyword as u16
-            || kind == syntax_kind_ext::TEMPLATE_EXPRESSION
     }
 
     /// Format the apparent type for display in TS2638 error messages.

--- a/crates/tsz-checker/src/types/computation/nullish_coalescing.rs
+++ b/crates/tsz-checker/src/types/computation/nullish_coalescing.rs
@@ -1,8 +1,8 @@
 //! Nullish-coalescing (`??`) diagnostic and result helpers.
 
+use super::binary_support::SyntacticNullishness;
 use crate::state::CheckerState;
-use tsz_parser::parser::{NodeArena, NodeIndex, syntax_kind_ext};
-use tsz_scanner::SyntaxKind;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
 
 pub(super) struct NullishCoalescingLeftDiagnostics {
@@ -14,43 +14,28 @@ impl<'a> CheckerState<'a> {
     pub(super) fn nullish_coalescing_left_diagnostics(
         &self,
         left_idx: NodeIndex,
-        non_nullish: Option<TypeId>,
-        nullish_cause: Option<TypeId>,
-        left_is_top_type: bool,
     ) -> NullishCoalescingLeftDiagnostics {
-        let left_is_nullish_chain_or_literal =
-            is_nullish_coalescing_or_literal(self.ctx.arena, left_idx);
-        let always_nullish_literal_diag =
-            self.nullish_coalescing_always_nullish_literal_diag(left_idx);
-
-        let never_nullish_diag =
-            if nullish_cause.is_none() && !left_is_top_type && left_is_nullish_chain_or_literal {
-                Some(self.ctx.arena.skip_parenthesized(left_idx))
-            } else {
-                None
-            };
-
-        let always_nullish_diag = always_nullish_literal_diag.or_else(|| {
-            (non_nullish.is_none()
-                && nullish_cause.is_some()
-                && !left_is_top_type
-                && left_is_nullish_chain_or_literal)
-                .then(|| self.ctx.arena.skip_parenthesized(left_idx))
-        });
-
-        NullishCoalescingLeftDiagnostics {
-            never_nullish_diag,
-            always_nullish_diag,
+        // tsc's `checkNullishCoalesceOperandLeft` is a purely syntactic check:
+        // it anchors at `skipOuterExpressions(left, All)` (through parentheses,
+        // type assertions, `satisfies`, and non-null assertions) and classifies
+        // that target with `getSyntacticNullishnessSemantics` — the static type
+        // of the operand never participates. We mirror that exactly, reusing the
+        // shared `get_syntactic_nullishness` classifier.
+        let target = self.ctx.arena.skip_parenthesized_and_assertions(left_idx);
+        match self.get_syntactic_nullishness(target) {
+            SyntacticNullishness::Always => NullishCoalescingLeftDiagnostics {
+                never_nullish_diag: None,
+                always_nullish_diag: Some(target),
+            },
+            SyntacticNullishness::Never => NullishCoalescingLeftDiagnostics {
+                never_nullish_diag: Some(target),
+                always_nullish_diag: None,
+            },
+            SyntacticNullishness::Sometimes => NullishCoalescingLeftDiagnostics {
+                never_nullish_diag: None,
+                always_nullish_diag: None,
+            },
         }
-    }
-
-    fn nullish_coalescing_always_nullish_literal_diag(
-        &self,
-        left_idx: NodeIndex,
-    ) -> Option<NodeIndex> {
-        let unwrapped_left_idx = self.ctx.arena.skip_parenthesized_and_assertions(left_idx);
-        self.is_literal_null_or_undefined_node(unwrapped_left_idx)
-            .then_some(unwrapped_left_idx)
     }
 
     pub(super) fn nullish_coalescing_result_type(
@@ -113,39 +98,4 @@ impl<'a> CheckerState<'a> {
             .and_then(|node| self.ctx.arena.get_literal_expr(node))
             .is_some_and(|lit| lit.elements.nodes.is_empty())
     }
-}
-
-/// Check if an AST node is a nullish-coalescing expression (`??`) or a
-/// literal value (string, number, boolean, bigint, template), unwrapping
-/// parentheses. TSC only emits TS2869 for these syntactic forms; general
-/// non-nullable expressions (identifiers, property access, `&&` chains)
-/// do not trigger TS2869 even when their type is never nullish.
-fn is_nullish_coalescing_or_literal(arena: &NodeArena, node_idx: NodeIndex) -> bool {
-    let Some(node) = arena.get(node_idx) else {
-        return false;
-    };
-
-    // Unwrap parentheses: (expr) -> expr
-    if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION {
-        if let Some(paren) = arena.get_parenthesized(node) {
-            return is_nullish_coalescing_or_literal(arena, paren.expression);
-        }
-        return false;
-    }
-
-    if node.kind == syntax_kind_ext::BINARY_EXPRESSION {
-        if let Some(binary) = arena.get_binary_expr(node) {
-            return binary.operator_token == SyntaxKind::QuestionQuestionToken as u16;
-        }
-        return false;
-    }
-
-    let kind = node.kind;
-    kind == SyntaxKind::StringLiteral as u16
-        || kind == SyntaxKind::NumericLiteral as u16
-        || kind == SyntaxKind::BigIntLiteral as u16
-        || kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
-        || kind == SyntaxKind::TrueKeyword as u16
-        || kind == SyntaxKind::FalseKeyword as u16
-        || kind == syntax_kind_ext::TEMPLATE_EXPRESSION
 }

--- a/crates/tsz-checker/tests/ts2869_syntactic_never_nullish_tests.rs
+++ b/crates/tsz-checker/tests/ts2869_syntactic_never_nullish_tests.rs
@@ -1,0 +1,219 @@
+//! Tests for TS2869 ("Right operand of ?? is unreachable because the left
+//! operand is never nullish.") across the full set of syntactic forms tsc
+//! classifies as *never nullish*.
+//!
+//! Structural rule (port of tsc's `getSyntacticNullishnessSemantics` over
+//! `skipOuterExpressions(left, All)`):
+//!
+//! > The `??` left-operand check is purely syntactic. After looking through
+//! > parentheses, type assertions, `satisfies`, and non-null assertions, an
+//! > operand is *never nullish* (→ TS2869) unless its syntactic kind makes it
+//! > *possibly* nullish (identifier reference, `this`, call / element &
+//! > property access / `new` / tagged-template / `await` / `yield` /
+//! > meta-property, `||`/`&&`) or *always* nullish (`null` / `undefined`,
+//! > → TS2871). Object/array literals, function/arrow/class expressions, regex
+//! > literals, `void`/`typeof`/unary expressions, and every non-logical binary
+//! > operator are never nullish.
+//!
+//! The companion files `ts2871_always_nullish_tests.rs` and
+//! `ts2871_through_assertions_tests.rs` cover the *always*-nullish arm.
+//!
+//! Per CLAUDE.md §25 the decision is over expression *shape*, not the static
+//! type or any identifier text, so the regression guards below rename binders.
+
+use tsz_checker::test_utils::check_source_strict_codes as check;
+
+fn count(source: &str, code: u32) -> usize {
+    check(source).iter().filter(|&&c| c == code).count()
+}
+
+// =========================================================================
+// Literal value forms previously missed by tsz — TS2869 must fire
+// =========================================================================
+
+/// Object and array literals are never nullish; both must emit TS2869.
+#[test]
+fn object_and_array_literals_emit_ts2869() {
+    assert_eq!(
+        count("const a = ({}) ?? 1;\n", 2869),
+        1,
+        "object literal left operand of ?? must emit TS2869",
+    );
+    assert_eq!(
+        count("const b = [] ?? 1;\n", 2869),
+        1,
+        "array literal left operand of ?? must emit TS2869",
+    );
+}
+
+/// Function, arrow, and class expressions are never nullish.
+#[test]
+fn function_arrow_class_expressions_emit_ts2869() {
+    assert!(check("const f = (function () {}) ?? 1;\n").contains(&2869));
+    assert!(check("const g = (() => 1) ?? 1;\n").contains(&2869));
+    assert!(check("const h = (class {}) ?? 1;\n").contains(&2869));
+}
+
+/// A regular-expression literal is never nullish.
+#[test]
+fn regex_literal_emits_ts2869() {
+    assert!(check("const r = /abc/ ?? 1;\n").contains(&2869));
+}
+
+/// `void`, `typeof`, and unary arithmetic operators all produce a non-nullish
+/// value (tsc classifies them via the `Never` default).
+#[test]
+fn void_typeof_and_unary_emit_ts2869() {
+    assert!(check("const a = (void 0) ?? 1;\n").contains(&2869));
+    assert!(check("declare const n: number;\nconst b = (typeof n) ?? 1;\n").contains(&2869));
+    assert!(check("declare const n: number;\nconst c = (-n) ?? 1;\n").contains(&2869));
+    assert!(check("declare const n: number;\nconst d = (!n) ?? 1;\n").contains(&2869));
+}
+
+// =========================================================================
+// Binary / conditional / comma / assignment classification
+// =========================================================================
+
+/// Every non-logical binary operator yields a never-nullish value, so the
+/// `??` right operand is unreachable.
+#[test]
+fn arithmetic_and_comparison_binaries_emit_ts2869() {
+    assert!(check("const a = (1 + 2) ?? 3;\n").contains(&2869));
+    assert!(
+        check("declare const x: number, y: number;\nconst b = (x * y) ?? 3;\n").contains(&2869)
+    );
+    assert!(
+        check("declare const x: number, y: number;\nconst c = (x === y) ?? 3;\n").contains(&2869)
+    );
+}
+
+/// `||` and `&&` may surface a nullish operand, so the left operand is *not*
+/// classified never-nullish — neither TS2869 nor TS2871 fires.
+#[test]
+fn logical_binaries_do_not_emit_nullish_diags() {
+    let diags =
+        check("declare const x: number | undefined, y: number;\nconst a = (x || y) ?? 3;\n");
+    assert!(
+        !diags.contains(&2869),
+        "|| left operand must not emit TS2869: {diags:?}"
+    );
+    assert!(
+        !diags.contains(&2871),
+        "|| left operand must not emit TS2871: {diags:?}"
+    );
+    let diags =
+        check("declare const x: number | undefined, y: number;\nconst b = (x && y) ?? 3;\n");
+    assert!(
+        !diags.contains(&2869),
+        "&& left operand must not emit TS2869: {diags:?}"
+    );
+}
+
+/// A conditional is never nullish only when *both* branches are; one
+/// possibly-nullish branch makes it `Sometimes`.
+#[test]
+fn conditional_branches_union_their_semantics() {
+    // both branches literal → never nullish → TS2869
+    assert!(check("declare const c: boolean;\nconst a = (c ? 1 : 2) ?? 3;\n").contains(&2869));
+    // one branch an identifier (possibly nullish) → no diagnostic
+    let diags =
+        check("declare const c: boolean, m: number | undefined;\nconst b = (c ? m : 1) ?? 3;\n");
+    assert!(
+        !diags.contains(&2869),
+        "mixed conditional must not emit TS2869: {diags:?}"
+    );
+    assert!(!diags.contains(&2871));
+    // both branches always-nullish → TS2871
+    assert!(
+        check("declare const c: boolean;\nconst d = (c ? null : null) ?? 3;\n").contains(&2871)
+    );
+}
+
+/// Comma and assignment expressions defer to their right operand.
+#[test]
+fn comma_and_assignment_defer_to_right_operand() {
+    // right operand is a literal → never nullish
+    assert!(check("declare const p: number;\nconst a = (p, 1) ?? 3;\n").contains(&2869));
+    assert!(check("let q: number;\nconst b = (q = 1) ?? 3;\n").contains(&2869));
+}
+
+// =========================================================================
+// skipOuterExpressions: assertions / non-null / parens reach the literal
+// =========================================================================
+
+/// A type assertion, `satisfies`, or non-null assertion wrapping a literal is
+/// transparent — tsc reaches the inner literal and reports never-nullish.
+#[test]
+fn assertions_are_transparent_for_never_nullish() {
+    assert!(check("const a = (1 as unknown) ?? 2;\n").contains(&2869));
+    assert!(check("const b = (1 satisfies number) ?? 2;\n").contains(&2869));
+    assert!(check("const c = (1)! ?? 2;\n").contains(&2869));
+    assert!(check("const d = (<number>1) ?? 2;\n").contains(&2869));
+}
+
+// =========================================================================
+// Regression guards — possibly-nullish forms must stay silent
+// =========================================================================
+
+/// Plain identifier references, member/element access, calls, `new`, and
+/// `this` are all possibly-nullish syntactic forms: no diagnostic regardless
+/// of their static type. Binder names are varied to prove the rule is over
+/// shape, not text.
+#[test]
+fn possibly_nullish_forms_emit_no_diagnostic() {
+    // identifier whose type is never nullish — still no TS2869 (tsc parity).
+    let diags = check("declare const widget: number;\nconst a = widget ?? 1;\n");
+    assert!(
+        !diags.contains(&2869),
+        "identifier must not emit TS2869: {diags:?}"
+    );
+
+    let diags = check("declare const payload: { count: number };\nconst b = payload.count ?? 1;\n");
+    assert!(
+        !diags.contains(&2869),
+        "property access must not emit TS2869: {diags:?}"
+    );
+
+    let diags = check("declare function produce(): number;\nconst c = produce() ?? 1;\n");
+    assert!(
+        !diags.contains(&2869),
+        "call must not emit TS2869: {diags:?}"
+    );
+
+    let diags = check("class Gadget {}\nconst d = new Gadget() ?? 1;\n");
+    assert!(
+        !diags.contains(&2869),
+        "new expression must not emit TS2869: {diags:?}"
+    );
+
+    let diags = check("class Holder {\n  read() {\n    return this ?? 1;\n  }\n}\n");
+    assert!(
+        !diags.contains(&2869),
+        "this must not emit TS2869: {diags:?}"
+    );
+}
+
+/// `await` is possibly nullish (the awaited value may be null/undefined).
+#[test]
+fn await_expression_emits_no_diagnostic() {
+    let diags = check(
+        "async function run(task: Promise<number | undefined>) {\n  return (await task) ?? 1;\n}\n",
+    );
+    assert!(
+        !diags.contains(&2869),
+        "await must not emit TS2869: {diags:?}"
+    );
+    assert!(!diags.contains(&2871));
+}
+
+/// An assertion wrapping a *possibly-nullish* inner form (an identifier) is
+/// still possibly nullish — the transparency must not invent a diagnostic.
+#[test]
+fn assertion_over_identifier_stays_silent() {
+    let diags =
+        check("declare const source: number;\nconst a = (source as unknown as number) ?? 1;\n");
+    assert!(
+        !diags.contains(&2869),
+        "assertion over identifier must not emit TS2869: {diags:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

## Summary

The `??` left-operand diagnostics — **TS2869** ("Right operand of ?? is unreachable because the left operand is never nullish.") and **TS2871** ("This expression is always nullish.") — are a **purely syntactic** check in `tsc`. `checkNullishCoalesceOperandLeft` anchors at `skipOuterExpressions(left, All)` and classifies the inner node with `getSyntacticNullishnessSemantics`; the operand's *static type* never participates.

tsz only recognized a handful of literal kinds (string/number/bigint/template/`true`/`false`) through parentheses, and additionally gated the diagnostic on type-level state (`nullish_cause`, `left_is_top_type`). It therefore **missed every other never-nullish form tsc flags**, and didn't look through assertions.

## Structural rule

> When classifying a `??` left operand, `tsc` looks *through* outer expressions (parentheses, `as`/`satisfies`/`<T>` assertions, non-null `!`) and decides nullishness from syntactic kind alone: literals / object & array literals / function / arrow / class / regex / `void` / `typeof` / unary / every non-logical binary operator are **never** nullish (→ TS2869); `null` / the `undefined` identifier (and `??`/comma/conditional resolving to them) are **always** nullish (→ TS2871); identifiers, member/element access, calls, `new`, `this`, `await`, `||`/`&&` are **possibly** nullish (no diagnostic). tsz now does the same through the shared `CheckerState::get_syntactic_nullishness` classifier — the static type is never consulted.

Owner layer: checker — `crates/tsz-checker/src/types/computation/{binary,binary_support,nullish_coalescing}.rs`.

## What changed

- **Consolidated to one classifier.** A complete-but-dead `get_syntactic_nullishness` already existed in `binary_support.rs` (`#[allow(dead_code)]`, zero callers) with the same assertion gaps. It is fixed to look through outer expressions via `skip_parenthesized_and_assertions` (so `(1 as any) ?? x` classifies on `1` and `null! ?? x` on `null`), promoted to `pub(super)`, and wired up.
- **Removed two ad-hoc duplicates** of `is_nullish_coalescing_or_literal` (one free fn, one associated fn) and the type-based gating. `nullish_coalescing_left_diagnostics` now takes only the left node and dispatches on `SyntacticNullishness`. Net diff is −115 lines.
- The diagnostic path is now purely syntactic (no `split_nullish_type` / top-type work in the diagnostic decision) and anchors at the skipped target, matching `tsc`'s reported column.

## Anti-hardcoding

The decision keys only on syntactic node kind and the existing `null`/`undefined` builtin shape — no user-identifier/file-name/printer-string predicate. New regression tests rename binders (`widget`/`payload`/`produce`/`Gadget`/`Holder`) to prove the rule is over expression shape, not text.

## Adjacent-case matrix (new `ts2869_syntactic_never_nullish_tests`, 12 tests)

| `?? ` left operand (through outer expressions) | tsc | tsz before | tsz after |
|---|---|---|---|
| `{}`, `[]`, `function`/`()=>`/`class`, `/re/` | TS2869 | (none) | TS2869 |
| `void`/`typeof`/`-x`/`!x`, `1+2`, `a===b` | TS2869 | (none) | TS2869 |
| `(1 as any)`, `(1)!`, `1 satisfies T`, `<T>1` | TS2869 | (none) | TS2869 |
| `(c ? 1 : 2)` (both branches never) | TS2869 | (none) | TS2869 |
| `(a, 1)`, `(a = 1)` (right operand controls) | TS2869 | (none) | TS2869 |
| `(c ? null : null)`, `null!`, `(null as s\|null)` | TS2871 | TS2871* | TS2871 |
| `\|\|`/`&&`, identifier, `a.b`, `f()`, `new`, `this`, `await` | (none) | (none) | (none) |

\* the always-nullish literal arm already worked; it is preserved (existing `ts2871_always_nullish_tests` + `ts2871_through_assertions_tests`, 23 tests, still pass).

## Verification

- Differential vs `node typescript/lib/tsc.js --noEmit --strict --target es2022 --lib es2022` (TypeScript 6.0.3) across **33 operand forms — 0 divergences** (codes and anchor columns match).
- `cargo test -p tsz-checker --test ts2869_syntactic_never_nullish_tests` — 12/12.
- `cargo test -p tsz-checker --test ts2871_always_nullish_tests --test ts2871_through_assertions_tests` — 23/23.
- `cargo test -p tsz-checker --lib -- nullish` — 47/47.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib --tests` clean. No file exceeds the 2000-line cap (both touched source files shrank).
- Pre-existing `cargo test --lib` lib-fixture artifacts (`ts2860`/`ts2861` instanceof `Symbol.hasInstance`) fail identically with this change reverted — unrelated.
- Broad conformance / emit / fourslash / project-corpus owned by ready-review CI per repo policy.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ht9X5Z1WtSyM9HMjQkbXL)_