### PR TITLE
fix(driver): exact-name ambient module precedence over path resolution (TS2614)

### DIFF
--- a/crates/tsz-cli/src/driver/source_resolution_setup.rs
+++ b/crates/tsz-cli/src/driver/source_resolution_setup.rs
@@ -172,10 +172,53 @@ pub(super) fn prepare_source_resolution_setup(
                     import_kind: *import_kind,
                     resolution_mode_override: *resolution_mode_override,
                 };
-                if let Some(discovered) = source_module_resolutions
-                    .and_then(|resolutions| resolutions.get(&source_resolution_key))
-                {
-                    resolved_module_specifiers.insert((file_idx, specifier.clone()));
+                // An exact-name `declare module "<spec>"` takes precedence over a
+                // file/path resolution that points at a *different* file than the
+                // one declaring the ambient module. tsc's `resolveExternalModule`
+                // consults `tryFindAmbientModule` (an exact-name ambient lookup)
+                // *before* `getResolvedModule`, so a project that declares
+                // `declare module "graphql-scalars"` in one file and also maps the
+                // same bare name through a catch-all `paths` entry (or unrelated
+                // on-disk stub) must read the ambient module's named exports, not
+                // the path-mapped file's surface. Source discovery runs before
+                // ambient modules are known (its `is_ambient_module` closure is
+                // hardcoded to `false`), so the recorded resolution can point at
+                // the path-mapped stub; re-assert ambient precedence here.
+                //
+                // Crucially, this must NOT fire when the path-resolved file *is*
+                // the file that declares the ambient module (e.g. a real package
+                // whose `index.d.ts` contains `declare module "express" { ... }`
+                // discovered through node resolution, possibly merged with a
+                // module augmentation). In that case the ambient declaration and
+                // the resolved file are the same module, so the normal resolved
+                // path must stand to preserve the full module surface and any
+                // augmentation merge.
+                //
+                // Only non-relative bare specifiers are eligible, mirroring tsc's
+                // `isExternalModuleNameRelative` guard. Pattern ambient modules
+                // (`*.svg`) never match a concrete specifier via the exact-name
+                // membership test and keep flowing through the wildcard path.
+                let specifier_is_ordinary_bare = !specifier.starts_with('.')
+                    && !specifier.starts_with('/')
+                    && (!specifier.contains(':') || specifier.starts_with("node:"));
+                let exact_name_ambient_match = specifier_is_ordinary_bare && {
+                    if let Some(idx) = skeleton_for_ambient {
+                        idx.is_ambient_module(specifier)
+                    } else {
+                        program.declared_modules.contains(specifier.as_str())
+                            || program
+                                .shorthand_ambient_modules
+                                .contains(specifier.as_str())
+                    }
+                };
+
+                let discovered = source_module_resolutions
+                    .and_then(|resolutions| resolutions.get(&source_resolution_key));
+
+                // Resolve the discovered target to a program file index up front so
+                // ambient precedence can compare it against the ambient module's
+                // declaring file(s).
+                let discovered_target = discovered.and_then(|discovered| {
                     let canonical = if should_apply_duplicate_package_redirect(file_path) {
                         package_redirects
                             .get(&discovered.canonical_path)
@@ -184,24 +227,58 @@ pub(super) fn prepare_source_resolution_setup(
                     } else {
                         discovered.canonical_path.clone()
                     };
-                    if let Some(target_idx) = program_file_index
+                    program_file_index
                         .get_with_symlink_fallback(&canonical, &canonical, options)
-                    {
-                        resolved_module_paths.insert((file_idx, specifier.clone()), target_idx);
-                        resolved_module_request_paths.insert(
-                            (
-                                file_idx,
-                                specifier.clone(),
-                                request_mode_key,
-                                request_kind_key,
-                            ),
-                            target_idx,
-                        );
-                        if discovered.resolved_using_ts_extension {
-                            resolved_module_ts_extension_flags
-                                .insert((file_idx, specifier.clone()), true);
+                        .map(|target_idx| (target_idx, discovered.resolved_using_ts_extension))
+                });
+
+                // The ambient module's declaring file(s): files whose binder
+                // recorded a bodied `declare module "<spec>"` export surface.
+                // When the discovered resolution target is one of these, the
+                // ambient is the resolved file itself — keep the resolved path.
+                let discovered_target_declares_ambient = exact_name_ambient_match
+                    && match (skeleton_for_ambient, discovered_target) {
+                        (Some(idx), Some((target_idx, _))) => {
+                            idx.module_binders_for(specifier).contains(&target_idx)
                         }
+                        // No skeleton: fall back to keeping the resolved path
+                        // whenever a concrete file resolved (conservative — only
+                        // path-less ambient when nothing resolved on disk). This
+                        // avoids dropping a genuine same-file ambient/package in
+                        // the sequential path where per-file declarer data is not
+                        // projected.
+                        (None, Some(_)) => true,
+                        _ => false,
+                    };
+
+                if exact_name_ambient_match && !discovered_target_declares_ambient {
+                    resolved_module_specifiers.insert((file_idx, specifier.clone()));
+                    continue;
+                }
+
+                if let Some((target_idx, resolved_using_ts_extension)) = discovered_target {
+                    resolved_module_specifiers.insert((file_idx, specifier.clone()));
+                    resolved_module_paths.insert((file_idx, specifier.clone()), target_idx);
+                    resolved_module_request_paths.insert(
+                        (
+                            file_idx,
+                            specifier.clone(),
+                            request_mode_key,
+                            request_kind_key,
+                        ),
+                        target_idx,
+                    );
+                    if resolved_using_ts_extension {
+                        resolved_module_ts_extension_flags
+                            .insert((file_idx, specifier.clone()), true);
                     }
+                    continue;
+                }
+                if discovered.is_some() {
+                    // Discovered a resolution but the target is not in the program
+                    // file index (e.g. filtered out). Preserve the prior behavior
+                    // of marking the specifier resolved without a path.
+                    resolved_module_specifiers.insert((file_idx, specifier.clone()));
                     continue;
                 }
 

--- a/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
@@ -383,3 +383,145 @@ fn compile_project_module_suffixes_relative_import_falls_back_to_base_when_no_va
          variant exists. Diagnostic codes: {codes:?}",
     );
 }
+
+// An exact-name `declare module "<spec>"` takes precedence over a catch-all
+// `paths` mapping (or on-disk stub) that also matches the bare specifier. tsc's
+// `resolveExternalModule` calls `tryFindAmbientModule` before `getResolvedModule`,
+// so the ambient module's named exports must be consulted instead of the
+// path-mapped file's surface. Witnessed by the type-graphql project, whose
+// `"*": ["stub.d.ts"]` mapping shadowed `declare module "graphql-scalars"`
+// and produced false TS2614.
+#[test]
+fn compile_exact_name_ambient_module_wins_over_catch_all_paths_mapping() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "es2022",
+            "module": "esnext",
+            "strict": true,
+            "types": [],
+            "skipLibCheck": true,
+            "noEmit": true,
+            "moduleResolution": "bundler",
+            "baseUrl": ".",
+            "ignoreDeprecations": "6.0",
+            "paths": { "*": ["stub.d.ts"] }
+          },
+          "include": ["src/**/*.ts", "ambients.d.ts"]
+        }"#,
+    );
+    // The path-mapped stub exposes no named exports (`export =` of `any`).
+    write_file(
+        &base.join("stub.d.ts"),
+        "declare const tszStub: any;\nexport = tszStub;\n",
+    );
+    // The exact-name ambient module DOES export the member.
+    write_file(
+        &base.join("ambients.d.ts"),
+        "declare module 'somepkg' {\n  export const NamedFromAmbient: any;\n}\n",
+    );
+    write_file(
+        &base.join("src/index.ts"),
+        "export { NamedFromAmbient } from 'somepkg';\n",
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let ts2614: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == 2614)
+        .collect();
+    let ts2305: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::MODULE_HAS_NO_EXPORTED_MEMBER)
+        .collect();
+    assert!(
+        ts2614.is_empty() && ts2305.is_empty(),
+        "Exact-name `declare module 'somepkg'` must win over the catch-all \
+         `paths` mapping so `NamedFromAmbient` resolves. Got diagnostics: {:#?}",
+        result.diagnostics
+    );
+}
+
+// Negative control: when the exact-name ambient module exists but genuinely
+// does NOT export the imported member, the no-exported-member diagnostic must
+// still fire. And a bare specifier with NO ambient declaration must continue to
+// resolve via `paths` (a present member is fine; an absent one still errors).
+#[test]
+fn compile_exact_name_ambient_precedence_keeps_missing_member_diagnostics() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "es2022",
+            "module": "esnext",
+            "strict": true,
+            "types": [],
+            "skipLibCheck": true,
+            "noEmit": true,
+            "moduleResolution": "bundler",
+            "baseUrl": ".",
+            "ignoreDeprecations": "6.0",
+            "paths": { "realpkg": ["realpkg.ts"], "*": ["stub.d.ts"] }
+          },
+          "include": ["src/**/*.ts", "ambients.d.ts"]
+        }"#,
+    );
+    write_file(
+        &base.join("stub.d.ts"),
+        "declare const tszStub: any;\nexport = tszStub;\n",
+    );
+    write_file(&base.join("realpkg.ts"), "export const RealNamed: number = 1;\n");
+    write_file(
+        &base.join("ambients.d.ts"),
+        "declare module 'ambientpkg' {\n  export const Present: any;\n}\n",
+    );
+    write_file(
+        &base.join("src/index.ts"),
+        // (1) ambient exists but lacks `Missing` -> error.
+        // (2) no ambient for `realpkg`; resolves via paths -> ok.
+        // (3) `realpkg` resolved member genuinely absent -> error.
+        "export { Missing } from 'ambientpkg';\n\
+         export { RealNamed } from 'realpkg';\n\
+         export { NotInReal } from 'realpkg';\n",
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let missing_member_lines: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| {
+            d.code == diagnostic_codes::MODULE_HAS_NO_EXPORTED_MEMBER || d.code == 2614
+        })
+        .map(|d| d.message_text.clone())
+        .collect();
+    // Exactly the two genuinely-absent members must error; `RealNamed` resolves.
+    assert!(
+        missing_member_lines.iter().any(|m| m.contains("Missing")),
+        "ambient module without `Missing` must still error. Got: {:#?}",
+        result.diagnostics
+    );
+    assert!(
+        missing_member_lines.iter().any(|m| m.contains("NotInReal")),
+        "path-resolved `realpkg` without `NotInReal` must still error. Got: {:#?}",
+        result.diagnostics
+    );
+    assert!(
+        !missing_member_lines.iter().any(|m| m.contains("RealNamed")),
+        "`RealNamed` must resolve via the `paths` mapping (no ambient declared). \
+         Got: {:#?}",
+        result.diagnostics
+    );
+}


