### PR TITLE
fix(solver): drop cosmetic value-names from canonical type identity

### DIFF
--- a/crates/tsz-checker/tests/ts2322_mode_routing_matrix.rs
+++ b/crates/tsz-checker/tests/ts2322_mode_routing_matrix.rs
@@ -93,8 +93,8 @@ fn test_target_sensitive_check_js_strictness_stability() {
     );
 
     assert!(count_code(&strict, diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE) >= 1);
-    assert!(count_code(&strict, 2345) == 0);
-    assert!(count_code(&loose, 2345) == 0);
+    assert_eq!(count_code(&strict, 2345), 0);
+    assert_eq!(count_code(&loose, 2345), 0);
 }
 
 #[test]

--- a/crates/tsz-solver/src/canonicalize/mod.rs
+++ b/crates/tsz-solver/src/canonicalize/mod.rs
@@ -39,7 +39,8 @@ use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::recursion::{RecursionGuard, RecursionProfile, RecursionResult};
 use crate::relations::subtype::TypeResolver;
 use crate::types::{
-    ConditionalType, IndexSignature, ObjectShapeId, TemplateSpan, TupleElement, TypeData, TypeId,
+    ConditionalType, IndexSignature, ObjectShapeId, ParamInfo, TemplateSpan, TupleElement,
+    TypeData, TypeId, TypePredicate, TypePredicateTarget,
 };
 use rustc_hash::FxHashMap;
 use std::mem::size_of;
@@ -215,7 +216,14 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
                         .iter()
                         .map(|e| TupleElement {
                             type_id: self.canonicalize(e.type_id),
-                            name: e.name,
+                            // Identity-exempt: a tuple element's label is cosmetic.
+                            // `[a: number]`, `[b: number]` and `[number]` are the
+                            // same type — `tsc` never compares labels for tuple
+                            // identity/assignability. `TupleElement` derives
+                            // `Eq`/`Hash` over `name`, so keeping it here fragments
+                            // alpha-equivalent tuples and misses the relation's
+                            // reflexive fast path (#13609, value-name axis).
+                            name: None,
                             optional: e.optional,
                             rest: e.rest,
                         })
@@ -296,17 +304,9 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
                     let c_this_type = shape.this_type.map(|t| self.canonicalize(t));
                     // Canonicalize return type
                     let c_return_type = self.canonicalize(shape.return_type);
-                    // Canonicalize parameter types
-                    let c_params: Vec<crate::types::ParamInfo> = shape
-                        .params
-                        .iter()
-                        .map(|p| crate::types::ParamInfo {
-                            name: p.name,
-                            type_id: self.canonicalize(p.type_id),
-                            optional: p.optional,
-                            rest: p.rest,
-                        })
-                        .collect();
+                    // Canonicalize parameter types (names dropped — see
+                    // `canonical_params`).
+                    let c_params = self.canonical_params(&shape.params);
 
                     // Canonicalize type parameter constraints. Names and the
                     // identity-irrelevant modifiers are dropped for
@@ -318,17 +318,12 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
                         .map(|&tp| self.canonical_bound_type_param(tp))
                         .collect();
 
-                    // Canonicalize type predicate (if it has a type_id)
-                    let c_type_predicate =
-                        shape
-                            .type_predicate
-                            .as_ref()
-                            .map(|pred| crate::types::TypePredicate {
-                                asserts: pred.asserts,
-                                target: pred.target,
-                                type_id: pred.type_id.map(|t| self.canonicalize(t)),
-                                parameter_index: pred.parameter_index,
-                            });
+                    // Canonicalize type predicate (identifier target normalized —
+                    // see `canonical_type_predicate`).
+                    let c_type_predicate = shape
+                        .type_predicate
+                        .as_ref()
+                        .map(|pred| self.canonical_type_predicate(pred));
 
                     // Pop scope
                     if pushed_scope {
@@ -619,7 +614,13 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
             key_type: self.canonicalize(idx.key_type),
             value_type: self.canonicalize(idx.value_type),
             readonly: idx.readonly,
-            param_name: idx.param_name,
+            // Identity-exempt: the source key name (`[k: string]` vs
+            // `[key: string]`) is cosmetic. `IndexSignature` itself excludes it
+            // from `Eq`/`Hash`, but `ObjectShape`/`CallableShape` re-add it to
+            // interned identity for display, so two structurally-identical
+            // index signatures fragment on it. The comparison-only canonical
+            // form drops it so they reduce identically (#13609, value-name axis).
+            param_name: None,
         })
     }
 
