### PR TITLE
fix(checker): emit TS1375 and TS1378 independently for top-level await

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "top_level_await_grammar_diagnostics_tests"
+path = "tests/top_level_await_grammar_diagnostics_tests.rs"
+[[test]]
 name = "reexport_generic_typeref_instantiation_tests"
 path = "tests/reexport_generic_typeref_instantiation_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
+++ b/crates/tsz-checker/src/types/type_checking/core_statement_checks.rs
@@ -598,18 +598,32 @@ impl<'a> CheckerState<'a> {
                         let at_top_level = self.ctx.function_depth == 0;
 
                         if at_top_level {
-                            // TS1378: Top-level await requires ES2022+/ESNext module and ES2017+ target
+                            // tsc's `checkAwaitExpression` emits these two
+                            // grammar diagnostics *independently*: a non-module
+                            // file gets TS1375, and an unsupported module/target
+                            // combination gets TS1378. Both fire when both
+                            // conditions hold, in this order — they are not
+                            // mutually exclusive. This mirrors the `await using`
+                            // sibling path, which emits TS2853/TS2854 the same
+                            // way (`check_using_declaration_list` in `core.rs`).
+
+                            // TS1375: top-level await is only valid in a module.
+                            if !self.ctx.is_external_module_file() {
+                                self.error_at_node(
+                                    current_idx,
+                                    diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FILE_IS,
+                                    diagnostic_codes::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FILE_IS,
+                                );
+                            }
+
+                            // TS1378: top-level await requires a module in
+                            // {ES2022, ESNext, System, Node16/18/20, NodeNext,
+                            // Preserve} and target >= ES2017.
                             if !self.supports_top_level_await() {
                                 self.error_at_node(
                                     current_idx,
                                     diagnostic_messages::TOP_LEVEL_AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES,
                                     diagnostic_codes::TOP_LEVEL_AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_WHEN_THE_MODULE_OPTION_IS_SET_TO_ES,
-                                );
-                            } else if !self.ctx.is_external_module_file() {
-                                self.error_at_node(
-                                    current_idx,
-                                    diagnostic_messages::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FILE_IS,
-                                    diagnostic_codes::AWAIT_EXPRESSIONS_ARE_ONLY_ALLOWED_AT_THE_TOP_LEVEL_OF_A_FILE_WHEN_THAT_FILE_IS,
                                 );
                             }
                         } else {

--- a/crates/tsz-checker/tests/top_level_await_grammar_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/top_level_await_grammar_diagnostics_tests.rs
@@ -1,0 +1,140 @@
+//! Grammar diagnostics for top-level `await` expressions (TS1375 / TS1378).
+//!
+//! `tsc`'s `checkAwaitExpression` emits two *independent* grammar diagnostics
+//! for a top-level `await`:
+//!
+//! - **TS1375** — the file is not a module (it has no imports/exports), so a
+//!   top-level `await` is not allowed.
+//! - **TS1378** — the `module`/`target` combination does not support top-level
+//!   `await` (it requires `module` in `{es2022, esnext, system, node16,
+//!   node18, node20, nodenext, preserve}` *and* `target >= es2017`).
+//!
+//! These are **not** mutually exclusive: a bare script under an unsupported
+//! module produces *both*. The sibling `await using` path already emits its
+//! TS2853/TS2854 pair this way; these tests lock the same behaviour for the
+//! `await` expression path, which previously short-circuited (an `else if`)
+//! and dropped one of the two diagnostics.
+//!
+//! The structural rule keys only on module-ness and the module/target pair, so
+//! the tests do not depend on any identifier, alias, or file-name spelling.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+use tsz_common::common::{ModuleKind, ScriptTarget};
+
+/// Diagnostic codes produced for `source` under the given module/target.
+fn codes(source: &str, module: ModuleKind, target: ScriptTarget) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            module,
+            target,
+            ..CheckerOptions::default()
+        },
+    )
+    .iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+#[test]
+fn script_with_unsupported_module_emits_both_ts1375_and_ts1378() {
+    // Non-module file + `module: ES2020` (not in the supported set): both the
+    // "file is not a module" (TS1375) and the "module/target unsupported"
+    // (TS1378) diagnostics must fire — they are independent.
+    let got = codes("await 1;", ModuleKind::ES2020, ScriptTarget::ES2020);
+    assert!(
+        got.contains(&1375),
+        "expected TS1375 (script file) alongside TS1378, got: {got:?}"
+    );
+    assert!(
+        got.contains(&1378),
+        "expected TS1378 (unsupported module/target) alongside TS1375, got: {got:?}"
+    );
+}
+
+#[test]
+fn script_with_commonjs_module_emits_both_ts1375_and_ts1378() {
+    // The same independence holds for CommonJS, the most common unsupported
+    // module. (`target: ES2020` keeps TS1378's target half satisfied so the
+    // module half is what drives it.)
+    let got = codes("await 1;", ModuleKind::CommonJS, ScriptTarget::ES2020);
+    assert!(
+        got.contains(&1375),
+        "expected TS1375 (script file) alongside TS1378, got: {got:?}"
+    );
+    assert!(
+        got.contains(&1378),
+        "expected TS1378 (unsupported module) alongside TS1375, got: {got:?}"
+    );
+}
+
+#[test]
+fn module_with_unsupported_module_emits_only_ts1378() {
+    // When the file IS a module (it has an `export`), the TS1375 "not a module"
+    // half no longer applies; only TS1378 fires.
+    let got = codes(
+        "export {};\nawait 1;",
+        ModuleKind::ES2020,
+        ScriptTarget::ES2020,
+    );
+    assert!(
+        got.contains(&1378),
+        "expected TS1378 for an unsupported module in a module file, got: {got:?}"
+    );
+    assert!(
+        !got.contains(&1375),
+        "expected NO TS1375 in an external module, got: {got:?}"
+    );
+}
+
+#[test]
+fn script_with_supported_module_emits_only_ts1375() {
+    // The converse: a supported module/target (ES2022 + ES2017) in a
+    // non-module file yields only the "not a module" diagnostic TS1375, never
+    // TS1378.
+    let got = codes("await 1;", ModuleKind::ES2022, ScriptTarget::ES2017);
+    assert!(
+        got.contains(&1375),
+        "expected TS1375 for a script file, got: {got:?}"
+    );
+    assert!(
+        !got.contains(&1378),
+        "expected NO TS1378 with a supported module/target, got: {got:?}"
+    );
+}
+
+#[test]
+fn module_with_supported_module_emits_neither() {
+    // Fully valid top-level await: a module file under a supported
+    // module/target emits neither grammar diagnostic.
+    let got = codes(
+        "export {};\nawait 1;",
+        ModuleKind::ES2022,
+        ScriptTarget::ES2017,
+    );
+    assert!(
+        !got.contains(&1375) && !got.contains(&1378),
+        "expected neither TS1375 nor TS1378 for valid top-level await, got: {got:?}"
+    );
+}
+
+#[test]
+fn unsupported_target_alone_emits_ts1378_in_module() {
+    // TS1378 also fires when only the target half fails: a supported module
+    // (ES2022) but `target: ES2015` (< ES2017). In a module file, only TS1378.
+    let got = codes(
+        "export {};\nawait 1;",
+        ModuleKind::ES2022,
+        ScriptTarget::ES2015,
+    );
+    assert!(
+        got.contains(&1378),
+        "expected TS1378 for target < ES2017, got: {got:?}"
+    );
+    assert!(
+        !got.contains(&1375),
+        "expected NO TS1375 in an external module, got: {got:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Found by differential testing against `tsc` 6.0.2: a top-level `await` in a
non-module file under an unsupported module emitted only one of the two grammar
diagnostics `tsc` reports.

## Structural rule

> When an `await` expression appears at the top level of a file, `tsc`'s
> `checkAwaitExpression` emits two **independent** grammar diagnostics:
> **TS1375** when the file is not a module (it has no imports/exports), and
> **TS1378** when the module/target combination does not support top-level
> `await` (`module` must be one of `es2022, esnext, system, node16, node18,
> node20, nodenext, preserve` **and** `target >= es2017`). Both fire when both
> conditions hold; they are not mutually exclusive.

tsz's `check_await_expression`
(`crates/tsz-checker/src/types/type_checking/core_statement_checks.rs`) gated the
two through a single `if !supports_top_level_await() { TS1378 } else if
!is_external_module_file() { TS1375 }`. The `else` made them mutually exclusive,
so a non-module script under an unsupported module (e.g. `--module es2020`,
`--module commonjs`) emitted only **TS1378** and silently dropped **TS1375**.

```ts
// foo.ts  (no imports/exports → not a module)
async function f(): Promise<number> { return 5; }
const v = await f();
// tsc --module es2020:  TS1375 + TS1378
// tsz (before):         TS1378 only
// tsz (after):          TS1375 + TS1378
```

## Owner layer / fix

Checker grammar diagnostics only. The top-level arm is rewritten as **two
independent `if`s** — the file-not-module check (TS1375) first, then the
module/target support check (TS1378) — exactly matching `tsc`'s emission order.
This mirrors the already-correct `await using` sibling
(`check_using_declaration_list` in `core.rs`), which emits its TS2853/TS2854 pair
the same independent way. The decision keys only on module-ness and the
module/target pair — no identifier, alias, or file-name predicate — so it applies
to every spelling. The fix only ever **adds** the co-occurring diagnostic that
`tsc` already emits; it never suppresses an existing one.

## Adjacent-case matrix (verified byte-for-`TS####` against `tsc` 6.0.2, `--target es2020`)

| file | module | tsc | tsz after |
|---|---|---|---|
| script (no exports) | es2015 / es2020 / commonjs | TS1375 + TS1378 | ✓ |
| script | es2022 / esnext | TS1375 | ✓ unchanged |
| module (`export {}`) | es2020 / commonjs | TS1378 | ✓ unchanged |
| module | es2022 + target es2015 (target half) | TS1378 | ✓ |
| module | es2022 + es2017 (supported) | none | ✓ unchanged |

## Verification

- New registered suite `crates/tsz-checker/tests/top_level_await_grammar_diagnostics_tests.rs`
  (6 tests, name-agnostic; registered as a `[[test]]` target so CI runs it):
  `cargo test -p tsz-checker --test top_level_await_grammar_diagnostics_tests`
  → **6 passed, 0 failed**. Verified failing on the pre-fix tree
  (the both-fire cases returned only TS1378).
- End-to-end CLI differential vs `tsc` 6.0.2 across `module ∈ {es2015, es2020,
  es2022, esnext, commonjs}` at `--target es2020`: the `es2015/es2020/commonjs`
  rows go from diverging to byte-identical; `es2022/esnext` rows unchanged.
- Existing await diagnostics tests unaffected (they use module/`export {}`
  configs where exactly one diagnostic applies).
- `cargo clippy -p tsz-checker --test top_level_await_grammar_diagnostics_tests`,
  `cargo fmt -p tsz-checker --check`, `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Notes / out of scope

Two adjacent divergences in the same family are intentionally **not** addressed
here to keep this fix bounded and low-risk:
- The default `module` (no `--module` flag) resolving to a TLA-supporting kind
  for an explicitly-set `--target` (a config-defaulting plumbing issue in
  `resolve_compiler_options` / CLI override order).
- `node16`/`nodenext` emitting TS1309 (CommonJS-package-detection) where tsz
  emits TS1378.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_011jqC9N5jzzzbiUHErDfyjN

---
_Generated by [Claude Code](https://claude.ai/code/session_011jqC9N5jzzzbiUHErDfyjN)_