### PR TITLE
fix(solver): accept apparent-type constructors as instanceof RHS (TS2359)

### DIFF
--- a/crates/tsz-solver/src/operations/binary_ops.rs
+++ b/crates/tsz-solver/src/operations/binary_ops.rs
@@ -562,28 +562,21 @@ impl<'a> BinaryOpEvaluator<'a> {
             return any_valid;
         }
 
-        // tsc: typeHasCallOrConstructSignatures — types with call/construct
-        // signatures are valid instanceof RHS even if not assignable to Function.
-        if self.type_has_call_or_construct_signatures(type_id) {
+        // tsc: `typeHasCallOrConstructSignatures(getApparentType(rightType))`.
+        // Any type whose *apparent* type carries a call or construct signature is a
+        // valid instanceof RHS even if it is not structurally assignable to the
+        // `Function` interface. The shared query resolves type parameters to their
+        // constraint and unwraps generic class constructor values, matching tsc —
+        // rather than depending on the (fragile, project-sensitive) structural
+        // relation below.
+        if crate::type_queries::apparent_type_has_call_or_construct_signatures(
+            self.interner,
+            type_id,
+        ) {
             return true;
         }
 
         assignable_check(type_id, func_ty)
-    }
-
-    /// Check if a type has call or construct signatures.
-    fn type_has_call_or_construct_signatures(&self, type_id: TypeId) -> bool {
-        if type_id.is_intrinsic() {
-            return false;
-        }
-        match self.interner.lookup(type_id) {
-            Some(crate::TypeData::Callable(shape_id)) => {
-                let shape = self.interner.callable_shape(shape_id);
-                !shape.call_signatures.is_empty() || !shape.construct_signatures.is_empty()
-            }
-            Some(crate::TypeData::Function(_)) => true,
-            _ => false,
-        }
     }
 
     /// Check if a type is valid for arithmetic operations (number, bigint, enum, or any).

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -7,7 +7,7 @@ use super::accessors::get_object_shape;
 use super::content_predicates::{
     contains_infer_types_db, contains_type_parameters_db, get_intersection_members,
 };
-use crate::construction::TypeDatabase;
+use crate::construction::{QueryDatabase, TypeDatabase};
 use crate::evaluation::evaluate::TypeEvaluator;
 use crate::evaluation::evaluate_rules::infer_pattern::InferPatternVisited;
 use crate::relations::subtype::SubtypeChecker;
@@ -483,6 +483,80 @@ pub fn get_construct_signatures(
         }
     }
     None
