### PR TITLE
fix(bench): time clean canary projects for charts

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1120,11 +1120,12 @@ jobs:
           # Passing-canary perf rows. Isolated from the required `projects` shard
           # so timing the opt-in canary corpus (PERF_TIMED_CANARY_PROJECT_ROWS in
           # scripts/bench/project-rows.mjs) never spends the required shard's
-          # budget or stalls the publish gate. Bounded to lighter external
-          # libraries; the website only charts the ones that check green.
+          # budget or stalls the publish gate. These are external-library rows
+          # with bench-vs-tsgo runners; the website only charts the ones that
+          # check green.
           - label: bench-canaries
             timeout: 135
-            filter: 'ofetch-project|ts-pattern-project|zustand-project|jotai-project|fp-ts-project|io-ts-project|immer-project|remeda-project|arktype-project|superstruct-project|runtypes-project|hotscript-project|typebox-project|neverthrow-project'
+            filter: 'valibot-project|msw-project|effect-project|drizzle-orm-project|ts-rest-project|ofetch-project|ts-pattern-project|trpc-project|tanstack-query-project|tanstack-router-project|zustand-project|jotai-project|fp-ts-project|io-ts-project|immer-project|remeda-project|ts-morph-project|arktype-project|superstruct-project|runtypes-project|hotscript-project|typebox-project|class-transformer-project|type-graphql-project|neverthrow-project|xstate-project|mobx-project'
           - label: large-ts-repo
             timeout: 135
             filter: '^large-ts-repo$'

--- a/crates/tsz-website/scripts/benchmark-data-smoke.mjs
+++ b/crates/tsz-website/scripts/benchmark-data-smoke.mjs
@@ -452,7 +452,7 @@ try {
   assert.equal(valibotPage.category, "Projects: external libraries");
   assert.equal(valibotPage.kind, "project");
   assert.equal(valibotPage.source_files.length, 0);
-  assert.match(valibotPage.detail_focus, /Full project type-check throughput/i);
+  assert.match(valibotPage.detail_focus, /schema-validation library/i);
 
   const charts = getBenchmarkCharts();
   assert.match(charts, /External libraries/);

--- a/crates/tsz-website/src/_data/benchmark_mean_chart.js
+++ b/crates/tsz-website/src/_data/benchmark_mean_chart.js
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { selectLatestBenchmarkArtifact } from "../../../../scripts/bench/benchmark-artifact-selection.mjs";
-import { REQUIRED_PROJECT_ROWS } from "../../../../scripts/bench/project-rows.mjs";
+import {
+  PERF_TIMED_CANARY_PROJECT_ROWS,
+  REQUIRED_PROJECT_ROWS,
+} from "../../../../scripts/bench/project-rows.mjs";
 import { fmt } from "./loc.js";
 
 const ROOT = path.resolve(import.meta.dirname, "..", "..", "..", "..");
@@ -24,7 +27,10 @@ function hasSuccessfulTiming(row) {
   );
 }
 
