### PR TITLE
fix(checker): credit nested unresolved built-in Application members in union/intersection property access (TS2339)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -740,6 +740,9 @@ path = "tests/union_source_missing_property_elaboration_tests.rs"
 name = "union_target_missing_property_elaboration_tests"
 path = "tests/union_target_missing_property_elaboration_tests.rs"
 [[test]]
+name = "union_generic_class_shared_member_tests"
+path = "tests/union_generic_class_shared_member_tests.rs"
+[[test]]
 name = "union_source_structural_elaboration_tests"
 path = "tests/union_source_structural_elaboration_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -437,6 +437,30 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // Composite-receiver rescue: a union/intersection whose member lookup
+        // degraded to a false `PropertyNotFound` because the boundary's noop
+        // resolver could not resolve a *nested* built-in `Lazy(DefId)` /
+        // `Application(Lazy, args)` constituent. Example: `value instanceof Set`
+        // narrowing of `T | U` yields `(T & Set<any>) | (U & Set<any>)` where one
+        // `Set<any>` arm stays an unresolved `Application` — its `.size` lookup
+        // returns `PropertyNotFound`, collapsing the whole union to TS2339. The
+        // whole-receiver lazy rescue above never fires here because the receiver
+        // is not a bare `Lazy`. Re-query through the checker's full `TypeResolver`,
+        // which resolves the nested ref and surfaces the concrete member; adopt
+        // only a genuine `Success` so a real missing property still reports TS2339.
+        if result.is_not_found()
+            && !crate::query_boundaries::common::is_lazy_type(self.ctx.types, original_object_type)
+            && crate::query_boundaries::common::contains_application_in_structure(
+                self.ctx.types,
+                object_type,
+            )
+        {
+            let resolver_result = self.resolve_property_access_via_resolver(object_type, prop_name);
+            if resolver_result.is_success() {
+                result = resolver_result;
+            }
+        }
+
         self.resolve_property_access_with_env_post_query(object_type, prop_name, result)
     }
 

