### PR TITLE
perf(checker): install on-demand-forcing cache-poisoning backstop (#12101 steps 1-3)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -1182,10 +1182,14 @@ impl<'a> CheckerState<'a> {
             inheritance_graph: &self.ctx.inheritance_graph,
             sound_mode: self.ctx.sound_mode(),
         };
+        // Snapshot the unresolved-`Lazy` counter before the relation so
+        // `failure_memo_store` can refuse to persist an analysis that compared
+        // against a not-yet-registered def body (issue #12101 backstop).
+        let lazy_failures_at_entry = crate::query_boundaries::common::lazy_resolve_failure_count();
         let (gate, capture) =
             check_assignable_gate_with_overrides(&inputs, &overrides, true, precomputed.as_ref());
         if let Some(capture) = capture {
-            self.failure_memo_store(memo_key, capture);
+            self.failure_memo_store(memo_key, capture, lazy_failures_at_entry);
         }
         if gate.related
             && let Some(reason) =

--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -160,6 +160,10 @@ impl<'a> CheckerState<'a> {
 
         let overrides = CheckerOverrideProvider::new(self, None);
 
+        // Snapshot the unresolved-`Lazy` counter before the relation so
+        // `failure_memo_store` can refuse to persist an analysis that compared
+        // against a not-yet-registered def body (issue #12101 backstop).
+        let lazy_failures_at_entry = crate::query_boundaries::common::lazy_resolve_failure_count();
         let (mut outcome, capture) = execute_relation(
             request,
             self.ctx.types,
@@ -172,7 +176,7 @@ impl<'a> CheckerState<'a> {
         );
 
         if let (Some(key), Some(capture)) = (memo_key, capture) {
-            self.failure_memo_store(key, capture);
+            self.failure_memo_store(key, capture, lazy_failures_at_entry);
         }
 
         self.propagate_overflow_flags(outcome.depth_exceeded, outcome.iteration_exceeded);

--- a/crates/tsz-checker/src/assignability/failure_memo.rs
+++ b/crates/tsz-checker/src/assignability/failure_memo.rs
@@ -43,8 +43,7 @@ impl CheckerState<'_> {
     /// relation walk can grow the type environments, and the captured
     /// analysis is valid for that *post*-pass state.
     ///
-    /// `lazy_failures_at_entry` is a snapshot of
-    /// [`lazy_resolve_failure_count`](crate::query_boundaries::common::lazy_resolve_failure_count)
+    /// `lazy_failures_at_entry` is a snapshot of `lazy_resolve_failure_count`
     /// taken by the caller immediately before it ran the captured relation. If
     /// the count advanced during the relation, the walk compared against a
     /// `Lazy(DefId)` whose body was not yet registered (`note_lazy_resolve_failure`),

--- a/crates/tsz-checker/src/assignability/failure_memo.rs
+++ b/crates/tsz-checker/src/assignability/failure_memo.rs
@@ -42,10 +42,31 @@ impl CheckerState<'_> {
     /// on them. The stamp is recomputed after the pass on purpose — the
     /// relation walk can grow the type environments, and the captured
     /// analysis is valid for that *post*-pass state.
+    ///
+    /// `lazy_failures_at_entry` is a snapshot of
+    /// [`lazy_resolve_failure_count`](crate::query_boundaries::common::lazy_resolve_failure_count)
+    /// taken by the caller immediately before it ran the captured relation. If
+    /// the count advanced during the relation, the walk compared against a
+    /// `Lazy(DefId)` whose body was not yet registered (`note_lazy_resolve_failure`),
+    /// so the analysis is a function of the registration window it ran in, not
+    /// of the prepared `(source, target, flags, sound_mode)` key alone. The
+    /// failure memo is keyed purely on that prepared key with no
+    /// generation/registration guard, so persisting an under-resolved analysis
+    /// would let it shadow the correct one once the body registers. This is the
+    /// relation-layer analog of the env-eval `unresolved_def_seen` backstop
+    /// (issue #12101) and mirrors the suppression
+    /// [`publish_shared_constraint_proof`](Self::publish_shared_constraint_proof)
+    /// already applies to the cross-file constraint-proof cache.
+    ///
+    /// Inert today: the eager `ensure_refs_resolved` pre-walk resolves every
+    /// referenced `DefId` before a committed relation, so the count does not
+    /// advance during a captured relation. The guard becomes load-bearing only
+    /// when the on-demand forcing rework drops that pre-walk.
     pub(crate) fn failure_memo_store(
         &mut self,
         key: AssignabilityFailureKey,
         analysis: CachedAssignabilityAnalysis,
+        lazy_failures_at_entry: u64,
     ) {
         use crate::state_domain::type_environment::lazy::{
             global_resolution_fuel_exhausted, refs_resolution_fuel_exhausted,
@@ -56,6 +77,8 @@ impl CheckerState<'_> {
             || refs_resolution_fuel_exhausted()
             || global_resolution_fuel_exhausted()
             || self.ctx.depth_exceeded.get()
+            || crate::query_boundaries::common::lazy_resolve_failure_count()
+                != lazy_failures_at_entry
         {
             return;
         }

--- a/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
@@ -401,6 +401,21 @@ pub(crate) struct EvalWithCacheResult {
     /// retry — the structural type-tree walk would hit the same protection
     /// limit at the same shape.
     pub silent_depth_bailed: bool,
+    /// Whether the evaluator observed an application whose base `DefId` had no
+    /// resolvable body during this pass (the registration-window artifact
+    /// tracked by `TypeEvaluator::is_unresolved_def_seen`).
+    ///
+    /// A `result` computed while a consumed `DefId` was still unresolved is a
+    /// function of the registration window it ran in, not of the input
+    /// `TypeId` alone. The env-eval memo (`cache_env_eval_result`) is keyed
+    /// purely on the input `TypeId` with no generation guard, so a caller that
+    /// would cache such a result must skip the write — otherwise the
+    /// under-resolved answer permanently shadows the correct one once the
+    /// declaring file registers the real body. Inert today: the eager
+    /// `ensure_refs_resolved` pre-walk resolves every referenced `DefId` before
+    /// a committed relation, so this flag stays `false` until the on-demand
+    /// forcing rework (issue #12101) removes that pre-walk.
+    pub unresolved_def_seen: bool,
     /// Cache entries produced by the evaluator (key -> evaluated value).
     ///
     /// Empty when `CacheEntryCollection::Skip` is selected. The top-level
@@ -486,6 +501,7 @@ pub(crate) fn evaluate_type_with_cache<R: tsz_solver::relations::subtype::TypeRe
         result,
         depth_exceeded: evaluator.is_depth_exceeded(),
         silent_depth_bailed: evaluator.is_silent_depth_bailed(),
+        unresolved_def_seen: evaluator.is_unresolved_def_seen(),
         cache_entries: if matches!(
             options.cache_entry_collection,
             CacheEntryCollection::Collect
@@ -515,6 +531,7 @@ pub(crate) fn evaluate_type_for_ts2589<R: tsz_solver::relations::subtype::TypeRe
         result,
         depth_exceeded: evaluator.is_depth_exceeded(),
         silent_depth_bailed: evaluator.is_silent_depth_bailed(),
+        unresolved_def_seen: evaluator.is_unresolved_def_seen(),
         cache_entries: evaluator.drain_cache().collect(),
     }
 }

--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -81,6 +81,39 @@ pub(crate) fn global_lazy_receiver_preserve_disabled() -> bool {
     })
 }
 
+/// Kill-switch for the planned on-demand lib-reference *forcing* rework
+/// (issue #12101). Set `TSZ_DISABLE_ON_DEMAND_FORCING=1` to force the legacy
+/// eager `ensure_refs_resolved` pre-walk once the forcing path lands, enabling
+/// byte-identical diagnostic comparison between the eager and on-demand paths.
+///
+/// # Status
+///
+/// Scaffolding only. No caller gates on this flag yet: the on-demand forcing
+/// path (Steps 4-9 of the rework) is not implemented. The companion
+/// cache-poisoning backstop (suppressing the `env_eval_cache` write when an
+/// evaluation observed an unresolved `DefId`) is installed and inert today
+/// because the current eager pre-walk pre-resolves every referenced `DefId`
+/// before a committed relation, so `unresolved_def_seen` never fires. This
+/// kill-switch becomes live only when the eager pre-walk is later removed.
+///
+/// Cached in a `OnceLock` so the environment is read at most once per process.
+// Scaffolding for the #12101 on-demand-forcing rework; the gating caller lands
+// with Steps 4-9. `expect` (not `allow`) is deliberate: it self-clears — once a
+// caller exists the unfulfilled-lint warning forces this attribute's removal.
+#[expect(
+    dead_code,
+    reason = "on-demand-forcing kill-switch caller lands in #12101 Steps 4-9"
+)]
+pub(crate) fn on_demand_forcing_disabled() -> bool {
+    use std::sync::OnceLock;
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        std::env::var("TSZ_DISABLE_ON_DEMAND_FORCING")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
 impl CheckerState<'_> {
     /// Compute the known-global value-type override for a property-access
     /// receiver identifier `ident_text`, given the receiver's `current_type`

--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -108,9 +108,9 @@ pub(crate) fn on_demand_forcing_disabled() -> bool {
     use std::sync::OnceLock;
     static DISABLED: OnceLock<bool> = OnceLock::new();
     *DISABLED.get_or_init(|| {
-        std::env::var("TSZ_DISABLE_ON_DEMAND_FORCING")
-            .map(|v| !v.is_empty() && v != "0")
-            .unwrap_or(false)
+        // `is_ok_and` (vs the sibling kill-switches' `.map(..).unwrap_or(false)`)
+        // keeps the clippy::map_unwrap_or warn-ratchet count from rising.
+        std::env::var("TSZ_DISABLE_ON_DEMAND_FORCING").is_ok_and(|v| !v.is_empty() && v != "0")
     })
 }
 

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -172,20 +172,10 @@ impl CheckerState<'_> {
         let seed_persist = use_cache && self.ctx.env_eval_seed_persist_enabled();
 
         let mut depth_exceeded = false;
-        // Cache-poisoning backstop (issue #12101): OR-accumulated across both
-        // evaluation passes, exactly like `depth_exceeded`. Set when an
-        // application's base `DefId` had no resolvable body during the pass, so
-        // the `result` is a function of the registration window it ran in, not
-        // of `type_id` alone. The authoritative env-eval memo
-        // (`cache_env_eval_result`) is keyed purely on `type_id` with no
-        // generation guard, so persisting such a result would permanently
-        // shadow the correct answer once the declaring file registers the real
-        // body — see the write-suppression below.
-        //
-        // Inert today: the eager `ensure_refs_resolved` pre-walk above
-        // pre-resolves every referenced `DefId` before a committed relation, so
-        // this flag stays `false` on every current path. It becomes live only
-        // when the on-demand forcing rework removes that pre-walk.
+        // Cache-poisoning backstop (#12101): OR-accumulated across both passes
+        // like `depth_exceeded`; suppresses the env-eval write below. See the
+        // `EvalWithCacheResult::unresolved_def_seen` doc for the full rationale.
+        // Inert today (the eager `ensure_refs_resolved` pre-walk keeps it false).
         let mut unresolved_def_seen = false;
         let first_pass_silent_bailed;
         let result = {
@@ -347,17 +337,8 @@ impl CheckerState<'_> {
 
         // Same Infer guard for the top-level result: don't cache results
         // containing unbound infer types from partially-evaluated conditional types.
-        //
-        // Cache-poisoning backstop (issue #12101): also suppress the write when
-        // either pass observed an unresolved application base `DefId`
-        // (`unresolved_def_seen`). The env-eval memo is keyed purely on
-        // `type_id` with no generation/registration guard, so persisting a
-        // result derived from a not-yet-registered body would permanently
-        // shadow the correct answer once that body is registered — mirroring
-        // the per-application epoch guard the solver's `application_eval_cache`
-        // already applies via `mark_unresolved_def_seen`. Inert today (the
-        // eager pre-walk keeps `unresolved_def_seen` false); becomes load-
-        // bearing only when the on-demand forcing rework drops the pre-walk.
+        // `!unresolved_def_seen` is the #12101 cache-poisoning backstop (see the
+        // `EvalWithCacheResult::unresolved_def_seen` doc); inert today.
         if use_cache
             && !unresolved_def_seen
             && !crate::query_boundaries::common::contains_this_type(self.ctx.types, type_id)

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -172,6 +172,21 @@ impl CheckerState<'_> {
         let seed_persist = use_cache && self.ctx.env_eval_seed_persist_enabled();
 
         let mut depth_exceeded = false;
+        // Cache-poisoning backstop (issue #12101): OR-accumulated across both
+        // evaluation passes, exactly like `depth_exceeded`. Set when an
+        // application's base `DefId` had no resolvable body during the pass, so
+        // the `result` is a function of the registration window it ran in, not
+        // of `type_id` alone. The authoritative env-eval memo
+        // (`cache_env_eval_result`) is keyed purely on `type_id` with no
+        // generation guard, so persisting such a result would permanently
+        // shadow the correct answer once the declaring file registers the real
+        // body — see the write-suppression below.
+        //
+        // Inert today: the eager `ensure_refs_resolved` pre-walk above
+        // pre-resolves every referenced `DefId` before a committed relation, so
+        // this flag stays `false` on every current path. It becomes live only
+        // when the on-demand forcing rework removes that pre-walk.
+        let mut unresolved_def_seen = false;
         let first_pass_silent_bailed;
         let result = {
             // First pass: evaluate with TypeEnvironment resolver.
@@ -203,6 +218,7 @@ impl CheckerState<'_> {
                 depth_exceeded = true;
                 self.ctx.depth_exceeded.set(true);
             }
+            unresolved_def_seen |= eval_result.unresolved_def_seen;
             first_pass_silent_bailed = eval_result.silent_depth_bailed;
             // Persist intermediate evaluation results to the shared cache.
             // Skip entries whose result contains unbound `infer` types or type queries.
@@ -316,6 +332,7 @@ impl CheckerState<'_> {
                 depth_exceeded = true;
                 self.ctx.depth_exceeded.set(true);
             }
+            unresolved_def_seen |= eval_result.unresolved_def_seen;
             if second_pass_seed_persist {
                 self.persist_eval_cache_entries(eval_result.cache_entries);
             }
@@ -330,7 +347,19 @@ impl CheckerState<'_> {
 
         // Same Infer guard for the top-level result: don't cache results
         // containing unbound infer types from partially-evaluated conditional types.
+        //
+        // Cache-poisoning backstop (issue #12101): also suppress the write when
+        // either pass observed an unresolved application base `DefId`
+        // (`unresolved_def_seen`). The env-eval memo is keyed purely on
+        // `type_id` with no generation/registration guard, so persisting a
+        // result derived from a not-yet-registered body would permanently
+        // shadow the correct answer once that body is registered — mirroring
+        // the per-application epoch guard the solver's `application_eval_cache`
+        // already applies via `mark_unresolved_def_seen`. Inert today (the
+        // eager pre-walk keeps `unresolved_def_seen` false); becomes load-
+        // bearing only when the on-demand forcing rework drops the pre-walk.
         if use_cache
+            && !unresolved_def_seen
             && !crate::query_boundaries::common::contains_this_type(self.ctx.types, type_id)
             && !crate::query_boundaries::common::contains_this_type(self.ctx.types, final_result)
             && !contains_infer_types_db(self.ctx.types, final_result)

--- a/crates/tsz-checker/tests/state_type_environment.rs
+++ b/crates/tsz-checker/tests/state_type_environment.rs
@@ -477,3 +477,51 @@ fn type_parameter_constraint_query_boundary() {
     let app = types.application(TypeId::STRING, vec![TypeId::NUMBER]);
     assert_eq!(type_parameter_constraint(&types, app), None);
 }
+
+/// Step 2 of the #12101 on-demand-forcing backstop: the env-eval boundary must
+/// surface the evaluator's unresolved-def-seen flag so the checker can refuse
+/// to write the `TypeId`-keyed env-eval cache for a registration-window
+/// artifact. A fully-resolvable evaluation reports `false` (the no-op default
+/// that holds on every current path), while evaluating an `Application` whose
+/// base `DefId` has nothing registered reports `true`.
+#[test]
+fn evaluate_type_with_cache_surfaces_unresolved_def_seen() {
+    use tsz_solver::relations::subtype::TypeEnvironment;
+
+    let types = TypeInterner::new();
+    let env = TypeEnvironment::new();
+    let options = EvaluateTypeWithCacheOptions {
+        expand_application_display_alias_args: false,
+        query_db: None,
+        authoritative: false,
+        cache_entry_collection: CacheEntryCollection::Skip,
+    };
+
+    // A concrete, fully-resolvable type evaluates without consulting any
+    // unresolved def, so the flag stays false (the inert default today).
+    let resolved = evaluate_type_with_cache(
+        &types,
+        &env,
+        TypeId::STRING,
+        std::iter::empty(),
+        false,
+        options,
+    );
+    assert!(
+        !resolved.unresolved_def_seen,
+        "a fully-resolvable evaluation must not flag unresolved_def_seen"
+    );
+
+    // An Application over a Lazy(DefId) whose base def has neither registered
+    // type params nor a body is the registration-window artifact the backstop
+    // guards: the empty resolver cannot resolve the def, so the evaluator marks
+    // unresolved_def_seen and the boundary surfaces it.
+    let unregistered = types.lazy(DefId(987_654));
+    let app = types.application(unregistered, vec![TypeId::NUMBER]);
+    let under_resolved =
+        evaluate_type_with_cache(&types, &env, app, std::iter::empty(), false, options);
+    assert!(
+        under_resolved.unresolved_def_seen,
+        "an application over an unregistered base def must flag unresolved_def_seen"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -661,6 +661,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.silent_depth_bailed
     }
 
+    /// Whether this run evaluated an application whose base `DefId` had no
+    /// resolvable body (the registration-window artifact tracked by
+    /// `unresolved_def_seen`).
+    ///
+    /// A result computed while a consumed `DefId` was still unresolved is a
+    /// function of the *registration window* it ran in, not of the input
+    /// `TypeId` alone: once the declaring file registers the real body, a fresh
+    /// evaluation produces a different (correct) answer. Callers that persist
+    /// the result in a cache keyed purely on the input `TypeId` — with no
+    /// generation/registration guard — must consult this flag and skip the
+    /// write, or the under-resolved answer permanently shadows the correct one.
+    /// This is the public counterpart of the in-module `unresolved_def_seen`,
+    /// exposed for the env-eval cache-poisoning backstop (issue #12101).
+    #[inline]
+    pub const fn is_unresolved_def_seen(&self) -> bool {
+        self.unresolved_def_seen
+    }
+
     /// Whether this run hit any recursion / depth / iteration limit.
     ///
     /// Single source of truth for the three flags that mark a result as a

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1452,7 +1452,15 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # all through the existing `query_boundaries::common` gateway joining the
         # sibling structural predicates already used in the same expressions —
         # no new quarantine entry. Removal condition remains #8225.
-        3076,
+        #
+        # Bumped 3076→3079 for the #12101 on-demand-forcing cache-poisoning
+        # backstop: `failure_memo_store` and its two callers
+        # (`assignability_relation.rs`, `assignability_diagnostics.rs`) each
+        # reference the existing `query_boundaries::common::lazy_resolve_failure_count`
+        # gateway helper — the same one `publish_shared_constraint_proof` already
+        # uses for the sibling cross-file proof cache. No new quarantine entry.
+        # Removal condition remains #8225.
+        3079,
     ),
 ]
 


