### PR TITLE
fix(lowering): give rest-position `infer` the `unknown[]` constraint (#14159)

### DIFF
--- a/crates/tsz-checker/tests/deferred_conditional_indexed_access_tests.rs
+++ b/crates/tsz-checker/tests/deferred_conditional_indexed_access_tests.rs
@@ -145,3 +145,117 @@ fn assertion_into_deferred_conditional_is_valid() {
                export const g = <T,>(b: Box<T>) => (b as { a: string });";
     assert_eq!(count(src, 2352), 0, "no TS2352 expected: {:?}", codes(src));
 }
+
+// ── #14159: indexed access / rest-spread of a conditional property whose
+//    branch values are an inferred tuple tail (remeda `TupleParts`) ──
+//
+// `...infer Tail` in a tuple rest position has the inferred constraint
+// `unknown[]` (tsc `getInferredTypeParameterConstraint`). When that captured
+// tail is re-extracted through `Parts<T>["rest"]`, the constraint must survive
+// so `["length"]`, numeric indexing, and rest-spread see an array. Without the
+// constraint, `Tail` looked unconstrained and the apparent type `Tail | []`
+// was flagged non-array (false TS2536/TS2574).
+
+fn codes_nuia(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        strict: true,
+        no_unchecked_indexed_access: true,
+        ..CheckerOptions::default()
+    };
+    diagnostic_codes(&check_source(source, "test.ts", options))
+}
+
+const PARTS: &str = "type Parts<T> = T extends readonly [infer _H, ...infer Tail] ? { rest: Tail } : { rest: [] };\n";
+
+#[test]
+fn conditional_tail_property_length_index_is_valid() {
+    let src = format!("{PARTS}export type Len<T> = Parts<T>[\"rest\"][\"length\"];");
+    let c = codes_nuia(&src);
+    assert!(!c.contains(&2536), "TS2536 should not fire: {c:?}");
+}
+
+#[test]
+fn conditional_tail_property_numeric_index_is_valid() {
+    let src = format!("{PARTS}export type Elem<T> = Parts<T>[\"rest\"][number];");
+    let c = codes_nuia(&src);
+    assert!(
+        !c.contains(&2536),
+        "TS2536 should not fire for numeric index: {c:?}"
+    );
+}
+
+#[test]
+fn conditional_tail_property_rest_spread_is_valid() {
+    let src = format!("{PARTS}export type Rebuilt<T> = [...Parts<T>[\"rest\"]];");
+    let c = codes_nuia(&src);
+    assert!(!c.contains(&2574), "TS2574 should not fire: {c:?}");
+}
+
+#[test]
+fn conditional_tail_property_rest_spread_between_fixed_elements_is_valid() {
+    // `[...A, ...Cond[K], ...B]` — the inferred-tail spread sits between other
+    // spreads and must still be array-like.
+    let src = format!("{PARTS}export type Wrap<T> = [boolean, ...Parts<T>[\"rest\"], string];");
+    let c = codes_nuia(&src);
+    assert!(!c.contains(&2574), "TS2574 should not fire: {c:?}");
+}
+
+#[test]
+fn conditional_tail_property_renamed_binders_is_valid() {
+    // Anti-hardcoding: vary every binder/property name; the rule is structural.
+    let src = "type Split<Elems> = Elems extends readonly [infer Head, ...infer Body] ? { tail: Body } : { tail: [] };\n\
+               export type A<Elems> = [...Split<Elems>[\"tail\"]];\n\
+               export type B<Elems> = Split<Elems>[\"tail\"][\"length\"];";
+    let c = codes_nuia(src);
+    assert!(
+        !c.contains(&2574) && !c.contains(&2536),
+        "no TS2574/TS2536 expected: {c:?}"
+    );
+}
+
+#[test]
+fn conditional_tail_property_named_rest_member_is_valid() {
+    // `...rest: infer Tail` (named tuple member rest) gets the same constraint.
+    let src = "type P<T> = T extends readonly [infer _H, ...rest: infer Tail] ? { rest: Tail } : { rest: [] };\n\
+               export type R<T> = [...P<T>[\"rest\"]];";
+    let c = codes_nuia(src);
+    assert!(!c.contains(&2574), "TS2574 should not fire: {c:?}");
+}
+
+#[test]
+fn conditional_tail_property_value_index_access_is_valid() {
+    // The value-position read was already accepted; keep it green as a guard.
+    let src =
+        format!("{PARTS}export function idx<T>(p: Parts<T>[\"rest\"]): unknown {{ return p[0]; }}");
+    let c = codes_nuia(&src);
+    assert!(
+        !c.contains(&2536) && !c.contains(&2574),
+        "no error expected: {c:?}"
+    );
+}
+
+#[test]
+fn conditional_non_array_tail_property_still_rejects_rest_spread() {
+    // Negative control: when the conditional's property is NOT array-like in a
+    // branch, the rest-spread must still report TS2574 (no over-acceptance).
+    let src = "type P<T> = T extends string ? { rest: string } : { rest: number };\n\
+               export type R<T> = [...P<T>[\"rest\"]];";
+    let c = codes_nuia(src);
+    assert!(
+        c.contains(&2574),
+        "TS2574 expected for non-array branch: {c:?}"
+    );
+}
+
+#[test]
+fn bare_rest_infer_constraint_does_not_leak_to_fixed_position() {
+    // The `unknown[]` constraint applies only to the rest element, so a fixed
+    // `infer _H` is unaffected and a non-rest `infer` reference is not array-like.
+    let src = "type P<T> = T extends readonly [infer Head, ...infer _Tail] ? { head: Head } : { head: unknown };\n\
+               export type R<T> = [...P<T>[\"head\"]];";
+    let c = codes_nuia(src);
+    assert!(
+        c.contains(&2574),
+        "TS2574 expected for non-array head property: {c:?}"
+    );
+}

