### PR TITLE
fix(solver): waive missing string-index requirement for array/tuple vs `{ [x: string]: any }` (#14162)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -301,6 +301,9 @@ path = "tests/array_generic_shorthand_canonical_tests.rs"
 name = "array_subclass_inheritance_tests"
 path = "tests/array_subclass_inheritance_tests.rs"
 [[test]]
+name = "array_source_any_string_index_waiver_tests"
+path = "tests/array_source_any_string_index_waiver_tests.rs"
+[[test]]
 name = "extends_readonly_array_assignability_tests"
 path = "tests/extends_readonly_array_assignability_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/array_source_any_string_index_waiver_tests.rs
+++ b/crates/tsz-checker/tests/array_source_any_string_index_waiver_tests.rs
@@ -1,0 +1,186 @@
+//! `tsc` waives the missing-string-index requirement for a named array/tuple
+//! source when the *value type* of the target's string index signature is `any`
+//! (`{ [x: string]: any }`, including the `{ [P in any]: any }` mapped form).
+//!
+//! A named array/tuple has a numeric index but no string index of its own, so
+//! it is normally rejected against a string-index target — and that rejection
+//! is correct for a concrete value type (`unknown`, `boolean | number`, …).
+//! The divergence covered here is *exactly and only* the `any` value type,
+//! which is an `any`-propagation (Lawyer) quirk rather than a structural
+//! invariant. Covers both the assignment relation (TS2322) and the generic
+//! constraint relation (TS2344). See issue #14162.
+
+use tsz_checker::context::CheckerOptions;
+
+fn strict_diagnostics(source: &str) -> Vec<(u32, String)> {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn relation_codes(diags: &[(u32, String)]) -> Vec<u32> {
+    diags
+        .iter()
+        .filter(|(code, _)| matches!(*code, 2322 | 2344 | 2345))
+        .map(|(code, _)| *code)
+        .collect()
+}
+
+#[test]
+fn tuple_and_array_satisfy_string_index_any_target() {
+    let diagnostics = strict_diagnostics(
+        r#"
+type StrIdxAny = { [x: string]: any };
+declare const tup: [boolean, number];
+declare const arr: boolean[];
+const a: StrIdxAny = tup;
+const b: StrIdxAny = arr;
+const c: { [x: string]: any } = tup;
+"#,
+    );
+    let codes = relation_codes(&diagnostics);
+    assert!(
+        codes.is_empty(),
+        "array/tuple source should satisfy a string-index-`any` target, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn readonly_array_satisfies_string_index_any_target() {
+    let diagnostics = strict_diagnostics(
+        r#"
+declare const ro: ReadonlyArray<number>;
+declare const tup: readonly [string, number];
+const a: { [x: string]: any } = ro;
+const b: { [x: string]: any } = tup;
+"#,
+    );
+    let codes = relation_codes(&diagnostics);
+    assert!(
+        codes.is_empty(),
+        "readonly array/tuple source should satisfy a string-index-`any` target, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn mapped_index_any_form_satisfied_by_array() {
+    // `{ [P in any]: any }` materializes to the same string+number index-`any`
+    // shape and must accept an array/tuple source identically.
+    let diagnostics = strict_diagnostics(
+        r#"
+type MappedAny = { [P in any]: any };
+declare const tup: [boolean, number];
+declare const arr: string[];
+const a: MappedAny = tup;
+const b: MappedAny = arr;
+"#,
+    );
+    let codes = relation_codes(&diagnostics);
+    assert!(
+        codes.is_empty(),
+        "`{{ [P in any]: any }}` should accept an array/tuple source, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn number_index_any_target_still_accepted() {
+    // Boundary control: a `{ [x: number]: any }` target was already accepted via
+    // the source's numeric index and must remain so.
+    let diagnostics = strict_diagnostics(
+        r#"
+declare const tup: [boolean, number];
+declare const arr: boolean[];
+const a: { [x: number]: any } = tup;
+const b: { [x: number]: any } = arr;
+"#,
+    );
+    let codes = relation_codes(&diagnostics);
+    assert!(
+        codes.is_empty(),
+        "number-index-`any` target should accept an array/tuple source, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn string_index_unknown_target_still_rejected() {
+    // Negative control: `unknown` is not `any`; the missing-string-index
+    // requirement still applies, so an array/tuple source must be rejected.
+    let diagnostics = strict_diagnostics(
+        r#"
+declare const tup: [boolean, number];
+declare const arr: boolean[];
+const a: { [x: string]: unknown } = tup;
+const b: { [x: string]: unknown } = arr;
+"#,
+    );
+    let codes = relation_codes(&diagnostics);
+    assert_eq!(
+        codes,
+        vec![2322, 2322],
+        "string-index-`unknown` target must still reject array/tuple sources, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn string_index_concrete_union_target_still_rejected() {
+    // Negative control: a concrete value type still requires a real string index.
+    let diagnostics = strict_diagnostics(
+        r#"
+declare const tup: [boolean, number];
+const a: { [x: string]: boolean | number } = tup;
+"#,
+    );
+    let codes = relation_codes(&diagnostics);
+    assert_eq!(
+        codes,
+        vec![2322],
+        "string-index-`boolean | number` target must still reject a tuple, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn string_index_any_inside_intersection_target_satisfied() {
+    // The waiver composes structurally: an intersection whose only object
+    // constituent is a string-index-`any` shape is still satisfied by a
+    // tuple/array source (the relation reaches the same per-constituent
+    // index decision).
+    let diagnostics = strict_diagnostics(
+        r#"
+declare const tup: [boolean, number];
+const a: { [x: string]: any } & {} = tup;
+"#,
+    );
+    let codes = relation_codes(&diagnostics);
+    assert!(
+        codes.is_empty(),
+        "string-index-`any` intersection target should accept a tuple source, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn string_index_any_with_extra_property_still_rejected() {
+    // The waiver only removes the *missing string index* requirement. A named
+    // member the array/tuple lacks is still a genuine mismatch, so adding a
+    // required property re-introduces the rejection.
+    let diagnostics = strict_diagnostics(
+        r#"
+declare const tup: [boolean, number];
+const a: { [x: string]: any; tag: string } = tup;
+"#,
+    );
+    let codes = relation_codes(&diagnostics);
+    assert!(
+        !codes.is_empty(),
+        "a missing required property must still be rejected even with a string-index-`any`, got: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -1723,7 +1723,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     // implicit string index signatures. They cannot be assigned to
                     // types with a string index signature requirement, e.g.
                     // `number[] <: { [x: string]: unknown }` is false.
-                    if t_shape.string_index.is_some() {
+                    //
+                    // The one exception is an `any`-valued string index
+                    // (`{ [x: string]: any }`, or its `{ [P in any]: any }`
+                    // mapped form): `tsc` waives the missing-string-index
+                    // requirement when the index value type is `any`. This is the
+                    // same `any`-propagation (Lawyer) quirk applied to object
+                    // sources in `check_string_index_compatibility`, not a
+                    // structural Judge invariant — a concrete value type
+                    // (`unknown`, `boolean | number`, …) still rejects.
+                    if let Some(ref str_idx) = t_shape.string_index
+                        && !self.target_string_index_any_waives_missing_index(str_idx.value_type)
+                    {
                         return SubtypeResult::False;
                     }
                     if let Some(ref num_idx) = t_shape.number_index {

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -996,6 +996,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             .is_some_and(|is_class_symbol| is_class_symbol(symbol_ref))
     }
 
+    /// Whether a target string index whose value type is `any` waives the
+    /// missing string-index requirement for a source that declares none. This is
+    /// `tsc`'s `indexSignaturesRelatedTo` short-circuit: a TS legacy
+    /// `any`-propagation quirk, disabled alongside method bivariance in Sound
+    /// Mode. A concrete value type such as `unknown` is never waived. Shared by
+    /// the object-source path below and the named array/tuple-source path in
+    /// `core_dispatch`.
+    pub(crate) fn target_string_index_any_waives_missing_index(&self, value_type: TypeId) -> bool {
+        !self.disable_method_bivariance && value_type.is_any()
+    }
+
     /// Check string index signature compatibility between source and target.
     ///
     /// Validates that string index signatures are compatible, handling:
@@ -1028,7 +1039,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         //   This is the rule that allows `{ [n: number]: any }` -> `{ [s: string]: any }`
         //   even when the source is a named class/interface. We mirror it here for
         //   the assignability path (non-strict subtype).
-        if !self.disable_method_bivariance && t_string_idx.value_type.is_any() {
+        if self.target_string_index_any_waives_missing_index(t_string_idx.value_type) {
             return SubtypeResult::True;
         }
 


### PR DESCRIPTION
Closes #14162.

Goal: green

## Structural rule
When the source is a named array/tuple and the target has a string index
signature whose **value type is `any`** (`{ [x: string]: any }`, or its
`{ [P in any]: any }` mapped form), `tsc` treats the source as assignable —
`indexSignaturesRelatedTo` short-circuits on an `any`-valued target index, so
the missing-string-index requirement is waived even though an array/tuple has
no string index of its own. `tsz` rejected unconditionally with TS2322. The
divergence is **exactly and only** the `any` value type; a concrete value type
(`unknown`, `boolean | number`, …) still rejects, matching `tsc`.

```ts
type StrIdxAny = { [x: string]: any };
declare const tup: [boolean, number];
declare const arr: boolean[];
const a: StrIdxAny = tup;   // tsc OK | tsz TS2322 (before)
const b: StrIdxAny = arr;   // tsc OK | tsz TS2322 (before)
```

## Owner layer & approach (solver)
This is a TS legacy `any`-propagation (Lawyer) quirk, not a structural Judge
invariant. The **object-source** path already implemented it in
`relations/subtype/rules/objects.rs::check_string_index_compatibility`, gated
on `!disable_method_bivariance` (the Sound-Mode toggle). The **array/tuple-source**
branch in `relations/subtype/core_dispatch.rs` (array/tuple vs object-with-index
target) missed the equivalent and rejected on `string_index.is_some()` without
inspecting the value type.

Rather than special-case the array branch, both sites now share one predicate,
`target_string_index_any_waives_missing_index(value_type)`
(`!disable_method_bivariance && value_type.is_any()`), so the quirk is decided
**identically** — and disabled together in Sound Mode — regardless of source
kind. The `{ [P in any]: any }` mapped form materializes to the same
string+number index-`any` shape (via `mapped_expansion.rs`) and reaches the same
branch, so it is covered by the same change.

## Anti-hardcoding
Purely structural: keyed on the target string-index value type being `any` and
the Sound-Mode bivariance toggle — no identifier, alias, file-name, or
rendered-type-string checks. Test binder/type-parameter names are varied.

## Adjacent matrix (verified against `tsc` 6.x)
- Accept: `[a,b]` / `T[]` / `readonly` tuple / `ReadonlyArray<T>` vs
  `{ [x: string]: any }`; the `{ [P in any]: any }` mapped form; the same inside
  an intersection target.
- Already-correct boundaries preserved: `{ [x: number]: any }` ← tuple/array
  accepted (via the source's numeric index).
- Negative controls (still reject): `{ [x: string]: unknown }` ← tuple/array
  (TS2322); `{ [x: string]: boolean | number }` ← tuple (TS2322); a target that
  adds a required named property the array/tuple lacks
  (`{ [x: string]: any; tag: string }`).

## Verification
- New `cargo test -p tsz-checker --test array_source_any_string_index_waiver_tests`
  — 8/8 (5 positive incl. mapped/readonly/intersection, 3 negative controls);
  the positive cases reproduce the bug on the pre-fix binary.
- `cargo test -p tsz-checker` related suites green: `any_propagation_tests`,
  `index_signature_argument_assignability_tests`,
  `extends_readonly_array_assignability_tests`, `mixin_any_base_index_sig_tests`,
  `symbol_index_signature_tests`, `ts7053_record_constraint_index_tests`,
  `intersection_index_signature_fingerprint_tests`.
- `cargo test -p tsz-solver --lib` (index/any/array/subtype/mapped/objects
  filter): **no net-new failures** vs the clean tree — the single failure
  (`narrowing::…::array_isarray_keeps_mutable_and_readonly_array_members`) is
  pre-existing and reproduces identically with the change stashed.
- `cargo clippy -p tsz-solver` clean; `cargo fmt` clean.
- Reviewed with `/simplify`: the array/tuple waiver was unified with the
  pre-existing object-source waiver into one shared predicate (consistent
  Sound-Mode gating); no further net-positive changes found.
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_017cyFXrK8Vs4pwDfUFU1VpD)_