### PR TITLE
fix(checker): guard interface heritage-merge recursion with the cross-context stack breaker

### DIFF
--- a/crates/tsz-checker/src/checkers/mod.rs
+++ b/crates/tsz-checker/src/checkers/mod.rs
@@ -76,6 +76,51 @@ pub fn headroom_below(min_bytes: usize) -> bool {
     measured_headroom_below(stacker::remaining_stack(), min_bytes)
 }
 
+/// Remaining-stack headroom below which a guarded entry point trips the breaker
+/// and bails. Sits well above the `stacker::maybe_grow` red zone so the breaker
+/// engages before a fresh segment would be needed for the next deep frame.
+const STACK_BAILOUT_HEADROOM_BYTES: usize = 1024 * 1024;
+/// `stacker::maybe_grow` red-zone: grow the stack once free headroom drops below
+/// this many bytes. Shared by every guarded checker recursion site.
+const STACK_RED_ZONE_BYTES: usize = 256 * 1024;
+/// `stacker::maybe_grow` new-segment size for guarded checker recursion sites.
+const STACK_GROW_BYTES: usize = 2 * 1024 * 1024;
+
+/// Run `body` under the shared checker stack-overflow breaker.
+///
+/// This is the single owner of the probe → trip → grow sequence that guards
+/// every deep, *cross-context* recursive checker entry point (expression
+/// dispatch, interface heritage merging, …). The thread-local breaker is the
+/// only stack-safety mechanism that survives the fresh / cross-arena child
+/// `CheckerContext`s spun up while resolving a base symbol — the per-context
+/// logical depth `Cell`s (`heritage_merge_depth`, `enter_recursion`) reset to
+/// zero across those boundaries, so a recursion that hops contexts accumulates
+/// real OS-stack frames that no per-context counter ever bounds (#14111).
+///
+/// Behaviour, mirroring the original inline `dispatch_type_computation` guard:
+/// 1. If the breaker has already tripped on this thread, return `on_exhausted`
+///    immediately (no further recursion for the rest of the file).
+/// 2. On a periodic [`should_probe_stack`] tick, measure remaining stack; if it
+///    is below [`STACK_BAILOUT_HEADROOM_BYTES`], trip the shared breaker and
+///    return `on_exhausted`.
+/// 3. Otherwise run `body` on a (possibly freshly grown) stack via
+///    `stacker::maybe_grow`.
+///
+/// `on_exhausted` is the safe, relation-preserving value the caller would have
+/// returned anyway when its own logical depth guard fires (e.g. the partially
+/// merged `derived_type`, or `TypeId::ERROR` for expression dispatch).
+#[inline]
+pub fn with_stack_guard<T>(on_exhausted: T, body: impl FnOnce() -> T) -> T {
+    if stack_overflow_tripped() {
+        return on_exhausted;
+    }
+    if should_probe_stack() && headroom_below(STACK_BAILOUT_HEADROOM_BYTES) {
+        trip_stack_overflow();
+        return on_exhausted;
+    }
+    stacker::maybe_grow(STACK_RED_ZONE_BYTES, STACK_GROW_BYTES, body)
+}
+
 /// Trip the stack overflow breaker.  Called from guards in `dispatch.rs` and
 /// `state/type_analysis/core.rs` when `stacker::remaining_stack()` reports
 /// < 256 KB remaining.
