### PR TITLE
perf(solver): pre-fetch Application union members so the sort comparator does no interner lookups

### DIFF
--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -578,11 +578,7 @@ impl TypeInterner {
     ///
     /// This is semantically identical to `compare_union_members` but avoids
     /// all DashMap/arena lookups since data was pre-fetched into `CachedUnionMember`.
-    fn compare_cached_members(
-        &self,
-        a: &CachedUnionMember,
-        b: &CachedUnionMember,
-    ) -> std::cmp::Ordering {
+    fn compare_cached_members(a: &CachedUnionMember, b: &CachedUnionMember) -> std::cmp::Ordering {
         use std::cmp::Ordering;
 
         // Fast path: built-in types have fixed sort positions. Break equal
@@ -787,7 +783,7 @@ impl TypeInterner {
             flat.iter().map(|&id| self.cache_union_member(id)).collect();
 
         // Sort using cached data: O(N log N) comparisons with zero further lookups.
-        cached.sort_by(|a, b| self.compare_cached_members(a, b));
+        cached.sort_by(Self::compare_cached_members);
 
         // Write sorted TypeIds back
         for (i, member) in cached.iter().enumerate() {

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -4,8 +4,8 @@
 //! interned types: literals, unions, intersections, objects, functions, etc.
 
 use super::interner::{
-    CachedUnionMember, PredicateCacheEntry, TYPE_LIST_INLINE, TypeInterner, TypeListBuffer,
-    TypeShard,
+    AppComponentKey, CachedUnionMember, PredicateCacheEntry, TYPE_LIST_INLINE, TypeInterner,
+    TypeListBuffer, TypeShard,
 };
 use crate::def::DefId;
 use crate::types::{
@@ -451,6 +451,7 @@ impl TypeInterner {
                 obj_anon_shape: None,
                 callable_symbol: None,
                 string_literal_text: None,
+                app_components: None,
                 alloc_order: None,
             };
         }
@@ -462,6 +463,7 @@ impl TypeInterner {
         let mut obj_anon_shape = None;
         let mut callable_symbol = None;
         let mut string_literal_text = None;
+        let mut app_components = None;
 
         if let Some(ref d) = data {
             match d {
@@ -482,6 +484,13 @@ impl TypeInterner {
                         callable_symbol = Some(sym.0);
                     }
                 }
+                TypeData::Application(app) => {
+                    let app = self.type_application(*app);
+                    let mut keys = Vec::with_capacity(1 + app.args.len());
+                    keys.push(self.app_component_key(app.base));
+                    keys.extend(app.args.iter().map(|&arg| self.app_component_key(arg)));
+                    app_components = Some(keys.into_boxed_slice());
+                }
                 _ => {}
             }
         }
@@ -494,8 +503,75 @@ impl TypeInterner {
             obj_anon_shape,
             callable_symbol,
             string_literal_text,
+            app_components,
             alloc_order,
         }
+    }
+
+    /// Pre-fetch the ordering key for a single `Application` component (base or
+    /// type argument), performing every interner lookup that
+    /// `compare_application_component` would otherwise do inside the sort
+    /// comparator. The key captures exactly the fields that comparator inspects,
+    /// so comparing two keys is order-identical to comparing the resolved ids.
+    fn app_component_key(&self, id: TypeId) -> AppComponentKey {
+        let builtin_key = Self::builtin_sort_key(id);
+
+        let mut rank = None;
+        let mut lazy_or_enum_defid = None;
+        // Builtins sort purely by their fixed key, so skip the interner lookup.
+        if builtin_key.is_none()
+            && let Some(data) = self.lookup(id)
+        {
+            rank = Some(Self::type_data_rank(&data));
+            match &data {
+                TypeData::Lazy(def) | TypeData::Enum(def, _) => {
+                    lazy_or_enum_defid = Some(def.0);
+                }
+                _ => {}
+            }
+        }
+
+        AppComponentKey {
+            builtin_key,
+            rank,
+            lazy_or_enum_defid,
+            raw: id.0,
+        }
+    }
+
+    /// Compare two pre-fetched `Application` component keys.
+    ///
+    /// This is the lookup-free equivalent of `compare_application_component`:
+    /// builtin-key bucket first, then `TypeData` rank, then `DefId` for
+    /// `Lazy`/`Enum`, then the raw `TypeId` as a stable tiebreak.
+    fn compare_app_component_key(a: &AppComponentKey, b: &AppComponentKey) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+
+        if a.raw == b.raw {
+            return Ordering::Equal;
+        }
+
+        match (a.builtin_key, b.builtin_key) {
+            (Some(ka), Some(kb)) => return ka.cmp(&kb).then_with(|| a.raw.cmp(&b.raw)),
+            (Some(ka), None) => return ka.cmp(&100),
+            (None, Some(kb)) => return 100u32.cmp(&kb),
+            (None, None) => {}
+        }
+
+        if let (Some(ra), Some(rb)) = (a.rank, b.rank) {
+            let rank_cmp = ra.cmp(&rb);
+            if rank_cmp != Ordering::Equal {
+                return rank_cmp;
+            }
+            if let (Some(da), Some(db)) = (a.lazy_or_enum_defid, b.lazy_or_enum_defid) {
+                let cmp = da.cmp(&db);
+                if cmp != Ordering::Equal {
+                    return cmp;
+                }
+            }
+        }
+
+        a.raw.cmp(&b.raw)
     }
 
     /// Compare two cached union members using pre-fetched data.
@@ -604,24 +680,23 @@ impl TypeInterner {
                         return cmp;
                     }
                 }
-                (TypeData::Application(app1), TypeData::Application(app2)) => {
+                (TypeData::Application(_), TypeData::Application(_)) => {
                     // Keep application ordering total by comparing the stable raw
-                    // component key sequence instead of recursing into union-member ordering.
-                    let a1 = self.type_application(*app1);
-                    let a2 = self.type_application(*app2);
-                    let cmp = self.compare_application_component(a1.base, a2.base);
-                    if cmp != Ordering::Equal {
-                        return cmp;
-                    }
-                    for (arg1, arg2) in a1.args.iter().zip(a2.args.iter()) {
-                        let cmp = self.compare_application_component(*arg1, *arg2);
+                    // component key sequence instead of recursing into union-member
+                    // ordering. Components (base followed by each type argument)
+                    // were pre-fetched into `app_components`, so this needs no
+                    // interner lookups.
+                    if let (Some(ca), Some(cb)) = (&a.app_components, &b.app_components) {
+                        for (ka, kb) in ca.iter().zip(cb.iter()) {
+                            let cmp = Self::compare_app_component_key(ka, kb);
+                            if cmp != Ordering::Equal {
+                                return cmp;
+                            }
+                        }
+                        let cmp = ca.len().cmp(&cb.len());
                         if cmp != Ordering::Equal {
                             return cmp;
                         }
-                    }
-                    let cmp = a1.args.len().cmp(&a2.args.len());
-                    if cmp != Ordering::Equal {
-                        return cmp;
                     }
                 }
                 _ => {}
@@ -695,39 +770,6 @@ impl TypeInterner {
             TypeData::Error => 32,
             TypeData::UnresolvedTypeName(_) => 33,
         }
-    }
-
-    fn compare_application_component(&self, a: TypeId, b: TypeId) -> std::cmp::Ordering {
-        if a == b {
-            return std::cmp::Ordering::Equal;
-        }
-
-        match (Self::builtin_sort_key(a), Self::builtin_sort_key(b)) {
-            (Some(ka), Some(kb)) => return ka.cmp(&kb).then_with(|| a.0.cmp(&b.0)),
-            (Some(ka), None) => return ka.cmp(&100),
-            (None, Some(kb)) => return 100u32.cmp(&kb),
-            (None, None) => {}
-        }
-
-        if let (Some(data_a), Some(data_b)) = (self.lookup(a), self.lookup(b)) {
-            let rank_cmp = Self::type_data_rank(&data_a).cmp(&Self::type_data_rank(&data_b));
-            if rank_cmp != std::cmp::Ordering::Equal {
-                return rank_cmp;
-            }
-
-            match (&data_a, &data_b) {
-                (TypeData::Lazy(def_a), TypeData::Lazy(def_b))
-                | (TypeData::Enum(def_a, _), TypeData::Enum(def_b, _)) => {
-                    let cmp = def_a.0.cmp(&def_b.0);
-                    if cmp != std::cmp::Ordering::Equal {
-                        return cmp;
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        a.0.cmp(&b.0)
     }
 
     /// Sort union members using pre-cached lookups to avoid redundant `DashMap` reads.

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -38,7 +38,7 @@ mod cache;
 mod display;
 mod storage;
 
-pub(super) use storage::{CachedUnionMember, TypeShard};
+pub(super) use storage::{AppComponentKey, CachedUnionMember, TypeShard};
 use storage::{ConcurrentSliceInterner, ConcurrentValueInterner, write_id_slot};
 
 /// Global counter for assigning unique `instance_id`s to `TypeInterner`

--- a/crates/tsz-solver/src/intern/core/interner/storage.rs
+++ b/crates/tsz-solver/src/intern/core/interner/storage.rs
@@ -21,6 +21,29 @@ use std::sync::{
     atomic::{AtomicU32, Ordering},
 };
 
+/// Pre-fetched ordering key for a single `Application` component (its base or
+/// one of its type arguments).
+///
+/// `compare_application_component` resolves each component through the interner
+/// (`builtin_sort_key`, `lookup`, `DefId` of `Lazy`/`Enum`) every time two
+/// `Application` union members are compared. Pre-computing this key once per
+/// component during the `O(N)` cache pass removes those lookups from the inner
+/// `O(N log N)` sort comparator. The fields mirror exactly what the resolving
+/// comparator inspects, so the cached comparison is order-identical.
+#[derive(Clone, Copy)]
+pub(in crate::intern::core) struct AppComponentKey {
+    /// `builtin_sort_key(id)` — `Some` for intrinsic/builtin component types.
+    pub(in crate::intern::core) builtin_key: Option<u32>,
+    /// `type_data_rank` of the component's `TypeData`; `None` when the component
+    /// has no resolvable `TypeData` (matches the comparator's `lookup` miss).
+    pub(in crate::intern::core) rank: Option<u8>,
+    /// Raw `DefId` for `Lazy`/`Enum` components; `None` otherwise. Only consulted
+    /// when both components share the same rank, mirroring the resolving path.
+    pub(in crate::intern::core) lazy_or_enum_defid: Option<u32>,
+    /// Raw `TypeId` of the component, used as the final stable tiebreak.
+    pub(in crate::intern::core) raw: u32,
+}
+
 /// Cached data for a union member, pre-fetched to avoid redundant DashMap/arena
 /// lookups during sort comparisons. Each field corresponds to a lookup that
 /// `compare_union_members` would otherwise perform per comparison.
@@ -39,6 +62,11 @@ pub(in crate::intern::core) struct CachedUnionMember {
     pub(in crate::intern::core) callable_symbol: Option<u32>,
     /// For string literals: resolved text used by union-member ordering.
     pub(in crate::intern::core) string_literal_text: Option<Arc<str>>,
+    /// For `Application` members: pre-fetched component ordering keys (base
+    /// followed by each type argument). Lets the comparator order two
+    /// `Application` members without any interner lookups. Boxed so that the
+    /// far more common non-`Application` members keep `CachedUnionMember` small.
+    pub(in crate::intern::core) app_components: Option<Box<[AppComponentKey]>>,
     /// Monotonic allocation counter for source-order sorting
     pub(in crate::intern::core) alloc_order: Option<u32>,
 }

--- a/crates/tsz-solver/src/intern/normalize.rs
+++ b/crates/tsz-solver/src/intern/normalize.rs
@@ -1939,4 +1939,63 @@ mod tests {
             "disjoint members must all survive the small bucketed partition path"
         );
     }
+
+    #[test]
+    fn application_union_member_order_is_permutation_independent() {
+        use crate::def::DefId;
+
+        // Build a set of distinct `Application` union members exercising every
+        // axis the comparator orders on: builtin vs deferred (`Lazy`) base,
+        // different `DefId`s, differing argument lists, and differing arity.
+        // Mixing in a non-application deferred member and a builtin also drives
+        // the `Application`-vs-other ranking. Canonical union construction must
+        // produce the SAME interned type regardless of input order — the
+        // comparator that orders these members (now reading pre-fetched
+        // component keys instead of resolving inside the sort) must remain a
+        // consistent strict total order.
+        let interner = TypeInterner::new();
+        let base_a = interner.lazy(DefId(101));
+        let base_b = interner.lazy(DefId(202));
+
+        let members = vec![
+            interner.application(base_a, vec![TypeId::NUMBER]),
+            interner.application(base_b, vec![TypeId::STRING]),
+            interner.application(base_a, vec![TypeId::STRING]),
+            interner.application(base_a, vec![TypeId::NUMBER, TypeId::STRING]),
+            interner.application(base_b, vec![]),
+            interner.application(TypeId::OBJECT, vec![TypeId::BOOLEAN]),
+            interner.lazy(DefId(303)),
+            TypeId::NUMBER,
+        ];
+
+        let canonical = interner.union(members.clone());
+        let Some(TypeData::Union(canonical_list)) = interner.lookup(canonical) else {
+            panic!("expected the application-bearing union to survive normalization");
+        };
+        let canonical_members: Vec<TypeId> = interner.type_list(canonical_list).to_vec();
+        assert!(
+            canonical_members.len() >= 2,
+            "the disjoint application members must survive reduction"
+        );
+
+        // Reversed, rotated, and swapped permutations of the SAME member set
+        // must all canonicalize to the identical interned union type id.
+        let mut reversed = members.clone();
+        reversed.reverse();
+
+        let mut rotated = members.clone();
+        rotated.rotate_left(3);
+
+        let mut swapped = members.clone();
+        swapped.swap(0, members.len() - 1);
+        swapped.swap(1, 4);
+
+        for perm in [reversed, rotated, swapped] {
+            assert_eq!(
+                interner.union(perm),
+                canonical,
+                "application union member ordering must be independent of input order"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Goal: fast

Refs #13242 (workstream B — "defer concrete-form materialization where tsc defers"). This lands the issue's explicitly-flagged "fix opportunistically" item: the union-member sort comparator still resolved through the interner *inside* the comparator for `Application` members.

## Structural rule
When a union is constructed, `sort_union_members` pre-fetches every lookup the comparator needs into `CachedUnionMember` during one O(N) pass, so the inner O(N·log N) sort (`compare_cached_members`) does zero DashMap/arena reads. The `Application`-vs-`Application` arm was the one remaining exception: it called `type_application` on both members and `compare_application_component` per component (each doing `lookup` / `builtin_sort_key`) **inside** the sort comparator, i.e. O(N·log N) interner reads on every union containing generic/application members (lib.dom and generic-heavy real projects).

tsz orders union members by a canonical key; that ordering must stay identical (diagnostic display order + canonical `TypeId` identity depend on it). This change moves the `Application` component resolution out of the comparator and into the existing pre-fetch pass — owner layer: solver `intern/core` (`TypeInterner`).

## What changed
- New `AppComponentKey` (in `interner/storage.rs`) captures exactly what the old resolving comparator inspected per component: builtin sort key, `TypeData` rank, `Lazy`/`Enum` `DefId`, and the raw `TypeId` tiebreak.
- `cache_union_member` pre-fetches the component keys (base followed by each type argument) for `Application` members into `app_components`. Stored as `Box<[AppComponentKey]>` so the far-more-common non-`Application` members keep `CachedUnionMember` small (one pointer, allocated only for actual applications).
- `compare_app_component_key` is the lookup-free equivalent of the deleted `compare_application_component`; the comparator now compares cached key sequences. Member ordering is unchanged by construction.

## Adjacent-case matrix
The pre-fetch + comparison covers every axis the old resolving path ordered on, exercised by the new test:
- builtin base (`OBJECT`) vs deferred (`Lazy`) base;
- different `DefId`s on the base;
- same base, differing single arg;
- differing arity (0, 1, 2 args);
- `Application` members mixed with a non-application `Lazy` member and a builtin (`Application`-vs-other ranking).

Negative/invariant case: the same member set in reversed, rotated, and swapped input orders must canonicalize to the **identical** interned union `TypeId` (strict-total-order / order-independence guard).

## Verification
- `cargo test -p tsz-solver --lib application_union_member_order_is_permutation_independent` — new permutation-independence test (passes).
- `cargo test -p tsz-solver --lib union` — 906 passed, 0 failed (member-ordering regression guard).
- `cargo test -p tsz-solver --lib intern::normalize` — all pass except one pre-existing failure (`literal_mask_preserves_object_vs_literal_reduction`) verified red on the base commit (e0e1725) before this change and unrelated (object reduction, no `Application` members).
- `cargo clippy -p tsz-solver` — clean.
- Ready-review CI owns conformance/emit parity (ordering must stay exact).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_0131KRUcsSPFCQdKhLHGrLLJ)_