### PR TITLE
fix(module-resolution): resolve tsconfig `paths` without `baseUrl`

### DIFF
--- a/crates/tsz-cli/src/driver/core_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/core_diagnostics.rs
@@ -324,6 +324,11 @@ pub(super) fn compile_inner(
     resolved.out_dir = out_dir.clone();
     resolved.declaration_dir = declaration_dir.clone();
     resolved.base_url = base_url;
+    // tsc's `pathsBasePath`: the tsconfig directory anchors `paths`
+    // substitutions when `baseUrl` is unset (TypeScript 4.1+). The resolver
+    // prefers `base_url` and only falls back to this, so setting it
+    // unconditionally is a no-op when `baseUrl` is present.
+    resolved.paths_base_path = Some(base_dir.clone());
     resolved.root_dirs = root_dirs;
     resolved.type_roots = normalize_type_roots(&base_dir, resolved.type_roots.clone());
 

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::checker::context::CheckerOptions;
 use crate::emitter::{ModuleKind, PrinterOptions, ScriptTarget};
@@ -35,6 +35,13 @@ pub struct ResolvedCompilerOptions {
     pub type_roots: Option<Vec<PathBuf>>,
     pub base_url: Option<PathBuf>,
     pub paths: Option<Vec<PathMapping>>,
+    /// Base directory for `paths` substitutions when `baseUrl` is not set
+    /// (tsc's `pathsBasePath`). Since TypeScript 4.1 `paths` may be configured
+    /// without `baseUrl`; relative substitutions then resolve against the
+    /// directory of the tsconfig that declared them. tsc's
+    /// `getPathsBasePath` returns `baseUrl ?? pathsBasePath`, so the resolver
+    /// prefers `base_url` and falls back to this when `baseUrl` is absent.
+    pub paths_base_path: Option<PathBuf>,
     pub root_dir: Option<PathBuf>,
     pub root_dirs: Vec<PathBuf>,
     pub out_dir: Option<PathBuf>,
@@ -296,6 +303,16 @@ impl ResolvedCompilerOptions {
         }
 
         default_module_resolution_for_module(self.printer.module)
+    }
+
+    /// Base directory for `paths` substitutions — tsc's `getPathsBasePath`,
+    /// which returns `baseUrl ?? pathsBasePath`. Since TypeScript 4.1 `paths`
+    /// may be configured without `baseUrl`, in which case relative
+    /// substitutions resolve against the tsconfig directory carried in
+    /// [`Self::paths_base_path`]. The bare `baseUrl` join fallback is NOT
+    /// derived from this — it stays anchored on `base_url` alone.
+    pub fn paths_base(&self) -> Option<&Path> {
+        self.base_url.as_deref().or(self.paths_base_path.as_deref())
     }
 }
 

