### PR TITLE
fix(checker): widen mutable element literals of a const fresh compound initializer (#14165)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/widening.rs
+++ b/crates/tsz-checker/src/query_boundaries/widening.rs
@@ -43,6 +43,14 @@ pub(crate) fn widen_type_for_mutable_binding(db: &dyn TypeDatabase, type_id: Typ
     tsz_solver::operations::widening::widen_type_for_mutable_binding(db, type_id)
 }
 
+/// Widen a `const` declaration's fresh initializer: preserve a top-level
+/// primitive literal (or union of them) while widening the mutable members of
+/// fresh arrays/tuples/objects. `const c = cond ? ["x"] : []` → `string[]`,
+/// `const c = cond ? "x" : "y"` → `"x" | "y"`.
+pub(crate) fn widen_const_initializer(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    tsz_solver::operations::widening::widen_const_initializer(db, type_id)
+}
+
 /// Whether `type_id` is a *plain* object/array shape: `Object`,
 /// `ObjectWithIndex`, `Array`, or `Tuple` only. Excludes `Function`,
 /// `Callable`, `Mapped`, `Intersection`, `TypeParameter`, and `Lazy`.

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -1023,6 +1023,18 @@ impl<'a> CheckerState<'a> {
                 literal
             } else if self.is_bare_object_literal_expression(var_decl.initializer) {
                 self.widen_mutable_object_literal_property_types(init_type)
+            } else if self.is_fresh_literal_expression(var_decl.initializer) {
+                // A fresh compound initializer (array / tuple / conditional over
+                // them) widens its mutable element literals while preserving any
+                // top-level primitive literal: `const c = cond ? ["x"] : []` is
+                // `string[]`; `const c = cond ? "x" : "y"` stays `"x" | "y"`. The
+                // bare array-literal case already widens via expression typing, so
+                // this is a no-op there; the conditional/union case is the fix.
+                // (#14165)
+                crate::query_boundaries::widening::widen_const_initializer(
+                    self.ctx.types,
+                    init_type,
+                )
             } else {
                 init_type
             }

--- a/crates/tsz-checker/tests/conformance_issues/types/const_initializer_widening.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/const_initializer_widening.rs
@@ -1,0 +1,88 @@
+//! `const` initializer widening: tsc preserves a top-level primitive literal
+//! under `const`, but still widens the *mutable* element literals of fresh
+//! arrays/tuples/objects — array/object element positions are mutable, so
+//! `const c = cond ? ["x"] : []` is `string[]`, not `("x")[]`. (#14165)
+
+use super::super::core::*;
+
+/// The remeda witness: a `const` conditional whose true branch is a fresh
+/// array literal and whose false branch is `[]` must widen the element literals
+/// so a later `.push(string)` type-checks. `tsz` previously kept the literal
+/// union element type, contravariantly intersecting the `.push` parameter and
+/// emitting a false TS2345.
+#[test]
+fn const_conditional_array_branches_widen_for_push_no_ts2345() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare const cond: boolean;
+const errors = cond
+  ? ["frozen error", "circular error", (x: string) => x]
+  : [];
+errors.push("Sets cannot have replace patches.");
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2345),
+        "no TS2345 expected — `cond ? [literals] : []` widens to a `string`-element \
+         array under `const`, so `.push(string)` type-checks. Actual: {diagnostics:#?}"
+    );
+}
+
+/// Both branches non-empty arrays: the union of the two array types still widens
+/// member-by-member so a `.push` of either element type is accepted.
+#[test]
+fn const_conditional_two_array_branches_widen_no_ts2345() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare const cond: boolean;
+const xs = cond ? ["frozen"] : ["circular"];
+xs.push("replace");
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2345),
+        "no TS2345 expected — both array branches widen their element literals to \
+         `string`. Actual: {diagnostics:#?}"
+    );
+}
+
+/// Negative control: `const` must STILL preserve a top-level primitive literal
+/// union — `const c = cond ? "x" : "y"` is `"x" | "y"`, not `string`. Assigning
+/// it to the literal-union annotation must stay clean (it would emit TS2322 if
+/// the fix wrongly widened the top-level union to `string`).
+#[test]
+fn const_conditional_primitive_literals_preserved_no_ts2322() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare const cond: boolean;
+const c = cond ? "x" : "y";
+const t: "x" | "y" = c;
+export { t };
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2322),
+        "no TS2322 expected — `const c = cond ? \"x\" : \"y\"` preserves `\"x\" | \"y\"` \
+         (const does not widen top-level primitive literals). Actual: {diagnostics:#?}"
+    );
+}
+
+/// Negative control: a non-fresh initializer (a function-call result) is NOT a
+/// fresh literal expression, so its declared literal type is preserved under
+/// `const` — the widening must not fire for non-fresh compounds.
+#[test]
+fn const_non_fresh_array_initializer_is_not_widened() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare function makeTuple(): ["a", "b"];
+const pair = makeTuple();
+const first: "a" = pair[0];
+export { first };
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2322),
+        "no TS2322 expected — `makeTuple()` is non-fresh, so `const pair` keeps the \
+         declared `[\"a\", \"b\"]` and `pair[0]` is `\"a\"`. Actual: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -1,3 +1,4 @@
+mod const_initializer_widening;
 mod cross_module_unique_symbol;
 mod defaults;
 mod distributive_tuple_union;

