### PR TITLE
fix(solver): resolve concrete-check vs generic-extends conditional via permissive false branch (#14232)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1982,6 +1982,11 @@ path = "tests/nullable_union_missing_property_tests.rs"
 [[test]]
 name = "partial_record_optional_index_assignability_tests"
 path = "tests/partial_record_optional_index_assignability_tests.rs"
+
 [[test]]
 name = "function_type_predicate_typeof_param_tests"
 path = "tests/function_type_predicate_typeof_param_tests.rs"
+
+[[test]]
+name = "conditional_concrete_check_generic_extends_false_branch_tests"
+path = "tests/conditional_concrete_check_generic_extends_false_branch_tests.rs"

--- a/crates/tsz-checker/tests/conditional_concrete_check_generic_extends_false_branch_tests.rs
+++ b/crates/tsz-checker/tests/conditional_concrete_check_generic_extends_false_branch_tests.rs
@@ -1,0 +1,104 @@
+//! Checker integration tests for resolving a conditional with a *concrete*
+//! check against a *generic* extends type to its false branch.
+//!
+//! Structural rule: when a conditional's relation fails and the check type is
+//! concrete while the extends type carries type parameters, tsc resolves
+//! eagerly via the permissive instantiation (every extends type parameter →
+//! `any`): if the relation still fails under `any`, take the false branch;
+//! otherwise defer. tsz used to defer unconditionally whenever the extends type
+//! had a type parameter, leaving the conditional opaque so the false-branch
+//! literal didn't match (spurious TS2322).
+//!
+//! Owner: `tsz_solver::evaluation::evaluate_rules::conditional::evaluate_conditional`
+//! — the post-relation deferral gate now consults
+//! `permissive_false_branch_is_definitive` for the `extends_has_type_params`
+//! operand (it previously short-circuited and never reached it for a concrete
+//! check). #14232 (ts-essentials).
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn assert_no_errors(source: &str, label: &str) {
+    let codes = check_source_codes(source);
+    assert!(
+        codes.is_empty(),
+        "{label}: expected no diagnostics, got {codes:?}"
+    );
+}
+
+fn assert_has_2322(source: &str, label: &str) {
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&2322),
+        "{label}: expected a TS2322, got {codes:?}"
+    );
+}
+
+// =============================================================================
+// Positive: concrete check vs generic extends resolves the false branch
+// =============================================================================
+
+#[test]
+fn empty_tuple_vs_generic_nonempty_tuple_takes_false_branch() {
+    // The reported repro (#14232): `[]` is not `[any, ...any[]]` regardless of T.
+    assert_no_errors(
+        r#"
+function f<T>() {
+  type A = [] extends [T, ...T[]] ? "yes" : "no";
+  const a: A = "no";
+}
+export {};
+"#,
+        "[] extends [T, ...T[]] resolves to \"no\"",
+    );
+}
+
+#[test]
+fn empty_tuple_vs_single_generic_element_takes_false_branch() {
+    assert_no_errors(
+        r#"
+function g<T>() {
+  type B = [] extends [T] ? "yes" : "no";
+  const b: B = "no";
+}
+export {};
+"#,
+        "[] extends [T] resolves to \"no\"",
+    );
+}
+
+#[test]
+fn false_branch_resolution_is_binder_name_independent() {
+    assert_no_errors(
+        r#"
+function pull<Elem>() {
+  type R = [] extends [Elem, ...Elem[]] ? 1 : 0;
+  const r: R = 0;
+}
+export {};
+"#,
+        "renamed binder still resolves the false branch",
+    );
+}
+
+// =============================================================================
+// Negative / must-still-defer: a genuinely indeterminate conditional stays
+// deferred (the fix must not over-resolve).
+// =============================================================================
+
+#[test]
+fn generic_check_stays_deferred() {
+    // `T extends string` is indeterminate until T is known: under the permissive
+    // instantiation `any extends string` holds, so the relation is NOT definitive
+    // false and the conditional must stay deferred — assigning a concrete to the
+    // deferred result still errors.
+    assert_has_2322(
+        r#"
+function h<T>() {
+  type C = T extends string ? "yes" : "no";
+  const c: C = "yes";
+}
+export {};
+"#,
+        "T extends string stays deferred (not eagerly resolved)",
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -220,6 +220,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         )
     }
 
+    fn generic_extends_can_use_permissive_false_branch(&self, extends_type: TypeId) -> bool {
+        crate::visitors::visitor_predicates::is_tuple_type(self.interner(), extends_type)
+    }
+
     /// Evaluate a conditional type: T extends U ? X : Y
     ///
     /// Algorithm:
