### PR TITLE
fix(solver): accept `unknown` source against deferred-conditional targets with top-type branches

### DIFF
--- a/crates/tsz-checker/src/tests/return_alias_unknown_eval_assignability_tests.rs
+++ b/crates/tsz-checker/src/tests/return_alias_unknown_eval_assignability_tests.rs
@@ -163,6 +163,73 @@ function bad(): () => string {
     );
 }
 
+/// The free-type-parameter gap: a generic alias *application* `C<T>` (`T`
+/// still free) used directly as the declared return type, returning `unknown`.
+/// `C<T>` evaluates to a *deferred* conditional whose branches are both
+/// `unknown`; the compat fast path rejected an `unknown` source against any
+/// non-top target before the structural `subtype_of_conditional_target` rule
+/// (source must relate to *both* branches) could accept it. tsc accepts this
+/// because each branch is itself `unknown`. The concrete `C<number>` and
+/// `() => C<number>` positions already evaluated to a literal `unknown`, so
+/// only the still-deferred generic-application form regressed.
+#[test]
+fn generic_alias_application_unknown_return_with_free_type_parameter() {
+    assert_clean(
+        r#"
+type C<T> = T extends 1 ? unknown : unknown;
+function g<T>(v: unknown): C<T> {
+  return v;
+}
+"#,
+    );
+}
+
+/// `any` branches must behave identically to `unknown` branches: a deferred
+/// conditional whose every branch is a top type accepts an `unknown` source.
+#[test]
+fn generic_alias_application_any_branches_accept_unknown_source() {
+    assert_clean(
+        r#"
+type C<U> = U extends 1 ? any : any;
+function g<U>(v: unknown): C<U> {
+  return v;
+}
+"#,
+    );
+}
+
+/// A non-distributive identical-top-branch conditional (`[T] extends [1]`)
+/// also accepts an `unknown` source — the fix is not distribution-specific.
+#[test]
+fn non_distributive_top_branch_conditional_accepts_unknown_source() {
+    assert_clean(
+        r#"
+type Wrap<Elem> = [Elem] extends [1] ? unknown : unknown;
+function g<Elem>(v: unknown): Wrap<Elem> {
+  return v;
+}
+"#,
+    );
+}
+
+/// Negative control: a deferred conditional with a non-top branch must still
+/// reject an `unknown` source (it is not assignable to the `string` branch).
+#[test]
+fn deferred_conditional_with_non_top_branch_rejects_unknown_source() {
+    let diags = diags_strict(
+        r#"
+type Mixed<T> = T extends 1 ? unknown : string;
+function bad<T>(v: unknown): Mixed<T> {
+  return v;
+}
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "Expected TS2322 for unknown source vs conditional with a string branch; got: {diags:?}"
+    );
+}
+
 /// Property position (already-passing control from the issue's adjacent
 /// matrix) stays clean alongside the signature-return fix.
 #[test]

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -1374,6 +1374,17 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             if self.empty_object_with_nullish_target(target).is_some() {
                 return Some(true);
             }
+            // A deferred conditional target (`T extends X ? A : B`) resolves to
+            // one of its branches once instantiated, so `unknown` is assignable
+            // to it exactly when every branch accepts `unknown` — i.e. each
+            // branch is itself a top type. tsc accepts `unknown` against
+            // `T extends X ? unknown : unknown` for this reason. Defer to the
+            // structural check, whose `subtype_of_conditional_target` rule
+            // requires the source to relate to *both* branches, instead of
+            // rejecting a top-type source here at the simple fast path.
+            if matches!(self.interner.lookup(target), Some(TypeData::Conditional(_))) {
+                return None;
+            }
             return Some(false);
         }
 


### PR DESCRIPTION
Goal: hold

Advances #13212 (valibot F1 family — `unknown`/top-type relation false positives on instantiated generic members). Found via the issue's 9-line gate repro; this closes the remaining **free-type-parameter** slice that the earlier return-position fix did not cover.

