### PR TITLE
fix(checker): guard every under-applied type-argument fill against the error sentinel

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -7,6 +7,7 @@ use crate::query_boundaries::class::{
     should_report_member_type_mismatch, should_report_property_type_mismatch,
 };
 use crate::state::CheckerState;
+use crate::state_domain::type_resolution::constructors::missing_base_type_arg_fill;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
@@ -532,10 +533,11 @@ impl<'a> CheckerState<'a> {
                 let mut substitution_args = level_type_args.unwrap_or_default();
                 if substitution_args.len() < level_type_params.len() {
                     for param in level_type_params.iter().skip(substitution_args.len()) {
-                        let fallback = param
-                            .default
-                            .or(param.constraint)
-                            .unwrap_or(TypeId::UNKNOWN);
+                        let fallback = missing_base_type_arg_fill(
+                            self.ctx.types,
+                            param.default,
+                            param.constraint,
+                        );
                         substitution_args.push(fallback);
                     }
                 }
@@ -1081,10 +1083,11 @@ impl<'a> CheckerState<'a> {
                         .unwrap_or_default();
                     if class_subst_args.len() < class_type_params.len() {
                         for param in class_type_params.iter().skip(class_subst_args.len()) {
-                            let fallback = param
-                                .default
-                                .or(param.constraint)
-                                .unwrap_or(TypeId::UNKNOWN);
+                            let fallback = missing_base_type_arg_fill(
+                                self.ctx.types,
+                                param.default,
+                                param.constraint,
+                            );
                             class_subst_args.push(fallback);
                         }
                     }
@@ -1518,10 +1521,8 @@ impl<'a> CheckerState<'a> {
 
             if type_args.len() < base_type_params.len() {
                 for param in base_type_params.iter().skip(type_args.len()) {
-                    let fallback = param
-                        .default
-                        .or(param.constraint)
-                        .unwrap_or(TypeId::UNKNOWN);
+                    let fallback =
+                        missing_base_type_arg_fill(self.ctx.types, param.default, param.constraint);
                     type_args.push(fallback);
                 }
             }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1402,6 +1402,9 @@ mod typeof_class_name_structural_lookup_arch_tests;
 #[path = "tests/typeof_const_spread_index_access_tests.rs"]
 mod typeof_const_spread_index_access_tests;
 #[cfg(test)]
+#[path = "tests/under_applied_generic_constructor_fill_tests.rs"]
+mod under_applied_generic_constructor_fill_tests;
+#[cfg(test)]
 #[path = "tests/union_call_resolution_tests.rs"]
 mod union_call_resolution_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_resolution/constructors.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors.rs
@@ -18,8 +18,10 @@ pub(super) const fn should_cache_base_expr_result(
     type_argument_count == 0 && !has_active_type_parameter_scope
 }
 
-/// Choose the type that fills a *missing* type argument of a generic base class,
-/// matching `tsc`'s `default -> constraint -> unknown` order.
+/// Choose the type that fills a *missing* type argument of a generic base class
+/// or constructor reference, matching `tsc`'s `default -> constraint -> unknown`
+/// order. Shared by every under-applied fill site (the base instance type and
+/// the construct-signature paths) so they enforce the same boundary invariant.
 ///
 /// `TypeId::ERROR` (and `TypeData::Error`) is tsz's internal cycle/fuel
 /// sentinel, never a type `tsc` produces. When a base parameter's default or
@@ -173,10 +175,7 @@ impl<'a> CheckerState<'a> {
                     let fallback = if missing_type_args_become_any {
                         TypeId::ANY
                     } else {
-                        param
-                            .default
-                            .or(param.constraint)
-                            .unwrap_or(TypeId::UNKNOWN)
+                        missing_base_type_arg_fill(self.ctx.types, param.default, param.constraint)
                     };
                     let substitution = TypeSubstitution::from_args(
                         self.ctx.types,
@@ -253,10 +252,11 @@ impl<'a> CheckerState<'a> {
                         let fallback = if missing_type_args_become_any {
                             TypeId::ANY
                         } else {
-                            param
-                                .default
-                                .or(param.constraint)
-                                .unwrap_or(TypeId::UNKNOWN)
+                            missing_base_type_arg_fill(
+                                self.ctx.types,
+                                param.default,
+                                param.constraint,
+                            )
                         };
                         // Substitute earlier type params in the default
                         // (e.g., `U = T` → `U = number` when T = number)

--- a/crates/tsz-checker/src/tests/under_applied_generic_constructor_fill_tests.rs
+++ b/crates/tsz-checker/src/tests/under_applied_generic_constructor_fill_tests.rs
@@ -1,0 +1,56 @@
+use crate::test_utils::check_source_code_messages;
+
+// #13484 family: when a generic *constructor* reference (`new C<…>()` / an
+// `extends` base) supplies fewer type arguments than parameters, the missing
+// slots fill from `default -> constraint -> unknown`, matching tsc. All
+// under-applied fill sites — the base-instance type and the construct-signature
+// paths — route through the shared `missing_base_type_arg_fill` boundary helper,
+// so none of them can bake tsz's internal `error` cycle sentinel into a
+// type-argument slot. These exercise the construct-signature paths end to end
+// and vary binder names.
+
+fn ts2322_count(messages: &[(u32, String)]) -> usize {
+    messages.iter().filter(|(code, _)| *code == 2322).count()
+}
+
+#[test]
+fn new_expression_under_applied_fills_trailing_default() {
+    // Both parameters have defaults, so `new Slot<boolean>(...)` is a valid
+    // under-application: the trailing `Backing` slot fills from its default
+    // `number`. The deliberate annotation mismatches pin the resolved arguments.
+    let messages = check_source_code_messages(
+        r#"
+class Slot<Stored = string, Backing extends number = number> {
+    constructor(public stored: Stored, public backing: Backing) {}
+}
+const made = new Slot<boolean>(true, 5);
+const wrongStored: number = made.stored;   // Stored = boolean (explicit arg)
+const wrongBacking: string = made.backing; // Backing = number (filled default)
+"#,
+    );
+    assert_eq!(
+        ts2322_count(&messages),
+        2,
+        "expected boolean->number and number->string mismatches that prove the filled default, got: {messages:?}"
+    );
+}
+
+#[test]
+fn new_expression_under_applied_default_references_prior_param() {
+    // The trailing default references an earlier parameter (`Echo = Head`), so
+    // the fill must substitute the already-supplied argument into the default.
+    let messages = check_source_code_messages(
+        r#"
+class Tandem<Head, Echo = Head> {
+    constructor(public head: Head, public echo: Echo) {}
+}
+const pair = new Tandem<string>("a", "b");
+const wrongEcho: number = pair.echo; // Echo = Head = string
+"#,
+    );
+    assert_eq!(
+        ts2322_count(&messages),
+        1,
+        "expected Echo to fill from a default referencing Head (string), got: {messages:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Advances #13484 (the cross-arena `error`/`never`-in-a-type-argument-slot family). Found by following the altitude finding of a constructor-fill audit: one fill site was consolidated onto the guarded boundary helper while its siblings were not.

## Structural rule

> When a generic base class or constructor reference supplies **fewer type arguments than parameters**, the missing slots fill from `default -> constraint -> unknown` (tsc parity). `tsc` never produces tsz's internal `error` cycle/fuel sentinel, so a default/constraint that degraded to `error` during cross-arena base resolution must be treated as **absent** and recovered to `unknown` — never baked into an inherited member's type-argument slot. This holds for **every** under-applied fill site.

A leaked `error` in a type-argument slot (kysely `SelectFrom<error, …>`, zod `{ checks: error[] }`) is invisible to the top-level `error` predicates and escapes error suppression, seeding cascading false positives — the family #13484 documents.

## Owner layer

Checker, cross-arena base/constructor type-argument binding. The boundary helper `missing_base_type_arg_fill` (`crates/tsz-checker/src/state/type_resolution/constructors.rs`) already encodes the rule (`default → constraint → unknown`, skipping a *genuine* `error` via `is_genuine_error_type` so a deferrable `UnresolvedTypeName` is still honored), but only the base-instance fill used it. The other under-applied fill sites still used a raw `param.default.or(param.constraint).unwrap_or(UNKNOWN)` that omitted the guard. This routes **all** of them through the shared helper:

- the constructor-function and construct-signature paths (`new C<…>()` / `super(…)`) — `constructors.rs`;
- the three heritage fills in the compat checker (base interface, base class, base-root interface) — `classes/class_checker_compat.rs`.

This **removes divergent copies rather than adding a special case**. The decision keys only on the structural `error` sentinel — no identifier/alias/file-name/printer-string predicate. Behavior is unchanged for every genuine default/constraint (the common case).

## Adjacent-case matrix (name-agnostic; binders varied)

| axis | case | result |
|---|---|---|
| genuine default | `default present` | default used (constraint ignored) |
| constraint fallback | no default, genuine constraint | constraint used |
| neither | no default/constraint | `unknown` |
| sentinel default | `default = error`, genuine constraint | constraint (error skipped) |
| sentinel both | `default = error`, `constraint = error` | `unknown` (leak recovered) |
| construct path, trailing default | `new Slot<boolean>(…)` under-applied | trailing slot = its default |
| construct path, default refs prior param | `class Tandem<Head, Echo = Head>`, `new Tandem<string>(…)` | `Echo = Head = string` |

## Verification

- New checker tests `under_applied_generic_constructor_fill_tests` (2, name-varied) exercising the construct-signature fill end to end — **pass**.
- Existing helper tests `constructors_tests::*` (genuine/degraded/deferrable fill matrix) — **6 pass**.
- Full `cargo test -p tsz-checker --lib` sweep: **6825 passed**; the 72 failures are pre-existing and **identical to `main` HEAD** (`fb91613`) — captured baseline vs head, diff of failing sets is empty (**zero regressions, zero new failures**). The transient 73rd seen once is a known schedule-sensitive flake (#13255), not reproduced on the deterministic re-run.
- `cargo fmt -p tsz-checker --check`, `cargo clippy -p tsz-checker --lib`, `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVY4JdabbThDYqjCerbknk)_