### PR TITLE
fix(resolver): exports field blocks typesVersions fallback for subpaths

### DIFF
--- a/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
+++ b/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
@@ -612,21 +612,16 @@ impl ModuleResolver {
                         extension: ModuleExtension::from_path(&resolved),
                     });
                 }
-                if let Some(types_versions) = &package_json.types_versions
-                    && let Some(resolved) =
-                        self.resolve_types_versions(package_dir, subpath, types_versions, target_pt)
-                {
-                    return Ok(ResolvedModule {
-                        resolved_path: resolved.clone(),
-                        resolved_using_ts_extension: false,
-                        is_external: true,
-                        package_name: Some(package_json.name.clone().unwrap_or_default()),
-                        original_specifier: original_specifier.to_string(),
-                        extension: ModuleExtension::from_path(&resolved),
-                    });
-                }
-                // In Node16/NodeNext/Bundler, exports field is authoritative for subpaths
-                // only after typesVersions fallback has also failed.
+                // In Node16/NodeNext/Bundler an `exports` field is authoritative:
+                // a subpath that the `exports` map does not expose is unresolved,
+                // and `typesVersions` must NOT be consulted as a fallback. This
+                // mirrors tsc's `loadModuleFromSpecificNodeModulesDirectory`, where
+                // `loadModuleFromExports` returns unconditionally when `exports` is
+                // present ("package exports are higher priority than
+                // file/directory/typesVersions lookups and ... blocks them"), so the
+                // `versionPaths`/`typesVersions` branch is never reached. The legacy
+                // `typesVersions` field only applies to packages WITHOUT an `exports`
+                // map (handled below).
                 if matches!(
                     self.resolution_kind,
                     ModuleResolutionKind::Node16

--- a/crates/tsz-core/src/module_resolver/tests/package_exports_imports.rs
+++ b/crates/tsz-core/src/module_resolver/tests/package_exports_imports.rs
@@ -10,6 +10,7 @@
 //!   absolute targets, bare-imports validity)
 
 use super::super::*;
+use super::fixtures::TempFixture;
 
 #[test]
 fn test_resolver_rejects_root_slash_package_import_with_wildcard() {
@@ -1141,5 +1142,167 @@ fn test_wildcard_export_beats_directory_key_independent_of_declaration_order() {
         resolved_b,
         star_then_dir.join("node_modules/pkg/dist/foo.d.ts"),
         "`./*` must win over `./` regardless of declaration order"
+    );
+}
+
+// ===========================================================================
+// `exports` authority over the legacy `typesVersions` field
+//
+// tsc's `loadModuleFromSpecificNodeModulesDirectory` returns from
+// `loadModuleFromExports` unconditionally when a package declares `exports`
+// ("package exports are higher priority than file/directory/typesVersions
+// lookups and ... blocks them"). So under Node16/NodeNext/Bundler the legacy
+// `typesVersions` field must NOT be consulted as a fallback when `exports` is
+// present: a subpath the `exports` map does not expose is unresolved (TS2307),
+// even if a `typesVersions` pattern would otherwise map it to an existing file.
+// `typesVersions` still applies to packages that declare NO `exports` map.
+// ===========================================================================
+
+/// A non-exported subpath must not fall back to `typesVersions` when the
+/// package declares an `exports` map (Node16). Even though the `typesVersions`
+/// target file exists on disk, `exports` authority blocks it.
+#[test]
+fn exports_present_blocks_types_versions_fallback_for_subpath_node16() {
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write("src/index.ts", "import {} from 'widget/internals';");
+    fixture.write(
+        "node_modules/widget/package.json",
+        r#"{
+            "name": "widget",
+            "exports": { "./panel": "./panel.js" },
+            "typesVersions": { ">=3.1": { "*": ["typed/*"] } }
+        }"#,
+    );
+    // The `typesVersions` target exists, but `exports` is authoritative.
+    fixture.write(
+        "node_modules/widget/typed/internals.d.ts",
+        "export const x = 0;",
+    );
+    fixture.write("node_modules/widget/panel.d.ts", "export const panel = 0;");
+
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        resolve_package_json_exports: true,
+        types_versions_compiler_version: Some("3.1.0".to_string()),
+        ..Default::default()
+    });
+    let result = resolver.resolve(
+        "widget/internals",
+        &dir.join("src/index.ts"),
+        Span::new(0, 1),
+    );
+
+    assert!(
+        matches!(result, Err(ResolutionFailure::NotFound { .. })),
+        "exports is authoritative: a non-exported subpath must not fall back to \
+         typesVersions, got {result:?}"
+    );
+}
+
+/// Same `exports`-authority rule under Bundler resolution, with a wildcard
+/// `exports` map that still does not cover the requested subpath.
+#[test]
+fn exports_present_blocks_types_versions_fallback_for_subpath_bundler() {
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write("app/main.ts", "import {} from 'gadget/secret';");
+    fixture.write(
+        "node_modules/gadget/package.json",
+        r#"{
+            "name": "gadget",
+            "exports": { "./public/*": "./lib/public/*.js" },
+            "typesVersions": { "*": { "*": ["legacy/*"] } }
+        }"#,
+    );
+    fixture.write(
+        "node_modules/gadget/legacy/secret.d.ts",
+        "export const s = 0;",
+    );
+
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Bundler),
+        resolve_package_json_exports: true,
+        ..Default::default()
+    });
+    let result = resolver.resolve("gadget/secret", &dir.join("app/main.ts"), Span::new(0, 1));
+
+    assert!(
+        matches!(result, Err(ResolutionFailure::NotFound { .. })),
+        "Bundler: a subpath outside the exports map must not resolve via \
+         typesVersions, got {result:?}"
+    );
+}
+
+/// Control: an exported subpath still resolves through `exports` (the fix must
+/// not break exports-based subpath resolution).
+#[test]
+fn exports_present_still_resolves_exported_subpath() {
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write("src/app.ts", "import {} from 'gizmo/panel';");
+    fixture.write(
+        "node_modules/gizmo/package.json",
+        r#"{
+            "name": "gizmo",
+            "exports": { "./panel": "./panel.js" },
+            "typesVersions": { ">=3.1": { "*": ["typed/*"] } }
+        }"#,
+    );
+    fixture.write("node_modules/gizmo/panel.d.ts", "export const panel = 0;");
+
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        resolve_package_json_exports: true,
+        types_versions_compiler_version: Some("3.1.0".to_string()),
+        ..Default::default()
+    });
+    let resolved = resolver
+        .resolve("gizmo/panel", &dir.join("src/app.ts"), Span::new(0, 1))
+        .expect("an exported subpath must still resolve through exports");
+
+    assert_eq!(
+        resolved.resolved_path,
+        dir.join("node_modules/gizmo/panel.d.ts")
+    );
+}
+
+/// Control: a package that declares NO `exports` map still honors the legacy
+/// `typesVersions` field for subpaths (the fix only blocks typesVersions when
+/// exports is present).
+#[test]
+fn no_exports_subpath_still_uses_types_versions() {
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write("src/app.ts", "import {} from 'doohickey/internals';");
+    fixture.write(
+        "node_modules/doohickey/package.json",
+        r#"{
+            "name": "doohickey",
+            "typesVersions": { ">=3.1": { "*": ["typed/*"] } }
+        }"#,
+    );
+    fixture.write(
+        "node_modules/doohickey/typed/internals.d.ts",
+        "export const x = 0;",
+    );
+
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        resolve_package_json_exports: true,
+        types_versions_compiler_version: Some("3.1.0".to_string()),
+        ..Default::default()
+    });
+    let resolved = resolver
+        .resolve(
+            "doohickey/internals",
+            &dir.join("src/app.ts"),
+            Span::new(0, 1),
+        )
+        .expect("without an exports map, typesVersions still resolves the subpath");
+
+    assert_eq!(
+        resolved.resolved_path,
+        dir.join("node_modules/doohickey/typed/internals.d.ts")
     );
 }

