### PR TITLE
fix(solver): relate same-base opaque applications by structural identity (#13609)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -7,7 +7,7 @@
 //! - Mapped types ({ [K in keyof T]: T[K] })
 //! - Type expansion and instantiation
 
-use super::super::{SubtypeChecker, SubtypeResult, TypeResolver};
+use super::super::{SubtypeChecker, SubtypeResult, TypeResolver, are_types_structurally_identical};
 pub(crate) use super::mapped_chain::flatten_mapped_chain;
 use crate::def::DefId;
 use crate::instantiation::instantiate::fill_application_defaults;
@@ -662,18 +662,39 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 let t_eval = self.evaluate_type(target_type);
                 if s_eval != source_type || t_eval != target_type {
                     self.check_subtype(s_eval, t_eval)
-                } else if same_application_family {
-                    // When both applications share the same base but cannot be structurally
-                    // expanded or evaluated, we cannot safely assume covariant assignability.
-                    // The variance-aware check above already attempted to determine the
-                    // correct variance; if that failed (e.g., variance unavailable or needs
-                    // structural fallback but evaluation didn't change types), we must
-                    // reject the assignability rather than using an unsound covariant fallback.
-                    // This fixes cases like `Promise<Bar>` being incorrectly assignable to
-                    // `Promise<Foo>` when T is contravariant (appears in function parameter
-                    // position in the Promise interface).
-                    SubtypeResult::False
+                } else if same_application_family
+                    && are_types_structurally_identical(
+                        self.interner,
+                        self.resolver,
+                        source_type,
+                        target_type,
+                    )
+                {
+                    // Same base, opaque/unresolvable body (neither expansion nor
+                    // evaluation made progress), but the two applications are
+                    // structurally identical — they denote the same type. This is
+                    // the reflexive identity that type-parameter `default` /
+                    // constraint-resolution-snapshot fragmentation (#13609) splits
+                    // into distinct `TypeId`s: `App(Base, [R = "json"])` vs
+                    // `App(Base, [R])`. The query-db canonical fast path in
+                    // `check_subtype` recovers it when a `QueryDatabase` is present,
+                    // but relation paths constructed without one (instanceof,
+                    // element-access, contextual, property lookup, `CompatChecker`
+                    // before `set_query_db`) never reached it, so two identical
+                    // applications were falsely reported non-assignable. Recover the
+                    // identity directly here; this runs only in this rare opaque-base
+                    // arm, so it adds no hot-path cost. Structural identity implies
+                    // mutual assignability under any variance, so this only proves
+                    // the relation, never weakens a genuine rejection.
+                    SubtypeResult::True
                 } else {
+                    // Same base but not structurally identical (or a different
+                    // family): the body is opaque and evaluation stalled, so we
+                    // cannot assume covariant assignability — the variance-aware
+                    // check above already tried, and an unsound covariant fallback
+                    // would e.g. make `Promise<Bar>` assignable to `Promise<Foo>`
+                    // when `T` is contravariant (a function-parameter position).
+                    // Reject.
                     SubtypeResult::False
                 }
             }

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_16.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_16.rs
@@ -291,3 +291,77 @@ fn test_missing_property_in_index_sig_target_returns_missing_property_directly()
         "missing-property case should surface the missing property reason directly, got: {reason:?}"
     );
 }
