### PR TITLE
fix(checker): treat unresolved-Lazy overload-return relations as undetermined (#14131)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1189,6 +1189,9 @@ mod overlap_relation_helper_routing_arch_tests;
 #[path = "tests/overload_anchor_at_argument_tests.rs"]
 mod overload_anchor_at_argument_tests;
 #[cfg(test)]
+#[path = "tests/overload_generic_wrapper_compat_tests.rs"]
+mod overload_generic_wrapper_compat_tests;
+#[cfg(test)]
 #[path = "tests/overload_param_relation_routing_arch_tests.rs"]
 mod overload_param_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
@@ -890,6 +890,44 @@ impl<'a> CheckerState<'a> {
         overload_type: tsz_solver::TypeId,
         bivariant_params: bool,
     ) -> bool {
+        // Snapshot the unresolved-`Lazy` sentinel before the comparison. tsc
+        // resolves the implementation and overload signature types fully before
+        // relating them (`getSignatureFromDeclaration` -> resolved return
+        // type), so it never derives TS2394 from a not-yet-registered
+        // reference. tsz computes these types from declarations that may still
+        // hold `Lazy(DefId)` bodies whose definitions are registered later in
+        // the same checking pass: when an overload/implementation return is a
+        // generic wrapper (`Wrapper<…>`) whose definition — or one of its type
+        // arguments — has not yet been resolved at the moment this check runs,
+        // the structural relation degrades to a transient `false`
+        // (`note_lazy_resolve_failure`). That negative is order/cache-dependent,
+        // not a proven mismatch, so treating it as an incompatibility produces a
+        // false-positive TS2394 that disappears once the body resolves. This is
+        // the same discipline the assignability/constraint proof paths apply to
+        // unresolved-`Lazy` negatives (`publish_shared_constraint_proof`,
+        // `failure_memo_store`).
+        let lazy_failures_at_entry = crate::query_boundaries::common::lazy_resolve_failure_count();
+        // Compatible outright, or — when the structural decision was a negative
+        // that observed an unresolved `Lazy(DefId)` body during the comparison —
+        // undetermined, which we treat as compatible to prefer parity (no false
+        // TS2394) over a verdict derived from a not-yet-resolvable reference.
+        // The counter read must follow `compute_*`, which is what advances it.
+        self.compute_implementation_compatible_with_overload(
+            impl_type,
+            overload_type,
+            bivariant_params,
+        ) || crate::query_boundaries::common::lazy_resolve_failure_count() != lazy_failures_at_entry
+    }
+
+    /// Structural overload/implementation compatibility decision, without the
+    /// unresolved-`Lazy` undetermined-negative guard applied by
+    /// [`Self::is_implementation_compatible_with_overload_inner`].
+    pub(crate) fn compute_implementation_compatible_with_overload(
+        &mut self,
+        impl_type: tsz_solver::TypeId,
+        overload_type: tsz_solver::TypeId,
+        bivariant_params: bool,
+    ) -> bool {
         let constructors_only =
             crate::query_boundaries::common::is_constructor_like_type(self.ctx.types, impl_type)
                 && crate::query_boundaries::common::is_constructor_like_type(

--- a/crates/tsz-checker/src/tests/overload_generic_wrapper_compat_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_generic_wrapper_compat_tests.rs
@@ -157,10 +157,9 @@ use crate::context::{CheckerContext, CheckerOptions};
 use crate::state::CheckerState;
 use tsz_binder::BinderState;
 use tsz_parser::parser::ParserState;
-use tsz_solver::TypeId;
 use tsz_solver::construction::TypeInterner;
 use tsz_solver::def::DefId;
-use tsz_solver::types::FunctionShape;
+use tsz_solver::{FunctionShape, TypeId};
 
 /// Build a checker over a trivial module and run `probe` against its
 /// [`CheckerState`].

--- a/crates/tsz-checker/src/tests/overload_generic_wrapper_compat_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_generic_wrapper_compat_tests.rs
@@ -1,0 +1,259 @@
+//! Structural regression tests for overload↔implementation compatibility
+//! (TS2394) over generic-wrapper / conditional-typed return positions.
+//!
+//! Companion to the unresolved-`Lazy` undetermined-negative guard in
+//! `is_implementation_compatible_with_overload_inner`: these lock the
+//! resolvable-in-isolation behavior (the wrapper overloads compile clean; a
+//! genuine return mismatch still reports TS2394) so the guard cannot silence a
+//! real incompatibility. Binder names are varied so no fix can key on an
+//! identifier.
+
+use crate::test_utils::check_source_diagnostics;
+
+/// A no-argument overload returning a concrete instantiation of a generic
+/// wrapper plus a generic overload whose return is a conditional instantiation
+/// of the same wrapper, with an implementation returning the wrapper union.
+/// tsc accepts every overload; tsz must not report TS2394 here.
+#[test]
+fn generic_wrapper_conditional_return_overloads_are_compatible() {
+    let diags = check_source_diagnostics(
+        r#"
+type Pat<a> = a | { [k in keyof a]: Pat<a[k]> };
+type UnknownPat = Pat<unknown>;
+
+interface SelP<a, k extends string = never> {
+  readonly __sel: a;
+  readonly __key: k;
+}
+interface AnonSelP {
+  readonly __anon: true;
+}
+
+interface Chain<p, omitted extends string = never> {
+  optional(): Chain<p, omitted>;
+  with(): Chain<p, omitted>;
+}
+
+function pick(): Chain<AnonSelP, never>;
+function pick<input, k extends string = never>(
+  keyOrPattern: k | (unknown extends input ? UnknownPat : Pat<input>),
+): k extends string
+  ? Chain<SelP<unknown, k>, never>
+  : Chain<SelP<input>, never>;
+function pick(
+  ..._args: any[]
+): Chain<SelP<unknown>, never> | Chain<AnonSelP, never> {
+  return undefined as any;
+}
+
+export { pick };
+"#,
+    );
+
+    let ts2394: Vec<_> = diags.iter().filter(|d| d.code == 2394).collect();
+    assert!(
+        ts2394.is_empty(),
+        "wrapper/conditional overloads are compatible with the wrapper-returning \
+         implementation; TS2394 must not fire. got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Renamed-binder variant of the same shape: identical structure, completely
+/// different identifiers. Locks out any name-based behavior.
+#[test]
+fn generic_wrapper_conditional_return_overloads_are_compatible_renamed() {
+    let diags = check_source_diagnostics(
+        r#"
+type Shape<q> = q | { [j in keyof q]: Shape<q[j]> };
+type AnyShape = Shape<unknown>;
+
+interface Holder<v, hidden extends string = never> {
+  readonly __hold: v;
+  readonly __hidden: hidden;
+}
+interface Blank {
+  readonly __blank: true;
+}
+
+interface Wrap<w, gone extends string = never> {
+  maybe(): Wrap<w, gone>;
+  also(): Wrap<w, gone>;
+}
+
+function grab(): Wrap<Blank, never>;
+function grab<src, j extends string = never>(
+  keyOrShape: j | (unknown extends src ? AnyShape : Shape<src>),
+): j extends string
+  ? Wrap<Holder<unknown, j>, never>
+  : Wrap<Holder<src>, never>;
+function grab(
+  ..._rest: any[]
+): Wrap<Holder<unknown>, never> | Wrap<Blank, never> {
+  return undefined as any;
+}
+
+export { grab };
+"#,
+    );
+
+    let ts2394: Vec<_> = diags.iter().filter(|d| d.code == 2394).collect();
+    assert!(
+        ts2394.is_empty(),
+        "renamed wrapper/conditional overloads must also stay clean of TS2394. got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Parity floor: a genuine return-type mismatch between an overload and its
+/// implementation — with no unresolved reference involved — must still report
+/// TS2394. The guard must only suppress *undetermined* negatives, never real
+/// ones.
+#[test]
+fn genuine_return_mismatch_still_reports_ts2394() {
+    let diags = check_source_diagnostics(
+        r#"
+function conv(x: string): string;
+function conv(x: number): number {
+  return x;
+}
+export { conv };
+"#,
+    );
+
+    let ts2394 = diags.iter().filter(|d| d.code == 2394).count();
+    assert_eq!(
+        ts2394,
+        1,
+        "an overload whose return ({{string}}) is incompatible with the implementation \
+         return ({{number}}) must still report exactly one TS2394. got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Boundary-level guard tests.
+//
+// These exercise `is_implementation_compatible_with_overload_inner` directly
+// against synthesized function types whose return relation depends on an
+// unresolved `Lazy(DefId)` — the order/cache-dependent shape that has no
+// single-file source witness (it only surfaces when a generic-wrapper return is
+// compared before its definition is registered, as in ts-pattern's
+// `patterns.ts`). They live in `src/tests/` so the synthesized-type
+// construction stays out of checker `src/` proper (the architecture contract
+// forbids direct solver-internal construction there).
+// ---------------------------------------------------------------------------
+
+use crate::context::{CheckerContext, CheckerOptions};
+use crate::state::CheckerState;
+use tsz_binder::BinderState;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeId;
+use tsz_solver::construction::TypeInterner;
+use tsz_solver::def::DefId;
+use tsz_solver::types::FunctionShape;
+
+/// Build a checker over a trivial module and run `probe` against its
+/// [`CheckerState`].
+fn with_trivial_checker<R>(
+    types: &TypeInterner,
+    probe: impl FnOnce(&mut CheckerState<'_>) -> R,
+) -> R {
+    let mut parser = ParserState::new("fixture.ts".to_string(), "export {};".to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let arena = parser.get_arena().clone();
+    let mut checker = CheckerState {
+        ctx: CheckerContext::new(
+            &arena,
+            &binder,
+            types,
+            "fixture.ts".to_string(),
+            CheckerOptions::default(),
+        ),
+    };
+    checker.check_source_file(root);
+    probe(&mut checker)
+}
+
+/// An overload/implementation compatibility verdict whose return relation could
+/// only be computed against an *unresolved* `Lazy(DefId)` body is undetermined,
+/// not a proven mismatch. The guard in
+/// `is_implementation_compatible_with_overload_inner` must report such a pair
+/// compatible (no false TS2394). The lazy-resolve-failure counter must advance,
+/// proving the verdict actually traveled the unresolved-`Lazy` path, and the
+/// guard must flip the raw (unguarded) incompatibility to compatible.
+#[test]
+fn unresolved_lazy_return_makes_overload_compat_undetermined() {
+    let types = TypeInterner::new();
+    // Implementation return is a generic wrapper whose definition is not yet
+    // registered (an unresolved `Lazy(DefId)`); the overload return is concrete.
+    // The structural return relation cannot resolve the wrapper
+    // (`note_lazy_resolve_failure`) and degrades to a transient incompatibility.
+    let impl_fn = types.function(FunctionShape::new(Vec::new(), types.lazy(DefId(900_001))));
+    let overload_fn = types.function(FunctionShape::new(Vec::new(), TypeId::STRING));
+
+    with_trivial_checker(&types, |checker| {
+        // Raw structural decision (no guard).
+        let before = crate::query_boundaries::common::lazy_resolve_failure_count();
+        let raw =
+            checker.compute_implementation_compatible_with_overload(impl_fn, overload_fn, false);
+        let after = crate::query_boundaries::common::lazy_resolve_failure_count();
+        assert!(
+            after > before,
+            "the unresolved-wrapper return relation must record a lazy-resolve failure \
+             (before={before}, after={after}); otherwise the guard is not under test",
+        );
+        assert!(
+            !raw,
+            "without the guard, the unresolved-wrapper return relation degrades to an \
+             incompatibility — the order/cache-dependent false TS2394",
+        );
+
+        // Guarded decision flips the undetermined negative to compatible.
+        let compatible =
+            checker.is_implementation_compatible_with_overload_inner(impl_fn, overload_fn, false);
+        assert!(
+            compatible,
+            "a compatibility verdict derived from an unresolved wrapper return must be treated \
+             as undetermined (compatible), not a TS2394 incompatibility",
+        );
+    });
+}
+
+/// Parity floor at the same boundary: a genuine concrete return mismatch
+/// (`string` vs `number`) with no unresolved reference must remain incompatible,
+/// so the guard never silences a real TS2394.
+#[test]
+fn concrete_return_mismatch_stays_incompatible() {
+    let types = TypeInterner::new();
+    let impl_fn = types.function(FunctionShape::new(Vec::new(), TypeId::NUMBER));
+    let overload_fn = types.function(FunctionShape::new(Vec::new(), TypeId::STRING));
+
+    with_trivial_checker(&types, |checker| {
+        let before = crate::query_boundaries::common::lazy_resolve_failure_count();
+        let compatible =
+            checker.is_implementation_compatible_with_overload_inner(impl_fn, overload_fn, false);
+        let after = crate::query_boundaries::common::lazy_resolve_failure_count();
+
+        assert_eq!(
+            before, after,
+            "a concrete primitive return mismatch must not record any lazy-resolve failure",
+        );
+        assert!(
+            !compatible,
+            "an overload returning `string` is genuinely incompatible with an implementation \
+             returning `number`; this must stay a TS2394 incompatibility",
+        );
+    });
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
@@ -1565,7 +1565,7 @@ impl<'a> DeclarationEmitter<'a> {
         };
 
         let export_subpath = format!("./{subpath}");
-        self.exports_map_allows_subpath(exports, &export_subpath)
+        Self::exports_map_allows_subpath(exports, &export_subpath)
     }
 
     /// Find the filesystem path of a package root directory.
@@ -1591,7 +1591,6 @@ impl<'a> DeclarationEmitter<'a> {
 
     /// Check whether a package's exports map allows a given subpath.
     pub(in crate::declaration_emitter) fn exports_map_allows_subpath(
-        &self,
         exports: &serde_json::Value,
         subpath: &str,
     ) -> bool {
@@ -1601,14 +1600,14 @@ impl<'a> DeclarationEmitter<'a> {
             }
             serde_json::Value::Array(entries) => entries
                 .iter()
-                .any(|entry| self.exports_map_allows_subpath(entry, subpath)),
+                .any(|entry| Self::exports_map_allows_subpath(entry, subpath)),
             serde_json::Value::Object(map) => {
                 for (key, value) in map {
                     if key == "." || key.starts_with("./") {
-                        if self.export_entry_matches_subpath(key, value, subpath) {
+                        if Self::export_entry_matches_subpath(key, value, subpath) {
                             return true;
                         }
-                    } else if self.exports_map_allows_subpath(value, subpath) {
+                    } else if Self::exports_map_allows_subpath(value, subpath) {
                         return true;
                     }
                 }
@@ -1619,7 +1618,6 @@ impl<'a> DeclarationEmitter<'a> {
     }
 
     pub(in crate::declaration_emitter) fn export_entry_matches_subpath(
-        &self,
         key: &str,
         value: &serde_json::Value,
         subpath: &str,
@@ -1638,7 +1636,7 @@ impl<'a> DeclarationEmitter<'a> {
                 for (k, v) in map {
                     if !k.starts_with("./") && k != "." {
                         // Condition key: recurse to check if any branch has a target
-                        if self.export_entry_matches_subpath(key, v, subpath) {
+                        if Self::export_entry_matches_subpath(key, v, subpath) {
                             return true;
                         }
                     }
@@ -1647,7 +1645,7 @@ impl<'a> DeclarationEmitter<'a> {
             }
             serde_json::Value::Array(entries) => entries
                 .iter()
-                .any(|entry| self.export_entry_matches_subpath(key, entry, subpath)),
+                .any(|entry| Self::export_entry_matches_subpath(key, entry, subpath)),
             _ => false,
         }
     }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_surface.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_surface.rs
@@ -75,7 +75,7 @@ impl<'a> DeclarationEmitter<'a> {
             && (self
                 .find_type_alias_type_node_in_arena(source_arena, &alias_name)
                 .is_some_and(|alias_type| {
-                    self.type_node_is_conditional_after_parens(source_arena, alias_type, depth + 1)
+                    Self::type_node_is_conditional_after_parens(source_arena, alias_type, depth + 1)
                 })
                 || self.type_reference_resolves_to_conditional_alias(
                     source_arena,
@@ -150,7 +150,11 @@ impl<'a> DeclarationEmitter<'a> {
                 return None;
             }
             let alias = alias_arena.get_type_alias(decl_node)?;
-            Some(self.type_node_is_conditional_after_parens(alias_arena, alias.type_node, 0))
+            Some(Self::type_node_is_conditional_after_parens(
+                alias_arena,
+                alias.type_node,
+                0,
+            ))
         })
         .unwrap_or(false)
     }
@@ -178,7 +182,6 @@ impl<'a> DeclarationEmitter<'a> {
     }
 
     fn type_node_is_conditional_after_parens(
-        &self,
         source_arena: &NodeArena,
         type_idx: NodeIndex,
         depth: u8,
@@ -195,7 +198,7 @@ impl<'a> DeclarationEmitter<'a> {
         if type_node.kind == syntax_kind_ext::PARENTHESIZED_TYPE
             && let Some(wrapped) = source_arena.get_wrapped_type(type_node)
         {
-            return self.type_node_is_conditional_after_parens(
+            return Self::type_node_is_conditional_after_parens(
                 source_arena,
                 wrapped.type_node,
                 depth + 1,
@@ -220,7 +223,7 @@ impl<'a> DeclarationEmitter<'a> {
         self.with_symbol_declarations(sym_id, |alias_arena, decl_idx| {
             let decl_node = alias_arena.get(decl_idx)?;
             let alias = alias_arena.get_type_alias(decl_node)?;
-            Some(self.type_node_is_conditional_after_parens(
+            Some(Self::type_node_is_conditional_after_parens(
                 alias_arena,
                 alias.type_node,
                 depth + 1,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_surface.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_surface.rs
@@ -123,7 +123,7 @@ impl<'a> DeclarationEmitter<'a> {
             return false;
         };
         let Some(top_reference) =
-            self.single_top_level_type_reference(source_arena, type_annotation)
+            Self::single_top_level_type_reference(source_arena, type_annotation)
         else {
             return false;
         };
@@ -164,7 +164,6 @@ impl<'a> DeclarationEmitter<'a> {
     /// composite types (unions, intersections, object literals, function types,
     /// …) where a contained alias reference does not name the whole type.
     fn single_top_level_type_reference(
-        &self,
         source_arena: &NodeArena,
         type_idx: NodeIndex,
     ) -> Option<NodeIndex> {

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -1276,10 +1276,10 @@ impl<'a> Printer<'a> {
             IRNode::ExpressionStatement(inner) => inner.as_ref(),
             other => other,
         };
-        self.collect_es5_computed_temp_decls_from_expr(expr, decls);
+        Self::collect_es5_computed_temp_decls_from_expr(expr, decls);
     }
 
-    fn collect_es5_computed_temp_decls_from_expr(&self, expr: &IRNode, decls: &mut Vec<String>) {
+    fn collect_es5_computed_temp_decls_from_expr(expr: &IRNode, decls: &mut Vec<String>) {
         let IRNode::BinaryExpr {
             left,
             operator,
@@ -1289,8 +1289,8 @@ impl<'a> Printer<'a> {
             return;
         };
         if operator.as_ref() == "," {
-            self.collect_es5_computed_temp_decls_from_expr(left, decls);
-            self.collect_es5_computed_temp_decls_from_expr(right, decls);
+            Self::collect_es5_computed_temp_decls_from_expr(left, decls);
+            Self::collect_es5_computed_temp_decls_from_expr(right, decls);
             return;
         }
         if operator.as_ref() == "="

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -1262,16 +1262,12 @@ impl<'a> Printer<'a> {
     fn es5_computed_temp_decls_from_init_exprs(&self, init_exprs: &[IRNode]) -> Vec<String> {
         let mut decls = Vec::new();
         for init_expr in init_exprs {
-            self.collect_es5_computed_temp_decls_from_init_expr(init_expr, &mut decls);
+            Self::collect_es5_computed_temp_decls_from_init_expr(init_expr, &mut decls);
         }
         decls
     }
 
-    fn collect_es5_computed_temp_decls_from_init_expr(
-        &self,
-        init_expr: &IRNode,
-        decls: &mut Vec<String>,
-    ) {
+    fn collect_es5_computed_temp_decls_from_init_expr(init_expr: &IRNode, decls: &mut Vec<String>) {
         let expr = match init_expr {
             IRNode::ExpressionStatement(inner) => inner.as_ref(),
             other => other,


### PR DESCRIPTION
Fixes #14131.

## Summary
Overload↔implementation compatibility (TS2394) compares the implementation and overload signature **return types** structurally. When a return type is a generic wrapper (`Wrapper<…>`) whose definition — or one of its type arguments — has **not yet been registered** at the moment the check runs, the structural relation degrades to a transient `false` and records it via the unresolved-`Lazy` sentinel (`note_lazy_resolve_failure`). The overload check trusted that order/cache-dependent negative and emitted a false-positive **TS2394** that disappears once the body resolves — exactly the emergent, no-single-file-witness ts-pattern `patterns.ts(673)` regression.

## Structural rule
When an overload/implementation return relation can only be computed against a not-yet-registered `Lazy(DefId)` body, `tsc` does not exist in that state — it resolves both signatures' types fully (`getSignatureFromDeclaration` → resolved return type) before relating them, so it never derives TS2394 from an unresolved reference. tsz now mirrors this in the checker overload-compatibility owner: `is_implementation_compatible_with_overload_inner` snapshots `lazy_resolve_failure_count()` around the structural decision and treats an incompatibility verdict as **undetermined → compatible** when the counter advanced during the comparison. This is the same discipline the assignability/constraint-proof paths already apply to unresolved-`Lazy` negatives (`publish_shared_constraint_proof`, `failure_memo_store`, and the solver's `record_definitive_verdict`, which already refuses to *cache* such a `false` but still *returns* it to the consumer).

## Why this altitude
The solver intentionally returns the transient negative and leaves each consumer to decide its own policy (caching, proof-sharing, diagnostics). Overload compatibility is the diagnostic consumer here, so the guard belongs at this boundary — consistent with the established per-consumer pattern, and without adding an undetermined state to the solver relation interface that every call site would pay for.

## Scope beyond the witness
The fix is general: it covers any overload whose return is an instantiation of a generic wrapper (concrete or conditional) compared before its definition resolves, not just the ts-pattern shape. Genuine return mismatches with no unresolved reference still report TS2394.

## Goal
Goal: green

## Verification
- New `crates/tsz-checker/src/tests/overload_generic_wrapper_compat_tests.rs`:
  - `unresolved_lazy_return_makes_overload_compat_undetermined` — drives the boundary directly: the raw (unguarded) decision returns incompatible **and** advances the lazy-resolve-failure counter, while the guarded entry flips it to compatible (proves the guard is the cause, not a fast path).
  - `concrete_return_mismatch_stays_incompatible` + `genuine_return_mismatch_still_reports_ts2394` — parity floor: real `string` vs `number` mismatches still report exactly one TS2394.
  - `generic_wrapper_conditional_return_overloads_are_compatible` (+ renamed-binder variant) — wrapper/conditional-return overloads stay clean; binder names varied so no fix can key on an identifier.
- `cargo test -p tsz-checker --lib overload` → 226 passed.
- Full `cargo test -p tsz-checker --lib` diffed against a clean-tree baseline: **zero net new failures** (pre-existing order-dependent flaky tests are identical in both).
- Architecture contract tests pass (solver-internal type construction kept under `src/tests/`).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Xc9bnEK85WhfFVBrWcbN7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xc9bnEK85WhfFVBrWcbN7y)_