### PR TITLE
fix(checker): honor authoritative module resolution for relative imports (moduleSuffixes)

### DIFF
--- a/crates/tsz-checker/src/context/package_resolution.rs
+++ b/crates/tsz-checker/src/context/package_resolution.rs
@@ -34,15 +34,22 @@ impl<'a> CheckerContext<'a> {
             && !specifier.starts_with("../")
             && !specifier.starts_with('/')
             && !specifier.starts_with('\\');
-        if is_bare_specifier && let Some(paths) = self.resolved_module_paths.as_ref() {
-            for candidate in module_specifier_candidates(specifier) {
-                if let Some(target_idx) = paths.get(&(source_file_idx, candidate)) {
-                    return Some(
-                        self.types_versions_redirected_target_index(specifier, *target_idx)
-                            .unwrap_or(*target_idx),
-                    );
-                }
-            }
+
+        // Prefer the driver's authoritative resolution (`resolved_module_paths`,
+        // computed by the real `ModuleResolver`) over the heuristic
+        // `global_file_name_index` fan-out below — for every specifier kind. The
+        // fan-out spells out `<stem>.<ext>` candidates directly and does NOT
+        // apply resolver features such as `moduleSuffixes`, so for a project that
+        // configures them (for example a React Native tree with `foo.ios.ts`
+        // alongside `foo.ts`) it would bind `./foo` to the base `foo.ts` instead
+        // of the higher-priority `foo.ios.ts` the resolver actually selected.
+        // Bare specifiers additionally pick up package-metadata redirects
+        // (`exports`, `typesVersions`) the fan-out does not model. Falling
+        // through to the fan-out when the authoritative map has no entry
+        // preserves the standalone-checker path that runs without a
+        // driver-populated map.
+        if let Some(target_idx) = self.resolved_module_path_target(source_file_idx, specifier) {
+            return Some(target_idx);
         }
 
         // An ambient `declare module "<specifier>"` takes priority over the
@@ -103,17 +110,30 @@ impl<'a> CheckerContext<'a> {
             }
         }
 
-        if let Some(paths) = self.resolved_module_paths.as_ref() {
-            for candidate in module_specifier_candidates(specifier) {
-                if let Some(target_idx) = paths.get(&(source_file_idx, candidate)) {
-                    return Some(
-                        self.types_versions_redirected_target_index(specifier, *target_idx)
-                            .unwrap_or(*target_idx),
-                    );
-                }
+        None
+    }
+
+    /// Resolve `specifier` through the driver's authoritative
+    /// `resolved_module_paths` map (populated by the real `ModuleResolver`),
+    /// trying each candidate spelling and applying any `typesVersions` redirect.
+    ///
+    /// Returns the target file index when the map resolved it, or `None` when no
+    /// driver-populated map exists or it has no entry for this
+    /// `(source_file_idx, specifier)`.
+    fn resolved_module_path_target(
+        &self,
+        source_file_idx: usize,
+        specifier: &str,
+    ) -> Option<usize> {
+        let paths = self.resolved_module_paths.as_ref()?;
+        for candidate in module_specifier_candidates(specifier) {
+            if let Some(target_idx) = paths.get(&(source_file_idx, candidate)) {
+                return Some(
+                    self.types_versions_redirected_target_index(specifier, *target_idx)
+                        .unwrap_or(*target_idx),
+                );
             }
         }
-
         None
     }
 

--- a/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
@@ -298,3 +298,88 @@ fn using_declaration_no_disposable_diagnostic_at_esnext() {
         result.diagnostics
     );
 }
+
+// Compile a `moduleSuffixes: [".ios", ""]` project from the given on-disk files
+// (the first file written is always the shared tsconfig) and return the emitted
+// diagnostic codes. Globs `**/*.ts`, so every written source enters the program.
+fn module_suffixes_project_codes(sources: &[(&str, &str)]) -> Vec<u32> {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "es2015",
+            "module": "esnext",
+            "moduleResolution": "bundler",
+            "strict": true,
+            "noEmit": true,
+            "skipLibCheck": true,
+            "moduleSuffixes": [".ios", ""]
+          },
+          "include": ["**/*.ts"],
+          "exclude": ["node_modules"]
+        }"#,
+    );
+    for (path, contents) in sources {
+        write_file(&base.join(path), contents);
+    }
+    let mut args = default_args();
+    args.project = Some(base.join("tsconfig.json"));
+    let result = compile(&args, base).expect("compile should succeed");
+    result.diagnostics.iter().map(|d| d.code).collect()
+}
+
+// A relative import in a project that configures `moduleSuffixes` must bind to
+// the highest-priority suffix variant the module resolver selected, even when
+// the lower-priority base file is *also* in the program (the React Native shape
+// where `widget.ios.ts` and `widget.ts` are both globbed and export the same
+// API). The checker's `global_file_name_index` fan-out spells `<stem>.<ext>`
+// directly and does not apply `moduleSuffixes`, so it used to bind `./widget`
+// to the base `widget.ts`; the fix prefers the driver's authoritative
+// `resolved_module_paths` (which honored the `.ios` suffix). Binder names
+// deliberately differ from the original witness so the behavior follows the
+// resolved file, not a spelling.
+#[test]
+fn compile_project_module_suffixes_relative_import_binds_suffix_variant_over_base() {
+    let codes = module_suffixes_project_codes(&[
+        // Highest-priority suffix variant: the API is a string-literal type.
+        ("src/mobileWidget.ios.ts", "export const palette = \"ios-theme\";\n"),
+        // Base file (also globbed into the program): the SAME export name with an
+        // incompatible type. If the import mis-binds here it surfaces as TS2322.
+        ("src/mobileWidget.ts", "export const palette: number = 42;\n"),
+        (
+            "src/appEntry.ts",
+            "import { palette } from \"./mobileWidget\";\nconst check: \"ios-theme\" = palette;\nexport { check };\n",
+        ),
+    ]);
+
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "`./mobileWidget` must bind to the `.ios` suffix variant (palette: \"ios-theme\"), \
+         not the base `mobileWidget.ts` (palette: number). Diagnostic codes: {codes:?}",
+    );
+}
+
+// Control: when `moduleSuffixes` is configured but no suffix variant exists on
+// disk, the relative import still resolves to the base file (the fix falls
+// through to the file-index fan-out when the authoritative map has no
+// higher-priority entry). Guards against the fix dropping plain relative
+// resolution.
+#[test]
+fn compile_project_module_suffixes_relative_import_falls_back_to_base_when_no_variant() {
+    let codes = module_suffixes_project_codes(&[
+        ("src/desktopWidget.ts", "export const palette: number = 7;\n"),
+        (
+            "src/appEntry.ts",
+            "import { palette } from \"./desktopWidget\";\nconst check: number = palette;\nexport { check };\n",
+        ),
+    ]);
+
+    assert!(
+        !codes.contains(&diagnostic_codes::CANNOT_FIND_MODULE_OR_ITS_CORRESPONDING_TYPE_DECLARATIONS)
+            && !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "`./desktopWidget` must still resolve to the base file when no suffix \
+         variant exists. Diagnostic codes: {codes:?}",
+    );
+}


