### PR TITLE
fix(solver): erase bound type-parameter name from canonical identity (full alpha-equivalence)

### DIFF
--- a/crates/tsz-solver/src/canonicalize/mod.rs
+++ b/crates/tsz-solver/src/canonicalize/mod.rs
@@ -308,12 +308,14 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
                         })
                         .collect();
 
-                    // Canonicalize type parameter constraints (defaults are
-                    // identity-irrelevant; see `canonical_type_param`).
+                    // Canonicalize type parameter constraints. Names and the
+                    // identity-irrelevant modifiers are dropped for
+                    // alpha-equivalence — references are already positional
+                    // (see `canonical_bound_type_param`).
                     let c_type_params: Vec<crate::types::TypeParamInfo> = shape
                         .type_params
                         .iter()
-                        .map(|&tp| self.canonical_type_param(tp))
+                        .map(|&tp| self.canonical_bound_type_param(tp))
                         .collect();
 
                     // Canonicalize type predicate (if it has a type_id)
@@ -372,12 +374,11 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
                     self.param_stack.pop();
 
                     // 6. Normalize the TypeParamInfo name for alpha-equivalence
-                    // We must erase the original name ("K", "P", etc.) so that
-                    // { [K in T]: K } and { [P in T]: P } hash to the same value.
-                    // Since we use De Bruijn indices (BoundParameter) in the body,
-                    // this name is never looked up, only used for hashing identity.
-                    let mut c_type_param = self.canonical_type_param(mapped.type_param);
-                    c_type_param.name = self.interner.intern_string("");
+                    // so that { [K in T]: K } and { [P in T]: P } hash to the
+                    // same value. Since we use De Bruijn indices (BoundParameter)
+                    // in the body, this name is never looked up, only used for
+                    // hashing identity (see `canonical_bound_type_param`).
+                    let c_type_param = self.canonical_bound_type_param(mapped.type_param);
 
                     let c_mapped = crate::types::MappedType {
                         type_param: c_type_param,
@@ -699,6 +700,35 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
         }
     }
 
+    /// Canonical (identity) form of a *bound* declared type parameter — one whose
+    /// references inside the surrounding type have already been rewritten to
+    /// positional [`TypeData::BoundParameter`](crate::types::TypeData::BoundParameter)
+    /// indices under a pushed alpha-equivalence scope (function / call-signature /
+    /// mapped binding sites).
+    ///
+    /// On top of [`Self::canonical_type_param`] this also erases the declared
+    /// `name`. Once every reference to the parameter is positional, its name is
+    /// purely cosmetic: `tsc`'s `compareTypeParametersIdentical` maps parameters
+    /// positionally and compares constraints only — never names. Keeping the name
+    /// in the canonical shape let two alpha-equivalent generic callables
+    /// (`<T extends X>() => T` vs `<U extends X>() => U`) hash to distinct
+    /// `TypeId`s and miss the relation's reflexive/identity fast path — the same
+    /// fragmentation family as #13609, here on the parameter *name* axis rather
+    /// than a declaration modifier. The mapped-type binder already erased the name
+    /// for exactly this reason (`{ [K in T]: K }` vs `{ [P in T]: P }`); this
+    /// generalizes it to every binding site. The name is never looked up off the
+    /// canonical form (it is identity/hashing only) and the *interned* parameter
+    /// keeps its name where it is actually rendered.
+    fn canonical_bound_type_param(
+        &mut self,
+        tp: crate::types::TypeParamInfo,
+    ) -> crate::types::TypeParamInfo {
+        crate::types::TypeParamInfo {
+            name: self.interner.intern_string(""),
+            ..self.canonical_type_param(tp)
+        }
+    }
+
     /// Canonicalize a single call signature with type parameter scope management.
     fn canonicalize_signature(
         &mut self,
@@ -731,12 +761,13 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
             })
             .collect();
 
-        // Canonicalize type parameter constraints (defaults are
-        // identity-irrelevant; see `canonical_type_param`).
+        // Canonicalize type parameter constraints. Names and the
+        // identity-irrelevant modifiers are dropped for alpha-equivalence —
+        // references are already positional (see `canonical_bound_type_param`).
         let c_type_params: Vec<crate::types::TypeParamInfo> = sig
             .type_params
             .iter()
