### PR TITLE
fix(solver): negative `in`-narrowing keeps a non-union optional property unchanged (TS2322)

### DIFF
--- a/crates/tsz-checker/src/tests/in_narrow_apparent_member_tests.rs
+++ b/crates/tsz-checker/src/tests/in_narrow_apparent_member_tests.rs
@@ -225,3 +225,90 @@ function reset(config: Config) {
         "expected no TS2790 deleting an optional property, got: {got:?}"
     );
 }
+
+/// The negative `in` branch over a *non-union* receiver must leave an optional
+/// property's value type unchanged, even when its declared type excludes
+/// `undefined`. tsc's `narrowTypeByInKeyword` keeps the constituent (the
+/// property may legitimately be absent at runtime), so a subsequent write of a
+/// valid value to the property still type-checks. The previous behavior
+/// intersected the receiver with a synthetic `{ p: undefined }`, collapsing the
+/// property to `never` and emitting a spurious TS2322 — the ofetch witness.
+#[test]
+fn negative_in_keeps_non_union_optional_property_assignable() {
+    let source = r#"
+interface Opts {
+  method?: string;
+  duplex?: "half";
+}
+declare const options: Opts;
+if (!("duplex" in options)) {
+  options.duplex = "half";
+}
+"#;
+    let got = codes(source);
+    assert!(
+        !got.contains(&2322),
+        "expected no TS2322 — negative `in` must keep an optional property assignable, got: {got:?}"
+    );
+}
+
+/// Binder-name and shape variation of the same rule: the behavior must be driven
+/// by the optional-own-property shape, not by any identifier spelling, and must
+/// hold when the property's declared type is a wider literal union that still
+/// excludes `undefined`.
+#[test]
+fn negative_in_keeps_optional_property_assignable_varied_binders() {
+    let source = r#"
+interface Settings {
+  retries?: number;
+  mode?: "fast" | "slow";
+}
+declare const settings: Settings;
+if (!("mode" in settings)) {
+  settings.mode = "fast";
+}
+"#;
+    let got = codes(source);
+    assert!(
+        !got.contains(&2322),
+        "expected no TS2322 — varied-binder optional property must stay assignable, got: {got:?}"
+    );
+}
+
+/// Negative counterpart for a *required* property: `!("p" in x)` is unreachable
+/// when `p` is guaranteed present, so tsc narrows the receiver to `never`. The
+/// fix preserves this — a required property still drops to `never` on the
+/// negative branch (no spurious acceptance, no synthetic intersection).
+#[test]
+fn negative_in_required_property_narrows_to_never() {
+    let source = r#"
+interface Tagged { tag: "x"; value: number; }
+declare const obj: Tagged;
+if (!("tag" in obj)) {
+    const unreachable: never = obj;
+}
+"#;
+    let got = codes(source);
+    assert!(
+        !got.contains(&2322),
+        "expected the receiver to be `never` on the negative branch of a required property, got: {got:?}"
+    );
+}
+
+/// Union variant: when *every* constituent requires the property, the negative
+/// branch filters them all out, so tsc narrows to `never`. Assigning the
+/// narrowed receiver to a `never` annotation must therefore be accepted.
+#[test]
+fn negative_in_union_all_required_narrows_to_never() {
+    let source = r#"
+declare const node: { kind: "a"; a: 1 } | { kind: "b"; a: 2 };
+if (!("a" in node)) {
+    const unreachable: never = node;
+}
+"#;
+    let got = codes(source);
+    assert!(
+        !got.contains(&2322),
+        "expected `never` when every union member requires the property, got: {got:?}"
+    );
+}

