### PR TITLE
fix(checker): preserve namespace/enum meaning through cross-binder re-exports

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1353,13 +1353,78 @@ impl<'a> CheckerContext<'a> {
     ) -> Option<tsz_binder::SymbolId> {
         let source_file_idx = self.resolve_symbol_file_index(alias_id)?;
         let target_idx = self.resolve_import_target_from_file(source_file_idx, module_specifier)?;
+        let mut visited = FxHashSet::default();
+        self.resolve_export_in_target_file(target_idx, member_name, &mut visited)
+    }
+
+    /// Resolve `export_name` from `target_idx`'s public surface, following named
+    /// and wildcard re-export edges across binder boundaries.
+    ///
+    /// Unlike [`tsz_binder::BinderState::resolve_import_with_reexports_type_only`],
+    /// this consults the program-wide export/re-export indexes through
+    /// [`Self::module_exports_for_module`], [`Self::reexports_for_file`], and
+    /// [`Self::wildcard_reexports_for_file`]. Those indexes are the authoritative
+    /// source of truth in multi-file mode, where each file's own binder keeps its
+    /// `module_exports`/`reexports`/`wildcard_reexports` tables empty and the
+    /// data is hoisted into the program skeleton instead. Resolving a member
+    /// through a re-exported namespace/alias that lives in another binder must go
+    /// through this program-aware path or the lookup silently misses every
+    /// export (the cause of the cross-binder TS2503/TS2339 family).
+    pub fn resolve_export_in_target_file(
+        &self,
+        target_idx: usize,
+        export_name: &str,
+        visited: &mut FxHashSet<usize>,
+    ) -> Option<tsz_binder::SymbolId> {
+        if !visited.insert(target_idx) {
+            return None;
+        }
         let target_binder = self.get_binder_for_file(target_idx)?;
         let target_arena = self.get_arena_for_file(target_idx as u32);
-        let file_name = &target_arena.source_files.first()?.file_name;
-        // Use the target binder's own re-export resolution (handles
-        // direct exports, named re-exports, and wildcard re-exports).
+        let file_name = target_arena.source_files.first()?.file_name.clone();
+
+        // Direct exports (program-aware).
+        if let Some(exports) = self.module_exports_for_module(target_binder, &file_name)
+            && let Some(sym_id) = exports.get(export_name)
+            && target_binder.get_symbol(sym_id).is_some()
+        {
+            self.register_symbol_file_target(sym_id, target_idx);
+            return Some(sym_id);
+        }
+
+        // Named re-exports: `export { foo } from './other'` (and `as` renames).
+        if let Some(reexports) = self.reexports_for_file(target_binder, &file_name)
+            && let Some((source_module, original_name)) = reexports.get(export_name)
+        {
+            let name = original_name.as_deref().unwrap_or(export_name);
+            if let Some(source_idx) =
+                self.resolve_import_target_from_file(target_idx, source_module)
+                && let Some(resolved) =
+                    self.resolve_export_in_target_file(source_idx, name, visited)
+            {
+                return Some(resolved);
+            }
+        }
+
+        // Wildcard re-exports: `export * from './other'`.
+        if let Some(source_modules) = self.wildcard_reexports_for_file(target_binder, &file_name) {
+            let source_modules = source_modules.clone();
+            for (source_module, _is_type_only) in &source_modules {
+                if let Some(source_idx) =
+                    self.resolve_import_target_from_file(target_idx, source_module)
+                    && let Some(resolved) =
+                        self.resolve_export_in_target_file(source_idx, export_name, visited)
+                {
+                    return Some(resolved);
+                }
+            }
+        }
+
+        // Fallback: the target binder's own re-export resolution for
+        // single-file / ambient-module binders whose local tables are
+        // populated (e.g. `declare module "x" { ... }`).
         target_binder
-            .resolve_import_with_reexports_type_only(file_name, member_name)
+            .resolve_import_with_reexports_type_only(&file_name, export_name)
             .map(|(sym_id, _)| {
                 self.register_symbol_file_target(sym_id, target_idx);
                 sym_id

--- a/crates/tsz-checker/src/types/computation/identifier/resolved.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/resolved.rs
@@ -1303,7 +1303,21 @@ impl CheckerState<'_> {
                 }
             }
         } else {
-            self.get_type_of_symbol(sym_id)
+            let base = self.get_type_of_symbol(sym_id);
+            if (flags & symbol_flags::ALIAS) != 0 {
+                // An import/re-export alias that (transitively) resolves to an
+                // enum yields the enum's *instance* type from
+                // `get_type_of_symbol`. In a value position the reference
+                // denotes the enum object (`typeof E`), so convert it to the
+                // enum-namespace type — the same mapping the direct-enum branch
+                // above applies. This matters across re-export hops
+                // (`export { E } from "..."`), where the local symbol is an
+                // alias rather than the enum itself. No-op for aliases that
+                // resolve to non-enum targets.
+                self.get_enum_namespace_type_for_value(base)
+            } else {
+                base
+            }
         };
         let mut declared_type = if self.ctx.is_js_file()
             && self.ctx.should_resolve_jsdoc()

