### PR TITLE
fix(solver): resolve delete-operand optionality through heritage (TS2790)

### DIFF
--- a/crates/tsz-checker/src/types/object_type.rs
+++ b/crates/tsz-checker/src/types/object_type.rs
@@ -30,17 +30,15 @@ impl<'a> CheckerState<'a> {
 
     /// Check if a property is optional.
     ///
-    /// Returns true if the property is marked as optional.
+    /// Returns true if the property is declared optional anywhere it is visible
+    /// on the receiver's apparent type — including base interfaces reached
+    /// through `extends` heritage and members surfaced only through a deferred
+    /// `Application` / intersection / union receiver. Delegates to the solver's
+    /// heritage-aware [`tsz_solver::objects::property_is_optional`] so a
+    /// base-only optional property is not misread as required (which would emit
+    /// a false TS2790 on `delete`).
     pub fn is_property_optional(&self, object_type: TypeId, property_name: &str) -> bool {
-        if let Some(shape) = object_shape_for_type(self.ctx.types, object_type) {
-            let name_atom = self.ctx.types.intern_string(property_name);
-            shape
-                .properties
-                .iter()
-                .find(|prop| prop.name == name_atom)
-                .is_some_and(|prop| prop.optional)
-        } else {
-            false
-        }
+        let name_atom = self.ctx.types.intern_string(property_name);
+        tsz_solver::objects::property_is_optional(object_type, name_atom, self.ctx.types, &self.ctx)
     }
 }

--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -92,6 +92,10 @@ name = "parallel_sequential_agreement_tests"
 path = "tests/parallel_sequential_agreement_tests.rs"
 
 [[test]]
+name = "delete_inherited_optional_heritage_tests"
+path = "tests/delete_inherited_optional_heritage_tests.rs"
+
+[[test]]
 name = "sound_declaration_projection_tests"
 path = "tests/sound_declaration_projection_tests.rs"
 

