### PR TITLE
fix(checker): model `typeof globalThis` as a concrete surface object (TS2322/TS7053)

### DIFF
--- a/crates/tsz-checker/src/context/lib_queries.rs
+++ b/crates/tsz-checker/src/context/lib_queries.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use tsz_binder::SymbolId;
 use tsz_parser::parser::node::NodeAccess;
+use tsz_solver::TypeId;
 
 use super::CheckerContext;
 
@@ -43,6 +44,120 @@ impl<'a> CheckerContext<'a> {
                 .iter()
                 .take(self.actual_lib_file_count)
                 .any(|lib_ctx| lib_ctx.binder.file_locals.has(name))
+    }
+
+    /// Resolve a name to the value-global symbol that contributes a property to
+    /// the synthetic `typeof globalThis` surface (a `var`/`function`/`class`
+    /// declaration in the current file or a lib). Block-scoped `let`/`const`
+    /// bindings are not properties of `globalThis`, so they are excluded.
+    fn global_this_surface_symbol(&self, name: &str) -> Option<SymbolId> {
+        if let Some(sym_id) = self.binder.file_locals.get(name)
+            && self
+                .binder
+                .get_symbol(sym_id)
+                .is_some_and(is_global_this_surface_value)
+        {
+            return Some(sym_id);
+        }
+
+        for lib_ctx in self.lib_contexts.iter() {
+            if let Some(sym_id) = lib_ctx.binder.file_locals.get(name)
+                && lib_ctx
+                    .binder
+                    .get_symbol(sym_id)
+                    .is_some_and(is_global_this_surface_value)
+            {
+                return Some(sym_id);
+            }
+        }
+
+        None
+    }
+
+    /// `typeof globalThis` resolves to the synthetic surface object, never `any`.
+    /// Returns it when `expr_name_idx` (resolved in `arena`) is the bare
+    /// `globalThis` identifier. Shared by the `Fn`-typed `typeof` lowering
+    /// overrides so the check lives in one place rather than at each call site.
+    pub(crate) fn global_this_typeof_override(
+        &self,
+        arena: &tsz_parser::parser::node::NodeArena,
+        expr_name_idx: tsz_parser::parser::NodeIndex,
+    ) -> Option<TypeId> {
+        (arena.get_identifier_text(expr_name_idx) == Some("globalThis"))
+            .then(|| self.global_this_surface_type())
+    }
+
+    /// Build (and memoize) the synthetic `typeof globalThis` object type for this
+    /// checker file. `typeof globalThis` is a concrete object whose properties are
+    /// the in-scope value globals (current-file `var`/`function`/`class` plus lib
+    /// globals); it is **not** `any`. Representing it as `any` made
+    /// `typeof globalThis extends X ? T : F` distribute to `T | F` and silenced
+    /// element-access diagnostics, so the lowering and member-access paths route
+    /// through this surface instead.
+    ///
+    /// The result is `&self`-buildable: it relies only on interior-mutable
+    /// interning and the file-local cache, so it can be consulted from the
+    /// `Fn`-typed `typeof` lowering overrides.
+    pub(crate) fn global_this_surface_type(&self) -> TypeId {
+        use tsz_solver::{ObjectShape, PropertyInfo, SymbolRef};
+
+        let cache = &self.type_reference_validation_caches.type_node_surface;
+        if let Some(cached) = cache.global_this_type.get() {
+            return cached;
+        }
+        // A nested `typeof globalThis` reached while the surface is being built
+        // (a self-edge through one of the property types) resolves to the
+        // `globalThis` self-property fallback rather than recursing forever.
+        if cache.global_this_type_in_progress.get() {
+            return TypeId::UNKNOWN;
+        }
+        cache.global_this_type_in_progress.set(true);
+
+        let mut names: rustc_hash::FxHashSet<String> = rustc_hash::FxHashSet::default();
+        for (name, _) in self.binder.file_locals.iter() {
+            names.insert(name.clone());
+        }
+        for lib_ctx in self.lib_contexts.iter() {
+            for (name, _) in lib_ctx.binder.file_locals.iter() {
+                names.insert(name.clone());
+            }
+        }
+        names.insert("globalThis".to_string());
+
+        let mut properties = Vec::new();
+        for name in names {
+            // `globalThis.globalThis` is `typeof globalThis`; modeled as the
+            // self-property fallback to avoid an infinite surface expansion.
+            let (type_id, parent_id) = if name == "globalThis" {
+                (TypeId::UNKNOWN, None)
+            } else {
+                let Some(sym_id) = self.global_this_surface_symbol(&name) else {
+                    continue;
+                };
+                let type_id = self
+                    .symbol_types
+                    .get(&sym_id)
+                    .filter(|&type_id| type_id != TypeId::ERROR)
+                    .unwrap_or_else(|| self.types.factory().type_query(SymbolRef(sym_id.0)));
+                (type_id, Some(sym_id))
+            };
+
+            let prop_name = self.types.intern_string(&name);
+            let mut prop = PropertyInfo::new(prop_name, type_id);
+            prop.write_type = type_id;
+            prop.readonly = name == "globalThis";
+            prop.parent_id = parent_id;
+            prop.declaration_order = properties.len() as u32;
+            properties.push(prop);
+        }
+
+        let global_this_type = self.types.factory().object_with_index(ObjectShape {
+            properties,
+            ..ObjectShape::default()
+        });
+        cache.global_this_type.set(Some(global_this_type));
+        cache.global_this_type_in_progress.set(false);
+        global_this_type
     }
 
     fn actual_lib_symbol_id_for_bare_name(&self, name: &str) -> Option<SymbolId> {
@@ -487,4 +602,14 @@ impl<'a> CheckerContext<'a> {
                 .get_symbol(sym_id)
                 .is_some_and(|symbol| symbol.escaped_name.as_str() == name)
     }
+}
+
+/// A symbol contributes a property to the `typeof globalThis` surface when it
+/// has value meaning and is not a block-scoped `let`/`const` (those are not
+/// properties of `globalThis`; only `var`/`function`/`class` are).
+const fn is_global_this_surface_value(symbol: &tsz_binder::Symbol) -> bool {
+    use tsz_binder::symbol_flags;
+    symbol.has_any_flags(symbol_flags::VALUE)
+        && (!symbol.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE)
+            || symbol.has_any_flags(symbol_flags::FUNCTION_SCOPED_VARIABLE))
 }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -274,6 +274,9 @@ mod generic_signature_context_instantiation_tests;
 #[path = "tests/global_augmentation_structural_lookup_arch_tests.rs"]
 mod global_augmentation_structural_lookup_arch_tests;
 #[cfg(test)]
