### PR TITLE
fix(module-resolution): ambient module shadows untyped on-disk package (#14169)

### DIFF
--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -736,8 +736,6 @@ impl ModuleResolver {
             .filter(|stripped| !stripped.is_empty());
         let ambient_match = is_ordinary_bare
             && (is_ambient_module(specifier) || node_builtin.is_some_and(&is_ambient_module));
-        let containing_is_declaration =
-            ModuleExtension::from_path(containing_file).is_declaration();
         if self.trace_resolution {
             println!(
                 "======== Resolving module '{}' from '{}'. ========",
@@ -764,12 +762,18 @@ impl ModuleResolver {
             }
         }
 
-        // Declaration files frequently stitch together sibling `declare module "..."`
-        // blocks with bare imports (for example, react16.d.ts declares both
-        // `"react"` and `"prop-types"` in the same file). If the ambient module is
-        // already known project-wide, prefer that over re-running filesystem-based
-        // bare-specifier resolution for each import inside the declaration layer.
-        if containing_is_declaration && ambient_match {
+        // An in-program ambient `declare module "X"` shadows on-disk resolution
+        // of the bare specifier `X`, mirroring tsc's `tryFindAmbientModule`,
+        // which is consulted before filesystem module resolution for any
+        // non-relative name (`ambient_match` already gates on `is_ordinary_bare`,
+        // so relative/rooted imports never reach here). This holds regardless of
+        // whether the importer is a `.ts` or a `.d.ts` and regardless of whether
+        // an on-disk package of the same name exists — including an *untyped*
+        // `node_modules/X` runtime package, which must NOT surface TS7016 when an
+        // ambient declaration provides the types (issue #14169; witnesses: rxjs
+        // node-builtin shims, msw events/punycode/string_decoder). Wildcard
+        // ambient patterns are matched separately by the driver before `lookup`.
+        if ambient_match {
             return ModuleLookupResult::ambient();
         }
 

--- a/crates/tsz-core/src/module_resolver/tests/lookup_classify.rs
+++ b/crates/tsz-core/src/module_resolver/tests/lookup_classify.rs
@@ -244,3 +244,72 @@ fn test_lookup_classify_ambient_no_path_no_error() {
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+/// Regression for issue #14169: an in-program ambient `declare module "X"`
+/// must shadow an *untyped* on-disk `node_modules/X` runtime package, mirroring
+/// tsc's `tryFindAmbientModule` (consulted before filesystem resolution for any
+/// non-relative specifier). Before the fix, the ambient match was gated on the
+/// importer being a declaration file, so a `.ts` importer resolved to the
+/// untyped `.js` and surfaced TS7016. The binder name is varied here (not
+/// `events`) so the rule cannot be a fixture-name fast path.
+#[test]
+fn test_lookup_ambient_shadows_untyped_ondisk_package_from_ts_importer() {
+    use std::fs;
+    let dir = std::env::temp_dir().join("tsz_lookup_ambient_shadows_untyped_ondisk_package");
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+
+    // An untyped runtime package on disk under the *same* bare name as the
+    // ambient declaration. Its presence must NOT win over the ambient module.
+    let pkg = dir.join("node_modules").join("evt-shim-pkg");
+    fs::create_dir_all(&pkg).unwrap();
+    fs::write(
+        pkg.join("package.json"),
+        r#"{ "name":"evt-shim-pkg","version":"3.0.0","main":"./index.js" }"#,
+    )
+    .unwrap();
+    fs::write(pkg.join("index.js"), "module.exports = {};").unwrap();
+
+    // A plain `.ts` (non-declaration) importer.
+    fs::write(
+        dir.join("main.ts"),
+        "import { EventEmitter } from 'evt-shim-pkg';",
+    )
+    .unwrap();
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node),
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+
+    let request = ModuleLookupRequest {
+        specifier: "evt-shim-pkg",
+        containing_file: &dir.join("main.ts"),
+        specifier_span: Span::new(28, 42),
+        import_kind: ImportKind::EsmImport,
+        resolution_mode_override: None,
+        no_implicit_any: true,
+        implied_classic_resolution: false,
+    };
+    // The driver reports the program-level ambient declaration through the
+    // `is_ambient_module` closure.
+    let result = resolver.lookup(&request, |_, _| None, |spec| spec == "evt-shim-pkg", None);
+    let outcome = result.classify();
+
+    assert!(
+        outcome.is_resolved,
+        "ambient module must win over untyped on-disk package"
+    );
+    assert!(
+        outcome.resolved_path.is_none(),
+        "ambient resolution has no on-disk path (must not pick the untyped .js)"
+    );
+    assert!(
+        outcome.error.is_none(),
+        "ambient resolution must not surface TS7016 for the untyped package"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
Fixes #14169

## Structural rule
When a bare specifier `X` is declared by an in-program ambient `declare module "X"` AND an untyped on-disk `node_modules/X` runtime package also exists, tsc resolves the import to the ambient declaration (`tryFindAmbientModule` is consulted before filesystem resolution for any non-relative specifier). tsz previously gated this on the *importer* being a declaration file, so a plain `.ts` importer fell through to the untyped `.js` and surfaced TS7016 (import form) / TS6504 (root form). tsz now resolves to the ambient declaration regardless of importer extension, via the module-resolution engine (`ModuleResolver::lookup`).

## Owner layer
`crates/tsz-core/src/module_resolver/mod.rs` — `ModuleResolver::lookup`. Dropped the `containing_is_declaration && ambient_match` gate so any `ambient_match` (already gated on `is_ordinary_bare`, i.e. non-relative/non-rooted) short-circuits to `ModuleLookupResult::ambient()`. The separate `containing_is_declaration` used for the TS6263 arbitrary-extension check is untouched.

## Adjacent cases
- `.ts` importer + untyped on-disk package of the same name as the ambient module -> ambient wins (the regression; witnesses: rxjs node-builtin shims, msw events/punycode/string_decoder).
- `.d.ts` importer + ambient module -> still ambient (prior behavior preserved; e.g. react16.d.ts declaring both `"react"` and `"prop-types"`).
- Relative/rooted imports never reach the ambient branch (`is_ordinary_bare` excludes them).
- `node:` builtin specifiers still route through the same ambient match.
- Test binder name varied (`evt-shim-pkg`, not `events`) so the rule is not a fixture-name fast path.

## Verification
- Repro (tsc clean, tsz was TS7016, now clean): `/tmp/land-14169` with untyped `node_modules/events` + `shims.d.ts` ambient `declare module "events"` + `main.ts`, flags `--strict --module esnext --moduleResolution bundler --noEmit`. tsc=0, tsz=0 after fix.
- Narrow test: `cargo nextest run -p tsz-core test_lookup_ambient_shadows_untyped_ondisk_package_from_ts_importer` (PASS).
- Smoke: `cargo nextest run -p tsz-core module_resolver::tests` -> 269 passed.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Goal: green