@@ -1092,14 +1096,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // permissive instantiation (every extends type parameter -> `any`,
                 // tsc's `getPermissiveInstantiation` gate). e.g.
                 // `[] extends [T, ...T[]] ? "yes" : "no"` is `"no"` because `[]`
-                // is not a `[any, ...any[]]` regardless of `T`. Only defer when
-                // that permissive relation is indeterminate — or during the
-                // TS2589 depth-detection pass, which keeps deferring so
-                // unconditionally-recursive aliases drive their recursive branch
-                // and surface the depth error. Never short-circuit when the
-                // extends type carries `infer` patterns: those are resolved by
-                // infer-matching, not by a permissive false-branch judgment.
-                && (extends_has_infer
+                // is not a `[any, ...any[]]` regardless of `T`. Keep the exception
+                // to tuple-like extends operands: richer generic extends operands,
+                // such as React's `ElementType extends T` component-props
+                // conditionals, must remain deferred so contextual JSX typing can
+                // infer `T` before the conditional chooses a branch.
+                && (!self.generic_extends_can_use_permissive_false_branch(extends_type)
+                    || extends_has_infer
                     || self.is_depth_detection_pass()
                     || !self.permissive_false_branch_is_definitive(check_type, extends_type)))
                 // tsc parity (`getConditionalType`): a conditional whose

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -1086,7 +1086,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             let result_branch = if is_sub {
                 // T <: U -> true branch
                 cond.true_type
-            } else if extends_has_type_params
+            } else if (extends_has_type_params
+                // A *concrete* check against a generic extends still resolves to
+                // the false branch when the relation also fails under the
+                // permissive instantiation (every extends type parameter -> `any`,
+                // tsc's `getPermissiveInstantiation` gate). e.g.
+                // `[] extends [T, ...T[]] ? "yes" : "no"` is `"no"` because `[]`
+                // is not a `[any, ...any[]]` regardless of `T`. Only defer when
+                // that permissive relation is indeterminate — or during the
+                // TS2589 depth-detection pass, which keeps deferring so
+                // unconditionally-recursive aliases drive their recursive branch
+                // and surface the depth error. Never short-circuit when the
+                // extends type carries `infer` patterns: those are resolved by
+                // infer-matching, not by a permissive false-branch judgment.
+                && (extends_has_infer
+                    || self.is_depth_detection_pass()
+                    || !self.permissive_false_branch_is_definitive(check_type, extends_type)))
                 // tsc parity (`getConditionalType`): a conditional whose
                 // effective check type is still generic — instantiable flags,
                 // or a type reference/tuple/template whose arguments are


### PR DESCRIPTION
Fixes #14232.

## Structural rule
When a conditional relation fails with a concrete tuple check and a tuple-like generic extends operand, `tsc` resolves the false branch if the relation still fails after permissive instantiation of the extends type parameters to `any`.

`[] extends [T, ...T[]] ? "yes" : "no"` is `"no"` because `[]` is not assignable to `[any, ...any[]]` regardless of `T`.

Richer generic extends operands must still defer. In particular, React component-props conditionals such as `ElementType extends T ? "a" : T` must remain unresolved long enough for JSX contextual typing to infer `T`; eagerly choosing a branch makes anchor props appear required and regresses `contextuallyTypedJsxAttribute2.tsx`.

## Owner layer
Solver — `tsz_solver::evaluation::evaluate_rules::conditional::evaluate_conditional`.

The post-relation deferral gate now consults the existing `permissive_false_branch_is_definitive` helper for the concrete-check/generic-extends tuple case, while keeping non-tuple generic extends operands deferred. No checker/printer logic, and no identifier/file-name semantic predicates.

## Fallback / safety
- `extends_has_infer`: still defers; infer patterns resolve through infer matching.
- `is_depth_detection_pass()`: still defers so recursive aliases can surface TS2589.
- Non-tuple generic extends operands still defer to preserve component/JSX contextual inference.
- `permissive_false_branch_is_definitive` remains conservative when permissive forms are still generic-conditional markers.

## Adjacent matrix
- `[] extends [T, ...T[]]` -> false branch.
- `[] extends [T]` -> false branch.
- renamed binder (`Elem`) -> false branch.
- `T extends string ? ...` stays deferred.
- `contextuallyTypedJsxAttribute2.tsx` stays green; no eager component-props branch.

Goal: green

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: high

## Verification
- `scripts/safe-run.sh cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test conditional_concrete_check_generic_extends_false_branch_tests` — 4/4 passed
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter contextuallyTypedJsxAttribute2 --verbose` — 1/1 passed