### PR TITLE
perf(solver): share this-bearing relation verdicts keyed by the resolved this binding (#13828)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -292,29 +292,44 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // the identity-mode flag, so a cached `true` from a normal subtype check
         // would incorrectly short-circuit the identity check (which needs stricter
         // Application type-argument comparison at cycle points for TS2403).
-        // Types containing ThisType are context-dependent (they depend on which class
-        // is currently being checked via the resolver's this_type_stack). Caching them
-        // in the shared cache would poison it with results computed outside of any
-        // class context (e.g., during class type construction), causing later
-        // legitimate checks inside class bodies to get the wrong cached result. Such
-        // pairs instead use the instance-local fallback memo (issue #13828), which is
-        // valid for the lifetime of this checker — the `this` binding is fixed for one
-        // top-level query — and dropped afterward, so it cannot poison sibling checks.
+        // Types containing ThisType are context-dependent: they resolve `ThisType`
+        // against the receiver currently being checked (the resolver's
+        // `this_type_stack`). Their verdict depends only on that binding, so when a
+        // concrete binding is available `make_cache_key` discriminates the shared
+        // key by it (`RelationCacheKey::this_context`, issue #13828) — the verdict
+        // is then valid for any checker comparing the same pair under the same
+        // receiver and cannot poison a sibling under a different one. Without a
+        // binding (e.g. during class type construction, where `ThisType` is still
+        // free) the pair stays on the instance-local fallback memo, which is valid
+        // for the lifetime of this checker — the `this` binding is fixed for one
+        // top-level query — and dropped afterward, so it cannot poison siblings.
         //
         // Use contains_this_type (not just is_this_type) because even after
         // substitute_this_type_if_needed the *target* may still be a class instance
         // type whose method signatures carry `ThisType` return types.
         let has_this_type =
             contains_this_type(self.interner, source) || contains_this_type(self.interner, target);
+        // Resolve the `this` binding only for the `this`-bearing pairs that need
+        // it (the `||` short-circuits otherwise), reusing it below as the shared
+        // cache key's `this_context` discriminator so the gate and the key agree.
+        let this_binding = if has_this_type {
+            self.resolver.resolve_this_type(self.interner)
+        } else {
+            None
+        };
+        let this_context = this_binding.unwrap_or(TypeId::NONE);
         // Class-symbol classification is also context-dependent: the callback
         // can make the same object shape behave as a named class/interface in
         // one checker and as a plain structural object in another. Since the
         // relation cache key cannot encode an arbitrary predicate, those answers
-        // are excluded from the cross-checker shared cache and likewise served by
-        // the instance-local fallback memo, whose `is_class_symbol` closure is fixed
+        // are excluded from the cross-checker shared cache and served by the
+        // instance-local fallback memo, whose `is_class_symbol` closure is fixed
         // for the checker's lifetime.
         let has_class_check_context = self.is_class_symbol.is_some();
-        let can_use_shared_relation_cache = !has_this_type && !has_class_check_context;
+        // A `this`-bearing pair is shareable once keyed by its resolved binding;
+        // without a binding (or inside a class-check context) it stays local.
+        let can_use_shared_relation_cache =
+            !has_class_check_context && (!has_this_type || this_binding.is_some());
         // The `in_callback_param_check` state is encoded in
         // `RelationFlags::IN_CALLBACK_PARAM_CHECK` via `make_cache_key`, so
         // callback-mode results live in a separate cache slot from
@@ -322,7 +337,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if !self.identity_cycle_check {
             if can_use_shared_relation_cache {
                 if let Some(db) = self.query_db {
-                    let key = self.make_cache_key(source, target);
+                    let key = self.make_cache_key_with_this_context(source, target, this_context);
                     match db.lookup_subtype_cache_value(key) {
                         Some(RelationCacheValue::True) => return SubtypeResult::True,
                         Some(RelationCacheValue::False) => return SubtypeResult::False,

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -215,12 +215,54 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// vs lax, with/without weak-type suppression, etc.) cannot
     /// contaminate each other.
     pub(crate) fn make_cache_key(&self, source: TypeId, target: TypeId) -> RelationCacheKey {
+        self.make_cache_key_with_this_context(
+            source,
+            target,
+            self.this_relation_context(source, target),
+        )
+    }
+
+    /// Build the relation cache key for `(source, target)` with an
+    /// already-resolved polymorphic-`this` discriminator.
+    ///
+    /// Callers on the hot cache-lookup path pass the discriminator they already
+    /// computed for the gate decision (see `check_subtype`'s cache section), so
+    /// the [`crate::contains_this_type`] walk in [`Self::this_relation_context`]
+    /// is not repeated per lookup. Passing [`TypeId::NONE`] produces a key
+    /// byte-identical to the legacy undiscriminated form.
+    pub(crate) fn make_cache_key_with_this_context(
+        &self,
+        source: TypeId,
+        target: TypeId,
+        this_context: TypeId,
+    ) -> RelationCacheKey {
         RelationCacheKey::for_subtype(
             source,
             target,
             self.cache_policy()
                 .cache_config_with_cached_any_mode(self.effective_cached_any_mode()),
         )
+        .with_this_context(this_context)
+    }
+
+    /// Resolve the polymorphic-`this` discriminator for a `(source, target)`
+    /// pair (issue #13828).
+    ///
+    /// Returns the resolver's current `this` binding when the pair carries a
+    /// polymorphic `this` (so its verdict depends on that binding), else
+    /// [`TypeId::NONE`]. A `None` binding also yields [`TypeId::NONE`]: with no
+    /// receiver to resolve `ThisType` against, the pair stays on the
+    /// instance-local memo rather than the shared cache.
+    pub(crate) fn this_relation_context(&self, source: TypeId, target: TypeId) -> TypeId {
+        match self.resolver.resolve_this_type(self.interner) {
+            Some(this_ty)
+                if crate::contains_this_type(self.interner, source)
+                    || crate::contains_this_type(self.interner, target) =>
+            {
+                this_ty
+            }
+            _ => TypeId::NONE,
+        }
     }
 
     /// Project this checker's behavior-affecting relation modes to a policy.

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -429,6 +429,18 @@ pub struct RelationCacheKey {
     pub target: TypeId,
     pub relation: RelationCacheKind,
     pub config: RelationCacheConfig,
+    /// Resolved polymorphic-`this` binding under which this verdict holds, or
+    /// [`TypeId::NONE`] when the pair does not depend on a `this` binding.
+    ///
+    /// A pair that carries a polymorphic `this` resolves `ThisType` against the
+    /// current receiver, so its relation outcome is valid only under that
+    /// receiver. Encoding the resolved binding here lets such verdicts live in
+    /// the cross-checker shared cache without poisoning a sibling checker that
+    /// compares the same `(source, target)` under a different receiver (issue
+    /// #13828). It is [`TypeId::NONE`] for every non-`this` pair, so ordinary
+    /// keys are byte-identical to the pre-`this`-context protocol and share
+    /// their existing cache slots unchanged.
+    pub this_context: TypeId,
 }
 
 impl RelationCacheKey {
@@ -465,6 +477,7 @@ impl RelationCacheKey {
             target,
             relation: RelationCacheKind::Subtype,
             config,
+            this_context: TypeId::NONE,
         }
     }
 
@@ -479,6 +492,7 @@ impl RelationCacheKey {
             target,
             relation: RelationCacheKind::Assignable,
             config,
+            this_context: TypeId::NONE,
         }
     }
 
@@ -497,6 +511,7 @@ impl RelationCacheKey {
             target,
             relation: RelationCacheKind::CheckerAssignable,
             config,
+            this_context: TypeId::NONE,
         }
     }
 
@@ -511,7 +526,18 @@ impl RelationCacheKey {
             target,
             relation: RelationCacheKind::Identical,
             config,
+            this_context: TypeId::NONE,
         }
+    }
+
+    /// Return this key discriminated by a resolved polymorphic-`this` binding.
+    ///
+    /// Passing [`TypeId::NONE`] (the default) is a no-op, leaving the key
+    /// byte-identical to the undiscriminated form. See [`Self::this_context`].
+    #[must_use]
+    pub const fn with_this_context(mut self, this_context: TypeId) -> Self {
+        self.this_context = this_context;
+        self
     }
 }
 

--- a/crates/tsz-solver/tests/subtype_cache_tests.rs
+++ b/crates/tsz-solver/tests/subtype_cache_tests.rs
@@ -882,3 +882,157 @@ fn flag_flip_does_not_reuse_stale_cache_entry() {
         "flag flip must not serve the previous-mode cache entry"
     );
 }
