### PR TITLE
fix(emit): lower ES5 destructuring in async var decls and catch clauses

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -303,6 +303,10 @@ name = "async_try_emit"
 path = "tests/async_try_emit.rs"
 
 [[test]]
+name = "async_es5_destructuring_tests"
+path = "tests/async_es5_destructuring_tests.rs"
+
+[[test]]
 name = "async_loop_emit"
 path = "tests/async_loop_emit.rs"
 

--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -69,6 +69,8 @@ mod cases;
 mod condition_await;
 #[path = "async_es5_ir_control.rs"]
 mod control;
+#[path = "async_es5_ir_destructuring.rs"]
+mod destructuring;
 #[path = "async_es5_ir_discovery.rs"]
 mod discovery;
 #[path = "async_es5_ir_disposables.rs"]

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
@@ -1041,6 +1041,12 @@ impl<'a> AsyncES5Transformer<'a> {
             }
 
             k if k == syntax_kind_ext::VARIABLE_STATEMENT => {
+                // A destructuring `var`/`const` cannot be emitted as a native
+                // binding pattern at ES5; lower it into a hoist + comma
+                // assignment chain (matching `tsc`'s generator emit).
+                if self.variable_statement_has_binding_pattern(node) {
+                    return self.lower_destructuring_variable_statement(node);
+                }
                 if let Some(var_data) = self.arena.get_variable(node) {
                     let mut decls = Vec::new();
                     for &decl_idx in &var_data.declarations.nodes {

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_destructuring.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_destructuring.rs
@@ -1,0 +1,601 @@
+//! ES5 destructuring lowering for the async->generator IR pipeline.
+//!
+//! Inside an `async` function lowered to ES5, a destructuring `var`/`const`
+//! declaration (or a destructuring `catch` binding) cannot be emitted as a
+//! native binding pattern -- ES5 has no destructuring syntax. `tsc` rewrites
+//! each pattern into a comma sequence of plain assignments that reads the
+//! source once (via a temp when it is not a reusable identifier) and extracts
+//! every bound name, e.g.
+//!
+//! ```js
+//! // const { a, b } = obj;   -->   a = obj.a, b = obj.b;
+//! // const { a, b } = g();   -->   _a = g(), a = _a.a, b = _a.b;
+//! // const [x, ...r] = arr;  -->   x = arr[0], r = arr.slice(1);
+//! ```
+//!
+//! The bound names (and any temps) are hoisted to the top of the `__generator`
+//! wrapper exactly like every other generator-local `var`, so this module emits
+//! hoist-only `VarDecl { initializer: None }` nodes for them and a single
+//! `ExpressionStatement` holding the comma-joined assignment chain. The shared
+//! `extract_and_remove_var_decl_groups` pass then collects the hoist names and
+//! leaves the assignment statement in place.
+//!
+//! This mirrors the synchronous printer-path destructuring lowering
+//! (`emitter::es5::bindings_patterns`) but produces `IRNode`s instead of writing
+//! directly, since the async pipeline works on IR.
+
+use super::AsyncES5Transformer;
+use crate::transforms::ir::IRNode;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::Node;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+impl<'a> AsyncES5Transformer<'a> {
+    /// Whether a variable statement declares at least one binding pattern, so it
+    /// must route through the destructuring lowering rather than the plain
+    /// identifier path.
+    pub(in crate::transforms) fn variable_statement_has_binding_pattern(
+        &self,
+        var_node: &Node,
+    ) -> bool {
+        self.variable_statement_declarations(var_node)
+            .into_iter()
+            .any(|decl_idx| {
+                self.arena
+                    .get(decl_idx)
+                    .and_then(|decl_node| self.arena.get_variable_declaration(decl_node))
+                    .is_some_and(|decl| self.is_binding_pattern_name(decl.name))
+            })
+    }
+
+    /// Flatten a `VARIABLE_STATEMENT` into its `VARIABLE_DECLARATION` indices,
+    /// transparently descending through the `VARIABLE_DECLARATION_LIST` level.
+    fn variable_statement_declarations(&self, var_node: &Node) -> Vec<NodeIndex> {
+        let mut out = Vec::new();
+        let Some(var_data) = self.arena.get_variable(var_node) else {
+            return out;
+        };
+        for &child_idx in &var_data.declarations.nodes {
+            let Some(child_node) = self.arena.get(child_idx) else {
+                continue;
+            };
+            if child_node.kind == syntax_kind_ext::VARIABLE_DECLARATION {
+                out.push(child_idx);
+            } else if child_node.kind == syntax_kind_ext::VARIABLE_DECLARATION_LIST {
+                if let Some(list) = self.arena.get_variable(child_node) {
+                    out.extend(list.declarations.nodes.iter().copied());
+                }
+            }
+        }
+        out
+    }
+
+    /// If a `catch` clause's variable declaration binds a destructuring
+    /// pattern, return the pattern node; otherwise `None` (plain identifier or
+    /// no binding).
+    pub(in crate::transforms) fn catch_binding_pattern(
+        &self,
+        var_decl_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let var_node = self.arena.get(var_decl_idx)?;
+        let var_decl = self.arena.get_variable_declaration(var_node)?;
+        self.is_binding_pattern_name(var_decl.name)
+            .then_some(var_decl.name)
+    }
+
+    /// Lower a destructuring variable declaration whose initializer is read
+    /// synchronously (no `await`) into the hoist-only declarations + comma
+    /// assignment chain, pushing them into `out`. Used for binding-pattern
+    /// declarations that share a statement with an awaited declaration.
+    pub(in crate::transforms) fn lower_destructuring_declaration_value(
+        &self,
+        pattern_idx: NodeIndex,
+        value: IRNode,
+        out: &mut Vec<IRNode>,
+    ) {
+        let reusable = matches!(value, IRNode::Identifier(_));
+        let mut hoist = Vec::new();
+        let mut assigns = Vec::new();
+        self.lower_binding_pattern(pattern_idx, value, reusable, &mut assigns, &mut hoist);
+        Self::push_hoist_and_assignments(hoist, assigns, out);
+    }
+
+    /// Lower a destructuring variable declaration whose initializer is a direct
+    /// `await`. The bound names + temps must be hoisted *before* the yield, and
+    /// the extraction (reading the resumed `_x.sent()` value) emitted *after*
+    /// the resume; the caller emits the yield between the two returned lists.
+    pub(in crate::transforms) fn split_suspended_destructuring_declaration(
+        &self,
+        pattern_idx: NodeIndex,
+    ) -> (Vec<IRNode>, Option<IRNode>) {
+        let mut hoist = Vec::new();
+        let mut assigns = Vec::new();
+        // The resumed value (`_x.sent()`) is not a reusable identifier, so a
+        // multi-element pattern captures it into a temp (`_a = _x.sent()`) while
+        // a single-element pattern reads it inline (`a = (_x.sent()).a`).
+        self.lower_binding_pattern(
+            pattern_idx,
+            IRNode::GeneratorSent,
+            false,
+            &mut assigns,
+            &mut hoist,
+        );
+        let decls = hoist
+            .into_iter()
+            .map(|name| IRNode::VarDecl {
+                name: name.into(),
+                initializer: None,
+            })
+            .collect();
+        (decls, Self::comma_assignment_statement(assigns))
+    }
+
+    /// True when `name_idx` is an object/array binding pattern (not an
+    /// identifier).
+    pub(in crate::transforms) fn is_binding_pattern_name(&self, name_idx: NodeIndex) -> bool {
+        self.arena.get(name_idx).is_some_and(|node| {
+            node.kind == syntax_kind_ext::OBJECT_BINDING_PATTERN
+                || node.kind == syntax_kind_ext::ARRAY_BINDING_PATTERN
+        })
+    }
+
+    /// Lower a variable statement containing at least one binding pattern into a
+    /// hoist + comma-assignment `Sequence`, matching `tsc`'s generator emit.
+    pub(in crate::transforms) fn lower_destructuring_variable_statement(
+        &self,
+        var_node: &Node,
+    ) -> IRNode {
+        let mut hoist = Vec::new();
+        let mut assigns = Vec::new();
+
+        for decl_idx in self.variable_statement_declarations(var_node) {
+            let Some(decl_node) = self.arena.get(decl_idx) else {
+                continue;
+            };
+            let Some(decl) = self.arena.get_variable_declaration(decl_node) else {
+                continue;
+            };
+            if self.is_binding_pattern_name(decl.name) {
+                if decl.initializer.is_none() {
+                    // A binding pattern without an initializer is not valid
+                    // TypeScript; nothing to extract.
+                    continue;
+                }
+                let value = self.expression_to_ir(decl.initializer);
+                let reusable = matches!(value, IRNode::Identifier(_));
+                self.lower_binding_pattern(decl.name, value, reusable, &mut assigns, &mut hoist);
+            } else {
+                // Plain identifier declaration in the same statement: `tsc`
+                // joins it into the same comma chain (e.g.
+                // `const a = 1, { b } = obj;` -> `a = 1, b = obj.b`).
+                let name =
+                    crate::transforms::emit_utils::identifier_text_or_empty(self.arena, decl.name);
+                if name.is_empty() {
+                    continue;
+                }
+                Self::push_hoist(&mut hoist, &name);
+                if decl.initializer.is_some() {
+                    assigns.push(IRNode::assign(
+                        IRNode::id(name),
+                        self.expression_to_ir(decl.initializer),
+                    ));
+                }
+            }
+        }
+
+        Self::assemble_destructuring_sequence(hoist, assigns)
+    }
+
+    /// Lower a destructuring `catch` binding into the assignment statements that
+    /// read each bound name out of `catch_temp` (the temp holding the caught
+    /// value). The caller has already emitted `catch_temp = _x.sent()`.
+    pub(in crate::transforms) fn lower_catch_binding_destructuring(
+        &self,
+        pattern_idx: NodeIndex,
+        catch_temp: &str,
+        out: &mut Vec<IRNode>,
+    ) {
+        let mut hoist = Vec::new();
+        let mut assigns = Vec::new();
+        // The catch temp is an identifier, so it is reused directly (no extra
+        // temp), matching `tsc`'s `_a = _b.sent(); a = _a.a, b = _a.b;`.
+        self.lower_binding_pattern(
+            pattern_idx,
+            IRNode::id(catch_temp.to_string()),
+            true,
+            &mut assigns,
+            &mut hoist,
+        );
+        Self::push_hoist_and_assignments(hoist, assigns, out);
+    }
+
+    /// Push hoist-only `var` declarations for each name, followed by the
+    /// comma-joined assignment chain, into `out`.
+    fn push_hoist_and_assignments(hoist: Vec<String>, assigns: Vec<IRNode>, out: &mut Vec<IRNode>) {
+        for name in hoist {
+            out.push(IRNode::VarDecl {
+                name: name.into(),
+                initializer: None,
+            });
+        }
+        if let Some(stmt) = Self::comma_assignment_statement(assigns) {
+            out.push(stmt);
+        }
+    }
+
+    /// Assemble the hoist-only declarations and the comma-joined assignment
+    /// statement into a single `Sequence` returned from `statement_to_ir`.
+    fn assemble_destructuring_sequence(hoist: Vec<String>, assigns: Vec<IRNode>) -> IRNode {
+        let mut stmts = Vec::with_capacity(hoist.len() + 1);
+        Self::push_hoist_and_assignments(hoist, assigns, &mut stmts);
+        if stmts.len() == 1 {
+            stmts.into_iter().next().expect("len checked")
+        } else {
+            IRNode::Sequence(stmts)
+        }
+    }
+
+    /// Build the `ExpressionStatement` holding the comma-joined assignment
+    /// chain (`a = obj.a, b = obj.b`). A `CommaExpr` directly under an
+    /// `ExpressionStatement` is rendered without the surrounding parentheses.
+    fn comma_assignment_statement(mut assigns: Vec<IRNode>) -> Option<IRNode> {
+        match assigns.len() {
+            0 => None,
+            1 => Some(IRNode::ExpressionStatement(Box::new(
+                assigns.pop().expect("len checked"),
+            ))),
+            _ => Some(IRNode::ExpressionStatement(Box::new(IRNode::CommaExpr(
+                assigns,
+            )))),
+        }
+    }
+
+    fn push_hoist(hoist: &mut Vec<String>, name: &str) {
+        if !hoist.iter().any(|existing| existing == name) {
+            hoist.push(name.to_string());
+        }
+    }
+
+    /// Recursively lower a binding pattern, reading bound names out of `value`.
+    ///
+    /// `value_is_reusable` indicates `value` is a plain identifier that can be
+    /// re-read for each element without a temp (matching `tsc`'s
+    /// `ensureIdentifier(reuseIdentifierExpressions)`).
+    fn lower_binding_pattern(
+        &self,
+        pattern_idx: NodeIndex,
+        value: IRNode,
+        value_is_reusable: bool,
+        assigns: &mut Vec<IRNode>,
+        hoist: &mut Vec<String>,
+    ) {
+        let Some(pattern_node) = self.arena.get(pattern_idx) else {
+            return;
+        };
+        match pattern_node.kind {
+            k if k == syntax_kind_ext::OBJECT_BINDING_PATTERN => {
+                self.lower_object_binding_pattern(
+                    pattern_idx,
+                    value,
+                    value_is_reusable,
+                    assigns,
+                    hoist,
+                );
+            }
+            k if k == syntax_kind_ext::ARRAY_BINDING_PATTERN => {
+                self.lower_array_binding_pattern(
+                    pattern_idx,
+                    value,
+                    value_is_reusable,
+                    assigns,
+                    hoist,
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn lower_object_binding_pattern(
+        &self,
+        pattern_idx: NodeIndex,
+        value: IRNode,
+        value_is_reusable: bool,
+        assigns: &mut Vec<IRNode>,
+        hoist: &mut Vec<String>,
+    ) {
+        let elements = self.binding_pattern_elements(pattern_idx);
+        let element_count = elements.len();
+        let has_computed_key = elements.iter().any(|&e| self.element_has_computed_key(e));
+        // A single non-computed element reads `value` exactly once, so it is
+        // inlined; otherwise the value is captured (a temp when not a reusable
+        // identifier) so it is read only once.
+        let needs_temp = element_count != 1 || has_computed_key;
+        // A computed property name forces the value into a temp even when it is
+        // a reusable identifier, matching `tsc` (`_a = obj, _b = k, v = _a[_b]`).
+        let reusable = value_is_reusable && !has_computed_key;
+        let src = self.ensure_value_source(value, reusable, needs_temp, assigns, hoist);
+
+        let mut excluded_keys: Vec<IRNode> = Vec::new();
+        for &elem_idx in &elements {
+            let Some(elem) = self
+                .arena
+                .get(elem_idx)
+                .and_then(|n| self.arena.get_binding_element(n))
+            else {
+                continue;
+            };
+            if elem.dot_dot_dot_token {
+                // Object rest: `rest = __rest(src, ["a", "b"])`.
+                let rhs = IRNode::call(
+                    IRNode::RuntimeHelper("__rest".into()),
+                    vec![src.clone(), IRNode::ArrayLiteral(excluded_keys.clone())],
+                );
+                self.bind_target(elem.name, rhs, elem.initializer, assigns, hoist);
+                continue;
+            }
+            let key_idx = self.binding_element_key(elem.property_name, elem.name);
+            let (access, exclude_key) =
+                self.object_member_access(src.clone(), key_idx, assigns, hoist);
+            excluded_keys.push(exclude_key);
+            self.bind_target(elem.name, access, elem.initializer, assigns, hoist);
+        }
+    }
+
+    fn lower_array_binding_pattern(
+        &self,
+        pattern_idx: NodeIndex,
+        value: IRNode,
+        value_is_reusable: bool,
+        assigns: &mut Vec<IRNode>,
+        hoist: &mut Vec<String>,
+    ) {
+        let elements = self.binding_pattern_elements_with_holes(pattern_idx);
+        let non_omitted = elements.iter().filter(|&&e| !e.is_none()).count();
+        let has_rest = elements.iter().any(|&e| {
+            self.arena
+                .get(e)
+                .and_then(|n| self.arena.get_binding_element(n))
+                .is_some_and(|elem| elem.dot_dot_dot_token)
+        });
+
+        let src = if self.downlevel_iteration {
+            // Under downlevelIteration the array is read through the iterator
+            // protocol: `_a = __read(value, n)` (or `__read(value)` with a rest).
+            let read_args = if has_rest {
+                vec![value]
+            } else {
+                vec![value, IRNode::number(non_omitted.to_string())]
+            };
+            let temp = self.generate_hoisted_temp();
+            Self::push_hoist(hoist, &temp);
+            assigns.push(IRNode::assign(
+                IRNode::id(temp.clone()),
+                IRNode::call(IRNode::RuntimeHelper("__read".into()), read_args),
+            ));
+            IRNode::id(temp)
+        } else {
+            let needs_temp = non_omitted != 1;
+            self.ensure_value_source(value, value_is_reusable, needs_temp, assigns, hoist)
+        };
+
+        for (index, &elem_idx) in elements.iter().enumerate() {
+            if elem_idx.is_none() {
+                continue;
+            }
+            let Some(elem) = self
+                .arena
+                .get(elem_idx)
+                .and_then(|n| self.arena.get_binding_element(n))
+            else {
+                continue;
+            };
+            if elem.dot_dot_dot_token {
+                // Array rest: `rest = src.slice(index)`.
+                let rhs = IRNode::call(
+                    IRNode::prop(src.clone(), "slice"),
+                    vec![IRNode::number(index.to_string())],
+                );
+                self.bind_target(elem.name, rhs, elem.initializer, assigns, hoist);
+                continue;
+            }
+            let access = IRNode::elem(src.clone(), IRNode::number(index.to_string()));
+            self.bind_target(elem.name, access, elem.initializer, assigns, hoist);
+        }
+    }
+
+    /// Bind `name_idx` (identifier or nested pattern) to `access`, applying an
+    /// optional `default_idx` initializer.
+    fn bind_target(
+        &self,
+        name_idx: NodeIndex,
+        access: IRNode,
+        default_idx: NodeIndex,
+        assigns: &mut Vec<IRNode>,
+        hoist: &mut Vec<String>,
+    ) {
+        let is_pattern = self.is_binding_pattern_name(name_idx);
+
+        if default_idx.is_some() {
+            // `_t = access` then `_t === void 0 ? default : _t`.
+            let temp = self.generate_hoisted_temp();
+            Self::push_hoist(hoist, &temp);
+            assigns.push(IRNode::assign(IRNode::id(temp.clone()), access));
+            let defaulted = IRNode::ConditionalExpr {
+                condition: Box::new(IRNode::binary(
+                    IRNode::id(temp.clone()),
+                    "===",
+                    IRNode::Undefined,
+                )),
+                when_true: Box::new(self.expression_to_ir(default_idx)),
+                when_false: Box::new(IRNode::id(temp)),
+            };
+            if is_pattern {
+                // A second temp holds the defaulted value before destructuring it.
+                let temp2 = self.generate_hoisted_temp();
+                Self::push_hoist(hoist, &temp2);
+                assigns.push(IRNode::assign(IRNode::id(temp2.clone()), defaulted));
+                self.lower_binding_pattern(name_idx, IRNode::id(temp2), true, assigns, hoist);
+            } else {
+                let name =
+                    crate::transforms::emit_utils::identifier_text_or_empty(self.arena, name_idx);
+                if !name.is_empty() {
+                    Self::push_hoist(hoist, &name);
+                    assigns.push(IRNode::assign(IRNode::id(name), defaulted));
+                }
+            }
+            return;
+        }
+
+        if is_pattern {
+            let reusable = matches!(access, IRNode::Identifier(_));
+            self.lower_binding_pattern(name_idx, access, reusable, assigns, hoist);
+        } else {
+            let name =
+                crate::transforms::emit_utils::identifier_text_or_empty(self.arena, name_idx);
+            if !name.is_empty() {
+                Self::push_hoist(hoist, &name);
+                assigns.push(IRNode::assign(IRNode::id(name), access));
+            }
+        }
+    }
+
+    /// Capture `value` into a temp when it is read more than once and is not a
+    /// reusable identifier; otherwise return it unchanged.
+    fn ensure_value_source(
+        &self,
+        value: IRNode,
+        value_is_reusable: bool,
+        needs_temp: bool,
+        assigns: &mut Vec<IRNode>,
+        hoist: &mut Vec<String>,
+    ) -> IRNode {
+        if !needs_temp || value_is_reusable {
+            return value;
+        }
+        let temp = self.generate_hoisted_temp();
+        Self::push_hoist(hoist, &temp);
+        assigns.push(IRNode::assign(IRNode::id(temp.clone()), value));
+        IRNode::id(temp)
+    }
+
+    /// Produce the property access for an object binding element key, plus the
+    /// key form used in a sibling rest element's exclusion list.
+    ///
+    /// Returns `(access, exclude_key)`. For a computed key the key expression is
+    /// captured into a temp first so it is evaluated once.
+    fn object_member_access(
+        &self,
+        src: IRNode,
+        key_idx: NodeIndex,
+        assigns: &mut Vec<IRNode>,
+        hoist: &mut Vec<String>,
+    ) -> (IRNode, IRNode) {
+        let Some(key_node) = self.arena.get(key_idx) else {
+            return (src, IRNode::StringLiteral("".into()));
+        };
+        if key_node.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME {
+            if let Some(computed) = self.arena.get_computed_property(key_node) {
+                let temp = self.generate_hoisted_temp();
+                Self::push_hoist(hoist, &temp);
+                assigns.push(IRNode::assign(
+                    IRNode::id(temp.clone()),
+                    self.expression_to_ir(computed.expression),
+                ));
+                let access = IRNode::elem(src, IRNode::id(temp.clone()));
+                // Excluded key for a computed property: `typeof _t === "symbol"
+                // ? _t : _t + ""` (matching the synchronous `__rest` lowering).
+                let exclude = IRNode::ConditionalExpr {
+                    condition: Box::new(IRNode::binary(
+                        IRNode::Raw(format!("typeof {temp}").into()),
+                        "===",
+                        IRNode::StringLiteral("symbol".into()),
+                    )),
+                    when_true: Box::new(IRNode::id(temp.clone())),
+                    when_false: Box::new(IRNode::binary(
+                        IRNode::id(temp),
+                        "+",
+                        IRNode::StringLiteral("".into()),
+                    )),
+                };
+                return (access, exclude);
+            }
+            return (src, IRNode::StringLiteral("".into()));
+        }
+        if key_node.is_identifier() {
+            let text = crate::transforms::emit_utils::identifier_text_or_empty(self.arena, key_idx);
+            let access = IRNode::prop(src, text.clone());
+            return (access, IRNode::RawStringLiteral(text.into()));
+        }
+        if key_node.kind == SyntaxKind::StringLiteral as u16 {
+            let text = self
+                .arena
+                .get_literal(key_node)
+                .map(|lit| lit.text.clone())
+                .unwrap_or_default();
+            let access = IRNode::elem(src, IRNode::RawStringLiteral(text.clone().into()));
+            return (access, IRNode::RawStringLiteral(text.into()));
+        }
+        if key_node.kind == SyntaxKind::NumericLiteral as u16 {
+            let text = self
+                .arena
+                .get_literal(key_node)
+                .map(|lit| lit.text.clone())
+                .unwrap_or_default();
+            let access = IRNode::elem(src, IRNode::number(text.clone()));
+            // Numeric keys are excluded as quoted strings, mirroring `tsc`.
+            return (access, IRNode::RawStringLiteral(text.into()));
+        }
+        (src, IRNode::StringLiteral("".into()))
+    }
+
+    const fn binding_element_key(&self, property_name: NodeIndex, name: NodeIndex) -> NodeIndex {
+        if property_name.is_some() {
+            property_name
+        } else {
+            name
+        }
+    }
+
+    fn binding_pattern_elements(&self, pattern_idx: NodeIndex) -> Vec<NodeIndex> {
+        self.arena
+            .get(pattern_idx)
+            .and_then(|n| self.arena.get_binding_pattern(n))
+            .map(|p| {
+                p.elements
+                    .nodes
+                    .iter()
+                    .copied()
+                    .filter(|idx| !idx.is_none())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Array elements preserving holes (`OMITTED_EXPRESSION`) so element indices
+    /// line up with source positions.
+    fn binding_pattern_elements_with_holes(&self, pattern_idx: NodeIndex) -> Vec<NodeIndex> {
+        self.arena
+            .get(pattern_idx)
+            .and_then(|n| self.arena.get_binding_pattern(n))
+            .map(|p| p.elements.nodes.clone())
+            .unwrap_or_default()
+    }
+
+    fn element_has_computed_key(&self, elem_idx: NodeIndex) -> bool {
+        let Some(elem) = self
+            .arena
+            .get(elem_idx)
+            .and_then(|n| self.arena.get_binding_element(n))
+        else {
+            return false;
+        };
+        if elem.dot_dot_dot_token {
+            return false;
+        }
+        let key_idx = self.binding_element_key(elem.property_name, elem.name);
+        self.arena
+            .get(key_idx)
+            .is_some_and(|n| n.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
+    }
+}

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_destructuring.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_destructuring.rs
@@ -31,7 +31,7 @@ use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
-impl<'a> AsyncES5Transformer<'a> {
+impl AsyncES5Transformer<'_> {
     /// Whether a variable statement declares at least one binding pattern, so it
     /// must route through the destructuring lowering rather than the plain
     /// identifier path.
@@ -334,7 +334,7 @@ impl<'a> AsyncES5Transformer<'a> {
                 self.bind_target(elem.name, rhs, elem.initializer, assigns, hoist);
                 continue;
             }
-            let key_idx = self.binding_element_key(elem.property_name, elem.name);
+            let key_idx = Self::binding_element_key(elem.property_name, elem.name);
             let (access, exclude_key) =
                 self.object_member_access(src.clone(), key_idx, assigns, hoist);
             excluded_keys.push(exclude_key);
@@ -549,7 +549,7 @@ impl<'a> AsyncES5Transformer<'a> {
         (src, IRNode::StringLiteral("".into()))
     }
 
-    const fn binding_element_key(&self, property_name: NodeIndex, name: NodeIndex) -> NodeIndex {
+    const fn binding_element_key(property_name: NodeIndex, name: NodeIndex) -> NodeIndex {
         if property_name.is_some() {
             property_name
         } else {
@@ -593,7 +593,7 @@ impl<'a> AsyncES5Transformer<'a> {
         if elem.dot_dot_dot_token {
             return false;
         }
-        let key_idx = self.binding_element_key(elem.property_name, elem.name);
+        let key_idx = Self::binding_element_key(elem.property_name, elem.name);
         self.arena
             .get(key_idx)
             .is_some_and(|n| n.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_statements.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_statements.rs
@@ -212,6 +212,16 @@ impl<'a> AsyncES5Transformer<'a> {
             }
 
             k if k == syntax_kind_ext::VARIABLE_STATEMENT => {
+                // A destructuring `var`/`const` cannot be emitted as a native
+                // binding pattern at ES5; lower the whole statement into a hoist
+                // + comma-assignment chain. The await-in-initializer destructuring
+                // case is handled by the per-declaration path below.
+                if self.variable_statement_has_binding_pattern(node)
+                    && !self.contains_await_recursive(idx)
+                {
+                    current_statements.push(self.lower_destructuring_variable_statement(node));
+                    return;
+                }
                 // Structure: VARIABLE_STATEMENT -> VARIABLE_DECLARATION_LIST -> VARIABLE_DECLARATION
                 if let Some(var_stmt) = self.arena.get_variable(node) {
                     let mut trailing_comment = self.extract_trailing_line_comment_in_node(idx);
@@ -1159,6 +1169,44 @@ impl<'a> AsyncES5Transformer<'a> {
         let Some(node) = self.arena.get(idx) else {
             return;
         };
+
+        // A destructuring declaration cannot use the identifier-name path below
+        // (its name is a binding pattern, not an identifier). Lower it into a
+        // hoist + comma-assignment chain, reading the resumed `_x.sent()` value
+        // when the initializer is a direct `await`.
+        let pattern_decl = self
+            .arena
+            .get_variable_declaration(node)
+            .map(|decl| (decl.name, decl.initializer));
+        if let Some((decl_name, decl_init)) = pattern_decl
+            && self.is_binding_pattern_name(decl_name)
+            && decl_init.is_some()
+        {
+            if self.is_suspension_expression(decl_init) {
+                let trailing = trailing_comment.take();
+                let (hoist_decls, comma_stmt) =
+                    self.split_suspended_destructuring_declaration(decl_name);
+                current_statements.extend(hoist_decls);
+                self.process_await_expression_with_trailing_comment(
+                    decl_init,
+                    cases,
+                    current_statements,
+                    current_label,
+                    trailing.as_deref(),
+                );
+                if let Some(stmt) = comma_stmt {
+                    current_statements.push(stmt);
+                }
+                return;
+            }
+            if !self.contains_await_recursive(decl_init) {
+                let value = self.expression_to_ir(decl_init);
+                self.lower_destructuring_declaration_value(decl_name, value, current_statements);
+                return;
+            }
+            // A nested (non-direct) `await` inside a binding-pattern initializer
+            // is left to the existing per-declaration path.
+        }
 
         if let Some(decl) = self.arena.get_variable_declaration(node) {
             let name =

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_try_statement.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_try_statement.rs
@@ -89,7 +89,29 @@ impl<'a> AsyncES5Transformer<'a> {
                 && let Some(catch_data) = self.arena.get_catch_clause(catch_node)
             {
                 let catch_rename_depth = self.catch_binding_renames.len();
-                if catch_data.variable_declaration.is_some() {
+                if let Some(catch_pattern) =
+                    self.catch_binding_pattern(catch_data.variable_declaration)
+                {
+                    // Destructuring catch binding (`catch ({ message }) { ... }`):
+                    // bind the caught value to a temp, then extract each name.
+                    let catch_temp = self.generate_hoisted_temp();
+                    self.blocked_temp_names
+                        .borrow_mut()
+                        .insert(catch_temp.clone());
+                    current_statements.push(IRNode::VarDecl {
+                        name: catch_temp.clone().into(),
+                        initializer: None,
+                    });
+                    current_statements.push(IRNode::ExpressionStatement(Box::new(IRNode::assign(
+                        IRNode::id(catch_temp.clone()),
+                        IRNode::GeneratorSent,
+                    ))));
+                    self.lower_catch_binding_destructuring(
+                        catch_pattern,
+                        &catch_temp,
+                        current_statements,
+                    );
+                } else if catch_data.variable_declaration.is_some() {
                     let catch_var_name =
                         self.get_catch_variable_name(catch_data.variable_declaration);
                     if !catch_var_name.is_empty() {

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -1089,6 +1089,12 @@ impl<'a> IRPrinter<'a> {
                 self.write(";");
             }
             IRNode::ExpressionStatement(expr) => {
+                // A comma expression in statement position needs no wrapping
+                // parentheses, unlike a `CommaExpr` in a sub-expression slot.
+                if let IRNode::CommaExpr(exprs) = expr.as_ref() {
+                    self.emit_statement_comma_expr(exprs);
+                    return;
+                }
                 if let IRNode::CommaExprMultiline(exprs) = expr.as_ref() {
                     self.indent_level += 1;
                     for (i, expr) in exprs.iter().enumerate() {

--- a/crates/tsz-emitter/src/transforms/ir_printer_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_helpers.rs
@@ -441,6 +441,20 @@ impl<'a> IRPrinter<'a> {
         self.decrease_indent();
     }
 
+    /// Emit a comma expression that sits directly in statement position
+    /// (`a = obj.a, b = obj.b;`), without the wrapping parentheses a `CommaExpr`
+    /// gets in a sub-expression slot. Used by the async ES5 destructuring
+    /// lowering, which joins its extraction assignments with commas.
+    pub(super) fn emit_statement_comma_expr(&mut self, exprs: &[IRNode]) {
+        for (i, expr) in exprs.iter().enumerate() {
+            if i > 0 {
+                self.write(", ");
+            }
+            self.emit_node(expr);
+        }
+        self.write(";");
+    }
+
     pub(super) fn emit_for_initializer(&mut self, init: &IRNode) {
         match init {
             IRNode::VarDecl { name, initializer } => {

--- a/crates/tsz-emitter/tests/async_es5_destructuring_tests.rs
+++ b/crates/tsz-emitter/tests/async_es5_destructuring_tests.rs
@@ -1,0 +1,360 @@
+//! ES5 emit parity for destructuring inside `async` functions.
+//!
+//! The async->generator IR pipeline previously passed binding patterns through
+//! verbatim, emitting syntactically invalid JavaScript (`var ;`, ` = obj;`) for
+//! every destructuring `var`/`const` and dropping destructuring `catch`
+//! bindings entirely. Each assertion below is the exact body `tsc` 6.x emits at
+//! `--target es5` (verified by differential testing). Binder names are varied
+//! per case so the lowering cannot key on any identifier text.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::output::printer::{PrintOptions, lower_and_print};
+use tsz_parser::parser::ParserState;
+
+fn emit_es5(source: &str) -> String {
+    emit_es5_opts(source, false)
+}
+
+fn emit_es5_downlevel(source: &str) -> String {
+    emit_es5_opts(source, true)
+}
+
+fn emit_es5_opts(source: &str, downlevel_iteration: bool) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let opts = PrintOptions {
+        target: ScriptTarget::ES5,
+        module: ModuleKind::CommonJS,
+        remove_comments: true,
+        downlevel_iteration,
+        ..PrintOptions::default()
+    };
+    lower_and_print(&parser.arena, root, opts).code
+}
+
+const PRELUDE: &str = "declare function g(): Promise<any>; declare const obj: any; declare const arr: any[]; \
+     declare function h(): any; declare const k: any; declare function use(...a: any[]): void;";
+
+fn assert_contains(output: &str, needle: &str, why: &str) {
+    assert!(
+        output.contains(needle),
+        "{why}\nexpected to find:\n  {needle}\nin output:\n{output}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Object binding patterns
+// ---------------------------------------------------------------------------
+
+#[test]
+fn object_pattern_identifier_source_reused_without_temp() {
+    // `tsc`: identifier source is reused per element (no temp).
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ await g(); const {{ a, b }} = obj; use(a, b); }}"
+    ));
+    assert_contains(&output, "var a, b;", "bound names hoisted");
+    assert_contains(&output, "a = obj.a, b = obj.b;", "comma-joined extraction");
+    assert!(
+        !output.contains("var ;") && !output.contains(" = obj;\n"),
+        "must not emit the invalid pre-fix shape.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn object_pattern_call_source_captured_into_temp() {
+    // Non-identifier source is read once via a temp.
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ await g(); const {{ first, second }} = h(); use(first, second); }}"
+    ));
+    assert_contains(&output, "var _a, first, second;", "temp + names hoisted");
+    assert_contains(
+        &output,
+        "_a = h(), first = _a.first, second = _a.second;",
+        "source captured once, then extracted",
+    );
+}
+
+#[test]
+fn object_pattern_single_element_inlines_source() {
+    // A single non-computed element reads the source exactly once: no temp.
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ await g(); const {{ only }} = h(); use(only); }}"
+    ));
+    assert_contains(&output, "only = h().only;", "single element inlines call");
+    assert!(
+        !output.contains("_a = h()"),
+        "single element must not allocate a source temp.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn object_pattern_renamed_and_default() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ await g(); const {{ value = 5, label: renamed }} = obj; use(value, renamed); }}"
+    ));
+    assert_contains(&output, "var _a, value, renamed;", "default temp + names");
+    assert_contains(
+        &output,
+        "_a = obj.value, value = _a === void 0 ? 5 : _a, renamed = obj.label;",
+        "default uses a temp + void-0 ternary; rename reads source property",
+    );
+}
+
+#[test]
+fn object_pattern_rest_uses_rest_helper() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ await g(); const {{ head, ...others }} = obj; use(head, others); }}"
+    ));
+    assert_contains(
+        &output,
+        "head = obj.head, others = __rest(obj, [\"head\"]);",
+        "object rest excludes preceding keys via __rest",
+    );
+    assert_contains(&output, "var __rest", "the __rest helper is emitted");
+}
+
+#[test]
+fn object_pattern_nested_single_inlines_access_chain() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ await g(); const {{ outer: {{ inner }} }} = obj; use(inner); }}"
+    ));
+    assert_contains(&output, "inner = obj.outer.inner;", "nested single inlines");
+}
+
+#[test]
+fn object_pattern_nested_with_default_uses_two_temps() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ await g(); const {{ a, b: {{ c }} = obj }} = obj; use(a, c); }}"
+    ));
+    assert_contains(
+        &output,
+        "a = obj.a, _a = obj.b, _b = _a === void 0 ? obj : _a, c = _b.c;",
+        "default on a nested pattern uses an access temp and a defaulted temp",
+    );
+}
+
+#[test]
+fn object_pattern_computed_key_captures_source_and_key() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ await g(); const {{ [\"x\" + k]: picked }} = obj; use(picked); }}"
+    ));
+    assert_contains(
+        &output,
+        "_a = obj, _b = \"x\" + k, picked = _a[_b];",
+        "computed key forces a source temp and a key temp",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Array binding patterns
+// ---------------------------------------------------------------------------
+
+#[test]
+fn array_pattern_index_access() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ await g(); const [one, two] = arr; use(one, two); }}"
+    ));
+    assert_contains(
+        &output,
+        "one = arr[0], two = arr[1];",
+        "index access per slot",
+    );
+}
+
+#[test]
+fn array_pattern_hole_skips_index() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ await g(); const [, , third] = arr; use(third); }}"
+    ));
+    assert_contains(&output, "third = arr[2];", "elisions advance the index");
+}
+
+#[test]
+fn array_pattern_rest_uses_slice() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ await g(); const [lead, ...tail] = h(); use(lead, tail); }}"
+    ));
+    assert_contains(
+        &output,
+        "_a = h(), lead = _a[0], tail = _a.slice(1);",
+        "array rest slices from its index",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mixed / multi declarations in one statement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mixed_identifier_and_pattern_join_one_statement() {
+    // `tsc` joins every declaration in the statement into one comma chain.
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ await g(); const plain = 1, {{ b, c }} = obj; use(plain, b, c); }}"
+    ));
+    assert_contains(
+        &output,
+        "plain = 1, b = obj.b, c = obj.c;",
+        "plain decl joins the destructuring comma chain",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// downlevelIteration array forms
+// ---------------------------------------------------------------------------
+
+#[test]
+fn array_pattern_downlevel_iteration_uses_read_with_count() {
+    let output = emit_es5_downlevel(&format!(
+        "{PRELUDE} async function f() {{ await g(); const [p, q] = arr; use(p, q); }}"
+    ));
+    assert_contains(
+        &output,
+        "_a = __read(arr, 2), p = _a[0], q = _a[1];",
+        "downlevelIteration reads with an explicit element count",
+    );
+}
+
+#[test]
+fn array_pattern_downlevel_iteration_rest_reads_without_count() {
+    let output = emit_es5_downlevel(&format!(
+        "{PRELUDE} async function f() {{ await g(); const [p, ...rest] = h(); use(p, rest); }}"
+    ));
+    assert_contains(
+        &output,
+        "_a = __read(h()), p = _a[0], rest = _a.slice(1);",
+        "a rest element drops the read count",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Destructuring a directly-awaited initializer (`const { a } = await g()`)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn await_initializer_object_pattern_reads_sent_value() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ const {{ a, b }} = await g(); use(a, b); }}"
+    ));
+    assert_contains(&output, "var _a, a, b;", "source temp + names hoisted");
+    assert_contains(
+        &output,
+        "_a = _b.sent(), a = _a.a, b = _a.b;",
+        "the resumed value is captured then destructured",
+    );
+}
+
+#[test]
+fn await_initializer_array_pattern_reads_sent_value() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ const [x, y] = await g(); use(x, y); }}"
+    ));
+    assert_contains(
+        &output,
+        "_a = _b.sent(), x = _a[0], y = _a[1];",
+        "array indices off the temp",
+    );
+}
+
+#[test]
+fn await_initializer_single_element_inlines_parenthesized_sent() {
+    // A single element reads the resumed value inline; the call result is
+    // parenthesized (`(_a.sent()).a`) so the member access stays well-formed.
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ const {{ only }} = await g(); use(only); }}"
+    ));
+    assert_contains(
+        &output,
+        "only = (_a.sent()).only;",
+        "single element inlines the sent value",
+    );
+}
+
+#[test]
+fn await_initializer_object_rest_reads_sent_value() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ const {{ head, ...others }} = await g(); use(head, others); }}"
+    ));
+    assert_contains(
+        &output,
+        "_a = _b.sent(), head = _a.head, others = __rest(_a, [\"head\"]);",
+        "rest excludes the named key from the captured resumed value",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// catch-clause destructuring bindings
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catch_object_pattern_binds_via_sent_temp() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ try {{ await g(); }} catch ({{ message }}) {{ use(message); }} }}"
+    ));
+    assert_contains(
+        &output,
+        "var _a, message;",
+        "catch temp + bound name hoisted",
+    );
+    assert_contains(&output, "_a = _b.sent();", "caught value bound to a temp");
+    assert_contains(
+        &output,
+        "message = _a.message;",
+        "pattern extracted from the temp",
+    );
+    assert!(
+        !output.contains("catch ({") && !output.contains("catch (["),
+        "the binding pattern must not survive as native ES5 catch syntax.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn catch_object_pattern_multi_binding() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ try {{ await g(); }} catch ({{ code, detail }}) {{ use(code, detail); }} }}"
+    ));
+    assert_contains(
+        &output,
+        "code = _a.code, detail = _a.detail;",
+        "multiple catch-pattern bindings are comma-joined",
+    );
+}
+
+#[test]
+fn catch_array_pattern_binding() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ try {{ await g(); }} catch ([reason, extra]) {{ use(reason, extra); }} }}"
+    ));
+    assert_contains(
+        &output,
+        "reason = _a[0], extra = _a[1];",
+        "array catch pattern reads by index from the temp",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Controls: plain identifier bindings stay on the existing path.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plain_identifier_catch_binding_unchanged() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ try {{ await g(); }} catch (err) {{ use(err); }} }}"
+    ));
+    assert_contains(
+        &output,
+        "err_1 = _a.sent();",
+        "plain catch identifier keeps its renamed temp",
+    );
+}
+
+#[test]
+fn plain_identifier_var_binding_unchanged() {
+    let output = emit_es5(&format!(
+        "{PRELUDE} async function f() {{ await g(); const plain = h(); use(plain); }}"
+    ));
+    assert_contains(
+        &output,
+        "plain = h();",
+        "plain identifier var keeps simple assignment",
+    );
+}


