### PR TITLE
fix(bench): time clean application rows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1140,7 +1140,7 @@ jobs:
           # flakiness never blocks required benchmark publishing.
           - label: bench-applications
             timeout: 135
-            filter: 'umami-project|dub-project|formbricks-project|lobe-chat-project|supabase-studio-project|infisical-project|payload-project|trigger-dev-project|directus-project|n8n-project|documenso-project|immich-server-project'
+            filter: 'umami-project|excalidraw-project|dub-project|formbricks-project|typebot-project|lobe-chat-project|supabase-studio-project|infisical-project|payload-project|medusa-project|outline-project|trigger-dev-project|joplin-project|directus-project|n8n-project|cal-com-project|documenso-project|affine-project|immich-server-project|rocketchat-project'
           - label: large-ts-repo
             timeout: 135
             filter: '^large-ts-repo$'

--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -1592,17 +1592,25 @@ main() {
     run_isolated "xstate-project"                    run_xstate_project_benchmarks
     run_isolated "mobx-project"                      run_mobx_project_benchmarks
     run_isolated "umami-project"                     run_application_project_benchmarks "umami-project"
+    run_isolated "excalidraw-project"                run_application_project_benchmarks "excalidraw-project"
     run_isolated "dub-project"                       run_application_project_benchmarks "dub-project"
     run_isolated "formbricks-project"                run_application_project_benchmarks "formbricks-project"
+    run_isolated "typebot-project"                   run_application_project_benchmarks "typebot-project"
     run_isolated "lobe-chat-project"                 run_application_project_benchmarks "lobe-chat-project"
     run_isolated "supabase-studio-project"           run_application_project_benchmarks "supabase-studio-project"
     run_isolated "infisical-project"                 run_application_project_benchmarks "infisical-project"
     run_isolated "payload-project"                   run_application_project_benchmarks "payload-project"
+    run_isolated "medusa-project"                    run_application_project_benchmarks "medusa-project"
+    run_isolated "outline-project"                   run_application_project_benchmarks "outline-project"
     run_isolated "trigger-dev-project"               run_application_project_benchmarks "trigger-dev-project"
+    run_isolated "joplin-project"                    run_application_project_benchmarks "joplin-project"
     run_isolated "directus-project"                  run_application_project_benchmarks "directus-project"
     run_isolated "n8n-project"                       run_application_project_benchmarks "n8n-project"
+    run_isolated "cal-com-project"                   run_application_project_benchmarks "cal-com-project"
     run_isolated "documenso-project"                 run_application_project_benchmarks "documenso-project"
+    run_isolated "affine-project"                    run_application_project_benchmarks "affine-project"
     run_isolated "immich-server-project"             run_application_project_benchmarks "immich-server-project"
+    run_isolated "rocketchat-project"                run_application_project_benchmarks "rocketchat-project"
     run_isolated "vite-vanilla-ts-app"    run_vite_app_project_benchmarks
     run_isolated "nextjs-fresh-app"       run_next_app_project_benchmarks
     run_isolated "nextjs"                 run_nextjs_benchmarks

--- a/scripts/bench/project-rows.mjs
+++ b/scripts/bench/project-rows.mjs
@@ -702,6 +702,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "28a9b1711dc0625b8ab5d643dc871810ee13642f",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -761,6 +762,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "c82ac4324a61376b3de3c8b75ccfad7c03f59e7a",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -860,6 +862,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "38725ac274d764031b52f6f35f7951aa9b3bb2a8",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -879,6 +882,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "62d5c25bd3f34c8914be6f8ab219b43e51854534",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -918,6 +922,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "1106aa85be38c84f883e6663a18ec3399d4c1fbd",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -977,6 +982,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "561cf889abc776d8553f9c692a16c47b5d1a5a03",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -1016,6 +1022,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "da7781a75171140fd966c6cfbe05da9f1fb111d6",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
   {
@@ -1055,6 +1062,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "02b80089e0f65df5e01d7d3c9422cf56c3771d86",
     guard_set: "canary",
     benchmark_set: "canary",
+    perf_timed: true,
     category: "application",
   },
 ];


### PR DESCRIPTION
Goal: green

## Summary
- Promote the eight compile-clean application rows that were still compile-only into `perf_timed` rows.
- Add those rows to the `bench-applications` runner list and workflow shard filter so Bench emits `tsz_ms`/`tsgo_ms` pairs for the website chart.
- Keep application compatibility rows separate from timing: clean rows still need green compat before the website promotes their timing data.

## Verification
- `node scripts/bench/test-project-rows.mjs`
- `node scripts/bench/test-bench-workflow-micro-coverage.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/validate-project-metadata.mjs`
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `git diff --check`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
