### PR TITLE
fix(solver): resolve `this` per side for tuple vs interface-extends-Array (#14170)

### DIFF
--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -71,5 +71,8 @@ mod symbol_keyed_member_cross_arena_cli_tests;
 #[path = "../tests/tsc_compat_tests.rs"]
 mod tsc_compat_tests;
 #[cfg(test)]
+#[path = "../tests/tuple_interface_extends_array_numeric_member_cli_tests.rs"]
+mod tuple_interface_extends_array_numeric_member_cli_tests;
+#[cfg(test)]
 #[path = "../tests/watch_tests.rs"]
 mod watch_tests;

--- a/crates/tsz-cli/tests/tuple_interface_extends_array_numeric_member_cli_tests.rs
+++ b/crates/tsz-cli/tests/tuple_interface_extends_array_numeric_member_cli_tests.rs
@@ -1,0 +1,198 @@
+//! A tuple literal satisfies an interface that `extends Array` and adds an own
+//! numeric member (issue #14170).
+//!
+//! Structural rule: when `interface I<A> extends Array<A> { 0: A }`, a tuple
+//! source `[a]` is assignable to `I<…>` in `tsc`. The interface's inherited
+//! `this`-returning Array members (`fill`/`sort`/`reverse`/`copyWithin`) resolve
+//! `this` to the *target* receiver. `tsz` compared a synthetic `Array<A>`
+//! surface whose `this`-returns stayed polymorphic (then resolved to
+//! `Array<A>`), forcing `Array<A> <: I<…>` (false) and a spurious `TS2322`.
+//! Resolving `this` per side — source surface bound to the tuple source, target
+//! members bound to the target — reduces a `this`-return to `source <: target`
+//! (the relation already in progress), satisfied coinductively, matching `tsc`.
+//!
+//! Run against the bundled `es2022` lib so `Array` carries its real
+//! `this`-returning members; this is exactly where the divergence lived.
+//!
+//! Binder names are varied (anti-hardcoding) and the negative controls are
+//! pinned so the acceptance is not a blanket "tuple ⇒ interface-extends-Array".
+
+use crate::args::CliArgs;
+use clap::Parser;
+
+/// Compile a single-file program with the bundled `es2022` lib and return the
+/// non-hint diagnostic codes.
+fn check(src: &str) -> Vec<u32> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::write(dir.path().join("main.ts"), src).expect("write source");
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--ignoreConfig",
+        "--noEmit",
+        "--strict",
+        "--target",
+        "es2022",
+        "--lib",
+        "es2022",
+        "main.ts",
+    ])
+    .expect("parse args");
+    let result = crate::driver::compile(&args, dir.path()).expect("compile");
+    result
+        .diagnostics
+        .iter()
+        .map(|d| d.code)
+        .filter(|code| code / 100 != 61) // drop unused-symbol hints
+        .collect()
+}
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|c| **c == code).count()
+}
+
+// ---- Positive: tsc-clean cases that tsz wrongly rejected with TS2322. ----
+
+#[test]
+fn generic_tuple_literal_returned_from_generic_arrow() {
+    // Exact issue repro shape.
+    let codes = check(
+        r#"
+interface NonEmptyArray<A> extends Array<A> {
+  0: A
+}
+const singleton = <A>(a: A): NonEmptyArray<A> => [a];
+"#,
+    );
+    assert_eq!(count(&codes, 2322), 0, "got {codes:?}");
+}
+
+#[test]
+fn generic_tuple_annotation() {
+    let codes = check(
+        r#"
+interface NE<A> extends Array<A> {
+  0: A
+}
+const x: NE<number> = [1];
+"#,
+    );
+    assert_eq!(count(&codes, 2322), 0, "got {codes:?}");
+}
+
+#[test]
+fn nongeneric_interface_extends_array() {
+    let codes = check(
+        r#"
+interface NE extends Array<number> {
+  0: number
+}
+const x: NE = [1];
+"#,
+    );
+    assert_eq!(count(&codes, 2322), 0, "got {codes:?}");
+}
+
+#[test]
+fn multiple_numeric_members_satisfied_by_matching_tuple() {
+    let codes = check(
+        r#"
+interface Pair<A> extends Array<A> {
+  0: A
+  1: A
+}
+const ok: Pair<number> = [1, 2];
+"#,
+    );
+    assert_eq!(count(&codes, 2322), 0, "got {codes:?}");
+}
+
+#[test]
+fn renamed_binders_are_irrelevant() {
+    // Anti-hardcoding: the rule is structural, never keyed on a spelling.
+    let codes = check(
+        r#"
+interface Crate<Widget> extends Array<Widget> {
+  0: Widget
+}
+const y: Crate<string> = ["a"];
+"#,
+    );
+    assert_eq!(count(&codes, 2322), 0, "got {codes:?}");
+}
+
+#[test]
+fn returned_from_generic_function_body() {
+    let codes = check(
+        r#"
+interface NE<A> extends Array<A> {
+  0: A
+}
+function make<T>(t: T): NE<T> {
+  return [t];
+}
+"#,
+    );
+    assert_eq!(count(&codes, 2322), 0, "got {codes:?}");
+}
+
+// ---- Negative controls: these must still report TS2322 (parity with tsc). ----
+
+#[test]
+fn plain_array_source_cannot_prove_numeric_member() {
+    // A plain array has no fixed `0` slot to satisfy `0: A`; tsc reports TS2741.
+    let codes = check(
+        r#"
+interface NE<A> extends Array<A> {
+  0: A
+}
+declare const a: number[];
+const x: NE<number> = a;
+"#,
+    );
+    // tsc surfaces the missing-property form (TS2741); pin that it is rejected.
+    assert!(
+        count(&codes, 2741) + count(&codes, 2322) >= 1,
+        "expected a rejection for number[] vs NE<number>, got {codes:?}"
+    );
+}
+
+#[test]
+fn wrong_element_type_rejected() {
+    let codes = check(
+        r#"
+interface NE<A> extends Array<A> {
+  0: A
+}
+const x: NE<string> = [1];
+"#,
+    );
+    assert_eq!(count(&codes, 2322), 1, "got {codes:?}");
+}
+
+#[test]
+fn extra_required_own_member_not_on_tuple_rejected() {
+    let codes = check(
+        r#"
+interface NE<A> extends Array<A> {
+  0: A
+  extra: string
+}
+const x: NE<number> = [1];
+"#,
+    );
+    assert_eq!(count(&codes, 2322), 1, "got {codes:?}");
+}
+
+#[test]
+fn tuple_too_short_for_required_numeric_member_rejected() {
+    let codes = check(
+        r#"
+interface Pair<A> extends Array<A> {
+  0: A
+  1: A
+}
+const x: Pair<number> = [1];
+"#,
+    );
+    assert_eq!(count(&codes, 2322), 1, "got {codes:?}");
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
@@ -513,6 +513,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let element_type =
             crate::type_queries::get_tuple_element_type_union(self.interner, source)?;
 
+        // Resolve `this` per side, mirroring `tsc`. The inherited `this`-returning
+        // Array members (`fill`/`sort`/`reverse`/`copyWithin`) resolve `this` to
+        // their receiver: the target interface's copies to `target`, the source
+        // array surface's to the `source` tuple (below). A `this`-return then
+        // reduces to `source <: target` — the relation already in progress,
+        // satisfied coinductively — instead of forcing `Array<T> <: Iface<Args>`
+        // (false). Without it the two sides disagree: `Iface<Args>` evaluation
+        // already rebound `this` to the concrete instance on the generic path,
+        // while the synthetic array surface kept `this` polymorphic.
+        let target = self.bind_polymorphic_this(target, target);
         let target_shape_id = object_with_index_shape_id(self.interner, target)?;
         let target_shape = self.interner.object_shape(target_shape_id);
         let target_props = target_shape.properties.clone();
@@ -528,6 +538,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             instantiate_type(self.interner, array_base, &subst)
         };
         let source_array_eval = self.evaluate_type(instantiated_array);
+        // Bind the synthetic array surface's polymorphic `this` to the real tuple
+        // `source` (see the per-side note above).
+        let source_array_eval = self.bind_polymorphic_this(source, source_array_eval);
         let source_shape_id = object_shape_id(self.interner, source_array_eval)
             .or_else(|| object_with_index_shape_id(self.interner, source_array_eval))?;
         let source_props = self


### PR DESCRIPTION
Closes #14170.

Goal: green

## Structural rule
When `interface I<A> extends Array<A> { 0: A }`, a tuple source `[a]` is
assignable to `I<…>` in `tsc`. `tsz` rejected it with a false TS2322.

`When a tuple source is related to an interface that extends Array and adds a
required numeric member, tsc resolves the inherited this-returning Array
members' this to each side's receiver; tsz now does this through the solver's
bind_polymorphic_this per side.`

```ts
interface NonEmptyArray<A> extends Array<A> {
  0: A
}
const singleton = <A>(a: A): NonEmptyArray<A> => [a]; // tsc OK | tsz TS2322 (before)
```
Flags: `--noEmit --strict --target esnext --module esnext --moduleResolution bundler --skipLibCheck`

## Root cause &amp; owner layer (solver)
The wrong semantic operation is **relation `this`-resolution**, in
`crates/tsz-solver/src/relations/subtype/rules/tuples.rs`
(`check_tuple_numeric_props_array_interface_subtype`).

That helper proves a fixed tuple satisfies an interface that extends `Array`
and declares required numeric members. It compares a synthetic `Array<T>`
surface against the target's members. Array's `this`-returning members
(`fill`/`sort`/`reverse`/`copyWithin`) carry polymorphic `this`. When the
target is a **generic** application `I<Args>`, evaluating it
(`evaluation/evaluate/application.rs`) rebinds those members' `this` to the
concrete instance, but the synthetic source surface keeps `this` polymorphic.
The two sides then disagree and the comparison degenerates to
`Array<T> <: I<Args>` (false) — a spurious TS2322. A non-generic interface
kept both sides polymorphic, which is why only the generic case failed.

`tsc` resolves `this` **per side** to its receiver. The helper now does the
same via the existing `bind_polymorphic_this(receiver, resolved)` helper:
the target's inherited members bind `this` to `target`, the source array
surface binds `this` to the `source` tuple. A `this`-return then reduces to
`source <: target` — the relation already in progress at this point —
satisfied coinductively by the relation's existing cycle detection. No new
machinery: the `runtypes`-style `Constraint<this>` invariance path (which
relies on the per-side concrete `this`) is untouched and still reports
TS2322.

## Anti-hardcoding
Purely structural: keyed on `contains_this_type` and the array/tuple-vs-
interface dispatch via solver helpers — no identifier, alias, file-name, or
rendered-type-string checks. Built-in `Array` is recovered through the
resolver's array-base helper, not by name. Tests vary binder names.

## Scope note
A **readonly** tuple source (`[1] as const`) against `extends ReadonlyArray`
is a distinct, pre-existing gap: readonly tuples are not unwrapped before the
array/tuple dispatch gate, so they never reach this helper at all. That is a
separate root cause (dispatch-level readonly unwrapping) and is intentionally
not bundled here.

## Adjacent matrix (verified against `tsc` 6.x and pinned in tests)
Accept (no TS2322), each reproduced on the pre-fix binary:
- generic `interface NE<A> extends Array<A> { 0: A }` via arrow `=> [a]`,
  via annotation `const x: NE<number> = [1]`, and via a generic function
  body `return [t]`;
- the non-generic form `interface NE extends Array<number> { 0: number }`;
- multiple numeric members satisfied by a matching-arity tuple
  (`{ 0: A; 1: A }` ← `[1, 2]`);
- renamed binders (anti-hardcoding).

Negative controls (still rejected):
- plain `number[]` source — no fixed slot `0` (tsc TS2741);
- wrong element type (`NE<string>` ← `[1]`);
- an extra required own member the tuple lacks;
- a tuple too short for a required numeric member (`{ 0; 1 }` ← `[1]`).

## Verification
- New CLI driver suite (real bundled `es2022` lib — the divergence is
  lib-sensitive)
  `crates/tsz-cli/tests/tuple_interface_extends_array_numeric_member_cli_tests.rs`:
  `cargo test -p tsz-cli --lib tuple_interface_extends_array` → **10 passed**
  (6 positive, 4 negative controls).
- `cargo test -p tsz-solver --lib relations::subtype` → 1048 passed, 0 failed.
- `cargo test -p tsz-checker --test ts2322_tests polymorphic_this` →
  `polymorphic_this_constraint_invariance_reports_ts2322` still passes
  (runtypes invariance unaffected).
- Differential check vs `tsc` 6.0 across the accept/negative matrix: all match.
- `cargo clippy -p tsz-solver --lib` clean; `cargo fmt` clean.
- Reviewed with `/simplify`: the two `this`-rebind blocks were collapsed onto
  the existing `bind_polymorphic_this` helper.
- Pre-existing-on-base (verified by re-running with the change stashed; not
  caused by this PR): 6 `ts2322_tests` elaboration-chain cases and
  `interface_extends_generic_alias_cli_tests::imported_interface_extending_omit_genuinely_missing_property_still_errors`.
- Broad conformance/emit/fourslash suites: delegated to ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01245WCM9ywvoCkcALiMUb1o

---
_Generated by [Claude Code](https://claude.ai/code/session_01245WCM9ywvoCkcALiMUb1o)_