### PR TITLE
fix(checker): preserve narrowing across a closure START boundary (TS18048)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -799,7 +799,8 @@ impl<'a> FlowAnalyzer<'a> {
                                                 | flow_flags::LOOP_LABEL
                                                 | flow_flags::ASSIGNMENT
                                                 | flow_flags::AWAIT_POINT
-                                                | flow_flags::YIELD_POINT,
+                                                | flow_flags::YIELD_POINT
+                                                | flow_flags::START,
                                         )
                                     });
                                 if ant_needs_defer {
@@ -848,7 +849,8 @@ impl<'a> FlowAnalyzer<'a> {
                                             | flow_flags::ASSIGNMENT
                                             | flow_flags::SWITCH_CLAUSE
                                             | flow_flags::AWAIT_POINT
-                                            | flow_flags::YIELD_POINT,
+                                            | flow_flags::YIELD_POINT
+                                            | flow_flags::START,
                                     )
                                 });
                             if ant_needs_defer {

--- a/crates/tsz-checker/tests/closure_boundary_property_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/closure_boundary_property_narrowing_tests.rs
@@ -214,3 +214,63 @@ function f(x: { a?: { b: number } }) {
         "IIFE property narrowing must be preserved, got: {codes:?}"
     );
 }
+
+/// Regression (zustand `createJSONStorage`): a `let` local with a *generic
+/// instantiation* declared type, narrowed to non-undefined in the enclosing
+/// scope (a `try` whose `catch` returns), keeps that narrowing inside a nested
+/// closure even when the use is NOT the closure's first statement. The flow
+/// worklist's pass-through branch previously failed to defer to an uncomputed
+/// `START` antecedent, dropping the inherited narrowing only for this
+/// generic-typed shape, producing a false TS18048.
+#[test]
+fn generic_local_narrowing_preserved_across_closure_start() {
+    let codes = check_source_strict_codes(
+        r#"
+interface StateStorage<R = unknown> { getItem: (name: string) => string | null }
+declare function getStorage<R>(): StateStorage<R>
+export function createJSONStorage<R = unknown>() {
+  let storage: StateStorage<R> | undefined
+  try {
+    storage = getStorage<R>()
+  } catch {
+    return
+  }
+  const fn = (name: string) => {
+    const dummy = name.length
+    return storage.getItem(name)
+  }
+  return fn
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&18048),
+        "narrowed generic-typed local must stay narrowed across the closure boundary, got: {codes:?}"
+    );
+}
+
+/// Negative guard: the same generic-typed-local-in-closure shape, but `storage`
+/// is genuinely `| undefined` (assigned a maybe-undefined value, never
+/// narrowed) — TS18048 MUST still fire. The fix preserves real narrowing; it
+/// must not blanket-suppress the diagnostic.
+#[test]
+fn genuinely_optional_generic_local_still_reports_in_closure() {
+    let codes = check_source_strict_codes(
+        r#"
+interface S<R = unknown> { getItem: (n: string) => string | null }
+declare function maybe<R>(): S<R> | undefined
+export function make<R = unknown>() {
+  let storage: S<R> | undefined = maybe<R>()
+  const fn = (name: string) => {
+    const dummy = name.length
+    return storage.getItem(name)
+  }
+  return fn
+}
+"#,
+    );
+    assert!(
+        codes.contains(&18048),
+        "genuinely possibly-undefined local must still report TS18048, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

Clears a false **TS18048** ("'x' is possibly 'undefined'") in zustand's `createJSONStorage`: a narrowed, constant-like local read inside a closure lost its inherited narrowing.

## Structural rule
When a constant-like local (a `let` narrowed to non-undefined in the enclosing scope — e.g. assigned in a `try` whose `catch` returns) with a **generic-instantiation** declared type is read inside a nested closure but **not** as the closure's first statement, tsc preserves the narrowing across the closure `START` boundary (`getTypeAtFlowNode` `FlowStart`). tsz's flow worklist dropped it: the two pass-through ASSIGNMENT branches in `flow/control_flow/core/flow_traversal.rs` did not treat a not-yet-computed `START` antecedent as needing deferral, so they read the un-narrowed declared type. Adding `flow_flags::START` to both defer sets resolves the inherited narrowing before use.

## Adjacent matrix (all three ingredients required to trigger; each removal silenced the FP)
- generic-instantiation declared type (`StateStorage<R>`) + closure + use-not-first-statement → was false TS18048, now clean.
- property-access narrowing inside a closure → still correctly **dropped** (TS18048/TS2532 still emitted) — all 10 existing `closure_boundary_property_narrowing_tests` unchanged.
- const-local / const-parameter / IIFE narrowing → still preserved (unchanged).
- **Negative guard:** a genuinely `| undefined` generic local (assigned a maybe-undefined value, never narrowed) read in a closure → still reports TS18048.

## Verification
- `cargo nextest run -p tsz-checker --test closure_boundary_property_narrowing_tests` — 12/12 pass (10 existing + 2 new: preserved-case + negative-guard).
- zustand project: TS18048 residual 1 → 0; minimal repro and faithful `createJSONStorage` repro both clean; bundled `tsc` emits nothing on them.
- No new failures vs clean `main` in the local `tsz-checker` lib suite (the suite has pre-existing environment-only failures unrelated to flow; CI's clean run is the authoritative gate).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
