### PR TITLE
fix(checker): interface inherits members from a cross-module class base (#14161)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/heritage.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage.rs
@@ -1278,14 +1278,31 @@ impl<'a> CheckerState<'a> {
                                 continue;
                             }
 
-                            // Emit TS2312 for interface extending a type parameter
+                            // Interface extending one of its own type parameters.
+                            // tsc's `isValidBaseType` accepts a type parameter whose
+                            // base constraint is a valid object base — members are
+                            // inherited from the constraint's statically-known shape
+                            // (`interface I<T extends { k: string }> extends T {}`).
+                            // Emit TS2312 only when the constraint is not such a base
+                            // (unconstrained, or constrained to a non-object). The
+                            // type-parameter scope is active here (heritage is checked
+                            // after the params are pushed), so the node resolves to the
+                            // constrained `TypeParameter` type.
                             if !is_class_declaration && class_type_param_names.contains(&name) {
-                                use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-                                self.error_at_node(
-                                    expr_idx,
-                                    diagnostic_messages::AN_INTERFACE_CAN_ONLY_EXTEND_AN_OBJECT_TYPE_OR_INTERSECTION_OF_OBJECT_TYPES_WITH,
-                                    diagnostic_codes::AN_INTERFACE_CAN_ONLY_EXTEND_AN_OBJECT_TYPE_OR_INTERSECTION_OF_OBJECT_TYPES_WITH,
-                                );
+                                let base_type = self.get_type_from_type_node(type_idx);
+                                if !crate::query_boundaries::class::is_valid_interface_base_type(
+                                    self.ctx.types,
+                                    base_type,
+                                ) {
+                                    use crate::diagnostics::{
+                                        diagnostic_codes, diagnostic_messages,
+                                    };
+                                    self.error_at_node(
+                                        expr_idx,
+                                        diagnostic_messages::AN_INTERFACE_CAN_ONLY_EXTEND_AN_OBJECT_TYPE_OR_INTERSECTION_OF_OBJECT_TYPES_WITH,
+                                        diagnostic_codes::AN_INTERFACE_CAN_ONLY_EXTEND_AN_OBJECT_TYPE_OR_INTERSECTION_OF_OBJECT_TYPES_WITH,
+                                    );
+                                }
                                 continue;
                             }
                             // Route through boundary for TS2304/TS2552 with suggestion collection

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -10,6 +10,7 @@
 //! - Type parameter instantiation for generic bases
 
 use crate::state::CheckerState;
+use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use crate::types_domain::type_node_helpers::type_node_includes_explicit_undefined;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
@@ -154,6 +155,40 @@ impl<'a> CheckerState<'a> {
             // declaring file is checked through cross-arena delegation,
             // making results depend on root-file order.
             .or_else(|| self.ctx.binder.program_global_type(normalized))
+    }
+
+    /// Resolve an interface-heritage base symbol to the underlying `class`
+    /// symbol — directly, through an import alias, or through a cross-file
+    /// re-export — or `None` when the base is not a class. Used to route a
+    /// class base through the class-instance resolver (so instance members are
+    /// inherited) instead of the symbol's constructor type.
+    fn heritage_base_class_symbol(
+        &mut self,
+        base_sym_id: tsz_binder::SymbolId,
+    ) -> Option<tsz_binder::SymbolId> {
+        use tsz_binder::symbol_flags;
+
+        let symbol_is_class = |this: &Self, sym: tsz_binder::SymbolId| {
+            this.get_cross_file_symbol(sym)
+                .or_else(|| this.ctx.binder.get_symbol(sym))
+                .is_some_and(|symbol| symbol.has_any_flags(symbol_flags::CLASS))
+        };
+
+        if symbol_is_class(self, base_sym_id) {
+            return Some(base_sym_id);
+        }
+
+        let mut visited_aliases = AliasCycleTracker::new();
+        if let Some(target) = self
+            .resolve_alias_symbol(base_sym_id, &mut visited_aliases)
+            .filter(|&t| t != base_sym_id)
+            && symbol_is_class(self, target)
+        {
+            return Some(target);
+        }
+
+        self.resolve_import_alias_cross_file(base_sym_id)
+            .filter(|&t| t != base_sym_id && symbol_is_class(self, t))
     }
 
     /// Get the type of an interface declaration.
@@ -919,6 +954,34 @@ impl<'a> CheckerState<'a> {
                         }
                     }
 
