### PR TITLE
fix(checker): report implicit-any params an annotated var initializer cannot type (TS7006)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -434,6 +434,9 @@ path = "tests/ts2636_method_bivariance_tests.rs"
 name = "function_bivariance"
 path = "tests/function_bivariance.rs"
 [[test]]
+name = "function_expression_excess_param_implicit_any_tests"
+path = "tests/function_expression_excess_param_implicit_any_tests.rs"
+[[test]]
 name = "global_type_tests"
 path = "tests/global_type_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
@@ -10,48 +10,6 @@ use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
-    fn enclosing_function_for_parameter_name(&self, param_name: NodeIndex) -> Option<NodeIndex> {
-        let param_idx = self.ctx.arena.get_extended(param_name)?.parent;
-        let func_idx = self.ctx.arena.get_extended(param_idx)?.parent;
-        let func_node = self.ctx.arena.get(func_idx)?;
-        (func_node.kind == tsz_parser::parser::syntax_kind_ext::ARROW_FUNCTION
-            || func_node.kind == tsz_parser::parser::syntax_kind_ext::FUNCTION_EXPRESSION)
-            .then_some(func_idx)
-    }
-
-    fn parameter_has_deferred_explicit_context(&self, param_name: NodeIndex) -> bool {
-        let Some(func_idx) = self.enclosing_function_for_parameter_name(param_name) else {
-            return false;
-        };
-        let mut current = self.ctx.arena.get_extended(func_idx).map(|ext| ext.parent);
-        while let Some(parent_idx) = current {
-            let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
-                return false;
-            };
-            if parent_node.kind == tsz_parser::parser::syntax_kind_ext::VARIABLE_DECLARATION {
-                let Some(var_decl) = self.ctx.arena.get_variable_declaration(parent_node) else {
-                    return false;
-                };
-                return var_decl.type_annotation.is_some()
-                    && self.explicit_annotation_can_defer_implicit_any_context(
-                        var_decl.type_annotation,
-                    );
-            }
-            if parent_node.kind == tsz_parser::parser::syntax_kind_ext::ARROW_FUNCTION
-                || parent_node.kind == tsz_parser::parser::syntax_kind_ext::FUNCTION_EXPRESSION
-                || parent_node.kind == tsz_parser::parser::syntax_kind_ext::FUNCTION_DECLARATION
-            {
-                return false;
-            }
-            current = self
-                .ctx
-                .arena
-                .get_extended(parent_idx)
-                .map(|ext| ext.parent);
-        }
-        false
-    }
-
     fn annotation_is_array_like_type_node(&self, annotation_idx: NodeIndex) -> bool {
         let Some(node) = self.ctx.arena.get(annotation_idx) else {
             return false;

--- a/crates/tsz-checker/src/state/state_checking_members/implicit_any_param_context.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/implicit_any_param_context.rs
@@ -1,0 +1,144 @@
+//! Deferral of implicit-`any` (TS7006) parameter diagnostics for function
+//! expressions whose parameters are contextually typed by an enclosing
+//! variable-declaration annotation.
+//!
+//! Split out of `implicit_any_checks` to keep each source file under the
+//! checker's 2000-line cap.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn enclosing_function_for_parameter_name(
+        &self,
+        param_name: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let param_idx = self.ctx.arena.get_extended(param_name)?.parent;
+        let func_idx = self.ctx.arena.get_extended(param_idx)?.parent;
+        let func_node = self.ctx.arena.get(func_idx)?;
+        (func_node.kind == tsz_parser::parser::syntax_kind_ext::ARROW_FUNCTION
+            || func_node.kind == tsz_parser::parser::syntax_kind_ext::FUNCTION_EXPRESSION)
+            .then_some(func_idx)
+    }
+
+    pub(super) fn parameter_has_deferred_explicit_context(
+        &mut self,
+        param_name: NodeIndex,
+    ) -> bool {
+        let Some(func_idx) = self.enclosing_function_for_parameter_name(param_name) else {
+            return false;
+        };
+        // Walk up to the nearest enclosing variable declaration, capturing its
+        // (Copy) type-annotation node. Stop at an enclosing function — a
+        // parameter whose function is itself nested inside another function is
+        // not directly contextually typed by an outer variable annotation.
+        let mut current = self.ctx.arena.get_extended(func_idx).map(|ext| ext.parent);
+        let mut annotation: Option<NodeIndex> = None;
+        while let Some(parent_idx) = current {
+            let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
+                return false;
+            };
+            let parent_kind = parent_node.kind;
+            if parent_kind == tsz_parser::parser::syntax_kind_ext::VARIABLE_DECLARATION {
+                annotation = self
+                    .ctx
+                    .arena
+                    .get_variable_declaration(parent_node)
+                    .map(|var_decl| var_decl.type_annotation)
+                    .filter(|type_annotation| type_annotation.is_some());
+                break;
+            }
+            if parent_kind == tsz_parser::parser::syntax_kind_ext::ARROW_FUNCTION
+                || parent_kind == tsz_parser::parser::syntax_kind_ext::FUNCTION_EXPRESSION
+                || parent_kind == tsz_parser::parser::syntax_kind_ext::FUNCTION_DECLARATION
+            {
+                return false;
+            }
+            current = self
+                .ctx
+                .arena
+                .get_extended(parent_idx)
+                .map(|ext| ext.parent);
+        }
+        let Some(annotation) = annotation else {
+            return false;
+        };
+        if !self.explicit_annotation_can_defer_implicit_any_context(annotation) {
+            return false;
+        }
+        // The annotation only defers the implicit-any check for a parameter it can
+        // actually supply a contextual type for, matching tsc's contextual typing:
+        //   1. When the function expression declares more *required* parameters
+        //      than the annotated signature accepts (and that signature has no
+        //      rest parameter), contextual typing is discarded for *every*
+        //      parameter — they are all genuinely implicit `any`.
+        //   2. Otherwise, contextual typing is applied per position: a parameter
+        //      whose position is beyond the signature's parameter count (with no
+        //      rest parameter) — e.g. a trailing optional param the signature does
+        //      not declare — still receives no contextual type and is implicit
+        //      `any`.
+        // Both are expressed via `contextual_signature_accepts_required_callback_params`,
+        // which reports whether the signature covers a given (1-based) arity.
+        self.annotation_defers_implicit_any_for_param(func_idx, annotation, param_name)
+    }
+
+    /// Whether the variable-declaration `annotation` supplies a contextual type
+    /// for the parameter named `param_name` of the function at `func_idx`. It
+    /// does when the signature both accepts the expression's required arity and
+    /// covers this parameter's own position; otherwise the parameter is implicit
+    /// `any` and its diagnostic must not be deferred.
+    fn annotation_defers_implicit_any_for_param(
+        &mut self,
+        func_idx: NodeIndex,
+        annotation: NodeIndex,
+        param_name: NodeIndex,
+    ) -> bool {
+        let counts = {
+            let Some(func_node) = self.ctx.arena.get(func_idx) else {
+                return true;
+            };
+            let Some(func) = self.ctx.arena.get_function(func_node) else {
+                return true;
+            };
+            let mut required = 0usize;
+            // Position of `param_name` among the non-`this` parameters (0-based),
+            // mirroring `get_type_of_function`'s `contextual_index`.
+            let mut contextual_index = 0usize;
+            let mut found_index: Option<usize> = None;
+            for &param_idx in &func.parameters.nodes {
+                let Some(param_node) = self.ctx.arena.get(param_idx) else {
+                    continue;
+                };
+                let Some(param) = self.ctx.arena.get_parameter(param_node) else {
+                    continue;
+                };
+                if self.is_this_parameter_name(param.name) {
+                    continue;
+                }
+                if param.name == param_name {
+                    found_index = Some(contextual_index);
+                }
+                if !param.question_token && param.initializer.is_none() && !param.dot_dot_dot_token
+                {
+                    required += 1;
+                }
+                contextual_index += 1;
+            }
+            found_index.map(|index| (required, index))
+        };
+        // Parameter not found among the function's own parameters (e.g. a binding
+        // element): keep the prior deferral behavior.
+        let Some((required_non_this_param_count, contextual_index)) = counts else {
+            return true;
+        };
+        // The annotation supplies a contextual type for this parameter only when
+        // its signature both accepts the expression's required arity and covers
+        // this parameter's own position. Since a signature covers a `(1-based)`
+        // arity `n` exactly when it has a rest parameter or at least `n`
+        // parameters, "covers both" reduces to covering the larger of the two
+        // arities — a single query (avoiding a redundant signature normalization).
+        let required_arity = required_non_this_param_count.max(contextual_index + 1);
+        let annotation_type = self.get_type_from_type_node(annotation);
+        self.contextual_signature_accepts_required_callback_params(annotation_type, required_arity)
+    }
+}

