### PR TITLE
fix(lsp): expand shorthand/destructuring rename on the symbol-based path

### DIFF
--- a/crates/tsz-lsp/src/rename/core.rs
+++ b/crates/tsz-lsp/src/rename/core.rs
@@ -6,7 +6,7 @@
 
 use super::{
     PrepareRenameResult, RenameProvider, RenameSymbolKind, RenameTextEdit, RenameWorkspaceEdit,
-    TextEdit, WorkspaceEdit,
+    WorkspaceEdit,
 };
 use crate::errors::RenameError;
 use crate::navigation::references::FindReferences;
@@ -214,9 +214,28 @@ impl<'a> RenameProvider<'a> {
             .find_references_for_symbol(root, symbol_id)
             .ok_or(RenameError::SymbolNotFound)?;
 
+        // The old name drives the shorthand-context expansion (shorthand
+        // property assignment, destructuring binding element) into its
+        // `old: new` form. Without it the symbol-based path emits a plain
+        // identifier replacement that silently changes which property is
+        // destructured -- e.g. `const { name } = o` renamed to `fullName`
+        // would become `const { fullName } = o` (binds a missing property)
+        // instead of `const { name: fullName } = o`. Import/export specifiers
+        // are renamed across files by the cross-file machinery, so their
+        // `as` expansion stays disabled here (`expand_specifiers = false`).
+        let old_name = self
+            .binder
+            .symbols
+            .get(symbol_id)
+            .map(|s| s.escaped_name.clone())
+            .unwrap_or_default();
+
         let mut workspace_edit = WorkspaceEdit::new();
         for loc in Self::dedup_locations(locations) {
-            workspace_edit.add_edit(loc.file_path, TextEdit::new(loc.range, new_name.clone()));
+            let edit = self
+                .build_rename_edit(loc.range, &old_name, &new_name, false)
+                .to_text_edit();
+            workspace_edit.add_edit(loc.file_path, edit);
         }
 
         Ok(workspace_edit)
@@ -328,7 +347,7 @@ impl<'a> RenameProvider<'a> {
         let mut workspace_edit = RenameWorkspaceEdit::new();
 
         for loc in Self::dedup_locations(locations) {
-            let edit = self.build_rename_edit(loc.range, &old_name, &normalized_name);
+            let edit = self.build_rename_edit(loc.range, &old_name, &normalized_name, true);
             workspace_edit.add_edit(loc.file_path, edit);
         }
 
@@ -358,13 +377,45 @@ impl<'a> RenameProvider<'a> {
     /// Build a `RenameTextEdit` for a single reference, detecting special
     /// contexts such as shorthand property assignments and import specifiers
     /// where simple text replacement would change semantics.
-    fn build_rename_edit(&self, range: Range, old_name: &str, new_name: &str) -> RenameTextEdit {
+    ///
+    /// `expand_specifiers` controls the import/export specifier `old as new`
+    /// expansion. The position-based local rename keeps the imported/exported
+    /// name stable and so expands; the symbol-based path renames the
+    /// imported/exported binding across files through the cross-file machinery
+    /// in [`crate::project`], which rewrites the specifier directly, so it must
+    /// not expand here (`import { value }` -> `import { renamed }`, not
+    /// `import { value as renamed }`).
+    fn build_rename_edit(
+        &self,
+        range: Range,
+        old_name: &str,
+        new_name: &str,
+        expand_specifiers: bool,
+    ) -> RenameTextEdit {
         // Determine the byte offset of the reference
         let Some(offset) = self
             .line_map
             .position_to_offset(range.start, self.source_text)
         else {
             return RenameTextEdit::new(range, new_name.to_string());
+        };
+
+        // A reference location's span can reach past the identifier itself:
+        // destructuring binding elements and shorthand property assignments
+        // carry a node span that includes the following delimiter, so the raw
+        // range covers e.g. `name,` or `name }`. Tighten the replaced span to
+        // exactly the identifier text (verified against the source) so the
+        // shorthand/destructuring expansion does not consume the trailing
+        // `,`/`}` and corrupt the surrounding code.
+        let start = offset as usize;
+        let range = match self.source_text.get(start..start + old_name.len()) {
+            Some(slice) if slice == old_name => {
+                let end = self
+                    .line_map
+                    .offset_to_position(offset + old_name.len() as u32, self.source_text);
+                Range::new(range.start, end)
+            }
+            _ => range,
         };
 
         let ref_node_idx = find_node_at_offset(self.arena, offset);
@@ -420,7 +471,8 @@ impl<'a> RenameProvider<'a> {
                 // Import specifier shorthand: `import { foo } from 'mod'`
                 // When renaming foo to bar, we need
                 // `import { foo as bar } from 'mod'`.
-                if parent_node.kind == syntax_kind_ext::IMPORT_SPECIFIER
+                if expand_specifiers
+                    && parent_node.kind == syntax_kind_ext::IMPORT_SPECIFIER
                     && let Some(spec) = self.arena.get_specifier(parent_node)
                     && spec.property_name.is_none()
                 {
@@ -434,7 +486,8 @@ impl<'a> RenameProvider<'a> {
                 // Export specifier shorthand: `export { foo }`
                 // When renaming local foo to bar, we need
                 // `export { bar as foo }` to keep the public API stable.
-                if parent_node.kind == syntax_kind_ext::EXPORT_SPECIFIER
+                if expand_specifiers
+                    && parent_node.kind == syntax_kind_ext::EXPORT_SPECIFIER
                     && let Some(spec) = self.arena.get_specifier(parent_node)
                     && spec.property_name.is_none()
                 {

--- a/crates/tsz-lsp/tests/project_tests/discovery_and_references.rs
+++ b/crates/tsz-lsp/tests/project_tests/discovery_and_references.rs
@@ -202,6 +202,61 @@ fn test_project_rename_cross_file() {
     assert_eq!(updated_b, "import { renamed } from \"./a\";\nrenamed;\n");
 }
 
+// The symbol-based production rename path must apply the destructuring
+// shorthand expansion: renaming a shorthand binding rewrites it to
+// `source: new` so it keeps destructuring the original property, instead of
+// the plain `new` replacement that would silently bind a missing property.
+// The unrelated object-literal key of the same name is left untouched.
+#[test]
+fn test_project_rename_destructuring_expands_shorthand() {
+    let mut project = Project::new();
+
+    project.set_file(
+        "a.ts".to_string(),
+        "const { name, age } = { name: 'Alice', age: 30 };\nconsole.log(name);\n".to_string(),
+    );
+
+    // Cursor on the destructuring binding `name` (line 0, char 8).
+    let edits = project
+        .get_rename_edits("a.ts", Position::new(0, 8), "fullName".to_string())
+        .expect("Expected rename edits");
+
+    let file = project.file("a.ts").unwrap();
+    let a_edits = edits.changes.get("a.ts").expect("Expected edits for a.ts");
+    let updated = apply_text_edits(file.source_text(), file.line_map(), a_edits);
+
+    assert_eq!(
+        updated,
+        "const { name: fullName, age } = { name: 'Alice', age: 30 };\nconsole.log(fullName);\n"
+    );
+}
+
+// Renaming an object-literal shorthand property value rewrites it to
+// `key: new` through the symbol-based path, leaving the property key intact.
+#[test]
+fn test_project_rename_object_shorthand_expands() {
+    let mut project = Project::new();
+
+    project.set_file(
+        "a.ts".to_string(),
+        "const name = 'Alice';\nconst person = { name };\n".to_string(),
+    );
+
+    // Cursor on the `const name` declaration (line 0, char 6).
+    let edits = project
+        .get_rename_edits("a.ts", Position::new(0, 6), "fullName".to_string())
+        .expect("Expected rename edits");
+
+    let file = project.file("a.ts").unwrap();
+    let a_edits = edits.changes.get("a.ts").expect("Expected edits for a.ts");
+    let updated = apply_text_edits(file.source_text(), file.line_map(), a_edits);
+
+    assert_eq!(
+        updated,
+        "const fullName = 'Alice';\nconst person = { name: fullName };\n"
+    );
+}
+
 #[test]
 fn test_project_rename_cross_file_alias_import() {
     let mut project = Project::new();


### PR DESCRIPTION
## Summary

The reference-walker false-positive family (object-literal keys / member names
matching same-named locals) was already fixed on `main`
(`is_non_lexical_name_position`). This PR fixes the remaining, separate defect:
the **symbol-based production rename path** (`provide_rename_edits_for_symbol`,
used by `Project::get_rename_edits`) emitted semantically broken edits for
shorthand and destructuring bindings.

Two compounding bugs, both fixed:

1. **No shorthand expansion.** The symbol path emitted a plain
   `TextEdit::new(range, new_name)` and never ran `build_rename_edit`, so a
   shorthand rename dropped the source property:
   - `const { name } = o` → `fullName` produced `const { fullName } = o`
     (binds a non-existent property) instead of `const { name: fullName } = o`;
   - `const o = { name }` produced `{ fullName }` instead of `{ name: fullName }`.
2. **Over-wide replacement span.** Destructuring binding elements and shorthand
   property assignments carry a node span that reaches past the identifier
   (it includes the following `,`/`}`), so the reference range was e.g. `name,`.
   Once expansion is applied that consumed the delimiter and corrupted the code
   (`const { name: fullName age } = ...`). Count-only rename tests never caught
   this because they assert edit *count*, not applied text.

## Structural rule

When renaming a binding through the symbol-based path, tsz must apply the same
shorthand/destructuring expansion as the position-based path **and** replace
exactly the identifier text. Import/export specifiers are renamed across files
by the cross-file machinery, so their `as` expansion stays disabled on the
symbol path (gated by a new `expand_specifiers` flag): `import { renamed }`,
not `import { value as renamed }`.

## Owner layer

LSP rename — `crates/tsz-lsp/src/rename/core.rs`. No compiler/type-semantics
change; emit and conformance are untouched.

Closes #14036

Goal: hold

## Verification

- `cargo test -p tsz-lsp --lib` — all 4057 lib tests pass, including:
  - new text-asserting `test_project_rename_destructuring_expands_shorthand`
    and `test_project_rename_object_shorthand_expands`
    (assert the produced source, not just edit count);
  - existing `test_project_rename_cross_file` /
    `test_project_rename_cross_file_alias_import` confirm import/export
    specifiers stay correct under the gated `expand_specifiers` path.
- `cargo clippy -p tsz-lsp --lib --tests` — clean.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01EvwWVv3G6ZQCj6swFMtnzB)_