### PR TITLE
fix(emit): lower ES5 destructuring in async/generator var decls and catch clauses

### DIFF
--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -69,6 +69,8 @@ mod cases;
 mod condition_await;
 #[path = "async_es5_ir_control.rs"]
 mod control;
+#[path = "async_es5_ir_destructuring.rs"]
+mod destructuring;
 #[path = "async_es5_ir_discovery.rs"]
 mod discovery;
 #[path = "async_es5_ir_disposables.rs"]

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_destructuring.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_destructuring.rs
@@ -1,0 +1,485 @@
+//! ES5 destructuring lowering for the async/generator IR pipeline.
+//!
+//! The async→generator transform hoists every binding name to the top of the
+//! `__awaiter` callback and runs the body as a state machine, so a destructuring
+//! *declaration* (`const { a, b } = obj;`) must be lowered the same way `tsc`
+//! lowers it inside a generator: the declared names are hoisted (`var a, b;`)
+//! and the pattern is flattened into a bare comma-sequence of *assignments*
+//! (`a = obj.a, b = obj.b;`). This mirrors `tsc`'s `flattenDestructuringAssignment`
+//! for the generator/async target, which is the reason its output differs from
+//! the synchronous printer path (which keeps the `var` keyword inline).
+//!
+//! The flattening rules implemented here match `tsc` exactly:
+//! - A temporary is introduced for the source value only when the pattern has
+//!   more than one element *and* the source is not a simple inlineable
+//!   expression (identifier/literal/`this`); single-element patterns inline the
+//!   source directly (`a = obj.a.b`, `a = h().a`).
+//! - Nested patterns chain property/element access through the same source.
+//! - Defaults capture the access in a temp and compare `=== void 0`.
+//! - Object rest uses `__rest(source, [excluded])`; array rest uses
+//!   `source.slice(index)`.
+
+use crate::transforms::async_es5_ir::AsyncES5Transformer;
+use crate::transforms::ir::{IRGeneratorCase, IRNode};
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+impl AsyncES5Transformer<'_> {
+    /// Lower a destructuring `const`/`let`/`var` declaration inside an async body.
+    ///
+    /// Handles the three initializer shapes the surrounding state machine can
+    /// produce: a direct `await` (value arrives via `_a.sent()`), an initializer
+    /// containing a nested `await`, and an await-free initializer. In every case
+    /// the binding names are hoisted and the pattern is flattened into a
+    /// comma-sequence of assignments.
+    pub(in crate::transforms) fn process_destructuring_declaration_in_async(
+        &mut self,
+        pattern_idx: NodeIndex,
+        initializer_idx: NodeIndex,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+        trailing_comment: &mut Option<String>,
+    ) {
+        if initializer_idx.is_none() {
+            return;
+        }
+
+        if self.is_suspension_expression(initializer_idx) {
+            let trailing = trailing_comment.take();
+            self.process_await_expression_with_trailing_comment(
+                initializer_idx,
+                cases,
+                current_statements,
+                current_label,
+                trailing.as_deref(),
+            );
+            // The awaited result is `_a.sent()`; tsc parenthesizes it when it is
+            // used directly as a member-access base.
+            self.emit_destructuring_extraction(
+                pattern_idx,
+                IRNode::GeneratorSent,
+                false,
+                true,
+                current_statements,
+            );
+            return;
+        }
+
+        if self.contains_await_recursive(initializer_idx) {
+            self.emit_nested_suspension(initializer_idx, cases, current_statements, current_label);
+            let source = self.expression_to_ir(initializer_idx);
+            self.emit_destructuring_extraction(
+                pattern_idx,
+                source,
+                false,
+                false,
+                current_statements,
+            );
+            return;
+        }
+
+        let inlineable = self.initializer_is_simple_inlineable(initializer_idx);
+        let source = self.expression_to_ir(initializer_idx);
+        self.emit_destructuring_extraction(
+            pattern_idx,
+            source,
+            inlineable,
+            false,
+            current_statements,
+        );
+        if let Some(comment) = trailing_comment.take() {
+            current_statements.push(IRNode::TrailingComment(comment.into()));
+        }
+    }
+
+    /// Flatten `pattern_idx` against `source`, hoist its names, and emit the
+    /// extraction as a single bare comma-sequence expression statement.
+    pub(in crate::transforms) fn emit_destructuring_extraction(
+        &mut self,
+        pattern_idx: NodeIndex,
+        source: IRNode,
+        source_inlineable: bool,
+        source_paren_as_member_base: bool,
+        current_statements: &mut Vec<IRNode>,
+    ) {
+        let mut assigns = Vec::new();
+        let mut hoist = Vec::new();
+        self.flatten_es5_destructuring_binding(
+            pattern_idx,
+            source,
+            source_inlineable,
+            source_paren_as_member_base,
+            &mut assigns,
+            &mut hoist,
+        );
+
+        for name in hoist {
+            current_statements.push(IRNode::VarDecl {
+                name: name.into(),
+                initializer: None,
+            });
+        }
+
+        match assigns.len() {
+            0 => {}
+            1 => current_statements.push(IRNode::ExpressionStatement(Box::new(
+                assigns.pop().expect("len checked == 1"),
+            ))),
+            _ => current_statements.push(IRNode::ExpressionStatement(Box::new(
+                IRNode::CommaSequence(assigns),
+            ))),
+        }
+    }
+    /// Return the binding pattern of a catch clause's variable declaration when
+    /// its name is an object/array pattern (`catch ({ message })`), else `None`.
+    pub(in crate::transforms) fn catch_binding_pattern(
+        &self,
+        var_decl_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let node = self.arena.get(var_decl_idx)?;
+        let decl = self.arena.get_variable_declaration(node)?;
+        self.is_binding_pattern_node(decl.name).then_some(decl.name)
+    }
+
+    /// True when `idx` is an object or array binding pattern.
+    pub(in crate::transforms) fn is_binding_pattern_node(&self, idx: NodeIndex) -> bool {
+        self.arena
+            .get(idx)
+            .is_some_and(|node| node.is_binding_pattern())
+    }
+
+    /// True when an expression can be repeated inline without first being
+    /// captured into a temporary, mirroring `tsc`'s `isSimpleInlineableExpression`
+    /// (identifiers, string/number literals, and the `this`/`true`/`false`/`null`
+    /// keywords). Property/element accesses and calls are *not* inlineable.
+    pub(in crate::transforms) fn initializer_is_simple_inlineable(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+        if node.is_identifier() || node.is_string_literal() || node.is_numeric_literal() {
+            return true;
+        }
+        matches!(
+            node.kind,
+            k if k == SyntaxKind::BigIntLiteral as u16
+                || k == SyntaxKind::ThisKeyword as u16
+                || k == SyntaxKind::TrueKeyword as u16
+                || k == SyntaxKind::FalseKeyword as u16
+                || k == SyntaxKind::NullKeyword as u16
+        )
+    }
+
+    /// Lower a destructuring binding `pattern_idx` against an already-lowered
+    /// `source` expression, in the async/generator assignment form.
+    ///
+    /// Every hoisted name (temporaries plus binding identifiers) is appended to
+    /// `hoist` in declaration order; the flattened assignment expressions are
+    /// appended to `assigns` in evaluation order. Callers hoist the names via
+    /// `VarDecl { initializer: None }` and emit the assignments as a single
+    /// `CommaSequence` expression statement.
+    ///
+    /// `source_inlineable` reports whether `source` may be repeated without a
+    /// temp. `source_paren_as_member_base` requests that an inlined `source`
+    /// used as a member-access base be wrapped in parentheses (needed for an
+    /// awaited value such as `_a.sent()`, which `tsc` prints as
+    /// `(_a.sent()).prop`).
+    pub(in crate::transforms) fn flatten_es5_destructuring_binding(
+        &mut self,
+        pattern_idx: NodeIndex,
+        source: IRNode,
+        source_inlineable: bool,
+        source_paren_as_member_base: bool,
+        assigns: &mut Vec<IRNode>,
+        hoist: &mut Vec<String>,
+    ) {
+        let Some(pattern_node) = self.arena.get(pattern_idx) else {
+            return;
+        };
+        let is_array = pattern_node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN;
+        let Some(pattern) = self.arena.get_binding_pattern(pattern_node) else {
+            return;
+        };
+        let element_indices = pattern.elements.nodes.clone();
+        let num_elements = element_indices.len();
+        // A dynamic (computed) property key forces the source into a temp even
+        // for a single-element pattern, because tsc captures both the source and
+        // the key in temporaries before indexing (`_a = obj, _b = k, a = _a[_b]`).
+        let has_computed_key = !is_array
+            && element_indices
+                .iter()
+                .any(|&e| self.binding_element_has_dynamic_computed_key(e));
+
+        // tsc captures the source in a temp when the pattern has more than one
+        // element and the source is not already inlineable (or whenever a
+        // computed key is present). Single-element patterns otherwise reference
+        // the source exactly once and inline it directly.
+        let base = if (num_elements != 1 && !source_inlineable) || has_computed_key {
+            let temp = self.generate_hoisted_temp();
+            hoist.push(temp.clone());
+            assigns.push(IRNode::assign(IRNode::id(temp.clone()), source));
+            IRNode::id(temp)
+        } else if source_paren_as_member_base && !source_inlineable {
+            IRNode::Parenthesized(Box::new(source))
+        } else {
+            source
+        };
+
+        let mut excluded: Vec<IRNode> = Vec::new();
+        for (index, &element_idx) in element_indices.iter().enumerate() {
+            let Some(element_node) = self.arena.get(element_idx) else {
+                continue;
+            };
+            if element_node.kind == syntax_kind_ext::OMITTED_EXPRESSION {
+                continue;
+            }
+            let Some(binding_elem) = self.arena.get_binding_element(element_node) else {
+                continue;
+            };
+
+            if binding_elem.dot_dot_dot_token {
+                let target = self.binding_name_ir(binding_elem.name, hoist);
+                let rest_value = if is_array {
+                    IRNode::call(
+                        IRNode::prop(base.clone(), "slice"),
+                        vec![IRNode::number(index.to_string())],
+                    )
+                } else {
+                    self.helpers_needed.mark_rest();
+                    IRNode::call(
+                        IRNode::RuntimeHelper("__rest".into()),
+                        vec![
+                            base.clone(),
+                            IRNode::ArrayLiteral(std::mem::take(&mut excluded)),
+                        ],
+                    )
+                };
+                if let Some(target) = target {
+                    assigns.push(IRNode::assign(target, rest_value));
+                }
+                continue;
+            }
+
+            // Build the property/element access for this binding.
+            let access = if is_array {
+                IRNode::elem(base.clone(), IRNode::number(index.to_string()))
+            } else {
+                let (member_access, key_for_rest) = self.object_member_access(
+                    &base,
+                    binding_elem.property_name,
+                    binding_elem.name,
+                    assigns,
+                    hoist,
+                );
+                if let Some(key) = key_for_rest {
+                    excluded.push(key);
+                }
+                member_access
+            };
+
+            self.flatten_binding_element(
+                binding_elem.name,
+                binding_elem.initializer,
+                access,
+                assigns,
+                hoist,
+            );
+        }
+    }
+
+    /// True when an object binding element uses a *dynamic* computed property
+    /// name. A computed key whose expression is a string/numeric literal
+    /// (`["x"]`, `[0]`) is static — tsc lowers it to plain element access and
+    /// does not force the source into a temp.
+    fn binding_element_has_dynamic_computed_key(&self, element_idx: NodeIndex) -> bool {
+        let Some(element_node) = self.arena.get(element_idx) else {
+            return false;
+        };
+        let Some(binding_elem) = self.arena.get_binding_element(element_node) else {
+            return false;
+        };
+        self.dynamic_computed_key_expr(binding_elem.property_name)
+            .is_some()
+    }
+
+    /// Returns the inner expression of a dynamic computed property key, or `None`
+    /// when the property name is absent, not computed, or a static literal.
+    fn dynamic_computed_key_expr(&self, property_name_idx: NodeIndex) -> Option<NodeIndex> {
+        let node = self.arena.get(property_name_idx)?;
+        if node.kind != syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            return None;
+        }
+        let computed = self.arena.get_computed_property(node)?;
+        let expr = self.arena.get(computed.expression)?;
+        let is_literal = expr.is_string_literal() || expr.is_numeric_literal();
+        (!is_literal).then_some(computed.expression)
+    }
+
+    /// Flatten a single (non-rest) binding element whose value is reached via
+    /// `access`, handling an optional default and nested sub-pattern.
+    fn flatten_binding_element(
+        &mut self,
+        name_idx: NodeIndex,
+        initializer_idx: NodeIndex,
+        access: IRNode,
+        assigns: &mut Vec<IRNode>,
+        hoist: &mut Vec<String>,
+    ) {
+        let has_default = initializer_idx.is_some();
+        let is_nested = self.is_binding_pattern_node(name_idx);
+
+        let value = if has_default {
+            // Capture the access so the default check evaluates it once:
+            // `_t = access, X = _t === void 0 ? default : _t`. A plain
+            // identifier access is already single-eval, so tsc reuses it.
+            let value_src = if matches!(access, IRNode::Identifier(_)) {
+                access
+            } else {
+                let temp = self.generate_hoisted_temp();
+                hoist.push(temp.clone());
+                assigns.push(IRNode::assign(IRNode::id(temp.clone()), access));
+                IRNode::id(temp)
+            };
+            let default_ir = self.expression_to_ir(initializer_idx);
+            IRNode::ConditionalExpr {
+                condition: Box::new(IRNode::binary(value_src.clone(), "===", IRNode::Undefined)),
+                when_true: Box::new(default_ir),
+                when_false: Box::new(value_src),
+            }
+        } else {
+            access
+        };
+
+        if is_nested {
+            if has_default {
+                // The defaulted value must be materialized before recursing so
+                // the nested pattern reads from a stable temp.
+                let temp = self.generate_hoisted_temp();
+                hoist.push(temp.clone());
+                assigns.push(IRNode::assign(IRNode::id(temp.clone()), value));
+                self.flatten_es5_destructuring_binding(
+                    name_idx,
+                    IRNode::id(temp),
+                    true,
+                    false,
+                    assigns,
+                    hoist,
+                );
+            } else {
+                self.flatten_es5_destructuring_binding(
+                    name_idx, value, false, false, assigns, hoist,
+                );
+            }
+            return;
+        }
+
+        if let Some(target) = self.binding_name_ir(name_idx, hoist) {
+            assigns.push(IRNode::assign(target, value));
+        }
+    }
+
+    /// Build the member access for an object binding element and, for non-computed
+    /// keys, return the property-key literal that must be threaded into a trailing
+    /// `__rest` exclusion list.
+    fn object_member_access(
+        &mut self,
+        base: &IRNode,
+        property_name_idx: NodeIndex,
+        name_idx: NodeIndex,
+        assigns: &mut Vec<IRNode>,
+        hoist: &mut Vec<String>,
+    ) -> (IRNode, Option<IRNode>) {
+        // Shorthand `{ a }`: the property key is the binding name.
+        if property_name_idx.is_none() {
+            let key = crate::transforms::emit_utils::identifier_text_or_empty(self.arena, name_idx);
+            return (
+                IRNode::prop(base.clone(), key.clone()),
+                (!key.is_empty()).then(|| IRNode::string(key)),
+            );
+        }
+
+        let Some(key_node) = self.arena.get(property_name_idx) else {
+            return (base.clone(), None);
+        };
+
+        // A dynamic computed key `{ [k]: a }` captures the key in its own temp
+        // ahead of the access (`_b = k, a = _a[_b]`) and uses that temp as the
+        // rest exclusion entry, matching tsc's single-evaluation of dynamic keys.
+        // A computed key wrapping a string/numeric literal (`["x"]`, `[0]`) is
+        // static: rebind to the inner literal and fall through to literal access.
+        let key_node = if key_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            if let Some(key_expr_idx) = self.dynamic_computed_key_expr(property_name_idx) {
+                let key_ir = self.expression_to_ir(key_expr_idx);
+                let key_temp = self.generate_hoisted_temp();
+                hoist.push(key_temp.clone());
+                assigns.push(IRNode::assign(IRNode::id(key_temp.clone()), key_ir));
+                // A rest sibling excludes a dynamic key by its runtime form,
+                // coerced to a string unless it is a symbol (tsc's __rest key
+                // form): `typeof _b === "symbol" ? _b : _b + ""`.
+                let key_id = IRNode::id(key_temp);
+                let rest_key = IRNode::ConditionalExpr {
+                    condition: Box::new(IRNode::binary(
+                        IRNode::PrefixUnaryExpr {
+                            operator: "typeof ".into(),
+                            operand: Box::new(key_id.clone()),
+                        },
+                        "===",
+                        IRNode::string("symbol"),
+                    )),
+                    when_true: Box::new(key_id.clone()),
+                    when_false: Box::new(IRNode::binary(key_id.clone(), "+", IRNode::string(""))),
+                };
+                return (IRNode::elem(base.clone(), key_id), Some(rest_key));
+            }
+            // Static literal computed key: rebind to the inner literal node.
+            match self
+                .arena
+                .get_computed_property(key_node)
+                .and_then(|computed| self.arena.get(computed.expression))
+            {
+                Some(inner) => inner,
+                None => return (base.clone(), None),
+            }
+        } else {
+            key_node
+        };
+
+        // String / numeric literal key `{ "a-b": x }` / `{ 0: x }`: element access.
+        // The rest exclusion entry is always the string form; only the access
+        // index distinguishes a numeric key (`x[0]`) from a string key (`x["k"]`).
+        if key_node.is_string_literal() || key_node.is_numeric_literal() {
+            if let Some(lit) = self.arena.get_literal(key_node) {
+                let text = lit.text.clone();
+                let access_key = if key_node.is_numeric_literal() {
+                    IRNode::number(text.clone())
+                } else {
+                    IRNode::string(text.clone())
+                };
+                return (
+                    IRNode::elem(base.clone(), access_key),
+                    Some(IRNode::string(text)),
+                );
+            }
+        }
+
+        // Identifier key (renamed binding `{ a: b }`).
+        let key =
+            crate::transforms::emit_utils::identifier_text_or_empty(self.arena, property_name_idx);
+        (
+            IRNode::prop(base.clone(), key.clone()),
+            (!key.is_empty()).then(|| IRNode::string(key)),
+        )
+    }
+
+    /// Resolve a binding-element `name` (always an identifier in non-nested
+    /// position) to its assignment target, recording it for hoisting.
+    fn binding_name_ir(&self, name_idx: NodeIndex, hoist: &mut Vec<String>) -> Option<IRNode> {
+        let name = crate::transforms::emit_utils::identifier_text_or_empty(self.arena, name_idx);
+        if name.is_empty() {
+            return None;
+        }
+        hoist.push(name.clone());
+        Some(IRNode::id(name))
+    }
+}

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_destructuring.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_destructuring.rs
@@ -147,7 +147,7 @@ impl AsyncES5Transformer<'_> {
     pub(in crate::transforms) fn is_binding_pattern_node(&self, idx: NodeIndex) -> bool {
         self.arena
             .get(idx)
-            .is_some_and(|node| node.is_binding_pattern())
+            .is_some_and(tsz_parser::parser::node::Node::is_binding_pattern)
     }
 
     /// True when an expression can be repeated inline without first being