--- a/crates/tsz-checker/src/state/state_checking_members/implicit_any_param_context.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/implicit_any_param_context.rs
@@ -45,7 +45,7 @@ impl<'a> CheckerState<'a> {
                     .arena
                     .get_variable_declaration(parent_node)
                     .map(|var_decl| var_decl.type_annotation)
-                    .filter(|type_annotation| type_annotation.is_some());
+                    .filter(tsz_parser::NodeIndex::is_some);
                 break;
             }
             if parent_kind == tsz_parser::parser::syntax_kind_ext::ARROW_FUNCTION

--- a/crates/tsz-checker/src/state/state_checking_members/mod.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/mod.rs
@@ -9,6 +9,7 @@ mod class_type_param_checks;
 mod decorator_signature_checks;
 mod function_declaration_checks;
 mod implicit_any_checks;
+mod implicit_any_param_context;
 mod index_signature_checks;
 #[cfg(test)]
 mod index_signature_checks_tests;

--- a/crates/tsz-checker/src/types/function_type/contextual_arity.rs
+++ b/crates/tsz-checker/src/types/function_type/contextual_arity.rs
@@ -3,7 +3,7 @@ use crate::state::CheckerState;
 use tsz_solver::{ParamInfo, TypeId};
 
 impl<'a> CheckerState<'a> {
-    pub(super) fn contextual_signature_accepts_required_callback_params(
+    pub(crate) fn contextual_signature_accepts_required_callback_params(
         &mut self,
         expected: TypeId,
         required_param_count: usize,

--- a/crates/tsz-checker/tests/function_expression_excess_param_implicit_any_tests.rs
+++ b/crates/tsz-checker/tests/function_expression_excess_param_implicit_any_tests.rs
@@ -1,0 +1,141 @@
+//! Implicit-`any` (TS7006) for function-expression parameters that an enclosing
+//! variable-declaration annotation cannot contextually type.
+//!
+//! Structural rule: when a function expression is the initializer of a variable
+//! declaration with an explicit type annotation, the annotation only supplies a
+//! contextual type for a parameter it actually covers. tsc applies contextual
+//! parameter typing exactly as follows:
+//!
+//!   * if the function expression declares more *required* parameters than the
+//!     annotated call signature accepts (and the signature has no rest
+//!     parameter), contextual typing is discarded for *every* parameter; or
+//!   * otherwise, contextual typing is positional, so a parameter whose position
+//!     is beyond the signature's parameter count (e.g. a trailing optional
+//!     parameter the signature does not declare) receives no contextual type.
+//!
+//! In both cases the uncovered parameters are implicit `any` and must raise
+//! TS7006 under `noImplicitAny`. tsz previously deferred (and so dropped) that
+//! diagnostic for any such initializer whose annotation resolved to a named
+//! type, even though sibling contexts (call arguments, object-literal methods,
+//! assignments, `as`/`satisfies`, array elements) already reported it.
+//!
+//! Every case varies its binder names (type alias, variable, and parameter
+//! identifiers) so the behavior cannot be keyed to a particular spelling.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn strict_options() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..Default::default()
+    }
+}
+
+fn count_7006(source: &str) -> usize {
+    check_source(source, "test.ts", strict_options())
+        .iter()
+        .filter(|d| d.code == 7006)
+        .count()
+}
+
+#[test]
+fn excess_required_params_over_annotation_are_implicit_any() {
+    // The signature `Handler` accepts one parameter; the initializer declares two
+    // required parameters, so the arity mismatch discards contextual typing for
+    // both — tsc emits TS7006 for `head` and `tail`.
+    let source = r#"
+        type Handler = (head: string) => void;
+        const onEvent: Handler = (head, tail) => {};
+    "#;
+    assert_eq!(count_7006(source), 2);
+}
+
+#[test]
+fn excess_required_params_renamed_binders_still_implicit_any() {
+    // Same shape, entirely different identifiers — proves the result is not keyed
+    // to any particular name.
+    let source = r#"
+        type Sink = (alpha: number) => void;
+        const drain: Sink = (omega, kappa) => {};
+    "#;
+    assert_eq!(count_7006(source), 2);
+}
+
+#[test]
+fn exact_arity_params_are_contextually_typed() {
+    // The initializer's required arity matches the signature, so both parameters
+    // are contextually typed and there is no TS7006.
+    let source = r#"
+        type Pair = (left: string, right: number) => void;
+        const combine: Pair = (left, right) => {};
+    "#;
+    assert_eq!(count_7006(source), 0);
+}
+
+#[test]
+fn fewer_params_than_annotation_are_contextually_typed() {
+    // Declaring fewer parameters than the signature is allowed and the declared
+    // parameter is still contextually typed — no TS7006.
+    let source = r#"
+        type Pair = (left: string, right: number) => void;
+        const ignoreSecond: Pair = (left) => {};
+    "#;
+    assert_eq!(count_7006(source), 0);
+}
+
+#[test]
+fn trailing_optional_param_beyond_annotation_is_implicit_any() {
+    // The required arity (one) is accepted, so `first` is contextually typed, but
+    // the trailing optional `second?` sits beyond the signature's single
+    // parameter and receives no contextual type: exactly one TS7006 (`second`).
+    let source = r#"
+        type Notify = (first: string) => void;
+        const ping: Notify = (first, second?) => {};
+    "#;
+    assert_eq!(count_7006(source), 1);
+}
+
+#[test]
+fn rest_parameter_in_annotation_covers_all_positions() {
+    // A rest parameter in the annotated signature contextually types every
+    // positional parameter of the initializer — no TS7006.
+    let source = r#"
+        type Variadic = (...items: string[]) => void;
+        const collect: Variadic = (first, second) => {};
+    "#;
+    assert_eq!(count_7006(source), 0);
+}
+
+#[test]
+fn inline_function_type_annotation_excess_params_are_implicit_any() {
+    // The annotation is an inline function type rather than a named alias; the
+    // arity-exceeding parameters are still implicit `any`.
+    let source = r#"
+        const route: (path: string) => void = (path, handler) => {};
+    "#;
+    assert_eq!(count_7006(source), 2);
+}
+
+#[test]
+fn this_parameter_does_not_count_toward_excess_arity() {
+    // A leading `this` parameter is not a value parameter: the single value
+    // parameter `value` matches the signature's one value parameter, so there is
+    // no TS7006.
+    let source = r#"
+        type Bound = (this: { tag: string }, value: number) => void;
+        const apply: Bound = function (value) {};
+    "#;
+    assert_eq!(count_7006(source), 0);
+}
+
+#[test]
+fn explicitly_typed_excess_params_do_not_report_implicit_any() {
+    // Excess parameters that carry their own annotations are not implicit `any`
+    // (the arity mismatch is still a TS2322, but no TS7006 is raised).
+    let source = r#"
+        type Handler = (head: string) => void;
+        const onEvent: Handler = (head: string, tail: number) => {};
+    "#;
+    assert_eq!(count_7006(source), 0);
+}


### PR DESCRIPTION
Goal: hold

Closes #14041.

## Summary

When a function expression is the initializer of a **variable declaration with an explicit type annotation**, `tsc` applies contextual parameter typing only to the parameters that annotation's call signature can actually cover. Parameters it cannot cover are implicit `any` and raise **TS7006** under `noImplicitAny`. tsz already typed those parameters as `any` (the arity gate in `get_type_of_function` forces it) but **silently dropped the TS7006** — found by differential testing against `tsc` 6.0.2.

```ts
type Handler = (head: string) => void;
const onEvent: Handler = (head, tail) => {};   // tsc: TS2322 + TS7006 on head AND tail; tsz (before): only TS2322
```
```ts
type Notify = (first: string) => void;
const ping: Notify = (first, second?) => {};   // tsc: TS7006 on second; tsz (before): (none)
```

## Structural rule

> When a function expression initializes a variable with an explicit type annotation, `tsc` contextually types a parameter only if the annotated signature **accepts the expression's required arity** (otherwise contextual typing is discarded for *every* parameter) **and covers that parameter's position** (a rest parameter, or at least that many parameters); otherwise the parameter is implicit `any` and raises TS7006.

`parameter_has_deferred_explicit_context` deferred the implicit-any check for *any* var-decl initializer whose annotation resolved to a deferrable named/inline type, **without** checking whether the signature actually covered the parameter — so the diagnostic was deferred and then never emitted. Every sibling context (call arguments, object-literal methods, plain `=` assignment, `as`/`satisfies`, array elements) already reported it; only the direct variable-initializer form regressed.

## Owner layer

Checker — implicit-any parameter diagnostics. The deferral is now arity- and position-aware: it defers only when `contextual_signature_accepts_required_callback_params` reports the annotated signature covers `max(required_non_this_param_count, contextual_index + 1)` (the two conditions — "accepts required arity" and "covers this position" — reduce to covering the larger arity, a single signature query). The helpers move to a new `implicit_any_param_context` submodule to keep `implicit_any_checks` under the 2000-line cap; no logic moved with them beyond this change.

## Why this is broad, not a one-off

The fix keys purely on structural arity/position, never on identifiers, file names, or printer output. It applies to every `const`/`let`/`var x: F = <function expression>` regardless of how `F` is spelled (named alias, inline function type, union of callables), and is symmetric with the already-correct sibling contexts.

## Adjacent-case matrix (exact-code parity vs `tsc` 6.0.2, `--noEmit --strict`)

| initializer vs annotation | tsc | tsz after |
|---|---|---|
| more **required** params than signature | TS2322 + TS7006 on **all** params | ✓ |
| exact arity | (none) | ✓ |
| fewer params | (none) | ✓ |
| trailing **optional** param beyond signature arity | TS7006 on that param only | ✓ |
| signature has **rest** param | (none — rest covers all) | ✓ |
| inline function-type annotation, excess params | TS2322 + TS7006 | ✓ |
| leading `this` param (not counted) | (none) | ✓ |
| excess params **explicitly typed** | TS2322 only (no TS7006) | ✓ |
| sibling contexts (call arg / object method / assignment / cast / array) | TS7006 | ✓ (unchanged) |

## Verification

- New name-agnostic suite `function_expression_excess_param_implicit_any_tests` (9 cases; varies type-alias, variable, and parameter identifiers) — pass.
- `cargo test -p tsz-checker --lib implicit_any` (55), `--test contextual_typing_tests` (87), `--test function_bivariance` / `co_contra_inference_tests` / `covariant_callbacks_tests` / `context_sensitive_callback_inference_tests` / `class_arrow_property_type_inference_tests` — pass, no regressions.
- Differential check vs the system `tsc` 6.0.2 on the full matrix above — exact line+code parity.
- `cargo fmt --check`, `cargo clippy -p tsz-checker --lib`, `python3 scripts/arch/arch_guard.py` (incl. 2000-line cap) — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_0161BVutkPs8qxUnPcfanQQj


---
_Generated by [Claude Code](https://claude.ai/code/session_0161BVutkPs8qxUnPcfanQQj)_