### PR TITLE
fix(solver): infer array-target element from variadic tuple rest element type, not the spread constraint array (#14175)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1805,6 +1805,9 @@ path = "tests/optional_property_required_elaboration_tests.rs"
 name = "variadic_tuple_arity_inference_tests"
 path = "tests/variadic_tuple_arity_inference_tests.rs"
 [[test]]
+name = "variadic_infer_element_tests"
+path = "tests/variadic_infer_element_tests.rs"
+[[test]]
 name = "diagnostic_index_suppression_tests"
 path = "tests/diagnostic_index_suppression_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/variadic_infer_element_tests.rs
+++ b/crates/tsz-checker/tests/variadic_infer_element_tests.rs
@@ -1,0 +1,96 @@
+//! Regression tests for issue #14175.
+//!
+//! Inferring `T` from a parameter `T[]` given an argument of variadic-tuple
+//! type `[...End extends string[]]` must infer `T = string` (the element type),
+//! not `T = string[]` (the spread's constraint array). The wrong inference made
+//! `head(end)` resolve to `string[]` and a downstream `const s: string = x`
+//! failed with a spurious TS2322.
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs, load_default_lib_files};
+
+/// Type-check `source` with the default lib bundle wired in (array/tuple
+/// element semantics depend on the `Array<T>` global), returning every
+/// diagnostic code. The empty-lib fast path cannot resolve `End[number]`.
+fn diag_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs)
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+/// The exact issue repro: `head<T>(a: T[])` called with a `[...End]` argument
+/// where `End extends string[]`. tsc infers `x: string`, so `const s: string =
+/// x` type-checks. Before the fix tsz inferred `x: string[]` and reported a
+/// spurious TS2322.
+#[test]
+fn variadic_tuple_spread_infers_element_type_not_constraint_array() {
+    let source = r#"
+declare function head<T>(array: T[]): T;
+function probe<End extends string[]>(end: [...End]) {
+  const x = head(end);
+  const s: string = x;
+}
+"#;
+    let codes = diag_codes(source);
+    assert!(
+        !codes.contains(&2322),
+        "expected no TS2322 (x should be inferred as string); got {codes:?}"
+    );
+}
+
+/// Adjacent binder-name variation with a different constraint element type:
+/// `Tail extends number[]`, so the spread element is `number` and a downstream
+/// `const m: number = y` must type-check.
+#[test]
+fn variadic_tuple_spread_infers_element_type_binder_variation() {
+    let source = r#"
+declare function take<U>(items: U[]): U;
+function gather<Tail extends number[]>(tail: [...Tail]) {
+  const y = take(tail);
+  const m: number = y;
+}
+"#;
+    let codes = diag_codes(source);
+    assert!(
+        !codes.contains(&2322),
+        "expected no TS2322 (y should be inferred as number); got {codes:?}"
+    );
+}
+
+/// Negative control: a concrete array argument still infers the element type as
+/// before. `head([1, 2, 3])` must infer `T = number`, so assigning the result
+/// to a `string` must still report TS2322 (the fix must not blanket-suppress).
+#[test]
+fn concrete_array_still_infers_element_type() {
+    let source = r#"
+declare function head<T>(array: T[]): T;
+const n = head([1, 2, 3]);
+const bad: string = n;
+"#;
+    let codes = diag_codes(source);
+    assert!(
+        codes.contains(&2322),
+        "expected TS2322 assigning number element to string; got {codes:?}"
+    );
+}
+
+/// Negative control: a genuine nested `T[][]` vs `T[]` parameter still infers
+/// the inner element-array correctly. `flat<T>(a: T[][]): T[]` called with
+/// `[[1],[2]]` infers `T = number`, returns `number[]`, and assigning that to a
+/// `string[]` must report TS2322 (the element-extraction rule must not collapse
+/// the nesting one level too far).
+#[test]
+fn nested_array_parameter_still_infers_one_level() {
+    let source = r#"
+declare function flat<T>(a: T[][]): T[];
+const ff = flat([[1], [2]]);
+const bad: string[] = ff;
+"#;
+    let codes = diag_codes(source);
+    assert!(
+        codes.contains(&2322),
+        "expected TS2322 assigning number[] to string[]; got {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/operations/call_args.rs
+++ b/crates/tsz-solver/src/operations/call_args.rs
@@ -1211,6 +1211,31 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         }
     }
 
