### PR TITLE
fix(solver): accept a deferred indexed-access as an instanceof left operand

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -304,6 +304,9 @@ mod index_sig_param_resolved_key_type_tests;
 #[path = "../tests/indexed_access_alias_application_relation_tests.rs"]
 mod indexed_access_alias_application_relation_tests;
 #[cfg(test)]
+#[path = "tests/instanceof_indexed_access_lhs_tests.rs"]
+mod instanceof_indexed_access_lhs_tests;
+#[cfg(test)]
 #[path = "tests/instantiation_expression_inline_utility_modifier_tests.rs"]
 mod instantiation_expression_inline_utility_modifier_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/instanceof_indexed_access_lhs_tests.rs
+++ b/crates/tsz-checker/src/tests/instanceof_indexed_access_lhs_tests.rs
@@ -1,0 +1,75 @@
+//! A deferred indexed-access `T[K]` is a valid `instanceof` left operand.
+//!
+//! Structural rule: tsc's instanceof-LHS check accepts `any`, an object type, or
+//! a type parameter; for a deferred indexed access `T[K]` it looks through to the
+//! apparent (object-like constraint) type, so `shape[k] instanceof C` is legal
+//! when `T extends { [k: string]: Base }`. tsz's `InstanceofLeftOperandVisitor`
+//! had no `visit_index_access` arm, so a `T[K]` fell to the default (invalid) and
+//! produced a false TS2358. A *concrete* indexed access is already evaluated to
+//! its element type before the visitor, so a primitive element stays invalid.
+//! Owner: `tsz-solver` `operations/binary_ops.rs` `InstanceofLeftOperandVisitor`.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+const TS2358: u32 = 2358; // LHS of instanceof must be any/object/type-parameter.
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+#[test]
+fn deferred_indexed_access_is_valid_instanceof_lhs() {
+    // `shape[k]` has type `T[keyof T]` (a deferred indexed access) — a valid LHS.
+    let codes = check_strict(
+        r#"
+class Base { x!: number; }
+class Sub extends Base { y!: number; }
+type Shape = { [k: string]: Base };
+function f<T extends Shape>(shape: T, k: keyof T) {
+  const v = shape[k];
+  if (v instanceof Sub) {
+    v.y;
+  }
+}
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS2358),
+        0,
+        "deferred T[K] is a valid instanceof LHS: {codes:?}"
+    );
+}
+
+#[test]
+fn deferred_indexed_access_lhs_is_name_independent() {
+    // Anti-hardcoding cover: renamed binders, same rule.
+    let codes = check_strict(
+        r#"
+class P { a!: number; }
+class Q extends P { b!: number; }
+type Rec = { [key: string]: P };
+function g<U extends Rec>(rec: U, key: keyof U) {
+  if (rec[key] instanceof Q) {}
+}
+"#,
+    );
+    assert_eq!(count(&codes, TS2358), 0, "{codes:?}");
+}
+
+#[test]
+fn concrete_primitive_indexed_access_stays_invalid_instanceof_lhs() {
+    // Negative control: a concrete `o["name"]` evaluates to `string` before the
+    // visitor, so it is still an invalid instanceof LHS (TS2358), matching tsc.
+    let codes = check_strict(
+        r#"
+declare const o: { name: string };
+class X {}
+const r = o["name"] instanceof X;
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS2358),
+        1,
+        "concrete string indexed access stays invalid: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/operations/binary_ops.rs
+++ b/crates/tsz-solver/src/operations/binary_ops.rs
@@ -167,6 +167,15 @@ impl<'a> TypeVisitor for InstanceofLeftOperandVisitor<'a> {
     fn visit_application(&mut self, _app_id: u32) -> bool {
         true
     }
+    fn visit_index_access(&mut self, _object_type: TypeId, _key_type: TypeId) -> bool {
+        // A deferred indexed access `T[K]` (e.g. `shape[k]` where `T extends
+        // { [k: string]: Base }`) is generic-valued: its apparent type is the
+        // object-like constraint, so like a bare type parameter it is a valid
+        // `instanceof` left operand. tsc looks through to the apparent type; a
+        // concrete indexed access would already be evaluated to its element type
+        // before reaching this visitor.
+        true
+    }
     fn visit_lazy(&mut self, _def_id: u32) -> bool {
         // Lazy types represent interfaces/classes which are object types —
         // valid left operands for instanceof.


### PR DESCRIPTION
Goal: green

## Summary

`shape[k] instanceof C`, where `shape: T` and `T extends { [k: string]: Base }`, falsely emitted **TS2358** ("the left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter"). The value `shape[k]` is a deferred indexed access `T[keyof T]`; tsc looks through to its apparent (object-like constraint) type and accepts it.

## Structural rule

tsc's instanceof-LHS check accepts `any`, an object type, or a type parameter, and looks through a deferred indexed access `T[K]` to its apparent constraint type. A deferred `T[K]` is generic-valued (it could be any subtype of its constraint), so — like a bare type parameter — it is a valid LHS.

## Owner layer

`crates/tsz-solver/src/operations/binary_ops.rs` — `InstanceofLeftOperandVisitor`.

## Fix

The visitor returned `true` for type parameters, objects, applications, and lazy types, but had no `visit_index_access` arm, so a deferred `T[K]` fell to the default (`false`/invalid) → false TS2358. Add the arm returning `true`. A *concrete* indexed access is already evaluated to its element type before the visitor, so a primitive element (`o["name"]: string`) still correctly stays invalid — the fix does not over-broaden.

## Adjacent-case matrix (verified vs tsc)
- `shape[k] instanceof Sub` (deferred `T[keyof T]`, `T extends { [k:string]: Base }`) → clean (was TS2358). Renamed-binder cover included.
- Negative control: `o["name"] instanceof X` (concrete `string`) → still TS2358, matching tsc.

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo nextest run -p tsz-checker instanceof_indexed_access_lhs` — 3/3 (deferred valid + renamed-binder cover + concrete-primitive negative control).
- Verified vs tsc: deferred `T[K] instanceof` clean; concrete `o["name"] instanceof X` stays TS2358 (no over-broadening). zod canary false TS2358 cleared.
- Conformance 100%: `instanceof` 14/14, `narrowing` 29/29, `controlFlow` 94/94, `expressions/binaryOperators` 66/66.
- `arch_guard.py` pass, `cargo fmt --all --check` clean, `cargo clippy -p tsz-solver -p tsz-checker --all-targets` clean.

Found via the 20-agent corpus FP triage; verified against tsc before implementing.