### PR TITLE
fix(solver): absorb the error sentinel in the raw intersection path

### DIFF
--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -1128,6 +1128,18 @@ impl TypeInterner {
         // O(1) Fast Paths (Safe to do without recursion)
         // =========================================================
 
+        // 0. If any member is the `error` sentinel, the result is `error`.
+        // `error` is contagious and absorbs every other member (precedence
+        // `error` > `never` > `any`), exactly as the full `normalize_intersection`
+        // path does. Skipping this here let `error` survive *inside* an
+        // `Intersection(error, T)` node, which the top-level error predicates
+        // (`is_error_type`, the `== TypeId::ERROR` fast paths) do not see — so the
+        // leaked `error` silently defeated error suppression and seeded cascading
+        // false positives downstream.
+        if flat.contains(&TypeId::ERROR) {
+            return TypeId::ERROR;
+        }
+
         // 1. If any member is Never, the result is Never
         if flat.contains(&TypeId::NEVER) {
             return TypeId::NEVER;

--- a/crates/tsz-solver/tests/intern_normalize_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/intern_normalize_tests_parts/part_01.rs
@@ -297,6 +297,49 @@ fn intersect_types_raw_with_unknown() {
 }
 
 #[test]
+fn intersect_types_raw_absorbs_error() {
+    let i = TypeInterner::new();
+    // The raw (unsimplified) intersection path must absorb the `error` sentinel
+    // exactly like the full `normalize_intersection` path. Otherwise `error`
+    // survives inside an `Intersection(error, T)` node that the top-level error
+    // predicates cannot see, defeating error suppression downstream.
+    assert_eq!(
+        i.intersect_types_raw(vec![TypeId::ERROR, TypeId::STRING]),
+        TypeId::ERROR,
+        "Raw intersection with error => error"
+    );
+    // Order-independent, and independent of which concrete member it pairs with.
+    let obj = i.object(vec![PropertyInfo::new(
+        i.intern_string("p"),
+        TypeId::NUMBER,
+    )]);
+    assert_eq!(
+        i.intersect_types_raw(vec![obj, TypeId::ERROR]),
+        TypeId::ERROR,
+        "Raw intersection with error (reversed, object member) => error"
+    );
+    assert_eq!(
+        i.intersect_types_raw2(TypeId::ERROR, TypeId::NUMBER),
+        TypeId::ERROR,
+        "Raw intersection2 with error => error"
+    );
+    // `error` has highest precedence: it trumps even `never` (matching the full
+    // `normalize_intersection` path, so the two stay consistent).
+    assert_eq!(
+        i.intersect_types_raw(vec![TypeId::NEVER, TypeId::ERROR]),
+        TypeId::ERROR,
+        "error outranks never in the raw path, matching normalize_intersection"
+    );
+    // Consistency witness: the raw and full intersection paths now agree on the
+    // common `error & T` case.
+    assert_eq!(
+        i.intersect_types_raw(vec![TypeId::ERROR, TypeId::STRING]),
+        i.intersection(vec![TypeId::ERROR, TypeId::STRING]),
+        "raw and normalized intersection agree on error & T"
+    );
+}
+
+#[test]
 fn intersection_with_distinct_private_brand_sets_reduces_to_never() {
     let i = TypeInterner::new();
     let brand_a = i.intern_string("__private_brand_A");


### PR DESCRIPTION
Goal: hold

Found by inspecting the solver's intersection constructors (no existing
tracking issue). Restores the conformance/parity floor by closing an
`error`-leak that seeds cascading false positives — the same pathology the
canary false-positive umbrellas describe (`error` leaking into a structural
slot and never being recovered, e.g. #13484).

## Structural rule

> When an intersection member set contains the `error` sentinel, the
> intersection **is** `error` — `error` is contagious and absorbs every other
> member, with precedence `error` > `never` > `any` (`unknown` is the identity
> element). This holds for **every** intersection constructor.

`TypeInterner::normalize_intersection` (the full path) already applies this:
it scans for `error` first and returns `TypeId::ERROR` with highest
precedence. But the low-level `TypeInterner::intersect_types_raw`
(`crates/tsz-solver/src/intern/core/constructors.rs`) — the
structure-preserving constructor used to merge members without triggering
recursive normalization — only short-circuited on `never` and `any`. It
**omitted the `error` absorption**.

So `intersect_types_raw([error, T])` produced a non-normalized
`Intersection(error, T)` node instead of `error`. The top-level error
predicates — `is_error_type` (`crates/tsz-solver/src/visitors/visitor_extract.rs`,
which descends through `Application` bases but **not** `Intersection` members)
and the `== TypeId::ERROR` fast paths — cannot see an `error` buried inside an
intersection. The leaked `error` therefore escaped error suppression and
seeded cascading false positives downstream.

## Owner layer

- **Root** — `crates/tsz-solver/src/intern/core/constructors.rs`:
  `intersect_types_raw` now short-circuits to `TypeId::ERROR` at the top of its
  O(1) fast paths, mirroring `normalize_intersection`'s precedence. Because the
  fix is at the shared raw constructor, **all ~25 call sites are corrected at
  once** (property merge in `objects::collect` / `intern::intersection`,
  discriminant narrowing in `narrowing::property`, type-literal intersection in
  the checker's `type_literal_checker`, excess-property tails, assignability
  display targets, etc.) — not just one witnessed path.
- The decision keys only on the structural `TypeId::ERROR` sentinel — no
  identifier/alias/file-name/printer-string predicate.

This makes the raw and normalized intersection constructors **consistent**:
they now agree on the common `error & T` case, and both treat `error` as
highest-precedence (so `error & never` is `error` in both, an otherwise
unobservable edge case kept consistent on purpose).

## Adjacent-case matrix (name-agnostic; binders varied)

| case | result |
|---|---|
| `intersect_types_raw([error, string])` (witness) | `error` |
| `intersect_types_raw([object{p}, error])` (reversed, object member) | `error` |
| `intersect_types_raw2(error, number)` | `error` |
| `intersect_types_raw([never, error])` (precedence) | `error` (matches `normalize_intersection`) |
| raw vs `intersection([error, string])` (consistency) | identical |
| control: `[string, never]` / `[string, unknown]` / object merge | unchanged (`never` / `string` / `Intersection`) |

## Verification

- New name-agnostic unit test
  `intern::intern_normalize_tests::intersect_types_raw_absorbs_error`
  (ordering-independent, object-member and primitive pairings,
  `error`-outranks-`never`, plus a raw/normalized consistency witness) —
  **passed** (red on the pre-fix tree, which returns `Intersection(error, …)`).
- `cargo test -p tsz-solver --lib intersect`: **471 passed, 0 failed** — the
  existing `intersect_types_raw_with_never` / `_with_unknown` / `_basic`
  controls stay green, zero regressions across the intersection/normalization
  suites.
- `cargo fmt -p tsz-solver --check`, `cargo clippy -p tsz-solver --lib`,
  `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Vwz8r6zaXn9EFJk4v3FY3g

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vwz8r6zaXn9EFJk4v3FY3g)_