### PR TITLE
fix(resolver): resolve package.json #imports against the nearest package scope only

### DIFF
--- a/crates/tsz-cli/src/driver/resolution/package_resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution/package_resolution.rs
@@ -346,94 +346,97 @@ pub(crate) fn resolve_package_imports_specifier(
 ) -> Option<PathBuf> {
     let conditions = export_conditions(options);
     let compiler_version = types_versions_compiler_version(options);
+
+    // Per Node.js LOOKUP_PACKAGE_SCOPE + PACKAGE_IMPORTS_RESOLVE (and tsc's
+    // `getPackageScopeForPath` / `loadModuleFromImports`), a `#`-prefixed
+    // specifier resolves against the SINGLE nearest enclosing package.json — the
+    // importer's own package scope. We walk up only to *find* that scope (the
+    // importer may live in a subdirectory such as `src/`), bounded by `base_dir`;
+    // once a readable package.json is found we resolve `#imports` against it alone
+    // and never fall through to an ancestor package, even when the nearest scope
+    // has no `imports` field or no matching key. (An unreadable/invalid
+    // package.json is not a usable scope, so we keep walking past it.)
     let mut current = from_file.parent().unwrap_or(base_dir);
-
-    loop {
+    let (package_json, scope_dir) = loop {
         let package_json_path = current.join("package.json");
-        if let Some(package_json) = resolution_cache.read_package_json(&package_json_path)
-            && let Some(imports) = package_json.imports.as_ref()
-        {
-            let package_type = package_type_from_json(Some(&package_json));
-            // Node.js (and tsc) resolve `imports`/`exports` targets via
-            // PACKAGE_TARGET_RESOLVE: the target is taken verbatim, with no
-            // directory-index lookup and no extension invention. tsc only
-            // remaps an explicit `.js`/`.mjs`/`.cjs` target to its `.ts`
-            // sibling. Under the `exports`/`imports`-aware modes
-            // (Node16/NodeNext/Bundler) an EXTENSIONLESS runtime target must
-            // therefore NOT resolve. The legacy `Node`(node10)/`Classic`
-            // modes predate this and keep classic extension/index probing.
-            let strict_extensionless = matches!(
-                options.effective_module_resolution(),
-                ModuleResolutionKind::Node16
-                    | ModuleResolutionKind::NodeNext
-                    | ModuleResolutionKind::Bundler
-            );
-            for (target, is_types_condition) in resolve_imports_subpath_candidates_with_flavor(
-                imports,
-                module_specifier,
-                &conditions,
-                compiler_version,
-            ) {
-                let target = target.trim();
-                if target.starts_with("./") {
-                    if package_relative_target_path(current, target).is_none() {
-                        continue;
-                    }
-                } else if !is_valid_bare_imports_target(target) {
-                    continue;
-                }
-
-                // An extensionless relative target under a spec'd mode does not
-                // gain a `.ts`/`index.*` lookup — unless the value came through
-                // a types-flavored condition, which keeps declaration-aware
-                // probing (`./types/api` -> `./types/api.d.ts`) exactly like the
-                // `exports` field and `typesVersions`.
-                if strict_extensionless
-                    && target.starts_with("./")
-                    && split_path_extension(Path::new(target)).is_none()
-                {
-                    if is_types_condition
-                        && let Some(resolved) = resolve_declaration_package_entry(
-                            current,
-                            target,
-                            options,
-                            package_type,
-                            resolution_cache,
-                        )
-                    {
-                        return Some(resolved);
-                    }
-                    continue;
-                }
-
-                if let Some(resolved) =
-                    resolve_package_entry(current, target, options, package_type, resolution_cache)
-                {
-                    return Some(resolved);
-                }
-                // Output-to-source remapping for package imports.
-                // When outDir/declarationDir is set, import targets like "./dist/index.js"
-                // point to the output directory which doesn't exist at compile time.
-                // Remap back to source files (e.g., "./index.ts").
-                if let Some(resolved) = try_remap_output_to_source(
-                    current,
-                    target,
-                    from_file,
-                    options,
-                    resolution_cache,
-                ) {
-                    return Some(resolved);
-                }
-            }
+        if let Some(package_json) = resolution_cache.read_package_json(&package_json_path) {
+            break (package_json, current);
         }
-
         if current == base_dir {
-            break;
+            return None;
         }
-        let Some(parent) = current.parent() else {
-            break;
-        };
-        current = parent;
+        current = current.parent()?;
+    };
+
+    // Nearest package scope defines no `imports` map: fail here without searching
+    // ancestor packages, matching tsc.
+    let imports = package_json.imports.as_ref()?;
+    let package_type = package_type_from_json(Some(&package_json));
+    // Node.js (and tsc) resolve `imports`/`exports` targets via
+    // PACKAGE_TARGET_RESOLVE: the target is taken verbatim, with no
+    // directory-index lookup and no extension invention. tsc only remaps an
+    // explicit `.js`/`.mjs`/`.cjs` target to its `.ts` sibling. Under the
+    // `exports`/`imports`-aware modes (Node16/NodeNext/Bundler) an EXTENSIONLESS
+    // runtime target must therefore NOT resolve. The legacy `Node`(node10)/
+    // `Classic` modes predate this and keep classic extension/index probing.
+    let strict_extensionless = matches!(
+        options.effective_module_resolution(),
+        ModuleResolutionKind::Node16
+            | ModuleResolutionKind::NodeNext
+            | ModuleResolutionKind::Bundler
+    );
+    for (target, is_types_condition) in resolve_imports_subpath_candidates_with_flavor(
+        imports,
+        module_specifier,
+        &conditions,
+        compiler_version,
+    ) {
+        let target = target.trim();
+        if target.starts_with("./") {
+            if package_relative_target_path(scope_dir, target).is_none() {
+                continue;
+            }
+        } else if !is_valid_bare_imports_target(target) {
+            continue;
+        }
+
+        // An extensionless relative target under a spec'd mode does not gain a
+        // `.ts`/`index.*` lookup — unless the value came through a types-flavored
+        // condition, which keeps declaration-aware probing (`./types/api` ->
+        // `./types/api.d.ts`) exactly like the `exports` field and
+        // `typesVersions`.
+        if strict_extensionless
+            && target.starts_with("./")
+            && split_path_extension(Path::new(target)).is_none()
+        {
+            if is_types_condition
+                && let Some(resolved) = resolve_declaration_package_entry(
+                    scope_dir,
+                    target,
+                    options,
+                    package_type,
+                    resolution_cache,
+                )
+            {
+                return Some(resolved);
+            }
+            continue;
+        }
+
+        if let Some(resolved) =
+            resolve_package_entry(scope_dir, target, options, package_type, resolution_cache)
+        {
+            return Some(resolved);
+        }
+        // Output-to-source remapping for package imports.
+        // When outDir/declarationDir is set, import targets like "./dist/index.js"
+        // point to the output directory which doesn't exist at compile time.
+        // Remap back to source files (e.g., "./index.ts").
+        if let Some(resolved) =
+            try_remap_output_to_source(scope_dir, target, from_file, options, resolution_cache)
+        {
+            return Some(resolved);
+        }
     }
 
     None

--- a/crates/tsz-cli/src/driver/resolution/paths_imports_tests.rs
+++ b/crates/tsz-cli/src/driver/resolution/paths_imports_tests.rs
@@ -310,6 +310,119 @@ fn hash_prefix_without_paths_still_uses_package_imports() {
 }
 
 #[test]
+fn hash_prefix_imports_resolve_only_against_nearest_package_scope() {
+    // Per Node.js LOOKUP_PACKAGE_SCOPE, a `#`-import resolves only against the
+    // nearest enclosing package.json. When that nearest scope has no `imports`
+    // field, resolution fails — the resolver must NOT keep walking up to an
+    // ancestor package whose `imports` happens to define the specifier. This is
+    // the monorepo shape: a nested package without `imports`, under a root
+    // package that defines `#shared`.
+    let dir = TempDir::new().expect("temp dir creation should succeed in test");
+    let dir = dir.path();
+    fs::create_dir_all(dir.join("packages/inner/src")).unwrap();
+
+    // Root package DOES define `#/shared`, with a real target on disk.
+    fs::write(
+        dir.join("package.json"),
+        r##"{"name":"root","type":"module","imports":{"#/shared":"./shared.ts"}}"##,
+    )
+    .unwrap();
+    fs::write(dir.join("shared.ts"), "").unwrap();
+
+    // Nearest scope for the importer has NO `imports` field.
+    fs::write(
+        dir.join("packages/inner/package.json"),
+        r##"{"name":"inner","type":"module"}"##,
+    )
+    .unwrap();
+
+    let options = resolve_options(CompilerOptions {
+        module_resolution: Some("nodenext".to_string()),
+        module: Some("nodenext".to_string()),
+        ..Default::default()
+    });
+
+    let mut cache = ModuleResolutionCache::default();
+    let known_files: FxHashSet<PathBuf> = FxHashSet::default();
+    let resolved = resolve_module_specifier(
+        &dir.join("packages/inner/src/main.ts"),
+        "#/shared",
+        &options,
+        dir,
+        &mut cache,
+        &known_files,
+    );
+    assert_eq!(
+        resolved, None,
+        "#/shared must not resolve against the ancestor root package once a \
+         nearer package scope (without a matching import) is found"
+    );
+}
+
+#[test]
+fn hash_prefix_imports_no_match_in_nearest_scope_does_not_reach_ancestor() {
+    // Variant: the nearest scope HAS an `imports` map, but no matching key.
+    // tsc fails here too — it does not continue to ancestor package scopes.
+    let dir = TempDir::new().expect("temp dir creation should succeed in test");
+    let dir = dir.path();
+    fs::create_dir_all(dir.join("packages/inner/src")).unwrap();
+
+    fs::write(
+        dir.join("package.json"),
+        r##"{"name":"root","type":"module","imports":{"#/shared":"./shared.ts"}}"##,
+    )
+    .unwrap();
+    fs::write(dir.join("shared.ts"), "").unwrap();
+
+    // Nearest scope defines only an unrelated `#/local` key.
+    fs::write(
+        dir.join("packages/inner/package.json"),
+        r##"{"name":"inner","type":"module","imports":{"#/local":"./local.ts"}}"##,
+    )
+    .unwrap();
+    fs::write(dir.join("packages/inner/local.ts"), "").unwrap();
+
+    let options = resolve_options(CompilerOptions {
+        module_resolution: Some("nodenext".to_string()),
+        module: Some("nodenext".to_string()),
+        ..Default::default()
+    });
+
+    let mut cache = ModuleResolutionCache::default();
+    let known_files: FxHashSet<PathBuf> = FxHashSet::default();
+
+    // The nearest scope's own key resolves fine.
+    let local = resolve_module_specifier(
+        &dir.join("packages/inner/src/main.ts"),
+        "#/local",
+        &options,
+        dir,
+        &mut cache,
+        &known_files,
+    );
+    assert_eq!(
+        local.map(|path| canonicalize_or_owned(&path)),
+        Some(canonicalize_or_owned(&dir.join("packages/inner/local.ts"))),
+        "#/local must resolve against the nearest package scope"
+    );
+
+    // But the ancestor-only `#/shared` must not be reached.
+    let shared = resolve_module_specifier(
+        &dir.join("packages/inner/src/main.ts"),
+        "#/shared",
+        &options,
+        dir,
+        &mut cache,
+        &known_files,
+    );
+    assert_eq!(
+        shared, None,
+        "#/shared (defined only in the ancestor) must not fall through past the \
+         nearest import-bearing scope"
+    );
+}
+
+#[test]
 fn hash_prefix_invalid_for_node16_still_blocked_for_imports_after_paths_miss() {
     // In `node16` resolution, the bare `#/foo` form is invalid for package
     // imports. If `paths` doesn't match either, the function must return

--- a/crates/tsz-core/src/module_resolver/exports_imports.rs
+++ b/crates/tsz-core/src/module_resolver/exports_imports.rs
@@ -101,106 +101,115 @@ impl ModuleResolver {
         importing_module_kind: ImportingModuleKind,
         importer_package_type: Option<super::PackageType>,
     ) -> Result<ResolvedModule, ResolutionFailure> {
-        // Walk up directory tree looking for package.json with imports field
-        let mut current = containing_dir.to_path_buf();
-
-        loop {
-            let package_json_path = current.join("package.json");
-
-            if cached_is_file(&package_json_path)
-                && let Ok(package_json) = self.read_package_json(&package_json_path)
-                && let Some(imports) = &package_json.imports
-            {
-                let conditions = self.get_export_conditions(importing_module_kind);
-                // `#imports` always resolve inside the importer's own package,
-                // so use the package_json we just read to anchor the extension
-                // priority. The importer's own context is the fallback when
-                // this package.json has no `"type"` field.
-                let host_pt =
-                    self.target_package_type_from_json(&package_json, importer_package_type);
-
-                for (target, resolved_using_ts_extension, is_types_condition) in
-                    self.resolve_imports_subpath_candidates(imports, specifier, &conditions)
-                {
-                    // Per Node.js PACKAGE_IMPORTS_RESOLVE spec, the resolved
-                    // (post-substitution) target must either be a relative
-                    // path within the package (`./...`) or a bare package
-                    // specifier. Absolute paths and parent escapes are
-                    // invalid targets and must not resolve.
-                    if target.starts_with("./") {
-                        let Some(resolved_path) = package_relative_target_path(&current, &target)
-                        else {
-                            continue;
-                        };
-                        // Imports targets follow the same PACKAGE_TARGET_RESOLVE
-                        // algorithm as exports targets, so route them through the
-                        // shared runtime probe (`try_export_target`) rather than
-                        // the classic `try_file_or_directory`. This makes an
-                        // extensionless imports target (e.g. `"#core/*":
-                        // "./src/core/*"` imported as `#core/sharedOptions`)
-                        // refuse extension/directory-index addition under
-                        // Node16/NodeNext/Bundler, matching tsc, while explicit
-                        // `.js`->`.ts` substitution still applies.
-                        //
-                        // A types-flavored condition (`types`/`types@<range>`)
-                        // keeps declaration-aware probing via `try_types_entry`
-                        // so an extensionless versioned-types target still finds
-                        // its `.d.ts` sibling, mirroring the exports path.
-                        let probed = if is_types_condition {
-                            self.try_types_entry(&resolved_path, host_pt)
-                                .or_else(|| self.try_export_target(&resolved_path, host_pt))
-                        } else {
-                            self.try_export_target(&resolved_path, host_pt)
-                        };
-                        if let Some(resolved) = probed {
-                            return Ok(ResolvedModule {
-                                resolved_path: resolved.clone(),
-                                resolved_using_ts_extension,
-                                is_external: false,
-                                package_name: package_json.name.clone(),
-                                original_specifier: specifier.to_string(),
-                                extension: ModuleExtension::from_path(&resolved),
-                            });
-                        }
-                        continue;
-                    }
-
-                    if !is_valid_bare_imports_target(&target) {
-                        continue;
-                    }
-
-                    // Bare specifier: resolve as a package (PACKAGE_RESOLVE),
-                    // supporting self-referencing imports like
-                    // `"#type": "some-package"`.
-                    match self.resolve_bare_specifier(
-                        &target,
-                        &current,
-                        containing_file,
-                        specifier_span,
-                        importing_module_kind,
-                    ) {
-                        Ok(resolved) => return Ok(resolved),
-                        Err(
-                            ResolutionFailure::NotFound { .. }
-                            | ResolutionFailure::AmbiguousProjectRoot { .. },
-                        ) => continue,
-                        Err(other) => return Err(other),
-                    }
-                }
-            }
-
-            // Move to parent directory
-            match current.parent() {
-                Some(parent) if parent != current => current = parent.to_path_buf(),
-                _ => break,
-            }
-        }
-
-        Err(ResolutionFailure::NotFound {
+        let not_found = || ResolutionFailure::NotFound {
             specifier: specifier.to_string(),
             containing_file: containing_file.to_string(),
             span: specifier_span,
-        })
+        };
+
+        // Per Node.js LOOKUP_PACKAGE_SCOPE + PACKAGE_IMPORTS_RESOLVE (and tsc's
+        // `getPackageScopeForPath` / `loadModuleFromImports`), a `#`-prefixed
+        // specifier resolves against the SINGLE nearest enclosing package.json —
+        // the importer's own package scope. We walk up only to *find* that scope
+        // (the importer may live in a subdirectory such as `src/`); once a
+        // readable package.json is found we resolve `#imports` against it alone
+        // and never fall through to an ancestor package, even when the nearest
+        // scope has no `imports` field or no matching key.
+        //
+        // (An unreadable/invalid package.json is not a usable scope, so we keep
+        // walking past it rather than treating a parse failure as a hard wall.)
+        let mut current = containing_dir.to_path_buf();
+        let (package_json, scope_dir) = loop {
+            let package_json_path = current.join("package.json");
+            // `read_package_json` caches both hit and miss, so it doubles as the
+            // existence check — no separate `cached_is_file` probe needed.
+            if let Ok(package_json) = self.read_package_json(&package_json_path) {
+                break (package_json, current);
+            }
+            let Some(parent) = current.parent().filter(|&p| p != current) else {
+                return Err(not_found());
+            };
+            current = parent.to_path_buf();
+        };
+
+        let Some(imports) = &package_json.imports else {
+            // Nearest package scope defines no `imports` map: fail here without
+            // searching ancestor packages, matching tsc.
+            return Err(not_found());
+        };
+
+        let conditions = self.get_export_conditions(importing_module_kind);
+        // `#imports` always resolve inside the importer's own package, so use the
+        // scope package.json we just read to anchor the extension priority. The
+        // importer's own context is the fallback when it has no `"type"` field.
+        let host_pt = self.target_package_type_from_json(&package_json, importer_package_type);
+
+        for (target, resolved_using_ts_extension, is_types_condition) in
+            self.resolve_imports_subpath_candidates(imports, specifier, &conditions)
+        {
+            // Per Node.js PACKAGE_IMPORTS_RESOLVE spec, the resolved
+            // (post-substitution) target must either be a relative path within
+            // the package (`./...`) or a bare package specifier. Absolute paths
+            // and parent escapes are invalid targets and must not resolve.
+            if target.starts_with("./") {
+                let Some(resolved_path) = package_relative_target_path(&scope_dir, &target) else {
+                    continue;
+                };
+                // Imports targets follow the same PACKAGE_TARGET_RESOLVE
+                // algorithm as exports targets, so route them through the
+                // shared runtime probe (`try_export_target`) rather than the
+                // classic `try_file_or_directory`. This makes an extensionless
+                // imports target (e.g. `"#core/*": "./src/core/*"` imported as
+                // `#core/sharedOptions`) refuse extension/directory-index
+                // addition under Node16/NodeNext/Bundler, matching tsc, while
+                // explicit `.js`->`.ts` substitution still applies.
+                //
+                // A types-flavored condition (`types`/`types@<range>`) keeps
+                // declaration-aware probing via `try_types_entry` so an
+                // extensionless versioned-types target still finds its `.d.ts`
+                // sibling, mirroring the exports path.
+                let probed = if is_types_condition {
+                    self.try_types_entry(&resolved_path, host_pt)
+                        .or_else(|| self.try_export_target(&resolved_path, host_pt))
+                } else {
+                    self.try_export_target(&resolved_path, host_pt)
+                };
+                if let Some(resolved) = probed {
+                    return Ok(ResolvedModule {
+                        resolved_path: resolved.clone(),
+                        resolved_using_ts_extension,
+                        is_external: false,
+                        package_name: package_json.name.clone(),
+                        original_specifier: specifier.to_string(),
+                        extension: ModuleExtension::from_path(&resolved),
+                    });
+                }
+                continue;
+            }
+
+            if !is_valid_bare_imports_target(&target) {
+                continue;
+            }
+
+            // Bare specifier: resolve as a package (PACKAGE_RESOLVE), supporting
+            // self-referencing imports like `"#type": "some-package"`.
+            match self.resolve_bare_specifier(
+                &target,
+                &scope_dir,
+                containing_file,
+                specifier_span,
+                importing_module_kind,
+            ) {
+                Ok(resolved) => return Ok(resolved),
+                Err(
+                    ResolutionFailure::NotFound { .. }
+                    | ResolutionFailure::AmbiguousProjectRoot { .. },
+                ) => continue,
+                Err(other) => return Err(other),
+            }
+        }
+
+        Err(not_found())
     }
 
     /// Resolve imports field subpath into ordered target candidates.

--- a/crates/tsz-core/src/module_resolver/tests/package_exports_imports.rs
+++ b/crates/tsz-core/src/module_resolver/tests/package_exports_imports.rs
@@ -485,6 +485,163 @@ fn test_package_imports_target_cannot_contain_node_modules_segment() {
 }
 
 #[test]
+fn test_package_imports_resolve_only_against_nearest_package_scope() {
+    // Per Node.js LOOKUP_PACKAGE_SCOPE + PACKAGE_IMPORTS_RESOLVE (and tsc's
+    // `getPackageScopeForPath` / `loadModuleFromImports`), a `#`-prefixed
+    // specifier resolves ONLY against the nearest enclosing `package.json`. If
+    // that nearest scope has no `imports` field (or no matching key), resolution
+    // fails — the resolver must NOT keep walking up to an ancestor package that
+    // happens to define a matching `#import`.
+    use std::fs;
+    let dir = std::env::temp_dir().join("tsz_test_imports_nearest_scope_only");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("packages/inner/src")).unwrap();
+
+    // Outer package defines `#shared`, with a real target on disk.
+    fs::write(
+        dir.join("package.json"),
+        r##"{"name":"root","imports":{"#shared":"./shared.d.ts"}}"##,
+    )
+    .unwrap();
+    fs::write(dir.join("shared.d.ts"), "export declare const v: number;").unwrap();
+
+    // Nearest package scope for the importer has NO `imports` field.
+    fs::write(
+        dir.join("packages/inner/package.json"),
+        r##"{"name":"inner"}"##,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("packages/inner/src/index.ts"),
+        "import { v } from '#shared'; v;",
+    )
+    .unwrap();
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        resolve_package_json_imports: true,
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+    let result = resolver.resolve(
+        "#shared",
+        &dir.join("packages/inner/src/index.ts"),
+        Span::new(0, 7),
+    );
+
+    assert!(
+        matches!(result, Err(ResolutionFailure::NotFound { .. })),
+        "#shared must NOT resolve against an ancestor package once a nearer \
+         package scope (without a matching import) is found, got {result:?}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_package_imports_no_match_in_nearest_scope_does_not_fall_through_to_ancestor() {
+    // A variant where the nearest scope DOES have an `imports` field, but the
+    // specifier does not match any of its keys. tsc fails here too — it does not
+    // continue searching ancestor package scopes for a matching key.
+    use std::fs;
+    let dir = std::env::temp_dir().join("tsz_test_imports_nearest_scope_nomatch");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("packages/inner/src")).unwrap();
+
+    fs::write(
+        dir.join("package.json"),
+        r##"{"name":"root","imports":{"#shared":"./shared.d.ts"}}"##,
+    )
+    .unwrap();
+    fs::write(dir.join("shared.d.ts"), "export declare const v: number;").unwrap();
+
+    // Nearest scope has an `imports` map, but only an unrelated key.
+    fs::write(
+        dir.join("packages/inner/package.json"),
+        r##"{"name":"inner","imports":{"#local":"./local.d.ts"}}"##,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("packages/inner/local.d.ts"),
+        "export declare const w: number;",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("packages/inner/src/index.ts"),
+        "import { v } from '#shared'; v;",
+    )
+    .unwrap();
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        resolve_package_json_imports: true,
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+
+    // The unrelated `#local` key in the nearest scope resolves fine.
+    let local = resolver.resolve(
+        "#local",
+        &dir.join("packages/inner/src/index.ts"),
+        Span::new(0, 6),
+    );
+    assert!(
+        local.is_ok(),
+        "#local should resolve against the nearest scope, got {local:?}"
+    );
+
+    // But `#shared`, defined only in the ancestor, must not be reached.
+    let shared = resolver.resolve(
+        "#shared",
+        &dir.join("packages/inner/src/index.ts"),
+        Span::new(0, 7),
+    );
+    assert!(
+        matches!(shared, Err(ResolutionFailure::NotFound { .. })),
+        "#shared (only in ancestor) must not fall through past the nearest \
+         import-bearing scope, got {shared:?}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_package_imports_resolve_from_subdir_within_same_scope() {
+    // Control: walking UP to find the nearest package.json is still correct when
+    // the importer lives in a subdirectory of its own package. `#shared` must
+    // resolve from `src/nested/` against the single enclosing package scope.
+    use std::fs;
+    let dir = std::env::temp_dir().join("tsz_test_imports_same_scope_subdir");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("src/nested")).unwrap();
+
+    fs::write(
+        dir.join("package.json"),
+        r##"{"name":"app","imports":{"#shared":"./shared.d.ts"}}"##,
+    )
+    .unwrap();
+    fs::write(dir.join("shared.d.ts"), "export declare const v: number;").unwrap();
+    fs::write(
+        dir.join("src/nested/index.ts"),
+        "import { v } from '#shared'; v;",
+    )
+    .unwrap();
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        resolve_package_json_imports: true,
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+    let result = resolver.resolve("#shared", &dir.join("src/nested/index.ts"), Span::new(0, 7));
+
+    let resolved = result.expect("#shared should resolve from a subdir of its own package");
+    assert_eq!(resolved.resolved_path, dir.join("shared.d.ts"));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn test_exports_js_target_substitutes_dts() {
     use std::fs;
     let dir = std::env::temp_dir().join("tsz_test_exports_js_target");


### PR DESCRIPTION
Goal: hold

Fixes a `#imports` resolver correctness gap under #13826 (module-resolution umbrella). Distinct from the landed `node:`-classification slices (#13963/#13985) and from the fixture install-scope sub-roots (#3/#4).

## Structural rule

When a module specifier begins with `#`, `tsc` resolves it against the **single nearest** enclosing `package.json` — the importer's own package scope (`getPackageScopeForPath` → `loadModuleFromImports`, i.e. Node.js `LOOKUP_PACKAGE_SCOPE` + `PACKAGE_IMPORTS_RESOLVE`). If that nearest scope has no `imports` field, or no matching key, resolution **fails** — `tsc` does not continue up to an ancestor package.

tsz did `X` through the wrong owner: **both** `#imports` resolvers walked the entire directory tree, *skipping past* any `package.json` that lacked an `imports` field (or whose `imports` had no matching key) and resolving `#foo` against an **ancestor** package. In a monorepo this resolves specifiers that `tsc` rejects.

## Owner layer

Module resolver, both parallel layers:
- `crates/tsz-core/src/module_resolver/exports_imports.rs` — `ModuleResolver::resolve_package_imports`
- `crates/tsz-cli/src/driver/resolution/package_resolution.rs` — `resolve_package_imports_specifier` (the path the checker/CLI use)

Both now walk up only to **locate** the nearest readable `package.json`, then resolve `#imports` against that scope alone. An unreadable/invalid `package.json` is not a usable scope, so the walk continues past it (matching `getPackageJsonInfo` tolerance).

## Fallback

- Nearest scope **has** `imports` and the specifier matches → resolves exactly as before (the common case is unchanged; the walk-up only ever *located* the scope here too).
- Nearest scope **has** `imports` but no matching key → fail (was: wrongly resolved via ancestor).
- Nearest scope **lacks** `imports` → fail (was: wrongly resolved via ancestor).
- Importer in a subdirectory (`src/…`) of its own single package → still resolves against that enclosing scope (control).

## Adjacent-case matrix (name-agnostic unit tests, both crates)

| case | before | after / tsc |
|---|---|---|
| nested pkg without `imports` under root defining `#shared` | resolved (wrong) | `NotFound` |
| nearest scope with non-matching `imports` key (`#local` present, `#shared` only in ancestor) | `#shared` resolved (wrong) | `#shared` `NotFound`; `#local` resolves |
| importer in `src/nested/` of its own package | resolves | resolves (unchanged) |

Tests vary keys/paths and assert both the negative (no fall-through) and the positive (nearest-scope key still resolves) sides.

## Anti-hardcoding

No identifier/file-name/printer-string predicates. The decision is purely structural: the nearest readable `package.json` on the directory walk is the scope boundary. No fixture-name fast paths.

## Cleanup (no behavior change)

Loop-invariant work (export conditions, compiler version, package type, host package type, `strict_extensionless`) is hoisted out of the walk — previously recomputed at every directory level. A redundant `cached_is_file` probe is dropped (the package.json cache already gates existence, caching both hit and miss), and the `NotFound` construction is deduped behind a closure.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- `cargo test -p tsz-core --lib module_resolver` — 246 passed, 0 failed (incl. 3 new nearest-scope tests).
- `cargo test -p tsz-cli --lib resolution::` — 94 passed; `paths_imports_tests` 10 passed (incl. 2 new nested-scope tests).
- `cargo fmt -p tsz-core -p tsz-cli --check` clean; `cargo clippy -p tsz-core --lib --tests -- -D warnings` and `cargo clippy -p tsz-cli --lib -- -D warnings` clean.
- Both touched files stay under the 2000-line cap.
- Broad conformance / emit / fourslash / project-corpus owned by ready-review CI per repo policy.

https://claude.ai/code/session_018tC7bxSvzRSunTWmo3Uxuu

---
_Generated by [Claude Code](https://claude.ai/code/session_018tC7bxSvzRSunTWmo3Uxuu)_