--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -144,6 +144,10 @@ name = "lib_target_suggestion_ts2550_tests"
 path = "tests/lib_target_suggestion_ts2550_tests.rs"
 
 [[test]]
+name = "cross_binder_reexport_meaning_tests"
+path = "tests/cross_binder_reexport_meaning_tests.rs"
+
+[[test]]
 name = "imported_infer_readonly_alias_cli_tests"
 path = "tests/imported_infer_readonly_alias_cli_tests.rs"
 

--- a/crates/tsz-cli/tests/cross_binder_reexport_meaning_tests.rs
+++ b/crates/tsz-cli/tests/cross_binder_reexport_meaning_tests.rs
@@ -1,0 +1,213 @@
+//! Cross-binder re-export meaning preservation (issue #14168).
+//!
+//! A symbol re-exported across binder/module boundaries must preserve **all**
+//! of its meanings (value, type, namespace). These CLI tests run the real
+//! multi-file driver — the bug only manifests once the program skeleton hoists
+//! each file's exports into the program-wide index and leaves the per-file
+//! binder `module_exports` table empty, which an entry-only checker harness
+//! does not reproduce.
+//!
+//! Two regressions are pinned:
+//!
+//! * A re-exported `import * as ns` namespace keeps its **type** meaning, so
+//!   `ns.SomeType` in type position resolves the member instead of reporting
+//!   `TS2503` ("Cannot find namespace").
+//! * A re-exported `enum` referenced in a value position is typed as
+//!   `typeof Enum`, so `Enum.Member` resolves instead of reporting `TS2339`,
+//!   even across several re-export hops where the local symbol is an alias.
+//!
+//! Binder names and file names are varied across cases so the behaviour follows
+//! structure, not identifier text.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+/// Run `tsz -p tsconfig.json` over `files` (relative name, contents), returning
+/// combined stdout+stderr.
+///
+/// The driver is invoked in **project mode** (a generated `tsconfig.json`),
+/// not single-entry mode. The cross-binder namespace regression only manifests
+/// once the program skeleton hoists each file's exports into the program-wide
+/// index and leaves the per-file binder `module_exports` table empty — which
+/// only happens on the project path. `entry` is recorded for documentation but
+/// the project's `include` covers every written file.
+fn run_tsz(files: &[(&str, &str)], _entry: &str) -> String {
+    let Some(tsz_bin) = find_tsz_binary() else {
+        return String::from("__SKIP__");
+    };
+    let dir = tempfile::tempdir().expect("temp dir");
+    for (name, contents) in files {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dir");
+        }
+        std::fs::write(path, contents).expect("write file");
+    }
+    std::fs::write(
+        dir.path().join("tsconfig.json"),
+        r#"{ "compilerOptions": { "noEmit": true, "strict": true, "target": "esnext", "module": "esnext", "moduleResolution": "bundler", "skipLibCheck": true } }"#,
+    )
+    .expect("write tsconfig.json");
+
+    let output = Command::new(tsz_bin)
+        .args(["-p", "tsconfig.json", "--pretty", "false"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run tsz");
+
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    combined
+}
+
+/// Repro A: a namespace import re-exported by name keeps its type meaning, so a
+/// `ns.Member` reference in type position resolves rather than reporting TS2503.
+#[test]
+fn reexported_namespace_keeps_type_meaning() {
+    let out = run_tsz(
+        &[
+            ("sub/impl.ts", "export type Compose<X> = [X];\n"),
+            (
+                "sub/barrel.ts",
+                "import * as F from './impl';\nexport { F };\n",
+            ),
+            (
+                "consumer.ts",
+                "import { F } from './sub/barrel';\ndeclare const x: F.Compose<'sync'>;\nexport {};\n",
+            ),
+        ],
+        "consumer.ts",
+    );
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("TS2503"),
+        "re-exported namespace must keep its type meaning (no TS2503), got:\n{out}"
+    );
+}
+
+/// The re-exported namespace must keep BOTH meanings: the value form
+/// (`ns.value`) and the type form (`ns.Type`) resolve from the same import.
+#[test]
+fn reexported_namespace_keeps_value_and_type_meaning() {
+    let out = run_tsz(
+        &[
+            (
+                "pkg/origin.ts",
+                "export const tag = 1;\nexport type Wrap<X> = [X];\n",
+            ),
+            (
+                "pkg/hub.ts",
+                "import * as NS from './origin';\nexport { NS };\n",
+            ),
+            (
+                "site.ts",
+                "import { NS } from './pkg/hub';\nconst v = NS.tag;\ntype T = NS.Wrap<'x'>;\ndeclare const y: T;\nexport {};\n",
+            ),
+        ],
+        "site.ts",
+    );
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("TS2503") && !out.contains("TS2339"),
+        "re-exported namespace must keep value and type meaning, got:\n{out}"
+    );
+}
+
+/// Repro B: an enum re-exported through several hops is typed as `typeof Enum`
+/// in value position, so member access resolves instead of reporting TS2339.
+#[test]
+fn reexported_enum_typed_as_typeof_through_hops() {
+    let out = run_tsz(
+        &[
+            (
+                "kinds.ts",
+                "export enum Kind { NAME = 'Name', DIRECTIVE = 'Directive' }\n",
+            ),
+            ("language.ts", "export { Kind } from './kinds';\n"),
+            ("index.ts", "export { Kind } from './language';\n"),
+            (
+                "use.ts",
+                "import { Kind } from './index';\nconst a = Kind.DIRECTIVE;\nconst b = Kind.NAME;\nexport {};\n",
+            ),
+        ],
+        "use.ts",
+    );
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("TS2339"),
+        "re-exported enum must be typed as typeof Enum (no TS2339), got:\n{out}"
+    );
+}
+
+/// Same as above with different binder names and a numeric enum declared in a
+/// `.d.ts`, so the fix is structural and not keyed to `Kind`/`DIRECTIVE` text.
+#[test]
+fn reexported_numeric_enum_typed_as_typeof_renamed_binders() {
+    let out = run_tsz(
+        &[
+            (
+                "codes.d.ts",
+                "declare enum Status { Open = 1, Closed = 2 }\nexport { Status };\n",
+            ),
+            ("mid.d.ts", "export { Status } from './codes';\n"),
+            ("top.d.ts", "export { Status } from './mid';\n"),
+            (
+                "app.ts",
+                "import { Status } from './top';\nconst s = Status.Open;\nconst t = Status.Closed;\nexport {};\n",
+            ),
+        ],
+        "app.ts",
+    );
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("TS2339"),
+        "re-exported numeric enum must be typed as typeof Enum (no TS2339), got:\n{out}"
+    );
+}
+
+/// Parity guard: a genuinely absent enum member on a re-exported enum still
+/// reports TS2339 — the fix must not blanket-suppress member errors.
+#[test]
+fn reexported_enum_missing_member_still_errors() {
+    let out = run_tsz(
+        &[
+            ("e.ts", "export enum Color { Red = 'r' }\n"),
+            ("re1.ts", "export { Color } from './e';\n"),
+            ("re2.ts", "export { Color } from './re1';\n"),
+            (
+                "consume.ts",
+                "import { Color } from './re2';\nconst c = Color.Blue;\nexport {};\n",
+            ),
+        ],
+        "consume.ts",
+    );
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        out.contains("TS2339"),
+        "a genuinely absent enum member must still report TS2339, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Closes #14168.

Goal: green

## Summary
A symbol re-exported across binder/module boundaries lost a meaning. Two facets fixed:

- **Re-exported namespace lost its type meaning** (`TS2503`): `import * as F` re-exported via `export { F }` and consumed as `F.SomeType` in type position reported "Cannot find namespace 'F'".
- **Re-exported enum mistyped** (`TS2339`): an `enum` re-exported through one or more hops was typed as its *instance* type rather than `typeof Enum`, so `Enum.Member` reported "Property does not exist".

## Structural rule
When a symbol is re-exported across binder boundaries, `tsc` preserves all of its meanings (value, type, namespace); `tsz` must too.

- **Member resolution through a cross-binder alias**: `resolve_alias_import_member` resolved the member through the target file's **per-binder** `module_exports` table. In multi-file/project mode that table is empty — exports are hoisted into the program-wide index — so every member lookup silently missed. Owner layer: `tsz_checker` `CheckerContext`. The new `resolve_export_in_target_file` walks direct exports + named re-exports + wildcard re-exports via the program-aware `module_exports_for_module` / `reexports_for_file` / `wildcard_reexports_for_file` accessors, fixing all five callers of `resolve_alias_import_member`.
- **Enum value-position type through an alias**: the value-position identifier resolver applied the enum→`typeof Enum` conversion only when the local symbol carried the `ENUM` flag directly; across a re-export hop the local symbol is an alias. It now applies the same `get_enum_namespace_type_for_value` mapping for alias symbols (a no-op for aliases resolving to non-enum targets), mirroring the direct-enum branch.

## Adjacent-case matrix
- Namespace re-export: value-only meaning already worked; type meaning now resolves; both meanings together resolve.
- Enum re-export: 0 hops (already passed), 1 hop, 2+ hops, numeric enum, `.d.ts`/`declare enum`, varied binder names.
- Fallback preserved: single-file / ambient `declare module "x" { ... }` binders still resolve through the binder's own table.
- Parity guard: a genuinely absent enum member still reports `TS2339` on `typeof Enum` (no blanket suppression).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New CLI project-mode regression suite (`crates/tsz-cli/tests/cross_binder_reexport_meaning_tests.rs`), 5 tests; 4 reproduce the bug (fail on the pre-fix binary) and all 5 pass with the fix:
  - `cargo test -p tsz-cli --test cross_binder_reexport_meaning_tests`
- `cargo build --release -p tsz-cli`; manual repros for both issue repros + multi-hop/value/`.d.ts` variants are clean; negative control still emits `TS2339` on `typeof Kind`.
- `cargo test -p tsz-checker --lib`: 74 pre-existing failures on the base branch → 73 with this change (net −1; no new failures introduced).
- `cargo clippy -p tsz-checker`: clean.

https://claude.ai/code/session_01Q1R4rWPx3suDfTCXYjfbTL