### PR TITLE
fix(solver): canonicalize infer-parameter identity so it does not fragment on default/constraint snapshot

### DIFF
--- a/crates/tsz-solver/src/canonicalize/mod.rs
+++ b/crates/tsz-solver/src/canonicalize/mod.rs
@@ -184,6 +184,25 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
                     }
                 }
 
+                // `infer R` declarations carry the same `TypeParamInfo` as a
+                // type parameter, so their identity follows the same rule as the
+                // free `TypeParameter` branch above: the parameter is identified
+                // by itself — its name and the *shape* of its constraint — never
+                // by the optional `default` nor by the *resolution state* its
+                // constraint snapshot was captured in. Leaving `Infer` in the
+                // catch-all passthrough let two structurally-identical
+                // conditionals whose `infer` parameter captured a resolved
+                // constraint on one path and a still-`Lazy` cross-file alias on
+                // the other (or merely differed in a captured default) fragment
+                // into distinct identities, losing the relation's reflexive
+                // short-circuit (#13609 — the `Infer` analogue of the free
+                // `TypeParameter` fix). Reuse `canonical_type_param` so an
+                // `infer` parameter and a declared parameter reduce identically.
+                TypeData::Infer(info) => {
+                    let normalized = self.canonical_type_param(info);
+                    self.interner.infer(normalized)
+                }
+
                 // Recurse into composite types
                 TypeData::Array(elem) => {
                     let c_elem = self.canonicalize(elem);

--- a/crates/tsz-solver/tests/canonicalize_tests.rs
+++ b/crates/tsz-solver/tests/canonicalize_tests.rs
@@ -1397,3 +1397,139 @@ fn canonicalize_free_type_param_constraint_convergence_is_name_agnostic() {
         "a genuinely different constraint shape must not be merged by canonicalization"
     );
 }
+
+// ===================================================================
+// `infer` parameters must canonicalize like free type parameters (#13609)
+// ===================================================================
+
+// An `infer R` declaration carries the same `TypeParamInfo` as a type
+// parameter, so the same identity rule applies: `tsc` identifies the parameter
+// by itself — its name and the *shape* of its constraint — never by the
+// optional `default` nor the *resolution state* its constraint snapshot
+// happened to be in. The canonicalizer previously left `Infer` in the
+// catch-all passthrough (it only normalized `TypeParameter`), so two
+// structurally-identical conditionals whose `infer` parameter captured a
+// resolved constraint on one path and a still-`Lazy` alias on the other (or
+// merely differed in a captured default) fragmented into distinct identities,
+// losing the relation's reflexive/identity fast path. This is the `Infer`
+// analogue of `canonicalize_free_type_param_*`.
+#[test]
+fn canonicalize_infer_param_ignores_optional_default() {
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let name = interner.intern_string("R");
+    let constraint = Some(TypeId::STRING);
+    let make_infer = |default| {
+        interner.infer(TypeParamInfo {
+            name,
+            constraint,
+            default,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        })
+    };
+
+    let infer_with_default = make_infer(Some(TypeId::NUMBER));
+    let infer_no_default = make_infer(None);
+
+    assert_ne!(
+        infer_with_default, infer_no_default,
+        "precondition: interning keeps the default distinct"
+    );
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(infer_with_default),
+        c2.canonicalize(infer_no_default),
+        "an infer parameter's default must not fragment canonical identity"
+    );
+}
+
+// The same convergence the free-`TypeParameter` branch gives for a constraint
+// captured as a still-`Lazy` alias vs its expanded body must hold for `infer`
+// parameters too (`infer R extends SomeCrossFileAlias`), restoring the
+// relation's reflexive short-circuit (#13609 `507`/`516` axis).
+#[test]
+fn canonicalize_infer_param_constraint_resolution_state_converges() {
+    let interner = TypeInterner::new();
+    let union_body = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    let resolver = AliasConstraintResolver { body: union_body };
+
+    let r = interner.intern_string("R");
+    let make_infer = |constraint| {
+        interner.infer(TypeParamInfo {
+            name: r,
+            constraint: Some(constraint),
+            default: None,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        })
+    };
+    let infer_lazy = make_infer(interner.lazy(DefId(1)));
+    let infer_resolved = make_infer(union_body);
+
+    assert_ne!(
+        infer_lazy, infer_resolved,
+        "precondition: interning keeps the two constraint snapshots distinct"
+    );
+
+    let mut c1 = Canonicalizer::new(&interner, &resolver);
+    let mut c2 = Canonicalizer::new(&interner, &resolver);
+    assert_eq!(
+        c1.canonicalize(infer_lazy),
+        c2.canonicalize(infer_resolved),
+        "an infer parameter's constraint resolution state must not fragment identity"
+    );
+}
+
+// Identity-widening must not erase genuine distinctions: the normalization only
+// drops `default` and converges the constraint's resolution state. A different
+// constraint *shape* or a different binder name must stay distinct, and the
+// rule is name-agnostic (anti-hardcoding gate).
+#[test]
+fn canonicalize_infer_param_preserves_real_distinctions() {
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let make_infer = |name, constraint, default| {
+        interner.infer(TypeParamInfo {
+            name,
+            constraint: Some(constraint),
+            default,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        })
+    };
+    let r = interner.intern_string("R");
+    let infer_r = make_infer(r, TypeId::STRING, None);
+    // Same parameter, differing only in a captured default — collapses.
+    let infer_r_default = make_infer(r, TypeId::STRING, Some(TypeId::NUMBER));
+    // Different constraint shape — stays distinct.
+    let infer_r_num = make_infer(r, TypeId::NUMBER, None);
+    // Different binder name — stays distinct.
+    let infer_s = make_infer(interner.intern_string("S"), TypeId::STRING, None);
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    let mut c3 = Canonicalizer::new(&interner, &env);
+    let mut c4 = Canonicalizer::new(&interner, &env);
+    let mut c5 = Canonicalizer::new(&interner, &env);
+
+    assert_eq!(
+        c1.canonicalize(infer_r),
+        c2.canonicalize(infer_r_default),
+        "infer params differing only in default canonicalize identically"
+    );
+    assert_ne!(
+        c3.canonicalize(infer_r),
+        c4.canonicalize(infer_r_num),
+        "distinct infer constraints stay distinct after dropping default"
+    );
+    assert_ne!(
+        c3.canonicalize(infer_r),
+        c5.canonicalize(infer_s),
+        "distinct infer parameter names stay distinct"
+    );
+}


