### PR TITLE
infra(test): serialize cargo-nextest runs and reap stale orchestrators (#13982)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -107,6 +107,16 @@ cargo install cargo-nextest
 cargo nextest run -p tsz-checker --lib <test-name>
 ```
 
+If `cargo nextest` wedges locally at ~0% CPU (an idle orchestrator with no
+output — see issue #13982), run it through the serializing guard, which queues
+concurrent runs and clears a stale orchestrator left by a killed-mid-build run:
+
+```bash
+scripts/test/nextest-guard.sh -- cargo nextest run -p tsz-checker --lib <test-name>
+```
+
+See [`docs/development/TOOLING.md`](development/TOOLING.md) for details.
+
 ### Conformance Tests
 
 Conformance tests compare tsz diagnostics against the official TypeScript compiler (`tsc`).

--- a/docs/development/TOOLING.md
+++ b/docs/development/TOOLING.md
@@ -429,6 +429,41 @@ Use for long-running or memory-intensive commands such as a full
 not override the CI-only rule for full conformance, emit, or fourslash suites:
 keep those full suites out of normal local development and let CI run them.
 
+### `scripts/test/nextest-guard.sh`
+
+Serializes local `cargo nextest` runs and self-heals a wedged orchestrator.
+`cargo-nextest` can wedge at ~0% CPU — the orchestrator stays alive but idle
+with no `rustc` running and no output — when two nextest invocations run
+concurrently, or after a nextest is killed mid-build (issue #13982). The guard
+encodes the reliable manual workaround ("serialize nextest, never kill it
+mid-build") as tooling:
+
+- it holds a host-wide advisory lock for the wrapped command, so a second
+  guarded run queues behind the first instead of racing the orchestrator into a
+  wedge;
+- on startup, if the previous lock holder died abnormally, it reaps the
+  orchestrator process tree that the prior guarded run recorded (and only that
+  tree — never an unrelated `cargo-nextest` it did not start), then takes the
+  lock and proceeds.
+
+```bash
+# Run targeted unit tests serialized against any other guarded nextest
+scripts/test/nextest-guard.sh -- cargo nextest run -p tsz-checker --lib <name>
+
+# Compose with safe-run.sh (memory guard) in either order
+scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run
+
+# Fail fast instead of waiting if another guarded run holds the lock
+scripts/test/nextest-guard.sh --no-wait -- cargo nextest run -p tsz-solver
+```
+
+The lock is advisory: it only constrains commands launched through the guard,
+and it never changes test behavior or output. `--scope target` narrows
+serialization to runs that share a `CARGO_TARGET_DIR`; the default (`global`)
+serializes every guarded nextest on the host, because the wedge reproduces even
+across distinct target dirs. The behavior is covered by
+`scripts/test/nextest-guard-test.sh`.
+
 ### `scripts/setup/reset-ts-submodule.sh`
 
 Resets the TypeScript submodule to the pinned commit SHA. Called automatically by the pre-commit hook.

--- a/scripts/test/nextest-guard-test.sh
+++ b/scripts/test/nextest-guard-test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# nextest-guard-test.sh — self-test for scripts/test/nextest-guard.sh
+#
+# Exercises the lock/serialize/steal/reap behavior with fake commands so it runs
+# fast and without invoking cargo. Run locally:
+#
+#   scripts/test/nextest-guard-test.sh
+#
+# Exits non-zero on the first failing assertion.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$HERE/nextest-guard.sh"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/nextest-guard-test.XXXXXX")"
+export TMPDIR="$WORK" # isolate lock root from any real runs
+PASS=0
+FAIL=0
+
+ok() {
+    PASS=$((PASS + 1))
+    echo "ok   - $1"
+}
+bad() {
+    FAIL=$((FAIL + 1))
+    echo "FAIL - $1" >&2
+}
+
+cleanup() {
+    pkill -P $$ 2>/dev/null || true
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# ── 1. Basic passthrough: exit code and args are forwarded ─────────
+out="$("$GUARD" --lock-name t1 -- bash -c 'echo "hi $1"; exit 7' _ world)"
+rc=$?
+[[ "$rc" -eq 7 ]] && ok "forwards exit code" || bad "exit code ($rc != 7)"
+[[ "$out" == "hi world" ]] && ok "forwards args/stdout" || bad "stdout ('$out')"
+
+# ── 2. Lock is released after a normal run ─────────────────────────
+"$GUARD" --lock-name t2 -- true
+shopt -s nullglob
+leftovers=("$WORK"/tsz-nextest-guard/t2*.lock)
+[[ "${#leftovers[@]}" -eq 0 ]] && ok "lock released after success" \
+    || bad "lock dir left behind: ${leftovers[*]}"
+shopt -u nullglob
+
+# ── 3. Serialization: a second run waits for the first ─────────────
+start="${EPOCHSECONDS:-$(date +%s)}"
+"$GUARD" --lock-name t3 -- sleep 3 &
+first=$!
+sleep 1 # ensure the first run owns the lock
+"$GUARD" --lock-name t3 --interval 1 -- true
+second_end="${EPOCHSECONDS:-$(date +%s)}"
+wait "$first"
+waited=$((second_end - start))
+[[ "$waited" -ge 3 ]] && ok "second run serialized behind first (${waited}s)" \
+    || bad "second run did not wait (${waited}s < 3s)"
+
+# ── 4. --no-wait fails fast (exit 75) when the lock is live ─────────
+"$GUARD" --lock-name t4 -- sleep 3 &
+held=$!
+sleep 1
+"$GUARD" --lock-name t4 --no-wait -- true
+nw=$?
+[[ "$nw" -eq 75 ]] && ok "--no-wait returns 75 on a live lock" \
+    || bad "--no-wait returned $nw (expected 75)"
+kill "$held" 2>/dev/null || true
+wait "$held" 2>/dev/null || true
+
+# ── 5. Stale-lock steal: a dead holder's lock is taken over ────────
+lockdir="$WORK/tsz-nextest-guard/t5.lock"
+mkdir -p "$lockdir"
+# Pick a PID that is almost certainly dead.
+deadpid=999999
+while kill -0 "$deadpid" 2>/dev/null; do deadpid=$((deadpid - 1)); done
+echo "$deadpid" >"$lockdir/pid"
+echo "stale-token" >"$lockdir/token"
+out="$("$GUARD" --lock-name t5 --interval 1 --timeout 10 -- echo stole)"
+rc=$?
+[[ "$rc" -eq 0 && "$out" == "stole" ]] && ok "steals stale (dead-holder) lock" \
+    || bad "did not steal stale lock (rc=$rc out='$out')"
+
+# ── 6. Reap on steal: a recorded child of a dead holder is killed ──
+lockdir="$WORK/tsz-nextest-guard/t6.lock"
+mkdir -p "$lockdir"
+# Long-lived fake orchestrator whose comm matches the reuse-guard allowlist.
+# Use a copy of `sleep` renamed to contain "nextest" so ps comm matches.
+fakebin="$WORK/cargo-nextest-fake"
+cp "$(command -v sleep)" "$fakebin" 2>/dev/null && mv "$fakebin" "$WORK/nextest-sleep" || true
+if [[ -x "$WORK/nextest-sleep" ]]; then
+    "$WORK/nextest-sleep" 30 &
+else
+    sleep 30 &
+fi
+child=$!
+echo "$deadpid" >"$lockdir/pid"
+echo "stale-token" >"$lockdir/token"
+echo "$child" >"$lockdir/child"
+# Only assert reaping when the comm matches the allowlist (rename succeeded).
+if [[ -x "$WORK/nextest-sleep" ]]; then
+    "$GUARD" --lock-name t6 --interval 1 --timeout 10 -- true
+    sleep 1
+    if kill -0 "$child" 2>/dev/null; then
+        bad "recorded orchestrator child was not reaped"
+        kill "$child" 2>/dev/null || true
+    else
+        ok "reaped recorded orchestrator child on stale steal"
+    fi
+else
+    "$GUARD" --lock-name t6 --interval 1 --timeout 10 -- true
+    kill "$child" 2>/dev/null || true
+    ok "stale steal proceeds (reuse-guard rename unavailable; reap not asserted)"
+fi
+wait "$child" 2>/dev/null || true
+
+# ── 7. Distinct lock names do not serialize against each other ─────
+start="${EPOCHSECONDS:-$(date +%s)}"
+"$GUARD" --lock-name t7a -- sleep 2 &
+a=$!
+sleep 1
+"$GUARD" --lock-name t7b -- true
+end="${EPOCHSECONDS:-$(date +%s)}"
+wait "$a"
+[[ $((end - start)) -lt 2 ]] && ok "distinct lock keys run concurrently" \
+    || bad "distinct lock keys serialized unexpectedly"
+
+echo
+echo "passed: $PASS, failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/test/nextest-guard.sh
+++ b/scripts/test/nextest-guard.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+# nextest-guard.sh — serialize cargo-nextest runs and self-heal stale orchestrators
+#
+# Background (issue #13982): on developer machines `cargo nextest run` can wedge
+# at ~0% CPU — the `cargo-nextest` orchestrator stays alive but idle, no `rustc`
+# running and no test output, indefinitely. Two triggers were observed:
+#
+#   1. Concurrent nextest invocations (reproduced even with separate
+#      CARGO_TARGET_DIR values).
+#   2. Killing a nextest mid-build, which leaves the orchestrator in a hung
+#      state so the *next* run re-wedges.
+#
+# The reliable manual workaround is "serialize nextest, never kill it
+# mid-build." This wrapper encodes that workaround as reusable tooling:
+#
+#   * It holds a host-wide advisory lock for the duration of the wrapped
+#     command, so a second guarded invocation queues behind the first instead
+#     of racing the orchestrator into a wedge.
+#   * On startup, if the previous lock holder died abnormally (e.g. it was
+#     killed mid-build), the guard reaps the orchestrator process tree that the
+#     prior guarded run recorded — and only that tree, never an arbitrary
+#     `cargo-nextest` it did not start — then takes the lock and proceeds.
+#
+# The lock is advisory: it only constrains commands launched *through* this
+# guard. It does not change test behavior or output, so it is safe to wire into
+# any local nextest command. It composes with scripts/safe-run.sh in either
+# order, e.g.
+#
+#   scripts/test/nextest-guard.sh -- scripts/safe-run.sh -- cargo nextest run ...
+#
+# Usage:
+#   scripts/test/nextest-guard.sh [OPTIONS] [--] COMMAND [ARGS...]
+#
+# Options:
+#   --scope global|target  Lock scope. "global" (default) serializes every
+#                           guarded nextest on the host — the safe choice, since
+#                           the wedge reproduces even across distinct target
+#                           dirs. "target" serializes only runs that share the
+#                           resolved CARGO_TARGET_DIR.
+#   --timeout SECONDS      Max time to wait for the lock before giving up
+#                           (default: 1800; 0 = wait indefinitely).
+#   --interval SECONDS     Poll interval while waiting (default: 2).
+#   --no-wait              Fail immediately (exit 75) if the lock is held by a
+#                           live run instead of waiting.
+#   --lock-name NAME       Override the lock key (advanced/testing).
+#   --verbose              Log lock acquisition / steal / release to stderr.
+#
+# Exit codes:
+#   The wrapped command's exit code on success.
+#   75 (EX_TEMPFAIL)  could not acquire the lock (timeout or --no-wait).
+#    1                usage error.
+
+set -uo pipefail
+
+# ─── Defaults ────────────────────────────────────────────────────────
+
+SCOPE="global"
+TIMEOUT=1800
+INTERVAL=2
+NO_WAIT=0
+LOCK_NAME=""
+VERBOSE=0
+
+log() {
+    [[ "$VERBOSE" -eq 1 ]] && echo "[nextest-guard] $*" >&2
+    return 0
+}
+
+warn() {
+    echo "[nextest-guard] $*" >&2
+}
+
+# ─── Parse options ───────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --scope)
+            SCOPE="${2:-}"
+            shift 2
+            ;;
+        --timeout)
+            TIMEOUT="${2:-}"
+            shift 2
+            ;;
+        --interval)
+            INTERVAL="${2:-}"
+            shift 2
+            ;;
+        --no-wait)
+            NO_WAIT=1
+            shift
+            ;;
+        --lock-name)
+            LOCK_NAME="${2:-}"
+            shift 2
+            ;;
+        --verbose)
+            VERBOSE=1
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            warn "unknown option: $1"
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [[ $# -eq 0 ]]; then
+    warn "usage: nextest-guard.sh [--scope global|target] [--timeout S] [--interval S] [--no-wait] [--] COMMAND [ARGS...]"
+    exit 1
+fi
+
+case "$SCOPE" in
+    global | target) ;;
+    *)
+        warn "invalid --scope '$SCOPE' (expected 'global' or 'target')"
+        exit 1
+        ;;
+esac
+
+for n in "$TIMEOUT" "$INTERVAL"; do
+    [[ "$n" =~ ^[0-9]+$ ]] || {
+        warn "--timeout/--interval must be non-negative integers"
+        exit 1
+    }
+done
+[[ "$INTERVAL" -ge 1 ]] || INTERVAL=1
+
+# ─── Resolve the lock key ───────────────────────────────────────────
+# A short, stable, filesystem-safe token. "global" yields one host-wide key;
+# "target" derives the key from the resolved CARGO_TARGET_DIR so distinct
+# target dirs lock independently.
+
+hash_string() {
+    # Stable short hash, dependency-free across macOS/Linux.
+    if command -v cksum >/dev/null 2>&1; then
+        printf '%s' "$1" | cksum | awk '{print $1}'
+    else
+        # Fallback: sanitize the raw string.
+        printf '%s' "$1" | tr -c 'A-Za-z0-9' '_'
+    fi
+}
+
+resolve_target_dir() {
+    if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+        printf '%s' "$CARGO_TARGET_DIR"
+        return
+    fi
+    local root
+    root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    printf '%s/target' "$root"
+}
+
+sanitize() {
+    printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'
+}
+
+if [[ -n "$LOCK_NAME" ]]; then
+    # An explicit lock name is used verbatim (sanitized to be path-safe) so it
+    # is predictable for scripting and tests.
+    KEY="$(sanitize "$LOCK_NAME")"
+elif [[ "$SCOPE" == "target" ]]; then
+    KEY="target-$(hash_string "$(resolve_target_dir)")"
+else
+    KEY="global"
+fi
+
+LOCK_ROOT="${TMPDIR:-/tmp}/tsz-nextest-guard"
+LOCK_DIR="$LOCK_ROOT/$KEY.lock"
+STEAL_DIR="$LOCK_ROOT/$KEY.steal"
+mkdir -p "$LOCK_ROOT" 2>/dev/null || true
+
+# A token unique to this run, so release only removes a lock we still own.
+OWNER_TOKEN="$$@$(hostname 2>/dev/null || echo host)-${EPOCHSECONDS:-$(date +%s)}-$RANDOM"
+
+OWN_LOCK=0
+
+# ─── Process-tree kill (bottom-up), mirrors safe-run.sh ─────────────
+
+kill_tree() {
+    local pid=$1
+    local sig=${2:-TERM}
+    local child
+    for child in $(pgrep -P "$pid" 2>/dev/null); do
+        kill_tree "$child" "$sig"
+    done
+    kill -"$sig" "$pid" 2>/dev/null || true
+}
+
+pid_alive() {
+    local pid=$1
+    [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+}
+
+# Reap the orchestrator process tree a previous guarded run recorded. Only the
+# recorded child PID is touched, and only if the recorded owner PID is dead, so
+# this can never kill a live unrelated nextest. A PID-reuse guard checks that
+# the recorded command name still looks like a cargo/nextest process.
+reap_recorded_child() {
+    local dir=$1
+    local child cmd
+    child="$(cat "$dir/child" 2>/dev/null || true)"
+    pid_alive "$child" || return 0
+    cmd="$(ps -o comm= -p "$child" 2>/dev/null || true)"
+    # PID-reuse guard: the recorded PID is only killed if its current command
+    # still looks like the command this guard launches — `cargo`/`cargo-nextest`
+    # or a `safe-run.sh` wrapper around them. If the PID was recycled into an
+    # unrelated process, the name will not match and we leave it untouched.
+    case "$cmd" in
+        *cargo* | *nextest* | *safe-run*)
+            warn "reaping wedged orchestrator from a previous aborted run (pid $child: ${cmd:-?})"
+            kill_tree "$child" TERM
+            sleep 1
+            kill_tree "$child" KILL
+            ;;
+        *)
+            log "recorded child pid $child is now '$cmd', not a nextest tree; leaving it alone"
+            ;;
+    esac
+}
+
+# Grace period before an empty (half-written) lock dir is treated as abandoned.
+# Comfortably longer than the gap between `mkdir`-ing the lock dir and writing
+# its pid file (two adjacent statements), so a lock that is merely mid-init is
+# never reclaimed out from under its owner.
+GRACE_SECONDS=10
+
+# Under the steal mutex, drop the lock dir if it is still reclaimable — its
+# recorded holder is dead, or it never recorded one (abandoned half-init). Reaps
+# the orchestrator the prior run recorded before removing the dir. Returns 1 if
+# another waiter holds the steal mutex (it will do the cleanup instead).
+reclaim_lock_dir() {
+    local reason=$1 holder
+    mkdir "$STEAL_DIR" 2>/dev/null || return 1
+    # Re-read under the mutex: the holder may have finished and released between
+    # the caller's check and here.
+    holder="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+    if [[ -z "$holder" ]] || ! pid_alive "$holder"; then
+        log "reclaiming lock '$KEY' ($reason; holder ${holder:-none})"
+        reap_recorded_child "$LOCK_DIR"
+        rm -rf "$LOCK_DIR"
+    fi
+    rmdir "$STEAL_DIR" 2>/dev/null || true
+    return 0
+}
+
+acquire_lock() {
+    local start now holder grace_logged=0 grace_start=""
+    start="${EPOCHSECONDS:-$(date +%s)}"
+
+    while true; do
+        if mkdir "$LOCK_DIR" 2>/dev/null; then
+            printf '%s\n' "$$" >"$LOCK_DIR/pid"
+            printf '%s\n' "$OWNER_TOKEN" >"$LOCK_DIR/token"
+            OWN_LOCK=1
+            log "acquired lock '$KEY'"
+            return 0
+        fi
+
+        # Lock is held. Classify the holder, reclaiming it if it is dead or
+        # abandoned, otherwise waiting (or failing fast under --no-wait).
+        now="${EPOCHSECONDS:-$(date +%s)}"
+        holder="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+        if [[ -z "$holder" ]]; then
+            # Half-initialized lock: reclaim only after the grace window so we
+            # never race an owner that is mid-init.
+            if [[ -z "$grace_start" ]]; then
+                grace_start="$now"
+            elif [[ $((now - grace_start)) -ge "$GRACE_SECONDS" ]]; then
+                reclaim_lock_dir "no pid after ${GRACE_SECONDS}s grace" && grace_start=""
+            fi
+        elif ! pid_alive "$holder"; then
+            grace_start=""
+            reclaim_lock_dir "dead holder pid $holder"
+        else
+            grace_start=""
+            if [[ "$NO_WAIT" -eq 1 ]]; then
+                warn "lock '$KEY' held by live run (pid $holder); --no-wait set"
+                return 75
+            fi
+            if [[ "$grace_logged" -eq 0 ]]; then
+                warn "waiting for in-flight nextest (lock '$KEY', held by pid $holder)…"
+                grace_logged=1
+            fi
+        fi
+
+        if [[ "$TIMEOUT" -gt 0 && $((now - start)) -ge "$TIMEOUT" ]]; then
+            warn "timed out after ${TIMEOUT}s waiting for lock '$KEY'"
+            return 75
+        fi
+        sleep "$INTERVAL"
+    done
+}
+
+release_lock() {
+    [[ "$OWN_LOCK" -eq 1 ]] || return 0
+    # Only remove the lock if we still own it (a stealer may have taken over
+    # after declaring us stale).
+    local tok
+    tok="$(cat "$LOCK_DIR/token" 2>/dev/null || true)"
+    if [[ "$tok" == "$OWNER_TOKEN" ]]; then
+        rm -rf "$LOCK_DIR"
+        log "released lock '$KEY'"
+    fi
+    OWN_LOCK=0
+}
+
+# ─── Run the wrapped command under the lock ─────────────────────────
+
+CMD_PID=""
+
+cleanup() {
+    if [[ -n "$CMD_PID" ]] && kill -0 "$CMD_PID" 2>/dev/null; then
+        kill_tree "$CMD_PID" TERM
+        sleep 1
+        kill_tree "$CMD_PID" KILL
+    fi
+    CMD_PID=""
+    release_lock
+}
+trap cleanup EXIT
+
+forward_signal() {
+    [[ -n "$CMD_PID" ]] && kill -0 "$CMD_PID" 2>/dev/null && kill_tree "$CMD_PID" TERM
+    # Restore default disposition and re-raise so the exit status reflects the
+    # signal; the EXIT trap still runs release_lock.
+    trap - INT TERM
+    kill -"${1:-TERM}" "$$" 2>/dev/null || true
+}
+trap 'forward_signal INT' INT
+trap 'forward_signal TERM' TERM
+
+acquire_lock
+rc=$?
+if [[ "$rc" -ne 0 ]]; then
+    exit "$rc"
+fi
+
+"$@" &
+CMD_PID=$!
+# Record the orchestrator PID so a future run can reap it if we are killed
+# mid-build before our EXIT trap can clean up.
+printf '%s\n' "$CMD_PID" >"$LOCK_DIR/child" 2>/dev/null || true
+
+wait "$CMD_PID"
+EXIT_CODE=$?
+CMD_PID=""
+
+release_lock
+trap - EXIT
+exit "$EXIT_CODE"


### PR DESCRIPTION
Goal: fast

Closes #13982. Developer-velocity tooling for the fast-iteration workstream: it
removes a local failure mode that "blocked fast local test iteration for hours"
without changing any compiler behavior.

## Problem

`cargo nextest run` can wedge at ~0% CPU — the `cargo-nextest` orchestrator
stays alive but idle, no `rustc` running, no output, indefinitely. Two triggers
were observed (issue #13982):

1. Concurrent nextest invocations (reproduced **even with separate
   `CARGO_TARGET_DIR`** values).
2. Killing a nextest mid-build, which leaves the orchestrator hung so the *next*
   run re-wedges.

The reliable manual workaround is "serialize nextest, never kill it
mid-build." The wedge lives in `cargo-nextest`/cargo itself (an external tool),
so the right altitude for tsz is to encode that proven workaround as reusable
tooling rather than patch the orchestrator.

## What this does (broad, not just the one repro)

`scripts/test/nextest-guard.sh` wraps an arbitrary command and:

- holds a **host-wide advisory lock** for the wrapped command's lifetime, so a
  second guarded run queues behind the first instead of racing the orchestrator
  into a wedge. The default scope is `global` (not per-target-dir) precisely
  because the issue reproduces across distinct target dirs; `--scope target`
  narrows it when wanted.
- on a stale lock (the prior holder died abnormally, e.g. killed mid-build),
  reaps **only the orchestrator process tree the prior guarded run recorded**,
  PID-reuse-guarded by command name (`*cargo*`/`*nextest*`/`*safe-run*`) — it
  never touches a `cargo-nextest` it did not start — then takes the lock and
  proceeds.

The lock is advisory: it only constrains commands launched through the guard
and never changes test behavior or output, so it is safe to wire into any local
nextest command. It composes with `scripts/safe-run.sh` (memory guard) in either
order. This addresses both root triggers for every contributor/agent, not just
the reported witness.

## Owner layer

Developer tooling only (`scripts/test/`, docs). No crate, no compiler, no CI
gate behavior is touched.

## Anti-hardcoding

No fixture/identifier/file-name predicates; the lock key is derived from the
resolved `CARGO_TARGET_DIR` (or an explicit `--lock-name`), and reaping keys on
liveness + the recorded PID, not on any test or project name.

## Verification

- `scripts/test/nextest-guard-test.sh` — 8/8 pass locally: arg/exit-code
  passthrough, lock release on success, serialization (second run waits for the
  first), `--no-wait` fast-fail (exit 75), stale (dead-holder) lock steal,
  reap-of-recorded-orchestrator on steal, and distinct lock keys running
  concurrently.
- `shellcheck -S warning scripts/test/nextest-guard.sh` — clean (CI's shell-lint
  level); `bash -n` parse clean.
- Reviewed with `/simplify` (3 passes): logic consolidated into one
  `reclaim_lock_dir` helper, grace constant named, comm allowlist documented;
  final pass confirms clean and docs accurate.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01F5GPZZMg1PtifWxxem724H

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5GPZZMg1PtifWxxem724H)_