### PR TITLE
fix(solver): drop the binder name from canonical type-parameter identity

### DIFF
--- a/crates/tsz-solver/src/canonicalize/mod.rs
+++ b/crates/tsz-solver/src/canonicalize/mod.rs
@@ -308,12 +308,16 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
                         })
                         .collect();
 
-                    // Canonicalize type parameter constraints (defaults are
-                    // identity-irrelevant; see `canonical_type_param`).
+                    // Canonicalize type parameter constraints. The declaration
+                    // name, the `default`, and the `const` modifier are all
+                    // identity-irrelevant here: references inside the function
+                    // are already rewritten to positional `BoundParameter`
+                    // indices, so the bound declaration is alpha-equivalent
+                    // (see `canonical_bound_type_param`).
                     let c_type_params: Vec<crate::types::TypeParamInfo> = shape
                         .type_params
                         .iter()
-                        .map(|&tp| self.canonical_type_param(tp))
+                        .map(|&tp| self.canonical_bound_type_param(tp))
                         .collect();
 
                     // Canonicalize type predicate (if it has a type_id)
@@ -371,13 +375,14 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
                     // 5. Pop scope
                     self.param_stack.pop();
 
-                    // 6. Normalize the TypeParamInfo name for alpha-equivalence
-                    // We must erase the original name ("K", "P", etc.) so that
-                    // { [K in T]: K } and { [P in T]: P } hash to the same value.
-                    // Since we use De Bruijn indices (BoundParameter) in the body,
-                    // this name is never looked up, only used for hashing identity.
-                    let mut c_type_param = self.canonical_type_param(mapped.type_param);
-                    c_type_param.name = self.interner.intern_string("");
+                    // 6. Normalize the iteration variable for alpha-equivalence.
+                    // The name ("K", "P", etc.) is erased so that { [K in T]: K }
+                    // and { [P in T]: P } hash to the same value: references in
+                    // the body use De Bruijn `BoundParameter` indices, so the
+                    // name is never looked up, only used for hashing identity.
+                    // Shared with the function/call-signature bound scopes via
+                    // `canonical_bound_type_param`.
+                    let c_type_param = self.canonical_bound_type_param(mapped.type_param);
 
                     let c_mapped = crate::types::MappedType {
                         type_param: c_type_param,
@@ -699,6 +704,33 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
         }
     }
 
+    /// Canonical form of a **bound** type parameter — like
+    /// [`Self::canonical_type_param`] but with the declaration name erased to the
+    /// [`Atom::NONE`] sentinel for alpha-equivalence.
+    ///
+    /// Used for `type_params` declarations in a scope already pushed onto
+    /// `param_stack` (function / call-signature / mapped type). References to the
+    /// parameter inside the scope are already rewritten to positional
+    /// `BoundParameter(n)` (De Bruijn) indices, so the surviving `name`
+    /// contributes only to the structural hash. Erasing it keeps two generic
+    /// signatures that differ only in the chosen binder (`<T>(x: T) => T` vs
+    /// `<U>(x: U) => U`) from fragmenting into distinct canonical identities and
+    /// missing the relation's reflexive short-circuit — the same fragmentation
+    /// #13609 closes for `default`/`is_const`, and what `tsc`'s
+    /// `compareSignaturesIdentical` (which remaps type parameters positionally)
+    /// already ignores. The mapped-type path always erased this name; routing the
+    /// function/call-signature paths here makes all three bound scopes agree.
+    fn canonical_bound_type_param(
+        &mut self,
+        tp: crate::types::TypeParamInfo,
+    ) -> crate::types::TypeParamInfo {
+        crate::types::TypeParamInfo {
+            // `intern_string("")` is the `Atom::NONE` sentinel; use it directly.
+            name: Atom::NONE,
+            ..self.canonical_type_param(tp)
+        }
+    }
+
     /// Canonicalize a single call signature with type parameter scope management.
     fn canonicalize_signature(
         &mut self,
@@ -731,12 +763,15 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
             })
             .collect();
 
-        // Canonicalize type parameter constraints (defaults are
-        // identity-irrelevant; see `canonical_type_param`).
+        // Canonicalize type parameter constraints. The declaration name, the
+        // `default`, and the `const` modifier are all identity-irrelevant here:
+        // references inside the signature are already rewritten to positional
+        // `BoundParameter` indices, so the bound declaration is alpha-equivalent
+        // (see `canonical_bound_type_param`).
         let c_type_params: Vec<crate::types::TypeParamInfo> = sig
             .type_params
             .iter()