+}
+
+/// Returns `true` when the *apparent* type of `type_id` carries a call or
+/// construct signature.
+///
+/// Mirrors tsc's `typeHasCallOrConstructSignatures(getApparentType(type))`:
+/// - the apparent type of a type parameter is the apparent type of its base
+///   constraint;
+/// - `readonly` wrappers are transparent;
+/// - an intersection qualifies when *any* member does;
+/// - a union qualifies only when *every* member does (an empty union never
+///   qualifies);
+/// - deferred forms (`Lazy`, `typeof` queries, generic class constructors, and
+///   anything that only exposes its constructor/call shape after evaluation)
+///   are resolved on demand, guarded against cycles.
+///
+/// This is the structural predicate behind `instanceof` right-operand
+/// eligibility (TS2359): it is intentionally broader than a bare
+/// `Callable`/`Function` shape check so a constructor-constrained type
+/// parameter or a generic class value is recognised as a constructor without
+/// depending on structural assignability to the global `Function` interface.
+pub fn apparent_type_has_call_or_construct_signatures(
+    db: &dyn QueryDatabase,
+    type_id: TypeId,
+) -> bool {
+    let mut visited = FxHashSet::default();
+    apparent_type_has_signatures_rec(db, type_id, &mut visited)
+}
+
+fn apparent_type_has_signatures_rec(
+    db: &dyn QueryDatabase,
+    type_id: TypeId,
+    visited: &mut FxHashSet<TypeId>,
+) -> bool {
+    if type_id.is_intrinsic() || !visited.insert(type_id) {
+        return false;
+    }
+    match db.lookup(type_id) {
+        Some(TypeData::Callable(shape_id)) => {
+            let shape = db.callable_shape(shape_id);
+            !shape.call_signatures.is_empty() || !shape.construct_signatures.is_empty()
+        }
+        Some(TypeData::Function(_)) => true,
+        Some(TypeData::ReadonlyType(inner)) => apparent_type_has_signatures_rec(db, inner, visited),
+        Some(TypeData::Intersection(list_id)) => db
+            .type_list(list_id)
+            .iter()
+            .any(|&m| apparent_type_has_signatures_rec(db, m, visited)),
+        Some(TypeData::Union(list_id)) => {
+            let members = db.type_list(list_id);
+            !members.is_empty()
+                && members
+                    .iter()
+                    .all(|&m| apparent_type_has_signatures_rec(db, m, visited))
+        }
+        Some(TypeData::TypeParameter(info)) | Some(TypeData::Infer(info)) => info
+            .constraint
+            .is_some_and(|c| apparent_type_has_signatures_rec(db, c, visited)),
+        Some(TypeData::Lazy(def_id)) => {
+            db.resolve_lazy(def_id, db.as_type_database())
+                .is_some_and(|resolved| {
+                    resolved != type_id && apparent_type_has_signatures_rec(db, resolved, visited)
+                })
+        }
+        // `typeof Class` (TypeQuery), generic class constructors (Application),
+        // and other deferred forms only expose their constructor/call shape
+        // after (resolver-backed) evaluation. Resolve once; the visited guard
+        // prevents cycles.
+        Some(_) => {
+            let evaluated = db.evaluate_type(type_id);
+            evaluated != type_id && apparent_type_has_signatures_rec(db, evaluated, visited)
+        }
+        None => false,
+    }
 }
 
 /// Get the union of all construct signature return types from a callable shape.

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -538,7 +538,7 @@ fn apparent_type_has_signatures_rec(
                     .iter()
                     .all(|&m| apparent_type_has_signatures_rec(db, m, visited))
         }
-        Some(TypeData::TypeParameter(info)) | Some(TypeData::Infer(info)) => info
+        Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => info
             .constraint
             .is_some_and(|c| apparent_type_has_signatures_rec(db, c, visited)),
         Some(TypeData::Lazy(def_id)) => {

--- a/crates/tsz-solver/tests/binary_ops_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/binary_ops_comprehensive_tests.rs
@@ -1670,3 +1670,144 @@ fn test_string_constrained_type_param_or_empty_object_not_assignable_to_object()
          but got {result_id:?} which appears to be assignable."
     );
 }
