### PR TITLE
refactor(arch): enforce CheckerContext lifetime→destination-shell contract

### DIFF
--- a/crates/tsz-checker/src/context/lifetime_shells.rs
+++ b/crates/tsz-checker/src/context/lifetime_shells.rs
@@ -21,15 +21,24 @@
 //! until the corresponding T2.1.B/C/D PR**, where the migration of the
 //! relevant fields is reviewed alongside the new behavior.
 //!
-//! Mapping from `PERFORMANCE_PLAN.md` §6:
+//! Mapping from each manifest lifetime class to its destination shell:
 //!
 //! ```text
-//! ProgramContext      — already exists (renamed from ProjectEnv in PR 5B)
-//! WorkerContext       — this file
-//! FileSession         — this file
-//! SpeculationScope    — this file
-//! LspPersistentCache  — this file
+//! ProgramStable      -> ProgramContext      — already exists (renamed from ProjectEnv in PR 5B)
+//! WorkerReusable     -> WorkerContext       — this file
+//! FileLocalReset     -> FileSession         — this file
+//! DiagnosticsOnly    -> FileSession         — this file
+//! SpeculationScoped  -> SpeculationScope    — this file
+//! LspPersistent      -> LspPersistentCache  — this file
 //! ```
+//!
+//! This class -> shell mapping is **CI-enforced** by
+//! `scripts/arch/checker_field_inventory.py` (the `LIFETIME_DESTINATION_SHELL`
+//! contract): every classifiable lifetime must name a destination shell, and
+//! every named shell must exist as a `pub struct` here (or, for
+//! `ProgramContext`, in `program_context.rs`). Run
+//! `python3 scripts/arch/checker_field_inventory.py --shells` for the
+//! per-shell migration burndown.
 
 /// Worker-scoped reusable scratch state.
 ///

--- a/scripts/arch/check-checker-boundaries.sh
+++ b/scripts/arch/check-checker-boundaries.sh
@@ -30,6 +30,8 @@ else
 fi
 
 # T2.1.A field-lifetime inventory: every CheckerContext field must be
-# classified in `crates/tsz-checker/src/context/checker_context_lifetimes.toml`.
-# See `docs/plan/PERFORMANCE_PLAN.md` §6.
+# classified in `crates/tsz-checker/src/context/checker_context_lifetimes.toml`,
+# and every lifetime class must map to an existing destination shell
+# (`LIFETIME_DESTINATION_SHELL`). See `context/lifetime_shells.rs`. Run with
+# `--shells` for the (informational) per-shell decomposition burndown.
 python3 scripts/arch/checker_field_inventory.py

--- a/scripts/arch/checker_field_inventory.py
+++ b/scripts/arch/checker_field_inventory.py
@@ -101,6 +101,39 @@ VALID_CAPABILITIES = frozenset(
     }
 )
 
