### PR TITLE
fix(checker): render apparent type of TS7053 index receiver (object -> {})

### DIFF
--- a/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
+++ b/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
@@ -690,7 +690,21 @@ impl<'a> CheckerState<'a> {
             .object_literal_initializer_display_type_for_receiver(expr_idx)
             .map(|init_type| self.format_type_for_assignability_message(init_type))
             .unwrap_or_else(|| {
-                self.property_receiver_display_for_node(display_object_type, expr_idx)
+                // tsc renders `typeToString(getApparentType(objectType))` for the
+                // receiver. The apparent type of the `object` intrinsic is the empty
+                // object type `{}`, and a bare primitive's apparent type is its boxed
+                // wrapper interface (`string` -> `String`, ...). When the apparent type
+                // differs from the raw receiver the plain formatter matches tsc; every
+                // other receiver keeps the existing annotation-aware display path.
+                let apparent = crate::query_boundaries::diagnostics::index_receiver_apparent_type(
+                    self.ctx.types,
+                    display_object_type,
+                );
+                if apparent != display_object_type {
+                    self.format_type_for_assignability_message(apparent)
+                } else {
+                    self.property_receiver_display_for_node(display_object_type, expr_idx)
+                }
             });
         let message = format!(
             "Element implicitly has an 'any' type because expression of type '{index_str}' can't be used to index type '{object_str}'."

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -556,6 +556,9 @@ mod ts7036_tests;
 #[path = "../tests/ts7041_tests.rs"]
 mod ts7041_tests;
 #[cfg(test)]
+#[path = "tests/ts7053_apparent_receiver_display_tests.rs"]
+mod ts7053_apparent_receiver_display_tests;
+#[cfg(test)]
 #[path = "../tests/ts7057_yield_implicit_any.rs"]
 mod ts7057_yield_implicit_any;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -609,6 +609,16 @@ pub(crate) fn widen_argument_type_for_display(db: &dyn TypeDatabase, type_id: Ty
     tsz_solver::operations::widening::widen_argument_type_for_display(db, type_id)
 }
 
+/// Apparent type of an element-access receiver for the implicit-any index
+/// diagnostic (`TS7053`). `tsc` renders `typeToString(getApparentType(objectType))`,
+/// so the `object` intrinsic prints as its apparent type `{}` and a bare
+/// primitive as its boxed wrapper interface (`string` -> `String`, ...); every
+/// other type is the identity, letting the caller keep its annotation-aware
+/// display path.
+pub(crate) fn index_receiver_apparent_type(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    tsz_solver::objects::index_receiver_apparent_type(db, type_id)
+}
+
 /// Display the boolean-literal-array element form (`boolean[]` rather than the
 /// `(true | false)[]` fresh form) for argument-mismatch diagnostics.
 pub(crate) fn boolean_literal_array_display_type(

--- a/crates/tsz-checker/src/tests/ts7053_apparent_receiver_display_tests.rs
+++ b/crates/tsz-checker/src/tests/ts7053_apparent_receiver_display_tests.rs
@@ -1,0 +1,121 @@
+//! Regression tests for the receiver type rendered in `TS7053`
+//! ("Element implicitly has an 'any' type ... can't be used to index type 'X'").
+//!
+//! Structural rule (one sentence): `tsc` renders
+//! `typeToString(getApparentType(objectType))` for the receiver, so the `object`
+//! intrinsic prints as its apparent type `{}` (not the raw `object`), and a bare
+//! primitive prints as its boxed wrapper interface.
+//!
+//! Witness: `superstruct` `src/structs/types.ts(377,21)` / `src/utils.ts(9,32)`
+//! index a value whose type is the `object` intrinsic and previously rendered
+//! `object` where `tsc` renders `{}`.
+
+use crate::test_utils::check_source_code_messages;
+
+const TS7053: u32 = 7053;
+
+fn ts7053_messages(source: &str) -> Vec<String> {
+    check_source_code_messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code == TS7053)
+        .map(|(_, message)| message)
+        .collect()
+}
+
+/// The reported repro: indexing an `object`-typed receiver with a `string` key.
+/// `tsc` renders the apparent type `{}`, not the raw `object`.
+#[test]
+fn object_intrinsic_receiver_renders_apparent_empty_object() {
+    let source = r#"
+function h(o: object, k: string) {
+  return o[k];
+}
+"#;
+    let messages = ts7053_messages(source);
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one TS7053 for `o[k]` on an `object` receiver; got: {messages:?}",
+    );
+    let message = &messages[0];
+    assert!(
+        message.contains("can't be used to index type '{}'"),
+        "TS7053 must render the apparent type `{{}}` for the `object` intrinsic; got: {message:?}",
+    );
+    assert!(
+        !message.contains("index type 'object'"),
+        "TS7053 must not render the raw `object` intrinsic; got: {message:?}",
+    );
+}
+
+/// Anti-hardcoding: the receiver display must not depend on the parameter or
+/// alias identifiers chosen by the user. Renaming every binder keeps the `{}`
+/// rendering, and an alias of `object` behaves identically.
+#[test]
+fn object_intrinsic_receiver_display_is_name_agnostic() {
+    let source = r#"
+type Bag = object;
+function lookup(container: Bag, slot: string) {
+  return container[slot];
+}
+"#;
+    let messages = ts7053_messages(source);
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one TS7053 for an aliased `object` receiver; got: {messages:?}",
+    );
+    assert!(
+        messages[0].contains("can't be used to index type '{}'"),
+        "an alias of `object` resolves to the same apparent type `{{}}`; got: {:?}",
+        messages[0],
+    );
+}
+
+/// Control: a receiver that is already the empty object type `{}` keeps
+/// rendering `{}` (apparent type is the identity here), confirming the change
+/// is specific to the apparent-type mapping and does not perturb the common
+/// path.
+#[test]
+fn empty_object_receiver_still_renders_empty_object() {
+    let source = r#"
+function h(o: {}, k: string) {
+  return o[k];
+}
+"#;
+    let messages = ts7053_messages(source);
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one TS7053 for `o[k]` on a `{{}}` receiver; got: {messages:?}",
+    );
+    assert!(
+        messages[0].contains("can't be used to index type '{}'"),
+        "an already-empty-object receiver renders `{{}}` unchanged; got: {:?}",
+        messages[0],
+    );
+}
+
+/// Control: a named interface receiver is unaffected — its apparent type is the
+/// interface itself, so it keeps rendering its nominal name (not collapsed to
+/// `{}`).
+#[test]
+fn named_interface_receiver_keeps_nominal_display() {
+    let source = r#"
+interface Shape { area: number; }
+function h(o: Shape, k: string) {
+  return o[k];
+}
+"#;
+    let messages = ts7053_messages(source);
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one TS7053 for `o[k]` on a `Shape` receiver; got: {messages:?}",
+    );
+    assert!(
+        messages[0].contains("can't be used to index type 'Shape'"),
+        "a named interface keeps its nominal display, not `{{}}`; got: {:?}",
+        messages[0],
+    );
+}