--- a/crates/tsz-cli/tests/delete_inherited_optional_heritage_tests.rs
+++ b/crates/tsz-cli/tests/delete_inherited_optional_heritage_tests.rs
@@ -1,0 +1,198 @@
+//! #14112 regression: `delete obj.prop` must stay legal when `prop` is declared
+//! optional in a *base* interface and inherited (without redeclaration) through
+//! the heritage chain, even when — under the project pipeline's fresh per-file
+//! parallel checking — the receiver is a deferred cross-file
+//! `Application`/intersection at the delete site.
+//!
+//! Witness: ofetch `src/fetch.ts` — `delete context.options.query`, where
+//! `query?: Record<string, any>` is declared on `FetchOptions`
+//! (`extends Omit<RequestInit, ...>`) and inherited by
+//! `ResolvedFetchOptions extends FetchOptions`. The `Omit<RequestInit, ...>`
+//! heritage layer keeps the cross-file merged receiver from collapsing to a
+//! flat object shape, so the deleted property is absent from the receiver's own
+//! `ObjectShape`; tsz's optionality lookup read only that shape and emitted a
+//! false `TS2790`. `tsc`/`tsgo` accept the delete.
+//!
+//! This drives the real binary (DOM lib via the explicit `lib` set) with the
+//! consumer file listed before the declaring module and the genuine
+//! per-file `par_iter` fresh-checker path forced
+//! (`TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK[_TINY]`), reproducing the project-row
+//! schedule under which the receiver stays deferred. A negative case pins that
+//! a genuinely required inherited member still reports `TS2790`.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_delete_heritage_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+// `include` (glob discovery) rather than `files`: it drives the module-graph
+// discovery / check order under which the consumer is checked before the
+// declaring module's interface flattens — the schedule that leaves the
+// receiver a deferred cross-file form at the delete site (the witness does not
+// reproduce under an explicit `files` list).
+const TSCONFIG: &str = r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2020", "DOM"],
+    "noEmit": true
+  },
+  "include": ["fetch.ts", "types.ts"]
+}
+"#;
+
+/// Run the project on the genuine concurrent per-file checker path and return
+/// stdout (diagnostics, one per line). Both force-parallel flags are set so a
+/// sub-floor (2-file) witness actually runs through `par_iter`.
+fn run_tiny_parallel(files: &[(&str, &str)]) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new("witness").expect("temp dir");
+    for (name, source) in files {
+        std::fs::write(temp.path.join(name), source).expect("write source");
+    }
+    std::fs::write(temp.path.join("tsconfig.json"), TSCONFIG).expect("write tsconfig");
+
+    let output = Command::new(&tsz_bin)
+        .args(["-p", "tsconfig.json", "--pretty", "false"])
+        .current_dir(&temp.path)
+        .env("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK", "1")
+        .env("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK_TINY", "1")
+        .output()
+        .expect("run tsz on witness");
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn count_ts2790(stdout: &str) -> usize {
+    stdout
+        .lines()
+        .filter(|line| line.contains("error TS2790"))
+        .count()
+}
+
+/// Build the declaring module. `fetch_options_members` is spliced into the
+/// generic `FetchOptions<R, T>` body (which `extends Omit<RequestInit, ...>`);
+/// `ResolvedFetchOptions<R, T> extends FetchOptions<R, T>` inherits them, and
+/// `FetchContext.options: ResolvedFetchOptions<R, T>` keeps the delete-site
+/// receiver a generic (deferred) application.
+fn types_src(fetch_options_members: &str) -> String {
+    format!(
+        r#"export type ResponseType = "json" | "text" | "blob";
+
+export interface FetchContext<T = any, R extends ResponseType = ResponseType> {{
+  request: string;
+  options: ResolvedFetchOptions<R, T>;
+}}
+
+export interface FetchOptions<R extends ResponseType = ResponseType, T = any>
+  extends Omit<RequestInit, "body"> {{
+{fetch_options_members}
+}}
+
+export interface ResolvedFetchOptions<
+  R extends ResponseType = ResponseType,
+  T = any
+> extends FetchOptions<R, T> {{
+  extra: number;
+}}
+"#
+    )
+}
+
+/// The reduced ofetch witness: deleting a base-inherited optional through an
+/// `Omit<...>` heritage layer (guarded + bare) must not emit TS2790.
+#[test]
+fn delete_base_inherited_optional_through_omit_heritage_is_legal() {
+    // Consumer first: `fetch.ts` is checked before `types.ts` has flattened
+    // `ResolvedFetchOptions`, so the receiver stays a deferred cross-file form.
+    let types = types_src(
+        "  baseURL?: string;\n  params?: Record<string, any>;\n  query?: Record<string, any>;\n  responseType?: R;",
+    );
+    let files = &[
+        (
+            "fetch.ts",
+            r#"import type { FetchContext } from "./types";
+export function handle(context: FetchContext) {
+  if (context.options.query) {
+    delete context.options.query;
+  }
+  delete context.options.params;
+}
+"#,
+        ),
+        ("types.ts", types.as_str()),
+    ];
+    let Some(stdout) = run_tiny_parallel(files) else {
+        println!("skipping #14112 witness: tsz binary not found");
+        return;
+    };
+    assert_eq!(
+        count_ts2790(&stdout),
+        0,
+        "base-inherited optional through Omit heritage must not emit TS2790.\nstdout:\n{stdout}"
+    );
+}
+
+/// Negative control: deleting a genuinely *required* base-inherited property
+/// still reports TS2790 — the heritage-aware optionality lookup must not
+/// blanket-suppress the error.
+#[test]
+fn delete_base_inherited_required_property_still_errors() {
+    let types = types_src("  anchor: number;");
+    let files = &[
+        (
+            "fetch.ts",
+            r#"import type { FetchContext } from "./types";
+export function handle(context: FetchContext) {
+  delete context.options.anchor;
+}
+"#,
+        ),
+        ("types.ts", types.as_str()),
+    ];
+    let Some(stdout) = run_tiny_parallel(files) else {
+        println!("skipping #14112 negative control: tsz binary not found");
+        return;
+    };
+    assert_eq!(
+        count_ts2790(&stdout),
+        1,
+        "deleting a required base-inherited property must still report TS2790.\nstdout:\n{stdout}"
+    );
+}

--- a/crates/tsz-solver/src/objects/collect.rs
+++ b/crates/tsz-solver/src/objects/collect.rs
@@ -175,6 +175,49 @@ where
     collect_properties_cached(type_id, interner, resolver, None)
 }
 