@@ -724,8 +725,60 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
         tp: crate::types::TypeParamInfo,
     ) -> crate::types::TypeParamInfo {
         crate::types::TypeParamInfo {
-            name: self.interner.intern_string(""),
+            name: Atom::NONE,
             ..self.canonical_type_param(tp)
+        }
+    }
+
+    /// Canonical (identity) forms of a parameter list, with the cosmetic
+    /// parameter `name` dropped.
+    ///
+    /// A function/method parameter's name is **not** part of TypeScript
+    /// structural identity: `(a: string) => void` and `(b: string) => void` are
+    /// the same type, and `compareSignaturesIdentical` matches parameters
+    /// positionally and compares their types only — never their names. But
+    /// [`ParamInfo`] derives `Eq`/`Hash` over `name`, so keeping it would let two
+    /// alpha-equivalent signatures intern to distinct canonical `TypeId`s and
+    /// miss the relation's reflexive/identity fast path (#13609, the value-name
+    /// analogue of the type-parameter name fix #14096). The optional/rest flags
+    /// and the parameter *type* are identity-bearing and preserved; only the
+    /// comparison/hashing-only canonical form drops the name — the *interned*
+    /// signature keeps it where it is rendered.
+    fn canonical_params(&mut self, params: &[ParamInfo]) -> Vec<ParamInfo> {
+        params
+            .iter()
+            .map(|p| ParamInfo {
+                name: None,
+                type_id: self.canonicalize(p.type_id),
+                optional: p.optional,
+                rest: p.rest,
+            })
+            .collect()
+    }
+
+    /// Canonical (identity) form of a type predicate.
+    ///
+    /// The asserted `type_id` is canonicalized recursively. An `Identifier`
+    /// target's atom is dropped (normalized to the empty atom) on the same
+    /// rationale as [`Self::canonical_params`]: the predicate names a parameter
+    /// that `parameter_index` already anchors positionally, so the identifier
+    /// text is cosmetic and `(x: unknown): x is string` and
+    /// `(y: unknown): y is string` are the same type. The `This`/`Identifier`
+    /// discriminant, `asserts`, and `parameter_index` are identity-bearing and
+    /// preserved.
+    fn canonical_type_predicate(&mut self, pred: &TypePredicate) -> TypePredicate {
+        let target = match pred.target {
+            // `parameter_index` already anchors the referenced parameter; the
+            // identifier atom is cosmetic, so erase it to the empty sentinel.
+            // `This` is identity-bearing and passes through unchanged.
+            TypePredicateTarget::Identifier(_) => TypePredicateTarget::Identifier(Atom::NONE),
+            other => other,
+        };
+        TypePredicate {
+            asserts: pred.asserts,
+            target,
+            type_id: pred.type_id.map(|t| self.canonicalize(t)),
+            parameter_index: pred.parameter_index,
         }
     }
 
@@ -749,17 +802,8 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
         // Canonicalize return type
         let c_return_type = self.canonicalize(sig.return_type);
 
-        // Canonicalize parameter types
-        let c_params: Vec<crate::types::ParamInfo> = sig
-            .params
-            .iter()
-            .map(|p| crate::types::ParamInfo {
-                name: p.name,
-                type_id: self.canonicalize(p.type_id),
-                optional: p.optional,
-                rest: p.rest,
-            })
-            .collect();
+        // Canonicalize parameter types (names dropped — see `canonical_params`).
+        let c_params = self.canonical_params(&sig.params);
 
         // Canonicalize type parameter constraints. Names and the
         // identity-irrelevant modifiers are dropped for alpha-equivalence —
