### PR TITLE
fix(emit): lower ES2015+ CommonJS export destructuring via flatten form

### DIFF
--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_module_exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_module_exports.rs
@@ -1473,6 +1473,42 @@ fn commonjs_exported_destructuring_rest_forms_match_tsc() {
     );
 }
 
+/// Leading comments attached to a binding element in an exported pattern are
+/// printable output trivia and must move with the generated `exports.*`
+/// assignment.
+#[test]
+fn commonjs_exported_destructuring_preserves_binding_element_leading_comments() {
+    let output = emit_commonjs_es2015(
+        "export let {\n    /**\n     * retained leaf\n     */\n    pickedMethod\n} = source;\n",
+    );
+    let comment_pos = output
+        .find("retained leaf")
+        .unwrap_or_else(|| panic!("Binding-element comment must be emitted.\nOutput:\n{output}"));
+    let export_pos = output
+        .find("exports.pickedMethod = source.pickedMethod;")
+        .unwrap_or_else(|| panic!("Export assignment must be emitted.\nOutput:\n{output}"));
+    assert!(
+        comment_pos < export_pos,
+        "Binding-element leading comment must precede its export assignment.\nOutput:\n{output}"
+    );
+
+    let renamed = emit_commonjs_es2015(
+        "export let { sourceName:\n    /**\n     * renamed retained\n     */\n    renamedMethod\n} = bag;\n",
+    );
+    let renamed_comment_pos = renamed
+        .find("renamed retained")
+        .unwrap_or_else(|| panic!("Renamed binding comment must be emitted.\nOutput:\n{renamed}"));
+    let renamed_export_pos = renamed
+        .find("exports.renamedMethod = bag.sourceName;")
+        .unwrap_or_else(|| {
+            panic!("Renamed export assignment must be emitted.\nOutput:\n{renamed}")
+        });
+    assert!(
+        renamed_comment_pos < renamed_export_pos,
+        "Renamed binding-element comment must precede its export assignment.\nOutput:\n{renamed}"
+    );
+}
+
 /// Non-identifier property keys read through bracket access (string/number).
 #[test]
 fn commonjs_exported_destructuring_uses_bracket_access_for_non_identifier_keys() {

--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_module_exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_module_exports.rs
@@ -1372,6 +1372,117 @@ export const { a: bar2 } = { a: 2 };
     );
 }
 
