### PR TITLE
fix(checker): canonicalize cross-module unique-symbol identity for computed keys

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -752,6 +752,9 @@ path = "tests/ts2353_mapped_template_literal_key_tests.rs"
 name = "ts2353_generic_constraint_excess_property_tests"
 path = "tests/ts2353_generic_constraint_excess_property_tests.rs"
 [[test]]
+name = "ts2353_cross_module_symbol_computed_key_tests"
+path = "tests/ts2353_cross_module_symbol_computed_key_tests.rs"
+[[test]]
 name = "relational_operator_type_display_tests"
 path = "tests/relational_operator_type_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_merged_value.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_merged_value.rs
@@ -61,6 +61,75 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// Resolve the VALUE type of a named import whose export resolves (possibly
+    /// through intermediate re-export/import aliases) to a symbol that merges a
+    /// `const`/`function`/`var` value with a same-named `type X = ...` alias.
+    ///
+    /// On a `TYPE_ALIAS`+`VALUE` merge with a computable value type, caches the alias
+    /// body under `alias_sym_id` for type-position consumers, applies module
+    /// augmentations, and returns the value type. Returns `None` otherwise, so
+    /// the caller falls through to its existing alias/interface/value handling.
+    ///
+    /// The value type is computed in the declaration's own arena so it survives
+    /// cross-file re-export hops, where `get_type_of_symbol` would instead return
+    /// the type-alias body (`typeof X`) — which collapses to `error` across the
+    /// extra hop. Mirrors the `import X = NS.Foo` `TYPE_ALIAS`+`VALUE` branch.
+    pub(crate) fn imported_merged_type_alias_value_type(
+        &mut self,
+        export_sym_id: SymbolId,
+        alias_sym_id: SymbolId,
+        module_name: &str,
+        export_name: &str,
+    ) -> Option<TypeId> {
+        use crate::symbols_domain::alias_cycle::AliasCycleTracker;
+
+        // Follow re-export / import alias hops to the ultimate declaration so a
+        // chain like `pattern.ts -> patterns.ts (re-export) -> symbols.ts (const +
+        // type)` lands on the merged declaration rather than an intermediate alias.
+        let mut visited = AliasCycleTracker::new();
+        let ultimate = self
+            .resolve_alias_symbol(export_sym_id, &mut visited)
+            .unwrap_or(export_sym_id);
+
+        let symbol = self.get_symbol_globally(ultimate)?;
+        let has_type_alias = symbol.has_any_flags(tsz_binder::symbol_flags::TYPE_ALIAS);
+        let has_value = symbol.has_any_flags(
+            tsz_binder::symbol_flags::FUNCTION_SCOPED_VARIABLE
+                | tsz_binder::symbol_flags::BLOCK_SCOPED_VARIABLE
+                | tsz_binder::symbol_flags::FUNCTION,
+        );
+        let value_decl = symbol.value_declaration;
+        if !has_type_alias || !has_value || value_decl.is_none() {
+            return None;
+        }
+
+        // Compute the value declaration's type in the arena that owns it. The
+        // declaration `NodeIndex` is arena-relative, so a same-file symbol must
+        // use the current arena while a cross-file symbol must spawn a child
+        // checker on the owning file (a raw `NodeIndex` reused against the wrong
+        // arena would resolve an unrelated node).
+        let owning_file = self.ctx.resolve_symbol_file_index(ultimate);
+        let value_type = if owning_file == Some(self.ctx.current_file_idx) {
+            self.type_of_value_declaration_for_symbol(ultimate, value_decl)
+        } else {
+            self.cross_file_value_declaration_type(ultimate, value_decl)
+                .unwrap_or(TypeId::ERROR)
+        };
+        if matches!(value_type, TypeId::ERROR | TypeId::UNKNOWN) {
+            return None;
+        }
+
+        // The alias body is the type-position meaning; cache it best-effort so
+        // type-position uses of the import keep resolving the alias. Skip caching
+        // when it can't be computed cleanly (it must never leak into value space).
+        let ta = self.get_type_of_symbol(ultimate);
+        if ta != TypeId::ERROR && ta != TypeId::UNKNOWN {
+            self.ctx.import_type_alias_types.insert(alias_sym_id, ta);
+        }
+
+        Some(self.apply_module_augmentations(module_name, export_name, value_type))
+    }
+
     pub(crate) fn merged_alias_value_decl_refs_type_alias(&self, sym_id: SymbolId) -> bool {
         let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
             return false;

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -1693,6 +1693,18 @@ impl<'a> CheckerState<'a> {
                         module_name,
                     );
 
+                    // TYPE_ALIAS + VALUE merge (`const x = Symbol.for(...)` paired
+                    // with `type x = typeof x`): a value-context import resolves the
+                    // VALUE declaration's type, not the type-alias body. See helper.
+                    if let Some(result) = self.imported_merged_type_alias_value_type(
+                        export_sym_id,
+                        sym_id,
+                        module_name,
+                        export_name,
+                    ) {
+                        return (result, Vec::new());
+                    }
+
                     // TYPE_ALIAS + ALIAS merge: cache type alias body for type contexts,
                     // return namespace type for value contexts.
                     if let Some(alias_id) =

--- a/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
@@ -442,6 +442,11 @@ impl CheckerState<'_> {
 
         let text = Self::cross_arena_expression_name_text(arena, computed.expression)?;
         let sym_id = resolve_symbol(&text)?;
+        // `resolve_symbol` resolves in the binder of the file computing the alias
+        // body, so a re-exported symbol lands on a per-file alias copy. Canonicalize
+        // to the declaring binder's id so this `[k]: T` member key agrees with the
+        // same `const`'s key minted on any other import path (matching #14126).
+        let sym_id = crate::types_domain::computed_names::follow_import_aliases(&self.ctx, sym_id);
         self.cross_arena_symbol_is_unique(sym_id)
             .then(|| format!("__unique_{}", sym_id.0))
     }