@@ -337,6 +382,56 @@ mod tests {
         // After 255 calls, counter == 255. Call 256: 255 + 1 = 256, masked
         // to 0. `0 & 0x0F == 0` → true.
         assert!(should_probe_stack());
+        reset();
+    }
+
+    #[test]
+    fn with_stack_guard_runs_body_when_healthy() {
+        reset();
+        let mut ran = false;
+        let out = with_stack_guard(-1, || {
+            ran = true;
+            42
+        });
+        assert!(ran, "body must run when the breaker is healthy");
+        assert_eq!(out, 42, "with_stack_guard must return the body result");
+        reset();
+    }
+
+    #[test]
+    fn with_stack_guard_bails_without_running_body_when_tripped() {
+        reset();
+        trip_stack_overflow();
+        let mut ran = false;
+        let out = with_stack_guard(-1, || {
+            ran = true;
+            42
+        });
+        assert!(
+            !ran,
+            "body must NOT run once the shared breaker has tripped — this is what \
+             unwedges the cross-context heritage-merge recursion (#14111)"
+        );
+        assert_eq!(
+            out, -1,
+            "with_stack_guard must return on_exhausted when tripped"
+        );
+        reset();
+    }
+
+    #[test]
+    fn with_stack_guard_does_not_trip_on_probe_ticks_when_headroom_is_ample() {
+        reset();
+        // Drive enough calls to cross several probe ticks. A real test thread has
+        // ample headroom, so none of the probes should trip the breaker.
+        for _ in 0..64 {
+            let out = with_stack_guard(0u32, || 7u32);
+            assert_eq!(out, 7, "body must keep running while headroom is ample");
+        }
+        assert!(
+            !stack_overflow_tripped(),
+            "ample-headroom probes must not trip the breaker"
+        );
         reset();
     }
 

