### PR TITLE
fix(checker): generic indexed access of a callable member satisfies a callable constraint (#14164)

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/callable_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/callable_constraint_helpers.rs
@@ -135,7 +135,14 @@ impl<'a> CheckerState<'a> {
                 return true;
             }
         }
-        // Resolve the object type's constraint chain to find a mapped type
+        // Resolve the object type to its apparent form, then index it. For a
+        // bare type parameter this is its base constraint (`T extends C` ⟹ apply
+        // `C`); for any other generic-but-deferred object (e.g. a conditional
+        // that still mentions an `infer` variable, `Win extends { x?: infer U }
+        // ? U : …`) evaluate the object to its concrete apparent type so the
+        // covariant index-access rule below can see through to the underlying
+        // callable member. When neither resolves to something other than the
+        // object itself there is nothing to prove callable, so bail.
         let object_constraint = if query::is_bare_type_parameter(db, object) {
             let base = query::base_constraint_of_type(db, object);
             if base != object {
@@ -144,9 +151,44 @@ impl<'a> CheckerState<'a> {
                 return false;
             }
         } else {
-            return false;
+            let evaluated = self.evaluate_type_for_assignability(object);
+            if evaluated == object {
+                return false;
+            }
+            evaluated
         };
+
+        // General, structural rule: `T[K]` carries a call/construct signature
+        // whenever the apparent (base-constraint) type of `T`, indexed by `K`,
+        // yields a callable type. Indexed access is covariant in the object, so
+        // `T <: C` implies `T[K] <: C[K]`; if `C[K]` is callable, so is `T[K]`.
+        //
+        // This covers a *concrete* interface/object member that is itself
+        // callable (e.g. `interface I { connect: (...) => ... }`, `I['connect']`,
+        // or a hybrid call-signature-plus-properties interface) — the
+        // mapped-template and index-signature special cases below recognise only
+        // those two constraint shapes and miss a plain named callable property.
+        // Evaluating the access through the resolved constraint is sound for a
+        // generic key as well: a key that distributes to a non-callable value
+        // produces a union/deferred form that is not callable, so callability is
+        // never over-claimed.
+        let constraint_indexed = self
+            .ctx
+            .types
+            .factory()
+            .index_access(object_constraint, index);
+        let constraint_indexed = self.evaluate_type_for_assignability(constraint_indexed);
+        // Re-borrow after the `&mut self` evaluation above; this `db` stays valid
+        // through the mapped-template lookup below (no further `&mut self` call
+        // until that block's own evaluation re-borrows).
         let db = self.ctx.types.as_type_database();
+        if constraint_indexed != type_id
+            && (query::is_callable_type(db, constraint_indexed)
+                || query::callable_shape_for_type(db, constraint_indexed).is_some())
+        {
+            return true;
+        }
+
         // Check if the resolved constraint is a mapped type with callable template
         if let Some(template) = query::mapped_type_template(db, object_constraint) {
             let template_eval = self.evaluate_type_for_assignability(template);

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -931,6 +931,9 @@ mod index_signature_property_relation_routing_arch_tests;
 #[path = "tests/index_signature_value_relation_routing_arch_tests.rs"]
 mod index_signature_value_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/indexed_access_callable_member_constraint_ts2344_tests.rs"]
+mod indexed_access_callable_member_constraint_ts2344_tests;
+#[cfg(test)]
 #[path = "tests/indexed_access_constraint_relation_routing_arch_tests.rs"]
 mod indexed_access_constraint_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/indexed_access_callable_member_constraint_ts2344_tests.rs
+++ b/crates/tsz-checker/src/tests/indexed_access_callable_member_constraint_ts2344_tests.rs
@@ -1,0 +1,223 @@
+//! Regression tests for TS2344 on a generic/deferred indexed access whose
+//! member is callable, used where a callable signature constraint is required
+//! (`Parameters<T[K]>`, `ReturnType<T[K]>`, …).
+//!
+//! Structural rule: indexed access is covariant in the object, so for any
+//! `T <: C` the access `T[K]` is a subtype of `C[K]`. When the apparent
+//! (base-constraint) type `C[K]` carries a call/construct signature, `T[K]` is
+//! callable too and must satisfy a `(...args: any) => any` constraint — even
+//! when `C` is an interface (`Lazy`), a hybrid call-signature-plus-properties
+//! interface, or the object is a deferred conditional that still mentions an
+//! `infer` variable. Conversely, when `C[K]` is not provably callable (a plain
+//! non-callable member, or a generic key that distributes to a non-callable
+//! value) tsz must still emit TS2344, matching `tsc`.
+//!
+//! Witnesses: zustand `ReduxDevtoolsExtension['connect']` (issue #14164,
+//! Repro A) and the reduced `T['connect']` generic form.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+/// Type-check `source` with the default lib (so `Parameters` / `ReturnType`
+/// resolve) under strict mode, returning the emitted diagnostic codes.
+fn check(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+macro_rules! assert_code {
+    ($codes:ident, $code:literal, $msg:literal) => {
+        assert!($codes.contains(&$code), concat!($msg, " Got: {:?}"), $codes)
+    };
+}
+
+macro_rules! assert_no_code {
+    ($codes:ident, $code:literal, $msg:literal) => {
+        assert!(
+            !$codes.contains(&$code),
+            concat!($msg, " Got: {:?}"),
+            $codes
+        )
+    };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Generic `T[K]` whose constraint member is callable satisfies a callable
+//    signature constraint (positive — no TS2344).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generic_type_param_indexed_callable_member_satisfies_parameters_no_ts2344() {
+    let codes = check(
+        r#"
+interface Hybrid {
+    (config?: { type?: string }): unknown;
+    connect: (preConfig: { type?: string }) => { send: (a: unknown) => void };
+}
+function probe<T extends Hybrid>(): Parameters<T['connect']>[0] {
+    return null as any;
+}
+"#,
+    );
+    assert_no_code!(
+        codes,
+        2344,
+        "`T['connect']` where T extends a hybrid interface must satisfy `(...args)=>any`."
+    );
+}
+
+#[test]
+fn generic_type_param_indexed_callable_member_renamed_satisfies_return_type_no_ts2344() {
+    // Renamed binders (Svc/run/Q) prove the fix is structural, not name-driven.
+    let codes = check(
+        r#"
+interface Svc { run: (n: number) => string }
+function probe<Q extends Svc>(): ReturnType<Q['run']> {
+    return 'x' as any;
+}
+"#,
+    );
+    assert_no_code!(
+        codes,
+        2344,
+        "renamed `Q['run']` callable member must satisfy a callable constraint."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Deferred conditional object whose resolved member is callable
+//    (zustand Repro A — `(Win extends {x?: infer T} ? T : ...)['connect']`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn conditional_infer_object_indexed_callable_member_satisfies_parameters_no_ts2344() {
+    let codes = check(
+        r#"
+interface ReduxDevtoolsExtension {
+    (config?: { type?: string }): unknown;
+    connect: (preConfig: { type?: string }) => { send: (a: unknown) => void };
+}
+interface Win { ext?: ReduxDevtoolsExtension }
+type Config = Parameters<
+    (Win extends { ext?: infer T } ? T : { connect: (param: any) => unknown })['connect']
+>[0];
+const c: Config = { type: 'x' };
+export { c };
+"#,
+    );
+    assert_no_code!(
+        codes,
+        2344,
+        "indexing a conditional that resolves to a hybrid interface must keep its callable member."
+    );
+}
+
+#[test]
+fn conditional_infer_object_indexed_callable_member_renamed_no_ts2344() {
+    let codes = check(
+        r#"
+interface Plugin {
+    (cfg?: unknown): void;
+    open: (name: string) => number;
+}
+interface Host { slot?: Plugin }
+type Opened = Parameters<
+    (Host extends { slot?: infer P } ? P : { open: (k: any) => unknown })['open']
+>[0];
+const o: Opened = 'name';
+export { o };
+"#,
+    );
+    assert_no_code!(
+        codes,
+        2344,
+        "renamed conditional-resolved hybrid interface member must satisfy a callable constraint."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Wrapper / alias nesting around the constraint (positive — no TS2344).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn wrapper_aliased_constraint_indexed_callable_member_no_ts2344() {
+    let codes = check(
+        r#"
+interface Box { fn: (s: string) => number }
+type Wrap<T> = T;
+function probe<B extends Wrap<Box>>(x: Parameters<B['fn']>[0]): string {
+    return x;
+}
+"#,
+    );
+    assert_no_code!(
+        codes,
+        2344,
+        "a wrapper-aliased constraint must still expose its callable member through `B['fn']`."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Negative: a non-callable member still emits TS2344 (parity with tsc).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn non_callable_indexed_member_still_emits_ts2344() {
+    let codes = check(
+        r#"
+interface Data { value: number }
+type Bad = Parameters<Data['value']>;
+export type { Bad };
+"#,
+    );
+    assert_code!(
+        codes,
+        2344,
+        "indexing a non-callable member (`Data['value']` is number) must still emit TS2344."
+    );
+}
+
+#[test]
+fn non_callable_indexed_member_renamed_still_emits_ts2344() {
+    let codes = check(
+        r#"
+interface Record1 { count: bigint }
+type Bad = ReturnType<Record1['count']>;
+export type { Bad };
+"#,
+    );
+    assert_code!(
+        codes,
+        2344,
+        "renamed non-callable member must still emit TS2344."
+    );
+}
+
+#[test]
+fn generic_key_into_mixed_object_not_provably_callable_emits_ts2344() {
+    // `M[K]` distributes to `((n:number)=>void) | string`, which is not
+    // callable as a union — tsc emits TS2344, so tsz must too.
+    let codes = check(
+        r#"
+interface Mix { a: (n: number) => void; b: string }
+function neg<M extends Mix, K extends keyof M>(x: Parameters<M[K]>) { return x }
+"#,
+    );
+    assert_code!(
+        codes,
+        2344,
+        "a generic key into a mixed callable/non-callable object is not provably callable."
+    );
+}


### PR DESCRIPTION
Addresses #14164 (Repro A / zustand).

Goal: green

## Structural rule
When a generic/deferred indexed access `T[K]` is used where a
`(...args: any) => any` constraint is required (`Parameters<T[K]>`,
`ReturnType<T[K]>`), and `K` selects a member of `T`'s constraint whose type is
callable — `tsc` accepts it; `tsz` now does too through the checker's eager
TS2344 gate (`indexed_access_resolves_to_callable`).

Indexed access is covariant in the object: for any `T <: C`, the access `T[K]`
is a subtype of `C[K]`. So when the apparent (base-constraint) type `C[K]`
carries a call/construct signature, `T[K]` is callable too.

`tsz` previously emitted a false **TS2344** here. The eager TS2344 gate asked
`indexed_access_resolves_to_callable`, which recognised only two constraint
shapes — a mapped-type template, and an index signature — and **missed a plain
named callable property** on a concrete interface (e.g. a hybrid
call-signature-plus-properties interface's `connect`, or a function-typed
member). A provably-callable access was therefore rejected.

```ts
interface ReduxDevtoolsExtension {
  (config?: { type?: string }): unknown
  connect: (preConfig: { type?: string }) => { send: (a: unknown) => void }
}
interface Win { __REDUX_DEVTOOLS_EXTENSION__?: ReduxDevtoolsExtension }
type Config = Parameters<
  (Win extends { __REDUX_DEVTOOLS_EXTENSION__?: infer T } ? T : { connect: (param: any) => unknown })['connect']
>[0]
const c: Config = { type: 'x' }   // tsc: OK | tsz before: TS2344
```

Reduced generic witness: `function probe<T extends ReduxDevtoolsExtension>(): Parameters<T['connect']>[0]`.

## Owner layer
Checker — generic type-argument constraint validation:
`crates/tsz-checker/src/checkers/generic_checker/callable_constraint_helpers.rs`
(`indexed_access_resolves_to_callable`). The fix resolves the object to its
apparent form (base constraint for a bare type parameter; evaluated apparent
type for a deferred conditional that still mentions an `infer` variable),
builds `object_constraint[index]`, evaluates it through the shared evaluation
boundary, and accepts when the result is callable. Shape decisions go through
the existing `query::` boundary helpers (`is_callable_type`,
`callable_shape_for_type`, `base_constraint_of_type`) — no raw `TypeData`
matching, no identifier/file-name strings, no printer-output predicates. The two
pre-existing special cases (mapped-template, index-signature) are kept as
structural fast-paths for forms whose index access does not evaluate to
progress.

## Adjacent-case matrix
Accept (no TS2344):
- generic `T['connect']` where `T extends` a hybrid interface — via `Parameters`
  and via `ReturnType`, with **renamed binders** (`Svc`/`run`/`Q`);
- the deferred conditional object `(Win extends { x?: infer T } ? T : …)['connect']`
  (zustand Repro A), plus a renamed variant;
- a wrapper-aliased constraint `B extends Wrap<Box>`, `B['fn']`.

Negative controls (still TS2344, parity with `tsc`):
- a non-callable member (`Data['value']` where `value: number`; renamed
  `Record1['count']` where `count: bigint`);
- a generic key into a mixed object (`M[K]`, `K extends keyof M`,
  `M = { a: (n:number)=>void; b: string }`) — the distributed value union is not
  callable, so not provably callable.

## Scope note
The issue's Repro B (jotai, TS2349) is a **distinct** defect: it requires the
conjunction of the lib `Parameters` utility (cross-arena), an interface
(`Lazy`), **and** a hoisted top-level function-declaration parameter position —
remove any one and it already passes (an unconstrained/constrained user-defined
`ParamsOf`, a type-alias/inline object instead of an interface, or an
arrow/`const`/class-method parameter all type-check). That is a cross-arena
hoisted-resolution ordering/caching issue in the resolution-eagerness family
(cf. #13980 / #13936), not the indexed-access apparent-type bug fixed here, and
is intentionally not bundled. #14164 stays open for it.

## Verification
- Repro A and its family (`Parameters`/`ReturnType`, conditional-infer, hybrid
  interface, wrapper alias) compile clean on a freshly built
  `.target/release/tsz` with `--noEmit --strict --target esnext --module esnext
  --moduleResolution bundler --skipLibCheck`; negative controls still emit
  TS2344.
- New targeted suite (default lib, strict): `cargo test -p tsz-checker --lib
  indexed_access_callable_member_constraint` → **8 passed** (5 positive incl.
  renamed binders, 3 negative controls).
- Full `cargo test -p tsz-checker --lib`: the failing-test set is **byte-identical
  with and without this change** (74 pre-existing environment-local failures;
  `comm` of the two failure lists is empty in both directions) — zero
  regressions. Broad conformance/emit/fourslash delegated to ready-review CI.
- `cargo fmt` clean; `cargo clippy -p tsz-checker --lib` clean for the changed
  file.
- Reviewed with `/simplify` (4 cleanup angles): folded the callable check into a
  single non-nested condition and removed one redundant `db` re-borrow; the
  remaining suggestions (remove the structural fast-paths / relocate into the
  solver) were declined as behavior-changing / out-of-scope for this fix.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_014Jas1HrdUckgz2ig5oX7T2