### PR TITLE
fix(checker): render apparent type of receiver in TS7053 (object -> {})

### DIFF
--- a/crates/tsz-checker/src/error_reporter/apparent_type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/apparent_type_display.rs
@@ -1,0 +1,22 @@
+//! Shared apparent-type display strings for index/destructuring diagnostics.
+
+use tsz_solver::TypeId;
+
+/// Display string for the *apparent* type of a primitive/`object` intrinsic, as
+/// used in implicit-any index and destructuring diagnostics (`TS7053`/`TS2538`/
+/// `TS2339`). `tsc` reports `typeToString(getApparentType(receiver))` for these
+/// failures, so the `object` intrinsic widens to the empty object type `{}` and
+/// each primitive widens to its global wrapper interface (`number` -> `Number`,
+/// etc.). Returns `None` for any other type so callers fall back to the normal
+/// type formatter.
+pub(crate) fn apparent_intrinsic_type_display(type_id: TypeId) -> Option<String> {
+    match type_id {
+        TypeId::OBJECT => Some("{}".to_string()),
+        TypeId::STRING => Some("String".to_string()),
+        TypeId::NUMBER => Some("Number".to_string()),
+        TypeId::BOOLEAN => Some("Boolean".to_string()),
+        TypeId::BIGINT => Some("BigInt".to_string()),
+        TypeId::SYMBOL => Some("Symbol".to_string()),
+        _ => None,
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -9,6 +9,7 @@ pub(crate) enum TypeOnlyKind {
 }
 
 // Submodules
+pub(crate) mod apparent_type_display;
 pub(crate) mod assignability;
 mod assignability_alias_display;
 mod assignability_anchor_helpers;
@@ -42,7 +43,7 @@ mod name_resolution;
 mod noinfer_diagnostic_display;
 mod operator_errors;
 mod primitive_intersection_display;
-pub(crate) mod properties;
+mod properties;
 mod property_receiver_formatting;
 mod recursive_alias_display;
 mod render_failure;

--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -42,7 +42,7 @@ mod name_resolution;
 mod noinfer_diagnostic_display;
 mod operator_errors;
 mod primitive_intersection_display;
-mod properties;
+pub(crate) mod properties;
 mod property_receiver_formatting;
 mod recursive_alias_display;
 mod render_failure;

--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -13,25 +13,6 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
-/// Display string for the *apparent* type of a primitive/`object` intrinsic, as
-/// used in implicit-any index and destructuring diagnostics (`TS7053`/`TS2538`/
-/// `TS2339`). `tsc` reports `typeToString(getApparentType(receiver))` for these
-/// failures, so the `object` intrinsic widens to the empty object type `{}` and
-/// each primitive widens to its global wrapper interface (`number` -> `Number`,
-/// etc.). Returns `None` for any other type so callers fall back to the normal
-/// type formatter.
-pub(crate) fn apparent_intrinsic_type_display(type_id: TypeId) -> Option<String> {
-    match type_id {
-        TypeId::OBJECT => Some("{}".to_string()),
-        TypeId::STRING => Some("String".to_string()),
-        TypeId::NUMBER => Some("Number".to_string()),
-        TypeId::BOOLEAN => Some("Boolean".to_string()),
-        TypeId::BIGINT => Some("BigInt".to_string()),
-        TypeId::SYMBOL => Some("Symbol".to_string()),
-        _ => None,
-    }
-}
-
 impl<'a> CheckerState<'a> {
     fn property_type_has_array_like_length(&self, type_id: TypeId) -> bool {
         let kind = crate::query_boundaries::type_checking_utilities::classify_array_like(

--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -13,6 +13,25 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
+/// Display string for the *apparent* type of a primitive/`object` intrinsic, as
+/// used in implicit-any index and destructuring diagnostics (`TS7053`/`TS2538`/
+/// `TS2339`). `tsc` reports `typeToString(getApparentType(receiver))` for these
+/// failures, so the `object` intrinsic widens to the empty object type `{}` and
+/// each primitive widens to its global wrapper interface (`number` -> `Number`,
+/// etc.). Returns `None` for any other type so callers fall back to the normal
+/// type formatter.
+pub(crate) fn apparent_intrinsic_type_display(type_id: TypeId) -> Option<String> {
+    match type_id {
+        TypeId::OBJECT => Some("{}".to_string()),
+        TypeId::STRING => Some("String".to_string()),
+        TypeId::NUMBER => Some("Number".to_string()),
+        TypeId::BOOLEAN => Some("Boolean".to_string()),
+        TypeId::BIGINT => Some("BigInt".to_string()),
+        TypeId::SYMBOL => Some("Symbol".to_string()),
+        _ => None,
+    }
+}
+
 impl<'a> CheckerState<'a> {
     fn property_type_has_array_like_length(&self, type_id: TypeId) -> bool {
         let kind = crate::query_boundaries::type_checking_utilities::classify_array_like(

--- a/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
+++ b/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
@@ -695,7 +695,11 @@ impl<'a> CheckerState<'a> {
             // does this; share the same mapping here so element access matches.
             // For a type parameter `display_object_type` is its constraint, so a
             // `T extends number` receiver also widens to `Number`, matching tsc.
-            .or_else(|| super::apparent_intrinsic_type_display(display_object_type))
+            .or_else(|| {
+                crate::error_reporter::apparent_type_display::apparent_intrinsic_type_display(
+                    display_object_type,
+                )
+            })
             .unwrap_or_else(|| {
                 self.property_receiver_display_for_node(display_object_type, expr_idx)
             });

--- a/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
+++ b/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
@@ -689,6 +689,13 @@ impl<'a> CheckerState<'a> {
         let object_str = self
             .object_literal_initializer_display_type_for_receiver(expr_idx)
             .map(|init_type| self.format_type_for_assignability_message(init_type))
+            // tsc renders the *apparent* type of the receiver in TS7053:
+            // `object` -> `{}`, and primitives widen to their wrapper interface
+            // (`number` -> `Number`, etc.). The destructuring TS2538 path already
+            // does this; share the same mapping here so element access matches.
+            // For a type parameter `display_object_type` is its constraint, so a
+            // `T extends number` receiver also widens to `Number`, matching tsc.
+            .or_else(|| super::apparent_intrinsic_type_display(display_object_type))
             .unwrap_or_else(|| {
                 self.property_receiver_display_for_node(display_object_type, expr_idx)
             });

--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -1535,7 +1535,7 @@ impl<'a> CheckerState<'a> {
                             // patterns like `var { a } = "s"` report `type 'String'`
                             // rather than the raw `type 'string'`.
                             let apparent_type_display =
-                                crate::error_reporter::properties::apparent_intrinsic_type_display(
+                                crate::error_reporter::apparent_type_display::apparent_intrinsic_type_display(
                                     parent_type,
                                 );
                             if let Some(ce) = computed_expr {

--- a/crates/tsz-checker/src/state/variable_checking/destructuring.rs
+++ b/crates/tsz-checker/src/state/variable_checking/destructuring.rs
@@ -13,21 +13,6 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
-/// Returns the tsc apparent-type display name used in destructuring TS2339
-/// messages (e.g. `string` → `String`, `object` → `{}`). Returns `None` for
-/// types that use their regular diagnostic formatting.
-fn apparent_type_display_for_destructuring(type_id: TypeId) -> Option<String> {
-    match type_id {
-        TypeId::OBJECT => Some("{}".to_string()),
-        TypeId::STRING => Some("String".to_string()),
-        TypeId::NUMBER => Some("Number".to_string()),
-        TypeId::BOOLEAN => Some("Boolean".to_string()),
-        TypeId::BIGINT => Some("BigInt".to_string()),
-        TypeId::SYMBOL => Some("Symbol".to_string()),
-        _ => None,
-    }
-}
-
 impl<'a> CheckerState<'a> {
     fn report_unknown_empty_binding_pattern(
         &mut self,
@@ -1550,7 +1535,9 @@ impl<'a> CheckerState<'a> {
                             // patterns like `var { a } = "s"` report `type 'String'`
                             // rather than the raw `type 'string'`.
                             let apparent_type_display =
-                                apparent_type_display_for_destructuring(parent_type);
+                                crate::error_reporter::properties::apparent_intrinsic_type_display(
+                                    parent_type,
+                                );
                             if let Some(ce) = computed_expr {
                                 let type_str = apparent_type_display.clone().unwrap_or_else(|| {
                                     self.format_type_for_assignability_message(parent_type)


### PR DESCRIPTION
## Summary

`tsc` renders the **apparent type** of the indexed receiver in the implicit-any
element-access diagnostic (`TS7053`), but `tsz` rendered the raw type. Both
compilers emit `TS7053` at the same location; only the message text diverged:

```ts
function h(o: object, k: string) { return o[k]; } // TS7053
```
- `tsc`:  `... can't be used to index type '{}'.`
- `tsz` (before): `... can't be used to index type 'object'.`

The apparent type widens the `object` intrinsic to the empty object type `{}`
and each primitive to its global wrapper interface (`number` -> `Number`,
`boolean` -> `Boolean`, `symbol` -> `Symbol`, `bigint` -> `BigInt`,
`string` -> `String`). For a type-parameter receiver the apparent type is its
constraint's apparent type (e.g. `T extends number` -> `Number`).

## Structural rule

When element access fails the implicit-any index check, `tsc` displays
`typeToString(getApparentType(receiver))`. The destructuring `TS2538`/`TS2339`
path already applied exactly this widening via a local helper
(`apparent_type_display_for_destructuring`); the element-access `TS7053` path was
written separately and never did. Promote that helper to a shared
`apparent_intrinsic_type_display` (`error_reporter::properties`) and apply it to
the element-access `object_str` as well. Other receivers return `None` and fall
back to the existing formatter, so the behavior change is confined to the six
intrinsics — and since `tsc` always renders the apparent type here, matching it
can only converge tsz toward `tsc`.

## Owner layer

Checker diagnostic rendering. Shared helper:
`crates/tsz-checker/src/error_reporter/properties.rs`. Applied at the TS7053
emission in `error_reporter/properties/diagnostic_methods_tail.rs`; the
destructuring site (`state/variable_checking/destructuring.rs`) now reuses the
same helper (DRY, behavior-preserving). No type semantics changed.

## Adjacent cases

- Receivers `object`/`number`/`boolean`/`symbol`/`bigint`/`string`: render
  apparent type (now match tsc).
- Type-parameter receivers `T extends <intrinsic>`: render the constraint's
  apparent type (match tsc).
- Unconstrained `T` -> `unknown`, `{}` -> `{}`, object/union/etc.: unchanged.
- Destructuring TS2538/TS2339: unchanged (same helper, same mapping).

Goal: green

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- Minimal repros match `tsc` byte-for-byte (`diff` empty) for all receiver kinds
  (`object`/`number`/`boolean`/`symbol`/`bigint`/`{}`/`unknown`) and type-param
  constraints (`T extends number|object|symbol`, unconstrained `T`, `bigint`).
- superstruct canary: 16 -> 14 tsz-only FPs (`comm -23` vs `tsc` oracle);
  exactly `types.ts(377,21)` + `utils.ts(9,32)` removed, zero new lines.
- kysely / msw canaries: zero new lines (no regression).
- Conformance (prebuilt dist-fast, all 100%): noImplicitAny 37/37,
  indexedAccess 13/13, indexSignature 24/24, destructuring 174/174, keyof 14/14,
  member 261/261, mappedType 55/55, computedProperties 149/149, generics 13/13,
  objectTypes 49/49, indexer 13/13, expressions 377/377, narrowing 29/29,
  controlFlow 94/94.
- `cargo clippy -p tsz-checker` clean; `cargo fmt -p tsz-checker --check` clean.

Resolves #14008.
