### PR TITLE
fix(solver): allow assertion to object-constrained type parameter (#14152)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -776,6 +776,9 @@ path = "tests/ts2677_intersection_predicate_tests.rs"
 name = "ts2673_anonymous_class_private_ctor_tests"
 path = "tests/ts2673_anonymous_class_private_ctor_tests.rs"
 [[test]]
+name = "ts2352_object_constrained_param_assertion_tests"
+path = "tests/ts2352_object_constrained_param_assertion_tests.rs"
+[[test]]
 name = "ts2352_merged_type_alias_const_tests"
 path = "tests/ts2352_merged_type_alias_const_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/ts2352_object_constrained_param_assertion_tests.rs
+++ b/crates/tsz-checker/tests/ts2352_object_constrained_param_assertion_tests.rs
@@ -1,0 +1,95 @@
+//! Regression coverage for #14152: assertion comparability from an object-like
+//! value to a type parameter whose base constraint is the `object` primitive.
+//!
+//! Structural rule: when the source of an `as` / comparability check is an
+//! object-like value (e.g. `Record<PropertyKey, unknown>`, `{ [k: string]:
+//! unknown }`, a concrete object literal type) and the target is a type
+//! parameter whose base constraint resolves to the `object` primitive (`T
+//! extends object`, transitively through `V extends U extends object`), `tsc`'s
+//! `isTypeComparableTo` resolves the parameter to its `object` constraint. Since
+//! `object` is the structureless non-primitive supertype, every object-like
+//! source overlaps it, so the assertion is allowed without an intermediate
+//! `as unknown`. The check is symmetric (source/target may be either side).
+//!
+//! Before the fix, comparability against a bare `object`-constrained parameter
+//! fell through to the property-overlap check (both sides expose no extractable
+//! properties against the parameter), so `copiedValue as T` in remeda's
+//! `clone.ts` emitted a false `TS2352`.
+//!
+//! Only the bare `object` primitive triggers the rule; primitive sources keep
+//! firing `TS2352` (a number/string truly does not overlap `object`).
+//!
+//! Verified against `tsc` 5.8.3 (all positive cases exit 0; the primitive
+//! negative controls still report `TS2352`).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source, diagnostic_codes};
+
+fn codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    diagnostic_codes(&check_source(source, "test.ts", options))
+}
+
+fn count(source: &str, code: u32) -> usize {
+    codes(source).into_iter().filter(|&c| c == code).count()
+}
+
+// ── Positive cases: object-like source asserted to an object-constrained param ──
+
+#[test]
+fn record_propertykey_unknown_as_object_param_is_valid() {
+    // remeda clone.ts witness: the universal object record asserted to `T`.
+    let src = "export const f = <T extends object,>(v: Record<PropertyKey, unknown>) => v as T;";
+    assert_eq!(count(src, 2352), 0, "no TS2352 expected: {:?}", codes(src));
+}
+
+#[test]
+fn record_string_unknown_as_object_param_is_valid() {
+    let src = "export const f = <T extends object,>(v: Record<string, unknown>) => v as T;";
+    assert_eq!(count(src, 2352), 0, "no TS2352 expected: {:?}", codes(src));
+}
+
+#[test]
+fn string_index_signature_as_object_param_is_valid() {
+    let src = "export const f = <T extends object,>(v: { [k: string]: unknown }) => v as T;";
+    assert_eq!(count(src, 2352), 0, "no TS2352 expected: {:?}", codes(src));
+}
+
+#[test]
+fn concrete_object_literal_as_object_param_is_valid() {
+    let src = "export const f = <T extends object,>(v: { a: number }) => v as T;";
+    assert_eq!(count(src, 2352), 0, "no TS2352 expected: {:?}", codes(src));
+}
+
+#[test]
+fn renamed_binder_object_param_is_valid() {
+    // Binder name varies; the structural rule must not depend on identifiers.
+    let src =
+        "export const f = <Shape extends object,>(v: Record<PropertyKey, unknown>) => v as Shape;";
+    assert_eq!(count(src, 2352), 0, "no TS2352 expected: {:?}", codes(src));
+}
+
+#[test]
+fn transitive_object_constraint_chain_is_valid() {
+    // `V extends U extends object`: the base constraint resolves to `object`
+    // through a parameter chain.
+    let src = "export const f = <U extends object, V extends U,>(v: Record<PropertyKey, unknown>) => v as V;";
+    assert_eq!(count(src, 2352), 0, "no TS2352 expected: {:?}", codes(src));
+}
+
+// ── Negative controls: primitive sources still report TS2352 ──
+
+#[test]
+fn number_as_object_param_still_reports_ts2352() {
+    let src = "export const f = <T extends object,>(v: number) => v as T;";
+    assert_eq!(count(src, 2352), 1, "TS2352 expected: {:?}", codes(src));
+}
+
+#[test]
+fn string_as_object_param_still_reports_ts2352() {
+    let src = "export const f = <T extends object,>(v: string) => v as T;";
+    assert_eq!(count(src, 2352), 1, "TS2352 expected: {:?}", codes(src));
+}