+# Canonical lifetime-class -> destination decomposition shell.
+#
+# Each field's lifetime class names the shell that owns it once the
+# `CheckerContext` god-object is split per the T2.1 decomposition (see the
+# `crates/tsz-checker/src/context/lifetime_shells.rs` module doc). That mapping
+# previously lived only in prose, so the shells could silently drift from the
+# manifest taxonomy and the field-migration PRs had no machine-checked
+# destination. Encoding it here makes the decomposition target a CI-enforced
+# contract: a new lifetime class must declare its destination shell, and a
+# mapped shell must exist as a real `pub struct`.
+LIFETIME_DESTINATION_SHELL = {
+    "ProgramStable": "ProgramContext",
+    "WorkerReusable": "WorkerContext",
+    "FileLocalReset": "FileSession",
+    "DiagnosticsOnly": "FileSession",
+    "SpeculationScoped": "SpeculationScope",
+    "LspPersistent": "LspPersistentCache",
+}
+
+# `ProgramContext` predates the T2.1 shells and lives in its own module; the
+# remaining shells live in `lifetime_shells.rs`. Both files are scanned for the
+# `pub struct <Shell>` declaration so the destination contract stays honest if a
+# shell is renamed or removed.
+LIFETIME_SHELLS_RS = (
+    ROOT / "crates" / "tsz-checker" / "src" / "context" / "lifetime_shells.rs"
+)
+PROGRAM_CONTEXT_RS = (
+    ROOT / "crates" / "tsz-checker" / "src" / "context" / "program_context.rs"
+)
+DESTINATION_SHELL_SOURCES = (LIFETIME_SHELLS_RS, PROGRAM_CONTEXT_RS)
+
+PUB_STRUCT_RE = re.compile(r"^\s*pub struct ([A-Za-z_][A-Za-z_0-9]*)", re.MULTILINE)
+
 SIMPLE_INLINE_ENTRY_RE = re.compile(
     r'^\s*([A-Za-z_][A-Za-z_0-9]*)\s*=\s*\{\s*'
     r'lifetime\s*=\s*"([^"]*)"\s*,\s*'
@@ -311,6 +344,99 @@ def check_inventory(
     return failures
 
 
+def declared_shell_structs(
+    sources: tuple[pathlib.Path, ...] = DESTINATION_SHELL_SOURCES,
+) -> set[str]:
+    """Return the set of `pub struct <Name>` declarations across `sources`.
+
+    Used to prove that every destination shell named by
+    `LIFETIME_DESTINATION_SHELL` actually exists as a real type, so the
+    decomposition target cannot silently drift from the manifest taxonomy.
+    """
+    names: set[str] = set()
+    for path in sources:
+        if not path.exists():
+            continue
+        names.update(PUB_STRUCT_RE.findall(path.read_text(encoding="utf-8")))
+    return names
+
+
+def check_destination_shells(declared_shells: set[str]) -> list[str]:
+    """Enforce the lifetime-class -> destination-shell decomposition contract.
+
+    Returns a list of failure messages (empty means PASS). Fails when a valid
+    lifetime class has no destination shell mapped, or when a mapped shell does
+    not exist as a `pub struct`. This keeps the `lifetime_shells.rs`
+    decomposition target in lockstep with the manifest's lifetime taxonomy.
+    """
+    failures: list[str] = []
+
+    unmapped = sorted(VALID_LIFETIMES - LIFETIME_DESTINATION_SHELL.keys())
+    if unmapped:
+        failures.append(
+            f"{len(unmapped)} lifetime class(es) with no destination shell in "
+            "LIFETIME_DESTINATION_SHELL (every valid lifetime must name its "
+            "decomposition target shell):"
+        )
+        for cls in unmapped:
+            failures.append(f"  - {cls}")
+
+    missing_shells = sorted(
+        {
+            shell
+            for shell in LIFETIME_DESTINATION_SHELL.values()
+            if shell not in declared_shells
+        }
+    )
+    if missing_shells:
+        shell_files = " / ".join(
+            str(path.relative_to(ROOT)) for path in DESTINATION_SHELL_SOURCES
+        )
+        failures.append(
+            f"{len(missing_shells)} destination shell(s) mapped by a lifetime "
+            f"class but not declared as `pub struct` (expected in {shell_files}):"
+        )
+        for shell in missing_shells:
+            owners = sorted(
+                cls
+                for cls, dest in LIFETIME_DESTINATION_SHELL.items()
+                if dest == shell
+            )
+            failures.append(f"  - {shell} (owns: {', '.join(owners)})")
+
+    return failures
+
+
+def render_shell_progress(
+    fields: list[Field],
+    manifest: dict[str, dict[str, str]],
+) -> str:
+    """Render the per-shell migration burndown: how many `CheckerContext`
+    fields still live in the god-object for each destination shell."""
+    counts: dict[str, int] = {}
+    for f in fields:
+        entry = manifest.get(f.name)
+        if entry is None:
+            continue
+        shell = LIFETIME_DESTINATION_SHELL.get(entry["lifetime"], "UNMAPPED")
+        counts[shell] = counts.get(shell, 0) + 1
+
+    lines = [
+        "# CheckerContext Decomposition Burndown",
+        "",
+        "Fields still owned by the `CheckerContext` god-object, grouped by the",
+        "destination shell that will own them after the T2.1 split.",
+        "",
+        f"Total fields: {len(fields)}",
+        "",
+        "| Destination shell | Fields remaining in CheckerContext |",
+        "| --- | ---: |",
+    ]
+    for shell in sorted(counts, key=lambda s: (-counts[s], s)):
+        lines.append(f"| `{shell}` | {counts[shell]} |")
+    return "\n".join(lines)
+
+
 def render_markdown(
     fields: list[Field],
     manifest: dict[str, dict[str, str]],
@@ -378,6 +504,11 @@ def render_markdown(
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--render", action="store_true", help="Print markdown report.")
+    ap.add_argument(
+        "--shells",
+        action="store_true",
+        help="Print the per-shell decomposition burndown table.",
+    )
     ap.add_argument("--list", action="store_true", help="Print raw field list.")
     args = ap.parse_args()
 
@@ -393,21 +524,28 @@ def main() -> int:
         print(render_markdown(fields, manifest))
         return 0
 
+    if args.shells:
+        print(render_shell_progress(fields, manifest))
+        return 0
+
     failures = check_inventory(fields, manifest)
+    failures += check_destination_shells(declared_shell_structs())
     if failures:
         print("Checker field-lifetime inventory FAILED:", file=sys.stderr)
         for line in failures:
             print(line, file=sys.stderr)
         print(
             "\nFix by editing the manifest at "
-            f"{MANIFEST_TOML.relative_to(ROOT)} per PERFORMANCE_PLAN.md §6.",
+            f"{MANIFEST_TOML.relative_to(ROOT)} (lifetime/capability classes) or "
+            f"the destination shells in {LIFETIME_SHELLS_RS.relative_to(ROOT)} "
+            "(decomposition contract).",
             file=sys.stderr,
         )
         return 1
 
     print(
         f"Checker field-lifetime inventory passed: {len(fields)} field(s) "
-        "all classified."
+        "all classified; destination-shell contract intact."
     )
     return 0
 

--- a/scripts/arch/test_arch_guard_support.py
+++ b/scripts/arch/test_arch_guard_support.py
@@ -1,5 +1,6 @@
 import importlib.util
 import pathlib
+import sys
 import tempfile
 import unittest
 
@@ -8,9 +9,19 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 ARCH_GUARD_PATH = ROOT / "scripts" / "arch" / "arch_guard.py"
 
 
-def load_arch_guard_module():
-    spec = importlib.util.spec_from_file_location("arch_guard", ARCH_GUARD_PATH)
+def load_arch_script_module(module_name: str, path: pathlib.Path):
+    """Load a `scripts/arch` Python module by file path.
+
+    Registers the module in `sys.modules` before executing it so module-level
+    `@dataclass` definitions can resolve their own `__module__`.
+    """
+    spec = importlib.util.spec_from_file_location(module_name, path)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def load_arch_guard_module():
+    return load_arch_script_module("arch_guard", ARCH_GUARD_PATH)

--- a/scripts/arch/test_checker_field_inventory.py
+++ b/scripts/arch/test_checker_field_inventory.py
@@ -1,0 +1,88 @@
+"""Tests for the CheckerContext field-lifetime inventory guard.
+
+Covers the T2.1 destination-shell decomposition contract added on top of the
+existing lifetime/capability classification: every valid lifetime class must
+name a destination shell, and every mapped shell must exist as a real
+`pub struct`. Run standalone (as CI's arch-tool-smoke job does):
+
+    python3 scripts/arch/test_checker_field_inventory.py
+"""
+
+from unittest import mock
+
+from test_arch_guard_support import ROOT, load_arch_script_module, pathlib, unittest
+
+INVENTORY_PATH = ROOT / "scripts" / "arch" / "checker_field_inventory.py"
+
+
+def load_inventory_module():
+    return load_arch_script_module("checker_field_inventory", INVENTORY_PATH)
+
+
+class DestinationShellContractTests(unittest.TestCase):
+    def setUp(self):
+        self.inv = load_inventory_module()
+        self.declared = self.inv.declared_shell_structs()
+
+    def test_every_valid_lifetime_maps_to_a_shell(self):
+        """The decomposition contract must name a destination for every
+        classifiable lifetime; otherwise a newly classified field would have no
+        machine-checked home."""
+        unmapped = self.inv.VALID_LIFETIMES - self.inv.LIFETIME_DESTINATION_SHELL.keys()
+        self.assertEqual(
+            unmapped,
+            set(),
+            f"lifetime classes with no destination shell: {sorted(unmapped)}",
+        )
+
+    def test_declared_shells_include_every_mapped_shell(self):
+        """Every shell named by the mapping must exist as a `pub struct` in the
+        scanned source files — proving the shells are real, not prose."""
+        for shell in set(self.inv.LIFETIME_DESTINATION_SHELL.values()):
+            self.assertIn(
+                shell,
+                self.declared,
+                f"destination shell {shell!r} is not declared as a `pub struct`",
+            )
+
+    def test_check_passes_on_the_real_tree(self):
+        """The shipped manifest + shells must satisfy the contract."""
+        self.assertEqual(self.inv.check_destination_shells(self.declared), [])
+
+    def test_missing_shell_struct_is_reported(self):
+        """A mapped shell that is absent from the declared structs must fail —
+        this is the drift guard the contract exists to provide."""
+        # Drop one real shell to simulate a rename/removal that left the mapping
+        # pointing at a now-missing type.
+        victim = "FileSession"
+        self.assertIn(victim, self.declared)
+        failures = self.inv.check_destination_shells(self.declared - {victim})
+        self.assertTrue(failures, "expected a failure when a shell is missing")
+        self.assertTrue(
+            any(victim in line for line in failures),
+            f"missing-shell failure did not mention {victim!r}: {failures}",
+        )
+
+    def test_unmapped_lifetime_is_reported(self):
+        """A valid lifetime with no destination must fail the mapping check."""
+        # `patch.dict` snapshots and restores the mapping around the mutation.
+        with mock.patch.dict(self.inv.LIFETIME_DESTINATION_SHELL):
+            # Simulate a newly classified lifetime that nobody mapped to a shell.
+            self.inv.LIFETIME_DESTINATION_SHELL.pop("SpeculationScoped")
+            failures = self.inv.check_destination_shells(self.declared)
+        self.assertTrue(
+            any("SpeculationScoped" in line for line in failures),
+            f"unmapped lifetime not reported: {failures}",
+        )
+
+    def test_shell_sources_exist(self):
+        """The scanned shell source files must exist, else the guard would
+        silently find zero structs and pass vacuously."""
+        for path in self.inv.DESTINATION_SHELL_SOURCES:
+            self.assertTrue(
+                pathlib.Path(path).exists(), f"shell source missing: {path}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Goal: fast

Refactor (behavior unchanged) advancing the T2.1 `CheckerContext` decomposition prerequisite called out in #13246's evidence map: *"planned lifetime-tier decomposition is empty placeholder structs (`context/lifetime_shells.rs`)"*. This session does **not** attempt the bounded-partitions rework or the reuse-accumulation root-cause (both correctly multi-session); it removes one concrete blocker so the field-migration PRs have a machine-checked destination and the shells can no longer drift from the manifest taxonomy.

## Structural rule

> Every classifiable `CheckerContext` field lifetime (`ProgramStable`, `WorkerReusable`, `FileLocalReset`, `DiagnosticsOnly`, `SpeculationScoped`, `LspPersistent`) maps to exactly one destination decomposition shell, and that shell must exist as a real `pub struct`. The mapping is the contract the T2.1 split migrates fields against.

Before this PR that class→shell mapping lived only in prose, duplicated across three places (the manifest header, the `lifetime_shells.rs` module doc, and the shell doc comments). Nothing enforced it, so renaming/removing a shell or adding a lifetime class would silently desync the decomposition target from the manifest, and migration PRs had no validated home for a field.

## Owner layer

Architecture guard / tooling only — no checker, solver, or emitter behavior change, no Rust logic change (only a doc-comment correction in `lifetime_shells.rs`).

- `scripts/arch/checker_field_inventory.py` — encodes `LIFETIME_DESTINATION_SHELL` and a `check_destination_shells` gate (run in CI via `check-checker-boundaries.sh`): fails when a valid lifetime has no destination, or a mapped shell is not declared as a `pub struct` in `lifetime_shells.rs` / `program_context.rs`. Adds a `--shells` decomposition burndown report.
- `scripts/arch/test_checker_field_inventory.py` — new standalone test suite (CI's `arch-tool-smoke` runs every `scripts/arch/test_*.py`), covering mapping completeness, shell existence, the real-tree pass, and the negative drift cases (missing shell, unmapped lifetime).
- `scripts/arch/test_arch_guard_support.py` — extracts a shared `load_arch_script_module` loader (reused by the existing `load_arch_guard_module` and the new test) so the dynamic-import + `sys.modules` registration isn't duplicated.
- `crates/tsz-checker/src/context/lifetime_shells.rs` — module doc now states the mapping explicitly and notes it is CI-enforced.

The contract keys only on lifetime classes and Rust `pub struct` declarations — no identifier/alias/file-name/printer-string predicate.

## Decomposition burndown (current)

`python3 scripts/arch/checker_field_inventory.py --shells` over the 252 classified fields:

| Destination shell | Fields remaining in CheckerContext |
| --- | ---: |
| `FileSession` | 201 |
| `ProgramContext` | 41 |
| `SpeculationScope` | 10 |

(`WorkerContext` / `LspPersistentCache` have zero destined fields today — consistent with the manifest having no `WorkerReusable` / `LspPersistent` entries yet.)

## Verification

- `python3 scripts/arch/checker_field_inventory.py` → `252 field(s) all classified; destination-shell contract intact` (exit 0).
- `python3 scripts/arch/test_checker_field_inventory.py` → **6 passed** (incl. negative drift cases: missing shell struct, unmapped lifetime).
- `python3 -m py_compile scripts/arch/*.py` → clean.
- `python3 scripts/arch/test_arch_guard.py` → no new failures vs the pre-change tree (the 2 residual failures — `test_no_unguarded_oversized_production_files`, `test_real_count_passes_at_pinned_cap` — are pre-existing ratchets, reproduced with this branch stashed).
- Reviewed via `/simplify` (3 rounds): shared loader extracted, informational `--shells` invocation kept off the guard path, tests deduped.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_0187FeTXn3VT1j1swZpHWt3X

---
_Generated by [Claude Code](https://claude.ai/code/session_0187FeTXn3VT1j1swZpHWt3X)_