### PR TITLE
fix(resolver): single owner for import-site ESM/CJS classification

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -72,34 +72,17 @@ use source_resolution_setup::{
 
 fn checker_lookup_resolution_mode(
     module_resolver: &mut ModuleResolver,
-    options: &ResolvedCompilerOptions,
     file_path: &Path,
     import_kind: tsz::module_resolver::ImportKind,
     resolution_mode_override: Option<tsz::module_resolver::ImportingModuleKind>,
 ) -> Option<tsz::checker::context::ResolutionModeOverride> {
-    use tsz::module_resolver::{ImportKind, ImportingModuleKind, ModuleExtension};
-
-    let mode = resolution_mode_override.unwrap_or_else(|| {
-        match import_kind {
-            // Mirror ModuleResolver::resolve_with_kind_and_module_kind() so request-keyed
-            // checker maps line up with the actual lookup mode used by the resolver.
-            ImportKind::DynamicImport => ImportingModuleKind::Esm,
-            ImportKind::CjsRequire => ImportingModuleKind::CommonJs,
-            ImportKind::EsmImport | ImportKind::EsmReExport => match options.checker.module {
-                ModuleKind::Preserve => {
-                    let extension = ModuleExtension::from_path(file_path);
-                    if extension.forces_esm() {
-                        ImportingModuleKind::Esm
-                    } else if extension.forces_cjs() {
-                        ImportingModuleKind::CommonJs
-                    } else {
-                        ImportingModuleKind::Esm
-                    }
-                }
-                _ => module_resolver.get_importing_module_kind(file_path),
-            },
-        }
-    });
+    // Single owner of the ESM/CJS import-site classification, so the request-keyed
+    // checker maps line up with the actual lookup mode the resolver uses.
+    let mode = module_resolver.importing_module_kind_for_import(
+        file_path,
+        import_kind,
+        resolution_mode_override,
+    );
 
     checker_resolution_mode_override(Some(mode))
 }

--- a/crates/tsz-cli/src/driver/check_utils/tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/tests.rs
@@ -3,6 +3,7 @@
 //! production module under the 2000-line limit (§19; ratchet tracked by #9412).
 
 use super::*;
+use tsz_common::common::ModuleKind;
 
 /// Parse source text and return the `BoundFile` from a merged program.
 fn bound_file(source: &str) -> BoundFile {

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -25,7 +25,7 @@ use tsz::lib_loader::LibFile;
 use tsz::module_resolver::{ImportKind, ImportingModuleKind, ModuleResolver};
 use tsz::span::Span;
 use tsz_binder::state::BinderStateScopeInputs;
-use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_common::common::ScriptTarget;
 use tsz_common::file_extensions::{
     JS_FAMILY_EXTENSIONS, JSON_EXTENSION, TS_FAMILY_EXTENSIONS, is_default_lib_file, is_json_file,
 };

--- a/crates/tsz-cli/src/driver/source_resolution_setup.rs
+++ b/crates/tsz-cli/src/driver/source_resolution_setup.rs
@@ -161,7 +161,6 @@ pub(super) fn prepare_source_resolution_setup(
                 };
                 let request_mode_key = checker_lookup_resolution_mode(
                     &mut module_resolver,
-                    options,
                     file_path,
                     *import_kind,
                     *resolution_mode_override,

--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -359,24 +359,11 @@ impl ModuleResolver {
 
         // Determine the module kind of the importing file, honoring any explicit
         // driver-provided resolution-mode override from import attributes.
-        let importing_module_kind =
-            importing_module_kind_override.unwrap_or_else(|| match import_kind {
-                ImportKind::DynamicImport => ImportingModuleKind::Esm,
-                ImportKind::CjsRequire => ImportingModuleKind::CommonJs,
-                ImportKind::EsmImport | ImportKind::EsmReExport => match self.module_kind {
-                    ModuleKind::Preserve => {
-                        let extension = ModuleExtension::from_path(containing_file);
-                        if extension.forces_esm() {
-                            ImportingModuleKind::Esm
-                        } else if extension.forces_cjs() {
-                            ImportingModuleKind::CommonJs
-                        } else {
-                            ImportingModuleKind::Esm
-                        }
-                    }
-                    _ => self.get_importing_module_kind(containing_file),
-                },
-            });
+        let importing_module_kind = self.importing_module_kind_for_import(
+            containing_file,
+            import_kind,
+            importing_module_kind_override,
+        );
         // The IMPORTER's package type drives extension-priority choices for
         // any file probing that lives in the importer's own package context
         // (relative paths, baseUrl/path-mapping targets, classic walk-up).
@@ -495,6 +482,51 @@ impl ModuleResolver {
             }
         } else {
             ImportingModuleKind::CommonJs
+        }
+    }
+
+    /// Canonical ESM/CJS classification for an import *site*.
+    ///
+    /// This is the single owner of the rule every resolution entry point (and
+    /// the checker's resolution-mode map in the CLI driver) must agree on. The
+    /// classification decides which conditional-`exports`/`imports` branch
+    /// (`import` vs `require`) and which Node16/NodeNext extension priority a
+    /// lookup uses, so any divergence between entry points silently resolves the
+    /// same import two different ways:
+    ///
+    /// - An explicit driver-supplied `resolution_mode_override` (from an import
+    ///   attribute / `resolution-mode`) wins over everything else.
+    /// - A dynamic `import()` is always ESM; a `require(...)` is always CJS,
+    ///   regardless of the importing file's extension or package type.
+    /// - An ordinary `import` / `export ... from` under `module: preserve` is
+    ///   ESM unless the importing file's extension forces CJS (`.cts`/`.cjs`);
+    ///   `.mts`/`.mjs` and the extensionless default are ESM. (`module:
+    ///   preserve` is tsc's bundler-style mode, where ordinary imports resolve
+    ///   with the `import` condition.)
+    /// - Otherwise the importing file's extension, `module` target, and nearest
+    ///   `package.json#type` decide, via [`Self::get_importing_module_kind`].
+    pub fn importing_module_kind_for_import(
+        &mut self,
+        containing_file: &Path,
+        import_kind: ImportKind,
+        resolution_mode_override: Option<ImportingModuleKind>,
+    ) -> ImportingModuleKind {
+        if let Some(over) = resolution_mode_override {
+            return over;
+        }
+        match import_kind {
+            ImportKind::DynamicImport => ImportingModuleKind::Esm,
+            ImportKind::CjsRequire => ImportingModuleKind::CommonJs,
+            ImportKind::EsmImport | ImportKind::EsmReExport => match self.module_kind {
+                ModuleKind::Preserve => {
+                    if ModuleExtension::from_path(containing_file).forces_cjs() {
+                        ImportingModuleKind::CommonJs
+                    } else {
+                        ImportingModuleKind::Esm
+                    }
+                }
+                _ => self.get_importing_module_kind(containing_file),
+            },
         }
     }
 
@@ -722,26 +754,11 @@ impl ModuleResolver {
             return ModuleLookupResult::ambient();
         }
 
-        let importing_module_kind_for_lookup =
-            request
-                .resolution_mode_override
-                .unwrap_or_else(|| match import_kind {
-                    ImportKind::DynamicImport => ImportingModuleKind::Esm,
-                    ImportKind::CjsRequire => ImportingModuleKind::CommonJs,
-                    ImportKind::EsmImport | ImportKind::EsmReExport => match self.module_kind {
-                        ModuleKind::Preserve => {
-                            let extension = ModuleExtension::from_path(containing_file);
-                            if extension.forces_esm() {
-                                ImportingModuleKind::Esm
-                            } else if extension.forces_cjs() {
-                                ImportingModuleKind::CommonJs
-                            } else {
-                                ImportingModuleKind::Esm
-                            }
-                        }
-                        _ => self.get_importing_module_kind(containing_file),
-                    },
-                });
+        let importing_module_kind_for_lookup = self.importing_module_kind_for_import(
+            containing_file,
+            import_kind,
+            request.resolution_mode_override,
+        );
 
         // 1. Try primary resolution
         match self.resolve_with_kind_and_module_kind(
@@ -937,9 +954,13 @@ impl ModuleResolver {
                 if matches!(
                     failure,
                     ResolutionFailure::NotFound { .. } | ResolutionFailure::PackageJsonError { .. }
-                ) && let Some(js_path) =
-                    self.probe_js_file(specifier, containing_file, span, import_kind)
-                {
+                ) && let Some(js_path) = self.probe_js_file(
+                    specifier,
+                    containing_file,
+                    span,
+                    import_kind,
+                    request.resolution_mode_override,
+                ) {
                     return ModuleLookupResult::untyped_js(
                         js_path,
                         request.no_implicit_any,
@@ -1029,6 +1050,7 @@ impl ModuleResolver {
         containing_file: &Path,
         specifier_span: Span,
         import_kind: ImportKind,
+        resolution_mode_override: Option<ImportingModuleKind>,
     ) -> Option<PathBuf> {
         if self.allow_js {
             return None; // Already tried JS in normal resolution
@@ -1038,7 +1060,16 @@ impl ModuleResolver {
             .unwrap_or_else(|| Path::new("."))
             .to_path_buf();
         let containing_file_str = containing_file.display().to_string();
-        let importing_module_kind = self.get_importing_module_kind(containing_file);
+        // Classify the import site exactly as the primary resolution did, so the
+        // probe re-resolves the same specifier under the same export condition /
+        // extension priority. Using the raw `get_importing_module_kind` here
+        // diverged under `module: preserve`, letting the probe bind a
+        // `require`-only JS target the ESM primary resolution had rejected.
+        let importing_module_kind = self.importing_module_kind_for_import(
+            containing_file,
+            import_kind,
+            resolution_mode_override,
+        );
 
         self.allow_js = true;
         let importer_package_type = self.importer_package_type(importing_module_kind);

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -12,6 +12,7 @@ mod conditional_types_flavor;
 mod diagnostics_ts2307;
 mod diagnostics_ts2792;
 mod diagnostics_ts2835;
+mod importing_module_kind;
 mod lookup_classify;
 mod lookup_integration;
 mod mixed_esm_cjs_exports;

--- a/crates/tsz-core/src/module_resolver/tests/importing_module_kind.rs
+++ b/crates/tsz-core/src/module_resolver/tests/importing_module_kind.rs
@@ -1,0 +1,260 @@
+//! Tests for the single-owner import-site ESM/CJS classifier
+//! (`ModuleResolver::importing_module_kind_for_import`).
+//!
+//! This classifier decides whether an import site uses the `import` or
+//! `require` conditional-`exports`/`imports` branch (and the matching
+//! Node16/NodeNext extension priority). It is the one place every resolution
+//! entry point — the primary `resolve`, the `lookup` fallback bookkeeping, the
+//! TS7016 `probe_js_file`, and the CLI driver's checker resolution-mode map —
+//! must agree on. These tests pin the rule structurally (by extension / import
+//! kind / `module` target / `package.json#type`), never by a specific file
+//! name, and protect the consistency the consolidation restored: `probe_js_file`
+//! must classify a `module: preserve` import site exactly like the primary
+//! resolution it probes on behalf of, instead of falling back to the bare
+//! `get_importing_module_kind` (which ignores `module: preserve`).
+
+use super::super::*;
+
+fn resolver_with_module(module: crate::emitter::ModuleKind) -> ModuleResolver {
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Bundler),
+        printer: crate::emitter::PrinterOptions {
+            module,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    ModuleResolver::new(&options)
+}
+
+#[test]
+fn dynamic_import_is_always_esm() {
+    let mut resolver = resolver_with_module(crate::emitter::ModuleKind::CommonJS);
+    // A `.cts` file would force CJS for a static import, but a dynamic
+    // `import()` is ESM regardless of the importing file's extension.
+    assert_eq!(
+        resolver.importing_module_kind_for_import(
+            std::path::Path::new("/proj/loader.cts"),
+            ImportKind::DynamicImport,
+            None,
+        ),
+        ImportingModuleKind::Esm
+    );
+}
+
+#[test]
+fn require_call_is_always_commonjs() {
+    let mut resolver = resolver_with_module(crate::emitter::ModuleKind::ESNext);
+    // An `.mts` file forces ESM for a static import, but a `require(...)` call
+    // is CJS regardless.
+    assert_eq!(
+        resolver.importing_module_kind_for_import(
+            std::path::Path::new("/proj/runtime.mts"),
+            ImportKind::CjsRequire,
+            None,
+        ),
+        ImportingModuleKind::CommonJs
+    );
+}
+
+#[test]
+fn resolution_mode_override_wins_over_everything() {
+    let mut resolver = resolver_with_module(crate::emitter::ModuleKind::CommonJS);
+    // Override beats a `require` import kind and a `.cts` file.
+    assert_eq!(
+        resolver.importing_module_kind_for_import(
+            std::path::Path::new("/proj/attr.cts"),
+            ImportKind::CjsRequire,
+            Some(ImportingModuleKind::Esm),
+        ),
+        ImportingModuleKind::Esm
+    );
+}
+
+#[test]
+fn preserve_plain_extension_static_import_is_esm() {
+    let mut resolver = resolver_with_module(crate::emitter::ModuleKind::Preserve);
+    // Under `module: preserve`, an ordinary `import` from a plain-extension
+    // file resolves with the `import` condition (ESM), matching tsc's
+    // bundler-style mode — independent of any nearby `package.json#type`.
+    for name in ["entry.ts", "widget.tsx", "data.js", "view.jsx"] {
+        assert_eq!(
+            resolver.importing_module_kind_for_import(
+                std::path::Path::new("/proj").join(name).as_path(),
+                ImportKind::EsmImport,
+                None,
+            ),
+            ImportingModuleKind::Esm,
+            "preserve static import from {name} should be ESM"
+        );
+    }
+}
+
+#[test]
+fn preserve_respects_extension_forced_cjs_and_esm() {
+    let mut resolver = resolver_with_module(crate::emitter::ModuleKind::Preserve);
+    // `.cts`/`.cjs` force CJS even under preserve...
+    for name in ["legacy.cts", "shim.cjs"] {
+        assert_eq!(
+            resolver.importing_module_kind_for_import(
+                std::path::Path::new("/proj").join(name).as_path(),
+                ImportKind::EsmImport,
+                None,
+            ),
+            ImportingModuleKind::CommonJs,
+            "{name} should force CJS under preserve"
+        );
+    }
+    // ...and `.mts`/`.mjs` force ESM.
+    for name in ["modern.mts", "esm.mjs"] {
+        assert_eq!(
+            resolver.importing_module_kind_for_import(
+                std::path::Path::new("/proj").join(name).as_path(),
+                ImportKind::EsmImport,
+                None,
+            ),
+            ImportingModuleKind::Esm,
+            "{name} should force ESM under preserve"
+        );
+    }
+}
+
+#[test]
+fn preserve_plain_import_is_esm_even_in_a_commonjs_package() {
+    use std::fs;
+    // The consistency crux: a plain `.ts` import inside a `"type": "commonjs"`
+    // (or type-less) package is ESM under `module: preserve`. The bare
+    // `get_importing_module_kind` returns CJS for exactly this shape, so the
+    // canonical classifier must NOT defer to it for preserve static imports —
+    // otherwise the primary resolution and the TS7016 `probe_js_file` would
+    // pick different export conditions for the same import site.
+    let dir = std::env::temp_dir().join("tsz_importing_module_kind_preserve_cjs_pkg");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("app")).unwrap();
+    fs::write(dir.join("package.json"), r#"{"type": "commonjs"}"#).unwrap();
+    let importer = dir.join("app/main.ts");
+    fs::write(&importer, "import { x } from 'pkg';").unwrap();
+
+    let mut resolver = resolver_with_module(crate::emitter::ModuleKind::Preserve);
+
+    // Bare classifier (used pre-consolidation by probe_js_file) sees the CJS
+    // package and returns CommonJs — the divergence the fix removes.
+    assert_eq!(
+        resolver.get_importing_module_kind(&importer),
+        ImportingModuleKind::CommonJs,
+        "bare classifier follows package.json#type"
+    );
+
+    // Canonical classifier keeps the preserve static-import site ESM.
+    assert_eq!(
+        resolver.importing_module_kind_for_import(&importer, ImportKind::EsmImport, None),
+        ImportingModuleKind::Esm,
+        "preserve static import stays ESM regardless of CJS package.json"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn non_preserve_module_defers_to_package_type() {
+    use std::fs;
+    // Outside `module: preserve`, a plain-extension static import follows the
+    // existing `get_importing_module_kind` rule (here: package.json type), so
+    // the consolidation is behavior-preserving for the common Node16 path.
+    let dir = std::env::temp_dir().join("tsz_importing_module_kind_node16_pkg_type");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("esm")).unwrap();
+    fs::create_dir_all(dir.join("cjs")).unwrap();
+    fs::write(dir.join("esm/package.json"), r#"{"type": "module"}"#).unwrap();
+    fs::write(dir.join("cjs/package.json"), r#"{"type": "commonjs"}"#).unwrap();
+    let esm_importer = dir.join("esm/a.ts");
+    let cjs_importer = dir.join("cjs/b.ts");
+    fs::write(&esm_importer, "import 'pkg';").unwrap();
+    fs::write(&cjs_importer, "import 'pkg';").unwrap();
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::NodeNext),
+        printer: crate::emitter::PrinterOptions {
+            module: crate::emitter::ModuleKind::NodeNext,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+
+    assert_eq!(
+        resolver.importing_module_kind_for_import(&esm_importer, ImportKind::EsmImport, None),
+        ImportingModuleKind::Esm
+    );
+    assert_eq!(
+        resolver.importing_module_kind_for_import(&cjs_importer, ImportKind::EsmImport, None),
+        ImportingModuleKind::CommonJs
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn preserve_static_import_of_require_only_js_is_ts2307_not_ts7016() {
+    use std::fs;
+    // End-to-end witness of the `probe_js_file` consistency fix. A package
+    // exposes a JS entry ONLY via the `require` condition (no `import`, no
+    // types). A static `import` from a plain `.ts` file under `module:
+    // preserve` resolves with the `import` condition, which the package does
+    // not satisfy → tsc reports TS2307 ("Cannot find module").
+    //
+    // Before the fix, the primary resolution failed under ESM but the TS7016
+    // `probe_js_file` re-resolved under CommonJS (the bare classifier), matched
+    // the `require`-only JS, and downgraded the diagnostic to TS7016 with the
+    // module treated as resolved. The probe must classify the import site the
+    // same way as the primary resolution, so the require-only JS stays
+    // unreachable and the diagnostic remains TS2307.
+    let dir = std::env::temp_dir().join("tsz_preserve_require_only_js_probe");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("node_modules/pkg")).unwrap();
+    fs::create_dir_all(dir.join("app")).unwrap();
+    fs::write(
+        dir.join("node_modules/pkg/package.json"),
+        r#"{"name":"pkg","exports":{".":{"require":"./impl.js"}}}"#,
+    )
+    .unwrap();
+    fs::write(dir.join("node_modules/pkg/impl.js"), "module.exports = {};").unwrap();
+    let importer = dir.join("app/main.ts");
+    fs::write(&importer, "import { x } from 'pkg';").unwrap();
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Bundler),
+        resolve_package_json_exports: true,
+        module_suffixes: vec![String::new()],
+        printer: crate::emitter::PrinterOptions {
+            module: crate::emitter::ModuleKind::Preserve,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+
+    let request = ModuleLookupRequest {
+        specifier: "pkg",
+        containing_file: &importer,
+        specifier_span: Span::new(15, 20),
+        import_kind: ImportKind::EsmImport,
+        resolution_mode_override: None,
+        no_implicit_any: true,
+        implied_classic_resolution: false,
+    };
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+
+    assert!(
+        result.resolved_path.is_none() && !result.treat_as_resolved,
+        "require-only JS must stay unreachable for a preserve static import"
+    );
+    let error = result.error.expect("should report a not-found diagnostic");
+    assert_eq!(
+        error.code, CANNOT_FIND_MODULE,
+        "should be TS2307, not the TS7016 the divergent CJS probe produced: {}",
+        error.message
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Goal: hold

Part of the #13826 module-resolution umbrella (sub-roots #1/#2). Removes a divergent copy of the import-site ESM/CJS classifier rather than adding one, and fixes the TS7016-vs-TS2307 divergence it caused under `module: preserve`. Does not claim or close the umbrella.

## Structural rule

When an import site must be classified as ESM vs CJS — which decides whether the `import` or `require` conditional-`exports`/`imports` branch (and the Node16/NodeNext extension priority) is used — `tsc` applies one rule consistently across every resolution entry point: a dynamic `import()` is always ESM; a `require(...)` is always CJS; an ordinary `import` / `export ... from` under `module: preserve` resolves with the `import` condition unless the importing file's extension forces CJS (`.cts`/`.cjs`); otherwise the file extension, `module` target, and nearest `package.json#type` decide.

tsz duplicated this rule in **four** places — `ModuleResolver::resolve_with_kind_and_module_kind`, `ModuleResolver::lookup`, and the CLI driver's `checker_lookup_resolution_mode` (whose own comment said it must "Mirror `resolve_with_kind_and_module_kind`") — with a **divergent fourth copy** in `ModuleResolver::probe_js_file` (the TS7016 untyped-JS probe), which called the bare `get_importing_module_kind` and therefore **ignored the `module: preserve` / import-kind rule** the other three apply.

Consequence (tsc divergence): under `module: preserve` (the recommended bundler setting), the primary resolution of an ordinary `import` is classified ESM (`import` condition), but when it fails and `probe_js_file` runs, the probe re-resolved the *same* specifier under CommonJS (`require` condition). The probe could then bind a `require`-only JS target the ESM primary resolution correctly rejected, so tsz emitted **TS7016** (and treated the module as resolved) where `tsc` emits **TS2307**.

## Owner layer

Module resolver (`tsz-core`), consumed by the CLI driver. A single `ModuleResolver::importing_module_kind_for_import(containing_file, import_kind, resolution_mode_override)` now owns the rule (dynamic→ESM, require→CJS, `module: preserve` extension handling, else `get_importing_module_kind`, override wins). All four sites call it; `probe_js_file` additionally threads the primary lookup's `resolution_mode_override`, so the probe classifies the import site identically to the resolution it probes on behalf of. The now-unused `options` param of `checker_lookup_resolution_mode` (and the resulting orphaned `ModuleKind` import) are removed.

## Anti-hardcoding

No identifier / file-name / printer-string predicate. The classification keys only on the structural import kind, the importing file's extension, the `module` target, and `package.json#type`. The new unit tests vary the importing file's base names and assert on the structural outcome, not on specific names.

## Adjacent-case matrix

| import site | expected | covered by |
|---|---|---|
| dynamic `import()` from a `.cts` file | ESM | `dynamic_import_is_always_esm` |
| `require(...)` from an `.mts` file | CJS | `require_call_is_always_commonjs` |
| `resolution-mode` override vs `require` + `.cts` | override wins | `resolution_mode_override_wins_over_everything` |
| `module: preserve` plain `.ts`/`.tsx`/`.js`/`.jsx` static import | ESM | `preserve_plain_extension_static_import_is_esm` |
| `module: preserve` `.cts`/`.cjs` vs `.mts`/`.mjs` | CJS vs ESM | `preserve_respects_extension_forced_cjs_and_esm` |
| `module: preserve` plain `.ts` in a `"type":"commonjs"` package | ESM (bare classifier returns CJS) | `preserve_plain_import_is_esm_even_in_a_commonjs_package` |
| non-preserve (`NodeNext`) defers to `package.json#type` | unchanged | `non_preserve_module_defers_to_package_type` |
| `module: preserve` static import of a `require`-only JS package | TS2307, not TS7016 | `preserve_static_import_of_require_only_js_is_ts2307_not_ts7016` |

## Verification

- `cargo test -p tsz-core --lib module_resolver::tests` — **252 passed, 0 failed** (includes 8 new tests; no regressions across the resolver suite).
- `cargo check -p tsz-core` and `cargo check -p tsz-cli` clean.
- `cargo fmt -p tsz-core -p tsz-cli --check` clean; `cargo clippy -p tsz-core --lib` clean.
- Rebased onto current `origin/main` (`2cb8518`); no conflicts.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01UHTY7192coBNyZBiCzHAYE

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHTY7192coBNyZBiCzHAYE)_