### PR TITLE
fix(emit): down-level destructuring patterns inside async es5 generator bodies

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -27,6 +27,10 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 
 [[test]]
+name = "async_es5_destructuring_tests"
+path = "tests/async_es5_destructuring_tests.rs"
+
+[[test]]
 name = "es5_super_object_literal_accessor_tests"
 path = "tests/es5_super_object_literal_accessor_tests.rs"
 

--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -69,6 +69,8 @@ mod cases;
 mod condition_await;
 #[path = "async_es5_ir_control.rs"]
 mod control;
+#[path = "async_es5_ir_destructuring.rs"]
+mod destructuring;
 #[path = "async_es5_ir_discovery.rs"]
 mod discovery;
 #[path = "async_es5_ir_disposables.rs"]

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
@@ -1043,10 +1043,26 @@ impl<'a> AsyncES5Transformer<'a> {
             k if k == syntax_kind_ext::VARIABLE_STATEMENT => {
                 if let Some(var_data) = self.arena.get_variable(node) {
                     let mut decls = Vec::new();
+                    let mut has_destructuring = false;
                     for &decl_idx in &var_data.declarations.nodes {
                         if let Some(decl_node) = self.arena.get(decl_idx)
                             && let Some(decl) = self.arena.get_variable_declaration(decl_node)
                         {
+                            // Binding patterns (`{ a } = obj`) cannot be emitted
+                            // as a `var` name; down-level them to member-access
+                            // assignments instead. Reached only for non-suspended
+                            // declarations — async statement processing routes
+                            // awaited initializers through
+                            // `process_destructuring_variable_declaration` first.
+                            if self.is_binding_pattern_name(decl.name) && decl.initializer.is_some()
+                            {
+                                has_destructuring = true;
+                                decls.extend(self.lower_sync_destructuring_declaration(
+                                    decl.name,
+                                    decl.initializer,
+                                ));
+                                continue;
+                            }
                             let name = crate::transforms::emit_utils::identifier_text_or_empty(
                                 self.arena, decl.name,
                             );
@@ -1063,6 +1079,12 @@ impl<'a> AsyncES5Transformer<'a> {
                     }
                     if decls.len() == 1 {
                         decls.remove(0)
+                    } else if has_destructuring {
+                        // The lowering mixes hoisted `var` decls and extraction
+                        // expression statements, so a `var`-only declaration list
+                        // node cannot represent it; a sequence keeps each
+                        // statement distinct and lets the hoist pass recurse.
+                        IRNode::Sequence(decls)
                     } else {
                         IRNode::VarDeclList(decls)
                     }

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_destructuring.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_destructuring.rs
@@ -156,7 +156,7 @@ impl AsyncES5Transformer<'_> {
     pub(in crate::transforms) fn is_binding_pattern_name(&self, name_idx: NodeIndex) -> bool {
         self.arena
             .get(name_idx)
-            .is_some_and(|node| node.is_binding_pattern())
+            .is_some_and(tsz_parser::parser::node::Node::is_binding_pattern)
     }
 
     /// `tsc`'s `flattenObjectBindingOrAssignmentPattern` /
@@ -274,7 +274,7 @@ impl AsyncES5Transformer<'_> {
             } else {
                 Some(num_elements)
             };
-            let read_value = self.array_read_helper(value, read_count);
+            let read_value = Self::array_read_helper(value, read_count);
             self.ensure_identifier(read_value, false, out)
         } else if num_elements != 1 || all_omitted {
             self.ensure_identifier(value, num_elements != 0, out)
@@ -472,7 +472,7 @@ impl AsyncES5Transformer<'_> {
     }
 
     /// `tsc`'s array `createReadHelper`: `__read(value, count)`.
-    fn array_read_helper(&self, value: IRNode, count: Option<usize>) -> IRNode {
+    fn array_read_helper(value: IRNode, count: Option<usize>) -> IRNode {
         let mut args = vec![value];
         if let Some(count) = count {
             args.push(IRNode::number(count.to_string()));

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_destructuring.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_destructuring.rs
@@ -1,0 +1,517 @@
+//! ES5 destructuring lowering for binding patterns inside async generator
+//! bodies.
+//!
+//! The async-to-generator IR pipeline lowers statements into generator
+//! opcodes. Binding patterns in `var`/`const`/`let` declarations and in
+//! `catch` clauses must be down-leveled to plain member-access assignments,
+//! because ES5/ES3 has no destructuring syntax. This module mirrors `tsc`'s
+//! `flattenBindingOrAssignmentElement`
+//! (`src/compiler/transformers/destructuring.ts`): it walks a binding pattern
+//! and produces, for a given source value,
+//!
+//! - a list of hoisted variable names (leaf bindings plus any temporaries), and
+//! - a single comma-joined assignment expression that extracts each binding.
+//!
+//! The generator hoist pass (`async_es5_ir_hoists`) lifts the names into the
+//! `__awaiter` wrapper's `var` list; the comma expression stays inline at the
+//! point of declaration, matching `tsc`'s
+//! `transformAndEmitVariableDeclarationList`, which joins all initialized
+//! declarations of one list with `inlineExpressions`.
+//!
+//! The `__rest`/`__read` helper *definitions* are registered by the Phase-1
+//! lowering pass (`crate::lowering`), which scans every binding pattern in the
+//! tree regardless of async context; this module only emits the call sites via
+//! [`IRNode::RuntimeHelper`].
+
+use super::AsyncES5Transformer;
+use crate::transforms::ir::IRNode;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+/// Accumulator for a destructuring lowering: hoisted variable names (in
+/// declaration order) and the assignment expressions to comma-join.
+#[derive(Default)]
+struct DestructuringLowering {
+    /// Names to hoist into the surrounding `var` list, in the order `tsc`
+    /// would hoist them (temporaries appear where they are created).
+    names: Vec<String>,
+    /// Assignment expressions, in evaluation order, to comma-join into a
+    /// single expression statement.
+    assigns: Vec<IRNode>,
+}
+
+impl DestructuringLowering {
+    /// Record a hoisted name, de-duplicating so the `var` list stays clean.
+    fn push_name(&mut self, name: String) {
+        if !self.names.contains(&name) {
+            self.names.push(name);
+        }
+    }
+
+    /// Fold the collected assignments into a single comma expression. A
+    /// left-folded binary `,` chain prints without the wrapping parentheses a
+    /// `CommaExpr` would add, matching `tsc`'s statement-level comma list.
+    fn into_comma_expression(self) -> Option<IRNode> {
+        self.assigns
+            .into_iter()
+            .reduce(|acc, next| IRNode::binary(acc, ",", next))
+    }
+}
+
+impl AsyncES5Transformer<'_> {
+    /// Lower a binding-pattern declaration whose name is an object or array
+    /// binding pattern. Returns the statements to splice into the current
+    /// generator case: an initializer-less `var` declaration for every
+    /// extracted name (lifted by the hoist pass) followed by one comma-joined
+    /// extraction statement.
+    ///
+    /// `source` is the value being destructured. Callers pass the initializer
+    /// identifier directly (when it is a plain identifier the pattern does not
+    /// rebind) or a temp that already holds the value. When `force_source_temp`
+    /// is set the source is captured into a fresh temp first, even if it is a
+    /// plain identifier — required when the pattern rebinds that identifier
+    /// (`var { foo, baz } = foo`), so later bindings read the original value.
+    pub(in crate::transforms) fn lower_binding_pattern_statements(
+        &self,
+        pattern_idx: NodeIndex,
+        source: IRNode,
+        force_source_temp: bool,
+    ) -> Vec<IRNode> {
+        let mut lowering = DestructuringLowering::default();
+        let source = if force_source_temp && matches!(source, IRNode::Identifier(_)) {
+            self.ensure_identifier(source, false, &mut lowering)
+        } else {
+            source
+        };
+        self.flatten_binding_pattern(pattern_idx, source, &mut lowering);
+        let mut statements = Vec::new();
+        for name in &lowering.names {
+            statements.push(IRNode::VarDecl {
+                name: name.clone().into(),
+                initializer: None,
+            });
+        }
+        if let Some(expr) = lowering.into_comma_expression() {
+            statements.push(IRNode::ExpressionStatement(Box::new(expr)));
+        }
+        statements
+    }
+
+    /// Down-level a synchronous destructuring declaration (`{ a } = init`)
+    /// where `init` does not suspend: extract from the initializer value,
+    /// capturing it into a temp first only when the pattern rebinds the source
+    /// identifier (`var { foo } = foo`). Shared by the async-statement and
+    /// `statement_to_ir` declaration paths.
+    pub(in crate::transforms) fn lower_sync_destructuring_declaration(
+        &self,
+        pattern_idx: NodeIndex,
+        initializer_idx: NodeIndex,
+    ) -> Vec<IRNode> {
+        let force_source_temp = self.destructuring_source_needs_temp(pattern_idx, initializer_idx);
+        let source = self.expression_to_ir(initializer_idx);
+        self.lower_binding_pattern_statements(pattern_idx, source, force_source_temp)
+    }
+
+    /// Whether the initializer is a plain identifier that the pattern also
+    /// rebinds as a leaf — the `var { foo } = foo` hazard. Such a source must
+    /// be captured into a temp before extraction.
+    pub(in crate::transforms) fn destructuring_source_needs_temp(
+        &self,
+        pattern_idx: NodeIndex,
+        initializer_idx: NodeIndex,
+    ) -> bool {
+        let Some(init_node) = self.arena.get(initializer_idx) else {
+            return false;
+        };
+        if !init_node.is_identifier() {
+            return false;
+        }
+        let ident =
+            crate::transforms::emit_utils::identifier_text_or_empty(self.arena, initializer_idx);
+        if ident.is_empty() {
+            return false;
+        }
+        let mut names = Vec::new();
+        self.collect_binding_name(pattern_idx, &mut names);
+        names.iter().any(|name| name == &ident)
+    }
+
+    /// If a `catch` clause binds a destructuring pattern, return the pattern
+    /// node so the caller can extract it from the caught value.
+    pub(in crate::transforms) fn catch_binding_pattern(
+        &self,
+        var_decl_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let var_node = self.arena.get(var_decl_idx)?;
+        let var_decl = self.arena.get_variable_declaration(var_node)?;
+        if self.is_binding_pattern_name(var_decl.name) {
+            Some(var_decl.name)
+        } else {
+            None
+        }
+    }
+
+    /// Whether the declaration name is a destructuring binding pattern.
+    pub(in crate::transforms) fn is_binding_pattern_name(&self, name_idx: NodeIndex) -> bool {
+        self.arena
+            .get(name_idx)
+            .is_some_and(|node| node.is_binding_pattern())
+    }
+
+    /// `tsc`'s `flattenObjectBindingOrAssignmentPattern` /
+    /// `flattenArrayBindingOrAssignmentPattern` dispatch.
+    fn flatten_binding_pattern(
+        &self,
+        pattern_idx: NodeIndex,
+        value: IRNode,
+        out: &mut DestructuringLowering,
+    ) {
+        let Some(node) = self.arena.get(pattern_idx) else {
+            return;
+        };
+        if node.kind == syntax_kind_ext::OBJECT_BINDING_PATTERN {
+            self.flatten_object_pattern(pattern_idx, value, out);
+        } else if node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN {
+            self.flatten_array_pattern(pattern_idx, value, out);
+        }
+    }
+
+    fn flatten_object_pattern(
+        &self,
+        pattern_idx: NodeIndex,
+        value: IRNode,
+        out: &mut DestructuringLowering,
+    ) {
+        let Some(pattern_node) = self.arena.get(pattern_idx) else {
+            return;
+        };
+        let Some(pattern) = self.arena.get_binding_pattern(pattern_node) else {
+            return;
+        };
+        let elements: Vec<NodeIndex> = pattern.elements.nodes.clone();
+        let num_elements = elements.len();
+
+        // For anything other than a single-element pattern `tsc` evaluates the
+        // value exactly once via a temp (reusing an identifier source). Empty
+        // patterns still force a temp so a value with side effects is evaluated.
+        let value = if num_elements != 1 {
+            self.ensure_identifier(value, num_elements != 0, out)
+        } else {
+            value
+        };
+
+        // Computed-key temps in source order, consumed by `__rest`'s exclusion
+        // list to mirror `tsc`'s `computedTempVariables` threading.
+        let mut computed_temps: Vec<IRNode> = Vec::new();
+        for (i, &element_idx) in elements.iter().enumerate() {
+            let Some(element_node) = self.arena.get(element_idx) else {
+                continue;
+            };
+            if element_node.kind != syntax_kind_ext::BINDING_ELEMENT {
+                continue;
+            }
+            let Some(element) = self.arena.get_binding_element(element_node).cloned() else {
+                continue;
+            };
+
+            if element.dot_dot_dot_token {
+                if i != num_elements - 1 {
+                    continue;
+                }
+                let rest_value = self.object_rest_value(value.clone(), &elements, &computed_temps);
+                self.flatten_binding_element(element.name, rest_value, NodeIndex::NONE, out);
+                continue;
+            }
+
+            let property_name = if element.property_name.is_some() {
+                element.property_name
+            } else {
+                element.name
+            };
+            let (access, computed_temp) =
+                self.destructuring_property_access(value.clone(), property_name, out);
+            if let Some(temp) = computed_temp {
+                computed_temps.push(temp);
+            }
+            self.flatten_binding_element(element.name, access, element.initializer, out);
+        }
+    }
+
+    fn flatten_array_pattern(
+        &self,
+        pattern_idx: NodeIndex,
+        value: IRNode,
+        out: &mut DestructuringLowering,
+    ) {
+        let Some(pattern_node) = self.arena.get(pattern_idx) else {
+            return;
+        };
+        let Some(pattern) = self.arena.get_binding_pattern(pattern_node) else {
+            return;
+        };
+        let elements: Vec<NodeIndex> = pattern.elements.nodes.clone();
+        let num_elements = elements.len();
+
+        let all_omitted = !elements.is_empty()
+            && elements.iter().all(|&idx| {
+                self.arena
+                    .get(idx)
+                    .is_some_and(|n| n.kind == syntax_kind_ext::OMITTED_EXPRESSION)
+            });
+
+        let has_trailing_rest = elements.last().is_some_and(|&idx| {
+            self.arena
+                .get(idx)
+                .and_then(|n| self.arena.get_binding_element(n))
+                .is_some_and(|e| e.dot_dot_dot_token)
+        });
+
+        let value = if self.downlevel_iteration {
+            // Read the elements of the iterable into an array, then bind.
+            let read_count = if has_trailing_rest {
+                None
+            } else {
+                Some(num_elements)
+            };
+            let read_value = self.array_read_helper(value, read_count);
+            self.ensure_identifier(read_value, false, out)
+        } else if num_elements != 1 || all_omitted {
+            self.ensure_identifier(value, num_elements != 0, out)
+        } else {
+            value
+        };
+
+        for (i, &element_idx) in elements.iter().enumerate() {
+            let Some(element_node) = self.arena.get(element_idx) else {
+                continue;
+            };
+            if element_node.kind == syntax_kind_ext::OMITTED_EXPRESSION {
+                continue;
+            }
+            if element_node.kind != syntax_kind_ext::BINDING_ELEMENT {
+                continue;
+            }
+            let Some(element) = self.arena.get_binding_element(element_node).cloned() else {
+                continue;
+            };
+
+            if element.dot_dot_dot_token {
+                if i != num_elements - 1 {
+                    continue;
+                }
+                let slice = IRNode::call(
+                    IRNode::prop(value.clone(), "slice"),
+                    vec![IRNode::number(i.to_string())],
+                );
+                self.flatten_binding_element(element.name, slice, NodeIndex::NONE, out);
+                continue;
+            }
+
+            let access = IRNode::elem(value.clone(), IRNode::number(i.to_string()));
+            self.flatten_binding_element(element.name, access, element.initializer, out);
+        }
+    }
+
+    /// `tsc`'s `flattenBindingOrAssignmentElement`: apply a default-value
+    /// check, then either recurse into a nested pattern or emit the leaf
+    /// assignment.
+    fn flatten_binding_element(
+        &self,
+        name_idx: NodeIndex,
+        value: IRNode,
+        initializer_idx: NodeIndex,
+        out: &mut DestructuringLowering,
+    ) {
+        let value = if initializer_idx.is_some() {
+            let checked = self.default_value_check(value, initializer_idx, out);
+            // When the default is not a simple inlineable expression and the
+            // target is itself a pattern, `tsc` binds the checked value to a
+            // temp so side effects run before the nested destructuring.
+            if self.is_binding_pattern_name(name_idx)
+                && !self.is_simple_inlineable_expression(initializer_idx)
+            {
+                self.ensure_identifier(checked, true, out)
+            } else {
+                checked
+            }
+        } else {
+            value
+        };
+
+        if self.is_binding_pattern_name(name_idx) {
+            self.flatten_binding_pattern(name_idx, value, out);
+            return;
+        }
+
+        let name = crate::transforms::emit_utils::identifier_text_or_empty(self.arena, name_idx);
+        if name.is_empty() {
+            return;
+        }
+        out.push_name(name.clone());
+        out.assigns.push(IRNode::assign(IRNode::id(name), value));
+    }
+
+    /// `tsc`'s `createDefaultValueCheck`: bind `value` to a temp (reusing an
+    /// identifier) and return `temp === void 0 ? default : temp`.
+    fn default_value_check(
+        &self,
+        value: IRNode,
+        initializer_idx: NodeIndex,
+        out: &mut DestructuringLowering,
+    ) -> IRNode {
+        let value = self.ensure_identifier(value, true, out);
+        let default_value = self.expression_to_ir(initializer_idx);
+        IRNode::ConditionalExpr {
+            condition: Box::new(IRNode::binary(value.clone(), "===", IRNode::Undefined)),
+            when_true: Box::new(default_value),
+            when_false: Box::new(value),
+        }
+    }
+
+    /// `tsc`'s `createDestructuringPropertyAccess`: `value.name`,
+    /// `value["literal"]`, or `value[_t]` for a computed key (cached in a temp).
+    /// Returns the access expression and, for computed keys, the key temp so
+    /// the caller can thread it into a trailing `__rest` exclusion list.
+    fn destructuring_property_access(
+        &self,
+        value: IRNode,
+        property_name_idx: NodeIndex,
+        out: &mut DestructuringLowering,
+    ) -> (IRNode, Option<IRNode>) {
+        let Some(name_node) = self.arena.get(property_name_idx) else {
+            return (value, None);
+        };
+        if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            if let Some(computed) = self.arena.get_computed_property(name_node) {
+                let key = self.expression_to_ir(computed.expression);
+                let key = self.ensure_identifier(key, false, out);
+                return (IRNode::elem(value, key.clone()), Some(key));
+            }
+            return (value, None);
+        }
+        if name_node.is_string_literal() {
+            if let Some(lit) = self.arena.get_literal(name_node) {
+                return (IRNode::elem(value, IRNode::string(lit.text.clone())), None);
+            }
+        }
+        if name_node.kind == SyntaxKind::NumericLiteral as u16 {
+            if let Some(lit) = self.arena.get_literal(name_node) {
+                return (IRNode::elem(value, IRNode::number(lit.text.clone())), None);
+            }
+        }
+        let name =
+            crate::transforms::emit_utils::identifier_text_or_empty(self.arena, property_name_idx);
+        (IRNode::prop(value, name), None)
+    }
+
+    /// `tsc`'s `createRestHelper`: `__rest(value, ["a", "b", ...])` excluding
+    /// every non-rest property name that precedes the rest element. Computed
+    /// keys reuse their cached temp via `typeof _t === "symbol" ? _t : _t + ""`.
+    fn object_rest_value(
+        &self,
+        value: IRNode,
+        elements: &[NodeIndex],
+        computed_temps: &[IRNode],
+    ) -> IRNode {
+        let mut excluded = Vec::new();
+        let mut computed_offset = 0usize;
+        for &element_idx in &elements[..elements.len().saturating_sub(1)] {
+            let Some(element_node) = self.arena.get(element_idx) else {
+                continue;
+            };
+            let Some(element) = self.arena.get_binding_element(element_node) else {
+                continue;
+            };
+            if element.dot_dot_dot_token {
+                continue;
+            }
+            let property_name = if element.property_name.is_some() {
+                element.property_name
+            } else {
+                element.name
+            };
+            let Some(name_node) = self.arena.get(property_name) else {
+                continue;
+            };
+            if name_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+                if let Some(temp) = computed_temps.get(computed_offset) {
+                    computed_offset += 1;
+                    excluded.push(IRNode::ConditionalExpr {
+                        condition: Box::new(IRNode::binary(
+                            IRNode::PrefixUnaryExpr {
+                                operator: "typeof ".into(),
+                                operand: Box::new(temp.clone()),
+                            },
+                            "===",
+                            IRNode::string("symbol"),
+                        )),
+                        when_true: Box::new(temp.clone()),
+                        when_false: Box::new(IRNode::binary(temp.clone(), "+", IRNode::string(""))),
+                    });
+                }
+                continue;
+            }
+            if name_node.is_string_literal() || name_node.kind == SyntaxKind::NumericLiteral as u16
+            {
+                if let Some(lit) = self.arena.get_literal(name_node) {
+                    excluded.push(IRNode::string(lit.text.clone()));
+                }
+                continue;
+            }
+            let name =
+                crate::transforms::emit_utils::identifier_text_or_empty(self.arena, property_name);
+            if !name.is_empty() {
+                excluded.push(IRNode::string(name));
+            }
+        }
+        IRNode::call(
+            IRNode::RuntimeHelper("__rest".into()),
+            vec![value, IRNode::ArrayLiteral(excluded)],
+        )
+    }
+
+    /// `tsc`'s array `createReadHelper`: `__read(value, count)`.
+    fn array_read_helper(&self, value: IRNode, count: Option<usize>) -> IRNode {
+        let mut args = vec![value];
+        if let Some(count) = count {
+            args.push(IRNode::number(count.to_string()));
+        }
+        IRNode::call(IRNode::RuntimeHelper("__read".into()), args)
+    }
+
+    /// `tsc`'s `ensureIdentifier`: return `value` unchanged when it is already
+    /// an identifier and reuse is allowed; otherwise allocate a hoisted temp,
+    /// emit `temp = value`, and return the temp.
+    fn ensure_identifier(
+        &self,
+        value: IRNode,
+        reuse_identifier: bool,
+        out: &mut DestructuringLowering,
+    ) -> IRNode {
+        if reuse_identifier && matches!(value, IRNode::Identifier(_)) {
+            return value;
+        }
+        let temp = self.generate_hoisted_temp();
+        out.push_name(temp.clone());
+        out.assigns
+            .push(IRNode::assign(IRNode::id(temp.clone()), value));
+        IRNode::id(temp)
+    }
+
+    /// Whether the initializer expression is a simple inlineable expression
+    /// (`tsc`'s `isSimpleInlineableExpression`): literals and identifiers that
+    /// can be duplicated without changing evaluation semantics.
+    fn is_simple_inlineable_expression(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+        node.is_identifier()
+            || node.is_string_literal()
+            || node.kind == SyntaxKind::NumericLiteral as u16
+            || node.kind == SyntaxKind::BigIntLiteral as u16
+            || node.kind == SyntaxKind::TrueKeyword as u16
+            || node.kind == SyntaxKind::FalseKeyword as u16
+            || node.kind == SyntaxKind::NullKeyword as u16
+    }
+}

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_statements.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_statements.rs
@@ -1161,6 +1161,23 @@ impl<'a> AsyncES5Transformer<'a> {
         };
 
         if let Some(decl) = self.arena.get_variable_declaration(node) {
+            // Binding patterns (`var { a, b } = obj` / `var [x] = arr`) have no
+            // identifier name: down-level them to member-access assignments
+            // (`a = obj.a, b = obj.b`) instead of emitting an empty `var`.
+            if self.is_binding_pattern_name(decl.name) {
+                let pattern = decl.name;
+                let initializer = decl.initializer;
+                self.process_destructuring_variable_declaration(
+                    pattern,
+                    initializer,
+                    cases,
+                    current_statements,
+                    current_label,
+                    trailing_comment,
+                );
+                return;
+            }
+
             let name =
                 crate::transforms::emit_utils::identifier_text_or_empty(self.arena, decl.name);
 
@@ -1310,6 +1327,71 @@ impl<'a> AsyncES5Transformer<'a> {
                     initializer: init,
                 });
             }
+        }
+    }
+
+    /// Down-level a destructuring variable declaration (`var { a } = obj`,
+    /// `var [x] = arr`) inside an async generator body. ES5 has no
+    /// destructuring syntax, so each binding becomes a member-access
+    /// assignment; the extracted names are hoisted by the generator var pass
+    /// and the assignments are comma-joined into one statement, matching `tsc`.
+    pub(in crate::transforms) fn process_destructuring_variable_declaration(
+        &mut self,
+        pattern: NodeIndex,
+        initializer: NodeIndex,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+        trailing_comment: &mut Option<String>,
+    ) {
+        // An absent initializer cannot be destructured at runtime; `tsc` rejects
+        // it (`A destructuring declaration must have an initializer`), so there
+        // is nothing to extract.
+        if initializer.is_none() {
+            return;
+        }
+
+        if self.contains_await_recursive(initializer) {
+            // Capture the (possibly awaited) value into a temp, then destructure
+            // from that temp once it is resolved.
+            let source_temp = self.generate_hoisted_temp();
+            current_statements.push(IRNode::VarDecl {
+                name: source_temp.clone().into(),
+                initializer: None,
+            });
+
+            if self.is_suspension_expression(initializer) {
+                let trailing_comment = trailing_comment.take();
+                self.process_await_expression_with_trailing_comment(
+                    initializer,
+                    cases,
+                    current_statements,
+                    current_label,
+                    trailing_comment.as_deref(),
+                );
+                current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+                    IRNode::id(source_temp.clone()),
+                    IRNode::GeneratorSent,
+                ))));
+            } else {
+                self.emit_nested_suspension(initializer, cases, current_statements, current_label);
+                let value = self.expression_to_ir(initializer);
+                current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+                    IRNode::id(source_temp.clone()),
+                    value,
+                ))));
+            }
+
+            let statements =
+                self.lower_binding_pattern_statements(pattern, IRNode::id(source_temp), false);
+            current_statements.extend(statements);
+            return;
+        }
+
+        // Synchronous initializer: extract directly from the initializer value.
+        current_statements.extend(self.lower_sync_destructuring_declaration(pattern, initializer));
+        if let Some(comment) = trailing_comment.take() {
+            current_statements.push(IRNode::TrailingComment(comment.into()));
         }
     }
 

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_try_statement.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_try_statement.rs
@@ -89,7 +89,28 @@ impl<'a> AsyncES5Transformer<'a> {
                 && let Some(catch_data) = self.arena.get_catch_clause(catch_node)
             {
                 let catch_rename_depth = self.catch_binding_renames.len();
-                if catch_data.variable_declaration.is_some() {
+                if let Some(catch_pattern) =
+                    self.catch_binding_pattern(catch_data.variable_declaration)
+                {
+                    // Destructuring catch binding (`catch ({ message }) { ... }`).
+                    // tsc binds the caught value to a synthesized temp, then
+                    // extracts the pattern from it.
+                    let source_temp = self.generate_hoisted_temp();
+                    current_statements.push(IRNode::VarDecl {
+                        name: source_temp.clone().into(),
+                        initializer: None,
+                    });
+                    current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+                        IRNode::id(source_temp.clone()),
+                        IRNode::GeneratorSent,
+                    ))));
+                    let statements = self.lower_binding_pattern_statements(
+                        catch_pattern,
+                        IRNode::id(source_temp),
+                        false,
+                    );
+                    current_statements.extend(statements);
+                } else if catch_data.variable_declaration.is_some() {
                     let catch_var_name =
                         self.get_catch_variable_name(catch_data.variable_declaration);
                     if !catch_var_name.is_empty() {

--- a/crates/tsz-emitter/tests/async_es5_destructuring_tests.rs
+++ b/crates/tsz-emitter/tests/async_es5_destructuring_tests.rs
@@ -1,0 +1,188 @@
+//! ES5 down-level emit for destructuring binding patterns inside `async`
+//! function bodies (issue #14080).
+//!
+//! The async→generator IR pipeline previously passed binding patterns through
+//! verbatim, emitting syntactically-invalid JavaScript (`var ;` / ` = obj;`)
+//! for destructuring `var`/`const` declarations and silently dropping
+//! destructuring `catch` bindings. These tests pin the down-leveled output to
+//! `tsc`'s `flattenBindingOrAssignmentElement` form: hoisted names plus a
+//! comma-joined extraction expression. Binder names are varied per case so the
+//! lowering keys on pattern shape, never on a specific identifier.
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print;
+use tsz_emitter::output::printer::PrintOptions;
+
+fn emit_es5(source: &str) -> String {
+    parse_and_lower_print(source, PrintOptions::es5())
+}
+
+fn emit_es5_downlevel(source: &str) -> String {
+    let mut opts = PrintOptions::es5();
+    opts.downlevel_iteration = true;
+    parse_and_lower_print(source, opts)
+}
+
+/// The pre-fix bug witness: a destructuring `const` after an `await` must not
+/// emit an empty `var ;` or a nameless ` = obj;` assignment.
+#[test]
+fn object_pattern_after_await_extracts_each_binding() {
+    let output = emit_es5("async function f() { await g(); const { a, b } = obj; sink(a, b); }");
+    assert!(
+        output.contains("a = obj.a, b = obj.b;"),
+        "object pattern should extract each property; got:\n{output}"
+    );
+    assert!(
+        !output.contains("var ;") && !output.contains(" = obj;\n"),
+        "invalid empty var / nameless assignment must not appear; got:\n{output}"
+    );
+}
+
+/// Leaf names and temporaries are hoisted into the `__awaiter` wrapper's `var`
+/// list, leaving only the assignment inline.
+#[test]
+fn extracted_names_are_hoisted_not_declared_inline() {
+    let output = emit_es5("async function f() { await g(); const { first, second } = pair; }");
+    assert!(
+        output.contains("var first, second;"),
+        "binding names should be hoisted; got:\n{output}"
+    );
+}
+
+/// Property rename and a defaulted binding take `tsc`'s temp form
+/// `_t = src.p, name = _t === void 0 ? d : _t`.
+#[test]
+fn rename_and_default_use_tsc_temp_form() {
+    let output =
+        emit_es5("async function f() { await g(); const { message: note, code = 500 } = err; }");
+    assert!(
+        output.contains("note = err.message, _a = err.code, code = _a === void 0 ? 500 : _a;"),
+        "rename + default should match tsc's temp form; got:\n{output}"
+    );
+}
+
+/// A single-element nested pattern inlines the access path (no temp), matching
+/// `tsc`'s `flattenObjectBindingOrAssignmentPattern` fast path.
+#[test]
+fn single_nested_pattern_inlines_access_path() {
+    let output = emit_es5("async function f() { await g(); const { outer: { inner } } = box; }");
+    assert!(
+        output.contains("inner = box.outer.inner;"),
+        "single nested pattern should inline the access path; got:\n{output}"
+    );
+}
+
+/// Array binding patterns index into the source; holes are skipped.
+#[test]
+fn array_pattern_indexes_and_skips_holes() {
+    let output = emit_es5("async function f() { await g(); const [head, , third] = list; }");
+    assert!(
+        output.contains("head = list[0], third = list[2];"),
+        "array pattern should index and skip the hole; got:\n{output}"
+    );
+}
+
+/// Object rest lowers to `__rest` with the excluded keys, and the helper is
+/// emitted.
+#[test]
+fn object_rest_uses_rest_helper() {
+    let output = emit_es5("async function f() { await g(); const { kept, ...others } = bag; }");
+    assert!(
+        output.contains("kept = bag.kept, others = __rest(bag, [\"kept\"]);"),
+        "object rest should call __rest with excluded keys; got:\n{output}"
+    );
+    assert!(
+        output.contains("var __rest ="),
+        "the __rest helper definition must be emitted; got:\n{output}"
+    );
+}
+
+/// Array rest slices the tail.
+#[test]
+fn array_rest_slices_tail() {
+    let output = emit_es5("async function f() { await g(); const [lead, ...rest] = items; }");
+    assert!(
+        output.contains("lead = items[0], rest = items.slice(1);"),
+        "array rest should slice the tail; got:\n{output}"
+    );
+}
+
+/// A non-identifier initializer with multiple bindings is captured into a temp
+/// once, matching `tsc`'s `ensureIdentifier`.
+#[test]
+fn complex_initializer_is_captured_once() {
+    let output = emit_es5("async function f() { await g(); const { x, y } = make(); }");
+    assert!(
+        output.contains("_a = make(), x = _a.x, y = _a.y;"),
+        "complex initializer should be captured into one temp; got:\n{output}"
+    );
+}
+
+/// A destructuring `catch` binding extracts from the caught value instead of
+/// being dropped.
+#[test]
+fn catch_pattern_extracts_from_caught_value() {
+    let output =
+        emit_es5("async function f() { try { await g(); } catch ({ reason }) { sink(reason); } }");
+    assert!(
+        output.contains("reason = _a.reason;"),
+        "catch pattern should extract from the caught value; got:\n{output}"
+    );
+    assert!(
+        output.contains(".sent();"),
+        "the caught value should be bound via the generator sent value; got:\n{output}"
+    );
+}
+
+/// `await` in the initializer captures the resolved value into a temp, then
+/// destructures from it.
+#[test]
+fn awaited_initializer_destructures_resolved_value() {
+    let output = emit_es5("async function f() { const { a, b } = await load(); }");
+    assert!(
+        output.contains("a = _a.a, b = _a.b;"),
+        "an awaited initializer should be destructured after resolution; got:\n{output}"
+    );
+    assert!(
+        output.contains(".sent();"),
+        "the resolved value should come from the generator sent value; got:\n{output}"
+    );
+}
+
+/// The plain-identifier `catch (e)` path is unaffected by the pattern handling.
+#[test]
+fn plain_identifier_catch_binding_unchanged() {
+    let output = emit_es5("async function f() { try { await g(); } catch (e) { sink(e); } }");
+    assert!(
+        output.contains("e_1 = _a.sent();"),
+        "plain identifier catch should still bind the sent value; got:\n{output}"
+    );
+    assert!(
+        !output.contains("__rest"),
+        "a plain catch should not pull in destructuring helpers; got:\n{output}"
+    );
+}
+
+/// Under `downlevelIteration`, an array binding pattern reads the iterable via
+/// `__read` before indexing.
+#[test]
+fn downlevel_iteration_array_pattern_uses_read_helper() {
+    let output = emit_es5_downlevel("async function f() { await g(); const [one, two] = seq; }");
+    assert!(
+        output.contains("__read(seq, 2)"),
+        "downlevelIteration array pattern should use __read; got:\n{output}"
+    );
+}
+
+/// Binder names do not drive the lowering: a differently-named witness emits
+/// the structurally identical shape.
+#[test]
+fn lowering_is_binder_name_agnostic() {
+    let output = emit_es5("async function f() { await g(); const { alpha, beta } = src; }");
+    assert!(
+        output.contains("alpha = src.alpha, beta = src.beta;"),
+        "renamed binders should produce the same structural shape; got:\n{output}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Closes #14080.

## Structural rule

> When the target is ES5/ES3 (no destructuring syntax) and a binding pattern
> appears in a `var`/`const`/`let` declaration or a `catch` clause **inside an
> `async` function**, `tsc` runs its destructuring transform before the
> generator transform: it flattens the pattern into member-access assignments,
> hoists the bound names, and joins the initializers of one declaration list
> into a single comma expression (`a = obj.a, b = obj.b`).
>
> tsz's async→generator IR pipeline passed binding patterns through verbatim,
> producing **syntactically-invalid JavaScript**: an empty `var ;` hoist plus a
> nameless ` = obj;` assignment for declarations, and a *dropped* binding for
> destructuring catch clauses.

```ts
// --target es5
async function f() { await g(); const { a, b } = obj; }
async function h() { try { await g(); } catch ({ message }) { use(message); } }
```

| | output |
|---|---|
| tsz (before) | `var ;` … ` = obj;` (invalid); catch `message` dropped |
| tsz (after) | `var a, b;` … `a = obj.a, b = obj.b;`; catch `_a = _b.sent(); message = _a.message;` |
| `tsc` | matches |

## Owner layer

Emitter only — the async ES5 IR transform
(`crates/tsz-emitter/src/transforms/async_es5_ir_*`). No semantic/checker
change, no output surgery.

The new module `async_es5_ir_destructuring.rs` ports `tsc`'s
`flattenBindingOrAssignmentElement`
(`src/compiler/transformers/destructuring.ts`): it walks a binding pattern over
a source value into **hoisted names + one comma-joined extraction expression**.
The generator var-hoist pass lifts the names into the `__awaiter` wrapper's
`var` list, and the generator state-param name dodges them — exactly how `tsc`
allocates temps (so the state param shifts `_a`→`_b` when the lowering
introduces an `_a` temp). The decision keys purely on syntactic shape (ES5
target + binding pattern), so it applies to every binder spelling.

Three declaration paths share one `lower_binding_pattern_statements` entry:
the async-statement path (`process_destructuring_variable_declaration`), the
`statement_to_ir` fallback (no-await subtrees), and the `catch` path. Awaited
initializers and the caught value are captured into a temp first, then
destructured from it. `__rest`/`__read` call sites use `IRNode::RuntimeHelper`;
the helper *definitions* are already registered by the Phase-1 lowering pass,
which scans every binding pattern regardless of async context.

This is the async-IR follow-up explicitly scoped out of the synchronous
printer-path fixes (#14079 / #14081), which it does not touch.

## Adjacent-case matrix (name-agnostic; binders varied; `--target es5`, byte-equal to `tsc`)

| case | result |
|---|---|
| `{ a, b }` | `a = obj.a, b = obj.b` |
| `{ message: note }` (rename) | `note = err.message` |
| `{ code = 500 }` (default) | `_a = err.code, code = _a === void 0 ? 500 : _a` |
| `{ outer: { inner } }` (single nested) | `inner = box.outer.inner` (inlined, no temp) |
| `[head, , third]` (array + hole) | `head = list[0], third = list[2]` |
| `{ kept, ...others }` (object rest) | `kept = bag.kept, others = __rest(bag, ["kept"])` |
| `[lead, ...rest]` (array rest) | `lead = items[0], rest = items.slice(1)` |
| `{ x, y } = make()` (complex source) | `_a = make(), x = _a.x, y = _a.y` |
| `{ a, b } = await load()` (awaited) | captured via `.sent()`, then `a = _a.a, b = _a.b` |
| `catch ({ reason })` | `_a = _b.sent(); reason = _a.reason;` |
| `[one, two]` under `downlevelIteration` | `__read(seq, 2)` then index |
| `catch (e)` (plain ident, control) | unchanged (`e_1 = _a.sent()`) |

## Verification

- New name-agnostic suite
  `crates/tsz-emitter/tests/async_es5_destructuring_tests.rs` (13 tests, binder
  names varied per case, asserting byte-exact `tsc` forms) — **13 passed**.
- End-to-end CLI emit (`tsz --target es5`) confirmed valid: `__rest` helper
  definition emitted, comma-joined extraction, catch destructuring.
- `crates/tsz-emitter` lib unit tests — **3780 passed, 0 failed**.
- Adjacent suites green: `async_es5_ir` (117), `async_try_emit`,
  `async_loop_emit`, `destructuring_*`, es5 lib tests (764).
- `cargo fmt -p tsz-emitter`, `cargo clippy -p tsz-emitter --tests`,
  `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_013oBe6wzokjT4E53CLsYSfn

---
_Generated by [Claude Code](https://claude.ai/code/session_013oBe6wzokjT4E53CLsYSfn)_