--- a/crates/tsz-solver/src/type_queries/flow/comparability.rs
+++ b/crates/tsz-solver/src/type_queries/flow/comparability.rs
@@ -219,6 +219,24 @@ pub(in crate::type_queries) fn types_are_comparable_for_assertion_inner(
         return true;
     }
 
+    // A type parameter whose base constraint is the `object` primitive (e.g.
+    // `T extends object`) is comparable to any object-like value for assertion
+    // purposes. tsc's `isTypeComparableTo` resolves the type parameter to its
+    // base constraint; since `object` is the structureless non-primitive
+    // supertype, every object-like source overlaps it without the "could be a
+    // different subtype" objection that named/structural constraints raise.
+    // This is strictly narrower than unwrapping arbitrary constraints: only the
+    // bare `object` primitive triggers it, so `B as T extends A`
+    // (genericTypeAssertions4.ts) and `{ x } as T extends {}` keep firing
+    // TS2352 because their constraints are not the `object` primitive.
+    if (is_object_like_for_assertion(db, source)
+        && type_param_base_constraint_is_object(db, target, depth))
+        || (is_object_like_for_assertion(db, target)
+            && type_param_base_constraint_is_object(db, source, depth))
+    {
+        return true;
+    }
+
     // The empty object type `{}` is comparable to any type parameter whose
     // constraint contains an object-like or `object`-primitive member. tsc's
     // `isTypeComparableTo` walks the type parameter's constraint when the
@@ -326,6 +344,39 @@ fn deferred_conditional_assertion_constraint(
         }
     }
     None
+}
+
+/// Returns true when `type_id` is a type parameter (`TypeData::TypeParameter`)
+/// whose base constraint resolves to the `object` primitive (`TypeId::OBJECT`).
+///
+/// Walks a chain of type-parameter constraints (`T extends U`, `U extends
+/// object`) up to a small depth bound so that transitively `object`-constrained
+/// parameters are recognized. Only the bare `object` primitive qualifies;
+/// structural constraints like `{}` or named interfaces are intentionally
+/// excluded so that source-specific overlap (and tsc's "different subtype"
+/// objection) is preserved for those constraints.
+fn type_param_base_constraint_is_object(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    depth: u32,
+) -> bool {
+    if depth > 5 {
+        return false;
+    }
+    let Some(TypeData::TypeParameter(info)) = db.lookup(type_id) else {
+        return false;
+    };
+    let Some(constraint) = info
+        .constraint
+        .filter(|&c| c != TypeId::ANY && c != TypeId::UNKNOWN)
+    else {
+        return false;
+    };
+    if constraint == TypeId::OBJECT {
+        return true;
+    }
+    // Follow a constraint that is itself an `object`-constrained type parameter.
+    type_param_base_constraint_is_object(db, constraint, depth + 1)
 }
 
 fn type_param_primitive_comparable_with_constraint(


### PR DESCRIPTION
Fixes #14152.

Goal: green

## Structural rule
When the source of an `as` / comparability check is an object-like value (e.g. `Record<PropertyKey, unknown>`, `{ [k: string]: unknown }`, a concrete object literal) and the target is a type parameter whose base constraint resolves to the `object` primitive (`T extends object`, transitively through `V extends U extends object`), tsc's `isTypeComparableTo` resolves the parameter to its `object` constraint. Since `object` is the structureless non-primitive supertype, every object-like source overlaps it, so the assertion is allowed without an intermediate `as unknown`. tsz now does the same via the solver assertion-comparability path. The check is symmetric (source/target may be either side).

Before the fix, comparability against a bare `object`-constrained parameter fell through to the property-overlap check (neither side exposes extractable properties against the parameter), so remeda's `copiedValue as T` in `clone.ts` emitted a false TS2352.

Only the bare `object` primitive triggers the rule; structural constraints (`{}`, named interfaces) and primitive sources are intentionally excluded, so the "different subtype" objection is preserved and `123 as T` keeps firing TS2352.

## Owner layer
Solver — assertion comparability: `crates/tsz-solver/src/type_queries/flow/comparability.rs` (`types_are_comparable_for_assertion_inner` + new `type_param_base_constraint_is_object` helper).

## Adjacent cases
- Source variants: `Record<PropertyKey, unknown>`, `Record<string, unknown>`, `{ [k: string]: unknown }`, concrete object literal — all allowed (match tsc 0).
- Renamed binder (`Shape extends object`) — structural, not identifier-driven.
- Transitive constraint chain `V extends U extends object` — allowed.
- Negative controls: `number as T`, `string as T` for `T extends object` — still TS2352 (match tsc).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Repro (issue minimal): `tsz -p /tmp/land-14152/tsconfig.json` -> 0 errors; `tsc -p` -> 0 errors (was tsz TS2352 before fix). Negative control `123 as T` -> both TS2352.
- Narrow test: `cargo nextest run -p tsz-checker --test ts2352_object_constrained_param_assertion_tests` (8 tests pass).
- Smoke: `cargo nextest run -p tsz-checker --test deferred_conditional_indexed_access_tests` (11 tests pass, same comparability module).
