### PR TITLE
fix(emit): down-level destructuring patterns in es5 catch clauses

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -247,6 +247,10 @@ name = "try_statement_recovery_tests"
 path = "tests/try_statement_recovery_tests.rs"
 
 [[test]]
+name = "es5_catch_clause_destructuring_tests"
+path = "tests/es5_catch_clause_destructuring_tests.rs"
+
+[[test]]
 name = "system_top_level_using_env_position_tests"
 path = "tests/system_top_level_using_env_position_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/statements/try_statement.rs
+++ b/crates/tsz-emitter/src/emitter/statements/try_statement.rs
@@ -149,6 +149,37 @@ impl<'a> Printer<'a> {
         self.write("catch");
 
         if catch.variable_declaration.is_some() {
+            // ES5/ES3 has no destructuring syntax, so a binding pattern in a
+            // catch clause is invalid output. Mirror tsc's down-level transform:
+            // bind the caught value to a synthesized catch parameter, then
+            // extract the pattern into a leading `var` statement.
+            //   catch ({ message }) { use(message); }
+            // becomes
+            //   catch (_a) { var message = _a.message; use(message); }
+            if self.ctx.target_es5
+                && let Some(pattern_idx) = self.catch_var_pattern_idx(catch.variable_declaration)
+                && self.is_binding_pattern(pattern_idx)
+            {
+                self.emit_catch_temp_wrapper(node.pos, node.end, catch.block, |s, temp| {
+                    // An empty pattern (`catch ({})` / `catch ([])`, or one that
+                    // only holds elisions) extracts nothing, so no `var`
+                    // statement is emitted — just the synthesized parameter and
+                    // the original body. The shared ES5 destructuring lowering
+                    // handles defaults, nested patterns, and object/array rest.
+                    if let Some(pattern_node) = s.arena.get(pattern_idx) {
+                        let (count, has_rest) = s.count_effective_bindings(pattern_node);
+                        if count > 0 || has_rest {
+                            s.write("var ");
+                            let mut first = true;
+                            s.emit_es5_destructuring_pattern_direct(pattern_node, temp, &mut first);
+                            s.write(";");
+                            s.write_line();
+                        }
+                    }
+                });
+                return;
+            }
+
             // Check if catch variable has object rest that needs ES2018 lowering.
             let needs_rest_lowering = self.ctx.needs_es2018_lowering
                 && !self.ctx.target_es5
@@ -157,33 +188,12 @@ impl<'a> Printer<'a> {
             if needs_rest_lowering
                 && let Some(pattern_idx) = self.catch_var_pattern_idx(catch.variable_declaration)
             {
-                let temp = self.get_temp_var_name();
-                self.write(" ");
-                self.map_token_after(node.pos, node.end, b'(');
-                self.write("(");
-                self.write(&temp);
-                self.write(")");
-
-                self.write(" {");
-                self.write_line();
-                self.increase_indent();
-
-                self.write("var ");
-                self.emit_object_rest_var_decl(pattern_idx, NodeIndex::NONE, Some(&temp));
-                self.write(";");
-                self.write_line();
-
-                if let Some(block_node) = self.arena.get(catch.block)
-                    && let Some(block) = self.arena.get_block(block_node)
-                {
-                    for &stmt in &block.statements.nodes {
-                        self.emit(stmt);
-                        self.write_line();
-                    }
-                }
-
-                self.decrease_indent();
-                self.write("}");
+                self.emit_catch_temp_wrapper(node.pos, node.end, catch.block, |s, temp| {
+                    s.write("var ");
+                    s.emit_object_rest_var_decl(pattern_idx, NodeIndex::NONE, Some(temp));
+                    s.write(";");
+                    s.write_line();
+                });
                 return;
             }
 
@@ -211,6 +221,44 @@ impl<'a> Printer<'a> {
 
         self.write(" ");
         self.emit(catch.block);
+    }
+
+    /// Emit a catch clause whose binding has been replaced by a synthesized
+    /// parameter: `catch (<temp>) { <preamble> <original statements> }`. The
+    /// `preamble` writes the leading extraction statement(s) that recover the
+    /// original binding from `<temp>`. Shared by the ES2018 object-rest and
+    /// ES5 down-level paths, which differ only in how they extract.
+    fn emit_catch_temp_wrapper(
+        &mut self,
+        node_pos: u32,
+        node_end: u32,
+        block_idx: NodeIndex,
+        preamble: impl FnOnce(&mut Self, &str),
+    ) {
+        let temp = self.get_temp_var_name();
+        self.write(" ");
+        self.map_token_after(node_pos, node_end, b'(');
+        self.write("(");
+        self.write(&temp);
+        self.write(")");
+
+        self.write(" {");
+        self.write_line();
+        self.increase_indent();
+
+        preamble(self, &temp);
+
+        if let Some(block_node) = self.arena.get(block_idx)
+            && let Some(block) = self.arena.get_block(block_node)
+        {
+            for &stmt in &block.statements.nodes {
+                self.emit(stmt);
+                self.write_line();
+            }
+        }
+
+        self.decrease_indent();
+        self.write("}");
     }
 
     fn catch_clause_has_recovered_empty_binding_parens(

--- a/crates/tsz-emitter/tests/es5_catch_clause_destructuring_tests.rs
+++ b/crates/tsz-emitter/tests/es5_catch_clause_destructuring_tests.rs
@@ -1,0 +1,196 @@
+//! ES5/ES3 down-level parity for destructuring patterns in a catch clause.
+//!
+//! Structural rule:
+//!   When the target is ES5 or below (no destructuring syntax) and a catch
+//!   clause binds a destructuring pattern (`catch ({ message }) { ... }`), tsc
+//!   binds the caught value to a synthesized catch parameter and extracts the
+//!   pattern into a leading `var` statement inside the catch block:
+//!     `catch (_a) { var message = _a.message; ... }`.
+//!   tsz previously emitted the destructuring pattern verbatim, which is not
+//!   valid ES5 and throws at runtime.
+//!
+//! The decision keys purely on the syntactic shape (ES5 target + binding
+//! pattern), never on the chosen identifier names, so the binder names are
+//! varied across cases to guard against name-based hardcoding. The extraction
+//! reuses the shared ES5 destructuring lowering, so defaults, nested patterns,
+//! renamed properties, array patterns, and object rest are all covered.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print as parse_lower_emit;
+
+fn es5_opts() -> PrintOptions {
+    PrintOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::CommonJS,
+        ..Default::default()
+    }
+}
+
+/// A bare object pattern lowers to a temp parameter plus a single extraction.
+#[test]
+fn catch_object_pattern_extracts_into_leading_var() {
+    let source =
+        "try {} catch ({ message }) { use(message); }\ndeclare function use(x: any): void;\n";
+    let output = parse_lower_emit(source, es5_opts());
+    assert!(
+        output.contains("catch (_a) {") && output.contains("var message = _a.message;"),
+        "object pattern in catch must lower to `catch (_a) {{ var message = _a.message; }}`.\nOutput:\n{output}"
+    );
+    // The destructuring pattern must not survive verbatim in ES5 output.
+    assert!(
+        !output.contains("catch ({ message })"),
+        "ES5 output must not retain the binding pattern.\nOutput:\n{output}"
+    );
+}
+
+/// Multiple properties extract as a comma-separated `var` list.
+#[test]
+fn catch_object_pattern_multiple_props() {
+    let source = "try {} catch ({ reason, detail }) { sink(reason, detail); }\ndeclare function sink(a: any, b: any): void;\n";
+    let output = parse_lower_emit(source, es5_opts());
+    assert!(
+        output.contains("var reason = _a.reason, detail = _a.detail;"),
+        "multiple properties must extract as a comma list.\nOutput:\n{output}"
+    );
+}
+
+/// A renamed property reads the source key, not the local binding name.
+#[test]
+fn catch_object_pattern_renamed_property() {
+    let source =
+        "try {} catch ({ message: msg }) { use(msg); }\ndeclare function use(x: any): void;\n";
+    let output = parse_lower_emit(source, es5_opts());
+    assert!(
+        output.contains("var msg = _a.message;"),
+        "renamed property must read `_a.message` and bind `msg`.\nOutput:\n{output}"
+    );
+}
+
+/// A defaulted property emits the `=== void 0` guard.
+#[test]
+fn catch_object_pattern_default_value() {
+    let source =
+        "try {} catch ({ code = 500 }) { use(code); }\ndeclare function use(x: any): void;\n";
+    let output = parse_lower_emit(source, es5_opts());
+    assert!(
+        output.contains("code = ") && output.contains("=== void 0 ? 500 :"),
+        "defaulted property must guard with `=== void 0 ? 500 : ...`.\nOutput:\n{output}"
+    );
+}
+
+/// A nested object pattern reads through the access path.
+#[test]
+fn catch_nested_object_pattern() {
+    let source = "try {} catch ({ outer: { inner } }) { use(inner); }\ndeclare function use(x: any): void;\n";
+    let output = parse_lower_emit(source, es5_opts());
+    assert!(
+        output.contains("var inner = _a.outer.inner;"),
+        "nested pattern must read `_a.outer.inner`.\nOutput:\n{output}"
+    );
+}
+
+/// An array pattern extracts by index (no `downlevelIteration`).
+#[test]
+fn catch_array_pattern_extracts_by_index() {
+    let source = "try {} catch ([head, tail]) { sink(head, tail); }\ndeclare function sink(a: any, b: any): void;\n";
+    let output = parse_lower_emit(source, es5_opts());
+    assert!(
+        output.contains("var head = _a[0], tail = _a[1];"),
+        "array pattern must extract `_a[0]`/`_a[1]`.\nOutput:\n{output}"
+    );
+}
+
+/// Object rest pulls in the `__rest` helper and excludes the named key.
+#[test]
+fn catch_object_pattern_with_rest() {
+    let source = "try {} catch ({ label, ...others }) { sink(label, others); }\ndeclare function sink(a: any, b: any): void;\n";
+    let output = parse_lower_emit(source, es5_opts());
+    assert!(
+        output.contains("var label = _a.label, others = __rest(_a, [\"label\"]);"),
+        "object rest must lower via `__rest(_a, [\"label\"])`.\nOutput:\n{output}"
+    );
+}
+
+/// Renaming every binder keeps the same structural lowering — no name-based
+/// fast path. This mirrors the multi-prop case with different identifiers.
+#[test]
+fn catch_pattern_lowering_is_name_agnostic() {
+    let source = "try {} catch ({ alpha, beta: renamed }) { sink(alpha, renamed); }\ndeclare function sink(a: any, b: any): void;\n";
+    let output = parse_lower_emit(source, es5_opts());
+    assert!(
+        output.contains("var alpha = _a.alpha, renamed = _a.beta;"),
+        "lowering must follow structure regardless of binder names.\nOutput:\n{output}"
+    );
+}
+
+/// A simple identifier catch binding is left untouched at ES5.
+#[test]
+fn catch_simple_identifier_unchanged() {
+    let source = "try {} catch (err) { use(err); }\ndeclare function use(x: any): void;\n";
+    let output = parse_lower_emit(source, es5_opts());
+    assert!(
+        output.contains("catch (err) {"),
+        "a plain identifier binding must be preserved verbatim.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("var err = "),
+        "a plain identifier binding must not be re-extracted.\nOutput:\n{output}"
+    );
+}
+
+/// An empty pattern extracts nothing, so no `var` statement is emitted — the
+/// synthesized parameter must not be followed by an invalid `var ;`.
+#[test]
+fn catch_empty_object_pattern_emits_no_var() {
+    let source = "try {} catch ({}) { log(); }\ndeclare function log(): void;\n";
+    let output = parse_lower_emit(source, es5_opts());
+    assert!(
+        output.contains("catch (_a) {") && !output.contains("var ;"),
+        "empty object pattern must not emit an invalid `var ;`.\nOutput:\n{output}"
+    );
+}
+
+/// An empty array pattern is likewise extraction-free.
+#[test]
+fn catch_empty_array_pattern_emits_no_var() {
+    let source = "try {} catch ([]) { log(); }\ndeclare function log(): void;\n";
+    let output = parse_lower_emit(source, es5_opts());
+    assert!(
+        output.contains("catch (_a) {") && !output.contains("var ;"),
+        "empty array pattern must not emit an invalid `var ;`.\nOutput:\n{output}"
+    );
+}
+
+/// An array pattern with a leading elision reads the correct index.
+#[test]
+fn catch_array_pattern_with_hole() {
+    let source =
+        "try {} catch ([, second]) { use(second); }\ndeclare function use(x: any): void;\n";
+    let output = parse_lower_emit(source, es5_opts());
+    assert!(
+        output.contains("var second = _a[1];"),
+        "an elided first element must shift the index to `_a[1]`.\nOutput:\n{output}"
+    );
+}
+
+/// At ES2015+ (native destructuring) the catch pattern is preserved verbatim.
+#[test]
+fn catch_object_pattern_preserved_at_es2015() {
+    let source =
+        "try {} catch ({ message }) { use(message); }\ndeclare function use(x: any): void;\n";
+    let opts = PrintOptions {
+        target: ScriptTarget::ES2015,
+        module: ModuleKind::CommonJS,
+        ..Default::default()
+    };
+    let output = parse_lower_emit(source, opts);
+    assert!(
+        output.contains("catch ({ message })"),
+        "ES2015 supports destructuring catch bindings natively.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Closes #14079.

## Structural rule

> When the target is ES5/ES3 (no destructuring syntax) and a catch clause binds
> a destructuring pattern, `tsc` binds the caught value to a synthesized catch
> parameter and extracts the pattern into a leading `var` statement inside the
> catch block, mirroring its down-level transform for `var { a } = obj`:
>
> ```js
> // catch ({ message }) { use(message); }   -->
> catch (_a) { var message = _a.message; use(message); }
> ```
>
> tsz emitted the binding pattern verbatim, which is invalid ES5 and throws at
> runtime.

Found by differential testing against `tsc`.

```ts
// --target es5
try {} catch ({ message }) { console.log(message); }
```

| | output |
|---|---|
| `tsc` 6.x | `catch (_a) { var message = _a.message; console.log(message); }` |
| tsz (before) | `catch ({ message }) { ... }` ← invalid ES5 |
| tsz (after) | matches `tsc` |

## Owner layer

Emitter only — `crates/tsz-emitter/src/emitter/statements/try_statement.rs`,
`emit_catch_clause`. No semantic/checker change, no output surgery.

This is the **same printer layer** where normal ES5 variable destructuring is
lowered (`emit_variable_declaration_list_es5` →
`emit_es5_destructuring_pattern_direct`, in `emitter/es5/bindings.rs`) and where
the existing ES2018 object-rest catch lowering already lives — so the fix is at
the right altitude and reuses the shared destructuring machinery rather than
re-implementing extraction. The decision keys purely on syntactic shape (ES5
target + binding pattern), so it applies to every binder spelling.

A shared `emit_catch_temp_wrapper` is extracted so the new ES5 path and the
pre-existing ES2018 object-rest path no longer duplicate the
`catch (temp) { <preamble> <statements> }` scaffolding (verified the ES2018
output is byte-identical after the refactor).

## Adjacent-case matrix (name-agnostic; binders varied; `--target es5`, byte-equal to `tsc`)

| case | result |
|---|---|
| `catch ({ message })` | `var message = _a.message;` |
| `catch ({ reason, detail })` | `var reason = _a.reason, detail = _a.detail;` |
| `catch ({ message: msg })` (renamed) | `var msg = _a.message;` |
| `catch ({ code = 500 })` (default) | `var _b = _a.code, code = _b === void 0 ? 500 : _b;` |
| `catch ({ outer: { inner } })` (nested) | `var inner = _a.outer.inner;` |
| `catch ([head, tail])` (array) | `var head = _a[0], tail = _a[1];` |
| `catch ({ label, ...others })` (rest) | `var label = _a.label, others = __rest(_a, ["label"]);` |
| `catch ([, second])` (elision) | `var second = _a[1];` |
| `catch ({})` / `catch ([])` (empty) | no `var` emitted — `catch (_a) { ... }` |
| `catch (err)` (plain ident, control) | unchanged |
| `catch ({ message })` at **ES2015** (control) | native pattern preserved |

## Out of scope (filed separately)

The **async** ES5 IR pipeline (`transforms/async_es5_ir*`) lowers no
destructuring at all (invalid `var ;` / ` = obj;` for both var decls and catch
bindings inside `async` functions at es5). Deeper, pre-existing, different
subsystem — tracked in #14080.

## Verification

- New name-agnostic suite
  `crates/tsz-emitter/tests/es5_catch_clause_destructuring_tests.rs` (13 tests),
  binder names varied per case — **13 passed**. The pattern-lowering assertions
  fail on the pre-fix tree (verbatim `catch ({ message })`), confirming genuine
  regression guards; the plain-ident and ES2015 controls stay green either way.
- `crates/tsz-emitter` lib unit tests — **3780 passed, 0 failed**.
- Adjacent suites green: `try_statement_recovery_tests`,
  `destructuring_es5_array_nested_order_tests`,
  `destructuring_es5_nested_single_inline_tests`,
  `destructuring_assignment_es5_shorthand_default_tests`,
  `destructuring_downlevel_iteration_read_tests`, `async_try_emit`.
- ES2018 object-rest-in-catch output confirmed **byte-identical** before/after
  the shared-wrapper refactor.
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --tests`,
  `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_014dRyWsqNwJZGwC4X1ryiEb

---
_Generated by [Claude Code](https://claude.ai/code/session_014dRyWsqNwJZGwC4X1ryiEb)_