### PR TITLE
fix(website): gate benchmark deploys on app compat readiness

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -84,6 +84,33 @@ jobs:
             echo "should_deploy=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          artifact_ready_for_pages() {
+            local artifact_id="$1"
+            local tmpdir
+            tmpdir="$(mktemp -d)"
+            if ! gh api \
+              "repos/${{ github.repository }}/actions/artifacts/${artifact_id}/zip" \
+              > "${tmpdir}/artifact.zip"; then
+              rm -rf "${tmpdir}"
+              return 1
+            fi
+            if ! unzip -q "${tmpdir}/artifact.zip" -d "${tmpdir}/artifact"; then
+              rm -rf "${tmpdir}"
+              return 1
+            fi
+            if ! jq -e '
+              .application_compatibility.required == true and
+              .application_compatibility.missing == 0 and
+              .application_compatibility.incomplete == 0 and
+              .application_compatibility.duplicates == 0 and
+              .successful_project_timing_pairs >= .required_project_timing_pairs
+            ' "${tmpdir}/artifact/bench-results-readiness.json" >/dev/null; then
+              rm -rf "${tmpdir}"
+              return 1
+            fi
+            rm -rf "${tmpdir}"
+            return 0
+          }
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
             if [ "$WORKFLOW_RUN_CONCLUSION" != "success" ] || \
               [ "$WORKFLOW_RUN_HEAD_BRANCH" != "main" ]; then
@@ -96,9 +123,12 @@ jobs:
                 "repos/${{ github.repository }}/actions/runs/${WORKFLOW_RUN_ID}/artifacts" \
                 --jq '.artifacts[]? | select(.name == "bench-results-merged" and .expired == false) | .id' 2>/dev/null |
                 head -n 1)"
-              if [ -n "$artifact_id" ]; then
-                echo "Bench run ${WORKFLOW_RUN_ID} published bench-results-merged; deploying fresh benchmark data."
+              if [ -n "$artifact_id" ] && artifact_ready_for_pages "$artifact_id"; then
+                echo "Bench run ${WORKFLOW_RUN_ID} published a readiness-clean bench-results-merged artifact; deploying fresh benchmark data."
                 echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+              elif [ -n "$artifact_id" ]; then
+                echo "Bench run ${WORKFLOW_RUN_ID} published bench-results-merged, but readiness failed; skipping benchmark redeploy."
+                echo "should_deploy=false" >> "$GITHUB_OUTPUT"
               else
                 echo "Bench run ${WORKFLOW_RUN_ID} did not publish bench-results-merged; skipping stale benchmark redeploy."
                 echo "should_deploy=false" >> "$GITHUB_OUTPUT"
@@ -209,18 +239,58 @@ jobs:
         run: |
           set -euo pipefail
 
-          artifact_record="$(gh api \
+          artifact_ready_for_pages() {
+            local artifact_id="$1"
+            local tmpdir
+            tmpdir="$(mktemp -d)"
+            if ! gh api \
+              "repos/${{ github.repository }}/actions/artifacts/${artifact_id}/zip" \
+              > "${tmpdir}/artifact.zip"; then
+              rm -rf "${tmpdir}"
+              return 1
+            fi
+            if ! unzip -q "${tmpdir}/artifact.zip" -d "${tmpdir}/artifact"; then
+              rm -rf "${tmpdir}"
+              return 1
+            fi
+            if ! jq -e '
+              .application_compatibility.required == true and
+              .application_compatibility.missing == 0 and
+              .application_compatibility.incomplete == 0 and
+              .application_compatibility.duplicates == 0 and
+              .successful_project_timing_pairs >= .required_project_timing_pairs
+            ' "${tmpdir}/artifact/bench-results-readiness.json" >/dev/null; then
+              rm -rf "${tmpdir}"
+              return 1
+            fi
+            rm -rf "${tmpdir}"
+            return 0
+          }
+
+          RUN_ID=""
+          ARTIFACT_ID=""
+          ARTIFACT_CREATED=""
+          while IFS=$'\t' read -r candidate_run_id candidate_artifact_id candidate_created; do
+            if [[ -z "${candidate_run_id}" || -z "${candidate_artifact_id}" ]]; then
+              continue
+            fi
+            if artifact_ready_for_pages "${candidate_artifact_id}"; then
+              RUN_ID="${candidate_run_id}"
+              ARTIFACT_ID="${candidate_artifact_id}"
+              ARTIFACT_CREATED="${candidate_created}"
+              break
+            fi
+            echo "Skipping benchmark artifact ${candidate_artifact_id} from run ${candidate_run_id}: readiness failed."
+          done < <(gh api \
             "repos/${{ github.repository }}/actions/artifacts?name=bench-results-merged&per_page=20" \
-            --jq '[.artifacts[]? | select(.expired == false and (.workflow_run.head_branch // "") == "main")] | first | if . == null then "" else [.workflow_run.id, .id, .created_at] | @tsv end')"
-          RUN_ID="$(cut -f1 <<<"${artifact_record}")"
-          ARTIFACT_ID="$(cut -f2 <<<"${artifact_record}")"
-          ARTIFACT_CREATED="$(cut -f3 <<<"${artifact_record}")"
+            --jq '.artifacts[]? | select(.expired == false and (.workflow_run.head_branch // "") == "main") | [.workflow_run.id, .id, .created_at] | @tsv')
+
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
           echo "artifact_id=${ARTIFACT_ID}" >> "$GITHUB_OUTPUT"
           if [[ -n "$RUN_ID" ]]; then
