### PR TITLE
fix(checker): constructor throw paths don't constrain definite assignment (TS2564)

### DIFF
--- a/crates/tsz-checker/src/flow/flow_analysis/core.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/core.rs
@@ -75,7 +75,7 @@ impl<'a> CheckerState<'a> {
             self.analyze_statement(body_idx, &FxHashSet::default(), tracked)
         };
 
-        self.flow_result_to_assigned(result)
+        self.flow_result_to_assigned(result, tracked)
     }
 
     /// Analyze a constructor body starting after the `super()` call.
@@ -132,7 +132,11 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Convert a `FlowResult` to a set of definitely assigned properties.
-    fn flow_result_to_assigned(&self, result: FlowResult) -> FxHashSet<PropertyKey> {
+    fn flow_result_to_assigned(
+        &self,
+        result: FlowResult,
+        tracked: &FxHashSet<PropertyKey>,
+    ) -> FxHashSet<PropertyKey> {
         let mut assigned = None;
         if let Some(normal) = result.normal {
             assigned = Some(normal);
@@ -144,7 +148,13 @@ impl<'a> CheckerState<'a> {
             });
         }
 
-        assigned.unwrap_or_default()
+        // No completion path at all (both `normal` and `exits` are `None`) means
+        // every path through the constructor exits via `throw`, so the end is
+        // unreachable. tsc treats an unreachable constructor end as vacuously
+        // satisfying definite assignment for ALL tracked properties (the
+        // instance is never observably constructed), so return the full tracked
+        // set rather than the empty set.
+        assigned.unwrap_or_else(|| tracked.clone())
     }
 
     // =========================================================================