-            .map(|&tp| self.canonical_type_param(tp))
+            .map(|&tp| self.canonical_bound_type_param(tp))
             .collect();
 
         // Canonicalize type predicate (if it has a type_id)

--- a/crates/tsz-solver/tests/canonicalize_tests.rs
+++ b/crates/tsz-solver/tests/canonicalize_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::construction::TypeDatabase;
 use crate::def::{DefId, DefKind};
 use crate::intern::TypeInterner;
-use crate::relations::subtype::{TypeEnvironment, TypeResolver};
+use crate::relations::subtype::{TypeEnvironment, TypeResolver, are_types_structurally_identical};
 use crate::types::{PropertyInfo, SymbolRef, TypeData, TypeParamInfo};
 
 // ===================================================================
@@ -419,87 +419,207 @@ fn canonicalize_function_with_type_params_uses_bound_parameter() {
     }
 }
 
+/// Build `<NAME>(x: NAME) => NAME` as an interned function type, where `NAME`
+/// is the type-parameter name. Used to probe alpha-equivalence: only the
+/// binder name varies between calls.
+fn identity_fn_with_type_param_named(interner: &TypeInterner, name: &str) -> TypeId {
+    use crate::types::{FunctionShape, ParamInfo};
+    let atom = interner.intern_string(name);
+    let param = interner.type_param(TypeParamInfo {
+        name: atom,
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    interner.function(FunctionShape {
+        type_params: vec![TypeParamInfo {
+            name: atom,
+            constraint: None,
+            default: None,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        }],
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("x")),
+            type_id: param,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: param,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    })
+}
+
 #[test]
-fn canonicalize_function_type_params_name_preserved_in_shape() {
-    // Note: The canonicalizer preserves type parameter names in function shapes
-    // (unlike mapped types where the name is erased). This means two functions
-    // with different type param names but same structure will have different
-    // canonical TypeIds. Full alpha-equivalence for functions would require
-    // erasing names in the TypeParamInfo as well.
+fn canonicalize_function_type_params_are_alpha_equivalent_on_binder_name() {
+    // #13609: the canonicalizer alpha-renames type-parameter *references* to
+    // positional `BoundParameter` indices, so the *declaration* name on the
+    // bound `type_params` entry is identity-irrelevant — exactly like the
+    // mapped-type iteration variable, which was already erased. Two structurally
+    // identical generic functions that differ only in the chosen binder name
+    // (`<T>(x: T) => T` vs `<U>(x: U) => U`) must canonicalize to the SAME form,
+    // matching tsc's `compareSignaturesIdentical` (which remaps type parameters
+    // positionally and never compares their names).
     let interner = TypeInterner::new();
     let env = TypeEnvironment::new();
 
-    use crate::types::{FunctionShape, ParamInfo};
-
-    let t_atom = interner.intern_string("T");
-    let t_param = interner.type_param(TypeParamInfo {
-        name: t_atom,
-        constraint: None,
-        default: None,
-        is_const: false,
-        origin: crate::types::TypeParamOrigin::User,
-    });
-    let func_t = interner.function(FunctionShape {
-        type_params: vec![TypeParamInfo {
-            name: t_atom,
-            constraint: None,
-            default: None,
-            is_const: false,
-            origin: crate::types::TypeParamOrigin::User,
-        }],
-        params: vec![ParamInfo {
-            name: Some(interner.intern_string("x")),
-            type_id: t_param,
-            optional: false,
-            rest: false,
-        }],
-        this_type: None,
-        return_type: t_param,
-        type_predicate: None,
-        is_constructor: false,
-        is_method: false,
-    });
-
-    let u_atom = interner.intern_string("U");
-    let u_param = interner.type_param(TypeParamInfo {
-        name: u_atom,
-        constraint: None,
-        default: None,
-        is_const: false,
-        origin: crate::types::TypeParamOrigin::User,
-    });
-    let func_u = interner.function(FunctionShape {
-        type_params: vec![TypeParamInfo {
-            name: u_atom,
-            constraint: None,
-            default: None,
-            is_const: false,
-            origin: crate::types::TypeParamOrigin::User,
-        }],
-        params: vec![ParamInfo {
-            name: Some(interner.intern_string("x")),
-            type_id: u_param,
-            optional: false,
-            rest: false,
-        }],
-        this_type: None,
-        return_type: u_param,
-        type_predicate: None,
-        is_constructor: false,
-        is_method: false,
-    });
+    let func_t = identity_fn_with_type_param_named(&interner, "T");
+    let func_u = identity_fn_with_type_param_named(&interner, "U");
+    // A third, differently-spelled binder, to be sure nothing keys on a
+    // specific identifier.
+    let func_elem = identity_fn_with_type_param_named(&interner, "Element");
 
     let mut c1 = Canonicalizer::new(&interner, &env);
     let mut c2 = Canonicalizer::new(&interner, &env);
+    let mut c3 = Canonicalizer::new(&interner, &env);
     let r1 = c1.canonicalize(func_t);
     let r2 = c2.canonicalize(func_u);
+    let r3 = c3.canonicalize(func_elem);
 
-    // Due to type param name preservation, these produce different canonical forms
-    // Both use BoundParameter(0) in body, but the TypeParamInfo name differs
-    assert_ne!(
+    assert_eq!(
         r1, r2,
-        "Functions with different type param names have different canonical forms \
-         (name is preserved in function shapes, unlike mapped types)"
+        "`<T>(x: T) => T` and `<U>(x: U) => U` are alpha-equivalent and must \
+         canonicalize identically"
+    );
+    assert_eq!(
+        r1, r3,
+        "alpha-equivalence must not depend on the chosen binder spelling"
+    );
+
+    // End-to-end through the relation's structural-identity gateway.
+    assert!(
+        are_types_structurally_identical(&interner, &env, func_t, func_u),
+        "alpha-equivalent generic functions must be structurally identical"
+    );
+}
+
+#[test]
+fn canonicalize_constrained_type_params_are_alpha_equivalent_on_binder_name() {
+    // The binder name stays identity-irrelevant when the parameter carries a
+    // constraint: `<T extends string>(x: T) => T` and
+    // `<U extends string>(x: U) => U` are alpha-equivalent. (The constraint
+    // itself is still part of identity — that is covered by the negative
+    // control below.)
+    use crate::types::{FunctionShape, ParamInfo};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let make = |name: &str, constraint: TypeId| {
+        let atom = interner.intern_string(name);
+        let info = TypeParamInfo {
+            name: atom,
+            constraint: Some(constraint),
+            default: None,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        };
+        let param = interner.type_param(info);
+        interner.function(FunctionShape {
+            type_params: vec![info],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("x")),
+                type_id: param,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: param,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+
+    let t_string = make("T", TypeId::STRING);
+    let u_string = make("U", TypeId::STRING);
+    let t_number = make("T", TypeId::NUMBER);
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    let mut c3 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(t_string),
+        c2.canonicalize(u_string),
+        "alpha-equivalence holds with a shared constraint"
+    );
+    assert_ne!(
+        c1.canonicalize(t_string),
+        c3.canonicalize(t_number),
+        "the constraint itself remains part of identity (string vs number)"
+    );
+}
+
+#[test]
+fn canonicalize_two_type_params_alpha_equivalence_respects_position() {
+    // With two binders, alpha-renaming both at once is identity-preserving, but
+    // the *positional* role each plays is not: `<A, B>(a: A, b: B) => B` must
+    // stay distinct from `<A, B>(a: A, b: B) => A`. Position is carried by the
+    // `BoundParameter` index, not the erased declaration name.
+    use crate::types::{FunctionShape, ParamInfo};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let make_info = |name: &str| TypeParamInfo {
+        name: interner.intern_string(name),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    };
+    // Builds `<P0, P1>(a: P0, b: P1) => P{return_first ? 0 : 1}` with the two
+    // binders named `n0`/`n1`.
+    let make = |n0: &str, n1: &str, return_first: bool| {
+        let info0 = make_info(n0);
+        let info1 = make_info(n1);
+        let p0 = interner.type_param(info0);
+        let p1 = interner.type_param(info1);
+        interner.function(FunctionShape {
+            type_params: vec![info0, info1],
+            params: vec![
+                ParamInfo {
+                    name: Some(interner.intern_string("a")),
+                    type_id: p0,
+                    optional: false,
+                    rest: false,
+                },
+                ParamInfo {
+                    name: Some(interner.intern_string("b")),
+                    type_id: p1,
+                    optional: false,
+                    rest: false,
+                },
+            ],
+            this_type: None,
+            return_type: if return_first { p0 } else { p1 },
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+
+    // Positive: rename both binders, same positional roles → identical.
+    assert!(
+        are_types_structurally_identical(
+            &interner,
+            &env,
+            make("A", "B", false),
+            make("X", "Y", false),
+        ),
+        "renaming all binders preserves identity"
+    );
+    // Negative: same binders, but the returned position differs → distinct.
+    assert!(
+        !are_types_structurally_identical(
+            &interner,
+            &env,
+            make("A", "B", false),
+            make("A", "B", true),
+        ),
+        "returning the first vs second positional parameter is a real difference"
     );
 }
 


### PR DESCRIPTION
Goal: hold

Closes a facet of #13609 (the type-parameter canonical-identity family, alongside the already-landed `default` #13888, free-reference constraint #13915, `Infer` arm #14074, and `const` #14090 slices). Restores the conformance/parity floor: two structurally identical generic signatures that differ only in the chosen type-parameter binder name now share canonical identity, matching `tsc`.

## Structural rule

> When two generic signatures differ only in the **name** chosen for a bound type parameter — `<T>(x: T) => T` vs `<U>(x: U) => U` — `tsc` treats them as identical (`compareSignaturesIdentical` instantiates one signature's type parameters to the other's, so the declared name is irrelevant to identity). tsz must canonicalize them to the same form.

## Root cause / owner layer

`Canonicalizer` (`crates/tsz-solver/src/canonicalize/mod.rs`) already alpha-renames type-parameter **references** to positional `BoundParameter(n)` (De Bruijn) indices via `find_param_index`, so a bound declaration's `name` is never resolved — it only feeds the structural hash that `are_types_structurally_identical` reduces to `TypeId` equality.

The **mapped-type** path already erased that name (`{ [K in T]: K }` == `{ [P in T]: P }`), but the **function-shape** and **call-signature** paths kept it (`canonical_type_param` copied `name: tp.name`). So `<T>(x: T) => T` and `<U>(x: U) => U` canonicalized to distinct `TypeId`s, missed the relation's reflexive short-circuit, and fell into the resolver-state-dependent member walk that seeds the #13609 false positives.

Fix: a shared `canonical_bound_type_param` helper (constraint canonicalized, `default`/`is_const` dropped, name erased to the `Atom::NONE` sentinel) now backs **all three** bound scopes — function shape, call signature, mapped type — so they agree. Identity-widening only; interning is unchanged and the interned parameter keeps its real name/default/const for instantiation and inference. The free-`TypeParameter` and `Infer` reference arms keep the name (their identity **is** the name; they are not in a binding scope). Name-agnostic — keyed on structural position, no identifier/alias/file-name/printer-string predicate.

## Adjacent-case matrix (name-agnostic; binders varied)

| case | result |
|---|---|
| `<T>(x: T) => T` vs `<U>(x: U) => U` (witness) | identical |
| same, vs a third spelling `<Element>(…)` | identical (no specific-name dependence) |
| `<T extends string>(x: T) => T` vs `<U extends string>(x: U) => U` | identical |
| `<T extends string>` vs `<T extends number>` (control) | distinct — constraint stays part of identity |
| `<A, B>(a: A, b: B) => B` vs `<X, Y>(a: X, b: Y) => Y` (rename all) | identical |
| `<A, B>(a, b) => B` vs `<A, B>(a, b) => A` (control) | distinct — positional role differs |
| mapped `{ [K in T]: K }` vs `{ [P in T]: P }` (pre-existing) | identical (unchanged) |

## Verification

- New solver unit tests in `crates/tsz-solver/tests/canonicalize_tests.rs`: `canonicalize_function_type_params_are_alpha_equivalent_on_binder_name` (rewritten from the prior `..._name_preserved_in_shape`, which asserted and documented the bug), `canonicalize_constrained_type_params_are_alpha_equivalent_on_binder_name`, and `canonicalize_two_type_params_alpha_equivalence_respects_position` — both the direct canonical-form check and the end-to-end `are_types_structurally_identical` gateway. **58 passed** (`cargo test -p tsz-solver --lib canonicalize`).
- Full solver lib sweep (`cargo test -p tsz-solver --lib`): **6827 passed**, the 4 reds are pre-existing on `main` (`fb91613`), verified by re-running each on a clean stash — **zero new failures**.
- `cargo fmt -p tsz-solver --check`, `cargo clippy -p tsz-solver --lib --tests`, `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Vxbrs5G67WwZU67QVxoEEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vxbrs5G67WwZU67QVxoEEp)_