### PR TITLE
fix(emit): fold public auto-accessor storage into private-name init (#14064)

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -439,13 +439,15 @@ impl<'a> Printer<'a> {
         }
 
         if !auto_accessor_members.is_empty() && lower_auto_accessors_to_weakmap {
-            // Hoist auto-accessor storage vars to the top of the scope,
-            // matching tsc behavior (emits all class-related vars before the first class).
+            // Hoist the static-accessor class alias to the top of the scope,
+            // matching tsc behavior (emits all class-related vars before the
+            // first class). The auto-accessor *storage* vars are hoisted *after*
+            // the private-name vars so the combined `var` declaration matches
+            // tsc's order (instances/alias, then private members in source order,
+            // then auto-accessor storages last); see the `var_names` collection
+            // below and the no-private-lowering fallback after the block.
             if let Some(alias) = auto_accessor_class_alias.as_ref() {
                 self.hoisted_assignment_temps.push(alias.clone());
-            }
-            for (_, storage_name, _, _) in &auto_accessor_members {
-                self.hoisted_assignment_temps.push(storage_name.clone());
             }
             self.emit_comments_before_pos(node.pos);
         }
@@ -834,6 +836,16 @@ impl<'a> Printer<'a> {
                 var_names.push(accessor.storage_name.clone());
             }
 
+            // Public auto-accessor storage WeakMaps come last in tsc's class var
+            // list, after every private-name var (in source order). When this
+            // class has no private-name lowering the storages are hoisted in the
+            // no-private fallback after this block instead.
+            if lower_auto_accessors_to_weakmap {
+                for (_, storage_name, _, _) in &auto_accessor_members {
+                    var_names.push(storage_name.clone());
+                }
+            }
+
             if !var_names.is_empty() {
                 if node.kind == syntax_kind_ext::CLASS_DECLARATION
                     && (self.ctx.options.target as u32) < (ScriptTarget::ES2015 as u32)
@@ -1143,6 +1155,15 @@ impl<'a> Printer<'a> {
             }
             for accessor in &private_auto_accessors {
                 self.private_members_to_skip.insert(accessor.member_idx);
+            }
+        }
+
+        // When the class has no private-name lowering, the `var_names` walk above
+        // did not run, so hoist the public auto-accessor storage vars here (they
+        // are the only class-related vars besides the static-accessor alias).
+        if !has_any_private_lowering && lower_auto_accessors_to_weakmap {
+            for (_, storage_name, _, _) in &auto_accessor_members {
+                self.hoisted_assignment_temps.push(storage_name.clone());
             }
         }
 

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_after_body.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_after_body.rs
@@ -90,6 +90,44 @@ impl<'a> Printer<'a> {
             auto_accessor_static_inits,
         } = after;
 
+        // A public auto-accessor's instance storage WeakMap is initialized in the
+        // class-declaration body's trailing statements (it lowers to the WeakMap
+        // pattern for targets < ES2022). `tsc` does not emit it as its own
+        // trailing statement; it places it relative to the private-name helpers /
+        // static elements. This base condition is the relocatable case: a
+        // declaration (not a comma-expression class expression) with instance
+        // storage to emit after the class body.
+        let relocatable_auto_accessor_instance_inits = !needs_private_comma_expr
+            && lower_auto_accessors_to_weakmap
+            && emit_auto_accessor_instance_inits_after_class
+            && !auto_accessor_instance_inits.is_empty();
+        // With private-name lowering, fold the instance-storage inits into the
+        // single combined private-name init statement (right after the
+        // private-method WeakSet / before the private method+accessor defs).
+        let fold_auto_accessor_instance_inits =
+            relocatable_auto_accessor_instance_inits && has_any_private_lowering;
+        // With no private-name lowering to fold into but static field/block
+        // initializers present, emit the instance storage as its own statement
+        // *before* those static initializers (the storage must exist before a
+        // static initializer could instantiate the class).
+        let emit_auto_accessor_instance_inits_pre_static = relocatable_auto_accessor_instance_inits
+            && !has_any_private_lowering
+            && (!static_field_inits.is_empty() || !deferred_static_blocks.is_empty());
+        // In either case the separate trailing auto-accessor block must not also
+        // emit the instance storage.
+        let suppress_trailing_auto_accessor_instance_inits =
+            fold_auto_accessor_instance_inits || emit_auto_accessor_instance_inits_pre_static;
+        let auto_accessor_instance_weakmap_inits: Vec<String> =
+            if suppress_trailing_auto_accessor_instance_inits {
+                auto_accessor_instance_inits
+                    .iter()
+                    .map(|(storage_name, _)| format!("{storage_name} = new WeakMap()"))
+                    .collect()
+            } else {
+                Vec::new()
+            };
+        let mut emitted_folded_auto_accessor_instance_inits = false;
+
         // Emit computed property name hoisting comma expression or standalone side effects.
         if !computed_prop_entries.is_empty() {
             if class_expr_temp.is_some() {
@@ -259,6 +297,16 @@ impl<'a> Printer<'a> {
                     self.write(init);
                     first = false;
                 }
+                if fold_auto_accessor_instance_inits {
+                    for init in &auto_accessor_instance_weakmap_inits {
+                        if !first {
+                            self.write(", ");
+                        }
+                        self.write(init);
+                        first = false;
+                        emitted_folded_auto_accessor_instance_inits = true;
+                    }
+                }
                 for def in &method_defs {
                     if !first {
                         self.write(", ");
@@ -319,6 +367,19 @@ impl<'a> Printer<'a> {
                     self.emit_static_private_init(init, &class_name, true);
                 }
             }
+        }
+        // No private lowering but static elements present: emit the auto-accessor
+        // instance storage WeakMaps as their own statement before the static
+        // field/block work, matching tsc.
+        if emit_auto_accessor_instance_inits_pre_static {
+            self.write_line();
+            for (i, init) in auto_accessor_instance_weakmap_inits.iter().enumerate() {
+                if i > 0 {
+                    self.write(", ");
+                }
+                self.write(init);
+            }
+            self.write(";");
         }
         // Private helper/state initialization can be part of a class-expression
         // comma list. Gather it before static element scheduling so lowered
@@ -773,7 +834,8 @@ impl<'a> Printer<'a> {
         // ...
         // _Class_prop_accessor_storage = new WeakMap();
         if lower_auto_accessors_to_weakmap
-            && ((emit_auto_accessor_instance_inits_after_class
+            && ((!suppress_trailing_auto_accessor_instance_inits
+                && emit_auto_accessor_instance_inits_after_class
                 && !auto_accessor_instance_inits.is_empty())
                 || !auto_accessor_static_inits.is_empty()
                 || auto_accessor_class_alias.is_some())
@@ -791,7 +853,8 @@ impl<'a> Printer<'a> {
                 wrote_alias_line = true;
             }
 
-            if emit_auto_accessor_instance_inits_after_class
+            if !suppress_trailing_auto_accessor_instance_inits
+                && emit_auto_accessor_instance_inits_after_class
                 && !auto_accessor_instance_inits.is_empty()
             {
                 if wrote_alias_line {
@@ -936,6 +999,16 @@ impl<'a> Printer<'a> {
                 }
                 self.write(init);
                 first = false;
+            }
+
+            if fold_auto_accessor_instance_inits && !emitted_folded_auto_accessor_instance_inits {
+                for init in &auto_accessor_instance_weakmap_inits {
+                    if !first {
+                        self.write(", ");
+                    }
+                    self.write(init);
+                    first = false;
+                }
             }
 
             // Private method function definitions:

--- a/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
@@ -431,3 +431,193 @@ class A {
         "instance-brand storage is still emitted for conflicting private methods.\nOutput:\n{output}"
     );
 }
+
+// A public auto-accessor's instance storage WeakMap is part of the single
+// combined private-name initialization statement that `tsc` emits at the end of
+// a lowered class declaration (private-field WeakMaps, then the private-method
+// WeakSet, then the auto-accessor storages, then private method/accessor
+// function defs) — not a separate trailing statement. These tests lock that
+// folding and var-declaration ordering. Binder names are varied across tests so
+// the assertions track structure, not a particular spelling.
+//
+// `tsc --target es2015` (and every target < ES2022, since auto-accessors lower
+// to the WeakMap pattern there) for `class C { #x = 1; accessor y = 3; ... }`:
+//   var _C_x, _C_y_accessor_storage;
+//   ...
+//   _C_x = new WeakMap(), _C_y_accessor_storage = new WeakMap();
+
+#[test]
+fn auto_accessor_storage_folds_into_private_field_init_statement() {
+    let source = r#"
+class Wrapper {
+    #value = 1;
+    accessor label = "x";
+    get peek() { return this.#value; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    // Single combined init statement, private field first then accessor storage.
+    assert!(
+        output.contains(
+            "_Wrapper_value = new WeakMap(), _Wrapper_label_accessor_storage = new WeakMap();"
+        ),
+        "auto-accessor storage must fold into the private-field init statement, after the field.\nOutput:\n{output}"
+    );
+    // The accessor storage must not start its own statement (the pre-fix bug
+    // emitted `\n_Wrapper_label_accessor_storage = new WeakMap()` on its own line).
+    assert!(
+        !output.contains("\n_Wrapper_label_accessor_storage = new WeakMap()"),
+        "auto-accessor storage must not be emitted as its own statement.\nOutput:\n{output}"
+    );
+    // var-declaration order: field name before accessor-storage name.
+    let field_decl = output
+        .find("var _Wrapper_value, _Wrapper_label_accessor_storage;")
+        .or_else(|| output.find("_Wrapper_value, _Wrapper_label_accessor_storage"));
+    assert!(
+        field_decl.is_some(),
+        "var declaration must list the private field before the accessor storage.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn auto_accessor_storage_folds_after_private_method_weakset() {
+    // Private method (→ instances WeakSet) plus a public auto-accessor: tsc emits
+    // `_K_instances = new WeakSet(), _K_a_accessor_storage = new WeakMap(), _K_run = function ...`
+    let source = r#"
+class Kit {
+    accessor a = 1;
+    #run() { return 2; }
+    call() { return this.#run(); }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains(
+            "_Kit_instances = new WeakSet(), _Kit_a_accessor_storage = new WeakMap(), _Kit_run = function"
+        ),
+        "accessor storage must sit between the instance WeakSet and the private-method def, in one statement.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_Kit_a_accessor_storage = new WeakMap();"),
+        "accessor storage must not be emitted as its own statement when private lowering is present.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn multiple_auto_accessors_fold_in_source_order_after_private_fields() {
+    let source = r#"
+class Grid {
+    #m = 1;
+    accessor p = 2;
+    #n = 3;
+    accessor q = 4;
+    get sum() { return this.#m + this.#n; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    // Private fields first (source order), then accessor storages (source order),
+    // all in one statement.
+    assert!(
+        output.contains(
+            "_Grid_m = new WeakMap(), _Grid_n = new WeakMap(), _Grid_p_accessor_storage = new WeakMap(), _Grid_q_accessor_storage = new WeakMap();"
+        ),
+        "fields then accessor storages, source order, single statement.\nOutput:\n{output}"
+    );
+    assert!(
+        output
+            .contains("var _Grid_m, _Grid_n, _Grid_p_accessor_storage, _Grid_q_accessor_storage;"),
+        "var declaration order must match: fields then accessor storages.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn pure_auto_accessors_keep_their_standalone_init_statement() {
+    // With no private-name lowering there is nothing to fold into; the
+    // standalone auto-accessor init statement is preserved (tsc parity).
+    let source = r#"
+class Plain {
+    accessor a = 1;
+    accessor b = 2;
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains(
+            "_Plain_a_accessor_storage = new WeakMap(), _Plain_b_accessor_storage = new WeakMap();"
+        ),
+        "pure auto-accessor classes still emit their combined storage init.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var _Plain_a_accessor_storage, _Plain_b_accessor_storage;"),
+        "pure auto-accessor var declaration is unchanged.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn auto_accessor_storage_folds_when_static_field_forces_pre_static_inits() {
+    // A static field routes the private inits through the pre-static emission
+    // path (private-name storage must exist before a static initializer could
+    // instantiate the class). The auto-accessor storage must still fold into
+    // that single combined statement.
+    let source = r#"
+class Reg {
+    #x = 1;
+    accessor y = 2;
+    static count = 0;
+    get g() { return this.#x; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("_Reg_x = new WeakMap(), _Reg_y_accessor_storage = new WeakMap();"),
+        "auto-accessor storage folds into the pre-static private-init statement.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("\n_Reg_y_accessor_storage = new WeakMap()"),
+        "auto-accessor storage must not be emitted as its own statement.\nOutput:\n{output}"
+    );
+    // The static field assignment follows the private inits.
+    let inits = output
+        .find("_Reg_x = new WeakMap()")
+        .expect("private inits present");
+    let static_assign = output.find("Reg.count = 0").expect("static field present");
+    assert!(
+        inits < static_assign,
+        "private/auto-accessor storage initializes before the static field.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn auto_accessor_storage_precedes_static_field_without_private_lowering() {
+    // No private-name lowering to fold into, but a static field is present: tsc
+    // still emits the auto-accessor instance storage WeakMap *before* the static
+    // field initializer (the storage must exist before a static initializer could
+    // instantiate the class).
+    let source = r#"
+class Conf {
+    accessor opt = 2;
+    static total = 0;
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    let storage = output
+        .find("_Conf_opt_accessor_storage = new WeakMap();")
+        .expect("auto-accessor storage init present");
+    let static_assign = output.find("Conf.total = 0").expect("static field present");
+    assert!(
+        storage < static_assign,
+        "auto-accessor storage must initialize before the static field, even with no private lowering.\nOutput:\n{output}"
+    );
+    // It is its own statement (no private statement to fold into) and not left
+    // trailing after the static field with a blank line (the pre-fix bug).
+    assert!(
+        !output.contains("Conf.total = 0;\n\n_Conf_opt_accessor_storage = new WeakMap()"),
+        "auto-accessor storage must not trail after the static field.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Closes #14064.

## Structural rule

> For targets `< ES2022`, a public `accessor` field lowers to a backing `WeakMap` (`_C_<name>_accessor_storage`). `tsc` treats that instance storage `WeakMap` as part of the **same private-name environment initialization** as `#field` WeakMaps, the private-method `WeakSet`, and extracted private method/accessor function defs:
> - `var` declaration order: instances `WeakSet`, class alias, private members in source order, then **auto-accessor storages last**.
> - Initialization: a **single combined comma statement** — private-field WeakMaps, instances `WeakSet`, then the auto-accessor storage WeakMaps (instance slot), then private method/accessor function defs.
> - With no private lowering but static field/block initializers present, the storage `WeakMap` is still emitted **before** those static initializers (it must exist before a static initializer could instantiate the class).

tsz ran a separate auto-accessor pipeline that hoisted the storage var early and emitted its init as its own trailing statement, so any class mixing a public auto-accessor with private members or a static field diverged — wrong `var` order, wrong init order, a stray blank line, and (no-private case) the storage initialized *after* the static field.

```ts
class Foo { #x = 1; accessor y = 3; get g() { return this.#x; } }
```
```js
// tsc:  var _Foo_x, _Foo_y_accessor_storage;  ...  _Foo_x = new WeakMap(), _Foo_y_accessor_storage = new WeakMap();
// tsz before:  var _Foo_y_accessor_storage, _Foo_x;  ...  _Foo_y_accessor_storage = new WeakMap();\n\n_Foo_x = new WeakMap();
```

Found by JS-emit differential testing against `tsc` 6.0.2.

## Owner layer

Emitter only (`crates/tsz-emitter`, ES6 / `< ES2022` class lowering). No semantic/checker change, no output surgery. The fix folds the instance-storage inits into the existing private-name init emission (or, with no private lowering, emits them just before the static elements), suppresses the separate trailing block for those inits, and hoists the storage var names alongside the private-name vars. Keys purely on structural lowering shape — no identifier/property/file-name/printer-string predicates — so it applies to every binder spelling.

## Scope

Instance public auto-accessors mixed with private fields/methods/accessors and/or static fields/blocks. Static-only public auto-accessors (`static accessor`) have a separate, independent defect family (missing `__classPrivateFieldGet/Set` helpers, duplicate class alias) and are intentionally left for a follow-up; this change must not regress them, and does not.

## Adjacent-case matrix (byte-equal to `tsc` 6.0.2; binder/field/accessor names varied)

| case | result |
|---|---|
| `#field` + `accessor` (instance) | ✓ folded, field before storage |
| private method (`WeakSet`) + `accessor` | ✓ storage between WeakSet and method def |
| multiple `#fields` + multiple `accessor`s | ✓ fields then storages, source order, one statement |
| `#field` + `accessor` + `static field` (pre-static path) | ✓ storage in pre-static statement, before static field |
| `accessor` + `static field`, **no** private lowering | ✓ storage emitted before the static field |
| pure `accessor`s (no private, no static) | ✓ unchanged |
| targets es2015 / es2017 / es2020 / esnext; module commonjs / esnext / nodenext | ✓ |

## Verification

- New name-agnostic regression tests in `private_field_helper_order_tests.rs` (folding into the combined statement, post-WeakSet slot, multi-accessor source order, pre-static path, no-private-lowering pre-static, pure-accessor unchanged). `cargo test -p tsz-emitter --lib private_field_helper_order` — 22 pass.
- `cargo test -p tsz-emitter --lib` — 3767 pass, 0 fail.
- Differential vs `tsc` 6.0.2: a generated matrix of 60 class shapes × {es2015, es2017+commonjs} (plus targeted es2020/esnext/nodenext checks) is byte-identical; zero divergences for the instance auto-accessor family.
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --lib --tests`, `python3 scripts/arch/arch_guard.py` (incl. 2000-line cap) — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01G5CAtm1gMekzUDCRMH9NG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5CAtm1gMekzUDCRMH9NG5)_