### PR TITLE
perf(solver): discriminate single-def vs multi-member SCC re-entries (#14101 probe)

### DIFF
--- a/crates/tsz-solver/src/evaluation/eval_materialization_probe.rs
+++ b/crates/tsz-solver/src/evaluation/eval_materialization_probe.rs
@@ -91,6 +91,41 @@ pub(crate) fn record_def_reentry(prior_depth: u32) {
     DEF_REENTRY_MAX_DEPTH.fetch_max(prior_depth as u64, Ordering::Relaxed);
 }
 
+/// #14101 SCC-DISCRIMINATING counters: of all observed re-entries, how many are
+/// MULTI-MEMBER (>=1 distinct other `DefId` on the eval stack between the two
+/// entries of the same `DefId` = a genuine A->B->A SCC) vs single-def self-
+/// recursion, plus the max distinct-member count. Settles whether the SCC
+/// materialize-once fixpoint has any valid target (the open xstate/arktype branch).
+static DEF_REENTRY_OBSERVED: AtomicU64 = AtomicU64::new(0);
+static DEF_REENTRY_MULTIMEMBER: AtomicU64 = AtomicU64::new(0);
+static DEF_REENTRY_MAX_DISTINCT: AtomicU64 = AtomicU64::new(0);
+
+/// Record one re-entry, classified by the count of distinct OTHER `DefId`s on
+/// `stack` between its top and the previous entry of `def_id`. 0 distinct =
+/// single-def self-recursion; >=1 = a multi-member SCC. No-op unless gated on,
+/// so the (bounded) scan never runs in a production build.
+#[inline]
+pub(crate) fn record_def_reentry_distinct(stack: &[crate::def::DefId], def_id: crate::def::DefId) {
+    if !gate_enabled() {
+        return;
+    }
+    let mut others: Vec<crate::def::DefId> = Vec::new();
+    for &d in stack.iter().rev() {
+        if d == def_id {
+            break;
+        }
+        if !others.contains(&d) {
+            others.push(d);
+        }
+    }
+    let n = others.len() as u64;
+    DEF_REENTRY_OBSERVED.fetch_add(1, Ordering::Relaxed);
+    if n > 0 {
+        DEF_REENTRY_MULTIMEMBER.fetch_add(1, Ordering::Relaxed);
+    }
+    DEF_REENTRY_MAX_DISTINCT.fetch_max(n, Ordering::Relaxed);
+}
+
 /// Eval-engine kinds the lever targets. Index into [`ProbeState`] arrays.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(usize)]
@@ -645,6 +680,14 @@ pub fn dump_report() -> String {
             "[scc] def re-entries (recursive-heritage back-edges) {reentries}, \
              max prior depth {}  (#14101 step-2 materialize-once headroom)",
             DEF_REENTRY_MAX_DEPTH.load(Ordering::Relaxed)
+        );
+        let observed = DEF_REENTRY_OBSERVED.load(Ordering::Relaxed);
+        let multimember = DEF_REENTRY_MULTIMEMBER.load(Ordering::Relaxed);
+        let _ = writeln!(
+            out,
+            "[scc] multi-member re-entries {multimember}/{observed} (max distinct members {}) \
+             — 0 multi-member means single-def recursion, SCC fixpoint has no target",
+            DEF_REENTRY_MAX_DISTINCT.load(Ordering::Relaxed)
         );
     }
     out

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -79,6 +79,12 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// deep and possibly infinite" behavior. Unlike a set-based cycle detector, this
     /// permits legitimate bounded recursion where each expansion converges.
     def_depth: FxHashMap<DefId, u32>,
+    /// #14101 SCC-discriminating probe: ordered stack of in-flight `DefId`
+    /// application entries (pushed on a successful `increment_def_depth`, popped
+    /// in `decrement_def_depth`). Lets the re-entry probe count the distinct
+    /// OTHER `DefId`s between two entries of the same `DefId` — 0 = single-def
+    /// self-recursion, >=1 = a multi-member A->B->A SCC. Observe-only.
+    def_eval_stack: Vec<DefId>,
     /// Number of currently active `DefId` expansions at or above the threshold
     /// that turns a structural recursion bailout into a real TS2589 failure.
     real_instantiation_depth_count: u32,
