### PR TITLE
fix(checker): exempt for-of/for-in destructured loop bindings from TS2454 in closures (#14013)

### DIFF
--- a/crates/tsz-checker/src/flow/flow_analysis/usage.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/usage.rs
@@ -784,6 +784,21 @@ impl<'a> CheckerState<'a> {
         let decl_scope = self.find_enclosing_function_or_source_file(decl_id_to_check);
         let usage_scope = self.find_enclosing_function_or_source_file(idx);
         if decl_scope != usage_scope && decl_scope.is_some() {
+            // A `for...in` / `for...of` loop binding — a simple identifier
+            // (`for (const x of …)`) or a destructuring pattern
+            // (`for (const [k, v] of …)`, `for (const { x } of …)`) — is
+            // assigned by the loop on every iteration before the body runs, so
+            // it is definitely assigned throughout the body. A reference inside
+            // a deferred closure declared in the body can only execute after
+            // that assignment, so `tsc` never reports TS2454 for it. tsz already
+            // exempts the simple-`const` shape via the `!has_initializer` +
+            // const path below; recognize destructured (`BindingElement`) and
+            // `let`/`var` loop bindings here so every loop binding is uniform.
+            if self.is_for_in_of_loop_binding(decl_id_to_check)
+                && self.is_usage_in_deferred_function_relative_to_scope(idx, decl_scope)
+            {
+                return false;
+            }
             let decl_is_source_file = self
                 .ctx
                 .arena
@@ -865,24 +880,8 @@ impl<'a> CheckerState<'a> {
             let is_function_scoped =
                 symbol.has_any_flags(tsz_binder::symbol_flags::FUNCTION_SCOPED_VARIABLE);
             if is_function_scoped {
-                // Check if this var is a for-in/for-of loop variable
-                let is_for_in_of_var = self
-                    .ctx
-                    .arena
-                    .node_info(decl_id_to_check)
-                    .and_then(|info| {
-                        let list_node = self.ctx.arena.get(info.parent)?;
-                        if list_node.kind != syntax_kind_ext::VARIABLE_DECLARATION_LIST {
-                            return None;
-                        }
-                        let list_info = self.ctx.arena.node_info(info.parent)?;
-                        let for_node = self.ctx.arena.get(list_info.parent)?;
-                        Some(
-                            for_node.kind == syntax_kind_ext::FOR_IN_STATEMENT
-                                || for_node.kind == syntax_kind_ext::FOR_OF_STATEMENT,
-                        )
-                    })
-                    .unwrap_or(false);
+                // Check if this var is a for-in/for-of loop variable.
+                let is_for_in_of_var = self.is_for_in_of_loop_binding(decl_id_to_check);
 
                 if !is_for_in_of_var {
                     let has_type_annotation =
@@ -1563,6 +1562,57 @@ impl<'a> CheckerState<'a> {
             current = ext.parent;
         }
         false
+    }
+
+    /// Returns `true` when `decl` is the binding of a `for...in` / `for...of`
+    /// loop header — either the loop's `VariableDeclaration` directly
+    /// (`for (const x of …)`) or a `BindingElement` nested inside that
+    /// declaration's destructuring pattern (`for (const [k, v] of …)`,
+    /// `for (const { x } of …)`).
+    ///
+    /// Such a binding is assigned by the loop on every iteration before the
+    /// body runs, so it is definitely assigned throughout the loop body. The
+    /// decision is purely structural (the declaration's AST position), never
+    /// keyed on the binding's name.
+    fn is_for_in_of_loop_binding(&self, decl: NodeIndex) -> bool {
+        let arena = self.ctx.arena;
+        // Resolve the enclosing `VariableDeclaration` for `decl`: a simple
+        // binding already is one; a destructured binding is a `BindingElement`
+        // nested in the declaration's pattern, so walk up until the declaration
+        // is reached (bailing if the walk leaves its subtree). The walk always
+        // terminates — the parent chain reaches the source file or a NONE
+        // parent.
+        let mut current = decl;
+        let var_decl = loop {
+            match arena.get(current).map(|node| node.kind) {
+                Some(kind) if kind == syntax_kind_ext::VARIABLE_DECLARATION => break current,
+                Some(kind) if kind == syntax_kind_ext::SOURCE_FILE => return false,
+                Some(_) => {}
+                None => return false,
+            }
+            match arena.node_info(current) {
+                Some(info) => current = info.parent,
+                None => return false,
+            }
+        };
+        // `VariableDeclaration` → `VariableDeclarationList` → `For{Of,In}`.
+        let Some(list_info) = arena.node_info(var_decl) else {
+            return false;
+        };
+        if arena.get(list_info.parent).map(|node| node.kind)
+            != Some(syntax_kind_ext::VARIABLE_DECLARATION_LIST)
+        {
+            return false;
+        }
+        let Some(for_info) = arena.node_info(list_info.parent) else {
+            return false;
+        };
+        matches!(
+            arena.get(for_info.parent).map(|node| node.kind),
+            Some(kind)
+                if kind == syntax_kind_ext::FOR_OF_STATEMENT
+                    || kind == syntax_kind_ext::FOR_IN_STATEMENT
+        )
     }
 
     /// Check whether a symbol has any flow ASSIGNMENT node in the current file.

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -214,6 +214,9 @@ mod environment_capabilities_tests;
 #[path = "tests/flow_assignment_relation_routing_arch_tests.rs"]
 mod flow_assignment_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/flow_for_of_destructure_closure_assignment_tests.rs"]
+mod flow_for_of_destructure_closure_assignment_tests;
+#[cfg(test)]
 #[path = "tests/flow_guard_boundary_tests.rs"]
 mod flow_guard_boundary_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/flow_for_of_destructure_closure_assignment_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_for_of_destructure_closure_assignment_tests.rs
@@ -1,0 +1,288 @@
+//! Definite-assignment (TS2454) parity for `for...of` / `for...in` loop
+//! bindings captured by a closure.
+//!
+//! Structural rule: a `for...in` / `for...of` loop binding — a simple
+//! identifier (`for (const x of …)`) or a destructuring pattern
+//! (`for (const [k, v] of …)`, `for (const { x } of …)`) — is assigned by the
+//! loop on every iteration before the body runs, so it is definitely assigned
+//! throughout the body. A reference inside a deferred closure declared in the
+//! body can only execute after that assignment, so `tsc` never reports TS2454
+//! for it. tsz previously exempted the simple-binding shape but reported a
+//! false TS2454 for the *destructured* loop binding captured by a closure.
+//!
+//! The decision is purely structural (the binding's AST position is a loop
+//! header), never keyed on the binding's name — the renamed-binder cases prove
+//! it is not name-driven.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+fn count_2454(source: &str) -> usize {
+    check_strict(source).iter().filter(|&&c| c == 2454).count()
+}
+
+// ---------------------------------------------------------------------------
+// False positives that the fix removes (clean under tsc).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn for_of_array_destructure_captured_by_closure_is_clean() {
+    // The witnessed bug: array destructuring in a `for...of`, a bound variable
+    // captured by a nested arrow. tsc is clean.
+    assert_eq!(
+        count_2454(
+            r#"
+function b() {
+  const out: any = {};
+  for (const [key, refKey] of [["data", "_data"]] as const) {
+    out[key] = () => refKey;
+  }
+}
+"#,
+        ),
+        0,
+        "array-destructured for-of binding captured by a closure must not report TS2454",
+    );
+}
+
+#[test]
+fn for_of_object_destructure_captured_by_closure_is_clean() {
+    assert_eq!(
+        count_2454(
+            r#"
+function h() {
+  const o: any = {};
+  for (const { x } of [{ x: 1 }] as const) {
+    o.f = () => x;
+  }
+}
+"#,
+        ),
+        0,
+        "object-destructured for-of binding captured by a closure must not report TS2454",
+    );
+}
+
+#[test]
+fn for_of_nested_destructure_captured_by_closure_is_clean() {
+    // Nested array/object pattern — every leaf binding is loop-assigned.
+    assert_eq!(
+        count_2454(
+            r#"
+function n() {
+  const sink: any = {};
+  for (const [{ a }, [b]] of [[{ a: 1 }, [2]]] as const) {
+    sink.f = () => a + b;
+  }
+}
+"#,
+        ),
+        0,
+        "nested-destructured for-of bindings captured by a closure must not report TS2454",
+    );
+}
+
+#[test]
+fn for_of_let_destructure_captured_by_closure_is_clean() {
+    assert_eq!(
+        count_2454(
+            r#"
+function l() {
+  const out: any = {};
+  for (let [p, q] of [[1, 2]] as const) {
+    out[p] = () => q;
+  }
+}
+"#,
+        ),
+        0,
+        "let-declared destructured for-of binding captured by a closure must not report TS2454",
+    );
+}
+
+#[test]
+fn for_of_var_destructure_captured_by_closure_is_clean() {
+    assert_eq!(
+        count_2454(
+            r#"
+function v() {
+  const out: any = {};
+  for (var [p, q] of [[1, 2]] as const) {
+    out[p] = () => q;
+  }
+}
+"#,
+        ),
+        0,
+        "var-declared destructured for-of binding captured by a closure must not report TS2454",
+    );
+}
+
+#[test]
+fn for_in_destructure_captured_by_closure_is_clean() {
+    assert_eq!(
+        count_2454(
+            r#"
+function fin() {
+  const sink: any = {};
+  const obj: Record<string, number> = {};
+  for (const [c0] in obj) {
+    sink.f = () => c0;
+  }
+}
+"#,
+        ),
+        0,
+        "destructured for-in binding captured by a closure must not report TS2454",
+    );
+}
+
+#[test]
+fn for_of_destructure_in_defineproperty_getter_is_clean() {
+    // The ofetch canary witness shape: the closure is a getter inside an object
+    // literal passed to `Object.defineProperty`.
+    assert_eq!(
+        count_2454(
+            r#"
+function ofetchLike(e: any, ctx: any) {
+  for (const [key, refKey] of [["data", "_data"]] as const) {
+    Object.defineProperty(e, key, {
+      get() {
+        return ctx.response && ctx.response[refKey];
+      },
+    });
+  }
+}
+"#,
+        ),
+        0,
+        "for-of destructured binding read inside a defineProperty getter must not report TS2454",
+    );
+}
+
+#[test]
+fn for_of_destructure_captured_by_closure_is_name_agnostic() {
+    // Anti-hardcoding: identical structure, every binder renamed. The exemption
+    // is structural (loop-header binding), not keyed on `key`/`refKey`/etc.
+    assert_eq!(
+        count_2454(
+            r#"
+function alpha() {
+  const bravo: any = {};
+  for (const [charlie, delta] of [["echo", "foxtrot"]] as const) {
+    bravo[charlie] = () => delta;
+  }
+}
+"#,
+        ),
+        0,
+        "renamed destructured for-of binding captured by a closure must not report TS2454",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls that must stay clean (already correct before the fix).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn for_of_destructure_direct_use_is_clean() {
+    // Direct use in the body (no closure) was already clean; the fix must not
+    // disturb it.
+    assert_eq!(
+        count_2454(
+            r#"
+function a() {
+  for (const [k, v] of [["a", "b"]] as const) {
+    console.log(k, v);
+  }
+}
+"#,
+        ),
+        0,
+        "direct use of a destructured for-of binding must remain clean",
+    );
+}
+
+#[test]
+fn for_of_simple_binding_captured_by_closure_is_clean() {
+    // Simple (non-destructured) for-of binding captured by a closure — already
+    // exempt; this guards against a regression in that path.
+    assert_eq!(
+        count_2454(
+            r#"
+function d() {
+  const o: any = {};
+  for (const x of [1, 2] as const) {
+    o.f = () => x;
+  }
+}
+"#,
+        ),
+        0,
+        "simple for-of binding captured by a closure must remain clean",
+    );
+}
+
+#[test]
+fn plain_destructure_captured_by_closure_is_clean() {
+    // Plain (non-for-of) destructuring with an initializer, captured by a
+    // closure — already clean.
+    assert_eq!(
+        count_2454(
+            r#"
+function e() {
+  const [a, b] = [1, 2] as const;
+  const f = () => b;
+  f();
+}
+"#,
+        ),
+        0,
+        "plain destructuring captured by a closure must remain clean",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Over-suppression guards: genuine TS2454 must still fire.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plain_let_used_before_assignment_still_reports() {
+    // A plain (non-loop) annotated `let` read before assignment in the same
+    // scope still reports TS2454 — the fix must not silence real diagnostics.
+    assert_eq!(
+        count_2454(
+            r#"
+function g() {
+  let x: number;
+  const y: number = x;
+  return y;
+}
+"#,
+        ),
+        1,
+        "a genuine use-before-assignment must still report exactly one TS2454",
+    );
+}
+
+#[test]
+fn for_of_binding_used_before_the_loop_still_reports() {
+    // A binding read *before* its for-of loop (a separate annotated `let`) is a
+    // genuine use-before-assignment; the loop-binding exemption must not bleed
+    // into unrelated references.
+    assert_eq!(
+        count_2454(
+            r#"
+function p() {
+  let z: number;
+  const w: number = z;
+  for (const [z2] of [[1]] as const) {
+    void z2;
+  }
+  return w;
+}
+"#,
+        ),
+        1,
+        "a real use-before-assignment outside the loop body must still report TS2454",
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes #14013.

## Summary

A `for...of` / `for...in` loop binding using a **destructuring** pattern
(`for (const [k, v] of …)`, `for (const { x } of …)`), where a bound variable is
**captured by a nested closure**, produced a false **TS2454** ("used before being
assigned"). `tsc` is clean.

```ts
function b() {
  const out: any = {};
  for (const [key, refKey] of [["data", "_data"]] as const) {
    out[key] = () => refKey;          // tsz: false TS2454 on `refKey`; tsc: clean
  }
}
```

The false positive requires the intersection of all three: `for...of`/`for...in` ×
destructuring pattern × closure capture. tsz already exempted simple loop bindings
(`for (const x of …)`) and plain (non-loop) destructuring; the destructured loop
binding slipped past.

## Structural rule

> When a reference to a `for...in` / `for...of` loop binding (a simple identifier
> or a destructuring pattern; `const`/`let`/`var`) lives in a deferred closure
> declared in the loop body, the binding is assigned by the loop on every
> iteration before the body runs, so it is definitely assigned and `tsc` does not
> report TS2454.

## Root cause / owner layer

Checker definite-assignment flow analysis (`crates/tsz-checker/src/flow/flow_analysis/usage.rs`,
`should_check_definite_assignment`). The binder *does* create a recognized flow
ASSIGNMENT for destructured loop bindings, so direct use in the body is already
clean. The gap was only in the **cross-scope / deferred-closure** suppression
heuristic: it keyed the simple-loop exemption on `is_const_variable_declaration`,
which is `false` for the `BindingElement` declaration of a destructured binding,
so the destructured case fell through to flow analysis (whose graph is
disconnected across the closure boundary) and reported TS2454.

The fix adds a structural `is_for_in_of_loop_binding` helper that resolves a
declaration — or a destructuring `BindingElement` — up to its
`VariableDeclaration` → `VariableDeclarationList` → `For{Of,In}` header, and gates
the cross-scope suppression on it. The same helper **replaces** the pre-existing
inline for-in/of detection (DRY). This is the established owner layer for
cross-scope definite-assignment parity, alongside the existing simple-loop,
var-hoisting, and exported-module exemptions.

## Anti-hardcoding

The decision is purely structural (the binding's AST position is a loop header),
never keyed on the binding's name, identifier text, or file name. A renamed-binder
test proves the result is not name-driven.

## Adjacent-case matrix (vs `tsc`, all now match)

| case | before | after / tsc |
|---|---|---|
| `for (const [k, refKey] of …)` + closure | TS2454 | clean |
| `for (const { x } of …)` + closure | TS2454 | clean |
| nested `for (const [{ a }, [b]] of …)` + closure | TS2454 | clean |
| `for (let [p, q] of …)` + closure | TS2454 | clean |
| `for (var [p, q] of …)` + closure | TS2454 | clean |
| `for (const [c] in obj)` + closure | TS2454 | clean |
| `Object.defineProperty` getter witness (ofetch) | TS2454 | clean |
| renamed binders | TS2454 | clean |
| direct use, no closure (negative) | clean | clean |
| simple `for (const x of …)` + closure (negative) | clean | clean |
| plain destructuring + closure (negative) | clean | clean |
| plain `let x: number; … = x;` used-before-assigned (guard) | TS2454 | TS2454 |
| read before the loop (guard) | TS2454 | TS2454 |

## Verification

- New `flow_for_of_destructure_closure_assignment_tests` — **13/13 pass**.
- `cargo test -p tsz-checker --lib -- flow_ definite for_of for_in narrowing_assignment used_before var_utils` — 455 pass; the only 3 failures are **pre-existing on clean `main`** (verified by stashing this change): two `*_relation_routing_arch`/`relation_flags_boundary_contract` source-grep arch tests and `imported_generator_return_type_is_iterable_in_for_of` — the known `cargo test --lib`-vs-nextest harness artifacts. Zero new failures.
- `cargo test -p tsz-checker --lib -- control_flow tdz destructur loop_` — 324 pass.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib` clean. Touched file stays under the 2000-line cap.
- Broad conformance / emit / fourslash / project-corpus owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01QnihddcRHwRRz7NqXU7GmE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnihddcRHwRRz7NqXU7GmE)_