### PR TITLE
fix(solver): accept union of valid index types in strict TS2538 check

### DIFF
--- a/crates/tsz-solver/src/type_queries/extended.rs
+++ b/crates/tsz-solver/src/type_queries/extended.rs
@@ -369,6 +369,23 @@ fn is_invalid_index_type_strict_inner(
                 }
                 true
             }
+            Some(TypeData::Union(list_id)) => {
+                // A union index type is valid iff EVERY member is a valid index
+                // type: tsc distributes `T[A | B]` to `T[A] | T[B]`, so each
+                // branch must be valid. The canonical case is the `PropertyKey`
+                // alias `string | number | symbol` used as a computed
+                // destructuring key (`const { [k]: v } = obj`). Without this arm
+                // the union falls through to the `_ => false` invalid case,
+                // producing a false TS2538. When a member is itself invalid the
+                // whole union is still rejected, preserving the existing
+                // whole-union TS2538 message for partially-invalid unions.
+                for &member in db.type_list(list_id).iter() {
+                    if is_invalid_index_type_strict_inner(db, member, visited).is_some() {
+                        return Some(type_id);
+                    }
+                }
+                true
+            }
             Some(TypeData::TypeParameter(info)) => {
                 // Valid if the constraint is a valid index type
                 if let Some(constraint) = info.constraint {


### PR DESCRIPTION
## Summary

The strict index-type validity check `is_invalid_index_type_strict_inner`
(`crates/tsz-solver/src/type_queries/extended.rs`), used by destructuring
computed-key checking in `destructuring.rs:1233`, had no `Union` arm. A union
index type therefore fell through to the invalid `_ => false` default and was
rejected with a false **TS2538**.

The canonical case is the `PropertyKey` alias `string | number | symbol` used
as a computed destructuring key:

```ts
const { [pivot]: currentValue, ...remaining } = data as Record<PropertyKey, unknown>;
```

`tsc` accepts this; tsz emitted `TS2538: Type 'string | number | symbol'
cannot be used as an index type`.

## Structural rule

When the index type is a union, `tsc` distributes `T[A | B]` to `T[A] | T[B]`,
so the union is a valid index type **iff every member is a valid index type**.
This is owned by the solver's strict index-type query. The new `Union` arm
mirrors the existing `Intersection` arm: valid when all members are valid,
otherwise rejected. The still-invalid case reports the whole-union type,
preserving the existing TS2538 message for partially-invalid unions — only the
all-valid case changes behavior (minimal blast radius).

The permissive sibling `is_invalid_index_type_inner` (element-access
expressions) already had this arm; the strict variant (computed destructuring
keys) had diverged.

## Adjacent cases

- All-valid union (`string | number | symbol`): now accepted (was false TS2538).
- Partially-invalid union (`string | boolean`): still rejected, identical
  TS2538 message as before (no change).
- Intersection / type-parameter / literal index types: unchanged.

Goal: green

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- Minimal repro: `const { [k]: v } = data` with `k: string | number | symbol`
  over `Record<PropertyKey, unknown>` — Case 1 (all-valid) now clean; Case 2
  (`string | boolean`) emits the same TS2464 + whole-union TS2538 as before and
  as the pre-fix binary.
- remeda canary: 55 -> 54 tsz-only FPs (`comm -23` vs `tsc` oracle); exactly
  `setPath.ts(108,12)` removed, zero new FPs.
- Conformance (prebuilt dist-fast, all 100%): destructuring 174/174,
  indexedAccess 13/13, indexSignature 24/24, keyof 14/14, computedProperties
  149/149, mappedType 55/55, union 60/60, member 261/261, typeRelationships
  265/265, spread 71/71, restElement 14/14.
- `cargo clippy -p tsz-solver` clean; `cargo fmt -p tsz-solver --check` clean.
