### PR TITLE
fix(checker): report this-rooted nullish operand as TS2532, not TS18050

### DIFF
--- a/crates/tsz-checker/src/error_reporter/operator_errors.rs
+++ b/crates/tsz-checker/src/error_reporter/operator_errors.rs
@@ -199,6 +199,12 @@ impl<'a> CheckerState<'a> {
                         );
                         return;
                     }
+                    // A property access whose receiver has no nameable text (e.g. a
+                    // `this`-rooted `this.version`) is reported by tsc as the object
+                    // being possibly nullish (TS2532/2531/2533), like an element
+                    // access — not the literal-value TS18050 fallback below.
+                    self.report_nullish_object(idx, cause, false);
+                    return;
                 } else if node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
                     self.report_nullish_object(idx, cause, false);
                     return;

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -424,6 +424,9 @@ mod string_literal_arithmetic_tests;
 #[path = "../tests/symbol_resolver_stability_tests.rs"]
 mod symbol_resolver_stability_tests;
 #[cfg(test)]
+#[path = "tests/this_prop_nullish_operand_code_tests.rs"]
+mod this_prop_nullish_operand_code_tests;
+#[cfg(test)]
 #[path = "../tests/this_type_tests.rs"]
 mod this_type_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/this_prop_nullish_operand_code_tests.rs
+++ b/crates/tsz-checker/src/tests/this_prop_nullish_operand_code_tests.rs
@@ -1,0 +1,83 @@
+//! A nullish property-access operand of a relational/arithmetic operator whose
+//! receiver has no nameable text (e.g. a `this`-rooted `this.version`) is
+//! reported as the object being possibly nullish (TS2532/TS2531/TS2533), not the
+//! literal-value TS18050.
+//!
+//! Structural rule: tsc reports `this.x >= n` (where `this.x: number | undefined`)
+//! as TS2532 "Object is possibly 'undefined'". tsz could not produce a simple
+//! name for the `this`-rooted access (`expression_text` returns `None`), so the
+//! property-access branch fell through to the TS18050 "value cannot be used here"
+//! fallback reserved for literal `null`/`undefined`. The fix routes the unnameable
+//! receiver through `report_nullish_object`, like an element access already does.
+//! Owner: `error_reporter/operator_errors.rs` `emit_nullish_operand_error`.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+const TS18050: u32 = 18050; // The value '<x>' cannot be used here.
+const TS18048: u32 = 18048; // '<x>' is possibly 'undefined'.
+const TS2532: u32 = 2532; // Object is possibly 'undefined'.
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+#[test]
+fn this_prop_nullish_relational_operand_is_ts2532_not_ts18050() {
+    let codes = check_strict(
+        r#"
+class C {
+  constructor(private version: number | undefined) {}
+  check(n: number): boolean {
+    return this.version >= n;
+  }
+}
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS2532),
+        1,
+        "this-rooted nullish operand reports TS2532: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, TS18050),
+        0,
+        "must not use the literal-value TS18050 for a property access: {codes:?}"
+    );
+}
+
+#[test]
+fn nameable_prop_nullish_operand_keeps_ts18048() {
+    // Control: a property access WITH nameable text keeps the named TS18048,
+    // exactly as tsc does (`'a.b' is possibly 'undefined'`).
+    let codes = check_strict(
+        r#"
+declare const a: { b: number | undefined };
+declare const n: number;
+const r = a.b >= n;
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS18048),
+        1,
+        "nameable property access keeps named TS18048: {codes:?}"
+    );
+    assert_eq!(count(&codes, TS2532), 0, "{codes:?}");
+    assert_eq!(count(&codes, TS18050), 0, "{codes:?}");
+}
+
+#[test]
+fn literal_undefined_operand_still_ts18050() {
+    // Control: a literal `undefined` operand still gets TS18050 (the `is_literal`
+    // path, untouched by the fix).
+    let codes = check_strict(
+        r#"
+declare const n: number;
+const r = undefined >= n;
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS18050),
+        1,
+        "literal `undefined` keeps TS18050: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary

A nullish property-access operand of a relational/arithmetic operator whose receiver has no nameable text — e.g. a `this`-rooted `this.version` where `this.version: number | undefined` — was reported as **TS18050** ("the value 'undefined' cannot be used here"), the diagnostic reserved for a literal `null`/`undefined`. tsc reports it as **TS2532** ("Object is possibly 'undefined'").

## Structural rule

When a possibly-nullish value is used in a non-nullable operator position, tsc reports: TS18047/18048/18049 ("'<x>' is possibly ...") when it can name the operand, TS2532/2531/2533 ("Object is possibly ...") when the operand is an object access it cannot simply name, and TS18050 ("the value '<x>' cannot be used here") only for a *literal* `null`/`undefined`. tsz must pick the same one.

## Owner layer

`crates/tsz-checker/src/error_reporter/operator_errors.rs` — `emit_nullish_operand_error`.

## Fix

`emit_nullish_operand_error` names the operand via `expression_text`; for a `this`-rooted access that returns `None`, so the `PROPERTY_ACCESS_EXPRESSION` branch fell through to the literal-value TS18050 fallback. Route a property access with no nameable text through `report_nullish_object` (TS2532/2531/2533), mirroring the `ELEMENT_ACCESS_EXPRESSION` branch directly below. The `is_literal` path (TS18050) and the nameable-access path (TS18048) are untouched.

## Adjacent-case matrix (verified vs tsc)
- `this.version >= n` (unnameable receiver) → TS2532 (was TS18050). Matches tsc.
- `a.b >= n` (nameable) → TS18048 `'a.b' is possibly 'undefined'`. Matches tsc, unchanged.
- `undefined >= n` (literal) → TS18050. Unchanged.
- `this.arr[0] >= n` (element access) → already TS2532 via the existing branch.

Goal: green

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo nextest run -p tsz-checker this_prop_nullish_operand` — 3/3 new regression tests pass (this-rooted TS2532; nameable TS18048 control; literal TS18050 control).
- class-transformer canary: 2 false TS18050 now emit tsc's TS2532 (`TS18050` count 2→0, `TS2532` 8→10; total unchanged as tsc emits TS2532 there).
- Conformance 100%: `strictNullChecks` 1/1, `controlFlow` 94/94, `comparisonOperator` 28/28, `binaryOperator` 66/66, `nullishCoalescing` 20/20, `optionalChaining` 25/25, `narrowing` 29/29.
- `arch_guard.py` pass, `cargo fmt --all --check` clean, `cargo clippy -p tsz-checker --all-targets` clean.

Found via the 20-agent corpus FP triage workflow; verified against tsc before implementing.