### PR TITLE
fix(checker): treat as/&lt;T&gt; type-assertion arguments as non-fresh in literal elaboration

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -60,6 +60,9 @@ path = "tests/const_assertion_tests.rs"
 name = "freshness_stripping_tests"
 path = "tests/freshness_stripping_tests.rs"
 [[test]]
+name = "assertion_freshness_elaboration_tests"
+path = "tests/assertion_freshness_elaboration_tests.rs"
+[[test]]
 name = "any_user_predicate_keeps_any_for_object_function_tests"
 path = "tests/any_user_predicate_keeps_any_for_object_function_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -585,6 +585,22 @@ impl<'a> CheckerState<'a> {
     ) -> bool {
         use tsz_parser::parser::syntax_kind_ext;
 
+        // A plain `expr as T` / `<T>expr` assertion (not `as const`, not
+        // `satisfies`) yields the asserted, *non-fresh* type `T`. Per-property /
+        // excess elaboration applies only to fresh object/array literals, so
+        // descending into the assertion operand below (`skip_parenthesized_and_assertions`
+        // strips the assertion and re-derives a fresh inner-literal type) would
+        // manufacture diagnostics `tsc` never reports: TS2353 instead of the
+        // weak-type TS2559, or a per-property TS2322 instead of the argument-level
+        // TS2345 with its structural chain. Returning `false` defers to the
+        // caller's argument/assignment-level report. `satisfies` and `as const`
+        // preserve freshness (excluded by the predicate) and still elaborate.
+        // Matches `tsc`'s `getRegularTypeOfObjectLiteral` / `elaborateError`
+        // boundary (the latter descends through parens but not assertions).
+        if self.expression_is_plain_type_assertion(source_idx) {
+            return false;
+        }
+
         let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(source_idx);
         if let Some(node) = self.ctx.arena.get(expr_idx)
             && node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION

--- a/crates/tsz-checker/src/tests/dispatch_tests/part_01.rs
+++ b/crates/tsz-checker/src/tests/dispatch_tests/part_01.rs
@@ -1663,6 +1663,13 @@ fn satisfies_array_literal_elaborates_per_element() {
     // the offending `"20"` element with `Type 'string' is not assignable to
     // type 'number'.`, matching its `elaborateElementwise` behavior.
     //
+    // tsc's `elaborateError` descends through *parenthesized* operands but NOT
+    // through `as` / `<T>` type assertions (its switch handles only
+    // ParenthesizedExpression / ObjectLiteral / ArrayLiteral / ArrowFunction).
+    // So a parenthesized array source still elaborates per-element, but an
+    // `as`-asserted source yields the asserted (non-fresh) type and reports the
+    // top-level TS1360 with the relation's own structural chain instead.
+    //
     // Iteration variable / property names are deliberately varied across
     // assertions to avoid fingerprinting a specific spelling — the rule is
     // structural over array literal sources, not over specific identifiers.
@@ -1678,22 +1685,29 @@ take(10, ...(([1, "asserted"] as (number | string)[]) satisfies number[]));
 
     // First satisfies has one bad element: "20" (string).
     // Second satisfies has one bad element: "x" (string).
-    // The wrapped cases prove source unwrapping reaches the same array-literal
-    // element path for parenthesized and asserted array sources.
-    // Each source should emit TS2322 at the bad element, NOT TS1360 on the whole satisfies.
+    // Third (parenthesized) source also reaches the array-literal element path.
+    // The fourth source is an `as`-assertion: tsc reports a top-level TS1360
+    // (not per-element), because `elaborateError` does not descend through `as`.
     let ts2322 = diagnostics_with_code(&diags, 2322);
     let ts1360 = diagnostics_with_code(&diags, 1360);
 
     assert_eq!(
         ts1360.len(),
-        0,
-        "Expected NO TS1360 generic-satisfies error; expected per-element TS2322 instead, got TS1360s: {:?}",
+        1,
+        "Expected exactly one TS1360 (the `as`-asserted source reports top-level), got: {:?}",
         diagnostic_messages(&ts1360)
+    );
+    assert!(
+        ts1360[0]
+            .message_text
+            .contains("does not satisfy the expected type 'number[]'"),
+        "Expected TS1360 to name the satisfies target, got: {}",
+        ts1360[0].message_text
     );
     assert_eq!(
         ts2322.len(),
-        4,
-        "Expected exactly 4 TS2322 elaborations (one per bad element), got: {:?}",
+        3,
+        "Expected exactly 3 per-element TS2322 elaborations (the non-asserted sources), got: {:?}",
         diagnostic_messages(&ts2322)
     );
     for diag in &ts2322 {

--- a/crates/tsz-checker/tests/assertion_freshness_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/assertion_freshness_elaboration_tests.rs
@@ -1,0 +1,152 @@
+//! Freshness through a type assertion (`as T` / `<T>expr`) — refs #13942 / #8432.
+//!
+//! A plain `expr as T` / `<T>expr` assertion yields the asserted (non-fresh)
+//! type `T`. `tsc`'s `elaborateError` descends through *parenthesized* operands
+//! but NOT through `as` / `<T>` type assertions, so fresh-literal elaboration
+//! (per-property `TS2322` and excess-property `TS2353`) never runs on an
+//! assertion operand. A non-fresh asserted source instead surfaces the
+//! argument/assignment-level report: the weak-type `TS2559`, or the
+//! argument-level `TS2345` with the relation's own structural elaboration
+//! chain. `satisfies` and `as const` preserve freshness, so they still
+//! elaborate per-element/property.
+//!
+//! Binder, parameter, and property names are varied across cases so the rule is
+//! structural over the assertion shape, not keyed on any spelling
+//! (anti-hardcoding).
+
+use tsz_checker::test_utils::{check_source_diagnostics, diagnostic_codes};
+
+#[test]
+fn weak_target_assertion_arg_reports_ts2559_not_ts2353() {
+    // `{ gamma: 5 } as { gamma: number }` passed to a weak parameter
+    // (all-optional) has no common properties: `tsc` reports the weak-type
+    // TS2559, never the fresh-literal excess TS2353. (Regression: tsz descended
+    // through the `as` into the inner fresh literal and emitted TS2353.)
+    let diags = check_source_diagnostics(
+        r#"
+interface Settings { alpha?: number; beta?: string }
+declare function configure(opts: Settings): void;
+configure({ gamma: 5 } as { gamma: number });
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2559),
+        "Expected weak-type TS2559, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !diags.iter().any(|d| d.code == 2353),
+        "Did not expect fresh-literal excess TS2353 for an `as`-asserted source, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn weak_target_assertion_spellings_all_report_ts2559() {
+    // Every plain-assertion spelling strips freshness: angle-bracket, a double
+    // `as ... as ...`, and a parenthesized `as`. None should excess-check.
+    for (label, source) in [
+        (
+            "angle",
+            r#"
+interface Prefs { one?: number; two?: string }
+declare function apply(p: Prefs): void;
+apply(<{ three: number }>{ three: 9 });
+"#,
+        ),
+        (
+            "double_as",
+            r#"
+interface Opts { aa?: number; bb?: string }
+declare function run(o: Opts): void;
+run({ zz: 1 } as any as { zz: number });
+"#,
+        ),
+        (
+            "paren_as",
+            r#"
+interface Conf { p?: number; q?: string }
+declare function init(c: Conf): void;
+init(({ r: 2 } as { r: number }));
+"#,
+        ),
+    ] {
+        let diags = check_source_diagnostics(source);
+        assert!(
+            diags.iter().any(|d| d.code == 2559) && !diags.iter().any(|d| d.code == 2353),
+            "[{label}] expected TS2559 and no TS2353, got: {:?}",
+            diagnostic_codes(&diags)
+        );
+    }
+}
+
+#[test]
+fn fresh_and_freshness_preserving_forms_still_excess_check() {
+    // A bare fresh literal, `satisfies`, and `as const` all keep freshness, so
+    // the excess check (TS2353) still fires — proving the assertion fix is
+    // narrowly scoped to freshness-stripping `as` / `<T>` assertions. These
+    // three cases share one binder spelling and vary only the wrapper form, so
+    // the preamble is factored out (name-variation across the sibling tests
+    // already covers the anti-hardcoding requirement).
+    let preamble = "interface Settings { alpha?: number; beta?: string }\n\
+                    declare function configure(opts: Settings): void;\n";
+    for (label, call) in [
+        ("fresh", "configure({ gamma: 5 });"),
+        (
+            "satisfies",
+            "configure({ gamma: 5 } satisfies { gamma: number });",
+        ),
+        ("as_const", "configure({ gamma: 5 } as const);"),
+    ] {
+        let diags = check_source_diagnostics(&format!("{preamble}{call}"));
+        assert!(
+            diags.iter().any(|d| d.code == 2353),
+            "[{label}] expected fresh-literal excess TS2353, got: {:?}",
+            diagnostic_codes(&diags)
+        );
+    }
+}
+
+#[test]
+fn property_mismatch_assertion_arg_reports_argument_level_not_per_property() {
+    // `{ key: "x" } as { key: string }` to a parameter whose `key` is numeric:
+    // the asserted source is non-fresh, so `tsc` reports the argument-level
+    // TS2345 (with a nested "Types of property" chain), not a per-property
+    // TS2322.
+    let asserted = check_source_diagnostics(
+        r#"
+interface Holder { key?: number; note?: string }
+declare function accept(h: Holder): void;
+accept({ key: "x" } as { key: string });
+"#,
+    );
+    assert!(
+        asserted.iter().any(|d| d.code == 2345),
+        "Expected argument-level TS2345 for an `as`-asserted property mismatch, got: {:?}",
+        asserted
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+
+    // A fresh literal in the same position still elaborates to per-property
+    // TS2322; the assertion form must not.
+    let fresh = check_source_diagnostics(
+        r#"
+interface Holder { key?: number; note?: string }
+declare function accept(h: Holder): void;
+accept({ key: "x" });
+"#,
+    );
+    assert!(
+        fresh.iter().any(|d| d.code == 2322),
+        "Expected fresh literal to still elaborate per-property TS2322, got: {:?}",
+        diagnostic_codes(&fresh)
+    );
+}


### PR DESCRIPTION
Goal: hold

Refs #8432 (conformance parity floor — object-literal freshness / excess / weak-type family). Surfaced while triaging #13942. Does not close either umbrella.

## Structural rule

> When a call argument / assignment source / return expression is a **plain
> type assertion** (`expr as T` or `<T>expr`, **not** `as const`, **not**
> `satisfies`), its value is the asserted, **non-fresh** type `T`. `tsc`'s
> `elaborateError` descends through *parenthesized* operands but **not** through
> `as` / `<T>` assertions, so fresh-literal elaboration — per-property `TS2322`
> and excess-property `TS2353` — never runs on an assertion operand. The
> argument/assignment-level relation report is authoritative instead.

tsz's `try_elaborate_assignment_source_error_with_options` called
`skip_parenthesized_and_assertions`, **stripping the assertion** to reach the
inner object/array literal and then re-deriving a *fresh* inner-literal type via
`get_type_of_node`. The assertion node's own (correctly non-fresh) type was
discarded, so fresh-literal elaboration manufactured diagnostics `tsc` never
emits.

```ts
interface Options { a?: number; b?: string }   // weak (all-optional) target
declare function g(o: Options): void;

g({ z: 5 } as { z: number });        // tsc: TS2559   tsz before: TS2353  ❌
g({ a: "x" } as { a: string });      // tsc: TS2345   tsz before: TS2322  ❌
```

The variable-assignment path already reported these correctly (the `as`
expression's type is non-fresh) — the divergence was isolated to the
literal-elaboration descent. Found by differential testing against `tsc` 6.0.2
(`--noEmit --strict`).

## Owner layer

Checker error-reporter / diagnostic elaboration —
`crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs`,
`try_elaborate_assignment_source_error_with_options`. A single guard skips the
inner-literal elaboration when the source is a plain type assertion, deferring
to the caller's argument/assignment-level report (which carries the relation's
own structural chain). This is the **single chokepoint** for object/array
per-property/excess elaboration across the call-argument, assignment, and return
paths, so one guard covers the whole family. No semantic/relation change, no
output surgery.

It reuses the existing `expression_is_plain_type_assertion` predicate (which
already excludes `as const` and `satisfies`); the decision keys purely on the
assertion shape — never on identifier / property / file-name strings — so it
applies to every binder spelling.

## Adjacent-case matrix (all byte-equal to `tsc` 6.0.2, `--strict`)

| case | tsc | tsz after |
|---|---|---|
| weak target, `{ k } as { k }` | TS2559 | ✓ |
| weak target, `<{ k }>{ k }` (angle) | TS2559 | ✓ |
| weak target, `({ k } as { k })` (paren-wrapped) | TS2559 | ✓ |
| weak target, `{ k } as any as { k }` (double) | TS2559 | ✓ |
| property mismatch `{ a:"x" } as { a:string }` | TS2345 (arg-level + chain) | ✓ |
| excess + mismatch `as` | TS2345 | ✓ |
| **fresh** literal (no assertion) | TS2353 / TS2322 | unchanged ✓ |
| `satisfies` (freshness preserved) | TS2353 | unchanged ✓ |
| `as const` (freshness preserved) | TS2353 | unchanged ✓ |
| array `[...] as [...]` element mismatch | arg-level TS2345 | ✓ |
| satisfies over an `as`-asserted array operand | top-level TS1360 | ✓ |

## Verification

- New name-agnostic suite `crates/tsz-checker/tests/assertion_freshness_elaboration_tests.rs` (4 tests; binder/parameter/property names varied) — pass; verified red on the pre-fix tree.
- Updated `dispatch_tests::part_01::satisfies_array_literal_elaborates_per_element` to `tsc`'s true behavior: a `satisfies` over an `as`-asserted operand reports a top-level TS1360, not per-element TS2322 (`elaborateError` does not descend through `as`). The prior expectation encoded a pre-existing tsz divergence the fix corrects.
- Full `cargo test -p tsz-checker --lib` diffed pre/post: **zero new deterministic failures** (the single run-to-run delta is a pre-existing flaky cross-arena module-augmentation test that passes 3/3 in isolation; the ~73 other failures are pre-existing lib-environment cases present on `main`).
- End-to-end CLI differential vs `tsc` 6.0.2 across the matrix above — byte-identical, including the nested elaboration chains.
- `cargo fmt -p tsz-checker --check`, `cargo clippy -p tsz-checker --tests`, `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01TD2Q98JWTRNYeE8uUsaDeY)_