+                    // Cross-module class base: the base class declaration lives in
+                    // another file's arena, so the local-arena lookups above cannot
+                    // see it (NodeIndex is per-arena). For a class base — including one
+                    // reached through an import alias or cross-file re-export — resolve
+                    // the class *instance* type from the class symbol (the same resolver
+                    // class heritage uses), rather than falling through to
+                    // `get_type_of_symbol`, which for a class symbol yields its
+                    // *constructor* (static) type. Merging a constructor type would
+                    // contribute only static/construct members, dropping every inherited
+                    // instance member (TS2339). This makes the interface-extends-class
+                    // direction symmetric with the class-extends-class direction in
+                    // `instance_merge.rs`.
+                    //
+                    // The returned instance type embeds the base class's own type
+                    // parameter `TypeId`s, so its params (not the alias symbol's) drive
+                    // the generic-base instantiation below.
+                    let mut base_class_params: Option<Vec<tsz_solver::TypeParamInfo>> = None;
+                    if base_type.is_none()
+                        && let Some(class_sym) = self.heritage_base_class_symbol(base_sym_id)
+                        && let Some((instance_type, instance_params)) =
+                            self.class_instance_type_with_params_from_symbol(class_sym)
+                        && instance_type != TypeId::ERROR
+                        && instance_type != TypeId::UNKNOWN
+                    {
+                        base_type = Some(instance_type);
+                        base_class_params = Some(instance_params);
+                    }
+
                     // For interfaces/type aliases, resolve through symbol type
                     if base_type.is_none() {
                         let resolved = self.get_type_of_symbol(base_sym_id);
@@ -947,7 +1010,13 @@ impl<'a> CheckerState<'a> {
                     // TypeIds that match the ones in base_type's member signatures.
                     // Previously we used push_type_parameters which creates NEW
                     // TypeIds that don't match, causing substitution to be a no-op.
-                    let base_type_params = self.get_type_params_for_symbol(base_sym_id);
+                    //
+                    // A class base resolves through `class_instance_type_with_params_from_symbol`,
+                    // which returns the base class's own type parameters matching the
+                    // `TypeId`s embedded in the (uninstantiated) instance type; use those
+                    // so the substitution below applies the heritage arguments correctly.
+                    let base_type_params = base_class_params
+                        .unwrap_or_else(|| self.get_type_params_for_symbol(base_sym_id));
 
                     if type_args.len() < base_type_params.len() {
                         for (param_index, param) in

--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -50,6 +50,9 @@ mod fs_tests;
 #[path = "../tests/generic_interface_bivariant_param_relation_tests.rs"]
 mod generic_interface_bivariant_param_relation_tests;
 #[cfg(test)]
+#[path = "../tests/interface_extends_cross_module_class_cli_tests.rs"]
+mod interface_extends_cross_module_class_cli_tests;
+#[cfg(test)]
 #[path = "../tests/interface_extends_generic_alias_cli_tests.rs"]
 mod interface_extends_generic_alias_cli_tests;
 #[cfg(test)]

--- a/crates/tsz-cli/tests/interface_extends_cross_module_class_cli_tests.rs
+++ b/crates/tsz-cli/tests/interface_extends_cross_module_class_cli_tests.rs
@@ -47,8 +47,8 @@ fn compile_in_order(files: &[(&str, &str)], root_order: &[&str]) -> Vec<Diagnost
     ];
     argv.extend_from_slice(root_order);
 
-    let args = CliArgs::try_parse_from(argv).expect("parse args");
-    crate::driver::compile(&args, dir.path())
+    let cli_args = CliArgs::try_parse_from(argv).expect("parse args");
+    crate::driver::compile(&cli_args, dir.path())
         .expect("compile should succeed")
         .diagnostics
 }

--- a/crates/tsz-cli/tests/interface_extends_cross_module_class_cli_tests.rs
+++ b/crates/tsz-cli/tests/interface_extends_cross_module_class_cli_tests.rs
@@ -1,0 +1,296 @@
+//! An interface inheriting members from a base that is not a plain same-file
+//! interface.
+//!
+//! (A) `interface D extends Base {}` where `Base` is a `class` imported from
+//!     another module. tsc materializes the base class's *instance* members
+//!     into the interface; tsz dropped them because the local heritage merge
+//!     only resolved class declarations in the current file's arena and then
+//!     fell back to the class symbol's *constructor* type. The fix resolves a
+//!     class base — including one reached through an import alias / default
+//!     import — through the class-instance resolver, symmetric with the
+//!     class-extends-class direction. This is the runtypes/arktype canary
+//!     defect (#14161): both reduce to this one invariant.
+//!
+//! (B) `interface I<T extends {...}> extends T {}` — extending one of its own
+//!     type parameters. tsc's `isValidBaseType` resolves the parameter to its
+//!     base constraint, so an object-constrained parameter is a valid base and
+//!     no TS2312 is reported. tsz emitted a spurious TS2312; the fix gates the
+//!     diagnostic on the solver's `is_valid_interface_base_type`, which now
+//!     resolves type-parameter constraints.
+//!
+//! Needs the real multi-module driver: the in-crate `check_multi_file_with_libs`
+//! harness does not set up the cross-arena class-instance resolution path, so
+//! these reproduce only end-to-end (mirrors `interface_extends_generic_alias_cli_tests`).
+//! Cases vary binder names and import forms so the rule follows the type shape,
+//! not identifier text.
+
+use crate::args::CliArgs;
+use clap::Parser;
+use tsz_checker::diagnostics::Diagnostic;
+
+/// Compile `files` (written into one temp dir) with the given root-file order.
+fn compile_in_order(files: &[(&str, &str)], root_order: &[&str]) -> Vec<Diagnostic> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    for (name, contents) in files {
+        std::fs::write(dir.path().join(name), contents).expect("write repro file");
+    }
+
+    let mut argv: Vec<&str> = vec![
+        "tsz",
+        "--ignoreConfig",
+        "--noEmit",
+        "--strict",
+        "--target",
+        "es2022",
+        "--lib",
+        "es2022,dom,dom.iterable",
+    ];
+    argv.extend_from_slice(root_order);
+
+    let args = CliArgs::try_parse_from(argv).expect("parse args");
+    crate::driver::compile(&args, dir.path())
+        .expect("compile should succeed")
+        .diagnostics
+}
+
+fn codes_with_code(diagnostics: &[Diagnostic], code: u32) -> Vec<String> {
+    diagnostics
+        .iter()
+        .filter(|d| d.code == code)
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+/// Assert no TS2339 "property does not exist" in either root-file order
+/// (consumer-first is the cross-file regression direction).
+fn assert_no_missing_property_both_orders(files: &[(&str, &str)]) {
+    let names: Vec<&str> = files.iter().map(|(name, _)| *name).collect();
+    let forward = codes_with_code(&compile_in_order(files, &names), 2339);
+    assert!(
+        forward.is_empty(),
+        "expected no TS2339 in forward root order {names:?}, got: {forward:?}"
+    );
+    let reversed: Vec<&str> = names.iter().rev().copied().collect();
+    let backward = codes_with_code(&compile_in_order(files, &reversed), 2339);
+    assert!(
+        backward.is_empty(),
+        "expected no TS2339 in reversed root order {reversed:?}, got: {backward:?}"
+    );
+}
+
+// ── (A) interface extends cross-module class ──────────────────────────────
+
+#[test]
+fn imported_class_base_inherits_instance_members() {
+    assert_no_missing_property_both_orders(&[
+        (
+            "main.ts",
+            r#"
+import { Base } from "./base";
+interface Derived extends Base {}
+declare const d: Derived;
+const s: string = d.greet();
+const t: string = d.tag;
+"#,
+        ),
+        (
+            "base.ts",
+            r#"
+export class Base {
+    tag!: string;
+    greet(): string { return ""; }
+}
+"#,
+        ),
+    ]);
+}
+
+#[test]
+fn renamed_default_import_class_base_inherits_members() {
+    // Default export + locally renamed import: the rule is structural, not
+    // keyed on the imported identifier.
+    assert_no_missing_property_both_orders(&[
+        (
+            "main.ts",
+            r#"
+import Renamed from "./widget";
+interface Panel extends Renamed {}
+declare const p: Panel;
+const n: number = p.id;
+p.render();
+"#,
+        ),
+        (
+            "widget.ts",
+            r#"
+export default class Widget {
+    id!: number;
+    render(): void {}
+}
+"#,
+        ),
+    ]);
+}
+
+#[test]
+fn imported_generic_class_base_inherits_instantiated_members() {
+    assert_no_missing_property_both_orders(&[
+        (
+            "main.ts",
+            r#"
+import { Container } from "./container";
+interface StrBox extends Container<string> {}
+declare const b: StrBox;
+const v: string = b.value;
+const w: string = b.wrap("x");
+"#,
+        ),
+        (
+            "container.ts",
+            r#"
+export class Container<T> {
+    value!: T;
+    wrap(v: T): T { return v; }
+}
+"#,
+        ),
+    ]);
+}
+
+#[test]
+fn imported_generic_class_base_member_is_instantiated_not_widened() {
+    // The inherited member is instantiated to `string`, so a `number`
+    // annotation must still be rejected (no widening to `any`).
+    let files = &[
+        (
+            "main.ts",
+            r#"
+import { Container } from "./container";
+interface StrBox extends Container<string> {}
+declare const b: StrBox;
+export const bad: number = b.value;
+"#,
+        ),
+        (
+            "container.ts",
+            r#"
+export class Container<T> {
+    value!: T;
+}
+"#,
+        ),
+    ];
+    let diags = compile_in_order(files, &["main.ts", "container.ts"]);
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "the inherited member must be instantiated to `string` (TS2322 on a \
+         `number` annotation), got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn imported_class_base_genuinely_missing_member_still_errors() {
+    // Negative control: inherited members resolve, but a truly absent member
+    // still reports TS2339 (the fix must not blanket-suppress).
+    let files = &[
+        (
+            "main.ts",
+            r#"
+import { Base } from "./base";
+interface Derived extends Base {}
+declare const d: Derived;
+export const x = d.nope;
+"#,
+        ),
+        (
+            "base.ts",
+            r#"
+export class Base { tag!: string; }
+"#,
+        ),
+    ];
+    let missing = codes_with_code(&compile_in_order(files, &["main.ts", "base.ts"]), 2339);
+    assert!(
+        missing.iter().any(|m| m.contains("nope")),
+        "a member on neither the interface nor its base class must still report \
+         TS2339, got: {missing:?}"
+    );
+}
+
+#[test]
+fn imported_interface_base_still_clean() {
+    // Boundary that already worked — guard against regression.
+    assert_no_missing_property_both_orders(&[
+        (
+            "main.ts",
+            r#"
+import { BaseI } from "./base";
+interface DerivedI extends BaseI {}
+declare const d: DerivedI;
+const s: string = d.greet();
+const t: string = d.tag;
+"#,
+        ),
+        (
+            "base.ts",
+            r#"
+export interface BaseI { tag: string; greet(): string; }
+"#,
+        ),
+    ]);
+}
+
+// ── (B) interface extends a constrained type parameter: diagnostic parity ─
+
+#[test]
+fn object_constrained_type_param_base_no_ts2312() {
+    let files = &[(
+        "a.ts",
+        r#"
+interface Box<attachments extends { kind: string }> extends attachments {}
+declare const b: Box<{ kind: string }>;
+"#,
+    )];
+    let ts2312 = codes_with_code(&compile_in_order(files, &["a.ts"]), 2312);
+    assert!(
+        ts2312.is_empty(),
+        "interface extending a type parameter whose constraint is an object \
+         base must not report TS2312, got: {ts2312:?}"
+    );
+}
+
+#[test]
+fn unconstrained_type_param_base_still_reports_ts2312() {
+    let files = &[(
+        "a.ts",
+        r#"
+interface Bag<contents> extends contents {}
+"#,
+    )];
+    let ts2312 = codes_with_code(&compile_in_order(files, &["a.ts"]), 2312);
+    assert!(
+        !ts2312.is_empty(),
+        "interface extending an unconstrained type parameter must still report \
+         TS2312"
+    );
+}
+
+#[test]
+fn primitive_constrained_type_param_base_still_reports_ts2312() {
+    let files = &[(
+        "a.ts",
+        r#"
+interface Wrap<v extends number> extends v {}
+"#,
+    )];
+    let ts2312 = codes_with_code(&compile_in_order(files, &["a.ts"]), 2312);
+    assert!(
+        !ts2312.is_empty(),
+        "interface extending a type parameter constrained to a primitive must \
+         still report TS2312"
+    );
+}

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -1936,6 +1936,15 @@ pub fn is_valid_interface_base_type(db: &dyn TypeDatabase, type_id: TypeId) -> b
                     .is_some_and(|name_type| contains_type_parameters_db(db, name_type))
         }
         Some(TypeData::ReadonlyType(inner)) => is_valid_interface_base_type(db, inner),
