### PR TITLE
fix(checker): accept unary +/- numeric &amp; bigint literal computed property names (TS1170)

### DIFF
--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -938,6 +938,35 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Whether `expr_node` is a unary `+`/`-` applied directly to a numeric or bigint
+    /// literal (e.g. `-1`, `+1`, `-1n`, `+0x10n`).
+    ///
+    /// Such a `PrefixUnaryExpression` has a numeric/bigint *literal* type in tsc, so it
+    /// is a valid literal computed-property name. The operand must be the literal itself;
+    /// a non-literal operand like `-x` is not accepted (the caller then falls through to
+    /// the TS1166/TS1169/TS1170 error).
+    fn is_unary_numeric_literal_name(
+        arena: &tsz_parser::parser::NodeArena,
+        expr_node: &tsz_parser::parser::node::Node,
+    ) -> bool {
+        if expr_node.kind != tsz_parser::parser::syntax_kind_ext::PREFIX_UNARY_EXPRESSION {
+            return false;
+        }
+        let Some(unary) = arena.get_unary_expr(expr_node) else {
+            return false;
+        };
+        if unary.operator != SyntaxKind::PlusToken as u16
+            && unary.operator != SyntaxKind::MinusToken as u16
+        {
+            return false;
+        }
+        let Some(operand_node) = arena.get(unary.operand) else {
+            return false;
+        };
+        operand_node.kind == SyntaxKind::NumericLiteral as u16
+            || operand_node.kind == SyntaxKind::BigIntLiteral as u16
+    }
+
     /// Check a computed property name requires a simple literal or unique symbol type.
     ///
     /// Used for TS1166 (class properties), TS1169 (interfaces), and TS1170 (type literals).
@@ -978,13 +1007,17 @@ impl<'a> CheckerState<'a> {
 
         let is_entity_name = self.is_entity_name_expression(computed.expression);
 
-        // Literal expressions (string, number, no-substitution template) are always OK
-        // since they inherently have literal types
+        // Literal expressions (string, number, bigint, no-substitution template) are
+        // always OK since they inherently have literal types. A unary `+`/`-` applied
+        // directly to a numeric/bigint literal (e.g. `[-1]`, `[+1]`, `[-1n]`) is also a
+        // literal-typed name in tsc, so accept it via the same structural gate.
         if let Some(expr_node) = self.ctx.arena.get(computed.expression) {
             let kind = expr_node.kind;
             if kind == SyntaxKind::StringLiteral as u16
                 || kind == SyntaxKind::NumericLiteral as u16
+                || kind == SyntaxKind::BigIntLiteral as u16
                 || kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+                || Self::is_unary_numeric_literal_name(self.ctx.arena, expr_node)
             {
                 return false;
             }

--- a/crates/tsz-checker/src/tests/ts1170_computed_property_syntactic_form_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1170_computed_property_syntactic_form_tests.rs
@@ -144,7 +144,7 @@ type M = { [+1]: 0 };
     );
 }
 
