### PR TITLE
fix(checker): strip undefined from defaulted params with a deferred annotation (TS2488/TS18048)

### DIFF
--- a/crates/tsz-checker/src/flow/flow_analysis/definite.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/definite.rs
@@ -272,9 +272,7 @@ impl<'a> CheckerState<'a> {
                 declared_type,
                 true,
             );
-            if stripped != declared_type {
-                stripped
-            } else {
+            if stripped == declared_type {
                 let resolved =
                     crate::query_boundaries::state::type_environment::evaluate_type_with_resolver(
                         self.ctx.types,
@@ -286,11 +284,13 @@ impl<'a> CheckerState<'a> {
                     resolved,
                     true,
                 );
-                if stripped_resolved != resolved {
-                    stripped_resolved
-                } else {
+                if stripped_resolved == resolved {
                     declared_type
+                } else {
+                    stripped_resolved
                 }
+            } else {
+                stripped
             }
         } else {
             declared_type

--- a/crates/tsz-checker/src/flow/flow_analysis/definite.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/definite.rs
@@ -255,11 +255,43 @@ impl<'a> CheckerState<'a> {
             && param.initializer.is_some()
             && !self.is_in_default_parameter(idx)
         {
-            crate::query_boundaries::flow::narrow_destructuring_default(
+            // tsc strips `undefined` from a defaulted parameter's declared type
+            // (`getTypeForVariableLikeDeclaration` -> `getTypeWithFacts`). The
+            // solver-boundary strip below no-ops on a DEFERRED annotation
+            // (indexed-access / conditional / mapped) that is not yet a surface
+            // union, so `undefined` leaks into the parameter's body type and
+            // produces false TS2488/TS18048/TS2322 (e.g. jotai
+            // `names: Opts['names'] = []` then `[...names]`). Resolve the deferred
+            // annotation first — using the checker context as the type resolver,
+            // the same `&self`-reachable path the relation layer uses — then strip.
+            // Adopt the resolved form only when stripping actually removes
+            // `undefined`, so concrete and undefined-free annotations stay
+            // unchanged (minimal blast radius).
+            let stripped = crate::query_boundaries::flow::narrow_destructuring_default(
                 self.ctx.types,
                 declared_type,
                 true,
-            )
+            );
+            if stripped != declared_type {
+                stripped
+            } else {
+                let resolved =
+                    crate::query_boundaries::state::type_environment::evaluate_type_with_resolver(
+                        self.ctx.types,
+                        &self.ctx,
+                        declared_type,
+                    );
+                let stripped_resolved = crate::query_boundaries::flow::narrow_destructuring_default(
+                    self.ctx.types,
+                    resolved,
+                    true,
+                );
+                if stripped_resolved != resolved {
+                    stripped_resolved
+                } else {
+                    declared_type
+                }
+            }
         } else {
             declared_type
         };

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -190,6 +190,9 @@ mod cross_module_class_self_member_tests;
 #[path = "tests/decorator_return_relation_routing_arch_tests.rs"]
 mod decorator_return_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/defaulted_param_deferred_undefined_strip_tests.rs"]
+mod defaulted_param_deferred_undefined_strip_tests;
+#[cfg(test)]
 #[path = "../tests/definite_assignment_tests.rs"]
 mod definite_assignment_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/defaulted_param_deferred_undefined_strip_tests.rs
+++ b/crates/tsz-checker/src/tests/defaulted_param_deferred_undefined_strip_tests.rs
@@ -1,0 +1,113 @@
+//! Defaulted-parameter `undefined`-strip for DEFERRED annotation types.
+//!
+//! Structural rule: a parameter with a default initializer has `undefined`
+//! stripped from its declared type (tsc's `getTypeForVariableLikeDeclaration`
+//! -> `getTypeWithFacts(type, ~Undefined)`), so the body sees the non-undefined
+//! type. tsz's strip runs at the solver boundary and no-ops on a DEFERRED
+//! annotation (indexed-access / conditional / mapped) that is not yet a surface
+//! union — leaking `undefined` into the body and producing false TS18048 /
+//! TS2488 / TS2322 (witness: jotai `src/babel/utils.ts` `customAtomNames:
+//! PluginOptions['customAtomNames'] = []`). The fix resolves the deferred
+//! annotation (via the checker context as the type resolver) before stripping.
+//!
+//! Owner: `flow/flow_analysis/definite.rs` defaulted-parameter initial-type step.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+const TS18048: u32 = 18048; // 'x' is possibly 'undefined'.
+const TS2488: u32 = 2488; // Type must have a '[Symbol.iterator]()' method.
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+#[test]
+fn defaulted_param_with_indexed_access_annotation_strips_undefined() {
+    // `names: Opts['names'] = []` then `names.length` — tsc clean, was TS18048.
+    let codes = check_strict(
+        r#"
+interface Opts { names?: string[]; }
+function read(names: Opts["names"] = []) {
+  return names.length;
+}
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS18048),
+        0,
+        "deferred-default must strip undefined: {codes:?}"
+    );
+}
+
+#[test]
+fn defaulted_param_with_conditional_annotation_strips_undefined() {
+    let codes = check_strict(
+        r#"
+type Cond<B extends boolean> = B extends true ? string[] | undefined : number;
+function read(xs: Cond<true> = []) {
+  return xs.length;
+}
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS18048),
+        0,
+        "conditional deferred-default must strip undefined: {codes:?}"
+    );
+}
+
+#[test]
+fn defaulted_param_with_mapped_index_annotation_strips_undefined() {
+    let codes = check_strict(
+        r#"
+interface Opts { names?: string[]; }
+type Pick1<T, K extends keyof T> = { [P in K]: T[P] }[K];
+function read(xs: Pick1<Opts, "names"> = []) {
+  return xs.length;
+}
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS18048),
+        0,
+        "mapped-index deferred-default must strip undefined: {codes:?}"
+    );
+}
+
+#[test]
+fn eager_union_default_control_stays_clean() {
+    // Already-resolved union annotation — worked before the fix, must stay clean.
+    let codes = check_strict(
+        r#"
+type U = string[] | undefined;
+function read(names: U = []) {
+  return names.length;
+}
+"#,
+    );
+    assert_eq!(count(&codes, TS18048), 0);
+}
+
+// (The "no-default optional keeps undefined" true-positive is verified at the
+// CLI/canary level; it is structurally guaranteed here because the fix is gated
+// on `param.initializer.is_some()`, so a no-default parameter never reaches the
+// strip. It is omitted as a unit test because the unit-test lib resolves the
+// possibly-undefined access differently from the full CLI.)
+
+#[test]
+fn defaulted_param_deferred_spread_is_iterable() {
+    // The spread form of the same root (was false TS2488 on `string[] | undefined`).
+    let codes = check_strict(
+        r#"
+interface Opts { names?: string[]; }
+function read(names: Opts["names"] = []) {
+  return [...names];
+}
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS2488),
+        0,
+        "deferred-default spread must be iterable: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary

A parameter with a default initializer has `undefined` stripped from its declared
type (tsc's `getTypeForVariableLikeDeclaration` -> `getTypeWithFacts(type, ~Undefined)`),
so the body sees the non-undefined type. tsz runs that strip at the solver
boundary (`narrow_destructuring_default` -> `remove_undefined`), which **no-ops on
a DEFERRED annotation** — indexed-access (`Opts['names']`), conditional, or
mapped-index — that is not yet a surface union. So `undefined` leaks into the
parameter's body type and produces false **TS2488 / TS18048 / TS2322**.

Witness (jotai `src/babel/utils.ts:12`):
```ts
function isAtom(customAtomNames: PluginOptions['customAtomNames'] = []) {
  for (const n of customAtomNames) { /* tsz: TS2488 'string[] | undefined' */ }
}
```

## Structural rule

`When a parameter has a default initializer, undefined is stripped from its
declared type before the body is checked.` The strip must see the *resolved*
type; a deferred indexed-access / conditional / mapped annotation has to be
evaluated first (tsc resolves the apparent type), otherwise `remove_undefined`
sees a non-union and leaves `undefined` in place.

## Owner layer

Checker flow-analysis, `flow/flow_analysis/definite.rs` defaulted-parameter
initial-type step. When the existing strip is a no-op, resolve the deferred
annotation via the **checker context as the type resolver** (`&self.ctx`,
`query_boundaries::state::type_environment::evaluate_type_with_resolver` — the
same `&self`-reachable path the relation layer uses), then strip. Adopt the
resolved form **only when stripping actually removes `undefined`**, so concrete
and undefined-free annotations are untouched. The `param.initializer.is_some() &&
!is_in_default_parameter` gate already scopes this to defaulted parameters.

## Adjacent-case matrix (CLI byte-parity with tsc)

Cleared (was false FP): indexed-access (`Opts['names'] = []`), conditional
(`Cond<true> = []`), mapped-index (`Pick1<Opts,'names'> = []`) — each via spread
(TS2488), property access (TS18048), and assignment (TS2322). Unchanged:
eager-union default (clean before and after); no-default optional param still
keeps `undefined` (true positive — the strip is gated on a default).

Goal: green

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- New `defaulted_param_deferred_undefined_strip_tests` (5 cases): 5/5 pass.
- CLI suite: `diff` vs `tsc` empty across the indexed-access/conditional/mapped
  forms + spread/property/assignment + the eager-union and no-default controls.
- jotai canary: `src/babel/utils.ts(12,..)` TS2488 cleared (24 -> 23 tsz-only);
  zod / superstruct unchanged (zero new lines).
- Conformance (prebuilt dist-fast, all 100%): destructuring 174/174, controlFlow
  94/94, definiteAssignment 4/4, narrowing 29/29, iterators 1/1, functions 39/39,
  spread 71/71, generics 13/13, expressions 377/377.
- `python3 scripts/arch/arch_guard.py` passes; `cargo clippy --workspace
  --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean.
