### PR TITLE
fix(checker): existential spread-arity for overloaded callables (TS2556)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -935,6 +935,9 @@ path = "tests/inline_mapped_array_return_tests.rs"
 name = "overload_inference_literal_preservation_tests"
 path = "tests/overload_inference_literal_preservation_tests.rs"
 [[test]]
+name = "overload_spread_into_rest_ts2556_tests"
+path = "tests/overload_spread_into_rest_ts2556_tests.rs"
+[[test]]
 name = "issue_3768_generic_callback_outer_inference_tests"
 path = "tests/issue_3768_generic_callback_outer_inference_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
@@ -586,20 +586,19 @@ impl<'a> CheckerState<'a> {
                             tuple_slice_variable_rest_offset(self.ctx.types, &elems)
                         {
                             let variable_index = effective_index + variable_offset;
-                            let at_rest_position = if let Some(callable_type) =
-                                callable_ctx.callable_type
-                            {
-                                let ctx = ContextualTypeContext::with_expected(
-                                    self.ctx.types,
-                                    callable_type,
-                                );
-                                ctx.allows_non_tuple_spread_position(variable_index, expanded_count)
-                            } else {
-                                // No callable type means callee is
-                                // any/error/unknown; accept the spread when a
-                                // large-index probe still resolves a param.
-                                expected_for_index(usize::MAX / 2, expanded_count).is_some()
-                            };
+                            let at_rest_position =
+                                if let Some(callable_type) = callable_ctx.callable_type {
+                                    let ctx = ContextualTypeContext::with_expected(
+                                        self.ctx.types,
+                                        callable_type,
+                                    );
+                                    ctx.allows_non_tuple_spread_position(variable_index)
+                                } else {
+                                    // No callable type means callee is
+                                    // any/error/unknown; accept the spread when a
+                                    // large-index probe still resolves a param.
+                                    expected_for_index(usize::MAX / 2, expanded_count).is_some()
+                                };
                             if !at_rest_position
                                 && !self.spread_callee_infers_params_from_arguments(
                                     arg_idx,
@@ -832,13 +831,10 @@ impl<'a> CheckerState<'a> {
                             // fall back to the large-index probe heuristic.
                             let at_rest_position =
                                 if let Some(callable_type) = callable_ctx.callable_type {
-                                    let ctx = ContextualTypeContext::with_expected(
-                                        self.ctx.types,
+                                    self.spread_lands_on_rest_position(
                                         callable_type,
-                                    );
-                                    ctx.allows_non_tuple_spread_position(
                                         effective_index,
-                                        expanded_count,
+                                        callable_ctx.union_is_overload_set,
                                     )
                                 } else {
                                     // No callable type means callee is any/error/unknown.
@@ -895,17 +891,18 @@ impl<'a> CheckerState<'a> {
                         // a rest parameter position (same logic as array spread above).
                         let current_expected = expected_for_index(effective_index, expanded_count);
 
-                        let at_rest_position = if let Some(callable_type) =
-                            callable_ctx.callable_type
-                        {
-                            let ctx =
-                                ContextualTypeContext::with_expected(self.ctx.types, callable_type);
-                            ctx.allows_non_tuple_spread_position(effective_index, expanded_count)
-                        } else {
-                            // No callable type → callee is any/error/unknown; accept spread
+                        let at_rest_position =
+                            if let Some(callable_type) = callable_ctx.callable_type {
+                                self.spread_lands_on_rest_position(
+                                    callable_type,
+                                    effective_index,
+                                    callable_ctx.union_is_overload_set,
+                                )
+                            } else {
+                                // No callable type → callee is any/error/unknown; accept spread
 
-                            expected_for_index(usize::MAX / 2, expanded_count).is_some()
-                        };
+                                expected_for_index(usize::MAX / 2, expanded_count).is_some()
+                            };
 
                         if !at_rest_position {
                             if current_expected.is_none() {
@@ -1825,32 +1822,6 @@ impl<'a> CheckerState<'a> {
         func_type: TypeId,
     ) {
         let ctx = ContextualTypeContext::with_expected(self.ctx.types, func_type);
-        let mut expanded_count = 0usize;
-        for &arg_idx in args {
-            if let Some(arg_node) = self.ctx.arena.get(arg_idx)
-                && arg_node.kind == syntax_kind_ext::SPREAD_ELEMENT
-                && let Some(spread_data) = self.ctx.arena.get_spread(arg_node)
-            {
-                let spread_type = self.normalized_spread_argument_type(spread_data.expression);
-                // A variadic-tuple type-parameter spread stays a single unit (see argument
-                // collection); do not count its constraint's tuple elements.
-                if let Some(elems) = tuple_elements_for_type(self.ctx.types, spread_type)
-                    && !type_param_variadic_tuple_spread(self.ctx.types, spread_type, &elems)
-                {
-                    expanded_count += elems.len();
-                    continue;
-                }
-                if array_element_type_for_type(self.ctx.types, spread_type).is_some()
-                    && let Some(expr_node) = self.ctx.arena.get(spread_data.expression)
-                    && let Some(literal) = self.ctx.arena.get_literal_expr(expr_node)
-                {
-                    expanded_count += literal.elements.nodes.len();
-                    continue;
-                }
-            }
-            expanded_count += 1;
-        }
-
         let mut effective_index = 0usize;
         for &arg_idx in args {
             let Some(arg_node) = self.ctx.arena.get(arg_idx) else {
@@ -1905,9 +1876,7 @@ impl<'a> CheckerState<'a> {
             let is_non_tuple_spread = array_element_type_for_type(self.ctx.types, spread_type)
                 .is_some()
                 || self.is_iterable_type(spread_type);
-            if is_non_tuple_spread
-                && !ctx.allows_non_tuple_spread_position(effective_index, expanded_count)
-            {
+            if is_non_tuple_spread && !ctx.allows_non_tuple_spread_position(effective_index) {
                 self.error_spread_must_be_tuple_or_rest_at(arg_idx);
                 return;
             }

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -27,18 +27,43 @@ use tsz_solver::TypeId;
 pub(crate) struct CallableContext {
     /// The callable type of the call expression being processed.
     pub callable_type: Option<TypeId>,
+    /// Whether [`CallableContext::callable_type`] is the synthetic
+    /// `sigA | sigB | ...` union built for the overload-resolution first pass.
+    ///
+    /// That union is an *existential* alternative set: a call type-checks when
+    /// *some* member admits it, not all. The non-tuple-spread arity check
+    /// (TS2556) must therefore treat the union existentially here — a non-tuple
+    /// spread lands on a rest position as long as *any* overload has a rest
+    /// parameter at that slot. Without this, `Array.prototype.splice`'s
+    /// `(start, deleteCount?)` overload (no rest) would poison a valid spread
+    /// into the `(start, deleteCount, ...items)` overload's rest. A genuine
+    /// union-typed *value* (not an overload set) keeps the conjunctive
+    /// semantics, since calling it must satisfy every member.
+    pub union_is_overload_set: bool,
 }
 
 impl CallableContext {
     pub const fn new(callable_type: TypeId) -> Self {
         Self {
             callable_type: Some(callable_type),
+            union_is_overload_set: false,
         }
     }
 
     pub const fn none() -> Self {
         Self {
             callable_type: None,
+            union_is_overload_set: false,
+        }
+    }
+
+    /// As [`CallableContext::new`], but marking `callable_type` as the synthetic
+    /// union of overload signatures (see
+    /// [`CallableContext::union_is_overload_set`]).
+    pub const fn new_overload_union(callable_type: TypeId) -> Self {
+        Self {
+            callable_type: Some(callable_type),
+            union_is_overload_set: true,
         }
     }
 }

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -184,7 +184,18 @@ impl<'a> CheckerState<'a> {
         for &arg_idx in &contextual_refresh_args {
             self.invalidate_expression_for_contextual_retry(arg_idx);
         }
-        let union_callable_ctx = CallableContext::new(union_contextual);
+        // With multiple overloads the contextual type is a synthetic union of
+        // every signature. That union is an existential alternative set, so the
+        // speculative non-tuple-spread arity check (which demands *every* union
+        // member admit the spread) must not fire TS2556 here — a sibling
+        // overload without a rest parameter would otherwise poison a valid
+        // spread into another overload's rest (e.g. `splice`). The authoritative
+        // TS2556 is reported per selected/failed signature below.
+        let union_callable_ctx = if signatures.len() > 1 {
+            CallableContext::new_overload_union(union_contextual)
+        } else {
+            CallableContext::new(union_contextual)
+        };
         // Preserve literal types during overload argument collection so that
         // string/number literal arguments keep their literal types (e.g., "canvas"
         // stays as literal "canvas" instead of widening to string).  This is

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/helpers.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/helpers.rs
@@ -1,6 +1,7 @@
 //! Small standalone helpers for overload resolution — pure code motion from
 //! the parent `overload_resolution` module.
 
+use crate::query_boundaries::checkers::call::array_element_type_for_type;
 use crate::query_boundaries::common::CallResult;
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
@@ -23,6 +24,18 @@ impl<'a> CheckerState<'a> {
         sig: &tsz_solver::CallSignature,
         arg_types: &[TypeId],
     ) -> Option<CallResult> {
+        // Position of the trailing rest parameter, if any. Arguments at or past
+        // this index are matched element-wise against the rest's element type,
+        // not against the rest's (array-like) declared type — so a `string`
+        // spread element landing on a `...items: string[]` rest is *not* a
+        // mismatch. Without this, a non-tuple spread (`f(..., ...stringArr)`)
+        // whose element type was collected as `string` would be wrongly rejected
+        // here as "string argument vs array parameter".
+        let rest_start = sig
+            .params
+            .last()
+            .filter(|param| param.rest)
+            .map(|_| sig.params.len() - 1);
         arg_types
             .iter()
             .copied()
@@ -35,15 +48,14 @@ impl<'a> CheckerState<'a> {
                 {
                     return None;
                 }
-                let expected = sig
-                    .params
-                    .get(index)
-                    .map(|param| param.type_id)
-                    .or_else(|| {
-                        sig.params
-                            .last()
-                            .and_then(|param| param.rest.then_some(param.type_id))
-                    })?;
+                let expected = if rest_start.is_some_and(|start| index >= start) {
+                    // `index` lands on the trailing rest parameter: compare
+                    // against its element type.
+                    let rest_type = sig.params.last()?.type_id;
+                    array_element_type_for_type(self.ctx.types, rest_type).unwrap_or(rest_type)
+                } else {
+                    sig.params.get(index).map(|param| param.type_id)?
+                };
                 self.is_array_like_type(expected)
                     .then_some(CallResult::ArgumentTypeMismatch {
                         index,

--- a/crates/tsz-checker/src/checkers/call_checker/spread_arity.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/spread_arity.rs
@@ -3,11 +3,37 @@
 //! Split from `candidate_collection` to keep that module under the per-file
 //! line ceiling. Hosts the open-ended-tuple-spread TS2556 suppression query.
 
+use crate::query_boundaries::common::ContextualTypeContext;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// Whether a non-tuple array/iterable spread covering positional argument
+    /// `index` lands on a rest parameter (or an optional trailing slot) of
+    /// `callable_type` — the gate for TS2556.
+    ///
+    /// When `union_is_overload_set` is set, `callable_type` is the synthetic
+    /// `sigA | sigB | ...` union built for the overload-resolution first pass; a
+    /// union member is then treated as an *alternative* (existential), so the
+    /// spread is admitted when any overload has a rest at `index`. A genuine
+    /// union-typed value keeps the conjunctive semantics (all members must
+    /// admit the spread).
+    pub(crate) fn spread_lands_on_rest_position(
+        &self,
+        callable_type: TypeId,
+        index: usize,
+        union_is_overload_set: bool,
+    ) -> bool {
+        let ctx = ContextualTypeContext::with_expected(self.ctx.types, callable_type);
+        if union_is_overload_set {
+            ctx.allows_non_tuple_spread_position_existential_union(index)
+        } else {
+            ctx.allows_non_tuple_spread_position(index)
+        }
+    }
+
     /// Whether the open-ended tuple spread `arg_idx`, whose variable rest lands
     /// at positional argument index `variable_index`, targets a callee whose
     /// parameter at that position tsc contextually types from the spread — in

--- a/crates/tsz-checker/tests/overload_spread_into_rest_ts2556_tests.rs
+++ b/crates/tsz-checker/tests/overload_spread_into_rest_ts2556_tests.rs
@@ -46,8 +46,7 @@ fn mutable_and_readonly_array_spread_into_splice_shaped_overload_is_clean() {
     assert_eq!(
         diagnostic_count(&diags, 2556),
         0,
-        "spread into a rest-bearing overload (declared after a no-rest sibling) must be clean: {:?}",
-        diags
+        "spread into a rest-bearing overload (declared after a no-rest sibling) must be clean: {diags:?}"
     );
 }
 
@@ -67,8 +66,7 @@ fn rest_bearing_overload_declared_first_is_clean() {
     assert_eq!(
         diagnostic_count(&diags, 2556),
         0,
-        "rest-bearing overload declared first must be clean: {:?}",
-        diags
+        "rest-bearing overload declared first must be clean: {diags:?}"
     );
 }
 
@@ -101,8 +99,7 @@ fn spread_with_zero_one_and_many_leading_fixed_args_is_clean() {
     assert_eq!(
         diagnostic_count(&diags, 2556),
         0,
-        "leading-fixed-arg variations spreading into a rest overload must be clean: {:?}",
-        diags
+        "leading-fixed-arg variations spreading into a rest overload must be clean: {diags:?}"
     );
 }
 
@@ -127,8 +124,7 @@ fn overload_set_without_any_rest_still_emits_ts2556() {
     assert_eq!(
         diagnostic_count(&diags, 2556),
         1,
-        "overload set with no rest parameter must still emit TS2556: {:?}",
-        diags
+        "overload set with no rest parameter must still emit TS2556: {diags:?}"
     );
 }
 
@@ -145,7 +141,6 @@ fn plain_function_without_rest_still_emits_ts2556() {
     assert_eq!(
         diagnostic_count(&diags, 2556),
         1,
-        "plain no-rest function must still emit TS2556: {:?}",
-        diags
+        "plain no-rest function must still emit TS2556: {diags:?}"
     );
 }

--- a/crates/tsz-checker/tests/overload_spread_into_rest_ts2556_tests.rs
+++ b/crates/tsz-checker/tests/overload_spread_into_rest_ts2556_tests.rs
@@ -1,0 +1,151 @@
+//! TS2556 for non-tuple array spreads into the rest parameter of an
+//! **overloaded** callable.
+//!
+//! Structural rule: `tsc` resolves overloads existentially. A non-tuple array
+//! (or iterable) spread is legal as long as *some* call/construct signature has
+//! a rest parameter that can absorb it at the spread position — exactly
+//! `hasCorrectArity`'s spread branch, where TS2556 fires only when *no*
+//! signature has correct arity for the spread. A sibling overload without a
+//! rest parameter (e.g. `Array.prototype.splice`'s `(start, deleteCount?)`
+//! overload) must not poison a valid spread into another overload's rest.
+//!
+//! Owner layer: the spread-position decision routes through the solver
+//! `allows_non_tuple_spread_position` boundary; the overload-resolution first
+//! pass marks the synthetic `sigA | sigB | ...` contextual union as an
+//! existential alternative set so the union check is disjunctive rather than
+//! conjunctive. A genuine union-typed *value* keeps the conjunctive semantics.
+//!
+//! Anti-hardcoding: every fixture varies the receiver/method/binder names so the
+//! rule is exercised structurally, never keyed on an identifier or on `splice`.
+
+use tsz_checker::test_utils::{check_source_diagnostics, diagnostic_count};
+
+// ---------------------------------------------------------------------------
+// Positive: spread into a rest-bearing overload -> no TS2556.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mutable_and_readonly_array_spread_into_splice_shaped_overload_is_clean() {
+    // The remeda witness, modelled on `Array.prototype.splice`'s overload set:
+    // a no-rest `(head, mid?)` signature plus a rest-bearing
+    // `(head, mid, ...tail)` signature, with the rest sitting after two fixed
+    // args. Both a mutable `U[]` and a `readonly U[]` may spread into the rest,
+    // and the rest-bearing signature is declared second (the lib `splice` order).
+    let src = r#"
+        interface Sink {
+            push(head: number, mid?: number): void;
+            push(head: number, mid: number, ...tail: string[]): void;
+        }
+        declare const sink: Sink;
+        declare const mut: string[];
+        declare const ro: readonly string[];
+        sink.push(1, 2, ...mut);
+        sink.push(1, 2, ...ro);
+    "#;
+    let diags = check_source_diagnostics(src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        0,
+        "spread into a rest-bearing overload (declared after a no-rest sibling) must be clean: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn rest_bearing_overload_declared_first_is_clean() {
+    // Declaration order must not matter: rest-bearing overload first.
+    let src = r#"
+        interface Box {
+            put(head: number, mid: number, ...tail: string[]): void;
+            put(head: number, mid?: number): void;
+        }
+        declare const box: Box;
+        declare const xs: string[];
+        box.put(1, 2, ...xs);
+    "#;
+    let diags = check_source_diagnostics(src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        0,
+        "rest-bearing overload declared first must be clean: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn spread_with_zero_one_and_many_leading_fixed_args_is_clean() {
+    // The rest slot may begin after 0, 1, or N fixed positional args, in each
+    // case alongside a no-rest sibling overload.
+    let src = r#"
+        interface Multi {
+            f(...rest: string[]): void;
+            f(only: number): void;
+        }
+        interface One {
+            g(head: number, ...rest: string[]): void;
+            g(head: number, extra?: boolean): void;
+        }
+        interface Many {
+            h(a: number, b: number, c: number, ...rest: string[]): void;
+            h(a: number, b: number): void;
+        }
+        declare const m: Multi;
+        declare const o: One;
+        declare const k: Many;
+        declare const ss: string[];
+        m.f(...ss);
+        o.g(1, ...ss);
+        k.h(1, 2, 3, ...ss);
+    "#;
+    let diags = check_source_diagnostics(src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        0,
+        "leading-fixed-arg variations spreading into a rest overload must be clean: {:?}",
+        diags
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative: no overload has a rest at the spread position -> TS2556.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn overload_set_without_any_rest_still_emits_ts2556() {
+    // Neither overload has a rest parameter, so a non-tuple spread cannot land
+    // anywhere legal: TS2556 must still fire.
+    let src = r#"
+        interface NoRest {
+            q(a: number): void;
+            q(a: number, b: number): void;
+        }
+        declare const nr: NoRest;
+        declare const ss: string[];
+        nr.q(...ss);
+    "#;
+    let diags = check_source_diagnostics(src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        1,
+        "overload set with no rest parameter must still emit TS2556: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn plain_function_without_rest_still_emits_ts2556() {
+    // Single-signature negative control is unchanged by the existential-union
+    // overload handling.
+    let src = r#"
+        function pair(a: number, b: number): void {}
+        declare const ss: string[];
+        pair(...ss);
+    "#;
+    let diags = check_source_diagnostics(src);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        1,
+        "plain no-rest function must still emit TS2556: {:?}",
+        diags
+    );
+}

--- a/crates/tsz-solver/src/contextual/core.rs
+++ b/crates/tsz-solver/src/contextual/core.rs
@@ -7,7 +7,7 @@ use crate::contextual::extractors::{
     ApplicationArgExtractor, ArrayElementExtractor, ParameterExtractor, ParameterForCallExtractor,
     PropertyExtractor, RestOrOptionalTailPositionExtractor, RestParameterExtractor,
     RestPositionCheckExtractor, ReturnTypeExtractor, ThisTypeExtractor, ThisTypeMarkerExtractor,
-    TupleElementExtractor, collect_from_intersection, collect_single_or_union,
+    TupleElementExtractor, UnionSpreadMode, collect_from_intersection, collect_single_or_union,
     collect_single_or_union_no_reduce, collect_single_or_union_preserve,
     extract_param_type_at_for_call,
 };
@@ -700,7 +700,27 @@ impl<'a> ContextualTypeContext<'a> {
 
     /// Check if a non-tuple spread is allowed because it lands on a rest
     /// parameter or only covers optional trailing parameters.
-    pub fn allows_non_tuple_spread_position(&self, index: usize, arg_count: usize) -> bool {
+    ///
+    /// A union expected type is treated *conjunctively*: every member must admit
+    /// the spread, because calling a union-typed value must satisfy all members.
+    pub fn allows_non_tuple_spread_position(&self, index: usize) -> bool {
+        self.allows_non_tuple_spread_position_impl(index, UnionSpreadMode::Conjunctive)
+    }
+
+    /// As [`ContextualTypeContext::allows_non_tuple_spread_position`], but treats
+    /// a union expected type *existentially*: the spread is admitted when *any*
+    /// member accepts it. Used for the synthetic `sigA | sigB | ...` union built
+    /// during overload resolution, where a call type-checks if some overload
+    /// admits it (mirroring tsc's `chooseOverload`).
+    pub fn allows_non_tuple_spread_position_existential_union(&self, index: usize) -> bool {
+        self.allows_non_tuple_spread_position_impl(index, UnionSpreadMode::Existential)
+    }
+
+    fn allows_non_tuple_spread_position_impl(
+        &self,
+        index: usize,
+        union_mode: UnionSpreadMode,
+    ) -> bool {
         let Some(expected) = self.expected else {
             return false;
         };
@@ -716,14 +736,14 @@ impl<'a> ContextualTypeContext<'a> {
         if let Some(TypeData::Application(app_id)) = self.interner.lookup(expected) {
             let app = self.interner.type_application(app_id);
             let ctx = ContextualTypeContext::with_expected(self.interner, app.base);
-            return ctx.allows_non_tuple_spread_position(index, arg_count);
+            return ctx.allows_non_tuple_spread_position_impl(index, union_mode);
         }
 
         if let Some(constraint) =
             crate::type_queries::get_type_parameter_constraint(self.interner, expected)
         {
             let ctx = ContextualTypeContext::with_expected(self.interner, constraint);
-            return ctx.allows_non_tuple_spread_position(index, arg_count);
+            return ctx.allows_non_tuple_spread_position_impl(index, union_mode);
         }
 
         // PERF: Single lookup for guard + IndexAccess check
@@ -739,15 +759,18 @@ impl<'a> ContextualTypeContext<'a> {
             let evaluated = crate::evaluation::evaluate::evaluate_type(self.interner, expected);
             if evaluated != expected {
                 let ctx = ContextualTypeContext::with_expected(self.interner, evaluated);
-                return ctx.allows_non_tuple_spread_position(index, arg_count);
+                return ctx.allows_non_tuple_spread_position_impl(index, union_mode);
             }
             if matches!(expected_key, TypeData::IndexAccess(_, _)) {
                 return true;
             }
         }
 
-        let mut extractor =
-            RestOrOptionalTailPositionExtractor::new(self.interner, index, arg_count);
+        let mut extractor = RestOrOptionalTailPositionExtractor::new_with_union_mode(
+            self.interner,
+            index,
+            union_mode,
+        );
         extractor.extract(expected)
     }
 

--- a/crates/tsz-solver/src/contextual/extractors.rs
+++ b/crates/tsz-solver/src/contextual/extractors.rs
@@ -1800,33 +1800,39 @@ impl<'a> TypeVisitor for RestPositionCheckExtractor<'a> {
     }
 }
 
+/// How a union expected type is combined when deciding whether a non-tuple
+/// spread lands on a rest position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UnionSpreadMode {
+    /// Every member must admit the spread (a union-typed value: a call must
+    /// satisfy all members).
+    Conjunctive,
+    /// Any member may admit the spread (a synthetic overload-signature union:
+    /// a call type-checks when some overload admits it).
+    Existential,
+}
+
 pub(crate) struct RestOrOptionalTailPositionExtractor<'a> {
     db: &'a dyn TypeDatabase,
     index: usize,
-    arg_count: usize,
+    union_mode: UnionSpreadMode,
 }
 
 impl<'a> RestOrOptionalTailPositionExtractor<'a> {
-    pub(crate) fn new(db: &'a dyn TypeDatabase, index: usize, arg_count: usize) -> Self {
+    pub(crate) fn new_with_union_mode(
+        db: &'a dyn TypeDatabase,
+        index: usize,
+        union_mode: UnionSpreadMode,
+    ) -> Self {
         Self {
             db,
             index,
-            arg_count,
+            union_mode,
         }
     }
 
     pub(crate) fn extract(&mut self, type_id: TypeId) -> bool {
         self.visit_type(self.db, type_id).unwrap_or(false)
-    }
-
-    fn signature_accepts_arg_count(&self, params: &[ParamInfo], arg_count: usize) -> bool {
-        let required_count = params.iter().filter(|p| !p.optional).count();
-        let has_rest = params.iter().any(|p| p.rest);
-        if has_rest {
-            arg_count >= required_count
-        } else {
-            arg_count >= required_count && arg_count <= params.len()
-        }
     }
 }
 
@@ -1848,62 +1854,64 @@ impl<'a> TypeVisitor for RestOrOptionalTailPositionExtractor<'a> {
 
     fn visit_callable(&mut self, shape_id: u32) -> Self::Output {
         let shape = self.db.callable_shape(CallableShapeId(shape_id));
-        let all_sigs: Vec<&[ParamInfo]> = shape
+        let mut sigs = shape
             .call_signatures
             .iter()
             .chain(shape.construct_signatures.iter())
-            .map(|sig| sig.params.as_slice())
-            .collect();
+            .peekable();
+        sigs.peek()?;
 
-        if all_sigs.is_empty() {
-            return None;
-        }
-
-        let mut any_matched = false;
-        let mut all_allowed = true;
-        for &params in &all_sigs {
-            if self.signature_accepts_arg_count(params, self.arg_count) {
-                any_matched = true;
-                if !is_rest_or_optional_tail_position(params, self.index) {
-                    all_allowed = false;
-                }
-            }
-        }
-
-        if !any_matched {
-            for &params in &all_sigs {
-                if !is_rest_or_optional_tail_position(params, self.index) {
-                    return Some(false);
-                }
-            }
-            return Some(true);
-        }
-
-        Some(all_allowed)
+        // tsc resolves overloads existentially: a non-tuple spread is legal as
+        // long as *any* call/construct signature can absorb it at a rest (or
+        // optional-tail) position. This mirrors `hasCorrectArity`'s spread
+        // branch — TS2556 is reported only when *no* signature has correct
+        // arity for the spread. A non-rest overload (e.g. `splice`'s
+        // `(start, deleteCount?)` signature) must not poison the decision for a
+        // sibling overload whose trailing rest does absorb the spread.
+        Some(sigs.any(|sig| is_rest_or_optional_tail_position(&sig.params, self.index)))
     }
 
     fn visit_union(&mut self, list_id: u32) -> Self::Output {
         let members = self.db.type_list(TypeListId(list_id));
-        for &m in members.iter() {
-            let mut extractor =
-                RestOrOptionalTailPositionExtractor::new(self.db, self.index, self.arg_count);
-            if !extractor.extract(m) {
-                return Some(false);
-            }
-        }
-        Some(true)
+        let admits = |m| {
+            RestOrOptionalTailPositionExtractor::new_with_union_mode(
+                self.db,
+                self.index,
+                self.union_mode,
+            )
+            .extract(m)
+        };
+        Some(match self.union_mode {
+            // Calling a union-typed value must satisfy *every* member, so the
+            // spread is legal only when all members accept it at a
+            // rest/optional-tail slot.
+            UnionSpreadMode::Conjunctive => members.iter().all(|&m| admits(m)),
+            // A synthetic union of overload signatures is an alternative set: the
+            // spread is legal when *any* member admits it.
+            UnionSpreadMode::Existential => members.iter().any(|&m| admits(m)),
+        })
     }
 
     fn visit_intersection(&mut self, list_id: u32) -> Self::Output {
         let members = self.db.type_list(TypeListId(list_id));
+        // An intersection of function types is an overload set: the spread is
+        // legal when *any* callable member can absorb it, mirroring the
+        // existential overload resolution in `visit_callable`.
+        let mut saw_answer = false;
         for &m in members.iter() {
-            let mut extractor =
-                RestOrOptionalTailPositionExtractor::new(self.db, self.index, self.arg_count);
+            let mut extractor = RestOrOptionalTailPositionExtractor::new_with_union_mode(
+                self.db,
+                self.index,
+                self.union_mode,
+            );
             if let Some(result) = extractor.visit_type(self.db, m) {
-                return Some(result);
+                if result {
+                    return Some(true);
+                }
+                saw_answer = true;
             }
         }
-        None
+        saw_answer.then_some(false)
     }
 
     fn default_output() -> Self::Output {


### PR DESCRIPTION
Fixes #14155.

Goal: green

## Summary
On a clean clone of **remeda** (strict, tsc 5.8.3 → 0 errors), tsz rejected
spreading a `readonly U[]` into a **native rest parameter**
(`Array.prototype.splice`):

```
src/splice.ts(78,37): TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
```

The wrong semantic operation is **overload resolution arity**. The
overload-resolution first pass collects arguments once against a synthetic
`sigA | sigB | ...` contextual union, and the non-tuple-spread arity check
treated that union **conjunctively** (every member must admit the spread). The
sibling no-rest overload — `splice(start, deleteCount?)` — therefore poisoned a
valid spread into the rest overload `splice(start, deleteCount, ...items)`.

## Structural rule
When a non-tuple array/iterable spread covers positional argument index `i`,
tsc admits it iff **some** call/construct signature has correct arity for the
spread there (a rest, or an optional tail, at `i`) — exactly `hasCorrectArity`'s
spread branch. TS2556 fires only when **no** signature can absorb it. tsz now
makes this decision through the solver `allows_non_tuple_spread_position`
boundary: the synthetic union of overload signatures is resolved
**existentially**, while a genuine union-typed *value* keeps the conjunctive
semantics (calling it must satisfy every member).

## Changes (owner layer: solver query boundary + checker call resolution)
- **solver `contextual`**: add `UnionSpreadMode` (`Conjunctive`/`Existential`)
  to `allows_non_tuple_spread_position`; new
  `allows_non_tuple_spread_position_existential_union`. The
  `RestOrOptionalTailPositionExtractor` callable/union visitors are existential
  where appropriate and drop the per-signature arg-count filtering that has no
  `hasCorrectArity` counterpart for spreads.
- **checker `call_checker`**: thread `union_is_overload_set` through
  `CallableContext`, set only for the multi-signature first pass
  (`signatures.len() > 1`); route the array/iterable spread-position decision
  through the new `spread_lands_on_rest_position` helper.
- **checker `overload_resolution/helpers`**: make
  `overload_string_argument_array_parameter_mismatch` rest-aware — a `string`
  spread element landing on a `...items: string[]` rest is compared against the
  rest's **element** type, not the array type (previously it shortcut to a
  spurious mismatch once the union pass began pushing element types).

## Adjacent-case matrix (all match tsc)
- Spread of `readonly U[]` **and** mutable `U[]` into a rest overload → clean.
- Rest-bearing overload declared first **or** second (lib `splice` order) → clean.
- Rest slot beginning after 0, 1, or N leading fixed args → clean.
- Negative control: overload set where **no** overload has a rest → TS2556.
- Negative control: plain single-signature no-rest function `g(a, b)` called
  `g(...arr)` → TS2556 (unchanged).
- Binder/method/receiver names are varied across fixtures (anti-hardcoding;
  the rule is structural, never keyed on `splice`).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New suite `crates/tsz-checker/tests/overload_spread_into_rest_ts2556_tests.rs`
  (5 tests): `cargo test -p tsz-checker --test overload_spread_into_rest_ts2556_tests` → green.
- Regression guards: `cargo test -p tsz-checker --test variadic_tuple_spread_arity_ts2556_tests` → 18 passed; `--test spread_rest_tests` → 78 passed (1 failure, `test_array_like_rest_rejects_aggregate_rest_arguments`, is **pre-existing on the base** — verified by re-running with the change stashed; it panics on a reduced-lib `NewableFunction` lookup unrelated to this change).
- `cargo test -p tsz-checker --lib call` → 684 passed; the 7 failures are **pre-existing on the base** (identical set with the change stashed).
- `cargo clippy -p tsz-solver -p tsz-checker` → clean.
- Manual repro (full lib): the issue witness and a broad splice/overload matrix emit 0 TS2556; negative controls still fire.
- Broad conformance/emit/fourslash suites: delegated to ready-review CI.

https://claude.ai/code/session_01H6JqzCo7NZKK8gF8vD2mom

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6JqzCo7NZKK8gF8vD2mom)_