--- a/crates/tsz-checker/tests/union_generic_class_shared_member_tests.rs
+++ b/crates/tsz-checker/tests/union_generic_class_shared_member_tests.rs
@@ -1,0 +1,140 @@
+//! Property access on a union of *generic* class/interface instances reached
+//! through a deferred `IndexAccess` must credit a member that is present on
+//! every union arm, even when one arm stays an unresolved
+//! `Application(Lazy(DefId), args)` that the property-access boundary's noop
+//! `TypeResolver` cannot crack.
+//!
+//! Regression for #14128: `(input & Set<any>) | (UnknownInput & Set<any>)`
+//! (from `value instanceof Set` narrowing of `input | UnknownInput`) reported
+//! a false `TS2339` on `.size` because one `Set<any>` arm remained an
+//! unresolved `Application`, whose member lookup degraded to `PropertyNotFound`
+//! and collapsed the whole union. The minimized, deterministic witness uses
+//! generic classes behind a `Slices[SliceId][SliceKey]` indexed access so the
+//! union arms stay deferred `Application`s under the test harness.
+
+use tsz_common::diagnostics::Diagnostic;
+
+fn check(source: &str) -> Vec<Diagnostic> {
+    tsz_checker::test_utils::check_source_diagnostics(source)
+}
+
+/// A method present on *both* generic-class arms of a deferred indexed-access
+/// union must resolve — no `TS2339`. Names are deliberately varied (`Alpha`/
+/// `Beta`, `read`) so the fix cannot be a name-keyed special case.
+///
+/// The two-class shape (`Simple` *and* `Complex`) is load-bearing: it keeps one
+/// `Alpha<number>`/`Beta<string>` arm as an unresolved `Application(Lazy, args)`
+/// in the boundary's noop-resolver path, which is exactly the state that made
+/// the pre-fix member lookup degrade to a false `PropertyNotFound`.
+#[test]
+fn shared_member_on_union_of_generic_class_applications_is_not_missing() {
+    let source = r#"
+class Alpha<T extends number> {
+  private value!: T;
+  shared(): T { return this.value; }
+  onlyAlpha(): void {}
+}
+class Beta<T extends string> {
+  private value!: T;
+  shared(): T { return this.value; }
+  onlyBeta(): void {}
+}
+const isAlpha = <Candidate extends Alpha<number> | Beta<string>>(
+  candidate: Candidate
+): candidate is Extract<Candidate, Alpha<any>> => candidate instanceof Alpha;
+
+class Simple<Entries extends { [index: string]: Alpha<number> | Beta<string> }> {
+  private entries = {} as Entries;
+  read<EntryId extends keyof Entries>(entryId: EntryId): Entries[EntryId] {
+    let entry = this.entries[entryId];
+    if (isAlpha(entry)) {
+      return entry;
+    }
+    return entry;
+  }
+}
+
+type Slice = { [index: string]: Alpha<number> | Beta<string> };
+class Complex<Slices extends { [index: string]: Slice }> {
+  private slices = {} as Slices;
+  read<SliceId extends keyof Slices, SliceKey extends keyof Slices[SliceId]>(
+    sliceId: SliceId,
+    sliceKey: SliceKey
+  ): Slices[SliceId][SliceKey] {
+    let item = this.slices[sliceId][sliceKey];
+    if (isAlpha(item)) {
+      item.onlyAlpha();
+    }
+    item.shared();
+    return item;
+  }
+}
+"#;
+    let diags = check(source);
+    assert!(
+        !diags
+            .iter()
+            .any(|d| d.code == 2339 && d.message_text.contains("shared")),
+        "`shared` exists on every union arm; it must not report TS2339. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// A member present on only *one* arm must still report `TS2339` — the rescue
+/// must not blanket-suppress genuine missing-property errors on the same shape.
+#[test]
+fn member_on_single_arm_of_generic_class_union_still_reports_ts2339() {
+    let source = r#"
+class Alpha<T extends number> {
+  private value!: T;
+  shared(): T { return this.value; }
+  onlyAlpha(): void {}
+}
+class Beta<T extends string> {
+  private value!: T;
+  shared(): T { return this.value; }
+  onlyBeta(): void {}
+}
+const isAlpha = <Candidate extends Alpha<number> | Beta<string>>(
+  candidate: Candidate
+): candidate is Extract<Candidate, Alpha<any>> => candidate instanceof Alpha;
+
+class Simple<Entries extends { [index: string]: Alpha<number> | Beta<string> }> {
+  private entries = {} as Entries;
+  read<EntryId extends keyof Entries>(entryId: EntryId): Entries[EntryId] {
+    let entry = this.entries[entryId];
+    if (isAlpha(entry)) {
+      return entry;
+    }
+    return entry;
+  }
+}
+
+type Slice = { [index: string]: Alpha<number> | Beta<string> };
+class Complex<Slices extends { [index: string]: Slice }> {
+  private slices = {} as Slices;
+  read<SliceId extends keyof Slices, SliceKey extends keyof Slices[SliceId]>(
+    sliceId: SliceId,
+    sliceKey: SliceKey
+  ): Slices[SliceId][SliceKey] {
+    let item = this.slices[sliceId][sliceKey];
+    item.onlyAlpha();
+    return item;
+  }
+}
+"#;
+    let diags = check(source);
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.code == 2339 && d.message_text.contains("onlyAlpha")),
+        "`onlyAlpha` is absent on the `Beta` arm; TS2339 must still fire. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-solver/src/operations/property_helpers.rs
+++ b/crates/tsz-solver/src/operations/property_helpers.rs
@@ -907,11 +907,26 @@ impl<'a> PropertyAccessEvaluator<'a> {
         };
 
         let Some(body_type) = body_type else {
-            // Resolution failed - fall back to structural evaluation
+            // Resolution failed - fall back to structural evaluation.
             let evaluated = self
                 .db
                 .evaluate_type_with_options(app_type, self.no_unchecked_indexed_access);
-            return self.resolve_property_access_inner(evaluated, prop_atom);
+            if evaluated != app_type {
+                return self.resolve_property_access_inner(evaluated, prop_atom);
+            }
+            // Structural evaluation made no progress: the `Lazy(DefId)` base could
+            // not be resolved by this evaluator's resolver (e.g. the boundary's
+            // noop resolver cannot crack a cross-file built-in interface ref), and
+            // re-entering with the unchanged `Application` would only hit the
+            // recursion guard and degrade to a false `PropertyNotFound`. Mirror the
+            // bare-`Lazy` branch (which yields the deferred `any` fallback when its
+            // ref cannot be resolved) so an unresolvable generic built-in
+            // constituent of an intersection/union does not suppress the property:
+            // the env-aware checker re-queries with a full resolver to recover the
+            // concrete member type.
+            return self
+                .resolve_object_member(prop_atom)
+                .unwrap_or_else(|| PropertyAccessResult::simple(TypeId::ANY));
         };
 
         let Some(type_params) = type_params else {


### PR DESCRIPTION
Fixes #14128.

Goal: green

## Structural rule
When a union arm is an intersection containing a concrete built-in constituent
(`(input & Set<any>) | (UnknownInput & Set<any>)`, produced by
`value instanceof Set` narrowing of `input | UnknownInput`), that constituent's
members must be credited even when the built-in reference is an unresolved
cross-file `Lazy`/`Application` and a sibling constituent is a generic type
parameter. A generic-parameter constituent must not suppress lookup of a
concrete built-in constituent's members: `(T & Set<any>).size` resolves
regardless of `T`.

tsz emitted a false **TS2339** on `.size`/`Map.size` because one `Set<any>` arm
stayed an unresolved `Application(Lazy(DefId), args)` that the property-access
boundary's noop `TypeResolver` could not crack. Its member lookup degraded to
`PropertyNotFound`, which collapsed the whole union to a missing-property error
(the other arm's `Set<any>` was a materialized `Object` shape and resolved
fine — the two representations of the same `Set<any>` diverged).

## Fix / owner layer
Two coordinated parts:

- **Solver / `operations::property` (`resolve_application_property`)**: when the
  `Lazy(DefId)` base body cannot be resolved and structural evaluation makes no
  progress (`evaluated == app_type`), return the deferred `any` fallback instead
  of re-entering with the unchanged `Application` (which only hits the recursion
  guard and degrades to a false `PropertyNotFound`). This mirrors the existing
  bare-`Lazy` branch, which already yields the deferred `any` fallback when its
  ref cannot be resolved.
- **Checker / `state_checking::property_access`
  (`resolve_property_access_with_env`)**: when the noop-resolver boundary returns
  `PropertyNotFound` for a **composite** receiver (not a bare `Lazy`) that
  contains a nested `Application`, re-query through the checker's full
  `TypeResolver`, which resolves the cross-file `DefId` and surfaces the concrete
  member type. Only a genuine `Success` is adopted, so a real missing property
  still reports `TS2339`. This complements the two existing rescues just above it
  (bare-interface-`DefId` `PropertyNotFound`, and bare-`Lazy` `Success { any }`),
  which cannot see a nested-`Application` composite because the receiver itself
  is not a bare `Lazy`.

## Adjacent matrix
New regression tests (`union_generic_class_shared_member_tests`), name-varied
(`Alpha`/`Beta`, `shared`/`onlyAlpha`, `read`) so the fix cannot be a
name-keyed special case, over a deferred `Slices[SliceId][SliceKey]` indexed
access whose union arms stay unresolved `Application`s:
- **positive**: a method present on *every* generic-class arm resolves — no TS2339;
- **negative / fallback**: a method present on only *one* arm still reports TS2339.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

## Verification
- ts-pattern @ `c92ca435`: `patterns.ts(311,21)` and `patterns.ts(377,21)`
  TS2339 on `.size` cleared; project diagnostics 28 → 26 (remaining deltas are
  separate open issues, e.g. #14130).
- `cargo test -p tsz-checker --test union_generic_class_shared_member_tests` — 2 passed; verified red on the pristine base (false `shared` TS2339), green with the fix.
- Relevant checker batches (property-access / union / intersection / lazy /
  lib-interface / TS2339, ~72 test binaries) — no new failures. One pre-existing
  schedule-sensitive failure
  (`indexed_access_resolved_union_property_tests::quickinfo_return_position_conformance_shape_keeps_only_expected_missing_property`,
  red on `origin/main`) is **improved** by this change (3 → 2 diagnostics; the
  false `get` positive is removed) — its remaining delta is an orthogonal
  predicate-narrowing gap, not this fix's scope.
- `cargo clippy -p tsz-solver -p tsz-checker` — clean.
- Ready-review CI owns broad conformance/emit/fourslash.

https://claude.ai/code/session_01JLjTRQdcUBWtK5nDji6ALr

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLjTRQdcUBWtK5nDji6ALr)_