### PR TITLE
fix(checker): resolve globalThis.X in type position to the global type (TS2339) (#14227)

### DIFF
--- a/crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs
@@ -282,6 +282,24 @@ impl<'a> CheckerState<'a> {
             Some(qn) => qn,
             None => return TypeSymbolResolution::NotFound,
         };
+
+        // `globalThis.X` in type position: `globalThis` is the synthetic global
+        // namespace anchor with no binder symbol, so resolving it as the left
+        // qualifier fails and `globalThis.RegExp` reports a false TS2339 (typebox).
+        // Resolve the member `X` as a global type, matching tsc. Guarded on the
+        // left being the *unshadowed* `globalThis` identifier (a user binding
+        // named `globalThis` resolves to a real symbol and keeps the normal
+        // path), and an unknown member still fails through the global type
+        // lookup. (#14227)
+        if let Some(left_node) = self.ctx.arena.get(qn.left)
+            && left_node.kind == SyntaxKind::Identifier as u16
+            && let Some(ident) = self.ctx.arena.get_identifier(left_node)
+            && ident.escaped_text == "globalThis"
+            && self.resolve_identifier_symbol(qn.left).is_none()
+        {
+            return self.resolve_identifier_symbol_in_type_position(qn.right);
+        }
+
         let mut left_sym = match self.resolve_qualified_symbol_inner_in_type_position(
             qn.left,
             visited_aliases,

--- a/crates/tsz-checker/tests/conformance_issues/types/global_this_type.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/global_this_type.rs
@@ -1,0 +1,61 @@
+//! `globalThis.X` in type position resolves to the global type `X`. (#14227)
+
+use super::super::core::*;
+
+/// `globalThis.X` in a type position (here a type-predicate's asserted type)
+/// must resolve `globalThis` to the synthetic global namespace and `X` to the
+/// ambient global type, matching tsc. tsz previously failed to resolve the
+/// `globalThis` qualifier and reported a false TS2339 on the narrowed value
+/// (typebox). Binder-varied across distinct global types.
+#[test]
+fn global_this_qualified_type_resolves_no_ts2339() {
+    for ty in ["RegExp", "Boolean", "Number"] {
+        let source = format!(
+            r#"
+function isThing(value: unknown): value is globalThis.{ty} {{
+  return typeof value === "object";
+}}
+declare const v: unknown;
+function use() {{
+  if (isThing(v)) {{
+    return v.valueOf();
+  }}
+  return undefined;
+}}
+export {{ use }};
+"#
+        );
+        let diagnostics = compile_and_get_diagnostics(&source);
+        assert!(
+            !has_error(&diagnostics, 2339),
+            "[globalThis.{ty}] must resolve to the global type; no TS2339 expected. \
+             Diagnostics: {diagnostics:#?}"
+        );
+        assert!(
+            !has_error(&diagnostics, 2304),
+            "[globalThis.{ty}] global qualifier must resolve; no TS2304 expected. \
+             Diagnostics: {diagnostics:#?}"
+        );
+    }
+}
+
+/// Negative control: an unknown member of `globalThis` must still fail to
+/// resolve (the fix routes the member through the normal global type lookup,
+/// it does not blanket-accept any `globalThis.X`).
+#[test]
+fn global_this_unknown_member_still_errors() {
+    let diagnostics = compile_and_get_diagnostics(
+        r"
+type Bad = globalThis.ThisIsDefinitelyNotARealGlobalType;
+export type { Bad };
+        ",
+    );
+    let resolved_error = diagnostics
+        .iter()
+        .any(|(code, _)| *code == 2304 || *code == 2694 || *code == 2552);
+    assert!(
+        resolved_error,
+        "an unknown `globalThis` member must report a not-found error. \
+         Diagnostics: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -3,6 +3,7 @@ mod cross_module_unique_symbol;
 mod defaults;
 mod distributive_tuple_union;
 mod r#enum;
+mod global_this_type;
 mod indexed_access;
 mod membership_semantics;
 mod narrowing;


### PR DESCRIPTION
Closes #14227.

## Structural rule
In a type position, `globalThis.X` must resolve `globalThis` to the synthetic global namespace and `X` to the ambient global type, matching tsc. `tsz` failed to resolve the `globalThis` qualifier (it has no binder symbol), so a type reference like `value is globalThis.RegExp` reported a false **TS2339** on the narrowed value (typebox).

## Owner layer
Checker qualified-type-name resolver `resolve_qualified_symbol_inner_in_type_position` in `crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs`. When the left qualifier is the **unshadowed** `globalThis` identifier, resolve the right member as a global type. Narrow blast radius — only fires for `globalThis.X`.

## Adjacent-case matrix
- `globalThis.RegExp` / `globalThis.Boolean` / `globalThis.Number` in a predicate's asserted type → resolve, no TS2339/TS2304.
- **Negative controls:** a user binding named `globalThis` (resolves to a real symbol) keeps the normal path; an unknown member (`globalThis.NotAType`) still reports a not-found error (routed through the global type lookup, not blanket-accepted).

## Verification
- New tests in `conformance_issues/types/global_this_type.rs` (witness ×3 binder-varied + unknown-member negative control). Local full-suite runs were memory-killed by concurrent multi-session build contention on this machine; the change compiles cleanly and is gated to `globalThis.X`. CI (isolated Linux) runs the full checker suite as the authoritative gate.

Goal: green

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max