### PR TITLE
fix(checker): preserve unique-symbol identity for value+typeof-alias merge across modules

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -51,7 +51,7 @@ impl<'a> CheckerState<'a> {
             // denotes — which is correct for both meanings and breaks the cycle.
             if flags & symbol_flags::VALUE != 0
                 && let Some(unique) =
-                    self.merged_self_typeof_unique_symbol_type(declarations, &escaped_name)
+                    self.merged_self_typeof_unique_symbol_type(declarations, escaped_name)
             {
                 return (unique, Vec::new());
             }

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -35,6 +35,26 @@ impl<'a> CheckerState<'a> {
             {
                 return (self.builtin_iterator_return_intrinsic_type(), Vec::new());
             }
+            // The unique-symbol idiom merges a value `const X = Symbol()` /
+            // `const X = Symbol.for(...)` / `const X: unique symbol` with a
+            // same-named type alias `type X = typeof X` (e.g. ts-pattern's
+            // `symbols.ts`). Both meanings denote the single `unique symbol`
+            // identity of `X`. Resolving the alias through the generic body path
+            // lowers `typeof X` by asking for the value of `X`, which re-enters
+            // this symbol while it is on the resolution stack: the lookup hits
+            // the circular guard, collapses to the error type, and caches it.
+            // Every later value- or type-position read of the merged symbol
+            // (including reads reached across a re-export chain or a namespace
+            // member access) then observes `any`, silently suppressing
+            // computed-key / indexed-access diagnostics. Resolve the value's
+            // `unique symbol` identity directly — exactly what `typeof X`
+            // denotes — which is correct for both meanings and breaks the cycle.
+            if flags & symbol_flags::VALUE != 0
+                && let Some(unique) =
+                    self.merged_self_typeof_unique_symbol_type(declarations, &escaped_name)
+            {
+                return (unique, Vec::new());
+            }
             let decl_idx = declarations
                 .iter()
                 .copied()
@@ -1983,5 +2003,83 @@ impl<'a> CheckerState<'a> {
         // Fallback: return ANY for unresolved symbols to prevent cascading errors
         // The actual "cannot find" error should already be emitted elsewhere
         (TypeId::ANY, Vec::new())
+    }
+
+    /// Resolve the `unique symbol` identity of a value+type-alias symbol that
+    /// follows the self-`typeof` idiom: a `const X = Symbol()` /
+    /// `const X = Symbol.for(...)` / `const X: unique symbol` value merged with a
+    /// same-named `type X = typeof X` alias.
+    ///
+    /// Returns `Some` only when this symbol owns BOTH a self-referential
+    /// `typeof X` type-alias declaration and a unique-symbol const value
+    /// declaration, so non-idiomatic value+type-alias merges (e.g. `const X =
+    /// 5; type X = string`) keep their generic alias-body resolution. The
+    /// returned type is exactly what `typeof X` denotes, so it is correct for
+    /// both the value and type meanings of the merged symbol.
+    fn merged_self_typeof_unique_symbol_type(
+        &mut self,
+        declarations: &[NodeIndex],
+        escaped_name: &str,
+    ) -> Option<TypeId> {
+        let has_self_typeof_alias = declarations
+            .iter()
+            .copied()
+            .any(|decl_idx| self.type_alias_body_is_self_typeof(decl_idx, escaped_name));
+        if !has_self_typeof_alias {
+            return None;
+        }
+        for decl_idx in declarations.iter().copied() {
+            // Unannotated `const X = Symbol()` / `const X = Symbol.for(...)`.
+            if let Some(unique) = self.const_symbol_factory_unique_value_type(decl_idx) {
+                return Some(unique);
+            }
+            // Annotated `const X: unique symbol`.
+            if let Some(node) = self.ctx.arena.get(decl_idx)
+                && let Some(var_decl) = self.ctx.arena.get_variable_declaration(node)
+                && var_decl.type_annotation.is_some()
+                && self.is_const_variable_declaration(decl_idx)
+            {
+                let upgraded = self.const_unique_symbol_value_type(
+                    decl_idx,
+                    var_decl.type_annotation,
+                    TypeId::SYMBOL,
+                );
+                if upgraded != TypeId::SYMBOL {
+                    return Some(upgraded);
+                }
+            }
+        }
+        None
+    }
+
+    /// Whether `decl_idx` is a `type X = typeof X` declaration whose `typeof`
+    /// operand names `escaped_name` — a self-referential typeof of the merged
+    /// symbol's own value. Pure syntactic check (no symbol resolution) so it
+    /// cannot re-enter symbol-type computation for the symbol being resolved.
+    fn type_alias_body_is_self_typeof(&self, decl_idx: NodeIndex, escaped_name: &str) -> bool {
+        let Some(node) = self.ctx.arena.get(decl_idx) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::TYPE_ALIAS_DECLARATION {
+            return false;
+        }
+        let Some(type_alias) = self.ctx.arena.get_type_alias(node) else {
+            return false;
+        };
+        let Some(body) = self.ctx.arena.get(type_alias.type_node) else {
+            return false;
+        };
+        if body.kind != syntax_kind_ext::TYPE_QUERY {
+            return false;
+        }
+        let Some(type_query) = self.ctx.arena.get_type_query(body) else {
+            return false;
+        };
+        // A self-`typeof` references a bare identifier (not a qualified name)
+        // whose text matches the merged symbol's name.
+        self.ctx
+            .arena
+            .get_identifier_text(type_query.expr_name)
+            .is_some_and(|name| name == escaped_name)
     }
 }

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -35,20 +35,9 @@ impl<'a> CheckerState<'a> {
             {
                 return (self.builtin_iterator_return_intrinsic_type(), Vec::new());
             }
-            // The unique-symbol idiom merges a value `const X = Symbol()` /
-            // `const X = Symbol.for(...)` / `const X: unique symbol` with a
-            // same-named type alias `type X = typeof X` (e.g. ts-pattern's
-            // `symbols.ts`). Both meanings denote the single `unique symbol`
-            // identity of `X`. Resolving the alias through the generic body path
-            // lowers `typeof X` by asking for the value of `X`, which re-enters
-            // this symbol while it is on the resolution stack: the lookup hits
-            // the circular guard, collapses to the error type, and caches it.
-            // Every later value- or type-position read of the merged symbol
-            // (including reads reached across a re-export chain or a namespace
-            // member access) then observes `any`, silently suppressing
-            // computed-key / indexed-access diagnostics. Resolve the value's
-            // `unique symbol` identity directly — exactly what `typeof X`
-            // denotes — which is correct for both meanings and breaks the cycle.
+            // Resolve the self-`typeof` unique-symbol merge before the generic
+            // alias body path can re-enter this symbol and poison the cached
+            // result with the circular-guard error type.
             if flags & symbol_flags::VALUE != 0
                 && let Some(unique) =
                     self.merged_self_typeof_unique_symbol_type(declarations, escaped_name)
@@ -2003,83 +1992,5 @@ impl<'a> CheckerState<'a> {
         // Fallback: return ANY for unresolved symbols to prevent cascading errors
         // The actual "cannot find" error should already be emitted elsewhere
         (TypeId::ANY, Vec::new())
-    }
-
-    /// Resolve the `unique symbol` identity of a value+type-alias symbol that
-    /// follows the self-`typeof` idiom: a `const X = Symbol()` /
-    /// `const X = Symbol.for(...)` / `const X: unique symbol` value merged with a
-    /// same-named `type X = typeof X` alias.
-    ///
-    /// Returns `Some` only when this symbol owns BOTH a self-referential
-    /// `typeof X` type-alias declaration and a unique-symbol const value
-    /// declaration, so non-idiomatic value+type-alias merges (e.g. `const X =
-    /// 5; type X = string`) keep their generic alias-body resolution. The
-    /// returned type is exactly what `typeof X` denotes, so it is correct for
-    /// both the value and type meanings of the merged symbol.
-    fn merged_self_typeof_unique_symbol_type(
-        &mut self,
-        declarations: &[NodeIndex],
-        escaped_name: &str,
-    ) -> Option<TypeId> {
-        let has_self_typeof_alias = declarations
-            .iter()
-            .copied()
-            .any(|decl_idx| self.type_alias_body_is_self_typeof(decl_idx, escaped_name));
-        if !has_self_typeof_alias {
-            return None;
-        }
-        for decl_idx in declarations.iter().copied() {
-            // Unannotated `const X = Symbol()` / `const X = Symbol.for(...)`.
-            if let Some(unique) = self.const_symbol_factory_unique_value_type(decl_idx) {
-                return Some(unique);
-            }
-            // Annotated `const X: unique symbol`.
-            if let Some(node) = self.ctx.arena.get(decl_idx)
-                && let Some(var_decl) = self.ctx.arena.get_variable_declaration(node)
-                && var_decl.type_annotation.is_some()
-                && self.is_const_variable_declaration(decl_idx)
-            {
-                let upgraded = self.const_unique_symbol_value_type(
-                    decl_idx,
-                    var_decl.type_annotation,
-                    TypeId::SYMBOL,
-                );
-                if upgraded != TypeId::SYMBOL {
-                    return Some(upgraded);
-                }
-            }
-        }
-        None
-    }
-
-    /// Whether `decl_idx` is a `type X = typeof X` declaration whose `typeof`
-    /// operand names `escaped_name` — a self-referential typeof of the merged
-    /// symbol's own value. Pure syntactic check (no symbol resolution) so it
-    /// cannot re-enter symbol-type computation for the symbol being resolved.
-    fn type_alias_body_is_self_typeof(&self, decl_idx: NodeIndex, escaped_name: &str) -> bool {
-        let Some(node) = self.ctx.arena.get(decl_idx) else {
-            return false;
-        };
-        if node.kind != syntax_kind_ext::TYPE_ALIAS_DECLARATION {
-            return false;
-        }
-        let Some(type_alias) = self.ctx.arena.get_type_alias(node) else {
-            return false;
-        };
-        let Some(body) = self.ctx.arena.get(type_alias.type_node) else {
-            return false;
-        };
-        if body.kind != syntax_kind_ext::TYPE_QUERY {
-            return false;
-        }
-        let Some(type_query) = self.ctx.arena.get_type_query(body) else {
-            return false;
-        };
-        // A self-`typeof` references a bare identifier (not a qualified name)
-        // whose text matches the merged symbol's name.
-        self.ctx
-            .arena
-            .get_identifier_text(type_query.expr_name)
-            .is_some_and(|name| name == escaped_name)
     }
 }

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -1538,114 +1538,12 @@ impl<'a> CheckerState<'a> {
                     && (self.source_file_import_uses_system_default_namespace_fallback(module_name)
                         || uses_module_exports_require_interop
                         || is_node_esm_importing_cjs)
-                {
-                    if self
-                        .ctx
-                        .module_namespace_resolution_set
-                        .contains(module_name)
-                    {
-                        return (TypeId::ANY, Vec::new());
-                    }
-                    self.ctx
-                        .module_namespace_resolution_set
-                        .insert(module_name.to_string());
-
-                    if let Some(exports_table) = self.resolve_effective_module_exports_from_file(
+                    && let Some(module_type) = self.resolve_default_import_namespace_fallback(
                         module_name,
-                        Some(self.ctx.current_file_idx),
-                    ) {
-                        let ordered_exports = self.ordered_namespace_export_entries(&exports_table);
-                        if exports_table.has("export=")
-                            && let Some(export_eq_sym) = exports_table.get("export=")
-                        {
-                            let export_eq_type = self.get_type_of_symbol(export_eq_sym);
-                            let export_eq_type =
-                                crate::query_boundaries::common::widen_literal_type(
-                                    self.ctx.types,
-                                    export_eq_type,
-                                );
-                            let export_eq_type = self
-                                .widen_fresh_object_literal_properties_for_display(export_eq_type);
-                            self.ctx.module_namespace_resolution_set.remove(module_name);
-                            return (export_eq_type, Vec::new());
-                        }
-
-                        use tsz_solver::PropertyInfo;
-                        let mut props: Vec<PropertyInfo> = Vec::new();
-                        for &(name, export_sym_id) in &ordered_exports {
-                            if self.should_skip_namespace_export_name(
-                                &exports_table,
-                                name,
-                                export_sym_id,
-                            ) {
-                                continue;
-                            }
-                            let declaration_order = if name == "default" {
-                                1
-                            } else {
-                                props.len() as u32 + 2
-                            };
-                            let prop_type = self.get_type_of_symbol(export_sym_id);
-                            let name_atom = self.ctx.types.intern_string(name);
-                            props.push(PropertyInfo {
-                                name: name_atom,
-                                type_id: prop_type,
-                                write_type: prop_type,
-                                optional: false,
-                                readonly: false,
-                                is_method: false,
-                                is_class_prototype: false,
-                                visibility: Visibility::Public,
-                                parent_id: None,
-                                declaration_order,
-                                is_string_named: false,
-                                is_symbol_named: false,
-                                single_quoted_name: false,
-                            });
-                        }
-                        Self::normalize_namespace_export_declaration_order(&mut props);
-                        let module_type = factory.object(props);
-                        self.ctx.namespace_module_names.insert(
-                            module_type,
-                            self.imported_namespace_display_module_name(module_name),
-                        );
-                        self.ctx.module_namespace_resolution_set.remove(module_name);
-                        return (module_type, Vec::new());
-                    }
-
-                    if is_node_esm_importing_cjs
-                        && let Some(default_sym_id) = self.resolve_cross_file_export_from_file(
-                            module_name,
-                            "default",
-                            Some(self.ctx.current_file_idx),
-                        )
-                    {
-                        use tsz_solver::PropertyInfo;
-                        let default_type = self.get_type_of_symbol(default_sym_id);
-                        let module_type = factory.object(vec![PropertyInfo {
-                            name: self.ctx.types.intern_string("default"),
-                            type_id: default_type,
-                            write_type: default_type,
-                            optional: false,
-                            readonly: false,
-                            is_method: false,
-                            is_class_prototype: false,
-                            visibility: Visibility::Public,
-                            parent_id: None,
-                            declaration_order: 1,
-                            is_string_named: false,
-                            is_symbol_named: false,
-                            single_quoted_name: false,
-                        }]);
-                        self.ctx.namespace_module_names.insert(
-                            module_type,
-                            self.imported_namespace_display_module_name(module_name),
-                        );
-                        self.ctx.module_namespace_resolution_set.remove(module_name);
-                        return (module_type, Vec::new());
-                    }
-
-                    self.ctx.module_namespace_resolution_set.remove(module_name);
+                        is_node_esm_importing_cjs,
+                    )
+                {
+                    return (module_type, Vec::new());
                 }
 
                 // Check if the module exists first (for proper error differentiation)

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias/helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias/helpers.rs
@@ -1,4 +1,4 @@
-//! Synthetic default-export alias resolution helpers.
+//! Type-alias/value-alias resolution helpers.
 //!
 //! Split out of the parent module to satisfy the source-file line cap.
 
@@ -104,5 +104,83 @@ impl<'a> CheckerState<'a> {
             stack.extend(self.ctx.arena.get_children(idx));
         }
         false
+    }
+
+    /// Resolve the `unique symbol` identity of a value+type-alias symbol that
+    /// follows the self-`typeof` idiom: a `const X = Symbol()` /
+    /// `const X = Symbol.for(...)` / `const X: unique symbol` value merged with a
+    /// same-named `type X = typeof X` alias.
+    ///
+    /// Returns `Some` only when this symbol owns BOTH a self-referential
+    /// `typeof X` type-alias declaration and a unique-symbol const value
+    /// declaration, so non-idiomatic value+type-alias merges (e.g. `const X =
+    /// 5; type X = string`) keep their generic alias-body resolution. The
+    /// returned type is exactly what `typeof X` denotes, so it is correct for
+    /// both the value and type meanings of the merged symbol.
+    pub(super) fn merged_self_typeof_unique_symbol_type(
+        &mut self,
+        declarations: &[NodeIndex],
+        escaped_name: &str,
+    ) -> Option<TypeId> {
+        let has_self_typeof_alias = declarations
+            .iter()
+            .copied()
+            .any(|decl_idx| self.type_alias_body_is_self_typeof(decl_idx, escaped_name));
+        if !has_self_typeof_alias {
+            return None;
+        }
+        for decl_idx in declarations.iter().copied() {
+            // Unannotated `const X = Symbol()` / `const X = Symbol.for(...)`.
+            if let Some(unique) = self.const_symbol_factory_unique_value_type(decl_idx) {
+                return Some(unique);
+            }
+            // Annotated `const X: unique symbol`.
+            if let Some(node) = self.ctx.arena.get(decl_idx)
+                && let Some(var_decl) = self.ctx.arena.get_variable_declaration(node)
+                && var_decl.type_annotation.is_some()
+                && self.is_const_variable_declaration(decl_idx)
+            {
+                let upgraded = self.const_unique_symbol_value_type(
+                    decl_idx,
+                    var_decl.type_annotation,
+                    TypeId::SYMBOL,
+                );
+                if upgraded != TypeId::SYMBOL {
+                    return Some(upgraded);
+                }
+            }
+        }
+        None
+    }
+
+    /// Whether `decl_idx` is a `type X = typeof X` declaration whose `typeof`
+    /// operand names `escaped_name` — a self-referential typeof of the merged
+    /// symbol's own value. Pure syntactic check (no symbol resolution) so it
+    /// cannot re-enter symbol-type computation for the symbol being resolved.
+    fn type_alias_body_is_self_typeof(&self, decl_idx: NodeIndex, escaped_name: &str) -> bool {
+        let Some(node) = self.ctx.arena.get(decl_idx) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::TYPE_ALIAS_DECLARATION {
+            return false;
+        }
+        let Some(type_alias) = self.ctx.arena.get_type_alias(node) else {
+            return false;
+        };
+        let Some(body) = self.ctx.arena.get(type_alias.type_node) else {
+            return false;
+        };
+        if body.kind != syntax_kind_ext::TYPE_QUERY {
+            return false;
+        }
+        let Some(type_query) = self.ctx.arena.get_type_query(body) else {
+            return false;
+        };
+        // A self-`typeof` references a bare identifier (not a qualified name)
+        // whose text matches the merged symbol's name.
+        self.ctx
+            .arena
+            .get_identifier_text(type_query.expr_name)
+            .is_some_and(|name| name == escaped_name)
     }
 }

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias/helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias/helpers.rs
@@ -106,6 +106,125 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    pub(super) fn resolve_default_import_namespace_fallback(
+        &mut self,
+        module_name: &str,
+        is_node_esm_importing_cjs: bool,
+    ) -> Option<TypeId> {
+        if self
+            .ctx
+            .module_namespace_resolution_set
+            .contains(module_name)
+        {
+            return Some(TypeId::ANY);
+        }
+        self.ctx
+            .module_namespace_resolution_set
+            .insert(module_name.to_string());
+
+        let result = self
+            .resolve_default_import_namespace_from_exports(module_name)
+            .or_else(|| {
+                is_node_esm_importing_cjs
+                    .then(|| self.resolve_node_esm_cjs_default_import_namespace(module_name))
+                    .flatten()
+            });
+
+        self.ctx.module_namespace_resolution_set.remove(module_name);
+        result
+    }
+
+    fn resolve_default_import_namespace_from_exports(
+        &mut self,
+        module_name: &str,
+    ) -> Option<TypeId> {
+        let exports_table = self.resolve_effective_module_exports_from_file(
+            module_name,
+            Some(self.ctx.current_file_idx),
+        )?;
+        let ordered_exports = self.ordered_namespace_export_entries(&exports_table);
+        if exports_table.has("export=")
+            && let Some(export_eq_sym) = exports_table.get("export=")
+        {
+            let export_eq_type = self.get_type_of_symbol(export_eq_sym);
+            let export_eq_type =
+                crate::query_boundaries::common::widen_literal_type(self.ctx.types, export_eq_type);
+            let export_eq_type =
+                self.widen_fresh_object_literal_properties_for_display(export_eq_type);
+            return Some(export_eq_type);
+        }
+
+        use tsz_solver::PropertyInfo;
+        let mut props: Vec<PropertyInfo> = Vec::new();
+        for &(name, export_sym_id) in &ordered_exports {
+            if self.should_skip_namespace_export_name(&exports_table, name, export_sym_id) {
+                continue;
+            }
+            let declaration_order = if name == "default" {
+                1
+            } else {
+                props.len() as u32 + 2
+            };
+            let prop_type = self.get_type_of_symbol(export_sym_id);
+            let name_atom = self.ctx.types.intern_string(name);
+            props.push(PropertyInfo {
+                name: name_atom,
+                type_id: prop_type,
+                write_type: prop_type,
+                optional: false,
+                readonly: false,
+                is_method: false,
+                is_class_prototype: false,
+                visibility: Visibility::Public,
+                parent_id: None,
+                declaration_order,
+                is_string_named: false,
+                is_symbol_named: false,
+                single_quoted_name: false,
+            });
+        }
+        Self::normalize_namespace_export_declaration_order(&mut props);
+        let module_type = self.ctx.types.factory().object(props);
+        self.ctx.namespace_module_names.insert(
+            module_type,
+            self.imported_namespace_display_module_name(module_name),
+        );
+        Some(module_type)
+    }
+
+    fn resolve_node_esm_cjs_default_import_namespace(
+        &mut self,
+        module_name: &str,
+    ) -> Option<TypeId> {
+        let default_sym_id = self.resolve_cross_file_export_from_file(
+            module_name,
+            "default",
+            Some(self.ctx.current_file_idx),
+        )?;
+        use tsz_solver::PropertyInfo;
+        let default_type = self.get_type_of_symbol(default_sym_id);
+        let module_type = self.ctx.types.factory().object(vec![PropertyInfo {
+            name: self.ctx.types.intern_string("default"),
+            type_id: default_type,
+            write_type: default_type,
+            optional: false,
+            readonly: false,
+            is_method: false,
+            is_class_prototype: false,
+            visibility: Visibility::Public,
+            parent_id: None,
+            declaration_order: 1,
+            is_string_named: false,
+            is_symbol_named: false,
+            single_quoted_name: false,
+        }]);
+        self.ctx.namespace_module_names.insert(
+            module_type,
+            self.imported_namespace_display_module_name(module_name),
+        );
+        Some(module_type)
+    }
+
     /// Resolve the `unique symbol` identity of a value+type-alias symbol that
     /// follows the self-`typeof` idiom: a `const X = Symbol()` /
     /// `const X = Symbol.for(...)` / `const X: unique symbol` value merged with a

--- a/crates/tsz-checker/tests/conformance_issues/types/cross_module_unique_symbol.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/cross_module_unique_symbol.rs
@@ -1,0 +1,154 @@
+//! Cross-module `unique symbol` identity for the value+type-alias merge idiom.
+//!
+//! A module commonly exports a `unique symbol` as both a value and a same-named
+//! type alias:
+//!
+//! ```ts
+//! export const k = Symbol.for("k");
+//! export type k = typeof k;
+//! ```
+//!
+//! Both meanings denote the single `unique symbol` identity of `k`. tsc keeps
+//! that identity when the binding is imported (directly, through a re-export
+//! chain, or via a namespace) and used in value position.
+//!
+//! tsz previously resolved the merged symbol through the generic type-alias
+//! body path: lowering `typeof k` asked for the value of `k`, which re-entered
+//! the symbol while it was on the resolution stack, collapsed to the error
+//! type, and cached it. Every later value read of the merged symbol then saw
+//! `any`, so `const s: string = k` was silently accepted (false negative) and
+//! computed-key / indexed accesses keyed on `k` lost their `unique symbol`
+//! identity. The regression below pins the value-position type back to a real
+//! `unique symbol` (assigning it to `string` must report `TS2322`).
+
+use super::super::core::*;
+
+fn ts2322_count(diags: &[(u32, String)]) -> usize {
+    diags.iter().filter(|(c, _)| *c == 2322).count()
+}
+
+/// Re-export chain: `a.ts` declares the merged value+type-alias, `b.ts`
+/// re-exports it, `c.ts` imports the re-exported binding and uses it in value
+/// position. The value must keep its `unique symbol` identity (not collapse to
+/// `any`), so assigning it to `string` reports `TS2322`.
+#[test]
+fn reexported_value_type_alias_unique_symbol_keeps_value_identity() {
+    let files = &[
+        (
+            "a.ts",
+            r#"
+export const tag = Symbol.for("tag");
+export type tag = typeof tag;
+"#,
+        ),
+        (
+            "b.ts",
+            r#"
+import { tag } from "./a";
+export { tag };
+"#,
+        ),
+        (
+            "c.ts",
+            r#"
+import { tag } from "./b";
+const s: string = tag;
+"#,
+        ),
+    ];
+    let diagnostics = compile_named_files_get_diagnostics_with_lib_and_options(
+        files,
+        "c.ts",
+        tsz_checker::context::CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            module: tsz_common::common::ModuleKind::ESNext,
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        ts2322_count(&diagnostics),
+        1,
+        "re-exported unique-symbol value must remain a symbol (TS2322 on string assignment), \
+         not collapse to `any`: {diagnostics:?}"
+    );
+}
+
+/// Direct cross-file import of the merged value+type-alias binding. The
+/// renamed binder (`brand`, not `tag`) guards against any name-based shortcut.
+#[test]
+fn imported_value_type_alias_unique_symbol_keeps_value_identity() {
+    let files = &[
+        (
+            "sym.ts",
+            r#"
+export const brand = Symbol.for("brand");
+export type brand = typeof brand;
+"#,
+        ),
+        (
+            "use.ts",
+            r#"
+import { brand } from "./sym";
+const s: string = brand;
+"#,
+        ),
+    ];
+    let diagnostics = compile_named_files_get_diagnostics_with_lib_and_options(
+        files,
+        "use.ts",
+        tsz_checker::context::CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            module: tsz_common::common::ModuleKind::ESNext,
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        ts2322_count(&diagnostics),
+        1,
+        "imported unique-symbol value must remain a symbol (TS2322 on string assignment): \
+         {diagnostics:?}"
+    );
+}
+
+/// The `typeof`-side type alias resolved cross-file must also denote the
+/// `unique symbol` (not `any`): a value of that aliased type is not assignable
+/// to `string`.
+#[test]
+fn cross_file_typeof_type_alias_resolves_to_unique_symbol() {
+    let files = &[
+        (
+            "sym.ts",
+            r#"
+export const handle = Symbol.for("handle");
+export type handle = typeof handle;
+"#,
+        ),
+        (
+            "use.ts",
+            r#"
+import * as syms from "./sym";
+type H = syms.handle;
+declare const h: H;
+const s: string = h;
+"#,
+        ),
+    ];
+    let diagnostics = compile_named_files_get_diagnostics_with_lib_and_options(
+        files,
+        "use.ts",
+        tsz_checker::context::CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            module: tsz_common::common::ModuleKind::ESNext,
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        ts2322_count(&diagnostics),
+        1,
+        "cross-file `typeof`-merged type alias must resolve to `unique symbol`, \
+         not `any`: {diagnostics:?}"
+    );
+}

--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -1,3 +1,4 @@
+mod cross_module_unique_symbol;
 mod defaults;
 mod distributive_tuple_union;
 mod r#enum;


### PR DESCRIPTION
## Summary

A module that exports a `unique symbol` as both a value and a same-named type
alias — the idiom

```ts
export const X = Symbol.for("x");
export type  X = typeof X;
```

used by ts-pattern's `internals/symbols.ts` — lost its `unique symbol` value
identity whenever the binding was imported in **value position**: directly,
through a re-export chain, or via a namespace member access. The imported
binding silently became `any`, which suppressed computed-key and indexed-access
diagnostics (false-negative `TS2322`/`TS7053`, and the inconsistent `TS2722`
on symbol-keyed call targets reported in #14130).

## Structural rule

When a symbol merges a `unique symbol` const value (`const X = Symbol()` /
`const X = Symbol.for(...)` / `const X: unique symbol`) with a same-named
self-referential `type X = typeof X` alias, both meanings denote the single
`unique symbol` identity of `X`. `tsc` keeps that identity across module
boundaries; tsz collapsed it to `any` through `<owner>` (the checker symbol-type
computation).

### Wrong operation (owner layer)

`compute_type_of_symbol` (checker, `state/type_analysis/computed/type_alias_variable_alias.rs`)
resolved the merged `TYPE_ALIAS | VALUE` symbol through the generic type-alias
body path. Lowering `typeof X` asks for the value of `X`, which re-enters
`get_type_of_symbol(X)` while `X` is already on the resolution stack: the
circular guard returns the error type and caches it. Every later value- or
type-position read of the merged symbol then observed `any`.

### Fix

Resolve the value's `unique symbol` identity directly at the top of the
`TYPE_ALIAS` branch when the symbol owns **both** a self-referential
`type X = typeof X` alias **and** a unique-symbol const value declaration —
which is exactly what `typeof X` denotes, so it is correct for the value and
type meanings alike, and it breaks the cycle before the poisoning re-entry. The
gate is purely syntactic (self-`typeof` shape + unique-symbol const), so
non-idiomatic merges such as `const X = 5; type X = string` keep their generic
alias-body resolution untouched.

## Adjacent cases covered

- Direct cross-file import of the merged binding.
- Re-export chain (`a.ts` declares, `b.ts` re-exports, `c.ts` consumes).
- Cross-file `typeof`-side type alias (`import * as s; type H = s.X`).
- Unannotated `Symbol()`/`Symbol.for()` and annotated `: unique symbol` forms.
- Renamed binders (`tag`, `brand`, `handle`) so no name-based shortcut is relied on.

## Scope / follow-up

This fixes the root cross-module resolution (the merged symbol now resolves to a
real `unique symbol` instead of `any`). #14130's ts-pattern row still needs
further work on symbol-keyed **member identity through generic instantiation and
re-export chains** (the `__unique_<ref>` member key vs. index ref must agree),
which now surfaces as `TS7053` where it was previously masked by `any`. That is a
separate, deeper issue; the issue stays `WIP`.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- `cargo test -p tsz-checker --test conformance_issues_types -- cross_module_unique_symbol`
  — 3 new regression tests pass (direct import, re-export chain, cross-file
  `typeof` alias).
- `cargo test -p tsz-checker --test conformance_issues_types` /
  `--test conformance_issues_modules` — no new failures; the 6 remaining
  failures are pre-existing on `main` (verified by stash/clean-tree run).
- Manual: a faithful clone of ts-pattern @ `c92ca435` no longer collapses
  `symbols.matcher` to `any`; the merged binding resolves to a real
  `unique symbol`.

Relates to #14130.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EM8mwWgTcVKLdWi1NUQiSC)_