+    /// Element type of a tuple rest element when inferring against a plain array
+    /// target `T[]` (tsc's `getElementTypeOfArrayType` for the variadic case).
+    ///
+    /// A concrete `...E[]` rest contributes `E`. A variadic `...G` rest, where
+    /// `G` is a generic spread (type parameter, lazy reference, application,
+    /// conditional, …) constrained to an array, contributes its number-indexed
+    /// element type `G[number]` rather than the spread type `G` itself. Binding
+    /// the array target's element to `G` would resolve to `G`'s whole constraint
+    /// array (e.g. `string[]` for `End extends string[]`); tsc instead infers the
+    /// element type (`End[number]`).
+    pub(crate) fn array_target_element_of_rest_type(&self, type_id: TypeId) -> TypeId {
+        if type_id.is_intrinsic() {
+            return type_id;
+        }
+        let unwrapped = self.unwrap_readonly(type_id);
+        match self.interner.lookup(unwrapped) {
+            // Concrete array spread `...E[]`: the element type is `E`.
+            Some(TypeData::Array(elem)) => elem,
+            // Variadic spread `...G` of a non-array-literal type: the element
+            // type is the number-indexed access `G[number]`, deferred until the
+            // spread's binding is known (matching tsc's display `End[number]`).
+            _ => self.interner.index_access(unwrapped, TypeId::NUMBER),
+        }
+    }
+
     /// Maximum iterations for type unwrapping loops to prevent infinite loops.
     const MAX_UNWRAP_ITERATIONS: usize = 1000;
 

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -1038,7 +1038,16 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 let s_elems = self.interner.tuple_list(s_elems);
                 for s_elem in s_elems.iter() {
                     if s_elem.rest {
-                        let rest_elem_type = self.rest_element_type(s_elem.type_id);
+                        // tsc infers a plain array target's element from the
+                        // *element type* of the rest. For a concrete `...E[]`
+                        // that is `E`; for a variadic `...T` (where `T` is a
+                        // generic spread constrained to an array, e.g. `[...End]`
+                        // with `End extends string[]`) the element type is
+                        // `T[number]`, NOT `T` itself. Constraining against the
+                        // raw spread type bound `T` to the whole constraint array
+                        // (`string[]`); using the number-indexed element matches
+                        // tsc, which infers the element type (`End[number]`).
+                        let rest_elem_type = self.array_target_element_of_rest_type(s_elem.type_id);
                         self.constrain_types(ctx, var_map, rest_elem_type, t_elem, priority);
                     } else {
                         self.constrain_types(ctx, var_map, s_elem.type_id, t_elem, priority);


### PR DESCRIPTION
Goal: green

## Summary
Inferring `T` from a parameter `T[]` against a variadic-tuple argument `[...End]` now infers the element type (`End[number]`), not the spread's whole constraint array.

Structural rule: When a tuple source is matched against a plain array target `T[]` during call-argument inference, tsc infers `getElementTypeOfArrayType(source)` against the target element; for a variadic rest element `...G` (a generic spread constrained to an array, e.g. `[...End]` with `End extends string[]`) the element type is `G[number]`, not `G`. tsz now does X through the solver constraint walker (`crates/tsz-solver/src/operations/constraints/walker.rs`, `(Tuple, Array)` arm).

Root cause: the `(Tuple source, Array target)` arm in the constraint walker used `rest_element_type`, which returns the rest element's array element for a concrete `...E[]` but the raw spread type for a variadic `...G` (a type parameter / lazy / application). For `[...End]` that bound `T` to `End` itself, which instantiated to `End`'s whole constraint array `string[]`, so `head(end)` resolved to `string[]` and `const s: string = x` produced a spurious TS2322. The fix adds `array_target_element_of_rest_type` (in `operations/call_args.rs`): a concrete `...E[]` still contributes `E`, while a variadic `...G` contributes the number-indexed element `G[number]` (a deferred index access that resolves to the constraint's element, matching tsc's displayed `End[number]`). This removes a false-positive TS2322 on a variadic-tuple call canary without widening any other inference. #13817 fixed the checker-side spread call-arg mirror; this solver-inference path is distinct.

## Verification
- `CARGO_TARGET_DIR=/Users/mohsen/code/.tsz-shared-target cargo nextest run -p tsz-checker --test variadic_infer_element_tests` — green (4/4). New flipping test `variadic_tuple_spread_infers_element_type_not_constraint_array` (plus a binder-renamed adjacent case `..._binder_variation`) fails on main and passes with the fix; negative controls `concrete_array_still_infers_element_type` and `nested_array_parameter_still_infers_one_level` keep their expected TS2322 and pass on both main and fix.
- `CARGO_TARGET_DIR=/Users/mohsen/code/.tsz-shared-target cargo nextest run -p tsz-solver infer constrain tuple variadic call` — 1948/1949 green; the sole failure (`test_conditional_infer_optional_property_present_distributive`) is pre-existing on clean main (verified by stashing the fix), unrelated to this change.
- The issue's minimal repro now matches tsc 6.0.3: `tsz --noEmit --strict --target esnext --skipLibCheck` exits 0 on the repro and on the negative controls (`head([1,2,3])` infers `T=number`; `flat<T>(a:T[][])` infers `T=number`), identical to `tsc`. `head(end)` now types `x` as `string` (`End[number]`), matching tsc.

Closes #14175

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
