### PR TITLE
test(binder,lsp): lock module-vs-script .d.ts global-scope contract (#12372)

### DIFF
--- a/crates/tsz-binder/src/state/tests/module_augments.rs
+++ b/crates/tsz-binder/src/state/tests/module_augments.rs
@@ -244,6 +244,73 @@ declare global {
     );
 }
 
+// Module-vs-script discrimination for the `is_external_module` branch of
+// `Symbol::is_cross_file_global` (issue #12372). A module file's top-level
+// declarations stay file-scoped — reachable from a sibling file only through an
+// explicit `import` — while a script file's top-level ambient declarations seed
+// the cross-file global scope. This is the layer that owns the predicate;
+// `cross_file_local_is_visible` is the gate both `program.globals` seeding and
+// the checker's `global_file_locals_index` consult. Binder names are arbitrary
+// to prove nothing keys on an identifier string. The end-to-end LSP matrix for
+// the same contract lives in tsz-cli `handlers_code_fixes_nested_pkg_tests`.
+
+#[test]
+fn module_export_declare_function_is_not_cross_file_global() {
+    // `export declare function` makes the file an external module, so the value
+    // is reachable only through an explicit import — never as an ambient global.
+    let (binder, _parser) = parse_and_bind("export declare function widgetInit(): void;\n");
+    assert!(
+        binder.is_external_module,
+        "a file with a top-level `export` is an external module"
+    );
+    let sym_id = binder
+        .file_locals
+        .get("widgetInit")
+        .expect("exported function is a file local");
+    assert!(
+        !binder.cross_file_local_is_visible(0, "widgetInit", sym_id),
+        "a module export must not leak into the cross-file global scope"
+    );
+}
+
+#[test]
+fn module_via_export_marker_keeps_ambient_declare_file_scoped() {
+    // A bare `export {}` marker makes the file a module even though the ambient
+    // `declare function` is not itself exported; it is therefore file-scoped.
+    let (binder, _parser) = parse_and_bind("declare function moduleOnlyFn(): void;\nexport {};\n");
+    assert!(
+        binder.is_external_module,
+        "`export {{}}` marks the file as a module"
+    );
+    let sym_id = binder
+        .file_locals
+        .get("moduleOnlyFn")
+        .expect("ambient function is a file local");
+    assert!(
+        !binder.cross_file_local_is_visible(0, "moduleOnlyFn", sym_id),
+        "an ambient declare in a module file must stay file-scoped"
+    );
+}
+
+#[test]
+fn script_ambient_declare_is_cross_file_global() {
+    // No top-level import/export: the file is a script, so its top-level ambient
+    // declaration seeds the global scope and resolves cross-file with no import.
+    let (binder, _parser) = parse_and_bind("declare function scriptGlobalFn(): void;\n");
+    assert!(
+        !binder.is_external_module,
+        "a file with no top-level import/export is a script"
+    );
+    let sym_id = binder
+        .file_locals
+        .get("scriptGlobalFn")
+        .expect("ambient function is a file local");
+    assert!(
+        binder.cross_file_local_is_visible(0, "scriptGlobalFn", sym_id),
+        "a script file's ambient declaration is a cross-file global"
+    );
+}
+
 // Regression for #6164: a `declare module "<self>"` augmentation must bind its
 // interface declaration to a separate `SymbolId` from the file-scope interface
 // of the same name. Merging the augmentation's declaration node into the

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_nested_pkg_tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_nested_pkg_tests.rs
@@ -57,15 +57,38 @@ fn make_server() -> Server {
     }
 }
 
+/// Register `app` plus one sibling `.d.ts` in a real-libs server and return the
+/// semantic diagnostic codes reported for `app`. Returns `None` when the
+/// TypeScript lib directory is not discoverable (caller should skip).
+fn dts_sibling_codes(app: &str, app_src: &str, dts: &str, dts_src: &str) -> Option<Vec<u32>> {
+    let mut server = make_server_with_real_libs()?;
+    server
+        .open_files
+        .insert(app.to_string(), app_src.to_string());
+    server
+        .open_files
+        .insert(dts.to_string(), dts_src.to_string());
+    Some(
+        server
+            .get_semantic_diagnostics_full(app, app_src)
+            .iter()
+            .map(|d| d.code)
+            .collect(),
+    )
+}
+
 /// Verify tsz generates TS2304 for `useMemo` even when its declaration file
 /// is in `open_files`. The `.d.ts` is a module (has top-level exports), so
 /// `useMemo` is NOT in global scope — `app.tsx` still needs an import.
 ///
