### PR TITLE
perf(checker): keep single-signature lib method-call returns lazy (#13983)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -561,6 +561,112 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Ready the relation inputs that *calling* `callee_type` consumes —
+    /// argument checking against its parameters, `this`, type-parameter bounds,
+    /// and predicate — while **deferring the return type** when the callee is
+    /// directly a function type.
+    ///
+    /// # Why (issue #13983)
+    ///
+    /// A call's return type is the call *result*: it is selected and carried as
+    /// the result type, not relationally consumed during argument checking.
+    /// [`Self::ensure_relation_input_ready`] readies the *whole* callee type,
+    /// which (transitively, via [`Self::ensure_refs_resolved`]) force-resolved
+    /// the return interface and its currently pre-flattened heritage closure on
+    /// every call — e.g. `document.getElementById("x")` lowered all of
+    /// `HTMLElement`/`Element`/`Node`/`EventTarget` just to type a call whose
+    /// result the caller may never touch. Property reads of the same interface
+    /// already stay lazy via the single-member fast path
+    /// ([`crate::state_checking::lazy_lib_member`]); this gives method-call
+    /// returns the same treatment.
+    ///
+    /// # Soundness
+    ///
+    /// The deferral is transparent, **not** a bound (contrast the rejected
+    /// static `ensure_relation_input_ready` bound in #13979): the carried result
+    /// `TypeId` is the identical `Lazy(DefId)` reference either way — only the
+    /// timing of populating the type environment with the def's body changes. A
+    /// consuming relation/evaluation forces the def on demand at the
+    /// [`crate::context::CheckerContext::resolve_lazy`] miss via
+    /// `force_def_on_miss` (the #14016 mechanism), so every resolution-dependent
+    /// path observes the same resolved type.
+    ///
+    /// Every *input* position is still readied eagerly. Only the callee's own
+    /// top-level `return_type` is replaced (with an intrinsic) before the
+    /// readiness walk; parameters keep their full structure, so a parameter that
+    /// is itself a callback (`(e: HTMLElement) => void`) still has its nested
+    /// return readied — a relation against that callback *does* consume it, and
+    /// leaving it unresolved would reintroduce the #12144 "unresolved `Lazy`
+    /// treated as compatible" hazard.
+    ///
+    /// The optimization applies only when `callee_type` is *directly* a function
+    /// type ([`tsz_solver::TypeData::Function`]); overload sets, callable
+    /// objects, and lazy/application/union callee forms take the unchanged
+    /// full-readiness path.
+    pub(crate) fn ensure_callee_relation_inputs_ready(&mut self, callee_type: TypeId) {
+        if let Some(shape) =
+            crate::query_boundaries::common::function_shape_for_type(self.ctx.types, callee_type)
+            && self.call_return_is_lazy_lib_deferrable(shape.return_type)
+        {
+            let inputs_probe =
+                self.ctx
+                    .types
+                    .factory()
+                    .function(crate::query_boundaries::common::FunctionShape {
+                        return_type: TypeId::UNKNOWN,
+                        ..(*shape).clone()
+                    });
+            self.ensure_relation_input_ready(inputs_probe);
+            return;
+        }
+        self.ensure_relation_input_ready(callee_type);
+    }
+
+    /// Whether a call's `return_type` may have its referenced interfaces left
+    /// unresolved during argument-checking readiness (deferred to on-demand
+    /// forcing) — see [`Self::ensure_callee_relation_inputs_ready`].
+    ///
+    /// Deferral is restricted to the **provably resolution-independent** shape:
+    /// a union of intrinsics and *bare* `Lazy(DefId)` references to
+    /// force-eligible simple lib interfaces (non-generic, unmerged, unaugmented,
+    /// unshadowed — [`Self::force_eligible_lib_def`]), with at least one such
+    /// lib reference to defer. A force-eligible lib interface resolves
+    /// identically in every requester/arena context, so populating the type
+    /// environment with its body on demand (at the consuming `resolve_lazy`
+    /// miss) yields the same resolved type the eager pre-walk would have — the
+    /// carried result `TypeId` is unchanged either way.
+    ///
+    /// Anything resolution-*dependent* in the return — type parameters,
+    /// `Application`s (e.g. `Promise<T>`, `Array<T>`), conditionals, mapped /
+    /// index-access / `infer` / template-literal types, function/object shapes,
+    /// or a `Lazy` to a non-lib / generic / augmented def — disqualifies it.
+    /// Those returns are read structurally by downstream computation (async
+    /// Promise-unwrap, index-access elaboration, `instanceof`, tuple growth,
+    /// utility-type expansion) whose results are cached as canonical node types;
+    /// deferring their refs would change computed type identity (the hazard
+    /// traced in #13979). They take the unchanged full-readiness path.
+    fn call_return_is_lazy_lib_deferrable(&self, return_type: TypeId) -> bool {
+        // Fast path for the most common return shapes (bare `void`/primitive): a
+        // single intrinsic references no def to defer, so skip the classifier
+        // walk and allocation on this per-call hot path.
+        if return_type.is_intrinsic() {
+            return false;
+        }
+        // Structural classification (union of intrinsics + bare `Lazy` refs) is
+        // owned by the solver query boundary; the checker only layers the
+        // force-eligibility (binder/symbol) judgement on each referenced def.
+        let Some(def_ids) = crate::query_boundaries::common::union_of_bare_lazy_def_ids(
+            self.ctx.types,
+            return_type,
+        ) else {
+            return false;
+        };
+        !def_ids.is_empty()
+            && def_ids
+                .iter()
+                .all(|&def_id| self.force_eligible_lib_def(def_id))
+    }
+
     // =========================================================================
     // Type Evaluation for Assignability
     // =========================================================================

--- a/crates/tsz-checker/src/checkers/call_checker/applicability.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/applicability.rs
@@ -119,7 +119,7 @@ impl<'a> CheckerState<'a> {
         contextual_type: Option<TypeId>,
         actual_this_type: Option<TypeId>,
     ) -> tsz_solver::operations::CallWithCheckerResult {
-        self.ensure_relation_input_ready(func_type);
+        self.ensure_callee_relation_inputs_ready(func_type);
         self.ensure_relation_inputs_ready(arg_types);
 
         let db = self.ctx.types;
@@ -148,7 +148,7 @@ impl<'a> CheckerState<'a> {
         arg_source_is_type_annotation: &[bool],
         arg_source_is_readonly_annotation: &[bool],
     ) -> tsz_solver::operations::CallWithCheckerResult {
-        self.ensure_relation_input_ready(func_type);
+        self.ensure_callee_relation_inputs_ready(func_type);
         self.ensure_relation_inputs_ready(arg_types);
 
         let db = self.ctx.types;
@@ -224,7 +224,7 @@ impl<'a> CheckerState<'a> {
         arg_source_is_type_annotation: &[bool],
         arg_source_is_readonly_annotation: &[bool],
     ) -> tsz_solver::operations::CallWithCheckerResult {
-        self.ensure_relation_input_ready(func_type);
+        self.ensure_callee_relation_inputs_ready(func_type);
         self.ensure_relation_inputs_ready(arg_types);
 
         let db = self.ctx.types;

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -288,7 +288,7 @@ impl<'a> CheckerState<'a> {
             };
             let func_type = factory.function(sig_shape.clone());
             tracing::debug!("Trying overload {} with {} args", idx, arg_types.len());
-            self.ensure_relation_input_ready(func_type);
+            self.ensure_callee_relation_inputs_ready(func_type);
             let resolved_func_type =
                 if let Some(def_id) = lazy_def_id_for_type(self.ctx.types, func_type) {
                     self.ctx
@@ -1332,7 +1332,7 @@ impl<'a> CheckerState<'a> {
             self.ctx.preserve_literal_types = prev_preserve_literals2;
             self.ctx.in_const_assertion = prev_in_const_assertion;
 
-            self.ensure_relation_input_ready(func_type);
+            self.ensure_callee_relation_inputs_ready(func_type);
 
             let (mut result, instantiated_predicate, instantiated_params) = self
                 .resolve_call_with_checker_adapter_maybe_arg_sources(

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1549,6 +1549,17 @@ pub(crate) fn contains_lazy_def_id(
     tsz_solver::visitor::contains_lazy_def_id(db, root, target_def_id)
 }
 
+/// If `root` is a (possibly nested) union of intrinsics and *bare*
+/// `Lazy(DefId)` references with no other structure, return the de-duplicated
+/// referenced `DefId`s; otherwise `None`. See
+/// [`tsz_solver::visitor::union_of_bare_lazy_def_ids`].
+pub(crate) fn union_of_bare_lazy_def_ids(
+    db: &dyn TypeDatabase,
+    root: TypeId,
+) -> Option<Vec<tsz_solver::def::DefId>> {
+    tsz_solver::visitor::union_of_bare_lazy_def_ids(db, root)
+}
+
 pub(crate) fn collect_type_queries(
     db: &dyn TypeDatabase,
     root: TypeId,

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -817,7 +817,7 @@ impl<'a> CheckerState<'a> {
         // the call result handler would see an empty this_type_stack and fall back to
         // the wrong contextual type, causing false TS2339 errors.
         // We pop it at the end of this function.
-        self.ensure_relation_input_ready(callee_type_for_resolution);
+        self.ensure_callee_relation_inputs_ready(callee_type_for_resolution);
 
         // Resolve applications/lazy refs to callable forms before solver dispatch.
         let callee_type_for_call = self.evaluate_application_type(callee_type_for_resolution);
@@ -846,7 +846,7 @@ impl<'a> CheckerState<'a> {
             };
         }
 
-        self.ensure_relation_input_ready(callee_type_for_call);
+        self.ensure_callee_relation_inputs_ready(callee_type_for_call);
 
         // `super()` uses construct signatures, not call signatures.
         let (generic_inference_arg_types, sanitized_generic_inference) = if is_generic_call {

--- a/crates/tsz-checker/src/types/computation/call/mod.rs
+++ b/crates/tsz-checker/src/types/computation/call/mod.rs
@@ -917,7 +917,7 @@ impl<'a> CheckerState<'a> {
         use crate::query_boundaries::common::ContextualTypeContext;
         use tsz_parser::parser::syntax_kind_ext;
 
-        self.ensure_relation_input_ready(callee_type_for_resolution);
+        self.ensure_callee_relation_inputs_ready(callee_type_for_resolution);
 
         let callee_type_for_call = self.evaluate_application_type(callee_type_for_resolution);
         let callee_type_for_call = self.resolve_lazy_type(callee_type_for_call);
@@ -940,7 +940,7 @@ impl<'a> CheckerState<'a> {
             };
         }
 
-        self.ensure_relation_input_ready(callee_type_for_call);
+        self.ensure_callee_relation_inputs_ready(callee_type_for_call);
 
         let (generic_inference_arg_types, sanitized_generic_inference) = if is_generic_call {
             self.sanitize_generic_inference_arg_types(callee_expr, args, &arg_types)

--- a/crates/tsz-solver/src/visitors/visitor.rs
+++ b/crates/tsz-solver/src/visitors/visitor.rs
@@ -446,6 +446,42 @@ pub fn collect_lazy_def_ids(types: &dyn TypeDatabase, root: TypeId) -> Vec<DefId
     out
 }
 
+/// If every type reachable from `root` is an intrinsic, a [`TypeData::Union`]
+/// container, or a *bare* [`TypeData::Lazy`] reference — i.e. `root` is a
+/// (possibly nested) union of intrinsics and bare lazy references with no other
+/// structure ([`TypeData::Application`], conditional, function, object, type
+/// parameter, index-access, mapped, ...) — return the de-duplicated `DefId`s of
+/// those lazy references. Otherwise return `None`.
+///
+/// Used by relation-input readiness to recognise a call return type whose
+/// referenced interfaces may be deferred to on-demand forcing: the caller
+/// additionally requires every returned `DefId` to be a force-eligible simple
+/// lib interface and the set to be non-empty (a resolution-*dependent* return —
+/// anything that is not a plain union of intrinsics and bare lib refs — is read
+/// structurally by downstream computation and must not be deferred).
+pub fn union_of_bare_lazy_def_ids(types: &dyn TypeDatabase, root: TypeId) -> Option<Vec<DefId>> {
+    let mut out = Vec::new();
+    let mut seen = FxHashSet::default();
+    let mut only_union_and_lazy = true;
+
+    walk_referenced_types(types, root, |type_id| {
+        if !only_union_and_lazy || type_id.is_intrinsic() {
+            return;
+        }
+        match types.lookup(type_id) {
+            Some(TypeData::Union(_)) => {}
+            Some(TypeData::Lazy(def_id)) => {
+                if seen.insert(def_id) {
+                    out.push(def_id);
+                }
+            }
+            _ => only_union_and_lazy = false,
+        }
+    });
+
+    only_union_and_lazy.then_some(out)
+}
+
 /// Return whether `root` contains `Lazy(target_def_id)`.
 pub fn contains_lazy_def_id(types: &dyn TypeDatabase, root: TypeId, target_def_id: DefId) -> bool {
     let mut found = false;
@@ -1209,5 +1245,70 @@ impl<'a> ConstAssertionVisitor<'a> {
             return self.db.union_from_sorted_vec(const_members);
         }
         self.apply_const_assertion(type_id)
+    }
+}
+
+#[cfg(test)]
+mod union_of_bare_lazy_def_ids_tests {
+    use super::union_of_bare_lazy_def_ids;
+    use crate::construction::TypeInterner;
+    use crate::def::DefId;
+    use crate::types::{FunctionShape, TypeId};
+
+    #[test]
+    fn bare_lazy_yields_its_def() {
+        let db = TypeInterner::new();
+        let lazy = db.lazy(DefId(11));
+        assert_eq!(union_of_bare_lazy_def_ids(&db, lazy), Some(vec![DefId(11)]));
+    }
+
+    #[test]
+    fn union_of_lazies_and_intrinsics_yields_the_lazy_defs() {
+        let db = TypeInterner::new();
+        // `Lazy(11) | Lazy(12) | null` — the `getElementById`-style return shape.
+        let u = db.union(vec![db.lazy(DefId(11)), db.lazy(DefId(12)), TypeId::NULL]);
+        let got = union_of_bare_lazy_def_ids(&db, u).expect("union of bare lazies is classified");
+        assert!(got.contains(&DefId(11)) && got.contains(&DefId(12)) && got.len() == 2);
+    }
+
+    #[test]
+    fn pure_intrinsic_is_classified_with_no_defs() {
+        let db = TypeInterner::new();
+        // Deferrable-shape-wise valid, but the caller requires a non-empty set.
+        assert_eq!(
+            union_of_bare_lazy_def_ids(&db, TypeId::STRING),
+            Some(vec![])
+        );
+    }
+
+    #[test]
+    fn application_is_not_classified() {
+        let db = TypeInterner::new();
+        // `Lazy(11)<string>` (e.g. `Promise<string>`) is resolution-dependent.
+        let app = db.application(db.lazy(DefId(11)), vec![TypeId::STRING]);
+        assert_eq!(union_of_bare_lazy_def_ids(&db, app), None);
+    }
+
+    #[test]
+    fn union_containing_a_non_bare_member_is_not_classified() {
+        let db = TypeInterner::new();
+        let app = db.application(db.lazy(DefId(12)), vec![TypeId::NUMBER]);
+        let u = db.union(vec![db.lazy(DefId(11)), app]);
+        assert_eq!(union_of_bare_lazy_def_ids(&db, u), None);
+    }
+
+    #[test]
+    fn function_type_is_not_classified() {
+        let db = TypeInterner::new();
+        let func = db.function(FunctionShape {
+            type_params: vec![],
+            params: vec![],
+            this_type: None,
+            return_type: db.lazy(DefId(11)),
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        });
+        assert_eq!(union_of_bare_lazy_def_ids(&db, func), None);
     }
 }


### PR DESCRIPTION
Goal: fast

Closes #13983.

## Problem

A DOM **property read** stays lazy (the shipped #12101 win), but the equivalent **method call** did not:

| access (target ES2020, lib ES2022+DOM+DOM.Iterable) | interned types (before) | after |
|---|--:|--:|
| `d.body` (property) | 1203 | 1203 |
| `d.getElementById` (method *ref*, no call) | 1204 | 1204 |
| `d.getElementById("a")` (**call**) | **4176** | **1206** |
| `d.querySelector("div")` (overloaded) | 4122 | 4122 (unchanged — #13862) |

Relation-input readiness for the callee (`ensure_relation_input_ready`) walked the **whole** callee function type, so `ensure_refs_resolved` force-resolved the **return** interface and its pre-flattened heritage closure (`HTMLElement`/`Element`/`Node`/`EventTarget`) on every call — to type a result the caller may never touch.

## Structural rule

> When a callee is directly a function type and its return is a (possibly nested) union of intrinsics and **bare** `Lazy(DefId)` references to force-eligible simple lib interfaces, ready only the *input* positions (params / `this` / type-param bounds / predicate) and defer the return. The return is the call **result** — selected and carried, not relationally consumed during argument checking — and is forced on demand only when a consumer structurally uses it (property access, `await`, a relation against an annotated/contextual target).

The deferral is **transparent, not a bound** (contrast the rejected static `ensure_relation_input_ready` bound in #13979): the carried result `TypeId` is the identical `Lazy(DefId)` either way — only the timing of populating the type environment changes. A consuming relation/evaluation forces the def on demand at the `resolve_lazy` miss (`force_def_on_miss`, the #14016 mechanism), so every resolution-dependent path observes the same resolved type.

### Why it is sound / not over-broad

- Only the callee's own top-level `return_type` is dropped; **parameters keep their full structure**, so a parameter that is itself a callback (`(e: HTMLElement) => void`) still has its nested return readied — a relation against that callback *does* consume it (preserving the #12144 "unresolved `Lazy` treated as compatible" hazard).
- The return must be a **plain union of intrinsics + bare force-eligible lib `Lazy` refs**. Anything resolution-*dependent* (`Application` like `Promise<T>`/`Array<T>`, conditionals, index-access, mapped, type parameters, or a `Lazy` to a non-lib/generic/augmented def) keeps the unchanged full-readiness path — those returns are read structurally by downstream computation (async Promise-unwrap, index-access elaboration, `instanceof`, tuple growth, utility-type expansion) whose results are cached as canonical node types, the #13979 type-identity hazard. (A first cut that deferred *all* function returns broke exactly that set of 72→76 unit tests; the restricted predicate is byte-identical.)

## Owner layer

- Solver query boundary owns the structural classification: new `union_of_bare_lazy_def_ids` (`tsz-solver/src/visitors/visitor.rs`), wrapped in `query_boundaries::common`. No `TypeData` matching or `tsz_solver::visitor::` call lives in the checker (arch-guard clean).
- Checker layers force-eligibility (binder/symbol judgement) on each referenced def and gates the new `CheckerState::ensure_callee_relation_inputs_ready`, wired at every callee-readiness site: call dispatch (`call/inner.rs`, `call/mod.rs`), overload resolution, and the call adapters (`applicability.rs`).
- No semantic validation moved; no diagnostic surgery.

## Adjacent-case matrix (verified on the release binary, name-varied)

- single-sig returns stay lazy: `getElementById`→`HTMLElement|null`, `createDocumentFragment`→`DocumentFragment`, `createComment`→`Comment`, `getBoundingClientRect`→`DOMRect` — all at the property-read floor.
- result property access resolves (`x.innerHTML` ✓) and a missing member still errors (`x.nope` → TS2339).
- incompatible annotation still forces the return: `const e: HTMLDivElement = d.getElementById("a")!` → TS2741; compatible `HTMLElement` clean.
- bad argument still errors: `d.getElementById(123)` → TS2345.
- inherited member on the result resolves on demand: `x.addEventListener(...)` clean.
- overloaded keyof-map methods (`querySelector`/`createElement`) unchanged — the separate #13862 lever.

## Verification

- **Witness:** `tsz --noEmit --extendedDiagnostics` on the issue repros — `getElementById` 4176 → 1206 (property floor ~1203); `querySelector` unchanged.
- **Soundness (the merge gate):** full `cargo test -p tsz-checker --lib` failure set is **byte-identical to `main`** (same pre-existing 72 lib-environment failures; the only run-to-run delta is the documented `delegate_cross_arena_source_option_bag_*` perf-counter flake from #14038, which shifts siblings between runs and is unrelated — it touches neither cross-arena delegation nor perf counters).
- `cargo test -p tsz-checker --lib lazy_lib_heritage` (15) green — the #13948 lazy-lib-heritage hazard + interner-ratchet guards.
- New `cargo test -p tsz-solver --lib union_of_bare_lazy_def_ids` (6) — direct coverage of the structural classifier.
- `cargo clippy -p tsz-solver -p tsz-checker --lib` clean; `cargo fmt --check` clean.
- `scripts/arch/arch_guard.py` + `scripts/arch/check-checker-boundaries.sh` pass (field inventory 252; all touched files < 2000 LOC).
- Broad conformance / emit / fourslash floors owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01RkifGvJJdVmyNB9byWd1WH

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkifGvJJdVmyNB9byWd1WH)_