### PR TITLE
fix(checker): node-global in type position gets install-@types diagnostic (TS2591)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/name_resolution.rs
+++ b/crates/tsz-checker/src/error_reporter/name_resolution.rs
@@ -1020,6 +1020,15 @@ impl<'a> CheckerState<'a> {
         // Route through the environment capability boundary for known globals.
         // `diagnose_missing_name` returns a structured CapabilityDiagnostic that
         // tells us which error to emit, keeping the decision centralized.
+        // Route through the environment capability boundary for known globals.
+        // `diagnose_missing_name` returns a structured CapabilityDiagnostic that
+        // tells us which error to emit. The es2015 "change target library" and
+        // DOM cases are value-position specific (tsc gates es2015 on a narrow
+        // value-lib set, and the es2015/DOM type-position cases are handled by
+        // `check_missing_global_types`), so they stay here. The position-
+        // independent "install @types/X" categories (Node, jQuery, test runner,
+        // Bun) are reported the same way in value and type position, so they live
+        // in the shared `try_emit_install_types_for_missing_global` helper.
         use crate::query_boundaries::environment::CapabilityDiagnostic;
         if let Some(cap_diag) = self.ctx.capabilities.diagnose_missing_name(name) {
             match cap_diag {
@@ -1038,34 +1047,11 @@ impl<'a> CheckerState<'a> {
                     self.error_cannot_find_name_change_target_lib(name, idx);
                     return;
                 }
-                CapabilityDiagnostic::MissingJQueryGlobal { .. } => {
-                    self.error_cannot_find_name_install_jquery_types(name, idx);
-                    return;
-                }
-                CapabilityDiagnostic::MissingNodeGlobal { .. } => {
-                    // Special cases: private-name access and "module" with parse errors
-                    // fall through to TS2304 instead of TS2591.
-                    if self.is_private_name_access_base(idx)
-                        || (name == "module" && self.has_parse_errors())
-                    {
-                        // Fall through to TS2304
-                    } else {
-                        self.error_cannot_find_name_install_node_types(name, idx);
-                        return;
-                    }
-                }
-                CapabilityDiagnostic::MissingTestRunnerGlobal { .. } => {
-                    self.error_cannot_find_name_install_test_types(name, idx);
-                    return;
-                }
-                CapabilityDiagnostic::MissingBunGlobal { .. } => {
-                    self.error_cannot_find_name_install_bun_types(name, idx);
-                    return;
-                }
-                // MissingGlobalType and FeatureRequiresGlobalType are handled by
-                // check_missing_global_types, not the name resolution path.
                 _ => {}
             }
+        }
+        if self.try_emit_install_types_for_missing_global(name, idx) {
+            return;
         }
 
         // The boundary's `report_name_resolution_failure` already checked for
@@ -1084,6 +1070,59 @@ impl<'a> CheckerState<'a> {
             let diag = builder.cannot_find_name(name, loc.start, loc.length());
             self.ctx
                 .push_diagnostic(diag.to_checker_diagnostic(&self.ctx.file_name));
+        }
+    }
+
+    /// Emit the "install @types/X" diagnostic for a missing global whose
+    /// category is reported the same way in value and type position: Node.js
+    /// (TS2591), jQuery, a test runner, or Bun. Returns `true` if a diagnostic
+    /// was emitted; `false` when `name` is not such a global (or a Node
+    /// special-case falls through), so callers emit their own position-correct
+    /// plain `Cannot find name` (TS2304).
+    ///
+    /// The es2015 "change target library" (TS2583) and DOM cases are
+    /// intentionally NOT handled here: tsc's choice there depends on
+    /// value-vs-type position (the es2015 value-lib gate, and
+    /// `check_missing_global_types` for type position), and type position
+    /// already matches tsc for those. This helper is the single source of truth
+    /// for the position-independent categories, shared by the value path
+    /// ([`error_cannot_find_name_at`]) and the type-position name-resolution
+    /// failure arm.
+    pub(crate) fn try_emit_install_types_for_missing_global(
+        &mut self,
+        name: &str,
+        idx: NodeIndex,
+    ) -> bool {
+        use crate::query_boundaries::environment::CapabilityDiagnostic;
+        let Some(cap_diag) = self.ctx.capabilities.diagnose_missing_name(name) else {
+            return false;
+        };
+        match cap_diag {
+            CapabilityDiagnostic::MissingNodeGlobal { .. } => {
+                // Private-name access bases and `module` amid parse errors fall
+                // through to plain TS2304, matching tsc and the value path.
+                if self.is_private_name_access_base(idx)
+                    || (name == "module" && self.has_parse_errors())
+                {
+                    false
+                } else {
+                    self.error_cannot_find_name_install_node_types(name, idx);
+                    true
+                }
+            }
+            CapabilityDiagnostic::MissingJQueryGlobal { .. } => {
+                self.error_cannot_find_name_install_jquery_types(name, idx);
+                true
+            }
+            CapabilityDiagnostic::MissingTestRunnerGlobal { .. } => {
+                self.error_cannot_find_name_install_test_types(name, idx);
+                true
+            }
+            CapabilityDiagnostic::MissingBunGlobal { .. } => {
+                self.error_cannot_find_name_install_bun_types(name, idx);
+                true
+            }
+            _ => false,
         }
     }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1354,6 +1354,9 @@ mod ts2565_jsdoc_prototype_type_decl_tests;
 #[path = "tests/ts2590_array_literal_identity_skip_tests.rs"]
 mod ts2590_array_literal_identity_skip_tests;
 #[cfg(test)]
+#[path = "tests/ts2591_node_global_type_position_tests.rs"]
+mod ts2591_node_global_type_position_tests;
+#[cfg(test)]
 #[path = "tests/ts2739_alias_unfold_display_tests.rs"]
 mod ts2739_alias_unfold_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/name_resolution.rs
+++ b/crates/tsz-checker/src/query_boundaries/name_resolution.rs
@@ -786,11 +786,21 @@ impl<'a> CheckerState<'a> {
                             request.idx,
                         );
                     } else if matches!(request.kind, NameLookupKind::Type) {
-                        self.error_at_node_msg(
-                            request.idx,
-                            crate::diagnostics::diagnostic_codes::CANNOT_FIND_NAME,
-                            &[request.name],
-                        );
+                        // A missing node/jQuery/test-runner/Bun global in TYPE
+                        // position gets the same "install @types/X" diagnostic
+                        // (e.g. TS2591) tsc emits — `let b: Buffer` without
+                        // @types/node is TS2591, not a bare TS2304. The value
+                        // path runs the same dispatch; es2015/DOM type-position
+                        // cases already match tsc and are handled elsewhere.
+                        if !self
+                            .try_emit_install_types_for_missing_global(request.name, request.idx)
+                        {
+                            self.error_at_node_msg(
+                                request.idx,
+                                crate::diagnostics::diagnostic_codes::CANNOT_FIND_NAME,
+                                &[request.name],
+                            );
+                        }
                     } else {
                         self.error_cannot_find_name_at(request.name, request.idx);
                     }

--- a/crates/tsz-checker/src/tests/ts2591_node_global_type_position_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2591_node_global_type_position_tests.rs
@@ -1,0 +1,82 @@
+//! Node-global cannot-find parity in TYPE position (TS2591).
+//!
+//! Structural rule: a missing Node.js global (`Buffer`, …) used as a *type*
+//! gets the same "install @types/node" diagnostic (TS2591) tsc emits in value
+//! position — `let b: Buffer` without `@types/node` is TS2591, not a bare
+//! TS2304. tsz's type-position name-resolution failure arm previously emitted
+//! plain TS2304, skipping the capability dispatch that the value path runs.
+//!
+//! The fix routes the position-independent "install @types/X" categories
+//! (Node/jQuery/test-runner/Bun) through the shared
+//! `try_emit_install_types_for_missing_global` helper from both paths. The
+//! es2015 ("change target library", TS2583) and DOM cases are excluded — they
+//! already match tsc in type position — so this is verified to NOT change them.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+/// TS2591: Cannot find name 'X'. Do you need to install type definitions for node?
+const TS2591: u32 = 2591;
+/// TS2304: Cannot find name 'X'. (generic)
+const TS2304: u32 = 2304;
+/// TS2583: Cannot find name 'X'. Do you need to change your target library?
+const TS2583: u32 = 2583;
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+#[test]
+fn node_global_in_type_annotation_position_reports_install_node_types() {
+    // `let b: Buffer` with no @types/node — tsc emits TS2591, not TS2304.
+    let codes = check_strict("let value: Buffer;");
+    assert_eq!(count(&codes, TS2591), 1, "expected TS2591, got: {codes:?}");
+    assert_eq!(
+        count(&codes, TS2304),
+        0,
+        "must not emit bare TS2304: {codes:?}"
+    );
+}
+
+#[test]
+fn node_global_in_parameter_type_position_reports_install_node_types() {
+    let codes = check_strict("function handle(chunk: Buffer) { return chunk; }");
+    assert_eq!(count(&codes, TS2591), 1, "expected TS2591, got: {codes:?}");
+    assert_eq!(count(&codes, TS2304), 0);
+}
+
+// Value-position node-global parity (`Buffer.from(...)` -> TS2591) is covered by
+// the CLI/canary verification and the moduleResolution conformance family; the
+// unit-test lib resolves `Buffer` as a value, so there is no cannot-find there
+// to assert on. The value path's behavior is unchanged — it now routes the same
+// install-@types categories through the shared helper.
+
+#[test]
+fn unknown_non_global_type_still_reports_plain_cannot_find_name() {
+    // A name that is not a known environment global stays TS2304 in type position.
+    let codes = check_strict("let thing: SomeProjectLocalType;");
+    assert_eq!(
+        count(&codes, TS2304),
+        1,
+        "non-global must stay TS2304: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, TS2591),
+        0,
+        "must not gain a node hint: {codes:?}"
+    );
+}
+
+#[test]
+fn es2015_global_in_type_position_keeps_change_target_library() {
+    // `Map` as a type (no es2015 lib) is the "change your target library"
+    // case (TS2583) — the fix must NOT reroute it to a node/install hint.
+    let codes = check_strict("let m: Map<string, number>;");
+    assert_eq!(
+        count(&codes, TS2591),
+        0,
+        "es2015 global must not get a node hint: {codes:?}"
+    );
+    // Either TS2583 (change lib) or, depending on the test lib, resolved; the
+    // invariant under test is simply that it is NOT rerouted to TS2591.
+    let _ = TS2583;
+}