### PR DESCRIPTION
Goal: green

Clears false **TS2614** ("Module '…' has no exported member '…'; did you mean…") in type-graphql, caused by path/`paths` resolution shadowing an exact-name ambient module declaration.

## Structural rule
When a non-relative bare specifier has an exact-name `declare module '<name>'` declared in a file **other than** the one path/node resolution would select (e.g. a catch-all `paths: { "*": [...] }` mapping or an unrelated on-disk stub), tsc resolves the import to the **ambient module** and reads its named exports — `resolveExternalModule` consults `tryFindAmbientModule` (an exact-name ambient lookup) *before* `getResolvedModule`. tsz let the path-mapped file win, so the ambient's exports were never consulted → false TS2614. The real bypass is in the **CLI driver's source-discovery consumption** (`source_resolution_setup.rs`): source discovery runs before ambient modules are known (its `is_ambient_module` is hardcoded `false`), so the recorded resolution points at the path-mapped stub. The fix re-asserts ambient precedence there, structurally (`declared_modules` / `shorthand_ambient_modules` membership + binder-derived `module_binders_for` declarer index — no name/file string checks).

## Adjacent matrix
- exact-name ambient declared in a *different* file + catch-all `paths` mapping → resolves to ambient (was false TS2614). 
- ambient declared in the **same** file path-resolution selects (real package `index.d.ts` with `declare module`, incl. augmentation merge) → keeps the resolved path / full surface (skip the override).
- ambient module genuinely missing the imported member → still TS2305/TS2614.
- bare specifier with **no** ambient declaration → still resolves via `paths`/node as before.
- pattern ambient modules (`*.svg`) → unaffected (never match the exact-name membership test).

## Verification
- Faithful repro (`paths "*": ["stub.d.ts"]` + `declare module 'somepkg'` + `export { NamedFromAmbient } from 'somepkg'`): tsz emitted false TS2614 before, now clean; bundled `tsc` clean on the identical project — parity achieved.
- type-graphql project: TS2614 **2 → 0**, total errors **11 → 8** (also resolved a `class-validator` `validateOrReject` TS2339 cascade from another shadowed ambient); `tsc` reports 0; remaining 8 are pre-existing unrelated FPs.
- Negatives + augmentation boundary confirmed tsc-parity (missing ambient member → TS2305; non-ambient bare → resolves via paths; same-file augmentation merges).
- Regression (delta vs clean `main`): `cargo nextest -p tsz-core --lib module_resolution` 180/180, `--lib ambient` 33/33, `-p tsz-cli` resolution/ambient/paths green; full driver suite 293 passed, 5 failed **all identical on clean main** (env-only) — zero new failures. clippy clean.
- Adds positive + negative driver regression tests (`driver_tests_parts/part_13.rs`).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
