### PR TITLE
fix(module-resolution): canonicalize package main/types/typings entry paths

### DIFF
--- a/crates/tsz-common/src/module_resolution/path_identity.rs
+++ b/crates/tsz-common/src/module_resolution/path_identity.rs
@@ -127,10 +127,31 @@ pub fn resolve_relative_slash_specifier(base_dir: &str, specifier: &str) -> Opti
 /// Returns `true` when `path` contains no `.` or `..` segment, i.e. it is
 /// already lexically canonical and [`normalize_segments`] would be an identity
 /// transform. Callers on hot probe paths use this to avoid an allocation.
+///
+/// This must scan the raw text rather than [`Path::components`]: that iterator
+/// silently collapses *interior* `.` segments, so `a/./b` yields the same
+/// components as `a/b` and would be misreported as already-normalized. But
+/// [`normalize_segments`] rebuilds from components and therefore *does* strip
+/// that interior `.`, so trusting `components` here let the fast path return
+/// `a/./b` verbatim while a direct `normalize_segments` call returned `a/b` —
+/// two textual spellings for one file, defeating the textual module identity
+/// this module exists to keep stable (e.g. a `package.json` `main`/`types`
+/// entry written `"./dist/index.js"` resolving to `pkg/./dist/index.js`).
 pub fn is_already_normalized(path: &Path) -> bool {
-    !path
-        .components()
-        .any(|c| matches!(c, Component::CurDir | Component::ParentDir))
+    match path.to_str() {
+        // Scan textual segments so an interior `.` (invisible to `components`)
+        // is still witnessed; a leading `.` and any `..` are caught here too.
+        Some(text) => !text
+            .split(std::path::is_separator)
+            .any(|segment| segment == "." || segment == ".."),
+        // Non-UTF-8 path: fall back to the component scan. This forgoes the
+        // interior-`.` correction (the owned `normalize_segments` rebuild below
+        // is always correct, so this only risks taking the borrow fast path for
+        // a non-UTF-8 path that has an interior `.`).
+        None => !path
+            .components()
+            .any(|c| matches!(c, Component::CurDir | Component::ParentDir)),
+    }
 }
 
 #[cfg(test)]
@@ -255,10 +276,13 @@ mod tests {
         // Already-canonical paths take the borrow fast path.
         assert!(is_already_normalized(Path::new("/a/b/c.ts")));
         assert!(is_already_normalized(Path::new("a/b/c.ts")));
-        // `std::path::Path::components` collapses *interior* `.` (so `a/./b`
-        // already has no `CurDir` component and compares equal to `a/b` as a
-        // map key); a *leading* `.` and any `..` survive and must be normalized.
+        // A leading `.`, an *interior* `.` (which `Path::components` hides but
+        // `normalize_segments` still strips), and any `..` must all be reported
+        // as not-yet-normalized so the fast path agrees with the rebuild.
         assert!(!is_already_normalized(Path::new("./a/b")));
+        assert!(!is_already_normalized(Path::new("a/./b")));
+        assert!(!is_already_normalized(Path::new("/pkg/./dist/index.d.ts")));
+        assert!(!is_already_normalized(Path::new("a/b/.")));
         assert!(!is_already_normalized(Path::new("a/../b")));
         // Any path the fast path skips must be byte-identical after normalizing,
         // so taking the borrow path never changes the resulting identity.
@@ -268,5 +292,23 @@ mod tests {
                 assert_eq!(normalize_segments(p), PathBuf::from(already));
             }
         }
+        // Conversely, every path the fast path declines must be exactly what the
+        // owned rebuild produces — the fast path and `normalize_segments` agree
+        // on one textual spelling. Interior `.` is the case that regressed.
+        for needs_norm in [
+            "a/./b",
+            "/pkg/./dist/index.d.ts",
+            "a/b/.",
+            "./a/b",
+            "a/../b",
+        ] {
+            let p = Path::new(needs_norm);
+            assert!(!is_already_normalized(p), "{needs_norm} is not canonical");
+        }
+        assert_eq!(normalize_segments(Path::new("a/./b")), PathBuf::from("a/b"));
+        assert_eq!(
+            normalize_segments(Path::new("/pkg/./dist/index.d.ts")),
+            PathBuf::from("/pkg/dist/index.d.ts")
+        );
     }
 }

--- a/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
+++ b/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
@@ -762,7 +762,12 @@ impl ModuleResolver {
             .clone()
             .or_else(|| package_json.typings.clone())
         {
-            let types_path = package_dir.join(&types);
+            // Canonicalize the joined field path so a `"./dist/index.d.ts"`
+            // spelling does not leak a stray `/./` into the resolved identity
+            // (the `declaration_substitution_for_main` / explicit-extension
+            // probes below return the path as-is rather than through
+            // `try_*`, which already normalize their input).
+            let types_path = normalize_path_segments(&package_dir.join(&types)).into_owned();
             if let Some(resolved) = self.try_types_entry(&types_path, target_pt) {
                 return Ok(ResolvedModule {
                     resolved_path: resolved.clone(),
@@ -777,7 +782,10 @@ impl ModuleResolver {
 
         // Try main field
         if let Some(main) = &package_json.main {
-            let main_path = package_dir.join(main);
+            // See the `types_path` note above: canonicalize before probing so the
+            // `resolve_explicit_unknown_extension` / `declaration_substitution_for_main`
+            // branches (which return the path verbatim) cannot emit a stray `/./`.
+            let main_path = normalize_path_segments(&package_dir.join(main)).into_owned();
             if let Some(resolved) = resolve_explicit_unknown_extension(&main_path) {
                 return Ok(ResolvedModule {
                     resolved_path: resolved.clone(),

--- a/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
+++ b/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
@@ -762,12 +762,10 @@ impl ModuleResolver {
             .clone()
             .or_else(|| package_json.typings.clone())
         {
-            // Canonicalize the joined field path so a `"./dist/index.d.ts"`
-            // spelling does not leak a stray `/./` into the resolved identity
-            // (the `declaration_substitution_for_main` / explicit-extension
-            // probes below return the path as-is rather than through
-            // `try_*`, which already normalize their input).
-            let types_path = normalize_path_segments(&package_dir.join(&types)).into_owned();
+            // `try_types_entry` segment-canonicalizes its input, so a
+            // `"./dist/index.d.ts"` field spelling does not leak a stray `/./`
+            // into the resolved identity here.
+            let types_path = package_dir.join(&types);
             if let Some(resolved) = self.try_types_entry(&types_path, target_pt) {
                 return Ok(ResolvedModule {
                     resolved_path: resolved.clone(),
@@ -782,10 +780,13 @@ impl ModuleResolver {
 
         // Try main field
         if let Some(main) = &package_json.main {
-            // See the `types_path` note above: canonicalize before probing so the
-            // `resolve_explicit_unknown_extension` / `declaration_substitution_for_main`
-            // branches (which return the path verbatim) cannot emit a stray `/./`.
-            let main_path = normalize_path_segments(&package_dir.join(main)).into_owned();
+            // Unlike `try_types_entry`/`try_file`, the `resolve_explicit_unknown_extension`
+            // and `declaration_substitution_for_main` branches below return the path
+            // verbatim, so canonicalize here to keep a `"./dist/index.js"` field
+            // spelling from leaking a stray `/./` into the resolved identity. The
+            // `Cow` stays borrowed (no allocation) when the join is already canonical.
+            let joined = package_dir.join(main);
+            let main_path = normalize_path_segments(&joined);
             if let Some(resolved) = resolve_explicit_unknown_extension(&main_path) {
                 return Ok(ResolvedModule {
                     resolved_path: resolved.clone(),

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -8,6 +8,7 @@
 mod fixtures;
 
 mod cache_statistics;
+mod canonical_entry_path;
 mod conditional_types_flavor;
 mod diagnostics_ts2307;
 mod diagnostics_ts2792;

--- a/crates/tsz-core/src/module_resolver/tests/canonical_entry_path.rs
+++ b/crates/tsz-core/src/module_resolver/tests/canonical_entry_path.rs
@@ -1,0 +1,164 @@
+//! Canonical resolved-path identity for package entry points.
+//!
+//! A `package.json` `main`/`types`/`typings` value is almost always written
+//! with a leading `./` (`"./dist/index.js"`). `package_dir.join(field)` keeps
+//! that segment verbatim, and the `main`-field probes that return the path
+//! without going through `try_file`/`try_types_entry`
+//! (`resolve_explicit_unknown_extension`, `declaration_substitution_for_main`)
+//! used to surface it as a stray `/./` in the resolved path
+//! (`node_modules/pkg/./dist/index.d.ts`). Because module identity in tsz is
+//! textual, that is a distinct spelling from the same file reached through a
+//! relative import or an `exports` target (both of which are normalized), so it
+//! risks minting duplicate module identities. These tests pin that the resolver
+//! emits a segment-canonical path for every entry-point field, regardless of
+//! how the field is spelled or the package is named.
+
+use super::super::*;
+use super::fixtures::TempFixture;
+
+fn node16_opts() -> ResolvedCompilerOptions {
+    ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        resolve_package_json_exports: true,
+        ..Default::default()
+    }
+}
+
+/// Resolve `specifier` and assert the resolved path is exactly `expected`
+/// (textually canonical — no `.`/`..` segments).
+#[track_caller]
+fn assert_resolves_to(
+    opts: &ResolvedCompilerOptions,
+    specifier: &str,
+    fixture: &TempFixture,
+    expected_rel: &str,
+) {
+    let mut resolver = ModuleResolver::new(opts);
+    let resolved = resolver
+        .resolve(specifier, &fixture.join("main.ts"), Span::new(0, 10))
+        .unwrap_or_else(|e| panic!("`{specifier}` should resolve, got {e:?}"));
+    let expected = fixture.join(expected_rel);
+    assert_eq!(
+        resolved.resolved_path, expected,
+        "`{specifier}` should resolve to a canonical path"
+    );
+    // Guard the actual invariant directly: no `.`/`..` segment survives.
+    assert!(
+        !resolved.resolved_path.components().any(|c| matches!(
+            c,
+            std::path::Component::CurDir | std::path::Component::ParentDir
+        )),
+        "resolved path must be segment-canonical, got {}",
+        resolved.resolved_path.display()
+    );
+    // And the textual spelling must not carry a stray `/./` (which `components`
+    // hides but the file-graph identity does not).
+    assert!(
+        !resolved.resolved_path.to_string_lossy().contains("/./"),
+        "resolved path must not contain a stray `/./`, got {}",
+        resolved.resolved_path.display()
+    );
+}
+
+#[test]
+fn types_field_with_dot_slash_resolves_canonically() {
+    let f = TempFixture::new();
+    f.write(
+        "node_modules/alpha/package.json",
+        r#"{"name":"alpha","types":"./dist/index.d.ts","main":"./dist/index.js"}"#,
+    );
+    f.write(
+        "node_modules/alpha/dist/index.d.ts",
+        "export const a: number;",
+    );
+    f.write("node_modules/alpha/dist/index.js", "");
+    f.write("main.ts", "");
+    assert_resolves_to(
+        &node16_opts(),
+        "alpha",
+        &f,
+        "node_modules/alpha/dist/index.d.ts",
+    );
+}
+
+#[test]
+fn typings_legacy_field_with_dot_slash_resolves_canonically() {
+    // Vary the binder: legacy `typings` field, different package + path names.
+    let f = TempFixture::new();
+    f.write(
+        "node_modules/beta-pkg/package.json",
+        r#"{"name":"beta-pkg","typings":"./out/types/entry.d.ts"}"#,
+    );
+    f.write(
+        "node_modules/beta-pkg/out/types/entry.d.ts",
+        "export const b: number;",
+    );
+    f.write("main.ts", "");
+    assert_resolves_to(
+        &node16_opts(),
+        "beta-pkg",
+        &f,
+        "node_modules/beta-pkg/out/types/entry.d.ts",
+    );
+}
+
+#[test]
+fn main_field_declaration_sibling_with_dot_slash_resolves_canonically() {
+    // `declaration_substitution_for_main`: `"./dist/index.js"` -> sibling
+    // `index.d.ts`. This is the branch that bypassed `try_file` normalization.
+    let f = TempFixture::new();
+    f.write(
+        "node_modules/gamma/package.json",
+        r#"{"name":"gamma","main":"./lib/main.js"}"#,
+    );
+    f.write(
+        "node_modules/gamma/lib/main.d.ts",
+        "export const g: number;",
+    );
+    f.write("node_modules/gamma/lib/main.js", "");
+    f.write("main.ts", "");
+    assert_resolves_to(
+        &node16_opts(),
+        "gamma",
+        &f,
+        "node_modules/gamma/lib/main.d.ts",
+    );
+}
+
+#[test]
+fn main_field_with_interior_dot_segment_resolves_canonically() {
+    // An explicit interior `.` segment (`./lib/./main.js`) must collapse too.
+    let f = TempFixture::new();
+    f.write(
+        "node_modules/delta/package.json",
+        r#"{"name":"delta","main":"./lib/./main.js"}"#,
+    );
+    f.write(
+        "node_modules/delta/lib/main.d.ts",
+        "export const d: number;",
+    );
+    f.write("node_modules/delta/lib/main.js", "");
+    f.write("main.ts", "");
+    assert_resolves_to(
+        &node16_opts(),
+        "delta",
+        &f,
+        "node_modules/delta/lib/main.d.ts",
+    );
+}
+
+#[test]
+fn main_field_runtime_js_with_dot_slash_resolves_canonically() {
+    // `try_file` / `resolve_explicit_unknown_extension` runtime-JS branch under
+    // allowJs: the resolved `.js` path must also be canonical.
+    let f = TempFixture::new();
+    let mut opts = node16_opts();
+    opts.allow_js = true;
+    f.write(
+        "node_modules/epsilon/package.json",
+        r#"{"name":"epsilon","main":"./bundle/entry.js"}"#,
+    );
+    f.write("node_modules/epsilon/bundle/entry.js", "");
+    f.write("main.ts", "");
+    assert_resolves_to(&opts, "epsilon", &f, "node_modules/epsilon/bundle/entry.js");
+}


### PR DESCRIPTION
Refs #13826 (a resolver-correctness slice in the module-resolution umbrella).

Goal: hold

## Structural rule

> When a resolved path is segment-canonicalized, an *interior* `.` segment
> (`a/./b`) must collapse exactly as a leading `.` or any `..` does. tsz keys
> module identity textually, so two spellings of one file are two identities.
> tsc emits canonical resolved paths; tsz now does too for every package
> entry-point field.

## Wrong operation / owner layer

Two coordinated defects, both in the resolver / shared path-identity helper:

1. **`tsz_common::module_resolution::path_identity::is_already_normalized`** (the
   fast-path guard for `normalize_path_segments`) scanned `Path::components()`.
   Rust's `components()` **silently collapses interior `.` segments**, so
   `a/./b` yields the same components as `a/b` and was misreported as already
   canonical — `normalize_path_segments` then returned it **verbatim**. But
   `normalize_segments` (the owned rebuild, called directly by the CLI driver
   and LSP) rebuilds from components and *does* strip that `.`. The fast-path
   wrapper thus disagreed with its own underlying function: `a/./b` via the
   borrow path, `a/b` via the rebuild — two textual spellings for one file.

2. **`ModuleResolver` package entry-point resolution** (`node_modules_resolution.rs`):
   a `package.json` `main`/`types`/`typings` value written `"./dist/index.js"`
   (the overwhelmingly common spelling) resolved to
   `node_modules/pkg/./dist/index.js`. The `main`-field probes that return the
   path **verbatim** — `resolve_explicit_unknown_extension` and
   `declaration_substitution_for_main` — bypass the `try_file`/`try_types_entry`
   helpers that normalize their input, so the stray `/./` survived into the
   resolved identity. That is a distinct identity from the same file reached via
   a relative import or an `exports` target (both already normalized), risking
   the "duplicate declaration roots / unstable canonical IDs" family.

## Fix

- `is_already_normalized` scans the raw text (`split` on path separators) so an
  interior `.` is witnessed; leading `.` and any `..` are still caught. Non-UTF-8
  paths fall back to the component scan (the owned rebuild is always correct).
  The CLI driver/LSP call `normalize_segments` directly, so this only affects
  `tsz-core`'s `normalize_path_segments` wrapper — it **reduces** drift between
  the two layers rather than changing driver behavior.
- The resolver canonicalizes the joined `main`/`types`/`typings` field paths
  before probing, so the verbatim-return branches cannot emit a stray `/./`.

## Anti-hardcoding

Purely structural — keyed on path-segment shape, not on any package/file-name
literal or rendered string. Regression tests vary the package names
(`alpha`/`beta-pkg`/`gamma`/`delta`/`epsilon`) and field paths so the fix cannot
be a name-keyed special case.

## Adjacent matrix (new `module_resolver::tests::canonical_entry_path`)

- `types` field `"./dist/index.d.ts"` — canonical.
- legacy `typings` field `"./out/types/entry.d.ts"` — canonical.
- `main` declaration-sibling (`declaration_substitution_for_main` branch) — canonical.
- `main` with an explicit interior `.` segment (`"./lib/./main.js"`) — collapses.
- `main` runtime-JS under `allowJs` (`try_file`/`resolve_explicit_unknown_extension`
  branch) — canonical.

Each guard asserts the path is segment-canonical (no `CurDir`/`ParentDir`) **and**
its text carries no `/./`.

## Verification

- `cargo test -p tsz-common --lib path_identity` — 8/8 (extended fast-path
  consistency: interior `.`, leading `.`, trailing `.`, `..`; `normalize_segments`
  agreement asserted directly).
- `cargo test -p tsz-core --lib module_resolver::tests::canonical_entry_path` — 5/5 new.
- `cargo test -p tsz-core --lib module_resolver` — 272/272 (full resolver suite, no regressions).
- `cargo test -p tsz-core --lib resolution::helpers` — 16/16.
- `cargo test -p tsz-cli --lib driver::resolution` — 98/98 (driver resolution + canonical-id, unaffected).
- `cargo fmt -p tsz-common -p tsz-core --check`, `cargo clippy -p tsz-common -p tsz-core --lib` — clean.
- Broad conformance/emit/fourslash owned by ready-review CI; the CLI compile path
  uses the driver's own normalizing resolver, so it is structurally unaffected.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01TrDxuk4zkxxB5r7z337kRr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrDxuk4zkxxB5r7z337kRr)_