### PR TITLE
fix(checker): inherit instance members when interface extends cross-module class (#14161)

### DIFF
--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -909,6 +909,50 @@ impl<'a> CheckerState<'a> {
                             break;
                         }
                     }
+                    // Cross-module class base: the class declaration lives in
+                    // another file's arena, so the same-arena probe above finds
+                    // no class node. Resolve the class *instance* surface through
+                    // the symbol-based path (which delegates to the owning arena
+                    // and follows import aliases), mirroring the class-extends-
+                    // class direction in `base_instance_type_from_expression`.
+                    // Without this, `base_type` falls through to
+                    // `get_type_of_symbol` below and returns the class
+                    // *constructor* (`Callable`) type, whose properties are the
+                    // static side; the `Object`+`Callable` merge then drops every
+                    // instance member and `interface D extends ImportedClass {}`
+                    // reports all inherited members missing (TS2339).
+                    if base_type.is_none() {
+                        let class_sym = {
+                            let mut visited =
+                                crate::symbols_domain::alias_cycle::AliasCycleTracker::new();
+                            self.resolve_alias_symbol(base_sym_id, &mut visited)
+                                .filter(|&t| t != base_sym_id)
+                                .or_else(|| self.resolve_import_alias_cross_file(base_sym_id))
+                                .unwrap_or(base_sym_id)
+                        };
+                        // Only the class-base direction routes through the
+                        // instance path. A type-alias / interface base
+                        // (`extends Omit<…>`, `extends ImportedInterface`)
+                        // must fall through to `get_type_of_symbol` below;
+                        // `class_instance_type_from_symbol` can return a broad
+                        // cached/delegated surface for a non-class symbol, which
+                        // would over-broaden the interface and swallow genuine
+                        // TS2339s. Gate on the resolved symbol's CLASS flag so
+                        // the materialization follows the declaration kind, not
+                        // the identifier.
+                        let resolved_is_class = self
+                            .get_cross_file_symbol(class_sym)
+                            .or_else(|| self.ctx.binder.get_symbol(class_sym))
+                            .is_some_and(|symbol| {
+                                symbol.has_any_flags(tsz_binder::symbol_flags::CLASS)
+                            });
+                        if resolved_is_class
+                            && let Some(instance_type) =
+                                self.class_instance_type_from_symbol(class_sym)
+                        {
+                            base_type = Some(instance_type);
+                        }
+                    }
                     if base_type.is_none() && base_symbol_value_declaration.is_some() {
                         let base_decl_idx = base_symbol_value_declaration;
                         if let Some(base_node) = self.ctx.arena.get(base_decl_idx)

--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -50,6 +50,9 @@ mod fs_tests;
 #[path = "../tests/generic_interface_bivariant_param_relation_tests.rs"]
 mod generic_interface_bivariant_param_relation_tests;
 #[cfg(test)]
+#[path = "../tests/interface_extends_cross_module_class_cli_tests.rs"]
+mod interface_extends_cross_module_class_cli_tests;
+#[cfg(test)]
 #[path = "../tests/interface_extends_generic_alias_cli_tests.rs"]
 mod interface_extends_generic_alias_cli_tests;
 #[cfg(test)]

--- a/crates/tsz-cli/tests/interface_extends_cross_module_class_cli_tests.rs
+++ b/crates/tsz-cli/tests/interface_extends_cross_module_class_cli_tests.rs
@@ -1,0 +1,225 @@
+//! Interface heritage that `extends` a **class imported from another module**
+//! (#14161 A).
+//!
+//! Structural rule: when `interface I extends ImportedClass<Args>` and the
+//! class declaration lives in another file's arena, tsc materializes the
+//! class's *instance* members into `I`; tsz must route the cross-arena base
+//! symbol through the symbol-based class-**instance** path before falling back
+//! to `get_type_of_symbol`. That fallback returns the class *constructor*
+//! (`Callable`) type, whose properties are the static side; the `Object` +
+//! `Callable` merge then drops every instance member, so cross-file property
+//! access on `I` reported every inherited member as missing (TS2339).
+//!
+//! The defect is cross-module only — same-file `interface extends class`
+//! already worked because the class node is in the local arena. It needs the
+//! real multi-module driver to reproduce (the in-crate checker harnesses
+//! resolve the entry-only generic case regardless of the fix and cannot host
+//! it). Cases vary generic vs non-generic bases, named vs default imports,
+//! root-file order, and renamed binders, plus controls so the rule follows the
+//! type shape rather than identifier names.
+
+use crate::args::CliArgs;
+use clap::Parser;
+use tsz_checker::diagnostics::Diagnostic;
+
+/// Compile `files` (written into one temp dir) with the given root-file order.
+fn compile_in_order(files: &[(&str, &str)], root_order: &[&str]) -> Vec<Diagnostic> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    for (name, contents) in files {
+        std::fs::write(dir.path().join(name), contents).expect("write repro file");
+    }
+
+    let mut argv: Vec<&str> = vec![
+        "tsz",
+        "--ignoreConfig",
+        "--noEmit",
+        "--strict",
+        "--target",
+        "es2022",
+        "--lib",
+        "es2022,dom,dom.iterable",
+    ];
+    argv.extend_from_slice(root_order);
+
+    let args = CliArgs::try_parse_from(argv).expect("parse args");
+    crate::driver::compile(&args, dir.path())
+        .expect("compile should succeed")
+        .diagnostics
+}
+
+fn missing_property_messages(diagnostics: &[Diagnostic]) -> Vec<String> {
+    diagnostics
+        .iter()
+        .filter(|d| d.code == 2339)
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+/// Assert no TS2339 "property does not exist" in either root-file order
+/// (consumer-first is the cross-file regression direction).
+fn assert_no_missing_property_both_orders(files: &[(&str, &str)]) {
+    let names: Vec<&str> = files.iter().map(|(name, _)| *name).collect();
+    let forward = missing_property_messages(&compile_in_order(files, &names));
+    assert!(
+        forward.is_empty(),
+        "expected no TS2339 in forward root order {names:?}, got: {forward:?}"
+    );
+    let reversed: Vec<&str> = names.iter().rev().copied().collect();
+    let backward = missing_property_messages(&compile_in_order(files, &reversed));
+    assert!(
+        backward.is_empty(),
+        "expected no TS2339 in reversed root order {reversed:?}, got: {backward:?}"
+    );
+}
+
+/// Core witness: interface extends a generic cross-module class (the issue's
+/// repro A, `Base<bigint>`). All inherited instance members must resolve.
+#[test]
+fn interface_extends_cross_module_generic_class_inherits_instance_members() {
+    assert_no_missing_property_both_orders(&[
+        (
+            "base.ts",
+            r#"
+export class Foundation<T = any> {
+    marker!: string;
+    emit(): string { return ""; }
+    payload!: T;
+}
+"#,
+        ),
+        (
+            "main.ts",
+            r#"
+import { Foundation } from './base';
+interface Wing extends Foundation<bigint> {}
+declare const w: Wing;
+const a: string = w.emit();
+const b: string = w.marker;
+const c: bigint = w.payload;
+"#,
+        ),
+    ]);
+}
+
+/// Non-generic cross-module class base with a renamed default import — the
+/// materialization is structural, not arity- or name-scoped.
+#[test]
+fn interface_extends_cross_module_nongeneric_default_class_inherits_members() {
+    assert_no_missing_property_both_orders(&[
+        (
+            "widget.ts",
+            r#"
+export default class Gadget {
+    serial!: number;
+    describe(): string { return ""; }
+}
+"#,
+        ),
+        (
+            "app.ts",
+            r#"
+import Thing from './widget';
+interface Panel extends Thing {}
+declare const p: Panel;
+const a: number = p.serial;
+const b: string = p.describe();
+"#,
+        ),
+    ]);
+}
+
+/// Multi-level: interface extends a class that extends another class, all
+/// cross-module — every inherited member up the chain must resolve.
+#[test]
+fn interface_extends_cross_module_class_chain_inherits_all_members() {
+    assert_no_missing_property_both_orders(&[
+        (
+            "animals.ts",
+            r#"
+export class Animal {
+    name!: string;
+}
+export class Dog extends Animal {
+    bark(): void {}
+}
+"#,
+        ),
+        (
+            "pets.ts",
+            r#"
+import { Dog } from './animals';
+interface Pet extends Dog {}
+declare const pet: Pet;
+const n: string = pet.name;
+pet.bark();
+"#,
+        ),
+    ]);
+}
+
+/// Control: interface extends a cross-module *interface* (not a class) must
+/// keep resolving — the new class-instance branch returns `None` for non-class
+/// bases so the interface/alias resolution still runs.
+#[test]
+fn interface_extends_cross_module_interface_still_resolves() {
+    assert_no_missing_property_both_orders(&[
+        (
+            "shapes.ts",
+            r#"
+export interface Shape {
+    area(): number;
+}
+"#,
+        ),
+        (
+            "solids.ts",
+            r#"
+import type { Shape } from './shapes';
+interface Solid extends Shape {}
+declare const s: Solid;
+const x: number = s.area();
+"#,
+        ),
+    ]);
+}
+
+/// Negative control: a genuinely missing member on an interface extending a
+/// cross-module class still reports exactly one TS2339 — instance-member
+/// materialization must not silence real violations.
+#[test]
+fn interface_extends_cross_module_class_missing_member_still_errors() {
+    let files = &[
+        (
+            "engine.ts",
+            r#"
+export class Engine {
+    rpm!: number;
+    start(): void {}
+}
+"#,
+        ),
+        (
+            "turbine.ts",
+            r#"
+import { Engine } from './engine';
+interface Turbine extends Engine {}
+declare const t: Turbine;
+t.rpm;
+t.start();
+t.absent;
+"#,
+        ),
+    ];
+    let names: Vec<&str> = files.iter().map(|(name, _)| *name).collect();
+    let missing = missing_property_messages(&compile_in_order(files, &names));
+    assert_eq!(
+        missing.len(),
+        1,
+        "expected exactly one TS2339 for the genuinely missing member, got: {missing:?}"
+    );
+    assert!(
+        missing[0].contains("'absent'"),
+        "the surviving TS2339 must be for the missing member, got: {:?}",
+        missing[0]
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes #14161

## Structural rule
When an `interface` extends a **class imported from another module**
(`interface D extends ImportedClass<Args> {}`), `tsc` materializes the class's
**instance** members into `D`. `tsz` now does the same: heritage resolution
routes the cross-arena base symbol through the symbol-based class-**instance**
path (`class_instance_type_from_symbol`, gated on the resolved symbol's binder
`CLASS` flag) before falling back to `get_type_of_symbol`.

Previously, the same-arena class-node probe found nothing (the class declaration
lives in another file's arena), so `base_type` fell through to
`get_type_of_symbol`, which returns the class **constructor** (`Callable`) type
— the static side. The `Object` + `Callable` merge then dropped every instance
member, so `interface D extends ImportedClass {}` reported all inherited members
as missing (TS2339). The class-extends-class direction already worked via
`class_instance_merge_base_members`; this restores the symmetric
interface-extends-class direction.

## Owner layer
Checker: `crates/tsz-checker/src/types/interface_type.rs` (interface
heritage-merge base-type resolution). The new branch is gated on
`tsz_binder::symbol_flags::CLASS` of the resolved base symbol, so a type-alias
or interface base (`extends Omit<…>`, `extends ImportedInterface`) still falls
through to the existing alias/interface resolution and is not over-broadened.

## Adjacent cases (all covered by the new test, both root-file orders)
- generic cross-module class base (`extends Foundation<bigint>`) — the issue's repro A
- non-generic cross-module class via a renamed **default** import
- multi-level: interface extends class extends class, all cross-module
- control: interface extends cross-module **interface** still resolves (CLASS gate returns false)
- negative control: a genuinely-missing member still reports exactly one TS2339

Binder names are varied across cases so no identifier is load-bearing.

## Verification
- Repro (issue #14161 A), tsc clean / tsz now clean:
  ```
  .target/debug/tsz -p /tmp/land-14161/tsconfig.json   # 0 errors
  /tmp/cinfer/node_modules/.bin/tsc -p /tmp/land-14161/tsconfig.json  # 0 errors
  ```
- Narrow regression test (new, faithful multi-module driver harness; fails
  without the fix, passes with it):
  ```
  cargo nextest run -p tsz-cli --lib interface_extends_cross_module_class
  ```
  `crates/tsz-cli/tests/interface_extends_cross_module_class_cli_tests.rs`
  (5 cases). Verified 4/5 FAIL on the unpatched tree (the interface-base control
  passes), all 5 PASS with the fix.
- Smoke (no regressions): `interface_extends_generic_alias_cli_tests`,
  `delete_inherited_optional_heritage_tests`, `lib_heritage_import_order_cli_tests`,
  and `cross_module_generic_interface_heritage_tests` all green. The single
  pre-existing failure `imported_interface_extending_omit_genuinely_missing_property_still_errors`
  fails identically on clean `origin/main` (unrelated to this change).

Note: repro B in the issue (interface extends a bare constrained type parameter)
is a distinct defect in `heritage.rs` and is out of scope here; tsc is also not
clean on repro B (it reports TS2430).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high