-            .map(|&tp| self.canonical_type_param(tp))
+            .map(|&tp| self.canonical_bound_type_param(tp))
             .collect();
 
         // Canonicalize type predicate (if it has a type_id)

--- a/crates/tsz-solver/tests/canonicalize_tests.rs
+++ b/crates/tsz-solver/tests/canonicalize_tests.rs
@@ -420,86 +420,215 @@ fn canonicalize_function_with_type_params_uses_bound_parameter() {
 }
 
 #[test]
-fn canonicalize_function_type_params_name_preserved_in_shape() {
-    // Note: The canonicalizer preserves type parameter names in function shapes
-    // (unlike mapped types where the name is erased). This means two functions
-    // with different type param names but same structure will have different
-    // canonical TypeIds. Full alpha-equivalence for functions would require
-    // erasing names in the TypeParamInfo as well.
+fn canonicalize_function_type_params_alpha_equivalent_across_names() {
+    // Two generic functions that differ only in their type-parameter name
+    // (`<T>(x: T) => T` vs `<U>(x: U) => U`) are alpha-equivalent and must
+    // canonicalize to the SAME identity: references are positional
+    // (BoundParameter), so the declared name is identity-irrelevant — exactly
+    // as mapped types already erase it. `tsc`'s compareTypeParametersIdentical
+    // compares constraints only, never names.
+    use crate::types::{FunctionShape, ParamInfo};
     let interner = TypeInterner::new();
     let env = TypeEnvironment::new();
 
-    use crate::types::{FunctionShape, ParamInfo};
-
-    let t_atom = interner.intern_string("T");
-    let t_param = interner.type_param(TypeParamInfo {
-        name: t_atom,
-        constraint: None,
-        default: None,
-        is_const: false,
-        origin: crate::types::TypeParamOrigin::User,
-    });
-    let func_t = interner.function(FunctionShape {
-        type_params: vec![TypeParamInfo {
-            name: t_atom,
+    // `<name>(x: name) => name`
+    let make = |name: &str| {
+        let info = TypeParamInfo {
+            name: interner.intern_string(name),
             constraint: None,
             default: None,
             is_const: false,
             origin: crate::types::TypeParamOrigin::User,
-        }],
-        params: vec![ParamInfo {
-            name: Some(interner.intern_string("x")),
-            type_id: t_param,
-            optional: false,
-            rest: false,
-        }],
-        this_type: None,
-        return_type: t_param,
-        type_predicate: None,
-        is_constructor: false,
-        is_method: false,
-    });
-
-    let u_atom = interner.intern_string("U");
-    let u_param = interner.type_param(TypeParamInfo {
-        name: u_atom,
-        constraint: None,
-        default: None,
-        is_const: false,
-        origin: crate::types::TypeParamOrigin::User,
-    });
-    let func_u = interner.function(FunctionShape {
-        type_params: vec![TypeParamInfo {
-            name: u_atom,
-            constraint: None,
-            default: None,
-            is_const: false,
-            origin: crate::types::TypeParamOrigin::User,
-        }],
-        params: vec![ParamInfo {
-            name: Some(interner.intern_string("x")),
-            type_id: u_param,
-            optional: false,
-            rest: false,
-        }],
-        this_type: None,
-        return_type: u_param,
-        type_predicate: None,
-        is_constructor: false,
-        is_method: false,
-    });
+        };
+        let pref = interner.type_param(info);
+        interner.function(FunctionShape {
+            type_params: vec![info],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("x")),
+                type_id: pref,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: pref,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    };
 
     let mut c1 = Canonicalizer::new(&interner, &env);
     let mut c2 = Canonicalizer::new(&interner, &env);
-    let r1 = c1.canonicalize(func_t);
-    let r2 = c2.canonicalize(func_u);
+    let r1 = c1.canonicalize(make("T"));
+    let r2 = c2.canonicalize(make("U"));
 
-    // Due to type param name preservation, these produce different canonical forms
-    // Both use BoundParameter(0) in body, but the TypeParamInfo name differs
-    assert_ne!(
+    // Both use BoundParameter(0) in body and the now-erased type-param name, so
+    // the two alpha-equivalent generic functions share one canonical identity.
+    assert_eq!(
         r1, r2,
-        "Functions with different type param names have different canonical forms \
-         (name is preserved in function shapes, unlike mapped types)"
+        "Functions differing only in type-parameter name are alpha-equivalent and \
+         must share one canonical form (name erased, like mapped types)"
+    );
+}
+
+/// Negative control: erasing the name must NOT erase the constraint. Two generic
+/// functions whose type parameters differ only in their *constraint*
+/// (`<T extends string>` vs `<U extends number>`) are not alpha-equivalent and
+/// must keep distinct canonical identities.
+#[test]
+fn canonicalize_function_distinct_constraints_stay_distinct() {
+    use crate::types::{FunctionShape, ParamInfo};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let make = |name: &str, constraint: TypeId| {
+        let atom = interner.intern_string(name);
+        let info = TypeParamInfo {
+            name: atom,
+            constraint: Some(constraint),
+            default: None,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        };
+        let pref = interner.type_param(info);
+        interner.function(FunctionShape {
+            type_params: vec![info],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("x")),
+                type_id: pref,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: pref,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+
+    let func_t = make("T", TypeId::STRING);
+    let func_u = make("U", TypeId::NUMBER);
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_ne!(
+        c1.canonicalize(func_t),
+        c2.canonicalize(func_u),
+        "type parameters with different constraints must not be alpha-equivalent"
+    );
+}
+
+/// Multi-parameter positional identity: renaming both parameters keeps identity
+/// (`<A, B>(a: A) => B` ≡ `<X, Y>(x: X) => Y`), but swapping which positional
+/// parameter the body references must change identity (`=> B` vs `=> A`). The
+/// erased name cannot collapse the positional `BoundParameter` distinction.
+#[test]
+fn canonicalize_function_multi_param_positional_identity() {
+    use crate::types::{FunctionShape, ParamInfo};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    // `<P0, P1>(a: P0) => <return is P1 or P0?>`
+    let make = |n0: &str, n1: &str, return_second: bool| {
+        let a0 = interner.intern_string(n0);
+        let a1 = interner.intern_string(n1);
+        let mk = |atom| TypeParamInfo {
+            name: atom,
+            constraint: None,
+            default: None,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        };
+        let p0 = interner.type_param(mk(a0));
+        let p1 = interner.type_param(mk(a1));
+        interner.function(FunctionShape {
+            type_params: vec![mk(a0), mk(a1)],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("a")),
+                type_id: p0,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: if return_second { p1 } else { p0 },
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+
+    let ab = make("A", "B", true); // <A,B>(a:A) => B
+    let xy = make("X", "Y", true); // <X,Y>(x:X) => Y  — alpha-equivalent
+    let aa = make("A", "B", false); // <A,B>(a:A) => A  — different positional ref
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    let mut c3 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(ab),
+        c2.canonicalize(xy),
+        "renaming both type parameters is alpha-equivalent"
+    );
+    assert_ne!(
+        c1.canonicalize(ab),
+        c3.canonicalize(aa),
+        "the positional parameter the body references is identity-relevant"
+    );
+}
+
+/// Call-signature path (`canonicalize_signature`, used by `Callable` for both
+/// call and construct signatures): a callable with `<T>(x: T) => T` and one with
+/// `<U>(x: U) => U` are alpha-equivalent.
+#[test]
+fn canonicalize_call_signature_alpha_equivalent_across_names() {
+    use crate::types::{CallSignature, CallableShape, ParamInfo};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let make = |name: &str| {
+        let atom = interner.intern_string(name);
+        let info = TypeParamInfo {
+            name: atom,
+            constraint: None,
+            default: None,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        };
+        let pref = interner.type_param(info);
+        let sig = CallSignature {
+            type_params: vec![info],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("x")),
+                type_id: pref,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: pref,
+            type_predicate: None,
+            is_method: false,
+        };
+        interner.callable(CallableShape {
+            call_signatures: vec![sig],
+            construct_signatures: vec![],
+            properties: vec![],
+            string_index: None,
+            number_index: None,
+            symbol: None,
+            is_abstract: false,
+        })
+    };
+
+    let call_t = make("T");
+    let call_u = make("U");
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(call_t),
+        c2.canonicalize(call_u),
+        "generic call signatures differing only in type-parameter name are alpha-equivalent"
     );
 }
 


### PR DESCRIPTION
Goal: hold

Completes the #13609 type-parameter identity-fragmentation family on its last axis: the declared parameter **name**. Restores the relation/identity parity floor — alpha-equivalent generic callables were fragmenting into distinct canonical `TypeId`s and missing the reflexive/identity fast path.

## Structural rule

> Once every reference to a bound type parameter is rewritten to a positional `BoundParameter`, the declared **name** is identity-irrelevant. `tsc`'s `compareTypeParametersIdentical` maps parameters positionally and compares **constraints only** — never names. So `<T extends X>() => T` and `<U extends X>() => U` are alpha-equivalent and must share one canonical identity. This holds for every binding site (function, call/construct signature, mapped type).

## Mechanism

The canonicalizer (`crates/tsz-solver/src/canonicalize/mod.rs`) rewrites in-scope parameter references to positional `BoundParameter` indices, but at the **function** and **call-signature** binding sites it still copied the declared `TypeParamInfo.name` straight into the canonical shape. Because `TypeParamInfo` derives `Eq`/`Hash` over `name`, two otherwise-identical generic callables interned to distinct canonical `TypeId`s, fragmenting the relation's reflexive/identity short-circuit — the same pathology this family fixed on the modifier axes (`default` #13888, `is_const` #14090, the `Infer` arm #14074), here on the name axis.

The **mapped-type** binder already erased the name inline (`{ [K in T]: K }` vs `{ [P in T]: P }`) for exactly this reason. This generalizes that to every binding site instead of leaving it a mapped-only special case.

## Owner layer

- **Root** — `crates/tsz-solver/src/canonicalize/mod.rs`: new shared `canonical_bound_type_param` helper = `canonical_type_param` (canonicalize constraint, drop `default`/`is_const`) **plus erase the name**. Routed through the `Function` arm, `canonicalize_signature` (covers `Callable` call + construct signatures), and the `Mapped` arm (replacing its inline erase). One helper at all binding sites, not a per-site patch.
- Free `TypeParameter`/`Infer` references intentionally keep `canonical_type_param` (name retained) — they are not bound binding sites.
- The canonical form is identity/hashing only (used by `are_types_structurally_identical` and the `canonical_id` cache keys); the *interned* parameter keeps its name where it is actually rendered. No identifier/alias/file-name/printer-string predicate.

## Adjacent-case matrix (name-agnostic; binders varied)

| case | result |
|---|---|
| `<T>(x:T)=>T` vs `<U>(x:U)=>U` (witness) | identical |
| generic call signature `<T>(x:T)=>T` vs `<U>(x:U)=>U` | identical |
| `<A,B>(a:A)=>B` vs renamed `<X,Y>(x:X)=>Y` | identical |
| `<A,B>(a:A)=>B` vs `<A,B>(a:A)=>A` (positional body ref) | **distinct** |
| `<T extends string>` vs `<U extends number>` (constraint) | **distinct** |
| mapped `{ [K in T]: K }` vs `{ [P in T]: P }` (control) | identical (unchanged) |

## Verification

- Replaced the documented limitation test `canonicalize_function_type_params_name_preserved_in_shape` (which asserted the buggy `assert_ne!`) with `canonicalize_function_type_params_alpha_equivalent_across_names` (`assert_eq!`), plus 3 new name-agnostic cases (constraint negative control, multi-param positional identity + body-ref distinction, call-signature path). **All 59 `canonicalize` lib tests pass** (the 4 new/updated were red pre-fix).
- `cargo test -p tsz-solver --lib`: **6828 passed**, 4 failed — the 4 are **pre-existing on baseline** `fb91613` (verified by stashing the change: identical failures, zero new).
- `cargo test -p tsz-checker --lib generic`: **833 passed**, 16 failed — the 16 are **pre-existing on baseline** (verified by diff vs stashed baseline: zero new, zero fixed).
- `cargo fmt -p tsz-solver --check`, `cargo clippy -p tsz-solver --lib`, `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mgqr6zBjfiZmnoCfznFwxZ)_