### PR TITLE
fix(lsp): claim references-full locations after the seed text-match check

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -832,19 +832,25 @@ impl Server {
                     .position_to_offset(loc.range.end, &loc_source)
                     .unwrap_or(start);
                 let len = end.saturating_sub(start);
+                // Only a location whose text matches this seed's symbol name is a
+                // reference for the seed's group. Claim it (within-group and
+                // globally) *after* that text check — claiming before it lets an
+                // earlier group burn chain locations it then discards on
+                // text-mismatch, starving the group that actually owns them (e.g.
+                // the export alias-side token of a re-export `X as "<other>"`).
+                let loc_text = loc_source
+                    .get(start as usize..end as usize)
+                    .unwrap_or_default()
+                    .trim();
+                if loc_text != seed_text {
+                    continue;
+                }
                 let key = (loc.file_path.clone(), start, len);
                 if !groups[group_idx].seen_refs.insert(key) {
                     continue;
                 }
                 let global_key = (loc.file_path.clone(), start, len);
                 if !seen_refs_global.insert(global_key) {
-                    continue;
-                }
-                let loc_text = loc_source
-                    .get(start as usize..end as usize)
-                    .unwrap_or_default()
-                    .trim();
-                if loc_text != seed_text {
                     continue;
                 }
 

--- a/crates/tsz-cli/src/bin/tsz_server/tests_parts/part_03.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/tests_parts/part_03.rs
@@ -1,4 +1,39 @@
-#[ignore = "regressed by blDAJ binder change; needs LSP follow-through"]
+/// True when some references-full `entry` carries a `definition` whose
+/// `textSpan` lies in `file` and slices to exactly `expected_text` within
+/// `source`. Shared by the export-alias-side span assertions below.
+fn references_full_has_definition_span_with_text(
+    entries: &[serde_json::Value],
+    file: &str,
+    source: &str,
+    expected_text: &str,
+) -> bool {
+    entries.iter().any(|entry| {
+        if entry["definition"]
+            .get("fileName")
+            .and_then(serde_json::Value::as_str)
+            != Some(file)
+        {
+            return false;
+        }
+        let Some(start) = entry["definition"]["textSpan"]
+            .get("start")
+            .and_then(serde_json::Value::as_u64)
+        else {
+            return false;
+        };
+        let Some(length) = entry["definition"]["textSpan"]
+            .get("length")
+            .and_then(serde_json::Value::as_u64)
+        else {
+            return false;
+        };
+        let end = start.saturating_add(length);
+        source
+            .get(start as usize..end as usize)
+            .is_some_and(|text| text == expected_text)
+    })
+}
+
 #[test]
 fn test_references_full_quoted_alias_includes_export_alias_side_definition_span() {
     let mut server = make_server();
@@ -39,40 +74,80 @@ fn test_references_full_quoted_alias_includes_export_alias_side_definition_span(
         .as_array()
         .expect("references-full response should be array");
 
-    let has_export_alias_side_span = entries.iter().any(|entry| {
-        let Some(def_file) = entry["definition"]
-            .get("fileName")
-            .and_then(serde_json::Value::as_str)
-        else {
-            return false;
-        };
-        if def_file != "/bar.ts" {
-            return false;
-        }
-        let Some(start) = entry["definition"]["textSpan"]
-            .get("start")
-            .and_then(serde_json::Value::as_u64)
-        else {
-            return false;
-        };
-        let Some(length) = entry["definition"]["textSpan"]
-            .get("length")
-            .and_then(serde_json::Value::as_u64)
-        else {
-            return false;
-        };
-        let end = start.saturating_add(length);
-        let bar_source = server
-            .open_files
-            .get("/bar.ts")
-            .expect("bar.ts should be open");
-        bar_source
-            .get(start as usize..end as usize)
-            .is_some_and(|text| text == "\"<other>\"")
-    });
+    let bar_source = server
+        .open_files
+        .get("/bar.ts")
+        .expect("bar.ts should be open");
     assert!(
-        has_export_alias_side_span,
+        references_full_has_definition_span_with_text(
+            entries,
+            "/bar.ts",
+            bar_source,
+            "\"<other>\"",
+        ),
         "expected one references-full definition span to anchor on export alias-side token \"<other>\": {entries:?}"
+    );
+}
+
+// Same re-export structure as the witness above, but every binder name and the
+// quoted-alias spellings differ, so a pass here proves the export alias-side
+// definition span is surfaced because of the alias *shape*, not a particular
+// spelling. The fix (claim a reference location globally only after its text
+// matches the seed's symbol name) must be name-agnostic.
+#[test]
+fn test_references_full_quoted_alias_export_alias_side_span_is_name_agnostic() {
+    let mut server = make_server();
+    server.open_files.insert(
+        "/mod-a.ts".to_string(),
+        [
+            "type Payload = \"p\";",
+            "export { type Payload as \"wire::payload\" };",
+        ]
+        .join("\n"),
+    );
+    server.open_files.insert(
+        "/mod-b.ts".to_string(),
+        [
+            "import { type \"wire::payload\" as localA } from \"./mod-a\";",
+            "export { type \"wire::payload\" as \"wire::relay\" } from \"./mod-a\";",
+            "import { type \"wire::relay\" as localB } from \"./mod-b\";",
+            "const useA: localA = \"p\";",
+            "const useB: localB = \"p\";",
+        ]
+        .join("\n"),
+    );
+
+    // Query on the quoted export alias-side token in mod-a:
+    // `export { type Payload as "wire::payload" };` — offset 27 lands inside
+    // the `"wire::payload"` string literal.
+    let req = make_request(
+        "references-full",
+        serde_json::json!({
+            "file": "/mod-a.ts",
+            "line": 2,
+            "offset": 27
+        }),
+    );
+    let resp = server.handle_tsserver_request(req);
+    assert!(resp.success);
+    let body = resp.body.expect("references-full should return body");
+    let entries = body
+        .as_array()
+        .expect("references-full response should be array");
+
+    let mod_b_source = server
+        .open_files
+        .get("/mod-b.ts")
+        .expect("mod-b.ts should be open");
+    assert!(
+        references_full_has_definition_span_with_text(
+            entries,
+            "/mod-b.ts",
+            mod_b_source,
+            "\"wire::relay\"",
+        ),
+        "expected a references-full definition span anchored on the re-export \
+         alias-side token \"wire::relay\": {entries:?}"
     );
 }
 


### PR DESCRIPTION
Goal: hold

Closes #14043.

## Problem

`references-full` for a quoted-alias chain dropped the **export alias-side
token** of a re-export. Querying a symbol that flows through
`export { "a" as "<other>" } from "./m"` returned no definition span anchored
on the `"<other>"` token: the group whose definition anchors on the alias-side
token ended up with zero references and was filtered out.

This was the committed `#[ignore]`d witness
`test_references_full_quoted_alias_includes_export_alias_side_definition_span`
("regressed by binder change; needs LSP follow-through"), which fails
deterministically on `main`.

## Structural rule

> When `references-full` groups quoted-alias chain locations
> (`Server::build_quoted_alias_referenced_symbols`), a candidate location must
> be claimed in the per-group (`seen_refs`) and global (`seen_refs_global`)
> dedup sets only **after** its text matches that group's seed symbol name. A
> location rejected by the text filter stays available to the group that owns
> it.

The loop previously inserted every candidate into both dedup sets *before* the
`loc_text != seed_text` check, so an earlier group globally burned chain
locations it then discarded on text-mismatch — starving the export alias-side
group of the references it needed to survive the `!references.is_empty()`
filter. The fix reorders the existing text check ahead of the two inserts.

## Owner layer

LSP `references-full` handler (`crates/tsz-cli/src/bin/tsz_server/handlers_info.rs`).
No compiler/type-semantics change.

## Anti-hardcoding

No identifier / file-name / printer-string predicate is introduced — the fix
only reorders an existing structural text-equality check against the dedup
inserts. The new test varies every binder name and quoted-alias spelling, and
asserts on the structural outcome (a definition span whose text equals the
re-export alias-side token), so behavior follows the alias *shape*, not a
spelling.

## Adjacent-case matrix

| case | expected | coverage |
|---|---|---|
| re-export `"a" as "<other>"`, query on upstream quoted export alias | a definition span anchors on `"<other>"` | `test_references_full_quoted_alias_includes_export_alias_side_definition_span` (un-ignored) |
| same shape, different file names + alias spellings | a definition span anchors on `"wire::relay"` | `test_references_full_quoted_alias_export_alias_side_span_is_name_agnostic` (new) |
| distinct symbol groups must not duplicate spans | unchanged | `test_references_full_quoted_alias_does_not_duplicate_reference_spans_across_groups` (still green) |
| type-only quoted alias refs / definition resolution | unchanged | existing `test_type_only_quoted_alias_*` suite (still green) |

## Verification

- `cargo test -p tsz-cli --bin tsz-server test_references_full_quoted_alias` -> 11 passed, 0 failed (incl. the un-ignored witness and the new name-agnostic test).
- Full `cargo test -p tsz-cli --bin tsz-server` -> 408 passed; the only 2 failures (`test_format_document_does_not_invalidate_fourslash_markers`, `collect_import_candidates_respects_node_next_package_exports_root_only`) reproduce identically on clean `main` (environment-dependent, unrelated to this change).
- `cargo fmt -p tsz-cli --check` clean; `cargo clippy -p tsz-cli --bin tsz-server --tests` clean.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01WQHXgm3naQLnH2f9beETCf

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQHXgm3naQLnH2f9beETCf)_