@@ -410,27 +410,27 @@ impl AsyncES5Transformer<'_> {
         // static: rebind to the inner literal and fall through to literal access.
         let key_node = if key_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
             if let Some(key_expr_idx) = self.dynamic_computed_key_expr(property_name_idx) {
-                let key_ir = self.expression_to_ir(key_expr_idx);
+                let key_expr = self.expression_to_ir(key_expr_idx);
                 let key_temp = self.generate_hoisted_temp();
                 hoist.push(key_temp.clone());
-                assigns.push(IRNode::assign(IRNode::id(key_temp.clone()), key_ir));
+                assigns.push(IRNode::assign(IRNode::id(key_temp.clone()), key_expr));
                 // A rest sibling excludes a dynamic key by its runtime form,
                 // coerced to a string unless it is a symbol (tsc's __rest key
                 // form): `typeof _b === "symbol" ? _b : _b + ""`.
-                let key_id = IRNode::id(key_temp);
+                let key_ref = IRNode::id(key_temp);
                 let rest_key = IRNode::ConditionalExpr {
                     condition: Box::new(IRNode::binary(
                         IRNode::PrefixUnaryExpr {
                             operator: "typeof ".into(),
-                            operand: Box::new(key_id.clone()),
+                            operand: Box::new(key_ref.clone()),
                         },
                         "===",
                         IRNode::string("symbol"),
                     )),
-                    when_true: Box::new(key_id.clone()),
-                    when_false: Box::new(IRNode::binary(key_id.clone(), "+", IRNode::string(""))),
+                    when_true: Box::new(key_ref.clone()),
+                    when_false: Box::new(IRNode::binary(key_ref.clone(), "+", IRNode::string(""))),
                 };
-                return (IRNode::elem(base.clone(), key_id), Some(rest_key));
+                return (IRNode::elem(base.clone(), key_ref), Some(rest_key));
             }
             // Static literal computed key: rebind to the inner literal node.
             match self

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_statements.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_statements.rs
@@ -1160,6 +1160,29 @@ impl<'a> AsyncES5Transformer<'a> {
             return;
         };
 
