### PR TITLE
fix(checker): debug-only purity invariant for stamp-keyed assignability memos (#13980)

### DIFF
--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -655,7 +655,18 @@ impl AssignabilityEvalMemo {
     /// Record an evaluation result computed under `stamp`.
     pub fn insert(&mut self, stamp: AssignabilityEvalStamp, type_id: TypeId, result: TypeId) {
         self.roll_to(stamp);
-        self.entries.insert(type_id, result);
+        let _previous = self.entries.insert(type_id, result);
+        // Debug-only purity invariant (#13980): under a fixed stamp this is a
+        // pure function, so overwriting an entry with a *different* result means
+        // a hidden input (lib-ref resolution eagerness) leaked into type
+        // identity. The displaced value is free; no extra lookup.
+        #[cfg(debug_assertions)]
+        super::eval_memo_purity::record_insert(
+            super::eval_memo_purity::ASSIGNABILITY_EVAL_MEMO,
+            type_id,
+            _previous,
+            &result,
+        );
     }
 
     /// Drop all entries and forget the stamp. Required between file sessions:
@@ -710,7 +721,15 @@ impl AwaitedAssignabilityEvalMemo {
     /// Record a normalization result computed under `stamp`.
     pub fn insert(&mut self, stamp: AssignabilityEvalStamp, type_id: TypeId, result: TypeId) {
         self.roll_to(stamp);
-        self.entries.insert(type_id, result);
+        let _previous = self.entries.insert(type_id, result);
+        // Debug-only purity invariant (#13980); see `AssignabilityEvalMemo::insert`.
+        #[cfg(debug_assertions)]
+        super::eval_memo_purity::record_insert(
+            super::eval_memo_purity::AWAITED_ASSIGNABILITY_EVAL_MEMO,
+            type_id,
+            _previous,
+            &result,
+        );
     }
 
     /// Drop all entries and forget the stamp. Required between file sessions
@@ -734,7 +753,7 @@ pub type AssignabilityFailureKey = (TypeId, TypeId, u16, bool);
 /// post-passes (excess-property suppression, intersection-constituent
 /// framing, array-extends weak-type suppression), which differ per consumer
 /// and must keep running on every path.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CachedAssignabilityAnalysis {
     /// Pass/fail verdict of the relation.
     pub related: bool,
@@ -795,7 +814,17 @@ impl AssignabilityFailureMemo {
         analysis: CachedAssignabilityAnalysis,
     ) {
         self.roll_to(stamp);
-        self.entries.insert(key, analysis);
+        let _previous = self.entries.insert(key, analysis);
+        // Debug-only purity invariant (#13980); see `AssignabilityEvalMemo::insert`.
+        // The value moved into the map, so the just-stored entry is borrowed back
+        // (a debug-only lookup) to compare against the displaced one.
+        #[cfg(debug_assertions)]
+        super::eval_memo_purity::record_insert(
+            super::eval_memo_purity::ASSIGNABILITY_FAILURE_MEMO,
+            key,
+            _previous,
+            self.entries.get(&key).expect("entry was just inserted"),
+        );
     }
 
     /// Drop all entries and forget the stamp (between file sessions; see

--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -655,7 +655,7 @@ impl AssignabilityEvalMemo {
     /// Record an evaluation result computed under `stamp`.
     pub fn insert(&mut self, stamp: AssignabilityEvalStamp, type_id: TypeId, result: TypeId) {
         self.roll_to(stamp);
-        let _previous = self.entries.insert(type_id, result);
+        let previous = self.entries.insert(type_id, result);
         // Debug-only purity invariant (#13980): under a fixed stamp this is a
         // pure function, so overwriting an entry with a *different* result means
         // a hidden input (lib-ref resolution eagerness) leaked into type
@@ -664,9 +664,11 @@ impl AssignabilityEvalMemo {
         super::eval_memo_purity::record_insert(
             super::eval_memo_purity::ASSIGNABILITY_EVAL_MEMO,
             type_id,
-            _previous,
+            previous,
             &result,
         );
+        #[cfg(not(debug_assertions))]
+        let _ = previous;
     }
 
     /// Drop all entries and forget the stamp. Required between file sessions:
@@ -721,15 +723,17 @@ impl AwaitedAssignabilityEvalMemo {
     /// Record a normalization result computed under `stamp`.
     pub fn insert(&mut self, stamp: AssignabilityEvalStamp, type_id: TypeId, result: TypeId) {
         self.roll_to(stamp);
-        let _previous = self.entries.insert(type_id, result);
+        let previous = self.entries.insert(type_id, result);
         // Debug-only purity invariant (#13980); see `AssignabilityEvalMemo::insert`.
         #[cfg(debug_assertions)]
         super::eval_memo_purity::record_insert(
             super::eval_memo_purity::AWAITED_ASSIGNABILITY_EVAL_MEMO,
             type_id,
-            _previous,
+            previous,
             &result,
         );
+        #[cfg(not(debug_assertions))]
+        let _ = previous;
     }
 
     /// Drop all entries and forget the stamp. Required between file sessions
@@ -814,7 +818,7 @@ impl AssignabilityFailureMemo {
         analysis: CachedAssignabilityAnalysis,
     ) {
         self.roll_to(stamp);
-        let _previous = self.entries.insert(key, analysis);
+        let previous = self.entries.insert(key, analysis);
         // Debug-only purity invariant (#13980); see `AssignabilityEvalMemo::insert`.
         // The value moved into the map, so the just-stored entry is borrowed back
         // (a debug-only lookup) to compare against the displaced one.
@@ -822,9 +826,11 @@ impl AssignabilityFailureMemo {
         super::eval_memo_purity::record_insert(
             super::eval_memo_purity::ASSIGNABILITY_FAILURE_MEMO,
             key,
-            _previous,
+            previous,
             self.entries.get(&key).expect("entry was just inserted"),
         );
+        #[cfg(not(debug_assertions))]
+        let _ = previous;
     }
 
     /// Drop all entries and forget the stamp (between file sessions; see

--- a/crates/tsz-checker/src/context/eval_memo_purity.rs
+++ b/crates/tsz-checker/src/context/eval_memo_purity.rs
@@ -1,0 +1,197 @@
+//! Debug-only purity invariant for the stamp-keyed assignability memos
+//! (issue #13980).
+//!
+//! [`AssignabilityEvalMemo`](super::caches::AssignabilityEvalMemo),
+//! [`AwaitedAssignabilityEvalMemo`](super::caches::AwaitedAssignabilityEvalMemo)
+//! and [`AssignabilityFailureMemo`](super::caches::AssignabilityFailureMemo) all
+//! encode the same contract: for a fixed
+//! [`AssignabilityEvalStamp`](super::caches::AssignabilityEvalStamp) — the two
+//! type-environment generations plus the symbol-type cache versions — the
+//! memoized value is a *pure function* of the key, so "a hit always returns
+//! exactly what a fresh evaluation under the current environment would".
+//!
+//! Issue #13980 traced a class of bug where that contract is silently broken:
+//! the eagerness with which `ensure_refs_resolved` / `ensure_relation_input_ready`
+//! forces `Lazy(DefId)` refs is a **hidden input** that is not folded into the
+//! stamp, yet it can change which `TypeId` an expression evaluates to
+//! (index-access, `Promise` unwrap, generic-constraint elaboration, ...). The
+//! sound direction is consumption-driven forcing; until that lands, the
+//! resolution mode is "load-bearing for type identity" and any laziness tweak
+//! in the #12101 campaign can change computed types in a way the diagnostic
+//! conformance floor does not catch.
+//!
+//! This module is the debug-only invariant the issue asks for. It does not
+//! change the resolution strategy; it makes the latent footgun observable. The
+//! detection point is cheap and exact: a memo `insert` that overwrites an
+//! existing entry **for the same stamp** with a **different** value is, by the
+//! purity contract, impossible — so when it happens a hidden input leaked. The
+//! displaced value is already returned by `HashMap::insert`, so the check adds
+//! no extra lookup, and the whole module compiles out of release builds.
+//!
+//! Reporting is non-fatal by default (a `tracing::warn!` plus a process-wide
+//! counter) so it never destabilises CI on a path that is only latently
+//! unsound. Set `TSZ_EVAL_MEMO_PURITY_PANIC=1` to escalate a divergence to a
+//! panic when actively hunting the leak.
+
+use std::fmt::Debug;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Label identifying which memo a divergence was observed in, for the warning
+/// payload. Kept as a `&'static str` so callers pass a constant with no
+/// allocation on the hot path.
+pub(crate) const ASSIGNABILITY_EVAL_MEMO: &str = "assignability_eval_memo";
+pub(crate) const AWAITED_ASSIGNABILITY_EVAL_MEMO: &str = "awaited_assignability_eval_memo";
+pub(crate) const ASSIGNABILITY_FAILURE_MEMO: &str = "assignability_failure_memo";
+
+/// Process-wide count of detected purity violations. Observability only; never
+/// gates behaviour. Relaxed ordering is sufficient — readers (tests, optional
+/// diagnostics) only need eventual visibility, not synchronisation with the
+/// evaluation that bumped it.
+static DIVERGENCE_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// Pure predicate behind the invariant: an overwrite is a purity violation iff
+/// an entry already existed for the key (same stamp, since the memo clears on
+/// any stamp move) and the freshly computed value differs from it. A first
+/// insert (`None`) or an identical re-insert is always fine.
+///
+/// Factored out of [`record_insert`] so the core rule is unit-testable without
+/// touching the process-wide counter or the tracing subscriber.
+pub(crate) fn is_divergent_overwrite<V: PartialEq>(previous: Option<&V>, result: &V) -> bool {
+    matches!(previous, Some(prev) if prev != result)
+}
+
+/// Record a memo insert and report when it violates the same-stamp purity
+/// contract. `previous` is the value `HashMap::insert` just displaced (so this
+/// adds no extra lookup) and `result` borrows the value now stored. Returns
+/// whether a divergence was detected so callers and tests can react without
+/// reading the global counter.
+pub(crate) fn record_insert<K: Debug, V: PartialEq + Debug>(
+    memo: &'static str,
+    key: K,
+    previous: Option<V>,
+    result: &V,
+) -> bool {
+    if !is_divergent_overwrite(previous.as_ref(), result) {
+        return false;
+    }
+    DIVERGENCE_COUNT.fetch_add(1, Ordering::Relaxed);
+    let previous = previous.expect("divergent overwrite implies a previous entry");
+    tracing::warn!(
+        memo,
+        key = ?key,
+        previous = ?previous,
+        recomputed = ?result,
+        "eval-memo purity violation: same-stamp re-evaluation produced a \
+         different result — a resolution-mode -> type-identity leak (issue #13980)"
+    );
+    if purity_panic_enabled() {
+        panic!(
+            "eval-memo purity violation in {memo}: key {key:?} mapped to \
+             {previous:?} then {result:?} under one stamp (issue #13980)"
+        );
+    }
+    true
+}
+
+/// Number of purity violations observed so far this process. Test/diagnostic
+/// surface only.
+pub(crate) fn divergence_count() -> u64 {
+    DIVERGENCE_COUNT.load(Ordering::Relaxed)
+}
+
+fn purity_panic_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("TSZ_EVAL_MEMO_PURITY_PANIC")
+            .map(|v| v != "0" && !v.is_empty())
+            .unwrap_or(false)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::caches::CachedAssignabilityAnalysis;
+    use super::*;
+    use tsz_solver::TypeId;
+
+    #[test]
+    fn first_insert_is_not_a_violation() {
+        assert!(!is_divergent_overwrite(None, &TypeId::STRING));
+    }
+
+    #[test]
+    fn identical_reinsert_is_not_a_violation() {
+        assert!(!is_divergent_overwrite(
+            Some(&TypeId::STRING),
+            &TypeId::STRING
+        ));
+    }
+
+    #[test]
+    fn differing_reinsert_under_same_stamp_is_a_violation() {
+        assert!(is_divergent_overwrite(
+            Some(&TypeId::STRING),
+            &TypeId::NUMBER
+        ));
+    }
+
+    #[test]
+    fn record_insert_reports_only_on_divergence() {
+        // First write: nothing displaced, no violation.
+        assert!(!record_insert(
+            ASSIGNABILITY_EVAL_MEMO,
+            TypeId::STRING,
+            None,
+            &TypeId::NUMBER
+        ));
+        // Stable replay of the same result: still fine.
+        assert!(!record_insert(
+            ASSIGNABILITY_EVAL_MEMO,
+            TypeId::STRING,
+            Some(TypeId::NUMBER),
+            &TypeId::NUMBER
+        ));
+        // A different result for the same key under the same stamp is the leak.
+        let before = divergence_count();
+        assert!(record_insert(
+            AWAITED_ASSIGNABILITY_EVAL_MEMO,
+            TypeId::STRING,
+            Some(TypeId::NUMBER),
+            &TypeId::BOOLEAN
+        ));
+        assert!(
+            divergence_count() > before,
+            "a detected divergence must advance the process-wide counter"
+        );
+    }
+
+    #[test]
+    fn record_insert_generalizes_to_struct_valued_memos() {
+        // The failure memo stores a struct, not a `TypeId`; the same contract
+        // and detector apply to a divergent `related` verdict for one key.
+        let related = CachedAssignabilityAnalysis {
+            related: true,
+            depth_exceeded: false,
+            iteration_exceeded: false,
+            weak_union_violation: false,
+            failure_reason: None,
+        };
+        let mut unrelated = related.clone();
+        unrelated.related = false;
+        let key = (TypeId::STRING, TypeId::NUMBER, 0u16, false);
+
+        assert!(!record_insert(
+            ASSIGNABILITY_FAILURE_MEMO,
+            key,
+            Some(related.clone()),
+            &related
+        ));
+        assert!(record_insert(
+            ASSIGNABILITY_FAILURE_MEMO,
+            key,
+            Some(related),
+            &unrelated
+        ));
+    }
+}

--- a/crates/tsz-checker/src/context/eval_memo_purity.rs
+++ b/crates/tsz-checker/src/context/eval_memo_purity.rs
@@ -85,12 +85,11 @@ pub(crate) fn record_insert<K: Debug, V: PartialEq + Debug>(
         "eval-memo purity violation: same-stamp re-evaluation produced a \
          different result — a resolution-mode -> type-identity leak (issue #13980)"
     );
-    if purity_panic_enabled() {
-        panic!(
-            "eval-memo purity violation in {memo}: key {key:?} mapped to \
-             {previous:?} then {result:?} under one stamp (issue #13980)"
-        );
-    }
+    assert!(
+        !purity_panic_enabled(),
+        "eval-memo purity violation in {memo}: key {key:?} mapped to \
+         {previous:?} then {result:?} under one stamp (issue #13980)"
+    );
     true
 }
 
@@ -103,9 +102,7 @@ pub(crate) fn divergence_count() -> u64 {
 fn purity_panic_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var("TSZ_EVAL_MEMO_PURITY_PANIC")
-            .map(|v| v != "0" && !v.is_empty())
-            .unwrap_or(false)
+        std::env::var("TSZ_EVAL_MEMO_PURITY_PANIC").is_ok_and(|v| v != "0" && !v.is_empty())
     })
 }
 

--- a/crates/tsz-checker/src/context/lib_type_resolution_caches.rs
+++ b/crates/tsz-checker/src/context/lib_type_resolution_caches.rs
@@ -1,0 +1,37 @@
+use rustc_hash::FxHashMap;
+use std::cell::RefCell;
+use tsz_common::interner::Atom;
+use tsz_solver::TypeId;
+use tsz_solver::def::DefId;
+
+/// File-session caches for lib type and lazy lib-member resolution.
+#[derive(Default)]
+pub struct LibTypeResolutionCaches {
+    /// Cache for `resolve_lib_type_by_name` results.
+    /// Keyed by type name and stores both hits (`Some(TypeId)`) and misses (`None`).
+    pub types: FxHashMap<String, Option<TypeId>>,
+
+    /// Per-checker cache for lazy single-member lib-interface property reads.
+    /// Keyed by `(interface_name, property_name)` atoms and stores both hits and
+    /// conservative misses after the existing lazy-member resolver has decided
+    /// whether it can lower only the requested member. This keeps repeated DOM
+    /// reads from rescanning declaration and heritage lists while preserving the
+    /// same full-materialization fallback on cached misses.
+    pub lazy_members: RefCell<FxHashMap<(Atom, Atom), Option<TypeId>>>,
+
+    /// Per-checker cache for lazy single-member property reads once a receiver
+    /// has already been classified as an eligible bare `Lazy(DefId)`.
+    /// Keyed by `(receiver_def_id, property_name)` and stores the same hit/miss
+    /// result as `lazy_members`, but lets the receiver hot path avoid mapping
+    /// the cached `DefId` back to a symbol name before a repeated lookup.
+    pub lazy_member_receiver_properties: RefCell<FxHashMap<(DefId, Atom), Option<TypeId>>>,
+
+    /// Per-checker cache for lazy single-member receiver eligibility.
+    /// Keyed by the bare receiver `Lazy(DefId)`. Stores both eligible and
+    /// ineligible decisions after the conservative receiver predicate has
+    /// inspected symbol provenance, generic parameters, shadowing, global
+    /// augmentations, and heritage bases. This keeps repeated DOM/lib property
+    /// reads from re-walking the same heritage/augmentation graph before they
+    /// can hit the member cache.
+    pub lazy_member_receivers: RefCell<FxHashMap<DefId, bool>>,
+}

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -39,6 +39,8 @@ pub(crate) mod eval_memo_purity;
 mod file_session_reset;
 pub mod lifetime_shells;
 pub use lifetime_shells::{FileSession, LspPersistentCache, SpeculationScope, WorkerContext};
+mod lib_type_resolution_caches;
+pub use lib_type_resolution_caches::LibTypeResolutionCaches;
 mod def_declaration;
 mod def_mapping;
 mod def_mapping_flow_mirror;
@@ -126,39 +128,6 @@ pub struct JSDocGlobalTypedefLookupCache {
     pub miss_cache: RefCell<FxHashSet<String>>,
     pub in_progress: RefCell<FxHashSet<String>>,
     pub typedef_presence_by_file: Arc<dashmap::DashMap<(u32, u32, String), bool>>,
-}
-
-/// File-session caches for lib type and lazy lib-member resolution.
-#[derive(Default)]
-pub struct LibTypeResolutionCaches {
-    /// Cache for `resolve_lib_type_by_name` results.
-    /// Keyed by type name and stores both hits (`Some(TypeId)`) and misses (`None`).
-    pub types: FxHashMap<String, Option<TypeId>>,
-
-    /// Per-checker cache for lazy single-member lib-interface property reads.
-    /// Keyed by `(interface_name, property_name)` atoms and stores both hits and
-    /// conservative misses after the existing lazy-member resolver has decided
-    /// whether it can lower only the requested member. This keeps repeated DOM
-    /// reads from rescanning declaration and heritage lists while preserving the
-    /// same full-materialization fallback on cached misses.
-    pub lazy_members: RefCell<FxHashMap<(Atom, Atom), Option<TypeId>>>,
-
-    /// Per-checker cache for lazy single-member property reads once a receiver
-    /// has already been classified as an eligible bare `Lazy(DefId)`.
-    /// Keyed by `(receiver_def_id, property_name)` and stores the same hit/miss
-    /// result as `lazy_members`, but lets the receiver hot path avoid mapping
-    /// the cached `DefId` back to a symbol name before a repeated lookup.
-    pub lazy_member_receiver_properties:
-        RefCell<FxHashMap<(tsz_solver::def::DefId, Atom), Option<TypeId>>>,
-
-    /// Per-checker cache for lazy single-member receiver eligibility.
-    /// Keyed by the bare receiver `Lazy(DefId)`. Stores both eligible and
-    /// ineligible decisions after the conservative receiver predicate has
-    /// inspected symbol provenance, generic parameters, shadowing, global
-    /// augmentations, and heritage bases. This keeps repeated DOM/lib property
-    /// reads from re-walking the same heritage/augmentation graph before they
-    /// can hit the member cache.
-    pub lazy_member_receivers: RefCell<FxHashMap<tsz_solver::def::DefId, bool>>,
 }
 
 /// Maximum depth for nested `get_type_of_symbol` calls before giving up.

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -32,6 +32,10 @@ mod cross_file_query;
 mod diagnostic_indices;
 mod diagnostic_push;
 pub(crate) mod env_eval_cache;
+/// Debug-only purity invariant for the stamp-keyed evaluation memos (#13980).
+/// Compiles out of release builds; the wiring in `caches.rs` is gated the same.
+#[cfg(debug_assertions)]
+pub(crate) mod eval_memo_purity;
 mod file_session_reset;
 pub mod lifetime_shells;
 pub use lifetime_shells::{FileSession, LspPersistentCache, SpeculationScope, WorkerContext};


### PR DESCRIPTION
## Summary

Closes the actionable in #13980 (resolution-mode → type-identity leak): add the **debug-only invariant** the issue asks for, wired into every stamp-keyed assignability memo.

The assignability evaluation memos document a purity contract: for a fixed `AssignabilityEvalStamp` (the two type-environment generations + symbol-type cache versions), the memoized value is a **pure function of the key** — "a hit always returns exactly what a fresh evaluation under the current environment would". #13980 traced a class of bug where lib-ref resolution eagerness (`ensure_refs_resolved` / `ensure_relation_input_ready`) is a **hidden input not folded into the stamp**, yet it can change which `TypeId` an expression evaluates to (index-access, `Promise` unwrap, generic-constraint elaboration, …). The diagnostic conformance floor only catches *symptomatic* regressions, not the underlying mechanism — a latent footgun for the #12101 lazy-lib campaign.

## Structural rule

When a stamp-keyed assignability memo overwrites an existing entry **for the same stamp** with a **different** value, the memoized function was not pure of the observable state — a hidden input (resolution eagerness) leaked into type identity. The detector lives at the memo `insert` chokepoint (owned by `tsz_checker::context::caches`), the one place every completed evaluation result funnels through, keyed by exactly the `(stamp, key)` pair the contract is about.

- `HashMap::insert` already returns the displaced value, so the check adds **no extra lookup**.
- The whole module is `#[cfg(debug_assertions)]` and **compiles out of release builds** (verified: release clippy clean, no unused-binding warnings).
- Reporting is **non-fatal by default** (`tracing::warn!` + a process-wide divergence counter) so it cannot destabilise CI on a path that is only latently unsound. `TSZ_EVAL_MEMO_PURITY_PANIC=1` escalates a divergence to a panic when hunting the leak.

## Breadth (not just the bug-report witness)

Wired into **all three** stamp-keyed memos carrying the identical contract, via one generic `record_insert` helper:

- `AssignabilityEvalMemo`
- `AwaitedAssignabilityEvalMemo`
- `AssignabilityFailureMemo` — `CachedAssignabilityAnalysis` now derives `PartialEq` so the struct-valued memo (verdict / failure-reason divergence) participates too.

## Owner layer

Checker session caches (`tsz_checker::context`). No resolution-strategy change, no semantics change in release; the sound direction (consumption-driven forcing, #13979) is unchanged and complementary — this makes the hazard observable until that lands.

## Verification

- `cargo test -p tsz-checker --lib eval_memo_purity` — 5 new unit tests pass (pure predicate; `record_insert` reports only on divergence; struct-valued generalization).
- `cargo test -p tsz-checker --lib assignability_eval_memo` — existing 8 integration tests still pass (exercise the real `insert` path under debug, detector runs, no spurious divergence/panic).
- `cargo clippy -p tsz-checker --lib` and `--release` — clean.
- `cargo fmt -p tsz-checker --check` — clean.
- Merged latest `origin/main` — no conflicts.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01EBsbTegHCZUjkuvKWBPJ5m