--- a/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
+++ b/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
@@ -230,6 +230,13 @@ impl<'a> CheckerState<'a> {
             return Some(name);
         }
         let sym_id = self.resolve_computed_property_symbol_in_arena(arena, computed.expression)?;
+        // Canonicalize to the declaring binder's symbol id so a cross-file
+        // interface member keyed here agrees with the same `const`'s key reached
+        // through a different import path (e.g. a fresh object literal's
+        // directly-imported `[matcher]`). Without this the member atom embeds
+        // whichever per-file alias copy resolved here, producing a spurious
+        // TS2353/TS2561 excess-property mismatch.
+        let sym_id = crate::types_domain::computed_names::follow_import_aliases(&self.ctx, sym_id);
         Some(format!("__unique_{}", sym_id.0))
     }
 

--- a/crates/tsz-checker/src/types/computed_names.rs
+++ b/crates/tsz-checker/src/types/computed_names.rs
@@ -204,7 +204,54 @@ pub(crate) fn follow_import_aliases(ctx: &CheckerContext<'_>, mut sym_id: Symbol
         }
         sym_id = next;
     }
-    sym_id
+    canonical_binding_symbol(ctx, sym_id)
+}
+
+/// Map a binding to the `SymbolId` assigned by the binder that OWNS its
+/// declaration.
+///
+/// Cross-file resolution mints a per-binder copy of an imported binding: one
+/// declaration acquires several distinct `SymbolId`s, one per importing file's
+/// view. Re-export chains land on whichever copy `resolve_import_symbol` reached
+/// (path-dependent), while a direct import lands on the declaring binder's own
+/// id. Keying `__unique_<id>` on the copy makes a member reached through a
+/// re-export chain (e.g. `Matcher.[matcher]`) mismatch the directly-imported
+/// member of the *same* `const` in a fresh object literal — a false TS2353/
+/// TS2561. Collapsing every copy onto the declaring binder's id gives one
+/// stable identity per declaration regardless of import path, matching tsc's
+/// single-symbol model. Idempotent for symbols already owned by their declaring
+/// binder (the common case), so local bindings are unaffected.
+fn canonical_binding_symbol(ctx: &CheckerContext<'_>, sym_id: SymbolId) -> SymbolId {
+    let Some(symbol) = symbol_from_any_context(ctx, sym_id) else {
+        return sym_id;
+    };
+    let owner_file = symbol.decl_file_idx;
+    // A symbol owned by the file under check already carries its declaring
+    // binder's id, so it is canonical and needs no remapping (the common case).
+    if owner_file == u32::MAX || owner_file as usize == ctx.current_file_idx {
+        return sym_id;
+    }
+    let Some(owner_binder) = ctx.get_binder_for_file(owner_file as usize) else {
+        return sym_id;
+    };
+    let decl = if symbol.value_declaration.is_some() {
+        symbol.value_declaration
+    } else {
+        symbol.primary_declaration().unwrap_or(NodeIndex::NONE)
+    };
+    if decl.is_none() {
+        return sym_id;
+    }
+    // The binder maps a variable declaration's NAME identifier to the canonical
+    // symbol; resolve through to it so the const declaration recovers the
+    // owner-binder id (non-variable declarations are bound at the node itself).
+    let owner_arena = ctx.get_arena_for_file(owner_file);
+    let name_node = owner_arena
+        .get(decl)
+        .and_then(|node| owner_arena.get_variable_declaration(node))
+        .and_then(|var_decl| var_decl.name.into_option())
+        .unwrap_or(decl);
+    owner_binder.get_node_symbol(name_node).unwrap_or(sym_id)
 }
 
 /// Run `pred` over every (owner binder, candidate arena, declaration) triple

--- a/crates/tsz-checker/tests/ts2353_cross_module_symbol_computed_key_tests.rs
+++ b/crates/tsz-checker/tests/ts2353_cross_module_symbol_computed_key_tests.rs
@@ -1,0 +1,233 @@
+//! Cross-module `unique symbol` computed-key identity guards (issue #14126).
+//!
+//! A `const k = Symbol.for(...)` name-merged with `type k = typeof k` is a
+//! merged `TYPE_ALIAS | VALUE` symbol. When such a binding is reached through a
+//! re-export chain (`export { k } from "./symbols"`, or `import { k };
+//! export { k }`), two things historically broke:
+//!
+//! 1. The imported binding's VALUE type resolved to the type-alias body
+//!    (`typeof k`), which collapses to `error` across the extra hop — so a
+//!    computed key `[k]()` emitted a false TS2464 ("A computed property name
+//!    must be of type 'string', 'number', 'symbol', or 'any'") and value-side
+//!    assignability silently passed (no TS2322 against `symbol`).
+//!
+//! 2. The `__unique_<id>` member key embedded whichever per-file alias *copy*
+//!    resolved at each site. An interface member `[k](): T` keyed in one
+//!    importing file's view and a fresh object literal `{ [k]() {} }` keyed in
+//!    another file's view embedded different ids for the *same* declaration, so
+//!    a literal flowing into a generic-constrained parameter
+//!    (`P extends Matcher`) reported a spurious TS2353 / TS2561 excess property
+//!    on the very method the constraint requires (ts-pattern's `Matcher`).
+//!
+//! tsc treats the `const` as one symbol with one identity regardless of import
+//! path. These tests pin both the value-meaning resolution and the canonical
+//! key identity, varying binder names so the fix stays structural.
+
+use tsz_checker::context::{CheckerOptions, ScriptTarget};
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_multi_file;
+use tsz_common::ModuleKind;
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        target: ScriptTarget::ES2020,
+        module: ModuleKind::CommonJS,
+        no_lib: false,
+        ..Default::default()
+    }
+}
+
+fn codes(diags: &[Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|d| d.code).collect()
+}
+
+fn assert_absent(diags: &[Diagnostic], code: u32, context: &str) {
+    let hits: Vec<_> = diags
+        .iter()
+        .filter(|d| d.code == code)
+        .map(|d| &d.message_text)
+        .collect();
+    assert!(
+        hits.is_empty(),
+        "{context}: expected no TS{code}; got {hits:#?}\nall codes: {:?}",
+        codes(diags)
+    );
+}
+
+// ── Primary repro: re-export + generic constraint (ts-pattern Matcher) ───────
+
+/// A merged `const matcher = Symbol.for(...)` / `type matcher = typeof matcher`
+/// re-exported through a barrel, used as a symbol-computed method in both a
+/// generic constraint interface and a fresh object literal flowing into that
+/// constraint. tsc emits nothing; tsz must agree (no TS2353/TS2561/TS2464).
+#[test]
+fn reexported_symbol_method_into_generic_constraint_has_no_excess() {
+    let files = [
+        (
+            "symbols.ts",
+            r#"
+export const matcher = Symbol.for('@x/matcher');
+export type matcher = typeof matcher;
+"#,
+        ),
+        (
+            "patterns.ts",
+            r#"
+import { matcher } from './symbols';
+export { matcher };
+"#,
+        ),
+        (
+            "pattern_type.ts",
+            r#"
+import { matcher } from './patterns';
+type MatchResult = { matched: boolean };
+export type MatcherProtocol<input, m> = {
+  match: <I>(value: I | input) => MatchResult;
+  matcherType?: m;
+};
+export interface Matcher<input = any, narrowed = any, m = 'default'> {
+  [matcher](): MatcherProtocol<input, m>;
+}
+type Chainable<p> = p & {};
+export function chainable<p extends Matcher<any, any, any>>(p: p): Chainable<p> {
+  return p as Chainable<p>;
+}
+"#,
+        ),
+        (
+            "use.ts",
+            r#"
+import { matcher } from './symbols';
+import { chainable } from './pattern_type';
+export function optional<input>() {
+  return chainable({
+    [matcher]() {
+      return {
+        match: <I>(value: I | input) => ({ matched: true }),
+        matcherType: 'optional' as const,
+      };
+    },
+  });
+}
+"#,
+        ),
+    ];
+    let diags = check_multi_file(&files, "use.ts", opts());
+    assert_absent(
+        &diags,
+        2353,
+        "re-exported symbol method into generic constraint",
+    );
+    assert_absent(
+        &diags,
+        2561,
+        "re-exported symbol method into generic constraint",
+    );
+    assert_absent(
+        &diags,
+        2464,
+        "re-exported symbol method into generic constraint",
+    );
+}
+
+/// Renamed binders everywhere — the fix keys on the symbol declaration, not the
+/// chosen identifier text.
+#[test]
+fn reexported_symbol_method_renamed_binders_has_no_excess() {
+    let files = [
+        (
+            "sym.ts",
+            r#"
+export const tag = Symbol.for('@x/tag');
+export type tag = typeof tag;
+"#,
+        ),
+        (
+            "barrel.ts",
+            r#"
+import { tag } from './sym';
+export { tag };
+"#,
+        ),
+        (
+            "proto.ts",
+            r#"
+import { tag } from './barrel';
+export type Proto<a, b> = { run: <I>(v: I | a) => boolean; kind?: b };
+export interface Tagged<a = any, b = 'def'> {
+  [tag](): Proto<a, b>;
+}
+type Wrap<q> = q & {};
+export function wrap<q extends Tagged<any, any>>(q: q): Wrap<q> {
+  return q as Wrap<q>;
+}
+"#,
+        ),
+        (
+            "site.ts",
+            r#"
+import { tag } from './sym';
+import { wrap } from './proto';
+export function build<a>() {
+  return wrap({
+    [tag]() {
+      return { run: <I>(v: I | a) => true, kind: 'def' as const };
+    },
+  });
+}
+"#,
+        ),
+    ];
+    let diags = check_multi_file(&files, "site.ts", opts());
+    assert_absent(&diags, 2353, "renamed binders");
+    assert_absent(&diags, 2561, "renamed binders");
+    assert_absent(&diags, 2464, "renamed binders");
+}
+
+// ── Value-meaning resolution ─────────────────────────────────────────────────
+//
+// The barrel-re-export *value* path (`import { sym } from './barrel'` where
+// `barrel` re-exports a merged `const`/`type`, then `[sym]()` / `const x: string
+// = sym`) is verified end-to-end against ts-pattern and via the `tsz` CLI on a
+// 3-file project: the merged binding keeps its `unique symbol` value type (no
+// false TS2464, and `symbol` is still rejected against `string` with TS2322).
+// The simplified `check_multi_file` harness does not materialise that
+// cross-file re-export value path the same way the driver does (the same
+// limitation the sibling `ts2527_unique_symbol_via_reexport_tests` documents),
+// so the in-harness value assertion below uses a direct import; the re-export
+// *keying* path — the actual #14126 false positive — is covered by the generic
+// constraint tests above, which do flow a barrel-reached interface member.
+
+// ── Negative / regression guard ─────────────────────────────────────────────
+
+/// A direct (single-hop) import of the merged binding already worked; it must
+/// stay working and keep the same value semantics.
+#[test]
+fn direct_import_merged_symbol_still_correct() {
+    let files = [
+        (
+            "symbols.ts",
+            r#"
+export const sym = Symbol.for('@x/sym');
+export type sym = typeof sym;
+"#,
+        ),
+        (
+            "probe.ts",
+            r#"
+import { sym } from './symbols';
+const bad: string = sym;
+const obj = { [sym]() { return 1; } };
+"#,
+        ),
+    ];
+    let diags = check_multi_file(&files, "probe.ts", opts());
+    assert_absent(&diags, 2464, "direct import merged symbol computed key");
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "direct import must still reject `symbol` assigned to `string`; got {:?}",
+        codes(&diags)
+    );
+}


