### PR TITLE
fix(website): download application compat artifacts in bench publish

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1517,22 +1517,37 @@ jobs:
       # Best-effort by design: only the workflow_run (push-to-main) publish
       # path has a triggering CI run; a missing/old artifact must NEVER block
       # publishing the timing benchmarks (app rows just fall back to gray).
-      - name: Download application compile compatibility (best-effort)
+      - name: Download required compile compatibility from triggering CI (best-effort)
         if: github.event_name == 'workflow_run'
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          CI_RUN_ID: ${{ github.event.workflow_run.id }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: project-compile-compatibility
+          path: .target/app-compile-required-compat
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Download canary compile compatibility from triggering CI (best-effort)
+        if: github.event_name == 'workflow_run'
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: project-compile-canary-logs
+          path: .target/app-compile-canary-compat
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: List application compile compatibility
+        if: github.event_name == 'workflow_run'
         shell: bash
         run: |
-          set -uo pipefail
-          mkdir -p .target/app-compile-compat
-          if [[ -n "${CI_RUN_ID:-}" ]]; then
-            gh run download "$CI_RUN_ID" -n project-compile-canary-logs \
-              -D .target/app-compile-compat \
-              || echo "::warning::could not download project-compile-canary-logs from run ${CI_RUN_ID}; application rows will render gray this run"
+          set -euo pipefail
+          if ! find .target/app-compile-required-compat .target/app-compile-canary-compat \
+            -name 'project-compatibility.jsonl' -type f -size +0c 2>/dev/null | grep -q .; then
+            echo "::warning::no triggering-CI project compatibility JSONL downloaded; application rows will render gray this run"
           fi
-          find .target/app-compile-compat -type f -print 2>/dev/null || true
+          find .target/app-compile-required-compat .target/app-compile-canary-compat \
+            -type f -print 2>/dev/null || true
 
       - id: merge
         name: Merge benchmark results
@@ -1561,10 +1576,17 @@ jobs:
           # Add the application-row compat from the triggering CI run if present
           # (mergeCompatibilityCanaries is idempotent: re-attaching the same
           # canary compat is harmless and required rows are never overwritten).
-          app_compat="$(find "$GITHUB_WORKSPACE/.target/app-compile-compat" -name 'project-compatibility.jsonl' -type f 2>/dev/null | head -1)"
-          if [[ -n "$app_compat" && -s "$app_compat" ]]; then
-            echo "Including application compile compatibility from triggering CI run: $app_compat"
-            compat_args+=( --compat-jsonl "$app_compat" )
+          mapfile -t triggering_compat_files < <(
+            find \
+              "$GITHUB_WORKSPACE/.target/app-compile-required-compat" \
+              "$GITHUB_WORKSPACE/.target/app-compile-canary-compat" \
+              -name 'project-compatibility.jsonl' -type f -size +0c 2>/dev/null | sort
+          )
+          if [[ "${#triggering_compat_files[@]}" -gt 0 ]]; then
+            for app_compat in "${triggering_compat_files[@]}"; do
+              echo "Including application compile compatibility from triggering CI run: $app_compat"
+              compat_args+=( --compat-jsonl "$app_compat" )
+            done
           else
             echo "::warning::no application compile compatibility found; application rows will render gray this run"
           fi

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -231,6 +231,27 @@ assert.match(
 
 assert.match(
   workflow,
+  /- name: Download required compile compatibility from triggering CI \(best-effort\)[\s\S]+uses: actions\/download-artifact@\S+[\s\S]+name: project-compile-compatibility[\s\S]+path: \.target\/app-compile-required-compat[\s\S]+run-id: \$\{\{ github\.event\.workflow_run\.id \}\}[\s\S]+github-token: \$\{\{ github\.token \}\}/,
+  "bench publish should download triggering-CI required compile compatibility with actions/download-artifact",
+);
+assert.match(
+  workflow,
+  /- name: Download canary compile compatibility from triggering CI \(best-effort\)[\s\S]+uses: actions\/download-artifact@\S+[\s\S]+name: project-compile-canary-logs[\s\S]+path: \.target\/app-compile-canary-compat[\s\S]+run-id: \$\{\{ github\.event\.workflow_run\.id \}\}[\s\S]+github-token: \$\{\{ github\.token \}\}[\s\S]+- name: List application compile compatibility/,
+  "bench publish should download triggering-CI canary compile compatibility with actions/download-artifact",
+);
+assert.match(
+  workflow,
+  /mapfile -t triggering_compat_files[\s\S]+\.target\/app-compile-required-compat[\s\S]+\.target\/app-compile-canary-compat[\s\S]+compat_args\+=\( --compat-jsonl "\$app_compat" \)/,
+  "bench publish should merge both required and canary triggering-CI project compatibility JSONL files",
+);
+assert.doesNotMatch(
+  workflow,
+  /gh run download "\$CI_RUN_ID" -n project-compile-canary-logs/,
+  "bench publish must not depend on gh being installed on the self-hosted publish runner",
+);
+
+assert.match(
+  workflow,
   /- id: readiness[\s\S]+continue-on-error: true[\s\S]+check-artifact-readiness\.mjs[\s\S]+- name: Upload merged benchmark artifact/,
   "bench publish should keep the merged artifact upload path reachable when public readiness fails",
 );


### PR DESCRIPTION
Goal: green

Fixes the website compatibility table's all-gray application group.

## Problem

The Bench publish job was supposed to merge application-project compatibility from the triggering CI run into the public benchmark artifact. That data exists in CI, but the self-hosted `bench-publish` runner does not have `gh` installed, so this step failed before downloading it:

- Bench run `27848293966`, `bench-publish` log: `gh: command not found`
- The same run's readiness report then showed `Application compatibility rows | 0/20 present, 0 incomplete`
- The triggering CI run `27848884884` did have the needed artifacts: `project-compile-canary-logs` contained 19 application rows, and `project-compile-compatibility` contained the required application row `infisical-project`.

## Fix

Use `actions/download-artifact` with `run-id: ${{ github.event.workflow_run.id }}` to fetch triggering-CI artifacts instead of shelling out to a runner-local `gh` binary.

The publish merge now includes both triggering-CI JSONL sources:

- `project-compile-compatibility` for required compile rows, including `infisical-project`
- `project-compile-canary-logs` for the other application canary rows

`mergeCompatibilityCanaries` already preserves required non-application timing compatibility while allowing required application rows to receive compile-only compatibility, so this is workflow wiring only.

## Application Row Report

Using the already-run CI artifacts from `27848884884` and the failed Bench artifact from `27848293966`:

- Before app artifact merge: `0/20` application rows present; all rendered gray placeholders.
- With canary JSONL only: `19/20` present; missing `infisical-project`.
- With required + canary JSONL: `20/20` present, `0` incomplete, readiness exit `0`.
- Actual application states from that merged artifact: `1 green`, `2 yellow`, `17 red`, `0 gray`.
- Samples: `infisical-project` green (`3847` files), `umami-project` yellow (`module-symbol-resolution`, `795` files), `rocketchat-project` red (`timeout`, `2905` files).

## Verification

- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-project-winner-regression-report.mjs`
- `node scripts/bench/test-merge-results.mjs`
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `TSZ_WEBSITE_BENCHMARK_ARTIFACT=/tmp/bench-results-with-all-apps.json node crates/tsz-website/scripts/benchmark-data-smoke.mjs`
- `node scripts/bench/merge-results.mjs /tmp/bench-results-with-all-apps.json --compat-jsonl /tmp/tsz-ci-required-27848884884/project-compatibility.jsonl --compat-jsonl /tmp/tsz-ci-27848884884/project-compatibility.jsonl /tmp/tsz-bench-27848293966/bench-results.json`
- `node scripts/bench/check-artifact-readiness.mjs --json --require-application-compat --require-project-timing-pairs=1 /tmp/bench-results-with-all-apps.json > /tmp/bench-results-with-all-apps-readiness.json` → `20/20` app rows present, readiness exit `0`

## Provenance
Machine: MacBookPro
Assistant: codex
Model: gpt-5
Effort: high
