### PR TITLE
fix(solver): resolve indexed access for number-subtype keys against a numeric index signature

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -21,7 +21,7 @@ use crate::visitor::{
 };
 
 use super::super::evaluate::TypeEvaluator;
-use super::string_index_helpers::string_index_signature_applies;
+use super::string_index_helpers::{number_index_signature_applies, string_index_signature_applies};
 use crate::objects::apparent::literal_value_intrinsic_kind;
 
 const MAX_UNION_INDEX_SIZE: usize = 500;
@@ -2011,6 +2011,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             && string_index_signature_applies(self, string_index, index_type)
         {
             return self.add_undefined_if_unchecked(string_index.value_type);
+        }
+
+        // Number subtypes that are neither a bare `number` nor a numeric literal
+        // — most commonly a `number & { brand }` tagged-number intersection, but
+        // also any other subtype of `number` — must resolve through the numeric
+        // index signature, exactly as `TypeId::NUMBER` and numeric literals do
+        // above. This mirrors the string-subtype branch (`string & { brand }`):
+        // without it a tagged-number key falls through to `UNDEFINED` and the
+        // `is_generic_index` guard then defers the access into an unreduced
+        // `Obj[Key]`, producing a spurious TS2322. A numeric key still falls back
+        // to a string index signature, since numeric keys coerce to string keys.
+        if number_index_signature_applies(self, index_type) {
+            if let Some(number_index) = shape.number_index.as_ref() {
+                return self.add_undefined_if_unchecked(number_index.value_type);
+            }
+            if let Some(string_index) = string_index {
+                return self.add_undefined_if_unchecked(string_index.value_type);
+            }
         }
 
         TypeId::UNDEFINED

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -14,14 +14,12 @@ use crate::types::{
     ObjectShape, ObjectShapeId, PropertyInfo, SymbolRef, TupleElement, TupleListId, TypeData,
     TypeId, TypeListId, TypeParamInfo,
 };
-use crate::utils;
 use crate::visitor::{
     TypeVisitor, intersection_list_id, keyof_inner_type, literal_number, type_param_info,
     union_list_id,
 };
 
 use super::super::evaluate::TypeEvaluator;
-use super::string_index_helpers::{number_index_signature_applies, string_index_signature_applies};
 use crate::objects::apparent::literal_value_intrinsic_kind;
 
 const MAX_UNION_INDEX_SIZE: usize = 500;
@@ -1837,7 +1835,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// placeholder. Object shapes store well-known symbol members under the
     /// canonical text, so without this the lookup misses the member and the
     /// access wrongly evaluates to `undefined`.