+
+// =============================================================================
+// instanceof RHS eligibility (TS2359)
+//
+// tsc accepts an `instanceof` RHS whose *apparent* type carries a call or
+// construct signature — including a type parameter constrained to a constructor
+// and a generic class constructor value — without requiring structural
+// assignability to the global `Function` interface. These tests drive the
+// eligibility predicate with an `assignable_check` stub that always reports
+// `false`, proving the apparent-type path is authoritative and does not lean on
+// the (project-sensitive) Function relation.
+// =============================================================================
+
+/// A constructor type: `new (...args: any[]) => any`, with no call signatures.
+fn make_constructor_callable(interner: &TypeInterner) -> TypeId {
+    let mut shape = CallableShape::default();
+    shape
+        .construct_signatures
+        .push(CallSignature::new(vec![], TypeId::ANY));
+    interner.callable(shape)
+}
+
+/// A plain function type: `(...args: any[]) => any`, with a call signature only.
+fn make_function_callable(interner: &TypeInterner) -> TypeId {
+    let mut shape = CallableShape::default();
+    shape
+        .call_signatures
+        .push(CallSignature::new(vec![], TypeId::ANY));
+    interner.callable(shape)
+}
+
+fn type_param_constrained_to(interner: &TypeInterner, name: &str, constraint: TypeId) -> TypeId {
+    interner.type_param(TypeParamInfo {
+        name: interner.intern_string(name),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    })
+}
+
+/// `assignable_check` that always denies — isolates the apparent-type path.
+fn never_assignable(_src: TypeId, _tgt: TypeId) -> bool {
+    false
+}
+
+#[test]
+fn instanceof_rhs_accepts_constructor_callable() {
+    let interner = TypeInterner::new();
+    let eval = BinaryOpEvaluator::new(&interner);
+    let ctor = make_constructor_callable(&interner);
+    assert!(
+        eval.is_valid_instanceof_right_operand(ctor, TypeId::FUNCTION, &mut never_assignable),
+        "a construct-signature type is a valid instanceof RHS without Function assignability"
+    );
+}
+
+#[test]
+fn instanceof_rhs_accepts_call_signature_function() {
+    let interner = TypeInterner::new();
+    let eval = BinaryOpEvaluator::new(&interner);
+    let func = make_function_callable(&interner);
+    assert!(
+        eval.is_valid_instanceof_right_operand(func, TypeId::FUNCTION, &mut never_assignable),
+        "a call-signature type is a valid instanceof RHS without Function assignability"
+    );
+}
+
+#[test]
+fn instanceof_rhs_accepts_constructor_constrained_type_param() {
+    let interner = TypeInterner::new();
+    let eval = BinaryOpEvaluator::new(&interner);
+    let ctor = make_constructor_callable(&interner);
+    // `K extends new (...args: any[]) => any`
+    let k = type_param_constrained_to(&interner, "K", ctor);
+    assert!(
+        eval.is_valid_instanceof_right_operand(k, TypeId::FUNCTION, &mut never_assignable),
+        "a constructor-constrained type parameter is a valid instanceof RHS via its constraint"
+    );
+}
+
+#[test]
+fn instanceof_rhs_accepts_constructor_via_intersection_member() {
+    let interner = TypeInterner::new();
+    let eval = BinaryOpEvaluator::new(&interner);
+    let ctor = make_constructor_callable(&interner);
+    let plain = interner.object(vec![]);
+    // `{} & (new (...args: any[]) => any)` — an intersection is eligible when any
+    // member carries a construct signature.
+    let intersection = interner.intersection(vec![plain, ctor]);
+    assert!(
+        eval.is_valid_instanceof_right_operand(
+            intersection,
+            TypeId::FUNCTION,
+            &mut never_assignable
+        ),
+        "an intersection with a constructor member is a valid instanceof RHS"
+    );
+}
+
+#[test]
+fn instanceof_rhs_accepts_type_param_constrained_to_constructor_intersection() {
+    let interner = TypeInterner::new();
+    let eval = BinaryOpEvaluator::new(&interner);
+    let ctor = make_constructor_callable(&interner);
+    let plain = interner.object(vec![]);
+    let intersection = interner.intersection(vec![plain, ctor]);
+    // `K extends {} & (new () => any)` — apparent type resolves through the
+    // constraint, then through the intersection.
+    let k = type_param_constrained_to(&interner, "K", intersection);
+    assert!(
+        eval.is_valid_instanceof_right_operand(k, TypeId::FUNCTION, &mut never_assignable),
+        "a type parameter constrained to a constructor-bearing intersection is valid"
+    );
+}
+
+#[test]
+fn instanceof_rhs_rejects_plain_object_without_signatures() {
+    let interner = TypeInterner::new();
+    let eval = BinaryOpEvaluator::new(&interner);
+    // A plain object literal type with no construct/call signatures is NOT a valid
+    // instanceof RHS; the `[Symbol.hasInstance]` allowance is handled separately in
+    // the checker, so here the predicate must reject it.
+    let plain = interner.object(vec![]);
+    assert!(
+        !eval.is_valid_instanceof_right_operand(plain, TypeId::FUNCTION, &mut never_assignable),
+        "a plain object without signatures must remain an invalid instanceof RHS"
+    );
+}
+
+#[test]
+fn instanceof_rhs_rejects_unconstrained_type_param() {
+    let interner = TypeInterner::new();
+    let eval = BinaryOpEvaluator::new(&interner);
+    // A bare `T` (no constraint) has no apparent construct/call signature.
+    let t = make_unconstrained_type_param(&interner, "T");
+    assert!(
+        !eval.is_valid_instanceof_right_operand(t, TypeId::FUNCTION, &mut never_assignable),
+        "an unconstrained type parameter must remain an invalid instanceof RHS"
+    );
+}


