### PR TITLE
fix(emit): lower generator yield* via __values delegation at ES5

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -283,6 +283,10 @@ name = "generator_downlevel_iteration_for_of_tests"
 path = "tests/generator_downlevel_iteration_for_of_tests.rs"
 
 [[test]]
+name = "generator_yield_star_es5_tests"
+path = "tests/generator_yield_star_es5_tests.rs"
+
+[[test]]
 name = "async_try_emit"
 path = "tests/async_try_emit.rs"
 

--- a/crates/tsz-emitter/src/lowering/visit_children.rs
+++ b/crates/tsz-emitter/src/lowering/visit_children.rs
@@ -619,6 +619,14 @@ impl<'a> LoweringPass<'a> {
             }
             k if k == syntax_kind_ext::YIELD_EXPRESSION => {
                 if let Some(unary) = self.arena.get_unary_expr_ex(node) {
+                    // A delegating `yield* x` lowered through the `__generator`
+                    // state machine wraps the delegate in `__values(x)` (op 5).
+                    // At ES5 every generator is lowered, so any `yield*` pulls in
+                    // the iterator helper; native (ES2015+) generators keep
+                    // `yield*` and need no helper.
+                    if unary.asterisk_token && self.ctx.target_es5 {
+                        self.transforms.helpers_mut().mark_values();
+                    }
                     self.visit(unary.expression);
                 }
             }

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_statements.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_statements.rs
@@ -954,6 +954,15 @@ impl<'a> AsyncES5Transformer<'a> {
                 return;
             }
 
+            // A delegating `yield* expr` in a (non-async) generator lowers to the
+            // `__values`-wrapped delegate with op 5 (`yield**`), matching tsc; the
+            // `__values` helper is requested by the lowering pass. A plain `yield`
+            // (and `await`) uses op 4. Async generators take the dedicated
+            // `process_async_generator_yield_expression` path above.
+            let is_yield_star = self.generator_mode
+                && node.kind == syntax_kind_ext::YIELD_EXPRESSION
+                && await_expr.asterisk_token;
+
             // Get the awaited expression. A bare generator `yield;` lowers to
             // `[4 /*yield*/]`, while `await;` keeps the historical empty
             // operand shape for invalid/recovered async input.
@@ -964,6 +973,13 @@ impl<'a> AsyncES5Transformer<'a> {
                 None
             } else if await_expr.expression.is_none() {
                 Some(IRNode::Raw("".to_string().into()))
+            } else if is_yield_star {
+                // `yield* x` delegates iteration: wrap the operand in `__values(x)`
+                // so the runtime drives the delegate's iterator protocol.
+                Some(IRNode::CallExpr {
+                    callee: Box::new(IRNode::RuntimeHelper("__values".into())),
+                    arguments: vec![self.generator_yield_operand_to_ir(await_expr.expression)],
+                })
             } else if self.generator_mode && node.kind == syntax_kind_ext::YIELD_EXPRESSION {
                 Some(self.generator_yield_operand_to_ir(await_expr.expression))
             } else {
@@ -981,12 +997,17 @@ impl<'a> AsyncES5Transformer<'a> {
                 }
             };
 
