### PR TITLE
fix(solver): function value assignable to an object & call-signature intersection (#14156)

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/types/function_intersection_target.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/function_intersection_target.rs
@@ -1,0 +1,144 @@
+//! Regression coverage for assigning a function value to an intersection
+//! target whose members combine an object type with a call signature
+//! (`Meta & ((...args) => Fn)`). Tracks issue #14156 (remeda
+//! `purryFromLazy.ts`).
+//!
+//! Structural rule under test:
+//!
+//! > A source is assignable to `A & B` iff it is assignable to each of `A`
+//! > and `B` independently. A function value is an object whose apparent
+//! > type carries the global `Function` interface members, so it satisfies
+//! > an all-optional object constituent (`{ x?: T }`) while still being
+//! > rejected by an object constituent with a required member it lacks.
+//!
+//! Every test varies binder names so a fixture-name fast path cannot pass
+//! these checks, and exercises `satisfies`, plain assignment, and parameter
+//! passing so they agree. Positive cases (all-optional object constituent)
+//! must type-check; negative controls (required member the function lacks)
+//! must still report TS1360/TS2322/TS2345.
+
+use super::super::core::*;
+
+fn no_assignability_errors(source: &str) {
+    let diagnostics = compile_and_get_diagnostics_with_lib(source);
+    assert!(
+        !has_error(&diagnostics, 1360)
+            && !has_error(&diagnostics, 2322)
+            && !has_error(&diagnostics, 2345),
+        "expected no assignability errors. diagnostics: {diagnostics:#?}\nsource:\n{source}"
+    );
+}
+
+#[test]
+fn satisfies_function_against_object_and_call_intersection_property() {
+    // The reduced remeda repro: the target property `lazy` has type
+    // `LazyMeta & ((...args: any) => LazyFn)`; the source `lazy` is a bare
+    // function whose return type is covariant-compatible with `LazyFn`.
+    no_assignability_errors(
+        r#"
+type LazyResult<R> = { done: boolean; next: R };
+type LazyEvaluator<T = unknown, R = unknown> = (
+  item: T,
+  index: number,
+  data: readonly T[],
+) => LazyResult<R>;
+type LazyFn = (
+  value: unknown,
+  index: number,
+  items: readonly unknown[],
+) => LazyResult<unknown>;
+type LazyMeta = { readonly single?: boolean };
+type LazyDefinition = {
+  readonly lazy: LazyMeta & ((...args: any) => LazyFn);
+  readonly lazyArgs: readonly unknown[];
+};
+
+export function make(
+  lazy: (...args: any) => LazyEvaluator,
+  args: readonly unknown[],
+) {
+  const [, ...rest] = args;
+  return { lazy, lazyArgs: rest } satisfies LazyDefinition;
+}
+"#,
+    );
+}
+
+#[test]
+fn satisfies_function_against_top_level_object_and_call_intersection() {
+    // Top-level form (not nested in an object literal target).
+    no_assignability_errors(
+        r#"
+type Meta = { readonly single?: boolean };
+type Call = (...args: any) => number;
+
+declare const fn: (...args: any) => number;
+const ok = fn satisfies Meta & Call;
+"#,
+    );
+}
+
+#[test]
+fn assignment_function_against_object_and_call_intersection_renamed_binders() {
+    // Renamed binders (anti-hardcoding) + plain assignment form.
+    no_assignability_errors(
+        r#"
+type Brand = { readonly tag?: string };
+type Handler = (input: unknown) => boolean;
+
+declare const probe: (input: unknown) => true;
+const slot: Brand & Handler = probe;
+"#,
+    );
+}
+
+#[test]
+fn parameter_passing_function_against_object_and_call_intersection() {
+    // Parameter-passing form must agree with `satisfies` / assignment.
+    no_assignability_errors(
+        r#"
+type Marker = { readonly hidden?: boolean };
+type Fn = (x: unknown) => void;
+
+declare function accept(value: Marker & Fn): void;
+declare const cb: (x: unknown) => void;
+accept(cb);
+"#,
+    );
+}
+
+#[test]
+fn function_against_intersection_with_required_member_is_rejected() {
+    // Negative control: the object constituent has a *required* member that
+    // a bare function does not carry, so the relation must fail (TS2322),
+    // matching tsc.
+    let source = r#"
+type RequiredMeta = { tag: string };
+type Fn = (x: unknown) => void;
+
+declare const cb: (x: unknown) => void;
+const slot: RequiredMeta & Fn = cb;
+"#;
+    let diagnostics = compile_and_get_diagnostics_with_lib(source);
+    assert!(
+        has_error(&diagnostics, 2322),
+        "expected TS2322 because the function lacks the required `tag`. diagnostics: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn function_against_weak_object_alone_is_rejected() {
+    // Negative control: a *direct* assignment to a weak (all-optional) object
+    // type — not an intersection member — still reports the weak-type error
+    // (TS2559), because the function has no property in common with it.
+    let source = r#"
+type Weak = { readonly single?: boolean };
+declare const cb: (...args: any) => void;
+const slot: Weak = cb;
+"#;
+    let diagnostics = compile_and_get_diagnostics_with_lib(source);
+    assert!(
+        has_error(&diagnostics, 2559) || has_error(&diagnostics, 2322),
+        "expected a weak-type / assignability error for a bare function vs a weak object. diagnostics: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -2,6 +2,7 @@ mod cross_module_unique_symbol;
 mod defaults;
 mod distributive_tuple_union;
 mod r#enum;
+mod function_intersection_target;
 mod indexed_access;
 mod membership_semantics;
 mod narrowing;

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -638,15 +638,52 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // directly to avoid polluting the subtype cache with results computed under
             // different weak-type-enforcement policies.
             let saved = self.in_intersection_member_check;
+            let saved_property_check = self.in_property_check;
             self.in_intersection_member_check = true;
-            for &member in member_list.iter() {
-                if !self.check_subtype(source, member).is_true() {
-                    self.in_intersection_member_check = saved;
-                    return SubtypeResult::False;
+
+            // tsc judges weak-ness on the WHOLE intersection target, not per
+            // member: `isWeakType(A & B)` is true only when *every* member is a
+            // weak object type. A member check inside an outer property comparison
+            // sets `in_property_check`, which would otherwise force the per-member
+            // weak check back on (objects.rs) even though the combined target is
+            // not weak — e.g. `Meta & ((...args) => Fn)` is non-weak because the
+            // call-signature member is not a weak object. When the whole
+            // intersection is not weak, clear `in_property_check` for the member
+            // checks so a source that satisfies every constituent — including a
+            // function value satisfying an all-optional object constituent — is
+            // accepted, matching tsc. When the whole intersection IS weak (every
+            // member weak), keep `in_property_check` so
+            // `{ c: string } <: { a?: string } & { b?: number }` still fails.
+            // The weak-ness prepass only matters when `in_property_check` is set
+            // (otherwise the clear is a no-op), so the common path pays nothing.
+            if self.in_property_check {
+                let intersection_target_is_weak = member_list.iter().all(|&member| {
+                    let resolved = self.resolve_lazy_type(member);
+                    object_shape_id(self.interner, resolved)
+                        .or_else(|| object_with_index_shape_id(self.interner, resolved))
+                        .map(|sid| self.interner.object_shape(sid))
+                        .is_some_and(|shape| Self::is_weak_type_shape(&shape))
+                });
+                if !intersection_target_is_weak {
+                    self.in_property_check = false;
                 }
             }
+
+            let mut all_members_match = true;
+            for &member in member_list.iter() {
+                if !self.check_subtype(source, member).is_true() {
+                    all_members_match = false;
+                    break;
+                }
+            }
+
             self.in_intersection_member_check = saved;
-            return SubtypeResult::True;
+            self.in_property_check = saved_property_check;
+            return if all_members_match {
+                SubtypeResult::True
+            } else {
+                SubtypeResult::False
+            };
         }
 
         if let (Some(s_kind), Some(t_kind)) = (

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -1805,7 +1805,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Check if an object shape is a "weak type": all properties are optional,
     /// there is at least one property, and there are no index signatures.
     /// Weak types trigger TS2559 when the source has no common properties.
-    fn is_weak_type_shape(shape: &ObjectShape) -> bool {
+    pub(crate) fn is_weak_type_shape(shape: &ObjectShape) -> bool {
         !shape.properties.is_empty()
             && shape.string_index.is_none()
             && shape.number_index.is_none()

--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -800,6 +800,40 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
             // Function expressions are assignable to the global `Function` interface.
             // Avoid expanding and comparing every `Function` interface member.
             SubtypeResult::True
+        } else if object_shape_id(self.checker.interner, self.target).is_some()
+            || object_with_index_shape_id(self.checker.interner, self.target).is_some()
+        {
+            // Function <: Object / ObjectWithIndex.
+            //
+            // A function value is an object whose apparent type carries the global
+            // `Function` interface members (`bind`, `call`, `apply`, `name`,
+            // `length`, ...). It is therefore assignable to a plain object target
+            // when that apparent type satisfies the target's required properties —
+            // e.g. an all-optional object constituent of an intersection such as
+            // `LazyMeta & ((...args: any) => Fn)`, where `LazyMeta` is `{ x?: T }`.
+            // This mirrors tsc relating `getApparentType` of a function to an
+            // object type, and parallels the existing `Callable <: Object` arm
+            // below (a hybrid callable already resolves its own properties here).
+            //
+            // The current `in_intersection_member_check` flag is preserved (not
+            // reset): as an intersection member the weak-type check (TS2559) stays
+            // suppressed, so the function satisfies an all-optional member, while a
+            // *direct* assignment to a weak type still triggers TS2559 because the
+            // boxed `Function` interface has properties yet none in common with the
+            // weak target.
+            let boxed_function = self
+                .checker
+                .resolver
+                .get_boxed_type(IntrinsicKind::Function)
+                .or_else(|| {
+                    self.checker
+                        .interner
+                        .get_boxed_type(IntrinsicKind::Function)
+                });
+            match boxed_function {
+                Some(boxed) => self.checker.check_subtype(boxed, self.target),
+                None => SubtypeResult::False,
+            }
         } else {
             SubtypeResult::False
         }


### PR DESCRIPTION
Fixes #14156.

Goal: green

## Structural rule
When a source is checked against an intersection target whose constituents combine an object type with a call signature (`Meta & ((...args: any) => Fn)`), `tsc` requires the source to be assignable to **each** constituent independently, and judges weak-ness on the **whole** intersection — `isWeakType(A & B)` is true only when *every* member is a weak object type. A function value is an object whose apparent type carries the global `Function` interface members, so it satisfies an all-optional object constituent (`{ x?: T }`) while a call-signature constituent is satisfied by return-type covariance. `tsz` rejected the function with a false **TS1360**/**TS2322**.

```ts
type LazyMeta = { readonly single?: boolean };
type LazyFn = (value: unknown, index: number, items: readonly unknown[]) => { done: boolean; next: unknown };
type LazyDefinition = {
  readonly lazy: LazyMeta & ((...args: any) => LazyFn);
  readonly lazyArgs: readonly unknown[];
};
export function make(lazy: (...args: any) => LazyFn, args: readonly unknown[]) {
  const [, ...rest] = args;
  return { lazy, lazyArgs: rest } satisfies LazyDefinition; // tsc OK | tsz before: TS1360
}
```

## Owner layer
Solver — structural subtype relation. Two coupled defects:

1. `crates/tsz-solver/src/relations/subtype/visitor.rs` — `visit_function` had **no `Function <: Object/ObjectWithIndex` arm** and returned `false` for a plain object target, so a bare function never satisfied an all-optional object constituent. It now resolves the function's apparent type (the boxed global `Function` interface, via the resolver→interner `get_boxed_type` fallback already used for primitives) and relates it to the object target — mirroring tsc's `getApparentType` and the adjacent `Callable <: Object` arm. The `in_intersection_member_check` flag is preserved (not reset), so the weak-type check (TS2559) stays suppressed as an intersection member yet still fires for a *direct* assignment to a weak type.

2. `crates/tsz-solver/src/relations/subtype/core_dispatch.rs` — the intersection-target per-member loop let an outer property comparison's `in_property_check` flag force the per-member weak-type check back on, even though `Meta & Call` is not weak. The loop now clears `in_property_check` for the member checks when the whole intersection is not weak (computed only when `in_property_check` is set, so the common path pays nothing), matching tsc applying `isWeakType` once to the combined target. A genuinely weak intersection keeps the check.

No raw `TypeData` matching in the checker, no identifier/file-name strings, no printer-output predicates; shape decisions go through the existing `object_shape_id` / `is_weak_type_shape` / `get_boxed_type` boundaries.

## Adjacent-case matrix (in `crates/tsz-checker/tests/conformance_issues/types/function_intersection_target.rs`, renamed binders throughout)
Accept (no error), verified vs `tsc`:
- the reduced remeda repro (`satisfies`, property-nested intersection target);
- top-level `fn satisfies Meta & Call`;
- plain assignment `const slot: Brand & Handler = probe` with return-covariant function;
- parameter passing `accept(cb)` where the param is `Marker & Fn`.

Negative controls (still error), verified vs `tsc`:
- object constituent with a **required** member the function lacks → **TS2322** (`(x: unknown) => void` not assignable to `RequiredMeta & Fn`);
- **direct** assignment of a function to a weak object type (not an intersection member) → **TS2559** (no properties in common).

## Verification
- New suite: `cargo test --release -p tsz-checker --test conformance_issues_types function_intersection_target` → **6 passed**.
- Targeted regression (no new failures): `weak_object_union_member_subtype_reduction_tests`, `global_function_intrinsic_assignability_tests`, `fresh_intersection_display_tests`, `excess_property_check_recursive_intersection_tests`, `intersection_merged_property_write_type_tests` → **40 passed, 0 failed**; full `conformance_issues_types` → 341 passed, the only 2 failures (`test_generic_indexed_access_variance_failure_preserves_ts2322`, `test_invariant_recursive_generic_error_elaboration_preserves_ts2322`) are **pre-existing** and fail identically on a stash of `main` (lib-submodule / no-lib environment-local).
- Built `.target/release/tsz` and confirmed the issue repro now compiles clean and both negative controls still report TS2322 / TS2559, matching `tsc`.
- `cargo fmt` clean; `cargo clippy --release -p tsz-solver --lib` clean.
- Reviewed with `/simplify`: folded the dual save/restore of `in_intersection_member_check` / `in_property_check` into a single restore point and gated the weak-ness prepass on `in_property_check` (no-op otherwise); the reuse suggestion (`CompatChecker::is_weak_type`) was declined as it is not reachable from `SubtypeChecker` without an architectural change.

Broad conformance/emit/fourslash delegated to ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwkQLryHGNnKCsqSfymShy)_