### PR TITLE
fix(checker): accept unary +/- numeric-literal computed property name (TS1170) (#14256)

### DIFF
--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -990,6 +990,22 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // A unary `+`/`-` applied directly to a numeric or bigint literal
+        // (`[-1]`, `[+1]`, `[-1n]`) is a numeric-literal-typed computed property
+        // name; tsc accepts it as a literal name. The operand must be the literal
+        // itself, so a non-literal operand like `[-x]` is still rejected. (#14256)
+        if let Some(expr_node) = self.ctx.arena.get(computed.expression)
+            && expr_node.kind == tsz_parser::parser::syntax_kind_ext::PREFIX_UNARY_EXPRESSION
+            && let Some(unary) = self.ctx.arena.get_unary_expr(expr_node)
+            && (unary.operator == SyntaxKind::PlusToken as u16
+                || unary.operator == SyntaxKind::MinusToken as u16)
+            && let Some(operand) = self.ctx.arena.get(unary.operand)
+            && (operand.kind == SyntaxKind::NumericLiteral as u16
+                || operand.kind == SyntaxKind::BigIntLiteral as u16)
+        {
+            return false;
+        }
+
         // Entity name expressions (identifiers, property access chains) are always
         // structurally OK for computed property names — skip the TS1166/TS1169 error.
         if is_entity_name {

--- a/crates/tsz-checker/tests/conformance_issues/types/computed_property_names.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/computed_property_names.rs
@@ -1,0 +1,39 @@
+//! Computed property name literal-form acceptance (TS1170). (#14256)
+
+use super::super::core::*;
+
+/// A unary `+`/`-` applied directly to a numeric or bigint literal is a
+/// numeric-literal-typed computed property name; tsc accepts it. tsz previously
+/// rejected `[-1]`/`[+1]`/`[-1n]` with TS1170 because its literal-form gate only
+/// recognized bare `NumericLiteral`/`StringLiteral`. Mined from ts-arithmetic.
+#[test]
+fn unary_numeric_literal_computed_property_no_ts1170() {
+    let diagnostics = compile_and_get_diagnostics(
+        r"
+type M = { [-1]: 0; [+2]: 1; [-3n]: 2 };
+type X = M[-1];
+        ",
+    );
+    assert!(
+        !has_error(&diagnostics, 1170),
+        "unary +/- over a numeric/bigint literal is a literal computed-property name; \
+         no TS1170 expected. Actual diagnostics: {diagnostics:#?}"
+    );
+}
+
+/// Negative control: a unary operator that is NOT `+`/`-` (here bitwise `~`) is
+/// not a numeric-literal-form name, so TS1170 must still fire — the fix is gated
+/// on the operator and a literal operand, not on "any prefix-unary expression".
+#[test]
+fn non_plusminus_unary_computed_property_still_ts1170() {
+    let diagnostics = compile_and_get_diagnostics(
+        r"
+type N = { [~1]: 0 };
+        ",
+    );
+    assert!(
+        has_error(&diagnostics, 1170),
+        "`[~1]` is not a numeric-literal-form computed property name; TS1170 expected. \
+         Actual diagnostics: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -1,3 +1,4 @@
+mod computed_property_names;
 mod const_initializer_widening;
 mod cross_module_unique_symbol;
 mod defaults;


### PR DESCRIPTION
Closes #14256.

## Structural rule
A computed property name that is a unary `+`/`-` applied directly to a numeric or bigint literal — `{ [-1]: 0 }`, `{ [+1]: 0 }`, `{ [-1n]: 0 }` — is a numeric-literal-typed name that `tsc` accepts. `tsz` emitted a false **TS1170** because the literal-form gate only recognized bare `StringLiteral`/`NumericLiteral`/`NoSubstitutionTemplateLiteral`, not the `PrefixUnaryExpression` form (mined from ts-arithmetic).

## Owner layer
Checker `check_computed_property_requires_literal` in `crates/tsz-checker/src/checkers/property_checker.rs` — the shared TS1166/TS1169/TS1170 gate. Accept a prefix-unary `+`/`-` whose operand is a numeric or bigint literal as a literal computed-property name. Structural AST-form gate (no name-string check).

## Adjacent-case matrix
- `{ [-1]: 0; [+2]: 1; [-3n]: 2 }` → no TS1170.
- **Negative controls preserved:** `[~1]` (non-`+/-` operator) → still TS1170; a non-literal operand (`[-x]`) → still TS1170 (operand must be the literal itself).

## Verification
- New tests in `conformance_issues/types/computed_property_names.rs` (witness + negative control) pass.
- Computed-property slice (`test(computed)+test(ts1166/1169/1170)+test(property_name)+test(class_property)`): **343/349 pass**. The 6 failures (`keyof` unique-symbol display, generic-property-mismatch display, `object_entries`, unique-symbol computed keys) do not use unary-numeric computed property names, so this AST-form gate change is provably inert for them (pre-existing Mac-only failures). CI (Linux) runs the full checker suite as the authoritative gate.

Goal: green

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max