--- a/crates/tsz-solver/src/narrowing/property.rs
+++ b/crates/tsz-solver/src/narrowing/property.rs
@@ -200,16 +200,26 @@ impl<'a> NarrowingContext<'a> {
                 .collect();
 
             if matching.is_empty() {
-                // When NO union member has the property, TypeScript narrows to
-                // `Union & Record<prop, unknown>` instead of `never`.
-                // This matches TSC behavior: if the type could structurally have the
-                // property at runtime (it passed the `in` operator check), we create
-                // an intersection rather than discarding the type entirely.
-                trace!(
-                    "No members have property, creating intersection with Record<prop, unknown>"
-                );
-                let record_type = self.make_record_type(property_name);
-                return self.db.intersect_types_raw2(source_type, record_type);
+                if present {
+                    // Positive branch with NO member declaring the property:
+                    // tsc's `narrowTypeByInKeyword` sees `isKnownProperty` as
+                    // false and, on the `assumeTrue` path, narrows to
+                    // `Union & Record<prop, unknown>` rather than discarding the
+                    // type entirely (it could structurally gain the property at
+                    // runtime, having passed the `in` check).
+                    trace!(
+                        "No members have property, creating intersection with Record<prop, unknown>"
+                    );
+                    let record_type = self.make_record_type(property_name);
+                    return self.db.intersect_types_raw2(source_type, record_type);
+                }
+                // Negative branch with every member *requiring* the property:
+                // `filterType` drops all constituents because the `in` check can
+                // never be false, so tsc narrows to `never`. (A member lacking
+                // the property, or holding it optionally, is kept above, so an
+                // empty result here means presence was guaranteed everywhere.)
+                trace!("All members require property; negative `in` branch is never");
+                return TypeId::NEVER;
             } else if matching.len() == 1 {
                 trace!(
                     "Found single member after filtering, returning {}",
@@ -260,32 +270,29 @@ impl<'a> NarrowingContext<'a> {
             }
         } else {
             // Negative: !("prop" in x)
-            // Exclude ONLY if property is required (not optional)
+            //
+            // tsc's `narrowTypeByInKeyword` runs
+            // `filterType(type, t => isTypePresencePossible(t, name, /*assumeTrue*/ false))`.
+            // For a non-union receiver `filterType` either keeps the whole type
+            // or drops it to `never`; it never rewrites the property's value
+            // type. `isTypePresencePossible` reports a property as *possibly
+            // absent* (keeping the receiver) for every case except a *required*
+            // own property, whose presence is guaranteed and therefore makes
+            // the negative branch unreachable (`never`).
+            //
+            // In particular an *optional* property keeps the receiver unchanged
+            // even when its declared type excludes `undefined`: the property may
+            // legitimately be missing at runtime, so a later `x.p = ...` write
+            // must still type-check. Intersecting the receiver with a synthetic
+            // `{ p: undefined }` shape (the previous behavior) collapsed `p` to
+            // `never` whenever its declared type omitted `undefined`, producing
+            // spurious TS2322 on the negative branch.
             if self.is_property_required(resolved_type, property_name) {
                 return TypeId::NEVER;
             }
-            if let Some(prop) = self.get_property_info(resolved_type, property_name)
-                && prop.optional
-            {
-                let absent_prop = PropertyInfo {
-                    name: property_name,
-                    type_id: TypeId::UNDEFINED,
-                    write_type: prop.write_type,
-                    optional: false,
-                    readonly: false,
-                    is_method: false,
-                    is_class_prototype: false,
-                    visibility: Visibility::Public,
-                    parent_id: None,
-                    declaration_order: 0,
-                    is_string_named: false,
-                    is_symbol_named: false,
-                    single_quoted_name: false,
-                };
-                let filter_obj = self.db.object(vec![absent_prop]);
-                return self.db.intersection2(source_type, filter_obj);
-            }
-            // Keep source_type (no required property found, or property is optional)
+            // Optional own property, index-signature match, or no property at
+            // all: the property may be absent at runtime, so the receiver is
+            // returned unchanged.
             source_type
         }
     }


### PR DESCRIPTION
Fixes #14163

Goal: green

## Structural rule
When the discriminant is `!("p" in x)` and `x` is a **non-union** receiver whose
property `p` is **optional**, `tsc` keeps `x` unchanged in the negative branch —
`p` may legitimately be absent at runtime, so a later `x.p = <value>` write must
still type-check. `tsz` instead synthesized `x & { p: undefined }`, which
collapsed `p` (and the receiver) to `never` whenever `p`'s declared type excluded
`undefined`, producing a spurious `TS2322`. Owner: solver
(`narrow_by_property_presence`).

## Wrong semantic operation
Narrowing. `tsc`'s `narrowTypeByInKeyword` runs
`filterType(type, t => isTypePresencePossible(t, name, assumeTrue))`, which only
**keeps or drops** a constituent — it never rewrites a property's value type.
`isTypePresencePossible` keeps a receiver for an optional property and drops it
to `never` only for a *required* own property (presence guaranteed ⇒ the
negative branch is unreachable). The previous code modeled the negative branch
as a property-rewriting intersection, which has no `tsc` counterpart.

## Fix (both branches aligned to the filter model)
- **Non-union negative branch**: return the receiver unchanged unless `p` is
  required (then `never`). The synthetic `{ p: undefined }` intersection is
  removed.
- **Union empty-result case** now splits by polarity: the positive branch keeps
  the `& Record<prop, unknown>` synthesis (adds structural info for a property no
  member declares); the negative branch — reached only when *every* member
  requires `p` — narrows to `never` instead of synthesizing presence.

The positive-branch `Record<prop, unknown>` synthesis is retained on purpose: it
is information-adding (mirrors `tsc`'s `assumeTrue` path for chained
`"a" in x && "b" in x`), not property-rewriting.

## Repro (verified: tsc clean, tsz was TS2322)
```ts
interface Opts { method?: string; duplex?: "half"; }
declare const options: Opts;
if (!("duplex" in options)) {
  options.duplex = "half";   // tsc OK | tsz was TS2322 (options narrowed to never)
}
```

## Adjacent matrix
- non-union optional, value type excludes `undefined` → receiver unchanged (the repro)
- binder/shape varied (`mode?: "fast" | "slow"`) → unchanged (driven by shape, not spelling)
- non-union required → `never` on the negative branch
- union, every member requires `p` → `never`
- regression guards retained: optional property stays deletable after `"p" in x`
  (TS2790), and `"p" in x` does not strip `undefined` from an optional value
  (TS2322 still reported)

## Verification
- `cargo test -p tsz-checker --lib in_narrow_apparent_member` → 14 passed (4 new + existing guards)
- `cargo test -p tsz-checker --test in_chain_narrows_unconstrained_type_param_tests` → 22 passed
- `cargo build -p tsz-solver` → clean
- Broad conformance/emit/fourslash suites: delegated to ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_0153Gy7dzshUKVS7RGkvvxLu)_