### PR TITLE
fix(solver): allow non-tuple spread into global Function/any callee (#14218)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -238,6 +238,9 @@ mod flow_truthy_proves_assignment_tests;
 #[path = "tests/flow_usage_relation_routing_arch_tests.rs"]
 mod flow_usage_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/function_callee_spread_ts2556_tests.rs"]
+mod function_callee_spread_ts2556_tests;
+#[cfg(test)]
 #[path = "tests/function_type_relation_routing_arch_tests.rs"]
 mod function_type_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/function_callee_spread_ts2556_tests.rs
+++ b/crates/tsz-checker/src/tests/function_callee_spread_ts2556_tests.rs
@@ -1,0 +1,125 @@
+//! Regression tests for false-positive TS2556 when spread-calling a value typed
+//! as the global `Function` interface (or `Function`/`any` intrinsic).
+//!
+//! Root cause of the original report (mined from deepkit-type): a value typed as
+//! the global `Function` interface is callable in TypeScript through the
+//! implicit any-signature `(...args: any[]): any`, so a non-tuple spread
+//! argument can never overflow a fixed-arity parameter list and `tsc` reports no
+//! TS2556. tsz's contextual "does this non-tuple spread land on a rest/optional
+//! tail position?" probe returned `false` for the object-shaped `Function`
+//! interface, and the global-`Function`-to-`any` re-collection threaded a
+//! `none()` callable context whose fallback also rejected the spread, so tsz
+//! emitted a spurious TS2556.
+//!
+//! Fix: the contextual rest-position extractor treats the `Function`/`any`
+//! intrinsic and the structurally-sniffed global `Function` interface object as
+//! having an implicit `(...args: any[])` rest position, and the boxed-`Function`
+//! call re-collection threads an `any` callable context (routed through the
+//! `expected == any` short-circuit) instead of a no-callable context.
+//!
+//! Test integrity: every assertion loads the real default libs
+//! ([`load_default_lib_files`]) so `Function`, `Map`, and the iterator protocol
+//! resolve to their genuine lib shapes — the minimal unit-test lib does not
+//! declare them, which would make these guards pass vacuously.
+//!
+//! Issue: <https://github.com/tsz-org/tsz/issues/14218>
+
+use std::sync::{Arc, OnceLock};
+use tsz_binder::lib_loader::LibFile;
+
+use crate::CheckerOptions;
+use crate::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
+
+/// The default lib bundle, parsed once and shared across this module.
+fn default_libs() -> &'static [Arc<LibFile>] {
+    static DEFAULT_LIBS: OnceLock<Vec<Arc<LibFile>>> = OnceLock::new();
+    DEFAULT_LIBS.get_or_init(load_default_lib_files)
+}
+
+fn check(src: &str) -> Vec<(u32, String)> {
+    check_source_with_libs_code_messages(src, "test.ts", CheckerOptions::default(), default_libs())
+}
+
+const TS2556: u32 = 2556;
+
+fn ts2556(diags: &[(u32, String)]) -> Vec<&(u32, String)> {
+    diags.iter().filter(|(code, _)| *code == TS2556).collect()
+}
+
+/// The exact witness from issue #14218: spreading a non-tuple iterable
+/// (`Map<...>.values()`) into a value typed as the global `Function` interface
+/// is clean in `tsc`; tsz must not emit TS2556.
+#[test]
+fn spread_iterable_into_global_function_value_no_ts2556() {
+    let diags = check(
+        r#"
+declare const f: Function;
+declare const m: Map<string, any>;
+const r = f(...m.values());
+void r;
+"#,
+    );
+
+    assert!(
+        ts2556(&diags).is_empty(),
+        "expected no TS2556 for spread into a global `Function` value, got: {diags:?}"
+    );
+}
+
+/// The same call shaped over an array spread and a renamed binder: the rule
+/// keys on the structural `Function` shape, not the identifier, so a differently
+/// named `Function`-typed value must be equally clean.
+#[test]
+fn spread_array_into_renamed_function_value_no_ts2556() {
+    let diags = check(
+        r#"
+declare const myCallable: Function;
+declare const xs: number[];
+const r = myCallable(...xs);
+void r;
+"#,
+    );
+
+    assert!(
+        ts2556(&diags).is_empty(),
+        "expected no TS2556 for array spread into a renamed `Function` value, got: {diags:?}"
+    );
+}
+
+/// An `any`-typed callee shares the implicit any-signature: a non-tuple spread
+/// is likewise clean.
+#[test]
+fn spread_into_any_callee_no_ts2556() {
+    let diags = check(
+        r#"
+declare const g: any;
+declare const xs: number[];
+const r = g(...xs);
+void r;
+"#,
+    );
+
+    assert!(
+        ts2556(&diags).is_empty(),
+        "expected no TS2556 for spread into an `any` callee, got: {diags:?}"
+    );
+}
+
+/// Negative control: spreading a non-tuple array into a callee with a fixed
+/// arity and no rest parameter still overflows the parameter list, so TS2556
+/// must still fire — the fix must not blanket-suppress the diagnostic.
+#[test]
+fn spread_array_into_fixed_arity_callee_still_emits_ts2556() {
+    let diags = check(
+        r#"
+declare function fixed(x: number, y: number): void;
+declare const xs: number[];
+fixed(...xs);
+"#,
+    );
+
+    assert!(
+        !ts2556(&diags).is_empty(),
+        "expected TS2556 for a non-tuple spread into a fixed-arity callee, got: {diags:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -832,12 +832,20 @@ impl<'a> CheckerState<'a> {
             self.replace_function_type_for_call(callee_type, callee_type_for_call);
         if callee_type_for_call == TypeId::ANY {
             let check_excess_properties = false;
+            // The callee resolved to the implicit any-signature `(...args: any[])`
+            // of the global `Function`/`any` callee, so the re-collection must
+            // treat the parameter list as `any`-callable: a non-tuple spread can
+            // never overflow a fixed-arity slot. Threading an `ANY` callable
+            // context (instead of `none()`) routes the TS2556 spread-arity check
+            // through the `expected == ANY` short-circuit in
+            // `ContextualTypeContext::allows_non_tuple_spread_position`, matching
+            // tsc which reports no TS2556 for `(f: Function)(...iter)`.
             self.collect_call_argument_types_with_context(
                 args,
                 |_i, _arg_count| None,
                 check_excess_properties,
                 None, // No skipping needed
-                CallableContext::none(),
+                CallableContext::new(TypeId::ANY),
             );
             return if nullish_cause.is_some() {
                 common::union_with_undefined(self.ctx.types, TypeId::ANY)

--- a/crates/tsz-solver/src/contextual/extractors.rs
+++ b/crates/tsz-solver/src/contextual/extractors.rs
@@ -1839,8 +1839,19 @@ impl<'a> RestOrOptionalTailPositionExtractor<'a> {
 impl<'a> TypeVisitor for RestOrOptionalTailPositionExtractor<'a> {
     type Output = Option<bool>;
 
-    fn visit_intrinsic(&mut self, _kind: IntrinsicKind) -> Self::Output {
-        None
+    fn visit_intrinsic(&mut self, kind: IntrinsicKind) -> Self::Output {
+        // The `Function` intrinsic (and `Any`) is callable with the
+        // any-signature `(...args: any[]): any` -- it imposes no fixed-arity
+        // parameter list, so a non-tuple spread can never overflow a non-rest
+        // parameter. tsc resolves `(f: Function)(...iter)` through that
+        // any-signature with no TS2556. Returning `true` here mirrors the
+        // `expected == ANY` short-circuit in
+        // `ContextualTypeContext::allows_non_tuple_spread_position`, which only
+        // covers the literal `ANY`/`ERROR` `TypeId`s and not this intrinsic.
+        match kind {
+            IntrinsicKind::Function | IntrinsicKind::Any => Some(true),
+            _ => None,
+        }
     }
 
     fn visit_literal(&mut self, _value: &LiteralValue) -> Self::Output {
@@ -1850,6 +1861,19 @@ impl<'a> TypeVisitor for RestOrOptionalTailPositionExtractor<'a> {
     fn visit_function(&mut self, shape_id: u32) -> Self::Output {
         let shape = self.db.function_shape(FunctionShapeId(shape_id));
         Some(is_rest_or_optional_tail_position(&shape.params, self.index))
+    }
+
+    fn visit_object(&mut self, shape_id: u32) -> Self::Output {
+        // The global `Function` interface object (carrying `apply`/`call`/
+        // `bind` but no explicit call signature) is callable with the same
+        // any-signature as the `Function` intrinsic in tsc, so a non-tuple
+        // spread into such a callee is allowed. Reuse the shared structural
+        // sniff that backs `matches_global_function_interface_shape`.
+        let shape = self.db.object_shape(ObjectShapeId(shape_id));
+        if crate::type_queries::object_shape_matches_global_function_interface(self.db, &shape) {
+            return Some(true);
+        }
+        None
     }
 
     fn visit_callable(&mut self, shape_id: u32) -> Self::Output {

--- a/crates/tsz-solver/src/type_queries/global_interfaces/mod.rs
+++ b/crates/tsz-solver/src/type_queries/global_interfaces/mod.rs
@@ -133,24 +133,36 @@ pub fn matches_global_object_interface_shape(db: &dyn TypeDatabase, type_id: Typ
     })
 }
 
+/// Shape-level structural fallback for the global `Function` interface.
+///
+/// `true` when the shape has at most
+/// [`GLOBAL_FUNCTION_INTERFACE_MAX_PROPERTIES`] properties and declares
+/// `apply`, `call`, and `bind`. This is the single shared copy of the
+/// historical sniff; prefer [`is_global_function_interface`] which tries
+/// identity first.
+pub fn object_shape_matches_global_function_interface(
+    db: &dyn TypeDatabase,
+    shape: &ObjectShape,
+) -> bool {
+    if shape.properties.len() > GLOBAL_FUNCTION_INTERFACE_MAX_PROPERTIES {
+        return false;
+    }
+    let apply = db.intern_string("apply");
+    let call = db.intern_string("call");
+    let bind = db.intern_string("bind");
+    shape.properties.iter().any(|p| p.name == apply)
+        && shape.properties.iter().any(|p| p.name == call)
+        && shape.properties.iter().any(|p| p.name == bind)
+}
+
 /// Structural fallback for the global `Function` interface on a `TypeId`.
 ///
-/// `true` when the type is an object shape with at most
-/// [`GLOBAL_FUNCTION_INTERFACE_MAX_PROPERTIES`] properties declaring `apply`,
-/// `call`, and `bind`. This is the single shared copy of the historical
-/// sniff; prefer [`is_global_function_interface`] which tries identity first.
+/// See [`object_shape_matches_global_function_interface`]. Returns `false` for
+/// intrinsics and non-object types.
 pub fn matches_global_function_interface_shape(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     object_like_shape_id(db, type_id).is_some_and(|shape_id| {
         let shape = db.object_shape(shape_id);
-        if shape.properties.len() > GLOBAL_FUNCTION_INTERFACE_MAX_PROPERTIES {
-            return false;
-        }
-        let apply = db.intern_string("apply");
-        let call = db.intern_string("call");
-        let bind = db.intern_string("bind");
-        shape.properties.iter().any(|p| p.name == apply)
-            && shape.properties.iter().any(|p| p.name == call)
-            && shape.properties.iter().any(|p| p.name == bind)
+        object_shape_matches_global_function_interface(db, &shape)
     })
 }
 


### PR DESCRIPTION
## Summary
Mined from **deepkit-type**. Spread-calling a value typed as the global `Function` interface (or the `Function`/`any` intrinsic) is clean in `tsc`, but tsz emitted a spurious **TS2556** ("A spread argument must either have a tuple type or be passed to a rest parameter").

```ts
declare const f: Function;
declare const m: Map<string, any>;
const r = f(...m.values());   // tsz: TS2556. tsc: clean.
void r;
```

`tsc -p` -> 0; `tsz -p` (pre-fix) -> TS2556. After this change both are 0.

Goal: green

## Structural rule
When a callee's expected type is the `Function`/`any` intrinsic or the global `Function` interface (an object shape carrying `apply`/`call`/`bind` with **no explicit call signature**), tsc resolves the call through the implicit any-signature `(...args: any[]): any`, so a non-tuple spread argument can never overflow a fixed-arity parameter list and **no TS2556** is reported. tsz does this through the solver contextual rest-position extractor plus the boxed-`Function` call re-collection.

## Owner layer
Two coordinated sites carry the rule (a single repro exercises both passes of argument collection):

- **`crates/tsz-solver/src/contextual/extractors.rs`** — `RestOrOptionalTailPositionExtractor`: `visit_intrinsic` now returns `Some(true)` for `IntrinsicKind::Function | IntrinsicKind::Any`, and a new `visit_object` returns `Some(true)` when the object shape structurally matches the global `Function` interface. This handles the first argument-collection pass, where the callable context still holds the lowered `Function` object shape.
- **`crates/tsz-checker/src/types/computation/call/inner.rs`** — when a global-`Function`/`any` callee is folded to `ANY` for the call, the re-collection now threads `CallableContext::new(TypeId::ANY)` (was `none()`), routing the TS2556 spread-arity check through the existing `expected == ANY` short-circuit in `ContextualTypeContext::allows_non_tuple_spread_position`. This handles the second (post-fold) pass.
- **`crates/tsz-solver/src/type_queries/global_interfaces/mod.rs`** — factored the canonical `apply`/`call`/`bind` + property-count-cap sniff into a shared `object_shape_matches_global_function_interface(db, shape)` (mirroring the existing `object_shape_matches_global_object_interface`), reused by both `matches_global_function_interface_shape` and the new `visit_object`. No new name/file-name literals; keys on the builtin `Function`/`any` shape, not an identifier.

## Adjacent cases (verified vs tsc, parity confirmed)
- Spread of a non-tuple **iterable** (`Map.values()`) and a non-tuple **array** into a `Function`-typed callee: clean.
- Renamed binder (`myCallable: Function`): clean (rule keys on shape, not name).
- `any`-typed callee: clean.
- Non-spread call `f(1, 2)` on a `Function` value: clean (already was).
- **Negative control**: non-tuple array spread into a callee with a **fixed** arity and no rest still emits TS2556 in both tsz and tsc.

## Verification
- Repro: `tsz -p /tmp/land4-14218/tsconfig.json` -> 0 and `tsc -p` -> 0 (strict, exactOptionalPropertyTypes, noUncheckedIndexedAccess, noEmit, target/lib ES2022, module ESNext, moduleResolution Bundler).
- Narrow regression test (lib-loaded, all 4 pass with fix; the two positive `Function`-value cases fail without it):
  `cargo nextest run -p tsz-checker function_callee_spread_ts2556`
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets -- -D warnings` and `cargo fmt --check`: clean.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Fixes #14218
