### PR TITLE
fix(bench): fail project rows >1.5x slower than tsgo (was 8x)

### DIFF
--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -184,7 +184,7 @@ while [[ $# -gt 0 ]]; do
             echo "  BENCH_PGO_FETCH_UTILITY_TYPES=0  Don't fetch utility-types for PGO training (default: 1)"
             echo "  BENCH_PGO_TSZ_TIMEOUT=<seconds>  Timeout for each PGO training compiler invocation (default: 900)"
             echo "  BENCH_CARGO_BUILD_TIMEOUT=<seconds>  Timeout for each cargo build in check_prerequisites (default: 1200)"
-            echo "  TSZ_BENCH_PROJECT_SLOWDOWN_FAILURE_FACTOR=<factor> Mark green project rows slower than tsgo by this factor as timing failures (default: 8; 0 disables)"
+            echo "  TSZ_BENCH_PROJECT_SLOWDOWN_FAILURE_FACTOR=<factor> Mark green project rows slower than tsgo by this factor as timing failures (default: 1.5; 0 disables)"
             echo "  BENCH_PGO_FETCH_CORE_PROJECTS=1  Fetch/train ts-toolbelt/ts-essentials during PGO (default: 0; slower)"
             echo "  BENCH_PGO_SYNTHETIC=0  Don't train PGO on generated benchmark stress cases (default: 1)"
             echo "  BENCH_PGO_PANIC_UNWIND=1  Build the trainer with panic=unwind for crashy inputs (default: 0)"

--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -264,7 +264,7 @@ NODE
 tsz_load_fixture_pins_from_rows
 
 tsz_project_slowdown_failure_factor() {
-  printf '%s\n' "${TSZ_BENCH_PROJECT_SLOWDOWN_FAILURE_FACTOR:-8}"
+  printf '%s\n' "${TSZ_BENCH_PROJECT_SLOWDOWN_FAILURE_FACTOR:-1.5}"
 }
 
 tsz_project_slowdown_failure_reached() {


### PR DESCRIPTION
## Summary

Lower the project-row slowdown-failure threshold default from **8×** to **1.5×**.
`tsz_project_slowdown_failure_factor()` (`scripts/bench/project-fixtures.sh`) is
the factor at which a benchmark project row where tsz is slower than tsgo stops
being an accepted "green-but-slow" row and is classified as a **timing failure**
(status `tsz slowdown (Nx slower than tsgo; threshold 1.5x)`, timing nulled to
`ERR`). This makes the corpus treat losing to tsgo by more than 1.5× as a
failure, consistent with the `fast` goal.

## Structural rule

When `winner == tsgo` and `tsz_mean / tsgo_mean >= threshold`, the row is recorded
as a slowdown timing failure. Only the default threshold changes (8 → 1.5); the
classification path, the `bench-canaries`-shard exemption (it intentionally charts
the gap), and the `TSZ_BENCH_PROJECT_SLOWDOWN_FAILURE_FACTOR` env override are
unchanged. Owner layer: benchmark measurement (`scripts/bench`), not checker/solver.

## Blast radius (verified against real bench data, run 27880719857)

- Rows that flip green→failure at 1.5×: `ts-toolbelt` (~3.1×), `Comlink` (~2.5×).
  Sub-1.5× rows stay green: `ts-essentials` (1.16×), generated Vite (1.46×),
  generated Next (1.50× → 244/163 = 1.497×).
- **Publish-safe:** ~7 project timing pairs remain (≥ the
  `--require-project-timing-pairs=1` floor), and slowdown rows are red, which does
  **not** block `bench-publish` (it does not pass `--require-green`).
- **Not merge-blocking:** the slowdown gate lives only in
  `bench-vs-tsgo.sh`/`lib/bench-vs-tsgo-results.sh`; `project-compile-guard.sh`
  (the CI merge gate) does not source it.

## Verification

- `node scripts/bench/test-merge-results.mjs` — PASS
- `node scripts/bench/test-tsgo-winner-report.mjs` — PASS
- `node scripts/bench/test-project-rows.mjs` — PASS
- Float-threshold behaviour confirmed with `bc -l` (1.5 is accepted by the
  `^[0-9]+([.][0-9]+)?$` validator): 2.52× and 3.14× → failure; 1.16×/1.46×/1.497×
  → not a failure.
- No test pins the previous default (the `threshold 8x` strings in
  `test-merge-results.mjs`/`test-tsgo-winner-report.mjs` are self-contained
  fixtures).

Goal: fast

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