+
+// ----------------------------------------------------------------------
+// #13609: two applications of the SAME opaque/unresolvable base that differ
+// ONLY in a type parameter's optional `default` denote the same type and must
+// relate reflexively on EVERY relation path — including those built without a
+// `QueryDatabase` (instanceof, element-access, contextual, property lookup,
+// `CompatChecker` before `set_query_db`), where the canonical-identity fast
+// path in `check_subtype` is unavailable. Before the fix the no-`query_db`
+// path dropped two structurally identical applications to a false `False`.
+// A genuinely different type argument must still be rejected (no unsound
+// covariant/identity fallback over the opaque base).
+// ----------------------------------------------------------------------
+#[test]
+fn application_over_opaque_base_relates_reflexively_despite_type_param_default_13609() {
+    use crate::caches::db::QueryDatabase;
+
+    let interner = TypeInterner::new();
+    let cache = QueryCache::new(&interner);
+
+    // Name-agnostic: the binder spelling must not influence the outcome.
+    for raw_name in ["R", "Elem", "TKey"] {
+        let name = interner.intern_string(raw_name);
+        let mk_param = |default| {
+            interner.type_param(TypeParamInfo {
+                name,
+                constraint: Some(TypeId::STRING),
+                default,
+                is_const: false,
+                origin: crate::types::TypeParamOrigin::User,
+            })
+        };
+        // Same logical parameter, fragmented only on the optional `default`.
+        let p_with = mk_param(Some(TypeId::NUMBER));
+        let p_without = mk_param(None);
+        assert_ne!(p_with, p_without, "precondition: default fragments interning");
+
+        // An opaque/unresolvable generic base (the resolver has no body for it),
+        // mirroring a cross-arena `Lazy` not resolvable in this generation.
+        let base = interner.lazy(DefId(90_001));
+        let app_with = interner.application(base, vec![p_with]);
+        let app_without = interner.application(base, vec![p_without]);
+        assert_ne!(app_with, app_without);
+
+        // Precondition: they canonicalize to one identity (the `default` drop).
+        assert_eq!(cache.canonical_id(app_with), cache.canonical_id(app_without));
+
+        // With a query database (the production checker path): reflexive both ways.
+        let mut with_db = SubtypeChecker::with_resolver(&interner, &cache).with_query_db(&cache);
+        assert!(with_db.is_subtype_of(app_with, app_without));
+        let mut with_db_rev = SubtypeChecker::with_resolver(&interner, &cache).with_query_db(&cache);
+        assert!(with_db_rev.is_subtype_of(app_without, app_with));
+
+        // WITHOUT a query database (the regressing path): the canonical fast path
+        // is absent, yet structurally identical applications must still relate.
+        let mut no_db = SubtypeChecker::with_resolver(&interner, &cache);
+        assert!(
+            no_db.is_subtype_of(app_with, app_without),
+            "{raw_name}: identical applications must relate without a query_db"
+        );
+        let mut no_db_rev = SubtypeChecker::with_resolver(&interner, &cache);
+        assert!(no_db_rev.is_subtype_of(app_without, app_with));
+
+        // Negative control: a genuinely different type argument must NOT relate,
+        // even over the opaque base — the recovery is strict structural identity,
+        // not an unsound covariant/identity fallback.
+        let app_string = interner.application(base, vec![TypeId::STRING]);
+        let app_number = interner.application(base, vec![TypeId::NUMBER]);
+        let mut neg = SubtypeChecker::with_resolver(&interner, &cache);
+        assert!(
+            !neg.is_subtype_of(app_string, app_number),
+            "{raw_name}: differing concrete args over an opaque base must stay unrelated"
+        );
+    }
+}


### PR DESCRIPTION
Goal: green

Part of #13609 — fixes the no-`QueryDatabase` relation-path residual of the type-parameter-identity fragmentation family.

## Structural rule