-            echo "Latest benchmark merged artifact: run=${RUN_ID} artifact=${ARTIFACT_ID} created=${ARTIFACT_CREATED}"
+            echo "Latest readiness-clean benchmark merged artifact: run=${RUN_ID} artifact=${ARTIFACT_ID} created=${ARTIFACT_CREATED}"
           else
-            echo "No non-expired main benchmark run has a bench-results-merged artifact."
+            echo "No non-expired main benchmark run has a readiness-clean bench-results-merged artifact."
           fi
         continue-on-error: true
 

--- a/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
+++ b/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
@@ -25,8 +25,8 @@ assert.match(
 
 assert.match(
   workflow,
-  /actions\/artifacts\?name=bench-results-merged&per_page=20[\s\S]+workflow_run\.head_branch[\s\S]+Latest benchmark merged artifact/,
-  "Pages deploy should find merged benchmark artifacts directly instead of scanning a small window of successful Bench runs",
+  /actions\/artifacts\?name=bench-results-merged&per_page=20[\s\S]+workflow_run\.head_branch[\s\S]+Latest readiness-clean benchmark merged artifact/,
+  "Pages deploy should find readiness-clean merged benchmark artifacts directly instead of scanning a small window of successful Bench runs",
 );
 
 assert.doesNotMatch(
@@ -39,6 +39,18 @@ assert.match(
   workflow,
   /select\(\.name == "bench-results-merged" and \.expired == false\)/,
   "Pages deploy should require a non-expired merged benchmark artifact",
+);
+
+assert.match(
+  workflow,
+  /artifact_ready_for_pages\(\)[\s\S]+application_compatibility\.required == true[\s\S]+application_compatibility\.missing == 0[\s\S]+application_compatibility\.incomplete == 0[\s\S]+application_compatibility\.duplicates == 0[\s\S]+successful_project_timing_pairs >= \.required_project_timing_pairs/,
+  "Pages deploy should require benchmark readiness JSON with complete application compatibility before using merged artifacts",
+);
+
+assert.match(
+  workflow,
+  /Bench run \$\{WORKFLOW_RUN_ID\} published bench-results-merged, but readiness failed; skipping benchmark redeploy\.[\s\S]+should_deploy=false/,
+  "Bench-triggered Pages deploys must skip diagnostic benchmark artifacts whose readiness gate failed",
 );
 
 assert.match(


### PR DESCRIPTION
Goal: green

## Summary
- Prevent GitHub Pages from deploying diagnostic `bench-results-merged` artifacts whose readiness check failed.
- Require `bench-results-readiness.json` to prove complete application compatibility rows before Bench-triggered deploys or latest-artifact selection use a benchmark artifact.
- Lock the behavior in the gh-pages benchmark artifact gate test.

## Application Row Report
Current CI artifacts from run `27854948762` were inspected for the application group:
- `20/20` application rows available across required + canary compatibility JSONL.
- Green: `infisical-project`.
- Yellow: `umami-project`, `documenso-project`.
- Red/timeouts or crash: `excalidraw-project`, `typebot-project`, `payload-project`, `trigger-dev-project`, `n8n-project`, `affine-project`, `dub-project`, `lobe-chat-project`, `medusa-project`, `joplin-project`, `cal-com-project`, `immich-server-project`, `formbricks-project`, `supabase-studio-project`, `outline-project`, `directus-project`, `rocketchat-project`.

Merging those required/canary compatibility JSONLs into the latest benchmark artifact made readiness report `20/20 present, 0 incomplete`.

## Verification
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `node scripts/bench/test-benchmark-artifact-selection.mjs`
- `node scripts/bench/project-row-summary.mjs --json >/tmp/project-row-summary.json`
- `git diff --check HEAD~1..HEAD`
- Inspected latest diagnostic merged benchmark artifact `27852463818`: application compatibility was `0/20 present` and readiness failed.
- Inspected CI compatibility artifacts from `27854948762` and merged them locally with `scripts/bench/merge-results.mjs`; readiness passed with `20/20 present, 0 incomplete`.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