-    fn literal_property_lookup_atom(&self, index_type: TypeId) -> Option<tsz_common::Atom> {
+    pub(super) fn literal_property_lookup_atom(
+        &self,
+        index_type: TypeId,
+    ) -> Option<tsz_common::Atom> {
         if let Some(TypeData::UniqueSymbol(sym)) = self.interner().lookup(index_type) {
             return Some(self.symbol_named_atom_from_unique_symbol_ref(sym));
         }
@@ -1906,132 +1907,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         shape: &ObjectShape,
         index_type: TypeId,
     ) -> TypeId {
-        let string_index = shape
-            .string_index
-            .as_ref()
-            .filter(|idx| idx.key_type != TypeId::SYMBOL);
-        let symbol_index = shape
-            .string_index
-            .as_ref()
-            .filter(|idx| idx.key_type == TypeId::SYMBOL);
-
-        // If index is a union, evaluate each member
-        if let Some(members) = union_list_id(self.interner(), index_type) {
-            let members = self.interner().type_list(members);
-            let mut results = Vec::new();
-            for &member in members.iter() {
-                let result = self.evaluate_object_with_index(shape, member);
-                if result != TypeId::UNDEFINED || self.no_unchecked_indexed_access() {
-                    results.push(result);
-                }
-            }
-            if results.is_empty() {
-                return TypeId::UNDEFINED;
-            }
-            return self.interner().union(results);
-        }
-
-        // If index is a literal string or unique symbol, look up the property first,
-        // then fallback to string index.
-        if let Some(name) = self.literal_property_lookup_atom(index_type) {
-            let is_symbol_key = self.index_type_is_symbol_key(index_type);
-            for prop in &shape.properties {
-                if prop.name == name {
-                    return self.optional_property_type(prop);
-                }
-            }
-            if utils::is_numeric_property_name(self.interner(), name)
-                && let Some(number_index) = shape.number_index.as_ref()
-            {
-                return self.add_undefined_if_unchecked(number_index.value_type);
-            }
-            if is_symbol_key && let Some(symbol_index) = symbol_index {
-                return self.add_undefined_if_unchecked(symbol_index.value_type);
-            }
-            // Symbol-keyed properties must not fall through to string index signatures.
-            if !is_symbol_key
-                && let Some(string_index) = string_index
-                && string_index_signature_applies(self, string_index, index_type)
-            {
-                return self.add_undefined_if_unchecked(string_index.value_type);
-            }
-            return TypeId::UNDEFINED;
-        }
-
-        // If index is a literal number, prefer number index, then string index.
-        if literal_number(self.interner(), index_type).is_some() {
-            if let Some(number_index) = shape.number_index.as_ref() {
-                return self.add_undefined_if_unchecked(number_index.value_type);
-            }
-            if let Some(string_index) = string_index
-                && string_index_signature_applies(self, string_index, index_type)
-            {
-                return self.add_undefined_if_unchecked(string_index.value_type);
-            }
-            return TypeId::UNDEFINED;
-        }
-
-        // Bare `string`/`number`/`symbol` indices that match no applicable index
-        // signature are a TS2536/TS2537 failure: tsc resolves the access to the error
-        // type rather than the union of all member value types, so downstream checks
-        // are suppressed. A numeric index still falls back to a string index signature
-        // (numeric keys are string keys).
-        if index_type == TypeId::STRING {
-            if let Some(string_index) = string_index
-                && string_index_signature_applies(self, string_index, index_type)
-            {
-                return self.add_undefined_if_unchecked(string_index.value_type);
-            }
-            return TypeId::ERROR;
-        }
-
-        if index_type == TypeId::NUMBER {
-            if let Some(number_index) = shape.number_index.as_ref() {
-                return self.add_undefined_if_unchecked(number_index.value_type);
-            }
-            if let Some(string_index) = string_index {
-                return self.add_undefined_if_unchecked(string_index.value_type);
-            }
-            return TypeId::ERROR;
-        }
-
-        if index_type == TypeId::SYMBOL {
-            if let Some(symbol_index) = symbol_index {
-                return self.add_undefined_if_unchecked(symbol_index.value_type);
-            }
-            return TypeId::ERROR;
-        }
-
-        // Template literal types (e.g., `foo${string}`), string intrinsic types
-        // (e.g., Lowercase<T>), and intersections containing string (e.g., string & { brand: any })
-        // are all subtypes of string. When the object has a string index signature,
-        // these index types should resolve to the string index signature's value type,
-        // just like TypeId::STRING does.
-        if let Some(string_index) = string_index
-            && string_index_signature_applies(self, string_index, index_type)
-        {
-            return self.add_undefined_if_unchecked(string_index.value_type);
-        }
-
-        // Number subtypes that are neither a bare `number` nor a numeric literal
-        // — most commonly a `number & { brand }` tagged-number intersection, but
-        // also any other subtype of `number` — must resolve through the numeric
-        // index signature, exactly as `TypeId::NUMBER` and numeric literals do
-        // above. This mirrors the string-subtype branch (`string & { brand }`):
-        // without it a tagged-number key falls through to `UNDEFINED` and the
-        // `is_generic_index` guard then defers the access into an unreduced
-        // `Obj[Key]`, producing a spurious TS2322. A numeric key still falls back
-        // to a string index signature, since numeric keys coerce to string keys.
-        if number_index_signature_applies(self, index_type) {
-            if let Some(number_index) = shape.number_index.as_ref() {
-                return self.add_undefined_if_unchecked(number_index.value_type);
-            }
-            if let Some(string_index) = string_index {
-                return self.add_undefined_if_unchecked(string_index.value_type);
-            }
-        }
-
-        TypeId::UNDEFINED
+        super::index_access_object_with_index::evaluate_object_with_index(self, shape, index_type)
     }
 
     pub(crate) fn optional_property_type(&self, prop: &PropertyInfo) -> TypeId {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_object_with_index.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_object_with_index.rs
@@ -1,0 +1,134 @@
+//! Object indexed-access evaluation for object shapes with index signatures.
+
+use crate::relations::subtype::TypeResolver;
+use crate::types::{ObjectShape, TypeId};
+use crate::utils;
+use crate::visitor::{literal_number, union_list_id};
+
+use super::super::evaluate::TypeEvaluator;
+use super::string_index_helpers::{number_index_signature_applies, string_index_signature_applies};
+
+pub(super) fn evaluate_object_with_index<R: TypeResolver>(
+    evaluator: &TypeEvaluator<'_, R>,
+    shape: &ObjectShape,
+    index_type: TypeId,
+) -> TypeId {
+    let string_index = shape
+        .string_index
+        .as_ref()
+        .filter(|idx| idx.key_type != TypeId::SYMBOL);
+    let symbol_index = shape
+        .string_index
+        .as_ref()
+        .filter(|idx| idx.key_type == TypeId::SYMBOL);
+
+    // If index is a union, evaluate each member.
+    if let Some(members) = union_list_id(evaluator.interner(), index_type) {
+        let members = evaluator.interner().type_list(members);
+        let mut results = Vec::new();
+        for &member in members.iter() {
+            let result = evaluator.evaluate_object_with_index(shape, member);
+            if result != TypeId::UNDEFINED || evaluator.no_unchecked_indexed_access() {
+                results.push(result);
+            }
+        }
+        if results.is_empty() {
+            return TypeId::UNDEFINED;
+        }
+        return evaluator.interner().union(results);
+    }
+
+    // If index is a literal string or unique symbol, look up the property first,
+    // then fallback to string index.
+    if let Some(name) = evaluator.literal_property_lookup_atom(index_type) {
+        let is_symbol_key = evaluator.index_type_is_symbol_key(index_type);
+        for prop in &shape.properties {
+            if prop.name == name {
+                return evaluator.optional_property_type(prop);
+            }
+        }
+        if utils::is_numeric_property_name(evaluator.interner(), name)
+            && let Some(number_index) = shape.number_index.as_ref()
+        {
+            return evaluator.add_undefined_if_unchecked(number_index.value_type);
+        }
+        if is_symbol_key && let Some(symbol_index) = symbol_index {
+            return evaluator.add_undefined_if_unchecked(symbol_index.value_type);
+        }
+        // Symbol-keyed properties must not fall through to string index signatures.
+        if !is_symbol_key
+            && let Some(string_index) = string_index
+            && string_index_signature_applies(evaluator, string_index, index_type)
+        {
+            return evaluator.add_undefined_if_unchecked(string_index.value_type);
+        }
+        return TypeId::UNDEFINED;
+    }
+
+    // If index is a literal number, prefer number index, then string index.
+    if literal_number(evaluator.interner(), index_type).is_some() {
+        if let Some(number_index) = shape.number_index.as_ref() {
+            return evaluator.add_undefined_if_unchecked(number_index.value_type);
+        }
+        if let Some(string_index) = string_index
+            && string_index_signature_applies(evaluator, string_index, index_type)
+        {
+            return evaluator.add_undefined_if_unchecked(string_index.value_type);
+        }
+        return TypeId::UNDEFINED;
+    }
+
+    // Bare `string`/`number`/`symbol` indices that match no applicable index
+    // signature are a TS2536/TS2537 failure: tsc resolves the access to the
+    // error type rather than the union of all member value types, so downstream
+    // checks are suppressed. A numeric index still falls back to a string index
+    // signature (numeric keys are string keys).
+    if index_type == TypeId::STRING {
+        if let Some(string_index) = string_index
+            && string_index_signature_applies(evaluator, string_index, index_type)
+        {
+            return evaluator.add_undefined_if_unchecked(string_index.value_type);
+        }
+        return TypeId::ERROR;
+    }
+
+    if index_type == TypeId::NUMBER {
+        if let Some(number_index) = shape.number_index.as_ref() {
+            return evaluator.add_undefined_if_unchecked(number_index.value_type);
+        }
+        if let Some(string_index) = string_index {
+            return evaluator.add_undefined_if_unchecked(string_index.value_type);
+        }
+        return TypeId::ERROR;
+    }
+
+    if index_type == TypeId::SYMBOL {
+        if let Some(symbol_index) = symbol_index {
+            return evaluator.add_undefined_if_unchecked(symbol_index.value_type);
+        }
+        return TypeId::ERROR;
+    }
+
+    // Template literal types, string intrinsic types, and intersections
+    // containing string are all subtypes of string. When the object has a
+    // string index signature, these resolve to that index signature's value.
+    if let Some(string_index) = string_index
+        && string_index_signature_applies(evaluator, string_index, index_type)
+    {
+        return evaluator.add_undefined_if_unchecked(string_index.value_type);
+    }
+
+    // Number subtypes that are neither a bare `number` nor a numeric literal
+    // must resolve through the numeric index signature, then fall back to the
+    // string index signature because numeric keys coerce to string keys.
+    if number_index_signature_applies(evaluator, index_type) {
+        if let Some(number_index) = shape.number_index.as_ref() {
+            return evaluator.add_undefined_if_unchecked(number_index.value_type);
+        }
+        if let Some(string_index) = string_index {
+            return evaluator.add_undefined_if_unchecked(string_index.value_type);
+        }
+    }
+
+    TypeId::UNDEFINED
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
@@ -18,6 +18,7 @@ pub mod conditional;
 pub mod index_access;
 mod index_access_callable;
 mod index_access_keys;
+mod index_access_object_with_index;
 mod index_access_tuple_literal;
 pub mod infer_pattern;
 mod infer_pattern_helpers;

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/string_index_helpers.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/string_index_helpers.rs
@@ -1,4 +1,5 @@
-//! Helpers for string index-signature applicability during indexed access.
+//! Helpers for index-signature applicability (string and numeric) during
+//! indexed access.
 
 use crate::evaluation::evaluate::TypeEvaluator;
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
@@ -40,6 +41,63 @@ pub(super) fn string_index_signature_applies<R: TypeResolver>(
         checker = checker.with_query_db(db);
     }
     checker.is_subtype_of(index_type, string_index.key_type)
+}
+
+/// Whether `index_type` is a *number subtype* that should resolve through a
+/// numeric index signature (and, failing that, a string index signature, since
+/// numeric keys coerce to string keys).
+///
+/// This is the numeric mirror of [`string_index_signature_applies`]. A numeric
+/// index signature's `key_type` is always `number`, so applicability reduces to
+/// "is `index_type` a subtype of `number`". The common cases (`number`, a
+/// numeric literal, and a `number & { brand }` intersection) are answered
+/// structurally on the hot path; anything else falls back to a subtype query so
+/// general number subtypes (e.g. an enum type) still apply, matching tsc's
+/// `isApplicableIndexType`.
+pub(super) fn number_index_signature_applies<R: TypeResolver>(
+    evaluator: &TypeEvaluator<'_, R>,
+    index_type: TypeId,
+) -> bool {
+    if index_type == TypeId::NUMBER {
+        return true;
+    }
+    // A single interner lookup answers both structural fast paths: a numeric
+    // literal, or a `number & { brand }` intersection.
+    match evaluator.interner().lookup(index_type) {
+        Some(TypeData::Literal(LiteralValue::Number(_))) => return true,
+        Some(TypeData::Intersection(list_id)) => {
+            if evaluator
+                .interner()
+                .type_list(list_id)
+                .iter()
+                .any(|&member| is_number_like_intersection_member(evaluator, member))
+            {
+                return true;
+            }
+        }
+        _ => {}
+    }
+    let mut checker = SubtypeChecker::with_resolver(evaluator.interner(), evaluator.resolver());
+    if let Some(db) = evaluator.query_db() {
+        checker = checker.with_query_db(db);
+    }
+    checker.is_subtype_of(index_type, TypeId::NUMBER)
+}
+
+fn is_number_like_intersection_member<R: TypeResolver>(
+    evaluator: &TypeEvaluator<'_, R>,
+    member: TypeId,
+) -> bool {
+    if member == TypeId::NUMBER {
+        return true;
+    }
+    if member.is_intrinsic() {
+        return false;
+    }
+    matches!(
+        evaluator.interner().lookup(member),
+        Some(TypeData::Literal(LiteralValue::Number(_)))
+    )
 }
 
 fn is_string_like_index<R: TypeResolver>(
@@ -85,7 +143,7 @@ mod tests {
     use super::*;
     use crate::evaluation::evaluate::evaluate_index_access;
     use crate::intern::TypeInterner;
-    use crate::types::{ObjectFlags, ObjectShape, TemplateSpan};
+    use crate::types::{ObjectFlags, ObjectShape, PropertyInfo, TemplateSpan};
 
     #[test]
     fn template_pattern_string_index_rejects_non_matching_literal_key() {
@@ -264,6 +322,136 @@ mod tests {
         assert_eq!(
             evaluate_index_access(&db, object, db.literal_number(42.0)),
             TypeId::UNDEFINED
+        );
+    }
+
+    // A `number & { brand }` tagged-number intersection used as an index key.
+    // Structural over the brand: the property name/type are arbitrary and do not
+    // change the rule.
+    fn tagged_number(db: &TypeInterner, brand_name: &str, brand_type: TypeId) -> TypeId {
+        let brand_atom = db.intern_string(brand_name);
+        let brand = db.object(vec![PropertyInfo::new(brand_atom, brand_type)]);
+        db.intersection2(TypeId::NUMBER, brand)
+    }
+
+    #[test]
+    fn tagged_number_index_resolves_numeric_index_signature() {
+        // `{ [x: number]: V }[number & { brand }]` -> V, exactly like `D[number]`.
+        // This is the numeric mirror of the existing `string & { brand }` path
+        // and the regression repro from operatorsAndIntersectionTypes.ts.
+        for value_type in [TypeId::STRING, TypeId::BOOLEAN, TypeId::NUMBER] {
+            let db = TypeInterner::new();
+            let object = db.object_with_index(ObjectShape {
+                flags: ObjectFlags::empty(),
+                properties: Vec::new(),
+                string_index: None,
+                number_index: Some(IndexSignature {
+                    key_type: TypeId::NUMBER,
+                    value_type,
+                    readonly: false,
+                    param_name: None,
+                }),
+                symbol: None,
+            });
+            // Vary the brand name/type so the rule is structural, not name-driven.
+            let key = tagged_number(&db, "serialNo", TypeId::BOOLEAN);
+            assert_eq!(
+                evaluate_index_access(&db, object, key),
+                value_type,
+                "tagged number key must resolve through the numeric index signature"
+            );
+        }
+    }
+
+    #[test]
+    fn tagged_number_index_falls_back_to_string_index_signature() {
+        // `{ [x: string]: V }[number & { brand }]` -> V: a numeric key coerces to
+        // a string key, so it resolves through a string index signature when no
+        // numeric one is present.
+        let db = TypeInterner::new();
+        let object = plain_string_index_object(&db, TypeId::BOOLEAN);
+        let key = tagged_number(&db, "tag", db.literal_number(1.0));
+        assert_eq!(evaluate_index_access(&db, object, key), TypeId::BOOLEAN);
+    }
+
+    #[test]
+    fn tagged_number_index_prefers_numeric_over_string_index_signature() {
+        // With both signatures present the numeric one wins, like a bare `number`
+        // key.
+        let db = TypeInterner::new();
+        let object = db.object_with_index(ObjectShape {
+            flags: ObjectFlags::empty(),
+            properties: Vec::new(),
+            string_index: Some(IndexSignature {
+                key_type: TypeId::STRING,
+                value_type: TypeId::NUMBER,
+                readonly: false,
+                param_name: None,
+            }),
+            number_index: Some(IndexSignature {
+                key_type: TypeId::NUMBER,
+                value_type: TypeId::BOOLEAN,
+                readonly: false,
+                param_name: None,
+            }),
+            symbol: None,
+        });
+        let key = tagged_number(&db, "id", TypeId::STRING);
+        assert_eq!(evaluate_index_access(&db, object, key), TypeId::BOOLEAN);
+    }
+
+    #[test]
+    fn tagged_number_index_without_any_index_signature_stays_deferred() {
+        // Negative control: no index signature to resolve through. A generic
+        // (intersection) key with nothing to match is kept as a deferred
+        // `IndexAccess` rather than collapsed to a concrete value type.
+        let db = TypeInterner::new();
+        let object = db.object_with_index(ObjectShape {
+            flags: ObjectFlags::empty(),
+            properties: Vec::new(),
+            string_index: None,
+            number_index: None,
+            symbol: None,
+        });
+        let key = tagged_number(&db, "tag", TypeId::NUMBER);
+        let result = evaluate_index_access(&db, object, key);
+        assert!(
+            matches!(db.lookup(result), Some(TypeData::IndexAccess(_, _))),
+            "an unmatched tagged-number key must stay deferred, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn tagged_string_does_not_match_numeric_index_signature() {
+        // Negative control / asymmetry: a `string & { brand }` key is NOT a
+        // number subtype, so it must not resolve through a numeric-only index
+        // signature (tsc errors on this). It must not collapse to the numeric
+        // value type; it stays a deferred `IndexAccess`.
+        let db = TypeInterner::new();
+        let object = db.object_with_index(ObjectShape {
+            flags: ObjectFlags::empty(),
+            properties: Vec::new(),
+            string_index: None,
+            number_index: Some(IndexSignature {
+                key_type: TypeId::NUMBER,
+                value_type: TypeId::BOOLEAN,
+                readonly: false,
+                param_name: None,
+            }),
+            symbol: None,
+        });
+        let brand_atom = db.intern_string("g");
+        let brand = db.object(vec![PropertyInfo::new(brand_atom, TypeId::NUMBER)]);
+        let tagged_string = db.intersection2(TypeId::STRING, brand);
+        let result = evaluate_index_access(&db, object, tagged_string);
+        assert_ne!(
+            result,
+            TypeId::BOOLEAN,
+            "a tagged-string key must not match the numeric index signature"
+        );
+        assert!(
+            matches!(db.lookup(result), Some(TypeData::IndexAccess(_, _))),
+            "an unmatched tagged-string key must stay deferred, got {result:?}"
         );
     }
 }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/string_index_helpers.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/string_index_helpers.rs
@@ -65,15 +65,14 @@ pub(super) fn number_index_signature_applies<R: TypeResolver>(
     // literal, or a `number & { brand }` intersection.
     match evaluator.interner().lookup(index_type) {
         Some(TypeData::Literal(LiteralValue::Number(_))) => return true,
-        Some(TypeData::Intersection(list_id)) => {
+        Some(TypeData::Intersection(list_id))
             if evaluator
                 .interner()
                 .type_list(list_id)
                 .iter()
-                .any(|&member| is_number_like_intersection_member(evaluator, member))
-            {
-                return true;
-            }
+                .any(|&member| is_number_like_intersection_member(evaluator, member)) =>
+        {
+            return true;
         }
         _ => {}
     }


### PR DESCRIPTION
Goal: hold

Refs #8432 (mapped/keyof/inference & type-relationship parity family).

## Structural rule

> When `Obj[Key]` is evaluated and `Obj` has a numeric index signature, `tsc`
> resolves the access to that signature's value type for **any `Key` that is a
> subtype of `number`** — not just a bare `number` or a numeric literal. The
> most common such key is a tagged-number intersection `number & { brand }`
> (the branded-primitive pattern), but the rule is general (`isApplicableIndexType`).
> A numeric key still falls back to a string index signature, since numeric keys
> coerce to string keys. A non-number key (e.g. `string & { brand }`) does **not**
> match a numeric index signature.

tsz already handled the symmetric **string-subtype** case (`string & { brand }`,
template literals, string intrinsics) in `evaluate_object_with_index`, but had
**no numeric counterpart**. A number-subtype key therefore fell through to
`UNDEFINED`; the `is_generic_index` guard (which treats `Intersection` as
deferrable) then deferred the access into an unreduced `Obj[Key]`, surfacing a
spurious `TS2322`:

```ts
type SerialNo = number & { tag: 1 };
declare const serialNo: SerialNo;
let map: { [x: number]: string } = {};
map[serialNo] = "hello";
// tsc: ok
// tsz (before): TS2322 Type 'string' is not assignable to type '{ [x: number]: string; }[SerialNo]'.
```

Found by differential testing against `tsc` 6.0.2 over the conformance type
corpus (`operatorsAndIntersectionTypes.ts`).

## Owner layer / fix

Solver indexed-access evaluation
(`crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs`,
`evaluate_object_with_index`). A numeric-subtype branch is added mirroring the
existing string-subtype branch, backed by a new `number_index_signature_applies`
helper (in `string_index_helpers.rs`, the numeric mirror of
`string_index_signature_applies`):

- structural fast paths (single interner lookup): bare `number`, a numeric
  literal, a number-bearing intersection;
- a general `is_subtype_of(key, number)` fallback so any number subtype applies.

The decision is purely structural over the key type and the object's index
signatures — no identifier/file-name/printer-string predicates.

## Adjacent-case matrix (all verified byte-equal to `tsc` 6.0.2)

| case | tsc | tsz after |
|---|---|---|
| `{ [x: number]: V }[number & { brand }]` | `V` | ✓ |
| `{ [x: string]: V }[number & { brand }]` (numeric coerces to string key) | `V` | ✓ |
| both index sigs present, `number & { brand }` key | numeric `V` (preferred) | ✓ |
| `{ [x: number]: V }[string & { brand }]` | error (not a number subtype) | unchanged ✓ |
| `{ [x: string]: V }[string & { brand }]` | `V` (pre-existing) | unchanged ✓ |
| bare `number` / numeric literal / enum key | `V` | unchanged ✓ |
| no index signature, intersection key | deferred `IndexAccess` | unchanged ✓ |

## Verification

- New name-agnostic solver unit tests in
  `string_index_helpers.rs` (brand name/type/value varied so the rule is
  structural): tagged-number resolves the numeric signature, falls back to a
  string signature, prefers numeric over string, stays deferred with no
  signature; negative control that a tagged-**string** key does not match a
  numeric signature. `cargo test -p tsz-solver --lib string_index_helpers` →
  **12 passed, 0 failed**.
- Full `cargo test -p tsz-solver --lib` → **6811 passed, 4 failed**; the 4
  failures are **pre-existing on `main`** (byte-identical set on a clean tree:
  `test_conditional_infer_optional_property_present_distributive`,
  `literal_mask_preserves_object_vs_literal_reduction`,
  `array_isarray_keeps_mutable_and_readonly_array_members`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`).
  **Zero new failures**; +5 new passing tests.
- Differential vs `tsc` 6.0.2 over **391 single-file `conformance/types` tests**:
  `operatorsAndIntersectionTypes.ts` goes from diverging to byte-identical, and
  the divergence set otherwise **shrinks by exactly that one file with no new
  divergences**.
- `cargo clippy -p tsz-solver --lib` and `cargo fmt -p tsz-solver --check` clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01AgZt1jDhLrFrrqk3SPJGcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgZt1jDhLrFrrqk3SPJGcD)_