### PR TITLE
fix(solver): relate same-base generic interface instantiations when every type-param usage is bivariant

### DIFF
--- a/crates/tsz-checker/tests/implements_type_param_generation_identity_tests.rs
+++ b/crates/tsz-checker/tests/implements_type_param_generation_identity_tests.rs
@@ -18,10 +18,14 @@
 //! same-constrained function params stay distinct (`S[K_outer]` vs `S[K_inner]`
 //! keeps erroring). All witnesses are tsc-5.5-verified.
 //!
-//! The remaining ignored test pins a separate residue: a deferred
-//! conditional instantiated with concrete type arguments must relate to its
-//! generic origin (tsc's same-conditional-root rule), which id convergence
-//! alone does not provide.
+//! The previously-ignored bivariant case is a separate concern handled in the
+//! solver, not by type-parameter id convergence: two instantiations of the same
+//! generic interface relate by per-parameter variance, and a parameter that
+//! appears solely in a conditional `extends` position is bivariant, so the
+//! instantiations relate regardless of that argument (the member's differing
+//! deferred conditional is never reached). See
+//! `relations::variance::visit_conditional` and the all-bivariant acceptance in
+//! `try_variance_fast_path`.
 //!
 //! Owner layer: checker type-parameter identity
 //! (`state/type_analysis/core.rs::intern_type_param_for_decl` and the shared