### PR DESCRIPTION
Fixes #14113.

Goal: green

## Structural rule
When the `instanceof` right-hand operand's **apparent** type carries a call or
construct signature — including a type parameter whose constraint is a construct
signature, and the constructor side of a generic class — tsc accepts it and
narrows the LHS (`typeHasCallOrConstructSignatures(getApparentType(rightType))`).
tsz accepts the same RHS through its owner, the solver `BinaryOpEvaluator`
instanceof RHS predicate. That predicate previously matched only a bare
`Callable`/`Function` shape and otherwise fell back to a structural relation
against the global `Function` interface. The relation is project-sensitive: it
succeeds on reduced repros but fails on real corpora (zod `instanceOfType`,
xstate `referenced instanceof StateNode`), producing a false **TS2359** plus a
**TS2358** LHS cascade.

## Fix / owner layer
- **Solver / `type_queries`**: new shared structural query
  `apparent_type_has_call_or_construct_signatures(db, type_id)` in
  `type_queries/data/signatures_and_advanced.rs`. It resolves the apparent type
  before checking for signatures — follows type-parameter constraints, unwraps
  `readonly`, recurses intersections (any member) and unions (all members),
  resolves `Lazy`, and evaluates deferred forms (`typeof`, generic class
  constructors), guarded against cycles with a visited set.
- **Solver / `operations::binary_ops`**: the instanceof RHS check delegates to
  that query instead of a bare shape check, so a constructor-bearing apparent
  type is eligible **without** depending on structural assignability to
  `Function`.

No checker change is needed; the checker already routes RHS eligibility through
the solver predicate and keeps the `[Symbol.hasInstance]` and JS-constructor
paths.

## Adjacent matrix
Covered by new solver unit tests (driven with an always-false `assignable_check`
stub, proving the apparent-type path is authoritative and independent of the
`Function` relation):
- constructor-constrained type parameter (`K extends new (...args: any[]) => any`) — accepted;
- call-signature-only function value — accepted;
- bare construct-signature `Callable` — accepted;
- intersection with a constructor member — accepted;
- type parameter constrained to a constructor-bearing intersection — accepted;
- **fallback / negative**: plain object without signatures — rejected (still TS2359 / `[Symbol.hasInstance]` path);
- **negative**: unconstrained type parameter — rejected.

CLI parity spot-checks (clean, matching tsc) for: generic class value
`v instanceof C`; `typeof Class` constraint/default; abstract-constructor
constraint; interface/object carrying a construct signature; `Function`-typed
variable.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

## Verification
- `cargo test -p tsz-solver --lib binary_ops_comprehensive` — 128 passed (incl. 7 new `instanceof_rhs_*`).
- `cargo test -p tsz-solver --lib instanceof` — 23 passed.
- `cargo test -p tsz-checker --lib instanceof` — no new failures vs. baseline (2 pre-existing `[Symbol.hasInstance]` computed-key failures unchanged, orthogonal mechanism).
- `cargo test -p tsz-solver --lib narrowing` — no new failures vs. baseline.
- `cargo clippy -p tsz-solver` — clean.
- Ready-review CI owns broad conformance/emit/fourslash.

https://claude.ai/code/session_01EZNZ18tbfPyzjR5XraoQJo