### PR TITLE
fix(bench): chart passing canaries + break the bench-gate deferral deadlock

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -143,10 +143,10 @@ jobs:
               {
                 gh run list --repo "${{ github.repository }}" --workflow bench.yml --branch main --status in_progress --limit 20 \
                   --json databaseId,headSha,url,createdAt \
-                  --jq '.[] | select(.databaseId != ${{ github.run_id }}) | [.databaseId, .headSha, .url, .createdAt] | @tsv'
+                  --jq '.[] | select(.databaseId < ${{ github.run_id }}) | [.databaseId, .headSha, .url, .createdAt] | @tsv'
                 gh run list --repo "${{ github.repository }}" --workflow bench.yml --branch main --status queued --limit 20 \
                   --json databaseId,headSha,url,createdAt \
-                  --jq '.[] | select(.databaseId != ${{ github.run_id }}) | [.databaseId, .headSha, .url, .createdAt] | @tsv'
+                  --jq '.[] | select(.databaseId < ${{ github.run_id }}) | [.databaseId, .headSha, .url, .createdAt] | @tsv'
               } | sort -u
             }
             if ! active_runs_raw="$(gh_retry list_other_active_runs)"; then
@@ -172,7 +172,15 @@ jobs:
               active_runs+="${run_id}"$'\t'"${run_sha}"$'\t'"${run_url}"$'\n'
             done <<< "$active_runs_raw"
             if [[ -n "$active_runs" ]]; then
-              echo "Another Bench run is already active; letting it finish even if main has moved, and skipping this duplicate run."
+              # Defer only to STRICTLY-OLDER active runs (databaseId < run_id, set
+              # in list_other_active_runs). Run ids are a strict total order, so
+              # among any set of near-simultaneous push-triggered runs exactly one
+              # — the oldest — finds no older-active run and proceeds; all newer
+              # ones defer to it. This breaks the symmetric "any other active run
+              # exists -> everyone defers" deadlock that left the site ~2h stale,
+              # while preserving the one-active-bench invariant (no concurrency:
+              # group needed) and the 180m stale-break above.
+              echo "An older Bench run is already active; deferring to the oldest concurrent run and skipping this newer duplicate."
               printf '%s\n' "$active_runs"
               IFS=$'\t' read -r active_run_id active_run_sha active_run_url <<< "$(printf '%s\n' "$active_runs" | head -n 1)"
               echo "active_run_id=${active_run_id}" >> "$GITHUB_OUTPUT"

--- a/scripts/bench/lib/bench-vs-tsgo-results.sh
+++ b/scripts/bench/lib/bench-vs-tsgo-results.sh
@@ -707,7 +707,13 @@ run_project_benchmark() {
                 ratio=$(printf "%.2f" "$(echo "$tsz_mean / $tsgo_mean" | bc -l 2>/dev/null)" 2>/dev/null || echo "N/A")
             fi
 
+            # The perf-comparison canary shard intentionally charts tsz-vs-tsgo
+            # even when tsz is much slower than tsgo — that gap IS the comparison
+            # we want to surface. The slowdown-failure gate nulls the timing
+            # (ERR,ERR), which would drop every canary off the chart, so it must
+            # not apply to the bench-canaries shard. Required project rows keep it.
             if [ "$winner" = "tsgo" ] \
+                && [ "${TSZ_BENCH_SHARD_LABEL:-}" != "bench-canaries" ] \
                 && tsz_project_slowdown_failure_reached "$tsz_mean" "$tsgo_mean"; then
                 local threshold
                 threshold="$(tsz_project_slowdown_failure_factor)"

--- a/scripts/bench/merge-results.mjs
+++ b/scripts/bench/merge-results.mjs
@@ -117,7 +117,13 @@ function mergeCompatibilityCanaries(results, compatibilityJsonlFiles) {
           continue;
         }
         existing.compatibility = compatibility;
-        existing.status ||= "compile canary tracked in CI; not timed by vs-tsgo benchmarks";
+        // Only stamp the "not timed" placeholder when the row genuinely lacks
+        // timing. A perf-timed canary (the bench-canaries shard) already carries
+        // real tsz_ms/tsgo_ms and an empty status; stamping a status here would
+        // make isGreen() false and silently drop it from the perf chart.
+        if (existing.tsz_ms == null) {
+          existing.status ||= "compile canary tracked in CI; not timed by vs-tsgo benchmarks";
+        }
         continue;
       }
 

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -207,7 +207,7 @@ assert.match(
 
 assert.match(
   workflow,
-  /"\$\{\{ github\.event_name \}\}" == "workflow_run"[\s\S]+Another Bench run is already active; letting it finish even if main has moved, and skipping this duplicate run\.[\s\S]+echo "active_run_id=\$\{active_run_id\}" >> "\$GITHUB_OUTPUT"[\s\S]+echo "active_run_sha=\$\{active_run_sha\}" >> "\$GITHUB_OUTPUT"[\s\S]+echo "active_run_url=\$\{active_run_url\}" >> "\$GITHUB_OUTPUT"/,
+  /"\$\{\{ github\.event_name \}\}" == "workflow_run"[\s\S]+An older Bench run is already active; deferring to the oldest concurrent run and skipping this newer duplicate\.[\s\S]+echo "active_run_id=\$\{active_run_id\}" >> "\$GITHUB_OUTPUT"[\s\S]+echo "active_run_sha=\$\{active_run_sha\}" >> "\$GITHUB_OUTPUT"[\s\S]+echo "active_run_url=\$\{active_run_url\}" >> "\$GITHUB_OUTPUT"/,
   "bench gate should let active runs finish, skip duplicate automatic runs, and remember the blocker",
 );
 

--- a/scripts/bench/test-merge-results.mjs
+++ b/scripts/bench/test-merge-results.mjs
@@ -1094,3 +1094,29 @@ withTempDir((dir) => {
   assert.equal(merged.totals.green_tsz_wins, 0, "artifact_missing row must not count as a green win");
   assert.equal(merged.totals.green_tsgo_wins, 1);
 });
+
+// A perf-timed canary (the bench-canaries shard already measured it) must keep
+// its real tsz_ms/tsgo_ms and must NOT be stamped the "not timed" placeholder
+// status when its compile-guard compat is attached — otherwise isGreen() becomes
+// false and the (green) canary silently drops off the perf chart. Regression for
+// the bench-canaries perf-chart fix.
+withTempDir((dir) => {
+  const canaryRow = COMPILE_ONLY_CANARY_PROJECT_ROWS[0];
+  const timedRow = { name: canaryRow, winner: "tsgo", tsz_ms: 2549, tsgo_ms: 206, ratio: 12.36 };
+  const input = writeInput(dir, "input.json", [timedRow]);
+  const compatibilityJsonl = path.join(dir, "project-compatibility.jsonl");
+  fs.writeFileSync(
+    compatibilityJsonl,
+    `${JSON.stringify({ ...SAMPLE_COMPATIBILITY, name: canaryRow, files_reached: 50 })}\n`,
+    "utf8",
+  );
+  const result = runMergeInputs(dir, ["--compat-jsonl", compatibilityJsonl, input]);
+  assert.equal(result.status, 0, result.stderr);
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  const row = merged.results.find((candidate) => candidate.name === canaryRow);
+  assert.ok(row, "expected the perf-timed canary row to survive merge");
+  assert.equal(row.tsz_ms, 2549, "perf-timed canary must keep its measured tsz_ms");
+  assert.equal(row.tsgo_ms, 206, "perf-timed canary must keep its measured tsgo_ms");
+  assert.ok(!row.status, "a perf-timed canary must not be stamped 'not timed' (would drop it off the chart)");
+  assert.equal(row.compatibility.state, "green");
+});


### PR DESCRIPTION
Goal: fast

Fixes two infra bugs that left tsz.dev/benchmarks stale with **zero** new canary perf charts. Root-caused via an orchestrated investigation; both confirmed against the live Bench run 27871280120.

## 1. No new canary charts (the 8x slowdown gate nulls canary timing)
The `bench-canaries` shard **did** measure the canaries — e.g. `hotscript` at **tsz 2549ms vs tsgo 206ms (12.36x)** — but `bench-vs-tsgo-results.sh` treats any tsgo win beyond an 8x slowdown as an ERROR and writes `ERR,ERR` (→ `tsz_ms`/`tsgo_ms` null). Since the entire point of the canary perf rows is to **show the tsz-vs-tsgo gap** (tsz is slower on all of them), the gate nulled every canary's timing → 0 charts. `merge-results.mjs` then re-greened the compat but stamped a `"not timed"` status, producing a self-contradictory row (green compat + slowdown status + null timing) that `isGreen()` excludes.

**Fix:**
- `scripts/bench/lib/bench-vs-tsgo-results.sh`: skip the slowdown-failure gate **only** for the `bench-canaries` shard (`TSZ_BENCH_SHARD_LABEL`), so a slow-but-green canary keeps real timing and charts. **Required project rows keep the gate.**
- `scripts/bench/merge-results.mjs`: only stamp the `"not timed"` placeholder status when the row genuinely lacks timing (`existing.tsz_ms == null`), so a perf-timed canary stays chartable.

## 2. Chronic ~2h staleness (symmetric deferral deadlock)
The `bench-gate` deferred to **any** other active run, so near-simultaneous push-triggered runs each saw the others active and **all deferred** → nobody published until the 180m stale-break (the observed ~2h staleness; the site kept redeploying old data).

**Fix:** `.github/workflows/bench.yml` — defer only to **strictly-older** active runs (`databaseId < github.run_id`). Run ids are a strict total order, so among concurrent runs exactly one (the oldest, furthest-along) proceeds and the rest defer to it. Preserves the one-active-bench invariant (no `concurrency:` group — deliberately avoided per the in-file comment), the 180m stale-break, and the catch-up dispatch.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- Functional: a green+timed canary (hotscript) now merges to a chartable row (`tsz_ms=2549`, empty status, green compat); a timed-but-yellow canary (ts-pattern) is correctly excluded.
- `node scripts/bench/test-merge-results.mjs` passes, including a new regression case asserting a perf-timed canary keeps its timing and is not stamped `"not timed"`.
- `bench.yml` is valid YAML; `bash -n` clean.
- Publish completeness gate untouched (still counts 9 required shards; `bench-results-bench-canaries.json` excluded from the count, merged for data).
- Note: only the **green** canaries chart (e.g. hotscript); yellow/red canaries stay off the chart until their false-positives/timeouts (separate issues #14126-14131, #14101-family) are fixed.