### PR TITLE
fix(solver): absorb top/bottom sentinels in union_preserve_members

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -574,6 +574,9 @@ mod typeof_operator_result_union_tests;
 #[path = "../tests/typeof_unique_symbol_source_display_tests.rs"]
 mod typeof_unique_symbol_source_display_tests;
 #[cfg(test)]
+#[path = "tests/typeof_unknown_logical_narrowing_tests.rs"]
+mod typeof_unknown_logical_narrowing_tests;
+#[cfg(test)]
 #[path = "../tests/using_binding_pattern_diagnostics_tests.rs"]
 mod using_binding_pattern_diagnostics_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/typeof_unknown_logical_narrowing_tests.rs
+++ b/crates/tsz-checker/src/tests/typeof_unknown_logical_narrowing_tests.rs
@@ -1,0 +1,105 @@
+//! The false branch of a logical condition over an `unknown` must absorb the
+//! top type. `typeof x === "object" && x !== null` narrows the *else* branch to
+//! the union of `narrow_false(typeof === "object")` (which is `unknown`) and the
+//! `x === null` residual (`null`); combining those must yield `unknown`, not a
+//! non-normalized `unknown | null`.
+//!
+//! The logical-condition combiner built that union with
+//! `union_preserve_members`, which (before the fix) skipped the universal
+//! top/bottom sentinel absorption that `normalize_union` applies. The stray
+//! `unknown | null` then mis-narrowed under a following `typeof x === "function"`
+//! guard, collapsing `x` to `never` so a subsequent call emitted a false
+//! `TS2349` ("This expression is not callable").
+//!
+//! Binder names are varied across cases per the anti-hardcoding gate.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(diagnostics: &[Diagnostic]) -> Vec<u32> {
+    diagnostics.iter().map(|d| d.code).collect()
+}
+
+/// The original witness: after the object branch returns, `typeof === "function"`
+/// must narrow the `unknown` residual to a callable function type.
+#[test]
+fn function_branch_after_object_and_nonnull_is_callable() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+function dispatch(payload: unknown) {
+    if (typeof payload === "object" && payload !== null) { return payload; }
+    if (typeof payload === "function") { return payload(); }
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "calling the function-narrowed `payload` must not error, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// Renamed binder + reordered nullish conjunct (`x != null && typeof ...`); the
+/// residual is still `unknown`, so the call stays valid.
+#[test]
+fn function_branch_with_renamed_binder_and_reordered_conjuncts() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+function invoke(candidate: unknown) {
+    if (candidate != null && typeof candidate === "object") { return candidate; }
+    if (typeof candidate === "function") { return candidate(0, "x"); }
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "reordered guard must still leave a callable residual, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// The residual of `typeof v === "object" && v !== null` over `unknown` is
+/// exactly `unknown` (tsc), so it is assignable to nothing narrower.
+#[test]
+fn else_residual_of_object_and_nonnull_is_unknown() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+function probe(value: unknown) {
+    if (typeof value === "object" && value !== null) { return; }
+    const widened: unknown = value;
+    const tooNarrow: string = value;
+    return widened;
+}
+"#,
+    );
+    // Only the `string` annotation is wrong; `unknown` is accepted. A spurious
+    // `unknown | null` would instead make BOTH assignments behave oddly.
+    assert_eq!(
+        codes(&diagnostics),
+        vec![2322],
+        "residual must be plain `unknown`: only the `string` assignment errors, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// `||` false branch over `unknown` is the conjunction of negations; the
+/// `unknown` constituent must still absorb.
+#[test]
+fn or_false_branch_keeps_callable_function_narrowing() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+function handle(input: unknown) {
+    if (typeof input === "string" || input === null) { return; }
+    if (typeof input === "function") { return input(); }
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "function call after an `||` guard must stay valid, got {:?}",
+        codes(&diagnostics)
+    );
+}

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -175,7 +175,19 @@ impl TypeInterner {
 
     /// Intern a union type while preserving member structure.
     ///
-    /// This keeps unknown/literal members intact for property access checks.
+    /// Unlike [`union`](Self::union), this skips structural subtype reduction, so
+    /// distinct members that merely share an interface (e.g. `Derived1 | Derived2`)
+    /// stay separate — narrowing and property-access need that structure.
+    ///
+    /// It still applies the *universal* absorptions that hold for every union
+    /// regardless of member structure: the top/bottom sentinels. A union that
+    /// contains `error`, `any`, or `unknown` collapses to that type (precedence
+    /// `error` > `any` > `unknown`), exactly as `normalize_union` does, because
+    /// `unknown | T` is `unknown`, `any | T` is `any`, and `error | T` is `error`
+    /// for all `T`. Without this, flow narrowing combiners (e.g. the false branch
+    /// of `typeof x === "object" && x !== null` on an `unknown`) produced a
+    /// non-normalized `unknown | null`, which then mis-narrowed under a later
+    /// `typeof` guard. `never` members are dropped (the identity of union).
     pub fn union_preserve_members(&self, members: Vec<TypeId>) -> TypeId {
         if members.is_empty() {
             return TypeId::NEVER;
@@ -189,6 +201,28 @@ impl TypeInterner {
             } else {
                 flat.push(member);
             }
+        }
+
+        // Absorb the universal sentinels before structural interning. These hold
+        // for any member set, so scanning the flattened list (which has already
+        // expanded nested unions) catches a sentinel nested inside a member union.
+        let mut has_any = false;
+        let mut has_unknown = false;
+        for &id in flat.iter() {
+            if id == TypeId::ERROR {
+                return TypeId::ERROR; // error trumps everything
+            }
+            if id == TypeId::ANY {
+                has_any = true;
+            } else if id == TypeId::UNKNOWN {
+                has_unknown = true;
+            }
+        }
+        if has_any {
+            return TypeId::ANY;
+        }
+        if has_unknown {
+            return TypeId::UNKNOWN;
         }
 
         self.sort_union_members(&mut flat);
@@ -1822,5 +1856,69 @@ impl TypeInterner {
 impl Default for TypeInterner {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod union_preserve_members_tests {
+    use crate::TypeInterner;
+    use crate::types::TypeId;
+
+    /// `union_preserve_members` skips structural subtype reduction but must still
+    /// apply the universal top/bottom sentinel absorptions (`error` > `any` >
+    /// `unknown`), since `unknown | T` is `unknown`, `any | T` is `any`, and
+    /// `error | T` is `error` for every `T`. The flow-narrowing logical-condition
+    /// combiner relied on this: the false branch of
+    /// `typeof x === "object" && x !== null` over an `unknown` produced a stray
+    /// `unknown | null`, which then mis-narrowed under a later `typeof` guard.
+    #[test]
+    fn union_preserve_members_absorbs_top_and_bottom_sentinels() {
+        let interner = TypeInterner::new();
+
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::UNKNOWN, TypeId::NULL]),
+            TypeId::UNKNOWN,
+            "unknown | null must absorb to unknown"
+        );
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::STRING, TypeId::UNKNOWN, TypeId::NUMBER]),
+            TypeId::UNKNOWN,
+            "any member set containing unknown collapses to unknown"
+        );
+
+        // `any | T` is `any`; `any` outranks `unknown`.
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::ANY, TypeId::STRING]),
+            TypeId::ANY,
+            "any | string must absorb to any"
+        );
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::UNKNOWN, TypeId::ANY]),
+            TypeId::ANY,
+            "any outranks unknown"
+        );
+
+        // `error | T` is `error`; `error` outranks everything.
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::ERROR, TypeId::ANY]),
+            TypeId::ERROR,
+            "error outranks any"
+        );
+
+        // A sentinel nested inside a member union is also caught (members are
+        // flattened before the scan).
+        let nested = interner.union_preserve_members(vec![TypeId::STRING, TypeId::UNKNOWN]);
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::NUMBER, nested]),
+            TypeId::UNKNOWN,
+            "unknown nested inside a member union still absorbs"
+        );
+
+        // Non-sentinel members keep their structure (no subtype reduction).
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::STRING, TypeId::NUMBER]),
+            interner.union(vec![TypeId::STRING, TypeId::NUMBER]),
+            "ordinary members are unaffected"
+        );
     }
 }

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -208,7 +208,7 @@ impl TypeInterner {
         // expanded nested unions) catches a sentinel nested inside a member union.
         let mut has_any = false;
         let mut has_unknown = false;
-        for &id in flat.iter() {
+        for &id in &flat {
             if id == TypeId::ERROR {
                 return TypeId::ERROR; // error trumps everything
             }


### PR DESCRIPTION
Goal: hold

Closes #14088. Found by differential testing against `tsc` 6.0.2 (no prior
tracking issue). Restores the conformance/parity floor for logical-condition
flow narrowing over `unknown`: tsz emitted a **false `TS2349` "This expression
is not callable"** on code `tsc` accepts.

```ts
// --strict
function dispatch(payload: unknown) {
  if (typeof payload === "object" && payload !== null) { return payload; }
  if (typeof payload === "function") { return payload(); }
}
```

| | line 3 `payload()` |
|---|---|
| `tsc` 6.0.2 | clean (`payload` narrows to a callable function type) |
| tsz (before) | `TS2349` This expression is not callable |
| tsz (after) | clean |

## Structural rule

> When a union member set contains a universal sentinel, the union **is** that
> sentinel regardless of the other members — `error | T = error`,
> `any | T = any`, `unknown | T = unknown` (precedence `error` > `any` >
> `unknown`). This holds for every union constructor.

`TypeInterner::union_preserve_members` is the structure-preserving constructor
(it skips subtype reduction so `Derived1 | Derived2` stay distinct for
narrowing). It flattened / sorted / deduped / dropped `never` but **omitted the
sentinel absorption** that `normalize_union` applies. So the flow-narrowing
false-branch combiner (`condition_narrowing::union_logical_condition_branches`)
combined the two constituents of `typeof x === "object" && x !== null` over an
`unknown`:

- `narrow_false(typeof === "object")` → `unknown`
- `x === null` residual → `null`

into a non-normalized **`unknown | null`** instead of `unknown`. The following
`typeof payload === "function"` guard then mis-narrowed that stray union to
`never`, so the call was rejected. The synthetic `unknown | null` is otherwise
unreachable for users because the general `union` constructor already absorbs
the sentinel; only `union_preserve_members` did not.

## Owner layer

- **Root** — `crates/tsz-solver/src/intern/core/constructors.rs`:
  `union_preserve_members` now scans the flattened members for the sentinels and
  collapses to `error`/`any`/`unknown` (in that precedence) before structural
  interning, mirroring `normalize_union`. Subtype reduction is still skipped. The
  fix is at the shared constructor, so all ~50 call sites are corrected, not just
  the witnessed narrowing path.
- Surfaced through the checker's logical-condition flow narrowing
  (`condition_narrowing.rs`), which is unchanged.

The decision keys only on the structural sentinel `TypeId`s — no
identifier/alias/file-name/printer-string predicate.

## Adjacent-case matrix (name-agnostic; binders varied; vs `tsc` 6.0.2)

| axis | case | result |
|---|---|---|
| witness | `typeof x === "object" && x !== null` then call | clean |
| reordered conjuncts | `v != null && typeof v === "object"` then call | clean |
| `\|\|` false branch | `typeof x === "string" \|\| x === null` then call | clean |
| residual identity | `else` of object+nonnull is exactly `unknown` | only the bad `string` annotation errors |
| constructor | `unknown\|null`, `string\|unknown\|number`, `any\|string`, `unknown\|any`, `error\|any`, nested-union sentinel | absorb |
| control | `string \| number` | unchanged |

## Verification

- New solver unit test
  `intern::core::constructors::union_preserve_members_tests::union_preserve_members_absorbs_top_and_bottom_sentinels`
  — **passed** (red on the pre-fix tree).
- New checker tests
  `crates/tsz-checker/src/tests/typeof_unknown_logical_narrowing_tests.rs`
  (4 name-agnostic, varied-binder cases) — **4 passed** (the witness case is red
  pre-fix).
- Differential battery (57 snippets) vs `tsc` 6.0.2 `--strict`: witness clears,
  **no new divergences** introduced.
- Solver lib sweep (`union normalize contextual mapped narrow display format
  template`): **2254 passed**, the 2 failures are pre-existing (identical on
  `main` HEAD `459e9bb`). Checker lib sweep (`narrow flow typeof contextual`):
  **863 passed**, the 6 failures are pre-existing (identical on baseline).
  **Zero new failures.**
- `cargo fmt --check`, `cargo clippy -p tsz-solver -p tsz-checker --lib`,
  `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01PJFZMPe5AHKuWai5QWjpKw

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJFZMPe5AHKuWai5QWjpKw)_