+#[path = "tests/global_this_typeof_surface_tests.rs"]
+mod global_this_typeof_surface_tests;
+#[cfg(test)]
 #[path = "tests/heritage_constraint_structural_name_lookup_arch_tests.rs"]
 mod heritage_constraint_structural_name_lookup_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -1815,6 +1815,12 @@ impl<'a> CheckerState<'a> {
                         .or_else(|| self.ctx.get_def_type_params(def_id))
                 };
                 let type_query_override = |expr_name_idx: NodeIndex| -> Option<TypeId> {
+                    if let Some(global_this) = self
+                        .ctx
+                        .global_this_typeof_override(self.ctx.arena, expr_name_idx)
+                    {
+                        return Some(global_this);
+                    }
                     self.const_array_to_enum_object_type_query(expr_name_idx)
                         .or_else(|| self.const_object_member_literal_type_query(expr_name_idx))
                         .or_else(|| {

--- a/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
@@ -259,6 +259,12 @@ impl CheckerState<'_> {
         );
         let computed_name_resolver = |expr_idx: NodeIndex| computed_names.get(&expr_idx).copied();
         let type_query_override = |expr_name_idx: NodeIndex| -> Option<TypeId> {
+            if let Some(global_this) = self
+                .ctx
+                .global_this_typeof_override(decl_arena, expr_name_idx)
+            {
+                return Some(global_this);
+            }
             if let Some(symbol_type) =
                 self.cross_arena_well_known_symbol_type_query(decl_arena, expr_name_idx)
             {

--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -477,6 +477,12 @@ impl<'a> CheckerState<'a> {
                         })
                 };
                 let type_query_override = |expr_name_idx: NodeIndex| -> Option<TypeId> {
+                    if let Some(global_this) = self
+                        .ctx
+                        .global_this_typeof_override(self.ctx.arena, expr_name_idx)
+                    {
+                        return Some(global_this);
+                    }
                     let type_query_idx = self.ctx.arena.get_extended(expr_name_idx)?.parent;
                     let type_query_node = self.ctx.arena.get(type_query_idx)?;
                     if type_query_node.kind != syntax_kind_ext::TYPE_QUERY {
@@ -1365,6 +1371,12 @@ impl<'a> CheckerState<'a> {
                         })
                 };
                 let type_query_override = |expr_name_idx: NodeIndex| -> Option<TypeId> {
+                    if let Some(global_this) = self
+                        .ctx
+                        .global_this_typeof_override(self.ctx.arena, expr_name_idx)
+                    {
+                        return Some(global_this);
+                    }
                     let type_query_idx = self.ctx.arena.get_extended(expr_name_idx)?.parent;
                     let type_query_node = self.ctx.arena.get(type_query_idx)?;
                     if type_query_node.kind != syntax_kind_ext::TYPE_QUERY {

--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -1983,23 +1983,4 @@ impl<'a> CheckerState<'a> {
         }
         TypeId::ERROR
     }
-
-    /// Resolve a primitive keyword like `number`, `string`, etc.
-    fn resolve_primitive_keyword(name: &str) -> Option<TypeId> {
-        match name {
-            "number" => Some(TypeId::NUMBER),
-            "string" => Some(TypeId::STRING),
-            "boolean" => Some(TypeId::BOOLEAN),
-            "void" => Some(TypeId::VOID),
-            "any" => Some(TypeId::ANY),
-            "never" => Some(TypeId::NEVER),
-            "unknown" => Some(TypeId::UNKNOWN),
-            "undefined" => Some(TypeId::UNDEFINED),
-            "null" => Some(TypeId::NULL),
-            "object" => Some(TypeId::OBJECT),
-            "bigint" => Some(TypeId::BIGINT),
-            "symbol" => Some(TypeId::SYMBOL),
-            _ => None,
-        }
-    }
 }

--- a/crates/tsz-checker/src/state/type_resolution/mod.rs
+++ b/crates/tsz-checker/src/state/type_resolution/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod import_type;
 pub(crate) mod judge;
 pub(crate) mod mixin_constraints;
 pub(crate) mod module;
+mod primitive_keyword;
 pub(crate) mod reference_helpers;
 pub(crate) mod reference_type_params;
 pub(crate) mod shadowed_lib_heritage;

--- a/crates/tsz-checker/src/state/type_resolution/primitive_keyword.rs
+++ b/crates/tsz-checker/src/state/type_resolution/primitive_keyword.rs
@@ -1,0 +1,22 @@
+use crate::state::CheckerState;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn resolve_primitive_keyword(name: &str) -> Option<TypeId> {
+        match name {
+            "number" => Some(TypeId::NUMBER),
+            "string" => Some(TypeId::STRING),
+            "boolean" => Some(TypeId::BOOLEAN),
+            "void" => Some(TypeId::VOID),
+            "any" => Some(TypeId::ANY),
+            "never" => Some(TypeId::NEVER),
+            "unknown" => Some(TypeId::UNKNOWN),
+            "undefined" => Some(TypeId::UNDEFINED),
+            "null" => Some(TypeId::NULL),
+            "object" => Some(TypeId::OBJECT),
+            "bigint" => Some(TypeId::BIGINT),
+            "symbol" => Some(TypeId::SYMBOL),
+            _ => None,
+        }
+    }
+}

--- a/crates/tsz-checker/src/tests/global_this_typeof_surface_tests.rs
+++ b/crates/tsz-checker/src/tests/global_this_typeof_surface_tests.rs
@@ -1,0 +1,165 @@
+//! `typeof globalThis` is a concrete object type, not `any`.
+//!
+//! Structural rule: `typeof globalThis` is the type of the global object — a
+//! concrete object whose members are the globally-visible value bindings
+//! (`var`/`function`/`class`, plus lib globals). tsz previously lowered it to
+//! `any`, which produced two `tsc` divergences:
+//!   1. (FP) `typeof globalThis extends X ? T : F` distributed like `any`,
+//!      yielding `T | F` instead of resolving the concrete branch — so an
+//!      assignment of the apparent union to one branch wrongly emitted TS2322.
+//!   2. (FN) `globalThis[key]` element access with a non-literal-node string
+//!      key never reached the implicit-any diagnostic, so the TS7053 that `tsc`
+//!      emits under `--strict` (`typeof globalThis` has no index signature) was
+//!      missing.
+//!
+//! Owner: `CheckerContext::global_this_surface_type` (surface object) consulted
+//! by the `typeof` lowering overrides; `types/computation/access.rs` for the
+//! element-access TS7053.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+const TS2322: u32 = 2322; // Type X is not assignable to type Y.
+const TS7053: u32 = 7053; // Element implicitly has an 'any' type (no index sig).
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+// ---------------------------------------------------------------------------
+// Part A — `typeof globalThis` in a conditional check type resolves concretely.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn typeof_global_this_extends_object_takes_true_branch() {
+    // The conditional must resolve to "TRUE"; if it stays deferred its apparent
+    // type is the union of both branches and the assignment emits TS2322.
+    let codes = check_strict(
+        r#"
+type Verdict = typeof globalThis extends object ? "TRUE" : "FALSE";
+const y: "TRUE" = null as unknown as Verdict;
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS2322),
+        0,
+        "`typeof globalThis extends object` is true, so Verdict is \"TRUE\": {codes:?}"
+    );
+}
+
+#[test]
+fn typeof_global_this_extends_missing_member_takes_false_branch() {
+    // The surface object lacks an arbitrary member, so the conditional resolves
+    // to the false branch concretely (not a deferred union).
+    let codes = check_strict(
+        r#"
+type Picked = typeof globalThis extends { __definitely_absent: number } ? "Y" : "N";
+const picked: "N" = null as unknown as Picked;
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS2322),
+        0,
+        "absent member means the false branch \"N\" is taken: {codes:?}"
+    );
+}
+
+#[test]
+fn typeof_global_this_as_generic_argument_resolves_concretely() {
+    // The same surface must flow through a generic application (a distinct
+    // lowering path) — alias name varied to avoid name-coupled behavior.
+    let codes = check_strict(
+        r#"
+type IsObjectShape<Candidate> = Candidate extends object ? 1 : 2;
+const flag: IsObjectShape<typeof globalThis> = 1;
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS2322),
+        0,
+        "Cond<typeof globalThis> must reduce to 1, not stay deferred: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Part B — `globalThis[key]` with a non-literal-node string key emits TS7053.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn global_this_indexed_by_missing_literal_typed_key_emits_ts7053() {
+    // `slot`'s type is the string literal "missingGlobal"; the AST node is an
+    // identifier, not a string literal, so the literal-node branch does not
+    // fire. The key is not a global member → TS7053.
+    let codes = check_strict(
+        r#"
+const slot = "missingGlobal";
+export function read(): unknown {
+  return globalThis[slot];
+}
+"#,
+    );
+    assert!(
+        codes.contains(&TS7053),
+        "indexing globalThis with an absent literal-typed key must emit TS7053: {codes:?}"
+    );
+}
+
+#[test]
+fn global_this_indexed_by_general_string_emits_ts7053() {
+    let codes = check_strict(
+        r#"
+declare const anyKey: string;
+export function read(): unknown {
+  return globalThis[anyKey];
+}
+"#,
+    );
+    assert!(
+        codes.contains(&TS7053),
+        "`typeof globalThis` has no string index signature → TS7053: {codes:?}"
+    );
+}
+
+#[test]
+fn global_this_indexed_by_present_global_var_literal_key_is_clean() {
+    // A key whose literal type names a real global `var` resolves to that
+    // value's type — no TS7053. (Self-contained: declares the global in-source
+    // so the assertion does not depend on which lib globals the harness loads.)
+    let codes = check_strict(
+        r#"
+var presentGlobal: number;
+const slot = "presentGlobal";
+export function read(): number {
+  return globalThis[slot];
+}
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS7053),
+        0,
+        "a resolvable global `var` key must not be flagged: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, TS2322),
+        0,
+        "the resolved member type (number) is assignable to the return type: {codes:?}"
+    );
+}
+
+#[test]
+fn global_this_indexed_by_block_scoped_binding_emits_ts7053() {
+    // `let`/`const` are NOT members of `typeof globalThis` (only `var`/
+    // `function`/`class` are), so indexing by such a name is still TS7053.
+    let codes = check_strict(
+        r#"
+const blockScoped = 1;
+const slot = "blockScoped";
+export function read(): unknown {
+  return globalThis[slot];
+}
+"#,
+    );
+    assert!(
+        codes.contains(&TS7053),
+        "a block-scoped binding is not a globalThis member → TS7053: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -481,6 +481,78 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // `globalThis[k]` / global `this[k]` where the key is a typed identifier
+        // (not a string-literal node) rather than a statically known global
+        // member. `typeof globalThis` has no index signature, so tsc reports
+        // TS7053 under `noImplicitAny`. The string-literal-node form is handled
+        // by the literal-key branch above; this covers a variable key whose
+        // *type* is a string literal (`const k = "x"; globalThis[k]`), a union
+        // of string literals, or a general `string`. A key that does resolve to
+        // a real global value still yields that value's type.
+        if literal_string.is_none()
+            && node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+            && (self.is_global_this_expression(access.expression) || is_this_global)
+            && self.ctx.no_implicit_any()
+            && !self.is_js_file()
+        {
+            let string_literal_keys = self
+                .get_literal_key_union_from_type(index_type)
+                .filter(|(string_keys, number_keys)| {
+                    number_keys.is_empty() && !string_keys.is_empty()
+                })
+                .map(|(string_keys, _)| string_keys);
+            let index_is_string_like = string_literal_keys.is_some()
+                || crate::query_boundaries::common::is_string_type(self.ctx.types, index_type);
+            if index_is_string_like {
+                if let Some(keys) = string_literal_keys {
+                    let mut resolved_types: Vec<TypeId> = Vec::with_capacity(keys.len());
+                    let mut all_resolved = true;
+                    for key_atom in &keys {
+                        let name = self.ctx.types.resolve_atom(*key_atom);
+                        let resolved = self.resolve_global_this_property_type(
+                            &name,
+                            idx,
+                            true,
+                            "typeof globalThis",
+                        );
+                        if resolved != TypeId::ANY && resolved != TypeId::ERROR {
+                            resolved_types.push(resolved);
+                        } else {
+                            all_resolved = false;
+                            break;
+                        }
+                    }
+                    if all_resolved && !resolved_types.is_empty() {
+                        // Read context: the result is one of the keyed properties
+                        // (union). Write context: the value must satisfy every
+                        // possible key (intersection) — mirroring the `window[k]`
+                        // branch above.
+                        return if skip_flow_narrowing {
+                            tsz_solver::utils::intersection_or_single(
+                                self.ctx.types,
+                                resolved_types,
+                            )
+                        } else {
+                            let combined =
+                                tsz_solver::utils::union_or_single(self.ctx.types, resolved_types);
+                            self.apply_flow_narrowing(idx, combined)
+                        };
+                    }
+                }
+                use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+                let index_str = self.format_type_diagnostic(index_type);
+                self.error_at_node(
+                    idx,
+                    &format_message(
+                        diagnostic_messages::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
+                        &[&index_str, "typeof globalThis"],
+                    ),
+                    diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
+                );
+                return TypeId::ANY;
+            }
+        }
+
         if self.report_namespace_value_access_for_type_only_import_equals_expr(access.expression) {
             return TypeId::ERROR;
         }

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1,4 +1,7 @@
-use self::global_this_keyed::GlobalThisStringLikeElementAccess;
+use self::global_this_keyed::{
+    GlobalThisAccessKind, GlobalThisFlowMode, GlobalThisKeyStatus, GlobalThisReceiverStatus,
+    GlobalThisStringLikeElementAccess,
+};
 use crate::context::TypingRequest;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -433,12 +436,28 @@ impl<'a> CheckerState<'a> {
         if let Some(result) =
             self.try_global_this_string_like_element_access(GlobalThisStringLikeElementAccess {
                 idx,
-                is_element_access: node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION,
+                access_kind: if node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+                    GlobalThisAccessKind::Element
+                } else {
+                    GlobalThisAccessKind::Other
+                },
                 access_expression: access.expression,
-                has_no_literal_string_key: literal_string.is_none(),
+                key_status: if literal_string.is_none() {
+                    GlobalThisKeyStatus::NoLiteralStringKey
+                } else {
+                    GlobalThisKeyStatus::HasLiteralStringKey
+                },
                 index_type,
-                is_this_global,
-                skip_flow_narrowing,
+                receiver_status: if is_this_global {
+                    GlobalThisReceiverStatus::GlobalThisLike
+                } else {
+                    GlobalThisReceiverStatus::Other
+                },
+                flow_mode: if skip_flow_narrowing {
+                    GlobalThisFlowMode::SkipFlowNarrowing
+                } else {
+                    GlobalThisFlowMode::ApplyFlowNarrowing
+                },
             })
         {
             return result;

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1,3 +1,4 @@
+use self::global_this_keyed::GlobalThisStringLikeElementAccess;
 use crate::context::TypingRequest;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -429,15 +430,17 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        if let Some(result) = self.try_global_this_string_like_element_access(
-            idx,
-            node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION,
-            access.expression,
-            literal_string.is_none(),
-            index_type,
-            is_this_global,
-            skip_flow_narrowing,
-        ) {
+        if let Some(result) =
+            self.try_global_this_string_like_element_access(GlobalThisStringLikeElementAccess {
+                idx,
+                is_element_access: node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION,
+                access_expression: access.expression,
+                has_no_literal_string_key: literal_string.is_none(),
+                index_type,
+                is_this_global,
+                skip_flow_narrowing,
+            })
+        {
             return result;
         }
 

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -5,67 +5,18 @@ use crate::symbols_domain::name_text::property_access_chain_text_in_arena;
 use crate::types_domain::queries::core::GlobalReceiver;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
+#[path = "access/global_this_keyed.rs"]
+mod global_this_keyed;
+#[path = "access/optional_chain.rs"]
+mod optional_chain;
 #[path = "access/symbol_constructor_index.rs"]
 mod symbol_constructor_index;
 
-pub(crate) fn is_optional_chain(arena: &NodeArena, idx: NodeIndex) -> bool {
-    let Some(node) = arena.get(idx) else {
-        return false;
-    };
-
-    match node.kind {
-        k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-            || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION =>
-        {
-            if let Some(access) = arena.get_access_expr(node) {
-                // Parentheses break the chain (fall through to `_ => false`),
-                // so `(o?.a).b` is not a continuation.
-                access.question_dot_token || is_optional_chain(arena, access.expression)
-            } else {
-                false
-            }
-        }
-        k if k == syntax_kind_ext::CALL_EXPRESSION => {
-            if node.is_optional_chain() {
-                return true;
-            }
-            if let Some(call) = arena.get_call_expr(node) {
-                is_optional_chain(arena, call.expression)
-            } else {
-                false
-            }
-        }
-        _ => false,
-    }
-}
-
-pub(crate) fn optional_chain_root(arena: &NodeArena, idx: NodeIndex) -> NodeIndex {
-    let Some(node) = arena.get(idx) else {
-        return idx;
-    };
-    match node.kind {
-        k if k == syntax_kind_ext::CALL_EXPRESSION => {
-            if let Some(call) = arena.get_call_expr(node) {
-                return optional_chain_root(arena, call.expression);
-            }
-            idx
-        }
-        k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-            || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION =>
-        {
-            if let Some(access) = arena.get_access_expr(node) {
-                return optional_chain_root(arena, access.expression);
-            }
-            idx
-        }
-        _ => idx,
-    }
-}
+pub(crate) use optional_chain::{is_optional_chain, optional_chain_root};
 
 impl<'a> CheckerState<'a> {
     /// Get the type of an element access expression (e.g., arr[0], obj["prop"]).
@@ -478,76 +429,16 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // `globalThis[k]` / global `this[k]` where the key is a typed identifier
-        // (not a string-literal node) rather than a statically known global
-        // member. `typeof globalThis` has no index signature, so tsc reports
-        // TS7053 under `noImplicitAny`. The string-literal-node form is handled
-        // by the literal-key branch above; this covers a variable key whose
-        // *type* is a string literal (`const k = "x"; globalThis[k]`), a union
-        // of string literals, or a general `string`. A key that does resolve to
-        // a real global value still yields that value's type.
-        if literal_string.is_none()
-            && node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
-            && (self.is_global_this_expression(access.expression) || is_this_global)
-            && self.ctx.no_implicit_any()
-            && !self.is_js_file()
-        {
-            let string_literal_keys = self
-                .get_literal_key_union_from_type(index_type)
-                .filter(|(string_keys, number_keys)| {
-                    number_keys.is_empty() && !string_keys.is_empty()
-                })
-                .map(|(string_keys, _)| string_keys);
-            let index_is_string_like = string_literal_keys.is_some()
-                || crate::query_boundaries::common::is_string_type(self.ctx.types, index_type);
-            if index_is_string_like {
-                if let Some(keys) = string_literal_keys {
-                    let mut resolved_types: Vec<TypeId> = Vec::with_capacity(keys.len());
-                    let mut all_resolved = true;
-                    for key_atom in &keys {
-                        let name = self.ctx.types.resolve_atom(*key_atom);
-                        let resolved = self.resolve_global_this_property_type(
-                            &name,
-                            idx,
-                            true,
-                            GlobalReceiver::GlobalThis,
-                        );
-                        if resolved != TypeId::ANY && resolved != TypeId::ERROR {
-                            resolved_types.push(resolved);
-                        } else {
-                            all_resolved = false;
-                            break;
-                        }
-                    }
-                    if all_resolved && !resolved_types.is_empty() {
-                        // Read context: the result is one of the keyed properties
-                        // (union). Write context: the value must satisfy every
-                        // possible key (intersection) — mirroring the `window[k]`
-                        // branch above.
-                        return if skip_flow_narrowing {
-                            tsz_solver::utils::intersection_or_single(
-                                self.ctx.types,
-                                resolved_types,
-                            )
-                        } else {
-                            let combined =
-                                tsz_solver::utils::union_or_single(self.ctx.types, resolved_types);
-                            self.apply_flow_narrowing(idx, combined)
-                        };
-                    }
-                }
-                use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
-                let index_str = self.format_type_diagnostic(index_type);
-                self.error_at_node(
-                    idx,
-                    &format_message(
-                        diagnostic_messages::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
-                        &[&index_str, "typeof globalThis"],
-                    ),
-                    diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
-                );
-                return TypeId::ANY;
-            }
+        if let Some(result) = self.try_global_this_string_like_element_access(
+            idx,
+            node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION,
+            access.expression,
+            literal_string.is_none(),
+            index_type,
+            is_this_global,
+            skip_flow_narrowing,
+        ) {
+            return result;
         }
 
         if self.report_namespace_value_access_for_type_only_import_equals_expr(access.expression) {

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -510,7 +510,7 @@ impl<'a> CheckerState<'a> {
                             &name,
                             idx,
                             true,
-                            "typeof globalThis",
+                            GlobalReceiver::GlobalThis,
                         );
                         if resolved != TypeId::ANY && resolved != TypeId::ERROR {
                             resolved_types.push(resolved);

--- a/crates/tsz-checker/src/types/computation/access/global_this_keyed.rs
+++ b/crates/tsz-checker/src/types/computation/access/global_this_keyed.rs
@@ -1,22 +1,28 @@
+use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use crate::state::CheckerState;
 use crate::types_domain::queries::core::GlobalReceiver;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
+pub(super) struct GlobalThisStringLikeElementAccess {
+    pub(super) idx: NodeIndex,
+    pub(super) is_element_access: bool,
+    pub(super) access_expression: NodeIndex,
+    pub(super) has_no_literal_string_key: bool,
+    pub(super) index_type: TypeId,
+    pub(super) is_this_global: bool,
+    pub(super) skip_flow_narrowing: bool,
+}
+
 impl<'a> CheckerState<'a> {
     pub(super) fn try_global_this_string_like_element_access(
         &mut self,
-        idx: NodeIndex,
-        is_element_access: bool,
-        access_expression: NodeIndex,
-        has_no_literal_string_key: bool,
-        index_type: TypeId,
-        is_this_global: bool,
-        skip_flow_narrowing: bool,
+        request: GlobalThisStringLikeElementAccess,
     ) -> Option<TypeId> {
-        if !has_no_literal_string_key
-            || !is_element_access
-            || !(self.is_global_this_expression(access_expression) || is_this_global)
+        if !request.has_no_literal_string_key
+            || !request.is_element_access
+            || !(self.is_global_this_expression(request.access_expression)
+                || request.is_this_global)
             || !self.ctx.no_implicit_any()
             || self.is_js_file()
         {
@@ -24,11 +30,11 @@ impl<'a> CheckerState<'a> {
         }
 
         let string_literal_keys = self
-            .get_literal_key_union_from_type(index_type)
+            .get_literal_key_union_from_type(request.index_type)
             .filter(|(string_keys, number_keys)| number_keys.is_empty() && !string_keys.is_empty())
             .map(|(string_keys, _)| string_keys);
         let index_is_string_like = string_literal_keys.is_some()
-            || crate::query_boundaries::common::is_string_type(self.ctx.types, index_type);
+            || crate::query_boundaries::common::is_string_type(self.ctx.types, request.index_type);
         if !index_is_string_like {
             return None;
         }
@@ -40,7 +46,7 @@ impl<'a> CheckerState<'a> {
                 let name = self.ctx.types.resolve_atom(*key_atom);
                 let resolved = self.resolve_global_this_property_type(
                     &name,
-                    idx,
+                    request.idx,
                     true,
                     GlobalReceiver::GlobalThis,
                 );
@@ -52,20 +58,19 @@ impl<'a> CheckerState<'a> {
                 }
             }
             if all_resolved && !resolved_types.is_empty() {
-                return Some(if skip_flow_narrowing {
+                return Some(if request.skip_flow_narrowing {
                     tsz_solver::utils::intersection_or_single(self.ctx.types, resolved_types)
                 } else {
                     let combined =
                         tsz_solver::utils::union_or_single(self.ctx.types, resolved_types);
-                    self.apply_flow_narrowing(idx, combined)
+                    self.apply_flow_narrowing(request.idx, combined)
                 });
             }
         }
 
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
-        let index_str = self.format_type_diagnostic(index_type);
+        let index_str = self.format_type_diagnostic(request.index_type);
         self.error_at_node(
-            idx,
+            request.idx,
             &format_message(
                 diagnostic_messages::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
                 &[&index_str, "typeof globalThis"],

--- a/crates/tsz-checker/src/types/computation/access/global_this_keyed.rs
+++ b/crates/tsz-checker/src/types/computation/access/global_this_keyed.rs
@@ -1,0 +1,77 @@
+use crate::state::CheckerState;
+use crate::types_domain::queries::core::GlobalReceiver;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn try_global_this_string_like_element_access(
+        &mut self,
+        idx: NodeIndex,
+        is_element_access: bool,
+        access_expression: NodeIndex,
+        has_no_literal_string_key: bool,
+        index_type: TypeId,
+        is_this_global: bool,
+        skip_flow_narrowing: bool,
+    ) -> Option<TypeId> {
+        if !has_no_literal_string_key
+            || !is_element_access
+            || !(self.is_global_this_expression(access_expression) || is_this_global)
+            || !self.ctx.no_implicit_any()
+            || self.is_js_file()
+        {
+            return None;
+        }
+
+        let string_literal_keys = self
+            .get_literal_key_union_from_type(index_type)
+            .filter(|(string_keys, number_keys)| number_keys.is_empty() && !string_keys.is_empty())
+            .map(|(string_keys, _)| string_keys);
+        let index_is_string_like = string_literal_keys.is_some()
+            || crate::query_boundaries::common::is_string_type(self.ctx.types, index_type);
+        if !index_is_string_like {
+            return None;
+        }
+
+        if let Some(keys) = string_literal_keys {
+            let mut resolved_types: Vec<TypeId> = Vec::with_capacity(keys.len());
+            let mut all_resolved = true;
+            for key_atom in &keys {
+                let name = self.ctx.types.resolve_atom(*key_atom);
+                let resolved = self.resolve_global_this_property_type(
+                    &name,
+                    idx,
+                    true,
+                    GlobalReceiver::GlobalThis,
+                );
+                if resolved != TypeId::ANY && resolved != TypeId::ERROR {
+                    resolved_types.push(resolved);
+                } else {
+                    all_resolved = false;
+                    break;
+                }
+            }
+            if all_resolved && !resolved_types.is_empty() {
+                return Some(if skip_flow_narrowing {
+                    tsz_solver::utils::intersection_or_single(self.ctx.types, resolved_types)
+                } else {
+                    let combined =
+                        tsz_solver::utils::union_or_single(self.ctx.types, resolved_types);
+                    self.apply_flow_narrowing(idx, combined)
+                });
+            }
+        }
+
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+        let index_str = self.format_type_diagnostic(index_type);
+        self.error_at_node(
+            idx,
+            &format_message(
+                diagnostic_messages::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
+                &[&index_str, "typeof globalThis"],
+            ),
+            diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN,
+        );
+        Some(TypeId::ANY)
+    }
+}

--- a/crates/tsz-checker/src/types/computation/access/global_this_keyed.rs
+++ b/crates/tsz-checker/src/types/computation/access/global_this_keyed.rs
@@ -4,14 +4,34 @@ use crate::types_domain::queries::core::GlobalReceiver;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
+pub(super) enum GlobalThisAccessKind {
+    Element,
+    Other,
+}
+
+pub(super) enum GlobalThisKeyStatus {
+    NoLiteralStringKey,
+    HasLiteralStringKey,
+}
+
+pub(super) enum GlobalThisReceiverStatus {
+    GlobalThisLike,
+    Other,
+}
+
+pub(super) enum GlobalThisFlowMode {
+    SkipFlowNarrowing,
+    ApplyFlowNarrowing,
+}
+
 pub(super) struct GlobalThisStringLikeElementAccess {
     pub(super) idx: NodeIndex,
-    pub(super) is_element_access: bool,
+    pub(super) access_kind: GlobalThisAccessKind,
     pub(super) access_expression: NodeIndex,
-    pub(super) has_no_literal_string_key: bool,
+    pub(super) key_status: GlobalThisKeyStatus,
     pub(super) index_type: TypeId,
-    pub(super) is_this_global: bool,
-    pub(super) skip_flow_narrowing: bool,
+    pub(super) receiver_status: GlobalThisReceiverStatus,
+    pub(super) flow_mode: GlobalThisFlowMode,
 }
 
 impl<'a> CheckerState<'a> {
@@ -19,10 +39,13 @@ impl<'a> CheckerState<'a> {
         &mut self,
         request: GlobalThisStringLikeElementAccess,
     ) -> Option<TypeId> {
-        if !request.has_no_literal_string_key
-            || !request.is_element_access
+        if !matches!(request.key_status, GlobalThisKeyStatus::NoLiteralStringKey)
+            || !matches!(request.access_kind, GlobalThisAccessKind::Element)
             || !(self.is_global_this_expression(request.access_expression)
-                || request.is_this_global)
+                || matches!(
+                    request.receiver_status,
+                    GlobalThisReceiverStatus::GlobalThisLike
+                ))
             || !self.ctx.no_implicit_any()
             || self.is_js_file()
         {
@@ -58,13 +81,15 @@ impl<'a> CheckerState<'a> {
                 }
             }
             if all_resolved && !resolved_types.is_empty() {
-                return Some(if request.skip_flow_narrowing {
-                    tsz_solver::utils::intersection_or_single(self.ctx.types, resolved_types)
-                } else {
-                    let combined =
-                        tsz_solver::utils::union_or_single(self.ctx.types, resolved_types);
-                    self.apply_flow_narrowing(request.idx, combined)
-                });
+                return Some(
+                    if matches!(request.flow_mode, GlobalThisFlowMode::SkipFlowNarrowing) {
+                        tsz_solver::utils::intersection_or_single(self.ctx.types, resolved_types)
+                    } else {
+                        let combined =
+                            tsz_solver::utils::union_or_single(self.ctx.types, resolved_types);
+                        self.apply_flow_narrowing(request.idx, combined)
+                    },
+                );
             }
         }
 

--- a/crates/tsz-checker/src/types/computation/access/optional_chain.rs
+++ b/crates/tsz-checker/src/types/computation/access/optional_chain.rs
@@ -1,0 +1,55 @@
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeArena;
+use tsz_parser::parser::syntax_kind_ext;
+
+pub(crate) fn is_optional_chain(arena: &NodeArena, idx: NodeIndex) -> bool {
+    let Some(node) = arena.get(idx) else {
+        return false;
+    };
+
+    match node.kind {
+        k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION =>
+        {
+            if let Some(access) = arena.get_access_expr(node) {
+                access.question_dot_token || is_optional_chain(arena, access.expression)
+            } else {
+                false
+            }
+        }
+        k if k == syntax_kind_ext::CALL_EXPRESSION => {
+            if node.is_optional_chain() {
+                return true;
+            }
+            if let Some(call) = arena.get_call_expr(node) {
+                is_optional_chain(arena, call.expression)
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+pub(crate) fn optional_chain_root(arena: &NodeArena, idx: NodeIndex) -> NodeIndex {
+    let Some(node) = arena.get(idx) else {
+        return idx;
+    };
+    match node.kind {
+        k if k == syntax_kind_ext::CALL_EXPRESSION => {
+            if let Some(call) = arena.get_call_expr(node) {
+                return optional_chain_root(arena, call.expression);
+            }
+            idx
+        }
+        k if k == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            || k == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION =>
+        {
+            if let Some(access) = arena.get_access_expr(node) {
+                return optional_chain_root(arena, access.expression);
+            }
+            idx
+        }
+        _ => idx,
+    }
+}

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -21,7 +21,7 @@ use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{ObjectShape, PropertyInfo, SymbolRef, TypeId};
+use tsz_solver::{SymbolRef, TypeId};
 
 impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     // =========================================================================
@@ -1106,112 +1106,11 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     }
 
     fn get_global_this_type(&mut self, _error_node: NodeIndex) -> TypeId {
-        if let Some(cached) = self
-            .ctx
-            .type_reference_validation_caches
-            .type_node_surface
-            .global_this_type
-            .get()
-        {
-            return cached;
-        }
-        if self
-            .ctx
-            .type_reference_validation_caches
-            .type_node_surface
-            .global_this_type_in_progress
-            .get()
-        {
-            return TypeId::UNKNOWN;
-        }
-        self.ctx
-            .type_reference_validation_caches
-            .type_node_surface
-            .global_this_type_in_progress
-            .set(true);
-
-        let mut names = rustc_hash::FxHashSet::default();
-        for (name, _) in self.ctx.binder.file_locals.iter() {
-            names.insert(name.clone());
-        }
-        for lib_ctx in self.ctx.lib_contexts.iter() {
-            for (name, _) in lib_ctx.binder.file_locals.iter() {
-                names.insert(name.clone());
-            }
-        }
-        names.insert("globalThis".to_string());
-
-        let mut properties = Vec::new();
-        for name in names {
-            let type_id = if name == "globalThis" {
-                TypeId::UNKNOWN
-            } else {
-                let Some(sym_id) = self.global_this_surface_symbol(&name) else {
-                    continue;
-                };
-                self.ctx
-                    .symbol_types
-                    .get(&sym_id)
-                    .filter(|&type_id| type_id != TypeId::ERROR)
-                    .or_else(|| self.declared_type_for_type_query_symbol(sym_id))
-                    .unwrap_or_else(|| {
-                        self.ctx
-                            .types
-                            .factory()
-                            .type_query(tsz_solver::SymbolRef(sym_id.0))
-                    })
-            };
-
-            let prop_name = self.ctx.types.intern_string(&name);
-            let mut prop = PropertyInfo::new(prop_name, type_id);
-            prop.write_type = type_id;
-            prop.readonly = name == "globalThis";
-            prop.parent_id = self.global_this_surface_symbol(&name);
-            prop.declaration_order = properties.len() as u32;
-            properties.push(prop);
-        }
-
-        let global_this_type = self.ctx.types.factory().object_with_index(ObjectShape {
-            properties,
-            ..ObjectShape::default()
-        });
-        self.ctx
-            .type_reference_validation_caches
-            .type_node_surface
-            .global_this_type
-            .set(Some(global_this_type));
-        self.ctx
-            .type_reference_validation_caches
-            .type_node_surface
-            .global_this_type_in_progress
-            .set(false);
-        global_this_type
-    }
-
-    fn global_this_surface_symbol(&self, name: &str) -> Option<tsz_binder::SymbolId> {
-        use tsz_binder::symbol_flags;
-
-        if let Some(sym_id) = self.ctx.binder.file_locals.get(name)
-            && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
-            && symbol.has_any_flags(symbol_flags::VALUE)
-            && (!symbol.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE)
-                || symbol.has_any_flags(symbol_flags::FUNCTION_SCOPED_VARIABLE))
-        {
-            return Some(sym_id);
-        }
-
-        for lib_ctx in self.ctx.lib_contexts.iter() {
-            if let Some(sym_id) = lib_ctx.binder.file_locals.get(name)
-                && let Some(symbol) = lib_ctx.binder.get_symbol(sym_id)
-                && symbol.has_any_flags(symbol_flags::VALUE)
-                && (!symbol.has_any_flags(symbol_flags::BLOCK_SCOPED_VARIABLE)
-                    || symbol.has_any_flags(symbol_flags::FUNCTION_SCOPED_VARIABLE))
-            {
-                return Some(sym_id);
-            }
-        }
-
-        None
+        // The synthetic `typeof globalThis` surface is owned by `CheckerContext`
+        // so the same object identity is shared with the `typeof` lowering
+        // overrides (`Fn`-typed, hence `&self`). See
+        // `CheckerContext::global_this_surface_type`.
+        self.ctx.global_this_surface_type()
     }
 
     /// Emit TS2693 for a type-only symbol used in a typeof type query.

--- a/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
@@ -246,11 +246,12 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 }
             }
 
-            // Special case: `(typeof globalThis)['key']` — typeof globalThis
-            // resolves to ANY in lowering (no synthetic globalThis type), so the
-            // solver would not emit any error. But tsc treats typeof globalThis
-            // as a specific type whose properties are the globally-visible
-            // `var`/`function`/`namespace` bindings. Reject when the key is:
+            // Special case: `(typeof globalThis)['key']` — `typeof globalThis`
+            // lowers to the synthetic surface object, whose properties are the
+            // globally-visible `var`/`function`/`namespace` bindings. The generic
+            // indexed-access path would surface a structural code (e.g. TS2536)
+            // for a missing literal key, but tsc reports TS2339 here, so this
+            // path owns the missing-property diagnostic. Reject when the key is:
             //   - a block-scoped variable (let/const) — block-scoped bindings
             //     are NOT properties of typeof globalThis;
             //   - a name not bound in the file's global locals at all (e.g.

--- a/crates/tsz-checker/src/types/type_node_lowering.rs
+++ b/crates/tsz-checker/src/types/type_node_lowering.rs
@@ -231,6 +231,12 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             Some(def_id)
         };
         let type_query_override = |expr_name_idx: NodeIndex| -> Option<TypeId> {
+            if let Some(global_this) = self
+                .ctx
+                .global_this_typeof_override(self.ctx.arena, expr_name_idx)
+            {
+                return Some(global_this);
+            }
             if let Some(expr_node) = self.ctx.arena.get(expr_name_idx)
                 && let Some(ident) = self.ctx.arena.get_identifier(expr_node)
                 && let Some(&param_type) =

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -1056,6 +1056,12 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             // These were pre-computed by `precompute_type_query_flow_types` during
             // `check_type_alias_declaration` and stored in `node_types`.
             let type_query_override = |expr_name_idx: NodeIndex| -> Option<TypeId> {
+                if let Some(global_this) = self
+                    .ctx
+                    .global_this_typeof_override(decl_arena, expr_name_idx)
+                {
+                    return Some(global_this);
+                }
                 let const_asserted_array_tuple_in_decl_arena = || -> Option<TypeId> {
                     let expr_node = decl_arena.get(expr_name_idx)?;
                     let ident = decl_arena.get_identifier(expr_node)?;


### PR DESCRIPTION
Closes #14172.

## Structural rule
`typeof globalThis` is the type of the global object — a concrete object whose
members are the globally-visible value bindings (`var`/`function`/`class` plus
lib globals). It is **not** `any`. `tsz` lowered it to `any`, which diverged
from `tsc` two ways:

1. **(FP) TS2322** — `typeof globalThis extends X ? T : F` distributed like
   `any`, producing the apparent union `T | F` instead of resolving the concrete
   branch, so assigning that union to one branch emitted a spurious TS2322.
2. **(FN) TS7053** — `globalThis[key]` element access with a key that is not a
   string-literal *node* (a variable whose type is a string literal/union, or a
   general `string`) never reached the implicit-any path, so the TS7053 `tsc`
   emits under `--strict` (`typeof globalThis` has no index signature) was
   missing.

## Owner layer
- The surface object is built once by `CheckerContext::global_this_surface_type`
  — a `&self`, file-cached builder so it can be consulted from the `Fn`-typed
  `typeof` lowering overrides (`global_this_typeof_override`). The prior
  `TypeNodeChecker` duplicate now delegates to it.
- Element-access TS7053 lives in `types/computation/access.rs`: it resolves a
  literal key against the surface first and only flags a genuinely-absent key
  (or a general-`string` index).

## Adjacent matrix
- Conditional check type, generic type argument, function/var/interface
  annotation positions all resolve `typeof globalThis` concretely.
- `globalThis[k]`: missing literal-typed key → TS7053; general `string` →
  TS7053; present global `var` key → resolved member type (clean); block-scoped
  `let`/`const` key → TS7053 (not a `globalThis` member).
- Fallback: `(typeof globalThis)["missing"]` in type position still reports
  TS2339 via the existing `indexed_access_type` special case.

## Verification
- `cargo test -p tsz-checker --lib global_this_typeof_surface` — 7/7 pass
  (new regression suite covering both parts + adjacent cases).
- Full `cargo test -p tsz-checker --lib`: **no new failures vs. base** (base 75
  failed / mine 73 failed — the 73 are pre-existing per #14149; this change also
  flips 2 pre-existing `source_option_bag` failures to passing).
- `cargo clippy -p tsz-checker --lib` clean; `cargo fmt`.
- Manual repro (release/debug binary) for both issue repros A and B confirms
  `tsc` parity.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude Opus 4.8
Effort: high

Goal: green

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSEwh8ooeu4L7xMsTQF7uY)_