-/// Currently ignored: tsz's binder promotes module-scoped exports from `.d.ts`
-/// files into global scope, so `useMemo` is incorrectly found without an import.
-/// Fix tracked separately (module-vs-script file determination for d.ts in `open_files`).
+/// A module's top-level exports stay file-scoped: they are reachable from a
+/// sibling file only through an explicit `import`. The shared
+/// `Symbol::is_cross_file_global` predicate (issue #12372) governs both the
+/// merged `program.globals` seeding and the checker's cross-file
+/// `global_file_locals_index`, so an installed-but-unimported package export
+/// never leaks as a global. See the `module_dts_*` / `script_dts_*` matrix
+/// below for the full module-vs-script contract.
 #[test]
-#[ignore = "known limitation: module exports from .d.ts in open_files leak into global scope"]
 fn semantic_diagnostics_ts2304_for_usememo_with_dts_in_open_files() {
     let Some(mut server) = make_server_with_real_libs() else {
         return; // skip when TypeScript lib files are not discoverable
@@ -91,6 +114,73 @@ fn semantic_diagnostics_ts2304_for_usememo_with_dts_in_open_files() {
     assert!(
         codes.contains(&2304),
         "expected TS2304 for 'useMemo', got diagnostic codes: {codes:?}"
+    );
+}
+
+/// Module `.d.ts` contract (name-agnostic): a sibling declaration file that is
+/// an external module — here because it carries a top-level `export declare` —
+/// keeps its exports file-scoped. An unqualified reference from another file is
+/// `TS2304`; the export is reachable only through an explicit `import`.
+/// Mirrors `tsc`: `export declare function widgetInit()` in a module `.d.ts`
+/// does not seed the global scope.
+#[test]
+fn module_dts_export_declare_does_not_leak_into_global_scope() {
+    // Sibling module `.d.ts` (module by virtue of the top-level `export`).
+    let Some(codes) = dts_sibling_codes(
+        "/project/consumer.ts",
+        "widgetInit();",
+        "/project/widget.d.ts",
+        "export declare function widgetInit(): void;\n",
+    ) else {
+        return; // skip when TypeScript lib files are not discoverable
+    };
+    assert!(
+        codes.contains(&2304),
+        "module `.d.ts` export must stay file-scoped (expected TS2304), got: {codes:?}"
+    );
+}
+
+/// Module determination drives global-scope contribution for *every* top-level
+/// declaration, not just the exported one: a bare `export {}` marker turns the
+/// file into a module, so even a non-exported ambient `declare function` in it
+/// is file-scoped and unreachable as a global. Matches `tsc` (`TS2304`).
+#[test]
+fn module_dts_via_export_marker_keeps_ambient_declare_file_scoped() {
+    // `export {}` makes this `.d.ts` a module even though `moduleOnlyFn` itself
+    // is not exported — so it must not land in the ambient global scope.
+    let Some(codes) = dts_sibling_codes(
+        "/project/site.ts",
+        "moduleOnlyFn();",
+        "/project/ambient.d.ts",
+        "declare function moduleOnlyFn(): void;\nexport {};\n",
+    ) else {
+        return; // skip when TypeScript lib files are not discoverable
+    };
+    assert!(
+        codes.contains(&2304),
+        "ambient declare in a module `.d.ts` must stay file-scoped (expected TS2304), got: {codes:?}"
+    );
+}
+
+/// Positive control (do not over-correct): a *script* `.d.ts` — no top-level
+/// `import`/`export`, so not an external module — contributes its top-level
+/// ambient declarations to the global scope. A sibling reference resolves with
+/// no import and no `TS2304`, exactly as `tsc` accepts it.
+#[test]
+fn script_dts_ambient_declare_is_globally_visible() {
+    // No top-level import/export: this `.d.ts` is a script, so its ambient
+    // declarations seed the global scope.
+    let Some(codes) = dts_sibling_codes(
+        "/project/page.ts",
+        "scriptGlobalFn();",
+        "/project/globals.d.ts",
+        "declare function scriptGlobalFn(): void;\n",
+    ) else {
+        return; // skip when TypeScript lib files are not discoverable
+    };
+    assert!(
+        !codes.contains(&2304),
+        "script `.d.ts` ambient declarations must be globally visible (expected no TS2304), got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Goal: hold

Parity-floor (test-only) PR. It un-ignores a stale `#[ignore]`d witness and locks
the module-vs-script `.d.ts` global-scope contract in at two altitudes. No
production code changes — the behavior is already correct (issue #12372); the
witness predated that fix.

## Structural rule

> When a `.d.ts` file is an external module — it has a top-level `import`/`export`
> (including a bare `export {}` marker) — its top-level declarations stay
> file-scoped: reachable from a sibling file only through an explicit `import`,
> so an unqualified reference is `TS2304`. When a `.d.ts` file is a script — no
> top-level `import`/`export` — its top-level ambient declarations seed the
> cross-file global scope and resolve with no import.

This is governed by the single `Symbol::is_cross_file_global(is_external_module,
is_global_augmentation)` predicate, which feeds both the merged
`program.globals` seeding (`bind_result_reducer`) and the checker's cross-file
`global_file_locals_index` (`cross_file_local_is_visible`), so the two tables
agree. The `is_external_module` branch had no low-altitude unit coverage — only
the sibling `declare global` (`is_global_augmentation`) branch did — and the LSP
witness reproducing the `open_files` path was left `#[ignore]`d ("module exports
from .d.ts in open_files leak into global scope") from before #12372 landed.

## Owner layer

- `tsz-binder` — `Symbol::is_cross_file_global` / `BinderState::cross_file_local_is_visible`,
  fed by `source_file_is_external_module`.
- `tsz-cli` `tsz-server` — the LSP `get_semantic_diagnostics_full` (`open_files`)
  end-to-end path that the original witness exercises (it also depends on the
  server's `package.json` `types` redirect + open-file project assembly).

No semantic/production change.

## Adjacent-case matrix (name-agnostic; cross-checked against `tsc`)

| case | file kind | tsc / tsz |
|---|---|---|
| `export declare function` referenced unqualified in a sibling | module | TS2304 |
| non-exported ambient `declare` + bare `export {}` marker | module | TS2304 |
| top-level ambient `declare` only (no import/export) | script | no error (global) |
| package `.d.ts` in `open_files` (`types` redirect), referenced unqualified | module | TS2304 (un-ignored witness) |
| no `.d.ts` present | — | TS2304 (sanity control, unchanged) |

Binder tests assert the predicate directly via `cross_file_local_is_visible`
(no lib discovery, so they cannot vacuously skip). LSP tests assert through
`get_semantic_diagnostics_full`, deduped behind a `dts_sibling_codes` helper.

## Anti-hardcoding

Every identifier in the new tests is arbitrary (`widgetInit`, `moduleOnlyFn`,
`scriptGlobalFn`, …) and assertions key on the diagnostic code (`2304`) and the
structural module/script shape — never on a name or rendered string.

## Verification

- `cargo test -p tsz-binder --lib module_augments` — 46 passed (incl. the 3 new
  `module_*` / `script_*` cross-file-global cases).
- `cargo test -p tsz-cli --bin tsz-server` (module_dts/script_dts/usememo) — 5
  passed, 0 ignored (the witness is no longer skipped).
- `cargo fmt -p tsz-binder -p tsz-cli` clean; `cargo clippy -p tsz-binder --lib --tests`
  and `cargo clippy -p tsz-cli --bin tsz-server --tests` clean.
- Differential check vs system `tsc`: module forms → `TS2304`, script form → none.
- Rebased onto current `origin/main` (`bb278f2`); no conflicts. Broad
  conformance/emit/fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01QHNZTanxFeTDCgy3uFvWpC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHNZTanxFeTDCgy3uFvWpC)_