### PR TITLE
chore(ci): green no-regression baseline for project-compile canary (data-only)

### DIFF
--- a/scripts/ci/project-compat-baseline.json
+++ b/scripts/ci/project-compat-baseline.json
@@ -1,0 +1,22 @@
+{
+  "schema": "tsz-project-compat-baseline/v1",
+  "description": "No-regression ratchet baseline for the project-compile canary. Each listed row currently compiles like tsc ('green'); once the canary is flipped to blocking, a merge that regresses any of these rows from green to non-green is blocked. Rows NOT listed (currently red/yellow/gray, or brand-new) are advisory and never block. Application rows that fail to clone/install are recorded as 'fixture invalid' (gray) and treated as inconclusive, not a regression. DATA ONLY at this stage: no gate reads this file yet; it is wired up when the canary becomes blocking. Regenerate by intersecting the green rows across recent successful main-CI project-compile-compatibility + project-compile-canary-logs artifacts (exclude any row that is green in only some runs).",
+  "source": {
+    "ci_run_ids": ["27887229928", "27886360536"],
+    "source_commit": "01bebe97d9bdf2a49c4e18419e94bcf3d6084392",
+    "artifact_generated_at": "2026-06-20T23:45:40.444Z",
+    "method": "intersection of green rows across the two most recent successful main CI runs (zero divergence between them)"
+  },
+  "rows": {
+    "comlink-project": "green",
+    "infisical-project": "green",
+    "nextjs-fresh-app": "green",
+    "rxjs-project": "green",
+    "ts-essentials-project": "green",
+    "ts-toolbelt-project": "green",
+    "type-challenges-solutions-project": "green",
+    "type-fest-project": "green",
+    "utility-types-project": "green",
+    "vite-vanilla-ts-app": "green"
+  }
+}


### PR DESCRIPTION
## Summary

Add `scripts/ci/project-compat-baseline.json` — the **green no-regression baseline** for the project-compile canary. It records the rows that currently compile like `tsc`; once the canary is flipped to blocking, a merge that regresses any of these from green will fail. **DATA ONLY** at this stage — no gate reads the file yet.

## How it was computed

Intersection of green rows across the **two most recent successful main-CI runs** (`27887229928` + `27886360536`, source `01bebe97d9`) over their `project-compile-compatibility` + `project-compile-canary-logs` artifacts. The two runs agreed exactly (no flaky-green excluded). Result: **10 stable green rows**.

Notably, **all 20 application rows are currently red/yellow**, so the future blocking ratchet installs **zero** apps in the gating path — keeping it inside the ~15–20m CI budget.

## Why land it separately (data-only first)

Keeps the upcoming gate-flip PR small and makes the protected set independently reviewable/greppable. Fully reversible — deleting the file is a no-op until the gate consumes it. Regeneration method is documented in the file's `description`.

Goal: green

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- `python3 -c "import json; json.load(open('scripts/ci/project-compat-baseline.json'))"` parses.
- Green set verified **stable across 2 runs** (intersection == each run's green set; zero divergence).
- No code reads the file yet → zero behavior change.
- Campaign step QW3 (compat no-regression ratchet baseline; perf=cadence / compat=per-commit gate simplification).
