### PR TITLE
fix(checker): resolve indexed access of a builtin-named namespace member

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -599,6 +599,9 @@ path = "tests/ts2303_tests.rs"
 name = "namespace_qualified_diagnostic_tests"
 path = "tests/namespace_qualified_diagnostic_tests.rs"
 [[test]]
+name = "namespace_builtin_collision_indexed_access_tests"
+path = "tests/namespace_builtin_collision_indexed_access_tests.rs"
+[[test]]
 name = "class_reserved_word_diagnostics_tests"
 path = "tests/class_reserved_word_diagnostics_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -1400,6 +1400,121 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         Some(def_id)
     }
 
+    /// Look up `member_name` among the exported members of a namespace / module /
+    /// enum `container` symbol.
+    ///
+    /// Checks the container's `exports` and `members` tables first. When both
+    /// miss, falls back to the binder's parent linkage: the member symbol records
+    /// its owning namespace in `Symbol::parent` even when the namespace's
+    /// `exports` table does not surface it. That gap appears when a user
+    /// namespace whose name collides with a global builtin type (`Iterator`,
+    /// `Array`, …) is merged with the lib symbol: the merge keeps the member's
+    /// `parent` pointer but drops the namespace's `exports` entry, so a plain
+    /// `exports` lookup would miss the member. The parent-linkage scan is bounded
+    /// by the number of same-named symbols and only runs after the direct lookup
+    /// fails.
+    fn namespace_member_symbol(
+        &self,
+        container: tsz_binder::SymbolId,
+        member_name: &str,
+        lib_binders: &[std::sync::Arc<tsz_binder::BinderState>],
+    ) -> Option<tsz_binder::SymbolId> {
+        let container_symbol = self
+            .ctx
+            .binder
+            .get_symbol_with_libs(container, lib_binders)?;
+        if let Some(member) = container_symbol
+            .exports
+            .as_ref()
+            .and_then(|exports| exports.get(member_name))
+            .or_else(|| {
+                container_symbol
+                    .members
+                    .as_ref()
+                    .and_then(|members| members.get(member_name))
+            })
+        {
+            return Some(member);
+        }
+        self.ctx
+            .binder
+            .symbols
+            .find_all_by_name(member_name)
+            .iter()
+            .copied()
+            .find(|&candidate| {
+                self.ctx
+                    .binder
+                    .get_symbol(candidate)
+                    .is_some_and(|symbol| symbol.parent == container)
+            })
+    }
+
+    /// Resolve an entity-name node (identifier or qualified name) to the binder
+    /// symbol bound by lexical scope, following nested namespace members.
+    ///
+    /// Unlike [`resolve_type_symbol`], this does not require the `TYPE` flag, so
+    /// it returns namespace / module declarations. It is used to locate a local
+    /// namespace that owns a qualified-name member even when a same-named global
+    /// builtin type would otherwise win the type-symbol race.
+    fn entity_name_scope_symbol(
+        &self,
+        node_idx: NodeIndex,
+        lib_binders: &[std::sync::Arc<tsz_binder::BinderState>],
+    ) -> Option<tsz_binder::SymbolId> {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let node = self.ctx.arena.get(node_idx)?;
+        if node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
+            return self.ctx.binder.resolve_identifier(self.ctx.arena, node_idx);
+        }
+        if node.kind == syntax_kind_ext::QUALIFIED_NAME {
+            let qn = self.ctx.arena.get_qualified_name(node)?;
+            let left_sym = self.entity_name_scope_symbol(qn.left, lib_binders)?;
+            let resolved_left = self
+                .ctx
+                .binder
+                .resolve_import_symbol(left_sym)
+                .unwrap_or(left_sym);
+            let right_name = self.ctx.arena.get_identifier_text(qn.right)?;
+            return self.namespace_member_symbol(resolved_left, right_name, lib_binders);
+        }
+        None
+    }
+
+    /// For `N.X` in type position, resolve `X` through a local namespace / module
+    /// declaration `N` reachable by lexical scope, returning its registered
+    /// `DefId`. Returns `None` (deferring to the broader walk) unless `N` resolves
+    /// to a namespace/module/enum that actually owns `X`, keeping import-alias and
+    /// lib-only cases on their existing paths.
+    fn qualified_name_member_def_via_local_namespace(
+        &self,
+        left: NodeIndex,
+        right: NodeIndex,
+        lib_binders: &[std::sync::Arc<tsz_binder::BinderState>],
+    ) -> Option<tsz_solver::def::DefId> {
+        use tsz_binder::symbol_flags;
+
+        let left_sym = self.entity_name_scope_symbol(left, lib_binders)?;
+        let resolved_left = self
+            .ctx
+            .binder
+            .resolve_import_symbol(left_sym)
+            .unwrap_or(left_sym);
+        let resolved_symbol = self
+            .ctx
+            .binder
+            .get_symbol_with_libs(resolved_left, lib_binders)?;
+        // Only namespace-like containers own qualified-name type members. Type
+        // parameters and bare type aliases/interfaces are handled elsewhere.
+        if !resolved_symbol.has_any_flags(symbol_flags::NAMESPACE) {
+            return None;
+        }
+        let right_name = self.ctx.arena.get_identifier_text(right)?;
+        let member_sym_id = self.namespace_member_symbol(resolved_left, right_name, lib_binders)?;
+        Some(self.ensure_def_id_with_alias(member_sym_id))
+    }
+
     /// Resolve a DefId with support for qualified names (e.g., `AnimalType.cat`).
     ///
     /// Used by the `compute_type` fallback path where template literal types may
