### PR TITLE
fix(module-resolution): substitute every '*' in package exports/imports targets

### DIFF
--- a/crates/tsz-cli/src/driver/resolution/exports_imports.rs
+++ b/crates/tsz-cli/src/driver/resolution/exports_imports.rs
@@ -343,7 +343,16 @@ pub(crate) fn match_imports_subpath(pattern: &str, subpath_key: &str) -> Option<
 
 pub(crate) fn apply_exports_subpath(target: &str, wildcard: &str) -> String {
     if target.contains('*') {
-        target.replacen('*', wildcard, 1)
+        // Node `PACKAGE_TARGET_RESOLVE` substitutes the captured subpath into
+        // EVERY `*` in the target (tsc's `resolvedTarget.replace(/\*/g, subpath)`),
+        // not just the first. A target with two or more `*` (e.g.
+        // `"./*": "./dist/*/*.js"`) must not strand a literal `*`, which would
+        // never resolve on disk and produce a spurious TS2307. This mirrors the
+        // tsz-core resolver's `apply_wildcard_substitution`; the two exports/
+        // imports substitution chokepoints must stay in agreement. (tsconfig
+        // `paths`/`typesVersions` substitution is a separate Node-spec concern
+        // that replaces only the first `*` and is handled elsewhere.)
+        target.replace('*', wildcard)
     } else if target.ends_with('/') {
         // Trailing-slash directory pattern: append the matched portion
         format!("{target}{wildcard}")
@@ -479,6 +488,42 @@ mod tests {
             resolve_exports_subpath(&exports_reversed, "./b/x", &["default"], TEST_VERSION)
                 .as_deref(),
             Some("./second.js"),
+        );
+    }
+
+    #[test]
+    fn apply_exports_subpath_replaces_every_star_in_target() {
+        // Node `PACKAGE_TARGET_RESOLVE` / tsc `replace(/\*/g, subpath)`: every
+        // `*` in the target is substituted with the captured subpath, matching
+        // the tsz-core resolver's `apply_wildcard_substitution`. The prior
+        // first-`*`-only substitution stranded a literal `*` (→ spurious TS2307).
+        assert_eq!(
+            apply_exports_subpath("./dist/*/*.js", "button"),
+            "./dist/button/button.js"
+        );
+        assert_eq!(apply_exports_subpath("./*/*/*.d.ts", "a"), "./a/a/a.d.ts");
+        // Single-star, no-star, and trailing-slash directory targets are
+        // unaffected by the fix.
+        assert_eq!(
+            apply_exports_subpath("./dist/*.js", "index"),
+            "./dist/index.js"
+        );
+        assert_eq!(
+            apply_exports_subpath("./dist/index.js", "x"),
+            "./dist/index.js"
+        );
+        assert_eq!(apply_exports_subpath("./lib/", "sub/mod"), "./lib/sub/mod");
+    }
+
+    #[test]
+    fn resolve_exports_subpath_substitutes_every_star_end_to_end() {
+        // The replace-all rule must hold through the driver's exports resolver,
+        // not just the leaf helper: a single-`*` KEY mapping to a multi-`*`
+        // TARGET resolves with no literal `*` left behind.
+        let exports = serde_json::json!({ "./*": "./dist/*/*.js" });
+        assert_eq!(
+            resolve_exports_subpath(&exports, "./button", &["default"], TEST_VERSION).as_deref(),
+            Some("./dist/button/button.js"),
         );
     }
 

--- a/crates/tsz-core/src/module_resolver/tests/package_exports_imports.rs
+++ b/crates/tsz-core/src/module_resolver/tests/package_exports_imports.rs
@@ -333,6 +333,69 @@ fn test_exports_pattern_key_is_not_treated_as_exact_match_for_literal_star_speci
 }
 
 #[test]