+fn emit_commonjs_es2015(source: &str) -> String {
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        module: ModuleKind::CommonJS,
+        target: ScriptTarget::ES2015,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer = Printer::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+/// A binding-element default initializer in an exported pattern must survive
+/// lowering as the `tmp === void 0 ? <default> : tmp` check (matching `tsc`'s
+/// `flattenDestructuringAssignment`). Binder/property names are arbitrary so the
+/// behavior follows the structural shape, not any identifier.
+#[test]
+fn commonjs_exported_object_destructuring_preserves_default_initializer() {
+    let output = emit_commonjs_es2015("export const { first, second = 9 } = bag;\n");
+    assert!(
+        output.contains(
+            "exports.first = bag.first, _a = bag.second, exports.second = _a === void 0 ? 9 : _a;"
+        ),
+        "Object default must lower to a void-0 check; got:\n{output}"
+    );
+    // The default value must not be dropped.
+    assert!(
+        !output.contains("exports.second = bag.second;"),
+        "Default initializer must not be dropped; got:\n{output}"
+    );
+}
+
+#[test]
+fn commonjs_exported_array_destructuring_preserves_default_initializer() {
+    let output = emit_commonjs_es2015("export const [head, tail = 7] = seq;\n");
+    assert!(
+        output
+            .contains("exports.head = seq[0], _a = seq[1], exports.tail = _a === void 0 ? 7 : _a;"),
+        "Array default must lower by element index with a void-0 check; got:\n{output}"
+    );
+}
+
+/// A nested binding pattern must recurse into the corresponding access path
+/// rather than emit an empty export name.
+#[test]
+fn commonjs_exported_nested_destructuring_recurses_into_access_path() {
+    let single = emit_commonjs_es2015("export const { outer, inner: { leaf } } = root;\n");
+    assert!(
+        single.contains("exports.outer = root.outer, exports.leaf = root.inner.leaf;"),
+        "Single-element nested pattern inlines the access chain; got:\n{single}"
+    );
+    assert!(
+        !single.contains("exports. ="),
+        "Nested pattern must never produce an empty export name; got:\n{single}"
+    );
+
+    let multi = emit_commonjs_es2015("export const { outer, inner: { left, right } } = root;\n");
+    assert!(
+        multi.contains(
+            "exports.outer = root.outer, _a = root.inner, exports.left = _a.left, exports.right = _a.right;"
+        ),
+        "Multi-element nested pattern caches the intermediate access; got:\n{multi}"
+    );
+}
+
+/// An identifier source is reused inline at every access; a non-identifier
+/// source used by more than one element is cached once.
+#[test]
+fn commonjs_exported_destructuring_source_caching_matches_tsc() {
+    let ident = emit_commonjs_es2015("export const { alpha, beta } = store;\n");
+    assert!(
+        ident.contains("exports.alpha = store.alpha, exports.beta = store.beta;"),
+        "Identifier source must be reused inline (no temp); got:\n{ident}"
+    );
+
+    let call = emit_commonjs_es2015("export const { alpha, beta } = make();\n");
+    assert!(
+        call.contains("_a = make(), exports.alpha = _a.alpha, exports.beta = _a.beta;"),
+        "Non-identifier multi-use source must be cached once; got:\n{call}"
+    );
+}
+
+/// Object rest uses `__rest`; array rest uses `.slice(<index>)`.
+#[test]
+fn commonjs_exported_destructuring_rest_forms_match_tsc() {
+    let obj = emit_commonjs_es2015("export const { keep, ...others } = source;\n");
+    assert!(
+        obj.contains("exports.keep = source.keep, exports.others = __rest(source, [\"keep\"]);"),
+        "Object rest must exclude collected keys; got:\n{obj}"
+    );
+
+    let arr = emit_commonjs_es2015("export const [lead, ...remainder] = list;\n");
+    assert!(
+        arr.contains("exports.lead = list[0], exports.remainder = list.slice(1);"),
+        "Array rest must use slice at the rest index; got:\n{arr}"
+    );
+}
+
+/// Non-identifier property keys read through bracket access (string/number).
+#[test]
+fn commonjs_exported_destructuring_uses_bracket_access_for_non_identifier_keys() {
+    let output = emit_commonjs_es2015("export const { \"dash-ed\": renamed, plain } = bag;\n");
+    assert!(
+        output.contains("exports.renamed = bag[\"dash-ed\"], exports.plain = bag.plain;"),
+        "String keys must read through bracket access; got:\n{output}"
+    );
+}
+
 #[test]
 fn async_arguments_capture_skips_parameter_and_pattern_bindings() {
     let source = r#"export async function f({ arguments_1 }: { arguments_1: string }) {

--- a/crates/tsz-emitter/src/emitter/module_emission/exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/exports.rs
@@ -1513,6 +1513,15 @@ impl<'a> Printer<'a> {
                     continue;
                 }
 
+                // ES2015+ targets lower the binding pattern through the recursive
+                // `flatten` form (`tsc`'s `flattenDestructuringAssignment`), which
+                // honors default initializers and nested patterns. The ES5 path
+                // below keeps its own inline-comma shape.
+                if !self.ctx.target_es5 {
+                    self.emit_cjs_destructuring_export_flattened(decl.name, decl.initializer);
+                    continue;
+                }
+
                 // Get binding pattern elements
                 let Some(pattern) = self.arena.get_binding_pattern(name_node) else {
                     continue;

--- a/crates/tsz-emitter/src/emitter/module_emission/exports_destructuring.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/exports_destructuring.rs
@@ -10,6 +10,7 @@
 
 use super::super::Printer;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
@@ -29,13 +30,13 @@ enum DestructBase {
 
 impl DestructBase {
     /// Extend the source with one more member access (`.prop` / `[i]`).
-    fn with_access(&self, suffix: &str) -> DestructBase {
+    fn with_access(&self, suffix: &str) -> Self {
         match self {
-            DestructBase::Str(text) => DestructBase::Str(format!("{text}{suffix}")),
-            DestructBase::Inline {
+            Self::Str(text) => Self::Str(format!("{text}{suffix}")),
+            Self::Inline {
                 node,
                 suffix: existing,
-            } => DestructBase::Inline {
+            } => Self::Inline {
                 node: *node,
                 suffix: format!("{existing}{suffix}"),
             },
@@ -43,7 +44,7 @@ impl DestructBase {
     }
 }
 
-impl<'a> Printer<'a> {
+impl Printer<'_> {
     /// Lower an ES2015+ CommonJS `export const <pattern> = <init>` through the
     /// recursive destructuring form `tsc` uses (`flattenDestructuringAssignment`).
     ///
@@ -151,7 +152,7 @@ impl<'a> Printer<'a> {
                     (self.get_identifier_text(elem.name), None)
                 };
                 excluded_props.push(prop_text.clone());
-                self.destructuring_export_property_suffix(&prop_text, prop_kind)
+                Self::destructuring_export_property_suffix(&prop_text, prop_kind)
             };
             let access_base = base.with_access(&access_suffix);
 
@@ -255,10 +256,7 @@ impl<'a> Printer<'a> {
                 // `1.foo` is a parse error (the `.` reads as a decimal point);
                 // `tsc` emits a second dot for a numeric-literal receiver.
                 if suffix.starts_with('.')
-                    && self
-                        .arena
-                        .get(*node)
-                        .is_some_and(|n| n.is_numeric_literal())
+                    && self.arena.get(*node).is_some_and(Node::is_numeric_literal)
                 {
                     self.write(".");
                 }
@@ -269,11 +267,7 @@ impl<'a> Printer<'a> {
 
     /// Build the property-access suffix for an object binding element, choosing
     /// dotted, numeric-indexed, or quoted-bracket form to match `tsc`.
-    fn destructuring_export_property_suffix(
-        &self,
-        prop_text: &str,
-        prop_kind: Option<u16>,
-    ) -> String {
+    fn destructuring_export_property_suffix(prop_text: &str, prop_kind: Option<u16>) -> String {
         if prop_kind == Some(SyntaxKind::NumericLiteral as u16) {
             format!("[{prop_text}]")
         } else if prop_kind == Some(SyntaxKind::StringLiteral as u16)

--- a/crates/tsz-emitter/src/emitter/module_emission/exports_destructuring.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/exports_destructuring.rs
@@ -1,0 +1,303 @@
+//! ES2015+ CommonJS export-destructuring lowering.
+//!
+//! `tsc` lowers `export const <pattern> = <init>` through
+//! `flattenDestructuringAssignment`: an identifier source is reused inline at
+//! every access, any other source is cached in a temp (or emitted inline when
+//! used exactly once), default initializers become `=== void 0` checks, and
+//! nested patterns recurse against the corresponding access. This module
+//! reproduces that form byte-for-byte. The ES5 path keeps its own inline-comma
+//! shape in `exports.rs`.
+
+use super::super::Printer;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+/// Source value for the recursive ES2015+ CommonJS export-destructuring lowering.
+///
+/// `tsc` reuses an identifier source inline at every access but emits any other
+/// source exactly once; `DestructBase` carries whichever form applies and grows
+/// member-access suffixes as the walk descends into the pattern.
+enum DestructBase {
+    /// A reusable string expression — an identifier or a hoisted temp, plus any
+    /// trailing member accesses. Safe to repeat at every access.
+    Str(String),
+    /// A non-identifier source emitted inline, with any pending member-access
+    /// suffix. Used exactly once (guaranteed by the single-element invariant).
+    Inline { node: NodeIndex, suffix: String },
+}
+
+impl DestructBase {
+    /// Extend the source with one more member access (`.prop` / `[i]`).
+    fn with_access(&self, suffix: &str) -> DestructBase {
+        match self {
+            DestructBase::Str(text) => DestructBase::Str(format!("{text}{suffix}")),
+            DestructBase::Inline {
+                node,
+                suffix: existing,
+            } => DestructBase::Inline {
+                node: *node,
+                suffix: format!("{existing}{suffix}"),
+            },
+        }
+    }
+}
+
+impl<'a> Printer<'a> {
+    /// Lower an ES2015+ CommonJS `export const <pattern> = <init>` through the
+    /// recursive destructuring form `tsc` uses (`flattenDestructuringAssignment`).
+    ///
+    /// The whole declaration is emitted as one comma-sequenced expression
+    /// statement. A simple identifier source is reused inline at every access;
+    /// any other source is cached in a hoisted temp when the pattern has more
+    /// than one element, or emitted inline when it has exactly one. Default
+    /// initializers become `temp = <access>, exports.x = temp === void 0 ?
+    /// <default> : temp`, and nested patterns recurse against the corresponding
+    /// access (or the defaulted value). This mirrors `tsc` byte-for-byte; the
+    /// ES5 path keeps its own inline-comma shape.
+    pub(in crate::emitter) fn emit_cjs_destructuring_export_flattened(
+        &mut self,
+        pattern_idx: NodeIndex,
+        initializer: NodeIndex,
+    ) {
+        let element_count = self.binding_pattern_element_count(pattern_idx);
+
+        let init_is_identifier = initializer.is_some()
+            && self
+                .arena
+                .get(initializer)
+                .is_some_and(|node| node.kind == SyntaxKind::Identifier as u16)
+            && !self.get_identifier_text(initializer).is_empty();
+
+        let mut first = true;
+        let base = if init_is_identifier {
+            DestructBase::Str(self.get_identifier_text(initializer))
+        } else if element_count != 1 {
+            // Source used more than once (or zero times): cache it once.
+            let temp = self.make_unique_name_cjs_destructuring();
+            self.emit_assignment_separator(&mut first);
+            self.write(&temp);
+            self.write(" = ");
+            if initializer.is_none() {
+                self.write("void 0");
+            } else {
+                self.emit(initializer);
+            }
+            DestructBase::Str(temp)
+        } else {
+            // Exactly one access: emit the source inline at that access.
+            DestructBase::Inline {
+                node: initializer,
+                suffix: String::new(),
+            }
+        };
+
+        self.flatten_cjs_destructuring_export(pattern_idx, &base, &mut first);
+        self.write(";");
+    }
+
+    /// Recursively emit the assignments for one binding pattern against the
+    /// already-prepared source `base`.
+    fn flatten_cjs_destructuring_export(
+        &mut self,
+        pattern_idx: NodeIndex,
+        base: &DestructBase,
+        first: &mut bool,
+    ) {
+        let Some(pattern_node) = self.arena.get(pattern_idx) else {
+            return;
+        };
+        let pattern_is_array = pattern_node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN;
+        let Some(pattern) = self.arena.get_binding_pattern(pattern_node) else {
+            return;
+        };
+        let element_indices: Vec<NodeIndex> = pattern.elements.nodes.clone();
+
+        let mut excluded_props: Vec<String> = Vec::new();
+        let mut rest: Option<(String, usize)> = None;
+
+        for (element_index, &elem_idx) in element_indices.iter().enumerate() {
+            let Some(elem_node) = self.arena.get(elem_idx) else {
+                continue;
+            };
+            if elem_node.kind == syntax_kind_ext::OMITTED_EXPRESSION {
+                continue;
+            }
+            let Some(elem) = self.arena.get_binding_element(elem_node) else {
+                continue;
+            };
+
+            if elem.dot_dot_dot_token {
+                rest = Some((self.get_identifier_text(elem.name), element_index));
+                continue;
+            }
+
+            let access_suffix = if pattern_is_array {
+                format!("[{element_index}]")
+            } else {
+                let (prop_text, prop_kind) = if elem.property_name.is_some() {
+                    let kind = self.arena.get(elem.property_name).map(|n| n.kind);
+                    let text = if kind == Some(SyntaxKind::StringLiteral as u16) {
+                        self.get_string_literal_text(elem.property_name)
+                            .unwrap_or_default()
+                    } else if kind == Some(SyntaxKind::NumericLiteral as u16) {
+                        self.get_numeric_literal_text(elem.property_name)
+                            .unwrap_or_default()
+                    } else {
+                        self.get_identifier_text_idx(elem.property_name)
+                    };
+                    (text, kind)
+                } else {
+                    (self.get_identifier_text(elem.name), None)
+                };
+                excluded_props.push(prop_text.clone());
+                self.destructuring_export_property_suffix(&prop_text, prop_kind)
+            };
+            let access_base = base.with_access(&access_suffix);
+
+            let target_is_pattern = self.arena.get(elem.name).is_some_and(|name_node| {
+                name_node.kind == syntax_kind_ext::OBJECT_BINDING_PATTERN
+                    || name_node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN
+            });
+
+            if elem.initializer.is_some() {
+                // `temp = <access>` then a `=== void 0 ? <default> : temp` check.
+                let access_temp = self.make_unique_name_cjs_destructuring();
+                self.emit_assignment_separator(first);
+                self.write(&access_temp);
+                self.write(" = ");
+                self.write_destructuring_export_base(&access_base);
+
+                if target_is_pattern {
+                    // The defaulted value feeds a nested pattern; bind it to a
+                    // temp so the nested accesses read a reusable identifier.
+                    let value_temp = self.make_unique_name_cjs_destructuring();
+                    self.emit_assignment_separator(first);
+                    self.write(&value_temp);
+                    self.write(" = ");
+                    self.write_destructuring_export_default(&access_temp, elem.initializer);
+                    self.flatten_cjs_destructuring_export(
+                        elem.name,
+                        &DestructBase::Str(value_temp),
+                        first,
+                    );
+                } else {
+                    let export_name = self.get_identifier_text(elem.name);
+                    self.write_export_assignment_start(first, &export_name);
+                    self.write_destructuring_export_default(&access_temp, elem.initializer);
+                }
+            } else if target_is_pattern {
+                let sub_count = self.binding_pattern_element_count(elem.name);
+                if sub_count == 1 {
+                    // Single nested access: reuse the access expression directly.
+                    self.flatten_cjs_destructuring_export(elem.name, &access_base, first);
+                } else {
+                    let temp = self.make_unique_name_cjs_destructuring();
+                    self.emit_assignment_separator(first);
+                    self.write(&temp);
+                    self.write(" = ");
+                    self.write_destructuring_export_base(&access_base);
+                    self.flatten_cjs_destructuring_export(
+                        elem.name,
+                        &DestructBase::Str(temp),
+                        first,
+                    );
+                }
+            } else {
+                let export_name = self.get_identifier_text(elem.name);
+                self.write_export_assignment_start(first, &export_name);
+                self.write_destructuring_export_base(&access_base);
+            }
+        }
+
+        if let Some((rest_name, rest_index)) = rest {
+            self.write_export_assignment_start(first, &rest_name);
+            if pattern_is_array {
+                // Array rest: `source.slice(<index>)`.
+                self.write_destructuring_export_base(base);
+                self.write(".slice(");
+                self.write(&rest_index.to_string());
+                self.write(")");
+            } else {
+                // Object rest: `__rest(source, [<excluded keys>])`.
+                self.write_helper("__rest");
+                self.write("(");
+                self.write_destructuring_export_base(base);
+                self.write(", [");
+                for (i, prop) in excluded_props.iter().enumerate() {
+                    if i > 0 {
+                        self.write(", ");
+                    }
+                    self.write("\"");
+                    self.write(prop);
+                    self.write("\"");
+                }
+                self.write("])");
+            }
+        }
+    }
+
+    /// Emit `<access_temp> === void 0 ? <default> : <access_temp>`.
+    fn write_destructuring_export_default(&mut self, access_temp: &str, initializer: NodeIndex) {
+        self.write(access_temp);
+        self.write(" === void 0 ? ");
+        self.emit(initializer);
+        self.write(" : ");
+        self.write(access_temp);
+    }
+
+    /// Write a [`DestructBase`] into the output buffer.
+    fn write_destructuring_export_base(&mut self, base: &DestructBase) {
+        match base {
+            DestructBase::Str(text) => self.write(text),
+            DestructBase::Inline { node, suffix } => {
+                self.emit(*node);
+                // `1.foo` is a parse error (the `.` reads as a decimal point);
+                // `tsc` emits a second dot for a numeric-literal receiver.
+                if suffix.starts_with('.')
+                    && self
+                        .arena
+                        .get(*node)
+                        .is_some_and(|n| n.is_numeric_literal())
+                {
+                    self.write(".");
+                }
+                self.write(suffix);
+            }
+        }
+    }
+
+    /// Build the property-access suffix for an object binding element, choosing
+    /// dotted, numeric-indexed, or quoted-bracket form to match `tsc`.
+    fn destructuring_export_property_suffix(
+        &self,
+        prop_text: &str,
+        prop_kind: Option<u16>,
+    ) -> String {
+        if prop_kind == Some(SyntaxKind::NumericLiteral as u16) {
+            format!("[{prop_text}]")
+        } else if prop_kind == Some(SyntaxKind::StringLiteral as u16)
+            || !super::super::is_valid_identifier_name(prop_text)
+        {
+            format!("[\"{prop_text}\"]")
+        } else {
+            format!(".{prop_text}")
+        }
+    }
+
+    /// Emit a `, exports.<name> = ` assignment head (with the leading separator).
+    fn write_export_assignment_start(&mut self, first: &mut bool, name: &str) {
+        self.emit_assignment_separator(first);
+        self.write("exports.");
+        self.write(name);
+        self.write(" = ");
+    }
+
+    /// Number of elements in a binding pattern node (0 when it is not one).
+    fn binding_pattern_element_count(&self, pattern_idx: NodeIndex) -> usize {
+        self.arena
+            .get(pattern_idx)
+            .and_then(|node| self.arena.get_binding_pattern(node))
+            .map_or(0, |pattern| pattern.elements.nodes.len())
+    }
+}

--- a/crates/tsz-emitter/src/emitter/module_emission/exports_destructuring.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/exports_destructuring.rs
@@ -115,7 +115,7 @@ impl Printer<'_> {
         let element_indices: Vec<NodeIndex> = pattern.elements.nodes.clone();
 
         let mut excluded_props: Vec<String> = Vec::new();
-        let mut rest: Option<(String, usize)> = None;
+        let mut rest: Option<(String, usize, u32)> = None;
 
         for (element_index, &elem_idx) in element_indices.iter().enumerate() {
             let Some(elem_node) = self.arena.get(elem_idx) else {
@@ -129,7 +129,11 @@ impl Printer<'_> {
             };
 
             if elem.dot_dot_dot_token {
-                rest = Some((self.get_identifier_text(elem.name), element_index));
+                rest = Some((
+                    self.get_identifier_text(elem.name),
+                    element_index,
+                    elem_node.pos,
+                ));
                 continue;
             }
 
@@ -155,6 +159,13 @@ impl Printer<'_> {
                 Self::destructuring_export_property_suffix(&prop_text, prop_kind)
             };
             let access_base = base.with_access(&access_suffix);
+            let leading_comment_pos = if elem.property_name.is_some() {
+                self.arena
+                    .get(elem.name)
+                    .map_or(elem_node.pos, |name_node| name_node.pos)
+            } else {
+                elem_node.pos
+            };
 
             let target_is_pattern = self.arena.get(elem.name).is_some_and(|name_node| {
                 name_node.kind == syntax_kind_ext::OBJECT_BINDING_PATTERN
@@ -184,7 +195,11 @@ impl Printer<'_> {
                     );
                 } else {
                     let export_name = self.get_identifier_text(elem.name);
-                    self.write_export_assignment_start(first, &export_name);
+                    self.write_export_assignment_start_with_comments(
+                        first,
+                        &export_name,
+                        leading_comment_pos,
+                    );
                     self.write_destructuring_export_default(&access_temp, elem.initializer);
                 }
             } else if target_is_pattern {
@@ -206,13 +221,17 @@ impl Printer<'_> {
                 }
             } else {
                 let export_name = self.get_identifier_text(elem.name);
-                self.write_export_assignment_start(first, &export_name);
+                self.write_export_assignment_start_with_comments(
+                    first,
+                    &export_name,
+                    leading_comment_pos,
+                );
                 self.write_destructuring_export_base(&access_base);
             }
         }
 
-        if let Some((rest_name, rest_index)) = rest {
-            self.write_export_assignment_start(first, &rest_name);
+        if let Some((rest_name, rest_index, rest_comment_pos)) = rest {
+            self.write_export_assignment_start_with_comments(first, &rest_name, rest_comment_pos);
             if pattern_is_array {
                 // Array rest: `source.slice(<index>)`.
                 self.write_destructuring_export_base(base);
@@ -279,9 +298,16 @@ impl Printer<'_> {
         }
     }
 
-    /// Emit a `, exports.<name> = ` assignment head (with the leading separator).
-    fn write_export_assignment_start(&mut self, first: &mut bool, name: &str) {
+    /// Emit a CJS export assignment head while preserving comments attached to
+    /// the corresponding binding element.
+    fn write_export_assignment_start_with_comments(
+        &mut self,
+        first: &mut bool,
+        name: &str,
+        leading_comment_pos: u32,
+    ) {
         self.emit_assignment_separator(first);
+        self.emit_comments_before_pos(leading_comment_pos);
         self.write("exports.");
         self.write(name);
         self.write(" = ");

--- a/crates/tsz-emitter/src/emitter/module_emission/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/mod.rs
@@ -3,6 +3,7 @@ mod core;
 #[cfg(test)]
 mod decorated_class_expression_export_tests;
 mod exports;
+mod exports_destructuring;
 mod imports;
 #[cfg(test)]
 mod namespace_export_fold_tests;


### PR DESCRIPTION
Goal: hold

Closes #14054.

## Structural rule

> When `module` is CommonJS and the target is ES2015+, `export const <pattern> = <init>` must lower exactly as `tsc`'s `flattenDestructuringAssignment`: a simple identifier source is reused inline at every access; any other source is cached in a hoisted temp when the pattern has more than one element, or emitted inline when it has exactly one; a binding-element default `= d` becomes `tmp = <access>, exports.x = tmp === void 0 ? d : tmp`; nested patterns recurse against the corresponding access (or the defaulted value); object rest uses `__rest(src, [keys])` and array rest uses `src.slice(<index>)`.

tsz previously lowered through a flat, single-level transform that **dropped default initializers** and emitted **invalid JS for nested patterns** (an empty property name):

```ts
export const { p, q = 5 } = { p: 1 } as { p: number; q?: number };
// tsc : _a = { p: 1 }, exports.p = _a.p, _b = _a.q, exports.q = _b === void 0 ? 5 : _b;
// tsz (before): _a = { p: 1 }, exports.p = _a.p, exports.q = _a.q;   // default `= 5` LOST

export const { a, b: { c } } = obj;
// tsc : exports.a = obj.a, exports.c = obj.b.c;
// tsz (before): _a = obj, exports.a = _a.a, exports. = _a.b;         // empty export name
```

Found by differential testing against `tsc` 6.0.2 (`--module commonjs --target es2017`).

## Owner layer

Emitter only (`crates/tsz-emitter`). The new recursive logic lives in `module_emission/exports_destructuring.rs`; `emit_cjs_destructuring_export` delegates to it for ES2015+ targets. No semantic/checker change, no output surgery. The ES5 CommonJS path has a genuinely different output shape (`exports.x = (_a = expr, _a).x`) and is left unchanged (tracked separately). The lowering keys purely on the structural pattern shape — never on identifier/property/file-name strings — so it applies to every binder spelling.

## Adjacent-case matrix (all byte-equal to tsc 6.0.2, `--module commonjs --target es2017`)

| case | result |
|---|---|
| object default `{ a, b = 9 }` | ✓ |
| array default `[x, y = 7]` | ✓ |
| rename + default `{ a: ra, b = 2 }` | ✓ |
| two defaults `{ a = 1, b = 2 }` | ✓ |
| nested no default `{ a, b: { c } }` (inlined) / `{ a, b: { c, d } }` (cached) | ✓ |
| nested array `[a, [b, c]]` | ✓ |
| nested + element default `{ a, c: { d = 3 } = {} }` | ✓ |
| identifier source reused inline / non-identifier multi-use source cached | ✓ |
| single-element non-identifier source emitted inline | ✓ |
| object rest `{ a, ...r }` → `__rest(src, ["a"])` | ✓ |
| array rest `[a, ...r]` → `src.slice(1)` | ✓ |
| array hole `[a, , c]` | ✓ |
| string / numeric keys `{ "x-y": a }` / `{ 0: a }` → bracket access | ✓ |
| plain (no default) and single-element forms (unchanged) | ✓ |

## Verification

- New name-agnostic suite (binder/property names varied) in `cjs_module_exports.rs`: defaults preserved (object + array), nested recursion (no empty export name), source caching (identifier inline vs non-identifier cached), object `__rest` vs array `.slice`, and bracket access for non-identifier keys — pass.
- `cargo test -p tsz-emitter --lib` — 3767 pass, 0 fail (no regressions; ES5 and ESM destructuring-export paths byte-unchanged).
- 22-case `tsc` 6.0.2 differential matrix — byte-identical.
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --lib --tests`, `python3 scripts/arch/arch_guard.py` (incl. 2000-line cap; both touched files < 2000 LOC) — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSxCbQw1ZsKT6QEn58rsiU)_