-            // Emit: return [4 /*yield*/, operand];
+            // Emit: return [4 /*yield*/, operand] (or [5 /*yield**/, __values(...)]).
+            let (opcode, comment) = if is_yield_star {
+                (opcodes::YIELD_STAR, "yield*")
+            } else {
+                (opcodes::YIELD, "yield")
+            };
             current_statements.push(IRNode::ReturnStatement(Some(Box::new(
                 IRNode::GeneratorOp {
-                    opcode: opcodes::YIELD,
+                    opcode,
                     value: operand.map(Box::new),
-                    comment: Some("yield".to_string().into()),
+                    comment: Some(comment.to_string().into()),
                 },
             ))));
             if let Some(comment) = trailing_comment {

--- a/crates/tsz-emitter/tests/generator_yield_star_es5_tests.rs
+++ b/crates/tsz-emitter/tests/generator_yield_star_es5_tests.rs
@@ -1,0 +1,132 @@
+//! Regression tests for `yield*` (delegated yield) down-leveling in the ES5
+//! `__generator` state machine.
+//!
+//! A delegating `yield* expr` must lower to the `[5 /*yield**/, __values(expr)]`
+//! op (op code 5 drives the delegate's iterator protocol), not the plain
+//! `[4 /*yield*/, expr]` op that yields the operand as a single value. The
+//! `__values` iterator helper must also be emitted. Asserting on the op-code
+//! structure (not specific identifiers) keeps these guards name-agnostic.
+
+use tsz_common::common::ScriptTarget;
+use tsz_emitter::output::printer::{PrintOptions, lower_and_print};
+use tsz_parser::parser::ParserState;
+
+fn emit_es5(source: &str) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let opts = PrintOptions {
+        target: ScriptTarget::ES5,
+        remove_comments: true,
+        ..PrintOptions::default()
+    };
+    lower_and_print(&parser.arena, root, opts).code
+}
+
+fn emit_es2015(source: &str) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let opts = PrintOptions {
+        target: ScriptTarget::ES2015,
+        remove_comments: true,
+        ..PrintOptions::default()
+    };
+    lower_and_print(&parser.arena, root, opts).code
+}
+
+#[test]
+fn yield_star_over_array_uses_delegated_op_and_values_helper() {
+    let output = emit_es5("function* gen() { yield* [2, 3]; }");
+    assert!(
+        output.contains("[5 /*yield**/, __values([2, 3])]"),
+        "`yield*` must lower to the delegated op (5) wrapping the operand in `__values`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("[4 /*yield*/, [2, 3]]"),
+        "`yield*` must not lower to a plain `yield` of the whole operand.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var __values ="),
+        "The `__values` iterator helper must be emitted for a delegated `yield*`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn yield_star_over_generator_call_delegates() {
+    let output = emit_es5("function* outer() { yield* inner(); } function* inner() { yield 1; }");
+    assert!(
+        output.contains("[5 /*yield**/, __values(inner())]"),
+        "`yield*` over a generator call must delegate via `__values`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var __values ="),
+        "The `__values` helper must be emitted.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn yield_star_renamed_binders_keep_delegated_structure() {
+    // Anti-hardcoding: every user binder is renamed; the lowering decision keys
+    // on the structural `yield*` (asterisk) marker, not any identifier text.
+    let output =
+        emit_es5("function* produce() { yield* makeSeq(); } function* makeSeq() { yield 7; }");
+    assert!(
+        output.contains("[5 /*yield**/, __values(makeSeq())]"),
+        "Delegated structure must be name-agnostic.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("[4 /*yield*/, makeSeq()]"),
+        "Renamed binders must not change `yield*` into a plain `yield`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn plain_yield_keeps_value_op_and_omits_values_helper() {
+    // Negative control: a non-delegating `yield` stays op 4 and does not pull in
+    // the `__values` iterator helper.
+    let output = emit_es5("function* gen() { yield 1; yield 2; }");
+    assert!(
+        output.contains("[4 /*yield*/, 1]") && output.contains("[4 /*yield*/, 2]"),
+        "Plain `yield` must keep the value op (4).\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("/*yield**/"),
+        "Plain `yield` must not emit the delegated op.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("var __values ="),
+        "Plain `yield` must not pull in the `__values` helper.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn yield_star_value_is_resumed_from_sent() {
+    // `const total = yield* delegate()` resumes the delegate's return value via
+    // `_a.sent()`, exactly like a plain yield's resume point.
+    let output = emit_es5(
+        "function* gen() { const total = yield* delegate(); return total; }
+         function* delegate() { return 1; }",
+    );
+    assert!(
+        output.contains("[5 /*yield**/, __values(delegate())]"),
+        "`yield*` used as a value still delegates via `__values`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a.sent()"),
+        "The delegated value must be resumed from `_a.sent()`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn native_generator_keeps_yield_star_without_helper() {
+    // At ES2015+ the generator is native: `yield*` is preserved verbatim and no
+    // `__generator`/`__values` lowering is performed.
+    let output = emit_es2015("function* gen() { yield* [2, 3]; }");
+    assert!(
+        output.contains("yield* [2, 3]"),
+        "Native generators must preserve `yield*`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("__values") && !output.contains("/*yield**/"),
+        "Native generators must not emit down-level helpers/ops.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Goal: hold

## Summary

A delegating `yield* expr` inside a generator down-leveled to the ES5
`__generator` state machine was emitted as a **plain** `yield` (op code 4),
yielding the operand as a single value instead of delegating to its iterator.

```ts
function* g() { yield* [2, 3]; }
```

- tsz (before): `return [4 /*yield*/, [2, 3]];` — runtime yields the array `[2, 3]` **once**.
- tsc 6.0.2:    `return [5 /*yield**/, __values([2, 3])];` — runtime yields `2` then `3`.

So `[...(function*(){ yield 1; yield* [2,3]; yield 4; })()]` produced
`[1, [2,3], 4]` under tsz vs the correct `[1, 2, 3, 4]` under tsc — a
runtime-incorrect transform.

## Structural rule

When a generator is lowered to the `__generator` state machine (ES5 target),
a `yield*` **delegates iteration**: `tsc` emits op code `5` (`yield**`) with
the operand wrapped in `__values(...)` and schedules the `__values` iterator
helper; a non-delegating `yield` keeps op code `4`. Native (ES2015+) generators
preserve `yield*` verbatim and need no helper.

## Owner layer

Emitter only — no semantic validation, no output surgery.

- `transforms/async_es5_ir_statements.rs`: the synchronous-generator suspension
  lowering now checks the `YieldExpression` asterisk token and emits op `5`
  with the `__values`-wrapped delegate (comment `yield**`), instead of always
  emitting op `4`. The async-generator path already handled delegation.
- `lowering/visit_children.rs`: the lowering pass requests the `__values`
  helper for any ES5 `yield*` (at ES5 every generator is lowered, so a `yield*`
  always pulls in the iterator helper; native generators do not).

## Anti-hardcoding

The decision keys on the structural `yield*` asterisk marker, not any
identifier, file name, or printer output. The renamed-binder companion test
changes every user binder and asserts the same op-`5`/`__values` structure.

## Adjacent-case matrix (verified against `tsc` 6.0.2)

| construct | tsc | tsz |
|---|---|---|
| `yield* [..]` (array delegate) | `[5, __values([..])]` + helper | ✓ |
| `yield* gen()` (generator delegate) | `[5, __values(gen())]` | ✓ |
| `const x = yield* gen()` (value position) | delegates, resumes via `_a.sent()` | ✓ |
| renamed binders | same op-5 structure | ✓ |
| plain `yield` (negative control) | stays op `4`, no `__values` | ✓ |
| ES2015 target (native) | `yield*` preserved, no helper | ✓ |

## Verification

- New `generator_yield_star_es5_tests` (6 tests) — all pass.
- Full `tsz-emitter` suite (lib + 75 integration binaries) — **0 failures**
  (no regressions).
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --lib`,
  `python3 scripts/arch/arch_guard.py` — all clean.
- Differential vs `tsc 6.0.2`: emitted op/operand/helper match for every case
  above (ES5 ± `downlevelIteration`).
- Runtime: tsz-emitted JS run under node yields `[1,2,3,4]` for
  `[...g()]` with a `yield*` mid-stream, matching tsc.
- Rebased onto current `origin/main`; no conflicts.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_012u9rFReG7xngAW47ApYHax

---
_Generated by [Claude Code](https://claude.ai/code/session_012u9rFReG7xngAW47ApYHax)_