### PR TITLE
fix(emit): allocate fresh temp for nested ES5 param binding default

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
@@ -354,6 +354,37 @@ impl<'a> Printer<'a> {
         Some(read_name)
     }
 
+    /// After the source temp `value_name` has been written, emit the
+    /// default-check temp `, _c = value_name === void 0 ? <init> : value_name`
+    /// when `initializer` is present, and return the name the nested pattern
+    /// should destructure from (the fresh default temp, or `value_name` when
+    /// there is no default).
+    ///
+    /// tsc materializes a *fresh* temp for the default-checked value before
+    /// destructuring the nested pattern (mirroring `ensureIdentifier` after
+    /// `createDefaultValueCheck`), rather than reusing the source temp, e.g.
+    /// `_b = _a.a, _c = _b === void 0 ? init : _b, x = _c.x` — not
+    /// `_b = _a.a, _b = _b === void 0 ? init : _b, x = _b.x`.
+    fn emit_param_nested_default_source(
+        &mut self,
+        value_name: String,
+        initializer: NodeIndex,
+    ) -> String {
+        if initializer.is_none() {
+            return value_name;
+        }
+        let default_name = self.get_temp_var_name();
+        self.write(", ");
+        self.write(&default_name);
+        self.write(" = ");
+        self.write(&value_name);
+        self.write(" === void 0 ? ");
+        self.emit_expression(initializer);
+        self.write(" : ");
+        self.write(&value_name);
+        default_name
+    }
+
     pub(in crate::emitter) fn emit_param_object_binding_element(
         &mut self,
         elem_idx: NodeIndex,
@@ -385,20 +416,8 @@ impl<'a> Printer<'a> {
                     computed_key_temp.as_deref(),
                 );
 
-                let source_name = if elem.initializer.is_some() {
-                    let default_name = self.get_temp_var_name();
-                    self.write(", ");
-                    self.write(&default_name);
-                    self.write(" = ");
-                    self.write(&value_name);
-                    self.write(" === void 0 ? ");
-                    self.emit_expression(elem.initializer);
-                    self.write(" : ");
-                    self.write(&value_name);
-                    default_name
-                } else {
-                    value_name
-                };
+                let source_name =
+                    self.emit_param_nested_default_source(value_name, elem.initializer);
 
                 // For defaulted empty nested patterns, tsc materializes a final
                 // pattern temp after applying the default. Empty patterns have nothing
@@ -435,18 +454,9 @@ impl<'a> Printer<'a> {
                 computed_key_temp.as_deref(),
             );
 
-            if elem.initializer.is_some() {
-                self.write(", ");
-                self.write(&value_name);
-                self.write(" = ");
-                self.write(&value_name);
-                self.write(" === void 0 ? ");
-                self.emit_expression(elem.initializer);
-                self.write(" : ");
-                self.write(&value_name);
-            }
+            let source_name = self.emit_param_nested_default_source(value_name, elem.initializer);
 
-            self.emit_param_binding_assignments(elem.name, &value_name, started);
+            self.emit_param_binding_assignments(elem.name, &source_name, started);
             return Some(rest_prop);
         }
 
@@ -566,21 +576,7 @@ impl<'a> Printer<'a> {
             self.write_usize(index);
             self.write("]");
 
-            let source_name = if elem.initializer.is_some() {
-                // Allocate a NEW temp for the defaulted value
-                let default_name = self.get_temp_var_name();
-                self.write(", ");
-                self.write(&default_name);
-                self.write(" = ");
-                self.write(&value_name);
-                self.write(" === void 0 ? ");
-                self.emit_expression(elem.initializer);
-                self.write(" : ");
-                self.write(&value_name);
-                default_name
-            } else {
-                value_name
-            };
+            let source_name = self.emit_param_nested_default_source(value_name, elem.initializer);
 
             self.emit_param_binding_assignments(elem.name, &source_name, started);
             return;

--- a/crates/tsz-emitter/src/emitter/source_file/es5_param_nested_default_temp_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_param_nested_default_temp_tests.rs
@@ -1,0 +1,118 @@
+//! ES5 parameter object-binding destructuring temp-ordering tests.
+//!
+//! Structural rule: when a function-parameter object-binding element has both a
+//! default initializer and a *nested binding pattern* target, `tsc` materializes
+//! a fresh temp for the default-checked value before destructuring the nested
+//! pattern (mirroring `ensureIdentifier` after `createDefaultValueCheck`):
+//!
+//! ```js
+//! function f(_a) { var _b = _a.outer, _c = _b === void 0 ? init : _b, leaf = _c.leaf; }
+//! ```
+//!
+//! It does NOT reuse the source temp (`_b = _a.outer, _b = _b === void 0 ? init : _b,
+//! leaf = _b.leaf`). This mirrors the sibling array-pattern path and the
+//! variable-statement path. Binder names are varied so the assertions track the
+//! structural shape, not any spelling.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit_es5(source: &str) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target: ScriptTarget::ES5,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn nested_object_pattern_default_uses_fresh_temp() {
+    let source = "function single({ outer: { leaf } = { leaf: 0 } }: any) {}\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output
+            .contains("var _b = _a.outer, _c = _b === void 0 ? { leaf: 0 } : _b, leaf = _c.leaf;"),
+        "Nested object-pattern default should destructure from a fresh temp.\nOutput:\n{output}"
+    );
+    // Guard against the old reused-temp shape.
+    assert!(
+        !output.contains("_b = _b === void 0"),
+        "The source temp must not be reused for the default-checked value.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn renamed_nested_object_pattern_default_uses_fresh_temp() {
+    let source = "function renamed({ src: { v: w } = { v: 0 } }: any) {}\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output.contains("var _b = _a.src, _c = _b === void 0 ? { v: 0 } : _b, w = _c.v;"),
+        "Renamed nested binding tracks the structural shape, not the name.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn multiple_nested_pattern_defaults_advance_temps_sequentially() {
+    let source = "function pair({ a: { x } = { x: 1 }, b: { y } = { y: 2 } }: any) {}\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output.contains(
+            "var _b = _a.a, _c = _b === void 0 ? { x: 1 } : _b, x = _c.x, \
+             _d = _a.b, _e = _d === void 0 ? { y: 2 } : _d, y = _e.y;"
+        ),
+        "Each nested default should claim its own source/default temp pair.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn nested_array_pattern_default_uses_fresh_temp() {
+    let source = "function arr({ p: [q] = [7] }: any) {}\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output.contains("var _b = _a.p, _c = _b === void 0 ? [7] : _b, q = _c[0];"),
+        "Nested array-pattern default mirrors the object-pattern path.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn nested_default_before_object_rest_uses_fresh_temp() {
+    let source = "function withRest({ k, m: { z } = { z: 1 }, ...others }: any) {}\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output.contains(
+            "var k = _a.k, _b = _a.m, _c = _b === void 0 ? { z: 1 } : _b, \
+             z = _c.z, others = __rest(_a, [\"k\", \"m\"]);"
+        ),
+        "A nested default ahead of an object rest still uses a fresh temp.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn identifier_target_default_reuses_source_temp() {
+    // Negative control: when the binding target is a plain identifier (no nested
+    // pattern to destructure), tsc reuses the source temp for the default check
+    // (`_b = _a.p, p = _b === void 0 ? 5 : _b`). This behavior is unchanged.
+    let source = "function identCtrl({ p = 5 }: any) {}\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output.contains("var _b = _a.p, p = _b === void 0 ? 5 : _b;"),
+        "Identifier-target defaults reuse the source temp (unchanged).\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -66,6 +66,8 @@ mod es5_for_assignment_destructure_temp_order_tests;
 #[cfg(test)]
 mod es5_for_of_destructure_temp_order_tests;
 #[cfg(test)]
