### PR TITLE
fix(solver): bind `this` to the receiver when indexing a `this`-typed property (#14166)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -467,6 +467,9 @@ path = "tests/lazy_class_constructor_type_tests.rs"
 name = "this_type_tests"
 path = "tests/this_type_tests.rs"
 [[test]]
+name = "this_type_indexed_access_receiver_tests"
+path = "tests/this_type_indexed_access_receiver_tests.rs"
+[[test]]
 name = "this_rooted_discriminant_narrowing_tests"
 path = "tests/this_rooted_discriminant_narrowing_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/this_type_indexed_access_receiver_tests.rs
+++ b/crates/tsz-checker/tests/this_type_indexed_access_receiver_tests.rs
@@ -1,0 +1,145 @@
+//! Regression coverage for #14166: an indexed access that reads a property whose
+//! declared type references the polymorphic `this` must bind `this` to the
+//! *receiver* the property is read from.
+//!
+//! Structural rule: when `interface I { return: this["args"] }` and the receiver
+//! is an intersection `(I & { args: V })`, `tsc` substitutes `this` with that
+//! receiver (`getTypeWithThisArgument`), so `(I & { args: V })["return"]` reduces
+//! to `(I & { args: V })["args"]` = `V`. `tsz` previously left an unreduced
+//! deferred `this["args"]`, which was neither assignable to nor identical with
+//! its reduced form, producing a false `TS2322` and breaking `Equal`-style
+//! identity tricks (the `Fn`/`Call`/`Apply` HKT core).
+//!
+//! The same rule binds a bare `this`-typed member (`self: this`) to the receiver,
+//! and — read directly on the interface — resolves `this` through the receiver
+//! `I` itself (so `I["return"]` is `I["args"]`, i.e. the declared constraint).
+//!
+//! Verified against `tsc` 6.x: every positive case exits 0; every negative
+//! control keeps its `TS2322`.
+
+use tsz_checker::test_utils::{check_source_strict, diagnostic_count};
+
+fn ts2322(source: &str) -> usize {
+    diagnostic_count(&check_source_strict(source), 2322)
+}
+
+/// The exact repro from #14166: `this["args"]` read through an intersection
+/// receiver reduces to the concrete value supplied by the sibling member.
+#[test]
+fn this_indexed_access_binds_to_intersection_receiver() {
+    let source = r#"
+interface Fn { args: unknown; return: unknown; }
+interface Identity extends Fn { return: this["args"]; }
+type R = (Identity & { args: true })["return"];
+const ok: true = null as any as R;
+"#;
+    assert_eq!(
+        ts2322(source),
+        0,
+        "reduced `this[\"args\"]` must accept `true`"
+    );
+}
+
+/// Negative control: the reduced value is `true`, so a `false` target still errors
+/// (the access is genuinely reduced, not widened to `any`/`unknown`).
+#[test]
+fn reduced_this_indexed_access_still_rejects_wrong_literal() {
+    let source = r#"
+interface Fn { args: unknown; return: unknown; }
+interface Identity extends Fn { return: this["args"]; }
+type R = (Identity & { args: true })["return"];
+const bad: false = null as any as R;
+"#;
+    assert_eq!(
+        ts2322(source),
+        1,
+        "`true` must not be assignable to `false`"
+    );
+}
+
+/// A non-literal value type flows through the same reduction.
+#[test]
+fn this_indexed_access_reduces_primitive_value() {
+    let ok = r#"
+interface Fn { args: unknown; return: unknown; }
+interface Identity extends Fn { return: this["args"]; }
+type R = (Identity & { args: string })["return"];
+const ok: string = null as any as R;
+"#;
+    assert_eq!(ts2322(ok), 0, "reduced value `string` must accept `string`");
+
+    let bad = r#"
+interface Fn { args: unknown; return: unknown; }
+interface Identity extends Fn { return: this["args"]; }
+type R = (Identity & { args: string })["return"];
+const bad: number = null as any as R;
+"#;
+    assert_eq!(
+        ts2322(bad),
+        1,
+        "reduced value `string` must reject `number`"
+    );
+}
+
+/// Anti-hardcoding: the rule is structural, not keyed on `Fn`/`Identity`/`args`.
+/// Renamed binders behave identically.
+#[test]
+fn this_indexed_access_is_binder_name_invariant() {
+    let ok = r#"
+interface Hkt { input: unknown; output: this["input"]; }
+type Run = (Hkt & { input: 7 })["output"];
+const ok: 7 = null as any as Run;
+"#;
+    assert_eq!(ts2322(ok), 0, "renamed-binder reduction must accept `7`");
+
+    let bad = r#"
+interface Hkt { input: unknown; output: this["input"]; }
+type Run = (Hkt & { input: 7 })["output"];
+const bad: 8 = null as any as Run;
+"#;
+    assert_eq!(ts2322(bad), 1, "renamed-binder reduction must reject `8`");
+}
+
+/// A bare `this`-typed member (not `this[K]`) also binds to the receiver: the
+/// member reads as the receiver intersection, so a follow-on key read sees the
+/// sibling member's concrete value.
+#[test]
+fn bare_this_member_binds_to_intersection_receiver() {
+    let ok = r#"
+interface Builder { self: this; name: string; }
+type S = (Builder & { name: "x" })["self"];
+type N = S["name"];
+const ok: "x" = null as any as N;
+"#;
+    assert_eq!(
+        ts2322(ok),
+        0,
+        "`this`-typed `self` must carry the receiver's `name`"
+    );
+
+    let bad = r#"
+interface Builder { self: this; name: string; }
+type S = (Builder & { name: "x" })["self"];
+type N = S["name"];
+const bad: "y" = null as any as N;
+"#;
+    assert_eq!(ts2322(bad), 1, "receiver `name` is `\"x\"`, not `\"y\"`");
+}
+
+/// Read directly on the interface (no intersection), `this` binds to the
+/// interface itself, so `this["args"]` resolves through `Identity`'s own
+/// `args` (`unknown` here) rather than leaking a deferred `this[...]`.
+#[test]
+fn standalone_this_indexed_access_resolves_through_receiver_interface() {
+    let source = r#"
+interface Fn { args: unknown; return: unknown; }
+interface Identity extends Fn { return: this["args"]; }
+type Solo = Identity["return"];
+const ok: unknown = null as any as Solo;
+"#;
+    assert_eq!(
+        ts2322(source),
+        0,
+        "`Identity[\"return\"]` resolves to `unknown` and accepts an `unknown` target"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -645,6 +645,128 @@ impl<'a, 'b, R: TypeResolver> IndexAccessVisitor<'a, 'b, R> {
         }
     }
 
+    /// Bind a `this`-typed property value to the receiver it was read from.
+    ///
+    /// When an indexed access reads a property whose declared type references the
+    /// polymorphic `this` (e.g. `interface I { return: this["args"] }`), `tsc`
+    /// binds `this` to the receiver object the property is read from — its
+    /// `getTypeWithThisArgument`. Without this binding the read leaks an
+    /// unreduced `this[...]` that is neither assignable to nor identical with its
+    /// reduced form, breaking both the assignability gateway and `Equal`-style
+    /// identity checks. `self.object_type` is the concrete object/intersection
+    /// shape the property was looked up on, i.e. exactly that receiver.
+    fn bind_property_this(&mut self, result: TypeId) -> TypeId {
+        if result == TypeId::UNDEFINED
+            || result.is_intrinsic()
+            || !crate::contains_this_type(self.evaluator.interner(), result)
+        {
+            return result;
+        }
+        crate::instantiation::instantiate::substitute_this_type(
+            self.evaluator.interner(),
+            result,
+            self.object_type,
+        )
+    }
+
+    /// Merge an intersection receiver's full property set into one object and
+    /// index that, so a property read observes every constituent at once. Used
+    /// for both generic-index distribution fallback and `this`-typed concrete
+    /// reads. Returns `None` (caller falls through) only when the collected
+    /// properties do not form an object.
+    fn index_intersection_via_collected_properties(&mut self) -> Option<TypeId> {
+        match crate::objects::collect_properties_cached(
+            self.object_type,
+            self.evaluator.interner(),
+            self.evaluator.resolver(),
+            self.evaluator.query_db(),
+        ) {
+            PropertyCollectionResult::Properties {
+                properties,
+                string_index,
+                number_index,
+            } => {
+                let merged = if string_index.is_some() || number_index.is_some() {
+                    let shape = ObjectShape {
+                        flags: crate::types::ObjectFlags::empty(),
+                        properties,
+                        string_index,
+                        number_index,
+                        symbol: None,
+                    };
+                    self.evaluator.interner().object_with_index(shape)
+                } else {
+                    self.evaluator.interner().object(properties)
+                };
+                Some(self.evaluator.recurse_index_access(merged, self.index_type))
+            }
+            PropertyCollectionResult::Any => Some(TypeId::ANY),
+            PropertyCollectionResult::NonObject => None,
+        }
+    }
+
+    /// Resolve a concrete (literal-named) index against an intersection when at
+    /// least one constituent declares the named property with a `this`-typed
+    /// value. Each constituent's own property type is read raw, its `this` is
+    /// rebound to the whole receiver intersection (`self.object_type`), and the
+    /// contributions are intersected — mirroring tsc's `getTypeWithThisArgument`
+    /// over the intersection. Returns `None` (caller falls through to plain
+    /// distribution) when no constituent's matching property references `this`.
+    fn try_index_intersection_this_property(&mut self, list_id: TypeListId) -> Option<TypeId> {
+        let name = self
+            .evaluator
+            .literal_property_lookup_atom(self.index_type)?;
+        let members: Vec<TypeId> = self
+            .evaluator
+            .interner()
+            .type_list(list_id)
+            .iter()
+            .copied()
+            .collect();
+
+        let mut parts = Vec::new();
+        let mut saw_this = false;
+        for member in members {
+            let Some(raw) = self.member_own_property_type(member, name) else {
+                continue;
+            };
+            if crate::contains_this_type(self.evaluator.interner(), raw) {
+                saw_this = true;
+                let bound = crate::instantiation::instantiate::substitute_this_type(
+                    self.evaluator.interner(),
+                    raw,
+                    self.object_type,
+                );
+                parts.push(self.evaluator.evaluate(bound));
+            } else {
+                parts.push(raw);
+            }
+        }
+
+        (saw_this && !parts.is_empty())
+            .then(|| crate::utils::intersection_or_single(self.evaluator.interner(), parts))
+    }
+
+    /// The raw (pre-`this`-binding) type of `member`'s own property `name`, if
+    /// `member` resolves to an object/object-with-index shape that declares it.
+    fn member_own_property_type(
+        &mut self,
+        member: TypeId,
+        name: tsz_common::Atom,
+    ) -> Option<TypeId> {
+        let resolved = self.evaluator.evaluate(member);
+        let shape_id = match self.evaluator.interner().lookup(resolved) {
+            Some(TypeData::Object(id) | TypeData::ObjectWithIndex(id)) => id,
+            _ => return None,
+        };
+        let shape = self.evaluator.interner().object_shape(shape_id);
+        shape
+            .properties
+            .iter()
+            .find(|prop| prop.name == name)
+            .map(|prop| self.evaluator.optional_property_type(prop))
+    }
+
     fn try_fast_index_large_union(&mut self, members: &[TypeId]) -> Option<TypeId> {
         if !self.can_fast_path_large_union_index() {
             return None;
@@ -717,7 +839,7 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
             return None;
         }
 
-        Some(result)
+        Some(self.bind_property_this(result))
     }
 
     fn visit_object_with_index(&mut self, shape_id: u32) -> Self::Output {
@@ -750,7 +872,7 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
             return None;
         }
 
-        Some(result)
+        Some(self.bind_property_this(result))
     }
 
     fn visit_callable(&mut self, shape_id: u32) -> Self::Output {
@@ -767,7 +889,7 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
             return None;
         }
 
-        Some(result)
+        Some(self.bind_property_this(result))
     }
 
     fn visit_union(&mut self, list_id: u32) -> Self::Output {
@@ -859,37 +981,23 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
                 ));
             }
 
