### PR TITLE
test(checker): correct deeplyNestedMappedTypes same-base bailout to tsc parity

### DIFF
--- a/crates/tsz-checker/tests/deeply_nested_mapped_types_tests.rs
+++ b/crates/tsz-checker/tests/deeply_nested_mapped_types_tests.rs
@@ -700,7 +700,7 @@ function g(items: Lhs[]): Rhs[] { return items; }
 }
 
 // ============================================================================
-// Same-base recursive-conditional false-negative witnesses (#8432)
+// Same-base recursive-conditional deep-nesting parity guards (#8432)
 //
 // `deeplyNestedMappedTypes.ts` includes a `NestedRecord` family:
 //
@@ -709,32 +709,29 @@ function g(items: Lhs[]): Rhs[] { return items; }
 //             ? { [P in K0]: NestedRecord<KR, V> }
 //             : Record<K, V>;
 //
-// `tsc` reports the `const bar2: Bar2 = bar1` assignment (a number-valued nested
-// record assigned to a string-valued one) as `TS2322`. tsz reproduces the error
-// only while the dotted key path is shallow; once the path reaches four
-// segments AND both operands are applications of the *same* recursive
-// conditional alias (differing only in the non-recursion-driving payload type
-// argument `V`), tsz silently accepts the assignment.
+// The conformance file marks `const bar2: Bar2 = bar1` (a `number`-valued nested
+// record assigned to a `string`-valued one, with a 6-segment path) `// Error
+// expected`, but `tsc`'s authoritative baseline emits NO error there. The file's
+// own source comment explains why: "object types produced by `NestedRecord` all
+// have the same symbol and thus are considered deeply nested after three levels
+// of nesting. Ideally we'd detect that recursion in this type always terminates,
+// but we're unaware of a general algorithm that accomplishes this." This is
+// `tsc`'s `isDeeplyNestedType` bailout (`getRecursionIdentity`, `maxDepth == 3`):
+// once three stack entries share the recursive alias's recursion identity, the
+// relation assumes `Ternary.Maybe` (related) and the genuine leaf mismatch is
+// never reached — a deliberate, documented `tsc` limitation, not a `tsz` bug to
+// patch away from (parity overrides convenience).
 //
-// Root cause (traced, deterministic): both operands evaluate correctly to
-// distinct structural nested objects, but the assignment relation between them
-// resolves a `Lazy(DefId)` whose body is unregistered in the relation-internal
-// resolver (`resolver_generation() == 0`; `resolve_lazy_type` ->
-// `note_lazy_resolve_failure`). The `False` derived from the genuine leaf
-// mismatch (`number` vs `string`) is then treated as undetermined and the
-// `TS2322` is suppressed. This is the resolver-availability-under-relation
-// family (#13232) and the latent-soundness hazard documented in #13980 — the
-// same root behind the #13609 `ApplyDefaultOptions`/`RequiredKeysOf`
-// false-positive family. The fix belongs in the solver/checker relation layer
-// (thread the def-resolving resolver into the relation-internal evaluator), not
-// in the recursive alias itself; these witnesses pin the minimal, deterministic,
-// name-agnostic shape so the eventual fix can be verified.
+// tsz matches that bailout structurally via
+// `recursive_conditional_path_alias_mismatch_is_tsc_bailout`: two same-base
+// conditional-alias applications that share a string-literal key argument whose
+// path is deep enough (>= 3 dots == >= 4 segments == the third recursive level,
+// matching `tsc`'s `maxDepth == 3`) suppress the diagnostic. Shallower paths and
+// distinct alias bases reach the leaf and must still report `TS2322`.
 //
 // An inline `Leaf<K, V> = { [P in K]: V }` stands in for the conformance test's
-// `Record<K, V>` base case so the witnesses stay lib-free. The two positive
-// guards reproduce the correct `TS2322` today and protect against the fix being
-// scoped too narrowly (e.g. a witness-shaped patch keyed on a single depth or
-// alias name).
+// `Record<K, V>` base case so the witnesses stay lib-free. Binder names are
+// varied so the result is structural, not keyed on any identifier.
 // ============================================================================
 
 /// Positive guard: at a shallow (3-segment) dotted key path the same-base
