### PR TITLE
fix(solver): requirement-free object comparable to object-constrained type param (TS2352) (#14152)

### DIFF
--- a/crates/tsz-checker/tests/ts2352_constrained_type_param_target_tests.rs
+++ b/crates/tsz-checker/tests/ts2352_constrained_type_param_target_tests.rs
@@ -115,6 +115,58 @@ function yes<T extends object | null | undefined>() {
     );
 }
 
+/// A universal index-signature record (`{ [k: string]: unknown }`, the inline
+/// shape of `Record<PropertyKey, unknown>`) asserted to a `T extends object`
+/// must NOT emit TS2352 — the record is object-like and comparable to the
+/// `object` constraint. Mirrors remeda's `clone.ts` `copiedValue as T` (#14152).
+/// The record has NO required named members, so the structural-fit walk is
+/// vacuously satisfied; only the empty-`{}` special case currently covers this,
+/// and it excludes objects carrying an index signature.
+#[test]
+fn index_signature_record_as_object_constrained_type_param_no_ts2352() {
+    for (rec, t_name) in [
+        ("{ [k: string]: unknown }", "T"),
+        ("{ [p: string]: unknown }", "U"),
+        ("{ [key: string]: any }", "Elem"),
+    ] {
+        let source = format!(
+            r#"
+function clone<{t_name} extends object>(value: {t_name}): {t_name} {{
+    const copied: {rec} = {{}};
+    return copied as {t_name};
+}}
+"#
+        );
+        let codes = check_strict(&source);
+        let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+        assert!(
+            ts2352.is_empty(),
+            "[{rec}/{t_name}] no TS2352 expected — an index-signature record is object-like \
+             and comparable to the `object` constraint. Got: {codes:?}"
+        );
+    }
+}
+
+/// Negative control for the index-signature-record rule: a primitive source
+/// asserted to a `T extends object` must STILL emit TS2352 (a primitive does
+/// not overlap an object constraint). Guards against over-permitting the
+/// constraint walk.
+#[test]
+fn primitive_as_object_constrained_type_param_still_emits_ts2352() {
+    let source = r#"
+function f<T extends object>(): T {
+    return 123 as T;
+}
+"#;
+    let codes = check_strict(source);
+    let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+    assert!(
+        !ts2352.is_empty(),
+        "TS2352 expected — a number primitive does not overlap an `object` constraint. \
+         Got: {codes:?}"
+    );
+}
+
 /// Source assigned to a constrained type parameter whose constraint is an
 /// intersection of object-likes — ANY intersection member providing a
 /// matching property is sufficient (the intersection exposes all members'

--- a/crates/tsz-solver/src/type_queries/flow/comparability.rs
+++ b/crates/tsz-solver/src/type_queries/flow/comparability.rs
@@ -219,19 +219,21 @@ pub(in crate::type_queries) fn types_are_comparable_for_assertion_inner(
         return true;
     }
 
-    // The empty object type `{}` is comparable to any type parameter whose
-    // constraint contains an object-like or `object`-primitive member. tsc's
-    // `isTypeComparableTo` walks the type parameter's constraint when the
-    // source is a "wide" object type like `{}`. We narrow this to the empty-
-    // object case only — fully unwrapping for any source would over-permit
-    // assertions like `B as T extends A` (genericTypeAssertions4.ts).
-    if is_empty_object_type(db, source)
+    // A requirement-free object — the empty `{}`, an all-optional object, or a
+    // universal index-signature record like `Record<PropertyKey, unknown>` — is
+    // comparable to any type parameter whose constraint contains an object-like
+    // or `object`-primitive member. tsc's `isTypeComparableTo` walks the type
+    // parameter's constraint when the source is a "wide" object type. We narrow
+    // this to sources with NO required named member — fully unwrapping for any
+    // source would over-permit `B as T extends A` (genericTypeAssertions4.ts),
+    // where `B`'s required `bar` must still report TS2352.
+    if is_object_without_required_members(db, source)
         && let Some(TypeData::TypeParameter(info)) = db.lookup(target)
         && let Some(constraint) = info.constraint
     {
         return types_are_comparable_for_assertion_inner(db, source, constraint, depth + 1, nested);
     }
