### PR TITLE
fix(emit): keep single-line function bodies single-line with object-rest params (#14006)

### DIFF
--- a/crates/tsz-emitter/src/emitter/functions.rs
+++ b/crates/tsz-emitter/src/emitter/functions.rs
@@ -1656,6 +1656,46 @@ mod tests {
         );
     }
 
+    /// An ES2018 object-rest parameter synthesizes a `var { a } = _a, rest =
+    /// __rest(_a, [...])` preamble into the function body. tsc keeps a
+    /// single-line source body on one line and writes that preamble inline;
+    /// tsz previously forced the body multi-line whenever such a preamble was
+    /// present. The body must stay single-line to match tsc byte-for-byte.
+    #[test]
+    fn object_rest_param_keeps_single_line_function_body() {
+        let source = "function f({ a, b = 2, ...rest }: any) { return a + b; }";
+        let (parser, root) = parse_test_source(source);
+        let mut printer = Printer::new(&parser.arena, PrintOptions::es6());
+        printer.set_source_text(source);
+        printer.print(root);
+        let output = printer.finish().code;
+
+        assert!(
+            output.contains(
+                "function f(_a) { var { a, b = 2 } = _a, rest = __rest(_a, [\"a\", \"b\"]); return a + b; }"
+            ),
+            "Object-rest parameter must keep a single-line body on one line (matching tsc).\nOutput:\n{output}"
+        );
+    }
+
+    /// When a single-line body also hoists optional-chaining / logical-assignment
+    /// temps (`var _b, _c;`), tsc emits those temp declarations BEFORE the
+    /// object-rest destructuring preamble. Lock that ordering.
+    #[test]
+    fn object_rest_param_single_line_body_hoists_temps_before_preamble() {
+        let source = "function f({ a, ...rest }: any) { return g.h?.() ?? a; }";
+        let (parser, root) = parse_test_source(source);
+        let mut printer = Printer::new(&parser.arena, PrintOptions::es6());
+        printer.set_source_text(source);
+        printer.print(root);
+        let output = printer.finish().code;
+
+        assert!(
+            output.contains("var _b, _c; var { a } = _a, rest = __rest(_a, [\"a\"]);"),
+            "Hoisted optional-chaining temps must precede the object-rest preamble on the single line.\nOutput:\n{output}"
+        );
+    }
+
     #[test]
     fn function_with_empty_parameter_comment_preserves_comment() {
         let source = "function foo(/** nothing */) { return 1; }";

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -167,6 +167,13 @@ impl<'a> Printer<'a> {
         // tsc preserves the single-line format for function body blocks regardless
         // of statement count, as long as the source was single-line.
         // (Forced multi-line when we need to inject `var _this = this;`.)
+        // An ES2018 object-rest parameter preamble (`var { a } = _a, rest =
+        // __rest(_a, ["a"]);`) does NOT force the body multi-line: tsc keeps a
+        // single-line source body single-line and writes the preamble inline
+        // (see the inline emission in the single-line branch below). Only state
+        // that genuinely needs hoisted line-leading declarations (`var _this =
+        // this;`, captured `new.target`, hoisted assignment/for-of temps) forces
+        // multi-line.
         let should_emit_single_line = !block.statements.nodes.is_empty()
             && self.is_single_line(node)
             && !needs_this_capture
@@ -174,9 +181,7 @@ impl<'a> Printer<'a> {
             && is_function_body_block
             && self.pending_lowered_async_arrow_super_capture.is_none()
             && self.hoisted_assignment_value_temps.is_empty()
-            && self.hoisted_for_of_temps.is_empty()
-            && self.pending_object_rest_params.is_empty()
-            && self.pending_object_rest_param_defaults.is_empty();
+            && self.hoisted_for_of_temps.is_empty();
 
         if should_emit_single_line {
             let private_static_shadow = self.block_shadows_private_static_class_alias(
@@ -199,12 +204,26 @@ impl<'a> Printer<'a> {
             }
             self.map_opening_brace(node);
             self.write("{ ");
-            let block_close_pos = self.find_block_closing_brace_end(node).saturating_sub(1);
+            // Anchor for inline hoisted temp vars (`var _b; `), captured right
+            // after `{ ` and BEFORE the object-rest preamble: tsc emits the
+            // optional-chaining / logical-assignment temp declarations ahead of
+            // the destructuring preamble, e.g.
+            //   { var _b, _c; var { a } = _a, rest = __rest(_a, ["a"]); ... }
             let var_insert_pos = if is_function_body_block {
                 Some(self.writer.len())
             } else {
                 None
             };
+            // Inject the ES2018 object-rest parameter preamble inline so a
+            // single-line source body stays single-line (matching tsc):
+            //   function f(_a) { var { a } = _a, rest = __rest(_a, ["a"]); return a; }
+            // The multi-line branch below emits the same preamble line-by-line;
+            // here it is written inline followed by a single separating space
+            // before the first body statement (which the loop never prefixes).
+            if self.emit_object_rest_param_prologue(is_function_body_block, true) {
+                self.write(" ");
+            }
+            let block_close_pos = self.find_block_closing_brace_end(node).saturating_sub(1);
             for (si, &stmt_idx) in block.statements.nodes.iter().enumerate() {
                 if si > 0 {
                     self.write(" ");
@@ -322,11 +341,7 @@ impl<'a> Printer<'a> {
 
         // Inject object rest parameter destructuring preamble for ES2018 lowering.
         // e.g., `function f(_a, b) { var { a } = _a, rest = __rest(_a, ["a"]); ... }`
-        if is_function_body_block && !self.pending_object_rest_params.is_empty() {
-            self.emit_pending_object_rest_param_preamble(false);
-        } else if is_function_body_block && !self.pending_object_rest_param_defaults.is_empty() {
-            self.emit_pending_object_rest_param_defaults(false);
-        }
+        self.emit_object_rest_param_prologue(is_function_body_block, false);
 
         let static_super_scope =
             self.enter_pending_lowered_async_arrow_super_capture_scope(is_function_body_block);
@@ -820,6 +835,28 @@ impl<'a> Printer<'a> {
             );
             self.writer
                 .insert_line_at(anchor.byte_offset, anchor.line_no, &var_decl);
+        }
+    }
+
+    /// Emit the pending ES2018 object-rest parameter prologue for a function
+    /// body block: the `var { a } = _a, rest = __rest(_a, [...])` preamble, or
+    /// — when only destructuring defaults are pending — the default guards.
+    /// `inline` selects single-line vs multi-line formatting. Returns whether
+    /// anything was emitted so a single-line caller can add the separating space
+    /// before the first body statement.
+    pub(in crate::emitter) fn emit_object_rest_param_prologue(
+        &mut self,
+        is_function_body_block: bool,
+        inline: bool,
+    ) -> bool {
+        if is_function_body_block && !self.pending_object_rest_params.is_empty() {
+            self.emit_pending_object_rest_param_preamble(inline);
+            true
+        } else if is_function_body_block && !self.pending_object_rest_param_defaults.is_empty() {
+            self.emit_pending_object_rest_param_defaults(inline);
+            true
+        } else {
+            false
         }
     }
 


### PR DESCRIPTION
Goal: hold

Fixes #14006.

## Summary

An ES2018 object-rest destructuring parameter (`{ a, ...rest }`) downleveled to
the `__rest` helper (target `< ES2018`) synthesizes a
`var { a } = _a, rest = __rest(_a, ["a"]);` preamble into the function body.
`tsc` keeps a **single-line** source body on one line and writes that preamble
**inline**; tsz forced the body multi-line whenever the preamble was pending,
diverging from tsc's JS output byte-for-byte.

```ts
export function f({ a, b = 2, ...rest }: any) { return a + b; }
```

tsc / tsz-after:
```js
export function f(_a) { var { a, b = 2 } = _a, rest = __rest(_a, ["a", "b"]); return a + b; }
```

tsz-before:
```js
export function f(_a) {
    var { a, b = 2 } = _a, rest = __rest(_a, ["a", "b"]);
    return a + b;
}
```

## Failure family / owner

JS emit formatting parity. Owner: emitter — `emit_block`
(`crates/tsz-emitter/src/emitter/statements/core.rs`).

`should_emit_single_line` no longer excludes a pending object-rest preamble
(`pending_object_rest_params` / `pending_object_rest_param_defaults`). The
single-line branch emits the preamble **inline** (the existing
`emit_pending_object_rest_param_preamble`/`..._defaults` helpers already take an
`inline: bool`), and the inline hoisted-temp anchor (`var_insert_pos`) is
captured **before** the preamble so optional-chaining / logical-assignment temps
(`var _b, _c;`) precede it, matching tsc. The two-arm preamble/defaults dispatch
shared by the single-line and multi-line branches is extracted into a single
`emit_object_rest_param_prologue(is_function_body_block, inline) -> bool` helper.

No semantic validation and no post-emit output surgery: the same lowering and
the same helper text are used; only the line-break placement is corrected.

## Adjacent-case matrix (tsz JS vs `tsc 6.0.2`, all now byte-identical)

| case | result |
|---|---|
| single-line body, `{ a, b = 2, ...rest }` param | MATCH (was multi-line) |
| single-line body, `{ a, ...rest }` (function decl / method / arrow-block) | MATCH |
| single-line body + optional-chaining temps (`g.h?.() ?? a`) | MATCH — `var _b, _c;` ordered before the preamble |
| 2-statement single-line body | MATCH |
| **multi-line** source body | MATCH (unchanged) |
| empty body `{}` with rest param | MATCH (unchanged) |
| nested object-rest pattern | MATCH |
| no rest param (control) | MATCH (unchanged) |

Out of scope (separate, **pre-existing** on `main` — verified, multi-line too):
object-rest params on async functions and constructors drop the `__rest`
preamble entirely (a semantic bug, not this formatting gap).

## Verification

- New regression tests in `crates/tsz-emitter/src/emitter/functions.rs`:
  `object_rest_param_keeps_single_line_function_body`,
  `object_rest_param_single_line_body_hoists_temps_before_preamble`.
- `cargo test -p tsz-emitter --lib` — 3759 passed, 0 failed.
- `cargo fmt -p tsz-emitter --check` clean; `cargo clippy -p tsz-emitter --lib` clean.
- Emit witnesses (above matrix) diffed against `tsc 6.0.2` JS output.
- Broad conformance / emit baseline owned by ready-review CI per repo policy.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_011teg7UktwZCiZPugKHCEbY)_