### PR TITLE
fix(solver): drop the `const` modifier from canonical type-parameter identity

### DIFF
--- a/crates/tsz-solver/src/canonicalize/mod.rs
+++ b/crates/tsz-solver/src/canonicalize/mod.rs
@@ -671,15 +671,21 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
 
     /// Canonical (identity) form of a declared type parameter.
     ///
-    /// The `constraint` is canonicalized recursively, but `default` is dropped:
-    /// `tsc` never distinguishes type parameters by their declared `default` in
-    /// relation/identity (the default is consumed only at instantiation when no
-    /// argument is supplied). Keeping it would let two otherwise-identical
-    /// generic signatures — `<R extends X = "json">` vs `<R extends X>` —
-    /// canonicalize to distinct identities and miss the relation's reflexive
-    /// short-circuit (#13609). Callers that manage an alpha-equivalence scope
-    /// (function/signature/mapped) must push the parameter name before calling
-    /// so the constraint's self/sibling references resolve to bound parameters.
+    /// The `constraint` is canonicalized recursively, but the identity-irrelevant
+    /// declaration modifiers `default` and `is_const` are dropped: `tsc` never
+    /// distinguishes type parameters by either in relation/identity. The `default`
+    /// is consumed only at instantiation when no argument is supplied, and the
+    /// `const` modifier (`<const R>`) is an inference-site modifier that preserves
+    /// literal types at call sites — `compareTypeParametersIdentical` compares
+    /// constraints only. Keeping either would let two otherwise-identical generic
+    /// signatures — `<R extends X = "json">` / `<const R extends X>` vs
+    /// `<R extends X>` — canonicalize to distinct identities and miss the
+    /// relation's reflexive short-circuit (#13609). Both modifiers are still read
+    /// where they matter (instantiation / inference) off the *interned* parameter,
+    /// which is unchanged; only this comparison/hashing-only canonical form drops
+    /// them. Callers that manage an alpha-equivalence scope (function/signature/
+    /// mapped) must push the parameter name before calling so the constraint's
+    /// self/sibling references resolve to bound parameters.
     fn canonical_type_param(
         &mut self,
         tp: crate::types::TypeParamInfo,
@@ -688,7 +694,7 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
             name: tp.name,
             constraint: tp.constraint.map(|c| self.canonicalize(c)),
             default: None,
-            is_const: tp.is_const,
+            is_const: false,
             origin: tp.origin,
         }
     }

--- a/crates/tsz-solver/tests/canonicalize_tests.rs
+++ b/crates/tsz-solver/tests/canonicalize_tests.rs
@@ -1533,3 +1533,180 @@ fn canonicalize_infer_param_preserves_real_distinctions() {
         "distinct infer parameter names stay distinct"
     );
 }