+
+// =============================================================================
+// Polymorphic-`this` relation cache discrimination (issue #13828)
+// =============================================================================
+//
+// A pair carrying a polymorphic `this` resolves `ThisType` against the current
+// receiver, so its verdict is valid only under that binding. The relation cache
+// key is discriminated by the resolved `this` binding
+// (`RelationCacheKey::this_context`) so such verdicts can live in the
+// cross-checker shared cache without poisoning a sibling checker that compares
+// the same pair under a different receiver — while pairs with no `this` (or no
+// resolvable binding) keep a byte-identical undiscriminated key.
+
+/// Minimal resolver exposing a configurable polymorphic-`this` binding.
+struct ThisBindingResolver {
+    this: Option<TypeId>,
+}
+
+impl crate::def::resolver::TypeResolver for ThisBindingResolver {
+    fn resolve_ref(
+        &self,
+        _symbol: crate::types::SymbolRef,
+        _interner: &dyn crate::caches::db::TypeDatabase,
+    ) -> Option<TypeId> {
+        None
+    }
+
+    fn resolve_this_type(&self, _interner: &dyn crate::caches::db::TypeDatabase) -> Option<TypeId> {
+        self.this
+    }
+}
+
+/// An object whose `self` property is typed `this` (so the pair is
+/// `this`-bearing), plus a structurally-comparable non-`this` counterpart.
+fn this_bearing_and_plain(interner: &TypeInterner) -> (TypeId, TypeId) {
+    let this_ty = interner.intern(crate::types::TypeData::ThisType);
+    let slot = interner.intern_string("slot");
+    let this_bearing = interner.object(vec![PropertyInfo::new(slot, this_ty)]);
+    let plain = interner.object(vec![PropertyInfo::new(slot, TypeId::STRING)]);
+    (this_bearing, plain)
+}
+
+#[test]
+fn this_bearing_key_is_discriminated_by_resolved_receiver() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let (this_bearing, plain) = this_bearing_and_plain(&interner);
+
+    // Two distinct receivers (binder names vary so the discriminator is keyed
+    // on the resolved type identity, not on any name).
+    let recv_a = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("alpha"),
+        TypeId::NUMBER,
+    )]);
+    let recv_b = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("omega"),
+        TypeId::BOOLEAN,
+    )]);
+    assert_ne!(recv_a, recv_b);
+
+    let res_a = ThisBindingResolver { this: Some(recv_a) };
+    let res_b = ThisBindingResolver { this: Some(recv_b) };
+
+    let key_a = SubtypeChecker::with_resolver(&interner, &res_a)
+        .with_query_db(&db)
+        .debug_cache_key_for(this_bearing, plain);
+    let key_b = SubtypeChecker::with_resolver(&interner, &res_b)
+        .with_query_db(&db)
+        .debug_cache_key_for(this_bearing, plain);
+
+    assert_eq!(key_a.this_context, recv_a);
+    assert_eq!(key_b.this_context, recv_b);
+    assert_ne!(
+        key_a, key_b,
+        "the same `this`-bearing pair under different receivers must key to \
+         different cache slots (no cross-receiver poisoning)"
+    );
+}
+
+#[test]
+fn non_this_pair_and_unbound_this_keep_undiscriminated_key() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let (this_bearing, plain) = this_bearing_and_plain(&interner);
+
+    let receiver = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("recv"),
+        TypeId::NUMBER,
+    )]);
+    let res_bound = ThisBindingResolver {
+        this: Some(receiver),
+    };
+    let res_unbound = ThisBindingResolver { this: None };
+
+    // A pair with no polymorphic `this` is never discriminated, even when a
+    // receiver is available — its verdict is receiver-independent.
+    let key_plain = SubtypeChecker::with_resolver(&interner, &res_bound)
+        .with_query_db(&db)
+        .debug_cache_key_for(plain, plain);
+    assert_eq!(key_plain.this_context, TypeId::NONE);
+
+    // A `this`-bearing pair with no resolvable binding stays undiscriminated
+    // (it falls to the instance-local memo rather than the shared cache).
+    let key_unbound = SubtypeChecker::with_resolver(&interner, &res_unbound)
+        .with_query_db(&db)
+        .debug_cache_key_for(this_bearing, plain);
+    assert_eq!(key_unbound.this_context, TypeId::NONE);
+}
+
+#[test]
+fn this_bearing_verdict_is_shared_under_its_receiver_only() {
+    use crate::types::RelationCacheValue;
+
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let (this_bearing, plain) = this_bearing_and_plain(&interner);
+
+    let recv_a = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("alpha"),
+        TypeId::NUMBER,
+    )]);
+    let recv_b = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("omega"),
+        TypeId::BOOLEAN,
+    )]);
+    let res_a = ThisBindingResolver { this: Some(recv_a) };
+    let res_b = ThisBindingResolver { this: Some(recv_b) };
+
+    // Compute the verdict under receiver A; it must be recorded in the shared
+    // cache under A's discriminated key (the pre-fix behavior kept it only in
+    // the dropped per-instance local memo, so the shared cache stayed empty).
+    let verdict = SubtypeChecker::with_resolver(&interner, &res_a)
+        .with_query_db(&db)
+        .is_subtype_of(this_bearing, plain);
+
+    let key_a = SubtypeChecker::with_resolver(&interner, &res_a)
+        .with_query_db(&db)
+        .debug_cache_key_for(this_bearing, plain);
+    assert_eq!(
+        db.lookup_subtype_cache_value(key_a),
+        Some(RelationCacheValue::from_bool(verdict)),
+        "the `this`-bearing verdict must be cached cross-checker under its receiver"
+    );
+
+    // A different receiver's key must NOT observe that verdict.
+    let key_b = SubtypeChecker::with_resolver(&interner, &res_b)
+        .with_query_db(&db)
+        .debug_cache_key_for(this_bearing, plain);
+    assert_eq!(
+        db.lookup_subtype_cache_value(key_b),
+        None,
+        "a different receiver must not be served the other receiver's verdict"
+    );
+}


