### PR TITLE
perf(solver): unify early application-eval probe onto expanded-arg key (#14101 step 1a)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate/application.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/application.rs
@@ -24,6 +24,25 @@ struct ApplicationFinalizeContext<'a> {
     no_unchecked_indexed_access: bool,
 }
 
+/// Debug kill-switch for unifying the early application-eval cache probe onto
+/// the same `expand_type_args(args)` key the insert path uses (#14101, step 1a).
+///
+/// The insert path keys entries on the *expanded* args (the body path runs
+/// `prepare_expanded_args_for_body`, which falls through to `expand_type_args`
+/// for non-conditional bodies), but the early Phase-4 probe historically keyed
+/// on the *raw* `app.args` and so missed those entries whenever an arg needed
+/// expansion. Unifying is a pure cache-hit dedupe — it never changes an insert
+/// key, a stored value, a relation verdict, or any interned `TypeId`.
+///
+/// Set `TSZ_DISABLE_APP_EVAL_KEY_UNIFY=1` to restore the legacy raw-args probe
+/// so a regression can be bisected and the two arms proved byte-identical;
+/// defaults to enabled.
+fn app_eval_key_unify_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("TSZ_DISABLE_APP_EVAL_KEY_UNIFY").is_err())
+}
+
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Evaluate a generic type application: Base<Args>
     ///
@@ -95,7 +114,19 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // skip the fallback behavior that preserves recursive/inference parity.
         if let Some(db) = self.query_db {
             let no_unchecked = self.no_unchecked_indexed_access;
-            let cached = db.lookup_application_eval_cache(def_id, &app.args, no_unchecked);
+            // #14101 (1a): align this early probe's key with the expanded-args
+            // form the insert path writes (`prepare_expanded_args_for_body` ->
+            // `expand_type_args` for non-conditional bodies). Without this the
+            // probe misses every entry whose args needed expansion (Lazy alias
+            // chains / meta-types — the common recursive-heritage shape) and
+            // re-walks to the deeper expanded probe in `evaluate_application_body`.
+            // Lookup-only; `TSZ_DISABLE_APP_EVAL_KEY_UNIFY=1` restores raw args.
+            let cached = if app_eval_key_unify_enabled() {
+                let expanded = self.expand_type_args(&app.args);
+                db.lookup_application_eval_cache(def_id, &expanded, no_unchecked)
+            } else {
+                db.lookup_application_eval_cache(def_id, &app.args, no_unchecked)
+            };
             crate::evaluation::eval_materialization_probe::record_application_cache_lookup(
                 crate::evaluation::eval_materialization_probe::ApplicationLookupSite::RawArgs,
                 cached.is_some(),


### PR DESCRIPTION
## Summary

Step **1a** of the #14101 campaign (the #1 compile-all blocker). A 6-reader trace **corrected the issue's stated mechanism** (#14101 comment 4757217715): `Application(base,args)` is *already* content-addressed (`test_interner_application_deduplication`), so args do **not** proliferate. The real residuals are (1b) **base-spelling divergence** — the same `DefId` minted as `Lazy(DefId)` vs resolved-object vs `Recursive(depth)` yields distinct Application `TypeId`s for one instantiation, proliferating the per-`(type,prop)` memo (#13787) that drives the timeouts — and (1a, **this PR**) a separable **raw-vs-expanded cache-key asymmetry**.

**Structural rule (1a):** the `application_eval_cache` insert path keys entries on `expand_type_args(args)` (the body path runs `prepare_expanded_args_for_body`, which falls through to `expand_type_args` for non-conditional bodies), but the early Phase-4 probe in `evaluate_application` keyed on the *raw* `app.args` and therefore missed those entries whenever an arg needed expansion (Lazy alias chains / meta-types — the common recursive-heritage shape), forcing a redundant re-walk to the deeper expanded probe. This PR unifies the early probe onto the same expanded key.

**Owner / scope:** `crates/tsz-solver/src/evaluation/evaluate/application.rs` (Phase-4 probe only). Lookup-only — never changes an insert key, a stored value, a relation verdict, or any interned `TypeId`. Gated by `TSZ_DISABLE_APP_EVAL_KEY_UNIFY` (default on) for byte-parity bisection.

**Honest framing:** this is the campaign's foundational slice (kill-switch + parity harness + dedupe groundwork). On a local recursive-heritage repro it is **wall-clock-neutral** — the timeout-**convergence** lever is the follow-on **1b (base canonicalization)** + **2 (SCC materialize-once)**. This PR's value is (a) the corrected diagnosis on the record, (b) the kill-switch scaffolding, and (c) letting CI's `project-compile-guard` measure 1a's standalone effect on the real timeout repros (no local fixtures).

Goal: green

## Provenance
Machine: MacBookPro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- **Byte-parity (local, ON vs `TSZ_DISABLE_APP_EVAL_KEY_UNIFY=1`):** full `tsz-solver` unit suite identical in both arms — 6841 pass, the same 4 pre-existing failures both arms (shared-`CARGO_TARGET_DIR` staleness; `origin/main` `unit-checker-integration` is green in CI). Diagnostics byte-identical on a recursive-heritage repro.
- `cargo nextest run -p tsz-solver cache_agreement` — 69/69 pass (cached == uncached invariant).
- **CI owns:** `project-compile-guard` on the timeout repros (`drizzle-orm`/`typebox`/`xstate`/`arktype`) + member-drop rows (`ts-morph`/`kysely`), plus conformance/emit/fourslash parity (the floor). The timeout-convergence claim is **1b/2**, not this PR.

Refs #14101.