### PR DESCRIPTION
Fixes #14126.

Goal: green

## Structural rule

> When a re-exported binding merges a `Symbol.for(...)` `const` with a
> same-named `type X = typeof X` alias, `tsc` treats it as one symbol with one
> value type and one identity regardless of import path. tsz now does the same
> through the named-import resolver and `computed_names::follow_import_aliases`.

A `const k = Symbol.for(...)` name-merged with `type k = typeof k` is a merged
`TYPE_ALIAS | VALUE` symbol. Reaching it through a re-export chain broke two
things that surface in ts-pattern's `Matcher` protocol (`P.optional`, `and`,
`not`, `select`, …), where `tsc`/`tsgo` emit zero diagnostics.

## Wrong semantic operations / owner layers

**1. Value-meaning resolution — checker named-import resolver
(`compute_type_of_symbol` ES6 named-import branch).**
A named import resolved the binding's value type to the type-alias body
(`typeof k`). That coincides with the const's value on a direct import but
collapses to `error` across an extra re-export hop (the `typeof` recursion
re-enters the alias before its value side exists), producing a false **TS2464**
on `[k]()` computed keys and silently dropping the `symbol` value type. The ES6
named-import path now mirrors the existing `import X = NS.Foo` TYPE_ALIAS+VALUE
branch: it follows alias hops to the declaration and computes the value type in
that declaration's own arena (new `imported_merged_type_alias_value_type`).