+fn test_exports_pattern_target_substitutes_every_star() {
+    // A single-`*` pattern KEY whose TARGET carries multiple `*` must substitute
+    // the captured subpath into ALL of them (Node `PACKAGE_TARGET_RESOLVE` /
+    // tsc `replace(/\*/g, subpath)`). The prior first-`*`-only substitution left
+    // a literal `*` in the resolved path, so the file was never found → a
+    // spurious TS2307 on a perfectly valid exports map. This exercises the core
+    // resolver's `exports`-map entry point.
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write(
+        "node_modules/pkg/package.json",
+        r#"{"name":"pkg","exports":{"./*":"./dist/*/*.d.ts"}}"#,
+    );
+    fixture.write(
+        "node_modules/pkg/dist/button/button.d.ts",
+        "export declare const value: number;",
+    );
+    fixture.write("src/index.ts", "import { value } from 'pkg/button';");
+
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        resolve_package_json_exports: true,
+        ..Default::default()
+    });
+    let result = resolver
+        .resolve("pkg/button", &dir.join("src/index.ts"), Span::new(22, 32))
+        .expect("multi-star exports target should substitute every '*' with the subpath");
+    assert_eq!(
+        result.resolved_path,
+        dir.join("node_modules/pkg/dist/button/button.d.ts")
+    );
+}
+
+#[test]
+fn test_imports_pattern_target_substitutes_every_star() {
+    // Same Node `PACKAGE_TARGET_RESOLVE` rule on the `#imports` side. This
+    // exercises the core resolver's distinct `imports`-map entry point, which
+    // routes through the same `apply_wildcard_substitution` chokepoint.
+    let fixture = TempFixture::new();
+    let dir = fixture.path();
+    fixture.write(
+        "package.json",
+        r##"{"name":"app","private":true,"imports":{"#feat/*":"./src/*/*.js"}}"##,
+    );
+    fixture.write("src/btn/btn.d.ts", "export declare const value: number;");
+    fixture.write("src/index.ts", "import { value } from '#feat/btn';");
+
+    let mut resolver = ModuleResolver::new(&ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        resolve_package_json_imports: true,
+        ..Default::default()
+    });
+    let result = resolver
+        .resolve("#feat/btn", &dir.join("src/index.ts"), Span::new(22, 32))
+        .expect("multi-star imports target should substitute every '*' with the subpath");
+    assert!(
+        result.resolved_path.ends_with("src/btn/btn.d.ts"),
+        "expected src/btn/btn.d.ts, got {}",
+        result.resolved_path.display()
+    );
+}
+
+#[test]
 fn test_package_exports_target_cannot_escape_package_root() {
     use std::fs;
     let dir = std::env::temp_dir().join("tsz_test_exports_target_escape");

--- a/crates/tsz-core/src/resolution/helpers.rs
+++ b/crates/tsz-core/src/resolution/helpers.rs
@@ -298,9 +298,14 @@ pub(crate) const TYPES_VERSIONS_COMPILER_VERSION_FALLBACK: SemVer =
 ///
 /// `is_directory_match` distinguishes the two pattern-key shapes:
 /// - `false` for `*`-pattern keys (e.g. `"./*"` matched against `"./foo"`):
-///   only replace `*` in the target. If the target has no `*`, leave it
-///   unchanged — Node.js does NOT append the wildcard to a `/`-ending
-///   target when the key was a `*` pattern.
+///   replace `*` in the target. Per Node.js `PACKAGE_TARGET_RESOLVE` — and
+///   tsc's `resolvedTarget.replace(/\*/g, subpath)` — **every** `*` in the
+///   target is substituted with the captured subpath, not just the first.
+///   A target with two or more `*` (e.g. `"./*": "./dist/*/*.js"`) must not
+///   leave a literal `*` behind, which would never resolve on disk and yield
+///   a spurious `TS2307`. If the target has no `*`, leave it unchanged —
+///   Node.js does NOT append the wildcard to a `/`-ending target when the key
+///   was a `*` pattern.
 /// - `true` for `/`-suffix directory keys (e.g. `"./lib/"`): also append
 ///   the wildcard to a target ending in `/`, matching Node's directory
 ///   prefix resolution.
@@ -310,7 +315,7 @@ pub(crate) fn apply_wildcard_substitution(
     is_directory_match: bool,
 ) -> String {
     if target.contains('*') {
-        target.replacen('*', wildcard, 1)
+        target.replace('*', wildcard)
     } else if is_directory_match && target.ends_with('/') {
         format!("{target}{wildcard}")
     } else {
@@ -710,6 +715,89 @@ mod tests {
         // Equal base length → longer total (longer suffix) wins.
         assert_eq!(best_key(&["./*", "./*.js"], "./a.js"), Some("./*.js"));
         assert_eq!(best_key(&["./*.js", "./*"], "./a.js"), Some("./*.js"));
+    }
+
+    #[test]
+    fn apply_wildcard_substitution_replaces_every_star_in_pattern_target() {
+        // Node `PACKAGE_TARGET_RESOLVE` / tsc `replace(/\*/g, subpath)`: a
+        // pattern target with two or more `*` substitutes the captured subpath
+        // into ALL of them. The prior `replacen(.., 1)` left a literal `*` in
+        // the resolved path, which never exists on disk → spurious TS2307.
+        assert_eq!(
+            apply_wildcard_substitution("./dist/*/*.js", "button", false),
+            "./dist/button/button.js"
+        );
+        assert_eq!(
+            apply_wildcard_substitution("./*/*/*.d.ts", "a/b", false),
+            "./a/b/a/b/a/b.d.ts"
+        );
+        // Single-star and no-star targets are unchanged by the fix (the common
+        // case): the two replacement strategies coincide for one occurrence.
+        assert_eq!(
+            apply_wildcard_substitution("./dist/*.js", "index", false),
+            "./dist/index.js"
+        );
+        assert_eq!(
+            apply_wildcard_substitution("./dist/index.js", "ignored", false),
+            "./dist/index.js"
+        );
+    }
+
+    #[test]
+    fn substitute_wildcard_in_exports_replaces_every_star_through_nesting() {
+        // The multi-`*` substitution must hold through conditional/array
+        // nesting, since `substitute_wildcard_in_exports` recurses to every
+        // string leaf. A barrel like `"./*": { "types": "./types/*/*.d.ts",
+        // "default": "./dist/*/*.js" }` must not strand a literal `*`.
+        let value = PackageExports::Conditional(vec![
+            (
+                "types".to_string(),
+                PackageExports::String("./types/*/*.d.ts".to_string()),
+            ),
+            (
+                "default".to_string(),
+                PackageExports::Array(vec![
+                    PackageExports::String("./dist/*/*.mjs".to_string()),
+                    PackageExports::String("./dist/*.cjs".to_string()),
+                ]),
+            ),
+        ]);
+
+        let substituted = substitute_wildcard_in_exports(&value, "widget", false);
+
+        let PackageExports::Conditional(entries) = substituted else {
+            panic!("expected a conditional value after substitution");
+        };
+        let leaves: Vec<String> = entries
+            .iter()
+            .flat_map(|(_, v)| collect_string_leaves(v))
+            .collect();
+        assert_eq!(
+            leaves,
+            vec![
+                "./types/widget/widget.d.ts".to_string(),
+                "./dist/widget/widget.mjs".to_string(),
+                "./dist/widget.cjs".to_string(),
+            ]
+        );
+        // No literal `*` survives anywhere in the substituted tree.
+        assert!(leaves.iter().all(|leaf| !leaf.contains('*')));
+    }
+
+    /// Flatten the string leaves of a `PackageExports` value in source order.
+    fn collect_string_leaves(value: &PackageExports) -> Vec<String> {
+        match value {
+            PackageExports::String(s) => vec![s.clone()],
+            PackageExports::Conditional(entries) => entries
+                .iter()
+                .flat_map(|(_, v)| collect_string_leaves(v))
+                .collect(),
+            PackageExports::Array(elements) => {
+                elements.iter().flat_map(collect_string_leaves).collect()
+            }
+            PackageExports::Map(map) => map.values().flat_map(collect_string_leaves).collect(),
+            PackageExports::Null => Vec::new(),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Refs #13826 (a reproducible `exports`/`imports` resolver slice of the module-resolution umbrella).

Goal: grow

## Structural rule

> When a package.json `exports`/`imports` **pattern** target contains more than
> one `*`, Node's `PACKAGE_TARGET_RESOLVE` — and tsc's
> `resolvedTarget.replace(/\*/g, subpath)` — substitutes the captured subpath
> into **every** `*`. tsz substituted only the **first** `*`, so a single-`*`
> pattern key mapping to a multi-`*` target (e.g. `"./*": "./dist/*/*.js"`)
> stranded a literal `*` in the resolved path, which never exists on disk and
> produced a spurious **TS2307**.

## Wrong operation / owner layer

Module resolver — package `exports`/`imports` wildcard substitution. The bug
lived at **two** chokepoints for the same Node-spec operation, both using
`replacen('*', wildcard, 1)`:

1. `crates/tsz-core/src/resolution/helpers.rs::apply_wildcard_substitution`
   (the tsz-core resolver path, reached by both the `exports`-map and
   `imports`-map entry points and through `substitute_wildcard_in_exports`'s
   conditional/array recursion).
2. `crates/tsz-cli/src/driver/resolution/exports_imports.rs::apply_exports_subpath`
   (the **CLI driver** path — the one that actually runs during `tsz`
   compilation, used by both exports and imports resolution).

Both now `replace('*', wildcard)` (replace-all), matching tsc 6.0.3
(`src/compiler/moduleNameResolver.ts`, pinned submodule `050880ce`).

## Deliberately NOT changed (verified against tsc source)

tsconfig `paths`/`typesVersions` substitution is a **separate** Node-spec
concern that replaces only the **first** `*`:
- tsc uses JS `String.replace("*", text)` for `paths` (first occurrence only),
  and `PathMapping::substitute_target`
  (`crates/tsz-core/src/config/resolved_options.rs`) documents this as the
  shared driver/core chokepoint — left as `replacen(.., 1)`.
- `typesVersions` `parse_pattern`
  (`crates/tsz-common/src/module_resolution/types_versions.rs`) already rejects
  multi-`*` patterns (mirroring tsc's `tryParsePattern`), so its
  `substitute_target` only ever sees ≤1 `*` — left as `replacen(.., 1)`.

Changing those would regress `paths`/`typesVersions` parity, so they are
intentionally untouched.

## Anti-hardcoding

Purely structural: a `str::replace` over the `*` token of the matched target.
No identifier/file-name literals, no rendered-type/printer predicates, no
fixture fast paths. Single-`*` and no-`*` targets are byte-identical under both
strategies, so the common case is unchanged — the fix only affects the
previously-broken multi-`*` targets.

## Adjacent matrix (verified)

- **tsz-core unit** (`resolution::helpers`): multi-`*` (`./dist/*/*.js`,
  `./*/*/*.d.ts`), single-`*`, no-`*`, and replace-all through
  conditional/array nesting in `substitute_wildcard_in_exports`.
- **tsz-core end-to-end** (`module_resolver::tests::package_exports_imports`,
  real temp FS via the in-file `TempFixture`): a multi-`*` target resolves on
  disk through the **`exports`** entry point and through the distinct
  **`imports`** entry point.
- **tsz-cli driver** (`driver::resolution::exports_imports`): leaf
  `apply_exports_subpath` (multi/single/no-`*` + trailing-slash directory) and
  end-to-end `resolve_exports_subpath`.

## Verification

- `cargo test -p tsz-core --lib module_resolver::tests::package_exports_imports`
  — 32/32 (incl. 2 new multi-`*` end-to-end cases).
- `cargo test -p tsz-core --lib resolution::helpers::tests` — green (incl. 2 new
  multi-`*` unit cases).
- `cargo test -p tsz-cli --lib driver::resolution::exports_imports` — 7/7
  (incl. 2 new).
- `cargo test -p tsz-core --lib module_resolver` — 269/269 (no regressions).
- `cargo fmt -p tsz-core -p tsz-cli --check` clean; `cargo clippy -p tsz-core --lib`
  / `-p tsz-cli --lib` clean.
- Reviewed with `/simplify` (reuse/simplification/efficiency/altitude): the
  altitude pass surfaced the second (driver) chokepoint — folded in; the new
  integration tests were moved onto the in-file `TempFixture` helper; a
  scope-creep directory-match test was dropped. The `paths`/`typesVersions`
  copies were confirmed as intentionally-distinct (first-`*`-only) per tsc, not
  divergences.
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1M2iUuQtznDWCC5mw84BY)_