+        let decl_name_and_init = self
+            .arena
+            .get_variable_declaration(node)
+            .map(|decl| (decl.name, decl.initializer));
+
+        // Destructuring declarations are lowered through the shared ES5
+        // destructuring flattener (hoisted names + comma-sequence assignments),
+        // matching tsc's generator/async output. The simple-identifier path
+        // below is left untouched.
+        if let Some((decl_name, decl_init)) = decl_name_and_init
+            && self.is_binding_pattern_node(decl_name)
+        {
+            self.process_destructuring_declaration_in_async(
+                decl_name,
+                decl_init,
+                cases,
+                current_statements,
+                current_label,
+                trailing_comment,
+            );
+            return;
+        }
+
         if let Some(decl) = self.arena.get_variable_declaration(node) {
             let name =
                 crate::transforms::emit_utils::identifier_text_or_empty(self.arena, decl.name);

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_try_statement.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_try_statement.rs
@@ -117,6 +117,27 @@ impl<'a> AsyncES5Transformer<'a> {
                         )));
                         self.catch_binding_renames
                             .push((catch_var_name, catch_temp));
+                    } else if let Some(pattern_idx) =
+                        self.catch_binding_pattern(catch_data.variable_declaration)
+                    {
+                        // Destructuring catch binding: bind the caught value to a
+                        // hoisted temp (`_a = _b.sent();`) and flatten the pattern
+                        // from it (`message = _a.message;`), mirroring tsc.
+                        let catch_temp = self.generate_hoisted_temp();
+                        current_statements.push(IRNode::VarDecl {
+                            name: catch_temp.clone().into(),
+                            initializer: None,
+                        });
+                        current_statements.push(IRNode::ExpressionStatement(Box::new(
+                            IRNode::assign(IRNode::id(catch_temp.clone()), IRNode::GeneratorSent),
+                        )));
+                        self.emit_destructuring_extraction(
+                            pattern_idx,
+                            IRNode::id(catch_temp),
+                            true,
+                            false,
+                            current_statements,
+                        );
                     }
                 }
                 self.process_block_or_statement_in_async(

--- a/crates/tsz-emitter/src/transforms/ir.rs
+++ b/crates/tsz-emitter/src/transforms/ir.rs
@@ -137,6 +137,14 @@ pub enum IRNode {
     /// multiline comma expression.
     CommaExprMultilineFlat(Vec<Self>),
 
+    /// Single-line comma sequence rendered WITHOUT surrounding parentheses,
+    /// e.g. `a = obj.a, b = obj.b`. Used at statement position for ES5
+    /// destructuring-assignment lowering inside async/generator bodies, where
+    /// `tsc` emits the flattened assignments as a bare comma expression
+    /// statement (`a = obj.a, b = obj.b;`). Constructed only as the direct child
+    /// of an `ExpressionStatement`.
+    CommaSequence(Vec<Self>),
+
     /// Array literal: `[a, b, c]`
     ArrayLiteral(Vec<Self>),
 
@@ -991,6 +999,7 @@ impl IRNode {
             Self::CommaExpr(nodes)
             | Self::CommaExprMultiline(nodes)
             | Self::CommaExprMultilineFlat(nodes)
+            | Self::CommaSequence(nodes)
             | Self::ArrayLiteral(nodes)
             | Self::VarDeclList(nodes)
             | Self::Block(nodes)
@@ -1320,6 +1329,7 @@ impl IRNode {
             Self::CommaExpr(nodes)
             | Self::CommaExprMultiline(nodes)
             | Self::CommaExprMultilineFlat(nodes)
+            | Self::CommaSequence(nodes)
             | Self::ArrayLiteral(nodes)
             | Self::VarDeclList(nodes)
             | Self::Block(nodes)

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -872,6 +872,8 @@ impl<'a> IRPrinter<'a> {
                 }
                 self.write(")");
             }
+            // Flat, single-line, no surrounding parentheses: `a = obj.a, b = obj.b`.
+            IRNode::CommaSequence(exprs) => self.emit_comma_separated(exprs),
             IRNode::ArrayLiteral(elements) => {
                 self.write("[");
                 self.emit_comma_separated(elements);

--- a/crates/tsz-emitter/tests/async_es5_ir.rs
+++ b/crates/tsz-emitter/tests/async_es5_ir.rs
@@ -21,3 +21,4 @@ fn transform_and_print(source: &str) -> String {
 
 include!("async_es5_ir_parts/part_00.rs");
 include!("async_es5_ir_parts/part_01.rs");
+include!("async_es5_ir_parts/part_02.rs");

--- a/crates/tsz-emitter/tests/async_es5_ir_parts/part_02.rs
+++ b/crates/tsz-emitter/tests/async_es5_ir_parts/part_02.rs
@@ -1,0 +1,196 @@
+// Destructuring lowering inside async/generator ES5 bodies (issue #14080).
+// Binder names are varied per case so the assertions cannot be satisfied by a
+// fixture-name fast path; every expected string is byte-checked against `tsc`
+// 6.0.2 output for the matching snippet.
+
+#[test]
+fn async_es5_object_destructuring_simple_identifier_source() {
+    let output =
+        transform_and_print("async function f() { await g(); const { alpha, beta } = obj; }");
+    assert!(
+        output.contains("var alpha, beta;"),
+        "destructured names must be hoisted.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("alpha = obj.alpha, beta = obj.beta;"),
+        "object destructuring of an identifier source must inline the source.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("var ;") && !output.contains(" = obj;"),
+        "no invalid empty binding may be emitted.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_object_destructuring_non_simple_source_uses_temp() {
+    let output =
+        transform_and_print("async function f() { await g(); const { one, two } = make(); }");
+    assert!(
+        output.contains("var _a, one, two;"),
+        "a non-inlineable source must be captured in a hoisted temp.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = make(), one = _a.one, two = _a.two;"),
+        "the temp must hold the source and each name reads from it.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_array_destructuring_simple_identifier_source() {
+    let output =
+        transform_and_print("async function f() { await g(); const [head, tail] = items; }");
+    assert!(
+        output.contains("var head, tail;"),
+        "array binding names must be hoisted.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("head = items[0], tail = items[1];"),
+        "array destructuring uses indexed access.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_nested_single_property_chains_access() {
+    let output =
+        transform_and_print("async function f() { await g(); const { outer: { inner } } = box; }");
+    assert!(
+        output.contains("var inner;"),
+        "only the leaf binding name is hoisted for a single-property nest.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("inner = box.outer.inner;"),
+        "a single-element nested pattern must chain property access (no temp).\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_default_value_uses_void_zero_temp() {
+    let output =
+        transform_and_print("async function f() { await g(); const { count = 500 } = config; }");
+    assert!(
+        output.contains("var _a, count;"),
+        "default lowering hoists the access temp and the binding.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = config.count, count = _a === void 0 ? 500 : _a;"),
+        "defaults capture the access in a temp and compare === void 0.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_object_rest_uses_rest_helper() {
+    let output =
+        transform_and_print("async function f() { await g(); const { taken, ...others } = source; }");
+    assert!(
+        output.contains("taken = source.taken, others = __rest(source, [\"taken\"]);"),
+        "object rest must exclude the taken keys via __rest.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_array_rest_uses_slice() {
+    let output =
+        transform_and_print("async function f() { await g(); const [first, ...remaining] = list; }");
+    assert!(
+        output.contains("first = list[0], remaining = list.slice(1);"),
+        "array rest must slice from the rest index.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_destructuring_before_first_await_in_case_zero() {
+    let output =
+        transform_and_print("async function f() { const { lhs, rhs } = pair; await g(); }");
+    assert!(
+        output.contains("var lhs, rhs;") && output.contains("lhs = pair.lhs, rhs = pair.rhs;"),
+        "a destructuring decl before the first await lowers in case 0.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_destructuring_of_awaited_value() {
+    let output =
+        transform_and_print("async function f() { const { left, right } = await make(); }");
+    assert!(
+        output.contains("var _a, left, right;"),
+        "awaited destructuring hoists the value temp and the names.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = _b.sent(), left = _a.left, right = _a.right;"),
+        "the awaited value flows through a temp into each name.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_catch_clause_object_pattern() {
+    let output = transform_and_print(
+        "async function f() { try { await g(); } catch ({ message }) { sink(message); } }",
+    );
+    assert!(
+        output.contains("var _a, message;"),
+        "the catch temp and the destructured name are hoisted.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_a = _b.sent();") && output.contains("message = _a.message;"),
+        "a destructuring catch binds the caught value then extracts the pattern.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("var ;"),
+        "no invalid empty binding may be emitted for a catch pattern.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_catch_clause_two_element_pattern() {
+    let output = transform_and_print(
+        "async function f() { try { await g(); } catch ({ code, detail }) { sink(code, detail); } }",
+    );
+    assert!(
+        output.contains("_a = _b.sent();")
+            && output.contains("code = _a.code, detail = _a.detail;"),
+        "multi-binding catch patterns extract from the caught-value temp.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_literal_computed_key_is_static_access() {
+    let output =
+        transform_and_print("async function f() { await g(); const { [\"name\"]: id, age } = rec; }");
+    assert!(
+        output.contains("id = rec[\"name\"], age = rec.age;"),
+        "a string-literal computed key lowers to static element access (no temp).\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_dynamic_computed_key_captures_key_temp() {
+    let output =
+        transform_and_print("async function f() { await g(); const { [sel]: picked, rest } = src; }");
+    assert!(
+        output.contains("_a = src, _b = sel, picked = _a[_b], rest = _a.rest;"),
+        "a dynamic computed key forces a source temp and captures the key.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_dynamic_computed_key_with_rest_coerces_exclusion() {
+    let output =
+        transform_and_print("async function f() { await g(); const { [sel]: picked, ...others } = src; }");
+    assert!(
+        output.contains(
+            "others = __rest(_a, [typeof _b === \"symbol\" ? _b : _b + \"\"]);"
+        ),
+        "a dynamic key excluded by an object rest is coerced to its __rest key form.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_es5_catch_clause_nested_pattern() {
+    let output = transform_and_print(
+        "async function f() { try { await g(); } catch ({ info: { reason } }) { sink(reason); } }",
+    );
+    assert!(
+        output.contains("_a = _b.sent();") && output.contains("reason = _a.info.reason;"),
+        "a nested catch pattern chains access through the caught-value temp.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Closes #14080.

## Structural rule

> When the target is ES5 and an `async` function's `VariableStatement` or
> `CatchClause` binds an object/array **pattern**, `tsc` hoists the binding
> names to the top of the `__awaiter` callback and flattens the pattern into a
> bare comma-sequence of **assignments** (mirroring `flattenDestructuringAssignment`
> for the generator/async target):
>
> ```js
> // async; --target es5;  await g(); const { a, b } = obj;  -->
> var a, b;                       // hoisted
> a = obj.a, b = obj.b;           // flattened assignments (no `var`)
> ```
>
> A source temp is introduced only when the pattern has more than one element
> *and* the source is not a simple inlineable expression; single-element
> patterns inline the source (`a = obj.a.b`, `a = h().a`). Dynamic computed keys
> are captured into their own temp, defaults capture the access in a temp and
> compare `=== void 0`, object rest uses `__rest`, and array rest uses `.slice`.

Before this change the async→generator IR pipeline passed binding patterns
through unchanged, so the same snippet emitted syntactically-invalid JavaScript
(`var ;` / ` = obj;`) and catch patterns dropped their bindings entirely.

```ts
// --target es5
async function f() { await g(); const { a, b } = obj; }
async function h() { try { await g(); } catch ({ message }) { use(message); } }
```

| | tsz (before) | tsz (after) |
|---|---|---|
| var decl | `var ;` … ` = obj;` ← invalid | `var a, b;` … `a = obj.a, b = obj.b;` ← matches `tsc` |
| catch | `message` dropped (undefined) | `_a = _b.sent(); message = _a.message;` ← matches `tsc` |

Found by differential testing against `tsc` 6.0.2.

## Owner layer

Emitter only (`crates/tsz-emitter`). A new `async_es5_ir_destructuring` module
owns the tsc-faithful flattening; it is wired in at the top of
`process_variable_declaration` (async statements) and the catch-binding branch
of `process_try_statement_in_async`. A new `CommaSequence` IR node provides the
parens-free statement-level comma form (`a = obj.a, b = obj.b;`) that no
existing comma variant produced. No semantic/checker change, no output surgery;
temps come from the existing `generate_hoisted_temp` namespace so they
coordinate with the generator state param (`_a` temp ⇒ `_b` param), exactly as
`tsc`. The existing (unused, non-tsc-accurate) `ES5DestructuringTransformer` was
intentionally not reused — it emits the declaration form with `!== void 0` and
no inlineable-source modeling.

`for-of` loop-variable destructuring is a separate pre-existing path and is out
of this issue's scope (which names `VariableStatement` and `CatchClause`).

## Adjacent-case matrix (name-agnostic; binders varied; `--target es5`, byte-equal to `tsc` 6.0.2)

| case | result |
|---|---|
| `const { a, b } = obj` (identifier source) | `a = obj.a, b = obj.b` |
| `const { a, b } = make()` (non-simple) | `_a = make(), a = _a.a, b = _a.b` |
| `const [x, y] = items` (array) | `x = items[0], y = items[1]` |
| `const { o: { i } } = box` (nested single) | `i = box.o.i` (chained, no temp) |
| `const { c = 500 } = cfg` (default) | `_a = cfg.c, c = _a === void 0 ? 500 : _a` |
| `const { t, ...r } = src` (object rest) | `t = src.t, r = __rest(src, ["t"])` |
| `const [f, ...rest] = list` (array rest) | `f = list[0], rest = list.slice(1)` |
| `const { ["x"]: a, b } = obj` (literal computed key) | `a = obj["x"], b = obj.b` (static) |
| `const { [k]: a, b } = obj` (dynamic key) | `_a = obj, _b = k, a = _a[_b], b = _a.b` |
| `const { [k]: a, ...r } = obj` (dynamic key + rest) | `r = __rest(_a, [typeof _b === "symbol" ? _b : _b + ""])` |
| `const { l, r } = await make()` (awaited) | `_a = _b.sent(), l = _a.l, r = _a.r` |
| `catch ({ message })` | `_a = _b.sent(); message = _a.message;` |
| `catch ({ info: { reason } })` (nested) | `reason = _a.info.reason;` |
| `catch ([first, ...rest])` (array) | `first = _a[0], rest = _a.slice(1);` |

## Verification

- New name-agnostic suite `crates/tsz-emitter/tests/async_es5_ir_parts/part_02.rs`
  (16 tests, binders varied per case) — pass; each expected string is the
  byte-equal `tsc` 6.0.2 output for the matching snippet.
- End-to-end differential vs `tsc` 6.0.2 over a 25-case battery (object/array,
  nested, defaults, object/array rest, computed/literal/numeric keys, dynamic
  key + rest coercion, awaited initializer, before/after first await, and four
  catch-pattern shapes) — emitted function bodies byte-identical.
- `cargo test -p tsz-emitter --lib` — **3795 passed, 0 failed**; adjacent
  integration suites green (`async_try_emit`, `async_loop_emit`,
  `try_statement_recovery_tests`, `destructuring_es5_*`,
  `async_awaiter_body_trailing_comment_tests`).
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --tests`,
  `python3 scripts/arch/arch_guard.py` — clean.
- Clean merge with `main` verified.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_0175yhinwuC8VSA1MoBQktcZ)_