### PR DESCRIPTION
Goal: hold

Closes #14095. Found by differential testing against `tsc` (no prior tracking issue). Restores the parity floor for relative imports in projects that configure `moduleSuffixes` (the React Native shape: `widget.ios.ts` / `widget.native.ts` alongside `widget.ts`).

```ts
// tsconfig: moduleResolution "bundler", moduleSuffixes [".ios", ""]
// src/widget.ios.ts  -> export const palette = "ios-theme";
// src/widget.ts      -> export const palette: number = 42;
// src/app.ts
import { palette } from "./widget";
const check: "ios-theme" = palette;   // tsc: clean | tsz before: false TS2322
```

| | `./widget` binds to | `palette` |
|---|---|---|
| `tsc` | `widget.ios.ts` (suffix priority) | `"ios-theme"` (clean) |
| tsz (before) | `widget.ts` (base) | `number` → false `TS2322` |
| tsz (after) | `widget.ios.ts` | `"ios-theme"` (clean) |

## Structural rule

> When resolving an import specifier to a program file, the checker must use the same authoritative resolution the real `ModuleResolver` produced (`resolved_module_paths`) — for relative specifiers too, not only bare ones — rather than a heuristic file-index fan-out that re-implements a subset of the resolution algorithm and silently drops resolver features such as `moduleSuffixes`.

## Owner layer

Checker module-resolution query boundary — `crates/tsz-checker/src/context/package_resolution.rs`, `resolve_import_target_from_file`.

The checker resolved a relative specifier to a program file index straight through the `global_file_name_index` fan-out (`resolve_specifier_via_file_index_uncached`), which spells `<stem>.<ext>` candidates directly (`widget.ts`, `widget.tsx`, …) and does **not** apply `moduleSuffixes`. So it bound `widget.ts` and never tried `widget.ios.ts`, diverging from the driver's authoritative, suffix-aware `resolved_module_paths` map (previously consulted only for bare specifiers, and as a post-fan-out fallback). The fix consults `resolved_module_paths` for **every** specifier kind first, falling back to the fan-out only when the driver-populated map has no entry (the standalone-checker path). The three duplicated lookup blocks collapse into one `resolved_module_path_target` helper. The standalone resolver itself already honored `moduleSuffixes`; only the checker's relative file-index probe did not.

Name-agnostic: keys on the structural specifier/resolution map only — no identifier/file-name/printer-string predicate. Gated purely on the specifier shape and the presence of a driver-populated map.

## Adjacent-case matrix (binder names varied; vs `tsc`)

| case | result |
|---|---|
| `./widget` with `widget.ios.ts` + `widget.ts` both globbed, same export | binds `.ios` variant (clean) |
| `[".native", ".ios", ""]` with `widget.native.ts` + `widget.ts` | binds `.native` variant |
| `moduleSuffixes` configured, no suffix variant on disk | falls back to base (clean) |
| plain relative import, no `moduleSuffixes` (control) | unchanged |
| `../` relative import (control) | unchanged |
| bare specifier (control) | unchanged (already map-first) |

## Verification

- New name-agnostic regression tests in `crates/tsz-cli/tests/driver_tests_parts/part_13.rs` (`compile_project_module_suffixes_relative_import_binds_suffix_variant_over_base` and `..._falls_back_to_base_when_no_variant`) — **2 passed** (the binds-variant case is red on the pre-fix tree).
- `cargo test -p tsz-checker --lib module_resolution` — **112 passed, 0 failed**.
- Full `cargo test -p tsz-cli --lib driver_tests::` failing set is **byte-identical before and after** the change (9 pre-existing sandbox-environment failures — `tsbuildinfo_is_not_writable`, incremental, jsdoc-enum, declaration-emit recursion — verified equal against stashed `main`). **Zero new failures.**
- End-to-end `tsz -p` differential vs `tsc` over `.ios`/`.native` suffix matrices and plain-relative controls — witness clears, no new divergences.
- `cargo fmt --check`, `cargo clippy -p tsz-checker --lib`, `python3 scripts/arch/arch_guard.py` — clean. Rebased on `main` (no conflicts).
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01K3KterwW5xfJDWmBcT3kUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3KterwW5xfJDWmBcT3kUE)_