### PR TITLE
fix(solver): resolve instantiable arithmetic operands to their base constraint (#14154)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -569,6 +569,9 @@ path = "tests/ambient_module_value_export_tests.rs"
 name = "export_star_module_augmentation_tests"
 path = "tests/export_star_module_augmentation_tests.rs"
 [[test]]
+name = "deferred_conditional_arithmetic_operand_tests"
+path = "tests/deferred_conditional_arithmetic_operand_tests.rs"
+[[test]]
 name = "hkt_self_augmentation_keyof_repro"
 path = "tests/hkt_self_augmentation_keyof_repro.rs"
 [[test]]

--- a/crates/tsz-checker/tests/deferred_conditional_arithmetic_operand_tests.rs
+++ b/crates/tsz-checker/tests/deferred_conditional_arithmetic_operand_tests.rs
@@ -1,0 +1,135 @@
+//! Regression tests for #14154: a deferred conditional type whose branches are
+//! all numeric (and, more generally, any instantiable operand whose base
+//! constraint is numeric) must be accepted as an arithmetic operand — no false
+//! TS2362/TS2363.
+//!
+//! Structural rule: `tsc`'s `checkArithmeticOperandType` validates an operand by
+//! assignability to `number | bigint`, which for an instantiable type (a deferred
+//! conditional, a bare type parameter, ...) is decided against that type's base
+//! constraint / apparent type. tsz now resolves the operand toward its apparent
+//! form (`BinaryOpEvaluator::is_arithmetic_operand`) before classifying it, so a
+//! conditional with all-numeric branches and a numeric-constrained type parameter
+//! pass, while a conditional with a non-numeric branch and an unconstrained
+//! parameter still fail. Anti-hardcoding: the rule is structural, every binder is
+//! renamed across the matrix and the behavior holds.
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn count_arith_operand_errors(source: &str) -> usize {
+    check_source_codes(source)
+        .iter()
+        .filter(|&&c| c == 2362 || c == 2363)
+        .count()
+}
+
+/// The minimal io-ts/remeda witness: `sum(data)` returns a deferred conditional
+/// `Sum<T> = T extends readonly [] ? 0 : number`; dividing it by a number must
+/// not warn (`0 | number = number` is a valid arithmetic operand).
+#[test]
+fn deferred_conditional_all_numeric_branches_is_valid_operand() {
+    let source = r#"
+type IterableContainer<T> = readonly T[] | readonly [];
+type Sum<T extends IterableContainer<number>> = T extends readonly [] ? 0 : number;
+declare function sum<T extends IterableContainer<number>>(data: T): Sum<T>;
+export function meanImpl<T extends IterableContainer<number>>(data: T): T[number] | undefined {
+  if (data.length === 0) return undefined;
+  return sum(data) / data.length;
+}
+"#;
+    assert_eq!(
+        count_arith_operand_errors(source),
+        0,
+        "deferred conditional with all-numeric branches must be a valid arithmetic operand"
+    );
+}
+
+/// Anti-hardcoding: rename every binder (alias, parameter, function); the rule
+/// is structural, not name-driven.
+#[test]
+fn deferred_conditional_numeric_operand_is_binder_name_independent() {
+    let source = r#"
+type Bag<U> = readonly U[] | readonly [];
+type Total<S extends Bag<number>> = S extends readonly [] ? 0 : number;
+declare function reduce<S extends Bag<number>>(xs: S): Total<S>;
+export function avg<S extends Bag<number>>(xs: S): number {
+  return reduce(xs) * 2;
+}
+"#;
+    assert_eq!(
+        count_arith_operand_errors(source),
+        0,
+        "renamed-binder deferred conditional must still be a valid arithmetic operand"
+    );
+}
+
+/// Adjacent: a bare type parameter with a numeric constraint is a valid operand.
+#[test]
+fn numeric_constrained_type_parameter_is_valid_operand() {
+    let source = r"
+export function dbl<T extends number>(x: T): number { return x * 2; }
+export function dbl2<T extends bigint>(x: T): bigint { return x * 2n; }
+";
+    assert_eq!(
+        count_arith_operand_errors(source),
+        0,
+        "a type parameter constrained to number/bigint must be a valid arithmetic operand"
+    );
+}
+
+/// Adjacent: a deferred conditional with mixed numeric branches
+/// (`... ? number : bigint`) is still a valid *operand* (no TS2362); any
+/// number/bigint mixing is reported separately (TS2365), not as TS2362.
+#[test]
+fn mixed_numeric_conditional_branches_is_valid_operand() {
+    let source = r"
+type Mix<T> = T extends string ? number : bigint;
+declare function pick<T>(t: T): Mix<T>;
+export const use1 = <T>(t: T): bigint => pick<string>('s') as never;
+export const use2 = <T>(t: T) => pick(t) - (0 as never);
+";
+    assert_eq!(
+        count_arith_operand_errors(source),
+        0,
+        "mixed-numeric conditional branches must not raise TS2362/TS2363 (operand validity)"
+    );
+}
+
+/// Negative control: a conditional with a non-numeric branch must STILL warn.
+#[test]
+fn conditional_with_non_numeric_branch_still_warns() {
+    let source = r"
+type Maybe<T> = T extends string ? number : string;
+declare function pick<T>(t: T): Maybe<T>;
+export const bad = <T>(t: T) => pick(t) * 2;
+";
+    assert!(
+        count_arith_operand_errors(source) >= 1,
+        "a conditional with a non-numeric branch must still raise TS2362"
+    );
+}
+
+/// Negative control: an unconstrained type parameter (base constraint `unknown`)
+/// must STILL warn — `unknown` is not assignable to `number | bigint`.
+#[test]
+fn unconstrained_type_parameter_still_warns() {
+    let source = r"
+export function bad<T>(x: T): number { return x * 2; }
+";
+    assert!(
+        count_arith_operand_errors(source) >= 1,
+        "an unconstrained type parameter must still raise TS2362"
+    );
+}
+
+/// Negative control: a type parameter constrained to `number | string` must
+/// STILL warn (the string constituent is not numeric).
+#[test]
+fn union_constraint_with_string_still_warns() {
+    let source = r"
+export function bad<T extends number | string>(x: T) { return x - 1; }
+";
+    assert!(
+        count_arith_operand_errors(source) >= 1,
+        "a type parameter constrained to number | string must still raise TS2362"
+    );
+}

--- a/crates/tsz-solver/src/operations/binary_ops.rs
+++ b/crates/tsz-solver/src/operations/binary_ops.rs
@@ -586,14 +586,30 @@ impl<'a> BinaryOpEvaluator<'a> {
     /// If a type couldn't be resolved (TS2304, etc.), we don't want to add noise
     /// with arithmetic errors - the primary error is more useful.
     pub fn is_arithmetic_operand(&self, type_id: TypeId) -> bool {
-        // Don't emit arithmetic errors for error/unknown/never types - prevents cascading errors.
+        self.is_arithmetic_operand_inner(type_id, false, 0)
+    }
+
+    /// Core arithmetic-operand predicate.
+    ///
+    /// `via_constraint` is `true` once we have descended into an instantiable
+    /// type's base constraint / apparent type: a bare `unknown` operand is
+    /// accepted at the surface (to avoid cascading after an earlier error), but
+    /// an instantiable type whose base constraint is merely `unknown` (e.g. an
+    /// unconstrained type parameter) is NOT a numeric operand in `tsc`, so the
+    /// constraint path holds `unknown` to the stricter test.
+    fn is_arithmetic_operand_inner(
+        &self,
+        type_id: TypeId,
+        via_constraint: bool,
+        depth: u8,
+    ) -> bool {
+        // Don't emit arithmetic errors for error/never types - prevents cascading errors.
         // NEVER (bottom type) is assignable to all types, so it's valid everywhere.
-        if type_id == TypeId::ANY
-            || type_id == TypeId::ERROR
-            || type_id == TypeId::UNKNOWN
-            || type_id == TypeId::NEVER
-        {
+        if type_id == TypeId::ANY || type_id == TypeId::ERROR || type_id == TypeId::NEVER {
             return true;
+        }
+        if type_id == TypeId::UNKNOWN {
+            return !via_constraint;
         }
         if self.is_number_like(type_id) || self.is_bigint_like(type_id) {
             return true;
@@ -601,18 +617,73 @@ impl<'a> BinaryOpEvaluator<'a> {
         // For unions like `bigint | number`, the all-number-like and all-bigint-like
         // checks both fail because neither is uniform. But each member is individually
         // a valid arithmetic type. Check if all union members are individually arithmetic.
-        if let Some(members) = crate::visitor::union_list_id(self.interner, type_id) {
-            let member_list = self.interner.type_list(members);
-            return !member_list.is_empty()
-                && member_list.iter().all(|&m| {
-                    m == TypeId::ANY
-                        || m == TypeId::ERROR
-                        || m == TypeId::NEVER
-                        || self.is_number_like(m)
-                        || self.is_bigint_like(m)
-                });
+        if self.all_union_members_arithmetic(type_id) {
+            return true;
+        }
+        // tsc's `checkArithmeticOperandType` validates an operand by assignability
+        // to `number | bigint`, which for an *instantiable* type (a deferred
+        // conditional, a bare type parameter, ...) is decided against the type's
+        // base constraint / apparent type. Resolve the operand toward that apparent
+        // form and re-check, so a deferred conditional whose branches are all numeric
+        // (`T extends [] ? 0 : number`) and a numeric-constrained type parameter
+        // (`T extends number`) are accepted exactly as tsc accepts them — while a
+        // conditional with a non-numeric branch (`... ? number : string`) and an
+        // unconstrained parameter still fail.
+        if depth < 4
+            && let Some(resolved) = self.arithmetic_operand_apparent_type(type_id)
+            && resolved != type_id
+        {
+            return self.is_arithmetic_operand_inner(resolved, true, depth + 1);
         }
         false
+    }
+
+    /// Whether `type_id` is a non-empty union whose members are each individually
+    /// a valid arithmetic operand (e.g. `number | bigint`).
+    fn all_union_members_arithmetic(&self, type_id: TypeId) -> bool {
+        let Some(members) = crate::visitor::union_list_id(self.interner, type_id) else {
+            return false;
+        };
+        let member_list = self.interner.type_list(members);
+        !member_list.is_empty()
+            && member_list.iter().all(|&m| {
+                m == TypeId::ANY
+                    || m == TypeId::ERROR
+                    || m == TypeId::NEVER
+                    || self.is_number_like(m)
+                    || self.is_bigint_like(m)
+            })
+    }
+
+    /// Resolve an instantiable operand to the apparent type / base constraint that
+    /// `tsc` uses to validate arithmetic-operand-ness, or `None` when there is no
+    /// such reduction (a concrete type, or a deferred form whose constituents stay
+    /// opaque). Mirrors the relevant slice of `getBaseConstraintOfType`.
+    fn arithmetic_operand_apparent_type(&self, type_id: TypeId) -> Option<TypeId> {
+        if type_id.is_intrinsic() {
+            return None;
+        }
+        match self.interner.lookup(type_id)? {
+            TypeData::TypeParameter(_) | TypeData::Infer(_) => {
+                let constraint =
+                    crate::type_queries::get_base_constraint_or_type(self.interner, type_id);
+                (constraint != type_id).then_some(constraint)
+            }
+            TypeData::Conditional(_) => {
+                // The union of the branch results is the conditional's base
+                // constraint (tsc's `getBaseConstraintOfType` of a conditional is
+                // `getUnionType([trueType, falseType])`); fall back to the default
+                // constraint for branch shapes the union helper keeps opaque.
+                crate::type_queries::conditional_branch_union_constraint(self.interner, type_id)
+                    .or_else(|| {
+                        crate::type_queries::get_conditional_default_constraint(
+                            self.interner,
+                            type_id,
+                        )
+                    })
+            }
+            _ => None,
+        }
     }
 
     /// Evaluate a binary operation on two types.


### PR DESCRIPTION
Fixes #14154.

## Structural rule
When an arithmetic operand is an **instantiable** type, `tsc`'s `checkArithmeticOperandType` validates it by assignability to `number | bigint`, which is decided against the type's **base constraint / apparent type** (`getBaseConstraintOfType`). tsz did X through the solver predicate `BinaryOpEvaluator::is_arithmetic_operand`, but that predicate only inspected the *structural* type — so a deferred conditional whose branches are all numeric (`Sum<T> = T extends readonly [] ? 0 : number`) and a numeric-constrained type parameter (`T extends number`) were classified as non-numeric and produced a false **TS2362/TS2363**.

The repro is the remeda `mean.ts` witness `sum(data) / data.length`, where `sum<T>(data: T): Sum<T>` returns the deferred conditional `Sum<T>`.

## Wrong operation
Relation/classification: the numeric-operand predicate did not resolve a deferred conditional / generic operand to its constraint before classifying it.

## Fix (owner layer: solver)
`is_arithmetic_operand` now, after the cheap direct numeric checks fail, resolves the operand toward its apparent form and re-checks (bounded recursion):
- bare type parameter / `infer` → base constraint (`get_base_constraint_or_type`),
- deferred conditional → branch-union (`conditional_branch_union_constraint`), falling back to the default constraint (`get_conditional_default_constraint`).

A constraint that reduces to `unknown` (an unconstrained parameter) is held to a stricter test (a surface `unknown` operand is still accepted to avoid cascading after an earlier error, but a constraint-derived `unknown` is not numeric — matching `tsc`). The change is in the shared solver predicate, so every arithmetic-operand call site benefits uniformly rather than via a checker-local special case.

## Adjacent matrix (verified on a freshly built `.target/release/tsz`)
Positive (now clean, `tsc` clean):
- deferred conditional all-numeric branches `T extends [] ? 0 : number` (the repro) + a binder-renamed variant;
- bare type parameter `T extends number` / `T extends bigint`;
- mixed-numeric conditional `T extends string ? number : bigint` — no longer TS2362 (any `number`×`bigint` mixing is still reported as TS2365, as in `tsc`);
- indexed access resolving to a numeric value.

Negative controls (still warn, `tsc` warns):
- conditional with a non-numeric branch `... ? number : string` → TS2362;
- unconstrained type parameter `T` → TS2362;
- type parameter constrained to `number | string` → TS2362;
- plain `string` operand → TS2362.

## Anti-hardcoding
No identifier/file-name literals drive the decision; no formatted-diagnostic string is used as a predicate. The structural rule is exercised with renamed binders in the test matrix.

## Verification
- New regression suite `crates/tsz-checker/tests/deferred_conditional_arithmetic_operand_tests.rs` (7 tests: repro, binder-rename, numeric-constrained param, mixed-numeric, + 3 negative controls) — passes.
- Existing arithmetic/operator checker suites (`string_literal_arithmetic_tests`, `ts18048_unary_arithmetic_nullish_tests`, `ts2469_symbol_operator_tests`, `value_usage_tests`) and `tsz-solver --lib` show **no new failures** vs. the clean tree (the few red tests fail identically with and without this change — pre-existing, lib-dependent locally).
- `cargo clippy -p tsz-solver --lib` clean.
- Branch fast-forwarded onto `origin/main` (no conflicts).

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high