## Witness (tsc 6.0.2 clean; tsz before: false TS2322)

```ts
type C<T> = T extends 1 ? unknown : unknown;
function g<T>(v: unknown): C<T> {
  return v; // tsc: clean | tsz before: TS2322 'unknown' is not assignable to 'C<T>'
}
```

| | `unknown` -> `C<T>` |
|---|---|
| `tsc` 6.0.2 | clean (`C<T>` resolves to one of its branches; both are `unknown`) |
| tsz (before) | false `TS2322` |
| tsz (after) | clean |

## Structural rule

> When the source is `unknown` (a top type) and the target is a **deferred conditional** `Check extends Ext ? A : B`, the conditional resolves to one of its branches once instantiated, so `unknown` is assignable to it exactly when **every branch accepts `unknown`** — i.e. each branch is itself a top type. The relation must therefore be decided by the structural branch rule, not rejected up front.

## Root cause / owner layer

Solver `CompatChecker::check_assignable_fast_path` (`crates/tsz-solver/src/relations/compat.rs`). The fast path encodes "`unknown` is assignable only to top types (or `{} | null | undefined`)" and otherwise returns `Some(false)` — short-circuiting **before** the structural relation can run. The subtype engine already has the correct rule: `subtype_of_conditional_target` requires the source to relate to **both** branches (verified directly — `is_subtype_of(unknown, T extends 1 ? unknown : unknown)` is already `true`). The fast path simply never reached it for an `unknown` source.

The concrete (`C<number>`) and `() => C<number>` positions already evaluated to a literal `unknown` and so were accepted by the existing fast path; only the **still-deferred** generic-application form (`C<T>`, `T` free) hit the early rejection.

Fix: when the source is `unknown` and the target is a `Conditional`, return `None` (defer to the structural check) instead of `Some(false)`. This **reuses** the existing, tested branch rule rather than adding a parallel one. It keys only on the structural `Conditional` shape — no identifier/alias/file-name/printer-string predicate — and is not distribution-specific.

## Adjacent matrix (name-agnostic; binders varied; vs `tsc` 6.0.2)

| case | result |
|---|---|
| `unknown` branches, free param (witness) | clean |
| `any` branches | clean |
| alias-to-`unknown` branch (`type U = unknown`) | clean |
| non-distributive `[T] extends [1] ? unknown : unknown` | clean |
| **non-top branch** (`... ? unknown : string`) | **TS2322** (still rejected) |
| concrete/`string`/object branches | unchanged |
| non-conditional alias target (`type C<T> = string`) | unchanged (still rejected) |

## Verification

- New name-agnostic checker tests in `crates/tsz-checker/src/tests/return_alias_unknown_eval_assignability_tests.rs` (4 added: free-param witness, `any` branches, non-distributive, negative non-top-branch control) — **pass** (all red on the pre-fix tree except the negative control).
- Full `cargo test -p tsz-checker --lib`: **6827 passed**; failing set is **strictly a subset of baseline** (`014f7f6`): captured failing-test sets before/after — **0 regressions**, and the change additionally **fixes 3 pre-existing failures** (`state_domain::…::source_option_bag_tests::delegate_cross_arena_source_option_bag_*`, same `unknown`-vs-deferred-conditional family). Baseline 75 fails -> 72 fails.
- Full `cargo test -p tsz-solver --lib`: **6826 passed**; the 4 reds are pre-existing on baseline (verified by stashing the change — identical set).
- tsc 6.0.2 differential matrix (9 cases above) — every case matches `tsc`.
- `cargo fmt -p tsz-solver -p tsz-checker --check`, `cargo clippy -p tsz-solver --lib`, `cargo clippy -p tsz-checker --lib --tests`, `python3 scripts/arch/arch_guard.py` — clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01BMQmX5yakWXq7VoVFAhpNX

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMQmX5yakWXq7VoVFAhpNX)_