### PR TITLE
fix(checker): consult signature type params before value-as-type in type literals (#14214)

### DIFF
--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -531,6 +531,16 @@ impl<'a> CheckerState<'a> {
                 _ => {}
             }
 
+            // A bare type-position identifier that names an in-scope type
+            // parameter (e.g. the `<E>` declared on a call/method signature of
+            // this type literal) binds to that type parameter, even when an
+            // enclosing value of the same name is visible. Mirror the canonical
+            // type-reference path, which consults the type-parameter scope before
+            // the value-used-as-type (TS2749) diagnostic.
+            if let Some(type_param) = self.lookup_type_parameter(name) {
+                return type_param;
+            }
+
             let recovered_type_symbol = if name != "Array"
                 && let TypeSymbolResolution::ValueOnly(sym_id) =
                     self.resolve_identifier_symbol_in_type_position(type_name_idx)
@@ -555,9 +565,6 @@ impl<'a> CheckerState<'a> {
                 None
             };
 
-            if let Some(type_param) = self.lookup_type_parameter(name) {
-                return type_param;
-            }
             if let Some(sym_id) = recovered_type_symbol.or_else(|| {
                 if let TypeSymbolResolution::Type(sym_id) =
                     self.resolve_identifier_symbol_in_type_position(type_name_idx)

--- a/crates/tsz-checker/tests/name_resolution_boundary_tests.rs
+++ b/crates/tsz-checker/tests/name_resolution_boundary_tests.rs
@@ -407,6 +407,69 @@ type T = { x: myFunc };
 }
 
 #[test]
+fn signature_type_param_in_type_literal_shadows_enclosing_value() {
+    // A bare type-position identifier inside a call/method signature member of
+    // an object type literal binds to that signature's own type parameter, even
+    // when an enclosing value of the same name is visible. tsc resolves the
+    // type parameter first; the type-literal resolver must consult the
+    // type-parameter scope before the value-used-as-type recovery (TS2749).
+    let diags = check(
+        r#"
+interface Either<E, A> { readonly _e: E; readonly _a: A }
+declare const E: number;
+type Sig<A> = {
+    <E>(a: A, ma: Either<E, A>): boolean
+};
+"#,
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2749),
+        0,
+        "Expected no TS2749 when a call-signature type parameter shadows an enclosing value, got: {diags:?}"
+    );
+}
+
+#[test]
+fn method_signature_type_param_in_type_literal_shadows_enclosing_value() {
+    // Same rule for a method signature, with an alternate binder name to keep
+    // the fix scope-based rather than identifier-based.
+    let diags = check(
+        r#"
+interface Wrap<G, A> { readonly _g: G; readonly _a: A }
+declare const G: number;
+type Sig<A> = {
+    pick<G>(ma: Wrap<G, A>): boolean
+};
+"#,
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2749),
+        0,
+        "Expected no TS2749 when a method-signature type parameter shadows an enclosing value, got: {diags:?}"
+    );
+}
+
+#[test]
+fn genuine_value_used_as_type_in_type_literal_still_reports() {
+    // Negative control: when no type parameter of the same name is in scope, a
+    // value used in type position is still a genuine TS2749 in the type-literal
+    // resolver.
+    let diags = check(
+        r#"
+interface Box<V> { readonly _v: V }
+declare const V: number;
+type Bad = {
+    (a: number): Box<V>
+};
+"#,
+    );
+    assert!(
+        has_diagnostic_code(&diags, 2749),
+        "Expected TS2749 when a genuine value with no type-parameter shadow is used as a type, got: {diags:?}"
+    );
+}
+
+#[test]
 fn phase2_value_only_in_qualified_type_routes_through_boundary() {
     let diags = check(
         r#"


### PR DESCRIPTION
Fixes #14214.

## Summary
Mined from **fp-ts** (`src/Either.ts:1469` `elem`, where a value parameter named `E` coexists with a signature type parameter `<E>`). tsz emitted a false TS2749; tsc is clean.

```ts
interface Either<E, A> { readonly _e: E; readonly _a: A }
declare const E: number
type Sig<A> = {
  <E>(a: A, ma: Either<E, A>): boolean   // tsz: TS2749 on the E in Either<E, A>; tsc: clean
}
```

## Structural rule
When a bare type-position identifier inside an object type literal's call/method/construct-signature member names a type parameter declared on that same signature (`<E>`), tsc binds it to the signature's type parameter and shadows any enclosing value of the same name. tsz consulted symbol-meaning before the signature's type-parameter scope, so it resolved `E` to the value and emitted TS2749.

The signature's `<E>` is correctly pushed into `type_parameter_scope`, so `lookup_type_parameter("E")` would succeed — but in the type-literal resolver's bare-identifier path the value-used-as-type recovery ran and returned `ERROR` before that lookup was reached. The canonical (non-type-literal) resolver already consults `lookup_type_parameter` first; the type-literal path inverted the order.

## Owner / fix
Checker — `crates/tsz-checker/src/types/type_literal_checker.rs`, `get_type_from_type_reference_in_type_literal` (bare-identifier branch). Moved the `lookup_type_parameter(name)` short-circuit to before the value-used-as-type (`report_wrong_meaning`/TS2749) recovery block, mirroring `state/type_resolution/core.rs`, and removed the now-redundant later copy. Pure scope-lookup ordering: no identifier/filename/printer-output predicate.

## Adjacent cases (verified vs tsc)
- Call signature and method signature in an object type literal: clean in both.
- Alternate binder name (`<G>`): clean in both (fix is scope-based, not identifier-based).
- Negative control: a genuine value-used-as-type with no type parameter in scope (`Box<V>` where `declare const V`) still emits TS2749 in both — the fix only fires when `lookup_type_parameter` returns `Some`, so genuine errors are preserved.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Repro: `tsz -p tsconfig.json` -> 0 diagnostics, `tsc -p tsconfig.json` -> 0 (strict, exactOptionalPropertyTypes, noUncheckedIndexedAccess, noEmit, target/lib ES2022, module ESNext, moduleResolution Bundler, skipLibCheck). Was TS2749 at (4,24) on clean main before the fix.
- Narrow regression test: `cargo nextest run -p tsz-checker --test name_resolution_boundary_tests signature_type_param_in_type_literal_shadows_enclosing_value method_signature_type_param_in_type_literal_shadows_enclosing_value genuine_value_used_as_type_in_type_literal_still_reports` -> 3 passed.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` clean; `cargo fmt -p tsz-checker --check` clean.

Goal: green
