### PR TITLE
fix(solver): substitute this with receiver when indexing a merged intersection (#14166)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1955,3 +1955,7 @@ path = "tests/nullable_union_missing_property_tests.rs"
 [[test]]
 name = "partial_record_optional_index_assignability_tests"
 path = "tests/partial_record_optional_index_assignability_tests.rs"
+
+[[test]]
+name = "this_type_indexed_access_intersection_tests"
+path = "tests/this_type_indexed_access_intersection_tests.rs"

--- a/crates/tsz-checker/tests/this_type_indexed_access_intersection_tests.rs
+++ b/crates/tsz-checker/tests/this_type_indexed_access_intersection_tests.rs
@@ -1,0 +1,122 @@
+//! Checker integration tests for reducing a `this`-relative property read off a
+//! receiver formed by intersection.
+//!
+//! Structural rule: a property whose declared type is `this`-relative
+//! (`return: this["args"]`) is stored with `this` unsubstituted. When the
+//! receiver is a *merged* object — the shape formed from an intersection like
+//! `Identity & { args: true }` — the merged member keeps the unbound `this`, and
+//! there is no `this`-type in scope at index-evaluation time, so the access used
+//! to leak a deferred `this["args"]` (neither assignable to nor identical to its
+//! reduced form: spurious TS2322). tsc substitutes `this` with the concrete
+//! receiver when reading a property off it, so `(Identity & { args: true })
+//! ["return"]` reduces to `true`.
+//!
+//! Owner: `evaluate_index_access`'s `visit_object` arm
+//! (`tsz_solver::evaluation::evaluate_rules::index_access`): when the looked-up
+//! member type still contains `this`, substitute `this` with the object being
+//! indexed.
+//!
+//! This is the hotscript `Call`/`Apply`/`Fn` HKT core (#14166). Cases vary
+//! binder names and cover the bare and conditional `this[K]` forms, plus the
+//! polymorphic-`this` method cases that must keep working.
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn assert_no_errors(source: &str, label: &str) {
+    let codes = check_source_codes(source);
+    assert!(
+        codes.is_empty(),
+        "{label}: expected no diagnostics, got {codes:?}"
+    );
+}
+
+// =============================================================================
+// Positive: `this[K]` reduces against an intersection receiver
+// =============================================================================
+
+#[test]
+fn this_indexed_access_reduces_over_intersection_receiver() {
+    // The reported repro (#14166): tsc reduces to `true`; tsz left it deferred.
+    assert_no_errors(
+        r#"
+interface Fn { args: unknown; return: unknown; }
+interface Identity extends Fn { return: this["args"]; }
+type R = (Identity & { args: true })["return"];
+const ok: true = (null as any as R);
+"#,
+        "(Identity & { args: true })[\"return\"] reduces to true",
+    );
+}
+
+#[test]
+fn this_indexed_access_intersection_is_binder_name_independent() {
+    assert_no_errors(
+        r#"
+interface Base { input: unknown; output: unknown; }
+interface Echo extends Base { output: this["input"]; }
+type Out = (Echo & { input: "x" })["output"];
+const v: "x" = (null as any as Out);
+"#,
+        "renamed binders still reduce this-indexed access over intersection",
+    );
+}
+
+#[test]
+fn this_indexed_access_in_conditional_reduces_over_intersection() {
+    // The actual hotscript HKT shape: `this["args"]` inside a conditional.
+    assert_no_errors(
+        r#"
+interface Fn { args: unknown; return: unknown; }
+interface Head extends Fn { return: this["args"] extends [infer H, ...any] ? H : never; }
+type Applied = (Head & { args: [1, 2, 3] })["return"];
+const h: 1 = (null as any as Applied);
+"#,
+        "conditional over this[\"args\"] reduces against intersection receiver",
+    );
+}
+
+// =============================================================================
+// Controls: plain-interface receivers and polymorphic `this` keep working
+// =============================================================================
+
+#[test]
+fn this_indexed_access_plain_interface_receiver_still_reduces() {
+    assert_no_errors(
+        r#"
+interface Direct { args: true; return: this["args"]; }
+type R = Direct["return"];
+const ok: true = (null as any as R);
+"#,
+        "Direct[\"return\"] reduces to true (plain interface receiver)",
+    );
+}
+
+#[test]
+fn this_indexed_access_resolves_to_member_type_without_intersection() {
+    assert_no_errors(
+        r#"
+interface Fn { args: unknown; return: unknown; }
+interface Identity extends Fn { return: this["args"]; }
+type R = Identity["return"];
+const ok: unknown = (null as any as R);
+"#,
+        "Identity[\"return\"] is unknown (this -> Identity, args: unknown)",
+    );
+}
+
+#[test]
+fn polymorphic_this_method_is_not_collapsed() {
+    // The fix must not bake `this` into polymorphic-`this` method results.
+    assert_no_errors(
+        r#"
+interface Box<T> { value: T; self(): this; }
+declare const b: Box<number>;
+const same = b.self();
+const val: number = same.value;
+type SelfFn = Box<string>["self"];
+declare const f: SelfFn;
+const rv: string = f().value;
+"#,
+        "polymorphic this method chaining still resolves the receiver",
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -709,6 +709,38 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
                     .evaluate_object_index(&shape.properties, self.index_type)
             });
 
+        // A property whose declared type is a `this`-relative type
+        // (`return: this["args"]`) is stored with `this` unsubstituted. When the
+        // receiver is a plain interface its members are materialized with `this`
+        // already bound, but a *merged* receiver (e.g. the object formed from an
+        // intersection `Identity & { args: true }`) keeps the unbound `this`, so
+        // the access would leak a deferred `this[K]`. tsc substitutes `this` with
+        // the concrete receiver when reading a property off it, so reduce here
+        // using the object being indexed.
+        //
+        // Only do this when no `this`-type is otherwise in scope
+        // (`resolve_this_type` is `None`) — the exact dangling-`this` condition of
+        // the bug. When a `this`-context already exists (class-method bodies,
+        // polymorphic-`this` chains, mapped/keyof evaluation that binds `this`),
+        // the existing machinery resolves `this` correctly and must not be
+        // pre-empted. The `contains_this_type` guard keeps the common no-`this`
+        // path free of the extra work entirely.
+        let result = if crate::contains_this_type(self.evaluator.interner(), result)
+            && self
+                .evaluator
+                .resolver()
+                .resolve_this_type(self.evaluator.interner())
+                .is_none()
+        {
+            crate::instantiation::instantiate::substitute_this_type(
+                self.evaluator.interner(),
+                result,
+                self.object_type,
+            )
+        } else {
+            result
+        };
+
         // CRITICAL FIX: If we can't find the property, but the index is generic,
         // we must defer evaluation (return None) instead of returning UNDEFINED.
         // This prevents mapped type template evaluation from hardcoding UNDEFINED


### PR DESCRIPTION
Fixes #14166.

## Structural rule
A property whose declared type is `this`-relative (`interface Identity extends
Fn { return: this["args"] }`) is stored with `this` unsubstituted. When the
receiver is a plain interface its members are materialized with `this` already
bound, so `Identity["return"]` reduces fine. But when the receiver is formed by
**intersection** — `(Identity & { args: true })["return"]` — the merged object's
`return` member keeps the *unbound* `this["args"]`, and no `this`-type is in
scope at index-evaluation time (`resolve_this_type` is `None`), so the access
leaked a deferred `this["args"]`. That deferred type is neither assignable to nor
identical to its reduced form, producing a spurious TS2322 and breaking the
`Equal<a,b>` identity trick.

`When reading a this-relative property off a concrete receiver, tsc substitutes
this with that receiver; tsz now does the same in evaluate_index_access.`

So `(Identity & { args: true })["return"]` reduces to `true`.

## Owner layer
Solver index-access evaluation. In
`tsz_solver::evaluation::evaluate_rules::index_access`, indexing an intersection
first evaluates (merges) the object, so the property lookup lands in the
`visit_object` arm with the merged shape as the receiver. After the member type
is looked up, if it still `contains_this_type`, substitute `this` with
`self.object_type` (the object being indexed) via `substitute_this_type`. The
substitution is guarded on `contains_this_type`, so the overwhelmingly common
no-`this` path is untouched.

## Why this is the right locus (verified by tracing)
The issue's suggested fix point (`visit_intersection` / a new
`substitute_this_type` thread) is not on the runtime path: the intersection is
merged to a single object *before* indexing, so `visit_intersection` is never
reached for this case. Tracing `visit_object`/`visit_this_type` showed the
merged shape returns `this["args"]` with `result_has_this = true` while
`resolve_this_type()` returns `None` — pinpointing `visit_object` as the locus.

