### PR TITLE
fix(bench): monotonic latest.json guard (older run can't clobber newer perf)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1792,16 +1792,42 @@ jobs:
             echo "Bench target ${TARGET_SHA} is behind current main ${MAIN_SHA}; publishing because active benchmark runs are intentionally allowed to finish."
           fi
 
-          gsutil -q cp "$GITHUB_WORKSPACE/bench-results.json" \
-            "${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.json"
-          echo "Published: ${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.json"
-          gsutil -q cp "$GITHUB_WORKSPACE/bench-results-tsgo-winners.json" \
-            "${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.tsgo-winners.json"
-          echo "Published: ${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.tsgo-winners.json"
-          gsutil -q cp "$GITHUB_WORKSPACE/bench-results-missing-attribution.md" \
-            "${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.missing-attribution.md"
-          echo "Published: ${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.missing-attribution.md"
-          echo "should_redeploy=true" >> "$GITHUB_OUTPUT"
+          # Monotonic latest.json guard. Incident: an older/slower bench finishing
+          # late must not clobber a newer latest.json (the root cause behind the
+          # website-side newest-wins selector). Refuse to overwrite latest.* when the
+          # already-published latest.json carries a newer-or-equal generated_at than
+          # this run's results. The timestamped ${TIMESTAMP}.json above is always kept
+          # for history regardless. Only refuses when BOTH timestamps parse and this
+          # run is not strictly newer, so it can never reduce publishing on first
+          # publish or on missing/unparseable metadata.
+          existing_latest="$GITHUB_WORKSPACE/bench-results-existing-latest.json"
+          if ! gsutil -q cp "${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.json" "$existing_latest" 2>/dev/null; then
+            rm -f "$existing_latest"
+          fi
+          latest_decision="$(node -e '
+            const fs = require("node:fs");
+            const gen = (p) => { try { return Date.parse(JSON.parse(fs.readFileSync(p, "utf8")).generated_at) || 0; } catch { return 0; } };
+            const incoming = gen(process.argv[1]);
+            const existing = gen(process.argv[2]);
+            process.stdout.write(incoming > 0 && existing > 0 && incoming <= existing ? "skip" : "publish");
+          ' "$GITHUB_WORKSPACE/bench-results.json" "$existing_latest")"
+          rm -f "$existing_latest"
+
+          if [[ "$latest_decision" == "skip" ]]; then
+            echo "latest.json guard: existing latest.json is newer-or-equal than this run; keeping it and skipping the latest.* overwrite (timestamped ${TIMESTAMP}.json was still published)."
+            echo "should_redeploy=false" >> "$GITHUB_OUTPUT"
+          else
+            gsutil -q cp "$GITHUB_WORKSPACE/bench-results.json" \
+              "${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.json"
+            echo "Published: ${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.json"
+            gsutil -q cp "$GITHUB_WORKSPACE/bench-results-tsgo-winners.json" \
+              "${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.tsgo-winners.json"
+            echo "Published: ${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.tsgo-winners.json"
+            gsutil -q cp "$GITHUB_WORKSPACE/bench-results-missing-attribution.md" \
+              "${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.missing-attribution.md"
+            echo "Published: ${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.missing-attribution.md"
+            echo "should_redeploy=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Report severe benchmark gaps
         if: steps.publish.outputs.should_redeploy == 'true'


### PR DESCRIPTION
## Summary

Add a **source-side monotonic guard** so a slow/older Bench run can't clobber a newer `latest.json`. In `Publish results`, before overwriting `bench-runs/latest.json` (+ `latest.tsgo-winners.json` / `latest.missing-attribution.md`), compare this run's `generated_at` against the already-published `latest.json`; if the existing one is **newer-or-equal**, keep it and skip the `latest.*` overwrite. The timestamped `<ts>.json` history copy is always written either way.

## Why

`Publish results` currently does an unconditional `gsutil cp … latest.json`, so a bench that started on an older commit and finishes late overwrites a newer published result (the "publishing behind main" path). This is the root cause the website papers over with a newest-of-GCS-vs-GitHub selector. Guarding at the source makes `latest.json` monotonic and is the prerequisite that lets the website later drop that selector.

## Behavior / safety

- **Pure-additive and reversible.** Refuses an overwrite *only* when BOTH timestamps parse AND this run is not strictly newer — so it never reduces publishing on first publish or on missing/unparseable `generated_at`.
- On skip, sets `should_redeploy=false` (suppresses the no-op severe-gap alert only); gh-pages still redeploys via the Bench `workflow_run` trigger, baking the newer existing data.
- Existing `latest.json` fetch failure (e.g. first publish) falls through to publish.

Goal: fast

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/bench.yml'))"` parses clean.
- Decision logic dry-run (node): incoming>existing → publish; incoming==existing → skip; incoming<existing → skip; missing existing → publish; unparseable incoming → publish.
- First incremental, publishing-safe step of the CI canary/perf/compat simplification (perf=per-tip cadence + per-commit compat). Follow-ups will source-guard then drop the website newest-wins selector.