### PR DESCRIPTION
Goal: hold

Refs #13609 (extends the #13888 / #13915 type-parameter canonical-identity work to `infer` parameters). Does not claim or close the issue; the residual `keyof <cross-file Lazy> → ERROR` axis is the separate #13232 resolver-availability campaign.

## Structural rule

> A type parameter's identity is the parameter itself — its name and the
> *shape* of its constraint — never the optional `default` nor the
> *resolution state* its constraint snapshot was captured in. `tsc` never
> distinguishes type parameters by their declared `default` in
> relation/identity; the default is metadata consumed only at instantiation.
> This rule applies equally to `infer R` declarations, which carry the same
> parameter information.

The canonicalizer already normalized `TypeData::TypeParameter` through
`canonical_type_param` (drop `default`, canonicalize the constraint) at every
declared and free-reference site, but left `TypeData::Infer` in the catch-all
`_ => type_id` passthrough. So two structurally-identical conditionals whose
`infer` parameter captured a resolved constraint on one path and a still-`Lazy`
cross-file alias on the other (or merely differed in a captured `default`)
fragmented into distinct `TypeId`s, losing the relation's reflexive/identity
fast path and surfacing false `TS2322`/`TS2344`.

```ts
// `infer R extends <cross-file alias>` captured in two resolution states
// must reduce to one identity, or `FetchResponse<MappedResponseType<R, T>>`
// is not identity-equal to itself across two signatures.
type MappedResponseType<R extends ResponseType, J = any> =
  R extends keyof ResponseMap ? ResponseMap[R] : J;
```

## Owner layer

Solver canonicalization (`crates/tsz-solver/src/canonicalize/mod.rs`). A
`TypeData::Infer(info)` arm now routes through the existing
`canonical_type_param` helper and re-interns via `interner.infer`, exactly
mirroring the free-`TypeParameter` reference branch. The decision is purely
structural over the parameter — no identifier/alias/file-name/printer-string
predicate — so it applies to every binder spelling.

`TypeParamInfo` is embedded by exactly two `TypeData` variants —
`TypeParameter` and `Infer` — so this completes the coverage; no sibling
variant is left to fragment. `infer` parameters are never bound on the De
Bruijn `param_stack` (they are introduced in conditional `extends` clauses,
not declared scopes), so the arm mirrors the *free*-reference path and
correctly does not consult `find_param_index`. Identity-widening only;
interning is unchanged and the interned parameter keeps its `default` for
instantiation.

## Adjacent-case matrix (name-agnostic; new solver unit tests)

| case | result |
|---|---|
| `infer R` differing only in captured `default` | canonicalize identically |
| `infer R extends Lazy(alias)` vs `infer R extends <expanded body>` | canonicalize identically |
| differing default on top of constraint convergence | still identical |
| genuinely different constraint shape (`string` vs `number`) | stay distinct |
| different binder name (`R` vs `S`) | stay distinct |
| renamed binder (anti-hardcoding) | rule holds structurally |

## Verification

- New name-agnostic suite in `crates/tsz-solver/tests/canonicalize_tests.rs`
  (`canonicalize_infer_param_ignores_optional_default`,
  `canonicalize_infer_param_constraint_resolution_state_converges`,
  `canonicalize_infer_param_preserves_real_distinctions`) — **verified red on
  the pre-fix tree (3/3 fail), green after (3/3 pass)**.
- `cargo test -p tsz-solver --lib` — **6816 passed, 4 failed**; the 4 failures
  are **pre-existing on `main`** (`test_conditional_infer_optional_property_present_distributive`,
  `literal_mask_preserves_object_vs_literal_reduction`,
  `array_isarray_keeps_mutable_and_readonly_array_members`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`),
  confirmed identical on the base tree with this change stashed. **Zero new
  failures**; +3 new passing tests.
- `cargo test -p tsz-solver --test conditional_infer_tuple_numeric_key_tests --test conditional_deferred_return_tests` — pass.
- #13609 committed witness `program_mode_generic_conditional_in_contextual_return_stays_deferred` — still passes (unchanged).
- `cargo fmt -p tsz-solver --check`, `cargo clippy -p tsz-solver --lib --tests`, `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance / emit / fourslash / canary parity owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01WiQq1atvoJEpkq5s4BxCzr)_