### PR TITLE
fix(checker): reset per-file resolution guards on every fresh-check file boundary

### DIFF
--- a/crates/tsz-checker/src/checkers/mod.rs
+++ b/crates/tsz-checker/src/checkers/mod.rs
@@ -105,7 +105,51 @@ pub fn reset_stack_overflow_flag() {
 /// thread-local, add its reset here too — the regression test
 /// `clear_all_thread_local_state_resets_cross_arena_and_alias_guards` guards the
 /// recursion-guard subset against drift.
+///
+/// Most of the reset surface — every recursion/cycle guard and depth counter —
+/// is delegated to [`reset_per_file_resolution_guards`], which the fresh-checker
+/// path also runs at every *file* boundary so a mid-walk bail cannot leak dirty
+/// guard state onto a shared worker thread (see that function's docs). This
+/// function additionally drops the warm cross-file memos that are only stale at
+/// a *compilation* boundary.
 pub fn clear_all_thread_local_state() {
+    // Recursion/cycle guards, depth counters, and arena-local scratch memos.
+    reset_per_file_resolution_guards();
+
+    // Drop the module-specifier candidate memo. It is a pure function of the
+    // specifier text (no correctness dependence on row state), but clearing at
+    // row boundaries keeps it from accumulating every project's specifiers on a
+    // reused worker thread while preserving within-compilation cross-file reuse.
+    // Unlike the guards above this is a *warm* cross-file memo, so it is dropped
+    // only at the compilation boundary, never per file.
+    crate::module_resolution::reset_module_specifier_candidates_memo();
+}
+
+/// Reset the checker's transient per-file resolution guards, depth counters, and
+/// arena-local visited-sets/memos on the current thread.
+///
+/// Every entry here is balanced (RAII or manual enter/leave / push/pop) in the
+/// normal path, so it is empty or zero at a clean file boundary. A mid-walk bail
+/// — the stack-overflow breaker, fuel/recursion-limit exhaustion, or a panic
+/// caught by the batch driver — can instead leave a depth counter non-zero or a
+/// visited-set non-empty.
+///
+/// The fresh-checker path checks files on shared rayon pool worker threads
+/// (`check_file_for_parallel`, used by both the sequential and parallel fresh
+/// arms), and reuses those threads across files within a compilation and across
+/// compilations in a batch worker. A dirty guard left by one file would suppress
+/// resolution in the *next* file scheduled onto the same worker thread —
+/// nondeterministically, because file→worker assignment depends on the parallel
+/// schedule. Running this reset at every file boundary makes a bail in one file
+/// unable to leak into another on any thread, closing a documented source of the
+/// schedule-sensitive conformance flakes (#13255 / #13368 family).
+///
+/// This deliberately does **not** drop the warm cross-file memos (e.g. the
+/// module-specifier candidate memo): those are pure functions of their inputs
+/// and are safe — and beneficial — to keep warm across files within a
+/// compilation. Only [`clear_all_thread_local_state`] (the per-compilation
+/// reset) drops those.
+pub fn reset_per_file_resolution_guards() {
     // Reset stack overflow breaker
     STACK_STATE.set(0);
 
@@ -141,12 +185,6 @@ pub fn clear_all_thread_local_state() {
     // mid-resolution bail-out could leave it non-zero and suppress the cycle
     // drain for every later row on this worker thread (#12299).
     crate::types_domain::queries::lib_resolution::reset_lib_resolution_state();
-
-    // Drop the module-specifier candidate memo. It is a pure function of the
-    // specifier text (no correctness dependence on row state), but clearing at
-    // row boundaries keeps it from accumulating every project's specifiers on a
-    // reused worker thread while preserving within-compilation cross-file reuse.
-    crate::module_resolution::reset_module_specifier_candidates_memo();
 
     // Reset the Awaited<…> assignability-normalization cycle guard and clamp
     // epoch. The visiting set keys on arena-local `TypeId`s reused across
@@ -382,6 +420,51 @@ mod tests {
         assert!(
             super::promise_checker_object_normalization::awaited_eval_thread_local_state_clear_for_test(),
             "clear_all_thread_local_state must reset the awaited-eval cycle guard and clamp epoch"
+        );
+    }
+
+    /// The fresh-checker path runs [`reset_per_file_resolution_guards`] at every
+    /// *file* boundary (in `check_file_for_parallel` / `reset_for_next_file`) so
+    /// a file that bails mid-walk cannot leak a dirty recursion/cycle guard into
+    /// the next file scheduled onto the same shared worker thread (#13255 /
+    /// #13368 schedule-sensitivity). This asserts the per-file reset clears the
+    /// same cross-arena / alias / awaited guards the compilation-boundary reset
+    /// does — they must not survive a file boundary on any thread.
+    #[test]
+    fn reset_per_file_resolution_guards_clears_cross_arena_and_alias_guards() {
+        use crate::{state_domain, types_domain};
+
+        // Dirty every guard the way an aborted mid-walk file would.
+        state_domain::state::set_cross_arena_depth_for_test(3);
+        state_domain::state::set_cross_arena_bailout_epoch_for_test(7);
+        state_domain::type_analysis::dirty_cross_file_recursion_guards_for_test();
+        types_domain::dirty_type_resolution_guards_for_test();
+        super::promise_checker_object_normalization::dirty_awaited_eval_thread_local_state_for_test(
+        );
+
+        reset_per_file_resolution_guards();
+
+        assert_eq!(
+            state_domain::state::cross_arena_depth_for_test(),
+            0,
+            "per-file reset must clear the cross-arena delegation depth"
+        );
+        assert_eq!(
+            state_domain::state::cross_arena_bailout_epoch_for_test(),
+            0,
+            "per-file reset must clear the cross-arena bailout epoch"
+        );
+        assert!(
+            state_domain::type_analysis::cross_file_recursion_guards_clear_for_test(),
+            "per-file reset must clear cross-file interface depth and alias stack"
+        );
+        assert!(
+            types_domain::type_resolution_guards_clear_for_test(),
+            "per-file reset must clear alias-resolution depth, stack, and scratch pool"
+        );
+        assert!(
+            super::promise_checker_object_normalization::awaited_eval_thread_local_state_clear_for_test(),
+            "per-file reset must clear the awaited-eval cycle guard and clamp epoch"
         );
     }
 

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -442,11 +442,12 @@ impl<'a> CheckerContext<'a> {
         self.request_cache_counters = crate::context::RequestCacheCounters::default();
         self.flow_shared.narrowing_cache = tsz_solver::narrowing::NarrowingCache::new();
 
-        // Module-scoped thread-local memoisations that key by file-
-        // local `NodeIndex`.
-        crate::types_domain::utilities::cycle_guard::clear_visited_sets();
-        crate::types_domain::utilities::enum_utils::clear_enum_eval_memo();
-        crate::types_domain::utilities::const_enum_eval::clear_const_eval_memo();
+        // Transient per-thread resolution guards, depth counters, and
+        // arena-local visited-set/enum memos keyed by file-local `NodeIndex`.
+        // Same per-file reset the fresh-checker path runs, so the session-reuse
+        // path is held to the identical isolation contract; see
+        // `reset_per_file_resolution_guards` docs for the rationale (#13255).
+        crate::checkers_domain::reset_per_file_resolution_guards();
 
         // Invariants: these stacks must be empty at the file
         // boundary. A non-empty state indicates a logic bug in the

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -56,7 +56,7 @@ mod types_domain;
 pub use checkers_domain::{
     accessor_checker, call_checker, clear_all_thread_local_state, enum_checker, generic_checker,
     iterable_checker, jsx, parameter_checker, promise_checker, property_checker,
-    reset_stack_overflow_flag, signature_builder,
+    reset_per_file_resolution_guards, reset_stack_overflow_flag, signature_builder,
 };
 
 pub use assignability_domain::{

--- a/crates/tsz-cli/src/driver/check_file.rs
+++ b/crates/tsz-cli/src/driver/check_file.rs
@@ -344,6 +344,13 @@ pub(super) fn check_file_for_parallel<'a>(
         program_has_unsupported_js_root,
         extract_type_cache,
     } = context;
+
+    // Start every file's check from a clean per-thread guard slate so a prior
+    // file that bailed mid-walk cannot leak a dirty guard onto the next file on
+    // this reused worker thread. Both fresh-checker arms route through here; see
+    // `reset_per_file_resolution_guards` docs for the full rationale (#13255).
+    tsz::checker::reset_per_file_resolution_guards();
+
     let file = &program.files[file_idx];
     // skipLibCheck: skip type checking of declaration files (.d.ts, .d.cts, .d.mts)
     if skip_lib_check && is_declaration_file(&file.file_name) {


### PR DESCRIPTION
Goal: hold

Hardens the per-file thread-local isolation contract that the recurring
`main`-red conformance flakes (#14002, #13255 / #13368 family) depend on.

## Structural rule

When a file is checked on a shared rayon pool worker thread, `tsc`'s
per-source isolation guarantees the file's result is independent of which
other files ran before it on that thread. tsz violates this: the
fresh-checker path (`check_file_for_parallel`, used by **both** the
sequential `iter().map` and parallel `par_iter` arms) builds a fresh
`CheckerState` per file but never resets the per-thread recursion/cycle
guards. Those guards are balanced (enter/leave, push/pop) on the normal
path, but a mid-walk bail — the stack-overflow breaker, fuel/recursion
exhaustion, or a panic caught by the batch driver — leaves a depth counter
non-zero or a visited-set non-empty. Because worker threads are reused
across files (within a compilation, and across compilations in a batch
worker), a dirty guard left by one file suppresses resolution in the next
file scheduled onto the same thread. File→worker assignment depends on the
parallel schedule, so the resulting diagnostic is nondeterministic.

> A per-thread resolution guard must not survive a file boundary on a
> reused worker thread; a bail in one file must be unable to leak into
> another.

## Owner layer

Checker. `clear_all_thread_local_state` already resets exactly these guards
— but only on the main thread at the **compilation** boundary, never on the
pool worker threads at a **file** boundary. The guard subset (everything
except the warm cross-file module-specifier memo, which is correct to keep
warm across files within a compilation) is extracted into
`reset_per_file_resolution_guards` and run at every file boundary:

- `check_file_for_parallel` (fresh-checker path — both arms), and
- `reset_for_next_file` (session-reuse path — replaces its narrower
  three-cache clear with the same superset).

`clear_all_thread_local_state` now delegates the guard reset and only adds
the warm-memo drop, so the two stay in sync (the existing drift-guard test
still covers the recursion-guard subset).

## Anti-hardcoding

No identifier/file-name/printer-string predicates. The reset keys only on
the structural "this thread is at a file boundary" fact; the new test
dirties the guards via the existing `*_for_test` helpers and asserts the
reset clears them, with no name dependence.

## Adjacent-case matrix

- Fresh sequential arm and fresh parallel arm both route through
  `check_file_for_parallel` → both covered by one chokepoint.
- Session-reuse arms (sequential, parallel-chunks, cost-balanced pool) all
  route through `switch_to_file` → `reset_for_next_file` → covered.
- Clean boundary (the common case): guards already empty → reset is a
  no-op → output byte-identical.
- Dirty boundary (post-bail): guards restored → next file resolves
  correctly instead of being suppressed.

## Performance

Per-file cost is ~9 thread-local counter `set(0)`s plus clearing
normally-empty visited-sets/maps — negligible on the hot check path, and a
no-op on a clean boundary. Warm cross-file memos are intentionally
preserved, so multi-file cold-start cost is unchanged.

## Verification

- `cargo test -p tsz-checker --lib reset_per_file_resolution_guards_clears_cross_arena_and_alias_guards` — passes (new guard-contract test).
- `cargo test -p tsz-checker --lib thread_local_state` — the refactored `clear_all_thread_local_state` drift-guard tests still pass.
- `cargo test -p tsz-cli --test parallel_sequential_agreement_tests` — 6/6 pass (parallel-vs-sequential determinism).
- Full `tsz-checker` lib suite vs clean `main`: **+1 passing test (the new one), 0 new failures** (the 75 pre-existing full-suite schedule-sensitive failures are identical on both).
- Output parity: the `inferentialTypingWithFunctionTypeZip` witness and a multi-file cross-import project produce byte-identical diagnostics with the change.
- `cargo fmt --check` + `cargo clippy --lib` clean on `tsz-checker` and `tsz-cli`; touched files stay under the 2000-line cap.
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_012wppQtT1Les32wZoMmbGX6

---
_Generated by [Claude Code](https://claude.ai/code/session_012wppQtT1Les32wZoMmbGX6)_