### PR DESCRIPTION
Goal: fast

Refs #12101, #13979, #13981.

## Summary
First increment of the #12101 on-demand lib-interface forcing rework (the comlink Fast-goal close; `ensure_refs_resolved` is 53.5% of comlink check time via eager transitive DOM-graph materialization). This PR ships **only the soundness mechanism** the later forcing steps require — pure hardening, **provably inert on the current ledger** (zero diagnostic delta). No forcing is wired yet.

## Structural rule
The eventual fix keeps a lib-interface ref `Lazy(DefId)` until structurally consumed, forcing on demand. That requires that a relation/evaluation run while a consumed `DefId` is still unresolved must **not** persist its result, because the result is a function of the registration window, not of the input key. `env_eval_cache` and the failure memo are keyed purely on the input key with **no generation guard** (#13981), so an under-resolved result would permanently shadow the correct one once the body registers. This PR installs the write-suppression backstop; the solver already tracks the needed signal (`unresolved_def_seen` / `lazy_resolve_failure_count`).

## Owner layer
Checker eval/relation caching + solver evaluator accessor.
- **Step 1** — `lazy_lib_member.rs`: `TSZ_DISABLE_ON_DEMAND_FORCING` kill-switch scaffold (gates nothing yet; enables byte-identical eager-vs-on-demand diffing once forcing lands). `#[expect(dead_code)]` so it self-clears when a Step 4-9 caller arrives.
- **Step 2** — expose the solver's existing `unresolved_def_seen` via `is_unresolved_def_seen()` (`evaluate.rs`), carry it on `EvalWithCacheResult` (`type_environment.rs`), OR-accumulate across both evaluation passes and add `&& !unresolved_def_seen` to the authoritative `cache_env_eval_result` write (`lazy.rs`). Mirrors the existing `depth_exceeded` plumbing and the evaluator's own `mark_unresolved_def_seen` application-cache epoch guard.
- **Step 3** — `failure_memo_store` refuses to persist when `lazy_resolve_failure_count` advanced during the captured relation (same signal/pattern `publish_shared_constraint_proof` already uses for the cross-file proof cache); both callers snapshot the count before the relation.

## Why this is a no-op today (and correctness-safe even if it weren't)
The eager `ensure_refs_resolved` pre-walk resolves every referenced `DefId` before a committed relation, so `unresolved_def_seen` / `lazy_resolve_failure_count` never advance during a committed relation — the new suppression clauses are always-true and the cache decisions are identical. Independently: suppressing a cache **write** only forces recomputation (same result), never alters a computed type — so the change cannot change a diagnostic regardless. The flags become load-bearing only when a later step (#12101 step 7) drops the pre-walk.

## Anti-hardcoding
No identifier/file-name/printer-string predicates. The signals are pre-existing structural evaluator/relation flags (`unresolved_def_seen`, `lazy_resolve_failure_count`); the kill-switch is an env var with no compiler-logic effect.

## Verification
- `cargo build -p tsz-checker --lib` / `-p tsz-solver --lib`, `cargo fmt --check`, `cargo clippy --lib` (both crates) — clean (the `#[expect(dead_code)]` is satisfied, confirming the scaffold is genuinely unused).
- New unit test `evaluate_type_with_cache_surfaces_unresolved_def_seen` — asserts the flag is `false` for a resolvable type and `true` for an `Application(Lazy(unregistered_def), [number])` over an empty resolver.
- `cargo test -p tsz-solver --lib evaluation`, `-p tsz-checker --lib {env_eval,assignability,failure_memo,lazy_lib_heritage_guard}` — every failing test is in the pre-change baseline (zero new failures).
- **Full `cargo test -p tsz-checker --lib` failing set IDENTICAL before/after** (6727→6729 passed accounts for the +1 new test; the only set delta is the known order-dependent `source_option_bag` cross-arena flake, proven by re-running the unmodified tree). Zero regressions.
- Broad conformance / emit / fourslash parity owned by ready-review CI per repo policy.

## Provenance
Machine: MacBookPro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

AgentName: M1FableArchitect