@@ -770,16 +814,12 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
             .map(|&tp| self.canonical_bound_type_param(tp))
             .collect();
 
-        // Canonicalize type predicate (if it has a type_id)
-        let c_type_predicate =
-            sig.type_predicate
-                .as_ref()
-                .map(|pred| crate::types::TypePredicate {
-                    asserts: pred.asserts,
-                    target: pred.target,
-                    type_id: pred.type_id.map(|t| self.canonicalize(t)),
-                    parameter_index: pred.parameter_index,
-                });
+        // Canonicalize type predicate (identifier target normalized — see
+        // `canonical_type_predicate`).
+        let c_type_predicate = sig
+            .type_predicate
+            .as_ref()
+            .map(|pred| self.canonical_type_predicate(pred));
 
         // Pop scope
         if pushed_scope {

--- a/crates/tsz-solver/src/canonicalize/mod.rs
+++ b/crates/tsz-solver/src/canonicalize/mod.rs
@@ -772,7 +772,7 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
             // identifier atom is cosmetic, so erase it to the empty sentinel.
             // `This` is identity-bearing and passes through unchanged.
             TypePredicateTarget::Identifier(_) => TypePredicateTarget::Identifier(Atom::NONE),
-            other => other,
+            TypePredicateTarget::This => TypePredicateTarget::This,
         };
         TypePredicate {
             asserts: pred.asserts,

--- a/crates/tsz-solver/tests/canonicalize_tests.rs
+++ b/crates/tsz-solver/tests/canonicalize_tests.rs
@@ -1839,3 +1839,310 @@ fn canonicalize_infer_param_ignores_const_modifier() {
         "a genuinely different constraint stays distinct after dropping `const`"
     );
 }
