### PR TITLE
test(checker): make built-in collection heritage guards load real libs

### DIFF
--- a/crates/tsz-checker/src/tests/builtin_iterator_implements_tests.rs
+++ b/crates/tsz-checker/src/tests/builtin_iterator_implements_tests.rs
@@ -1,37 +1,72 @@
 //! Regression tests for false-positive TS2416 / TS2322 when a class
 //! implements a built-in collection type that spans multiple lib declaration
-//! files (e.g. `Map<K,V>`, `Set<T>`, `WeakMap<K,V>`).
+//! files (e.g. `Map<K,V>`, `Set<T>`, `WeakMap<K,V>`), plus genuine override and
+//! iterator-heritage parity guards for that same lib-materialization path.
 //!
-//! Root cause: `compute_interface_type_from_declarations` used a single
-//! `self.ctx.arena` for *all* declarations of the built-in symbol, but each
-//! lib file has its own `NodeArena` with independent `NodeIndex` spaces.
-//! Using the wrong arena would retrieve an unrelated AST node (often the
-//! `Iterable` interface), whose `[Symbol.iterator](): Iterator<T, TReturn, TNext>`
-//! signature leaked into the resolved type and caused false override-mismatch
-//! errors.
+//! Root cause of the original report: `compute_interface_type_from_declarations`
+//! used a single `self.ctx.arena` for *all* declarations of the built-in
+//! symbol, but each lib file has its own `NodeArena` with independent
+//! `NodeIndex` spaces. Using the wrong arena would retrieve an unrelated AST
+//! node (often the `Iterable` interface), whose
+//! `[Symbol.iterator](): Iterator<T, TReturn, TNext>` signature leaked into the
+//! resolved type and caused false override-mismatch errors.
 //!
 //! Fix: when cross-arena delegation is active, resolve each declaration with
 //! its own `NodeArena` via `lower_merged_interface_declarations_with_symbol`.
 //!
+//! Test integrity: every assertion here references a lib collection type
+//! (`Map`/`Set`/`WeakMap`/`MapIterator`/`SetIterator`/`Symbol`), so the checks
+//! are only meaningful when those types are actually resolved. The shared
+//! helpers therefore load the real default libs ([`load_default_lib_files`]) —
+//! the minimal unit-test lib used by `check_source_codes` does not declare the
+//! collection types, which would leave every `Set`/`Map` reference an
+//! unresolved name (TS2304/TS2583) and make the guards pass vacuously without
+//! ever exercising the multi-arena heritage flattening they exist to protect.
+//!
 //! Issue: <https://github.com/tsz-org/tsz/issues/8422>
 
-use crate::test_utils::check_source_codes;
+use std::sync::{Arc, OnceLock};
+use tsz_binder::lib_loader::LibFile;
 
-fn assert_no_2416(src: &str) {
-    let codes = check_source_codes(src);
-    assert!(!codes.contains(&2416), "unexpected TS2416. Got: {codes:?}");
+use crate::CheckerOptions;
+use crate::test_utils::{
+    check_source_with_libs_code_messages, diagnostic_codes, load_default_lib_files,
+};
+
+/// The default lib bundle, parsed exactly once and shared across every test in
+/// this module (and across the harness's worker threads).
+fn default_libs() -> &'static [Arc<LibFile>] {
+    static DEFAULT_LIBS: OnceLock<Vec<Arc<LibFile>>> = OnceLock::new();
+    DEFAULT_LIBS.get_or_init(load_default_lib_files)
 }
 
