### PR TITLE
fix(checker): render narrowed type for unknown/any predicate-guard source in TS2322 (#14009)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
@@ -149,6 +149,14 @@ impl<'a> CheckerState<'a> {
         source_display: &str,
         target_display: &str,
     ) -> Option<(String, String)> {
+        // A source identifier narrowed away from a declared `unknown`/`any` must
+        // keep its narrowed checked-type display (already in `source_display`);
+        // the declared-annotation repaints below would otherwise restore the
+        // stale top type. tsc renders the narrowed type. This guards both
+        // callers (`render_type_mismatch` and the TS2322 message rewrite).
+        if self.assignment_source_narrowed_from_declared_top_type(anchor_idx, source) {
+            return None;
+        }
         if let Some(expr_idx) = self
             .direct_diagnostic_source_expression(anchor_idx)
             .or_else(|| self.assignment_source_expression(anchor_idx))

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -132,6 +132,55 @@ impl<'a> CheckerState<'a> {
             .then(|| self.format_assignability_type_for_message(source, target))
     }
 
+    /// True when an assignment/return diagnostic source is an identifier whose
+    /// declared type is *explicitly* `unknown` or `any`, yet whose checked
+    /// source type (`source`) has flow-narrowed to a more specific type — the
+    /// canonical case being a user-defined `x is T` type-predicate guard over
+    /// an `unknown`/`any` operand.
+    ///
+    /// `tsc` renders the narrowed checked type for such a source; tsz's
+    /// declared-annotation / node-derived fallbacks below would otherwise
+    /// repaint it with the stale declared top type (the source identifier's
+    /// declared type, not the checked source type, drives the annotation text).
+    /// Gated on the *declared symbol* type being a top type, on the checked
+    /// source differing from it (i.e. narrowing actually occurred), and on the
+    /// presence of an explicit annotation — so an implicit / control-flow `any`
+    /// (`let x;`) keeps its existing display, which a separate path owns, and
+    /// an un-narrowed `unknown`/`any` source still renders as declared. The
+    /// decision is structural (declared top type vs. a different checked
+    /// source), never keyed on rendered text or identifier name.
+    pub(in crate::error_reporter) fn assignment_source_narrowed_from_declared_top_type(
+        &mut self,
+        anchor_idx: NodeIndex,
+        source: TypeId,
+    ) -> bool {
+        if matches!(source, TypeId::ERROR) {
+            return false;
+        }
+        let Some(expr_idx) = self.assignment_source_expression(anchor_idx) else {
+            return false;
+        };
+        let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(expr_idx);
+        if self.ctx.arena.get(expr_idx).map(|node| node.kind)
+            != Some(tsz_scanner::SyntaxKind::Identifier as u16)
+        {
+            return false;
+        }
+        // Require an explicit `: unknown` / `: any` annotation on the
+        // declaration; this excludes implicit / control-flow `any`.
+        if self
+            .declared_diagnostic_source_annotation_text(expr_idx)
+            .is_none()
+        {
+            return false;
+        }
+        let Some(sym_id) = self.resolve_identifier_symbol(expr_idx) else {
+            return false;
+        };
+        let declared = self.get_type_of_symbol(sym_id);
+        matches!(declared, TypeId::UNKNOWN | TypeId::ANY) && declared != source
+    }
+
     pub(in crate::error_reporter) fn format_assignment_source_type_for_diagnostic(
         &mut self,
         source: TypeId,
@@ -248,6 +297,17 @@ impl<'a> CheckerState<'a> {
         {
             let name = self.ctx.types.resolve_atom_ref(def.name);
             return name.to_string();
+        }
+
+        // A source identifier explicitly declared `unknown`/`any` that
+        // flow-narrowed to a more specific checked type (the canonical case
+        // being a user-defined `x is T` predicate guard over an `unknown`/`any`
+        // operand) renders the narrowed checked type, exactly as tsc's
+        // `typeToString(sourceType)` does. Resolve it here, before the
+        // declared-annotation / widening fallbacks below repaint the source
+        // with the stale declared top type.
+        if self.assignment_source_narrowed_from_declared_top_type(anchor_idx, source) {
+            return self.format_assignability_type_for_message(source, target);
         }
 
         if let Some(display) = self.jsdoc_annotated_expression_display(anchor_idx, target) {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1177,6 +1177,9 @@ mod polymorphic_this_relation_routing_arch_tests;
 #[path = "tests/predicate_narrowed_lib_union_access_tests.rs"]
 mod predicate_narrowed_lib_union_access_tests;
 #[cfg(test)]
+#[path = "tests/predicate_narrowed_top_type_source_display_tests.rs"]
+mod predicate_narrowed_top_type_source_display_tests;
+#[cfg(test)]
 #[path = "../tests/private_brands.rs"]
 mod private_brands;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/predicate_narrowed_top_type_source_display_tests.rs
+++ b/crates/tsz-checker/src/tests/predicate_narrowed_top_type_source_display_tests.rs
@@ -1,0 +1,242 @@
+//! Diagnostic source-type display for a user-defined type-predicate guard
+//! applied to an `unknown` / `any` operand.
+//!
+//! Structural rule: when a source identifier is explicitly declared `unknown`
+//! or `any` and a user-defined `x is T` guard flow-narrows it to a more
+//! specific checked type, an assignment / return TS2322 diagnostic must render
+//! the **narrowed** checked type (tsc's `typeToString(sourceType)`), not the
+//! stale declared top type. Value-level narrowing already worked (the
+//! narrowed value is assignable to `T` and exposes `T`'s members); only the
+//! assignment-source *display* repainted the source with the declared
+//! `unknown` / `any`. The fix lives in the checker's assignment-source
+//! diagnostic formatter, which now resolves the narrowed top-type source
+//! before the declared-annotation / widening fallbacks run.
+//!
+//! Anti-hardcoding: the predicate functions and operands are renamed across
+//! tests; the decision is keyed on the declared type being a top type and the
+//! checked source being a different non-top type, never on identifier text.
+
+use std::sync::Arc;
+use tsz_binder::lib_loader::LibFile;
+use tsz_common::options::checker::CheckerOptions;
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn libs() -> Vec<Arc<LibFile>> {
+    crate::test_utils::load_lib_files(&["es5.d.ts"])
+}
+
+fn code_messages(source: &str) -> Vec<(u32, String)> {
+    crate::test_utils::check_source_with_libs_code_messages(source, "test.ts", opts(), &libs())
+}
+
+fn messages_for(source: &str, code: u32) -> Vec<String> {
+    code_messages(source)
+        .into_iter()
+        .filter(|(c, _)| *c == code)
+        .map(|(_, m)| m)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Reported repro (#14009): the `never`-assignment reveal of the narrowed type.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_predicate_guard_displays_narrowed_string_in_ts2322() {
+    let source = r#"
+declare function isStr(x: unknown): x is string;
+function a(v: unknown) { if (isStr(v)) { const r: never = v; } }
+"#;
+    let msgs = messages_for(source, 2322);
+    assert_eq!(msgs.len(), 1, "got {:?}", code_messages(source));
+    assert!(
+        msgs[0].contains("'string'") && !msgs[0].contains("'unknown'"),
+        "expected narrowed 'string' source, got {:?}",
+        msgs[0]
+    );
+}
+
+#[test]
+fn unknown_predicate_guard_displays_object_intrinsic_in_ts2322() {
+    let source = r#"
+declare function isObj(x: unknown): x is object;
+function b(v: unknown) { if (isObj(v)) { const r: never = v; } }
+"#;
+    let msgs = messages_for(source, 2322);
+    assert_eq!(msgs.len(), 1, "got {:?}", code_messages(source));
+    assert!(
+        msgs[0].contains("'object'") && !msgs[0].contains("'unknown'"),
+        "expected narrowed 'object' source, got {:?}",
+        msgs[0]
+    );
+}
+
+#[test]
+fn unknown_predicate_guard_displays_narrowed_generic_application_in_ts2322() {
+    // The narrowed type is a generic application (`Record<string, unknown>`),
+    // not an intrinsic — its display flows through the `TypeMismatch` render
+    // arm and the declared-generic-alias source rewrite, both of which must
+    // keep the narrowed application rather than repaint the declared top type.
+    let source = r#"
+declare function isRec(x: unknown): x is Record<string, unknown>;
+function d(v: unknown) { if (isRec(v)) { const r: never = v; } }
+"#;
+    let msgs = messages_for(source, 2322);
+    assert_eq!(msgs.len(), 1, "got {:?}", code_messages(source));
+    assert!(
+        msgs[0].contains("Record<string, unknown>") && !msgs[0].contains("'unknown'"),
+        "expected narrowed 'Record<string, unknown>' source, got {:?}",
+        msgs[0]
+    );
+}
+
+#[test]
+fn any_predicate_guard_displays_narrowed_string_in_ts2322() {
+    let source = r#"
+declare function isStrA(x: any): x is string;
+function e(v: any) { if (isStrA(v)) { const r: never = v; } }
+"#;
+    let msgs = messages_for(source, 2322);
+    assert_eq!(msgs.len(), 1, "got {:?}", code_messages(source));
+    assert!(
+        msgs[0].contains("'string'") && !msgs[0].contains("'any'"),
+        "expected narrowed 'string' source, got {:?}",
+        msgs[0]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Adjacent: return position and a non-`never` failing target use the same
+// assignment-source formatter, so both must show the narrowed source.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_predicate_guard_displays_narrowed_string_in_return_ts2322() {
+    let source = r#"
+declare function isStr(x: unknown): x is string;
+function ret(v: unknown): number { if (isStr(v)) { return v; } return 0; }
+"#;
+    let msgs = messages_for(source, 2322);
+    assert_eq!(msgs.len(), 1, "got {:?}", code_messages(source));
+    assert!(
+        msgs[0].contains("'string'") && !msgs[0].contains("'unknown'"),
+        "expected narrowed 'string' return source, got {:?}",
+        msgs[0]
+    );
+}
+
+#[test]
+fn unknown_predicate_guard_displays_narrowed_string_against_number_target() {
+    let source = r#"
+declare function isStr(x: unknown): x is string;
+function k(v: unknown) { if (isStr(v)) { const r: number = v; } }
+"#;
+    let msgs = messages_for(source, 2322);
+    assert_eq!(msgs.len(), 1, "got {:?}", code_messages(source));
+    assert!(
+        msgs[0].contains("'string'") && !msgs[0].contains("'unknown'"),
+        "expected narrowed 'string' source against number target, got {:?}",
+        msgs[0]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Anti-hardcoding: renamed binders behave identically.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_predicate_guard_display_is_not_name_keyed() {
+    let source = r#"
+declare function looksLikeText(payload: unknown): payload is string;
+function consume(blob: unknown) { if (looksLikeText(blob)) { const sink: never = blob; } }
+"#;
+    let msgs = messages_for(source, 2322);
+    assert_eq!(msgs.len(), 1, "got {:?}", code_messages(source));
+    assert!(
+        msgs[0].contains("'string'") && !msgs[0].contains("'unknown'"),
+        "expected narrowed 'string' source, got {:?}",
+        msgs[0]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Value-level narrowing must keep working (the relation already used the
+// narrowed type): a narrowed source assignable to its predicate type is clean,
+// and a narrowed source exposes the predicate type's members.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_predicate_guard_narrowed_value_is_assignable_to_predicate_type() {
+    let source = r#"
+declare function isStr(x: unknown): x is string;
+function ok(v: unknown) { if (isStr(v)) { const s: string = v; } }
+"#;
+    assert!(
+        code_messages(source).is_empty(),
+        "narrowed value should be assignable to its predicate type, got {:?}",
+        code_messages(source)
+    );
+}
+
+#[test]
+fn unknown_predicate_guard_narrowed_value_exposes_predicate_members() {
+    // Property access on the narrowed value resolves against `string` (a
+    // genuinely-missing member reports TS2339 against `string`, not TS18046
+    // against `unknown`).
+    let source = r#"
+declare function isStr(x: unknown): x is string;
+function members(v: unknown) { if (isStr(v)) { v.nonExistent(); } }
+"#;
+    let msgs = messages_for(source, 2339);
+    assert_eq!(msgs.len(), 1, "got {:?}", code_messages(source));
+    assert!(
+        msgs[0].contains("'string'"),
+        "expected receiver rendered as narrowed 'string', got {:?}",
+        msgs[0]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative / fallback: an un-narrowed `unknown` source still shows 'unknown'.
+// The fix must not blanket-rewrite every `unknown` source display.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unnarrowed_unknown_source_still_displays_unknown() {
+    let source = r#"
+function plain(v: unknown) { const r: string = v; }
+"#;
+    let msgs = messages_for(source, 2322);
+    assert_eq!(msgs.len(), 1, "got {:?}", code_messages(source));
+    assert!(
+        msgs[0].contains("'unknown'"),
+        "un-narrowed unknown source must still render 'unknown', got {:?}",
+        msgs[0]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Control: union operands already rendered the narrowed member; keep that.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn union_predicate_guard_still_displays_narrowed_member() {
+    let source = r#"
+declare function isS(x: string | number): x is string;
+function c(v: string | number) { if (isS(v)) { const r: never = v; } }
+"#;
+    let msgs = messages_for(source, 2322);
+    assert_eq!(msgs.len(), 1, "got {:?}", code_messages(source));
+    assert!(
+        msgs[0].contains("'string'"),
+        "union operand should still render narrowed 'string', got {:?}",
+        msgs[0]
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes #14009.

## Summary

A user-defined `x is T` type-predicate guard over an `unknown` / `any` operand
**does** narrow the operand at the value level in tsz — the narrowed value is
assignable to `T`, exposes `T`'s members, and is rejected against incompatible
targets. The bug the issue witnesses is purely in the **assignment/return
TS2322 source display**: it repainted the source with the identifier's stale
*declared* top type instead of its *narrowed* checked type.

```ts
declare function isStr(x: unknown): x is string;
function a(v: unknown) { if (isStr(v)) { const r: never = v; } }
// tsc: Type 'string' is not assignable to type 'never'.
// tsz (before): Type 'unknown' is not assignable to type 'never'.
// tsz (after):  Type 'string' is not assignable to type 'never'.
```

The investigator's "reveal narrowed type via `never` assignment" probe was
misled by this display bug: tsz narrows fine, but printed the declared type.
Witnessed clean post-fix: `string`, `object`, `Record<string, unknown>`, `any`.

## Structural rule

When a diagnostic source is an identifier **explicitly declared** `unknown` or
`any` whose checked (flow-narrowed) source type differs from that declared top
type, render the narrowed checked type — exactly tsc's
`typeToString(sourceType)`. The decision is structural (declared top type vs. a
different checked source), never keyed on rendered text or identifier name.

## Owner layer

Checker error-reporter source display (`crates/tsz-checker/src/error_reporter`).

- New `assignment_source_narrowed_from_declared_top_type` predicate
  (`diagnostic_source/assignment_formatting.rs`): identifier source, explicit
  `: unknown`/`: any` annotation, declared symbol type is a top type, and the
  checked `source` differs from it.
- It gates the `AssignmentSource`-role formatter
  (`format_assignment_source_type_for_diagnostic`) so the
  `IntrinsicTypeMismatch` catch-all renders the narrowed type, and it
  short-circuits `declared_generic_alias_assignment_pair_display`, which both
  `render_type_mismatch` (the `TypeMismatch` arm reached by a narrowed generic
  application such as `Record<string, unknown>`) and the TS2322 message rewrite
  call. Both repaint sites are covered by the single predicate.

## Fallback / non-regression

- Un-narrowed `unknown`/`any` source (declared == checked) → renders declared
  top type, unchanged.
- Implicit / control-flow `any` (`let x;`, no annotation) → excluded (no
  explicit annotation), unchanged; its dedicated control-flow-typed-any path
  still owns it.
- Union operands (declared type is not a top type) → untouched; the separate
  union-narrowing source-display gap is out of scope.

## Anti-hardcoding

No identifier/file-name/printer-string predicates: gated on the declared symbol
type being `TypeId::UNKNOWN`/`TypeId::ANY` and structurally differing from the
checked source. A regression test renames the predicate/operand binders to
prove the result is not name-keyed.

## Adjacent-case matrix (vs `tsc`, all now match)

| case | before | after / tsc |
|---|---|---|
| `isStr(v): v is string`, `unknown` → `never` | `unknown` | `string` |
| `isObj(v): v is object`, `unknown` → `never` | `unknown` | `object` |
| `isRec(v): v is Record<string, unknown>`, `unknown` → `never` | `unknown` | `Record<string, unknown>` |
| `isStrA(v): v is string`, `any` → `never` | `any` | `string` |
| narrowed `unknown` → `number` target (var-decl) | `unknown` | `string` |
| narrowed `unknown` → `number` (return position) | `unknown` | `string` |
| union operand `string \| number` → `never` | `string` | `string` (unchanged) |
| un-narrowed `unknown` → `string` (no guard) | `unknown` | `unknown` (unchanged) |
| narrowed value assignable to predicate type / exposes members | clean | clean (unchanged) |

## Verification

- New `crates/tsz-checker/src/tests/predicate_narrowed_top_type_source_display_tests.rs`
  (11 tests: `unknown`/`object`/`Record`/`any` reveals, return + number target,
  renamed binders, value-level narrowing still clean, un-narrowed negative,
  union control) — 11/11 pass.
- `cargo test -p tsz-checker --lib -- ts2322 narrowing_ predicate flow_guard`:
  failing set **identical** to clean `main` (15 pre-existing `cargo test
  --lib`-vs-nextest harness artifacts; +11 new passing tests, **zero new
  failures**).
- `cargo test -p tsz-checker --lib -- diagnostic_source assignability_alias type_mismatch` — 28/28 pass.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib` clean.
- Witnesses diffed against `tsc` (`--noEmit --strict --target es2022 --lib es2022`).
- Both touched files stay under the 2000-line cap.
- Broad conformance / emit / fourslash / project-corpus owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01D8ycXp7ns9QfozdaLmmpvJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8ycXp7ns9QfozdaLmmpvJ)_