### PR TITLE
fix(emit): order ES5 class instance field initializers by source position

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -330,6 +330,10 @@ path = "tests/legacy_decorator_member_order_tests.rs"
 name = "dynamic_import_amd_umd_parity_tests"
 path = "tests/dynamic_import_amd_umd_parity_tests.rs"
 
+[[test]]
+name = "es5_instance_field_init_order_tests"
+path = "tests/es5_instance_field_init_order_tests.rs"
+
 [lints]
 workspace = true
 

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_constructor.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_constructor.rs
@@ -20,6 +20,21 @@ use tsz_parser::syntax::transform_utils::{
 };
 use tsz_scanner::SyntaxKind;
 
+/// One instance field initializer, tagged by kind. The constructor emits public
+/// field assignments (`this.x = …`), private-field `WeakMap` stores
+/// (`_C_x.set(this, …)`), and auto-accessor stores in a single
+/// source-declaration-ordered pass so the runtime initialization order matches
+/// `tsc` (whose `flattenDestructuringAssignment`/constructor lowering preserves
+/// the textual order of instance members regardless of accessibility).
+enum InstanceFieldInit {
+    /// Public/protected instance property (index is its declaration node).
+    Public(NodeIndex),
+    /// Private instance field (index into `self.private_fields`).
+    Private(usize),
+    /// Instance auto-accessor (index into `self.auto_accessors`).
+    Accessor(usize),
+}
+
 impl<'a> ES5ClassTransformer<'a> {
     pub(super) fn emit_constructor_ir(&self, class_idx: NodeIndex) -> Option<IRNode> {
         let class_node = self.arena.get(class_idx)?;
@@ -192,18 +207,15 @@ impl<'a> ES5ClassTransformer<'a> {
                         ctor_body.push(Self::class_constructor_new_target_capture_ir());
                     }
 
-                    // Private brand and field initializations
+                    // Private brand, then instance field initializers in source
+                    // declaration order (public + private + auto-accessor).
                     self.emit_private_brand_initialization_ir(&mut ctor_body, true);
-                    self.emit_private_field_initializations_ir(&mut ctor_body, true);
-                    self.emit_auto_accessor_initializations_ir(&mut ctor_body, true);
-
-                    // Instance property initializations
-                    for &prop_idx in &instance_props {
-                        self.emit_property_leading_comment(&mut ctor_body, prop_idx);
-                        if let Some(ir) = self.emit_property_initializer_ir(prop_idx, true, true) {
-                            ctor_body.push(ir);
-                        }
-                    }
+                    self.emit_instance_field_initializations_ir(
+                        &mut ctor_body,
+                        true,
+                        true,
+                        &instance_props,
+                    );
                     self.emit_tc39_instance_extra_initializers_if_unconsumed_ir(
                         &mut ctor_body,
                         true,
@@ -225,22 +237,15 @@ impl<'a> ES5ClassTransformer<'a> {
                     ctor_body.push(Self::class_constructor_new_target_capture_ir());
                 }
 
-                // Emit private brand and field initializations
+                // Emit private brand, then instance field initializers in source
+                // declaration order (public + private + auto-accessor).
                 self.emit_private_brand_initialization_ir(&mut ctor_body, false);
-                self.emit_private_field_initializations_ir(&mut ctor_body, false);
-                self.emit_auto_accessor_initializations_ir(&mut ctor_body, false);
-
-                // Instance property initializations
-                for &prop_idx in &instance_props {
-                    self.emit_property_leading_comment(&mut ctor_body, prop_idx);
-                    if let Some(ir) = self.emit_property_initializer_ir(
-                        prop_idx,
-                        false,
-                        instance_props_need_this_capture,
-                    ) {
-                        ctor_body.push(ir);
-                    }
-                }
+                self.emit_instance_field_initializations_ir(
+                    &mut ctor_body,
+                    false,
+                    instance_props_need_this_capture,
+                    &instance_props,
+                );
                 self.emit_tc39_instance_extra_initializers_if_unconsumed_ir(&mut ctor_body, false);
                 self.emit_tc39_instance_field_extra_initializers_ir(&mut ctor_body, false);
             }
@@ -461,21 +466,13 @@ impl<'a> ES5ClassTransformer<'a> {
             body.extend(prologue);
         }
 
-        // Emit parameter properties
-        self.emit_parameter_properties_ir(body, params, true);
-
-        // Emit private brand and field initializations
+        // Emit private brand, parameter properties, then instance field
+        // initializers in source declaration order (public + private +
+        // auto-accessor). `tsc` orders these as brand → parameter properties →
+        // textual-order field initializers.
         self.emit_private_brand_initialization_ir(body, true);
-        self.emit_private_field_initializations_ir(body, true);
-        self.emit_auto_accessor_initializations_ir(body, true);
-
-        // Emit instance property initializers
-        for &prop_idx in instance_props {
-            self.emit_property_leading_comment(body, prop_idx);
-            if let Some(ir) = self.emit_property_initializer_ir(prop_idx, true, true) {
-                body.push(ir);
-            }
-        }
+        self.emit_parameter_properties_ir(body, params, true);
+        self.emit_instance_field_initializations_ir(body, true, true, instance_props);
         self.emit_tc39_instance_field_extra_initializers_ir(body, true);
 
         // Emit remaining statements after super()
@@ -560,17 +557,10 @@ impl<'a> ES5ClassTransformer<'a> {
             try_body.extend(prologue);
         }
 
-        self.emit_parameter_properties_ir(&mut try_body, params, true);
+        // brand → parameter properties → source-ordered instance field inits.
         self.emit_private_brand_initialization_ir(&mut try_body, true);
-        self.emit_private_field_initializations_ir(&mut try_body, true);
-        self.emit_auto_accessor_initializations_ir(&mut try_body, true);
-
-        for &prop_idx in instance_props {
-            self.emit_property_leading_comment(&mut try_body, prop_idx);
-            if let Some(ir) = self.emit_property_initializer_ir(prop_idx, true, true) {
-                try_body.push(ir);
-            }
-        }
+        self.emit_parameter_properties_ir(&mut try_body, params, true);
+        self.emit_instance_field_initializations_ir(&mut try_body, true, true, instance_props);
         self.emit_tc39_instance_field_extra_initializers_ir(&mut try_body, true);
 
         if super_stmt_idx.is_some() {
@@ -652,17 +642,10 @@ impl<'a> ES5ClassTransformer<'a> {
             body.extend(prologue);
         }
 
-        self.emit_parameter_properties_ir(body, params, true);
+        // brand → parameter properties → source-ordered instance field inits.
         self.emit_private_brand_initialization_ir(body, true);
-        self.emit_private_field_initializations_ir(body, true);
-        self.emit_auto_accessor_initializations_ir(body, true);
-
-        for &prop_idx in instance_props {
-            self.emit_property_leading_comment(body, prop_idx);
-            if let Some(ir) = self.emit_property_initializer_ir(prop_idx, true, true) {
-                body.push(ir);
-            }
-        }
+        self.emit_parameter_properties_ir(body, params, true);
+        self.emit_instance_field_initializations_ir(body, true, true, instance_props);
         self.emit_tc39_instance_field_extra_initializers_ir(body, true);
 
         let mut prev_stmt_end = body_node.pos;
@@ -977,22 +960,18 @@ impl<'a> ES5ClassTransformer<'a> {
             body.extend(prologue);
         }
 
-        // Emit private brand and field initializations
+        // Emit private brand, parameter properties, then instance field
+        // initializers in source declaration order (public + private +
+        // auto-accessor), matching `tsc`'s brand → parameter properties →
+        // textual-order initializer sequence.
         self.emit_private_brand_initialization_ir(body, false);
-        self.emit_private_field_initializations_ir(body, false);
-        self.emit_auto_accessor_initializations_ir(body, false);
-
-        // Emit parameter properties
         self.emit_parameter_properties_ir(body, params, false);
-
-        // Emit instance property initializers
-        for &prop_idx in instance_props {
-            self.emit_property_leading_comment(body, prop_idx);
-            if let Some(ir) = self.emit_property_initializer_ir(prop_idx, false, needs_this_capture)
-            {
-                body.push(ir);
-            }
-        }
+        self.emit_instance_field_initializations_ir(
+            body,
+            false,
+            needs_this_capture,
+            instance_props,
+        );
         self.emit_tc39_instance_field_extra_initializers_ir(body, false);
 
         // Emit original constructor body
@@ -1386,63 +1365,132 @@ impl<'a> ES5ClassTransformer<'a> {
         )));
     }
 
