### PR TITLE
fix(emit): key ES5 computed object-literal layout on the source multiLine flag

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/helpers_object_literal.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_object_literal.rs
@@ -1,4 +1,4 @@
-use super::super::{CommentKind, Printer, get_trailing_comment_ranges};
+use super::super::Printer;
 use crate::transforms::emit_utils;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{MethodDeclData, Node};
@@ -71,25 +71,16 @@ impl<'a> Printer<'a> {
         self.emit_object_literal_entries_es5_with_comments(elements, false, None, false);
     }
 
-    fn emit_object_literal_assign_entries_es5(
-        &mut self,
-        elements: &[NodeIndex],
-        source_range: Option<(u32, u32)>,
-    ) {
-        if self.object_literal_assign_segment_can_emit_compact(elements, source_range) {
-            self.emit_object_literal_entries_es5_compact(elements);
+    /// Emit the leading non-computed properties of a lowered object literal as the
+    /// `{ … }` target of the comma sequence. `multiline` is the source literal's
+    /// `multiLine` flag (a line break right after `{`): the prefix shares that
+    /// opening brace, so it lays out the same way — inline for single-line source.
+    fn emit_object_literal_prefix_entries_es5(&mut self, elements: &[NodeIndex], multiline: bool) {
+        if multiline {
+            self.emit_object_literal_entries_es5_with_comments(elements, false, None, true);
         } else {
-            self.emit_object_literal_entries_es5_with_comments(
-                elements,
-                false,
-                source_range,
-                false,
-            );
+            self.emit_object_literal_entries_es5_compact(elements);
         }
-    }
-
-    fn emit_object_literal_prefix_entries_es5(&mut self, elements: &[NodeIndex]) {
-        self.emit_object_literal_entries_es5_with_comments(elements, false, None, true);
     }
 
     fn emit_object_literal_entries_es5_compact(&mut self, elements: &[NodeIndex]) {
@@ -106,6 +97,23 @@ impl<'a> Printer<'a> {
             self.emit_object_literal_member_es5(prop);
         }
         self.write(" }");
+    }
+
+    fn emit_object_literal_assign_entries_es5(
+        &mut self,
+        elements: &[NodeIndex],
+        source_range: Option<(u32, u32)>,
+    ) {
+        if self.object_literal_assign_segment_can_emit_compact(elements, source_range) {
+            self.emit_object_literal_entries_es5_compact(elements);
+        } else {
+            self.emit_object_literal_entries_es5_with_comments(
+                elements,
+                false,
+                source_range,
+                false,
+            );
+        }
     }
 
     fn object_literal_assign_segment_can_emit_compact(
@@ -167,20 +175,7 @@ impl<'a> Printer<'a> {
             return;
         }
 
-        let open_brace_end = source_range.and_then(|(start_pos, end_pos)| {
-            self.source_text.and_then(|text| {
-                let bytes = text.as_bytes();
-                let start = start_pos as usize;
-                let end = std::cmp::min(end_pos as usize, bytes.len());
-                if start >= end {
-                    return None;
-                }
-                bytes[start..end]
-                    .iter()
-                    .position(|&b| b == b'{')
-                    .map(|off| (start + off + 1) as u32)
-            })
-        });
+        let open_brace_end = self.position_after_open_brace(source_range);
         let source_end = source_range.map(|(_, end)| end);
 
         if elements.len() > 1 {
@@ -563,35 +558,45 @@ impl<'a> Printer<'a> {
         self.emit_object_literal_with_spread_es5(elements, source_range);
     }
 
-    /// Emit object literal without spread (computed properties only)
+    /// Emit object literal without spread (computed properties only).
+    ///
+    /// A standalone (non-spread) computed-property literal preserves the source
+    /// `multiLine` flag in its lowered comma sequence — `tsc` reuses the original
+    /// literal node, so a line break right after `{` produces a multi-line layout.
     fn emit_object_literal_without_spread_es5(
         &mut self,
         elements: &[NodeIndex],
         source_range: Option<(u32, u32)>,
         has_trailing_comma: bool,
     ) {
-        // Use multiline layout when any element is an accessor: tsc always emits
-        // Object.defineProperty for accessors, and that descriptor spans multiple
-        // lines, so the whole comma expression must be multiline. Simple
-        // methods/properties stay inline.
-        let has_accessor = elements.iter().any(|&idx| {
-            self.arena.get(idx).is_some_and(|node| {
-                node.kind == syntax_kind_ext::GET_ACCESSOR
-                    || node.kind == syntax_kind_ext::SET_ACCESSOR
-            })
-        });
+        let multiline = self.object_literal_lowering_is_multiline(elements, source_range);
         self.emit_object_literal_without_spread_es5_with_layout(
             elements,
             source_range,
             has_trailing_comma,
             true,
-            has_accessor,
+            multiline,
         );
     }
 
     pub(in crate::emitter) fn try_emit_object_literal_es5_return_expression(
         &mut self,
         expression: NodeIndex,
+    ) -> bool {
+        // A return statement can own the comma expression directly, so `tsc` emits
+        // the lowering without an extra wrapping paren.
+        self.try_emit_object_literal_es5_computed_lowering(expression, false)
+    }
+
+    /// Lower a non-spread object literal that contains a computed property to the
+    /// ES5 `(_a = {}, _a[k] = …, _a)` comma sequence. Returns `false` (emitting
+    /// nothing) when `expression` is not such a literal, so callers can fall back
+    /// to their default emit. `wrap_in_parens` parenthesizes the comma sequence
+    /// for assignment-like contexts.
+    fn try_emit_object_literal_es5_computed_lowering(
+        &mut self,
+        expression: NodeIndex,
+        wrap_in_parens: bool,
     ) -> bool {
         if !self.ctx.target_es5 {
             return false;
@@ -624,12 +629,15 @@ impl<'a> Printer<'a> {
             return false;
         }
 
+        let elements = &literal.elements.nodes;
+        let source_range = Some((node.pos, node.end));
+        let multiline = self.object_literal_lowering_is_multiline(elements, source_range);
         self.emit_object_literal_without_spread_es5_with_layout(
-            &literal.elements.nodes,
-            Some((node.pos, node.end)),
-            self.has_trailing_comma_in_source(node, &literal.elements.nodes),
-            false,
-            false,
+            elements,
+            source_range,
+            self.has_trailing_comma_in_source(node, elements),
+            wrap_in_parens,
+            multiline,
         );
         true
     }
@@ -638,45 +646,9 @@ impl<'a> Printer<'a> {
         &mut self,
         expression: NodeIndex,
     ) -> bool {
-        if !self.ctx.target_es5 {
-            return false;
-        }
-
-        let Some(node) = self.arena.get(expression) else {
-            return false;
-        };
-        if node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
-            return false;
-        }
-
-        let Some(literal) = self.arena.get_literal_expr(node) else {
-            return false;
-        };
-        if literal
-            .elements
-            .nodes
-            .iter()
-            .any(|&idx| emit_utils::is_spread_element(self.arena, idx))
-        {
-            return false;
-        }
-        if !literal
-            .elements
-            .nodes
-            .iter()
-            .any(|&idx| emit_utils::is_computed_property_member(self.arena, idx))
-        {
-            return false;
-        }
-
-        self.emit_object_literal_without_spread_es5_with_layout(
-            &literal.elements.nodes,
-            Some((node.pos, node.end)),
-            self.has_trailing_comma_in_source(node, &literal.elements.nodes),
-            true,
-            false,
-        );
-        true
+        // Assignment-like contexts (variable initializers, using declarations, …)
+        // wrap the comma sequence in parens.
+        self.try_emit_object_literal_es5_computed_lowering(expression, true)
     }
 
     fn emit_object_literal_without_spread_es5_with_layout(
@@ -702,16 +674,8 @@ impl<'a> Printer<'a> {
             return;
         }
 
-        let use_multiline = use_multiline
-            || self.computed_object_literal_needs_multiline_layout(elements, source_range);
-
         // Get hoisted temp variable name
         let temp_var = self.make_unique_name_hoisted();
-
-        // Assignment-like expression contexts use the parenthesized multi-line
-        // lowering. A return statement can own the comma expression directly,
-        // and `tsc` keeps that form on one line.
-        let _ = source_range;
 
         if wrap_in_parens {
             self.write("(");
@@ -724,7 +688,10 @@ impl<'a> Printer<'a> {
 
         // Emit initial non-computed properties as the object literal
         if first_computed_idx > 0 {
-            self.emit_object_literal_prefix_entries_es5(&elements[..first_computed_idx]);
+            self.emit_object_literal_prefix_entries_es5(
+                &elements[..first_computed_idx],
+                use_multiline,
+            );
         } else {
             self.write("{}");
         }
@@ -756,56 +723,42 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn computed_object_literal_needs_multiline_layout(
+    /// Source offset just past the opening `{` of an object literal whose span is
+    /// `source_range`, or `None` when there is no source or no brace in range.
+    fn position_after_open_brace(&self, source_range: Option<(u32, u32)>) -> Option<u32> {
+        let (start, end) = source_range?;
+        let bytes = self.source_text?.as_bytes();
+        let start = (start as usize).min(bytes.len());
+        let end = (end as usize).min(bytes.len());
+        let brace_off = bytes[start..end].iter().position(|&b| b == b'{')?;
+        Some((start + brace_off + 1) as u32)
+    }
+
+    /// Whether the lowered comma-sequence form of an object literal should use a
+    /// multi-line layout. `tsc` keys this on the parser's `multiLine` flag, which
+    /// is `scanner.hasPrecedingLineBreak()` captured right after the opening `{`:
+    /// the literal is multi-line iff there is a line break between `{` and the
+    /// first property. A line break later in the literal (between properties or
+    /// before `}`) does not count, and accessors/line comments are irrelevant.
+    fn object_literal_lowering_is_multiline(
         &self,
         elements: &[NodeIndex],
         source_range: Option<(u32, u32)>,
     ) -> bool {
-        let has_computed = elements
-            .iter()
-            .any(|&idx| emit_utils::is_computed_property_member(self.arena, idx));
-        if !has_computed {
-            return false;
-        }
-
-        if let Some((start, end)) = source_range
-            && self.source_range_contains_line_comment(start, end)
-        {
-            return true;
-        }
-
-        elements.iter().any(|&idx| {
-            if !emit_utils::is_computed_property_member(self.arena, idx) {
-                return false;
-            }
-
-            let Some(text) = self.source_text else {
-                return false;
-            };
-            let Some(node) = self.arena.get(idx) else {
-                return false;
-            };
-
-            if self.source_range_contains_line_comment(node.pos, node.end) {
-                return true;
-            }
-
-            get_trailing_comment_ranges(text, node.end as usize)
-                .iter()
-                .any(|comment| comment.kind == CommentKind::SingleLine)
-        })
-    }
-
-    fn source_range_contains_line_comment(&self, start: u32, end: u32) -> bool {
         let Some(text) = self.source_text else {
             return false;
         };
-        let start = (start as usize).min(text.len());
-        let end = (end as usize).min(text.len());
-        start < end
-            && tsz_common::comments::get_comment_ranges(&text[start..end])
-                .iter()
-                .any(|comment| !comment.is_multi_line)
+        let Some(after_brace) = self.position_after_open_brace(source_range) else {
+            return false;
+        };
+        let Some(first) = elements.first().and_then(|&idx| self.arena.get(idx)) else {
+            return false;
+        };
+
+        let bytes = text.as_bytes();
+        let after_brace = (after_brace as usize).min(bytes.len());
+        let first_pos = (first.pos as usize).min(bytes.len());
+        after_brace < first_pos && bytes[after_brace..first_pos].contains(&b'\n')
     }
 
     /// Emit object literal with spread using __assign pattern
@@ -814,6 +767,12 @@ impl<'a> Printer<'a> {
         elements: &[NodeIndex],
         source_range: Option<(u32, u32)>,
     ) {
+        // The spread lowering builds fresh synthesized object literals for each
+        // `__assign` argument, none of which carry the original `multiLine` flag,
+        // so `tsc` always keeps these comma sequences (and their prefix literals)
+        // single-line — regardless of how the source literal was formatted.
+        let multiline = false;
+
         // Split into segments
         let mut segments: Vec<ObjectSegment> = Vec::new();
         let mut current_start = 0;
@@ -848,7 +807,13 @@ impl<'a> Printer<'a> {
                     .iter()
                     .any(|&idx| emit_utils::is_computed_property_member(self.arena, idx));
                 if has_computed {
-                    self.emit_object_literal_without_spread_es5(elems, source_range, false);
+                    self.emit_object_literal_without_spread_es5_with_layout(
+                        elems,
+                        source_range,
+                        false,
+                        true,
+                        multiline,
+                    );
                 } else {
                     self.emit_object_literal_entries_es5(elems);
                 }
@@ -883,7 +848,13 @@ impl<'a> Printer<'a> {
                 self.write_helper("__assign");
                 self.write("(");
                 if has_computed {
-                    self.emit_object_literal_without_spread_es5(elems, source_range, false);
+                    self.emit_object_literal_without_spread_es5_with_layout(
+                        elems,
+                        source_range,
+                        false,
+                        true,
+                        multiline,
+                    );
                 } else {
                     self.emit_object_literal_assign_entries_es5(elems, source_range);
                 }
@@ -921,7 +892,10 @@ impl<'a> Printer<'a> {
                         .position(|&idx| emit_utils::is_computed_property_member(self.arena, idx))
                         .unwrap_or(elems.len());
                     if first_computed > 0 {
-                        self.emit_object_literal_prefix_entries_es5(&elems[..first_computed]);
+                        self.emit_object_literal_prefix_entries_es5(
+                            &elems[..first_computed],
+                            multiline,
+                        );
                     } else {
                         self.write("{}");
                     }
@@ -988,6 +962,7 @@ impl<'a> Printer<'a> {
                             if first_computed > 0 {
                                 self.emit_object_literal_prefix_entries_es5(
                                     &elems[..first_computed],
+                                    multiline,
                                 );
                             } else {
                                 self.write("{}");
@@ -1036,6 +1011,7 @@ impl<'a> Printer<'a> {
                                 if first_computed > 0 {
                                     self.emit_object_literal_prefix_entries_es5(
                                         &elems[..first_computed],
+                                        multiline,
                                     );
                                 } else {
                                     self.write("{}");

--- a/crates/tsz-emitter/tests/computed_property_es5_tests.rs
+++ b/crates/tsz-emitter/tests/computed_property_es5_tests.rs
@@ -356,3 +356,95 @@ fn nested_object_literal_spread_keeps_empty_outer_assign_target() {
         "Trailing props should not mutate the inner object-spread assign result.\nOutput:\n{output2}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// `multiLine` parity for the lowered computed-property comma sequence.
+//
+// `tsc` lays the `(_a = {}, _a.k = …, _a)` comma sequence (and any leading
+// prefix object literal `{ … }`) out multi-line only when the *source* object
+// literal was multi-line — i.e. there is a line break right after the opening
+// `{` (the parser's `multiLine` flag, `hasPrecedingLineBreak()`). Accessors and
+// trailing line comments do not force a multi-line layout. The spread/`__assign`
+// lowering builds fresh synthesized literals with no `multiLine` flag, so those
+// comma sequences are always single-line regardless of source formatting.
+// ---------------------------------------------------------------------------
+
+/// The whole lowered sequence stays on one logical line when the source literal
+/// is single-line, even when it contains an accessor (which lowers to a
+/// multi-line `Object.defineProperty` descriptor). Only the descriptor object
+/// itself breaks; the comma sequence does not.
+#[test]
+fn single_line_computed_accessor_keeps_comma_sequence_inline() {
+    let output = emit_es5("const o = { ['k' + 1]: 1, m() {}, get g() { return 1; } };");
+    assert!(
+        output.contains(
+            "(_a = {}, _a['k' + 1] = 1, _a.m = function () { }, Object.defineProperty(_a, \"g\", {"
+        ),
+        "Single-line computed+accessor literal must keep the comma sequence inline.\nOutput:\n{output}"
+    );
+    // The comma sequence must not put each operand on its own line.
+    assert!(
+        !output.contains("_a = {},\n"),
+        "Comma sequence must not break after `_a = {{}}` for single-line source.\nOutput:\n{output}"
+    );
+}
+
+/// Binder-name-agnostic: the rule keys on source formatting, not identifiers.
+/// Renaming the computed key / accessor must not change the inline layout.
+#[test]
+fn single_line_computed_accessor_inline_is_name_agnostic() {
+    let output =
+        emit_es5("const widget = { [primaryKey]: 1, run() {}, get value() { return 1; } };");
+    assert!(
+        output.contains("(_a = {}, _a[primaryKey] = 1, _a.run = function () { }, Object.defineProperty(_a, \"value\", {"),
+        "Renamed single-line computed+accessor literal must still be inline.\nOutput:\n{output}"
+    );
+}
+
+/// A multi-line source literal (line break right after `{`) keeps the lowered
+/// comma sequence multi-line, with each operand on its own line.
+#[test]
+fn multiline_source_computed_breaks_comma_sequence() {
+    let source = "const o = {\n  ['k']: 1,\n  get g() { return 1; },\n  m() {},\n};";
+    let output = emit_es5(source);
+    assert!(
+        output.contains("(_a = {},\n"),
+        "Multi-line source literal must break the comma sequence after `_a = {{}}`.\nOutput:\n{output}"
+    );
+}
+
+/// A line break elsewhere (between properties, or before `}`) does NOT make the
+/// literal multi-line — only a break immediately after `{` does.
+#[test]
+fn line_break_between_props_keeps_inline() {
+    // `{` and the first property share a line; the break is between properties.
+    let output = emit_es5("const o = { ['k']: 1,\n a: 2 };");
+    assert!(
+        output.contains("(_a = {}, _a['k'] = 1, _a.a = 2, _a)"),
+        "Break between properties (not after `{{`) must stay inline.\nOutput:\n{output}"
+    );
+}
+
+/// The leading prefix object literal `{ a: 1, get g() {…} }` follows the same
+/// `multiLine` flag: inline for single-line source, even with an accessor.
+#[test]
+fn single_line_prefix_object_literal_stays_inline() {
+    let output = emit_es5("const o = { a: 1, get g() { return 1; }, ['k']: 2 };");
+    assert!(
+        output.contains("(_a = { a: 1, get g() { return 1; } }, _a['k'] = 2, _a)"),
+        "Single-line prefix object literal must stay inline.\nOutput:\n{output}"
+    );
+}
+
+/// The spread/`__assign` lowering is always single-line, even when the source
+/// literal is multi-line — the synthesized literals carry no `multiLine` flag.
+#[test]
+fn spread_lowering_is_always_inline_even_for_multiline_source() {
+    let source = "declare const spread: any;\nconst o = {\n  a: 1,\n  get g() { return 1; },\n  ['k']: 2,\n  ...spread,\n};";
+    let output = emit_es5(source);
+    assert!(
+        output
+            .contains("__assign((_a = { a: 1, get g() { return 1; } }, _a['k'] = 2, _a), spread)"),
+        "Spread lowering must keep the comma sequence inline for multi-line source.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Found by differential testing against `tsc` 6.0.2.

## Structural rule

> When an ES5 computed-property object literal is lowered to a
> `(_a = {}, _a[k] = …, _a)` comma sequence, `tsc` chooses a multi-line layout
> from the parser's `multiLine` flag — `scanner.hasPrecedingLineBreak()` captured
> immediately after the opening `{`. So the comma sequence (and its leading
> prefix object literal) is multi-line **iff there is a line break between `{`
> and the first property**. Accessors and trailing line comments are irrelevant,
> and a line break elsewhere (between properties or before `}`) does not count.
> The spread/`__assign` lowering builds fresh synthesized literals with no
> `multiLine` flag, so those comma sequences stay single-line regardless of how
> the source was formatted.

tsz instead decided multi-line from a `has_accessor` proxy plus a
trailing-line-comment heuristic, owned by the emitter
(`crates/tsz-emitter/src/emitter/es5/helpers_object_literal.rs`). That broke
every comma operand onto its own line whenever a **single-line** literal
contained an accessor or a line comment — diverging from `tsc` byte-for-byte.

```ts
// --target es5
const o = { ['k' + 1]: 1, m() {}, get g() { return 1; } };
```

| | output |
|---|---|
| `tsc` 6.0.2 | `var o = (_a = {}, _a['k' + 1] = 1, _a.m = function () { }, Object.defineProperty(_a, "g", { … }), _a);` (comma sequence inline; only the descriptor object breaks) |
| tsz (before) | each comma operand (`_a['k' + 1] = 1`, `_a.m = …`, …) on its own line |
| tsz (after)  | matches `tsc` byte-for-byte |

## Owner layer

Emitter only — `crates/tsz-emitter/src/emitter/es5/helpers_object_literal.rs`.
No semantic/checker change, no output surgery. The decision keys purely on
source structure (a `\n` between `{` and the first property's `pos`), never on
identifiers, file names, or rendered output, so it applies to every binder
spelling.

- New `object_literal_lowering_is_multiline` replaces both the `has_accessor`
  proxy and the `computed_object_literal_needs_multiline_layout` line-comment
  heuristic.
- The prefix object literal (`_a = { a: 1, get g() {…} }`) follows the same
  flag, so it is inline for single-line source even with an accessor.
- The spread/`__assign` path passes `multiline = false`, so its synthesized
  comma sequences and prefix literals stay single-line.
- Reuse/dedup: extracted the shared "position past `{`" scan into
  `position_after_open_brace` (the multi-line check and the comment-aware
  `_with_comments` path now share it), and folded the two near-identical
  `try_emit_object_literal_es5_{return,inline_computed}` entry points into one
  `try_emit_object_literal_es5_computed_lowering(expression, wrap_in_parens)`.

## Adjacent-case matrix (name-agnostic; binders varied; `--target es5`, byte-equal to `tsc` 6.0.2)

| case | result |
|---|---|
| `{ [k]: 1, m() {}, get g() {…} }` (single-line) | comma sequence inline |
| renamed `{ [primaryKey]: 1, run() {}, get value() {…} }` | inline (name-agnostic) |
| `{ a: 1, get g() {…}, [k]: 2 }` (prefix + accessor) | prefix `{ a: 1, get g() {…} }` inline |
| `{\n  [k]: 1,\n  get g() {…},\n  m() {}\n}` (break after `{`) | multi-line |
| `{ [k]: 1,\n a: 2 }` (break between props, not after `{`) | inline |
| `{ …, get g() {…}, ...spread }` (multi-line source + spread) | `__assign((…), spread)` inline |

## Verification

- New name-agnostic regression tests in
  `crates/tsz-emitter/tests/computed_property_es5_tests.rs` (6 cases:
  single-line accessor inline + renamed variant, multi-line break, break
  between props, single-line prefix, multi-line-source spread inline) — verified
  **4/6 fail on the pre-fix tree**, all green after (the 2 multi-line cases were
  already green and guard against the reverse regression).
- `cargo test -p tsz-emitter` — **4359 pass, 0 fail**.
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --tests`,
  `python3 scripts/arch/arch_guard.py` — clean.
- End-to-end differential vs `tsc` 6.0.2 over a 23-case object-literal battery
  (single/multi-line, computed/accessor/method/spread permutations) —
  byte-identical emitted files.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01YKAWKEVYUqGwK9VJnxs85N

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKAWKEVYUqGwK9VJnxs85N)_