-const PROJECT_BENCHMARK_NAMES = new Set(REQUIRED_PROJECT_ROWS);
+const PROJECT_BENCHMARK_NAMES = new Set([
+  ...REQUIRED_PROJECT_ROWS,
+  ...PERF_TIMED_CANARY_PROJECT_ROWS,
+]);
 
 function isProjectBenchmark(row) {
   return PROJECT_BENCHMARK_NAMES.has(String(row?.name || ""));

--- a/scripts/bench/project-rows.mjs
+++ b/scripts/bench/project-rows.mjs
@@ -201,6 +201,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "e7bcacb107b1c5a74dfd564babd2c8697037ee06",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -217,6 +218,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "8a19d5485adad2b8a816e04a937f4c76169cd5b9",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -249,6 +251,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "626c61b3ef0dce59ffb038590bc834d36afc5d1d",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -265,6 +268,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "48e5406027103a9fca6eb66417187c4a8b5c6aa3",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -281,6 +285,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "dd7239bc950d1e254d9c9cd6df7dbccc529c33cb",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -331,6 +336,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "f8f0c0e3979ecb980d38e9369fa8c98df95d212b",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -347,6 +353,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "feb1efd804c1262106f72c8adc1d82a8ce9cfbb0",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -363,6 +370,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "36ed57409a98878e5c1a7aabf50d3aa65ebde1e0",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -481,6 +489,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "699815f54ae9b5c2a93f016ba1a9df1e8ac1c014",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -582,6 +591,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "a2734a5d154c9b0beb9a10555a04416bc371de06",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -598,6 +608,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "4535c3192fd321be6bade6192f0cf8d264de9baf",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -631,6 +642,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "afa374afd52dc4f05baad1ead66c977a46aa5b47",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   {
@@ -647,6 +659,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "2a069e41024433da401f3e8b3470adf194924911",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "external",
   },
   // --- application/dashboard canary rows (category:"application") ---
@@ -1049,13 +1062,13 @@ export const COMPILE_CANARY_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS
 export const COMPILE_GUARD_CANARY_PROJECT_ROWS = COMPILE_CANARY_PROJECT_ROWS;
 
 // Canary rows opted into the vs-tsgo timing chart via `perf_timed: true`. These
-// are bounded, lighter external libraries: they get real tsz_ms/tsgo_ms timings
-// from the dedicated `bench-canaries` shard so the performance comparison page
-// can show passing canaries next to the required rows. They stay
-// benchmark_set:"canary", so they are NOT part of REQUIRED_PROJECT_ROWS and
-// never affect the artifact-readiness/publish gate; the website only promotes a
-// perf-timed canary onto the chart once it actually checks green (see the
-// green-compat filter in crates/tsz-website/src/_data/benchmark_data.js).
+// external-library rows already have bench-vs-tsgo runners, so the dedicated
+// `bench-canaries` shard can produce real tsz_ms/tsgo_ms timings for any row
+// that compiles cleanly. They stay benchmark_set:"canary", so they are NOT part
+// of REQUIRED_PROJECT_ROWS and never affect the artifact-readiness/publish gate;
+// the website only promotes a perf-timed canary onto the chart once it actually
+// checks green (see the green-compat filter in
+// crates/tsz-website/src/_data/benchmark_data.js).
 export const PERF_TIMED_CANARY_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS
   .filter((row) => row.perf_timed === true)
   .map((row) => row.name);


### PR DESCRIPTION
Goal: green

## Summary
- opt runner-supported external canary projects into perf timing so clean rows can receive vs-tsgo chart data
- add an optional bench-applications shard for npm/pnpm application rows, so clean application projects can publish real tsz_ms/tsgo_ms chart data without blocking required benchmark publishing
- classify all perf-timed project rows in the website mean chart and keep chart promotion gated on green project compatibility

## Notes
Application rows still use the triggering CI compatibility artifact for green/yellow/red state. The new timing shard is optional: if an application install/timing shard flakes or times out, required benchmark publish remains unblocked; when it succeeds, clean application rows get chart bars instead of remaining compile-only.

Yarn/Bun application rows are intentionally not timed in this PR because the Cloud Build timing image currently bootstraps npm/pnpm only.

## Verification
- bash -n scripts/bench/bench-vs-tsgo.sh scripts/bench/lib/application-benchmarks.sh
- node scripts/bench/test-project-rows.mjs
- node scripts/bench/test-bench-workflow-micro-coverage.mjs
- node scripts/bench/validate-project-metadata.mjs
- node scripts/bench/test-project-row-summary.mjs
- node scripts/bench/test-merge-results.mjs
- node scripts/bench/test-check-artifact-readiness.mjs
- npm --prefix crates/tsz-website install --no-package-lock
- npm --prefix crates/tsz-website run test:benchmarks
- node -e 'import("./crates/tsz-website/src/_data/benchmark_mean_chart.js").then(() => console.log("benchmark_mean_chart import ok"))'\n- git diff --check\n\n## Provenance\nMachine: MacBookPro.fritz.box\nAssistant: codex\nModel: gpt-5\nEffort: high