@@ -781,14 +778,18 @@ const dst: Trail<"x.y.z.w", string> = src;
     );
 }
 
-/// Witness (#8432, resolver-availability family #13232/#13980): at a deep
-/// (4-segment) path with both operands sharing the *same* recursive-conditional
-/// alias base, tsz silently accepts a `number`-valued nested record assigned to
-/// a `string`-valued one. `tsc` reports `TS2322`. Ignored until the
-/// relation-internal resolver-availability fix lands; remove `#[ignore]` then.
+/// Parity guard (#8432): at a deep (4-segment, third recursive level) path with
+/// both operands sharing the *same* recursive-conditional alias base, `tsc`'s
+/// `isDeeplyNestedType` bailout (`maxDepth == 3`) assumes the relation related
+/// and emits NO diagnostic — exactly the documented `NestedRecord`/`bar2`
+/// limitation whose `tsc` baseline carries no error despite the file's
+/// `// Error expected` comment. tsz must match that bailout (no spurious
+/// `TS2322`), which it does via
+/// `recursive_conditional_path_alias_mismatch_is_tsc_bailout`. Reporting an
+/// error here would diverge from `tsc` (parity overrides convenience); this
+/// guard pins the no-error behavior so a future change cannot regress it.
 #[test]
-#[ignore = "#8432: same-base deep recursive-conditional assignment relation suppresses the genuine TS2322 (resolver-availability-under-relation, #13232/#13980)"]
-fn nested_record_deep_same_base_recursive_conditional_false_negative() {
+fn nested_record_deep_same_base_recursive_conditional_matches_tsc_bailout() {
     let source = r#"
 type Leaf<K extends string, V> = { [P in K]: V };
 type Tree<K extends string, V> = K extends `${infer Head}.${infer Tail}`
@@ -799,7 +800,27 @@ const sink: Tree<"x.y.z.w", string> = leaf;
 "#;
     let codes = check(source);
     assert!(
-        codes.contains(&2322),
-        "deep same-base recursive-conditional number->string nested record must error (tsc: TS2322): {codes:?}"
+        !codes.contains(&2322),
+        "deep same-base recursive-conditional must hit tsc's isDeeplyNestedType bailout (no TS2322, matching tsc): {codes:?}"
+    );
+}
+
+/// Anti-hardcoding companion: the bailout keys on the structural recursion
+/// depth, not on the alias/key spelling. A renamed alias and a different (but
+/// equally deep, >= 3-dot) key path must take the same no-error bailout.
+#[test]
+fn nested_record_deep_same_base_recursive_conditional_bailout_is_name_agnostic() {
+    let source = r#"
+type Cell<S extends string, W> = { [Q in S]: W };
+type Branch<S extends string, W> = S extends `${infer First}.${infer Rest}`
+    ? { [Q in First]: Branch<Rest, W> }
+    : Cell<S, W>;
+declare const node: Branch<"alpha.beta.gamma.delta", number>;
+const slot: Branch<"alpha.beta.gamma.delta", string> = node;
+"#;
+    let codes = check(source);
+    assert!(
+        !codes.contains(&2322),
+        "renamed deep same-base recursive-conditional must take the same tsc bailout (no TS2322): {codes:?}"
     );
 }


### PR DESCRIPTION
Goal: hold

Refs #8432 (`deeplyNestedMappedTypes.ts` / mapped-keyof-inference parity family). Does not claim or close the umbrella.

## Structural rule

> When two applications of the **same** recursive conditional alias differ only in a non-recursion-driving type argument, and the shared recursion-driving key argument is deep enough that three stack entries share the alias's recursion identity, `tsc`'s `isDeeplyNestedType` bailout (`getRecursionIdentity`, `maxDepth == 3`) assumes the relation related (`Ternary.Maybe`) and never reaches the leaf mismatch — so `tsc` emits **no** diagnostic. tsz must match that bailout (no spurious `TS2322`); reporting an error would diverge from `tsc`.

## What was wrong

`crates/tsz-checker/tests/deeply_nested_mapped_types_tests.rs` carried an `#[ignore]`d "false-negative witness" (`nested_record_deep_same_base_recursive_conditional_false_negative`) asserting that `tsc` reports `TS2322` for

```ts
type Leaf<K extends string, V> = { [P in K]: V };
type Tree<K extends string, V> = K extends `${infer Head}.${infer Tail}`
    ? { [P in Head]: Tree<Tail, V> } : Leaf<K, V>;
declare const leaf: Tree<"x.y.z.w", number>;
const sink: Tree<"x.y.z.w", string> = leaf; // claimed: tsc TS2322
```

That claim is false. Verified against `tsc`'s authoritative baseline for `deeplyNestedMappedTypes.ts`: the `NestedRecord`/`bar2` case (a 6-segment same-base recursive conditional, `number` vs `string`) is marked `// Error expected` in the source but the `.errors.txt` baseline carries **no** diagnostic for it (the baseline jumps straight from `bar2` to the next section). The conformance file's own source comment documents why:

> object types produced by `NestedRecord` all have the same symbol and thus are considered deeply nested after three levels of nesting. Ideally we'd detect that recursion in this type always terminates, but we're unaware of a general algorithm that accomplishes this.

So the no-error behavior is a deliberate, documented `tsc` limitation — not a `tsz` bug. Per the parity discipline ("if an observed behavior is a definite `tsc` bug, do not patch away from parity"), tsz's existing suppression (`recursive_conditional_path_alias_mismatch_is_tsc_bailout`, which fires at `>= 3` dots `== >= 4` segments `==` the third recursive level, mirroring `tsc`'s `maxDepth == 3`) is **correct**. The ignored test and its preceding comment block asserted the opposite, and would have led a future change to make tsz report an error `tsc` does not — which also adds an extra diagnostic over the conformance baseline.