+        // tsc `isValidBaseType`: a type parameter is a valid interface base iff
+        // its base constraint is a valid base type. Members are inherited from
+        // the constraint's statically-known object shape (e.g.
+        // `interface I<T extends { k: string }> extends T {}` inherits `k`). An
+        // unconstrained parameter resolves to itself and is rejected (TS2312).
+        Some(TypeData::TypeParameter(_) | TypeData::Infer(_)) => {
+            let constraint = crate::type_queries::get_base_constraint_or_type(db, type_id);
+            constraint != type_id && is_valid_interface_base_type(db, constraint)
+        }
         _ => false,
     }
 }


### PR DESCRIPTION
Refs #14161.

Goal: green

## Structural rule
When an `interface` extends a base that is **not a plain same-file interface**,
`tsc` materializes the base's members into the interface. `tsz` materialized
none of them, so every inherited member was reported missing.

- **(A) cross-module class base.** `interface D extends Base {}` where `Base` is
  a `class` imported from another module. `tsz` only resolved class
  declarations in the *current file's arena* (`NodeIndex` is per-arena) and then
  fell back to the class symbol's **constructor** (static) type via
  `get_type_of_symbol`, contributing only static/construct members and dropping
  every inherited instance member (TS2339). This is the single highest-leverage
  green defect in the canary corpus — runtypes and arktype both reduce to it.