### PR DESCRIPTION
Goal: fast

Closes the `has_this_type` half of #13828: the cross-checker relation cache
bypass that forces class-heavy code (`this`-polymorphic methods, e.g.
ts-morph) to re-run the same structural subtype comparisons from scratch on
every top-level query.

## Structural rule

When a `(source, target)` subtype pair carries a polymorphic `this`, `tsc`'s
verdict depends only on the receiver that `ThisType` resolves against. That
receiver is the resolver's current `this` binding, which is **fixed for one
`SubtypeChecker`'s lifetime** — the same invariant the existing instance-local
fallback memo already relies on. So the verdict is safe to share
cross-checker once the cache key is discriminated by that binding.

Previously every `this`-bearing pair was excluded from the shared
`QueryCache` and routed to the per-instance `local_relation_cache`, which is
dropped at the end of each query — so the verdict was recomputed for every
later query that compared the same pair.

> When a subtype pair carries a polymorphic `this` and a concrete receiver
> binding is available, `tsc` reuses the verdict under that receiver; tsz now
> shares it cross-checker through the relation cache keyed by the resolved
> `this` binding, through the solver subtype-cache gateway.

## Owner layer

Solver relation cache (`crates/tsz-solver/src/relations/subtype/cache.rs`,
`types.rs`, `helpers.rs`).

