### PR TITLE
fix(emit): capture ES5 optional-call this-receiver inside the nullish guard

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -27,6 +27,10 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 
 [[test]]
+name = "es5_optional_chain_call_receiver_tests"
+path = "tests/es5_optional_chain_call_receiver_tests.rs"
+
+[[test]]
 name = "es5_super_object_literal_accessor_tests"
 path = "tests/es5_super_object_literal_accessor_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -1027,6 +1027,15 @@ pub struct Printer<'a> {
     pub(crate) async_arrow_generator_this_arg: Option<String>,
 
     pub(crate) tagged_template_var_map: FxHashMap<NodeIndex, String>,
+
+    /// Writer offset at which the *synchronous tail* of the most recently
+    /// emitted downlevel optional chain begins (the position right after the
+    /// final `=== void 0 ? void 0 : ` guard). Leaf optional-chain emitters set
+    /// this so a consumer that must capture the chain's `this` receiver — e.g.
+    /// `obj?.a.b?.(args)`, where the call needs `this = obj.a` — can splice the
+    /// capture `(_t = <tail>)` *inside* the guard instead of wrapping the whole
+    /// ternary (which would dereference `void 0` when the chain short-circuits).
+    pub(crate) optional_chain_sync_tail_start: Option<usize>,
 }
 
 impl<'a> Printer<'a> {

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -419,6 +419,7 @@ impl<'a> Printer<'a> {
             es5_class_expression_extends_this_captured: false,
             async_arrow_generator_this_arg: None,
             tagged_template_var_map: FxHashMap::default(),
+            optional_chain_sync_tail_start: None,
         }
     }
 

--- a/crates/tsz-emitter/src/emitter/expressions/access.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/access.rs
@@ -1063,6 +1063,7 @@ impl<'a> Printer<'a> {
                 self.emit_optional_chain_inline_gap_comments_untracked(expr_node.end, *dot_pos);
             }
             self.write(" === void 0 ? void 0 : ");
