### PR TITLE
fix(solver): optional tuple-pattern prefix may match zero source elements (#14176)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1930,3 +1930,7 @@ path = "tests/construct_signature_boundary_matrix_tests.rs"
 [[test]]
 name = "nullable_union_missing_property_tests"
 path = "tests/nullable_union_missing_property_tests.rs"
+
+[[test]]
+name = "empty_tuple_optional_infer_tests"
+path = "tests/empty_tuple_optional_infer_tests.rs"

--- a/crates/tsz-checker/tests/empty_tuple_optional_infer_tests.rs
+++ b/crates/tsz-checker/tests/empty_tuple_optional_infer_tests.rs
@@ -1,0 +1,136 @@
+//! Regression tests for issue #14176.
+//!
+//! An empty tuple `[]` **matches** an infer pattern whose leading element(s)
+//! are optional, e.g. `[(infer H)?, ...infer T]`: the optional prefix can match
+//! zero source elements, so the conditional takes its **true** branch. tsz's
+//! `match_tuple_elements` (rest-present branch) previously counted the optional
+//! prefix as required and rejected the empty source, taking the false branch
+//! and inverting the base case of tuple-deconstruction utilities (remeda
+//! `TupleParts`/`Head`).
+//!
+//! Each test pins the *branch selection* by assigning the conditional's true
+//! and false literal to a variable: the assignment that contradicts the
+//! resolved type must emit `TS2322` and the matching one must be clean. Binder
+//! names (type alias, infer variable names) are varied across cases so the fix
+//! is structural, not name-driven.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn ts2322_count(source: &str) -> usize {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == 2322)
+        .count()
+}
+
+#[test]
+fn empty_tuple_matches_optional_prefix_takes_true_branch() {
+    // Reported repro: `Test` resolves to "MATCH" (true branch), so assigning the
+    // false-branch literal "NO_MATCH" must error TS2322.
+    let source = r#"
+type Test = readonly [] extends readonly [(infer _H)?, ...infer _T] ? "MATCH" : "NO_MATCH";
+const t: Test = "NO_MATCH";
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "[] should match [(infer H)?, ...infer T] (true branch), so assigning the false-branch literal must error"
+    );
+}
+
+#[test]
+fn empty_tuple_matches_optional_prefix_accepts_true_literal() {
+    // Same pattern, assigning the true-branch literal must be clean.
+    let source = r#"
+type Test = readonly [] extends readonly [(infer _H)?, ...infer _T] ? "MATCH" : "NO_MATCH";
+const t: Test = "MATCH";
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        0,
+        "assigning the resolved true-branch literal must type-check cleanly"
+    );
+}
+
+#[test]
+fn negative_control_required_prefix_takes_false_branch() {
+    // Negative control: a REQUIRED leading element cannot match the empty
+    // source, so the conditional takes the FALSE branch ("NO_MATCH"). The
+    // matching assignment is clean; the contradicting one must error.
+    let clean = r#"
+type Req = readonly [] extends readonly [infer _H, ...infer _T] ? "MATCH" : "NO_MATCH";
+const r: Req = "NO_MATCH";
+"#;
+    assert_eq!(
+        ts2322_count(clean),
+        0,
+        "required prefix must take the false branch, so assigning \"NO_MATCH\" is clean"
+    );
+
+    let err = r#"
+type Req = readonly [] extends readonly [infer _H, ...infer _T] ? "MATCH" : "NO_MATCH";
+const r: Req = "MATCH";
+"#;
+    assert_eq!(
+        ts2322_count(err),
+        1,
+        "required prefix takes the false branch, so assigning the true-branch literal must error"
+    );
+}
+
+#[test]
+fn two_optional_prefix_elements_match_empty_tuple() {
+    // Adjacent case (varied binder names): two optional prefix elements both
+    // absorb the missing source, so `[]` still matches (true branch).
+    let source = r#"
+type Pair = readonly [] extends readonly [(infer Alpha)?, (infer Beta)?, ...infer Rest] ? "YES" : "NO";
+const p: Pair = "NO";
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "two optional prefix elements must both match zero source elements (true branch)"
+    );
+}
+
+#[test]
+fn required_then_optional_prefix_rejects_empty_tuple() {
+    // Adjacent negative control: a required element followed by an optional one.
+    // The required leading element still needs a source element, so `[]` does
+    // NOT match and the conditional takes the FALSE branch.
+    let clean = r#"
+type Mix = readonly [] extends readonly [infer Head, (infer Opt)?, ...infer Tail] ? "YES" : "NO";
+const m: Mix = "NO";
+"#;
+    assert_eq!(
+        ts2322_count(clean),
+        0,
+        "a required leading element keeps the empty source on the false branch"
+    );
+
+    let err = r#"
+type Mix = readonly [] extends readonly [infer Head, (infer Opt)?, ...infer Tail] ? "YES" : "NO";
+const m: Mix = "YES";
+"#;
+    assert_eq!(
+        ts2322_count(err),
+        1,
+        "false branch is selected, so assigning the true-branch literal must error"
+    );
+}
+
+#[test]
+fn one_element_source_matches_optional_prefix() {
+    // Adjacent case: a single-element source fills the optional prefix slot, so
+    // the pattern still matches (true branch). Confirms the fix did not regress
+    // the previously-accepted in-range arity.
+    let source = r#"
+type One = readonly [string] extends readonly [(infer _H)?, ...infer _T] ? "MATCH" : "NO_MATCH";
+const o: One = "NO_MATCH";
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "a one-element source filling the optional prefix must still match (true branch)"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -1240,14 +1240,34 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // collect remaining middle elements into the rest tuple.
             let prefix_len = rest_index;
             let suffix_len = pattern_len - rest_index - 1;
-            let fixed_count = prefix_len + suffix_len;
 
-            // Source must have at least enough elements for the fixed parts
-            if source_len < fixed_count {
+            // An *optional* prefix element (`[(infer H)?, ...rest]`) can match
+            // ZERO source elements, so the leading prefix slots that count
+            // toward the minimum source arity are only the non-optional ones.
+            // tsc treats `[] extends [(infer H)?, ...infer T]` as a match (true
+            // branch) because the optional `H` absorbs the missing element;
+            // counting every prefix slot as required would wrongly reject the
+            // empty source and take the false branch.
+            let required_prefix_len = pattern_elems[..prefix_len]
+                .iter()
+                .filter(|elem| !elem.optional)
+                .count();
+            let min_source_len = required_prefix_len + suffix_len;
+
+            // Source must have at least enough elements for the required fixed
+            // parts (required prefix slots + suffix).
+            if source_len < min_source_len {
                 return false;
             }
 
             let rest_source_end = source_len - suffix_len;
+            // The prefix can only consume source elements up to the suffix
+            // boundary; when the source is shorter than the full prefix, the
+            // trailing prefix slots have no source position and must be
+            // optional (verified below). They are filled with their `unknown`
+            // default after the matched slots, exactly as tsc leaves an
+            // unmatched optional `infer` slot at `unknown`.
+            let matched_prefix_len = std::cmp::min(prefix_len, rest_source_end);
 
             // Collect the fixed prefix and suffix `(source, pattern)` pairs.
             // These are all co-located *covariant* tuple positions: when the
@@ -1261,8 +1281,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // branch. The fixed-slot validity checks (no nested rest, optional
             // source cannot fill a required slot) stay eager so an invalid
             // shape rejects before any inference work.
-            let mut fixed_pairs: Vec<(TypeId, TypeId)> = Vec::with_capacity(fixed_count);
-            for i in 0..prefix_len {
+            let mut fixed_pairs: Vec<(TypeId, TypeId)> =
+                Vec::with_capacity(matched_prefix_len + suffix_len);
+            for i in 0..matched_prefix_len {
                 if !self.push_fixed_tuple_pair(
                     &source_elems[i],
                     &pattern_elems[i],
@@ -1270,6 +1291,16 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 ) {
                     return false;
                 }
+            }
+            // Any prefix slot beyond the matched range has no source position.
+            // It must be optional (a required prefix slot with no source
+            // element cannot match), and its `infer` variables default to
+            // `unknown` — the value tsc gives an unmatched optional slot.
+            for pattern_elem in &pattern_elems[matched_prefix_len..prefix_len] {
+                if !pattern_elem.optional {
+                    return false;
+                }
+                self.fill_unbound_infer_defaults(pattern_elem.type_id, TypeId::UNKNOWN, bindings);
             }
             for i in 0..suffix_len {
                 if !self.push_fixed_tuple_pair(
@@ -1308,7 +1339,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // each source element's `rest`/`optional` flags and structurally
             // simplify a single-rest-non-optional residual (`[...X[]]` -> `X[]`)
             // so that `infer R` binds to the array form tsc treats as identical.
-            let residual = &source_elems[prefix_len..rest_source_end];
+            let residual = &source_elems[matched_prefix_len..rest_source_end];
             let pattern_rest_type = pattern_elems[rest_index].type_id;
             return self.match_residual_against_pattern_rest(
                 residual,


### PR DESCRIPTION
Goal: green

## Summary
An optional leading element of a rest-bearing tuple infer-pattern may match zero source elements, so `[] extends [(infer H)?, ...infer T]` takes the true branch.

Structural rule: When a source tuple has fewer elements than a rest-bearing infer-pattern whose leading prefix element(s) are OPTIONAL (`[(infer H)?, ...infer T]`), tsc lets the optional prefix match zero source elements (the conditional takes the true branch and the unmatched optional `infer` slot defaults to `unknown`); tsz now does the same through the solver's `match_tuple_elements` rest-present branch in `evaluation/evaluate_rules/infer_pattern.rs`.

Root cause: the rest-present arity check computed `fixed_count = prefix_len + suffix_len` and rejected any source shorter than that, counting an optional prefix element as required. So `[] extends [(infer H)?, ...infer T]` was rejected and fell to the false branch, inverting the base case of tuple-deconstruction utilities (remeda `TupleParts`/`Head`). The fix counts only the non-optional prefix slots toward the minimum source arity (`required_prefix_len + suffix_len`), matches the prefix only up to the available source/suffix boundary, and fills any unmatched trailing prefix slot (which must be optional, else the match still fails) with the `unknown` default tsc gives an absent optional slot. Behavior is byte-identical for every previously-accepted shape because `matched_prefix_len == prefix_len` whenever the source already satisfied the old gate.

## Verification
- `cargo nextest run -p tsz-checker --test empty_tuple_optional_infer_tests` — 6/6 pass (new flipping suite). The three true-branch tests (`empty_tuple_matches_optional_prefix_takes_true_branch`, `empty_tuple_matches_optional_prefix_accepts_true_literal`, `two_optional_prefix_elements_match_empty_tuple`) fail on main and pass with the fix; the negative controls (`negative_control_required_prefix_takes_false_branch`, `required_then_optional_prefix_rejects_empty_tuple`) confirm a required prefix still takes the false branch.
- `cargo nextest run -p tsz-solver` tuple/variadic/infer/conditional suites (`infer_pattern_variadic_residual`, `matching_variadic_tuple`, `conditional_infer_tuple_numeric_key`, `tuple_comprehensive`, `tuple_cardinality`, `operations_tuple_rest_normalization`, `tuple_spread_splice`, `conditional_comprehensive`, `conditional_infer_callable_arity`, `conditional_readonly_array_relation`, `conditional_keyof_variance`, inline `infer_pattern`/`evaluate_rules`) — all green (73 + 116 + 91 = 280 passed).
- `cargo nextest run -p tsz-checker` conditional-infer / variadic-tuple owner-area suites — 81/81 of the targeted suites pass. The only failures observed in the broad tuple filter (`recursive_conditional_infer_termination_tests::awaited_shaped_distribution_reduces_free_param_union_member*`, `ts2589_tests::issue_9777::tuple_growth_*`, `generic_call_inference_tests::...primitive_array_constraint`, `assignment_checker_mapped_type_tests::tuple_to_object_preserves_unique_symbol_keys...`) fail identically on main HEAD with byte-identical diagnostics, i.e. pre-existing Mac platform-delta failures independent of this change (verified by stashing the fix).
- The minimal repro now matches tsc 6.0.3: `type Test = readonly [] extends readonly [(infer _H)?, ...infer _T] ? "MATCH" : "NO_MATCH"; const t: Test = "NO_MATCH";` errors TS2322 (Test is "MATCH"), and `const t2: Test = "MATCH"` is clean.

Closes #14176

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