@@ -285,6 +291,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 crate::recursion::RecursionProfile::TypeEvaluation,
             ),
             def_depth: FxHashMap::default(),
+            def_eval_stack: Vec::new(),
             real_instantiation_depth_count: 0,
             suppress_this_binding: false,
             conditional_subtype_cache: FxHashMap::default(),
@@ -373,6 +380,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // Pure instrumentation (probe-gated); quantifies SCC materialize-once headroom.
         if *depth >= 1 {
             crate::evaluation::eval_materialization_probe::record_def_reentry(*depth);
+            // #14101 discriminating probe: distinct OTHER DefIds between this and
+            // the prior same-DefId entry (0 = single-def recursion, >=1 = a
+            // multi-member A->B->A SCC). Disjoint-field read of def_eval_stack
+            // while `depth` borrows def_depth; gated internally on the probe.
+            crate::evaluation::eval_materialization_probe::record_def_reentry_distinct(
+                &self.def_eval_stack,
+                def_id,
+            );
         }
         if *depth >= Self::MAX_DEF_DEPTH {
             // Depth-bounded run (see `deep_recursion_seen`).
@@ -386,10 +401,21 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             self.real_instantiation_depth_count += 1;
             self.mark_deep_recursion_seen();
         }
+        // #14101 probe: push on success — balanced with the pop in
+        // `decrement_def_depth` (the MAX_DEF_DEPTH early-return above does not push,
+        // and its caller does not decrement, so the stack stays balanced). Gated on
+        // the probe flag (stable per run) so a non-profiling build pays nothing.
+        if tsz_common::perf_counters::enabled_fast() {
+            self.def_eval_stack.push(def_id);
+        }
         true
     }
 
     fn decrement_def_depth(&mut self, def_id: DefId) {
+        // #14101 probe: pop — balanced with the gated push on a successful increment.
+        if tsz_common::perf_counters::enabled_fast() {
+            self.def_eval_stack.pop();
+        }
         if let Some(depth) = self.def_depth.get_mut(&def_id) {
             let was_real_instantiation_depth = *depth >= Self::REAL_INSTANTIATION_BAILOUT_THRESHOLD;
             *depth = depth.saturating_sub(1);
@@ -545,6 +571,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.contains_type_by_id_cache.clear();
         self.guard.reset();
         self.def_depth.clear();
+        self.def_eval_stack.clear();
         self.real_instantiation_depth_count = 0;
     }
 


### PR DESCRIPTION
## Summary

Extends the #14133 re-entry probe so it can **discriminate single-def self-recursion (A→A) from a multi-member SCC (A→B→A)** — the one thing #14133's counter can't do (a counter has no ordering).

Maintains an ordered `def_eval_stack: Vec<DefId>` (push on a successful `increment_def_depth`, pop in `decrement_def_depth`, both gated on `TSZ_PERF_COUNTERS` so a non-profiling build pays nothing); at each back-edge it counts the distinct OTHER `DefId`s between the two same-`DefId` entries. The probe dump's `[scc]` section now reports `multi-member/observed re-entries` + `max distinct members`.

**Why:** the SCC probe-first gate (#14101) found the timeout cluster is recursive-**conditional** recursion / acyclic DAG (typebox, drizzle) — **not** an Application SCC — and closed the SCC fixpoint with that finding. But xstate/arktype were attributed-but-unmeasured. This probe settles that last branch definitively: run it (`TSZ_PERF_COUNTERS=1`) on those canaries — `multi-member = 0` confirms no SCC target (fixpoint stays closed); `> 0` would reopen it with evidence. It makes the campaign's "point-levers exhausted, residual is materialization" conclusion *measured* rather than inferred.

Goal: green

## Provenance
Machine: MacBookPro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo check -p tsz-solver` clean; `cargo nextest run -p tsz-solver eval_materialization_probe` 4/4 pass; `scripts/arch/check-checker-boundaries.sh` passes.
- **Byte-parity by construction:** pure instrumentation — the `def_eval_stack` push/pop and the distinct-count scan are all gated on `tsz_common::perf_counters::enabled_fast()` (the `TSZ_PERF_COUNTERS` flag, stable per run, so push/pop stay balanced), and the recorder no-ops when off. No behavior change; full conformance via ready-review CI.

Refs #14101.