-    if is_empty_object_type(db, target)
+    if is_object_without_required_members(db, target)
         && let Some(TypeData::TypeParameter(info)) = db.lookup(source)
         && let Some(constraint) = info.constraint
     {
@@ -502,19 +504,27 @@ fn is_object_like_for_assertion(db: &dyn TypeDatabase, type_id: TypeId) -> bool 
     )
 }
 
-/// Returns true when `type_id` is the empty object type `{}` — an Object
-/// type with no required properties, no callable signatures, and no index
-/// signatures. Used to narrow the type-parameter constraint-unwrap rule:
-/// only the "top" object type widely overlaps with any constraint that
-/// contains an object-like member.
-fn is_empty_object_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    let Some(TypeData::Object(shape_id)) = db.lookup(type_id) else {
-        return false;
+/// Returns true when `type_id` is an object type with **no required named
+/// members** — the empty object `{}`, an all-optional object (`{ a?: X }`),
+/// or a universal index-signature record (`{ [k: string]: V }`, the inline
+/// shape of `Record<PropertyKey, unknown>`). Such an object imposes no
+/// structural requirement, so it widely overlaps any type-parameter
+/// constraint that contains an object-like member, and the constraint-unwrap
+/// rule may walk the constraint for it.
+///
+/// Index signatures are permitted (a record is still requirement-free), unlike
+/// the original empty-`{}`-only predicate which excluded them and so reported a
+/// false TS2352 on `Record<PropertyKey, unknown> as T extends object` (#14152,
+/// remeda `clone.ts`). A required named member (e.g. `B`'s `bar` in
+/// `genericTypeAssertions4.ts`) still disqualifies the object, so
+/// `B as T extends A` continues to report TS2352.
+fn is_object_without_required_members(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    let shape_id = match db.lookup(type_id) {
+        Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => shape_id,
+        _ => return false,
     };
     let shape = db.object_shape(shape_id);
     shape.properties.iter().all(|p| p.optional)
-        && shape.string_index.is_none()
-        && shape.number_index.is_none()
 }
 
 /// Returns true when `keyof_side` is `KeyOf(_)` and `prim_side` is one of


### PR DESCRIPTION
Closes #14152.

## Structural rule
When `source as T` has `T extends C` and `source` is an object with **no required named members** — the empty `{}`, an all-optional object, or a universal index-signature record (`Record<PropertyKey, unknown>` / `{ [k: string]: unknown }`) — `tsc`'s `isTypeComparableTo` walks `T`'s constraint, finds the record object-like, and allows the assertion. `tsz` only walked the constraint for a *truly empty* `{}`, so an index-signature record fell through to the property-overlap check and emitted a false **TS2352** (remeda `clone.ts` `copiedValue as T`).

## Owner layer
Solver assertion-comparability: `types_are_comparable_for_assertion_inner` in `crates/tsz-solver/src/type_queries/flow/comparability.rs`. The empty-`{}`-only predicate (`is_empty_object_type`, used solely by the two type-parameter constraint-walk arms) is generalized to `is_object_without_required_members`: matches `Object`/`ObjectWithIndex`, all named members optional, **index signatures permitted**.

## Adjacent-case matrix
- `{ [k: string]: unknown }` / `{ [p: string]: unknown }` / `{ [key: string]: any }` as `T extends object` (binder-varied `T`/`U`/`Elem`) → no TS2352.
- **Fallback / negative controls preserved:**
  - `B as T extends A` where `B` has a required `bar` absent from `A` → **still TS2352** (`genericTypeAssertions4.ts`; `subclass_with_required_extras_as_constrained_type_param_emits_ts2352`).
  - `123 as T extends object` (primitive source) → **still TS2352** (new `primitive_as_object_constrained_type_param_still_emits_ts2352`).
  - `{}` empty source → unchanged (subsumed by the broadened predicate).

## Verification
- New + existing tests: `cargo nextest run -p tsz-checker -E 'test(ts2352) + test(constrained_type_param) + test(genericTypeAssertions) + test(assertion)'` → **279/280 pass**. The two new tests pass; all `genericTypeAssertions`/`constrained_type_param` anti-regressions pass.
- The single failure, `object_literal_this_member_order_tests::const_assertion_preserves_later_data_literal` (`got: [2322]`), is a **pre-existing Mac-only failure** — it fails identically with this change reverted (verified by stash + rebuild), has no type parameters, and so cannot be reached by this change (both edited arms are gated on the other operand being a `TypeData::TypeParameter`). CI runs on Linux, where it passes.

Goal: green

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max