### PR TITLE
perf(checker): memoize spelling-suggestion scan per reference node

### DIFF
--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -185,6 +185,13 @@ impl<'a> CheckerContext<'a> {
         self.name_resolution_diagnostics
             .spelling_suggestions_emitted
             .set(0);
+        // The suggestion-scan memo is keyed by per-file `NodeIndex`; clear it
+        // alongside `reported_nodes` so a new file's identically-numbered nodes
+        // never inherit the previous file's cached suggestions.
+        self.name_resolution_diagnostics
+            .suggestion_scan_cache
+            .borrow_mut()
+            .clear();
 
         // Class chain / heritage caches keyed by `NodeIndex`.
         self.class_chain_summary_cache.borrow_mut().clear();

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -476,6 +476,18 @@ pub struct NameResolutionDiagnostics {
     /// when the same type reference is resolved multiple times (e.g., due to
     /// re-evaluation in generic/contextual typing contexts).
     pub reported_nodes: FxHashSet<NodeIndex>,
+
+    /// Memoized spelling-suggestion candidate scans keyed by the failing
+    /// reference `NodeIndex`. The full-symbol-universe Levenshtein walk in
+    /// `scan_similar_identifiers` is a pure function of the binder/lib tables
+    /// (stable within a file session) and the reference site, but demand-driven
+    /// type evaluation re-resolves the *same* unresolved type reference many
+    /// times (constraint/alias/conditional/indexed-access revisits). Without a
+    /// memo the scan re-runs per revisit — `O(references × identifier-table)`
+    /// instead of `O(unique-unresolved-references)`. Caching the result per node
+    /// collapses the repeats while emitting exactly the same suggestions.
+    /// Cleared at the file-session boundary alongside `reported_nodes`.
+    pub suggestion_scan_cache: RefCell<FxHashMap<NodeIndex, Vec<String>>>,
 }
 
 /// File-session memo tables shared by flow narrowing helpers.

--- a/crates/tsz-checker/src/error_reporter/name_resolution.rs
+++ b/crates/tsz-checker/src/error_reporter/name_resolution.rs
@@ -1220,6 +1220,20 @@ impl<'a> CheckerState<'a> {
     /// (it does not re-apply the suppression predicates or touch the cap
     /// counter), and only when a diagnostic is actually being emitted.
     pub(crate) fn scan_similar_identifiers(&self, name: &str, idx: NodeIndex) -> Vec<String> {
+        // Memoize per reference site: the same unresolved reference is
+        // re-resolved many times under demand-driven evaluation, and each
+        // revisit would otherwise repeat the full-symbol-universe scan below.
+        // See `NameResolutionDiagnostics::suggestion_scan_cache`.
+        if let Some(cached) = self
+            .ctx
+            .name_resolution_diagnostics
+            .suggestion_scan_cache
+            .borrow()
+            .get(&idx)
+        {
+            return cached.clone();
+        }
+
         // Determine spelling suggestion meaning based on context.
         // In type positions (type annotations, implements clauses, type references),
         // only suggest TYPE-meaning symbols. In value positions, suggest VALUE symbols.
@@ -1230,8 +1244,17 @@ impl<'a> CheckerState<'a> {
             tsz_binder::symbol_flags::VALUE
         };
 
-        self.find_similar_identifiers(name, idx, suggestion_meaning)
-            .unwrap_or_default()
+        let suggestions = self
+            .find_similar_identifiers(name, idx, suggestion_meaning)
+            .unwrap_or_default();
+
+        self.ctx
+            .name_resolution_diagnostics
+            .suggestion_scan_cache
+            .borrow_mut()
+            .insert(idx, suggestions.clone());
+
+        suggestions
     }
 
     /// Report TS2318: Cannot find global type 'X' at a raw source position.


### PR DESCRIPTION
Goal: fast

Closes #14100.

A perf dive on the required `ts-toolbelt` bench row (`tsz` 5.25x slower than
`tsgo`) found the dominant cost — ~30-40% of single-thread check CPU — is the
"did you mean?" spelling-suggestion candidate scan (`scan_similar_identifiers`)
re-running on every revisit of an unresolved name during demand-driven type
evaluation. This is structural, not fixture-specific: it generalizes to the
other `tsgo` losses (`ts-essentials`, `vite-vanilla`, `nextjs-fresh`) whose
generic/conditional/alias bodies reference type names that fail to resolve under
the bench's stripped config.

## Structural rule

> When a name-resolution failure reaches diagnostic emission, the
> spelling-suggestion candidate scan is a pure function of the binder/lib symbol
> tables (stable within a file session) and the reference `NodeIndex` (which
> fixes both the name and the type/value meaning). The same unresolved reference
> must therefore produce the same suggestions every time it is scanned, so the
> scan should run **at most once per reference site** — `tsc` computes each
> suggestion once; `tsz` owns this in the checker's name-resolution reporter.

The candidate scan was already *deferred* to the emission path (`#13`-era
`suggestions_eligible`), so suppressed/recovered failures never pay for it. But
demand-driven type evaluation re-resolves the **same** unresolved type reference
many times (constraint / alias / conditional / indexed-access revisits), and
every revisit that reached emission re-ran the full-symbol-universe Levenshtein
walk. The cost was `O(references x identifier-table)` instead of
`O(unique-unresolved-references)`.

## Owner layer

- **Root** — `crates/tsz-checker/src/error_reporter/name_resolution.rs`:
  `scan_similar_identifiers` now serves repeated scans from a per-`NodeIndex`
  memo, computing `find_similar_identifiers` at most once per reference site.
  Because the memo wraps the single shared scan helper, **both** call sites (the
  deferred emission path in `query_boundaries/name_resolution.rs` and the eager
  `collect_spelling_suggestions` path) are covered at once.
- **State** — `crates/tsz-checker/src/context/mod.rs`: new
  `NameResolutionDiagnostics::suggestion_scan_cache:
  RefCell<FxHashMap<NodeIndex, Vec<String>>>`, mirroring the existing
  per-`NodeIndex` caches (`class_instance_type_cache`, `reported_nodes`).
- **Lifecycle** — `crates/tsz-checker/src/context/file_session_reset.rs`: the
  memo is cleared at the file-session boundary alongside `reported_nodes`, so a
  new file's identically-numbered nodes never inherit stale suggestions.
- The cache keys only on the structural `NodeIndex` — no
  identifier/alias/file-name/printer-string predicate.

Diagnostics are unchanged: the suggestion cap counter and the cheap suppression
predicates still run per failure in `suggestion_scan_eligible`; only the
redundant candidate scan is collapsed, emitting exactly the same suggestions
computed once.

## Adjacent-case matrix (name-agnostic)

| case | behavior |
|---|---|
| same unresolved reference revisited N times (witness) | one scan, suggestions reused |
| distinct references to the same name in different scopes | independent scans (scope-sensitive key = `NodeIndex`) |
| value-position vs type-position lookup at one node | meaning still derived from `idx`; cached result matches a fresh scan |
| node that never reaches emission (suppressed/recovered) | scan never runs, never cached (unchanged) |
| new file, identically-numbered nodes | cache cleared at file-session reset; no stale carryover |

## Verification

- `cargo check -p tsz-checker` — clean.
- `cargo test -p tsz-checker` name-resolution / suggestion suites —
  `lib_type_spelling_suggestions_tests`, `name_resolution_boundary_tests`,
  `cross_module_unimported_name_resolution_tests`,
  `await_call_identifier_diagnostics_tests`, `shadowed_symbol_global_tests`,
  `stage3_lib_namespace_resolution_tests`,
  `strict_mode_reserved_word_in_qualified_type_tests`,
  `recovery_any_sites_tests` — **all passed**, suggestions unchanged.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01CubcFE8LHXgVQaiTEa8BBS)_