### PR TITLE
fix(solver): coerce template-literal infer capture for literal numeric constraints

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_template_match.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_template_match.rs
@@ -90,6 +90,30 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         Some(self.interner().literal_bigint_with_sign(negative, digits))
     }
 
+    /// Non-string primitive coercions of a captured template segment.
+    ///
+    /// A captured `infer` segment is always a raw string. When the placeholder
+    /// carries an `extends` constraint that admits a non-string primitive, tsc
+    /// re-interprets the segment as that primitive (`"2"` -> the `2` literal,
+    /// `"true"` -> `true`, etc.). The candidates are constraint-agnostic — the
+    /// caller decides which one satisfies the constraint via a structural
+    /// subtype check — so this covers intrinsic, literal, and union-of-literal
+    /// constraints uniformly, e.g. `extends number`, `extends 5`, `extends
+    /// 0 | 1`, or `extends bigint`.
+    fn template_capture_coercions(&self, captured: &str) -> [Option<TypeId>; 5] {
+        [
+            self.parse_template_number_capture(captured),
+            self.parse_template_bigint_capture(captured),
+            match captured {
+                "true" => Some(self.interner().literal_boolean(true)),
+                "false" => Some(self.interner().literal_boolean(false)),
+                _ => None,
+            },
+            (captured == "null").then_some(TypeId::NULL),
+            (captured == "undefined").then_some(TypeId::UNDEFINED),
+        ]
+    }
+
     fn template_capture_for_constraint(
         &self,
         captured: &str,
@@ -101,33 +125,16 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return Some(captured_type);
         }
 
-        match self.interner().lookup(constraint) {
-            Some(TypeData::Intrinsic(IntrinsicKind::Number)) => self
-                .parse_template_number_capture(captured)
-                .filter(|&ty| checker.is_subtype_of(ty, constraint)),
-            Some(TypeData::Intrinsic(IntrinsicKind::Bigint)) => self
-                .parse_template_bigint_capture(captured)
-                .filter(|&ty| checker.is_subtype_of(ty, constraint)),
-            Some(TypeData::Intrinsic(IntrinsicKind::Boolean)) => match captured {
-                "true" => Some(self.interner().literal_boolean(true)),
-                "false" => Some(self.interner().literal_boolean(false)),
-                _ => None,
-            },
-            Some(TypeData::Intrinsic(IntrinsicKind::Null)) if captured == "null" => {
-                Some(TypeId::NULL)
-            }
-            Some(TypeData::Intrinsic(IntrinsicKind::Undefined)) if captured == "undefined" => {
-                Some(TypeId::UNDEFINED)
-            }
-            Some(TypeData::Union(members_id)) => {
-                let members = self.interner().type_list(members_id);
-                members.iter().find_map(|&member| {
-                    self.template_capture_for_constraint(captured, captured_type, member, checker)
-                        .filter(|&ty| checker.is_subtype_of(ty, constraint))
-                })
-            }
-            _ => None,
-        }
+        // The captured segment did not satisfy the constraint as a string.
+        // Re-interpret it as each non-string primitive and accept the first
+        // coercion the constraint admits. Matching on the *coerced value*
+        // rather than the constraint's shape keeps the rule structural:
+        // numeric/bigint/boolean/null/undefined literals, their intrinsics,
+        // and any union of them are all handled by the same subtype probe.
+        self.template_capture_coercions(captured)
+            .into_iter()
+            .flatten()
+            .find(|&candidate| checker.is_subtype_of(candidate, constraint))
     }
 
     /// Match a template literal string against a pattern.

--- a/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_infer_distribution.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_infer_distribution.rs
@@ -1593,6 +1593,95 @@ fn test_template_literal_pattern_infer_numeric() {
 }
 
 #[test]
