### PR TITLE
fix(checker): default missing Node built-in import hint to TS2591, not TS2580

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/core/helpers.rs
@@ -283,11 +283,18 @@ impl<'a> CheckerState<'a> {
         //
         // This takes priority over any resolution error from the driver.
         if is_known_node_module(module_name) {
+            // tsc emits the install-only TS2580 hint only when `compilerOptions.types`
+            // includes the literal wildcard `"*"`; otherwise it emits the
+            // add-to-types-field TS2591 variant. So a plain import site defaults to
+            // TS2591 (its conformance baselines use TS2591 exclusively), and the
+            // require-like / import-type / JS / no-types-and-symbols sites stay on
+            // TS2591 as before.
             let use_types_field_hint = matches!(
                 site,
                 ModuleNotFoundSite::RequireLike | ModuleNotFoundSite::ImportType
             ) || self.ctx.compiler_options.no_types_and_symbols
-                || self.ctx.is_js_file();
+                || self.ctx.is_js_file()
+                || !self.ctx.compiler_options.types_has_wildcard;
             let (message_template, code) = if use_types_field_hint {
                 (
                     diagnostic_messages::CANNOT_FIND_NAME_DO_YOU_NEED_TO_INSTALL_TYPE_DEFINITIONS_FOR_NODE_TRY_NPM_I_SAVE_2,

--- a/crates/tsz-cli/src/bin/tsz_server/check.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/check.rs
@@ -909,6 +909,7 @@ impl Server {
             no_lib: options.no_lib,
             no_types_and_symbols: false,
             types_explicitly_set: false,
+            types_has_wildcard: false,
             target: checker_target,
             module: Self::parse_module(&options.module),
             es_module_interop: options.es_module_interop,

--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -105,6 +105,7 @@ pub(super) fn apply_cli_overrides_with_config_options(
         options.declaration_dir = Some(declaration_dir.clone());
     }
     if let Some(types) = args.types.as_ref() {
+        options.checker.types_has_wildcard = types.iter().any(|entry| entry == "*");
         options.types = Some(types.clone());
         options.checker.types_explicitly_set = true;
     }

--- a/crates/tsz-common/src/options/checker.rs
+++ b/crates/tsz-common/src/options/checker.rs
@@ -35,6 +35,11 @@ pub struct CheckerOptions {
     /// This distinguishes install-only diagnostics from types-field diagnostics in
     /// module-resolution paths that consult ambient package loading.
     pub types_explicitly_set: bool,
+    /// Whether `compilerOptions.types` contains the literal wildcard `"*"`.
+    /// tsc reports a missing Node built-in's "cannot find name" hint as TS2580
+    /// (install-only) only in this mode; otherwise it uses TS2591 (install +
+    /// add to the `types` field).
+    pub types_has_wildcard: bool,
     /// Target ECMAScript version (ES3, ES5, ES2015, ES2016, etc.)
     /// Controls which built-in types are available (e.g., Promise requires ES2015)
     /// Defaults to ES3 for maximum compatibility
@@ -225,6 +230,7 @@ impl Default for CheckerOptions {
             no_lib: false,
             no_types_and_symbols: false,
             types_explicitly_set: false,
+            types_has_wildcard: false,
             target: ScriptTarget::default(),
             module: ModuleKind::default(),
             es_module_interop: false,

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -461,6 +461,7 @@ pub fn resolve_compiler_options(
             .iter()
             .filter_map(|value| trimmed_non_empty(value).map(String::from))
             .collect();
+        resolved.checker.types_has_wildcard = list.iter().any(|entry| entry == "*");
         resolved.types = Some(list);
         resolved.checker.types_explicitly_set = true;
     }

--- a/crates/tsz-core/tests/checker_state_tests_parts/part_16.rs
+++ b/crates/tsz-core/tests/checker_state_tests_parts/part_16.rs
@@ -355,6 +355,7 @@ fn test_tier_2_type_checker_accuracy_fixes() {
             no_lib: false,
             no_types_and_symbols: false,
             types_explicitly_set: false,
+            types_has_wildcard: false,
             no_property_access_from_index_signature: false,
             target: crate::checker::context::ScriptTarget::ESNext,
             module: crate::common::ModuleKind::ESNext,

--- a/crates/tsz-core/tests/module_resolution_tests_parts/part_00.rs
+++ b/crates/tsz-core/tests/module_resolution_tests_parts/part_00.rs
@@ -149,7 +149,12 @@ fn test_es_named_import_unresolved_module() {
 }
 
 #[test]
-fn test_ts_import_of_node_builtin_uses_ts2580() {
+fn test_ts_import_of_node_builtin_uses_ts2591() {
+    // tsc's module-specifier path (getCannotResolveModuleNameErrorForSpecificModule)
+    // emits the add-to-`types`-field hint TS2591 by default for a missing Node
+    // builtin import; it only switches to the install-only TS2580 when
+    // `compilerOptions.types` contains the literal wildcard "*". See the wildcard
+    // sibling below.
     let diags = check_with_module_not_found_errors(
         r#"import { parse } from "url";
 export const thing = () => parse();
@@ -163,12 +168,39 @@ export const thing = () => parse();
         },
     );
     assert!(
+        has_error_code(&diags, TS2591),
+        "TypeScript import of unresolved Node builtin should emit TS2591, got: {diags:?}"
+    );
+    assert!(
+        no_error_code(&diags, TS2580),
+        "default (no types wildcard) Node builtin import should not emit install-only TS2580, got: {diags:?}"
+    );
+}
+
+#[test]
+fn test_ts_import_of_node_builtin_with_types_wildcard_uses_ts2580() {
+    // With `compilerOptions.types: ["*"]` (usesWildcardTypes), tsc switches the
+    // same missing Node builtin import to the install-only hint TS2580.
+    let diags = check_with_module_not_found_errors(
+        r#"import { parse } from "url";
+export const thing = () => parse();
+"#,
+        "usage.ts",
+        vec![],
+        vec!["url"],
+        CheckerOptions {
+            module: crate::common::ModuleKind::CommonJS,
+            types_has_wildcard: true,
+            ..CheckerOptions::default()
+        },
+    );
+    assert!(
         has_error_code(&diags, TS2580),
-        "TypeScript import of unresolved Node builtin should emit TS2580, got: {diags:?}"
+        "types wildcard makes the Node builtin import install-only TS2580, got: {diags:?}"
     );
     assert!(
         no_error_code(&diags, TS2591),
-        "TypeScript import of unresolved Node builtin should not emit TS2591, got: {diags:?}"
+        "types wildcard should not emit the add-to-types-field TS2591, got: {diags:?}"
     );
 }
 
@@ -344,7 +376,7 @@ export const thing = parse();
 // previously suppressed it silently, while every other module kind (and `tsc`)
 // reports TS2580/TS2591.
 #[test]
-fn test_node_module_kind_static_import_of_node_builtin_emits_ts2580() {
+fn test_node_module_kind_static_import_of_node_builtin_emits_ts2591() {
     for module in [
         crate::common::ModuleKind::Node16,
         crate::common::ModuleKind::Node18,
@@ -364,12 +396,12 @@ export const thing = () => parse();
             },
         );
         assert!(
-            has_error_code(&diags, TS2580),
-            "{module:?} static import of unresolved Node builtin should emit TS2580 (not be silently suppressed), got: {diags:?}"
+            has_error_code(&diags, TS2591),
+            "{module:?} static import of unresolved Node builtin should emit TS2591 (not be silently suppressed), got: {diags:?}"
         );
         assert!(
             no_error_code(&diags, TS2307),
-            "{module:?} Node builtin should use the TS2580 install hint, not TS2307, got: {diags:?}"
+            "{module:?} Node builtin should use the TS2591 install hint, not TS2307, got: {diags:?}"
         );
     }
 }
@@ -392,8 +424,8 @@ export const run = () => pipeline;
         },
     );
     assert!(
-        has_error_code(&diags, TS2580),
-        "NodeNext static import of unresolved node:stream/promises should emit the @types/node install hint, got: {diags:?}"
+        has_error_code(&diags, TS2591),
+        "NodeNext static import of unresolved node:stream/promises should emit the add-to-types-field install hint TS2591, got: {diags:?}"
     );
 }
 


### PR DESCRIPTION
Goal: green

Default the "missing Node built-in import" diagnostic to **TS2591** (install + add to the `types` field), emitting the install-only **TS2580** only when `compilerOptions.types` contains the literal wildcard `"*"` — matching tsc's `getCannotResolveModuleNameErrorForSpecificModule` / `usesWildcardTypes`.

## Structural rule
When a known Node built-in module import fails to resolve and `compilerOptions.types` does **not** contain `"*"`, tsc emits TS2591; tsz now does the same through `module_not_found_diagnostic_for_site` (checker), gated by the new `CheckerOptions::types_has_wildcard` signal populated at config resolution (`resolved_options.rs`) and the CLI driver (`plan.rs`) from `types.iter().any(|t| t == "*")`. The require-like / import-type / JS / no-types-and-symbols sites already forced TS2591 and are unchanged.

## Adjacent matrix
- plain `import { parse } from "url"` (CommonJS + Node16/18/20/NodeNext) → TS2591 (was TS2580)
- `node:`-scheme subpath (`node:stream/promises`, NodeNext) → TS2591
- `import x = require(...)` / `import("...").T` / JS / `noTypesAndSymbols` → TS2591 (unchanged)
- `types: ["*"]` wildcard → TS2580 (install-only) — new lock test

## Verification
- `cargo nextest run -p tsz-core --lib builtin` — module_resolution node-builtin family green (default→TS2591, wildcard→TS2580, nodenext subpath→TS2591, require-like/import-type/dynamic unchanged).
- tsc parity confirmed against the TypeScript submodule: `usesWildcardTypes` (`utilities.ts`) + `getCannotResolveModuleNameErrorForSpecificModule` (`checker.ts`) → wildcard ⇒ 2580, else ⇒ 2591; conformance baselines emit TS2580 ×0, TS2591 ×37.
- Canary parity: trpc (12) + tanstack-router (21) TS2591 locations now identical to tsc — 33 false TS2580 cleared.
- Migrated the 3 `module_resolution_tests` that pinned the old TS2580 default to TS2591 and added a wildcard lock test.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
