### PR TITLE
fix(bench): require application compatibility before publishing

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1632,6 +1632,7 @@ jobs:
           set -euo pipefail
           node scripts/bench/check-artifact-readiness.mjs \
             --json \
+            --require-application-compat \
             --require-project-timing-pairs=1 \
             "$GITHUB_WORKSPACE/bench-results.json" \
             > "$GITHUB_WORKSPACE/bench-results-readiness.json"
@@ -1663,6 +1664,7 @@ jobs:
           fi
           if [[ "${{ steps.readiness.outcome }}" != "success" ]]; then
             echo "Benchmark artifact readiness check did not pass; refusing to publish it as latest."
+            echo "This includes application compatibility rows, so the website will not publish an all-gray application group."
           fi
           exit 1
 

--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -6,8 +6,9 @@
  *   0 — artifact present, all required rows included
  *   1 — artifact present, one or more required rows are missing, the
  *       --require-green release gate found non-green required rows, the
- *       --require-clean-metadata gate found artifact metadata warnings, or the
- *       --require-source-current gate found a stale artifact source commit
+ *       --require-clean-metadata gate found artifact metadata warnings,
+ *       --require-application-compat found missing/incomplete application rows,
+ *       or the --require-source-current gate found a stale artifact source commit
  *   2 — artifact file absent or unparseable
  *
  * Without --json: writes a markdown report to stdout (and GITHUB_STEP_SUMMARY
@@ -18,7 +19,7 @@
  * is absent (exit 2) so callers reliably get machine-readable status in all cases.
  *
  * Usage:
- *   node scripts/bench/check-artifact-readiness.mjs [--json] [--require-green] [--require-clean-metadata] [--require-project-timing-pairs[=<n>]] [--expect-source-commit=<sha>] [--require-source-current] <artifact.json>
+ *   node scripts/bench/check-artifact-readiness.mjs [--json] [--require-green] [--require-clean-metadata] [--require-application-compat] [--require-project-timing-pairs[=<n>]] [--expect-source-commit=<sha>] [--require-source-current] <artifact.json>
  */
 
 import fs from "node:fs";
@@ -26,6 +27,7 @@ import { execFileSync } from "node:child_process";
 
 import {
   REQUIRED_PROJECT_ROWS,
+  PROJECT_ROW_DEFINITIONS,
   PROJECT_ROWS_BY_NAME,
 } from "./project-rows.mjs";
 import { BENCH_RUNNER_EXCLUDED_ROWS } from "./project-row-summary.mjs";
@@ -49,6 +51,9 @@ const REQUIRED_MEASURED_ROWS = REQUIRED_PROJECT_ROWS.filter(
     !BENCH_RUNNER_EXCLUDED_ROWS.has(name) &&
     PROJECT_ROWS_BY_NAME[name]?.category !== "application",
 );
+const APPLICATION_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS
+  .filter((row) => row.category === "application")
+  .map((row) => row.name);
 
 const args = process.argv.slice(2);
 
@@ -57,6 +62,7 @@ function parseArgs(rawArgs) {
     jsonOutput: false,
     requireGreen: false,
     requireCleanMetadata: false,
+    requireApplicationCompat: false,
     requireSourceCurrent: false,
     requiredProjectTimingPairs: 0,
     expectedSourceCommit: process.env.TSZ_BENCH_EXPECT_SOURCE_COMMIT ?? null,
@@ -71,6 +77,8 @@ function parseArgs(rawArgs) {
       options.requireGreen = true;
     } else if (arg === "--require-clean-metadata") {
       options.requireCleanMetadata = true;
+    } else if (arg === "--require-application-compat") {
+      options.requireApplicationCompat = true;
     } else if (arg === "--require-source-current") {
       options.requireSourceCurrent = true;
     } else if (arg === "--require-project-timing-pairs") {
@@ -100,6 +108,7 @@ const {
   jsonOutput,
   requireGreen,
   requireCleanMetadata,
+  requireApplicationCompat,
   requireSourceCurrent,
   requiredProjectTimingPairs: rawRequiredProjectTimingPairs,
   expectedSourceCommit: rawExpectedSourceCommit,
@@ -151,6 +160,19 @@ function rowState(row, duplicate = false) {
   if (row.status) return "red";
   if (isGreen(row)) return "green";
   if (compat.state === "yellow" || compat.state === "red") return compat.state;
+  return "gray";
+}
+
+function applicationCompatibilityState(row, duplicate = false) {
+  if (!row) return "missing";
+  if (duplicate) return "gray";
+  if (row.artifact_missing === true) return "gray";
+  const compat = row.compatibility;
+  if (!compat) return "gray";
+  if (!hasCompletePhaseMetadata(compat)) return "gray";
+  if (compat.state === "green" || compat.state === "yellow" || compat.state === "red") {
+    return compat.state;
+  }
   return "gray";
 }
 
@@ -250,11 +272,11 @@ function analyzeArtifact(artifact, expectedCommit) {
     }
   }
 
-  const rows = REQUIRED_MEASURED_ROWS.map((name) => {
+  const compatibilityRow = (name, stateFn) => {
     const row = byName.get(name) ?? null;
     const duplicateCount = duplicateCounts.get(name) ?? (row ? 1 : 0);
     const duplicate = duplicateCount > 1;
-    const state = rowState(row, duplicate);
+    const state = stateFn(row, duplicate);
     const def = PROJECT_ROWS_BY_NAME[name];
     const compatibility = row?.compatibility ?? {};
     return {
@@ -283,13 +305,22 @@ function analyzeArtifact(artifact, expectedCommit) {
       peak_memory_bytes: compatibility.peak_memory_bytes ?? null,
       peak_memory_bytes_reason: compatibility.peak_memory_bytes_reason ?? null,
     };
-  });
+  };
+
+  const rows = REQUIRED_MEASURED_ROWS.map((name) => compatibilityRow(name, rowState));
+  const applicationRows = APPLICATION_PROJECT_ROWS.map((name) =>
+    compatibilityRow(name, applicationCompatibilityState),
+  );
 
   return {
     measurementProfile: measurementProfileStatus(artifact),
     validationWarnings: analyzeValidationWarnings(artifact),
     sourceFreshness: analyzeSourceFreshness(artifact, expectedCommit),
     rows,
+    applicationRows,
+    applicationMissing: applicationRows.filter((r) => r.state === "missing"),
+    applicationIncomplete: applicationRows.filter((r) => r.state === "gray"),
+    applicationDuplicates: applicationRows.filter((r) => r.duplicate_count > 1),
     successfulProjectTimingPairs: rows.filter((row) => (
       row.state === "green" &&
       Number.isFinite(Number(row.tsz_ms)) &&
@@ -316,7 +347,26 @@ function uniqueRowsByName(rows) {
   return [...byName.values()];
 }
 
-function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, validationWarnings, sourceFreshness, rows, successfulProjectTimingPairs, missing, red, yellow, gray, green, duplicates }) {
+function buildJson({
+  artifactAbsent,
+  parseError,
+  artifact,
+  measurementProfile,
+  validationWarnings,
+  sourceFreshness,
+  rows,
+  applicationRows,
+  applicationMissing,
+  applicationIncomplete,
+  applicationDuplicates,
+  successfulProjectTimingPairs,
+  missing,
+  red,
+  yellow,
+  gray,
+  green,
+  duplicates,
+}) {
   const missingNames = missing?.map((r) => r.name) ?? REQUIRED_MEASURED_ROWS;
   const metadataWarningsList = metadataWarnings(measurementProfile, validationWarnings);
   const nonGreenRows = rows
@@ -351,6 +401,20 @@ function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, v
     required_row_count: rows?.length ?? REQUIRED_MEASURED_ROWS.length,
     successful_project_timing_pairs: successfulProjectTimingPairs?.length ?? 0,
     required_project_timing_pairs: requiredProjectTimingPairs,
+    application_compatibility: applicationRows
+      ? {
+          required: requireApplicationCompat,
+          row_count: applicationRows.length,
+          present: applicationRows.length - (applicationMissing?.length ?? 0),
+          complete: applicationRows.length - (applicationMissing?.length ?? 0) - (applicationIncomplete?.length ?? 0),
+          missing: applicationMissing?.length ?? 0,
+          incomplete: applicationIncomplete?.length ?? 0,
+          duplicates: applicationDuplicates?.length ?? 0,
+          missing_rows: applicationMissing?.map((r) => r.name) ?? [],
+          incomplete_rows: applicationIncomplete?.map((r) => ({ name: r.name, state: r.state })) ?? [],
+          duplicate_rows: applicationDuplicates?.map((r) => ({ name: r.name, count: r.duplicate_count })) ?? [],
+        }
+      : null,
     green: green?.length ?? 0,
     yellow: yellow?.length ?? 0,
     red: red?.length ?? 0,
@@ -459,7 +523,24 @@ function artifactAge(generatedAt) {
   return `${h} h ago`;
 }
 
-function buildReport({ artifact, measurementProfile, validationWarnings, sourceFreshness, rows, successfulProjectTimingPairs, missing, red, yellow, gray, green, duplicates }) {
+function buildReport({
+  artifact,
+  measurementProfile,
+  validationWarnings,
+  sourceFreshness,
+  rows,
+  applicationRows,
+  applicationMissing,
+  applicationIncomplete,
+  applicationDuplicates,
+  successfulProjectTimingPairs,
+  missing,
+  red,
+  yellow,
+  gray,
+  green,
+  duplicates,
+}) {
   const sourceCommit = artifact?.source_commit?.slice(0, 10) ?? "unknown";
   const generatedAt = artifact?.generated_at ?? null;
   const workflowUrl = artifact?.workflow_run_url ?? null;
@@ -489,6 +570,7 @@ function buildReport({ artifact, measurementProfile, validationWarnings, sourceF
     `| Binary target CPU | ${profile.rust_target_cpu ? `\`${profile.rust_target_cpu}\`` : "—"} |`,
     `| Required rows | ${rows.length} |`,
     `| Successful project timing pairs | ${successfulProjectTimingPairs.length} |`,
+    `| Application compatibility rows | ${applicationRows.length - applicationMissing.length}/${applicationRows.length} present, ${applicationIncomplete.length} incomplete |`,
     `| ✅ green | ${green.length} |`,
     `| ⚠️ yellow | ${yellow.length} |`,
     `| ❌ red | ${red.length} |`,
@@ -509,6 +591,17 @@ function buildReport({ artifact, measurementProfile, validationWarnings, sourceF
   if (duplicates.length > 0) {
     lines.push(`### ⬜ Duplicate required rows (${duplicates.length})`, "");
     for (const r of duplicates) lines.push(`- \`${r.name}\` appears ${r.duplicate_count} times`);
+    lines.push("");
+  }
+
+  if (applicationMissing.length > 0 || applicationIncomplete.length > 0 || applicationDuplicates.length > 0) {
+    lines.push(
+      `### Application compatibility gaps (${applicationMissing.length + applicationIncomplete.length + applicationDuplicates.length})`,
+      "",
+    );
+    for (const r of applicationMissing) lines.push(`- \`${r.name}\`: missing compatibility row`);
+    for (const r of applicationIncomplete) lines.push(`- \`${r.name}\`: incomplete compatibility metadata`);
+    for (const r of applicationDuplicates) lines.push(`- \`${r.name}\`: duplicate compatibility row (${r.duplicate_count})`);
     lines.push("");
   }
 
@@ -585,6 +678,10 @@ if (artifactAbsent || parseError) {
         measurementProfile: null,
         sourceFreshness: null,
         rows: null,
+        applicationRows: null,
+        applicationMissing: null,
+        applicationIncomplete: null,
+        applicationDuplicates: null,
         missing: null,
         red: null,
         yellow: null,
@@ -604,6 +701,10 @@ const {
   validationWarnings,
   sourceFreshness,
   rows,
+  applicationRows,
+  applicationMissing,
+  applicationIncomplete,
+  applicationDuplicates,
   successfulProjectTimingPairs,
   missing,
   red,
@@ -625,6 +726,10 @@ if (jsonOutput) {
       validationWarnings,
       sourceFreshness,
       rows,
+      applicationRows,
+      applicationMissing,
+      applicationIncomplete,
+      applicationDuplicates,
       successfulProjectTimingPairs,
       missing,
       red,
@@ -649,6 +754,23 @@ if (missing.length > 0 || duplicates.length > 0) {
         missing.map((r) => r.name).join(", ") + "\n",
     );
   }
+  process.exit(1);
+}
+
+if (requireApplicationCompat && (
+  applicationMissing.length > 0 ||
+  applicationIncomplete.length > 0 ||
+  applicationDuplicates.length > 0
+)) {
+  const gaps = [
+    ...applicationMissing.map((r) => `${r.name} (missing)`),
+    ...applicationIncomplete.map((r) => `${r.name} (incomplete)`),
+    ...applicationDuplicates.map((r) => `${r.name} (${r.duplicate_count} duplicates)`),
+  ];
+  process.stderr.write(
+    `bench-artifact-readiness: application compatibility incomplete for ${gaps.length} row(s): ` +
+      gaps.join(", ") + "\n",
+  );
   process.exit(1);
 }
 

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -7,6 +7,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import {
   REQUIRED_PROJECT_ROWS as ALL_REQUIRED_PROJECT_ROWS,
+  PROJECT_ROW_DEFINITIONS,
   PROJECT_ROWS_BY_NAME,
 } from "./project-rows.mjs";
 import { BENCH_RUNNER_EXCLUDED_ROWS } from "./project-row-summary.mjs";
@@ -19,6 +20,9 @@ const REQUIRED_PROJECT_ROWS = ALL_REQUIRED_PROJECT_ROWS.filter(
     !BENCH_RUNNER_EXCLUDED_ROWS.has(name) &&
     PROJECT_ROWS_BY_NAME[name]?.category !== "application",
 );
+const APPLICATION_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS
+  .filter((row) => row.category === "application")
+  .map((row) => row.name);
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
@@ -449,6 +453,52 @@ withTempDir((dir) => {
   assert.match(result.stderr, /0 successful project timing pair\(s\); required 1/);
 });
 console.log("✅ --require-project-timing-pairs fails all-crashed project artifacts");
+
+// ---------------------------------------------------------------------------
+// Test: --require-application-compat fails the public publish gate when the
+// benchmark artifact has timing rows but no application compatibility rows.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const rows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  writeJson(file, makeArtifact(rows));
+  const result = run(file, ["--json", "--require-application-compat"]);
+  assert.equal(result.status, 1, "publish gate should fail when application compat rows are absent");
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.application_compatibility.required, true);
+  assert.equal(parsed.application_compatibility.row_count, APPLICATION_PROJECT_ROWS.length);
+  assert.equal(parsed.application_compatibility.present, 0);
+  assert.equal(parsed.application_compatibility.missing, APPLICATION_PROJECT_ROWS.length);
+  assert.match(result.stderr, /application compatibility incomplete/);
+  assert.match(result.stderr, new RegExp(`${APPLICATION_PROJECT_ROWS[0]} \\(missing\\)`));
+});
+console.log("✅ --require-application-compat fails missing application rows");
+
+// ---------------------------------------------------------------------------
+// Test: compile-only application rows with complete compatibility metadata pass
+// the application gate even though they are not timed by bench-vs-tsgo.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const requiredRows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  const applicationRows = APPLICATION_PROJECT_ROWS.map((name) =>
+    makeRow(name, "green", {
+      errorStatus: "compile canary tracked in CI; not timed by vs-tsgo benchmarks",
+      tsz_ms: null,
+      tsgo_ms: null,
+      winner: "error",
+    }),
+  );
+  writeJson(file, makeArtifact([...requiredRows, ...applicationRows]));
+  const result = run(file, ["--json", "--require-application-compat"]);
+  assert.equal(result.status, 0, `complete application compatibility rows should pass:\n${result.stderr}`);
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.application_compatibility.present, APPLICATION_PROJECT_ROWS.length);
+  assert.equal(parsed.application_compatibility.complete, APPLICATION_PROJECT_ROWS.length);
+  assert.equal(parsed.application_compatibility.missing, 0);
+  assert.equal(parsed.application_compatibility.incomplete, 0);
+});
+console.log("✅ --require-application-compat accepts complete compile-only app rows");
 
 // ---------------------------------------------------------------------------
 // Test: --require-green fails when any present required row is red.

--- a/scripts/bench/test-project-winner-regression-report.mjs
+++ b/scripts/bench/test-project-winner-regression-report.mjs
@@ -254,8 +254,8 @@ assert.match(
 );
 assert.match(
   benchWorkflow,
-  /check-artifact-readiness\.mjs\s+\\\s*\n\s+--json\s+\\\s*\n\s+--require-project-timing-pairs=1\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results\.json"/,
-  "bench publish should reject artifacts with no successful project timing pairs before publishing latest.json",
+  /check-artifact-readiness\.mjs\s+\\\s*\n\s+--json\s+\\\s*\n\s+--require-application-compat\s+\\\s*\n\s+--require-project-timing-pairs=1\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results\.json"/,
+  "bench publish should reject artifacts with missing app compatibility or no successful project timing pairs before publishing latest.json",
 );
 assert.match(
   benchWorkflow,


### PR DESCRIPTION
Goal: green

## Summary
- Require complete application compatibility rows before Bench publishes `bench-results.json` as website `latest.json`.
- Add readiness JSON/report output for missing, incomplete, and duplicate application compatibility rows.
- Cover the missing-app-row failure and complete compile-only app-row success path in readiness tests.

## Structural Rule
When the public benchmark artifact is promoted to the website, application project rows must carry complete compatibility metadata from the project compile guard; otherwise the website can only synthesize gray placeholders. The owner is the Bench artifact readiness gate, not the website renderer, so stale/incomplete artifacts are rejected before publication.

## Adjacent Cases
- Missing application rows fail `--require-application-compat` even when measured benchmark timing rows are present.
- Complete compile-only application rows pass even without `tsz_ms`/`tsgo_ms` timings.
- Existing required timing-pair and project winner regression guards still run.

## Verification
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `node scripts/bench/test-project-winner-regression-report.mjs`
- `node crates/tsz-website/scripts/benchmark-data-smoke.mjs`
- `git diff --check`
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz`
- Application-row sweep: `TSZ_PROJECT_COMPILE_SET=all TSZ_PROJECT_COMPILE_FILTER='umami-project|excalidraw-project|dub-project|formbricks-project|typebot-project|lobe-chat-project|supabase-studio-project|infisical-project|payload-project|medusa-project|outline-project|trigger-dev-project|joplin-project|directus-project|n8n-project|cal-com-project|documenso-project|affine-project|immich-server-project|rocketchat-project' TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 scripts/safe-run.sh scripts/ci/project-compile-guard.sh`
  - 20/20 application rows produced locally.
  - 2 green: `infisical-project`, `documenso-project`.
  - 17 red timeouts: `umami-project`, `excalidraw-project`, `dub-project`, `formbricks-project`, `typebot-project`, `lobe-chat-project`, `supabase-studio-project`, `payload-project`, `medusa-project`, `outline-project`, `trigger-dev-project`, `joplin-project`, `n8n-project`, `cal-com-project`, `affine-project`, `immich-server-project`, `rocketchat-project`.
  - 1 red crash: `directus-project` stack overflow.
  - Local dependency caveats observed: `typebot-project` needs `bun`; `supabase-studio-project`, `directus-project`, and `rocketchat-project` rejected local Node v25 before the compiler check continued.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5-codex
Effort: high