+fn test_template_literal_infer_extends_literal_union_coerces_numeric() {
+    // type Digit = 0|1|...|9;
+    // type FirstDigit<T> = T extends `${infer N extends Digit}${infer R}` ? N : "no-match";
+    // FirstDigit<"25"> === 2  (tsc captures the numeric literal, not "2")
+    let interner = TypeInterner::new();
+
+    let digit_members: Vec<TypeId> = (0..=9).map(|i| interner.literal_number(i as f64)).collect();
+    let digit = interner.union(digit_members);
+
+    let (_n_name, infer_n) = test_constrained_infer_param(&interner, "N", digit);
+    let (_r_name, infer_r) = test_infer_param(&interner, "R");
+
+    // `${infer N extends Digit}${infer R}`
+    let pattern = interner.template_literal(vec![
+        TemplateSpan::Type(infer_n),
+        TemplateSpan::Type(infer_r),
+    ]);
+
+    let no_match = interner.literal_string("no-match");
+    let cond = ConditionalType {
+        check_type: interner.literal_string("25"),
+        extends_type: pattern,
+        true_type: infer_n,
+        false_type: no_match,
+        is_distributive: false,
+    };
+
+    let result = evaluate_conditional(&interner, &cond);
+    assert_eq!(
+        result,
+        interner.literal_number(2.0),
+        "Expected N coerced to the numeric literal 2, got {:?}",
+        interner.lookup(result)
+    );
+}
+
+#[test]
+fn test_template_literal_infer_extends_single_numeric_literal() {
+    // `${infer N extends 5}` against "5" captures the 5 literal; "6" takes false.
+    let interner = TypeInterner::new();
+
+    let five = interner.literal_number(5.0);
+    let (_n_name, infer_n) = test_constrained_infer_param(&interner, "N", five);
+
+    let pattern = interner.template_literal(vec![TemplateSpan::Type(infer_n)]);
+    let no_match = interner.literal_string("no-match");
+
+    let cond_match = ConditionalType {
+        check_type: interner.literal_string("5"),
+        extends_type: pattern,
+        true_type: infer_n,
+        false_type: no_match,
+        is_distributive: false,
+    };
+    assert_eq!(evaluate_conditional(&interner, &cond_match), five);
+
+    // Negative control: captured value outside the literal set -> false branch.
+    let cond_miss = ConditionalType {
+        check_type: interner.literal_string("6"),
+        extends_type: pattern,
+        true_type: infer_n,
+        false_type: no_match,
+        is_distributive: false,
+    };
+    assert_eq!(evaluate_conditional(&interner, &cond_miss), no_match);
+}
+
+#[test]
+fn test_template_literal_infer_extends_bigint_literal() {
+    // `${infer N extends 7n}` against "7" captures the 7n bigint literal.
+    let interner = TypeInterner::new();
+
+    let seven_n = interner.literal_bigint_with_sign(false, "7");
+    let (_n_name, infer_n) = test_constrained_infer_param(&interner, "N", seven_n);
+
+    let pattern = interner.template_literal(vec![TemplateSpan::Type(infer_n)]);
+    let no_match = interner.literal_string("no-match");
+
+    let cond = ConditionalType {
+        check_type: interner.literal_string("7"),
+        extends_type: pattern,
+        true_type: infer_n,
+        false_type: no_match,
+        is_distributive: false,
+    };
+    assert_eq!(evaluate_conditional(&interner, &cond), seven_n);
+}
+
+#[test]
 fn test_template_literal_multiple_adjacent_types() {
     // `${A}${B}${C}` - multiple type interpolations
     let interner = TypeInterner::new();


### PR DESCRIPTION
## Summary

Closes #14236.

A template-literal `infer N extends C` placeholder re-interprets the captured
string segment as a non-string primitive when `C` admits one. tsz only did this
for the `number`/`bigint` **intrinsics**. Literal-typed constraints — `extends 5`,
`extends 0 | 1`, or a union-of-literals like `extends Digit` (`0|1|…|9`) — fell
through to `None`, so the capture failed and the conditional wrongly took its
false branch, producing a spurious `TS2322`.

```ts
type Digit = 0|1|2|3|4|5|6|7|8|9;
type FirstDigit<T> = T extends `${infer N extends Digit}${infer R}` ? N : "no-match";
type X = FirstDigit<"25">;   // tsc: 2 ; tsz (before): "no-match"
const x: X = 2;              // tsz (before): TS2322
```

## Structural rule

When a template-literal `infer` placeholder carries an `extends` constraint and
the captured segment is not already a subtype of it, tsc re-interprets the
segment as a non-string primitive (number/bigint/boolean/null/undefined literal)
and keeps the first interpretation the constraint admits. This is independent of
whether the constraint is written as an intrinsic, a single literal, or a union
of literals.

## Owner layer

Solver — template-literal `infer ... extends` capture/coercion in
`crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_template_match.rs`.

The old `template_capture_for_constraint` matched on the constraint's *shape*
(intrinsic `Number`/`Bigint`/`Boolean`/`Null`/`Undefined` arms plus a `Union`
recursion that bottomed out at literal members). This is replaced with a
constraint-agnostic rule: compute every primitive coercion of the captured
string once (`template_capture_coercions`) and accept the first candidate that
is a **structural subtype** of the constraint. Intrinsics, literals, and any
union of them are now handled by the same subtype probe — no per-shape special
cases. Equivalence for the previously handled cases is preserved (e.g. a boolean
literal is a subtype of the `boolean` intrinsic; a candidate is a subtype of a
union iff it is a subtype of some member).

## Adjacent-case matrix

- `extends Digit` (union of numeric literals) — the reported hotscript case.
- `extends 5` (single numeric literal) — positive and negative (`"6"` → false branch).
- `extends 7n` (bigint literal).
- Existing `extends number` / `extends bigint` / `extends boolean` intrinsics — unchanged.
- Negative control: captured segment outside the literal set → false branch.

## Anti-hardcoding

No identifier/alias/file-name checks; coercion is driven by structural subtype
against the actual constraint type, not by printer output or fixture names.

## Verification

- New unit tests in
  `crates/tsz-solver/tests/evaluate_tests_parts/template_literal_infer_distribution.rs`:
  - `test_template_literal_infer_extends_literal_union_coerces_numeric`
  - `test_template_literal_infer_extends_single_numeric_literal`
  - `test_template_literal_infer_extends_bigint_literal`
- `cargo test -p tsz-solver --lib template_literal` → 279 passed, 0 failed.
- `cargo test -p tsz-solver --lib template_literal_infer_extends` → 3 passed.
- `cargo clippy -p tsz-solver --tests` → clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude Opus 4
Effort: medium

Goal: green

https://claude.ai/code/session_01BjffgdWX5JwTNMEjM5B8Tz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjffgdWX5JwTNMEjM5B8Tz)_