@@ -1478,6 +1593,22 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 .iter()
                 .map(|ctx| std::sync::Arc::clone(&ctx.binder))
                 .collect();
+
+            // The leftmost segment of a qualified type name may name a namespace /
+            // module, which carries no `TYPE` flag. `resolve_type_symbol` only
+            // returns `TYPE`/`ENUM` symbols, so for `N.X` where a user namespace
+            // `N` shares its name with a global builtin type (`Iterator`, `Array`,
+            // …) it skips the local namespace and the ad-hoc walk below binds `N`
+            // to the global lib symbol, whose exports never contain `X`. Resolve
+            // `N` through the binder's lexical scope first: a local namespace /
+            // module declaration that exports `X` wins, matching how the global
+            // namespace merges with (and the lexical declaration shadows) the
+            // same-named builtin.
+            if let Some(member_def_id) =
+                self.qualified_name_member_def_via_local_namespace(qn.left, qn.right, &lib_binders)
+            {
+                return Some(member_def_id);
+            }
             // For the left part of a qualified name (e.g., `Lib` in `Lib.Base`),
             // we need to also consider ALIAS symbols because import declarations
             // like `import Lib = require('./helper')` create ALIAS-flagged symbols.

--- a/crates/tsz-checker/tests/namespace_builtin_collision_indexed_access_tests.rs
+++ b/crates/tsz-checker/tests/namespace_builtin_collision_indexed_access_tests.rs
@@ -1,0 +1,134 @@
+//! Regression tests: indexed access of a member of a user namespace whose name
+//! equals a global builtin type.
+//!
+//! In a script, a top-level `namespace Iterator { export type Obj = ... }`
+//! merges with the global lib `Iterator`. The qualified type `Iterator.Obj`
+//! resolves, but the indexed access `Iterator.Obj["foo"]` used to stay
+//! unevaluated (the leftmost `Iterator` resolved to the lib type symbol, whose
+//! exports never contain `Obj`), producing a false `TS2322`. Resolving the
+//! leftmost segment through lexical scope — preferring the local namespace and
+//! falling back to the member's namespace parent linkage — lets `N.X[K]` reduce.
+//!
+//! The names are varied (`Iterator`, `Array`, `Promise`) so the fix exercises a
+//! structural rule, not a single hardcoded builtin name.
+
+use std::sync::Arc;
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+
+fn check(source: &str) -> Vec<Diagnostic> {
+    let libs: Vec<Arc<LibFile>> = tsz_checker::test_utils::load_default_lib_files();
+    tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+        &libs,
+    )
+}
+
+fn codes(diags: &[Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|d| d.code).collect()
+}
+
+#[test]
+fn indexed_access_of_builtin_named_namespace_member_reduces() {
+    // tsc: clean. The indexed access must reduce to `number`, so the matching
+    // literal is assignable and no TS2322 is emitted.
+    let source = r#"
+namespace Iterator { export type Obj = { foo: number }; }
+const a: Iterator.Obj["foo"] = 5;
+"#;
+    let diags = check(source);
+    assert!(
+        !codes(&diags).contains(&2322),
+        "expected no TS2322 for Iterator.Obj[\"foo\"] = 5, got: {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn indexed_access_of_builtin_named_namespace_member_still_type_checks() {
+    // The reduced type is `number`, so a string value must still be rejected.
+    let source = r#"
+namespace Iterator { export type Obj = { foo: number }; }
+const b: Iterator.Obj["foo"] = "str";
+"#;
+    let diags = check(source);
+    assert!(
+        codes(&diags).contains(&2322),
+        "expected TS2322 for string assigned to Iterator.Obj[\"foo\"], got: {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn array_named_namespace_member_indexed_access_reduces() {
+    // Name varied to `Array` (also a global builtin) to keep the rule structural.
+    let source = r#"
+namespace Array { export type Box = { bar: string }; }
+const c: Array.Box["bar"] = "hi";
+const d: Array.Box["bar"] = 5;
+"#;
+    let diags = check(source);
+    let only_2322: Vec<u32> = codes(&diags).into_iter().filter(|&c| c == 2322).collect();
+    // The valid assignment must not error; the invalid one (number to string) must.
+    assert_eq!(
+        only_2322,
+        vec![2322],
+        "expected exactly one TS2322 (for `= 5`), got: {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn nested_builtin_named_namespace_member_indexed_access_reduces() {
+    // Nested namespace under a builtin-named outer namespace.
+    let source = r#"
+namespace Promise { export namespace Inner { export type T = { n: number }; } }
+const e: Promise.Inner.T["n"] = 3;
+const f: Promise.Inner.T["n"] = "x";
+"#;
+    let diags = check(source);
+    let only_2322: Vec<u32> = codes(&diags).into_iter().filter(|&c| c == 2322).collect();
+    assert_eq!(
+        only_2322,
+        vec![2322],
+        "expected exactly one TS2322 (for `= \"x\"`), got: {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn missing_member_of_builtin_named_namespace_still_reports_ts2694() {
+    // Negative control: a genuinely missing member must still surface TS2694,
+    // i.e. the parent-linkage fallback must not invent members.
+    let source = r#"
+namespace Iterator { export type Obj = { foo: number }; }
+const g: Iterator.Missing = 1;
+"#;
+    let diags = check(source);
+    assert!(
+        codes(&diags).contains(&2694),
+        "expected TS2694 for Iterator.Missing, got: {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn member_does_not_leak_to_global_scope() {
+    // The namespace member must not become resolvable as a bare global name.
+    let source = r#"
+namespace Iterator { export type Obj = { foo: number }; }
+const h: Obj = { foo: 1 };
+"#;
+    let diags = check(source);
+    assert!(
+        codes(&diags).contains(&2304),
+        "expected TS2304 for bare `Obj`, got: {:?}",
+        codes(&diags)
+    );
+}


### PR DESCRIPTION
Fixes #14237.

## Summary
Mined from **hotscript**. In a script, a top-level `namespace N` whose name
equals a global builtin type (`Iterator`, `Array`, …) merges with the lib
symbol, but the binder lib-merge keeps only the member symbol's `parent`
linkage and drops the namespace's `exports` entry for that member. The lowering
qualified-name resolver (`resolve_def_id_with_qualified_names`) bound the
leftmost segment `N` through `resolve_type_symbol`, which returns only
`TYPE`/`ENUM` symbols and therefore picked the global lib **type** — whose
exports never contain the member. `N.X` stayed unevaluated and `N.X[K]` emitted
a false **TS2322** (`'number' not assignable to 'Iterator.Obj["foo"]'`), while a
plain `N.X` (non-indexed) already resolved through a different path.

```ts
namespace Iterator { export type Obj = { foo: number }; }
const f: Iterator.Obj["foo"] = 5;   // tsc: ok ; tsz (before): TS2322
```

## Structural rule
When a qualified type name `N.X` has its leftmost segment bound to a local
namespace/module declaration that shares a name with a global builtin type, tsc
resolves `N` to the local namespace and looks `X` up in its members. tsz now
resolves the leftmost segment through the binder's **lexical scope** (which does
not require the `TYPE` flag, so it sees the namespace), and looks the member up
via `exports`/`members` with a fallback to the member symbol's namespace
`parent` linkage — recovering members the lib-merge dropped from the `exports`
table.

## Owner / layer
Checker — `resolve_def_id_with_qualified_names` and three new private helpers on
`TypeNodeChecker` (`namespace_member_symbol`, `entity_name_scope_symbol`,
`qualified_name_member_def_via_local_namespace`). The new path runs only in the
qualified-name fallback, after the existing entity-name and type-symbol lookups
miss, so import-alias and lib-only cases keep their current behavior. The
parent-linkage scan is name-indexed (`find_all_by_name`) and only runs after the
direct `exports`/`members` lookup fails.

## Adjacent cases (covered by tests)
- builtin-named namespace `Iterator`/`Array`/`Promise`, `N.X[K]` indexed;
- nested namespaces `Promise.Inner.T["n"]`;
- positive (valid value) and negative (wrong value still TS2322) forms;
- negative control: missing member still reports **TS2694**;
- the member does not leak to global scope (bare `Obj` still **TS2304**).

## Anti-hardcoding
Lexical-scope + parent-linkage structural rule, not a builtin-name allowlist.
Tests vary the colliding binder name (`Iterator`, `Array`, `Promise`).

## Known follow-up
The deeper cause is the binder lib-merge dropping a user namespace's `exports`
when it merges with a same-named global builtin. This change fixes the
qualified-name lowering path that surfaced the reported regression; a binder-side
fix to repopulate the merged symbol's `exports` would generalize the same parent
linkage to every consumer, but carries wider blast radius across global-type
merging and is left as a separate change.

## Verification
- New target `namespace_builtin_collision_indexed_access_tests` (6 tests) — pass.
- `cargo test -p tsz-checker --lib qualified` (17) and `namespace` (126) — pass.
- Full `cargo test -p tsz-checker --lib`: failure set identical before/after this
  change (0 introduced, 0 fixed at the unit level; the regression is conformance-
  shaped and covered by the new lib-loaded test target).

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2KQm4C8YuNPfCyzZrMAUP)_