- **(B) object-constrained type-parameter base.** `interface I<T extends { k: string }> extends T {}`.
  `tsc`'s `isValidBaseType` resolves a type parameter to its **base
  constraint**, so an object-constrained parameter is a valid base and no
  TS2312 is reported. `tsz` emitted a spurious TS2312.

`When an interface extends a class (directly or through an import alias /
default import), tsc materializes the class's resolved instance members; tsz
now does X through the solver-backed class-instance resolver.`

## Owner layer & approach
- **checker `types/interface_type.rs`** — in `merge_interface_heritage_types_inner`,
  after the existing local-arena class lookups and before the
  `get_type_of_symbol` fallback, a class base (resolved through aliases by
  `heritage_base_class_symbol`) is resolved with
  `class_instance_type_with_params_from_symbol` (the same resolver class
  heritage uses, which delegates cross-arena). Its returned type parameters —
  matching the `TypeId`s embedded in the uninstantiated instance type — drive
  the existing generic-base instantiation, so `extends Container<string>`
  inherits `value: string`. This makes the interface-extends-class direction
  symmetric with the class-extends-class direction in `class_type/instance_merge.rs`.
- **solver `type_queries/.../signatures_and_advanced.rs`** —
  `is_valid_interface_base_type` gains a `TypeParameter`/`Infer` arm that
  resolves the base constraint (`get_base_constraint_or_type`) and recurses,
  mirroring `tsc`'s `isValidBaseType`. An unconstrained parameter resolves to
  itself and stays invalid.