+/// Whether a named property is *declared optional* on the apparent type,
+/// resolving through heritage, intersection, application, union, mapped,
+/// conditional, and type-parameter constraints.
+///
+/// `tsc` decides `delete obj.p` legality (TS2790) from the deleted property's
+/// declared symbol — resolved through the receiver's full apparent type — not
+/// from the receiver's own flattened [`ObjectShape`]. A property declared `?`
+/// in a base interface and inherited (without redeclaration) by a derived
+/// interface, or one surfaced only through a deferred `Application` /
+/// intersection receiver, must therefore read as optional even though it is
+/// absent from — or required-looking on — the receiver's direct shape. A bare
+/// `get_object_shape` lookup returns `None` for `Lazy`/`Application`/
+/// intersection/union receivers and only the derived interface's own members
+/// for a flat shape, so it cannot answer this on its own.
+///
+/// Resolution order:
+/// 1. Fast path — a directly available object shape is already heritage-merged
+///    for nominal interfaces, so its own `optional` flag is authoritative when
+///    the property is present there.
+/// 2. Apparent-type path — otherwise collect the merged members through
+///    [`collect_properties`]; optionality survives unless a required occurrence
+///    overrides it (intersection semantics, matching the merge rule above).
+pub fn property_is_optional<R>(
+    type_id: TypeId,
+    name: Atom,
+    interner: &dyn TypeDatabase,
+    resolver: &R,
+) -> bool
+where
+    R: TypeResolver,
+{
+    if let Some(prop) = crate::type_queries::find_property_in_object(interner, type_id, name) {
+        return prop.optional;
+    }
+    match collect_properties(type_id, interner, resolver) {
+        PropertyCollectionResult::Properties { properties, .. } => properties
+            .iter()
+            .find(|prop| prop.name == name)
+            .is_some_and(|prop| prop.optional),
+        PropertyCollectionResult::Any | PropertyCollectionResult::NonObject => false,
+    }
+}
+
 /// [`collect_properties`] with an explicit cross-call query cache so spawned
 /// evaluators can reuse memoized application/instantiation results. Callers
 /// that already hold a `QueryDatabase` (checker/solver paths) should pass it to


### PR DESCRIPTION
Fixes #14112.

Goal: green

## Summary
`delete obj.prop` falsely reported **TS2790** ("The operand of a 'delete' operator must be optional") when `prop` is declared optional in a **base** interface and inherited (without redeclaration) by a derived interface whose receiver is a deferred `Application`/intersection at the delete site.

Witness (ofetch `src/fetch.ts`): `delete context.options.query`, where `query?: Record<string, any>` is declared on `FetchOptions` (which `extends Omit<RequestInit, ...>`) and inherited by `ResolvedFetchOptions extends FetchOptions`. `tsc`/`tsgo`: 0 diagnostics; tsz: false TS2790.

## Structural rule
When the deleted property is declared `?` in a base interface and inherited by the receiver, `tsc` resolves the property's declared symbol through the full **apparent type** (heritage chain) and reads its question token — the delete is legal. tsz instead read only the receiver's own flattened `ObjectShape`.

## Root cause / owner
`CheckerState::is_property_optional` (`crates/tsz-checker/src/types/object_type.rs`) bottomed out in `get_object_shape`, which returns `None` for `Lazy`/`Application`/intersection/union receivers and only the derived interface's own members for a flat shape. A base-only optional therefore read as **required**; once truthiness/`in` narrowing stripped the operand's `undefined`, the delete check (`types/computation/delete_optionality.rs`) fell through to TS2790.

The bug is schedule-sensitive: under the project pipeline's fresh per-file parallel checking, the consumer file is checked before the declaring module's interface has flattened, so the receiver stays a deferred generic `Application` (`ResolvedFetchOptions<R, T>`) at the delete site. The single-checker unit harness resolves it to a flat shape eagerly and never exercises the gap.

## Fix
Add a heritage-aware solver query `tsz_solver::objects::property_is_optional`:
1. **Fast path** — `find_property_in_object` (direct, already heritage-merged for nominal interfaces).
2. **Apparent-type path** — fall back to `collect_properties`, which resolves heritage / intersection / application / union / mapped / conditional / type-parameter constraints and merges optionality with required-wins semantics.

The checker's `is_property_optional` delegates to it, keeping type-shape recursion in the solver per the architecture contract (type semantics belong in the solver; the checker must not recurse type shapes when a solver query can own it). The fast path bounds cost — `collect_properties` only runs when the direct lookup misses (deferred receivers).

## Adjacent matrix
- required-in-derived (no redeclaration) — still errors (negative control).
- intersection `{a?}&{a}` — required-wins, optionality dropped.
- generic derived receiver with free type params — resolved through the application.
- truthiness/`in` narrowing — declared optionality recovered.

## Verification
- New end-to-end regression: `cargo test -p tsz-cli --test delete_inherited_optional_heritage_tests`
  - `delete_base_inherited_optional_through_omit_heritage_is_legal` — 0 TS2790 (reverting the fix reproduces the false positive: 1 TS2790).
  - `delete_base_inherited_required_property_still_errors` — exactly 1 TS2790 (negative control).
  - Drives the real binary with DOM lib and the genuine `par_iter` fresh-checker path forced (`TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK[_TINY]`).
- Ground truth confirmed against `tsc` (0 errors) and the pre-fix tsz binary (TS2790) on the reduced witness.
- No regressions: `cargo test -p tsz-checker --lib cross_module_generic_interface_heritage_tests` (8), `cargo test -p tsz-checker --test conformance_issues_types membership_semantics::test_delete` (9).
- `cargo clippy -p tsz-solver -p tsz-checker -p tsz-cli --tests` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01GqEV5UQZQuwGuA7NrvLRDk

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqEV5UQZQuwGuA7NrvLRDk)_