### PR TITLE
fix(solver): widen any-arity fresh literal union during inference (TS2345/TS2322)

### DIFF
--- a/crates/tsz-solver/src/operations/widening.rs
+++ b/crates/tsz-solver/src/operations/widening.rs
@@ -470,14 +470,30 @@ fn widen_type_cached(
                 }
             };
             let has_literal = members.iter().any(|&m| is_fresh_member(m));
-            let small_fresh_union = has_literal
-                && members.len() <= 3
+            // A union of only fresh literals (`"a" | "b" | …`, optionally with
+            // pass-through `undefined`/`null`/`void`). `small_fresh_union` caps
+            // this at 3 members for the general/display/argument paths because a
+            // larger literal union there is more likely to come from a type alias
+            // (`type Lang = "fr" | "en" | "es" | "de"`) that must keep its
+            // members. The inference and mutable-binding callers
+            // (`widen_object_union_members == true`) already establish freshness
+            // upstream — they only deep-widen array/tuple/object literals whose
+            // candidate is fresh (not a `type`-annotated source) — so for them
+            // the arity cap is wrong: tsc widens a fresh literal element union to
+            // its primitive regardless of how many distinct literals it has
+            // (`frz(["PATCH","POST","PUT","DELETE"])` → `Readonly<string[]>`).
+            let all_fresh_literal_or_passthrough = has_literal
                 && members
                     .iter()
                     .all(|&m| is_fresh_member(m) || is_passthrough_intrinsic(m));
+            let small_fresh_union = all_fresh_literal_or_passthrough && members.len() <= 3;
+            let fresh_literal_union =
+                widen_object_union_members && all_fresh_literal_or_passthrough;
             let has_fresh_object_or_array_member =
                 members.iter().any(|&m| is_fresh_object_or_array_member(m));
-            if small_fresh_union || (widen_object_union_members && has_fresh_object_or_array_member)
+            if small_fresh_union
+                || fresh_literal_union
+                || (widen_object_union_members && has_fresh_object_or_array_member)
             {
                 let mut members_to_widen = members.to_vec();
                 if widen_object_union_members {


### PR DESCRIPTION
Goal: green

Clears false **TS2345/TS2322** when a type parameter is inferred from a fresh literal array with 4+ distinct element literals (ofetch `isPayloadMethod` / `Object.freeze([...])`).

## Structural rule
When `T` is inferred from a fresh array/tuple/object-literal in whole-parameter position (`f<T>(o: T)`, e.g. `Object.freeze<T>(o: T): Readonly<T>`), tsc's `getWidenedType` widens the fresh literal element union to its primitive regardless of member count, so `["PATCH","POST","PUT","DELETE"]` infers `T = string[]`. tsz gated fresh-literal-union widening behind an arity cap `members.len() <= 3` for **all** callers (a heuristic standing in for tsc's `RequiresWidening`), so a 4+-member fresh literal union element was left un-widened → false errors. The fix splits the gate: the `≤3` heuristic stays for the display/general/argument paths (`widen_object_union_members == false`, where a large literal union is likely a non-fresh alias to preserve), but the two fresh-only callers `widen_type_for_inference` / `widen_type_for_mutable_binding` (already freshness-gated upstream via `has_type_annotation_candidate`) now widen any union of fresh-literal-or-passthrough members regardless of arity. Anti-hardcoding: purely structural (member freshness + the existing caller flag).

## Adjacent matrix
- `const y: string = frz(["A","B","C","D"])[0]` → clean (matches tsc; was un-widened union). Numeric + renamed-binder 5-member variants likewise.
- **Negatives:** non-fresh alias `const langs: Lang[] = [...]; new Set(frz(langs)).add("XYZ")` → still TS2345 vs `Lang` in both tsz and tsc (freshness gate intact). Display path (`type Color` 4-member alias) → un-widened in both (untouched).

## Verification
- Positive matches bundled tsc byte-for-byte; negatives still error in both.
- ofetch: TS2345 2→1 (the targeted `utils.ts:14` FP removed; the other 9 ofetch FPs are separate DOM-heritage roots, unchanged); no new errors.
- Regression delta vs clean `main`: `tsz-solver --lib widen` 130/130, `--lib inference` 570/570, `tsz-checker --lib widen` 126/126 (incl. the unique-symbol DTS display tests, which use the untouched `widen_object_union_members=false` path). Zero new failures. clippy clean.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