- **checker `state_checking/heritage.rs`** — the interface-extends-type-parameter
  TS2312 emission is gated on that solver predicate (structural rule in the
  solver; the checker only decides *when* to apply it).

## Anti-hardcoding
Purely structural: keyed on symbol class-ness and type-parameter constraint
shape via solver/query-boundary helpers — no identifier, alias, file-name, or
rendered-type-string checks. Tests vary binder names and import forms (named,
renamed default).

## Scope note
The interface-extends-class member inheritance (A) and the type-parameter-base
TS2312 false positive (B) are fixed. Materializing the inherited members for a
**generic interface that is then instantiated** (`Box<T extends {...}> extends T`
used as `Box<X>`) runs through the solver's lazy/application body path rather
than the checker heritage merge, and is a separate follow-up; this PR does not
close that part of #14161.

## Adjacent matrix (verified end-to-end on the real multi-module driver)
Accept (no TS2339):
- interface extends cross-module class (named import);
- interface extends a renamed **default**-imported class;
- interface extends a cross-module **generic** class `Container<string>` — and
  the inherited `value` is instantiated to `string` (a `number` annotation is
  still rejected with TS2322, i.e. not widened to `any`);
- interface extends a cross-module **interface** (pre-existing boundary, guarded).

Negative controls (still error):
- a member on neither the interface nor its base class → TS2339;
- interface extends an **unconstrained** type parameter → TS2312;
- interface extends a parameter constrained to a **primitive** → TS2312.

## Verification
- New CLI driver suite `crates/tsz-cli/tests/interface_extends_cross_module_class_cli_tests.rs`
  (9 tests, real multi-module driver — the in-crate harness cannot host
  cross-arena class resolution): `cargo test -p tsz-cli --lib interface_extends_cross_module_class`
  → **9 passed**. Each positive case reproduces the bug on the pre-fix binary.
- `cargo test -p tsz-cli --lib -- extends heritage`: 46 passed; the single
  failure (`interface_extends_generic_alias_cli_tests::imported_interface_extending_omit_genuinely_missing_property_still_errors`)
  is **pre-existing on the base** — verified by re-running with the change
  stashed (fails identically).
- `cargo clippy -p tsz-solver -p tsz-checker --lib` clean; `cargo fmt` clean.
- Reviewed with `/simplify`; the one suggested cleanup was applied.
- Broad conformance/emit/fourslash suites: delegated to ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01F8zET4ZTfxi9DBHGduzxg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8zET4ZTfxi9DBHGduzxg7)_