### PR TITLE
fix(checker): index a generic type parameter by a constraint unique-symbol key

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1594,6 +1594,9 @@ path = "tests/ts7053_template_mapped_tests.rs"
 name = "ts7053_record_constrained_type_param_index_tests"
 path = "tests/ts7053_record_constrained_type_param_index_tests.rs"
 [[test]]
+name = "ts7053_unique_symbol_constrained_type_param_index_tests"
+path = "tests/ts7053_unique_symbol_constrained_type_param_index_tests.rs"
+[[test]]
 name = "ts7053_unconstrained_type_param_index_tests"
 path = "tests/ts7053_unconstrained_type_param_index_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -775,35 +775,25 @@ impl<'a> CheckerState<'a> {
         let mut report_no_index = false;
         let mut use_index_signature_check = true;
 
-        if crate::query_boundaries::common::is_type_parameter(
-            self.ctx.types,
+        if self.report_symbol_only_type_param_index_mismatch(
+            access.expression,
             pre_resolution_object_type,
-        ) && crate::query_boundaries::common::is_type_parameter(self.ctx.types, index_type)
-            && crate::query_boundaries::common::type_parameter_constraint(
-                self.ctx.types,
-                index_type,
-            )
-            .is_some_and(|constraint| {
-                crate::query_boundaries::key_constraints::is_symbol_only_key_constraint(
-                    self.ctx.types,
-                    constraint,
-                )
-            })
-            && !self.is_valid_index_for_type_param(index_type, pre_resolution_object_type)
-        {
-            use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
-            let index_type_str = self.format_type(index_type);
-            let object_type_str = self.format_type(pre_resolution_object_type);
-            let message = format_message(
-                diagnostic_messages::TYPE_CANNOT_BE_USED_TO_INDEX_TYPE,
-                &[&index_type_str, &object_type_str],
-            );
-            self.error_at_node(
-                access.expression,
-                &message,
-                diagnostic_codes::TYPE_CANNOT_BE_USED_TO_INDEX_TYPE,
-            );
+            index_type,
+        ) {
             result_type = Some(TypeId::ERROR);
+            use_index_signature_check = false;
+        }
+
+        // A generic receiver indexed by a unique symbol that keys a member of its
+        // constraint is a valid indexed access: tsc produces the deferred
+        // `T[typeof sym]` rather than a false TS7053 (a non-key symbol falls
+        // through to the index-signature checks below). See
+        // `type_param_unique_symbol_index_access`.
+        if result_type.is_none()
+            && let Some(deferred) =
+                self.type_param_unique_symbol_index_access(pre_resolution_object_type, index_type)
+        {
+            result_type = Some(deferred);
             use_index_signature_check = false;
         }
 

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -766,6 +766,8 @@ impl<'a> CheckerState<'a> {
         pre_resolution_object_type: TypeId,
         index_type: TypeId,
     ) -> bool {
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+
         let symbol_only_constraint =
             crate::query_boundaries::common::is_type_parameter(
                 self.ctx.types,
@@ -785,7 +787,6 @@ impl<'a> CheckerState<'a> {
         if !symbol_only_constraint {
             return false;
         }
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
         let index_type_str = self.format_type(index_type);
         let object_type_str = self.format_type(pre_resolution_object_type);
         let message = format_message(
@@ -818,6 +819,8 @@ impl<'a> CheckerState<'a> {
         pre_resolution_object: TypeId,
         index_type: TypeId,
     ) -> Option<TypeId> {
+        const MAX_CONSTRAINT_CHAIN_DEPTH: usize = 8;
+
         if !crate::query_boundaries::common::is_type_parameter(
             self.ctx.types,
             pre_resolution_object,
@@ -831,7 +834,6 @@ impl<'a> CheckerState<'a> {
         // (non-type-parameter) constraint, then decide indexability against that
         // constraint's apparent type. The depth bound also terminates a
         // pathological self-referential constraint cycle.
-        const MAX_CONSTRAINT_CHAIN_DEPTH: usize = 8;
         let mut current = pre_resolution_object;
         let mut depth = 0;
         while depth < MAX_CONSTRAINT_CHAIN_DEPTH {

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -766,22 +766,23 @@ impl<'a> CheckerState<'a> {
         pre_resolution_object_type: TypeId,
         index_type: TypeId,
     ) -> bool {
-        if !crate::query_boundaries::common::is_type_parameter(
-            self.ctx.types,
-            pre_resolution_object_type,
-        ) || !crate::query_boundaries::common::is_type_parameter(self.ctx.types, index_type)
-            || !crate::query_boundaries::common::type_parameter_constraint(
+        let symbol_only_constraint =
+            crate::query_boundaries::common::is_type_parameter(
                 self.ctx.types,
-                index_type,
-            )
-            .is_some_and(|constraint| {
-                crate::query_boundaries::key_constraints::is_symbol_only_key_constraint(
+                pre_resolution_object_type,
+            ) && crate::query_boundaries::common::is_type_parameter(self.ctx.types, index_type)
+                && crate::query_boundaries::common::type_parameter_constraint(
                     self.ctx.types,
-                    constraint,
+                    index_type,
                 )
-            })
-            || self.is_valid_index_for_type_param(index_type, pre_resolution_object_type)
-        {
+                .is_some_and(|constraint| {
+                    crate::query_boundaries::key_constraints::is_symbol_only_key_constraint(
+                        self.ctx.types,
+                        constraint,
+                    )
+                })
+                && !self.is_valid_index_for_type_param(index_type, pre_resolution_object_type);
+        if !symbol_only_constraint {
             return false;
         }
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
@@ -826,12 +827,15 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let mut current = pre_resolution_object;
-        // Follow the constraint chain so a type parameter bounded by another
-        // type parameter still reaches the concrete object constraint. The bound
-        // also terminates a pathological self-referential constraint cycle.
+        // Advance `current` up the constraint chain until it reaches a concrete
+        // (non-type-parameter) constraint, then decide indexability against that
+        // constraint's apparent type. The depth bound also terminates a
+        // pathological self-referential constraint cycle.
         const MAX_CONSTRAINT_CHAIN_DEPTH: usize = 8;
-        for _ in 0..MAX_CONSTRAINT_CHAIN_DEPTH {
+        let mut current = pre_resolution_object;
+        let mut depth = 0;
+        while depth < MAX_CONSTRAINT_CHAIN_DEPTH {
+            depth += 1;
             let constraint = crate::query_boundaries::common::type_parameter_constraint(
                 self.ctx.types,
                 current,
@@ -845,15 +849,15 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .types
                 .resolve_element_access_type(apparent, index_type, None);
-            if member != TypeId::ERROR && member != TypeId::UNDEFINED {
-                return Some(
-                    self.ctx
-                        .types
-                        .factory()
-                        .index_access(pre_resolution_object, index_type),
-                );
+            if member == TypeId::ERROR || member == TypeId::UNDEFINED {
+                return None;
             }
-            return None;
+            return Some(
+                self.ctx
+                    .types
+                    .factory()
+                    .index_access(pre_resolution_object, index_type),
+            );
         }
         None
     }

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -755,6 +755,109 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    /// Reports TS7053 when a type parameter is indexed by *another* type
+    /// parameter whose constraint is symbol-only and which is not a valid key of
+    /// the receiver (e.g. `T[K]` where `K extends typeof sym` but `K` is unrelated
+    /// to `keyof T`). Returns true when a diagnostic was emitted, so the caller
+    /// can short-circuit the access to `error`.
+    pub(crate) fn report_symbol_only_type_param_index_mismatch(
+        &mut self,
+        access_expression: NodeIndex,
+        pre_resolution_object_type: TypeId,
+        index_type: TypeId,
+    ) -> bool {
+        if !crate::query_boundaries::common::is_type_parameter(
+            self.ctx.types,
+            pre_resolution_object_type,
+        ) || !crate::query_boundaries::common::is_type_parameter(self.ctx.types, index_type)
+            || !crate::query_boundaries::common::type_parameter_constraint(
+                self.ctx.types,
+                index_type,
+            )
+            .is_some_and(|constraint| {
+                crate::query_boundaries::key_constraints::is_symbol_only_key_constraint(
+                    self.ctx.types,
+                    constraint,
+                )
+            })
+            || self.is_valid_index_for_type_param(index_type, pre_resolution_object_type)
+        {
+            return false;
+        }
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+        let index_type_str = self.format_type(index_type);
+        let object_type_str = self.format_type(pre_resolution_object_type);
+        let message = format_message(
+            diagnostic_messages::TYPE_CANNOT_BE_USED_TO_INDEX_TYPE,
+            &[&index_type_str, &object_type_str],
+        );
+        self.error_at_node(
+            access_expression,
+            &message,
+            diagnostic_codes::TYPE_CANNOT_BE_USED_TO_INDEX_TYPE,
+        );
+        true
+    }
+
+    /// The deferred indexed access `T[typeof sym]` when `pre_resolution_object`
+    /// is a type parameter and `index_type` is a unique symbol that names a
+    /// member of that parameter's constraint; `None` otherwise.
+    ///
+    /// `tsc` resolves a generic receiver to its constraint's apparent type before
+    /// indexing, so `x[fooProp]` on `T extends Foo<number>` (where `Foo` declares
+    /// `[fooProp]: T`) is the deferred indexed access `T[typeof fooProp]`, never a
+    /// TS7053. The string-keyed property path already resolves the constraint for
+    /// member lookup; the symbol-keyed path otherwise indexed the bare,
+    /// unresolved type parameter — whose element access fails — and produced a
+    /// false implicit-any element access. `resolve_type_for_property_access`
+    /// intentionally leaves a type parameter unresolved, so this consults the
+    /// constraint directly, following it transitively (`T extends U extends Foo`).
+    pub(crate) fn type_param_unique_symbol_index_access(
+        &mut self,
+        pre_resolution_object: TypeId,
+        index_type: TypeId,
+    ) -> Option<TypeId> {
+        if !crate::query_boundaries::common::is_type_parameter(
+            self.ctx.types,
+            pre_resolution_object,
+        ) || crate::query_boundaries::common::unique_symbol_ref(self.ctx.types, index_type)
+            .is_none()
+        {
+            return None;
+        }
+
+        let mut current = pre_resolution_object;
+        // Follow the constraint chain so a type parameter bounded by another
+        // type parameter still reaches the concrete object constraint. The bound
+        // also terminates a pathological self-referential constraint cycle.
+        const MAX_CONSTRAINT_CHAIN_DEPTH: usize = 8;
+        for _ in 0..MAX_CONSTRAINT_CHAIN_DEPTH {
+            let constraint = crate::query_boundaries::common::type_parameter_constraint(
+                self.ctx.types,
+                current,
+            )?;
+            if crate::query_boundaries::common::is_type_parameter(self.ctx.types, constraint) {
+                current = constraint;
+                continue;
+            }
+            let apparent = self.resolve_type_for_property_access(constraint);
+            let member = self
+                .ctx
+                .types
+                .resolve_element_access_type(apparent, index_type, None);
+            if member != TypeId::ERROR && member != TypeId::UNDEFINED {
+                return Some(
+                    self.ctx
+                        .types
+                        .factory()
+                        .index_access(pre_resolution_object, index_type),
+                );
+            }
+            return None;
+        }
+        None
+    }
+
     pub(crate) fn constraint_keyof_write_target_for_type_param(
         &mut self,
         index_type: TypeId,

--- a/crates/tsz-checker/tests/ts7053_unique_symbol_constrained_type_param_index_tests.rs
+++ b/crates/tsz-checker/tests/ts7053_unique_symbol_constrained_type_param_index_tests.rs
@@ -1,0 +1,190 @@
+//! TS7053 — indexing a type parameter by a `unique symbol` that keys a member
+//! of the parameter's constraint.
+//!
+//! Structural rule: when the indexed object is a type parameter, indexability is
+//! governed by its base constraint's apparent type. A `unique symbol` that names
+//! a member of that constraint is a valid index, so `x[fooProp]` on
+//! `T extends Foo<number>` (where `Foo` declares `[fooProp]: T`) has the deferred
+//! type `T[typeof fooProp]` — never a TS7053. The string-keyed property path
+//! already resolves the constraint for member lookup; the symbol-keyed path
+//! previously indexed the bare, unresolved type parameter (whose element access
+//! fails) and produced a false implicit-any element access. The rule is purely
+//! structural: it keys on the constraint shape, not on any identifier spelling.
+//!
+//! Witness: `lateBoundConstraintTypeChecksCorrectly.ts` (upstream conformance).
+use tsz_checker::context::{CheckerOptions, ScriptTarget};
+use tsz_checker::test_utils::check_source;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            target: ScriptTarget::ES2022,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+// 1. Reported repro: a unique-symbol-keyed member of the constraint is a valid
+//    index — no TS7053.
+#[test]
+fn unique_symbol_key_of_constraint_no_ts7053() {
+    let result = codes(
+        r#"
+declare const fooProp: unique symbol;
+interface Foo<T> { [fooProp]: T; }
+function f<T extends Foo<number>>(x: T) { return x[fooProp]; }
+"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 indexing a constrained param by a constraint symbol key, got: {result:?}"
+    );
+}
+
+// 2. Renamed symbol / interface / parameter — proves the rule is structural,
+//    not name-based.
+#[test]
+fn unique_symbol_constraint_renamed_is_structural() {
+    let renamed = codes(
+        r#"
+declare const tag: unique symbol;
+interface Bag<V> { [tag]: V; }
+function pull<Row extends Bag<string>>(value: Row) { return value[tag]; }
+"#,
+    );
+    assert!(
+        !renamed.contains(&7053),
+        "expected no TS7053 with renamed symbol/interface/param, got: {renamed:?}"
+    );
+}
+
+// 3. The deferred result type is `T[typeof sym]`: a wrong-typed assignment
+//    target still errors (TS2322), and the matching annotation stays clean.
+#[test]
+fn unique_symbol_index_result_is_deferred_indexed_access() {
+    // Constraint declares the symbol-keyed member as `T` (a number here), so the
+    // access type is `number`: assigning to `string` must report TS2322.
+    let wrong = codes(
+        r#"
+declare const slot: unique symbol;
+interface Holder<T> { [slot]: T; }
+function g<T extends Holder<number>>(x: T) { const bad: string = x[slot]; }
+"#,
+    );
+    assert!(
+        wrong.contains(&2322),
+        "expected TS2322 assigning T[typeof slot] (number) to string, got: {wrong:?}"
+    );
+    assert!(
+        !wrong.contains(&7053),
+        "the deferred indexed access must not also report TS7053, got: {wrong:?}"
+    );
+
+    let ok = codes(
+        r#"
+declare const slot: unique symbol;
+interface Holder<T> { [slot]: T; }
+function g<T extends Holder<number>>(x: T) {
+    const fine: T[typeof slot] = x[slot];
+}
+"#,
+    );
+    assert!(
+        ok.is_empty(),
+        "expected no diagnostics for the matching annotation, got: {ok:?}"
+    );
+}
+
+// 4. Multiple symbol-keyed members, including one whose value is concrete
+//    (`string`) rather than the type parameter.
+#[test]
+fn multiple_unique_symbol_keys_no_ts7053() {
+    let result = codes(
+        r#"
+declare const fooProp: unique symbol;
+declare const barProp: unique symbol;
+interface Foo<T> { [fooProp]: T; [barProp]: string; }
+function f<T extends Foo<number>>(x: T) {
+    const a: T[typeof fooProp] = x[fooProp];
+    const b: T[typeof barProp] = x[barProp];
+}
+"#,
+    );
+    assert!(
+        result.is_empty(),
+        "expected no diagnostics for multiple constraint symbol keys, got: {result:?}"
+    );
+}
+
+// 5. Transitive constraint chain: `T extends U`, `U extends Foo<number>`.
+#[test]
+fn unique_symbol_key_through_constraint_chain_no_ts7053() {
+    let result = codes(
+        r#"
+declare const key: unique symbol;
+interface Foo<T> { [key]: T; }
+function f<U extends Foo<number>, T extends U>(x: T) { return x[key]; }
+"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 when the symbol keys a transitive constraint, got: {result:?}"
+    );
+}
+
+// 6. Negative control: a unique symbol that is NOT a key of the constraint must
+//    still report TS7053 (the fix resolves the constraint, it does not accept
+//    arbitrary symbol keys).
+#[test]
+fn unrelated_unique_symbol_still_emits_ts7053() {
+    let result = codes(
+        r#"
+declare const onProp: unique symbol;
+declare const offProp: unique symbol;
+interface Foo<T> { [onProp]: T; }
+function f<T extends Foo<number>>(x: T) { return x[offProp]; }
+"#,
+    );
+    assert!(
+        result.contains(&7053),
+        "expected TS7053 for a symbol that does not key the constraint, got: {result:?}"
+    );
+}
+
+// 6b. Negative control: an unconstrained parameter indexed by a unique symbol
+//     still reports TS7053.
+#[test]
+fn unconstrained_param_unique_symbol_still_emits_ts7053() {
+    let result = codes(
+        r#"
+declare const k: unique symbol;
+function f<T>(x: T) { return x[k]; }
+"#,
+    );
+    assert!(
+        result.contains(&7053),
+        "expected TS7053 for an unconstrained param indexed by a unique symbol, got: {result:?}"
+    );
+}
+
+// 7. Control: a well-known symbol (`Symbol.iterator`) member on the constraint
+//    was already accepted and must stay clean.
+#[test]
+fn well_known_symbol_key_of_constraint_no_ts7053() {
+    let result = codes(
+        r#"
+interface Foo { [Symbol.iterator](): number; }
+function f<T extends Foo>(x: T) { return x[Symbol.iterator]; }
+"#,
+    );
+    assert!(
+        !result.contains(&7053),
+        "expected no TS7053 indexing a constrained param by a well-known symbol, got: {result:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Conformance parity floor for the keyof/indexed-access family (umbrella #8432). Clears the upstream `lateBoundConstraintTypeChecksCorrectly.ts` row; does not claim or close the umbrella.

## Structural rule

> When a value of a generic type parameter `T` is indexed by a **unique symbol**
> that names a member of `T`'s constraint, `tsc` resolves the type parameter to
> its constraint's *apparent type* and forms the deferred indexed access
> `T[typeof sym]` — never a `TS7053`. tsz instead ran the symbol-keyed
> index-signature checks against the **bare, unresolved** type parameter (whose
> element access fails) and reported a false `TS7053`.

```ts
declare const fooProp: unique symbol;
declare const barProp: unique symbol;
interface Foo<T> { [fooProp]: T; [barProp]: string; }
function f<T extends Foo<number>>(x: T) {
  const def:  T[typeof fooProp] = x[fooProp];  // tsc: ok    tsz (before): TS7053
  const def2: T[typeof barProp] = x[barProp];  // tsc: ok    tsz (before): TS7053
  const wrong: string = x[fooProp];            // tsc: TS2322 (number→string); tsz (before): TS7053
}
```

The string-keyed property path already resolved the constraint for member
lookup (`x.a` / `x['a']` on a constrained `T` worked); this brings the
unique-symbol-keyed path to parity. Found by differential testing against `tsc`
6.0.2 (`--noEmit --strict`).

## Owner layer

Element access (`crates/tsz-checker/src/types/computation/access.rs`). The
structural decision lives in `type_param_unique_symbol_index_access`
(`access_helpers.rs`): it follows the receiver's constraint chain transitively
(`T extends U extends Foo`), resolves the concrete constraint to its apparent
type, and only forms `T[typeof sym]` when that symbol resolves to a real member.
It keys purely on the constraint shape — no identifier, alias, property-name, or
file-name string drives the decision — so it applies to every spelling.
`resolve_type_for_property_access` intentionally leaves a type parameter
unresolved, so the constraint is consulted directly.

Refactor: extracted the pre-existing symbol-only type-param/type-param index
mismatch reporting into `report_symbol_only_type_param_index_mismatch` so
`access.rs` stays under the 2000-line cap (1988).

## Adjacent-case matrix (name-agnostic; all byte-equal to tsc 6.0.2, `--strict`)

| case | expected |
|---|---|
| unique symbol that keys the constraint | no TS7053 (`T[typeof sym]`) |
| renamed symbol / interface / parameter | no TS7053 (structural) |
| deferred result type — wrong assignment | TS2322, no TS7053 |
| multiple symbol keys (incl. concrete value member) | no TS7053 |
| transitive constraint chain `T extends U extends Foo` | no TS7053 |
| unique symbol **not** a key of the constraint | TS7053 (unchanged) |
| unconstrained parameter indexed by a symbol | TS7053 (unchanged) |
| well-known symbol (`Symbol.iterator`) member | no TS7053 (control) |

## Verification

- New name-agnostic suite `ts7053_unique_symbol_constrained_type_param_index_tests` (8 cases) — pass.
- `cargo test -p tsz-checker --lib access` — 392 pass; the 11 failures are pre-existing on `main` (lib-environment), byte-identical before/after this change.
- Existing `ts7053_*` suites (`record_constrained_type_param_index`, `unconstrained_type_param_index`, `record_constraint_index`, `intersection_record_constrained_param`, `template_mapped`, `symbol_index_signature`, `ts2536_keyof_string_index_signature`) — pass.
- Differential vs `tsc` 6.0.2 over the symbol/index/keyof corpus areas (521 cases) and broad random samples (~1400 cases): the witness now matches; no new divergence is attributable to this change (residuals are pre-existing module-resolution / scanner / declaration-merge rows).
- `cargo fmt -p tsz-checker --check`, `cargo clippy -p tsz-checker --lib --tests`, `python3 scripts/arch/arch_guard.py` (incl. 2000-line cap) — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_019ois51WYxrdJv28nZMthj5)_