### PR TITLE
feat(bench): time passing compiler canaries on the perf comparison page

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1117,6 +1117,14 @@ jobs:
           - label: projects
             timeout: 135
             filter: 'utility-types/|ts-toolbelt/|ts-essentials/|utility-types-project|ts-toolbelt-project|ts-essentials-project|rxjs-project|type-fest-project|zod-project|kysely-project|comlink-project|vite-vanilla-ts-app|nextjs-fresh-app|nextjs'
+          # Passing-canary perf rows. Isolated from the required `projects` shard
+          # so timing the opt-in canary corpus (PERF_TIMED_CANARY_PROJECT_ROWS in
+          # scripts/bench/project-rows.mjs) never spends the required shard's
+          # budget or stalls the publish gate. Bounded to lighter external
+          # libraries; the website only charts the ones that check green.
+          - label: bench-canaries
+            timeout: 135
+            filter: 'ofetch-project|ts-pattern-project|zustand-project|jotai-project|fp-ts-project|io-ts-project|immer-project|remeda-project|arktype-project|superstruct-project|runtypes-project|hotscript-project|typebox-project|neverthrow-project'
           - label: large-ts-repo
             timeout: 135
             filter: '^large-ts-repo$'
@@ -1555,16 +1563,23 @@ jobs:
         run: |
           set -euo pipefail
           mapfile -t json_files < <(find bench-artifacts -name 'bench-results-*.json' -type f | sort)
+          # The bench-canaries shard (passing-canary perf rows) is OPTIONAL: it
+          # is merged when present but must NOT count toward — or break — the
+          # required-shard completeness gate. A failed/slow canary shard then
+          # never blocks publishing the required benchmark timings.
+          mapfile -t required_files < <(
+            printf '%s\n' "${json_files[@]}" | grep -v '/bench-results-bench-canaries\.json$' || true
+          )
           expected_shards=9
-          echo "json_count=${#json_files[@]}" >> "$GITHUB_OUTPUT"
+          echo "json_count=${#required_files[@]}" >> "$GITHUB_OUTPUT"
           echo "expected_json_count=${expected_shards}" >> "$GITHUB_OUTPUT"
-          if [[ "${#json_files[@]}" -eq 0 ]]; then
-            echo "No benchmark result JSON files found."
+          if [[ "${#required_files[@]}" -eq 0 ]]; then
+            echo "No required benchmark result JSON files found."
             find bench-artifacts -maxdepth 2 -type f -print || true
             exit 1
           fi
-          if [[ "${#json_files[@]}" -ne "${expected_shards}" ]]; then
-            echo "::warning::Expected ${expected_shards} benchmark shard JSON files, found ${#json_files[@]}; merging partial artifact for diagnosis, but public publish will fail."
+          if [[ "${#required_files[@]}" -ne "${expected_shards}" ]]; then
+            echo "::warning::Expected ${expected_shards} required benchmark shard JSON files, found ${#required_files[@]}; merging partial artifact for diagnosis, but public publish will fail."
             printf 'Found JSON files:\n'
             printf '  %s\n' "${json_files[@]}"
             find bench-artifacts -maxdepth 2 -type f -print || true

--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -5,6 +5,7 @@ import { marked } from "marked";
 import {
   COMPILE_CANARY_PROJECT_ROWS,
   COMPATIBILITY_CORPUS_ROWS,
+  PERF_TIMED_CANARY_PROJECT_ROWS,
   PROJECT_ROWS_BY_NAME,
   REQUIRED_PROJECT_ROWS,
 } from "../../../../scripts/bench/project-rows.mjs";
