### PR TITLE
fix(emit): inline single-element nested binding patterns in ES5 destructuring

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -195,6 +195,10 @@ name = "destructuring_es5_array_nested_order_tests"
 path = "tests/destructuring_es5_array_nested_order_tests.rs"
 
 [[test]]
+name = "destructuring_es5_nested_single_inline_tests"
+path = "tests/destructuring_es5_nested_single_inline_tests.rs"
+
+[[test]]
 name = "destructuring_assignment_es5_shorthand_default_tests"
 path = "tests/destructuring_assignment_es5_shorthand_default_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/es5/bindings.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings.rs
@@ -11,6 +11,19 @@ enum InlineBindingAccess {
     Property(NodeIndex),
 }
 
+/// How to write the parent member access of a nested destructuring element when
+/// flattening it inline (see [`Printer::try_emit_inline_nested_binding`]).
+#[derive(Clone, Copy)]
+pub(in crate::emitter) enum NestedBindingBase<'a> {
+    /// Object property access: `base.key` / `base["key"]` / `base[computed]`.
+    ObjectProperty {
+        key_idx: NodeIndex,
+        computed_temp: Option<&'a str>,
+    },
+    /// Array element access: `base[index]`.
+    ArrayElement(usize),
+}
+
 /// Represents a segment of assignment destructuring output.
 /// When the right-hand side is a simple identifier, we access properties/elements directly.
 /// When complex, we create a temp variable first.