-    /// Emit private field initializations using `__classPrivateFieldSet`.
-    fn emit_private_field_initializations_ir(&self, body: &mut Vec<IRNode>, use_this: bool) {
-        let receiver = if use_this {
-            IRNode::id("_this")
-        } else {
-            IRNode::this()
-        };
-
-        for field in &self.private_fields {
-            if field.is_static {
-                continue;
+    /// Emit every instance field initializer — public property assignments,
+    /// private-field `WeakMap` stores, and auto-accessor stores — in a single
+    /// pass ordered by source declaration position.
+    ///
+    /// `tsc` initializes instance members in textual order regardless of
+    /// accessibility (`this.a = 1; _C_p.set(this, 2); this.b = 3;` for
+    /// `a; #p; b`). Emitting all private/accessor stores as a block before the
+    /// public assignments (or vice versa) reorders observable initializer side
+    /// effects, so the three sources are merged and sorted by the declaration
+    /// node's source position here. The private brand `add(this)` and
+    /// parameter-property assignments are emitted by their own callers *before*
+    /// this pass, matching `tsc`.
+    fn emit_instance_field_initializations_ir(
+        &self,
+        body: &mut Vec<IRNode>,
+        use_this: bool,
+        lexical_this_capture: bool,
+        instance_props: &[NodeIndex],
+    ) {
+        for (_, entry) in self.instance_field_initializer_plan(instance_props) {
+            match entry {
+                InstanceFieldInit::Public(prop_idx) => {
+                    self.emit_property_leading_comment(body, prop_idx);
+                    if let Some(ir) =
+                        self.emit_property_initializer_ir(prop_idx, use_this, lexical_this_capture)
+                    {
+                        body.push(ir);
+                    }
+                }
+                InstanceFieldInit::Private(field_index) => {
+                    self.emit_one_private_field_init_ir(body, field_index, use_this);
+                }
+                InstanceFieldInit::Accessor(accessor_index) => {
+                    self.emit_one_auto_accessor_init_ir(body, accessor_index, use_this);
+                }
             }
-
-            self.emit_property_leading_comment(body, field.member_idx);
-            let value = if field.has_initializer && field.initializer.is_some() {
-                self.convert_expression(field.initializer)
-            } else {
-                IRNode::Undefined
-            };
-            // The in-constructor initializer for a private instance field is the
-            // field's definition point, so tsc emits a direct `_C_field.set(this, value)`
-            // WeakMap store (see `createPrivateInstanceFieldInitializer`). The
-            // `__classPrivateFieldSet` helper is reserved for later assignment
-            // expressions (`this.#x = v`) where a brand check is required.
-            body.push(IRNode::expr_stmt(IRNode::WeakMapSet {
-                weakmap_name: field.weakmap_name.clone().into(),
-                key: Box::new(receiver.clone()),
-                value: Box::new(value),
-            }));
         }
     }
 
-    /// Emit auto-accessor field initializations using `WeakMap.set()`
-    fn emit_auto_accessor_initializations_ir(&self, body: &mut Vec<IRNode>, use_this: bool) {
-        let key = if use_this {
-            IRNode::id("_this")
-        } else {
-            IRNode::this()
-        };
-
-        for accessor in &self.auto_accessors {
+    /// Build the source-ordered list of instance field initializers by merging
+    /// the public properties, private instance fields, and instance
+    /// auto-accessors and sorting on each declaration's source position. The
+    /// sort is stable, so members that (impossibly) share a position keep their
+    /// insertion order. Each entry keeps its source position so the caller can
+    /// iterate the sorted vec directly without a second allocation.
+    fn instance_field_initializer_plan(
+        &self,
+        instance_props: &[NodeIndex],
+    ) -> Vec<(u32, InstanceFieldInit)> {
+        let pos_of = |idx: NodeIndex| self.arena.get(idx).map_or(0u32, |node| node.pos);
+        let mut plan: Vec<(u32, InstanceFieldInit)> = Vec::new();
+        for &prop_idx in instance_props {
+            plan.push((pos_of(prop_idx), InstanceFieldInit::Public(prop_idx)));
+        }
+        for (i, field) in self.private_fields.iter().enumerate() {
+            if field.is_static {
+                continue;
+            }
+            plan.push((pos_of(field.member_idx), InstanceFieldInit::Private(i)));
+        }
+        for (i, accessor) in self.auto_accessors.iter().enumerate() {
             if accessor.is_static {
                 continue;
             }
-
-            let value = accessor
-                .initializer
-                .map(|initializer| self.convert_expression(initializer))
-                .unwrap_or(IRNode::Undefined);
-
-            // _Class_accessor_storage.set(this, value);
-            body.push(IRNode::expr_stmt(IRNode::WeakMapSet {
-                weakmap_name: accessor.weakmap_name.clone().into(),
-                key: Box::new(key.clone()),
-                value: Box::new(value),
-            }));
+            plan.push((pos_of(accessor.member_idx), InstanceFieldInit::Accessor(i)));
         }
+        plan.sort_by_key(|(pos, _)| *pos);
+        plan
+    }
+
+    /// The constructor receiver expression: `_this` once `this` has been
+    /// captured into the derived-class temp, otherwise `this`.
+    fn instance_receiver_ir(use_this: bool) -> IRNode {
+        if use_this {
+            IRNode::id("_this")
+        } else {
+            IRNode::this()
+        }
+    }
+
+    /// Emit a single private instance field's in-constructor `WeakMap` store.
+    fn emit_one_private_field_init_ir(
+        &self,
+        body: &mut Vec<IRNode>,
+        field_index: usize,
+        use_this: bool,
+    ) {
+        let receiver = Self::instance_receiver_ir(use_this);
+        let field = &self.private_fields[field_index];
+        self.emit_property_leading_comment(body, field.member_idx);
+        let value = if field.has_initializer && field.initializer.is_some() {
+            self.convert_expression(field.initializer)
+        } else {
+            IRNode::Undefined
+        };
+        // The in-constructor initializer for a private instance field is the
+        // field's definition point, so tsc emits a direct `_C_field.set(this, value)`
+        // WeakMap store (see `createPrivateInstanceFieldInitializer`). The
+        // `__classPrivateFieldSet` helper is reserved for later assignment
+        // expressions (`this.#x = v`) where a brand check is required.
+        body.push(IRNode::expr_stmt(IRNode::WeakMapSet {
+            weakmap_name: field.weakmap_name.clone().into(),
+            key: Box::new(receiver),
+            value: Box::new(value),
+        }));
+    }
+
+    /// Emit a single instance auto-accessor's backing-storage `WeakMap` store.
+    fn emit_one_auto_accessor_init_ir(
+        &self,
+        body: &mut Vec<IRNode>,
+        accessor_index: usize,
+        use_this: bool,
+    ) {
+        let key = Self::instance_receiver_ir(use_this);
+        let accessor = &self.auto_accessors[accessor_index];
+        let value = accessor
+            .initializer
+            .map(|initializer| self.convert_expression(initializer))
+            .unwrap_or(IRNode::Undefined);
+        // _Class_accessor_storage.set(this, value);
+        body.push(IRNode::expr_stmt(IRNode::WeakMapSet {
+            weakmap_name: accessor.weakmap_name.clone().into(),
+            key: Box::new(key),
+            value: Box::new(value),
+        }));
     }
 
     pub(super) fn find_auto_accessor(

--- a/crates/tsz-emitter/tests/es5_instance_field_init_order_tests.rs
+++ b/crates/tsz-emitter/tests/es5_instance_field_init_order_tests.rs
@@ -1,0 +1,161 @@
+//! Regression tests for ES5 class lowering: instance field initializers
+//! (public property assignments, private-field `WeakMap` stores, and
+//! auto-accessor stores) must run in **source declaration order**, exactly as
+//! `tsc` emits them.
+//!
+//! Previously the ES5 constructor lowering emitted every private-field /
+//! auto-accessor store as one block *before* the public property assignments,
+//! reordering observable initializer side effects. For `class C { a = 1; #p =
+//! 2; b = 3; }` `tsc` emits `this.a = 1; _C_p.set(this, 2); this.b = 3;` while
+//! tsz emitted `_C_p.set(this, 2); this.a = 1; this.b = 3;`.
+//!
+//! The constructor emission order `tsc` uses (and these tests lock) is:
+//! private brand `add(this)` → parameter-property assignments → instance field
+//! initializers in textual order → original constructor body.
+//!
+//! Binder names are deliberately varied (no `C`/`a`/`#p` reliance) so the
+//! assertions track the structural declaration order, not any spelling.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print as emit;
+
+fn es5() -> PrintOptions {
+    PrintOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::ESNext,
+        ..Default::default()
+    }
+}
+
+/// Assert that each needle appears in `haystack` and that they occur in the
+/// given order.
+#[track_caller]
+fn assert_order(haystack: &str, needles: &[&str]) {
+    let mut last = 0usize;
+    for needle in needles {
+        match haystack[last..].find(needle) {
+            Some(rel) => last += rel + needle.len(),
+            None => panic!(
+                "expected to find {needle:?} after offset {last} in order {needles:?}\nOutput:\n{haystack}"
+            ),
+        }
+    }
+}
+
+#[test]
+fn public_private_public_interleave_keeps_source_order() {
+    // a (public) ; #secret (private) ; omega (public)
+    let src = "class Widget { alpha = 1; #secret = 2; omega = 3; }";
+    let out = emit(src, es5());
+    assert_order(
+        &out,
+        &[
+            "function Widget()",
+            "this.alpha = 1;",
+            "_Widget_secret.set(this, 2);",
+            "this.omega = 3;",
+        ],
+    );
+}
+
+#[test]
+fn private_public_private_interleave_keeps_source_order() {
+    let src = "class Box { #first = 1; middle = 2; #last = 3; }";
+    let out = emit(src, es5());
+    assert_order(
+        &out,
+        &[
+            "_Box_first.set(this, 1);",
+            "this.middle = 2;",
+            "_Box_last.set(this, 3);",
+        ],
+    );
+}
+
+#[test]
+fn private_brand_then_fields_in_source_order() {
+    // Private method forces a WeakSet brand `add(this)`, which `tsc` emits
+    // before any field initializer; the public/private fields then interleave.
+    let src = "class Service { handle = 1; #token = 2; #run() {} ready = 3; }";
+    let out = emit(src, es5());
+    assert_order(
+        &out,
+        &[
+            "_Service_instances.add(this);",
+            "this.handle = 1;",
+            "_Service_token.set(this, 2);",
+            "this.ready = 3;",
+        ],
+    );
+}
+
+#[test]
+fn parameter_properties_precede_field_initializers() {
+    let src = "class Account { balance = 1; #pin = 2; constructor(public owner: string) {} }";
+    let out = emit(src, es5());
+    assert_order(
+        &out,
+        &[
+            "function Account(owner)",
+            "this.owner = owner;",
+            "this.balance = 1;",
+            "_Account_pin.set(this, 2);",
+        ],
+    );
+}
+
+#[test]
+fn auto_accessor_interleaves_with_public_and_private() {
+    let src = "class Model { name = 1; accessor count = 2; #hidden = 3; }";
+    let out = emit(src, es5());
+    assert_order(
+        &out,
+        &[
+            "this.name = 1;",
+            "_Model_count_accessor_storage.set(this, 2);",
+            "_Model_hidden.set(this, 3);",
+        ],
+    );
+}
+
+#[test]
+fn derived_class_interleaves_after_super_capture() {
+    let src = "class Base {} class Derived extends Base { head = 1; #mid = 2; tail = 3; constructor() { super(); } }";
+    let out = emit(src, es5());
+    assert_order(
+        &out,
+        &[
+            "_super.call(this)",
+            "_this.head = 1;",
+            "_Derived_mid.set(_this, 2);",
+            "_this.tail = 3;",
+        ],
+    );
+}
+
+#[test]
+fn field_initializers_precede_original_constructor_body() {
+    let src = "class Timer { tick = 1; #count = 2; constructor() { this.started = true; } }";
+    let out = emit(src, es5());
+    assert_order(
+        &out,
+        &[
+            "this.tick = 1;",
+            "_Timer_count.set(this, 2);",
+            "this.started = true;",
+        ],
+    );
+}
+
+#[test]
+fn public_only_fields_unchanged() {
+    // Control: classes without private members keep their plain source order.
+    let src = "class Plain { one = 1; two = 2; three = 3; }";
+    let out = emit(src, es5());
+    assert_order(&out, &["this.one = 1;", "this.two = 2;", "this.three = 3;"]);
+}


### PR DESCRIPTION
Goal: hold

Closes #14066.

## Structural rule

> When lowering a class for an ES5 target, the constructor must initialize
> instance members in **source declaration order** regardless of accessibility.
> `tsc` orders the constructor prologue as: private brand `add(this)` →
> parameter-property assignments → instance field initializers in **textual
> order** (public `this.x = …` assignments, private-field `WeakMap` stores, and
> auto-accessor backing-storage stores **interleaved**) → original constructor
> body.

The ES5 IR lowering instead emitted every private-field / auto-accessor store as
one block **before** the public property assignments, reordering observable
field-initializer side effects. It also emitted parameter-property assignments
*after* the private/accessor stores, and (in derived classes) the private brand
*after* the parameter properties.

```ts
class C { a = 1; #p = 2; b = 3; }
// tsc : this.a = 1; _C_p.set(this, 2); this.b = 3;
// tsz (before): _C_p.set(this, 2); this.a = 1; this.b = 3;   // private hoisted before public

class C { #p = 1; a = 2; #q = 3; }
// tsc : _C_p.set(this, 1); this.a = 2; _C_q.set(this, 3);
// tsz (before): _C_p.set(this, 1); _C_q.set(this, 3); this.a = 2;
```

Found by differential testing against `tsc` 6.0.2 (`--target es5`).

## Owner layer

Emitter only — `crates/tsz-emitter/src/transforms/class_es5_ir_constructor.rs`
(ES5 IR constructor lowering). No semantic/checker change, no output surgery.

The three field-initializer sources (public props, private fields,
auto-accessors) are merged into a single source-position-ordered pass
(`emit_instance_field_initializations_ir` + `instance_field_initializer_plan`,
sorting on each declaration node's `.pos`), and all **six** constructor-emission
sites (base / derived / derived-with-`using` / derived-with-nested-super, plus
the two default-constructor arms) are reordered to brand → parameter properties
→ merged field inits. The decision keys purely on declaration source position —
no identifier, property-name, or file-name predicate — so it applies to every
binder spelling. The ES2015+ native-class path already emitted the correct order
(verified) and is unchanged; this is ES5-IR-specific.

## Adjacent-case matrix (all byte-equal to `tsc` 6.0.2, `--target es5`)

| case | result |
|---|---|
| `a; #p; b` (public→private→public) | ✓ source order |
| `#p; a; #q` (private→public→private) | ✓ source order |
| `name; accessor count; #hidden` (auto-accessor interleave) | ✓ |
| `constructor(public x)` + fields (parameter property first) | ✓ |
| private method brand (`#run(){}`) + fields | ✓ brand → fields |
| derived class (`extends`, after `_super.call(this)` capture) | ✓ |
| field inits precede original constructor body | ✓ |
| public-only fields (control, unchanged) | ✓ |

Binder names are varied across the regression suite (`Widget`/`#secret`,
`Box`/`#first`, `Account`/`#pin`, …) so the assertions track the structural
declaration order, not any spelling.

## Verification

- New name-agnostic suite `crates/tsz-emitter/tests/es5_instance_field_init_order_tests.rs`
  (8 cases) — `cargo test -p tsz-emitter --test es5_instance_field_init_order_tests`
  → **8 passed**. Verified **7/8 fail on the pre-fix tree** (only the public-only
  control passes), confirming genuine regression guards.
- Differential vs `tsc` 6.0.2 over the class-field battery (public/private/
  accessor interleave, parameter properties, private brand, derived classes):
  the constructor function bodies are now **byte-identical** to `tsc`.
- `cargo test -p tsz-emitter --lib` → **3761 passed, 0 failed** (no regressions).
- Registered class/field/decorator integration binaries
  (`private_element_naming_tests`, `static_field_lowering_trailing_comment_tests`,
  `static_no_init_field_erasure_tests`, `computed_name_no_init_define_field_tests`,
  `legacy_decorator_member_order_tests`, `tc39_*`, `es5_super_*`, …) — all pass.
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --lib --tests`,
  `python3 scripts/arch/arch_guard.py` (incl. 2000-line cap) — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Gze3dEW9uGc5sAieGN7PLj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gze3dEW9uGc5sAieGN7PLj)_