-fn assert_no_2322(src: &str) {
-    let codes = check_source_codes(src);
-    assert!(!codes.contains(&2322), "unexpected TS2322. Got: {codes:?}");
+/// Type-check `src` as `test.ts` with the full default lib bundle loaded so
+/// that the collection/iterator types resolve, returning `(code, message)`.
+fn check_with_libs(src: &str) -> Vec<(u32, String)> {
+    check_source_with_libs_code_messages(src, "test.ts", CheckerOptions::default(), default_libs())
 }
 
+/// Assert the snippet is fully clean. This is strictly stronger than the old
+/// `!contains(2416)` form: it also fails if a collection type fails to resolve
+/// (TS2304/TS2583) — i.e. it guarantees the heritage path is actually
+/// exercised — and if any other false positive creeps in.
+fn assert_fully_clean(src: &str) {
+    let diags = check_with_libs(src);
+    assert!(diags.is_empty(), "expected no diagnostics, got: {diags:?}");
+}
+
+/// Assert TS2416 fires (a genuine override incompatibility) and no lib type was
+/// left unresolved (so the override is checked against real lib members).
 fn assert_has_2416(src: &str) {
-    let codes = check_source_codes(src);
+    let diags = check_with_libs(src);
+    let codes = diagnostic_codes(&diags);
     assert!(
         codes.contains(&2416),
-        "expected TS2416, got none. Got: {codes:?}"
+        "expected TS2416, got none. Got: {diags:?}"
+    );
+    assert!(
+        !codes.contains(&2304) && !codes.contains(&2583),
+        "lib type left unresolved — guard would be vacuous: {diags:?}"
     );
 }
 
@@ -41,7 +76,7 @@ fn assert_has_2416(src: &str) {
 
 #[test]
 fn no_false_positive_ts2416_class_extends_map() {
-    assert_no_2416(
+    assert_fully_clean(
         "
 class MyMap extends Map<string, number> {
     [Symbol.iterator](): MapIterator<[string, number]> {
@@ -54,7 +89,7 @@ class MyMap extends Map<string, number> {
 
 #[test]
 fn no_false_positive_ts2416_class_implements_map_generic_name_k_v() {
-    assert_no_2416(
+    assert_fully_clean(
         "
 class KVMap<K, V> extends Map<K, V> {
     [Symbol.iterator](): MapIterator<[K, V]> {
@@ -71,7 +106,7 @@ class KVMap<K, V> extends Map<K, V> {
 
 #[test]
 fn no_false_positive_ts2416_class_extends_set() {
-    assert_no_2416(
+    assert_fully_clean(
         "
 class NumberSet extends Set<number> {
     [Symbol.iterator](): SetIterator<number> {
@@ -84,7 +119,7 @@ class NumberSet extends Set<number> {
 
 #[test]
 fn no_false_positive_ts2416_class_extends_set_generic_element() {
-    assert_no_2416(
+    assert_fully_clean(
         "
 class TypedSet<E> extends Set<E> {
     [Symbol.iterator](): SetIterator<E> {
@@ -97,7 +132,7 @@ class TypedSet<E> extends Set<E> {
 
 #[test]
 fn no_false_positive_ts2416_merged_lib_interface_symbol_prepasses_use_decl_arenas() {
-    assert_no_2416(
+    assert_fully_clean(
         "
 interface Map<K, V> {
     [Symbol.toStringTag]: string;
@@ -114,10 +149,10 @@ class TaggedMap extends Map<string, number> {
 
 // ---------------------------------------------------------------------------
 // Negative / sanity cases — genuine mismatches must still produce TS2416.
-// The cross-arena fix must not suppress errors for real violations.
-// Note: tsz has a pre-existing gap detecting return-type incompatibility on
-// symbol-keyed overrides ([Symbol.iterator]); those are tracked separately.
-// These tests use named method overrides which tsz does reliably detect.
+// The cross-arena fix must not suppress errors for real violations. This
+// covers named, `[Symbol.iterator]`-keyed, `unique symbol`-keyed, and
+// string-literal computed-key overrides so the override check is verified to
+// fire regardless of how the member key is spelled.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -155,7 +190,7 @@ class DerivedX extends BaseX {
 
 #[test]
 fn no_false_positive_ts2322_map_entries_destructure() {
-    assert_no_2322(
+    assert_fully_clean(
         "
 function processMap(m: Map<string, number>) {
     for (const [k, v] of m) {
@@ -169,7 +204,7 @@ function processMap(m: Map<string, number>) {
 
 #[test]
 fn no_false_positive_ts2322_set_values_destructure() {
-    assert_no_2322(
+    assert_fully_clean(
         "
 function processSet(s: Set<number>) {
     for (const v of s) {
@@ -189,7 +224,7 @@ function processSet(s: Set<number>) {
 
 #[test]
 fn no_false_positive_ts2416_const_symbol_computed_property_name() {
-    assert_no_2416(
+    assert_fully_clean(
         "
 const sym = Symbol();
 interface IBase { [sym](): number; }
@@ -200,7 +235,7 @@ class ConcreteA implements IBase { [sym](): number { return 0; } }
 
 #[test]
 fn no_false_positive_ts2416_const_symbol_computed_property_name_renamed_var() {
-    assert_no_2416(
+    assert_fully_clean(
         "
 const myKey = Symbol();
 interface IBase2 { [myKey](): string; }
@@ -216,7 +251,7 @@ class ConcreteB implements IBase2 { [myKey](): string { return ''; } }
 
 #[test]
 fn no_false_positive_ts2416_class_extends_weak_map() {
-    assert_no_2416(
+    assert_fully_clean(
         "
 class TrackedWeakMap<K extends object, V> extends WeakMap<K, V> {
     override set(key: K, value: V): this {
@@ -229,12 +264,129 @@ class TrackedWeakMap<K extends object, V> extends WeakMap<K, V> {
 
 #[test]
 fn no_false_positive_ts2416_class_extends_weak_map_generic_name_a_b() {
-    assert_no_2416(
+    assert_fully_clean(
         "
 class TrackedWeakMap<A extends object, B> extends WeakMap<A, B> {
     override set(key: A, value: B): this {
         return super.set(key, value);
     }
+}
+",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Genuine override mismatches keyed by a symbol / computed name must still be
+// detected. The cross-arena heritage materialization must not become a blind
+// spot for return-type incompatibility on non-identifier member keys.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn genuine_ts2416_symbol_iterator_keyed_override_wrong_return() {
+    assert_has_2416(
+        "
+class Base {
+    [Symbol.iterator](): number { return 1; }
+}
+class Sub extends Base {
+    [Symbol.iterator](): string { return ''; }
+}
+",
+    );
+}
+
+#[test]
+fn genuine_ts2416_unique_symbol_keyed_override_wrong_return() {
+    assert_has_2416(
+        "
+const k: unique symbol = Symbol();
+class Base {
+    [k](): number { return 1; }
+}
+class Sub extends Base {
+    [k](): string { return ''; }
+}
+",
+    );
+}
+
+#[test]
+fn genuine_ts2416_string_literal_computed_override_wrong_return() {
+    assert_has_2416(
+        "
+class Base {
+    ['foo'](): number { return 1; }
+}
+class Sub extends Base {
+    ['foo'](): string { return ''; }
+}
+",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Iterator-heritage assignability: `Set`/`Map` collection iterators
+// (`SetIterator<T>` / `MapIterator<T>`) must flatten their heritage chain
+// `… extends IteratorObject<T,…> extends Iterator<T,…>` so that `next` is a
+// visible member and the iterator is assignable to `IterableIterator<T>`. This
+// is the lib-iterator-heritage materialization path that the immer canary
+// (#13942) reports drops at full-project scale; these guards pin the isolated
+// contract so a regression in heritage flattening is caught directly.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_values_iterator_assignable_to_iterable_iterator() {
+    assert_fully_clean(
+        "
+function f(s: Set<number>): IterableIterator<number> {
+    return s.values();
+}
+",
+    );
+}
+
+#[test]
+fn map_entries_iterator_assignable_to_iterable_iterator() {
+    assert_fully_clean(
+        "
+function f(m: Map<string, number>): IterableIterator<[string, number]> {
+    return m.entries();
+}
+",
+    );
+}
+
+#[test]
+fn set_values_iterator_exposes_inherited_next_member() {
+    assert_fully_clean(
+        "
+function f(s: Set<number>) {
+    const it = s.values();
+    it.next();
+}
+",
+    );
+}
+
+#[test]
+fn array_from_map_entries_infers_tuple_element() {
+    assert_fully_clean(
+        "
+function f(m: Map<string, number>) {
+    const arr = Array.from(m.entries());
+    const x: [string, number] = arr[0];
+}
+",
+    );
+}
+
+#[test]
+fn spread_set_values_infers_element_type() {
+    assert_fully_clean(
+        "
+function f(s: Set<number>) {
+    const arr = [...s.values()];
+    const x: number = arr[0];
 }
 ",
     );


### PR DESCRIPTION
Goal: hold

## Summary

The `#8422` regression suite (`builtin_iterator_implements_tests.rs`) guards against false `TS2416`/`TS2322` when a class extends a built-in collection type that spans multiple lib declaration files (`Map`/`Set`/`WeakMap` → `MapIterator`/`SetIterator` → `IteratorObject` → `Iterator`). Its assertions all ran through `check_source_codes`, whose **minimal** unit-test lib does **not** declare the collection types.

As a result every `Set`/`Map`/`SetIterator` reference in those snippets resolved to an unbound name (**TS2304/TS2583**), so the `!contains(2416)` guards passed **vacuously** — they never exercised the multi-arena heritage flattening they exist to protect. Verified directly: `check_source_codes("function f(s: Set<number>) {…}")` returns `[2583]` "Cannot find name 'Set'. … change the 'lib' compiler option to 'es2015' or later."

This is a hole in the `hold` parity floor for exactly the lib-heritage materialization area that keeps regressing (#13862 DOM/lib heritage; #13942 immer FP#3/#4/#7 `SetIterator`/`MapIterator` "missing `next`").

## What this changes (test-only)

- The suite now loads the **real** default libs (`load_default_lib_files`, parsed once via a module `OnceLock`) so the collection/iterator types actually resolve.
- Positive guards assert **full cleanliness** (`diags.is_empty()`) instead of the old narrow `!contains(2416)` — strictly stronger: a collection type that fails to resolve, or any other false positive, now fails the guard.
- `assert_has_2416` additionally asserts no `TS2304`/`TS2583`, so a negative guard can never pass while a lib type is unresolved.
- New genuine override-mismatch guards (must still emit `TS2416`) keyed by `[Symbol.iterator]`, a `unique symbol`, and a string-literal computed name — the file previously documented symbol-keyed override return-type checking as a "pre-existing gap"; it is now reliably detected, and these lock it in (stale comment removed).
- New iterator-heritage assignability guards: `Set#values()`/`Map#entries()` flatten their heritage to expose `next` and are assignable to `IterableIterator<T>`; `Array.from`/spread element inference over collection iterators. These pin the isolated contract behind the immer #13942 FP family (which only manifests at full-project scale, so it is not fixed here — only guarded in isolation).

No production code changes; no behavior change. The previously-vacuous scenarios all pass under real libs, so this restores genuine protection for the landed #8422 cross-arena fix rather than masking a regression.

## Anti-hardcoding

No identifier/file-name/printer-string predicates. The negative guards vary binder names (`Base`/`Sub`/`k`/`'foo'`) and key spellings; the assertions key only on diagnostic codes.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- `cargo test -p tsz-checker --lib builtin_iterator_implements` — **21 passed, 0 failed** (was 12 vacuous + 0 real lib-resolution; now all 21 resolve the lib types and assert real cleanliness/detection).
- Vacuity confirmed pre-change: `check_source_codes` with a `Set<number>` snippet returns `[2583]` (unresolved `Set`), proving the old guards passed without the types existing.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib --tests` clean.
- File stays well under the 2000-line cap (394 lines).
- Broad conformance / emit / fourslash owned by ready-review CI per repo policy.

https://claude.ai/code/session_01NkiWCEKQTWuvcWccPCvw2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkiWCEKQTWuvcWccPCvw2G)_