+mod es5_param_nested_default_temp_tests;
+#[cfg(test)]
 mod es5_super_recovery_tests;
 #[cfg(test)]
 mod labeled_for_await_tests;


### PR DESCRIPTION
Goal: hold

Closes #14068.

## Structural rule

> When an ES5 function-parameter **object-binding element** has both a **default
> initializer** and a **nested binding-pattern** target, `tsc` materializes a
> *fresh* temp for the default-checked value before destructuring the nested
> pattern (mirroring `ensureIdentifier` after `createDefaultValueCheck`), rather
> than reusing the source temp. tsz reused the source temp, redeclaring it in
> the same `var` statement.

```ts
// --target es5
function g({ a: { x } = { x: 1 } }: any) {}
```

| | output |
|---|---|
| `tsc` 6.0.2 | `var _b = _a.a, _c = _b === void 0 ? { x: 1 } : _b, x = _c.x;` |
| tsz (before) | `var _b = _a.a, _b = _b === void 0 ? { x: 1 } : _b, x = _b.x;` |
| tsz (after) | `var _b = _a.a, _c = _b === void 0 ? { x: 1 } : _b, x = _c.x;` |

The previous output was behaviorally equivalent (the second `_b` reads the
first) but redeclared `_b` in one `var` list and diverged byte-for-byte from
`tsc`. Found by differential testing against `tsc` 6.0.2.

## Owner layer

Emitter only — `crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs`,
`emit_param_object_binding_element`. The **sibling array path**
(`emit_param_array_binding_element`) and the **variable-statement path** already
allocated a fresh default temp, so the divergence was isolated to the parameter
object-pattern path. No semantic/checker change and no output surgery.

The default-check block was identical across the empty-nested, object, and array
parameter paths, so it is hoisted into one `emit_param_nested_default_source`
helper that keys purely on the structural shape (default present + nested
pattern) — never on identifier/property/file-name strings — so it applies to
every binder spelling. The source-access difference (`.prop` vs `[index]`)
correctly stays inline at each call site.

## Adjacent-case matrix (name-agnostic; binder names varied; `--target es5`, byte-equal to `tsc` 6.0.2)

| case | result |
|---|---|
| nested object default `{ a: { x } = { x: 1 } }` | fresh temp `_c`, `x = _c.x` |
| renamed nested `{ src: { v: w } = { v: 0 } }` | fresh temp, `w = _c.v` |
| multiple nested defaults `{ a: {x}=.., b: {y}=.. }` | `_b/_c` then `_d/_e`, sequential |
| nested array default `{ p: [q] = [7] }` | fresh temp, `q = _c[0]` |
| nested default ahead of object rest `{ k, m:{z}=.., ...others }` | fresh temp before `__rest` |
| identifier-target default `{ p = 5 }` (control) | reuses source temp (unchanged) |

## Verification

- New name-agnostic suite `crates/tsz-emitter/src/emitter/source_file/es5_param_nested_default_temp_tests.rs` (6 tests) — pass; verified red on the pre-fix tree (reused-temp form).
- `cargo test -p tsz-emitter --lib` — 3767 pass, 0 fail (no regressions; variable-statement and array destructuring paths byte-unchanged).
- End-to-end CLI differential vs `tsc` 6.0.2 across the matrix above — byte-identical.
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --lib --tests`, `python3 scripts/arch/arch_guard.py` (incl. 2000-line cap) — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: medium


---
_Generated by [Claude Code](https://claude.ai/code/session_0193cgWHKTdaDkRGbHf9p9pY)_