### PR DESCRIPTION
Goal: hold

Closes #14080.

> Note on overlap: #14083 and #14085 also target #14080. This PR is an
> independent implementation; whichever lands first should supersede the
> others. It is included because the work was complete, byte-parity-verified,
> and fully green.

## Structural rule

> When the target is ES5 and an `async` function's `VariableStatement` or
> `CatchClause` binds an object/array **pattern**, `tsc` hoists the bound names
> to the `__awaiter` callback's `var` list and flattens the pattern into a bare
> comma-sequence of **assignments** (its generator/async destructuring form):
>
> ```js
> // async; --target es5;  await g(); const { a, b } = obj;  -->
> var a, b;                       // hoisted
> a = obj.a, b = obj.b;           // flattened assignments (no `var`)
> ```
>
> A source temp is introduced only when the pattern has more than one element
> (or a computed key) and the source is not a reusable identifier; single-element
> patterns inline the source (`only = h().only`). Defaults capture the access in
> a temp and compare `=== void 0`, object rest uses `__rest`, array rest uses
> `.slice`, and computed keys capture both the source and the key into temps.

Before this change the async->generator IR pipeline passed binding patterns
through unchanged, so the same snippet emitted syntactically-invalid JavaScript
(`var ;` / ` = obj;`) and catch patterns dropped their bindings entirely.

