### PR TITLE
perf(checker): canonicalize type-param-bearing application args for identity convergence (#14101 step 1b)

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/app_canon_arg_identity.rs
+++ b/crates/tsz-checker/src/state/type_environment/app_canon_arg_identity.rs
@@ -1,0 +1,21 @@
+use std::sync::OnceLock;
+
+/// Debug kill-switch for extending the application-arg canonicalization in
+/// `CheckerState::evaluate_application_type` (`core.rs`) to type-parameter-bearing
+/// applications (#14101, step 1b).
+///
+/// Recursive-heritage materialization reaches the same logical `Base<Args>` along
+/// many paths carrying structurally-equal-but-differently-minted arg `TypeId`s;
+/// converging them onto one canonical-arg evaluation result bounds the
+/// per-`(type, prop)` memo proliferation that drives the exit-124 timeouts
+/// (drizzle-orm/typebox/xstate/arktype). The canonicalization reuses the existing
+/// `resolve_lazy_type` arg mapping, which preserves `Recursive`/cyclic refs (its
+/// `visited` guard) and is a no-op on non-`Lazy` args, so declaration/type-parameter
+/// identity is not collapsed.
+///
+/// Set `TSZ_DISABLE_APP_CANON_ARG_IDENTITY=1` to restore the legacy
+/// monomorphic-only canonicalization for byte-parity bisection; defaults to enabled.
+pub(super) fn app_canon_arg_identity_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("TSZ_DISABLE_APP_CANON_ARG_IDENTITY").is_err())
+}

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -235,12 +235,12 @@ impl CheckerState<'_> {
         // the same evaluation result within a file check context.
         let is_monomorphic = !self.contains_type_parameters_cached(type_id);
 
-        // Canonicalize application keys by evaluating type arguments first. This
-        // allows structurally equivalent applications from different declaration
-        // sites (e.g., repeated inline object-literal args) to share a cache hit.
-        // Only applies to monomorphic types where argument evaluation is meaningful.
+        // Canonicalize application keys by evaluating type arguments first so
+        // structurally equivalent applications share a cache hit. #14101 extends
+        // this from monomorphic-only to type-parameter-bearing apps (recursive-
+        // heritage convergence); see `super::app_canon_arg_identity_enabled`.
         let mut canonical_key: Option<TypeId> = None;
-        if is_monomorphic
+        if (is_monomorphic || super::app_canon_arg_identity_enabled())
             && let Some((base, args)) = query::application_info(self.ctx.types, type_id)
             && !args.is_empty()
         {

--- a/crates/tsz-checker/src/state/type_environment/mod.rs
+++ b/crates/tsz-checker/src/state/type_environment/mod.rs
@@ -1,6 +1,7 @@
 //! Type environment building, application type evaluation, property access
 //! type resolution, and type node resolution.
 
+mod app_canon_arg_identity;
 mod application;
 mod core;
 mod formatting;
@@ -11,3 +12,5 @@ mod property_access_visited;
 mod source_location;
 mod type_node_resolution;
 mod type_params;
+
+use app_canon_arg_identity::app_canon_arg_identity_enabled;


### PR DESCRIPTION
## Summary

Step **1b** of #14101 (the #1 compile-all blocker). Relaxes the `is_monomorphic` gate in `CheckerState::evaluate_application_type` (`type_environment/core.rs:243`) so **type-parameter-bearing** generic Applications also get the arg-canonicalization that already existed for monomorphic ones: each arg is mapped through `resolve_lazy_type`, the canonical `application(base, canonical_args)` is interned, and the evaluated result is shared via that canonical key.

**Structural rule:** when two generic instantiations share a `DefId` and structurally-equal args, `tsc` treats them as one type; `tsz` minted N divergent `Application` `TypeId`s because recursive-heritage materialization reaches the same `Base<Args>` along many paths carrying structurally-equal-but-differently-minted arg `TypeId`s. Converging them onto one canonical-arg evaluation result bounds the per-`(type,prop)` memo (`operations/property.rs:188`) proliferation that drives the exit-124 timeouts (drizzle-orm/typebox/xstate/arktype) and the opaque-base member-drop FP family.

**Why it's safe:** `resolve_lazy_type` is a no-op on non-`Lazy` args and preserves `Recursive`/cyclic refs (its `visited` guard), so type-parameter / declaration identity is not collapsed. Gated by `TSZ_DISABLE_APP_CANON_ARG_IDENTITY` (default on) for byte-parity bisection. This converges the **property-access** consumer family; the relation/heritage cycle case is step 2 (SCC materialize-once), tracked separately.

**Scope note:** the prior premise "canonicalize args at the interner / base-spelling divergence" was corrected during investigation — `ApplicationEvalCacheKey` already collapses base→`DefId`; the residual is arg identity, and `evaluate_application_type` is the resolver-bearing site that already owns the sound canonicalization (just gated off for the divergent case). Step-1a (the `:98` early-probe unification, PR #14107) was closed as a proven dead end (raw-by-design + a `propTypeValidatorInference` regression).

Goal: green

## Provenance
Machine: MacBookPro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- **Unit byte-parity (local, ON vs `TSZ_DISABLE_APP_CANON_ARG_IDENTITY=1`):** full `tsz-checker` unit suite identical in both arms — same 8 failures both arms (shared-`CARGO_TARGET_DIR` staleness across ~50 worktrees; `origin/main` `unit` CI is green), so the change introduces **zero unit divergence**. Diagnostics byte-identical on monomorphic + generic recursive-heritage repros.
- **CI owns:** full conformance/emit/fourslash (the authoritative parity gate — unit byte-parity is necessary-not-sufficient, per the #14107 `propTypeValidatorInference` lesson) + `project-compile-guard` on the timeout repros (drizzle/typebox/xstate/arktype) — the convergence proof, which is **not** locally measurable (synthetic repros can't reproduce deep-recursive-heritage convergence).

Refs #14101.
