### PR TITLE
fix(bench): time clean application rows for charts

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1126,6 +1126,13 @@ jobs:
           - label: bench-canaries
             timeout: 135
             filter: 'valibot-project|msw-project|effect-project|drizzle-orm-project|ts-rest-project|ofetch-project|ts-pattern-project|trpc-project|tanstack-query-project|tanstack-router-project|zustand-project|jotai-project|fp-ts-project|io-ts-project|immer-project|remeda-project|ts-morph-project|arktype-project|superstruct-project|runtypes-project|hotscript-project|typebox-project|class-transformer-project|type-graphql-project|neverthrow-project|xstate-project|mobx-project'
+          # Application rows need their real dependency graph to produce a
+          # meaningful tsz-vs-tsgo timing pair. Keep them in an optional shard:
+          # clean rows get chart data when timing completes, but app install
+          # flakiness never blocks required benchmark publishing.
+          - label: bench-applications
+            timeout: 135
+            filter: 'umami-project|dub-project|formbricks-project|lobe-chat-project|supabase-studio-project|infisical-project|payload-project|trigger-dev-project|directus-project|n8n-project|documenso-project|immich-server-project'
           - label: large-ts-repo
             timeout: 135
             filter: '^large-ts-repo$'
@@ -1564,12 +1571,12 @@ jobs:
         run: |
           set -euo pipefail
           mapfile -t json_files < <(find bench-artifacts -name 'bench-results-*.json' -type f | sort)
-          # The bench-canaries shard (passing-canary perf rows) is OPTIONAL: it
-          # is merged when present but must NOT count toward — or break — the
-          # required-shard completeness gate. A failed/slow canary shard then
-          # never blocks publishing the required benchmark timings.
+          # Optional perf shards are merged when present but must NOT count
+          # toward — or break — the required-shard completeness gate. A
+          # failed/slow canary or application shard then never blocks publishing
+          # the required benchmark timings.
           mapfile -t required_files < <(
-            printf '%s\n' "${json_files[@]}" | grep -v '/bench-results-bench-canaries\.json$' || true
+            printf '%s\n' "${json_files[@]}" | grep -Ev '/bench-results-bench-(canaries|applications)\.json$' || true
           )
           expected_shards=9
           echo "json_count=${#required_files[@]}" >> "$GITHUB_OUTPUT"

--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -5,7 +5,7 @@ import { marked } from "marked";
 import {
   COMPILE_CANARY_PROJECT_ROWS,
   COMPATIBILITY_CORPUS_ROWS,
-  PERF_TIMED_CANARY_PROJECT_ROWS,
+  PERF_TIMED_PROJECT_ROWS,
   PROJECT_ROWS_BY_NAME,
   REQUIRED_PROJECT_ROWS,
 } from "../../../../scripts/bench/project-rows.mjs";
@@ -235,28 +235,29 @@ function hasSuccessfulTiming(row) {
   return hasSuccessfulTimingPair(row);
 }
 
-const PERF_TIMED_CANARY_SET = new Set(PERF_TIMED_CANARY_PROJECT_ROWS);
+const PERF_TIMED_PROJECT_SET = new Set(PERF_TIMED_PROJECT_ROWS);
 
-// A perf-timed canary may produce a tsz/tsgo timing pair while still diverging
-// from `tsc` (yellow) or failing tsz (red). Such rows must NOT join the perf
-// comparison chart: only promote a perf-timed canary once it checks green.
+// A perf-timed optional row may produce a tsz/tsgo timing pair while still
+// diverging from `tsc` (yellow) or failing tsz (red). Such rows must NOT join
+// the perf comparison chart: only promote a perf-timed optional row once it
+// checks green.
 // Required rows keep their existing behavior (timing pair is sufficient) so this
