### PR TITLE
fix(narrowing): narrow alias/application union via in-operator (#14153)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -878,6 +878,9 @@ path = "tests/in_chain_narrows_unconstrained_type_param_tests.rs"
 name = "in_operator_lhs_key_type_tests"
 path = "tests/in_operator_lhs_key_type_tests.rs"
 [[test]]
+name = "in_operator_narrows_alias_union_member_tests"
+path = "tests/in_operator_narrows_alias_union_member_tests.rs"
+[[test]]
 name = "no_lib_async_promise_tests"
 path = "tests/no_lib_async_promise_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/in_operator_narrows_alias_union_member_tests.rs
+++ b/crates/tsz-checker/tests/in_operator_narrows_alias_union_member_tests.rs
@@ -10,12 +10,12 @@
 //! decision in the solver `in`-narrowing path, so `"length" in items` narrows to
 //! the `ArrayLike<T>` member and `items.length` is `number`.
 //!
-//! Before the fix the alias instantiation reached narrowing as a
-//! `TypeData::Application`, `union_list_id` returned `None`, the union-filtering
-//! path was skipped, and the receiver fell through to the non-union branch
-//! (`union & Record<prop, unknown>`), so the property read back as `unknown` —
-//! remeda's `length.ts:35` emitted a false `TS2322` (`unknown` not assignable to
-//! `number`).
+//! Before the fix the alias instantiation reached narrowing as an unresolved
+//! generic application (not a raw union), `union_list_id` returned `None`, the
+//! union-filtering path was skipped, and the receiver fell through to the
+//! non-union branch (`union & Record<prop, unknown>`), so the property read back
+//! as `unknown` — remeda's `length.ts:35` emitted a false `TS2322` (`unknown`
+//! not assignable to `number`).
 //!
 //! A non-literal computed key (`k in x`, `k: string`) must still NOT narrow
 //! (negative control). Verified against `tsc` 5.8.3.
@@ -23,7 +23,7 @@
 //! The remeda witness uses `ArrayLike<T> | Iterable<T>`; these cases use
 //! lib-free generic aliases of the same shape (a generic application union where
 //! one member declares the key) so the checker test harness resolves every name
-//! while still exercising the `TypeData::Application` resolution path.
+//! while still exercising the unresolved-generic-application resolution path.
 
 use tsz_checker::test_utils::check_source_strict_messages;
 
@@ -34,10 +34,10 @@ fn ts2322_count(diagnostics: &[(u32, String)]) -> usize {
 #[test]
 fn in_operator_narrows_generic_alias_application_union_to_member_with_key() {
     // remeda length.ts shape, lib-free so the harness resolves all names: a
-    // *generic* alias instantiation `Enumerable<T>` reaches narrowing as a
-    // `TypeData::Application` (not a raw `Union`), which is exactly the path the
-    // fix resolves. Only `WithLen<T>` has `length: number`; `"length" in items`
-    // narrows to it so `items.length` reads back as `number`.
+    // *generic* alias instantiation `Enumerable<T>` reaches narrowing as an
+    // unresolved generic application (not a raw `Union`), which is exactly the
+    // path the fix resolves. Only `WithLen<T>` has `length: number`; `"length" in
+    // items` narrows to it so `items.length` reads back as `number`.
     let diagnostics = check_source_strict_messages(
         r#"
 type WithLen<T> = { length: number; item: T };

--- a/crates/tsz-checker/tests/in_operator_narrows_alias_union_member_tests.rs
+++ b/crates/tsz-checker/tests/in_operator_narrows_alias_union_member_tests.rs
@@ -1,0 +1,122 @@
+//! Regression coverage for #14153: the `in` operator must narrow a *type alias /
+//! generic application* union to the member declaring the key.
+//!
+//! Structural rule: when the `in` receiver is a union reached through a type
+//! alias instantiation or generic application (e.g. `Enumerable<T> = ArrayLike<T>
+//! | Iterable<T>`), `tsc`'s `narrowTypeByInKeyword` filters the constituents of
+//! the *resolved* union — true branch keeps members whose apparent type has the
+//! (string-literal) key, false branch keeps the complement. tsz now resolves the
+//! alias/application to its structural union before the union-vs-non-union
+//! decision in the solver `in`-narrowing path, so `"length" in items` narrows to
+//! the `ArrayLike<T>` member and `items.length` is `number`.
+//!
+//! Before the fix the alias instantiation reached narrowing as a
+//! `TypeData::Application`, `union_list_id` returned `None`, the union-filtering
+//! path was skipped, and the receiver fell through to the non-union branch
+//! (`union & Record<prop, unknown>`), so the property read back as `unknown` —
+//! remeda's `length.ts:35` emitted a false `TS2322` (`unknown` not assignable to
+//! `number`).
+//!
+//! A non-literal computed key (`k in x`, `k: string`) must still NOT narrow
+//! (negative control). Verified against `tsc` 5.8.3.
+//!
+//! The remeda witness uses `ArrayLike<T> | Iterable<T>`; these cases use
+//! lib-free generic aliases of the same shape (a generic application union where
+//! one member declares the key) so the checker test harness resolves every name
+//! while still exercising the `TypeData::Application` resolution path.
+
+use tsz_checker::test_utils::check_source_strict_messages;
+
+fn ts2322_count(diagnostics: &[(u32, String)]) -> usize {
+    diagnostics.iter().filter(|(code, _)| *code == 2322).count()
+}
+
+#[test]
+fn in_operator_narrows_generic_alias_application_union_to_member_with_key() {
+    // remeda length.ts shape, lib-free so the harness resolves all names: a
+    // *generic* alias instantiation `Enumerable<T>` reaches narrowing as a
+    // `TypeData::Application` (not a raw `Union`), which is exactly the path the
+    // fix resolves. Only `WithLen<T>` has `length: number`; `"length" in items`
+    // narrows to it so `items.length` reads back as `number`.
+    let diagnostics = check_source_strict_messages(
+        r#"
+type WithLen<T> = { length: number; item: T };
+type WithoutLen<T> = { item: T; tag: string };
+type Enumerable<T> = WithLen<T> | WithoutLen<T>;
+export const inLen = <T>(items: Enumerable<T>): number =>
+  "length" in items ? items.length : 0;
+"#,
+    );
+    assert_eq!(
+        ts2322_count(&diagnostics),
+        0,
+        "expected `in` to narrow the generic-alias-application union member and read `length` as number, got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn in_operator_narrows_renamed_generic_alias_application_union_to_member_with_key() {
+    // Binder names vary; the structural rule must not depend on identifiers.
+    let diagnostics = check_source_strict_messages(
+        r#"
+type Sized<Item> = { length: number; first: Item };
+type Unsized<Item> = { first: Item; note: string };
+type Collection<Item> = Sized<Item> | Unsized<Item>;
+export const size = <Item>(coll: Collection<Item>): number =>
+  "length" in coll ? coll.length : 0;
+"#,
+    );
+    assert_eq!(
+        ts2322_count(&diagnostics),
+        0,
+        "renamed generic-alias-application union should still narrow via `in`, got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn in_operator_narrows_object_alias_union_true_branch() {
+    // Alias over a concrete object union: the key exists on one member only.
+    let diagnostics = check_source_strict_messages(
+        r#"
+type AB = { a: number } | { b: string };
+export const readA = (x: AB): number => ("a" in x ? x.a : 0);
+"#,
+    );
+    assert_eq!(
+        ts2322_count(&diagnostics),
+        0,
+        "object alias union true branch should narrow to the key-bearing member, got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn in_operator_narrows_object_alias_union_false_branch() {
+    // The false branch keeps the complement member.
+    let diagnostics = check_source_strict_messages(
+        r#"
+type AB = { a: number } | { b: string };
+export const readB = (x: AB): string => ("a" in x ? "" : x.b);
+"#,
+    );
+    assert_eq!(
+        ts2322_count(&diagnostics),
+        0,
+        "object alias union false branch should narrow to the complement member, got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn in_operator_does_not_narrow_with_non_literal_key() {
+    // Negative control: a non-literal computed key cannot identify a member, so
+    // `x.a` stays an error (tsc: TS2339). The fix must not over-narrow here.
+    let diagnostics = check_source_strict_messages(
+        r#"
+type AB = { a: number } | { b: string };
+export const bad = (x: AB, k: string): number => (k in x ? x.a : 0);
+"#,
+    );
+    assert!(
+        diagnostics.iter().any(|(code, _)| *code == 2339),
+        "non-literal `in` key must not narrow; expected TS2339 on `x.a`, got {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-solver/src/narrowing/property.rs
+++ b/crates/tsz-solver/src/narrowing/property.rs
@@ -123,6 +123,35 @@ impl<'a> NarrowingContext<'a> {
             return narrowed;
         }
 
+        // Resolve aliases / generic applications to their structural form before
+        // deciding union vs non-union. A type alias instantiation such as
+        // `Enumerable<T> = ArrayLike<T> | Iterable<T>` reaches here as a
+        // `TypeData::Application` (or a `Lazy`/`IndexAccess`), for which
+        // `union_list_id` returns `None`; without this resolution the
+        // union-filtering path below is skipped and the receiver wrongly falls
+        // through to the non-union branch (producing `union & Record<prop,
+        // unknown>`, so the property reads back as `unknown`). Resolving here
+        // mirrors tsc's `narrowTypeByInKeyword`, which filters the constituents
+        // of the *resolved* union. We deliberately skip resolution when the
+        // source is already a union (the existing path handles it) or a type
+        // parameter (the constraint-aware branch below must see the bare
+        // parameter so it can intersect with `Record<prop, unknown>` or its
+        // narrowed constraint).
+        let source_type = if union_list_id(self.db, source_type).is_none()
+            && type_param_info(self.db, source_type).is_none()
+        {
+            let resolved = self.resolve_type(source_type);
+            if resolved != source_type {
+                trace!(
+                    "Resolved alias/application {} to {}",
+                    source_type.0, resolved.0
+                );
+            }
+            resolved
+        } else {
+            source_type
+        };
+
         // Handle type parameters: narrow the constraint and intersect if changed
         if let Some(type_param_info) = type_param_info(self.db, source_type) {
             if let Some(constraint) = type_param_info.constraint


### PR DESCRIPTION
Fixes #14153.

Goal: green

## Structural rule
When the receiver of an `in` check is a union reached through a type alias instantiation or generic application (e.g. `Enumerable<T> = ArrayLike<T> | Iterable<T>`), tsc's `narrowTypeByInKeyword` filters the constituents of the *resolved* union: the true branch keeps members whose apparent type has the (string-literal) key, the false branch keeps the complement. tsz now resolves the alias/application to its structural form before the union-vs-non-union decision in the solver `in`-narrowing path, so `"length" in items` narrows to the `ArrayLike<T>` member and `items.length` is `number`.

Before the fix, a generic alias instantiation reached narrowing as a `TypeData::Application`, `union_list_id` returned `None`, the union-filtering path was skipped, and the receiver fell through to the non-union branch (`union & Record<prop, unknown>`), so the property read back as `unknown` — remeda's `length.ts:35` emitted a false TS2322 (`unknown` not assignable to `number`). Resolution is deliberately skipped when the source is already a union (existing path) or a bare type parameter (the constraint-aware branch must see the bare parameter).

## Owner layer
Solver — `in`-operator narrowing: `crates/tsz-solver/src/narrowing/property.rs` (`narrow_by_property_presence`).

## Adjacent cases
- Generic-alias-application union where one member declares the key (witness shape) — narrows; renamed-binder variant — narrows (structural, not identifier-driven).
- Object-union alias, true branch (key-bearing member) and false branch (complement) — both narrow.
- Negative control: non-literal computed key (`k in x`, `k: string`) must NOT narrow — still TS2339 on the property access (matches tsc).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Repro (issue minimal, real ES2022 lib): `tsz -p /tmp/land-14153/tsconfig.json` -> 0 errors; `tsc -p` -> 0 errors (was tsz TS2322 before fix).
- Narrow test: `cargo nextest run -p tsz-checker --test in_operator_narrows_alias_union_member_tests` (5 tests pass). Verified the two generic-alias-application cases FAIL without the fix (stash-revert reproduces TS2322), proving the test targets the fix path; the object-union/negative cases pass either way.
- Smoke: `cargo nextest run -p tsz-checker --test in_chain_narrows_unconstrained_type_param_tests` (22 tests pass, same in-narrowing module).