-/// BigInt literals (plain and negated) are literal-typed computed names — no TS1170.
+/// `BigInt` literals (plain and negated) are literal-typed computed names — no TS1170.
 #[test]
 fn ts1170_not_emitted_for_bigint_literals() {
     let codes = diag_codes(

--- a/crates/tsz-checker/src/tests/ts1170_computed_property_syntactic_form_tests.rs
+++ b/crates/tsz-checker/src/tests/ts1170_computed_property_syntactic_form_tests.rs
@@ -113,3 +113,94 @@ type X = {
         "TS1170 must fire for parenthesized access regardless of identifier names. Got: {codes:?}"
     );
 }
+
+/// A negative numeric-literal computed property name is literal-typed in tsc and
+/// must NOT produce TS1170. Source: `ts-arithmetic`.
+#[test]
+fn ts1170_not_emitted_for_negative_numeric_literal() {
+    let codes = diag_codes(
+        r#"
+type M = { [-1]: 0; 0: 1; 1: 2 };
+type X = M[-1];
+"#,
+    );
+    assert!(
+        !codes.contains(&1170),
+        "TS1170 must NOT fire for a negative numeric-literal computed name. Got: {codes:?}"
+    );
+}
+
+/// Unary `+` over a numeric literal is also literal-typed — no TS1170.
+#[test]
+fn ts1170_not_emitted_for_unary_plus_numeric_literal() {
+    let codes = diag_codes(
+        r#"
+type M = { [+1]: 0 };
+"#,
+    );
+    assert!(
+        !codes.contains(&1170),
+        "TS1170 must NOT fire for a unary-plus numeric-literal computed name. Got: {codes:?}"
+    );
+}
+
+/// BigInt literals (plain and negated) are literal-typed computed names — no TS1170.
+#[test]
+fn ts1170_not_emitted_for_bigint_literals() {
+    let codes = diag_codes(
+        r#"
+type M = { [1n]: 0; [-1n]: 1 };
+"#,
+    );
+    assert!(
+        !codes.contains(&1170),
+        "TS1170 must NOT fire for bigint-literal computed names. Got: {codes:?}"
+    );
+}
+
+/// Interfaces and classes share the same gate (TS1169/TS1166) — negative
+/// numeric-literal names are accepted there too.
+#[test]
+fn ts1169_ts1166_not_emitted_for_negative_numeric_literal() {
+    let iface = diag_codes(
+        r#"
+interface I {
+    [-1]: number;
+}
+"#,
+    );
+    assert!(
+        !iface.contains(&1169),
+        "TS1169 must NOT fire for a negative numeric-literal interface member. Got: {iface:?}"
+    );
+    let class = diag_codes(
+        r#"
+class C {
+    [-1]: number = 0;
+}
+"#,
+    );
+    assert!(
+        !class.contains(&1166),
+        "TS1166 must NOT fire for a negative numeric-literal class property. Got: {class:?}"
+    );
+}
+
+/// Negative control: a unary operator over a *non-literal* operand (`-x`) is not
+/// a literal name, so TS1170 still fires. The fix is structural, not a blanket
+/// accept of every `PrefixUnaryExpression`.
+#[test]
+fn ts1170_still_emitted_for_unary_over_non_literal() {
+    let codes = diag_codes(
+        r#"
+declare const x: number;
+type X = {
+    [-x]: number,
+};
+"#,
+    );
+    assert!(
+        codes.contains(&1170),
+        "TS1170 must still fire for a unary operator over a non-literal operand. Got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #14256.

A computed property name that is a unary `+`/`-` applied directly to a numeric
or bigint literal (e.g. `[-1]`, `[+1]`, `[-1n]`) is a **literal-typed** name in
`tsc` and must not be rejected. tsz emitted a false `TS1170` (and the parallel
`TS1166`/`TS1169` for classes/interfaces):

```ts
type M = { [-1]: 0; 0: 1; 1: 2 };
type X = M[-1];   // tsc: 0 ; tsz (before): repro.ts(...) TS1170
```

## Structural rule

When a computed property name in a type literal / interface / class is a unary
`+`/`-` (`PrefixUnaryExpression{Plus|Minus}`) over a `NumericLiteral` (or
`BigIntLiteral`), `tsc` treats it as a numeric/bigint-literal-typed name and
accepts it. tsz did `X` through the checker's `check_computed_property_requires_literal`
literal-form gate, which only recognized bare `StringLiteral`/`NumericLiteral`/
`NoSubstitutionTemplateLiteral` and so fell through to the "computed property
name must be a literal" error for the signed form. The gate also omitted plain
`BigIntLiteral` (`[1n]`).

## Owner layer

Checker — `crates/tsz-checker/src/checkers/property_checker.rs`,
`check_computed_property_requires_literal`. The fix is a purely structural
AST-form gate (matching how the existing literal kinds and entity-name checks
work, and how `tsc` itself decides this syntactically):

- accept `BigIntLiteral` directly, and
- accept a `PrefixUnaryExpression` with a `+`/`-` token over a `NumericLiteral`
  or `BigIntLiteral` operand (new `is_unary_numeric_literal_name` helper).

The gate is shared by type literals (TS1170), interfaces (TS1169) and classes
(TS1166), so all three are fixed together.

## Adjacent-case matrix

- Positive: `[-1]`, `[+1]`, `[1n]`, `[-1n]` accepted in type literal, interface,
  and class positions.
- Already-accepted control: plain `[1]`, `["a"]` still accepted.
- Negative/fallback control: `[-x]` (unary over a non-literal operand) **still**
  emits TS1170 — the fix is structural, not a blanket accept of every
  `PrefixUnaryExpression`.
- Anti-hardcoding: no identifier/file-name/printer-string checks; the gate reads
  only AST node kinds and the unary operator token.

## Verification

- New unit tests in
  `crates/tsz-checker/src/tests/ts1170_computed_property_syntactic_form_tests.rs`
  (negative numeric, unary plus, bigint plain+negated, interface/class parity,
  and the `[-x]` negative control).
- `cargo test -p tsz-checker --lib ts1170` → `11 passed; 0 failed`.
- Ready-review CI owns the broad conformance/emit suites.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvMVzS5Dtw2rLBUyzEHanJ)_