--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -137,6 +137,15 @@ pub struct ModuleResolver {
     resolution_kind: ModuleResolutionKind,
     /// Base URL for path resolution
     base_url: Option<PathBuf>,
+    /// Base directory for `paths` substitutions (tsc's `pathsBasePath`).
+    ///
+    /// Equal to `base_url` when `baseUrl` is set, otherwise the directory of
+    /// the tsconfig that declared `paths` (TypeScript 4.1+ allows `paths`
+    /// without `baseUrl`). `paths` resolution is anchored here; the bare
+    /// `baseUrl` join fallback stays anchored on `base_url` alone, so a project
+    /// that configures `paths` without `baseUrl` does not gain baseUrl-style
+    /// resolution for unmapped specifiers.
+    paths_base: Option<PathBuf>,
     /// Path mappings from tsconfig
     path_mappings: Vec<PathMapping>,
     /// Virtual root directories from tsconfig rootDirs
@@ -232,6 +241,7 @@ impl ModuleResolver {
         Self {
             resolution_kind,
             base_url: options.base_url.clone(),
+            paths_base: options.paths_base().map(Path::to_path_buf),
             path_mappings: options.paths.clone().unwrap_or_default(),
             root_dirs: options.root_dirs.clone(),
             type_roots: options.type_roots.clone().unwrap_or_default(),
@@ -273,6 +283,7 @@ impl ModuleResolver {
         Self {
             resolution_kind: ModuleResolutionKind::Node,
             base_url: None,
+            paths_base: None,
             path_mappings: Vec::new(),
             root_dirs: Vec::new(),
             type_roots: Vec::new(),
@@ -395,7 +406,7 @@ impl ModuleResolver {
         if !self.allow_importing_ts_extensions
             && !self.allow_arbitrary_extensions
             && !self.rewrite_relative_import_extensions
-            && (self.base_url.is_some() || self.path_mappings.is_empty())
+            && (self.paths_base.is_some() || self.path_mappings.is_empty())
             && let Some(extension) = explicit_ts_extension(specifier)
             && !path_mapping_attempted
             && matches!(result, Err(ResolutionFailure::NotFound { .. }))
@@ -586,10 +597,10 @@ impl ModuleResolver {
         // projects without `paths` never scan the specifier.
         let mut path_mapping_attempted = false;
         if !self.path_mappings.is_empty()
-            && let Some(base_url) = self.base_url.as_deref()
+            && let Some(paths_base) = self.paths_base.as_deref()
             && !is_external_module_name_relative(specifier)
         {
-            let attempt = self.try_path_mappings(specifier, base_url, importer_package_type);
+            let attempt = self.try_path_mappings(specifier, paths_base, importer_package_type);
             if let Some(resolved) = attempt.resolved {
                 return (Ok(resolved), path_mapping_attempted);
             }

--- a/crates/tsz-core/src/module_resolver/tests/path_mapping.rs
+++ b/crates/tsz-core/src/module_resolver/tests/path_mapping.rs
@@ -16,14 +16,27 @@ use crate::config::PathMapping;
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-fn make_options(dir: &std::path::Path, mappings: Vec<PathMapping>) -> ResolvedCompilerOptions {
+/// Bundler-mode options with the given `paths` and explicit `baseUrl` /
+/// `pathsBasePath` anchors. The `paths`-without-`baseUrl` cases vary the
+/// anchors; every other field is shared here so the tests differ only in what
+/// they exercise.
+fn make_options_with_anchors(
+    base_url: Option<&std::path::Path>,
+    paths_base_path: Option<&std::path::Path>,
+    mappings: Vec<PathMapping>,
+) -> ResolvedCompilerOptions {
     ResolvedCompilerOptions {
         module_resolution: Some(ModuleResolutionKind::Bundler),
-        base_url: Some(dir.to_path_buf()),
+        base_url: base_url.map(std::path::Path::to_path_buf),
+        paths_base_path: paths_base_path.map(std::path::Path::to_path_buf),
         paths: Some(mappings),
         module_suffixes: vec![String::new()],
         ..Default::default()
     }
+}
+
+fn make_options(dir: &std::path::Path, mappings: Vec<PathMapping>) -> ResolvedCompilerOptions {
+    make_options_with_anchors(Some(dir), None, mappings)
 }
 
 /// Convenience constructor for a single `PathMapping` with no suffix.
@@ -652,6 +665,147 @@ fn test_path_mapping_matched_pattern_miss_skips_base_url_fallback() {
         .resolve("loose/thing", &fx.join("index.ts"), Span::new(0, 1))
         .expect("a specifier matching no pattern must still resolve via baseUrl");
     assert_eq!(unmatched.resolved_path, fx.join("loose/thing.ts"));
+}
+
+// ── `paths` without `baseUrl` (TypeScript 4.1+) ───────────────────────────────
+//
+// Since TS 4.1, `paths` may be configured without `baseUrl`. Relative
+// substitutions then resolve against the directory of the tsconfig that
+// declared them — tsc's `pathsBasePath` (`getPathsBasePath` returns
+// `baseUrl ?? pathsBasePath`). Non-relative substitutions stay rejected at the
+// config layer, and the bare `baseUrl` join fallback must NOT activate, so an
+// unmapped specifier still fails rather than resolving against the config dir.
+
+/// Options with `paths` but no `baseUrl`; `paths_base_path` carries the config
+/// directory (what the CLI driver supplies as tsc's `pathsBasePath`).
+fn make_options_paths_only(
+    config_dir: &std::path::Path,
+    mappings: Vec<PathMapping>,
+) -> ResolvedCompilerOptions {
+    make_options_with_anchors(None, Some(config_dir), mappings)
+}
+
+#[test]
+fn test_path_mapping_without_base_url_resolves_against_config_dir() {
+    // A wildcard alias with a relative substitution resolves against the
+    // config directory even though `baseUrl` is unset. Binder names vary across
+    // rows so the rule stays structural, not keyed on any alias spelling.
+    struct Row {
+        pattern: &'static str,
+        prefix: &'static str,
+        target: &'static str,
+        on_disk: &'static str,
+        specifier: &'static str,
+    }
+    let rows = [
+        Row {
+            pattern: "@app/*",
+            prefix: "@app/",
+            target: "./src/*",
+            on_disk: "src/widget.ts",
+            specifier: "@app/widget",
+        },
+        Row {
+            pattern: "~/*",
+            prefix: "~/",
+            target: "./lib/*",
+            on_disk: "lib/nested/thing.ts",
+            specifier: "~/nested/thing",
+        },
+        Row {
+            pattern: "internal",
+            prefix: "internal",
+            target: "./types/internal.d.ts",
+            on_disk: "types/internal.d.ts",
+            specifier: "internal",
+        },
+    ];
+    for row in rows {
+        let fx = TempFixture::new();
+        fx.write(row.on_disk, "export const value = 1;");
+        fx.write("index.ts", "");
+
+        let options =
+            make_options_paths_only(fx.path(), vec![pm(row.pattern, row.prefix, &[row.target])]);
+        let mut resolver = ModuleResolver::new(&options);
+        let resolved = resolver
+            .resolve(row.specifier, &fx.join("index.ts"), Span::new(0, 1))
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{}: paths without baseUrl must resolve against the config dir, got {e:?}",
+                    row.specifier,
+                )
+            });
+        assert_eq!(
+            resolved.resolved_path,
+            fx.join(row.on_disk),
+            "{}",
+            row.specifier
+        );
+    }
+}
+
+#[test]
+fn test_path_mapping_without_base_url_unmapped_specifier_does_not_fall_back() {
+    // The bare `baseUrl` join fallback must stay anchored on `baseUrl`. With
+    // `paths` but no `baseUrl`, a specifier that matches no pattern must NOT
+    // resolve against the config dir — `shared/widget.ts` exists on disk, so
+    // the only way it could resolve is the (incorrect) baseUrl-style fallback.
+    let fx = TempFixture::new();
+    fx.write("shared/widget.ts", "export const w = 1;");
+    fx.write("index.ts", "");
+
+    let options = make_options_paths_only(fx.path(), vec![pm("@app/*", "@app/", &["./src/*"])]);
+    let mut resolver = ModuleResolver::new(&options);
+
+    let unmapped = resolver.resolve("shared/widget", &fx.join("index.ts"), Span::new(0, 1));
+    assert!(
+        unmapped.is_err(),
+        "without baseUrl, an unmapped specifier must not resolve via a baseUrl-style \
+         fallback against the config dir, got {unmapped:?}",
+    );
+}
+
+#[test]
+fn test_path_mapping_without_base_url_or_paths_base_is_skipped() {
+    // Defensive: with neither `baseUrl` nor `paths_base_path`, path mapping has
+    // no anchor and is skipped entirely (resolution fails) rather than panicking
+    // or resolving against an arbitrary directory.
+    let fx = TempFixture::new();
+    fx.write("src/widget.ts", "export const w = 1;");
+    fx.write("index.ts", "");
+
+    let options = make_options_with_anchors(None, None, vec![pm("@app/*", "@app/", &["./src/*"])]);
+    let mut resolver = ModuleResolver::new(&options);
+    let result = resolver.resolve("@app/widget", &fx.join("index.ts"), Span::new(0, 1));
+    assert!(
+        result.is_err(),
+        "path mapping with no baseUrl and no paths base must be skipped, got {result:?}",
+    );
+}
+
+#[test]
+fn test_path_mapping_base_url_takes_precedence_over_paths_base() {
+    // When both are present, `baseUrl` wins (tsc's `baseUrl ?? pathsBasePath`).
+    // The alias target resolves against `baseUrl`'s directory, not the config
+    // dir, proving the precedence.
+    let base = TempFixture::new();
+    base.write("src/widget.ts", "export const fromBaseUrl = 1;");
+    base.write("index.ts", "");
+
+    let other = TempFixture::new();
+    other.write("src/widget.ts", "export const fromConfigDir = 1;");
+
+    let options = make_options_with_anchors(
+        Some(base.path()),
+        Some(other.path()),
+        vec![pm("@app/*", "@app/", &["./src/*"])],
+    );
+    let mut resolver = ModuleResolver::new(&options);
+    let resolved = resolver
+        .resolve("@app/widget", &base.join("index.ts"), Span::new(0, 1))
+        .expect("alias must resolve via baseUrl when both anchors are set");
+    assert_eq!(resolved.resolved_path, base.join("src/widget.ts"));
 }
 
 #[test]

--- a/crates/tsz-solver/src/relations/subtype/overlap.rs
+++ b/crates/tsz-solver/src/relations/subtype/overlap.rs
@@ -164,10 +164,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // For object-like types, use refined overlap detection with PropertyCollector
         // This handles: objects, objects with index signatures, and intersections
         // This replaces the simplified check that only handled direct object-to-object
-        let is_a_obj = self.is_object_like(a_resolved);
-        let is_b_obj = self.is_object_like(b_resolved);
+        let left_is_object_like = self.is_object_like(a_resolved);
+        let right_is_object_like = self.is_object_like(b_resolved);
 
-        if is_a_obj && is_b_obj {
+        if left_is_object_like && right_is_object_like {
             return self.do_refined_object_overlap_check(a_resolved, b_resolved);
         }
 


### PR DESCRIPTION
Goal: hold

Refs #13826 (module-resolution false-`TS2307` umbrella). A distinct, unit-reproducible resolver slice — not the `node:` classification (#13963/#13985), `exports`/`typesVersions` (#14028), `#imports`-scope, or ESM/CJS-classification slices, and not the harness install-scope sub-roots (#3/#4). The umbrella stays open.

## Structural rule

> When a tsconfig configures `paths` **without** `baseUrl`, `tsc` resolves each
> relative path-mapping substitution against the directory of the tsconfig that
> declared it (tsc's `pathsBasePath`; `getPathsBasePath` returns
> `baseUrl ?? pathsBasePath`). The bare `baseUrl` join fallback stays anchored
> on an explicit `baseUrl`, so a project with `paths` and no `baseUrl` does
> **not** gain baseUrl-style resolution for unmapped specifiers.

`paths` without `baseUrl` has been supported since TypeScript 4.1.

## What was wrong

The core `ModuleResolver` gated path mapping on `base_url` being `Some`:

```rust
if !self.path_mappings.is_empty()
    && let Some(base_url) = self.base_url.as_deref()   // None when baseUrl unset
    && !is_external_module_name_relative(specifier)
```

So a project with `paths` and no `baseUrl` skipped path mapping entirely and
returned `NotFound` for every aliased specifier — even though the config layer
already validates and **accepts** relative substitutions in that mode (it only
rejects non-relative ones, TS5090). Confirmed at the resolver layer: with
`base_url: None` and `paths: { "@app/*": ["./src/*"] }`, `@app/widget` resolved
to `Err(NotFound)` before this change.

The end-to-end CLI happened to mask this because `lookup` falls back to the
driver's legacy `resolve_module_specifier` (which already used
`base_url.unwrap_or(base_dir)`), but the core resolver — the architectural
source of truth, consumed directly off its primary resolution path — was wrong
and diverged from both `tsc` and the driver.

## Owner layer

Module resolver (`crates/tsz-core/src/module_resolver`). The
`baseUrl ?? pathsBasePath` rule is given a single canonical definition,
`ResolvedCompilerOptions::paths_base()`, and `paths` resolution is anchored on
it. `base_url` is retained separately so the bare-`baseUrl` join fallback is
unchanged. The CLI driver supplies the tsconfig directory as `paths_base_path`
(the same place it finalizes `base_url`, `root_dir`, `out_dir`, …). The
decision keys purely on config structure — no identifier/alias/file-name
predicate — so it applies to every binder spelling.

## Adjacent-case matrix (name-agnostic; binder names varied)

| case | result |
|---|---|
| `@app/*` → `./src/*`, no `baseUrl` | resolves against config dir |
| renamed `~/*` → `./lib/*` (nested subpath) | resolves against config dir |
| exact key `internal` → `./types/internal.d.ts`, no `baseUrl` | resolves |
| unmapped `shared/widget` (file exists under config dir), no `baseUrl` | **stays `TS2307`** (no baseUrl-style fallback) |
| both `baseUrl` and `pathsBasePath` set | `baseUrl` wins (`baseUrl ?? pathsBasePath`) |
| neither anchor set | path mapping skipped (fails closed) |

## Verification

- New core-resolver unit tests `crates/tsz-core/src/module_resolver/tests/path_mapping.rs`
  (renamed aliases; relative alias resolves against config dir; unmapped
  specifier does not fall back; `baseUrl` precedence; no-anchor skipped) —
  verified **red** on the pre-fix tree (`@app/widget` → `NotFound`) and green
  after. `cargo test -p tsz-core --lib module_resolver::tests::path_mapping` →
  24 passed.
- Existing end-to-end `compile_paths_without_base_url_resolve_before_ts_extension_diagnostic`
  and the `driver_tests_ts2307` / `config_tests` resolution suites pass
  unchanged (now resolved via the fixed primary path).
- `cargo fmt --check`, `cargo clippy -p tsz-core --lib --tests`,
  `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01XF7oz7yrWo1iXSWPsyo7qy)_