+
+// ===================================================================
+// Value-name axis: parameter names / tuple labels / index-key names /
+// predicate target identifiers are cosmetic and must not fragment
+// canonical structural identity (#13609, value-name analogue of #14096).
+// ===================================================================
+
+#[test]
+fn canonicalize_function_value_param_names_alpha_equivalent() {
+    use crate::types::{FunctionShape, ParamInfo};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    // `(<name>: string) => number` — only the value-parameter name varies.
+    let make = |name: &str| {
+        interner.function(FunctionShape {
+            type_params: vec![],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string(name)),
+                type_id: TypeId::STRING,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: TypeId::NUMBER,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(make("a")),
+        c2.canonicalize(make("verbose_name")),
+        "functions differing only in a value-parameter name are the same type \
+         and must share one canonical form"
+    );
+}
+
+#[test]
+fn canonicalize_function_param_type_and_arity_stay_distinct() {
+    // Negative control: dropping the name must not merge functions whose
+    // parameter *types*, arity, or optional/rest flags differ.
+    use crate::types::{FunctionShape, ParamInfo};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let one = |ty: TypeId, optional: bool, rest: bool| {
+        interner.function(FunctionShape {
+            type_params: vec![],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("p")),
+                type_id: ty,
+                optional,
+                rest,
+            }],
+            this_type: None,
+            return_type: TypeId::NUMBER,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+
+    let string_param = one(TypeId::STRING, false, false);
+    let number_param = one(TypeId::NUMBER, false, false);
+    let optional_param = one(TypeId::STRING, true, false);
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    let mut c3 = Canonicalizer::new(&interner, &env);
+    let cs = c1.canonicalize(string_param);
+    let cn = c2.canonicalize(number_param);
+    let co = c3.canonicalize(optional_param);
+    assert_ne!(cs, cn, "different parameter types must stay distinct");
+    assert_ne!(cs, co, "optional vs required must stay distinct");
+}
+
+#[test]
+fn canonicalize_tuple_labels_alpha_equivalent() {
+    use crate::types::TupleElement;
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    // `[<label>: number, number]` vs an unlabeled `[number, number]`.
+    let labeled = interner.tuple(vec![
+        TupleElement {
+            type_id: TypeId::NUMBER,
+            name: Some(interner.intern_string("first")),
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: TypeId::NUMBER,
+            name: Some(interner.intern_string("second")),
+            optional: false,
+            rest: false,
+        },
+    ]);
+    let unlabeled = interner.tuple(vec![
+        TupleElement {
+            type_id: TypeId::NUMBER,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: TypeId::NUMBER,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(labeled),
+        c2.canonicalize(unlabeled),
+        "tuple labels are cosmetic and must not fragment canonical identity"
+    );
+}
+
+#[test]
+fn canonicalize_tuple_optional_and_element_type_stay_distinct() {
+    // Negative control: labels drop, but optionality and element type are
+    // identity-bearing.
+    use crate::types::TupleElement;
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let elem = |ty: TypeId, optional: bool| {
+        interner.tuple(vec![TupleElement {
+            type_id: ty,
+            name: Some(interner.intern_string("x")),
+            optional,
+            rest: false,
+        }])
+    };
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    let mut c3 = Canonicalizer::new(&interner, &env);
+    let req_num = c1.canonicalize(elem(TypeId::NUMBER, false));
+    let opt_num = c2.canonicalize(elem(TypeId::NUMBER, true));
+    let req_str = c3.canonicalize(elem(TypeId::STRING, false));
+    assert_ne!(req_num, opt_num, "optional element must stay distinct");
+    assert_ne!(
+        req_num, req_str,
+        "different element type must stay distinct"
+    );
+}
+
+#[test]
+fn canonicalize_index_signature_key_name_alpha_equivalent() {
+    use crate::types::{IndexSignature, ObjectShape};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    // `{ [<key>: string]: number }` — only the cosmetic key name varies.
+    let make = |key_name: &str| {
+        interner.object_with_index(ObjectShape {
+            properties: vec![],
+            string_index: Some(IndexSignature {
+                key_type: TypeId::STRING,
+                value_type: TypeId::NUMBER,
+                readonly: false,
+                param_name: Some(interner.intern_string(key_name)),
+            }),
+            number_index: None,
+            symbol: None,
+            flags: Default::default(),
+        })
+    };
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(make("k")),
+        c2.canonicalize(make("key")),
+        "index-signature key names are cosmetic and must not fragment identity"
+    );
+}
+
+#[test]
+fn canonicalize_index_signature_readonly_and_value_stay_distinct() {
+    // Negative control: key name drops, but readonly and value type are
+    // identity-bearing.
+    use crate::types::{IndexSignature, ObjectShape};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let make = |value: TypeId, readonly: bool| {
+        interner.object_with_index(ObjectShape {
+            properties: vec![],
+            string_index: Some(IndexSignature {
+                key_type: TypeId::STRING,
+                value_type: value,
+                readonly,
+                param_name: Some(interner.intern_string("k")),
+            }),
+            number_index: None,
+            symbol: None,
+            flags: Default::default(),
+        })
+    };
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    let mut c3 = Canonicalizer::new(&interner, &env);
+    let mutable_num = c1.canonicalize(make(TypeId::NUMBER, false));
+    let readonly_num = c2.canonicalize(make(TypeId::NUMBER, true));
+    let mutable_str = c3.canonicalize(make(TypeId::STRING, false));
+    assert_ne!(mutable_num, readonly_num, "readonly must stay distinct");
+    assert_ne!(mutable_num, mutable_str, "value type must stay distinct");
+}
+
+#[test]
+fn canonicalize_predicate_identifier_target_alpha_equivalent() {
+    use crate::types::{FunctionShape, ParamInfo, TypePredicate, TypePredicateTarget};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    // `(<name>: unknown): <name> is string` — both the value-parameter name and
+    // the predicate target identifier vary, but `parameter_index` is the same.
+    let make = |name: &str| {
+        interner.function(FunctionShape {
+            type_params: vec![],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string(name)),
+                type_id: TypeId::UNKNOWN,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: TypeId::BOOLEAN,
+            type_predicate: Some(TypePredicate {
+                asserts: false,
+                target: TypePredicateTarget::Identifier(interner.intern_string(name)),
+                type_id: Some(TypeId::STRING),
+                parameter_index: Some(0),
+            }),
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(make("x")),
+        c2.canonicalize(make("value")),
+        "predicate functions differing only in the referenced parameter name \
+         are the same type and must share one canonical form"
+    );
+}
+
+#[test]
+fn canonicalize_predicate_asserts_and_narrowed_type_stay_distinct() {
+    // Negative control: the identifier name drops, but `asserts`, the narrowed
+    // type, and the `This`/`Identifier` discriminant are identity-bearing.
+    use crate::types::{FunctionShape, ParamInfo, TypePredicate, TypePredicateTarget};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let make = |asserts: bool, narrowed: TypeId, target: TypePredicateTarget| {
+        interner.function(FunctionShape {
+            type_params: vec![],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("x")),
+                type_id: TypeId::UNKNOWN,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: TypeId::BOOLEAN,
+            type_predicate: Some(TypePredicate {
+                asserts,
+                target,
+                type_id: Some(narrowed),
+                parameter_index: Some(0),
+            }),
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+
+    let ident = || TypePredicateTarget::Identifier(interner.intern_string("x"));
+    let base = make(false, TypeId::STRING, ident());
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    let mut c3 = Canonicalizer::new(&interner, &env);
+    let mut c4 = Canonicalizer::new(&interner, &env);
+    let cbase = c1.canonicalize(base);
+    let casserts = c2.canonicalize(make(true, TypeId::STRING, ident()));
+    let cnarrow = c3.canonicalize(make(false, TypeId::NUMBER, ident()));
+    let cthis = c4.canonicalize(make(false, TypeId::STRING, TypePredicateTarget::This));
+    assert_ne!(cbase, casserts, "`asserts` must stay distinct");
+    assert_ne!(cbase, cnarrow, "narrowed type must stay distinct");
+    assert_ne!(
+        cbase, cthis,
+        "`this` vs identifier target must stay distinct"
+    );
+}

--- a/crates/tsz-solver/tests/evaluate_tests_parts/literal_satisfies_intrinsics.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/literal_satisfies_intrinsics.rs
@@ -1052,7 +1052,7 @@ fn test_boolean_literal_union() {
     match interner.lookup(union) {
         Some(TypeData::Union(list_id)) => {
             let members = interner.type_list(list_id);
-            assert!(members.len() == 2);
+            assert_eq!(members.len(), 2);
         }
         Some(TypeData::Intrinsic(IntrinsicKind::Boolean)) => {
             // Simplified to boolean

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_13.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_13.rs
@@ -692,7 +692,7 @@ fn test_overload_subtype_signature_order_matters() {
     });
 
     // These should be different types due to signature order
-    assert!(specific_first != general_first);
+    assert_ne!(specific_first, general_first);
 }
 
 #[test]
@@ -1804,4 +1804,3 @@ fn test_explain_failure_intrinsic_mismatch() {
         other => panic!("Expected IntrinsicTypeMismatch, got {other:?}"),
     }
 }
-


### PR DESCRIPTION
Goal: hold

Advances #13609 (canonical-identity fragmentation family). Closes the **value-name** axis — the analogue of the landed type-*parameter* slices (#13888 `default`, #14090 `const`, #14074 the `Infer` arm, #14096 the type-param name), here on parameter/label/key/predicate names. Behavior is unchanged on `main` except that strictly more alpha-equivalent types now hit the relation's reflexive fast path (zero conformance regressions); the residual degraded-`R` resolver-availability work (#13232) stays out of scope.

## Structural rule

> Value-parameter names, tuple-element labels, index-signature key names, and a type-predicate's `Identifier` target are **not** part of TypeScript structural identity. `tsc`'s `isTypeIdenticalTo` / `compareSignaturesIdentical` match parameters **positionally** and compare their *types* only — never these names; tuple labels and index-key names are documentation-only. So `(a: string) => void` ≡ `(b: string) => void`, `[a: number]` ≡ `[number]`, `{ [k: string]: T }` ≡ `{ [key: string]: T }`, and `(x): x is string` ≡ `(y): y is string`.

## Root cause / owner layer

Solver canonicalizer (`crates/tsz-solver/src/canonicalize/mod.rs`), consumed by the reflexive identity fast path `are_types_structurally_identical` (`relations/subtype/core.rs`), which reduces identity to canonical `TypeId` equality.

`ParamInfo` and `TupleElement` derive `Eq`/`Hash` over their cosmetic `name`; `IndexSignature` excludes `param_name` from its own identity but `ObjectShape`/`CallableShape` deliberately **re-add** it for display; and the predicate `target` kept its `Identifier(atom)` even though `parameter_index` already anchors the referenced parameter positionally. The canonicalizer copied all of them straight through, so two structurally-identical function/tuple/object types canonicalized to **distinct** `TypeId`s and the relation's reflexive/identity short-circuit fragmented — the same defect #14096 just fixed on the type-parameter name axis, here on the value-name axis.

Fix — drop the cosmetic names in the **comparison/hashing-only** canonical form (the *interned* shapes keep their names where they are rendered):
- a shared `canonical_params` helper (used by the `Function` arm and `canonicalize_signature`) sets `ParamInfo.name = None` — also removing the prior inline duplication between the two sites;
- the `Tuple` arm sets `TupleElement.name = None`;
- `canonicalize_index_signature` sets `IndexSignature.param_name = None`;
- a shared `canonical_type_predicate` helper normalizes an `Identifier` target to the empty atom (positional `parameter_index`, `asserts`, and the `This`/`Identifier` discriminant preserved).

`Atom::NONE` replaces re-interning `""` here and in the adjacent `canonical_bound_type_param` (one less interner lookup per bound parameter / predicate on this hot path). Name-agnostic; structural-only — no identifier/alias/file-name/printer-string predicate.

## Adjacent-case matrix (name-agnostic; binders/labels varied)

| case | result |
|---|---|
| functions differ only in value-parameter name | one canonical form |
| labeled tuple vs unlabeled, same element types | one canonical form |
| index signatures differ only in key name | one canonical form |
| predicates differ only in referenced parameter name (same `parameter_index`) | one canonical form |
| **different parameter type / arity / optional / rest** | **distinct** |
| **different tuple element type / optionality** | **distinct** |
| **different index value type / readonly** | **distinct** |
| **different `asserts` / narrowed type / `This` vs `Identifier`** | **distinct** |

## Verification

- New name-agnostic tests in `crates/tsz-solver/tests/canonicalize_tests.rs` (6 added: function/tuple/index-sig/predicate alpha-equivalence + the negative controls above) — **pass**; full `canonicalize` suite **67 passed**.
- Full `cargo test -p tsz-solver --lib`: **6838 passed**; failing set is **byte-identical** to baseline `main` (the same 4 pre-existing reds — `test_conditional_infer_optional_property_present_distributive`, `literal_mask_preserves_object_vs_literal_reduction`, `array_isarray_keeps_mutable_and_readonly_array_members`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`), verified by stash-diff — **0 regressions**.
- Full `cargo test -p tsz-checker --lib`: deterministic failing set **byte-identical** before/after (stash-diff); the only delta is an order-dependent swap **within** the documented schedule-sensitive `source_option_bag_tests::delegate_cross_arena_*` family (#13255/#13368), which passes in isolation — **0 real regressions**.
- `cargo fmt -p tsz-solver --check`, `cargo clippy -p tsz-solver --lib --tests`, `python3 scripts/arch/arch_guard.py` — clean. Rebased on `main` HEAD (no conflicts).
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01YboJUMsvBMSdkcM8qr3Q6L

---
_Generated by [Claude Code](https://claude.ai/code/session_01YboJUMsvBMSdkcM8qr3Q6L)_