### PR TITLE
fix(solver): guard infer object-pattern application unwrap against non-converging cycles (TS stack overflow)

### DIFF
--- a/crates/tsz-cli/tests/recursive_conditional_infer_termination_tests.rs
+++ b/crates/tsz-cli/tests/recursive_conditional_infer_termination_tests.rs
@@ -341,3 +341,122 @@ fn awaited_unwraps_user_thenable_nested_in_promise() {
         4,
     );
 }
+
+// ===========================================================================
+// Issue #14123 — recursive conditional `infer` over a generic-alias array
+// element must not stack-overflow and must resolve like `tsc`.
+// ===========================================================================
+//
+// `type D<T> = T extends Promise<infer U> ? D<U> : T extends { payload: infer P }
+//  ? D<P> : T extends (infer E)[] ? D<E> : T` applied through a *generic type
+// alias* whose array element is an object type parameter
+// (`type Box<T> = Promise<{ payload: T[] }>`; `D<Box<{ id: 0 }>>`) used to abort
+// the process with a stack overflow (SIGABRT). The object-pattern `infer`
+// matcher unwrapped each deferred `Application` source by recursing into itself
+// directly, bypassing the `visited` cycle guard at the `match_infer_pattern`
+// entry; with the modern `esnext.iterator` lib active a pair of
+// mutually-recursive deferred conditionals evaluated into each other and the
+// unwrap loop never converged. `tsc`/`tsgo` resolve the alias to `{ id: 0 }` in
+// a few steps. These run the real binary (full pipeline + embedded libs, which
+// is required — the in-crate checker harness leaves the recursive alias
+// deferred and cannot reproduce it) and assert termination plus the correct
+// resolved shape, with binder names varied so the fix is structural.
+
+/// Assert the binary did not abort with a stack overflow on `source`.
+fn assert_no_stack_overflow(name: &str, out: &str) {
+    assert!(
+        !out.contains("overflowed its stack") && !out.contains("stack overflow"),
+        "`{name}` stack-overflowed instead of terminating:\n{out}"
+    );
+}
+
+#[test]
+fn recursive_conditional_infer_generic_alias_array_element_resolves() {
+    let out = run_check(
+        "cond_infer_alias_14123",
+        "type D<T> =\n\
+         \x20   T extends Promise<infer U> ? D<U> :\n\
+         \x20   T extends { payload: infer P } ? D<P> :\n\
+         \x20   T extends (infer E)[] ? D<E> :\n\
+         \x20   T;\n\
+         type Box<T> = Promise<{ payload: T[] }>;\n\
+         type R = D<Box<{ id: 0 }>>;\n\
+         declare const r: R;\n\
+         const good: { id: number } = r;\n\
+         const bad: string = r;\n",
+    );
+    if out.is_empty() {
+        return; // binary not found; run_check already logged the skip.
+    }
+    assert_no_stack_overflow("cond_infer_alias_14123", &out);
+    // R resolves to `{ id: 0 }`: the `{ id: number }` target (line 9) type-checks,
+    // the `string` target (line 10) is a genuine mismatch and must error.
+    assert!(
+        out.contains("repro.ts(10,"),
+        "resolved `{{ id: 0 }}` must not be assignable to `string` (line 10).\noutput:\n{out}"
+    );
+    assert!(
+        !out.contains("repro.ts(9,"),
+        "resolved `{{ id: 0 }}` must be assignable to `{{ id: number }}` (line 9).\noutput:\n{out}"
+    );
+}
+
+#[test]
+fn recursive_conditional_infer_generic_alias_renamed_binders_resolve() {
+    // Same structure, every binder renamed: the fix is structural, not by name.
+    let out = run_check(
+        "cond_infer_alias_renamed_14123",
+        "type Unwrap<Source> =\n\
+         \x20   Source extends Promise<infer Inner> ? Unwrap<Inner> :\n\
+         \x20   Source extends { payload: infer Field } ? Unwrap<Field> :\n\
+         \x20   Source extends (infer Element)[] ? Unwrap<Element> :\n\
+         \x20   Source;\n\
+         type Wrapper<Value> = Promise<{ payload: Value[] }>;\n\
+         type Result = Unwrap<Wrapper<{ tag: 7 }>>;\n\
+         declare const r: Result;\n\
+         const good: { tag: number } = r;\n\
+         const bad: string = r;\n",
+    );
+    if out.is_empty() {
+        return;
+    }
+    assert_no_stack_overflow("cond_infer_alias_renamed_14123", &out);
+    assert!(
+        out.contains("repro.ts(10,"),
+        "renamed alias must resolve to `{{ tag: 7 }}` (line 10 mismatch).\noutput:\n{out}"
+    );
+    assert!(
+        !out.contains("repro.ts(9,"),
+        "renamed alias must accept a `{{ tag: number }}` target (line 9).\noutput:\n{out}"
+    );
+}
+
+#[test]
+fn recursive_conditional_infer_inlined_form_resolves() {
+    // The inlined equivalent (no generic alias) was always clean; guard the
+    // non-aliased path so the fix does not perturb it.
+    let out = run_check(
+        "cond_infer_inlined_14123",
+        "type D<T> =\n\
+         \x20   T extends Promise<infer U> ? D<U> :\n\
+         \x20   T extends { payload: infer P } ? D<P> :\n\
+         \x20   T extends (infer E)[] ? D<E> :\n\
+         \x20   T;\n\
+         type R = D<Promise<{ payload: { id: 0 }[] }>>;\n\
+         declare const r: R;\n\
+         const good: { id: number } = r;\n\
+         const bad: string = r;\n",
+    );
+    if out.is_empty() {
+        return;
+    }
+    assert_no_stack_overflow("cond_infer_inlined_14123", &out);
+    assert!(
+        out.contains("repro.ts(9,"),
+        "inlined form must resolve to `{{ id: 0 }}` (line 9 mismatch).\noutput:\n{out}"
+    );
+    assert!(
+        !out.contains("repro.ts(8,"),
+        "inlined form must accept a `{{ id: number }}` target (line 8).\noutput:\n{out}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
@@ -78,6 +78,33 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
+    /// Unwrap a deferred `Application` source one structural step and re-match
+    /// it through the guarded [`Self::match_infer_pattern`] entry.
+    ///
+    /// The object / object-with-index pattern matchers reach this when the
+    /// source is still an `Application`. Recursing back into the per-shape
+    /// matcher directly would bypass `match_infer_pattern`'s `(source, pattern)`
+    /// cycle guard, so a pair of mutually-recursive deferred conditionals that
+    /// evaluate into each other (`eval(A) = B`, `eval(B) = A`) without ever
+    /// reducing to a concrete object would unwind `A -> B -> A -> ...` forever
+    /// and overflow the stack (issue #14123). Routing through the guarded entry
+    /// records each unwrapped source in `visited` and short-circuits the cycle,
+    /// and reuses the canonical `never`/union/intersection source handling.
+    fn match_infer_unwrapped_application(
+        &self,
+        source: TypeId,
+        pattern: TypeId,
+        bindings: &mut FxHashMap<Atom, TypeId>,
+        visited: &mut InferPatternVisited,
+        checker: &mut SubtypeChecker<'_, R>,
+    ) -> bool {
+        let evaluated = self.evaluate_for_infer_match(source);
+        if evaluated == source {
+            return false;
+        }
+        self.match_infer_pattern(evaluated, pattern, bindings, visited, checker)
+    }
+
     /// Match each pattern property against the corresponding source property,
     /// extracting infer bindings with variance-aware merging.
     ///
@@ -189,18 +216,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 true
             }
             Some(TypeData::Application(_)) => {
-                let evaluated = self.evaluate_for_infer_match(source);
-                if evaluated == source {
-                    return false;
-                }
-                self.match_infer_object_pattern(
-                    evaluated,
-                    pattern_shape_id,
-                    pattern,
-                    bindings,
-                    visited,
-                    checker,
-                )
+                self.match_infer_unwrapped_application(source, pattern, bindings, visited, checker)
             }
             Some(TypeData::Callable(callable_shape_id)) => {
                 // Callable types (class constructors) have properties (static members)
@@ -573,18 +589,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 true
             }
             Some(TypeData::Application(_)) => {
-                let evaluated = self.evaluate_for_infer_match(source);
-                if evaluated == source {
-                    return false;
-                }
-                self.match_infer_object_with_index_pattern(
-                    evaluated,
-                    pattern_shape_id,
-                    pattern,
-                    bindings,
-                    visited,
-                    checker,
-                )
+                self.match_infer_unwrapped_application(source, pattern, bindings, visited, checker)
             }
             Some(TypeData::Union(members)) => {
                 let members = self.interner().type_list(members);


### PR DESCRIPTION
Fixes #14123.

Goal: green

## Structural rule
When a conditional `infer` object pattern (`{ payload: infer P }`) is matched
against a source that is still a deferred `Application`, `tsc` resolves the
application to its concrete shape and matches against that. tsz must unwrap the
application **through the cycle-guarded matcher entry** so a non-converging
application chain is detected and terminated, instead of recursing forever.

> When the unwrapped source of an infer object/object-with-index pattern is
> itself an `Application`, tsz re-matches it through the solver
> `match_infer_pattern` entry (which records `(source, pattern)` in `visited`),
> rather than recursing into the per-shape matcher directly.

## Wrong semantic operation
Infer-pattern matching (solver conditional/`infer` evaluation). A recursive
distributive conditional that re-applies itself through `Promise<infer U>` /
`{ payload: infer P }` / `(infer E)[]` branches **stack-overflowed (SIGABRT,
exit 134)** when the check type came through a generic type alias whose array
element was an object type parameter (`type Box<T> = Promise<{ payload: T[] }>`;
`type R = D<Box<{ id: 0 }>>`). `tsc`/`tsgo` resolve `R = { id: 0 }`.

Root cause: `match_infer_object_pattern` / `match_infer_object_with_index_pattern`
unwrapped a deferred `Application` source by evaluating one step
(`evaluate_for_infer_match`) and then recursing **into the per-shape matcher
directly**. That direct recursion bypassed the `(source, pattern)` cycle guard
applied at the top of `match_infer_pattern`. With the modern `esnext.iterator`
lib active, a pair of mutually-recursive deferred conditionals evaluates into
each other (`eval(A) = B`, `eval(B) = A`) without ever reducing to a concrete
object, so the unwrap unwound `A -> B -> A -> ...` forever. `evaluate_for_infer_match`'s
own expansion budget is RAII-scoped to a single call and resets on each unwrap,
so it could not bound this cross-call recursion.

## Fix / owner layer
- **Solver / `evaluation::evaluate_rules::infer_pattern_object_match`**: both
  `Application` arms now delegate to a single `match_infer_unwrapped_application`
  helper that evaluates one step and routes the result back through the guarded
  `match_infer_pattern` entry. The `visited` guard records each unwrapped source
  and short-circuits the cycle; the canonical `never`/union/intersection source
  handling is reused for free. No checker change is required.

Name-agnostic and structural: keyed purely on the `Application` type-data shape
and the existing visited-set identity, with no identifier/alias/file-name
predicate.

## Adjacent matrix (vs `tsc`/`tsgo`; binders varied)
End-to-end CLI tests in
`crates/tsz-cli/tests/recursive_conditional_infer_termination_tests.rs` (the
in-crate checker harness leaves a recursive alias deferred and cannot reproduce
this — it requires the real driver + embedded libs):
- generic-alias witness `D<Box<{ id: 0 }>>` — terminates, resolves to `{ id: 0 }`
  (accepts `{ id: number }`, rejects `string`);
- the same with every binder renamed (`Unwrap`/`Wrapper`/`Source`/...) — same outcome;
- inlined form `D<Promise<{ payload: { id: 0 }[] }>>` (no generic alias) — still clean;
- negative control in each case: the mismatching assignment still reports TS2322,
  proving the type converged to the precise literal shape rather than an
  opaque/widened residue.

The pre-existing #11586 termination tests in the same file continue to pass.

## Verification
- `cargo test -p tsz-cli --test recursive_conditional_infer_termination_tests`
  — 15 passed (3 new #14123 cases + 12 existing #11586). Confirmed the new
  cases **fail with a stack overflow on the pre-fix source** and pass after.
- `cargo test -p tsz-solver --lib` — 6849 passed, 4 failed; the 4 failures are
  **byte-identical to the `main` baseline** (pre-existing), so zero regressions.
- `cargo test -p tsz-checker --test conditional_infer_tests` — 104 passed,
  3 failed (all pre-existing on baseline).
- `cargo clippy -p tsz-solver --lib` clean; `cargo fmt` clean.
- CLI repro (`--lib es2022,dom,dom.iterable`, and default libs): before — SIGABRT
  (exit 134); after — clean, `R` resolves to `{ id: 0 }` (TS2322 only on the
  intentional `string` mismatch).
- Reviewed with `/simplify`: the two identical Application-arm bodies were DRYed
  into one guarded helper that centralizes the cycle-guard rationale.
- Broad conformance/emit/fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpffFTjqYH9QEuQfbKoeRj)_