### PR TITLE
fix(solver): seed contextual return type into generic construct-signature inference (#14171)

### DIFF
--- a/crates/tsz-checker/tests/contextual_typing_tests/part_02.rs
+++ b/crates/tsz-checker/tests/contextual_typing_tests/part_02.rs
@@ -185,3 +185,120 @@ const b: { a: number }[] | { b: string }[] = [{ b: "x" }];
         "union-of-object-arrays element should match the right arm, got: {diagnostics:?}"
     );
 }
+
+// Regression tests for #14171: when a generic class is constructed in a
+// contextual-return position, the contextual class type must seed the
+// construct-signature's type-parameter inference. The construct argument here
+// only constrains `S` (via the present `schema` property); `T` is reachable
+// only through the *omitted* optional `refiner` member, so round-1 argument
+// inference must not falsely mark `T` as covered and skip contextual-return
+// seeding — otherwise `T` falls back to `unknown` (spurious TS2322).
+fn strict() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn generic_new_seeds_type_param_from_contextual_return() {
+    let source = r#"
+class Box<T, S> {
+  value!: T;
+  schema: S;
+  set: (v: T) => void;
+  constructor(props: { schema: S; refiner?: (value: T) => boolean }) {
+    this.schema = props.schema;
+    this.set = () => {};
+  }
+}
+function define(): Box<string, null> {
+  return new Box({ schema: null });
+}
+"#;
+    let diagnostics = check_with_options(source, strict());
+    assert!(
+        ts2322(&diagnostics).is_empty(),
+        "contextual return type Box<string, null> should infer T = string, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn generic_new_contextual_return_renamed_binders() {
+    // Structural, not identifier-keyed: rename every type parameter and property.
+    let source = r#"
+class Container<Elem, Sch> {
+  val!: Elem;
+  cfg: Sch;
+  apply: (v: Elem) => void;
+  constructor(opts: { cfg: Sch; refine?: (value: Elem) => boolean }) {
+    this.cfg = opts.cfg;
+    this.apply = () => {};
+  }
+}
+function make(): Container<number, boolean> {
+  return new Container({ cfg: true });
+}
+"#;
+    let diagnostics = check_with_options(source, strict());
+    assert!(
+        ts2322(&diagnostics).is_empty(),
+        "renamed-binder construct should infer Elem = number from contextual return, got: {diagnostics:?}"
+    );
+}
+
+// Minimal generic class whose constructor argument only constrains `S`; `T` is
+// reachable solely through the omitted optional `refiner` member. Shared by the
+// alias / arrow-body / negative-control variants below.
+const BOX_CLASS: &str = r#"
+class Box<T, S> {
+  value!: T;
+  schema: S;
+  constructor(props: { schema: S; refiner?: (value: T) => boolean }) {
+    this.schema = props.schema;
+  }
+}
+"#;
+
+#[test]
+fn generic_new_contextual_return_through_alias() {
+    // The contextual return type is an alias of the generic application.
+    let source = format!(
+        "{BOX_CLASS}\ntype Aliased = Box<string, null>;\n\
+         function define(): Aliased {{ return new Box({{ schema: null }}); }}"
+    );
+    let diagnostics = check_with_options(&source, strict());
+    assert!(
+        ts2322(&diagnostics).is_empty(),
+        "aliased contextual return type should seed T = string, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn generic_new_contextual_return_arrow_body() {
+    // Arrow expression body is also a contextual-return position.
+    let source = format!(
+        "{BOX_CLASS}\nconst define = (): Box<number, null> => new Box({{ schema: null }});"
+    );
+    let diagnostics = check_with_options(&source, strict());
+    assert!(
+        ts2322(&diagnostics).is_empty(),
+        "arrow-body contextual return should seed T = number, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn generic_new_argument_inference_still_overrides_contextual_return() {
+    // Negative control: when the argument *does* constrain T (via the provided
+    // `refiner`), argument inference must win over the contextual return type,
+    // so the genuine mismatch is still reported (T = number vs declared string).
+    let source = format!(
+        "{BOX_CLASS}\nfunction define(): Box<string, null> {{\n  \
+         return new Box({{ schema: null, refiner: (value: number) => true }});\n}}"
+    );
+    let diagnostics = check_with_options(&source, strict());
+    assert!(
+        !ts2322(&diagnostics).is_empty(),
+        "argument-supplied T = number must override contextual return and still report TS2322, got: {diagnostics:?}"
+    );
+}

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -634,6 +634,141 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         result
     }
 
+    /// Collect the inference placeholder vars that round-1 *direct argument*
+    /// inference will actually constrain for `arg_type` against `target_type`.
+    ///
+    /// Unlike [`Self::collect_placeholder_vars_in_type`], which returns every
+    /// placeholder structurally present in the parameter type, this walks the
+    /// argument and parameter in parallel so placeholders reachable only through
+    /// parameter members the argument never supplies (e.g. an omitted optional
+    /// property's callback parameter) are not counted as covered. Over-counting
+    /// them wrongly marked a return-type var as "already covered" and skipped
+    /// contextual-return seeding, leaving that type parameter at `unknown`
+    /// (see #14171).
+    ///
+    /// Shapes this walker does not decompose precisely (functions, mismatched
+    /// constructs, index-signature objects, etc.) fall back to the structural
+    /// over-approximation so existing behaviour is preserved.
+    pub(super) fn collect_round1_reachable_placeholder_vars(
+        &self,
+        arg_type: TypeId,
+        target_type: TypeId,
+        var_map: &FxHashMap<TypeId, InferenceVar>,
+        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        out: &mut FxHashSet<InferenceVar>,
+    ) {
+        if var_map.is_empty() {
+            return;
+        }
+        if !visited.insert((arg_type, target_type)) {
+            return;
+        }
+
+        // The target is itself a placeholder: the argument constrains it directly.
+        if let Some(&var) = var_map.get(&target_type) {
+            out.insert(var);
+            return;
+        }
+
+        // Targets with no placeholder vars contribute nothing.
+        if target_type.is_intrinsic() {
+            return;
+        }
+
+        let db = self.interner.as_type_database();
+
+        // Plain object / object: only properties the argument actually supplies
+        // can carry inference into the parameter's placeholder vars. Parameter-
+        // only members (omitted optionals) are left for the contextual return
+        // type to seed. Index-signature objects fall through to the
+        // over-approximation below.
+        if let (Some(TypeData::Object(arg_shape_id)), Some(TypeData::Object(target_shape_id))) = (
+            self.interner.lookup(arg_type),
+            self.interner.lookup(target_type),
+        ) {
+            let arg_shape = self.interner.object_shape(arg_shape_id);
+            let target_shape = self.interner.object_shape(target_shape_id);
+            for target_prop in &target_shape.properties {
+                if let Some(arg_prop) = arg_shape
+                    .properties
+                    .iter()
+                    .find(|p| p.name == target_prop.name)
+                {
+                    self.collect_round1_reachable_placeholder_vars(
+                        arg_prop.type_id,
+                        target_prop.type_id,
+                        var_map,
+                        visited,
+                        out,
+                    );
+                }
+            }
+            return;
+        }
+
+        // Array element / array element.
+        if let (Some(arg_elem), Some(target_elem)) = (
+            crate::type_queries::get_array_element_type(db, arg_type),
+            crate::type_queries::get_array_element_type(db, target_type),
+        ) {
+            self.collect_round1_reachable_placeholder_vars(
+                arg_elem,
+                target_elem,
+                var_map,
+                visited,
+                out,
+            );
+            return;
+        }
+
+        // Tuple / tuple: align element types positionally.
+        if let (Some(TypeData::Tuple(arg_list)), Some(TypeData::Tuple(target_list))) = (
+            self.interner.lookup(arg_type),
+            self.interner.lookup(target_type),
+        ) {
+            let arg_elems = self.interner.tuple_list(arg_list);
+            let target_elems = self.interner.tuple_list(target_list);
+            for (arg_elem, target_elem) in arg_elems.iter().zip(target_elems.iter()) {
+                self.collect_round1_reachable_placeholder_vars(
+                    arg_elem.type_id,
+                    target_elem.type_id,
+                    var_map,
+                    visited,
+                    out,
+                );
+            }
+            return;
+        }
+
+        // Same-base application: align type arguments positionally.
+        if let (Some((arg_base, arg_args)), Some((target_base, target_args))) = (
+            crate::type_queries::get_application_info(db, arg_type),
+            crate::type_queries::get_application_info(db, target_type),
+        ) && arg_base == target_base
+            && arg_args.len() == target_args.len()
+        {
+            for (arg_arg, target_arg) in arg_args.iter().zip(target_args.iter()) {
+                self.collect_round1_reachable_placeholder_vars(
+                    *arg_arg,
+                    *target_arg,
+                    var_map,
+                    visited,
+                    out,
+                );
+            }
+            return;
+        }
+
+        // Shapes we do not decompose precisely fall back to the structural
+        // over-approximation, preserving prior behaviour.
+        out.extend(self.collect_placeholder_vars_in_type(
+            target_type,
+            var_map,
+            &mut FxHashMap::default(),
+            &mut FxHashSet::default(),
+        ));
+    }
+
     pub(super) fn collect_noinfer_placeholder_vars_in_type(
         &mut self,
         ty: TypeId,

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -617,6 +617,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         let mut return_type_bare_var: Option<(crate::inference::infer::InferenceVar, TypeId)> =
             None;
         let mut round1_direct_seed_vars = FxHashSet::default();
+        let mut pair_visited = FxHashSet::default();
 
         for (i, &arg_type) in arg_types.iter().enumerate() {
             let Some(target_type) =
@@ -631,12 +632,30 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 .contextual_round1_arg_types(arg_type, target_type)
                 .is_some()
             {
-                round1_direct_seed_vars.extend(self.collect_placeholder_vars_in_type(
-                    target_type,
-                    &var_map,
-                    &mut placeholder_probe_map,
-                    &mut placeholder_visited,
-                ));
+                if self.is_contextually_sensitive(arg_type) {
+                    // Context-sensitive arguments resolve in Round 2; keep the
+                    // structural estimate of which return-type vars they cover.
+                    round1_direct_seed_vars.extend(self.collect_placeholder_vars_in_type(
+                        target_type,
+                        &var_map,
+                        &mut placeholder_probe_map,
+                        &mut placeholder_visited,
+                    ));
+                } else {
+                    // A non-sensitive argument only constrains placeholders its
+                    // own structure reaches. Counting every placeholder in the
+                    // parameter type falsely marked vars behind omitted optional
+                    // members as covered, skipping contextual-return seeding and
+                    // leaving those type parameters at `unknown` (#14171).
+                    pair_visited.clear();
+                    self.collect_round1_reachable_placeholder_vars(
+                        arg_type,
+                        target_type,
+                        &var_map,
+                        &mut pair_visited,
+                        &mut round1_direct_seed_vars,
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #14171. When a generic class is constructed in a contextual-return position, `tsc` infers the class type parameters from the contextual instance type before argument inference; `tsz` was skipping that contextual-return seeding and falling back to `unknown`, producing a spurious `TS2322`.

```ts
class Box<T, S> {
  value!: T
  schema: S
  set: (v: T) => void
  constructor(props: { schema: S; refiner?: (value: T) => boolean }) {
    this.schema = props.schema
    this.set = () => {}
  }
}
function define(): Box<string, null> {
  return new Box({ schema: null })   // tsc OK | tsz (before): TS2322, T inferred unknown
}
```

## Structural rule

When a generic call/construct runs in a contextual-return position, `tsc` seeds the inference context from the contextual return type (priority `ReturnType`), then lets argument inference (higher priority) override. `tsz` short-circuits that seeding when round-1 argument inference already covers every return-type variable — but the *coverage estimate* over-approximated.

For a non-context-sensitive argument, `round1_direct_seed_vars` collected **every** placeholder structurally present in the parameter type, including placeholders reachable only through parameter members the argument never supplies (here `T`, reachable solely through the omitted optional `refiner?: (value: T) => boolean`). Those vars were marked "covered", so `all_return_vars_covered` became true and the solver skipped contextual-return seeding, leaving `T` at its constraint/`unknown`.

## Fix

For non-context-sensitive arguments, compute coverage precisely by walking the argument and parameter types in parallel (`collect_round1_reachable_placeholder_vars`), counting only placeholders the argument's own structure actually reaches: present object properties, array elements, tuple positions, and same-base application arguments. Context-sensitive arguments (resolved in round 2) and shapes the walker does not decompose keep the structural over-approximation, so existing behaviour is preserved. Argument inference still wins over the contextual return type through inference priority (`NakedTypeVariable` < `ReturnType`).

Owner layer: solver generic-call inference (`operations/generic_call/{resolve,inference_helpers}.rs`). No checker pattern-matching or printer-output predicates; the walk is purely structural over solver type shapes.

## Adjacent-case matrix

New regression tests in `contextual_typing_tests/part_02.rs`:
- base case (issue repro),
- renamed binders + renamed properties (structural, not identifier-keyed),
- contextual return via a type alias of the application,
- arrow expression body return position,
- negative control: an argument-supplied `refiner` must override the contextual return type and still report `TS2322`.

## Scope note

Variable-declaration / call-argument / `satisfies` positions remain a separate, pre-existing gap: the checker passes `contextual_type=None` to call/new expressions there (it also affects plain generic calls), so this solver fix cannot reach them. That is checker-side contextual *threading*, distinct from the inference defect this issue describes.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-checker --test contextual_typing_tests generic_new` — 5 new tests pass; full `contextual_typing_tests` green (92 passed).
- Built `tsz` release and confirmed the issue repro now compiles clean (`--noEmit --strict --target esnext --module esnext --moduleResolution bundler --skipLibCheck`).
- `cargo clippy -p tsz-solver --lib` clean.
- `generic_call_inference_tests` / `call_resolution_regression_tests`: only pre-existing failures remain (identical set on clean `main`, lib-submodule dependent); this change introduces zero new failures.

https://claude.ai/code/session_013SJEvRXsSTsDoiGD5sGMaz

---
_Generated by [Claude Code](https://claude.ai/code/session_013SJEvRXsSTsDoiGD5sGMaz)_