- `RelationCacheKey` gains a `this_context: TypeId` field (the resolved `this`
  binding, or `TypeId::NONE`). It is part of "every behavior-affecting input
  that can change the outcome of a relation check," which the key's own
  contract requires it to represent.
- The shared-cache gate is relaxed from `!has_this_type && !class_context` to
  `!class_context && (!has_this_type || this_binding.is_some())`. A
  `this`-bearing pair is shared only once keyed by its concrete binding.
- `make_cache_key` discriminates the key via the resolved binding;
  `make_cache_key_with_this_context` lets the hot cache-lookup site reuse the
  binding the gate already resolved, so no extra `contains_this_type` walk is
  added to the hit path (`contains_this_type` is itself memoized; the binding
  lookup is an O(1) stack peek).

## Soundness / what stays local (unchanged)

- **Non-`this` pairs**: `this_context == TypeId::NONE`, so the key is
  byte-identical to the pre-change protocol and shares its existing slot.
- **`this`-bearing pair with no resolvable binding** (e.g. during class type
  construction, where `ThisType` is still free): stays on the local memo.
- **Class-check context** (`is_class_symbol` is an unhashable closure): stays
  on the local memo, exactly as before.
- A verdict computed under receiver A keys to A and can never be served to a
  checker comparing the same pair under receiver B (different key → different
  slot).
- For any resolver that returns no `this` binding (`NoopResolver` / basic
  mode, every solver unit test), the gate reduces **exactly** to the previous
  `!has_this_type && !class_context` condition — that path is byte-identical.

## Anti-hardcoding

The discriminator is the resolved receiver `TypeId`, not any identifier,
file-name, or printer string. New tests vary every binder name
(`alpha`/`omega`/`slot`/`recv`) and assert on type identity and cache
behavior, never on names.

## Verification

- New regression tests in `subtype_cache_tests` (3): different receivers key a
  `this`-bearing pair to different slots (no poisoning); a non-`this` pair and
  an unbound-`this` pair keep an undiscriminated `TypeId::NONE` key; a
  `this`-bearing verdict is recorded in the shared cache under its receiver and
  is not visible to a different receiver. All pass.
- `cargo test -p tsz-solver --lib`: 6806 passed, 4 failed — the **same 4**
  failures present on clean base (verified via `git stash`); +3 new passing
  tests, **0 new failures**.
- `cargo test -p tsz-checker --lib this_type`: 38 passed, 0 failed (the real
  checker path that supplies a concrete `this` binding). The one failing
  `class_member` test (`mapped_type_generic_indexed_access_class_member`) also
  fails on clean base (pre-existing main drift).
- `cargo fmt -p tsz-solver --check` clean; `cargo clippy -p tsz-solver --lib`
  clean.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Honest scope

This lands the `this`-bearing dimension only (the issue's option 1, "encode
`this` context in the key"). The `is_class_symbol` class-check-context bypass
is left on the local memo because that classifier is an unhashable closure;
per the typebox profiling note on #13828 the two dimensions are ~half each, so
the class-context half remains tracked there.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_012WqXrZrtbtxHnmUjTEaB3n

---
_Generated by [Claude Code](https://claude.ai/code/session_012WqXrZrtbtxHnmUjTEaB3n)_