## Adjacent matrix
- `(Identity & { args: true })["return"]` → `true` (repro).
- renamed binders (`Base`/`Echo`/`input`/`output`) → same (anti-hardcoding).
- conditional over `this["args"]` — `this["args"] extends [infer H, ...any] ? H
  : never` with `(Head & { args: [1,2,3] })["return"]` → `1` (the real hotscript
  `Call`/`Apply`/`Fn` HKT shape).
- Control `Direct["return"]` (plain interface, `args: true`) → `true`.
- Control `Identity["return"]` (no intersection, `args: unknown`) → `unknown`.
- Negative/ripple: polymorphic-`this` methods (`self(): this`) and indexing a
  method type (`Box<string>["self"]`) keep resolving the receiver — the fix does
  not collapse polymorphic `this`.

## Fallback / safety
Guarded on `contains_this_type(result)`; types without `this` are returned
unchanged. `self.object_type` is the concrete receiver being indexed, which is
exactly what `this` denotes in that position, so the substitution matches tsc.

Goal: green

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo nextest run -p tsz-checker -E 'test(/this_type_indexed_access_intersection/)'`
  (new file: 6 tests).
- Regression: `cargo nextest run -p tsz-checker -E 'binary(~indexed_access) +
  binary(~this_type) + binary(~ts4105) + binary(~intersection)'`.
- Manual: repro + conditional/hotscript + polymorphic-`this` cases compiled with
  a dev-fast `tsz` binary vs the documented `tsc` results.
