### PR TITLE
fix(checker): exempt for-of/for-in destructured loop bindings from TS2454 in closures (#14013)

### DIFF
--- a/crates/tsz-checker/src/flow/flow_analysis/usage.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/usage.rs
@@ -768,6 +768,33 @@ impl<'a> CheckerState<'a> {
                 return false;
             };
 
+        // A `for...in`/`for...of` loop binding (plain or destructured) is
+        // assigned by the loop on every iteration before the body runs. Any read
+        // at or after the loop — including reads captured by closures created
+        // inside the loop body — therefore sees an assigned value, so TS2454 must
+        // not fire. tsc applies this exemption uniformly; the gap was destructured
+        // `for...of`/`for...in` bindings (`[k, v]`, `{ x }`) captured by a nested
+        // closure, where `decl_id_to_check` is a `BindingElement` (not a direct
+        // `VariableDeclaration`) and the cross-scope (deferred-function) heuristics
+        // below would fall through to flow analysis and emit a false TS2454.
+        //
+        // A usage that precedes the loop in source order (e.g. `v; for (var v of
+        // …)`) is intentionally NOT covered — the binding is not yet assigned
+        // there — so it falls through to the definite-assignment check.
+        //
+        // Gated on `!has_initializer`: a loop binding's `VariableDeclaration`
+        // never carries an initializer, so this skips the parent-walk for the
+        // common case of ordinary initialized declarations (which the initializer
+        // guards further below suppress anyway).
+        if !has_initializer
+            && let Some(for_node_idx) = self.for_in_of_loop_binding(decl_id_to_check)
+            && let Some(for_node) = self.ctx.arena.get(for_node_idx)
+            && let Some(usage_node) = self.ctx.arena.get(idx)
+            && usage_node.pos >= for_node.pos
+        {
+            return false;
+        }
+
         // Skip TS2454 when the variable is used from a different function scope
         // than where it is declared. The nested function could be called later,
         // so tsz conservatively suppresses TS2454 for captured locals.
@@ -954,34 +981,9 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        // If the variable is declared in a for-in or for-of loop header,
-        // it's assigned by the loop iteration itself - but only when usage is at or after the loop.
-        // A usage BEFORE the loop in source order (e.g. `v; for (var v of [0]) {}`) must still
-        // be checked for definite assignment.
-        if let Some(decl_list_info) = self.ctx.arena.node_info(decl_id_to_check) {
-            let decl_list_idx = decl_list_info.parent;
-            if let Some(decl_list_node) = self.ctx.arena.get(decl_list_idx)
-                && decl_list_node.kind == syntax_kind_ext::VARIABLE_DECLARATION_LIST
-                && let Some(for_info) = self.ctx.arena.node_info(decl_list_idx)
-            {
-                let for_idx = for_info.parent;
-                if let Some(for_node) = self.ctx.arena.get(for_idx)
-                    && (for_node.kind == syntax_kind_ext::FOR_IN_STATEMENT
-                        || for_node.kind == syntax_kind_ext::FOR_OF_STATEMENT)
-                {
-                    // Only skip the check if the usage is at or after the start of the loop.
-                    // If the usage precedes the loop in source order, fall through to DAA.
-                    if let Some(usage_node) = self.ctx.arena.get(idx) {
-                        if usage_node.pos >= for_node.pos {
-                            return false;
-                        }
-                        // Usage is before the loop - continue to definite assignment check
-                    } else {
-                        return false;
-                    }
-                }
-            }
-        }
+        // (The for-in/for-of loop-binding exemption — including destructured
+        // bindings and closure captures — is applied earlier, before the
+        // cross-scope heuristics, via `for_in_of_loop_binding`.)
 
         // For namespace-scoped variables, skip TS2454 when the usage is inside
         // a nested namespace (MODULE_DECLARATION) relative to the declaration.
@@ -1273,6 +1275,54 @@ impl<'a> CheckerState<'a> {
             return true;
         }
         false
+    }
+
+    /// If `decl_id_to_check` is the binding of a `for...in`/`for...of` loop,
+    /// return the loop statement node, else `None`.
+    ///
+    /// Handles a plain loop variable (`for (const x of …)`) as well as
+    /// destructured loop bindings (`for (const [a, b] of …)`,
+    /// `for (const { x } of …)`), including nested patterns, by walking up
+    /// through the binding (`BindingElement`/array+object `BindingPattern`/
+    /// `VariableDeclaration`) to the enclosing `VariableDeclarationList` and
+    /// confirming its parent is a `for...in`/`for...of` statement.
+    ///
+    /// A for-in/for-of loop binding is assigned by the loop on every iteration
+    /// before the body runs, so reads of it are never used-before-assigned.
+    fn for_in_of_loop_binding(&self, decl_id_to_check: NodeIndex) -> Option<NodeIndex> {
+        let mut current = decl_id_to_check;
+        for _ in 0..MAX_TREE_WALK_ITERATIONS {
+            let info = self.ctx.arena.node_info(current)?;
+            let parent = info.parent;
+            // `arena.get` yields `None` for a none index, so no explicit
+            // `parent.is_none()` guard is needed.
+            let parent_node = self.ctx.arena.get(parent)?;
+            match parent_node.kind {
+                // Walk up through the binding: the declaration itself and any
+                // nested destructuring patterns/elements.
+                k if k == syntax_kind_ext::VARIABLE_DECLARATION
+                    || k == syntax_kind_ext::ARRAY_BINDING_PATTERN
+                    || k == syntax_kind_ext::OBJECT_BINDING_PATTERN
+                    || k == syntax_kind_ext::BINDING_ELEMENT =>
+                {
+                    current = parent;
+                }
+                // Reached the declaration list: the loop header iff its parent
+                // is a for-in/for-of statement.
+                k if k == syntax_kind_ext::VARIABLE_DECLARATION_LIST => {
+                    let list_info = self.ctx.arena.node_info(parent)?;
+                    let for_node = self.ctx.arena.get(list_info.parent)?;
+                    if for_node.kind == syntax_kind_ext::FOR_IN_STATEMENT
+                        || for_node.kind == syntax_kind_ext::FOR_OF_STATEMENT
+                    {
+                        return Some(list_info.parent);
+                    }
+                    return None;
+                }
+                _ => return None,
+            }
+        }
+        None
     }
 
     /// Check if an identifier is an assignment target in a destructuring assignment.