--- a/crates/tsz-checker/src/dispatch/mod.rs
+++ b/crates/tsz-checker/src/dispatch/mod.rs
@@ -57,21 +57,10 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
         idx: NodeIndex,
         request: &TypingRequest,
     ) -> TypeId {
-        // Hard stack guard: bail when remaining stack is critically low.
-        if crate::checkers_domain::stack_overflow_tripped() {
-            return TypeId::ERROR;
-        }
-        // Periodically probe remaining stack and trip the breaker if low.
-        // This prevents unbounded stack growth from stacker::maybe_grow
-        // which would eventually hit the OS stack limit and crash.
-        if crate::checkers_domain::should_probe_stack()
-            && crate::checkers_domain::headroom_below(1024 * 1024)
-        {
-            crate::checkers_domain::trip_stack_overflow();
-            return TypeId::ERROR;
-        }
-        // Dynamically grow the stack when depth becomes significant.
-        stacker::maybe_grow(256 * 1024, 2 * 1024 * 1024, || {
+        // Shared cross-context stack-overflow breaker: probe → trip → grow.
+        // Bails with `TypeId::ERROR` when the breaker has tripped or remaining
+        // stack is critically low, otherwise grows the stack as depth rises.
+        crate::checkers_domain::with_stack_guard(TypeId::ERROR, || {
             self.dispatch_type_computation_inner(idx, request)
         })
     }

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1040,25 +1040,21 @@ impl CheckerState<'_> {
     /// type T = string;         // get_type_of_symbol(T) → string
     /// ```
     pub fn get_type_of_symbol(&mut self, sym_id: SymbolId) -> TypeId {
-        // Hard stack guard: bail with ERROR when the stack overflow breaker
-        // has been tripped by a previous deep recursion.
-        if crate::checkers_domain::stack_overflow_tripped() {
-            self.ctx.symbol_types.insert(sym_id, TypeId::ERROR);
-            return TypeId::ERROR;
+        // Shared cross-context stack-overflow breaker: probe → trip → grow.
+        // Symbol type resolution is a node in the heritage-merge recursion
+        // cycle (`merge → get_type_of_symbol(base) → … → merge`), so it must
+        // carry the same breaker as the merge entry points (#14111). `None`
+        // signals a bail (already tripped, or this probe tripped it); cache
+        // `ERROR` for the symbol on that path, matching the prior behaviour.
+        match crate::checkers_domain::with_stack_guard(None, || {
+            Some(self.get_type_of_symbol_inner(sym_id))
+        }) {
+            Some(type_id) => type_id,
+            None => {
+                self.ctx.symbol_types.insert(sym_id, TypeId::ERROR);
+                TypeId::ERROR
+            }
         }
-        // Periodically probe remaining stack and trip the breaker if low.
-        if crate::checkers_domain::should_probe_stack()
-            && crate::checkers_domain::headroom_below(1024 * 1024)
-        {
-            crate::checkers_domain::trip_stack_overflow();
-            self.ctx.symbol_types.insert(sym_id, TypeId::ERROR);
-            return TypeId::ERROR;
-        }
-        // Dynamically grow the stack for deeply recursive symbol resolution
-        // chains.
-        stacker::maybe_grow(256 * 1024, 2 * 1024 * 1024, || {
-            self.get_type_of_symbol_inner(sym_id)
-        })
     }
 
     fn get_type_of_symbol_inner(&mut self, sym_id: SymbolId) -> TypeId {

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1046,14 +1046,13 @@ impl CheckerState<'_> {
         // carry the same breaker as the merge entry points (#14111). `None`
         // signals a bail (already tripped, or this probe tripped it); cache
         // `ERROR` for the symbol on that path, matching the prior behaviour.
-        match crate::checkers_domain::with_stack_guard(None, || {
+        if let Some(type_id) = crate::checkers_domain::with_stack_guard(None, || {
             Some(self.get_type_of_symbol_inner(sym_id))
         }) {
-            Some(type_id) => type_id,
-            None => {
-                self.ctx.symbol_types.insert(sym_id, TypeId::ERROR);
-                TypeId::ERROR
-            }
+            type_id
+        } else {
+            self.ctx.symbol_types.insert(sym_id, TypeId::ERROR);
+            TypeId::ERROR
         }
     }
 

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -715,6 +715,27 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn merge_interface_heritage_types(
         &mut self,
         declarations: &[NodeIndex],
+        derived_type: TypeId,
+    ) -> TypeId {
+        // Cross-context OS-stack breaker (#14111). The heritage-merge cycle
+        // `merge → get_type_of_symbol(base) → compute_type_of_symbol → merge`
+        // hops fresh / cross-arena child `CheckerContext`s that reset the
+        // per-context `heritage_merge_depth` `Cell` (and `enter_recursion`
+        // counter) to zero, so neither logical guard can bound the real OS
+        // call stack across those boundaries — a declaration-merged /
+        // augmented-module interface graph (NestJS-style backends such as
+        // directus/api) recurses until the thread stack aborts. The
+        // thread-local breaker survives context boundaries and is the only
+        // mechanism that does. Bail to the partially-merged `derived_type`,
+        // matching the logical `heritage_merge_depth` bail below.
+        crate::checkers_domain::with_stack_guard(derived_type, || {
+            self.merge_interface_heritage_types_inner(declarations, derived_type)
+        })
+    }
+
+    fn merge_interface_heritage_types_inner(
+        &mut self,
+        declarations: &[NodeIndex],
         mut derived_type: TypeId,
     ) -> TypeId {
         use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
@@ -1079,7 +1100,13 @@ impl<'a> CheckerState<'a> {
         if !self.ctx.enter_recursion() {
             return derived;
         }
-        let result = self.merge_interface_types_impl(derived, base, mode);
+        // Cross-context OS-stack breaker (#14111): `enter_recursion` is a
+        // per-context `Cell` that resets across the fresh / cross-arena child
+        // contexts this structural merge can hop while resolving members, so
+        // it cannot bound the real call stack on its own. Bail to `derived`.
+        let result = crate::checkers_domain::with_stack_guard(derived, || {
+            self.merge_interface_types_impl(derived, base, mode)
+        });
         self.ctx.leave_recursion();
         result
     }


### PR DESCRIPTION
Fixes #14111.

Goal: green

## Structural rule

> When a recursive checker type computation can hop a fresh / cross-arena child
> `CheckerContext` (so its per-context logical depth counter resets to zero), the
> only mechanism that can still bound the **real OS stack** is the thread-local
> stack-overflow breaker. tsc never crashes here; tsz must convert the exhausted
> stack into a bounded partial result rather than aborting.

`directus/api` (~1139 files; tsc/tsgo compile it with 0 diagnostics) aborted tsz
with a `stack overflow` (SIGABRT, exit 134) that survived a 512 MB
`RUST_MIN_STACK` — the signature of unbounded recursion, not a deep-but-finite
chain.

## Wrong semantic operation / owner layer

Recursion bounding in the checker's interface heritage-merge closure
(`merge_interface_heritage_types` / `merge_interface_types`,
`crates/tsz-checker/src/types/interface_type.rs`). It was the one major
recursive checker type path with **no dynamic stack guard** — its only
protection was the per-`CheckerContext` logical counters (`heritage_merge_depth`
`Cell`, `enter_recursion`). Those counters **reset to zero across the fresh /
cross-arena child contexts** created while resolving a base symbol, so the
combined cycle

```
merge → get_type_of_symbol(base) → compute_type_of_symbol → merge → …
```

accumulates real call-stack frames that no single per-context cap bounds. A
NestJS-style backend dominated by declaration-merged / augmented-module generic
interfaces is exactly this workload. This is the same fresh-instance-reset class
the solver's thread-local frame breaker (`with_solver_frame`) already fixed on
its side.

## Fix

Extract the checker's existing thread-local breaker (the `probe → trip → grow`
sequence already inlined in expression dispatch) into one shared
`with_stack_guard<T>(on_exhausted, body)` helper in `checkers/mod.rs`, and apply
it at the cross-context recursion entry points. The thread-local breaker is the
only stack-safety mechanism that survives context boundaries.

- **`checkers/mod.rs`** — new `with_stack_guard` is the single owner of the
  `stack_overflow_tripped → should_probe_stack/headroom_below → trip → maybe_grow`
  sequence, plus named segment-size constants. Bails with the caller's
  relation-preserving default.
- **`dispatch/mod.rs`** and **`state/type_analysis/core.rs`** —
  `dispatch_type_computation` and `get_type_of_symbol` now reuse the helper
  instead of duplicating the inline guard. Behaviour preserved, including
  `get_type_of_symbol`'s `ERROR`-cache on its bail path.
- **`interface_type.rs`** — `merge_interface_heritage_types` and
  `merge_interface_types` are guarded so the heritage cycle trips the shared
  breaker and bails to the partially-merged type (matching the existing
  `heritage_merge_depth >= 5` / fuel-exhaustion bails) instead of overflowing.

The per-context logical counters are kept as the cheap semantic bound; the
thread-local breaker is the cross-context backstop. This converts the crash into
a bounded partial result; the underlying non-convergence on this corpus is
tracked separately (#14101 family).

## Anti-hardcoding

Purely structural: the breaker keys on measured remaining stack and the shared
tripped flag — no user/file-name literals, no rendered-type-string predicates,
no fixture-name fast path. It generalizes the breaker the dispatch path already
used rather than adding a special case.

## Verification

- `cargo test -p tsz-checker --lib checkers_domain::tests` — 16 passed, incl. 3
  new `with_stack_guard_*` tests (runs body when healthy; bails without running
  body once tripped; ample-headroom probes don't trip).
- `cargo check -p tsz-checker`, `cargo clippy -p tsz-checker --lib`,
  `cargo fmt -p tsz-checker --check`, `python3 scripts/arch/arch_guard.py` — all
  clean.
- Reviewed with `/simplify` (reuse/simplification/efficiency/altitude): folded
  `get_type_of_symbol`'s duplicated inline guard into the shared helper; left the
  `lib_aliases.rs` `maybe_grow` site untouched (deliberately different
  thresholds).
- Broad conformance / emit / fourslash and the directus/api canary are owned by
  ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_018eTxfSH3bFLqgjbrcfLTf6

---
_Generated by [Claude Code](https://claude.ai/code/session_018eTxfSH3bFLqgjbrcfLTf6)_