### PR TITLE
fix(checker): widen array/object-literal conditional branches like tsc

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -198,6 +198,9 @@ path = "tests/ts2371_binding_pattern_default_tests.rs"
 name = "block_body_callback_literal_widening_tests"
 path = "tests/block_body_callback_literal_widening_tests.rs"
 [[test]]
+name = "conditional_branch_array_literal_widening_tests"
+path = "tests/conditional_branch_array_literal_widening_tests.rs"
+[[test]]
 name = "extract_alias_distributive_mapped_tests"
 path = "tests/extract_alias_distributive_mapped_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -164,10 +164,26 @@ impl<'a> CheckerState<'a> {
         // the union is checked against the contextual type.
         let contextual_type = request.contextual_type;
 
-        // Preserve literal types in conditional branches so that
-        // `const x = cond ? "a" : "b"` infers `"a" | "b"` (tsc behavior).
+        // Preserve the *fresh literal* type of a branch so that
+        // `const x = cond ? "a" : "b"` infers `"a" | "b"` (tsc behavior). tsc's
+        // `checkConditionalExpression` types each branch with `checkExpression`,
+        // which keeps the fresh literal of a primitive-literal expression but
+        // still widens nested array/object literal element types via
+        // best-common-type (those go through `checkExpressionForMutableLocation`,
+        // independent of the surrounding conditional). The `preserve_literal_types`
+        // context flag models the freshness, but it *also* suppresses
+        // array/object-literal element widening, so enabling it for every branch
+        // makes `cond ? ["a", "b"] : []` keep `("a" | "b")[]` instead of widening
+        // to `string[]` — a later `.push(string)` then wrongly fails (TS2345).
+        //
+        // Scope the flag to syntactic primitive-literal branches, exactly as the
+        // `&&`/`||`/`??` logical-operator path does (see
+        // `logical_operand_is_primitive_literal`): a primitive-literal branch
+        // keeps its fresh literal, while an array/object-literal branch widens its
+        // elements like any other expression.
+        let preserve_when_true = self.logical_operand_is_primitive_literal(cond.when_true);
+        let preserve_when_false = self.logical_operand_is_primitive_literal(cond.when_false);
         let prev_preserve = self.ctx.preserve_literal_types;
-        self.ctx.preserve_literal_types = true;
 
         // tsc always evaluates BOTH branches and unions them for the result
         // type, even when the condition is a literal boolean.  This ensures
