### PR TITLE
fix(checker): fold multi-block/cross-file `declare global` interfaces into keyof/indexed access (#14173)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -581,6 +581,9 @@ path = "tests/hkt_self_augmentation_keyof_repro.rs"
 name = "hkt_cross_file_augmentation_13653_repro"
 path = "tests/hkt_cross_file_augmentation_13653_repro.rs"
 [[test]]
+name = "declare_global_interface_keyof_merge_tests"
+path = "tests/declare_global_interface_keyof_merge_tests.rs"
+[[test]]
 name = "hkt_typeof_uri_instance_assignability_13930_repro"
 path = "tests/hkt_typeof_uri_instance_assignability_13930_repro.rs"
 [[test]]

--- a/crates/tsz-checker/src/context/cross_file_query.rs
+++ b/crates/tsz-checker/src/context/cross_file_query.rs
@@ -54,6 +54,21 @@ impl<'a> CheckerContext<'a> {
             || !self.binder.augmentation_target_modules.is_empty()
     }
 
+    /// Whether any file in the program registers a `declare global { ... }`
+    /// augmentation. Checks the current binder and every cross-file binder so
+    /// the global-augmentation fold runs whether or not the program was loaded
+    /// through a single pre-aggregated primary binder.
+    pub fn program_has_global_augmentations(&self) -> bool {
+        if !self.binder.global_augmentations.is_empty() {
+            return true;
+        }
+        self.all_binders.as_ref().is_some_and(|binders| {
+            binders
+                .iter()
+                .any(|binder| !binder.global_augmentations.is_empty())
+        })
+    }
+
     pub fn source_file_symbol_type_cache_scope(&self) -> u64 {
         self.definition_store.source_file_symbol_type_cache_scope()
     }

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1335,6 +1335,36 @@ impl CheckerState<'_> {
             result
         };
 
+        // Fold cross-block / cross-file `declare global { interface X }`
+        // declarations into a user-declared global interface's materialized body
+        // at this same canonical resolution point, so `keyof X`, `X[K]`,
+        // assignability, and display all observe the merged shape regardless of
+        // declaration/file order — matching the value-position member-access
+        // path that already reunites the partial symbols through
+        // `global_augmentations`. Cheap guards first: the program-wide
+        // global-augmentation map, then the interface-flag test, and only then
+        // the per-`TypeId` `classify_for_augmentation` lookup.
+        let result = if self.ctx.program_has_global_augmentations()
+            && self
+                .ctx
+                .binder
+                .get_symbol(sym_id)
+                .or_else(|| self.get_cross_file_symbol(sym_id))
+                .is_some_and(|symbol| {
+                    symbol.has_any_flags(symbol_flags::INTERFACE)
+                        && !symbol.has_any_flags(symbol_flags::CLASS)
+                })
+            && matches!(
+                crate::query_boundaries::common::classify_for_augmentation(self.ctx.types, result),
+                crate::query_boundaries::common::AugmentationTargetKind::Object(_)
+                    | crate::query_boundaries::common::AugmentationTargetKind::ObjectWithIndex(_)
+                    | crate::query_boundaries::common::AugmentationTargetKind::Callable(_)
+            ) {
+            self.apply_self_global_augmentations(sym_id, result)
+        } else {
+            result
+        };
+
         // Pop from resolution stack
         if use_local_symbol_state {
             self.ctx.symbol_resolution_stack.pop();

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -1447,6 +1447,173 @@ impl<'a> CheckerState<'a> {
         self.apply_module_augmentations(&home_file_name, &interface_name, base_type)
     }
 
+    /// Fold `declare global { interface X { ... } }` declarations into the
+    /// materialized body of a user-declared global interface `X`, so every
+    /// type-level consumer (`keyof X`, `X[K]`, assignability, type display)
+    /// observes the SAME merged shape that value-position member access already
+    /// reaches through the global-augmentation channel — independent of
+    /// declaration or file order.
+    ///
+    /// Each `declare global { ... }` block binds its interface to a SEPARATE
+    /// symbol: the binder restores the boundary scope between augmentation
+    /// blocks so they cannot shadow lib globals, which also prevents repeated
+    /// `declare global { interface X }` blocks (and cross-file `declare global`s)
+    /// from declaration-merging into one symbol. Member lookup reunites those
+    /// partial symbols through `global_augmentations`, but a bare type reference
+    /// resolves just one of them, leaving `keyof X` / `X["k"]` blind to the
+    /// other blocks' members (false `TS2339`/`TS2536`/`TS2344`, and a `keyof`
+    /// that drops keys). This mirrors `apply_self_module_augmentations` for the
+    /// `declare module` case, reusing the global-augmentation lowering helpers
+    /// (`lower_augmentation_for_arena` / `combine_augmentation_with_lib`) over
+    /// declarations gathered from every binder in the program.
+    pub(crate) fn apply_self_global_augmentations(
+        &mut self,
+        sym_id: tsz_binder::SymbolId,
+        base_type: TypeId,
+    ) -> TypeId {
+        use tsz_parser::parser::{NodeArena, NodeIndex};
+
+        if base_type == TypeId::ERROR
+            || base_type == TypeId::UNKNOWN
+            || !self.ctx.program_has_global_augmentations()
+        {
+            return base_type;
+        }
+        // Lib/global builtin interfaces (e.g. `Array`, `Symbol`) already fold
+        // their global augmentations through the lib-resolution path; folding
+        // again here would double-apply.
+        if self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
+            || self.ctx.binder.lib_symbol_ids.contains(&sym_id)
+        {
+            return base_type;
+        }
+        let (name, own_declarations) = {
+            let Some(symbol) = self
+                .ctx
+                .binder
+                .get_symbol(sym_id)
+                .or_else(|| self.get_cross_file_symbol(sym_id))
+            else {
+                return base_type;
+            };
+            // Imported aliases get their augmentations applied on the import
+            // path; leave them to it to avoid double application.
+            if symbol.import_module().is_some() {
+                return base_type;
+            }
+            (symbol.escaped_name.clone(), symbol.all_declarations())
+        };
+
+        // Gather every `declare global { interface <name> }` declaration in the
+        // program, grouped by the arena it lives in so each group is lowered
+        // against its own arena/binder. Two sources contribute:
+        //   * the current binder (current-file entries lower against
+        //     `self.ctx.arena`; cross-file entries carry their own arena), and
+        //   * every cross-file binder in `all_binders`, paired with its arena.
+        // Pairing across `all_binders`/`all_arenas` makes the fold correct
+        // whether or not the program was loaded through a single pre-aggregated
+        // primary binder.
+        let current_arena_ptr = self.ctx.arena as *const NodeArena as usize;
+        let mut current_decls: Vec<NodeIndex> = Vec::new();
+        let mut cross_groups: FxHashMap<usize, (Arc<NodeArena>, Vec<NodeIndex>)> =
+            FxHashMap::default();
+        let mut is_self_global_aug = false;
+
+        if let Some(aug_decls) = self.ctx.binder.global_augmentations.get(&name) {
+            for aug in aug_decls {
+                if own_declarations.contains(&aug.node) {
+                    is_self_global_aug = true;
+                }
+                match aug.arena {
+                    Some(ref arena) => {
+                        cross_groups
+                            .entry(Arc::as_ptr(arena) as usize)
+                            .or_insert_with(|| (Arc::clone(arena), Vec::new()))
+                            .1
+                            .push(aug.node);
+                    }
+                    None => current_decls.push(aug.node),
+                }
+            }
+        }
+
+        if let (Some(all_binders), Some(all_arenas)) =
+            (self.ctx.all_binders.clone(), self.ctx.all_arenas.clone())
+        {
+            for (binder, arena) in all_binders.iter().zip(all_arenas.iter()) {
+                // The current binder's entries were already gathered above; when
+                // it is also one of `all_binders` (single-checker programs)
+                // re-reading it would duplicate every current-file declaration.
+                if std::ptr::eq(binder.as_ref(), self.ctx.binder) {
+                    continue;
+                }
+                let Some(aug_decls) = binder.global_augmentations.get(&name) else {
+                    continue;
+                };
+                let arena_ptr = Arc::as_ptr(arena) as usize;
+                for aug in aug_decls {
+                    // Entries in a cross-file binder are current-file relative to
+                    // THAT binder, so their declaration nodes belong to `arena`.
+                    if aug.arena.is_some() {
+                        continue;
+                    }
+                    if own_declarations.contains(&aug.node) {
+                        is_self_global_aug = true;
+                    }
+                    if arena_ptr == current_arena_ptr {
+                        current_decls.push(aug.node);
+                    } else {
+                        cross_groups
+                            .entry(arena_ptr)
+                            .or_insert_with(|| (Arc::clone(arena), Vec::new()))
+                            .1
+                            .push(aug.node);
+                    }
+                }
+            }
+        }
+
+        // Only fold when THIS symbol is itself one of the `declare global`
+        // interface declarations of `name`. A module-scoped `interface X` that
+        // merely shares its name with a `declare global { interface X }` must
+        // NOT absorb the global members — they live in different declaration
+        // scopes in `tsc`.
+        if !is_self_global_aug {
+            return base_type;
+        }
+
+        let lib_contexts = self.ctx.lib_contexts.clone();
+        let mut result = base_type;
+        if !current_decls.is_empty() {
+            let aug_type =
+                self.lower_augmentation_for_arena(self.ctx.arena, &current_decls, &lib_contexts);
+            result = self.combine_augmentation_with_lib(Some(result), aug_type);
+        }
+        for (arena, decls) in cross_groups.into_values() {
+            let aug_type = self.lower_augmentation_for_arena(arena.as_ref(), &decls, &lib_contexts);
+            result = self.combine_augmentation_with_lib(Some(result), aug_type);
+        }
+
+        // Publish the merged body to the symbol's `DefId` so the solver's
+        // `Lazy(DefId)`-driven consumers — `keyof`, indexed access, constraint
+        // satisfaction — resolve the merged shape, not the partial body that
+        // `compute_type_of_symbol` registered from a single block. Mirrors
+        // `update_augmentation_local_symbol_types` for the `declare module` case.
+        if result != base_type {
+            use crate::query_boundaries::state::type_environment;
+            let def_id = self.ctx.get_or_create_def_id(sym_id);
+            self.ctx.symbol_types.insert(sym_id, result);
+            self.ctx.symbol_instance_types.insert(sym_id, result);
+            if let Some(shape) = type_environment::object_shape(self.ctx.types, result) {
+                self.ctx.definition_store.set_instance_shape(def_id, shape);
+            }
+            if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
+                env.insert_def(def_id, result);
+            }
+        }
+        result
+    }
+
     /// Update `symbol_types` and `type_env` for augmentation-local interface symbols
     /// so self-referential type references resolve to the merged type.
     /// Searches both the current binder and `all_binders` since the augmentation

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -10,7 +10,7 @@ use crate::state::CheckerState;
 use rustc_hash::FxHashMap;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