## Change (test-only; no compiler/source change)

- Convert the ignored false-negative witness into an enabled parity guard `nested_record_deep_same_base_recursive_conditional_matches_tsc_bailout` asserting **no** `TS2322`.
- Add a name-agnostic companion (`..._bailout_is_name_agnostic`, renamed alias `Branch`/`Cell` and a different 4-dot key path) proving the bailout is structural, not keyed on the `Tree`/`Leaf`/`.`-spelling.
- Rewrite the preceding comment block to describe `tsc`'s actual `isDeeplyNestedType` deep-nesting bailout and how tsz matches it, replacing the prior (incorrect) "resolver-availability false-negative" narrative.

The two existing positive guards are unchanged and still pass: shallow (3-segment, 2 recursive levels) same-base **does** error, and deep different-base **does** error — both reach the leaf because neither hits the `maxDepth == 3` recursion-identity bailout.

## Scope note

This corrects a mischaracterized parity guard; it does **not** remove the `deeplyNestedMappedTypes.ts` accepted-regression. With the bundled lib, tsz already produces the correct five `TS2322` errors at the right locations (`foo2`/`foo4`/`problematicFunction1..3`) and correctly suppresses `bar2`; the row's residual is the TypeBox `Static`/`PropertiesReduce` reducer being left unresolved in the `problematicFunction1`/`problematicFunction3` diagnostic **message** under the full pinned lib (a message-text fingerprint divergence), which is tracked separately and out of scope here.

## Verification

- `cargo test -p tsz-checker --test deeply_nested_mapped_types_tests` — **19 passed, 0 failed, 0 ignored** (was 18 + 1 ignored). The corrected test was verified red on the pre-fix expectation (it previously asserted `TS2322`) and is green asserting parity.
- `cargo fmt -p tsz-checker --check` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- Broad conformance/emit/fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01ViXXnTCqYkttdjFddQciEX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViXXnTCqYkttdjFddQciEX)_