### PR TITLE
refactor(checker): structural checks replace type-display-string semantic predicates (#14142)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -494,7 +494,7 @@ impl<'a> CheckerState<'a> {
                 .map(|name| self.ctx.types.resolve_atom_ref(name).to_string())
                 .unwrap_or_else(|| format!("arg{index}"));
             let mut type_display = self.format_type_for_assignability_message(param.type_id);
-            if type_display == "error"
+            if crate::query_boundaries::common::is_genuine_error_type(self.ctx.types, param.type_id)
                 && let Some(&actual_param_idx) = func.parameters.nodes.get(index)
                 && let Some(actual_param_node) = self.ctx.arena.get(actual_param_idx)
                 && let Some(actual_param) = self.ctx.arena.get_parameter(actual_param_node)
@@ -517,7 +517,8 @@ impl<'a> CheckerState<'a> {
         }
 
         let mut return_display = self.format_type_for_assignability_message(shape.return_type);
-        if return_display == "error" {
+        if crate::query_boundaries::common::is_genuine_error_type(self.ctx.types, shape.return_type)
+        {
             return_display = self
                 .explicit_callback_return_display_from_parameter(func)
                 .unwrap_or(return_display);

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
@@ -162,7 +162,10 @@ impl<'a> CheckerState<'a> {
             let (type_display, display_type_id) = if param.type_annotation.is_some() {
                 let annotated_type = self.get_type_from_type_node(param.type_annotation);
                 let rendered_annotated = self.format_type_for_assignability_message(annotated_type);
-                let display = if rendered_annotated == "error" {
+                let display = if crate::query_boundaries::common::is_genuine_error_type(
+                    self.ctx.types,
+                    annotated_type,
+                ) {
                     self.sanitized_type_node_display(param.type_annotation)
                         .unwrap_or(rendered_annotated)
                 } else {
@@ -245,7 +248,10 @@ impl<'a> CheckerState<'a> {
                 shape.return_type,
             );
             let rendered_return = self.format_type_for_assignability_message(return_display_type);
-            if rendered_return == "error" {
+            if crate::query_boundaries::common::is_genuine_error_type(
+                self.ctx.types,
+                return_display_type,
+            ) {
                 self.explicit_callback_return_display_from_parameter(func)
                     .unwrap_or(rendered_return)
             } else {

--- a/crates/tsz-checker/src/types/class_type/js_class_properties.rs
+++ b/crates/tsz-checker/src/types/class_type/js_class_properties.rs
@@ -31,8 +31,8 @@ impl ImplicitAnyKind {
     /// The `tsc` display label (`any` / `any[]`) for the `TS7008` message.
     const fn label(self) -> &'static str {
         match self {
-            ImplicitAnyKind::Any => "any",
-            ImplicitAnyKind::AnyArray => "any[]",
+            Self::Any => "any",
+            Self::AnyArray => "any[]",
         }
     }
 }

--- a/crates/tsz-checker/src/types/class_type/js_class_properties.rs
+++ b/crates/tsz-checker/src/types/class_type/js_class_properties.rs
@@ -14,6 +14,29 @@ use tsz_solver::{
     Visibility,
 };
 
+/// Structural classification of an implicit-`any` constructor property, carried
+/// as a fact rather than re-derived from its rendered display string. The
+/// producer already knows which case applies (it chooses between `TypeId::ANY`
+/// and an `any`-element array); the `TS7008` display label is derived from this
+/// enum only at the message site, so semantics never read the rendered text back.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ImplicitAnyKind {
+    /// The property is implicitly `any`.
+    Any,
+    /// The property is implicitly `any[]` (an array whose element type is `any`).
+    AnyArray,
+}
+
+impl ImplicitAnyKind {
+    /// The `tsc` display label (`any` / `any[]`) for the `TS7008` message.
+    const fn label(self) -> &'static str {
+        match self {
+            ImplicitAnyKind::Any => "any",
+            ImplicitAnyKind::AnyArray => "any[]",
+        }
+    }
+}
+
 impl CheckerState<'_> {
     /// Push the enclosing JS class's `@template T` JSDoc-derived type
     /// parameters into `type_parameter_scope` for the lifetime of a
@@ -564,7 +587,7 @@ impl CheckerState<'_> {
         let this_aliases = self.collect_this_aliases(&stmts);
         let mut constructor_collected_props = FxHashSet::default();
         let mut pending_implicit_any =
-            FxHashMap::<Atom, (String, &'static str, NodeIndex)>::default();
+            FxHashMap::<Atom, (String, ImplicitAnyKind, NodeIndex)>::default();
 
         for &stmt_idx in &stmts {
             let Some((prop_name, rhs_idx, is_private, report_idx)) = self
@@ -679,23 +702,23 @@ impl CheckerState<'_> {
                 && !any_is_explicit
                 && !enclosing_has_this_tag
             {
-                let implicit_type = if type_id == TypeId::ANY
+                let implicit_kind = if type_id == TypeId::ANY
                     || (provisional_open && matches!(type_id, TypeId::NULL | TypeId::UNDEFINED))
                 {
-                    Some("any")
+                    Some(ImplicitAnyKind::Any)
                 } else if crate::query_boundaries::common::array_element_type(
                     self.ctx.types,
                     type_id,
                 ) == Some(TypeId::ANY)
                 {
-                    Some("any[]")
+                    Some(ImplicitAnyKind::AnyArray)
                 } else {
                     None
                 };
-                if let Some(implicit_type) = implicit_type {
+                if let Some(implicit_kind) = implicit_kind {
                     pending_implicit_any
                         .entry(name_atom)
-                        .or_insert_with(|| (prop_name.clone(), implicit_type, stmt_idx));
+                        .or_insert_with(|| (prop_name.clone(), implicit_kind, stmt_idx));
                 }
             }
 
@@ -758,7 +781,7 @@ impl CheckerState<'_> {
             );
         }
 
-        for (name_atom, (prop_name, implicit_type, implicit_anchor)) in pending_implicit_any {
+        for (name_atom, (prop_name, implicit_kind, implicit_anchor)) in pending_implicit_any {
             let still_implicit = properties.get(&name_atom).is_some_and(|property| {
                 property.write_type == TypeId::ANY
                     || property.type_id == TypeId::ANY
@@ -772,7 +795,7 @@ impl CheckerState<'_> {
             }
 
             if let Some(property) = properties.get_mut(&name_atom) {
-                if implicit_type == "any[]" {
+                if implicit_kind == ImplicitAnyKind::AnyArray {
                     let any_array = self.ctx.types.factory().array(TypeId::ANY);
                     let nullish_part = if property.type_id.is_nullable() {
                         Some(property.type_id)
@@ -806,7 +829,10 @@ impl CheckerState<'_> {
                 }
             }
 
-            let message = format!("Member '{prop_name}' implicitly has an '{implicit_type}' type.");
+            let message = format!(
+                "Member '{prop_name}' implicitly has an '{}' type.",
+                implicit_kind.label()
+            );
             let already_emitted = self.ctx.diagnostics.iter().any(|d| {
                 d.code == crate::diagnostics::diagnostic_codes::MEMBER_IMPLICITLY_HAS_AN_TYPE
                     && d.start == self.ctx.arena.get(implicit_anchor).map_or(0, |n| n.pos)
@@ -816,7 +842,7 @@ impl CheckerState<'_> {
                 self.error_at_node_msg(
                     implicit_anchor,
                     crate::diagnostics::diagnostic_codes::MEMBER_IMPLICITLY_HAS_AN_TYPE,
-                    &[&prop_name, implicit_type],
+                    &[&prop_name, implicit_kind.label()],
                 );
             }
         }


### PR DESCRIPTION
## Summary

Removes type-display-string semantic predicates from the checker (issue #14142).
The affected sites computed a structural fact, rendered it to a type-display
string, then branched logic on `==` over that string — the exact pattern the
Anti-Hardcoding Gate forbids:

> "No formatted diagnostic string used as a semantic predicate."
> "The printer may read types; types must not read printer output."

## Structural rule

When the checker needs to know **what a type is** (the implicit-`any`
classification of a JS constructor property, or whether a type is the `error`
sentinel), `tsc` decides on the type's structure. tsz now decides on the
`TypeId`/enum through the solver query boundary and derives any display label
only at the render site — semantics never read the rendered text back.

## Changes (owner layer: checker → query boundary)

- `types/class_type/js_class_properties.rs`: replace the
  `implicit_type == "any[]"` rendered-string discriminator with an
  `ImplicitAnyKind` enum (`Any` / `AnyArray`). The producer already chooses
  between `TypeId::ANY` and an `any`-element array; the `any` / `any[]` `TS7008`
  label is derived from the enum only at the `format!` message site.
- `error_reporter/call_errors/display_formatting.rs` (×2) and
  `error_reporter/call_errors/display_formatting_parameters.rs` (×2): replace
  `<display> == "error"` with the structural
  `query_boundaries::common::is_genuine_error_type(type_id)` predicate.

### Why `is_genuine_error_type` is the faithful mirror

The bare `"error"` token is rendered only for `TypeId::ERROR` / `TypeData::Error`.
An `UnresolvedTypeName` is **display-preserving** — it renders as its own name,
not `"error"` — so the old `== "error"` check never matched it, and
`is_genuine_error_type` (which excludes unresolved names) reproduces that exactly.

## Scope / triage (adjacent matrix)

- Both checker sites named in #14142 are converted, **plus** the two identical
  sibling `== "error"` predicates in `display_formatting_parameters.rs` (same
  module, same anti-pattern). After this change, **no `== "error"`
  rendered-string predicate remains in the checker.**
- **Emitter `type_text == "…"` sites (19): triaged as the correct DTS text
  boundary, left unchanged.** The DTS declaration pipeline deliberately lowers
  types to declaration text (`print_type_id_for_inferred_declaration`,
  `js_define_property_descriptor`, short-circuit literal detection) and the
  comparison points have no equivalent in-scope `TypeId`; converting them would
  not be behavior-preserving. Tracked as the remainder on #14142.
- Out of scope (different families): the
  `assignability_display == "true"/"false"` boolean-display checks in
  `assignment_formatting.rs`, and `base_display == "Window & typeof globalThis"`
  (separately tracked/claimed as #14140).

## Verification

- `cargo test -p tsz-checker --test js_constructor_property_more_tests --test unannotated_callback_arity_tests --test thisless_functions_not_context_sensitive_tests` → green
- `cargo test -p tsz-checker --test ts7006_iife_arg_implicit_any --test ts7006_broad_jsdoc_type_cast` → green
- `cargo test -p tsz-checker --test conformance_issues_features` → no new failures; the 9 failing tests are **pre-existing on this branch's baseline** (verified by re-running them on the clean tree with the change stashed — same 9 fail). They span unrelated subsystems (TS2351 emit, TS2882 node-builtin, typeof narrowing, async-generator yield) and are not touched by this change.
- `cargo check -p tsz-checker` clean; `grep -rE '(==|!=) *"error"' crates/tsz-checker/src` → no matches.
- ready-review CI owns the broad conformance/emit/fourslash suites.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXkVFndmFohgYiUs4vKaaq)_