### PR TITLE
fix(checker): recognize never-returning imported functions as terminating (TS2366)

### DIFF
--- a/crates/tsz-checker/src/flow/reachability_checker.rs
+++ b/crates/tsz-checker/src/flow/reachability_checker.rs
@@ -214,11 +214,30 @@ impl<'a> CheckerState<'a> {
     }
 
     fn symbol_explicitly_returns_never(&mut self, sym_id: tsz_binder::SymbolId) -> bool {
-        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
-            return false;
+        let (is_alias, decl_idx) = {
+            let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+                return false;
+            };
+            (
+                symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS),
+                symbol.primary_declaration(),
+            )
         };
 
-        let Some(decl_idx) = symbol.primary_declaration() else {
+        // An imported function's symbol is an alias whose primary declaration is
+        // the import specifier (no return-type annotation) and whose real
+        // declaration lives in another file's arena, so neither can be read
+        // through `self.ctx.arena`. Inspect the alias's computed function-type
+        // return instead — arena-independent and already resolved by the type
+        // system through import and `export *` re-export chains — matching tsc's
+        // `isNeverReturningCall`, which examines the resolved signature. Covers a
+        // direct `import { die }` and transitive `export *` barrel re-exports.
+        if is_alias {
+            let ty = self.get_type_of_symbol(sym_id);
+            return query::function_return_type(self.ctx.types, ty) == Some(TypeId::NEVER);
+        }
+
+        let Some(decl_idx) = decl_idx else {
             return false;
         };
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1132,6 +1132,9 @@ mod never_absorption_call_spread_tests;
 #[path = "../tests/never_initializer_falls_through_tests.rs"]
 mod never_initializer_falls_through_tests;
 #[cfg(test)]
+#[path = "tests/never_return_import_alias_tests.rs"]
+mod never_return_import_alias_tests;
+#[cfg(test)]
 #[path = "../tests/never_returning_narrowing_tests.rs"]
 mod never_returning_narrowing_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/never_return_import_alias_tests.rs
+++ b/crates/tsz-checker/src/tests/never_return_import_alias_tests.rs
@@ -1,0 +1,85 @@
+//! Control-flow termination through a never-returning *imported* function.
+//!
+//! Structural rule: when a function's last statement is a call to a function
+//! declared `: never`, tsc treats the call as terminating, marks the endpoint
+//! unreachable, and suppresses TS2366 ("Function lacks ending return
+//! statement…"). This must hold when the never-returning callee is reached
+//! through an import alias — directly (`import { die }`) or transitively through
+//! an `export *` barrel re-export. tsz previously read the import specifier's
+//! (annotation-less) declaration, so the `: never` was invisible across the
+//! module boundary; the fix inspects the alias's resolved function-type return
+//! (`reachability_checker.rs` `symbol_explicitly_returns_never`).
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_multi_file;
+use tsz_common::common::ModuleKind;
+
+fn ts2366_count(files: &[(&str, &str)], entry: &str) -> usize {
+    let opts = CheckerOptions {
+        strict: true,
+        module: ModuleKind::ESNext,
+        ..CheckerOptions::default()
+    };
+    check_multi_file(files, entry, opts)
+        .iter()
+        .filter(|d| d.code == 2366)
+        .count()
+}
+
+const DIE: &str = "export function die(code: number): never { throw new Error(String(code)); }\n";
+const CONSUMER: &str =
+    "export function values(obj: unknown): string[] { if (obj) { return [\"a\"]; } die(6); }\n";
+
+#[test]
+fn direct_imported_never_returning_call_terminates_control_flow() {
+    let files = &[
+        ("errors.ts", DIE),
+        (
+            "main.ts",
+            &format!("import {{ die }} from \"./errors\";\n{CONSUMER}"),
+        ),
+    ];
+    assert_eq!(
+        ts2366_count(files, "main.ts"),
+        0,
+        "a direct-imported never-returning call must terminate control flow (no TS2366)"
+    );
+}
+
+#[test]
+fn never_returning_through_export_star_barrel_terminates() {
+    let files = &[
+        ("errors.ts", DIE),
+        ("internal.ts", "export * from \"./errors\";\n"),
+        (
+            "main.ts",
+            &format!("import {{ die }} from \"./internal\";\n{CONSUMER}"),
+        ),
+    ];
+    assert_eq!(
+        ts2366_count(files, "main.ts"),
+        0,
+        "a never-returning call reached through an export* barrel must terminate control flow"
+    );
+}
+
+#[test]
+fn non_never_imported_call_still_reports_ts2366() {
+    // Negative guard: an imported function whose return type is NOT `never` must
+    // still leave the endpoint reachable and report TS2366.
+    let files = &[
+        (
+            "errors.ts",
+            "export function notNever(code: number): string { return String(code); }\n",
+        ),
+        (
+            "main.ts",
+            "import { notNever } from \"./errors\";\nexport function values(obj: unknown): string[] { if (obj) { return [\"a\"]; } notNever(6); }\n",
+        ),
+    ];
+    assert_eq!(
+        ts2366_count(files, "main.ts"),
+        1,
+        "a non-never imported call must still report TS2366"
+    );
+}


### PR DESCRIPTION
Goal: green

Clears false **TS2366** ("Function lacks ending return statement and return type does not include 'undefined'") when a function ends in a call to a never-returning **imported** function. Witnessed in mobx (`internal.ts` `export *` barrel of `errors.ts`'s `die(): never`).

## Structural rule
When a function's last statement is a call to a function declared `: never`, tsc treats the call as control-flow-terminating, marks the endpoint unreachable, and suppresses TS2366 (`isNeverReturningCall`). This must hold when the never-returning callee is reached through an **import alias** — directly (`import { die }`) or transitively through an `export *` barrel re-export. tsz's `symbol_explicitly_returns_never` read the alias's `primary_declaration()` — the import specifier, which has no return-type annotation and whose real declaration lives in another file's arena — so the `: never` was invisible across the module boundary. It now detects an `ALIAS` symbol and inspects the alias's resolved function-type return (arena-independent; the type system already chases import / `export *` chains), matching tsc.

## Adjacent matrix
- direct `import { die }` then `die(...)` as the last statement → terminates (no TS2366).
- `export *` barrel re-export → terminates.
- **Negative guard:** an imported function whose return type is NOT `never` → still reports TS2366.
- Local never-returning function (unchanged path) → still terminates via the declaration check.

## Verification
- `cargo nextest run -p tsz-checker --lib never_return_import_alias` — 3/3 pass (direct, export* barrel, negative).
- mobx project: 2 of its 3 false TS2366 cleared (the third, `derivation.ts:84`, is a separate exhaustive-switch-over-enum root, out of scope).
- Minimal repros confirmed against the prebuilt binary; bundled `tsc` emits nothing on the positive cases and TS2366 on the negative.
- No new failures vs clean `main` in the local `tsz-checker` lib suite (pre-existing environment-only failures aside; CI's clean run is the authoritative gate). Note: this reads the alias's resolved type during reachability — CI conformance is the gate confirming no stale-type interaction.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