### PR DESCRIPTION
## Summary

A missing Node.js global used as a **type** (`let b: Buffer`, `function f(chunk: Buffer)`)
with no `@types/node` emitted a bare **TS2304**, but `tsc` emits **TS2591**
("Cannot find name 'Buffer'. Do you need to install type definitions for node?
Try `npm i --save-dev @types/node` …"). tsz already emits TS2591 in *value*
position; only the **type**-position path was wrong.

## Structural rule

`When a missing global belongs to an "install @types/X" category (Node, jQuery,
test runner, Bun), tsc emits the category-specific diagnostic in BOTH value and
type position.` The type-position name-resolution failure arm
(`query_boundaries/name_resolution.rs`) emitted plain `CANNOT_FIND_NAME`,
skipping the environment-capability dispatch (`capabilities.diagnose_missing_name`
→ `CapabilityDiagnostic`) that the value path (`error_cannot_find_name_at`) runs.

## Owner layer

Checker name-resolution diagnostics. Extracted the position-independent
install-@types dispatch into a shared
`error_reporter::name_resolution::try_emit_install_types_for_missing_global`
helper, called from **both** the value path and the type-position arm. The
es2015 "change target library" (TS2583) and DOM cases are intentionally excluded
— `tsc`'s choice there is value-vs-type nuanced (the es2015 value-lib gate; type
position handled by `check_missing_global_types`) and type position already
matches `tsc`.

## Adjacent-case matrix (6-case suite, byte-for-byte parity with tsc, `--lib es5`)

- `let b: Buffer` / `chunk: Buffer` (node, type pos): **TS2591** (was TS2304) — fixed.
- `Buffer.from(...)` (node, value pos): TS2591 — preserved (value path shares the helper).
- `let m: Map<…>` (es2015, type pos): TS2583 — unchanged.
- `let h: HTMLElement` (dom, type pos): TS2304 — unchanged.
- `let u: SomeUndefinedType` (non-global, type pos): TS2304 — unchanged.

Goal: green

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- New regression test `ts2591_node_global_type_position_tests` (4 cases): 4/4 pass.
- 6-case hand suite: `diff` vs `tsc` empty (code+name parity) incl. all negatives above.
- trpc canary: zero `tsz`-only TS2304/TS2591 lines after fix (`comm -23` vs `tsc`
  oracle); clears the node-global type-position FPs (e.g.
  `incomingMessageToRequest.ts` `chunk: Buffer`).
- Conformance (prebuilt dist-fast, all 100%): moduleResolution 111/111, library
  20/20, ambient 59/59, typeReferenceDirectives 13/13, salsa 191/191, expressions
  377/377, importDeclaration 9/9, externalModules 227/227.
- `python3 scripts/arch/arch_guard.py` passes;
  `cargo clippy --workspace --all-targets -- -D warnings` clean;
  `cargo fmt --all --check` clean.