+            self.optional_chain_sync_tail_start = Some(self.writer.len());
             self.emit(access.expression);
             if let Some((expr_node, name_node, dot_pos)) = suffix_parts.as_ref() {
                 self.emit_optional_property_access_downlevel_suffix(
@@ -1088,6 +1089,7 @@ impl<'a> Printer<'a> {
             self.write(" === null || ");
             self.write(&base_temp);
             self.write(" === void 0 ? void 0 : ");
+            self.optional_chain_sync_tail_start = Some(self.writer.len());
             self.write(&base_temp);
             self.write(".");
             self.emit_property_name_without_import_substitution(access.name_or_argument);
@@ -1111,6 +1113,7 @@ impl<'a> Printer<'a> {
             self.write(" === null || ");
             self.emit(access.expression);
             self.write(" === void 0 ? void 0 : ");
+            self.optional_chain_sync_tail_start = Some(self.writer.len());
             self.emit(access.expression);
             self.write("[");
             self.emit(access.name_or_argument);
@@ -1131,6 +1134,7 @@ impl<'a> Printer<'a> {
             self.write(" === null || ");
             self.write(&base_temp);
             self.write(" === void 0 ? void 0 : ");
+            self.optional_chain_sync_tail_start = Some(self.writer.len());
             self.write(&base_temp);
             self.write("[");
             self.emit(access.name_or_argument);

--- a/crates/tsz-emitter/src/emitter/expressions/call.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/call.rs
@@ -1390,7 +1390,7 @@ impl<'a> Printer<'a> {
                 access_node.kind,
                 access.expression,
                 access.name_or_argument,
-                args,
+                args.as_ref(),
             );
         } else {
             // Lower the receiver first so a receiver that is itself an optional
@@ -1472,7 +1472,7 @@ impl<'a> Printer<'a> {
         access_kind: u16,
         access_expression: NodeIndex,
         access_name_or_argument: NodeIndex,
-        args: &Option<tsz_parser::parser::NodeList>,
+        args: Option<&tsz_parser::parser::NodeList>,
     ) {
         self.optional_chain_sync_tail_start = None;
         let before = self.writer.len();
@@ -1520,7 +1520,7 @@ impl<'a> Printer<'a> {
         self.write(&func_temp);
         self.write(".call(");
         self.write(&this_temp);
-        self.emit_optional_call_tail_arguments(args.as_ref());
+        self.emit_optional_call_tail_arguments(args);
     }
 
     fn emit_optional_call_tail_arguments(&mut self, args: Option<&tsz_parser::parser::NodeList>) {

--- a/crates/tsz-emitter/src/emitter/expressions/call.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/call.rs
@@ -1218,18 +1218,29 @@ impl<'a> Printer<'a> {
             self.write(" === null || ");
             self.emit(callee);
             self.write(" === void 0 ? void 0 : ");
+            self.optional_chain_sync_tail_start = Some(self.writer.len());
             self.emit(callee);
             self.emit_call_arguments(node, args.as_ref());
         } else {
+            // Lower the callee first so a callee that is itself an optional
+            // chain (e.g. `a?.b.c?.(1)?.(2)`) allocates its temps before this
+            // call's capture temp, matching tsc's allocation order.
+            let before = self.writer.len();
+            self.emit(callee);
+            let after = self.writer.len();
+            let full = self.writer.get_output().to_string();
+            let callee_text = full[before..after].to_string();
+            self.writer.truncate(before);
             let temp = self.make_unique_name_hoisted();
             self.write("(");
             self.write(&temp);
             self.write(" = ");
-            self.emit(callee);
+            self.write(&callee_text);
             self.write(")");
             self.write(" === null || ");
             self.write(&temp);
             self.write(" === void 0 ? void 0 : ");
+            self.optional_chain_sync_tail_start = Some(self.writer.len());
             self.write(&temp);
             self.emit_call_arguments(node, args.as_ref());
         }
@@ -1265,6 +1276,7 @@ impl<'a> Printer<'a> {
                     self.write(" === null || ");
                     self.emit(access.expression);
                     self.write(" === void 0 ? void 0 : ");
+                    self.optional_chain_sync_tail_start = Some(self.writer.len());
                 }
                 self.emit(access.expression);
             } else {
@@ -1278,6 +1290,7 @@ impl<'a> Printer<'a> {
                     self.write(" === null || ");
                     self.write(&this_temp);
                     self.write(" === void 0 ? void 0 : ");
+                    self.optional_chain_sync_tail_start = Some(self.writer.len());
                 }
                 if access.question_dot_token {
                     self.write(&this_temp);
@@ -1361,11 +1374,34 @@ impl<'a> Printer<'a> {
             self.write(") === null || ");
             self.write(&func_temp);
             self.write(" === void 0 ? void 0 : ");
+            self.optional_chain_sync_tail_start = Some(self.writer.len());
             self.write(&func_temp);
             self.write(".call(");
             self.emit(access.expression);
             self.emit_optional_call_tail_arguments(args.as_ref());
+        } else if !access.question_dot_token
+            && self.receiver_continues_optional_chain(access.expression)
+        {
+            // The final access (`obj.name`) is non-optional, but `obj` is itself
+            // an optional chain. The call's `this` receiver must be captured
+            // *inside* the chain's nullish guard, not by wrapping the whole
+            // lowered receiver (which would dereference `void 0` on short-circuit).
+            self.emit_optional_call_chain_receiver_capture(
+                access_node.kind,
+                access.expression,
+                access.name_or_argument,
+                args,
+            );
         } else {
+            // Lower the receiver first so a receiver that is itself an optional
+            // chain (e.g. `a?.b.c?.(1)?.[2]?.(3)`) allocates its temps before
+            // this call's `this`/function temps, matching tsc's allocation order.
+            let before = self.writer.len();
+            self.emit(access.expression);
+            let after = self.writer.len();
+            let full = self.writer.get_output().to_string();
+            let expr_text = full[before..after].to_string();
+            self.writer.truncate(before);
             let this_temp = self.make_unique_name_hoisted();
             let func_temp = self.make_unique_name_hoisted();
             self.write("(");
@@ -1374,7 +1410,7 @@ impl<'a> Printer<'a> {
             self.write("(");
             self.write(&this_temp);
             self.write(" = ");
-            self.emit(access.expression);
+            self.write(&expr_text);
             self.write(")");
             if access.question_dot_token {
                 self.write(" === null || ");
@@ -1398,6 +1434,7 @@ impl<'a> Printer<'a> {
             self.write(") === null || ");
             self.write(&func_temp);
             self.write(" === void 0 ? void 0 : ");
+            self.optional_chain_sync_tail_start = Some(self.writer.len());
             self.write(&func_temp);
             self.write(".call(");
             self.write(&this_temp);
@@ -1408,6 +1445,84 @@ impl<'a> Printer<'a> {
         }
     }
 
+    /// Lower `obj.name?.(args)` for the ES5 target when the final access
+    /// `obj.name` is **non-optional** but its receiver `obj` is itself a
+    /// downlevel optional chain (e.g. `a?.b.c?.(1)`, `a?.b?.c.d?.(1)`,
+    /// `a?.b().c?.(1)`).
+    ///
+    /// The call's `this` receiver is `obj` evaluated synchronously. It must be
+    /// captured **inside** the chain's nullish guard — mirroring tsc's
+    /// `flattenOptionalChain` — so that short-circuiting yields `void 0` instead
+    /// of dereferencing it:
+    ///
+    /// ```text
+    /// (_f = <guards> ? void 0 : (_t = <sync>).name)
+    ///     === null || _f === void 0 ? void 0 : _f.call(_t, args)
+    /// ```
+    ///
+    /// The receiver chain is lowered first so its own temps take the lower
+    /// ordinals (matching tsc's allocation order), then the `this`/function
+    /// temps are allocated and the synchronous tail is rewrapped in place. The
+    /// tail boundary is the writer offset recorded by the leaf optional-chain
+    /// emitters in `optional_chain_sync_tail_start` (the position right after
+    /// the final `=== void 0 ? void 0 : ` guard), never a textual scan of the
+    /// rendered output.
+    fn emit_optional_call_chain_receiver_capture(
+        &mut self,
+        access_kind: u16,
+        access_expression: NodeIndex,
+        access_name_or_argument: NodeIndex,
+        args: &Option<tsz_parser::parser::NodeList>,
+    ) {
+        self.optional_chain_sync_tail_start = None;
+        let before = self.writer.len();
+        self.emit(access_expression);
+        let after = self.writer.len();
+        let sync_start = self.optional_chain_sync_tail_start.take();
+
+        let full = self.writer.get_output().to_string();
+        let (guards, sync) = match sync_start {
+            Some(start) if start >= before && start <= after => (
+                full[before..start].to_string(),
+                full[start..after].to_string(),
+            ),
+            // Defensive: no synchronous-tail marker was recorded by a leaf
+            // optional-chain emitter. Fall back to wrapping the whole lowered
+            // receiver — no worse than the legacy behaviour for this shape.
+            _ => (String::new(), full[before..after].to_string()),
+        };
+        self.writer.truncate(before);
+
+        let this_temp = self.make_unique_name_hoisted();
+        let func_temp = self.make_unique_name_hoisted();
+
+        self.write("(");
+        self.write(&func_temp);
+        self.write(" = ");
+        self.write(&guards);
+        self.write("(");
+        self.write(&this_temp);
+        self.write(" = ");
+        self.write(&sync);
+        self.write(")");
+        if access_kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            self.write(".");
+            self.emit(access_name_or_argument);
+        } else {
+            self.write("[");
+            self.emit(access_name_or_argument);
+            self.write("]");
+        }
+        self.write(") === null || ");
+        self.write(&func_temp);
+        self.write(" === void 0 ? void 0 : ");
+        self.optional_chain_sync_tail_start = Some(self.writer.len());
+        self.write(&func_temp);
+        self.write(".call(");
+        self.write(&this_temp);
+        self.emit_optional_call_tail_arguments(args.as_ref());
+    }
+
     fn emit_optional_call_tail_arguments(&mut self, args: Option<&tsz_parser::parser::NodeList>) {
         if let Some(args) = args
             && !args.nodes.is_empty()
@@ -1416,6 +1531,28 @@ impl<'a> Printer<'a> {
             self.emit_comma_separated(&args.nodes);
         }
         self.write(")");
+    }
+
+    /// Whether `expression` (the receiver of a non-optional access) syntactically
+    /// *continues* an optional chain. Unlike
+    /// `expression_is_optional_chain_continuation`, a **parenthesized** or
+    /// type-asserted receiver terminates the chain (per the language spec:
+    /// `(a?.b).c` is a fresh, non-optional access that throws when `a?.b` is
+    /// nullish), so it is not treated as a continuation here.
+    fn receiver_continues_optional_chain(&self, expression: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(expression) else {
+            return false;
+        };
+        match node.kind {
+            k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+                || k == syntax_kind_ext::AS_EXPRESSION
+                || k == syntax_kind_ext::TYPE_ASSERTION
+                || k == syntax_kind_ext::SATISFIES_EXPRESSION =>
+            {
+                false
+            }
+            _ => self.expression_is_optional_chain_continuation(expression),
+        }
     }
 
     fn expression_is_optional_chain_continuation(&self, expression: NodeIndex) -> bool {

--- a/crates/tsz-emitter/tests/es5_optional_chain_call_receiver_tests.rs
+++ b/crates/tsz-emitter/tests/es5_optional_chain_call_receiver_tests.rs
@@ -1,0 +1,176 @@
+//! ES5 down-level parity with tsc for an optional-chain **call** whose `this`
+//! receiver is itself reached through an optional (`?.`) link.
+//!
+//! When the final access of a call's callee is non-optional (`obj.fn?.(...)`)
+//! but its receiver `obj` is an optional chain (`a?.b`), the call's `this`
+//! receiver must be captured **inside** the chain's nullish guard, mirroring
+//! tsc's `flattenOptionalChain`:
+//!
+//! ```text
+//! (_f = a === null || a === void 0 ? void 0 : (_t = a.b).fn)
+//!     === null || _f === void 0 ? void 0 : _f.call(_t, args)
+//! ```
+//!
+//! tsz previously wrapped the capture around the whole lowered receiver
+//! (`(_t = a === null || a === void 0 ? void 0 : a.b).fn`), which dereferences
+//! `void 0` — throwing `TypeError` — whenever the chain short-circuits. Found
+//! by differential testing against tsc 6.0.2 (`--target es5`).
+//!
+//! Assertions compare against tsc's exact byte output and vary binder names so
+//! the parity is proven structural, not keyed to any identifier spelling.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+use test_support::parse_and_lower_print as lower_emit;
+
+const DECLS: &str =
+    "let obj:any,root:any,box:any,node:any,svc:any,p:any,m:any,n:any,x:any,req:any;";
+
+fn es5_emit(expr: &str) -> String {
+    let src = format!("{DECLS}\nlet out = {expr};\n");
+    lower_emit(
+        &src,
+        PrintOptions {
+            target: ScriptTarget::ES5,
+            module: ModuleKind::CommonJS,
+            ..Default::default()
+        },
+    )
+}
+
+/// Assert the emitted `out = ...` statement is byte-identical to tsc 6.0.2.
+fn assert_out(expr: &str, expected_stmt: &str) {
+    let output = es5_emit(expr);
+    let line = output
+        .lines()
+        .find(|l| l.trim_start().starts_with("var out ="))
+        .unwrap_or_else(|| panic!("no `var out =` line in output:\n{output}"));
+    assert_eq!(
+        line.trim(),
+        expected_stmt,
+        "\nexpr: {expr}\nfull output:\n{output}"
+    );
+}
+
+#[test]
+fn property_receiver_through_optional_link() {
+    // `this` (obj.a) captured inside the guard, not wrapping it.
+    assert_out(
+        "obj?.a.fn?.(1)",
+        "var out = (_b = obj === null || obj === void 0 ? void 0 : (_a = obj.a).fn) === null || _b === void 0 ? void 0 : _b.call(_a, 1);",
+    );
+}
+
+#[test]
+fn property_receiver_is_name_agnostic() {
+    // Same structural shape under different binder/property spellings.
+    assert_out(
+        "root?.left.run?.(x)",
+        "var out = (_b = root === null || root === void 0 ? void 0 : (_a = root.left).run) === null || _b === void 0 ? void 0 : _b.call(_a, x);",
+    );
+}
+
+#[test]
+fn element_access_receiver_through_optional_link() {
+    assert_out(
+        "box?.[\"item\"].go?.(7)",
+        "var out = (_b = box === null || box === void 0 ? void 0 : (_a = box[\"item\"]).go) === null || _b === void 0 ? void 0 : _b.call(_a, 7);",
+    );
+}
+
+#[test]
+fn double_optional_receiver_splices_at_inner_synchronous_tail() {
+    // The receiver `node?.next?.value` itself has two optional links; the `this`
+    // for `.emit` is the synchronous tail `_a.value`.
+    assert_out(
+        "node?.next?.value.emit?.(1)",
+        "var out = (_c = (_a = node === null || node === void 0 ? void 0 : node.next) === null || _a === void 0 ? void 0 : (_b = _a.value).emit) === null || _c === void 0 ? void 0 : _c.call(_b, 1);",
+    );
+}
+
+#[test]
+fn call_in_the_middle_of_the_receiver_chain() {
+    // `svc?.api()` is a call; its result is the `this` receiver of `.handler`.
+    assert_out(
+        "svc?.api().handler?.(req)",
+        "var out = (_b = svc === null || svc === void 0 ? void 0 : (_a = svc.api()).handler) === null || _b === void 0 ? void 0 : _b.call(_a, req);",
+    );
+}
+
+#[test]
+fn nested_optional_call_allocates_inner_temps_first() {
+    // `a?.b.c?.(1)?.(2)` — the inner call's temps must precede the outer one.
+    assert_out(
+        "p?.q.r?.(1)?.(2)",
+        "var out = (_c = (_b = p === null || p === void 0 ? void 0 : (_a = p.q).r) === null || _b === void 0 ? void 0 : _b.call(_a, 1)) === null || _c === void 0 ? void 0 : _c(2);",
+    );
+}
+
+#[test]
+fn optional_call_after_non_optional_access_on_call_result() {
+    // `obj?.a.b?.(1).c?.(2)` — `.c`'s receiver is the inner call result.
+    assert_out(
+        "obj?.a.b?.(1).c?.(2)",
+        "var out = (_d = (_b = obj === null || obj === void 0 ? void 0 : (_a = obj.a).b) === null || _b === void 0 ? void 0 : (_c = _b.call(_a, 1)).c) === null || _d === void 0 ? void 0 : _d.call(_c, 2);",
+    );
+}
+
+#[test]
+fn long_synchronous_receiver_tail() {
+    // Several non-optional links after the optional one collapse into one tail.
+    assert_out(
+        "obj?.a.b.c.run?.(x)",
+        "var out = (_b = obj === null || obj === void 0 ? void 0 : (_a = obj.a.b.c).run) === null || _b === void 0 ? void 0 : _b.call(_a, x);",
+    );
+}
+
+#[test]
+fn parenthesized_receiver_terminates_the_chain() {
+    // `(p?.q).r?.(1)` — parens end the optional chain, so the whole lowered
+    // receiver is captured (tsc throws on short-circuit here, by design).
+    assert_out(
+        "(p?.q).r?.(1)",
+        "var out = (_b = (_a = (p === null || p === void 0 ? void 0 : p.q)).r) === null || _b === void 0 ? void 0 : _b.call(_a, 1);",
+    );
+}
+
+#[test]
+fn non_optional_complex_receiver_is_unchanged() {
+    // Control: a non-optional complex receiver keeps the legacy wrap form.
+    assert_out(
+        "(m + n).fn?.(1)",
+        "var out = (_b = (_a = (m + n)).fn) === null || _b === void 0 ? void 0 : _b.call(_a, 1);",
+    );
+}
+
+#[test]
+fn capture_sits_inside_the_nullish_guard_not_around_it() {
+    // Name-agnostic structural guard against the regression: the `this` capture
+    // must open *after* a `? void 0 : ` (inside the else branch), never wrap the
+    // ternary. In the buggy form the capture opens *before* the guard, so the
+    // text immediately following `void 0 : ` is the bare receiver rather than a
+    // fresh `(_temp = ` capture.
+    for expr in [
+        "obj?.a.fn?.(1)",
+        "root?.left.run?.(x)",
+        "box?.[\"item\"].go?.(7)",
+        "obj?.a.b.c.run?.(x)",
+    ] {
+        let out = es5_emit(expr);
+        assert!(
+            out.contains("? void 0 : (_"),
+            "expected `this` capture inside the guard for `{expr}`:\n{out}"
+        );
+        // The buggy form opens the capture immediately around the guard, e.g.
+        // `(_a = obj === null || obj === void 0 ? void 0 : obj.a).fn`. The
+        // synchronous tail must instead be a captured access ending in `.<name>)`
+        // or `[...])`, so the over-wide `void 0 : <ident>).` shape never appears.
+        assert!(
+            !out.contains("void 0 : obj.a)"),
+            "regressed: `this` capture wraps the whole guard for `{expr}`:\n{out}"
+        );
+    }
+}

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -551,6 +551,10 @@ FILE_LINE_LIMIT_CHECKS = [
         2608,
     ),
     # Emitter property/element access: split by access kind per §19.
+    # Bumped by 4 (1499->1503) for the ES5 optional-chain `this`-receiver fix:
+    # the four leaf downlevel branches (property/element x simple/non-simple)
+    # each record `optional_chain_sync_tail_start` so a consuming optional call
+    # can splice the captured receiver inside the nullish guard.
     (
         "Emitter boundary: emitter/expressions/access size ratchet",
         ROOT
@@ -560,7 +564,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "emitter"
         / "expressions"
         / "access.rs",
-        1499,
+        1503,
     ),
     # --- Blanket coverage batch: all production files > 2000 lines per §19 ---
     # These entries pin the current baseline and prevent silent growth.


### PR DESCRIPTION
Goal: hold

Closes #14076.

## Structural rule

> When an ES5 optional **call** (`obj.name?.(args)`) has a callee whose final
> access `obj.name` is **non-optional** but whose receiver `obj` is itself an
> optional chain (`a?.b`), `tsc` captures the call's `this` receiver **inside**
> the chain's nullish guard (mirroring `flattenOptionalChain`):
>
> ```js
> (_f = a === null || a === void 0 ? void 0 : (_t = a.b).c)
>     === null || _f === void 0 ? void 0 : _f.call(_t, 1)
> ```
>
> tsz wrapped the capture **around** the whole lowered receiver
> (`(_t = a === null || a === void 0 ? void 0 : a.b).c`), dereferencing `void 0`
> and throwing `TypeError` whenever the chain short-circuits.

```ts
// --target es5
let a: any; let r = a?.b.c?.(1);
```

| | output |
|---|---|
| `tsc` 6.0.2 | `(_b = a === null \|\| a === void 0 ? void 0 : (_a = a.b).c) === null \|\| _b === void 0 ? void 0 : _b.call(_a, 1)` |
| tsz (before) | `(_b = (_a = a === null \|\| a === void 0 ? void 0 : a.b).c) === null \|\| _b === void 0 ? void 0 : _b.call(_a, 1)` |
| tsz (after) | matches `tsc` byte-for-byte |

Found by differential testing against `tsc` 6.0.2.

## Owner layer

Emitter only — `crates/tsz-emitter/src/emitter/expressions/{call,access}.rs`.
No semantic/checker change, no output surgery.

The four leaf optional-chain emitters (property/element × simple/non-simple)
record the **synchronous-tail** writer offset (`optional_chain_sync_tail_start`)
— the position right after the final `=== void 0 ? void 0 : ` guard — and the
optional-call emitters record theirs (the `_f.call(...)` value). The call
lowering then splices the `this` capture `(_t = <sync>)` at that offset instead
of wrapping the whole ternary. The boundary is a recorded writer offset, never a
textual scan of rendered output. The decision keys purely on syntactic shape
(non-optional final access + optional-chain receiver), so it applies to every
binder spelling.

Two adjacent ordering fixes fall out of the same root cause: `emit_optional_call_expression`
and the optional-method-call receiver branch now lower the receiver **before**
allocating the call's temps, matching `tsc`'s temp ordering for nested optional
calls (`a?.b.c?.(1)?.(2)`). Parenthesized/asserted receivers terminate the
chain and keep the legacy wrap form (`tsc` throws there by design).

## Adjacent-case matrix (name-agnostic; binders varied; `--target es5`, byte-equal to `tsc` 6.0.2)

| case | result |
|---|---|
| `obj?.a.fn?.(1)` (property receiver) | `(_a = obj.a).fn`, this `= _a` |
| `box?.["item"].go?.(7)` (element receiver) | `(_a = box["item"]).go` |
| `svc?.api().handler?.(req)` (call receiver) | `(_a = svc.api()).handler` |
| `node?.next?.value.emit?.(1)` (double optional) | splice at `_a.value` |
| `obj?.a.b.c.run?.(x)` (long sync tail) | `(_a = obj.a.b.c).run` |
| `p?.q.r?.(1)?.(2)` (nested calls) | inner temps allocated first |
| `obj?.a.b?.(1).c?.(2)` (access on call result) | splice at `_b.call(_a,1)` |
| `(p?.q).r?.(1)` (parens terminate chain) | legacy wrap (unchanged) |
| `(m + n).fn?.(1)` (non-optional receiver, control) | legacy wrap (unchanged) |

## Verification

- New name-agnostic suite `crates/tsz-emitter/tests/es5_optional_chain_call_receiver_tests.rs`
  (11 tests) — pass; verified **9/11 fail on the pre-fix tree** (the 2 controls
  that do not use the splice stay green), confirming genuine regression guards.
- End-to-end differential vs `tsc` 6.0.2 over a 20-case optional-chain battery —
  full emitted file (incl. hoisted temp decls) byte-identical.
- Node runtime check: with a nullish base the chain yields `undefined` (no
  throw) and `this` binds to the correct receiver.
- `cargo test -p tsz-emitter` — **4350 pass, 0 fail**.
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --tests`,
  `python3 scripts/arch/arch_guard.py` — clean (access.rs ratchet bumped 1499→1503
  with justification for the four sync-tail markers).
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_0186aM6XbiJ4HrCv9NpAT11m

---
_Generated by [Claude Code](https://claude.ai/code/session_0186aM6XbiJ4HrCv9NpAT11m)_