### PR TITLE
fix(solver): model optional index signatures so object-typed sources satisfy Partial&lt;Record&gt; (#14158)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1939,3 +1939,7 @@ path = "tests/construct_signature_boundary_matrix_tests.rs"
 [[test]]
 name = "nullable_union_missing_property_tests"
 path = "tests/nullable_union_missing_property_tests.rs"
+
+[[test]]
+name = "partial_record_optional_index_assignability_tests"
+path = "tests/partial_record_optional_index_assignability_tests.rs"

--- a/crates/tsz-checker/tests/partial_record_optional_index_assignability_tests.rs
+++ b/crates/tsz-checker/tests/partial_record_optional_index_assignability_tests.rs
@@ -1,0 +1,240 @@
+//! Assignability against an *optional* index signature (`[k: K]?: V`), as
+//! produced by `Partial<Record<K, V>>`.
+//!
+//! Regression for the remeda `omitBy` false positive (issue #14158): an object
+//! spread of a generic `T extends object` (typed as `T` itself) — and, more
+//! broadly, any `object`-constrained / property-less source — is assignable to
+//! `Partial<Record<string, unknown>>` even though it is correctly rejected by a
+//! *required* `Record<string, unknown>`. tsc accepts the optional form because
+//! the `?` modifier makes the index signature impose no requirement on a source
+//! that declares no own properties.
+//!
+//! The structural rule (matched against `tsc` 6.x): a source `S` satisfies a
+//! target's string/number index signature when `S` provides a compatible index
+//! signature, OR `S`'s own properties are individually compatible (with `S`
+//! inferable / an explicit index), OR — and this is the optional-only relaxation
+//! — the index signature is OPTIONAL and `S` has no own properties.
+//!
+//! Binder and type-parameter names are varied across cases so no fix can key on
+//! an identifier.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_lib_files};
+
+/// Type-check `source` in strict mode with the es5 lib loaded (so `Record` and
+/// `Partial` resolve) and count the TS2322 assignability errors.
+fn ts2322_count(source: &str) -> usize {
+    let lib_files = load_lib_files(&["es5.d.ts"]);
+    check_source_with_libs_code_messages(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+        &lib_files,
+    )
+    .iter()
+    .filter(|(code, _)| *code == 2322)
+    .count()
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases: must be CLEAN (no TS2322), matching tsc.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn object_spread_of_generic_into_partial_record_is_clean() {
+    // The exact issue witness (renamed binders): `{ ...data }` is typed as the
+    // spread source `T`, which must still satisfy the optional index signature.
+    assert_eq!(
+        ts2322_count(
+            r#"
+export function omitByImpl<Elem extends object>(payload: Elem): Record<string, unknown> {
+  const out: Partial<Record<string, unknown>> = { ...payload };
+  return out;
+}
+"#,
+        ),
+        0,
+        "object spread of a generic must be assignable to Partial<Record<string, unknown>>",
+    );
+}
+
+#[test]
+fn bare_object_constrained_generic_into_partial_record_is_clean() {
+    assert_eq!(
+        ts2322_count(
+            r#"
+function pass<U extends object>(value: U) {
+  const sink: Partial<Record<string, unknown>> = value;
+  return sink;
+}
+"#,
+        ),
+        0,
+        "a bare object-constrained generic must be assignable to an optional index signature",
+    );
+}
+
+#[test]
+fn record_constrained_generic_into_partial_record_is_clean() {
+    assert_eq!(
+        ts2322_count(
+            r#"
+function pass<R extends Record<string, number>>(rec: R) {
+  const sink: Partial<Record<string, unknown>> = { ...rec };
+  return sink;
+}
+"#,
+        ),
+        0,
+        "a Record-constrained generic spread must be assignable to an optional index signature",
+    );
+}
+
+#[test]
+fn object_keyword_into_partial_record_is_clean() {
+    assert_eq!(
+        ts2322_count(
+            r#"
+declare const anything: object;
+const stringIndexed: Partial<Record<string, unknown>> = anything;
+const numberIndexed: Partial<Record<number, unknown>> = anything;
+"#,
+        ),
+        0,
+        "the `object` keyword must be assignable to an optional string/number index signature",
+    );
+}
+
+#[test]
+fn empty_interface_into_partial_record_is_clean() {
+    assert_eq!(
+        ts2322_count(
+            r#"
+interface Empty {}
+declare const blank: Empty;
+const sink: Partial<Record<string, unknown>> = blank;
+"#,
+        ),
+        0,
+        "a property-less named interface must be assignable to an optional index signature",
+    );
+}
+
+#[test]
+fn type_literal_with_props_into_partial_record_is_clean() {
+    // A type literal is an inferable-index source; its members are checked
+    // against the index value type (`number <: unknown`), so it is accepted.
+    assert_eq!(
+        ts2322_count(
+            r#"
+type Lit = { width: number };
+declare const lit: Lit;
+const sink: Partial<Record<string, unknown>> = lit;
+"#,
+        ),
+        0,
+        "a type literal with index-compatible members satisfies the optional index signature",
+    );
+}
+
+#[test]
+fn spread_with_extra_member_into_partial_record_is_clean() {
+    assert_eq!(
+        ts2322_count(
+            r#"
+function withExtra<T extends object>(data: T) {
+  const out: Partial<Record<string, unknown>> = { ...data, extra: 1 };
+  return out;
+}
+"#,
+        ),
+        0,
+        "a spread combined with explicit members must satisfy the optional index signature",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: must STILL error (TS2322), matching tsc. These prove the
+// optional relaxation did not loosen the *required* index relation, nor the
+// value-type check.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generic_into_required_record_still_errors() {
+    // A *required* index signature still rejects a property-less source: the
+    // optionality relaxation must not leak here.
+    assert!(
+        ts2322_count(
+            r#"
+function omit<T extends object>(data: T) {
+  const out: Record<string, unknown> = { ...data };
+  return out;
+}
+"#,
+        ) >= 1,
+        "object spread of a generic must NOT satisfy a required Record<string, unknown>",
+    );
+}
+
+#[test]
+fn object_keyword_into_required_record_still_errors() {
+    assert!(
+        ts2322_count(
+            r#"
+declare const anything: object;
+const sink: Record<string, unknown> = anything;
+"#,
+        ) >= 1,
+        "the `object` keyword must NOT satisfy a required index signature",
+    );
+}
+
+#[test]
+fn named_interface_with_props_into_partial_record_still_errors() {
+    // A named interface/class with own properties is NOT an inferable-index
+    // source, so it stays rejected even against the optional index signature.
+    assert!(
+        ts2322_count(
+            r#"
+interface Point { x: number }
+declare const point: Point;
+const sink: Partial<Record<string, unknown>> = point;
+"#,
+        ) >= 1,
+        "a named interface with properties must NOT satisfy the optional index signature",
+    );
+}
+
+#[test]
+fn class_instance_with_props_into_partial_record_still_errors() {
+    assert!(
+        ts2322_count(
+            r#"
+class Widget { id = 1 }
+declare const widget: Widget;
+const sink: Partial<Record<string, unknown>> = widget;
+"#,
+        ) >= 1,
+        "a class instance with properties must NOT satisfy the optional index signature",
+    );
+}
+
+#[test]
+fn spread_into_partial_record_with_incompatible_value_still_errors() {
+    // The optional relaxation only covers property-less sources. A source with a
+    // property whose value is incompatible with the index value type must error.
+    assert!(
+        ts2322_count(
+            r#"
+function bad(data: { label: string }) {
+  const out: Partial<Record<string, number>> = { ...data };
+  return out;
+}
+"#,
+        ) >= 1,
+        "an incompatible property value must NOT satisfy an optional numeric-valued index signature",
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -842,18 +842,26 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             &mut properties,
         );
 
+        // Track whether each materialized index signature is optional (`?`
+        // modifier). Recorded as shape-level flags below, since `IndexSignature`
+        // cannot carry it.
+        let mut string_index_optional = false;
+        let mut number_index_optional = false;
+
         let string_index = if key_set.has_string {
             match self.remap_key_type_for_mapped(mapped, TypeId::STRING) {
                 Ok(Some(remapped)) => {
                     if remapped != TypeId::STRING {
                         return self.interner().mapped(*mapped);
                     }
-                    Some(self.build_index_signature_for_mapped(
+                    let (sig, optional) = self.build_index_signature_for_mapped(
                         *mapped,
                         TypeId::STRING,
                         is_identity_homomorphic || is_homomorphic,
                         source_object,
-                    ))
+                    );
+                    string_index_optional = optional;
+                    Some(sig)
                 }
                 Ok(None) => None,
                 Err(()) => return self.interner().mapped(*mapped),
@@ -868,12 +876,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     if remapped != TypeId::NUMBER {
                         return self.interner().mapped(*mapped);
                     }
-                    Some(self.build_index_signature_for_mapped(
+                    let (sig, optional) = self.build_index_signature_for_mapped(
                         *mapped,
                         TypeId::NUMBER,
                         is_identity_homomorphic || is_homomorphic,
                         source_object,
-                    ))
+                    );
+                    number_index_optional = optional;
+                    Some(sig)
                 }
                 Ok(None) => None,
                 Err(()) => return self.interner().mapped(*mapped),
@@ -885,12 +895,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let string_index = if string_index.is_none() && !key_set.template_literals.is_empty() {
             let key_type =
                 crate::utils::union_or_single(self.interner(), key_set.template_literals);
-            Some(self.build_index_signature_for_mapped(
+            let (sig, optional) = self.build_index_signature_for_mapped(
                 *mapped,
                 key_type,
                 is_identity_homomorphic || is_homomorphic,
                 source_object,
-            ))
+            );
+            string_index_optional = optional;
+            Some(sig)
         } else {
             string_index
         };
@@ -900,11 +912,17 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // constraint, so `keyof` of the materialized object is the
             // constraint key space (see `ObjectFlags::MAPPED_CONSTRAINT_KEYS`).
             // Homomorphic maps keep `keyof T` and stay unflagged.
-            let flags = if is_homomorphic || is_identity_homomorphic {
+            let mut flags = if is_homomorphic || is_identity_homomorphic {
                 ObjectFlags::empty()
             } else {
                 ObjectFlags::MAPPED_CONSTRAINT_KEYS
             };
+            if string_index_optional {
+                flags |= ObjectFlags::STRING_INDEX_OPTIONAL;
+            }
+            if number_index_optional {
+                flags |= ObjectFlags::NUMBER_INDEX_OPTIONAL;
+            }
             self.interner().object_with_index(ObjectShape {
                 flags,
                 properties,
@@ -917,13 +935,19 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
+    /// Build the result index signature for a mapped type, returning whether the
+    /// `?` modifier made it *optional* (`[k: K]?: V`). The optionality cannot be
+    /// stored on `IndexSignature` itself (it has no such slot); the caller records
+    /// it as a shape-level `STRING_INDEX_OPTIONAL` / `NUMBER_INDEX_OPTIONAL` flag
+    /// so the assignability relation can relax the index requirement for a
+    /// property-less source, exactly as tsc does for an optional index signature.
     fn build_index_signature_for_mapped(
         &mut self,
         mapped: MappedType,
         key_type: TypeId,
         inherits_modifiers: bool,
         source_object: Option<TypeId>,
-    ) -> IndexSignature {
+    ) -> (IndexSignature, bool) {
         let subst = TypeSubstitution::single(mapped.type_param.name, key_type);
         let instantiated =
             instantiate_type_cached(self.interner(), self.query_db(), mapped.template, &subst);
@@ -933,12 +957,15 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         if idx_optional {
             value_type = self.interner().union2(value_type, TypeId::UNDEFINED);
         }
-        IndexSignature {
-            key_type,
-            value_type,
-            readonly: idx_readonly,
-            param_name: None,
-        }
+        (
+            IndexSignature {
+                key_type,
+                value_type,
+                readonly: idx_readonly,
+                param_name: None,
+            },
+            idx_optional,
+        )
     }
 
     /// Evaluate a mapped type with an `as` clause when the constraint is a union of

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -734,20 +734,24 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // It's assignable to any object type where all properties are optional,
             // since no required properties need to be satisfied.
             //
-            // However, `object` is NOT assignable to types with index signatures
-            // (e.g., `{ [s: string]: unknown }`). In tsc, `object` lacks an implicit
-            // index signature, so assigning it to `{ [s: string]: T }` fails with
-            // "Index signature for type 'string' is missing in type '{}'".
-            // Note: `{}` IS assignable to indexed types (handled elsewhere), but the
-            // `object` keyword gets stricter treatment in tsc.
+            // However, `object` is NOT assignable to types with a *required* index
+            // signature (e.g., `{ [s: string]: unknown }`). In tsc, `object` lacks an
+            // implicit index signature, so assigning it to `Record<string, T>` fails
+            // with "Index signature for type 'string' is missing in type '{}'".
+            // An *optional* index signature (`Partial<Record<string, T>>`) imposes no
+            // requirement, so `object` IS assignable to it — the same relaxation the
+            // structural index-relation applies for a property-less source.
+            // Note: `{}` IS assignable to required indexed types too (handled
+            // elsewhere via the inferable-index rule), but the `object` keyword gets
+            // stricter treatment in tsc.
             if s_kind == IntrinsicKind::Object {
                 let target_shape = object_shape_id(self.interner, target)
                     .or_else(|| object_with_index_shape_id(self.interner, target));
                 if let Some(t_shape_id) = target_shape {
                     let t_shape = self.interner.object_shape(t_shape_id);
                     if t_shape.properties.iter().all(|p| p.optional)
-                        && t_shape.string_index.is_none()
-                        && t_shape.number_index.is_none()
+                        && (t_shape.string_index.is_none() || t_shape.string_index_is_optional())
+                        && (t_shape.number_index.is_none() || t_shape.number_index_is_optional())
                     {
                         return SubtypeResult::True;
                     }

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -1051,6 +1051,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 SubtypeResult::True
             }
             None => {
+                // An *optional* target string index (`[k: string]?: V`, e.g.
+                // `Partial<Record<string, V>>`) imposes no requirement on a
+                // property-less source. tsc accepts `object`, `{}`, an empty
+                // interface, or an `object`-constrained generic `T` against it,
+                // even though a *required* `Record<string, V>` rejects them all.
+                // (A source WITH properties is still subject to the inferable-
+                // index / explicit-index rules below — `interface Foo { x }` is
+                // rejected, a `{ x }` type literal checks its members.)
+                if target.string_index_is_optional() && source.properties.is_empty() {
+                    return SubtypeResult::True;
+                }
+
                 // Target has string index, source doesn't have a string index.
                 // Check if source has a number index — in TypeScript, a numeric index
                 // signature implies a string index (JS converts numeric keys to strings).
@@ -1214,6 +1226,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 SubtypeResult::True
             }
             None => {
+                // An *optional* target number index (`[k: number]?: V`, e.g.
+                // `Partial<Record<number, V>>`) imposes no requirement on a
+                // property-less source — the numeric mirror of the optional
+                // string-index relaxation above.
+                if target.number_index_is_optional() && source.properties.is_empty() {
+                    return SubtypeResult::True;
+                }
+
                 // TypeScript only synthesizes an implicit numeric index signature
                 // for anonymous object types and enum namespaces. Named class/interface
                 // instance types must declare a real number/string index signature.
@@ -1705,11 +1725,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // Named class/interface types require an explicit string index signature to
         // satisfy a string-indexed target — compatible properties alone are not enough.
         // Symbol-keyed indices and any-value targets are exempted (same shortcircuits
-        // as check_string_index_compatibility).
-        if target.string_index.as_ref().is_some_and(|idx| {
-            idx.key_type != TypeId::SYMBOL
-                && (self.disable_method_bivariance || !idx.value_type.is_any())
-        }) && self.requires_explicit_declared_index_signature_for(&source_shape, source_receiver)
+        // as check_string_index_compatibility). An *optional* target string index
+        // imposes no requirement on a property-less source, so it is exempt too
+        // (mirrors the relaxation in `check_string_index_compatibility`).
+        let optional_index_satisfied_by_empty_source =
+            target.string_index_is_optional() && source_shape.properties.is_empty();
+        if !optional_index_satisfied_by_empty_source
+            && target.string_index.as_ref().is_some_and(|idx| {
+                idx.key_type != TypeId::SYMBOL
+                    && (self.disable_method_bivariance || !idx.value_type.is_any())
+            })
+            && self.requires_explicit_declared_index_signature_for(&source_shape, source_receiver)
         {
             return SubtypeResult::False;
         }

--- a/crates/tsz-solver/src/tests/file_size_baselines.txt
+++ b/crates/tsz-solver/src/tests/file_size_baselines.txt
@@ -27,13 +27,13 @@ solver_file_narrowing_core 2718
 solver_file_relations_compat 2950
 solver_file_constraints_walker 2348
 solver_file_diag_format_mod 2318
-solver_file_eval_mapped 1384
+solver_file_eval_mapped 1396
 solver_file_subtype_generics 2217
 solver_file_call_args 2097
 solver_file_eval_index_access 2226
 solver_file_def_core 2244
 solver_file_visitor_predicates 742
-solver_file_types 2018
+solver_file_types   2045
 
 binder_max_loc        2890
 binder_oversized      1

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -1256,6 +1256,22 @@ bitflags::bitflags! {
         /// object of the same shape. It is identity-only: structural subtyping
         /// ignores it (a merged `A & B` and a plain `{ a; b }` still relate).
         const INTERSECTION_MERGED = 1 << 9;
+
+        /// The `string_index` signature is *optional* (`[k: string]?: V`), as
+        /// produced by an optional mapped type such as `Partial<Record<string, V>>`.
+        /// tsc has no `optional` slot on an `IndexInfo`; the `?` modifier instead
+        /// makes the index signature impose no requirement on a property-less
+        /// source, so an `object`-typed value (or an `object`-constrained generic)
+        /// is assignable to it even though it is rejected by a *required* index
+        /// signature. The value type already carries `| undefined` (added when the
+        /// mapped type is evaluated); this flag records the relaxation needed by
+        /// the assignability relation and keeps the optional form a distinct
+        /// interned shape from the required `Record<string, V>`.
+        const STRING_INDEX_OPTIONAL = 1 << 10;
+
+        /// The `number_index` signature is *optional* (`[k: number]?: V`). The
+        /// numeric mirror of [`Self::STRING_INDEX_OPTIONAL`].
+        const NUMBER_INDEX_OPTIONAL = 1 << 11;
     }
 }
 
@@ -1324,6 +1340,18 @@ impl ObjectShape {
     /// directly outside the solver.
     pub fn mark_no_module_augmentation_lookup(&mut self) {
         self.flags |= ObjectFlags::NO_MODULE_AUGMENTATION_LOOKUP;
+    }
+
+    /// Return true if this shape's `string_index` signature is optional
+    /// (`[k: string]?: V`, e.g. from `Partial<Record<string, V>>`).
+    pub const fn string_index_is_optional(&self) -> bool {
+        self.flags.contains(ObjectFlags::STRING_INDEX_OPTIONAL)
+    }
+
+    /// Return true if this shape's `number_index` signature is optional
+    /// (`[k: number]?: V`, e.g. from `Partial<Record<number, V>>`).
+    pub const fn number_index_is_optional(&self) -> bool {
+        self.flags.contains(ObjectFlags::NUMBER_INDEX_OPTIONAL)
     }
 }
 


### PR DESCRIPTION
Closes #14158.

Goal: green

## Summary

On a clean clone of remeda (strict, tsc 0 errors), tsz rejected an object spread
of a generic into an index-signature record:

```
src/omitBy.ts(173,9): TS2322: Type 'T' is not assignable to type 'Partial<Record<string, unknown>>'.
```

Minimal witness (tsc: 0, tsz: 1 before this PR):

```ts
export function omitByImpl<T extends object>(data: T): Record<string, unknown> {
  const out: Partial<Record<string, unknown>> = { ...data }; // tsz TS2322
  return out;
}
```

## Root cause

An *optional* mapped type such as `Partial<Record<string, V>>` produces an
index signature whose `?` modifier makes it impose **no** requirement on a
property-less source. tsc accepts `object`, `{}`, an empty interface, or an
`object`-constrained generic `T` against `Partial<Record<...>>`, even though it
rejects all of them against a *required* `Record<...>`.

tsz had **no representation for an optional index signature** — `IndexSignature`
has no such slot, so `Partial<Record<string, unknown>>` interned identically to
`Record<string, unknown>`, and the assignability relation over-rejected. (The
spread `{ ...data }` is typed as the source `T`, which then fails `T <:
Partial<Record<...>>`.)

## Structural rule

> When a target's string/number index signature is OPTIONAL and the source
> declares no own properties, tsc treats the index requirement as vacuously
> satisfied; tsz now does the same through the solver.

A source WITH properties is unaffected: a `{ x }` type literal still checks its
members against the index value type, and a named `interface Foo { x }` / class
instance is still rejected for lacking an inferable index. A REQUIRED index
signature is unchanged.

## Owner layer & approach (solver)

`IndexSignature` cannot grow a field without touching ~49 construction sites and
is, in tsc's model, not where optionality lives. Optionality is instead recorded
as two shape-level flags — `ObjectFlags::STRING_INDEX_OPTIONAL` /
`NUMBER_INDEX_OPTIONAL` — set when an optional mapped type materializes its index
signature (`evaluate_rules/mapped.rs`). This is consistent with existing
shape-level facts (`FRESH_LITERAL`, `MAPPED_CONSTRAINT_KEYS`) and keeps the
optional form a **distinct interned shape** from the required `Record`.

The relation relaxation ("optional target index + property-less source =>
assignable") lives at the index-requirement decision sites:
`check_string_index_compatibility`, `check_number_index_compatibility`,
`check_object_to_indexed`, and the `object`-keyword dispatch in
`core_dispatch.rs`.

## Anti-hardcoding

Purely structural: keyed on the shape's index-signature optionality flag and
`source.properties.is_empty()` — no identifier, alias, file-name, or
rendered-type-string checks. Test binder/type-parameter names are varied.

## Adjacent matrix (verified against tsc 6.x)

Accept `Partial<Record<...>>`: object-spread of a generic; bare
`object`-constrained `T`; `Record`-constrained `T`; the `object` keyword
(string + number index); empty interface; index-compatible type literal; spread
combined with an explicit member.

Still error (negative controls): required `Record<string, unknown>`; named
interface/class with properties against `Partial<Record<...>>`; incompatible
property value against `Partial<Record<string, number>>`.

## Verification

- New `cargo test -p tsz-checker --test partial_record_optional_index_assignability_tests` — 12/12 (7 positive, 5 negative controls), red on base / green with the fix.
- `cargo test -p tsz-solver --lib` — no net-new failures (the 4 pre-existing platform-delta failures are identical with the change stashed); the file-size ratchet baseline was updated for the +12 lines in `evaluate_rules/mapped.rs`.
- `cargo test -p tsz-checker --lib` — no net-new failures vs the clean-tree baseline; the only delta is a different member of the pre-existing order-dependent `source_option_bag_tests` flaky family (passes in isolation; orthogonal to index-signature semantics).
- Witness + full adjacent matrix diffed against `tsc` 6.x: identical error codes/locations.
- `cargo fmt -p tsz-solver -p tsz-checker --check`, `cargo clippy -p tsz-solver`, `git diff --check` — clean.
- Reviewed with `/simplify` (reuse/simplification/efficiency/altitude): the ObjectFlags altitude was confirmed correct; no net-positive changes found.
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfDnuFhDUNniMU61sqUMHz)_