### PR TITLE
fix(solver): reject deferred recursive-alias self-applications from the concrete-fixpoint cache (#14123)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1844,6 +1844,9 @@ path = "tests/recursive_utility_alias_fanout_tests.rs"
 name = "recursive_conditional_alias_concrete_fixpoint_tests"
 path = "tests/recursive_conditional_alias_concrete_fixpoint_tests.rs"
 [[test]]
+name = "issue_14123_repro_tests"
+path = "tests/issue_14123_repro_tests.rs"
+[[test]]
 name = "recursive_alias_counter_convergence_ts2589_tests"
 path = "tests/recursive_alias_counter_convergence_ts2589_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/issue_14123_repro_tests.rs
+++ b/crates/tsz-checker/tests/issue_14123_repro_tests.rs
@@ -1,0 +1,83 @@
+//! Regression for issue #14123: a recursive conditional alias that extracts an
+//! `(infer E)[]` element from a generic-alias array property must converge to a
+//! concrete fixpoint instead of stack-overflowing (SIGABRT).
+//!
+//! Root cause: the concrete recursive-conditional application-fixpoint sharing
+//! permit (#13508/#13894) treated a *deferred* self-application — e.g.
+//! `D<{id:0}[]>` finalizing to the unevaluated `D<{id:0}>` — as a converged
+//! fixpoint, because it carries no free type parameter and no `error`. Caching
+//! `(D, args) -> D<…>` poisoned the resolver-independent application-eval cache:
+//! a later read returned the deferred self-application, which re-applied `D` on
+//! the same input forever. The fix rejects results that still contain an
+//! application of a recursive alias (a body that re-references its own `DefId`).
+//!
+//! These assert convergence (no SIGABRT, no TS2589) AND the exact `tsc` result
+//! (`R = { id: 0 }`): the positive assignment must hold and a mismatched target
+//! must report TS2322. Binder names are varied across cases so the guard is
+//! structural, not identifier-driven.
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::check_source_with_libs_code_messages;
+
+fn codes(source: &str) -> Vec<u32> {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    let opts = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    check_source_with_libs_code_messages(source, "test.ts", opts, &libs)
+        .into_iter()
+        .map(|(c, _)| c)
+        .collect()
+}
+
+/// The minimal witness from the issue: Promise → `{ payload }` → `(infer E)[]`
+/// over a generic alias `Box<T> = Promise<{ payload: T[] }>`.
+#[test]
+fn issue_14123_alias_array_infer_converges_to_object() {
+    let c = codes(
+        r#"
+type D<T> =
+    T extends Promise<infer U> ? D<U> :
+    T extends { payload: infer P } ? D<P> :
+    T extends (infer E)[] ? D<E> :
+    T;
+type Box<T> = Promise<{ payload: T[] }>;
+type R = D<Box<{ id: 0 }>>;
+declare const r: R;
+const ok: { id: 0 } = r;
+"#,
+    );
+    assert!(!c.contains(&2589), "must converge, no TS2589. Got: {c:?}");
+    assert!(
+        !c.contains(&2322),
+        "R must equal {{ id: 0 }} (positive assignment holds). Got: {c:?}"
+    );
+}
+
+/// Same shape, renamed binders, with a mismatched target: the conditional still
+/// resolves to `{ id: 0 }`, so assigning it to `{ id: 1 }` reports exactly one
+/// TS2322 — proving the recursion converged to a concrete value rather than a
+/// deferred placeholder.
+#[test]
+fn issue_14123_alias_array_infer_reports_mismatch() {
+    let c = codes(
+        r#"
+type Unwrap<Q> =
+    Q extends Promise<infer A> ? Unwrap<A> :
+    Q extends { payload: infer B } ? Unwrap<B> :
+    Q extends (infer C)[] ? Unwrap<C> :
+    Q;
+type Wrapper<S> = Promise<{ payload: S[] }>;
+type Result = Unwrap<Wrapper<{ id: 0 }>>;
+declare const value: Result;
+const bad: { id: 1 } = value;
+"#,
+    );
+    assert!(!c.contains(&2589), "must converge, no TS2589. Got: {c:?}");
+    assert_eq!(
+        c.iter().filter(|&&x| x == 2322).count(),
+        1,
+        "mismatched target must report exactly one TS2322. Got: {c:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate/application.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/application.rs
@@ -923,6 +923,23 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// DAG is re-walked, and sharing is blocked *because* the limit fired).
     /// Termination stays owned by the recursion guards and fuel, so this only
     /// collapses redundant re-evaluation.
+    ///
+    /// Parameter-freedom and `error`-freedom alone are NOT sufficient: a
+    /// recursive conditional alias whose body expansion was *deferred* (a depth
+    /// guard returned the unevaluated branch, or a relation/limited-resolver
+    /// sub-evaluation declined to reduce) leaves a residual `Application` of the
+    /// alias **in the result** — e.g. `D<{id:0}[]>` finalizing to the
+    /// unevaluated `D<{id:0}>`. That residue carries no free type parameter and
+    /// no `error`, so it passes both predicates above, yet it is a self-applied
+    /// placeholder, not a converged value. Persisting `(D, args) -> D<…>` poisons
+    /// the resolver-independent cache: a later authoritative read returns the
+    /// deferred self-application, whose re-evaluation re-reads the same entry and
+    /// re-applies `D` on the same input without ever recognizing the cycle —
+    /// unbounded recursion to a SIGABRT (#14123, a regression introduced when
+    /// this permit was added in #13508/#13894). A genuine concrete fixpoint of a
+    /// terminating recursion contains no residual application of a recursive
+    /// alias, so [`Self::result_has_residual_recursive_alias`] is the final
+    /// discriminator.
     fn is_concrete_application_fixpoint(&self, args: &[TypeId], result: TypeId) -> bool {
         // Concrete instantiation: every argument must itself be parameter-free,
         // so the key identifies one global instantiation rather than a
@@ -942,6 +959,56 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         result != TypeId::ERROR
             && !crate::type_queries::contains_error_type_db(self.interner, result)
             && !crate::type_queries::contains_type_parameters_db(self.interner, result)
+            && !self.result_has_residual_recursive_alias(result)
+    }
+
+    /// Whether `result` still contains an unevaluated `Application` of a
+    /// *recursive* generic type — one whose resolved body re-references its own
+    /// `DefId`. Such a residue means the recursion was deferred (a depth guard
+    /// returned the unevaluated branch, or a relation/limited sub-evaluation
+    /// declined to reduce it) rather than converged, so `result` is a self- or
+    /// mutually-applied placeholder, not a fixpoint. Caching it would let a
+    /// later read re-enter the same recursive evaluation and re-apply the alias
+    /// on the same input without recognizing the cycle (#14123).
+    ///
+    /// Only `Application` (generic-instantiation) nodes are inspected: a
+    /// concrete, fully-reduced result of a terminating recursion never retains
+    /// an application of a recursive alias. Non-recursive applications (whose
+    /// body does not refer to itself) cannot re-enter their own evaluation on a
+    /// cache read, so they remain cacheable residue.
+    ///
+    /// `DefKind` is intentionally *not* consulted: under a limited/relation
+    /// resolver `get_def_kind` can return `None` for a def that nonetheless
+    /// `resolve_lazy`-resolves to a self-referential body (the exact case in
+    /// #14123). The body-self-reference signal is the resolver-robust
+    /// discriminator.
+    fn result_has_residual_recursive_alias(&self, result: TypeId) -> bool {
+        // Memoize the self-reference verdict per `DefId`: a result can carry many
+        // applications of the same alias, and `contains_lazy_def_id` walks the
+        // alias body on every call. The cache collapses that to one body walk
+        // per distinct def.
+        let mut is_recursive: FxHashMap<DefId, bool> = FxHashMap::default();
+        let mut found = false;
+        crate::visitor::walk_referenced_types(self.interner, result, |current| {
+            if found {
+                return;
+            }
+            let Some(TypeData::Application(app_id)) = self.interner.lookup(current) else {
+                return;
+            };
+            let base = self.interner.type_application(app_id).base;
+            let Some(def_id) = self.resolve_application_def_id(base) else {
+                return;
+            };
+            found = *is_recursive.entry(def_id).or_insert_with(|| {
+                self.resolver
+                    .resolve_lazy(def_id, self.interner)
+                    .is_some_and(|body| {
+                        crate::visitor::contains_lazy_def_id(self.interner, body, def_id)
+                    })
+            });
+        });
+        found
     }
 
     /// Extract the instance side of a class-shaped resolved body.


### PR DESCRIPTION
Fixes #14123 — a stack overflow (SIGABRT, exit 134) evaluating a 7-line
recursive conditional that `tsc` accepts. Surfaced on the
`Conditional infer hotspot N=25/50/100/200` benchmark rows ("tsz error; tsc ok").

Goal: green

## Root cause
Bisected to #13508/#13894 (`perf(solver): share concrete recursive-conditional
application fixpoints`), which added a second application-eval cache-write permit,
`is_concrete_application_fixpoint`: a parameter-free, `error`-free result of a
concrete application is shared across evaluators even when the epoch gate
withholds the write.

Parameter-freedom + `error`-freedom is not sufficient. Evaluating
`Application(D, args)` for a recursive conditional alias can finalize to a
*deferred* self-application — e.g. `D<{id:0}[]>` returning the unevaluated
`D<{id:0}>` when a depth guard or a relation/limited-resolver sub-evaluation
declines to reduce it. That residue has no free type parameter and no `error`,
so it passed the permit, and `(D, args) -> D<…>` was persisted. A later
authoritative read returned the deferred self-application, whose re-evaluation
re-read the same entry and re-applied `D` on the same input without recognizing
the cycle → unbounded native recursion → SIGABRT.

Confirmed by disabling the permit (crash vanishes) and by tracing the poison
write `(D, [{id:0}[]]) -> D<{id:0}>`.

## Fix
**Structural rule:** when `Application(DefId, args)` evaluates to a result that
still contains an unevaluated application of a *recursive* generic type (a `Lazy`
def whose resolved body re-references its own `DefId`), that result is a deferred
placeholder, not a converged fixpoint, and must not be shared. Non-recursive
applications and nominal class/interface applications (`Promise<X>`, `Map<K,V>`)
remain cacheable residue.

**Owner layer:** solver — the single application-eval cache-write decision in
`is_concrete_application_fixpoint` / `insert_application_eval_cache_if_some`
(`crates/tsz-solver/src/evaluation/evaluate/application.rs`). No checker/emitter
involvement.

`DefKind` is intentionally not consulted: under a limited/relation resolver
`get_def_kind` returns `None` for a def that nonetheless `resolve_lazy`-resolves
to a self-referential body (the exact #14123 case). The body-self-reference
signal is the resolver-robust discriminator, and it also covers mutual recursion
(`A<…>` whose result retains `B<…>` where `B` re-references itself).

The #13508 perf win is preserved: typebox `Static<…>` and remeda
`FilteredArray<…>` reduce to pure structural results with no residual alias
applications, so they still share their fixpoints.

**Adjacent matrix:** self-recursive alias (the repro), renamed binders
(`Unwrap`/`Wrapper`), positive assignment (`R = { id: 0 }` holds) and negative
assignment (mismatched target → exactly one TS2322).

## Provenance
Machine: cloud
Assistant: claude-code
Model: Opus 4.8
Effort: high

## Verification
- `TSZ_USE_EMBEDDED_LIBS=1 tsz --noEmit --strict repro.ts` → exit 0 (was 134);
  `R` resolves to `{ id: 0 }` (positive assignment holds, `{ id: 1 }` target
  reports TS2322), matching `tsc`.
- `cargo nextest run -p tsz-checker --test issue_14123_repro_tests` — new
  regression guards (convergence + exact result, varied binders).
- `cargo nextest run -p tsz-checker --test recursive_conditional_alias_concrete_fixpoint_tests --test recursive_utility_alias_fanout_tests`
  — the #13508 fixpoint-sharing suite still green (no perf-sharing regression).
- `cargo clippy -p tsz-solver` clean.

https://claude.ai/code/session_012me3W5piwy466xjtjQ14uL

---
_Generated by [Claude Code](https://claude.ai/code/session_012me3W5piwy466xjtjQ14uL)_