-use tsz_binder::ModuleAugmentation;
+use tsz_binder::{ModuleAugmentation, symbol_flags};
 use tsz_solver::TypeId;
 use tsz_solver::Visibility;
 
@@ -1471,7 +1471,35 @@ impl<'a> CheckerState<'a> {
         sym_id: tsz_binder::SymbolId,
         base_type: TypeId,
     ) -> TypeId {
-        use tsz_parser::parser::{NodeArena, NodeIndex};
+        use tsz_parser::parser::{NodeArena, NodeIndex, syntax_kind_ext};
+        use tsz_scanner::SyntaxKind;
+
+        fn is_direct_declare_global_member(arena: &NodeArena, node: NodeIndex) -> bool {
+            let Some(block_idx) = arena.parent_of(node) else {
+                return false;
+            };
+            let Some(block) = arena.get(block_idx) else {
+                return false;
+            };
+            if block.kind != syntax_kind_ext::MODULE_BLOCK {
+                return false;
+            }
+            let Some(module_idx) = arena.parent_of(block_idx) else {
+                return false;
+            };
+            let Some(module_node) = arena.get(module_idx) else {
+                return false;
+            };
+            if module_node.kind != syntax_kind_ext::MODULE_DECLARATION {
+                return false;
+            }
+            let Some(module) = arena.get_module(module_node) else {
+                return false;
+            };
+            arena
+                .get(module.name)
+                .is_some_and(|name| name.kind == SyntaxKind::GlobalKeyword as u16)
+        }
 
         if base_type == TypeId::ERROR
             || base_type == TypeId::UNKNOWN
@@ -1501,6 +1529,9 @@ impl<'a> CheckerState<'a> {
             if symbol.import_module().is_some() {
                 return base_type;
             }
+            if !symbol.has_any_flags(symbol_flags::INTERFACE) {
+                return base_type;
+            }
             (symbol.escaped_name.clone(), symbol.all_declarations())
         };
 
@@ -1513,7 +1544,7 @@ impl<'a> CheckerState<'a> {
         // Pairing across `all_binders`/`all_arenas` makes the fold correct
         // whether or not the program was loaded through a single pre-aggregated
         // primary binder.
-        let current_arena_ptr = self.ctx.arena as *const NodeArena as usize;
+        let current_arena_ptr = std::ptr::from_ref::<NodeArena>(self.ctx.arena) as usize;
         let mut current_decls: Vec<NodeIndex> = Vec::new();
         let mut cross_groups: FxHashMap<usize, (Arc<NodeArena>, Vec<NodeIndex>)> =
             FxHashMap::default();
@@ -1521,6 +1552,12 @@ impl<'a> CheckerState<'a> {
 
         if let Some(aug_decls) = self.ctx.binder.global_augmentations.get(&name) {
             for aug in aug_decls {
+                if !is_direct_declare_global_member(
+                    aug.arena.as_deref().unwrap_or(self.ctx.arena),
+                    aug.node,
+                ) {
+                    continue;
+                }
                 if own_declarations.contains(&aug.node) {
                     is_self_global_aug = true;
                 }
@@ -1555,6 +1592,9 @@ impl<'a> CheckerState<'a> {
                     // Entries in a cross-file binder are current-file relative to
                     // THAT binder, so their declaration nodes belong to `arena`.
                     if aug.arena.is_some() {
+                        continue;
+                    }
+                    if !is_direct_declare_global_member(arena.as_ref(), aug.node) {
                         continue;
                     }
                     if own_declarations.contains(&aug.node) {

--- a/crates/tsz-checker/src/types/queries/lib_augmentations.rs
+++ b/crates/tsz-checker/src/types/queries/lib_augmentations.rs
@@ -130,7 +130,7 @@ impl<'a> CheckerState<'a> {
         result
     }
 
-    fn combine_augmentation_with_lib(
+    pub(crate) fn combine_augmentation_with_lib(
         &mut self,
         lib_type: Option<TypeId>,
         aug_type: TypeId,

--- a/crates/tsz-checker/tests/declare_global_interface_keyof_merge_tests.rs
+++ b/crates/tsz-checker/tests/declare_global_interface_keyof_merge_tests.rs
@@ -1,0 +1,130 @@
+//! Repro + adjacent matrix for the `declare global` analogue of #13509/#13653:
+//! interface declarations spread across multiple `declare global { ... }` blocks
+//! (in one file, or across files) must be folded into the global interface
+//! BEFORE type-level operations — `keyof X`, indexed access `X[K]`,
+//! assignability — observe it, not only value-position member access.
+//!
+//! Structural rule: when a global interface `X` is declared by more than one
+//! `declare global { interface X { ... } }` block, every type-level consumer of
+//! `X` must see the union of all blocks' members. Each block binds a SEPARATE
+//! symbol (the binder restores the boundary scope between blocks so they cannot
+//! shadow lib globals), so a bare type reference resolves only one partial
+//! symbol unless the global augmentations are folded back in at the canonical
+//! symbol-type resolution point (`apply_self_global_augmentations`).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file_with_global_index;
+
+fn diagnostics(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
+    check_multi_file_with_global_index(
+        files,
+        entry,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn count_code(diags: &[(u32, String)], expected: u32) -> usize {
+    diags.iter().filter(|(code, _)| *code == expected).count()
+}
+
+/// Two `declare global { interface Registry }` blocks in one file: `keyof` and
+/// indexed access must see both members, and only a genuinely-absent key errors.
+#[test]
+fn two_global_blocks_merge_into_keyof_and_indexed_access() {
+    let diags = diagnostics(
+        &[(
+            "main.ts",
+            r#"
+declare global { interface Registry { a: number } }
+declare global { interface Registry { b: string } }
+type Va = Registry["a"];
+type Vb = Registry["b"];
+const va: Va = 1;
+const vb: Vb = "x";
+type K = keyof Registry;
+const k1: K = "a";
+const k2: K = "b";
+const kbad: K = "c";
+export {};
+"#,
+        )],
+        "main.ts",
+    );
+
+    // Both members are real keys: indexed access must resolve them (no TS2339),
+    // and the literal-key assignments must hold (no spurious TS2322 / TS2536).
+    assert_eq!(
+        count_code(&diags, 2339),
+        0,
+        "indexed access of a merged-global member must resolve; got {diags:#?}"
+    );
+    assert_eq!(
+        count_code(&diags, 2536),
+        0,
+        "merged-global indexed access must not raise TS2536; got {diags:#?}"
+    );
+    // Exactly one TS2322: the bogus key `"c"`.
+    assert_eq!(
+        count_code(&diags, 2322),
+        1,
+        "only the absent key `\"c\"` should be rejected; got {diags:#?}"
+    );
+}
+
+/// Negative control: a key declared by NO block is still rejected — the fold
+/// merges members, it does not widen `keyof` to `string` or the value to `any`.
+#[test]
+fn merged_global_keyof_still_rejects_absent_key() {
+    let diags = diagnostics(
+        &[(
+            "main.ts",
+            r#"
+declare global { interface Registry { a: number } }
+declare global { interface Registry { b: string } }
+type Missing = Registry["nope"];
+export {};
+"#,
+        )],
+        "main.ts",
+    );
+
+    assert_eq!(
+        count_code(&diags, 2339),
+        1,
+        "an absent key must still raise TS2339; got {diags:#?}"
+    );
+}
+
+/// Anti-hardcoding: the rule is structural, not name-driven. Rename every binder
+/// (interface, members, alias) and the merge still holds.
+#[test]
+fn merged_global_keyof_rule_is_binder_name_independent() {
+    let diags = diagnostics(
+        &[(
+            "main.ts",
+            r#"
+declare global { interface Slots { widget: number } }
+declare global { interface Slots { gadget: string } }
+type Tags = keyof Slots;
+const t1: Tags = "widget";
+const t2: Tags = "gadget";
+const tbad: Tags = "absent";
+export {};
+"#,
+        )],
+        "main.ts",
+    );
+
+    assert_eq!(
+        count_code(&diags, 2322),
+        1,
+        "renamed-binder global registry should merge both keys, rejecting only \
+         the absent one; got {diags:#?}"
+    );
+}

--- a/crates/tsz-cli/src/driver/declare_global_interface_keyof_merge_tests.rs
+++ b/crates/tsz-cli/src/driver/declare_global_interface_keyof_merge_tests.rs
@@ -1,0 +1,177 @@
+//! Project-mode coverage: interface declarations spread across multiple
+//! `declare global { ... }` blocks — in one file or across files — must be
+//! folded into the global interface BEFORE type-level operations (`keyof X`,
+//! indexed access `X[K]`, assignability) observe it, not only value-position
+//! member access.
+//!
+//! Each `declare global` block binds a SEPARATE interface symbol (the binder
+//! restores the boundary scope between blocks so they cannot shadow lib
+//! globals), so a bare type reference resolved only one partial symbol and left
+//! `keyof X` / `X["k"]` blind to the other blocks' members — a false
+//! `TS2339`/`TS2322` and a `keyof` that dropped keys. `tsc` merges all blocks.
+//!
+//! These run the full project driver (shared `DefinitionStore`, cross-file
+//! global resolution) because the cross-file global merge only arises under the
+//! project pipeline. The matrix varies the binder names (anti-hardcoding) and
+//! keeps negative cases so the fold does not widen `keyof` to `string` or values
+//! to `any`.
+
+use super::compile;
+use crate::args::CliArgs;
+use clap::Parser;
+use std::fs;
+use tsz_common::diagnostics::Diagnostic;
+
+const TS2322: u32 = 2322;
+const TS2339: u32 = 2339;
+const TS2536: u32 = 2536;
+
+/// Write `files` plus a strict `noEmit` tsconfig into a fresh temp dir and run
+/// the project-mode compile. Returns every emitted diagnostic.
+fn compile_project(files: &[(&str, &str)]) -> Vec<Diagnostic> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let names: Vec<String> = files
+        .iter()
+        .map(|(name, _)| format!("\"{name}\""))
+        .collect();
+    let tsconfig = format!(
+        r#"{{ "compilerOptions": {{ "strict": true, "target": "esnext", "module": "esnext", "moduleResolution": "bundler", "skipLibCheck": true, "noEmit": true }}, "files": [{}] }}"#,
+        names.join(", ")
+    );
+    fs::write(dir.path().join("tsconfig.json"), tsconfig).expect("write tsconfig");
+    for (name, source) in files {
+        fs::write(dir.path().join(name), source).expect("write source");
+    }
+
+    let project = dir.path().to_string_lossy().to_string();
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--project",
+        project.as_str(),
+        "--noEmit",
+        "--pretty",
+        "false",
+    ])
+    .expect("project args");
+    compile(&args, dir.path())
+        .expect("compile succeeds")
+        .diagnostics
+}
+
+fn count_code(diags: &[Diagnostic], code: u32) -> usize {
+    diags.iter().filter(|d| d.code == code).count()
+}
+
+/// Two `declare global { interface Registry }` blocks in one file: `keyof` and
+/// indexed access must see both members; only a genuinely-absent key errors.
+#[test]
+fn two_global_blocks_in_one_file_merge_type_level() {
+    let diags = compile_project(&[(
+        "main.ts",
+        r#"
+declare global { interface Registry { a: number } }
+declare global { interface Registry { b: string } }
+type Va = Registry["a"];
+type Vb = Registry["b"];
+const va: Va = 1;
+const vb: Vb = "x";
+type K = keyof Registry;
+const k1: K = "a";
+const k2: K = "b";
+const kbad: K = "c";
+export {};
+"#,
+    )]);
+
+    assert_eq!(
+        count_code(&diags, TS2339),
+        0,
+        "indexed access of a merged-global member must resolve; got {diags:#?}"
+    );
+    assert_eq!(
+        count_code(&diags, TS2536),
+        0,
+        "merged-global indexed access must not raise TS2536; got {diags:#?}"
+    );
+    assert_eq!(
+        count_code(&diags, TS2322),
+        1,
+        "only the absent key `\"c\"` should be rejected; got {diags:#?}"
+    );
+}
+
+/// Cross-file `declare global` blocks: the registry interface is declared empty
+/// in one module, augmented in another, and `keyof` / indexed access consumed in
+/// a third. The merge must be order-independent.
+#[test]
+fn cross_file_global_blocks_merge_type_level() {
+    let files = [
+        (
+            "registry.ts",
+            r#"
+declare global { interface Registry {} }
+export type Keys = keyof Registry;
+export {};
+"#,
+        ),
+        (
+            "augment.ts",
+            r#"
+declare global { interface Registry { foo: number } }
+export {};
+"#,
+        ),
+        (
+            "use.ts",
+            r#"
+import type { Keys } from "./registry";
+const ok: Keys[] = ["foo"];
+const bad: Keys[] = ["nope"];
+type Vfoo = Registry["foo"];
+const vf: Vfoo = 1;
+type Vbad = Registry["nope"];
+export {};
+"#,
+        ),
+    ];
+
+    let diags = compile_project(&files);
+
+    // `"foo"` is a real merged key: the `bad` array element (`"nope"`) is the
+    // single TS2322, and `Registry["nope"]` is the single TS2339.
+    assert_eq!(
+        count_code(&diags, TS2322),
+        1,
+        "only the absent key `\"nope\"` should be rejected; got {diags:#?}"
+    );
+    assert_eq!(
+        count_code(&diags, TS2339),
+        1,
+        "only `Registry[\"nope\"]` should miss; `Registry[\"foo\"]` must resolve; got {diags:#?}"
+    );
+}
+
+/// Anti-hardcoding: the rule is structural, not name-driven. Rename every binder
+/// and the merge still holds across two blocks.
+#[test]
+fn merged_global_keyof_rule_is_binder_name_independent() {
+    let diags = compile_project(&[(
+        "main.ts",
+        r#"
+declare global { interface Slots { widget: number } }
+declare global { interface Slots { gadget: string } }
+type Tags = keyof Slots;
+const t1: Tags = "widget";
+const t2: Tags = "gadget";
+const tbad: Tags = "absent";
+export {};
+"#,
+    )]);
+
+    assert_eq!(
+        count_code(&diags, TS2322),
+        1,
+        "renamed-binder global registry should merge both keys, rejecting only \
+         the absent one; got {diags:#?}"
+    );
+}

--- a/crates/tsz-cli/src/driver/mod.rs
+++ b/crates/tsz-cli/src/driver/mod.rs
@@ -20,3 +20,7 @@ pub(crate) use self::core::with_types_versions_env;
 #[cfg(test)]
 #[path = "cross_file_user_interface_name_override_tests.rs"]
 mod cross_file_user_interface_name_override_tests;
+
+#[cfg(test)]
+#[path = "declare_global_interface_keyof_merge_tests.rs"]
+mod declare_global_interface_keyof_merge_tests;


### PR DESCRIPTION
## Summary

When an interface is declared by more than one `declare global { interface X { ... } }` block — in a single file or across files — `tsc` merges every block's members into the global interface. `tsz` merged them only for **value-position member access** (through the `global_augmentations` channel); **type-level** consumers (`keyof X`, indexed access `X[K]`, assignability, type display) resolved a bare type reference to **one** of the partial symbols and saw only that block's members.

Witness (verified vs vendored `tsc` 6.0.2, `--noEmit --strict --target esnext --module esnext --moduleResolution bundler --skipLibCheck`):

```ts
declare global { interface Registry { a: number } }
declare global { interface Registry { b: string } }
type Va = Registry["a"];   // tsz: TS2339 'a' does not exist; tsc: ok
type K = keyof Registry;
const k: K[] = ["a", "b"]; // tsz: TS2322 (keyof dropped both keys); tsc: ok
```

`r.a` / `r.b` member access already resolved correctly, proving the gap was specific to the type-level resolution path. The same divergence reproduced across files (registry declared empty in one module, augmented in another, `keyof`/`X[K]` consumed in a third). This was the `declare global` analogue of the `declare module` keyof folding shipped in #13509/#13653, and is the cache/order-honesty defect tracked in #14173 (the io-ts HKT pattern).

## Structural rule

When interface `X` has more than one `declare global { interface X }` declaration, every type-level use of `X` must observe the union of all blocks' members, regardless of declaration/file order — owned by the checker's canonical `get_type_of_symbol` resolution point. Each block binds a **separate** symbol because the binder restores the boundary scope between augmentation blocks (so they cannot shadow lib globals), which also prevents declaration-merging into one symbol; the partial symbols are reunited at type-resolution time.

## Fix

`apply_self_global_augmentations`, called from `get_type_of_symbol_inner` immediately after the existing `apply_self_module_augmentations` fold (mirroring it). It:
- gathers every `declare global` declaration of the name across all binders, grouped by arena (so each group lowers against its own arena/binder — works whether or not the program was loaded through a single pre-aggregated primary binder);
- lowers and merges them via the existing `lower_augmentation_for_arena` / `combine_augmentation_with_lib` helpers;
- publishes the merged body to `symbol_types` / `symbol_instance_types` / `type_env` / the def store so `Lazy(DefId)`-driven solver consumers (`keyof`, indexed access, constraint satisfaction) resolve the merged shape.

Gating (anti-over-merge): skips lib/global builtin interfaces (they fold through the lib-resolution path — avoids double-apply), import aliases (applied on the import path), and only folds when the symbol is itself one of the `declare global` declarations of the name, so a module-scoped `interface X` sharing a name does not absorb global members.

## Adjacent matrix

- Single `declare global` block: unchanged (still merges, still rejects absent keys).
- Two blocks in one file / cross-file blocks: now merge for `keyof` + indexed access; absent keys still rejected (`TS2339`/`TS2322` preserved — `keyof` is not widened to `string`, values not widened to `any`).
- Renamed binders (anti-hardcoding): structural, name-independent.
- Module-local `interface X` sharing a name with a global `X`: not affected by the fold (pre-existing behavior unchanged).

## Goal
Goal: green

## Verification
- `cargo test --test declare_global_interface_keyof_merge_tests` (new, tsz-checker) — 3 passed
- `cargo test -p tsz-cli --lib declare_global_interface_keyof` (new, full project-driver: intra-file + cross-file + renamed-binder) — 3 passed
- Regression: `cargo test --test hkt_self_augmentation_keyof_repro --test hkt_cross_file_augmentation_13653_repro --test self_module_augmentation_isolation_tests`, `cargo test -p tsz-checker --lib augmentation` (46), `cargo test -p tsz-cli --lib augmentation` (10) — all green
- `cargo clippy -p tsz-checker --lib`, `cargo clippy -p tsz-cli --lib --tests -- -D warnings` — clean
- Manual repro both file orders matches `tsc` 6.0.2 (positive + negative controls)

## Provenance
Machine: cloud
Assistant: claude-code
Model: opus
Effort: high

https://claude.ai/code/session_01EVxP54xaWh5hp1mrAR27wp

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVxP54xaWh5hp1mrAR27wp)_