### PR TITLE
fix(module-resolution): resolve `node:` protocol builtins like tsc

### DIFF
--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -716,7 +716,15 @@ impl ModuleResolver {
         let is_ordinary_bare = !specifier.starts_with('.')
             && !specifier.starts_with('/')
             && (!specifier.contains(':') || specifier.starts_with("node:"));
-        let ambient_match = is_ordinary_bare && is_ambient_module(specifier);
+        // A `node:` builtin specifier (e.g. `node:fs`, `node:stream/promises`)
+        // resolves like its scheme-less form: tsc strips the `node:` scheme and
+        // resolves the remainder against the Node typings (`@types/node`, which
+        // declares each builtin as an ambient module / package subpath).
+        let node_builtin: Option<&str> = specifier
+            .strip_prefix("node:")
+            .filter(|stripped| !stripped.is_empty());
+        let ambient_match = is_ordinary_bare
+            && (is_ambient_module(specifier) || node_builtin.is_some_and(&is_ambient_module));
         let containing_is_declaration =
             ModuleExtension::from_path(containing_file).is_declaration();
         if self.trace_resolution {
@@ -760,14 +768,31 @@ impl ModuleResolver {
             request.resolution_mode_override,
         );
 
-        // 1. Try primary resolution
-        match self.resolve_with_kind_and_module_kind(
+        // 1. Try primary resolution. A `node:` builtin that does not resolve
+        // under its full specifier retries with the scheme stripped, matching
+        // tsc's resolution of Node builtins through `@types/node`.
+        let mut primary_resolution = self.resolve_with_kind_and_module_kind(
             specifier,
             containing_file,
             span,
             import_kind,
             request.resolution_mode_override,
-        ) {
+        );
+        if primary_resolution.is_err()
+            && let Some(stripped) = node_builtin
+        {
+            let stripped_resolution = self.resolve_with_kind_and_module_kind(
+                stripped,
+                containing_file,
+                span,
+                import_kind,
+                request.resolution_mode_override,
+            );
+            if stripped_resolution.is_ok() {
+                primary_resolution = stripped_resolution;
+            }
+        }
+        match primary_resolution {
             Ok(resolved_module) => {
                 if self.trace_resolution {
                     println!(

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -18,6 +18,7 @@ mod lookup_integration;
 mod mixed_esm_cjs_exports;
 mod module_extension;
 mod node16_modes;
+mod node_protocol_builtins;
 mod package_exports_imports;
 mod package_json_data;
 mod path_existence_reset;

--- a/crates/tsz-core/src/module_resolver/tests/node_protocol_builtins.rs
+++ b/crates/tsz-core/src/module_resolver/tests/node_protocol_builtins.rs
@@ -1,0 +1,169 @@
+//! `node:` protocol builtin resolution for `module_resolver`.
+//!
+//! `tsc` resolves a `node:`-scheme specifier (e.g. `node:fs`,
+//! `node:stream/promises`) by stripping the scheme and resolving the remainder
+//! against the Node typings (`@types/node`), which declares each builtin as an
+//! ambient module / package subpath. tsz previously treated `node:foo` as an
+//! ordinary bare specifier, walked `node_modules` for a package literally named
+//! `node:foo`, and emitted a false TS2307. These tests pin the strip-and-resolve
+//! behavior (issue #13826, sub-root #1) without over-resolving non-builtins.
+
+use super::super::*;
+
+fn node_resolver() -> ModuleResolver {
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node),
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    };
+    ModuleResolver::new(&options)
+}
+
+fn request_for<'a>(
+    specifier: &'a str,
+    containing_file: &'a std::path::Path,
+) -> ModuleLookupRequest<'a> {
+    ModuleLookupRequest {
+        specifier,
+        containing_file,
+        specifier_span: Span::new(0, specifier.len() as u32),
+        import_kind: ImportKind::EsmImport,
+        resolution_mode_override: None,
+        no_implicit_any: false,
+        implied_classic_resolution: false,
+    }
+}
+
+/// `node:stream/promises` resolves when the Node typings declare the
+/// scheme-less ambient module `stream/promises` (the common `@types/node`
+/// shape). The scheme is stripped before the ambient lookup.
+#[test]
+fn node_scheme_resolves_via_scheme_less_ambient() {
+    let mut resolver = node_resolver();
+    let containing = std::path::Path::new("/proj/src/index.ts");
+    let request = request_for("node:stream/promises", containing);
+
+    let result = resolver.lookup(
+        &request,
+        |_, _| None,
+        |spec| spec == "stream/promises",
+        None,
+    );
+
+    assert!(
+        result.treat_as_resolved,
+        "`node:stream/promises` must resolve through the scheme-less ambient module"
+    );
+    assert!(result.error.is_none(), "resolution should not emit TS2307");
+}
+
+/// A `node:`-prefixed ambient (the shape newer `@types/node` also ships,
+/// `declare module "node:fs"`) still resolves — the raw specifier is tried
+/// before the stripped form.
+#[test]
+fn node_scheme_resolves_via_scheme_prefixed_ambient() {
+    let mut resolver = node_resolver();
+    let containing = std::path::Path::new("/proj/src/index.ts");
+    let request = request_for("node:fs", containing);
+
+    let result = resolver.lookup(&request, |_, _| None, |spec| spec == "node:fs", None);
+
+    assert!(
+        result.treat_as_resolved,
+        "`node:fs` must resolve through a `node:`-prefixed ambient module"
+    );
+    assert!(result.error.is_none(), "resolution should not emit TS2307");
+}
+
+/// The bare builtin name `assert/strict` and its `node:` form resolve the same
+/// way — the fix is name-agnostic across builtins and subpaths.
+#[test]
+fn node_scheme_is_name_agnostic_across_builtins() {
+    for (specifier, ambient) in [
+        ("node:assert/strict", "assert/strict"),
+        ("node:test", "test"),
+        ("node:worker_threads", "worker_threads"),
+    ] {
+        let mut resolver = node_resolver();
+        let containing = std::path::Path::new("/proj/src/index.ts");
+        let request = request_for(specifier, containing);
+        let result = resolver.lookup(&request, |_, _| None, |spec| spec == ambient, None);
+        assert!(
+            result.treat_as_resolved,
+            "`{specifier}` should resolve via the scheme-less ambient `{ambient}`"
+        );
+        assert!(
+            result.error.is_none(),
+            "`{specifier}` should not emit TS2307"
+        );
+    }
+}
+
+/// When the scheme-less name is an installed package on disk (e.g. a builtin
+/// polyfill or the `@types/node`-provided typings that ship a resolvable
+/// package), the `node:` specifier resolves to that file via the strip-retry,
+/// without any ambient declaration.
+#[test]
+fn node_scheme_resolves_via_installed_package_on_disk() {
+    use std::fs;
+    let dir = std::env::temp_dir().join("tsz_node_proto_installed_pkg");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(dir.join("node_modules/events")).unwrap();
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::write(
+        dir.join("node_modules/events/package.json"),
+        r#"{"name":"events","version":"1.0.0","types":"index.d.ts"}"#,
+    )
+    .unwrap();
+    fs::write(
+        dir.join("node_modules/events/index.d.ts"),
+        "export class EventEmitter {}\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("src/index.ts"),
+        "import { EventEmitter } from 'node:events';",
+    )
+    .unwrap();
+
+    let mut resolver = node_resolver();
+    let containing = dir.join("src/index.ts");
+    let request = request_for("node:events", &containing);
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+
+    assert!(
+        result
+            .resolved_path
+            .as_ref()
+            .is_some_and(|p| p.ends_with("index.d.ts")),
+        "`node:events` should resolve to the installed `events` package; got {:?}",
+        result.resolved_path
+    );
+    assert!(result.error.is_none(), "resolution should not emit TS2307");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// A `node:` specifier whose scheme-less form is not a known module still
+/// fails — the fix only adds the strip-retry, it does not invent modules. The
+/// emitted TS2307 keeps the original `node:`-scheme spelling.
+#[test]
+fn unknown_node_scheme_specifier_still_reports_ts2307() {
+    let mut resolver = node_resolver();
+    let containing = std::path::Path::new("/proj/src/index.ts");
+    let request = request_for("node:totally-not-a-builtin", containing);
+
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+
+    assert!(
+        !result.treat_as_resolved,
+        "an unknown `node:` specifier must not be treated as resolved"
+    );
+    let error = result.error.expect("should emit a resolution error");
+    assert_eq!(error.code, CANNOT_FIND_MODULE);
+    assert!(
+        error.message.contains("node:totally-not-a-builtin"),
+        "the diagnostic should keep the original `node:` spelling; got: {}",
+        error.message
+    );
+}


### PR DESCRIPTION
Goal: grow

Refs #13826 (sub-root #1 — `node:` protocol builtins). Does not close the umbrella; the `exports`/subpath and bare/workspace sub-roots stay tracked there.

## Structural rule

> A `node:`-scheme module specifier (`node:fs`, `node:stream/promises`, `node:assert/strict`, …) resolves the same way as its scheme-less form: `tsc` strips the `node:` scheme and resolves the remainder against the Node typings (`@types/node`), which declares each builtin as an ambient module / resolvable package. tsz instead treated `node:foo` as an ordinary bare specifier, walked `node_modules` for a package literally named `node:foo`, found nothing, and emitted a false **TS2307**.

```ts
import { finished } from "node:stream/promises"; // tsc: ok (via @types/node)   tsz (before): TS2307
```

Each unresolved specifier degrades the importing symbol to `error`, seeding downstream false positives, so this also inflates the yellow FP counts on the affected canary rows (trpc, …).

## Owner layer

Module resolver only — `crates/tsz-core/src/module_resolver/mod.rs` (`ModuleResolver::lookup`). For any `node:`-prefixed specifier the resolver now:

- matches an ambient declaration under **either** the raw `node:`-prefixed name (newer `@types/node`, which ships `declare module "node:fs"`) **or** the scheme-less name (the common `@types/node` shape, `declare module "fs"`); and
- retries filesystem resolution with the scheme stripped when the full specifier does not resolve.

The decision keys purely on the `node:` URL scheme — **no builtin-name allowlist, no identifier/file-name string predicate** — so it applies to every builtin and subpath spelling. The change is strictly additive: it only resolves `node:` specifiers that previously failed, and an unknown `node:` specifier still reports TS2307 with its original `node:` spelling.

## Adjacent-case matrix (name-agnostic; binder/builtin names varied)

| case | result |
|---|---|
| `node:stream/promises` with scheme-less ambient `stream/promises` | ✓ resolved |
| `node:fs` with `node:`-prefixed ambient `node:fs` | ✓ resolved |
| `node:assert/strict` / `node:test` / `node:worker_threads` (subpaths + bare) | ✓ resolved |
| `node:events` resolving to an installed `events` package on disk (strip-retry) | ✓ resolved to file |
| `node:totally-not-a-builtin` (no ambient, no package) | TS2307, original `node:` spelling preserved |

## Verification

- New name-agnostic suite `crates/tsz-core/src/module_resolver/tests/node_protocol_builtins.rs` (5 tests: scheme-less ambient, `node:`-prefixed ambient, multi-builtin name-agnostic, installed-package strip-retry, unknown-specifier TS2307) — pass; verified the strip cases fail on the pre-fix tree (TS2307).
- `cargo test -p tsz-core --lib module_resolver::` — **263 passed, 0 failed** (no regressions across the resolver suite).
- `cargo clippy -p tsz-core --lib`, `cargo fmt -p tsz-core --check`, `python3 scripts/arch/arch_guard.py` (incl. 2000-line cap) — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_019DFckTdbhRk8Wa8PA9cn9r

---
_Generated by [Claude Code](https://claude.ai/code/session_019DFckTdbhRk8Wa8PA9cn9r)_