@@ -220,15 +230,19 @@ impl<'a> CheckerState<'a> {
                 };
             }
             k if k == syntax_kind_ext::THROW_STATEMENT => {
-                let mut assigned = assigned_in.clone();
-                if let Some(ret) = self.ctx.arena.get_return_statement(node)
-                    && ret.expression.is_some()
-                {
-                    self.collect_assignments_in_expression(ret.expression, &mut assigned, tracked);
-                }
+                // A `throw` never completes the constructor: its path reaches
+                // neither the normal end nor a `return` completion, so it
+                // contributes no completion path to the definite-assignment
+                // reduction. Unlike `return` (an early *normal* completion whose
+                // assigned-set must constrain the result), a throw path is
+                // excluded entirely — otherwise an early-throw guard
+                // (`if (bad) throw;`) would wrongly cancel assignments made on
+                // the normal path that follows it. When every path throws, the
+                // resulting `(None, None)` is treated as vacuously-assigned in
+                // `flow_result_to_assigned`.
                 return FlowResult {
                     normal: None,
-                    exits: Some(assigned),
+                    exits: None,
                 };
             }
             k if k == syntax_kind_ext::EXPRESSION_STATEMENT => {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1345,6 +1345,9 @@ mod ts2341_private_access_via_type_param_constraint_tests;
 #[path = "tests/ts2353_generic_constraint_tests.rs"]
 mod ts2353_generic_constraint_tests;
 #[cfg(test)]
+#[path = "tests/ts2564_constructor_throw_guard_tests.rs"]
+mod ts2564_constructor_throw_guard_tests;
+#[cfg(test)]
 #[path = "tests/ts2565_jsdoc_prototype_type_decl_tests.rs"]
 mod ts2565_jsdoc_prototype_type_decl_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/ts2564_constructor_throw_guard_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2564_constructor_throw_guard_tests.rs
@@ -1,0 +1,191 @@
+//! Definite-assignment (TS2564, `strictPropertyInitialization`) parity for
+//! constructors that `throw`.
+//!
+//! Structural rule: a property is definitely assigned at the end of a
+//! constructor iff it is assigned on every path that *reaches the end* (the
+//! normal fall-through plus any early `return`). A `throw` path never reaches
+//! the end, so it contributes no completion path: an early-throw guard
+//! (`if (bad) throw;`) must NOT cancel an assignment made on the normal path
+//! that follows it, and a constructor whose every path throws satisfies
+//! definite assignment vacuously for all properties.
+//!
+//! tsz previously modelled `throw` identically to `return` (both folded their
+//! pre-exit assigned-set into `exits`, which was intersected with the normal
+//! path), so `if (bad) throw; this.x = v;` produced a false TS2564, and
+//! always-throwing constructors with no/conditional assignment also did. The
+//! fix lives in `flow/flow_analysis/core.rs`: `throw` yields `(None, None)`,
+//! and a `(None, None)` reduction (no completion path at all) is vacuously
+//! all-assigned.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+const TS2564: u32 = 2564;
+
+fn count_2564(source: &str) -> usize {
+    check_strict(source)
+        .iter()
+        .filter(|&&c| c == TS2564)
+        .count()
+}
+
+#[test]
+fn early_throw_guard_does_not_cancel_later_normal_assignment() {
+    // The witnessing pattern (ts-morph Node.ts): a guard clause throws, then
+    // the property is assigned on the normal path. tsc is clean.
+    assert_eq!(
+        count_2564(
+            r#"
+class Widget {
+  readonly size: number;
+  constructor(n: number) {
+    if (n < 0) { throw new Error("bad"); }
+    this.size = n;
+  }
+}
+"#,
+        ),
+        0,
+        "guard-throw followed by normal-path assignment must not report TS2564",
+    );
+}
+
+#[test]
+fn early_throw_guard_without_block_braces() {
+    // Same rule, brace-less `if (cond) throw;` form; differently-named binder.
+    assert_eq!(
+        count_2564(
+            r#"
+class Gadget {
+  readonly weight: number;
+  constructor(w: number) {
+    if (w < 0) throw new Error("bad");
+    this.weight = w;
+  }
+}
+"#,
+        ),
+        0,
+    );
+}
+
+#[test]
+fn constructor_that_always_throws_is_vacuously_assigned() {
+    // Every path throws -> the end is unreachable -> all properties vacuously
+    // definitely-assigned. Covers both no-assignment and conditional-assignment.
+    assert_eq!(
+        count_2564(
+            r#"
+class NeverBuilt {
+  readonly handle: number;
+  constructor() { throw new Error("unsupported"); }
+}
+class AlsoNeverBuilt {
+  readonly token: number;
+  constructor(p: boolean) {
+    if (p) { this.token = 1; }
+    throw new Error("unsupported");
+  }
+}
+"#,
+        ),
+        0,
+        "an always-throwing constructor must not report TS2564 (vacuous)",
+    );
+}
+
+#[test]
+fn throw_in_else_branch_keeps_then_assignment_definite() {
+    // The only completing path assigns the property; the other branch throws.
+    assert_eq!(
+        count_2564(
+            r#"
+class Conn {
+  readonly port: number;
+  constructor(ok: boolean, n: number) {
+    if (ok) { this.port = n; } else { throw new Error("closed"); }
+  }
+}
+"#,
+        ),
+        0,
+    );
+}
+
+#[test]
+fn derived_class_super_then_throw_guard_then_assign() {
+    assert_eq!(
+        count_2564(
+            r#"
+class Animal { constructor(_n: number) {} }
+class Dog extends Animal {
+  readonly age: number;
+  constructor(v: number) {
+    super(v);
+    if (v < 0) throw new Error("bad");
+    this.age = v;
+  }
+}
+"#,
+        ),
+        0,
+    );
+}
+
+#[test]
+fn early_return_guard_still_reports_when_normal_path_unassigned() {
+    // `return` IS a completion path (unlike `throw`): the early-return path
+    // reaches the end without assigning, so the property is not definitely
+    // assigned. tsc reports TS2564 here; the fix must preserve that.
+    assert_eq!(
+        count_2564(
+            r#"
+class Maybe {
+  readonly value: number;
+  constructor(n: number) {
+    if (n < 0) { return; }
+    this.value = n;
+  }
+}
+"#,
+        ),
+        1,
+        "early-return guard leaves the property unassigned on a completing path",
+    );
+}
+
+#[test]
+fn assignment_only_before_throw_still_reports_on_normal_path() {
+    // The property is assigned only inside the throwing branch; the normal
+    // (fall-through) completion never assigns it, so TS2564 still fires.
+    assert_eq!(
+        count_2564(
+            r#"
+class Partial {
+  readonly slot: number;
+  constructor(n: number) {
+    if (n < 0) { this.slot = n; throw new Error("bad"); }
+  }
+}
+"#,
+        ),
+        1,
+    );
+}
+
+#[test]
+fn never_assigned_property_still_reports() {
+    // Baseline: no throw involved, property never assigned -> TS2564.
+    assert_eq!(
+        count_2564(
+            r#"
+class Empty {
+  readonly field: number;
+  constructor(n: number) {
+    const unused = n;
+  }
+}
+"#,
+        ),
+        1,
+    );
+}


### PR DESCRIPTION
## Summary

The constructor `strictPropertyInitialization` analysis (TS2564) modelled
`throw` identically to `return`. Both folded their pre-exit assigned-set into the
`exits` set, which is then **intersected** with the normal fall-through set. That
is wrong for `throw`: a throw path never reaches the constructor's end, so it
must contribute no completion path to definite assignment.

Two false-positive families (tsc clean on both):

```ts
// 1. early-throw guard then assign — the guard's empty exit-set intersected
//    away the normal-path assignment of `x`.
class A { readonly x: number; constructor(n: number) { if (n < 0) throw new Error(); this.x = n; } }

// 2. always-throwing constructor (no / conditional assignment) — every path
//    throws, so the end is unreachable and all properties are vacuously
//    assigned, but tsz reduced to the empty set and reported.
class B { readonly x: number; constructor() { throw new Error(); } }
class C { readonly x: number; constructor(p: boolean) { if (p) { this.x = 1; } throw new Error(); } }
```

## Structural rule

`When a constructor property is assigned on every path that reaches the end of
the constructor — the normal fall-through plus any early `return`, but excluding
`throw` paths (which never complete) — tsc considers it definitely assigned.`
When every path throws, the end is unreachable and all properties are vacuously
assigned. tsz folded `throw`'s assigned-set into the intersected `exits` set,
conflating it with `return`.

## Owner layer

Checker constructor definite-assignment engine,
`crates/tsz-checker/src/flow/flow_analysis/core.rs`:
- `THROW_STATEMENT` now yields `FlowResult { normal: None, exits: None }` (no
  completion path) instead of `exits: Some(assigned)`. This also removes a
  copy-paste bug where the throw arm read the node via `get_return_statement`.
- `flow_result_to_assigned` treats a `(None, None)` reduction (no completion path
  — every path throws) as vacuously assigning all tracked properties.

`return` still folds into `exits` (an early *normal* completion that must
constrain). Scope is TS2564/TS2565 only; TS2454 variable definite-assignment uses
a separate engine (`control_flow/var_utils.rs`) and is untouched.

## Adjacent-case matrix (14-case suite, byte-for-byte parity with tsc)

Clean (was/stays clean): early-throw guard then assign; brace-less guard;
always-throw (no assign); conditional-assign then always-throw; throw-in-else
with then-assign; nested-if throw with both completing paths assigning; derived
class `super()` then guard-throw then assign; multi-property assign-around-guard;
switch with throw default. Still reports TS2564 (correctly preserved): early
`return` guard then assign; assignment only before a throw; never-assigned
baseline.

Goal: green

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- New regression test `ts2564_constructor_throw_guard_tests` (8 cases, binder/
  property names varied per the anti-hardcoding contract): 8/8 pass.
- 14-case hand suite: `diff` vs `tsc` empty (perfect TS2564 parity), incl. the
  vacuous always-throw, super-call, nested, else-throw, and switch forms.
- ts-morph canary: TS2564 tsz-only count 0 after fix (was the workflow witness —
  `Node.ts:55` `readonly _context` with a guard-throw then `this._context = ...`);
  `comm -23` vs `tsc` oracle empty for TS2564.
- Conformance (prebuilt dist-fast, all 100%): strictPropertyInitialization 1/1,
  definiteAssignment 4/4, classes 464/464, constructor 99/99, controlFlow 94/94,
  narrowing 29/29, statements 203/203, thisType 32/32, strictNullChecks 1/1,
  useDefineForClassFields 3/3.
- `python3 scripts/arch/arch_guard.py` passes;
  `cargo clippy --workspace --all-targets -- -D warnings` clean;
  `cargo fmt --all --check` clean.