> When two `Application` types share the same base and the base is opaque (neither `try_expand_application_type` nor `evaluate_type` can make progress — an unresolvable/cross-arena `Lazy`), `tsc` relates them by their type arguments. If the two applications are **structurally identical** — e.g. they fragment only on a type parameter's optional `default` (`App(Base, [R extends X = "json"])` vs `App(Base, [R extends X])`) or on its constraint's resolution snapshot (#13609) — they denote the same type and must relate reflexively. tsz must report them assignable through `check_application_to_application_subtype`, on **every** relation path.

tsz interns `TypeData::TypeParameter(TypeParamInfo)` with `default`/constraint in its structural identity, so the two operands get distinct `TypeId`s. The canonical-identity fast path in `check_subtype` (`crates/tsz-solver/src/relations/subtype/cache.rs`) recovers that identity — but only when a `QueryDatabase` is present (it is deliberately gated there to avoid a per-call `Canonicalizer` allocation on the hot path; see `core_dispatch.rs`). Relation paths built **without** a `query_db` — `instanceof`, element-access, contextual typing, property lookup, and `CompatChecker` before `set_query_db` — never reached it, so the `(None, None)` opaque-base arm of `check_application_to_application_subtype` dropped two structurally-identical applications to a false non-assignability.

## Owner layer

Solver relation. The fix lives in the `(None, None)` arm of `check_application_to_application_subtype` (`crates/tsz-solver/src/relations/subtype/rules/generics.rs`): when the same-base pair is opaque and evaluation stalled, recover identity via the existing `are_types_structurally_identical(self.interner, self.resolver, …)` helper before rejecting. It runs only in that rare opaque-base arm, so it adds no hot-path cost and respects the documented reason the universal fast path requires a `query_db`. Structural identity implies mutual assignability under any variance, so this only ever **proves** the relation — it never weakens a genuine rejection (the contravariant `Promise<Bar>` vs `Promise<Foo>` rejection and differing-concrete-arg rejection are preserved).

This keys purely on the structural same-base + canonical-identity shape — never on identifiers, aliases, property names, file names, or rendered output — so it applies to every spelling.

## Why scoped here (altitude)

A broader fix — making the `check_subtype` fast path fall back to `are_types_structurally_identical` whenever `query_db` is `None` — would pay a per-call `Canonicalizer` allocation on *every* subtype check (all type kinds) on those paths, which is exactly the regression that motivated gating the universal fast path on `query_db` in the first place. Type-parameter `default` fragmentation surfaces as application-argument fragmentation, so recovering it in the application arm is the correct, scoped depth, consistent with the existing SAME-BASE IDENTICAL-ARGS shortcut a few lines above.

## Adjacent-case matrix (name-agnostic; binder names varied `R`/`Elem`/`TKey`)

| case | path | expected |
|---|---|---|
| `App(Base, [R = number])` vs `App(Base, [R])`, opaque base | no `query_db` | assignable (was false `False`) |
| same, reverse direction | no `query_db` | assignable |
| same | with `query_db` | assignable (fast path, unchanged) |
| `App(Base, [string])` vs `App(Base, [number])`, opaque base | no `query_db` | **not** assignable (negative control) |
| canonical-id precondition | — | `canonical_id` converges (the `default` drop) |

## Verification

- New name-agnostic regression test `application_over_opaque_base_relates_reflexively_despite_type_param_default_13609` (`crates/tsz-solver/tests/subtype_tests_parts/part_16.rs`) — verified failing on the pre-fix tree (the no-`query_db` assertions returned `False`) and passing after. Covers both directions, with/without `query_db`, and the differing-arg negative control.
- `cargo test -p tsz-solver --lib relations::subtype` — 1048 pass, 0 fail.
- `cargo test -p tsz-solver --lib relations::` — 1362 pass, 0 fail.
- Full `cargo test -p tsz-solver --lib`: the only failures are 4 pre-existing ones (`test_conditional_infer_optional_property_present_distributive`, `literal_mask_preserves_object_vs_literal_reduction`, `array_isarray_keeps_mutable_and_readonly_array_members`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`), confirmed identical on clean `main` (stash-verified) and unrelated to this change.
- `cargo fmt -p tsz-solver --check`, `cargo clippy -p tsz-solver --lib --tests`, `python3 scripts/arch/arch_guard.py` (incl. 2000-line cap; both touched files under cap) — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Wu19tU3h5TuRp8V8VmWrdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wu19tU3h5TuRp8V8VmWrdN)_