+
+// ===================================================================
+// The `const` modifier must not fragment canonical type-parameter identity
+// (#13609 — the same family as the dropped `default` and the `Infer` arm)
+// ===================================================================
+
+// `tsc` identifies a type parameter by itself (its name and the *shape* of its
+// constraint), never by the `const` modifier. `const` (`<const R>`) is an
+// inference-site modifier that preserves literal types at call sites
+// (`compareTypeParametersIdentical` compares constraints only) — it is erased
+// from the parameter's type identity, exactly like `default`. `TypeParamInfo`
+// derives `Eq`/`Hash` over `is_const`, so a free reference to a `const`
+// parameter and one to its non-`const` twin intern to distinct `TypeId`s; both
+// must canonicalize to one identity or the relation's reflexive/identity fast
+// path fragments.
+#[test]
+fn canonicalize_free_type_param_ignores_const_modifier() {
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let name = interner.intern_string("R");
+    let constraint = Some(TypeId::STRING);
+    let make = |is_const| {
+        interner.type_param(TypeParamInfo {
+            name,
+            constraint,
+            default: None,
+            is_const,
+            origin: crate::types::TypeParamOrigin::User,
+        })
+    };
+
+    let r_const = make(true);
+    let r_plain = make(false);
+
+    assert_ne!(
+        r_const, r_plain,
+        "precondition: interning keeps the `const` modifier distinct"
+    );
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(r_const),
+        c2.canonicalize(r_plain),
+        "the `const` modifier must not fragment canonical identity"
+    );
+
+    // The `const` and `default` drops compose: a `const` param with a captured
+    // default still collapses onto its bare twin.
+    let r_const_default = interner.type_param(TypeParamInfo {
+        name,
+        constraint,
+        default: Some(TypeId::NUMBER),
+        is_const: true,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    let mut c3 = Canonicalizer::new(&interner, &env);
+    let mut c4 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c3.canonicalize(r_const_default),
+        c4.canonicalize(r_plain),
+        "dropping `const` and `default` compose to one identity"
+    );
+}
+
+// The same identity rule applies when the type parameter is declared in a
+// signature's type-parameter list: two generic function types that differ only
+// in a type parameter's `const` modifier must canonicalize to one identity, so
+// the relation's reflexive short-circuit holds for `<const R extends X>() => R`
+// against `<R extends X>() => R`.
+#[test]
+fn canonicalize_function_type_param_list_ignores_const_modifier() {
+    use crate::types::{FunctionShape, ParamInfo};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let r = interner.intern_string("R");
+    let make = |is_const: bool| {
+        let body = interner.type_param(TypeParamInfo {
+            name: r,
+            constraint: Some(TypeId::STRING),
+            default: None,
+            is_const,
+            origin: crate::types::TypeParamOrigin::User,
+        });
+        interner.function(FunctionShape {
+            type_params: vec![TypeParamInfo {
+                name: r,
+                constraint: Some(TypeId::STRING),
+                default: None,
+                is_const,
+                origin: crate::types::TypeParamOrigin::User,
+            }],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("x")),
+                type_id: body,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: body,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+
+    let const_fn = make(true);
+    let plain_fn = make(false);
+    assert_ne!(
+        const_fn, plain_fn,
+        "precondition: interning keeps the `const` modifier distinct"
+    );
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(const_fn),
+        c2.canonicalize(plain_fn),
+        "the `const` modifier in a signature list must not fragment identity"
+    );
+}
+
+// The `Infer` arm follows the same rule: `infer R` differing only in the
+// `const` modifier must canonicalize identically, while genuine distinctions
+// (name, constraint) stay distinct. Anti-hardcoding: the rule keys on the
+// structural `is_const` flag, not on any binder name.
+#[test]
+fn canonicalize_infer_param_ignores_const_modifier() {
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let name = interner.intern_string("R");
+    let constraint = Some(TypeId::STRING);
+    let make_infer = |is_const| {
+        interner.infer(TypeParamInfo {
+            name,
+            constraint,
+            default: None,
+            is_const,
+            origin: crate::types::TypeParamOrigin::User,
+        })
+    };
+
+    let infer_const = make_infer(true);
+    let infer_plain = make_infer(false);
+    assert_ne!(
+        infer_const, infer_plain,
+        "precondition: interning keeps the `const` modifier distinct"
+    );
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(infer_const),
+        c2.canonicalize(infer_plain),
+        "an infer parameter's `const` modifier must not fragment canonical identity"
+    );
+
+    // Negative control: dropping `const` must not merge genuinely different
+    // parameters (different constraint shape stays distinct).
+    let infer_const_num = interner.infer(TypeParamInfo {
+        name,
+        constraint: Some(TypeId::NUMBER),
+        default: None,
+        is_const: true,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    let mut c3 = Canonicalizer::new(&interner, &env);
+    let mut c4 = Canonicalizer::new(&interner, &env);
+    assert_ne!(
+        c3.canonicalize(infer_plain),
+        c4.canonicalize(infer_const_num),
+        "a genuinely different constraint stays distinct after dropping `const`"
+    );
+}


### PR DESCRIPTION
Goal: hold

Advances the type-parameter identity family for #13609 (the next identity-irrelevant declaration modifier after #13888 dropped `default`, #13915 unified the free-`TypeParameter` constraint snapshot, and #14074 handled the `Infer` arm). This is the `const`-modifier facet — distinct from those slices and from the residual #13232 resolver-availability campaign.

## Structural rule

> When two type parameters are structurally identical except for the `const`
> modifier (`<const R extends X>` vs `<R extends X>`), `tsc` treats them as the
> same parameter in relation/identity. `compareTypeParametersIdentical` compares
> *constraints only*; `const` is an inference-site modifier that preserves
> literal types at call sites and is erased from the parameter's type identity —
> exactly like a declared `default`.

`Canonicalizer::canonical_type_param` (`crates/tsz-solver/src/canonicalize/mod.rs`) already dropped `default` and canonicalizes `constraint`, but still copied `is_const` straight through into the canonical (comparison/hashing-only) form. `TypeParamInfo` derives `Eq`/`Hash` over `is_const`, so a `const` type parameter and its non-`const` twin interned to **distinct `TypeId`s and stayed distinct after canonicalization** — the same fragmentation #13888 fixed for `default`. The relation's reflexive/identity fast path then missed for `<const R extends X>() => R` vs `<R extends X>() => R`, falling into a structural member walk.

## Owner layer

- **Root** — `crates/tsz-solver/src/canonicalize/mod.rs`: `canonical_type_param` now drops `is_const` (sets it to `false`) alongside `default`, so canonical type-parameter identity depends only on `(name-for-free-refs, canonicalized constraint)`. The fix is at the single shared chokepoint, so every site routed through it is corrected at once: the free-`TypeParameter` reference, the `Infer` arm, and the function / call-signature / mapped type-parameter lists.

The `const`-ness is still read where it actually matters (inference / `fresh_type_param` / `from_args`) off the **interned** parameter, which is unchanged — only this comparison/hashing-only canonical form drops it. Identity-widening only; interning unchanged. The decision keys on the structural `is_const` flag — no identifier / alias / file-name / printer-string predicate (anti-hardcoding clean). Genuine distinctions (name, constraint) stay distinct.

A reflexive/identity short-circuit consumes the canonical id (`relations/subtype/cache.rs`); no relation fast-path compares `TypeParamInfo` fields directly, so canonicalize is the only identity site to touch.

## Adjacent-case matrix (name-agnostic; binders varied)

| case | result |
|---|---|
| free ref: `R(const)` vs `R(plain)`, same constraint | canonicalize equal |
| `const` + captured `default` vs bare twin | canonicalize equal (drops compose) |
| signature list: `<const R extends X>() => R` vs `<R extends X>() => R` | canonicalize equal |
| `infer R(const)` vs `infer R(plain)` | canonicalize equal |
| negative: `R(plain, string)` vs `R(const, number)` (diff constraint) | stay distinct |
| negative: different binder name / different constraint shape | stay distinct (existing tests) |

## Verification

- New `canonicalize` unit tests (`crates/tsz-solver/tests/canonicalize_tests.rs`): `canonicalize_free_type_param_ignores_const_modifier`, `canonicalize_function_type_param_list_ignores_const_modifier`, `canonicalize_infer_param_ignores_const_modifier` — **3 passed**, each red on the pre-fix tree (the `assert_eq!`s fail while `is_const` is kept), with negative controls that keep genuine distinctions distinct.
- `cargo test -p tsz-solver --lib`: **6825 passed, 4 failed**; the 4 failures are **pre-existing on `main`** (confirmed by stashing this change and re-running the exact 4 — 0 passed / 4 failed on the clean baseline). **Zero new failures.**
- `cargo fmt -p tsz-solver --check`, `cargo clippy -p tsz-solver --lib`, `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_0115n1PhKaeVR4EsV1m7zuux

---
_Generated by [Claude Code](https://claude.ai/code/session_0115n1PhKaeVR4EsV1m7zuux)_