### PR TITLE
perf(solver): probe recursive-heritage def re-entries for SCC headroom (#14101 step 2 probe)

### DIFF
--- a/crates/tsz-solver/src/evaluation/eval_materialization_probe.rs
+++ b/crates/tsz-solver/src/evaluation/eval_materialization_probe.rs
@@ -71,6 +71,26 @@ fn gate_enabled() -> bool {
     perf_counters::enabled_fast()
 }
 
+/// SCC re-entry probe (#14101 step-2 headroom). Counts how often a `DefId`'s
+/// application is re-entered while already in-flight up the evaluation stack
+/// (a recursive-heritage back-edge — `def_depth[def_id] >= 1`), plus the deepest
+/// such prior depth. This is the "redundant per-member re-eval" headroom that
+/// decides whether the SCC materialize-once fixpoint is worth its soundness
+/// cost; pure instrumentation, gated on the probe, no behavior change.
+static DEF_REENTRIES: AtomicU64 = AtomicU64::new(0);
+static DEF_REENTRY_MAX_DEPTH: AtomicU64 = AtomicU64::new(0);
+
+/// Record a recursive re-entry of a def's application at `prior_depth` (`>= 1`
+/// means a back-edge / cycle through that def). No-op unless the probe is gated on.
+#[inline]
+pub(crate) fn record_def_reentry(prior_depth: u32) {
+    if !gate_enabled() {
+        return;
+    }
+    DEF_REENTRIES.fetch_add(1, Ordering::Relaxed);
+    DEF_REENTRY_MAX_DEPTH.fetch_max(prior_depth as u64, Ordering::Relaxed);
+}
+
 /// Eval-engine kinds the lever targets. Index into [`ProbeState`] arrays.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(usize)]
@@ -618,6 +638,15 @@ pub fn dump_report() -> String {
         "[totals] computes {total_computes} -> distinct results {total_distinct_results} \
          (overall fan-out {overall_fanout:.1}%)"
     );
+    let reentries = DEF_REENTRIES.load(Ordering::Relaxed);
+    if reentries > 0 {
+        let _ = writeln!(
+            out,
+            "[scc] def re-entries (recursive-heritage back-edges) {reentries}, \
+             max prior depth {}  (#14101 step-2 materialize-once headroom)",
+            DEF_REENTRY_MAX_DEPTH.load(Ordering::Relaxed)
+        );
+    }
     out
 }
 

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -368,6 +368,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
     fn increment_def_depth(&mut self, def_id: DefId) -> bool {
         let depth = self.def_depth.entry(def_id).or_insert(0);
+        // #14101 step-2 probe: a non-zero prior depth means this def's application
+        // is re-entered while already in-flight (a recursive-heritage back-edge).
+        // Pure instrumentation (probe-gated); quantifies SCC materialize-once headroom.
+        if *depth >= 1 {
+            crate::evaluation::eval_materialization_probe::record_def_reentry(*depth);
+        }
         if *depth >= Self::MAX_DEF_DEPTH {
             // Depth-bounded run (see `deep_recursion_seen`).
             self.mark_deep_recursion_seen();


### PR DESCRIPTION
## Summary

Step **2 (probe phase)** of #14101. Lands a probe-gated counter that quantifies how often a `DefId`'s application is **re-entered while already in-flight** up the evaluation stack — a recursive-heritage back-edge, detected with zero new state as `def_depth[def_id] >= 1` at `increment_def_depth` (`evaluation/evaluate.rs:369`). Reports total re-entries + max prior depth in the eval-materialization probe dump (`[scc]` line).

**Why:** step-1b (#14132) converges *siblings* of one application; it does **not** converge a *cycle* of mutually-recursive deferred Applications (A→B→A), which the relation/heritage consumers re-walk per entry point. The high-value fix for that is an SCC materialize-once fixpoint — but it's a high-risk identity/order change. This probe is the measurement that decides whether that fixpoint is worth its soundness cost: run with `TSZ_PERF_COUNTERS` on the timeout canaries (drizzle-orm/typebox/xstate/arktype) to see the redundant per-member re-eval headroom.

**Why it's safe:** pure instrumentation — reuses the existing `def_depth` map as the on-stack set (no struct change, no push/pop balance hazard), and `record_def_reentry` early-returns unless `TSZ_PERF_COUNTERS` is set, so a production run is one predictable no-op branch. **Byte-parity by construction** (the recorder is a no-op when the probe gate is off, which is the default).

Goal: green

## Provenance
Machine: MacBookPro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo nextest run -p tsz-solver eval_materialization_probe` — 4/4 pass (existing probe assertions intact; the new `[scc]` line only renders when re-entries > 0, so it doesn't perturb `dump_report_nonempty_only_under_gate`).
- `cargo check -p tsz-solver` clean; `scripts/arch/check-checker-boundaries.sh` passes (no ratchet trip).
- Behavior-unchanged refactor/instrumentation (recorder no-op when the probe is off) — full conformance/emit via ready-review CI.

Refs #14101.