**2. Key identity — `computed_names::follow_import_aliases` (the computed-name
keying policy layer).**
`__unique_<id>` embedded whichever per-file alias *copy* resolved at each site,
so an interface member `[k](): T` (keyed through a re-export) and a fresh object
literal `{ [k]() {} }` (keyed through a direct import) embedded different ids for
the **same** `const`, yielding a spurious **TS2353 / TS2561** excess property on
the very method a `P extends Matcher` constraint requires. `follow_import_aliases`
now collapses every cross-file copy onto the declaring binder's id (one stable
identity per declaration); the two cross-arena computed-key mint sites that
bypassed it (`computed_property_names.rs`, `computed_alias.rs`) are routed
through it.

## Anti-hardcoding

Purely structural: keying is by the declaring binder's symbol id, value
resolution is by the merged `TYPE_ALIAS | VALUE` flags + the declaration's own
arena. No user/file-name literals, no rendered-type-string predicates, no
fixture fast paths. The renamed-binder test proves the fix keys on the symbol
declaration, not the identifier text. The `follow_import_aliases` canonicalizer
early-outs for symbols owned by the file under check (the common case), so local
bindings are untouched.

## Adjacent-case matrix

`crates/tsz-checker/tests/ts2353_cross_module_symbol_computed_key_tests.rs`:
- re-exported symbol method into a generic constraint (the ts-pattern witness) — clean
- renamed binders end to end (structural, not name-keyed) — clean
- **fallback/negative:** direct single-hop import keeps the same value semantics
  (rejects `symbol` against `string` with TS2322; no TS2464)

The barrel-re-export *value* path is verified end-to-end against ts-pattern and
the CLI; the simplified `check_multi_file` harness does not materialise that
cross-file value path (the same limitation `ts2527_unique_symbol_via_reexport_tests`
documents), so the in-harness value assertion uses a direct import while the
re-export *keying* path is covered by the constraint tests.

## Verification

- `cargo test -p tsz-checker --test ts2353_cross_module_symbol_computed_key_tests` → 3 passed.
- `cargo test -p tsz-checker --lib object_literal_computed_symbol_member` → 19 passed.
- Regression sweep (`--lib unique_symbol`, `computed_property`, `reexport`): no new
  failures vs. baseline (the one `unique_symbol` failure,
  `tuple_to_object_preserves_unique_symbol_keys_from_tuple_index_access`, fails
  identically on a clean `origin/main` checkout — pre-existing shared-target staleness).
- ts-pattern (pinned `c92ca435`, `tsz --noEmit -p tsconfig.json`):
  non-module-resolution errors **28 → 8**; all **TS2353 (×6)** and **TS2464 (×2)**
  eliminated. Remaining 8 are unrelated families (TS2536/TS2344/TS2339/TS2722),
  tracked separately.
- `cargo clippy -p tsz-checker --lib`, `cargo fmt -p tsz-checker --check`,
  `python3 scripts/arch/arch_guard.py` — all clean.
- Reviewed with `/simplify` (reuse/simplification/efficiency/altitude): folded the
  alias-body cache + augmentation into the helper, added the local early-out to the
  canonicalizer, and routed the sibling `computed_alias.rs` mint site through the
  shared helper. Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01VdERqi94Wtr7jCVwJ5y8se

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdERqi94Wtr7jCVwJ5y8se)_