-            let intersection_type = self.object_type;
-            match crate::objects::collect_properties_cached(
-                intersection_type,
-                self.evaluator.interner(),
-                self.evaluator.resolver(),
-                self.evaluator.query_db(),
-            ) {
-                PropertyCollectionResult::Properties {
-                    properties,
-                    string_index,
-                    number_index,
-                } => {
-                    let merged = if string_index.is_some() || number_index.is_some() {
-                        let shape = ObjectShape {
-                            flags: crate::types::ObjectFlags::empty(),
-                            properties,
-                            string_index,
-                            number_index,
-                            symbol: None,
-                        };
-                        self.evaluator.interner().object_with_index(shape)
-                    } else {
-                        self.evaluator.interner().object(properties)
-                    };
-                    return Some(self.evaluator.recurse_index_access(merged, self.index_type));
-                }
-                PropertyCollectionResult::Any => return Some(TypeId::ANY),
-                PropertyCollectionResult::NonObject => {
-                    // Fall through to existing distribution logic
-                }
+            if let Some(result) = self.index_intersection_via_collected_properties() {
+                return Some(result);
             }
+            // `PropertyCollectionResult::NonObject`: fall through to distribution.
+        }
+
+        // A `this`-typed member property must bind `this` to the *whole* receiver
+        // intersection, not to the single constituent it is declared on. Per-member
+        // distribution (below) reads such a property in isolation and would bind
+        // `this` to that one member (e.g. `Identity["return"]` → `Identity["args"]`),
+        // dropping the sibling member that actually supplies the key. Read each
+        // constituent's matching property raw, rebind `this` to the intersection,
+        // and intersect — tsc's `getTypeWithThisArgument` over the intersection.
+        // (Collecting/merging the property set instead would fold generic property
+        // values into an unsimplified raw intersection like `unknown & V`.)
+        if let Some(result) = self.try_index_intersection_this_property(TypeListId(list_id)) {
+            return Some(result);
         }
 
         // For concrete indexes, distribute over intersection members and intersect results.

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -749,9 +749,10 @@ impl<'a, 'b, R: TypeResolver> IndexAccessVisitor<'a, 'b, R> {
         name: tsz_common::Atom,
     ) -> Option<TypeId> {
         let resolved = self.evaluator.evaluate(member);
-        let shape_id = match self.evaluator.interner().lookup(resolved) {
-            Some(TypeData::Object(id) | TypeData::ObjectWithIndex(id)) => id,
-            _ => return None,
+        let Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) =
+            self.evaluator.interner().lookup(resolved)
+        else {
+            return None;
         };
         let shape = self.evaluator.interner().object_shape(shape_id);
         shape

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -716,17 +716,11 @@ impl<'a, 'b, R: TypeResolver> IndexAccessVisitor<'a, 'b, R> {
         let name = self
             .evaluator
             .literal_property_lookup_atom(self.index_type)?;
-        let members: Vec<TypeId> = self
-            .evaluator
-            .interner()
-            .type_list(list_id)
-            .iter()
-            .copied()
-            .collect();
+        let members = self.evaluator.interner().type_list(list_id);
 
         let mut parts = Vec::new();
         let mut saw_this = false;
-        for member in members {
+        for &member in members.iter() {
             let Some(raw) = self.member_own_property_type(member, name) else {
                 continue;
             };


### PR DESCRIPTION
Closes #14166.

Goal: green

## Structural rule
When an indexed access reads a property whose declared type references the
polymorphic `this` — e.g. `interface Identity extends Fn { return: this["args"] }`
indexed as `(Identity & { args: V })["return"]` — `tsc` substitutes `this` with
the **receiver** (`getTypeWithThisArgument`), so `this["args"]` reduces to the
concrete value the sibling member supplies (`V`).

`When an indexed access reads a property whose value references this, tsc binds
this to the receiver the property is read from; tsz now does this through the
solver's index-access evaluator (substitute_this_type at the read boundary).`

`tsz` previously left an unreduced deferred `this["args"]`, which is neither
assignable to nor identical with its reduced form — breaking both the
assignability gateway and the `Equal` identity trick (false `TS2322`).

## Repro (verified: tsc clean, tsz TS2322 before)
```ts
interface Fn { args: unknown; return: unknown; }
interface Identity extends Fn { return: this["args"]; }
type R = (Identity & { args: true })["return"];   // tsc reduces to `true`
const ok: true = (null as any as R);              // tsc OK | tsz TS2322 (before)
```
Flags: `--noEmit --strict --target esnext --module esnext --moduleResolution bundler --skipLibCheck`

## Owner layer & approach (solver)
The wrong semantic operation is **`this`-type substitution during index-access
evaluation**, in `crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs`
(`IndexAccessVisitor`). `this` is now bound to the receiver at the read boundary:

- **Plain object / object-with-index / callable receiver** — `bind_property_this`
  rebinds a `this`-typed property read to `self.object_type` (the receiver the
  property was looked up on). So a direct `Identity["return"]` resolves through
  `Identity` itself (its declared constraint), instead of leaking a deferred
  `this[...]`.
- **Intersection receiver** — `try_index_intersection_this_property` reads each
  constituent's matching **own** property raw, rebinds `this` to the *whole*
  intersection (not the lone constituent), and intersects the contributions —
  mirroring tsc's per-side `this`-binding. Reading raw (rather than merging the
  collected property set) keeps generic property values from folding into an
  unsimplified raw intersection like `unknown & V`. Per-member distribution would
  bind `this` to a single constituent and drop the sibling that supplies the key,
  which is exactly the bug.

The pre-existing intersection collect/merge fallback was extracted unchanged into
`index_intersection_via_collected_properties` and is still used by the
generic-index distribution path.

## Anti-hardcoding
Purely structural: keyed on `contains_this_type` and object/intersection shape
via solver helpers — no identifier, alias, file-name, or rendered-type-string
checks. Tests vary binder names (`Fn`/`Identity`/`args` vs `Hkt`/`input`/`output`).

## Adjacent matrix (verified against tsc 6.x; pinned in tests)
Accept (no TS2322), each reproduced on the pre-fix binary:
- `(Identity & { args: true })["return"]` → `true`;
- a non-literal value `(Identity & { args: string })["return"]` → `string`;
- a bare `this`-typed member `(Builder & { name: "x" })["self"]` reads as the
  receiver, so `S["name"]` → `"x"`;
- renamed binders (anti-hardcoding);
- standalone `Identity["return"]` resolves through `Identity` to `unknown`.

Negative controls (still rejected):
- reduced value is genuinely `true`, so a `false` target still errors (not widened
  to `any`/`unknown`);
- `string` reduction still rejects a `number` target;
- renamed-binder reduction `7` still rejects `8`;
- bare-`this` receiver `name` is `"x"`, so `"y"` still errors.

## Scope note
The generic higher-kinded form `Apply<F extends Fn, V> = (F & { args: V })["return"]`
(hotscript's `Call`/`Apply` core) additionally trips a **distinct, pre-existing**
root: evaluating `Identity & { args: V }` through the generic-application path
yields a schedule-dependent merged object whose `args` collapses to `unknown`
(the same constituent shape evaluates to `args: V` when indexed by `"args"`
directly). That order-dependent intersection-merge defect is independent of
`this`-substitution and is intentionally **not** folded in here; this PR resolves
the `this`-binding structural rule and the issue's verified repro.

## Verification
- New regression suite `crates/tsz-checker/tests/this_type_indexed_access_receiver_tests.rs`
  (6 tests, positive + negative controls + renamed binders + bare-`this` + standalone):
  `cargo test -p tsz-checker --test this_type_indexed_access_receiver_tests` → **6 passed**.
- `cargo test -p tsz-checker --test ts4105_this_type_indexed_access_tests --test this_type_tests --test polymorphic_this_display_tests --test homomorphic_indexed_access_tests --test homomorphic_indexed_access_edge_cases --test intersection_mapped_alias_indexed_access_tests --test deferred_conditional_indexed_access_tests` — all green (no regressions).
- `cargo test -p tsz-solver --lib` — 6856 passed; the only 4 failures are
  **pre-existing on base** (verified by re-running with the change stashed:
  `test_conditional_infer_optional_property_present_distributive`,
  `literal_mask_preserves_object_vs_literal_reduction`,
  `array_isarray_keeps_mutable_and_readonly_array_members`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`).
- `cargo clippy -p tsz-solver --lib` clean; `cargo fmt` clean.
- Reviewed with `/simplify`: dropped a throwaway member `Vec`; the suggested
  `lookup_property` reuse was skipped (it assumes name-sorted props, while object
  shapes here use linear lookup) and the >500-member union fast path is a
  pre-existing limitation that never bound `this` (out of scope).
- Broad conformance/emit/fourslash suites: delegated to ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_011VMY4qmY3sx3apDCuuHZJr

---
_Generated by [Claude Code](https://claude.ai/code/session_011VMY4qmY3sx3apDCuuHZJr)_