@@ -231,6 +232,32 @@ function hasSuccessfulTimingPair(row) {
 
 function hasSuccessfulTiming(row) {
   return hasSuccessfulTimingPair(row);
+}
+
+const PERF_TIMED_CANARY_SET = new Set(PERF_TIMED_CANARY_PROJECT_ROWS);
+
+// A perf-timed canary may produce a tsz/tsgo timing pair while still diverging
+// from `tsc` (yellow) or failing tsz (red). Such rows must NOT join the perf
+// comparison chart: only promote a perf-timed canary once it checks green.
+// Required rows keep their existing behavior (timing pair is sufficient) so this
+// only gates the opt-in canary set, never the required corpus.
+function isChartEligible(row) {
+  if (!hasSuccessfulTiming(row)) return false;
+  if (PERF_TIMED_CANARY_SET.has(row?.name)) {
+    return hasGreenProjectCompatibility(row);
+  }
+  return true;
+}
+
+// A perf-timed canary that produced a timing pair but is not green is excluded
+// from the chart by isChartEligible. It still has a timing pair, so the normal
+// isFailedBenchmark() check would treat it as "successful" and drop it from the
+// failures list too. Surface it explicitly in the canaries/incomplete section so
+// a timed-but-diverging canary stays visible instead of vanishing.
+function isExcludedNonGreenCanary(row) {
+  return PERF_TIMED_CANARY_SET.has(row?.name)
+    && hasSuccessfulTiming(row)
+    && !hasGreenProjectCompatibility(row);
 }
 
 function isFailedBenchmark(row) {
@@ -1427,7 +1454,7 @@ function decorateRow(row, category, options = {}) {
 
 function buildGroupedBenchmarks(data) {
   const allResults = withExpectedProjectRows(data?.results);
-  const results = allResults.filter(hasSuccessfulTiming);
+  const results = allResults.filter(isChartEligible);
   const grouped = new Map();
 
   for (const row of results) {
@@ -1441,7 +1468,9 @@ function buildGroupedBenchmarks(data) {
     ...results.map((row) => row.name),
     ...[...grouped.values()].flat().map((row) => row.name),
   ]);
-  const failedResults = allResults.filter((row) => isFailedBenchmark(row) && !successfulNames.has(row.name));
+  const failedResults = allResults.filter((row) => (
+    (isFailedBenchmark(row) || isExcludedNonGreenCanary(row)) && !successfulNames.has(row.name)
+  ));
 
   const order = [
     "Projects: external libraries",

--- a/scripts/bench/project-rows.mjs
+++ b/scripts/bench/project-rows.mjs
@@ -297,6 +297,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "dfbe3ca4ef8a22fc023fca5a5ef530e525f5e523",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -313,6 +314,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "c92ca435c7e1827e0fd55c539080ef1bfd6fe3f0",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -377,6 +379,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "566b5bf448f4354eb8e35c6243ea3772bdb3be96",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -393,6 +396,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "ddd36007f99903a2258ee47bcd4490ad4589602e",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -409,6 +413,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "c0a6472121c67a2b083e62fcff13e7d022e39d8f",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -425,6 +430,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "864a3a2f03c5d7b974afeb1da0faf46c21758779",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -441,6 +447,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "bf2d15439259887f98f2737cf7ebde4234d5adea",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -457,6 +464,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "53d22a60dcd1f854a6d7d7498715ba6f4f56473f",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -489,6 +497,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "d075962caee162bb28e241723863e8f11cb58390",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -505,6 +514,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "e414c8afd3b69f6bc0173b8ee25f71d8e5694f01",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -521,6 +531,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "16d83ca56a54569e4a2375a965567b31191c0035",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -537,6 +548,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "0bc205286bd5eea0b89fa903c411df9aca95923c",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -553,6 +565,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "22c9be6d4d26ef1feb797ffcf4f31b2c863e936b",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -601,6 +614,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "5ef3a018bda74fb960e44b68fc3672635ee8037d",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -1033,6 +1047,18 @@ export const COMPILE_CANARY_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS
   .map((row) => row.name);
 
 export const COMPILE_GUARD_CANARY_PROJECT_ROWS = COMPILE_CANARY_PROJECT_ROWS;
+
+// Canary rows opted into the vs-tsgo timing chart via `perf_timed: true`. These
+// are bounded, lighter external libraries: they get real tsz_ms/tsgo_ms timings
+// from the dedicated `bench-canaries` shard so the performance comparison page
+// can show passing canaries next to the required rows. They stay
+// benchmark_set:"canary", so they are NOT part of REQUIRED_PROJECT_ROWS and
+// never affect the artifact-readiness/publish gate; the website only promotes a
+// perf-timed canary onto the chart once it actually checks green (see the
+// green-compat filter in crates/tsz-website/src/_data/benchmark_data.js).
+export const PERF_TIMED_CANARY_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS
+  .filter((row) => row.perf_timed === true)
+  .map((row) => row.name);
 
 export const PROJECT_ROWS_BY_NAME = Object.fromEntries(
   PROJECT_ROW_DEFINITIONS.map((row) => [row.name, row])

--- a/scripts/bench/test-bench-workflow-micro-coverage.mjs
+++ b/scripts/bench/test-bench-workflow-micro-coverage.mjs
@@ -2,6 +2,8 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 
+import { PERF_TIMED_CANARY_PROJECT_ROWS } from "./project-rows.mjs";
+
 const workflow = fs.readFileSync(".github/workflows/bench.yml", "utf8");
 const runner = fs.readFileSync("scripts/bench/bench-vs-tsgo.sh", "utf8");
 const websiteData = fs.readFileSync(
@@ -80,6 +82,7 @@ assert.deepEqual(
     "algorithmic-constraint",
     "algorithmic-mapped",
     "projects",
+    "bench-canaries",
     "large-ts-repo",
   ],
   "bench workflow shard labels should stay explicit when adding timed benchmark families",
@@ -139,6 +142,17 @@ assert.match(
   websiteData,
   /Recursive utility aliases\|Indexed access hotspot\|Remapped accessor hotspot\|Conditional infer hotspot\|Object spread hotspot\|Contextual callback hotspot/,
   "website benchmark category logic should recognize every project-hotspots shard row family",
+);
+
+// The dedicated passing-canary perf shard must time exactly the rows opted in
+// via PERF_TIMED_CANARY_PROJECT_ROWS, so the single source of truth in
+// project-rows.mjs cannot drift away from the bench workflow filter.
+const benchCanariesFilter = shardFilters.find((filter) => filter.label === "bench-canaries");
+assert.ok(benchCanariesFilter, "bench workflow should have a dedicated bench-canaries shard");
+assert.deepEqual(
+  [...benchCanariesFilter.pattern.split("|")].sort(),
+  [...PERF_TIMED_CANARY_PROJECT_ROWS].sort(),
+  "bench-canaries shard filter must match PERF_TIMED_CANARY_PROJECT_ROWS exactly",
 );
 
 console.log("bench workflow micro coverage tests passed");


### PR DESCRIPTION
Goal: grow

Bring already-passing compiler canaries (hotscript, etc.) onto the tsz.dev/benchmarks tsz-vs-tsgo comparison so they can be compared on perf.

## Mechanism
- `scripts/bench/project-rows.mjs`: a declarative `perf_timed: true` flag on a **bounded set of 14 lighter external-library canaries** (`PERF_TIMED_CANARY_PROJECT_ROWS`: ofetch, ts-pattern, zustand, jotai, fp-ts, io-ts, immer, remeda, arktype, superstruct, runtypes, hotscript, typebox, neverthrow). They stay `benchmark_set:"canary"`, so they are never in `REQUIRED_PROJECT_ROWS` and cannot affect the readiness/publish gate.
- `.github/workflows/bench.yml`: a **dedicated, isolated `bench-canaries` Cloud Build shard** (own 135m timeout) filtered to exactly that set, so timing them never spends the required `projects` shard budget.
- `crates/tsz-website/src/_data/benchmark_data.js`: perf-chart inclusion is **green-gated** (`isChartEligible`) — only canaries that actually check green chart; non-green timed canaries are surfaced in the canaries/incomplete section, not the perf chart.

## Publish safety (added during integration)
The teammate’s shard addition would have broken publish (matrix went 9→10 shards but `expected_shards=9`). Fixed: the merge-completeness gate now counts **required** shards only (excludes `bench-results-bench-canaries.json`) while still merging the canary file. A slow/failed canary shard therefore **never blocks** publishing the required timings — important given the publish-timeout history.

## Deliberately excluded
Heavy/timeout canaries (effect, drizzle-orm, valibot) and all 19 application canaries — to respect the publish-timeout budget.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `node` tests pass: test-bench-workflow-micro-coverage (shard-filter drift test = `PERF_TIMED_CANARY_PROJECT_ROWS`), test-project-rows, project-row-summary, merge-results, check-artifact-readiness.
- `bench.yml` valid YAML; merge call passes all shard files (canary merged) while completeness gate uses required-only.
- Stub through `getBenchmarkCharts`/`getBenchmarkPages`: green hotscript charts with real timing; yellow ts-pattern excluded from chart and listed once in canaries section; required green row unaffected.
- NOTE: live green-state of the 14 is runtime-only (committed snapshot is stale); the green-gate makes this safe — non-green ones simply will not chart. First real `bench-canaries` shard run reveals which chart.