```ts
// --target es5
async function f() { await g(); const { a, b } = obj; }
async function h() { try { await g(); } catch ({ message }) { use(message); } }
```

| | tsz (before) | tsz (after) / `tsc` |
|---|---|---|
| var decl | `var ;` … ` = obj;` (invalid) | `var a, b;` … `a = obj.a, b = obj.b;` |
| catch | `message` dropped (undefined) | `_a = _b.sent(); message = _a.message;` |

Found by differential testing against `tsc` 6.x.

## Owner layer

Emitter only (`crates/tsz-emitter`). A new `async_es5_ir_destructuring` module
owns the tsc-faithful flattening (`IRNode` output, not writer text). It is wired
in at four sites that all share the one engine: the async variable-statement
dispatcher (`process_statement_in_async`), the `statement_to_ir` fallback (for
no-await subtrees), the per-declaration await path (`process_variable_declaration`,
for `const {a} = await g()`), and the catch-binding branch of
`process_try_statement_in_async`. No semantic/checker change, no output surgery.

Bound names and temps are hoisted via the existing generator var-hoist pass
(`extract_and_remove_var_decl_groups`, the same `VarDecl { initializer: None }`
mechanism the sibling async var path already uses), and temps come from the
existing `generate_hoisted_temp` namespace, so the generator state param dodges
them exactly as `tsc` (an `_a` destructuring temp shifts the state param to
`_b`). A `CommaExpr` directly under an `ExpressionStatement` now renders without
the wrapping parens a `CommaExpr` gets in a sub-expression slot — the correct
statement-level comma form (`a = obj.a, b = obj.b;`).