--- a/crates/tsz-core/src/module_resolver/tests/package_exports_imports.rs
+++ b/crates/tsz-core/src/module_resolver/tests/package_exports_imports.rs
@@ -1257,12 +1257,12 @@ fn exports_present_still_resolves_exported_subpath() {
         types_versions_compiler_version: Some("3.1.0".to_string()),
         ..Default::default()
     });
-    let resolved = resolver
+    let exported_subpath = resolver
         .resolve("gizmo/panel", &dir.join("src/app.ts"), Span::new(0, 1))
         .expect("an exported subpath must still resolve through exports");
 
     assert_eq!(
-        resolved.resolved_path,
+        exported_subpath.resolved_path,
         dir.join("node_modules/gizmo/panel.d.ts")
     );
 }
@@ -1293,7 +1293,7 @@ fn no_exports_subpath_still_uses_types_versions() {
         types_versions_compiler_version: Some("3.1.0".to_string()),
         ..Default::default()
     });
-    let resolved = resolver
+    let legacy_types_version_subpath = resolver
         .resolve(
             "doohickey/internals",
             &dir.join("src/app.ts"),
@@ -1302,7 +1302,7 @@ fn no_exports_subpath_still_uses_types_versions() {
         .expect("without an exports map, typesVersions still resolves the subpath");
 
     assert_eq!(
-        resolved.resolved_path,
+        legacy_types_version_subpath.resolved_path,
         dir.join("node_modules/doohickey/typed/internals.d.ts")
     );
 }


### PR DESCRIPTION
Goal: green

Refs #13826 (sub-root #2: package `exports` / subpath resolution). Distinct from the in-flight `#imports`-scope and `node:`-classification slices on that umbrella.

## Structural rule

`When a package declares an "exports" map (Node16/NodeNext/Bundler), tsc treats it as authoritative: a subpath the map does not expose is unresolved (TS2307), and the legacy "typesVersions" field is NOT consulted as a fallback. tsz instead probed typesVersions after an exports miss.`

This is the authoritative tsc behavior, read directly from `loadModuleFromSpecificNodeModulesDirectory` (`src/compiler/moduleNameResolver.ts`):

```ts
// "package exports are higher priority than file/directory/typesVersions
//  lookups and (and, if there's exports present, blocks them)"
if (packageInfo && packageInfo.contents.packageJsonContent.exports && state.features & NodeResolutionFeatures.Exports) {
    return loadModuleFromExports(packageInfo, extensions, combinePaths(".", rest), state, ...)?.value; // returns unconditionally
}
const versionPaths = rest !== "" && packageInfo ? getVersionPathsOfPackageJsonInfo(packageInfo, state) : undefined;
```

The `loadModuleFromExports` call `return`s unconditionally when `exports` is present, so the `versionPaths`/`typesVersions` branch below it is unreachable. tsz, by contrast, ran a `typesVersions` lookup between the exports miss and the authoritative `NotFound`, so a subpath that the `exports` map did not expose would still resolve whenever a `typesVersions` pattern happened to map it onto a real file — a false-negative (tsz silently resolves a specifier that tsc rejects with TS2307).

## Owner layer

Module resolver — `crates/tsz-core/src/module_resolver/node_modules_resolution.rs`. The fix removes the `typesVersions` fallback inside the `exports`-present subpath branch; the existing `NotFound` return for Node16/NodeNext/Bundler now fires directly, making `exports` authoritative. The legacy `typesVersions` path lower down (for packages with **no** `exports` map) is unchanged.

## Why this is broad, not a one-off

- Applies to every package with both an `exports` map and a `typesVersions` field, across Node16, NodeNext, and Bundler — not a fixture-shaped patch (no identifier/file-name predicates; binder names varied across the tests).
- The symmetric **package entry-point** branch was audited and is already correct: its exports miss returns `NotFound` for Node16/NodeNext/Bundler *before* reaching `typesVersions`, and tsc consults `typesVersions` for the entry (moduleName `"index"`) only when there is **no** `exports` map — which the entry path already honors. So the fix is complete at the right depth, not a bandaid on one path.

## Adjacent-case matrix (new tests, real on-disk fixtures)

| package shape | request | tsc | tsz (after) |
|---|---|---|---|
| `exports` + `typesVersions`, subpath not exported (Node16) | `widget/internals` | TS2307 | NotFound ✓ (was: resolved via typesVersions) |
| `exports` (wildcard) + `typesVersions`, subpath outside map (Bundler) | `gadget/secret` | TS2307 | NotFound ✓ |
| `exports` + `typesVersions`, exported subpath (Node16) | `gizmo/panel` | resolves | resolves via exports ✓ |
| **no** `exports`, `typesVersions` only (Node16) | `doohickey/internals` | resolves | resolves via typesVersions ✓ |

## Verification

- `cargo test -p tsz-core --lib module_resolver::tests` — **244 passed, 0 failed** (incl. the 4 new precedence tests).
- Bug-catch proof: reverting only the production change (keeping the tests) makes `exports_present_blocks_types_versions_fallback_for_subpath_node16` FAIL (tsz resolves `widget/internals` to `typed/internals.d.ts` via typesVersions); with the fix it returns `NotFound`.
- `cargo fmt -p tsz-core --check` clean; `cargo clippy -p tsz-core --lib --tests` clean (no warnings).
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01WCKFnfkw6SAgMZWBeL1Apf

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCKFnfkw6SAgMZWBeL1Apf)_