### PR TITLE
fix(binder): finalize if-statement merge label via finishFlowLabel (collapse dead merges)

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -489,17 +489,9 @@ impl BinderState {
             .pop()
             .expect("return_targets pushed before function body binding");
 
-        // Finalize: if the return label has antecedents, use it as current flow.
-        // This mirrors tsc's finishFlowLabel behavior.
-        if let Some(label_node) = self.flow_nodes.get(return_label) {
-            match label_node.antecedent.len() {
-                0 => self.current_flow = self.unreachable_flow,
-                1 => self.current_flow = label_node.antecedent[0],
-                _ => self.current_flow = return_label,
-            }
-        } else {
-            self.current_flow = self.unreachable_flow;
-        }
+        // Finalize the return label as current flow via the shared
+        // `finishFlowLabel` helper (also used by `bind_if_statement`'s merge label).
+        self.finish_flow_label(return_label);
     }
 
     /// Bind an arrow function expression - creates a scope and binds the body.

--- a/crates/tsz-binder/src/nodes/flow_statements.rs
+++ b/crates/tsz-binder/src/nodes/flow_statements.rs
@@ -78,7 +78,12 @@ impl BinderState {
         );
         self.add_antecedent(merge_label, after_then_flow);
         self.add_antecedent(merge_label, after_else_flow);
-        self.current_flow = merge_label;
+        // Finalize via tsc's `finishFlowLabel` rather than assigning the label
+        // directly: when both arms terminate (e.g. each `return`s), the merge
+        // label has no antecedents and must collapse to the unreachable flow so
+        // the code after the `if` is not treated as reachable through a dead
+        // branch (which would drop narrowing of subsequent statements).
+        self.finish_flow_label(merge_label);
     }
 
     pub(crate) fn bind_while_or_do_statement(&mut self, arena: &NodeArena, node: &Node) {

--- a/crates/tsz-binder/src/state/flow_helpers.rs
+++ b/crates/tsz-binder/src/state/flow_helpers.rs
@@ -111,4 +111,26 @@ impl BinderState {
             node.antecedent.push(antecedent);
         }
     }
+
+    /// Finalize a branch/merge label as `current_flow`, the way tsc's
+    /// `finishFlowLabel` does: a label with no (reachable) antecedents collapses
+    /// to the unreachable flow, a label with exactly one collapses to that
+    /// antecedent, and a label with several stays itself. `add_antecedent` skips
+    /// unreachable antecedents, so e.g. an `if` whose both arms `return` leaves an
+    /// antecedent-less merge label; assigning it directly to `current_flow` would
+    /// treat that unreachable merge point as reachable and drop the narrowing of
+    /// subsequent statements (a false negated-discriminant / definite-assignment
+    /// result). Use this instead of a bare `self.current_flow = label`.
+    pub(crate) fn finish_flow_label(&mut self, label: FlowNodeId) {
+        let unreachable = self.unreachable_flow;
+        let resolved = match self.flow_nodes.get(label) {
+            Some(node) => match node.antecedent.len() {
+                0 => unreachable,
+                1 => node.antecedent[0],
+                _ => label,
+            },
+            None => unreachable,
+        };
+        self.current_flow = resolved;
+    }
 }


### PR DESCRIPTION
Goal: green

## Summary
`bind_if_statement` assigned the merge label to `current_flow` unconditionally. When **both** arms terminate (each `return`s — including via a nested `if/else` whose every arm returns), `add_antecedent` skips the unreachable arm flows, so the merge label ends with **zero antecedents** — yet was still treated as reachable. That spuriously-reachable label became the branch's exit flow, so an enclosing `if`'s merge gained a reachable then-side antecedent and the negated-discriminant / definite-assignment narrowing of subsequent statements was dropped. In zod this is the root of the `ZodEffects._parse` `assertNever(effect)` cluster (the post-branch `effect` kept the full `Effect` union instead of being narrowed to `never`).

## Structural Rule
A branch merge label must be finalized the way tsc's `finishFlowLabel` does: **0** (reachable) antecedents → the unreachable flow, **1** → that antecedent, **else** → the label itself. tsz now does this for `bind_if_statement`'s merge label (and shares it with the function-body return-label finalizer that already implemented the same logic inline).

- **Owner layer:** binder — `crates/tsz-binder/src/state/flow_helpers.rs` (`finish_flow_label`), called from `bind_if_statement` (`nodes/flow_statements.rs`) and the function-body finalizer (`binding/declaration.rs`).
- **Fallback:** a merge with ≥1 reachable antecedent is unaffected (kept/collapsed exactly as before). Only the dead (0-antecedent) merge now correctly becomes unreachable.

### Adjacent-case matrix (verified vs `tsc`)
| pattern | tsc | tsz |
|---|---|---|
| `if (x.k==='r'){ if(s) return; else return }` then use `x` | narrowed (member `r` subtracted) | narrowed (was full union → TS2339) |
| same, arms do NOT both return | full union retained | full union (parity, unchanged) |
| `let v; if(c){v=1}else{return}; v` | definitely assigned | definitely assigned (unchanged) |

## Project Corpus Impact
- **zod:** 18 → 13 tsz-only FPs.
- **type-graphql:** 16 → 15 tsz-only FPs.
- No new errors introduced (verified against a freshly-built clean-main binary — the only delta is cleared FPs).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- Minimal repros (nested-if-both-return discriminant narrowing; both-arms-don't-return parity; definite-assignment after `if`/`else`-return) diffed against `node typescript/lib/tsc.js --noEmit --strict --target es2022 --lib es2022` — tsz matches tsc.
- Conformance: **controlFlow (94), narrowing (29), definiteAssignment (4), switch (15), statements (203), unreachable (6), typeGuard (86), expressions (377), assignmentCompatibility (71), returnType, conditionalTypes all 100% pass, zero regressions**.
- zod/type-graphql measured against a freshly-built clean-main binary; tsz-only delta via `comm` vs the tsc oracle; confirmed zero new errors vs clean main.
- `cargo clippy -p tsz-binder --all-targets -- -D warnings` clean; `cargo fmt` clean.