### PR TITLE
fix(checker): render flow-narrowed type for top-type sources in TS2322/TS2741 (#14009)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
@@ -149,9 +149,21 @@ impl<'a> CheckerState<'a> {
         source_display: &str,
         target_display: &str,
     ) -> Option<(String, String)> {
-        if let Some(expr_idx) = self
+        // When the assignment source is an identifier declared as a top type
+        // (`any`/`unknown`) but flow-narrowed to a concrete type, its declaration
+        // annotation text is stale relative to the narrowed value. `tsc` renders
+        // the narrowed type (`string`), not the declared `any`/`unknown`, so the
+        // declared-annotation source repaints below must be suppressed. The
+        // relation and the structural source display already use the narrowed
+        // type; only the annotation-text repaint diverges.
+        let source_expr = self
             .direct_diagnostic_source_expression(anchor_idx)
-            .or_else(|| self.assignment_source_expression(anchor_idx))
+            .or_else(|| self.assignment_source_expression(anchor_idx));
+        let source_narrowed_from_top_declaration = source_expr.is_some_and(|expr_idx| {
+            self.source_identifier_narrowed_from_top_declaration(expr_idx, source)
+        });
+        if !source_narrowed_from_top_declaration
+            && let Some(expr_idx) = source_expr
             && let Some(source_display) =
                 self.bare_type_parameter_annotation_for_assignment_identifier(expr_idx)
         {
@@ -177,12 +189,15 @@ impl<'a> CheckerState<'a> {
             let target_display = self.format_declared_annotation_for_diagnostic(&annotation_text);
             return Some((source_display.to_string(), target_display));
         }
-        if let Some(source_display) = self.declared_generic_alias_source_display_for_target_display(
-            anchor_idx,
-            source_fact,
-            source_display,
-            target_display,
-        ) {
+        if !source_narrowed_from_top_declaration
+            && let Some(source_display) = self
+                .declared_generic_alias_source_display_for_target_display(
+                    anchor_idx,
+                    source_fact,
+                    source_display,
+                    target_display,
+                )
+        {
             return Some((source_display, target_display.to_string()));
         }
         if self
@@ -191,10 +206,13 @@ impl<'a> CheckerState<'a> {
         {
             return None;
         }
+        // A flow-narrowed top-type source has no faithful declared-annotation
+        // repaint (see the note above); leave the structural narrowed display.
+        if source_narrowed_from_top_declaration {
+            return None;
+        }
 
-        let expr_idx = self
-            .direct_diagnostic_source_expression(anchor_idx)
-            .or_else(|| self.assignment_source_expression(anchor_idx))?;
+        let expr_idx = source_expr?;
         let annotation_text = self.declared_type_annotation_text_for_expression(expr_idx)?;
         // A non-generic alias whose body is a computed operator collapsing to a
         // shared singleton (or a direct intrinsic/literal) drops its alias symbol

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -446,6 +446,39 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// True when `expr_idx` is an assignment-source identifier whose declared
+    /// symbol type is a top type (`any`/`unknown`) while `narrowed_to` — the
+    /// type actually being displayed — is a different, more specific type
+    /// produced by flow narrowing (a user-defined type-predicate guard,
+    /// `typeof`, `instanceof`, a discriminant, …).
+    ///
+    /// In that case `tsc` renders the narrowed type (`getFlowTypeOfReference`),
+    /// not the operand's stale declaration annotation (`any`/`unknown`), so the
+    /// declared-annotation source repaints in the assignability diagnostic
+    /// display must be suppressed. The relation and the structural source
+    /// display already use the narrowed type. The check is name-agnostic and
+    /// keys only on the structural top-type identity of the declared symbol
+    /// type, never on any identifier, annotation, or printer-output text.
+    pub(in crate::error_reporter) fn source_identifier_narrowed_from_top_declaration(
+        &mut self,
+        expr_idx: NodeIndex,
+        narrowed_to: TypeId,
+    ) -> bool {
+        if narrowed_to.is_any_unknown_or_error() {
+            return false;
+        }
+        let Some(node) = self.ctx.arena.get(expr_idx) else {
+            return false;
+        };
+        if node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
+            return false;
+        }
+        let Some(sym_id) = self.resolve_identifier_symbol(expr_idx) else {
+            return false;
+        };
+        self.get_type_of_symbol(sym_id).is_any_or_unknown()
+    }
+
     pub(in crate::error_reporter) fn should_prefer_declared_source_annotation_display(
         &mut self,
         expr_idx: NodeIndex,
@@ -457,6 +490,15 @@ impl<'a> CheckerState<'a> {
             return false;
         };
         if node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
+            return false;
+        }
+
+        // A source identifier declared as a top type (`any`/`unknown`) that flow
+        // analysis narrowed to a concrete type renders the narrowed type in
+        // `tsc` (e.g. `v: unknown` narrowed by a `v is Record<string, unknown>`
+        // guard shows `Record<string, unknown>`), never the declared
+        // `any`/`unknown` annotation, so it must not be preferred here.
+        if self.source_identifier_narrowed_from_top_declaration(expr_idx, expr_type) {
             return false;
         }
 
@@ -1488,6 +1530,14 @@ impl<'a> CheckerState<'a> {
 
         let declared_type = self.get_type_of_symbol(sym_id);
         if matches!(declared_type, TypeId::ERROR | TypeId::UNKNOWN) {
+            return None;
+        }
+        // A source identifier explicitly declared `any` that flow analysis
+        // narrowed to a concrete type renders the narrowed type in `tsc`
+        // (e.g. `v: any` narrowed by a `v is string` guard shows `string`),
+        // not the declared `any`. Defer to the structural narrowed display,
+        // mirroring the `unknown` early return above.
+        if self.source_identifier_narrowed_from_top_declaration(expr_idx, expr_display_type) {
             return None;
         }
         if let Some(annotation_text) = self.declared_diagnostic_source_annotation_text(expr_idx)

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1090,6 +1090,9 @@ mod mutable_binding_widening_from_const_literal_tests;
 #[path = "tests/namespace_property_mismatch_boundary_arch_tests.rs"]
 mod namespace_property_mismatch_boundary_arch_tests;
 #[cfg(test)]
+#[path = "tests/narrowed_top_type_source_display_tests.rs"]
+mod narrowed_top_type_source_display_tests;
+#[cfg(test)]
 #[path = "tests/nested_tuple_literal_source_display_tests.rs"]
 mod nested_tuple_literal_source_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/narrowed_top_type_source_display_tests.rs
+++ b/crates/tsz-checker/src/tests/narrowed_top_type_source_display_tests.rs
@@ -1,0 +1,253 @@
+//! `TS2322`/`TS2741` source display for a top-type (`any`/`unknown`) operand
+//! that flow analysis narrowed to a concrete type.
+//!
+//! Structural rule: when an identifier declared as a top type (`any` or
+//! `unknown`) is narrowed by control flow — a user-defined type-predicate guard,
+//! `typeof`, `instanceof`, a discriminant, etc. — to a concrete type, an
+//! assignability diagnostic on that operand renders the **narrowed** type, the
+//! way `tsc` does (`getFlowTypeOfReference`). `tsz` previously repainted the
+//! source with the operand's stale *declaration* annotation (`unknown`/`any`)
+//! while the relation itself correctly used the narrowed type, so the diagnostic
+//! text diverged from `tsc`. The narrowing and the relation were always correct;
+//! only the diagnostic source-type display was wrong.
+//!
+//! Owner layer: checker diagnostic display
+//! (`error_reporter::core::diagnostic_source` /
+//! `error_reporter::assignability_alias_display`). The fix keys only on the
+//! structural top-type identity of the source's declared symbol type, never on
+//! any identifier, annotation, or printer-output text.
+
+use std::sync::Arc;
+use tsz_binder::lib_loader::LibFile;
+use tsz_common::options::checker::CheckerOptions;
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn libs() -> Vec<Arc<LibFile>> {
+    crate::test_utils::load_lib_files(&["es5.d.ts"])
+}
+
+fn messages(source: &str) -> Vec<(u32, String)> {
+    crate::test_utils::check_source_with_libs(source, "test.ts", opts(), &libs())
+        .into_iter()
+        .map(|diag| (diag.code, diag.message_text))
+        .collect()
+}
+
+/// The single `TS2322` (or `TS2741`) message emitted for `source`.
+fn sole_assignment_message(source: &str) -> String {
+    let msgs: Vec<String> = messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2322 || *code == 2741)
+        .map(|(_, text)| text)
+        .collect();
+    assert_eq!(
+        msgs.len(),
+        1,
+        "expected exactly one assignment diagnostic, got {msgs:?}"
+    );
+    msgs.into_iter().next().unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Positive: a top-type operand narrowed by a user-defined predicate renders the
+// narrowed type, not the declared `unknown`/`any`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_narrowed_by_predicate_renders_narrowed_type() {
+    let source = r#"
+declare function isStr(x: unknown): x is string;
+function f(v: unknown) {
+    if (isStr(v)) {
+        const r: never = v;
+    }
+}
+"#;
+    let msg = sole_assignment_message(source);
+    assert!(
+        msg.contains("Type 'string' is not assignable to type 'never'"),
+        "got: {msg}"
+    );
+    assert!(
+        !msg.contains("'unknown'"),
+        "stale declared type leaked: {msg}"
+    );
+}
+
+#[test]
+fn any_narrowed_by_predicate_renders_narrowed_type() {
+    let source = r#"
+declare function isStr(x: any): x is string;
+function f(v: any) {
+    if (isStr(v)) {
+        const r: never = v;
+    }
+}
+"#;
+    let msg = sole_assignment_message(source);
+    assert!(
+        msg.contains("Type 'string' is not assignable to type 'never'"),
+        "got: {msg}"
+    );
+    assert!(!msg.contains("'any'"), "stale declared type leaked: {msg}");
+}
+
+#[test]
+fn unknown_narrowed_to_object_intrinsic_renders_object() {
+    let source = r#"
+declare function isObj(x: unknown): x is object;
+function f(v: unknown) {
+    if (isObj(v)) {
+        const r: never = v;
+    }
+}
+"#;
+    let msg = sole_assignment_message(source);
+    assert!(
+        msg.contains("Type 'object' is not assignable to type 'never'"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn unknown_narrowed_to_record_renders_record_in_missing_property() {
+    // The narrowed `Record<string, unknown>` source must surface in the TS2741
+    // missing-property message, not the declared `unknown` (object-with-index
+    // signature source display path).
+    let source = r#"
+declare function isRec(x: unknown): x is Record<string, unknown>;
+function f(v: unknown) {
+    if (isRec(v)) {
+        const r: { a: number } = v;
+    }
+}
+"#;
+    let msg = sole_assignment_message(source);
+    assert!(msg.contains("type 'Record<string, unknown>'"), "got: {msg}");
+    assert!(
+        !msg.contains("'unknown'"),
+        "stale declared type leaked: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Broad: the rule is narrowing-kind agnostic (typeof / instanceof), not specific
+// to user-defined predicates.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_narrowed_by_typeof_renders_narrowed_type() {
+    let source = r#"
+function f(v: unknown) {
+    if (typeof v === "string") {
+        const r: never = v;
+    }
+}
+"#;
+    let msg = sole_assignment_message(source);
+    assert!(
+        msg.contains("Type 'string' is not assignable to type 'never'"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn any_narrowed_by_typeof_renders_narrowed_type() {
+    let source = r#"
+function f(v: any) {
+    if (typeof v === "number") {
+        const r: never = v;
+    }
+}
+"#;
+    let msg = sole_assignment_message(source);
+    assert!(
+        msg.contains("Type 'number' is not assignable to type 'never'"),
+        "got: {msg}"
+    );
+    assert!(!msg.contains("'any'"), "stale declared type leaked: {msg}");
+}
+
+#[test]
+fn unknown_narrowed_by_instanceof_renders_class_name() {
+    let source = r#"
+class Box {}
+function f(v: unknown) {
+    if (v instanceof Box) {
+        const r: never = v;
+    }
+}
+"#;
+    let msg = sole_assignment_message(source);
+    assert!(
+        msg.contains("Type 'Box' is not assignable to type 'never'"),
+        "got: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Anti-hardcoding: the result is independent of binder names.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn renamed_binders_render_identically() {
+    let source = r#"
+declare function looksLikeText(candidate: unknown): candidate is string;
+function process(payload: unknown) {
+    if (looksLikeText(payload)) {
+        const sink: never = payload;
+    }
+}
+"#;
+    let msg = sole_assignment_message(source);
+    assert!(
+        msg.contains("Type 'string' is not assignable to type 'never'"),
+        "got: {msg}"
+    );
+    assert!(
+        !msg.contains("'unknown'"),
+        "stale declared type leaked: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative / fallback: an *un-narrowed* top-type operand still renders its
+// declared top type, exactly as `tsc` does.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unnarrowed_unknown_still_renders_unknown() {
+    let source = r#"
+function f(v: unknown) {
+    const r: string = v;
+}
+"#;
+    let msg = sole_assignment_message(source);
+    assert!(
+        msg.contains("Type 'unknown' is not assignable to type 'string'"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn unnarrowed_any_to_never_still_renders_any() {
+    // `any` is assignable to everything except `never`; tsc reports TS2322 for
+    // `any` -> `never` and shows the source as `any` when un-narrowed.
+    let source = r#"
+function f(v: any) {
+    const r: never = v;
+}
+"#;
+    let msg = sole_assignment_message(source);
+    assert!(
+        msg.contains("Type 'any' is not assignable to type 'never'"),
+        "got: {msg}"
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes #14009.

## Summary

`#14009` reported that user-defined type-predicate guards "don't narrow" an
`unknown`/`any` operand: `const r: never = v` after `isStr(v)` rendered
`Type 'unknown' is not assignable to type 'never'` where `tsc` renders
`'string'`. Investigation showed **narrowing was always correct** — the
relation uses the narrowed type (`const r: string = v` is clean; `v.toUpperCase()`
resolves on `string`), and a copy `let w = v` carries `string`. The divergence
was purely in the **diagnostic source-type display**: a declared-annotation
repaint re-painted the narrowed source with the operand's stale *declaration*
type (`unknown`/`any`).

## Structural rule

When a source identifier's declared symbol type is a top type (`any`/`unknown`)
and the displayed type is a different, more specific **flow-narrowed** type — by
a type-predicate guard, `typeof`, `instanceof`, a discriminant, etc. — the
assignability diagnostic renders the narrowed type, matching `tsc`'s
`getFlowTypeOfReference`. The declared-annotation source repaint is suppressed.
Non-top declarations (unions, literals, classes) are already handled by existing
display exclusions, so the gate is scoped to top types. The check keys only on
the structural top-type identity of the declared symbol type, never on
identifier / annotation / printer-output text.

## Owner layer

Checker diagnostic display. A single
`source_identifier_narrowed_from_top_declaration` helper
(`error_reporter::core::diagnostic_source`) backs three repaint sites:

- `declared_generic_alias_assignment_pair_display` — the `TS2322` message
  post-process (`rewrite_declared_generic_alias_source_in_ts2322_message`), the
  primary culprit for the `unknown`/Record cases.
- `should_prefer_declared_source_annotation_display` — the object/index-signature
  source path (the `Record<string, unknown>` case).
- `declared_identifier_source_display` — the `any` companion to its existing
  `unknown` early return.

No relation, narrowing, or solver change — narrowing already produces the
correct type.

## Adjacent-case matrix (verified vs `tsc`)

| operand / narrowing | tsc | tsz after |
|---|---|---|
| `v: unknown`, `isStr` → `never` | `string` | `string` |
| `v: unknown`, `isObj` → `never` | `object` | `object` |
| `v: unknown`, `isRec<Record>` → `{a}` (TS2741) | `Record<string, unknown>` | `Record<string, unknown>` |
| `v: any`, `isStr` → `never` | `string` | `string` |
| `v: string \| number`, `isS` → `never` (control) | `string` | `string` |
| `v: unknown`, `typeof === "string"` → `never` | `string` | `string` |
| `v: unknown`, `instanceof Box` → `never` | `Box` | `Box` |
| `v: unknown` (un-narrowed) → `string` | `unknown` | `unknown` |
| `v: any` (un-narrowed) → `never` | `any` | `any` |

## Anti-hardcoding

No identifier/file-name/printer-string predicates. The gate is the structural
top-type identity (`TypeId::is_any_or_unknown`) of the declared symbol type. A
regression test varies binder names (`looksLikeText`/`payload`/`sink`) to prove
the result is not keyed on identifier text.

## Verification

- New `narrowed_top_type_source_display_tests` (10 cases) — predicate/`typeof`/
  `instanceof` narrowing of `unknown`/`any` to `string`/`number`/`object`/
  `Record` render the narrowed type; renamed-binder anti-hardcoding case; two
  negative controls keep `unknown`/`any` un-narrowed. `cargo test -p tsz-checker
  --lib narrowed_top_type_source_display` — 10 passed.
- Full `cargo test -p tsz-checker --lib` failing set **identical** to clean
  `main` (72 pre-existing `cargo test --lib`-vs-`nextest` harness baseline
  failures; **zero** new, **zero** accidentally fixed — verified by diffing the
  stashed-baseline failure set against the branch failure set).
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib`
  clean.
- Issue repro + broad narrowing-kind witnesses diffed against `tsc` semantics
  via the built `tsz` binary.
- Broad conformance / emit / fourslash / project-corpus owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_015QW49bYqrxSo4nTGmBLagW)_