-// only gates the opt-in canary set, never the required corpus.
+// only gates the opt-in timing set, never the required corpus.
 function isChartEligible(row) {
   if (!hasSuccessfulTiming(row)) return false;
-  if (PERF_TIMED_CANARY_SET.has(row?.name)) {
+  if (PERF_TIMED_PROJECT_SET.has(row?.name)) {
     return hasGreenProjectCompatibility(row);
   }
   return true;
 }
 
-// A perf-timed canary that produced a timing pair but is not green is excluded
-// from the chart by isChartEligible. It still has a timing pair, so the normal
-// isFailedBenchmark() check would treat it as "successful" and drop it from the
-// failures list too. Surface it explicitly in the canaries/incomplete section so
-// a timed-but-diverging canary stays visible instead of vanishing.
+// A perf-timed optional row that produced a timing pair but is not green is
+// excluded from the chart by isChartEligible. It still has a timing pair, so the
+// normal isFailedBenchmark() check would treat it as "successful" and drop it
+// from the failures list too. Surface it explicitly in the canaries/incomplete
+// section so a timed-but-diverging row stays visible instead of vanishing.
 function isExcludedNonGreenCanary(row) {
-  return PERF_TIMED_CANARY_SET.has(row?.name)
+  return PERF_TIMED_PROJECT_SET.has(row?.name)
     && hasSuccessfulTiming(row)
     && !hasGreenProjectCompatibility(row);
 }

--- a/crates/tsz-website/src/_data/benchmark_mean_chart.js
+++ b/crates/tsz-website/src/_data/benchmark_mean_chart.js
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { selectLatestBenchmarkArtifact } from "../../../../scripts/bench/benchmark-artifact-selection.mjs";
 import {
-  PERF_TIMED_CANARY_PROJECT_ROWS,
+  PERF_TIMED_PROJECT_ROWS,
   REQUIRED_PROJECT_ROWS,
 } from "../../../../scripts/bench/project-rows.mjs";
 import { fmt } from "./loc.js";
@@ -29,7 +29,7 @@ function hasSuccessfulTiming(row) {
 
 const PROJECT_BENCHMARK_NAMES = new Set([
   ...REQUIRED_PROJECT_ROWS,
-  ...PERF_TIMED_CANARY_PROJECT_ROWS,
+  ...PERF_TIMED_PROJECT_ROWS,
 ]);
 
 function isProjectBenchmark(row) {

--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -243,6 +243,10 @@ should_run_compile_canary_project() {
     [ "$TSZ_BENCH_INCLUDE_COMPILE_CANARIES" = "1" ]
 }
 
+# shellcheck source=scripts/bench/lib/application-benchmarks.sh
+source "$SCRIPT_DIR/lib/application-benchmarks.sh"
+
+
 ensure_nextjs_fixture() {
     mkdir -p "$EXTERNAL_BENCH_DIR"
 
@@ -1587,6 +1591,18 @@ main() {
     run_isolated "neverthrow-project"                run_neverthrow_project_benchmarks
     run_isolated "xstate-project"                    run_xstate_project_benchmarks
     run_isolated "mobx-project"                      run_mobx_project_benchmarks
+    run_isolated "umami-project"                     run_application_project_benchmarks "umami-project"
+    run_isolated "dub-project"                       run_application_project_benchmarks "dub-project"
+    run_isolated "formbricks-project"                run_application_project_benchmarks "formbricks-project"
+    run_isolated "lobe-chat-project"                 run_application_project_benchmarks "lobe-chat-project"
+    run_isolated "supabase-studio-project"           run_application_project_benchmarks "supabase-studio-project"
+    run_isolated "infisical-project"                 run_application_project_benchmarks "infisical-project"
+    run_isolated "payload-project"                   run_application_project_benchmarks "payload-project"
+    run_isolated "trigger-dev-project"               run_application_project_benchmarks "trigger-dev-project"
+    run_isolated "directus-project"                  run_application_project_benchmarks "directus-project"
+    run_isolated "n8n-project"                       run_application_project_benchmarks "n8n-project"
+    run_isolated "documenso-project"                 run_application_project_benchmarks "documenso-project"
+    run_isolated "immich-server-project"             run_application_project_benchmarks "immich-server-project"
     run_isolated "vite-vanilla-ts-app"    run_vite_app_project_benchmarks
     run_isolated "nextjs-fresh-app"       run_next_app_project_benchmarks
     run_isolated "nextjs"                 run_nextjs_benchmarks

--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -39,13 +39,15 @@ import { measurementProfileStatus } from "./measurement-profile.mjs";
 
 // The bench artifact readiness gate must not demand rows that the bench runner
 // never measures, or it fails every publish on a permanently-missing row. The
-// runner skips a row when it is in BENCH_RUNNER_EXCLUDED_ROWS OR its category is
-// "application" (see project-row-summary.mjs drift logic) — application rows are
-// compatibility/compile-guard canaries, never timed. Examples that broke
-// publishing: type-challenges-solutions-project (excluded-set, #13549) and
+// never measures as a required row, or it fails every publish on a permanently
+// missing/optional row. Rows in BENCH_RUNNER_EXCLUDED_ROWS are never measured;
+// application rows may be timed by an optional shard but must not be required,
+// because their package-manager installs are intentionally outside the public
+// publish completeness gate. Examples that broke publishing:
+// type-challenges-solutions-project (excluded-set, #13549) and
 // infisical/payload/medusa (category:application, promoted to benchmark_set
-// "required" by #13775). Mirror the runner's exclusion exactly: only rows that
-// are required AND actually measured belong in the readiness required-set.
+// "required" by #13775). Only rows that are required AND part of the required
+// timing shards belong in the readiness required-set.
 const REQUIRED_MEASURED_ROWS = REQUIRED_PROJECT_ROWS.filter(
   (name) =>
     !BENCH_RUNNER_EXCLUDED_ROWS.has(name) &&

--- a/scripts/bench/lib/application-benchmarks.sh
+++ b/scripts/bench/lib/application-benchmarks.sh
@@ -1,0 +1,79 @@
+should_run_application_project() {
+    if [ -n "$FILTER" ]; then
+        return 0
+    fi
+    [ "${TSZ_BENCH_INCLUDE_APPLICATIONS:-0}" = "1" ]
+}
+
+tsz_application_benchmark_metadata() {
+    local row_name="$1"
+    TSZ_PROJECT_ROWS_MJS="$TSZ_PROJECT_ROWS_MJS" \
+    TSZ_PROJECT_ROW_NAME="$row_name" \
+    node --input-type=module <<'NODE'
+import { pathToFileURL } from "node:url";
+
+const rowsPath = process.env.TSZ_PROJECT_ROWS_MJS;
+const rowName = process.env.TSZ_PROJECT_ROW_NAME;
+const { PROJECT_ROWS_BY_NAME } = await import(pathToFileURL(rowsPath));
+const row = PROJECT_ROWS_BY_NAME[rowName];
+
+if (!row || row.category !== "application" || row.perf_timed !== true) {
+  process.exit(1);
+}
+
+function shellQuote(value) {
+  return `'${String(value ?? "").replace(/'/g, `'\\''`)}'`;
+}
+
+const fields = {
+  app_name: row.name,
+  app_label: row.label || row.name,
+  app_fixture_dir: row.fixture_dir,
+  app_repo: row.repo,
+  app_ref: row.ref,
+  app_install_cmd: row.install_cmd,
+  app_install_root: row.install_root || ".",
+  app_tsconfig: row.app_tsconfig,
+  app_source_dir: row.source_dir || ".",
+};
+
+for (const [key, value] of Object.entries(fields)) {
+  if (!value) process.exit(1);
+  console.log(`${key}=${shellQuote(value)}`);
+}
+NODE
+}
+
+run_application_project_benchmarks() {
+    local row_name="$1"
+    should_run_application_project || return 0
+    if ! is_benchmark_selected "$row_name"; then
+        return
+    fi
+
+    eval "$(tsz_application_benchmark_metadata "$row_name")"
+
+    print_header "Real-world Application Project - $app_label"
+    local root="$EXTERNAL_BENCH_DIR/$app_fixture_dir"
+    tsz_ensure_git_fixture "$app_fixture_dir" "$app_repo" "$app_ref" "$root" 1
+    echo -e "${GREEN}✓${NC} $app_label pinned at $(git -C "$root" rev-parse --short HEAD)"
+
+    if ! (cd "$root/$app_install_root" && eval "$app_install_cmd"); then
+        find "$root" -type d -name node_modules -prune -exec rm -rf {} + 2>/dev/null || true
+        return 1
+    fi
+
+    local tsconfig="$root/$app_tsconfig"
+    local src_dir="$root/$app_source_dir"
+    if [ ! -f "$tsconfig" ]; then
+        echo -e "${RED}✗ tsconfig not found: $tsconfig${NC}"
+        find "$root" -type d -name node_modules -prune -exec rm -rf {} + 2>/dev/null || true
+        return 1
+    fi
+
+    local rc=0
+    run_project_benchmark "$app_name" "$tsconfig" "$src_dir" || rc=$?
+    find "$root" -type d -name node_modules -prune -exec rm -rf {} + 2>/dev/null || true
+    echo
+    return "$rc"
+}

--- a/scripts/bench/project-row-summary.mjs
+++ b/scripts/bench/project-row-summary.mjs
@@ -59,8 +59,13 @@ function extractShellFunctionBody(scriptText, functionName) {
 }
 
 export function extractBenchRunnerRows(scriptText) {
-  const rows = [...scriptText.matchAll(/run_project_benchmark\s+"([^"]+)"/g)]
-    .map((m) => m[1]);
+  const rows = [
+    ...[...scriptText.matchAll(/run_project_benchmark\s+"([^"]+)"/g)]
+      .map((m) => m[1])
+      .filter((name) => !name.startsWith("$")),
+    ...[...scriptText.matchAll(/run_application_project_benchmarks\s+"([^"]+)"/g)]
+      .map((m) => m[1]),
+  ];
   return [...new Set(rows)].sort();
 }
 
@@ -142,7 +147,8 @@ export function computeCoverage(surfaces) {
     const isRequired = requiredSet.has(name);
     const requiresFixtureSource = rowRequiresFixtureSource(def);
 
-    if (isTracked && !BENCH_RUNNER_EXCLUDED_ROWS.has(name) && def.category !== "application" && !benchRunnerSet.has(name)) {
+    const requiresBenchRunner = def.category !== "application" || def.perf_timed === true;
+    if (isTracked && !BENCH_RUNNER_EXCLUDED_ROWS.has(name) && requiresBenchRunner && !benchRunnerSet.has(name)) {
       drift.push(`${name}: present in project-rows.mjs but missing from scripts/bench/bench-vs-tsgo.sh`);
     }
     if (isTracked && !COMPILE_GUARD_EXCLUDED_ROWS.has(name) && !compileGuardSet.has(name)) {

--- a/scripts/bench/project-rows.mjs
+++ b/scripts/bench/project-rows.mjs
@@ -682,6 +682,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "c0ea3aefbee7a3429ee2f824b06dc4a9dbe0b7e1",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -720,6 +721,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "fcc6e9a7e8f182da90acacf3282f8411f6aca070",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -739,6 +741,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "8b0f5baaa55ccbda35fcfcfb68579ea3854f7605",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -777,6 +780,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "95db11309ea1b7f4d53f84adc15fa2038549e1aa",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -796,6 +800,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "6a6b7c90858b6b868c6d05bd3263a957357fa84a",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -815,6 +820,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "704c8cf7e76f1ce49301a5f943e51303c0db0058",
     guard_set: "required",
     benchmark_set: "required",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -834,6 +840,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "29ef906ba590fd168673da827ec484a1e2a723ad",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -891,6 +898,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "e829eddd5ecdfc622f90257cebc2ee881a8f8c10",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -929,6 +937,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "c305be58168012cfa5ae8bf3974264a61fb051d1",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -948,6 +957,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "f6afb3933a1ed086b11294fb1bfe298434375969",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -986,6 +996,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "d5ce222482c2da81a1b0e6740e7d829752ea8f7f",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -1024,6 +1035,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "983a005709cb55d0fb2ba3499a05b25c2291e152",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -1061,15 +1073,22 @@ export const COMPILE_CANARY_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS
 
 export const COMPILE_GUARD_CANARY_PROJECT_ROWS = COMPILE_CANARY_PROJECT_ROWS;
 
-// Canary rows opted into the vs-tsgo timing chart via `perf_timed: true`. These
-// external-library rows already have bench-vs-tsgo runners, so the dedicated
-// `bench-canaries` shard can produce real tsz_ms/tsgo_ms timings for any row
-// that compiles cleanly. They stay benchmark_set:"canary", so they are NOT part
-// of REQUIRED_PROJECT_ROWS and never affect the artifact-readiness/publish gate;
-// the website only promotes a perf-timed canary onto the chart once it actually
-// checks green (see the green-compat filter in
-// crates/tsz-website/src/_data/benchmark_data.js).
+// Project rows opted into optional vs-tsgo timing via `perf_timed: true`.
+// External-library rows run in the `bench-canaries` shard; application rows run
+// in the `bench-applications` shard. These optional shards produce real
+// tsz_ms/tsgo_ms timings for rows that complete, but they are NOT part of the
+// required artifact-readiness/publish gate. The website only promotes a
+// perf-timed row onto the chart once it also checks green (see the green-compat
+// filter in crates/tsz-website/src/_data/benchmark_data.js).
 export const PERF_TIMED_CANARY_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS
+  .filter((row) => row.perf_timed === true && row.category !== "application")
+  .map((row) => row.name);
+
+export const PERF_TIMED_APPLICATION_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS
+  .filter((row) => row.perf_timed === true && row.category === "application")
+  .map((row) => row.name);
+
+export const PERF_TIMED_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS
   .filter((row) => row.perf_timed === true)
   .map((row) => row.name);
 

--- a/scripts/bench/test-bench-workflow-micro-coverage.mjs
+++ b/scripts/bench/test-bench-workflow-micro-coverage.mjs
@@ -2,7 +2,10 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 
-import { PERF_TIMED_CANARY_PROJECT_ROWS } from "./project-rows.mjs";
+import {
+  PERF_TIMED_APPLICATION_PROJECT_ROWS,
+  PERF_TIMED_CANARY_PROJECT_ROWS,
+} from "./project-rows.mjs";
 
 const workflow = fs.readFileSync(".github/workflows/bench.yml", "utf8");
 const runner = fs.readFileSync("scripts/bench/bench-vs-tsgo.sh", "utf8");
@@ -83,6 +86,7 @@ assert.deepEqual(
     "algorithmic-mapped",
     "projects",
     "bench-canaries",
+    "bench-applications",
     "large-ts-repo",
   ],
   "bench workflow shard labels should stay explicit when adding timed benchmark families",
@@ -153,6 +157,14 @@ assert.deepEqual(
   [...benchCanariesFilter.pattern.split("|")].sort(),
   [...PERF_TIMED_CANARY_PROJECT_ROWS].sort(),
   "bench-canaries shard filter must match PERF_TIMED_CANARY_PROJECT_ROWS exactly",
+);
+
+const benchApplicationsFilter = shardFilters.find((filter) => filter.label === "bench-applications");
+assert.ok(benchApplicationsFilter, "bench workflow should have a dedicated bench-applications shard");
+assert.deepEqual(
+  [...benchApplicationsFilter.pattern.split("|")].sort(),
+  [...PERF_TIMED_APPLICATION_PROJECT_ROWS].sort(),
+  "bench-applications shard filter must match PERF_TIMED_APPLICATION_PROJECT_ROWS exactly",
 );
 
 console.log("bench workflow micro coverage tests passed");

--- a/scripts/bench/test-project-rows.mjs
+++ b/scripts/bench/test-project-rows.mjs
@@ -325,12 +325,14 @@ const compileCanaryGatedBenchmarkRows = sortedUnique(
     .filter((match) => match[1].includes("should_run_compile_canary_project"))
     .flatMap((match) => extractAll(match[1], /run_project_benchmark\s+"([^"]+)"/g)),
 );
-// Application rows are compile-guard canaries only; they crash/time out under a
-// real type-checker, so they are not perf-benchmarked in bench-vs-tsgo.
-const applicationRowNames = new Set(
-  PROJECT_ROW_DEFINITIONS.filter((row) => row.category === "application").map((row) => row.name),
+// Application rows are optional perf benchmarks only when opted in with
+// perf_timed. Untimed applications remain compile-guard canaries only.
+const untimedApplicationRowNames = new Set(
+  PROJECT_ROW_DEFINITIONS
+    .filter((row) => row.category === "application" && row.perf_timed !== true)
+    .map((row) => row.name),
 );
-const benchExcludedRows = new Set([...BENCH_RUNNER_EXCLUDED_ROWS, ...applicationRowNames]);
+const benchExcludedRows = new Set([...BENCH_RUNNER_EXCLUDED_ROWS, ...untimedApplicationRowNames]);
 assert.deepEqual(
   benchRows,
   sortedUnique(without(allTrackedRows, benchExcludedRows)),


### PR DESCRIPTION
Goal: green

## Summary
- add an optional bench-applications shard for npm/pnpm application rows, so clean application projects can publish real tsz_ms/tsgo_ms chart data
- reuse project-row metadata for app install command, tsconfig, source dir, repo, and ref rather than duplicating the application matrix
- classify all perf-timed project rows in the website mean chart and keep chart promotion gated on green project compatibility

## Notes
Application rows still use the triggering CI compatibility artifact for green/yellow/red state. The new timing shard is optional: if an application install/timing shard flakes or times out, required benchmark publish remains unblocked; when it succeeds, clean application rows get chart bars instead of remaining compile-only.

Yarn/Bun application rows are intentionally not timed in this PR because the Cloud Build timing image currently bootstraps npm/pnpm only.

## Verification
- bash -n scripts/bench/bench-vs-tsgo.sh scripts/bench/lib/application-benchmarks.sh
- node scripts/bench/test-project-rows.mjs
- node scripts/bench/test-bench-workflow-micro-coverage.mjs
- node scripts/bench/validate-project-metadata.mjs
- node scripts/bench/test-project-row-summary.mjs
- node scripts/bench/test-merge-results.mjs
- node scripts/bench/test-check-artifact-readiness.mjs
- npm --prefix crates/tsz-website install --no-package-lock
- npm --prefix crates/tsz-website run test:benchmarks
- node -e 'import("./crates/tsz-website/src/_data/benchmark_mean_chart.js").then(() => console.log("benchmark_mean_chart import ok"))'
- git diff --check

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high