--- a/crates/tsz-lowering/src/lower/advanced.rs
+++ b/crates/tsz-lowering/src/lower/advanced.rs
@@ -955,6 +955,32 @@ impl<'a> TypeLowering<'a> {
         (return_type, Some(predicate))
     }
 
+    /// Lower the inner type of a tuple rest element (`...X`).
+    ///
+    /// Mirrors tsc's `getInferredTypeParameterConstraint`: a bare `infer X`
+    /// declared directly in a rest position (`[...infer X]`,
+    /// `[...name: infer X]`) is inferred to capture the tail elements, so its
+    /// constraint is `unknown[]` when no explicit `extends` clause is present.
+    /// Baking the constraint at lowering keeps it on the interned `Infer` so it
+    /// survives wherever the captured parameter later flows — notably when it is
+    /// re-extracted through an indexed access into the conditional that bound it
+    /// (`(T extends [...infer X] ? { rest: X } : …)["rest"]`), where the array
+    /// constraint decides `["length"]`, numeric indexing, and rest-spread
+    /// array-likeness. An explicit `...infer X extends C`, or any non-bare-infer
+    /// rest inner (`...F<infer X>`, `...X[]`), keeps its own lowering.
+    pub(super) fn lower_rest_position_type(&self, inner_idx: NodeIndex) -> TypeId {
+        if let Some(node) = self.arena.get(inner_idx)
+            && node.kind == syntax_kind_ext::INFER_TYPE
+            && let Some(data) = self.arena.get_infer_type(node)
+            && let Some(mut info) = self.lower_type_parameter(data.type_parameter)
+            && info.constraint.is_none()
+        {
+            info.constraint = Some(self.interner.array(TypeId::UNKNOWN));
+            return self.interner.infer(info);
+        }
+        self.lower_type(inner_idx)
+    }
+
     /// Lower an infer type (infer R)
     pub(super) fn lower_infer_type(&self, node_idx: NodeIndex) -> TypeId {
         let data = lower_node_data!(self, node_idx, get_infer_type, TypeId::ERROR);

--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -1299,8 +1299,13 @@ impl<'a> TypeLowering<'a> {
                 None
             };
 
+            let type_id = if data.dot_dot_dot_token {
+                self.lower_rest_position_type(data.type_node)
+            } else {
+                self.lower_type(data.type_node)
+            };
             return TupleElement {
-                type_id: self.lower_type(data.type_node),
+                type_id,
                 name,
                 optional: data.question_token,
                 rest: data.dot_dot_dot_token,
@@ -1317,12 +1322,17 @@ impl<'a> TypeLowering<'a> {
                     .map(|data| data.type_node)
             };
 
+            let is_rest = node.kind == syntax_kind_ext::REST_TYPE;
+            let type_id = match wrapped {
+                None => self.lower_type(node_idx),
+                Some(inner) if is_rest => self.lower_rest_position_type(inner),
+                Some(inner) => self.lower_type(inner),
+            };
             return TupleElement {
-                type_id: wrapped
-                    .map_or_else(|| self.lower_type(node_idx), |inner| self.lower_type(inner)),
+                type_id,
                 name: None,
                 optional: node.kind == syntax_kind_ext::OPTIONAL_TYPE,
-                rest: node.kind == syntax_kind_ext::REST_TYPE,
+                rest: is_rest,
             };
         }
 


### PR DESCRIPTION
Fixes #14159.

## Structural rule
When `...infer X` (a bare `infer`, no explicit `extends`) appears directly in a
tuple rest position (`[...infer X]`, `[...name: infer X]`), `tsc` gives `X` the
inferred constraint `unknown[]` (`getInferredTypeParameterConstraint`), because
the parameter captures the tail elements. `tsz` lowered it unconstrained.

So when the captured tail was re-extracted through an indexed access into the
conditional that bound it —

```ts
type Parts<T> = T extends readonly [infer _H, ...infer Tail] ? { rest: Tail } : { rest: [] };
type Len<T>     = Parts<T>["rest"]["length"];   // tsz: false TS2536
type Elem<T>    = Parts<T>["rest"][number];     // tsz: false TS2536
type Rebuilt<T> = [...Parts<T>["rest"]];        // tsz: false TS2574
```

— the apparent type `Parts<T>["rest"] = Tail | []` looked non-array (`Tail` had
no constraint), so `["length"]` / numeric indexing tripped TS2536 and the
rest-spread tripped TS2574. `tsc`/`tsgo` report none of these (remeda
`TupleParts`, 6 witnesses across 5 files).

`When a bare ...infer X sits directly in a tuple rest element, tsc constrains X
to unknown[]; tsz now does the same at lowering so the constraint rides on the
interned Infer.`

## Owner layer
Lowering — `TypeLowering::lower_tuple_element` →
new `lower_rest_position_type` (`crates/tsz-lowering/src/lower/advanced.rs`).
Baking the constraint on the interned `TypeData::Infer` is the correct altitude:
the checker's per-alias infer-constraint scope
(`collect_infer_constraints_from_extends_type`) is ephemeral and does **not**
survive onto the stored conditional, so it cannot reach a cross-alias
re-extraction like `Parts<T>["rest"]`. The constraint must live on the type. No
checker/solver special-casing — it feeds the existing array-likeness and
apparent-type queries unchanged.

## Adjacent matrix (`tsz-checker` `deferred_conditional_indexed_access_tests`)
Accept (no false TS2536/TS2574):
- `Parts<T>["rest"]["length"]`, `Parts<T>["rest"][number]`, `[...Parts<T>["rest"]]`;
- rest-spread between fixed elements `[boolean, ...Parts<T>["rest"], string]`;
- **renamed binders** (`Split`/`Head`/`Body`/`tail`) — structural, not identifier-keyed;
- named-rest member `[...rest: infer Tail]`;
- value-position read `p[0]` (already accepted; kept as a guard).

Negative controls (parity preserved):
- non-array branch (`{ rest: string } : { rest: number }`) still emits TS2574;
- the `unknown[]` constraint does **not** leak to a fixed-position `infer`
  (`[infer Head, ...infer _Tail]` → `["head"]` spread still TS2574).

## Scope
This covers the tuple rest position, which is the defect family in #14159.
`tsc`'s `getInferredTypeParameterConstraint` also seeds template-literal spans
(`string`), type-reference args, and mapped-type keys; those positions are
unaffected by this bug and left to their existing handling to avoid unrelated
regression risk.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New/updated regression suite (default lib, strict + `noUncheckedIndexedAccess`):
  `cargo test -p tsz-checker --test deferred_conditional_indexed_access_tests`
  → 20 passed (3 witnesses + adjacent matrix + 2 negative controls); the three
  witnesses fail without the lowering change.
- Regression smoke (no new failures vs clean `main`): `tsz-lowering` (166 pass,
  1 pre-existing env-local template-literal failure unrelated to tuples),
  `tsz-solver --lib variadic/tuple/rest_element` (66/591/12), and checker
  `variadic_tuple_*`, `reverse_mapped_inference`, `tuple_index_access`,
  `tuple_rest_array_canonicalization`, `spread_rest_diagnostics`,
  lib `ts2574`/`ts2536` suites — all green.
- `cargo fmt` clean; `cargo clippy -p tsz-lowering --lib` clean.
- Reviewed with `/simplify` (reuse/simplification/efficiency/altitude): no
  changes warranted — the altitude pass confirmed lowering is the correct layer.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2XhCjvzMpdHLwZyucTqJw)_