@@ -180,9 +184,11 @@ class B7Impl<DB, TB extends keyof DB> implements B7<DB, TB> {
 
 /// Method-bivariance control: a concretely instantiated impl parameter is
 /// accepted bivariantly by tsc (method declarations relate bivariantly);
-/// verified against `tsc 5.5` (clean).
+/// verified against `tsc 6.0` (clean). The two `any` members differ only in a
+/// conditional whose `extends` mentions `TB`, a parameter that appears solely
+/// in that bivariant extends position; tsc relates the two `FM` instantiations
+/// by all-bivariant variance, not by a structural member walk.
 #[test]
-#[ignore = "pinned: relating a deferred conditional instantiated with concrete args against its generic origin still requires conditional-root identity (tsc relates same-root conditional instantiations); the generation-identity convergence fixed the generic-vs-generic family but not this concrete bivariant form"]
 fn implements_member_concrete_param_bivariant_accepted() {
     let source = r#"
 interface FM<DB, TB extends keyof DB> {

--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -47,6 +47,9 @@ mod dual_package_exports_tests;
 #[path = "../tests/fs_tests.rs"]
 mod fs_tests;
 #[cfg(test)]
+#[path = "../tests/generic_interface_bivariant_param_relation_tests.rs"]
+mod generic_interface_bivariant_param_relation_tests;
+#[cfg(test)]
 #[path = "../tests/interface_extends_generic_alias_cli_tests.rs"]
 mod interface_extends_generic_alias_cli_tests;
 #[cfg(test)]

--- a/crates/tsz-cli/tests/generic_interface_bivariant_param_relation_tests.rs
+++ b/crates/tsz-cli/tests/generic_interface_bivariant_param_relation_tests.rs
@@ -1,0 +1,157 @@
+//! Two instantiations of the same generic interface relate by per-parameter
+//! variance, not by a structural member walk, when every type parameter sits in
+//! a bivariant position.
+//!
+//! Structural rule: when a generic interface's type parameter appears *solely*
+//! in a bivariant position — e.g. the `extends` clause of a member's conditional
+//! return type, which selects a branch but never flows into either branch — two
+//! instantiations differing only in that argument relate in either direction.
+//! `tsc` relates them via `relateVariances` with all-bivariant marks before any
+//! structural expansion; the member's deferred conditional (which differs only
+//! in that argument and can never relate structurally) is never reached.
+//!
+//! Regression witness: the kysely/valibot/zod `T`-not-assignable-to-`T` family,
+//! where `tsz` materialized each interface instantiation to an object shape and
+//! then false-rejected (`TS2322`/`TS2416`) on the differing deferred conditional
+//! member. The fix recovers each side's originating application via display
+//! provenance and accepts the all-bivariant pair.
+//!
+//! These cases vary binder names so the behavior tracks the structural position,
+//! not any spelling, and pin the negative controls (covariant / check-position
+//! parameters must still discriminate) so the bivariance acceptance is not a
+//! blanket "same base ⇒ related" shortcut.
+
+use crate::args::CliArgs;
+use clap::Parser;
+
+/// Compile a single-file program with the bundled `es2022` lib and return the
+/// non-hint diagnostic codes.
+fn check(src: &str) -> Vec<u32> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::write(dir.path().join("main.ts"), src).expect("write source");
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--ignoreConfig",
+        "--noEmit",
+        "--strict",
+        "--target",
+        "es2022",
+        "--lib",
+        "es2022",
+        "main.ts",
+    ])
+    .expect("parse args");
+    let result = crate::driver::compile(&args, dir.path()).expect("compile");
+    result
+        .diagnostics
+        .iter()
+        .map(|d| d.code)
+        .filter(|code| code / 100 != 61) // drop unused-symbol hints
+        .collect()
+}
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|c| **c == code).count()
+}
+
+/// A parameter that appears only in a conditional `extends` position is
+/// bivariant: assigning between two instantiations with unrelated concrete
+/// arguments is clean in both directions (`tsc` 6.0: no error).
+#[test]
+fn extends_position_param_is_bivariant_both_directions() {
+    // `Col` appears only in `R extends Col[] ? ...`. The two instantiations use
+    // disjoint concrete arguments.
+    let forward = check(
+        r#"
+interface Registry<Schema, Col extends keyof Schema> {
+    pick<Row>(row: Row): Row extends Col[] ? number : never;
+}
+function up(g: Registry<{ a: 1 }, "a">): Registry<{ b: 2 }, "b"> { return g; }
+"#,
+    );
+    assert_eq!(forward, Vec::<u32>::new(), "forward got {forward:?}");
+
+    let backward = check(
+        r#"
+interface Registry<Schema, Col extends keyof Schema> {
+    pick<Row>(row: Row): Row extends Col[] ? number : never;
+}
+function down(g: Registry<{ b: 2 }, "b">): Registry<{ a: 1 }, "a"> { return g; }
+"#,
+    );
+    assert_eq!(backward, Vec::<u32>::new(), "backward got {backward:?}");
+}
+
+/// The `implements` witness, with binder names varied from the kysely original:
+/// a base method takes the generic interface, the impl takes a concretely
+/// instantiated one. Method parameters relate bivariantly and the interface
+/// argument is bivariant, so there is no `TS2416`.
+#[test]
+fn implements_member_concrete_bivariant_interface_param_is_accepted() {
+    let codes = check(
+        r#"
+interface Builder<Schema, Col extends keyof Schema> {
+    pick<Row>(row: Row): Row extends Col[] ? number : never;
+}
+interface Consumer<Schema, Col extends keyof Schema> {
+    run(builder: Builder<Schema, Col>): void;
+}
+class ConsumerImpl<Schema, Col extends keyof Schema> implements Consumer<Schema, Col> {
+    run(builder: Builder<{ a: 1 }, "a">): void {}
+}
+"#,
+    );
+    assert_eq!(count(&codes, 2416), 0, "got {codes:?}");
+}
+
+/// All type parameters unused (purely phantom): bivariant, relates regardless of
+/// arguments.
+#[test]
+fn fully_unused_params_relate_regardless_of_arguments() {
+    let codes = check(
+        r#"
+interface Tagged<First, Second> { value: number; }
+function f(g: Tagged<1, 2>): Tagged<3, 4> { return g; }
+"#,
+    );
+    assert_eq!(codes, Vec::<u32>::new(), "got {codes:?}");
+}
+
+/// Negative control: a parameter in an ordinary covariant property position is
+/// NOT bivariant. The unsound direction must still be rejected (`tsc`: TS2322).
+#[test]
+fn covariant_property_param_still_rejects_unsound_direction() {
+    let codes = check(
+        r#"
+interface Cell<Held> { value: Held; }
+function f(g: Cell<number>): Cell<1> { return g; }
+"#,
+    );
+    assert_eq!(count(&codes, 2322), 1, "got {codes:?}");
+}
+
+/// Negative control: the covariant direction is still accepted, proving the
+/// rejection above is variance-driven and not a blanket structural failure.
+#[test]
+fn covariant_property_param_accepts_sound_direction() {
+    let codes = check(
+        r#"
+interface Cell<Held> { value: Held; }
+function f(g: Cell<1>): Cell<number> { return g; }
+"#,
+    );
+    assert_eq!(codes, Vec::<u32>::new(), "got {codes:?}");
+}
+
+/// Negative control: a parameter genuinely used in a covariant conditional
+/// *branch* is measured (not bivariant); the unsound direction is rejected.
+#[test]
+fn conditional_branch_param_is_measured_not_bivariant() {
+    let codes = check(
+        r#"
+interface Wrap<Held> { read(): unknown extends never ? never : Held; }
+function f(g: Wrap<string>): Wrap<"a"> { return g; }
+"#,
+    );
+    assert_eq!(count(&codes, 2322), 1, "got {codes:?}");
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -849,7 +849,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             |s_arg, t_arg| self.check_subtype(s_arg, t_arg).is_true(),
         );
 