--- a/crates/tsz-checker/tests/definite_assignment_tests/part_01.rs
+++ b/crates/tsz-checker/tests/definite_assignment_tests/part_01.rs
@@ -437,3 +437,131 @@ class C {
         "Expected no diagnostics when constructor assigns [s] and [N.s], got: {diags:?}"
     );
 }
+
+/// A `for...of` *destructured* binding captured by a nested closure must not
+/// trigger TS2454. The loop assigns the binding on every iteration before the
+/// body (and the closure) runs. Regression for the ofetch canary pattern.
+#[test]
+fn test_ts2454_for_of_destructured_binding_captured_by_closure_is_clean() {
+    let source = r#"
+        function arrayPattern() {
+            const out: any = {};
+            for (const [key, refKey] of [["data", "_data"]] as const) {
+                out[key] = () => refKey;
+            }
+        }
+        function objectPattern() {
+            const o: any = {};
+            for (const { x } of [{ x: 1 }] as const) {
+                o.f = () => x;
+            }
+        }
+        function nestedArrayPattern() {
+            const out: any = {};
+            for (const [[a, b]] of [[["p", "q"]]] as const) {
+                out.f = () => a + b;
+            }
+        }
+        function forInDestructured() {
+            const out: any = {};
+            const src: Record<string, string> = {};
+            for (const key in src) {
+                out[key] = () => key;
+            }
+        }
+    "#;
+    let diags = diagnostics_with_options(
+        source,
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            target: ScriptTarget::ES2017,
+            ..CheckerOptions::default()
+        },
+    );
+    assert_eq!(
+        count_code(
+            &diags,
+            diagnostic_codes::VARIABLE_IS_USED_BEFORE_BEING_ASSIGNED
+        ),
+        0,
+        "for...of/for...in destructured loop bindings captured by closures must not emit TS2454, got: {diags:?}"
+    );
+}
+
+/// Adjacent negatives that already passed and must keep passing: direct use of
+/// a destructured loop binding, simple loop binding + closure, and plain
+/// destructuring + closure.
+#[test]
+fn test_ts2454_for_of_loop_binding_negatives_remain_clean() {
+    let source = r#"
+        function directUse() {
+            for (const [k, v] of [["a", "b"]] as const) {
+                console.log(k, v);
+            }
+        }
+        function simpleBindingClosure() {
+            const o: any = {};
+            for (const x of [1, 2] as const) {
+                o.f = () => x;
+            }
+        }
+        function plainDestructuringClosure() {
+            const [a, b] = [1, 2] as const;
+            const f = () => b;
+            f();
+            return a;
+        }
+    "#;
+    let diags = diagnostics_with_options(
+        source,
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            target: ScriptTarget::ES2017,
+            ..CheckerOptions::default()
+        },
+    );
+    assert_eq!(
+        count_code(
+            &diags,
+            diagnostic_codes::VARIABLE_IS_USED_BEFORE_BEING_ASSIGNED
+        ),
+        0,
+        "Loop-binding negatives must stay clean, got: {diags:?}"
+    );
+}
+
+/// The fix must not be over-broad: the `for_in_of_loop_binding` exemption only
+/// covers actual loop bindings, so a genuinely unassigned annotated local —
+/// even one declared in the same function as a `for...of` loop — must still
+/// report TS2454.
+#[test]
+fn test_ts2454_unassigned_local_still_reported_alongside_for_of() {
+    let source = r#"
+        function f() {
+            let unassigned: number;
+            for (const [key, refKey] of [["data", "_data"]] as const) {
+                console.log(key, refKey);
+            }
+            return unassigned;
+        }
+    "#;
+    let diags = diagnostics_with_options(
+        source,
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            target: ScriptTarget::ES2017,
+            ..CheckerOptions::default()
+        },
+    );
+    assert_eq!(
+        count_code(
+            &diags,
+            diagnostic_codes::VARIABLE_IS_USED_BEFORE_BEING_ASSIGNED
+        ),
+        1,
+        "A genuinely unassigned local must still be flagged TS2454 (only loop bindings are exempt), got: {diags:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes #14013.

## Summary

A `for...of`/`for...in` loop binding is assigned by the loop on **every
iteration before the body runs**, so any read at or after the loop — including
reads captured by a nested closure created inside the loop body — sees an
assigned value and must not raise `TS2454` ("used before being assigned").

tsz applied this exemption only for a **plain** loop variable (`for (const x
of …)`), where the declaration is a direct `VariableDeclaration` whose parent
is the `VariableDeclarationList`. For a **destructured** loop binding
(`for (const [k, v] of …)` / `for (const { x } of …)`) the declaration is a
`BindingElement` nested inside a binding pattern, so the narrow for-of
detection missed it; the cross-scope (deferred-function) closure heuristics
then fell through to flow analysis, whose closure-`START` boundary reports a
false `TS2454`. The false positive required the intersection of all three:
`for...of`/`for...in` × destructuring pattern × closure capture.

```ts
// FALSE TS2454 (tsz before) / clean (tsc):
function b() {
  const out: any = {};
  for (const [key, refKey] of [["data", "_data"]] as const) {
    out[key] = () => refKey;          // was TS2454 on `refKey`
  }
}
```

This is the exact ofetch canary pattern (`src/error.ts(61,45)`).

## Structural rule

> When a variable is referenced only inside a nested function/closure, `tsc`
> does not enforce definite-assignment (`TS2454`) on that reference; and a
> `for...in`/`for...of` loop binding is definitely assigned by the loop on
> every iteration. tsz now applies the loop-binding exemption uniformly —
> plain, array-destructured, object-destructured, and nested patterns —
> through the checker definite-assignment seam.

## Owner layer

Checker definite-assignment flow analysis
(`crates/tsz-checker/src/flow/flow_analysis/usage.rs`,
`should_check_definite_assignment`).

- New `for_in_of_loop_binding(decl_id_to_check) -> Option<NodeIndex>` walks up
  through the binding (`BindingElement` / array+object `BindingPattern` /
  `VariableDeclaration`) to the enclosing `VariableDeclarationList`, returning
  the loop statement when its parent is a `for...in`/`for...of`.
- The loop-binding suppression is **hoisted ahead of the cross-scope
  (deferred-function) heuristics** so it covers closure captures, and the
  narrower inline `VariableDeclaration`-only block it subsumes is removed
  (behavior-preserving, DRY).
- Gated on `!has_initializer` (a loop binding's declaration never carries one,
  and initialized declarations are suppressed by the existing initializer
  guards) and on `usage.pos >= for.pos`, so a read **preceding** the loop in
  source order (`v; for (var v of …)`) is still checked.

No solver/binder/emit change; the flow graph is unchanged — only the syntactic
loop-binding classification in the definite-assignment gate is generalized.

## Adjacent-case matrix

| case | tsc | tsz after |
|---|---|---|
| `for (const [k, refKey] of …) { out[k] = () => refKey }` | clean | clean |
| `for (const { x } of …) { o.f = () => x }` | clean | clean |
| `for (const [[a, b]] of …) { out.f = () => a + b }` (nested) | clean | clean |
| `for (const key in src) { out[key] = () => key }` (for-in) | clean | clean |
| `for (const [k, v] of …) { console.log(k, v) }` (direct, control) | clean | clean |
| `for (const x of …) { o.f = () => x }` (simple + closure, control) | clean | clean |
| `const [a, b] = …; const f = () => b` (plain destructuring, control) | clean | clean |
| `let unassigned: number; …; return unassigned` (over-breadth guard) | TS2454 | TS2454 |

## Anti-hardcoding

No identifier/file-name/printer-string predicates: the decision keys only on
structural node kinds (`BindingElement`/`BindingPattern`/`VariableDeclaration`
/`VariableDeclarationList` and the `for...in`/`for...of` parent) plus source
position. Tests vary binder names and include negative controls plus an
over-breadth guard (a genuinely unassigned local still emits `TS2454`).

## Verification

- New tests in `definite_assignment_tests/part_01.rs`: closure capture of
  array/object/nested-destructured + for-in loop bindings (clean); negative
  controls (direct use, simple binding + closure, plain destructuring +
  closure); over-breadth guard (unassigned local still `TS2454`).
- `cargo test -p tsz-checker --lib definite_assignment_tests` — 69 passed,
  0 failed.
- `cargo test -p tsz-checker --lib control_flow_tests` / `control_flow_type_guard_tests`
  — 101 / 87 passed, 0 failed.
- Full `cargo test -p tsz-checker --lib` failure set diffed against clean
  `main`: zero new failures (the pre-existing `cargo test`-vs-`nextest`
  harness baseline failures reproduce on `main` unchanged).
- `cargo build -p tsz-checker` clean.
- Broad conformance / emit / fourslash / project-corpus owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_014fDFiQoUxXcuB4xkbVWwQD

---
_Generated by [Claude Code](https://claude.ai/code/session_014fDFiQoUxXcuB4xkbVWwQD)_