--- a/crates/tsz-solver/src/operations/widening.rs
+++ b/crates/tsz-solver/src/operations/widening.rs
@@ -262,6 +262,57 @@ pub fn widen_type_for_mutable_binding(
     widen_type_cached(db, type_id, &mut cache, true, true, true, false, false)
 }
 
+/// Widen a `const` declaration's fresh initializer type the way tsc does.
+///
+/// `const` preserves a *top-level* primitive literal — `const c = "x"` is `"x"`,
+/// and `const c = cond ? "x" : "y"` is `"x" | "y"` — but array, tuple, and
+/// object-literal element positions are mutable, so their literal members still
+/// widen: `const c = cond ? ["x"] : []` is `string[]`, not `("x")[]` (#14165,
+/// remeda `errors.push(...)`). The plain [`widen_type_for_mutable_binding`]
+/// (used for `let`/`var`) would over-widen the top-level literal union to
+/// `string`, which is wrong for `const`.
+///
+/// Strategy: preserve a top-level literal / unique symbol; map a union member by
+/// member (literal members preserved, compound members widened); and widen a
+/// fresh array/tuple/object compound's members via the mutable-binding widener
+/// (which respects object freshness). Reached only for fresh compound
+/// initializers — the checker gates on `is_fresh_literal_expression`, so a
+/// non-fresh initializer keeps its declared type.
+pub fn widen_const_initializer(
+    db: &dyn crate::construction::TypeDatabase,
+    type_id: TypeId,
+) -> TypeId {
+    if type_id.is_intrinsic() {
+        return type_id;
+    }
+    match db.lookup(type_id) {
+        // Distribute over a union: literal members are preserved, array/object
+        // members widen. `cond ? "x" : ["y"]` → `"x" | string[]`.
+        Some(TypeData::Union(list_id)) => {
+            let members = db.type_list(list_id);
+            let mapped: Vec<TypeId> = members
+                .iter()
+                .map(|&m| widen_const_initializer(db, m))
+                .collect();
+            if mapped.iter().zip(members.iter()).all(|(a, b)| a == b) {
+                type_id
+            } else {
+                db.union(mapped)
+            }
+        }
+        // Mutable compounds: widen element / property literals (freshness-respecting).
+        Some(
+            TypeData::Array(_)
+            | TypeData::Tuple(_)
+            | TypeData::Object(_)
+            | TypeData::ObjectWithIndex(_),
+        ) => widen_type_for_mutable_binding(db, type_id),
+        // A top-level primitive literal / unique symbol (`const` preserves it) and
+        // everything else (functions, type parameters, applications, …) unchanged.
+        _ => type_id,
+    }
+}
+
 /// Deep-widen a type including inside function/callable signatures.
 ///
 /// Unlike `widen_type` which skips Function/Callable types for performance


### PR DESCRIPTION
Closes #14165.

## Structural rule
`const` preserves a **top-level** primitive literal — `const c = "x"` is `"x"`, `const c = cond ? "x" : "y"` is `"x" | "y"` — but array, tuple, and object-literal element positions are **mutable**, so their literal members still widen under `const`, matching tsc. `const errors = cond ? ["frozen", "circular", fn] : []` is `(string | ((x: string) => string))[]`, so `errors.push("…")` type-checks. `tsz` kept the un-widened conditional/union result and emitted a false **TS2345** (remeda `errors.push(...)`).

A bare array-literal initializer already widens via expression typing; only the conditional / union-of-arrays case fell through the `const` path's final `else` unchanged.

## Owner layer
- **Solver** `crates/tsz-solver/src/operations/widening.rs::widen_const_initializer` — preserve a top-level `Literal`/`UniqueSymbol`; distribute over a `Union` member-by-member (literal members preserved, compound members widened); widen `Array`/`Tuple`/`Object` members via the freshness-respecting `widen_type_for_mutable_binding`.
- **Checker** `crates/tsz-checker/src/types/computation/helpers.rs` const-initializer path calls it through the widening query boundary, gated on `is_fresh_literal_expression` so non-fresh initializers keep their declared types. No raw `TypeData` matching in the checker — the shape decision lives in the solver.

## Adjacent-case matrix
- `const c = cond ? ["x", fn] : []` → `.push(string)` clean (witness).
- `const c = cond ? ["frozen"] : ["circular"]` (two array branches) → `.push` clean.
- **Negative controls:**
  - `const c = cond ? "x" : "y"` → stays `"x" | "y"` (top-level literal union preserved; `const t: "x" | "y" = c` clean).
  - `const pair = makeTuple()` (non-fresh call result) → keeps declared `["a","b"]`; widening does not fire for non-fresh initializers.

## Verification
- New tests in `conformance_issues/types/const_initializer_widening.rs` (witnesses + 2 negative controls) pass.
- Local widening/const/array/ternary slice: **394/396 pass**. The 2 failures (`generic_call_inference_tests::noinfer_array_alias_widens_to_primitive`, `operator_literal_annotation_display_tests::short_type_alias_annotation_shows_widened_number`) are **pre-existing Mac-only failures**: neither test declares a `const` variable, so this change — which only modifies the `const`-initializer typing path — is provably inert for both. CI (Linux) runs the full checker suite and is the authoritative gate.

Goal: green

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max