-        if any_checked && all_ok && !needs_structural_fallback {
+        // Accept when the per-argument variance walk found no mismatch and no
+        // position needs the structural fallback. This covers two cases: at
+        // least one argument occupied a variance-relevant position and related
+        // (`any_checked`), OR every parameter is independent/bivariant so no
+        // argument is variance-relevant at all (`!any_checked`, with a
+        // non-empty variance list). In the all-bivariant case `tsc` relates the
+        // two instantiations via `relateVariances` before any structural
+        // expansion; without it a generic interface whose only type-parameter
+        // usages are bivariant (e.g. a member returning `R extends TB[] ? X : Y`,
+        // where `TB` appears solely in a conditional extends position) falls
+        // through to a structural member walk and spuriously rejects the pair
+        // because the deferred conditional members differ only in that bivariant
+        // argument (the kysely/valibot/zod `T`-not-assignable-to-`T` family).
+        // `needs_structural_fallback` keeps any not-cleanly-bivariant position
+        // (e.g. a conditional *check* position, or a modifier mapped type) on
+        // the structural path.
+        if all_ok && !needs_structural_fallback && (any_checked || !variances.is_empty()) {
             return Some(SubtypeResult::True);
         }
         // When structural fallback is needed (mapped types), variance failures

--- a/crates/tsz-solver/src/relations/variance.rs
+++ b/crates/tsz-solver/src/relations/variance.rs
@@ -1252,20 +1252,57 @@ impl<'a, 'b> TypeVisitor for VarianceVisitor<'a, 'b> {
         }
     }
 
-    /// Conditional types: `check_type` is COVARIANT, `extends_type` is CONTRAVARIANT.
+    /// Conditional types: branch types contribute variance; the `check_type`
+    /// selects a branch and the `extends_type` is a bound.
     fn visit_conditional(&mut self, cond_id: u32) {
         let cond = self.computer.db.get_conditional(ConditionalTypeId(cond_id));
         let current_polarity = self.get_current_polarity();
 
-        // In TypeScript, conditional types `T extends U ? X : Y` determine variance
-        // solely from the branch types X and Y. The check_type T acts as a guard
-        // condition, not a usage position, so it doesn't contribute to variance.
-        // Similarly, extends_type U is a bound, not a variance contributor.
-        // This matches tsc's probe-based variance inference behavior.
-
-        // True and false branches preserve polarity (covariant positions)
+        // The branch types X and Y are ordinary covariant usage positions.
         self.visit_with_polarity(cond.true_type, current_polarity);
         self.visit_with_polarity(cond.false_type, current_polarity);
+
+        // The `extends_type` U is only a bound on the branch selection. tsc
+        // treats a parameter that appears *solely* in an extends position as
+        // bivariant: two instantiations differing only in that argument relate
+        // in either direction (e.g. `M<DB, TB>` whose member returns
+        // `R extends TB[] ? X : Y` accepts `M<{a:1}, "a">` against `M<DB, TB>`).
+        // So the extends position is intentionally NOT visited — leaving such a
+        // parameter independent (bivariant).
+        //
+        // The `check_type` T, however, selects the branch: tsc measures a
+        // parameter appearing there (two instantiations differing in it do
+        // NOT relate, even when both branches collapse to the same type).
+        //
+        // When the parameter also occurs in a branch it is already measured by
+        // the covariant visits above (so it is not independent and the
+        // "all positions independent" shortcut cannot fire for it); only a
+        // parameter that appears *solely* in the check position would otherwise
+        // be left independent and wrongly treated as bivariant. The exact
+        // measured variance of a distributive check position is subtle (it
+        // depends on branch-vs-bound probing), so for that solely-check case we
+        // mark the result as needing the structural fallback rather than
+        // asserting a co/contra/invariant direction we cannot reliably model —
+        // the structural comparison then judges the pair.
+        let in_check = crate::contains_type_parameter_named_shallow(
+            self.computer.db,
+            cond.check_type,
+            self.target_param,
+        );
+        if in_check {
+            let in_branch = crate::contains_type_parameter_named_shallow(
+                self.computer.db,
+                cond.true_type,
+                self.target_param,
+            ) || crate::contains_type_parameter_named_shallow(
+                self.computer.db,
+                cond.false_type,
+                self.target_param,
+            );
+            if !in_branch {
+                self.result |= Variance::NEEDS_STRUCTURAL_FALLBACK;
+            }
+        }
     }
 
     /// Mapped types: constraint is contravariant, template is covariant.


