### PR TITLE
fix(bench): publish complete gray app compat rows

### DIFF
--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -281,10 +281,18 @@ function analyzeArtifact(artifact, expectedCommit) {
     const state = stateFn(row, duplicate);
     const def = PROJECT_ROWS_BY_NAME[name];
     const compatibility = row?.compatibility ?? {};
+    const metadataComplete = (
+      row != null &&
+      duplicate !== true &&
+      row.artifact_missing !== true &&
+      row.compatibility != null &&
+      hasCompletePhaseMetadata(row.compatibility)
+    );
     return {
       name,
       label: def?.label ?? name,
       state,
+      metadata_complete: metadataComplete,
       duplicate_count: duplicateCount,
       tsz_ms: row?.tsz_ms ?? null,
       tsgo_ms: row?.tsgo_ms ?? null,
@@ -321,7 +329,11 @@ function analyzeArtifact(artifact, expectedCommit) {
     rows,
     applicationRows,
     applicationMissing: applicationRows.filter((r) => r.state === "missing"),
-    applicationIncomplete: applicationRows.filter((r) => r.state === "gray"),
+    applicationIncomplete: applicationRows.filter((r) => (
+      r.state !== "missing" &&
+      r.duplicate_count <= 1 &&
+      r.metadata_complete !== true
+    )),
     applicationDuplicates: applicationRows.filter((r) => r.duplicate_count > 1),
     successfulProjectTimingPairs: rows.filter((row) => (
       row.state === "green" &&

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -501,6 +501,67 @@ withTempDir((dir) => {
 console.log("✅ --require-application-compat accepts complete compile-only app rows");
 
 // ---------------------------------------------------------------------------
+// Test: complete gray application compatibility is still authoritative data.
+// Fixture-invalid/reference-failed app rows should not block publishing green
+// timed app rows; only missing or partial compatibility metadata should.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const requiredRows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  const applicationRows = APPLICATION_PROJECT_ROWS.map((name) =>
+    makeRow(name, "gray", {
+      errorStatus: "tsc fixture error",
+      tsz_ms: null,
+      tsgo_ms: null,
+      winner: "error",
+    }),
+  );
+  for (const row of applicationRows) {
+    row.compatibility.exit_class = "fixture invalid";
+    row.compatibility.phase = "fixture setup";
+    row.compatibility.last_successful_phase = null;
+    row.compatibility.diagnostic_status = "tsc fixture failed";
+  }
+  writeJson(file, makeArtifact([...requiredRows, ...applicationRows]));
+  const result = run(file, ["--json", "--require-application-compat"]);
+  assert.equal(result.status, 0, `complete gray application compatibility rows should pass:\n${result.stderr}`);
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.application_compatibility.present, APPLICATION_PROJECT_ROWS.length);
+  assert.equal(parsed.application_compatibility.complete, APPLICATION_PROJECT_ROWS.length);
+  assert.equal(parsed.application_compatibility.missing, 0);
+  assert.equal(parsed.application_compatibility.incomplete, 0);
+});
+console.log("✅ --require-application-compat accepts complete gray app rows");
+
+// ---------------------------------------------------------------------------
+// Test: a gray application row with partial metadata is still incomplete.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const requiredRows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  const applicationRows = APPLICATION_PROJECT_ROWS.map((name) =>
+    makeRow(name, "green", {
+      errorStatus: "compile canary tracked in CI; not timed by vs-tsgo benchmarks",
+      tsz_ms: null,
+      tsgo_ms: null,
+      winner: "error",
+    }),
+  );
+  delete applicationRows[0].compatibility.phase;
+  writeJson(file, makeArtifact([...requiredRows, ...applicationRows]));
+  const result = run(file, ["--json", "--require-application-compat"]);
+  assert.equal(result.status, 1, "partial application compatibility should fail readiness");
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.application_compatibility.present, APPLICATION_PROJECT_ROWS.length);
+  assert.equal(parsed.application_compatibility.complete, APPLICATION_PROJECT_ROWS.length - 1);
+  assert.equal(parsed.application_compatibility.incomplete, 1);
+  assert.deepEqual(parsed.application_compatibility.incomplete_rows, [
+    { name: APPLICATION_PROJECT_ROWS[0], state: "gray" },
+  ]);
+});
+console.log("✅ --require-application-compat rejects partial app rows");
+
+// ---------------------------------------------------------------------------
 // Test: --require-green fails when any present required row is red.
 // ---------------------------------------------------------------------------
 withTempDir((dir) => {


### PR DESCRIPTION
Goal: fast

## Summary
- Let benchmark publish readiness distinguish complete gray application compatibility from missing or partial metadata.
- Keep the guard strict for absent, duplicate, or partial app compatibility rows, while allowing fixture-invalid gray app rows to coexist with clean timed app rows.
- Verified against failed Bench run `27880719857`: the downloaded `bench-results-merged` artifact changes from `20/20 present, 8 incomplete` to `20/20 present, 0 incomplete`, with 9 successful project timing pairs.

## Structural Rule
When an application project row has a compatibility object with complete phase/exit metadata, its compatibility state is authoritative even if that state is `gray`; publish readiness should only reject missing, duplicate, or partial application compatibility metadata. Owner layer: benchmark artifact readiness/publish.

## Verification
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `node scripts/bench/check-artifact-readiness.mjs --json --require-application-compat --require-project-timing-pairs=1 /tmp/tsz-bench-27880719857/bench-results.json > /tmp/tsz-bench-27880719857/patched-readiness.json`
- `node scripts/bench/test-bench-readiness-banner.mjs`
- `node scripts/bench/test-ci-health-benchmark-readiness.mjs`
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `git diff --check`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
