### PR TITLE
fix(checker): narrow let binding via array/object-literal assignment in flow fallback (#14219)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
@@ -95,6 +95,19 @@ impl<'a> FlowAnalyzer<'a> {
             return self.fallback_binary_expression_type(bin.left, bin.right, bin.operator_token);
         }
 
+        // Array/object literal right-hand sides have no dedicated branch above and
+        // are commonly uncached during return-type inference, where the inference
+        // pass evaluates only return expressions (not the assignment statements in
+        // sibling branches such as `if (!value) { value = ["a"]; }`). Route them
+        // through the general syntax resolver so assignment-based flow narrowing of
+        // a `let` binding produces the widened literal element type (matching the
+        // cached read pass), instead of silently keeping the declared union type.
+        if rhs_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+            || rhs_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+        {
+            return self.fallback_expression_type_from_syntax(rhs);
+        }
+
         None
     }
 

--- a/crates/tsz-checker/tests/assignment_branch_merge_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/assignment_branch_merge_narrowing_tests.rs
@@ -51,3 +51,56 @@ function f() {
         "without a branch assignment the value can still be undefined, got {diagnostics:?}"
     );
 }
+
+#[test]
+fn branch_array_literal_assignment_narrows_returned_let_binding() {
+    // deepkit-type repro for issue #14219: an array-literal RHS reassignment in a
+    // guard must kill the `undefined` member of the `let` binding so the inferred
+    // return type is `string[]`, not `string[] | undefined`.
+    let diagnostics = codes(
+        r#"
+declare function maybeLabels(): string[] | undefined;
+
+function getLabels() {
+    let value = maybeLabels();
+    if (!value) {
+        value = ["a"];
+    }
+    return value;
+}
+
+const n: number = getLabels().length;
+"#,
+    );
+
+    assert!(
+        !diagnostics.contains(&TS2322),
+        "array-literal branch assignment should narrow value to string[], got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn branch_object_literal_assignment_narrows_returned_let_binding() {
+    // Object-literal sibling of #14219: the object-literal RHS must also narrow
+    // away `undefined` through the flow fallback resolver.
+    let diagnostics = codes(
+        r#"
+declare function maybeConfig(): { a: number } | undefined;
+
+function getConfig() {
+    let value = maybeConfig();
+    if (!value) {
+        value = { a: 1 };
+    }
+    return value;
+}
+
+const n: number = getConfig().a;
+"#,
+    );
+
+    assert!(
+        !diagnostics.contains(&TS2322),
+        "object-literal branch assignment should narrow value to {{ a: number }}, got {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
## Summary
Mined from **deepkit-type**. A `let` binding (declared `T | undefined`, e.g. from `Map.get`) reassigned an array/object literal inside a guard was not narrowed during return-type inference, so tsz inferred `T | undefined` and emitted a spurious TS18048 at the call site; tsc is clean.

```ts
const cache = new Map<object, string[]>();
function getLabels(key: object) {
  let value = cache.get(key);     // string[] | undefined
  if (!value) { value = ["a"]; }  // assignment-narrows away undefined
  return value;                   // tsc infers string[]; tsz inferred string[] | undefined
}
const n: number = getLabels({}).length;   // was TS18048; now clean
```

## Structural rule
When return-type inference evaluates a function whose returned `let` binding is reassigned an array/object literal inside a guard branch, tsc applies assignment-based flow narrowing so the binding is `T` at the return. tsz's inference pass does not pre-type the literal RHS of that assignment (its `node_types` misses for the literal), and its flow fallback had no array/object-literal branch — so the assignment did not kill the `undefined` member and tsz kept `T | undefined`.

## Owner / fix
Checker flow — `crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs`, `fallback_assigned_type_from_expression`. Added an `ARRAY_LITERAL_EXPRESSION`/`OBJECT_LITERAL_EXPRESSION` branch routing the RHS to the existing structural syntax resolver `fallback_expression_type_from_syntax`, producing the widened element type and matching the cached read pass. Keyed purely on syntax kind — no identifier/filename/printer-output checks.

## Adjacent cases
- Array literal (`value = ["a"]`) — positive, proven to fail without the fix.
- Object literal (`value = { a: 1 }`) — positive sibling.
- Typed-expression RHS (already handled) — regression guard `branch_assignment_preserves_defined_local_after_intervening_read`.
- Negative control: a branch that does NOT assign still keeps `T | undefined` — `branch_without_assignment_still_keeps_possibly_undefined`.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Repro (strict, exactOptionalPropertyTypes, noUncheckedIndexedAccess, ES2022, ESNext, Bundler): `tsz -p` -> 0 and `tsc -p` -> 0.
- Narrow test: `cargo nextest run -p tsz-checker --test assignment_branch_merge_narrowing_tests` (4 passed). New array-literal test verified to FAIL against baseline `main` (got `[2322]`) and pass with the fix.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` and `cargo fmt --check` clean.

Goal: green

Fixes #14219