### PR DESCRIPTION
Goal: green

Refs #13212, #13484 (the kysely/valibot/zod `T`-not-assignable-to-`T` false-positive family).

## Structural rule

> When two instantiations of the **same** generic interface differ only in arguments that occupy **bivariant** positions, `tsc` relates them via `relateVariances` (all-bivariant marks) **before** any structural expansion. A type parameter that appears solely in a member's conditional `extends` clause (e.g. `R extends TB[] ? X : Y`) is one such bivariant position — it selects a branch but never flows into either branch — so two instantiations differing only in that argument relate in either direction.

tsz materializes each interface instantiation to an object shape and then **structurally** walks members. A member whose deferred conditional return type mentions a type parameter only in its `extends` clause can never relate structurally across two different instantiations (the two deferred conditionals differ in that argument and never reduce), so tsz spuriously rejected the pair.

```ts
interface FM<DB, TB extends keyof DB> { any<R>(e: R): R extends TB[] ? number : never }
function f(g: FM<{ a: 1 }, "a">): FM<{ b: 2 }, "b"> { return g; } // tsc: ok; tsz (before): TS2322
```

Found via the committed `#[ignore]`d witness `implements_member_concrete_param_bivariant_accepted` and differential testing against `tsc` 6.0.2.

## Owner layer / fix

Solver relation + variance, two parts:

- `relations::variance::visit_conditional` — a parameter appearing **solely** in a conditional `extends` position stays independent/bivariant (the extends position is intentionally not a variance contributor, matching tsc). A parameter appearing **solely** in the conditional `check` position is marked `NEEDS_STRUCTURAL_FALLBACK` (tsc measures the check position; its exact variance is not cleanly modeled here, so the structural comparison judges the pair) — consistent with how the file already flags unmeasurable mapped-type positions. Parameters that also occur in a branch are unchanged (already measured covariantly).
- `relations::subtype::rules::generics::try_variance_fast_path` — accepts a same-base pair as related when the per-argument variance walk finds no mismatch and no position needs the structural fallback, including the all-independent (all-bivariant) case where no argument is variance-relevant. Both materialized sides recover their originating `Application` via display provenance, so the existing pre-evaluation variance path reaches this case.

No identifier/file-name/printer-string predicates; the decision is purely the structural variance of the shared generic definition.

## Adjacent-case matrix (binder names varied; verified byte-equal to `tsc` 6.0.2)

| case | tsc | tsz after |
|---|---|---|
| param solely in conditional `extends`, disjoint concrete args, both directions | ok | ok |
| `implements` member takes a concretely-instantiated such interface | ok | ok |
| fully unused (phantom) params, any args | ok | ok |
| covariant property param, unsound direction | TS2322 | TS2322 (unchanged) |
| covariant property param, sound direction | ok | ok (unchanged) |
| param in a covariant conditional **branch**, unsound direction | TS2322 | TS2322 (unchanged) |

## Verification

- New name-agnostic suite `crates/tsz-cli/tests/generic_interface_bivariant_param_relation_tests.rs` (6 cases) — pass; the bivariant cases were red on the pre-fix tree.
- Previously-`#[ignore]`d witness `implements_member_concrete_param_bivariant_accepted` un-ignored and passing; negative control `implements_member_genuinely_incompatible_still_ts2416` still errors.
- `cargo test -p tsz-solver --lib variance` — 165 pass; full `-p tsz-solver --lib` — 6814 pass, 4 failures **pre-existing on main** (`higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`, `literal_mask_preserves_object_vs_literal_reduction`, `array_isarray_keeps_mutable_and_readonly_array_members`, `test_conditional_infer_optional_property_present_distributive`), zero new.
- Differential vs `tsc` 6.0.2 over a 15-case generic-interface relation matrix: the bivariant-extends family goes from diverging to matching; no new divergences. (Two residual check-position false-negatives are pre-existing and unchanged — a separate, harder distributive-check-variance gap, out of scope.)
- `cargo fmt`, `cargo clippy -p tsz-solver --lib`, `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance/emit/fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01PdLjC8G2XaqpRAooe9gT7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdLjC8G2XaqpRAooe9gT7y)_