Decisions key purely on syntactic shape (ES5 target + binding pattern), so they
apply to every binder spelling. `for-of`/`for-await` loop-variable destructuring
is a separate pre-existing path (named neither by #14080) and is left out of
scope; its non-byte-exact rest handling is tracked for follow-up.

## Adjacent-case matrix (name-agnostic; binders varied; `--target es5`, byte-equal to `tsc`)

| case | result |
|---|---|
| `const { a, b } = obj` (identifier source) | `a = obj.a, b = obj.b` |
| `const { first, second } = h()` (non-simple) | `_a = h(), first = _a.first, second = _a.second` |
| `const { only } = h()` (single element) | `only = h().only` (no temp) |
| `const [one, two] = arr` (array) | `one = arr[0], two = arr[1]` |
| `const [, , third] = arr` (hole) | `third = arr[2]` |
| `const { outer: { inner } } = obj` (nested single) | `inner = obj.outer.inner` |
| `const { value = 5, label: renamed } = obj` (default + rename) | `_a = obj.value, value = _a === void 0 ? 5 : _a, renamed = obj.label` |
| `const { a, b: { c } = obj } = obj` (default on nested) | `a = obj.a, _a = obj.b, _b = _a === void 0 ? obj : _a, c = _b.c` |
| `const { head, ...others } = obj` (object rest) | `head = obj.head, others = __rest(obj, ["head"])` |
| `const [lead, ...tail] = h()` (array rest) | `_a = h(), lead = _a[0], tail = _a.slice(1)` |
| `const { ["x" + k]: picked } = obj` (computed key) | `_a = obj, _b = "x" + k, picked = _a[_b]` |
| `const plain = 1, { b, c } = obj` (mixed decls) | `plain = 1, b = obj.b, c = obj.c` |
| `const [p, q] = arr` (`--downlevelIteration`) | `_a = __read(arr, 2), p = _a[0], q = _a[1]` |
| `const [p, ...rest] = h()` (`--downlevelIteration`) | `_a = __read(h()), p = _a[0], rest = _a.slice(1)` |
| `const { a, b } = await g()` (awaited) | `_a = _b.sent(), a = _a.a, b = _a.b` |
| `const { only } = await g()` (awaited single) | `only = (_a.sent()).only` |
| `catch ({ message })` | `_a = _b.sent(); message = _a.message;` |
| `catch ({ code, detail })` (multi) | `_a = _b.sent(); code = _a.code, detail = _a.detail;` |
| `catch ([reason, extra])` (array) | `_a = _b.sent(); reason = _a[0], extra = _a[1];` |
| `catch (err)` (plain ident, control) | unchanged (`err_1 = _a.sent()`) |
| `const plain = h()` (plain ident var, control) | unchanged (`plain = h()`) |

## Verification

- New name-agnostic suite `crates/tsz-emitter/tests/async_es5_destructuring_tests.rs`
  (23 tests, binder names varied per case, each asserting the byte-exact `tsc`
  form) — **23 passed**. The destructuring/extraction assertions fail on the
  pre-fix tree (`var ;` / ` = obj;`); the plain-identifier controls stay green
  either way.
- End-to-end differential vs `tsc` over object/array, nested, defaults,
  object/array rest, computed keys, holes, mixed declarations,
  downlevelIteration, awaited initializers, and three catch-pattern shapes —
  emitted function bodies byte-identical (the only whole-file diff is tsz's
  pre-existing multiline `__awaiter` callback formatting, unaffected here).
- Full `tsz-emitter` lib + integration suites — **4406 passed, 0 failed across
  81 targets**; adjacent suites green (`async_try_emit`, `async_loop_emit`,
  `try_statement_recovery_tests`, `destructuring_es5_*`,
  `async_awaiter_body_trailing_comment_tests`).
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --tests`,
  `python3 scripts/arch/arch_guard.py` — clean. Rebased on `main`, no conflicts.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01V12r8HXA4uCsWE8rD891Hf

---
_Generated by [Claude Code](https://claude.ai/code/session_01V12r8HXA4uCsWE8rD891Hf)_