@@ -941,13 +954,37 @@ impl<'a> Printer<'a> {
         pattern_node: &Node,
         access_path: &mut Vec<InlineBindingAccess>,
     ) -> Option<NodeIndex> {
+        let (leaf, leaf_initializer) =
+            self.nested_single_binding_chain(pattern_node, access_path)?;
+        // This caller emits the leaf binding without any default substitution, so
+        // a defaulted leaf must fall back to the temp-based path.
+        if leaf_initializer.is_some() {
+            return None;
+        }
+        Some(leaf)
+    }
+
+    /// Walk a chain of single-element (non-rest) binding patterns, recording the
+    /// member-access path to the leaf identifier so the source value can be
+    /// referenced inline (`value.a.b[0]`) instead of through an intermediate
+    /// temp. Returns the leaf binding identifier together with the leaf's
+    /// default initializer (`NodeIndex::NONE` when absent).
+    ///
+    /// This mirrors tsc's `flattenObjectBindingOrAssignmentPattern` /
+    /// `flattenArrayBindingOrAssignmentPattern` fast path: a nested pattern with
+    /// exactly one element does not introduce a temp for its source value. A
+    /// default on the final leaf is permitted (the caller applies it to a single
+    /// value temp); a default on any intermediate level forces a temp, matching
+    /// tsc, so the chain stops there.
+    fn nested_single_binding_chain(
+        &self,
+        pattern_node: &Node,
+        access_path: &mut Vec<InlineBindingAccess>,
+    ) -> Option<(NodeIndex, NodeIndex)> {
         let pattern = self.arena.get_binding_pattern(pattern_node)?;
         let elem_idx = self.single_non_rest_binding_element(pattern)?;
         let elem_node = self.arena.get(elem_idx)?;
         let elem = self.arena.get_binding_element(elem_node)?;
-        if elem.initializer.is_some() {
-            return None;
-        }
 
         match pattern_node.kind {
             k if k == syntax_kind_ext::ARRAY_BINDING_PATTERN => {
@@ -969,12 +1006,121 @@ impl<'a> Printer<'a> {
 
         let name_node = self.arena.get(elem.name)?;
         if name_node.is_identifier() {
-            return Some(elem.name);
+            return Some((elem.name, elem.initializer));
         }
         if !self.is_binding_pattern(elem.name) {
             return None;
         }
-        self.single_nested_binding_access(name_node, access_path)
+        // An intermediate nested pattern carrying a default cannot be flattened:
+        // tsc materializes a temp so the default substitution has something to
+        // test. Stop the chain and let the temp-based path handle it.
+        if elem.initializer.is_some() {
+            return None;
+        }
+        self.nested_single_binding_chain(name_node, access_path)
+    }
+
+    /// Append the member-access segments collected by
+    /// [`Self::nested_single_binding_chain`] to an already-emitted base
+    /// expression (e.g. `_a.b` -> `_a.b.c[0]`).
+    fn emit_inline_access_path_parts(&mut self, access_path: &[InlineBindingAccess]) {
+        for part in access_path {
+            match *part {
+                InlineBindingAccess::Element(index) => {
+                    self.write("[");
+                    self.write_usize(index);
+                    self.write("]");
+                }
+                InlineBindingAccess::Property(key_idx) => {
+                    self.write(".");
+                    self.write_identifier_text(key_idx);
+                }
+            }
+        }
+    }
+
+    /// Try to emit a destructuring binding element whose target is a nested
+    /// pattern *inline* — without introducing an intermediate temp for the
+    /// element's source value — when the pattern collapses to a single
+    /// non-rest identifier (`{ b: { c } }` -> `c = base.b.c`).
+    ///
+    /// `element_initializer` is the element's own default (`NodeIndex::NONE`
+    /// when absent); a default here forces the temp-based path so it is not
+    /// inlined. `first`, when `Some`, threads the leading-separator flag used by
+    /// the `*_direct` emitters. Returns `true` when the element was emitted
+    /// inline.
+    pub(in crate::emitter) fn try_emit_inline_nested_binding(
+        &mut self,
+        element_name: NodeIndex,
+        element_initializer: NodeIndex,
+        base_source: &str,
+        base: NestedBindingBase<'_>,
+        first: Option<&mut bool>,
+    ) -> bool {
+        if element_initializer.is_some() {
+            return false;
+        }
+        let Some(name_node) = self.arena.get(element_name) else {
+            return false;
+        };
+        let mut access_path = Vec::new();
+        let Some((leaf, leaf_initializer)) =
+            self.nested_single_binding_chain(name_node, &mut access_path)
+        else {
+            return false;
+        };
+        if access_path.is_empty() {
+            return false;
+        }
+
+        match first {
+            Some(first) => {
+                if !*first {
+                    self.write(", ");
+                }
+                *first = false;
+            }
+            None => self.write(", "),
+        }
+
+        if leaf_initializer.is_none() {
+            self.write_binding_identifier_text(leaf);
+            self.write(" = ");
+            self.emit_nested_binding_base(base_source, &base);
+            self.emit_inline_access_path_parts(&access_path);
+        } else {
+            let value_name = self.get_temp_var_name();
+            self.write(&value_name);
+            self.write(" = ");
+            self.emit_nested_binding_base(base_source, &base);
+            self.emit_inline_access_path_parts(&access_path);
+            self.write(", ");
+            self.write_binding_identifier_text(leaf);
+            self.write(" = ");
+            self.write(&value_name);
+            self.write(" === void 0 ? ");
+            self.emit_expression(leaf_initializer);
+            self.write(" : ");
+            self.write(&value_name);
+        }
+        true
+    }
+
+    fn emit_nested_binding_base(&mut self, base_source: &str, base: &NestedBindingBase<'_>) {
+        match *base {
+            NestedBindingBase::ObjectProperty {
+                key_idx,
+                computed_temp,
+            } => {
+                self.emit_assignment_target_es5_with_computed(key_idx, base_source, computed_temp);
+            }
+            NestedBindingBase::ArrayElement(index) => {
+                self.write(base_source);
+                self.write("[");
+                self.write_usize(index);
+                self.write("]");
+            }
+        }
     }
 
     fn single_non_rest_binding_element(

--- a/crates/tsz-emitter/src/emitter/es5/bindings_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_patterns.rs
@@ -1,6 +1,7 @@
 //! ES5 destructuring - binding element patterns and parameter bindings.
 
 use super::super::Printer;
+use super::bindings::NestedBindingBase;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{BindingElementData, Node, NodeAccess};
 use tsz_parser::parser::syntax_kind_ext;
@@ -144,6 +145,19 @@ impl<'a> Printer<'a> {
                 return Some(rest_prop);
             }
 
+            if self.try_emit_inline_nested_binding(
+                elem.name,
+                elem.initializer,
+                temp_name,
+                NestedBindingBase::ObjectProperty {
+                    key_idx,
+                    computed_temp: computed_key_temp.as_deref(),
+                },
+                None,
+            ) {
+                return Some(rest_prop);
+            }
+
             let value_name = self.get_temp_var_name();
             self.write(", ");
             self.write(&value_name);
@@ -259,6 +273,16 @@ impl<'a> Printer<'a> {
         }
 
         if self.is_binding_pattern(elem.name) {
+            if self.try_emit_inline_nested_binding(
+                elem.name,
+                elem.initializer,
+                temp_name,
+                NestedBindingBase::ArrayElement(index),
+                None,
+            ) {
+                return;
+            }
+
             let value_name = self.get_temp_var_name();
             self.write(", ");
             self.write(&value_name);
@@ -359,6 +383,16 @@ impl<'a> Printer<'a> {
         }
 
         if self.is_binding_pattern(elem.name) {
+            if self.try_emit_inline_nested_binding(
+                elem.name,
+                elem.initializer,
+                temp_name,
+                NestedBindingBase::ArrayElement(index),
+                None,
+            ) {
+                return None;
+            }
+
             let value_name = self.get_temp_var_name();
             self.write(", ");
             self.write(&value_name);
@@ -468,6 +502,16 @@ impl<'a> Printer<'a> {
         }
 
         if self.is_binding_pattern(elem.name) {
+            if self.try_emit_inline_nested_binding(
+                elem.name,
+                elem.initializer,
+                temp_name,
+                NestedBindingBase::ArrayElement(index),
+                Some(first),
+            ) {
+                return None;
+            }
+
             let value_name = self.get_temp_var_name();
             if !*first {
                 self.write(", ");
@@ -591,6 +635,19 @@ impl<'a> Printer<'a> {
                     computed_key_temp.as_deref(),
                     Some(first),
                 );
+                return Some(rest_prop);
+            }
+
+            if self.try_emit_inline_nested_binding(
+                elem.name,
+                elem.initializer,
+                temp_name,
+                NestedBindingBase::ObjectProperty {
+                    key_idx,
+                    computed_temp: computed_key_temp.as_deref(),
+                },
+                Some(first),
+            ) {
                 return Some(rest_prop);
             }
 
@@ -844,6 +901,16 @@ impl<'a> Printer<'a> {
         }
 
         if self.is_binding_pattern(elem.name) {
+            if self.try_emit_inline_nested_binding(
+                elem.name,
+                elem.initializer,
+                temp_name,
+                NestedBindingBase::ArrayElement(index),
+                Some(first),
+            ) {
+                return;
+            }
+
             let value_name = self.get_temp_var_name();
             if !*first {
                 self.write(", ");

--- a/crates/tsz-emitter/tests/destructuring_es5_nested_single_inline_tests.rs
+++ b/crates/tsz-emitter/tests/destructuring_es5_nested_single_inline_tests.rs
@@ -1,0 +1,142 @@
+//! ES5 downlevel parity with tsc for variable-declaration destructuring whose
+//! element target is a nested binding pattern that collapses to a single
+//! non-rest identifier.
+//!
+//! tsc's `flattenObjectBindingOrAssignmentPattern` /
+//! `flattenArrayBindingOrAssignmentPattern` only introduce an intermediate temp
+//! for a nested element's source value when the nested pattern has more than one
+//! element (`numElements !== 1`). A single-element nested pattern reuses the
+//! source expression directly, inlining the member-access path into the leaf
+//! binding (`{ m: { n } }` -> `n = _a.m.n`) instead of capturing `_a.m` in a
+//! fresh temp. Parameter patterns already did this; these cases pin the same
+//! behaviour for variable declarations across the object/array, temp/identifier
+//! source, and defaulted-leaf paths.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print as parse_lower_emit;
+
+fn es5_opts() -> PrintOptions {
+    PrintOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::CommonJS,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn object_nested_single_binding_inlines_path_within_multi_element_pattern() {
+    let source = "const { a, m: { n }, z } = { a: 1, m: { n: 2 }, z: 3 };\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        output.contains("a = _a.a, n = _a.m.n, z = _a.z"),
+        "Single-element nested pattern `m: {{ n }}` must inline `_a.m.n` with no \
+         intermediate temp.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("= _a.m,"),
+        "No intermediate `_b = _a.m` temp should be emitted.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn object_nested_single_binding_inlines_against_identifier_source() {
+    let source =
+        "declare const oo: { m: { n: number }, p: number };\nconst { m: { n }, p } = oo;\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        output.contains("var n = oo.m.n, p = oo.p;"),
+        "An identifier source must be reused inline as `oo.m.n` for a single \
+         nested binding.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn object_nested_single_array_binding_inlines_index_path() {
+    let source = "const { d: [e], f } = { d: [1], f: 2 };\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        output.contains("e = _a.d[0], f = _a.f"),
+        "A single-element nested array pattern `d: [e]` must inline `_a.d[0]`.\n\
+         Output:\n{output}"
+    );
+}
+
+#[test]
+fn object_deeply_nested_single_binding_inlines_full_path() {
+    let source = "const { s: { t: { u } } } = { s: { t: { u: 1 } } };\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        output.contains(".s.t.u;"),
+        "A deep single-element chain must inline the full `.s.t.u` path with no \
+         temps.\nOutput:\n{output}"
+    );
+    assert_eq!(
+        output.matches(" = ").count(),
+        1,
+        "Only the single `u = ...` binding should be emitted; no intermediate \
+         temps.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn object_nested_single_binding_with_leaf_default_uses_one_value_temp() {
+    let source = "const { a, k: { l = 5 }, z } = { a: 1, k: { l: 2 }, z: 3 };\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    // The access path is inlined into a single value temp before the default is
+    // applied: `_b = _a.k.l, l = _b === void 0 ? 5 : _b`.
+    assert!(
+        output.contains("_b = _a.k.l, l = _b === void 0 ? 5 : _b"),
+        "A defaulted leaf must inline the access path into one value temp.\n\
+         Output:\n{output}"
+    );
+    assert!(
+        !output.contains("= _a.k,"),
+        "No intermediate `_b = _a.k` temp should be emitted for the defaulted \
+         leaf.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn array_nested_single_binding_inlines_alongside_object_rest_sibling() {
+    // The object-rest sibling forces the deferred (two-phase) array path; the
+    // single-element nested sibling must still inline its read+decomposition in
+    // source order rather than capturing a temp.
+    let source = "declare const arr2: [{ p: number, q: number }, { m: { n: number } }];\n\
+         const [{ p, ...pr }, { m: { n } }] = arr2;\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        output.contains("n = arr2[1].m.n"),
+        "The single nested sibling must inline `arr2[1].m.n` even on the \
+         deferred object-rest path.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("pr = __rest(_a"),
+        "The object-rest sibling still decomposes through its own temp.\n\
+         Output:\n{output}"
+    );
+}
+
+#[test]
+fn multi_element_nested_pattern_keeps_intermediate_temp() {
+    // Sanity: a nested pattern with more than one binding still materializes the
+    // source once into a temp (`numElements !== 1`) — unchanged behaviour.
+    let source = "const { p: { q, r } } = { p: { q: 1, r: 2 } };\n";
+    let output = parse_lower_emit(source, es5_opts());
+
+    assert!(
+        output.contains(".p, q = _a.q, r = _a.r"),
+        "A 2-element nested pattern must keep its `_a = ....p` source temp.\n\
+         Output:\n{output}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Fixes #14046.

## Structural rule

When downleveling a destructuring binding element whose target is a nested binding pattern that collapses to a single non-rest identifier (no defaults along the chain), `tsc` inlines the member-access path into the leaf binding rather than introducing an intermediate temp — `flattenObjectBindingOrAssignmentPattern` / `flattenArrayBindingOrAssignmentPattern` only materialize a temp when a pattern level has `numElements !== 1`. `tsz` now does the same; previously it always captured the nested source in a temp.

```
const { a, m: { n }, z } = o;
// tsc : var _a = o, a = _a.a, n = _a.m.n, z = _a.z;
// tsz : var _a = o, a = _a.a, _b = _a.m, n = _b.n, z = _a.z;   // before
```

The extra temp also cascaded into renumbered temps for later declarators, so a single nested pattern perturbed an entire file's emit. Parameter destructuring already inlined this shape (`param_nested_array_with_single_binding_keeps_direct_source_path`); only the variable-declaration / assignment-target ES5 path diverged.

## Owner layer

Emitter only. The inline decision + emission are centralized in `nested_single_binding_chain` and `try_emit_inline_nested_binding` (`crates/tsz-emitter/src/emitter/es5/bindings.rs`). The six per-element ES5 emit functions in `bindings_patterns.rs` (object/array × temp-source/identifier-source × immediate/deferred) call the shared helper before falling back to the temp-based path. No semantic validation, no output surgery.

## Adjacent-case matrix (all verified byte-equal to tsc 6.0.2 at `--target es5`)

- object nested single, temp source: `{ a, m: { n }, z }` → `n = _a.m.n`
- object nested single, identifier source: `{ m: { n }, p } = oo` → `n = oo.m.n`
- nested array single inside object: `{ d: [e], f }` → `e = _a.d[0]`
- deep chain: `{ s: { t: { u } } }` → `....s.t.u`
- defaulted leaf: `{ a, k: { l = 5 }, z }` → `_b = _a.k.l, l = _b === void 0 ? 5 : _b`
- object-rest sibling (deferred path): `[{ p, ...pr }, { m: { n } }]` → `n = arr[1].m.n` in source order, rest unchanged
- negative: 2-element nested pattern still materializes its source temp (`{ p: { q, r } }` → `_a = ....p, q = _a.q, r = _a.r`)

## Verification

- New target `destructuring_es5_nested_single_inline_tests` (7 cases) — pinned to exact tsc output.
- Existing `destructuring_es5_array_nested_order_tests` (incl. parameter single/multi nested) still green.
- Full `tsz-emitter` suite: 4313 passed, 0 failed (pre-change baseline) + 7 new = green.
- `cargo clippy -p tsz-emitter --tests`: clean.
- Ready-review CI owns the JS-emit baseline floor.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01NcQ1Q13R8xHmE5vYU9Efpx)_