@@ -215,6 +231,7 @@ impl<'a> CheckerState<'a> {
         let true_ctx = contextual_type
             .map(|ctx| self.contextual_type_for_conditional_branch(ctx, cond.when_true));
         let true_request = request.contextual_opt(true_ctx);
+        self.ctx.preserve_literal_types = prev_preserve || preserve_when_true;
         let when_true = if condition_is_false {
             // Dead branch — suppress diagnostics but still compute type.
             // Must save/restore BOTH the diagnostics vec AND the dedup set,
@@ -228,10 +245,12 @@ impl<'a> CheckerState<'a> {
             suppress_contextual_branch_ts2322(self, cond.when_true, snap);
             ty
         };
+        self.ctx.preserve_literal_types = prev_preserve;
 
         let false_ctx = contextual_type
             .map(|ctx| self.contextual_type_for_conditional_branch(ctx, cond.when_false));
         let false_request = request.contextual_opt(false_ctx);
+        self.ctx.preserve_literal_types = prev_preserve || preserve_when_false;
         let when_false = if condition_is_true {
             // Dead branch — suppress diagnostics but still compute type.
             self.speculative_type_of_node(cond.when_false, &false_request)
@@ -241,7 +260,6 @@ impl<'a> CheckerState<'a> {
             suppress_contextual_branch_ts2322(self, cond.when_false, snap);
             ty
         };
-
         self.ctx.preserve_literal_types = prev_preserve;
 
         // Do NOT widen branch literal types here. In tsc, conditional expressions

--- a/crates/tsz-checker/tests/conditional_branch_array_literal_widening_tests.rs
+++ b/crates/tsz-checker/tests/conditional_branch_array_literal_widening_tests.rs
@@ -1,0 +1,199 @@
+//! Regression tests for issue #14165.
+//!
+//! `tsc` types each branch of a conditional (`cond ? a : b`) with
+//! `checkExpression`, which keeps the fresh literal of a *primitive-literal*
+//! branch (`cond ? "a" : "b"` is `"a" | "b"`) but still widens the element
+//! types of an *array/object-literal* branch via best-common-type, because those
+//! elements go through `checkExpressionForMutableLocation` (widening is
+//! independent of the surrounding conditional). tsz previously forced
+//! literal preservation for *both* branches, so `cond ? ["a", "b"] : []` kept
+//! `("a" | "b")[]` instead of widening to `string[]`, and a later
+//! `.push(string)` wrongly failed with TS2345.
+//!
+//! The fix scopes literal preservation to syntactic primitive-literal branches,
+//! exactly as the `&&`/`||`/`??` logical-operator path already does. Binder
+//! names are varied across fixtures so the rule stays structural.
+
+use tsz_checker::test_utils::check_source_code_messages as compile_and_get_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    compile_and_get_diagnostics(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+fn assert_clean(source: &str, why: &str) {
+    let found = codes(source);
+    assert!(
+        found.is_empty(),
+        "{why}: expected no diagnostics, got {found:?}"
+    );
+}
+
+fn assert_has(source: &str, code: u32, why: &str) {
+    let found = codes(source);
+    assert!(
+        found.contains(&code),
+        "{why}: expected TS{code}, got {found:?}"
+    );
+}
+
+// --- The reported witness (immer canary family) ---------------------------
+//
+// The widening is observed by assigning an *arbitrary*, wider array into the
+// inferred `const` type via `typeof`: a wider `string[]` is assignable to the
+// inferred type only when the conditional widened its element type to `string`.
+// If the literal element union survived (`("x" | "y")[]`), the wider `string[]`
+// would be rejected with TS2322. This keeps the test independent of
+// `Array.prototype.push` (absent in the unit-test reduced lib).
+
+#[test]
+fn issue_repro_mixed_array_branch_widens_elements() {
+    let source = r#"
+declare const cond: boolean;
+const errors = cond
+    ? ["frozen error", "circular error", (x: string) => x]
+    : [];
+const wider: (string | ((x: string) => string))[] = ["Sets cannot have replace patches."];
+const sink: typeof errors = wider;
+"#;
+    assert_clean(
+        source,
+        "array-literal branch element types widen so an arbitrary string element is accepted",
+    );
+}
+
+// --- Array-literal branches widen their elements --------------------------
+
+#[test]
+fn string_array_branch_widens_to_string_array() {
+    let source = r#"
+declare const flag: boolean;
+const items = flag ? ["x", "y"] : [];
+const wider: string[] = ["z"];
+const sink: typeof items = wider;
+"#;
+    assert_clean(source, "string-literal array branch widens to string[]");
+}
+
+#[test]
+fn both_array_branches_widen() {
+    let source = r#"
+declare const pick: boolean;
+const values = pick ? ["x"] : ["y"];
+const wider: string[] = ["z"];
+const sink: typeof values = wider;
+"#;
+    assert_clean(source, "both array-literal branches widen to string[]");
+}
+
+#[test]
+fn numeric_array_branch_widens_to_number_array() {
+    let source = r#"
+declare const which: boolean;
+const nums = which ? [1, 2, 3] : [];
+const wider: number[] = [4];
+const sink: typeof nums = wider;
+"#;
+    assert_clean(source, "numeric-literal array branch widens to number[]");
+}
+
+#[test]
+fn nested_array_branch_widens() {
+    let source = r#"
+declare const sel: boolean;
+const grid = sel ? [["a"]] : [];
+const wider: string[][] = [["z"]];
+const sink: typeof grid = wider;
+"#;
+    assert_clean(source, "nested array-literal branch widens to string[][]");
+}
+
+#[test]
+fn array_branch_widened_element_assignable_to_annotation() {
+    let source = r#"
+declare const branch: boolean;
+const list: string[] = branch ? ["a", "b"] : [];
+"#;
+    assert_clean(source, "widened array branch is assignable to string[]");
+}
+
+#[test]
+fn unwidened_literal_array_rejects_wider_string_array() {
+    // Negative control: a genuinely literal-typed array (`as const`) is NOT
+    // assignable from a wider `string[]`, proving the assignability probe above
+    // actually discriminates widening.
+    let source = r#"
+declare const cond: boolean;
+const frozen = cond ? (["x", "y"] as const) : (["x", "y"] as const);
+const wider: string[] = ["z"];
+const sink: typeof frozen = wider;
+"#;
+    assert_has(
+        source,
+        2322,
+        "string[] is not assignable to a readonly literal tuple",
+    );
+}
+
+// --- Object-literal branches widen their property types -------------------
+
+#[test]
+fn object_branch_property_widens() {
+    let source = r#"
+declare const route: boolean;
+const node = route ? { tag: "open" } : { tag: "close" };
+const sink: { tag: string } = node;
+"#;
+    assert_clean(source, "object-literal branch property widens to string");
+}
+
+// --- Primitive-literal branches still preserve their fresh literal --------
+
+#[test]
+fn scalar_branches_preserve_literal_union() {
+    let source = r#"
+declare const toggle: boolean;
+const mode = toggle ? "a" : "b";
+const annotated: "a" | "b" = mode;
+"#;
+    assert_clean(
+        source,
+        "primitive-literal branches keep the literal union 'a' | 'b'",
+    );
+}
+
+#[test]
+fn scalar_branch_literal_rejects_wrong_literal_target() {
+    // `"a" | "b"` must NOT be assignable to a narrower `"a"` target.
+    let source = r#"
+declare const swap: boolean;
+const mode = swap ? "a" : "b";
+const narrow: "a" = mode;
+"#;
+    assert_has(source, 2322, "'a' | 'b' is not assignable to 'a'");
+}
+
+#[test]
+fn numeric_scalar_branches_preserve_literal_union() {
+    let source = r#"
+declare const choose: boolean;
+const n = choose ? 1 : 2;
+const annotated: 1 | 2 = n;
+"#;
+    assert_clean(source, "numeric primitive-literal branches keep 1 | 2");
+}
+
+// --- `as const` branch keeps its readonly/literal shape (negative control) -
+
+#[test]
+fn const_asserted_array_branch_keeps_literals() {
+    let source = r#"
+declare const guard: boolean;
+const tup = guard ? (["x", "y"] as const) : ([] as const);
+tup.push("z");
+"#;
+    // `as const` makes the surviving branch a readonly tuple; `.push` is absent.
+    assert_has(source, 2339, "readonly tuple from `as const` has no push");
+}


### PR DESCRIPTION
Closes #14165.

Goal: green

## Structural rule
When a conditional's branch is an **array/object literal** (`cond ? ["a","b"] : []`,
`cond ? { tag: "x" } : { tag: "y" }`), `tsc` widens the literal element/property
types via best-common-type, just as it would outside the conditional; only a
**primitive-literal** branch (`cond ? "a" : "b"`) keeps its fresh literal. tsz
diverged by keeping the literal element union for array/object branches, so a
later `.push(string)` failed with a spurious **TS2345**.

```ts
declare const cond: boolean;
const errors = cond
  ? ["frozen error", "circular error", (x: string) => x]
  : [];
errors.push("Sets cannot have replace patches."); // tsc OK | tsz TS2345 (before)
```

## Wrong operation
Expression typing / literal freshness vs. best-common-type element widening.
`tsc`'s `checkConditionalExpression` types each branch with `checkExpression`,
which preserves the fresh literal of a primitive-literal expression but routes
array/object literal **elements** through `checkExpressionForMutableLocation`
(best-common-type widening, independent of the surrounding conditional). tsz
models freshness with the `preserve_literal_types` context flag — but that flag
*also* suppresses array/object-literal element widening, and the conditional
forced it true for **both** branches, so element literals never widened.

## Fix (owner layer: checker)
`get_type_of_conditional_expression_with_request`
(`crates/tsz-checker/src/types/computation/helpers.rs`) now scopes
`preserve_literal_types` to **syntactic primitive-literal branches**, via the
existing `logical_operand_is_primitive_literal` predicate — exactly the pattern
the `&&`/`||`/`??` logical-operator path (`binary.rs`) already uses for the same
freshness-vs-widening tension. A primitive-literal branch keeps its fresh
literal; an array/object-literal branch widens its elements like any other
expression. An inherited outer flag (e.g. generic-call-argument literal
preservation) is still honored (`prev_preserve || preserve_when_*`).

This unifies the conditional with the established logical-operator behavior
rather than adding a conditional-specific special case.

## Adjacent matrix (verified)
Positive (now clean, `tsc` clean):
- the reported witness (mixed `string`/function array branch);
- `string` / `number` array branches widen (`string[]` / `number[]`);
- both-array branches; nested array branch (`string[][]`);
- object-literal branch property widening (`{ tag: string }`);
- widened array branch assignable to a `string[]` annotation.

Preserved (primitive-literal branches keep their fresh literal):
- `cond ? "a" : "b"` stays `"a" | "b"`; `cond ? 1 : 2` stays `1 | 2`.

Negative controls (still report, `tsc` reports):
- `"a" | "b"` is **not** assignable to a narrower `"a"` target (TS2322);
- an `as const` array branch keeps its readonly literal tuple — `.push` absent
  (TS2339) and a wider `string[]` is rejected (TS2322), proving the
  widening probe discriminates.

## Anti-hardcoding
Purely structural: the decision is a syntactic node-kind classification (shared
`logical_operand_is_primitive_literal`), never keyed on identifiers, aliases,
file names, or rendered-type strings. The regression matrix varies binder names
and includes the negative controls above.

## Verification
- New suite `crates/tsz-checker/tests/conditional_branch_array_literal_widening_tests.rs`
  (12 tests: repro, array/object widening, scalar preservation, `as const`
  negative controls) — `cargo test -p tsz-checker --test conditional_branch_array_literal_widening_tests` → 12/12.
- Manual CLI repro on the issue flags (`--noEmit --strict --target esnext
  --module esnext --moduleResolution bundler --skipLibCheck`): the witness and
  adjacent cases emit 0 diagnostics; the `as const` negative control still
  reports.
- Related suites show **no net-new failures** vs. the clean tree across the
  conditional/array/tuple/widening test families (the handful of red tests —
  e.g. `type_alias_annotation_does_not_show_raw_alias_name`,
  `conditional_infer_tests::equal_any_array_element_is_false` — fail identically
  with the change stashed; pre-existing).
- `cargo clippy -p tsz-checker --lib` clean; `cargo fmt`.
- Reviewed with `/simplify` (reuse / simplification / efficiency / altitude):
  co-located the `prev_preserve` capture; no further net-positive changes.
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_014ozSgpm4LpeVZNc4ovN1qP)_