--- a/crates/tsz-solver/src/objects/apparent.rs
+++ b/crates/tsz-solver/src/objects/apparent.rs
@@ -14,6 +14,35 @@ pub const fn literal_value_intrinsic_kind(lit: &LiteralValue) -> IntrinsicKind {
     }
 }
 
+/// Apparent type of an element-access receiver for the implicit-any index
+/// diagnostic (`TS7053`).
+///
+/// `tsc` renders `typeToString(getApparentType(objectType))` for the receiver.
+/// `getApparentType` maps the `object` intrinsic to the empty object type `{}`
+/// and a bare primitive to its boxed wrapper interface (`string` -> `String`,
+/// `number` -> `Number`, ...). Every other type is returned unchanged; callers
+/// reduce type parameters to their constraint upstream, mirroring
+/// `getBaseConstraintOfType`.
+pub fn index_receiver_apparent_type(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    if type_id == TypeId::OBJECT
+        || crate::intrinsic_kind(db, type_id) == Some(IntrinsicKind::Object)
+    {
+        return db.object(Vec::new());
+    }
+    let boxed_kind = match type_id {
+        TypeId::NUMBER => Some(IntrinsicKind::Number),
+        TypeId::STRING => Some(IntrinsicKind::String),
+        TypeId::BOOLEAN => Some(IntrinsicKind::Boolean),
+        TypeId::BIGINT => Some(IntrinsicKind::Bigint),
+        TypeId::SYMBOL => Some(IntrinsicKind::Symbol),
+        _ => None,
+    };
+    match boxed_kind {
+        Some(kind) => db.get_boxed_type(kind).unwrap_or(type_id),
+        None => type_id,
+    }
+}
+
 pub enum ApparentMemberKind {
     Value(TypeId),
     Method(TypeId),

--- a/crates/tsz-solver/src/objects/mod.rs
+++ b/crates/tsz-solver/src/objects/mod.rs
@@ -16,7 +16,8 @@ mod literal;
 
 pub use apparent::{
     ApparentMemberKind, apparent_object_member_kind, apparent_primitive_member_kind,
-    apparent_primitive_members, apparent_primitive_shape, literal_value_intrinsic_kind,
+    apparent_primitive_members, apparent_primitive_shape, index_receiver_apparent_type,
+    literal_value_intrinsic_kind,
 };
 pub use collect::*;
 pub use element_access::*;


### PR DESCRIPTION
Goal: green

Fixes #14008.

## Summary

The implicit-any element-access diagnostic (`TS7053`) rendered the **raw**
receiver type where `tsc` renders its **apparent** type. For the `object`
intrinsic the apparent type is the empty object type `{}`, so:

```ts
function h(o: object, k: string) { return o[k]; } // TS7053
```

- `tsc`:  `... can't be used to index type '{}'.`
- `tsz` (before): `... can't be used to index type 'object'.`

Both compilers emit `TS7053` at the same location; only the rendered receiver
type differed, so the conformance/project line diff counted it as a `tsz`-only
delta (superstruct `src/structs/types.ts(377,21)`, `src/utils.ts(9,32)`).

## Structural rule

When element access fails the implicit-any index check, `tsc` displays
`typeToString(getApparentType(objectType))`. `getApparentType` maps the `object`
intrinsic to the empty object type `{}` and a bare primitive to its boxed
wrapper interface (`string` → `String`, `number` → `Number`, …); every other
type is the identity. `tsz` now renders the receiver's apparent type in `TS7053`.

## Owner layer

The apparent-type-for-display rule is **solver** type semantics:
`tsz_solver::objects::apparent::index_receiver_apparent_type` (composes the
existing `intrinsic_kind`, `object`, and `get_boxed_type` primitives). The
checker reaches it through a `query_boundaries::diagnostics` wrapper
(`index_receiver_apparent_type`) and, in
`error_reporter/properties/diagnostic_methods_tail.rs`, renders the apparent
form with the plain formatter **only when it differs** from the raw receiver —
matching tsc's plain `typeToString`. When the apparent type equals the raw type
(every non-intrinsic), the shared annotation-aware
`property_receiver_display_for_node` path (also used by `TS2339`) is unchanged,
keeping blast radius minimal. Type parameters are already reduced to their
constraint upstream, mirroring `getBaseConstraintOfType`.

## Anti-hardcoding

No user-name/file-name/printer-output predicates: the decision keys purely on
the structural intrinsic kind (`is`-`object`-intrinsic / boxed-primitive). The
apparent type is computed as a `TypeId` and rendered by the normal formatter —
the printer reads types, types never read printer output. A regression test
renames every binder (`Bag`/`container`/`slot`) and exercises an alias of
`object` to prove the result is not keyed on identifier text.

## Adjacent-case matrix (verified vs the `tsc` oracle cache)

| receiver | tsc / tsz-after | note |
|---|---|---|
| `object` intrinsic | `{}` | the fix |
| `type Bag = object` (alias) | `{}` | name-agnostic |
| already-`{}` empty object | `{}` | control, unchanged |
| named interface `Shape` | `Shape` | control, apparent type is the identity |

The full `tsc` conformance corpus contains **no** bare-primitive receivers for
`TS7053` (only `{}`, named interfaces, object-literal types, `typeof` forms), so
the primitive→wrapper arm is correct-by-construction per `getApparentType` and
conformance-neutral; the conformance-relevant change is `object` → `{}`.

## Verification

- New `crates/tsz-checker/src/tests/ts7053_apparent_receiver_display_tests.rs`
  (4 tests): `object` receiver renders `{}`; name-agnostic alias; `{}` control
  unchanged; named-interface control keeps its nominal display — all pass.
- `cargo test -p tsz-checker --lib` targeted run (`ts7053_apparent_receiver_display`,
  `index_signature`, `element_access`, `implicit_any`): 224 passed, 0 failed.
- `cargo fmt -p tsz-checker -p tsz-solver --check` clean;
  `cargo clippy -p tsz-solver -p tsz-checker --lib` clean. Touched files stay
  under the 2000-line cap.
- Broad conformance / emit / fourslash / project-corpus owned by ready-review CI
  per repo policy.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmWxxUKiHBJapxetFAv33Z)_