### PR TITLE
fix(solver): peel transparent identity-alias union arms in generic inference (#14251)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -174,6 +174,9 @@ path = "tests/async_iterable_type_param_element_tests.rs"
 name = "array_element_naked_inference_tests"
 path = "tests/array_element_naked_inference_tests.rs"
 [[test]]
+name = "identity_alias_union_arm_inference_tests"
+path = "tests/identity_alias_union_arm_inference_tests.rs"
+[[test]]
 name = "recursive_array_utility_inference_tests"
 path = "tests/recursive_array_utility_inference_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/identity_alias_union_arm_inference_tests.rs
+++ b/crates/tsz-checker/tests/identity_alias_union_arm_inference_tests.rs
@@ -1,0 +1,138 @@
+//! Regression tests for issue #14251.
+//!
+//! When a generic call infers a type parameter `A` from a union target whose
+//! arm is a *transparent identity-alias application* — an alias whose body is
+//! exactly its own type parameter, e.g. `type Some<X> = X`, applied as
+//! `Some<A>` — tsc treats the arm as the naked variable `A` and unions the
+//! unmatched source constituents into it (`A = number`). tsz previously kept
+//! `Some<A>` as an opaque `Application`, so the arm partitioned as a structured
+//! member instead of a naked variable; the unmatched source constituents never
+//! reached `A`, which collapsed to its `{}` default and leaked the `None`
+//! branch, producing a spurious `TS2362` (`O.map(O.fromNullable(...), x => x * 2)`
+//! mined from ts-belt).
+//!
+//! The fix peels a transparent identity-alias arm to its forwarded type during
+//! union-inference partitioning. These tests pin the behaviour for several
+//! structurally equivalent shapes — not just the reported spelling — and guard
+//! the cases that must *not* be peeled (aliases whose body adds structure).
+
+use tsz_checker::test_utils::check_source_code_messages as compile_and_get_diagnostics;
+
+fn diag_count(source: &str, code: u32) -> usize {
+    compile_and_get_diagnostics(source)
+        .iter()
+        .filter(|(c, _)| *c == code)
+        .count()
+}
+
+fn total_diags(source: &str) -> usize {
+    compile_and_get_diagnostics(source).len()
+}
+
+/// The reported repro: ts-belt-style `Option`, overloaded `map`, identity-alias
+/// `Some<A>` arm. tsc infers `A = number`, so `x * 2` is clean.
+#[test]
+fn ts_belt_option_map_identity_alias_arm_no_ts2362() {
+    let source = r#"
+type Some<A> = A
+type None = undefined | null
+type Option<A> = Some<A> | None
+declare function fromNullable<A>(value: A): Option<NonNullable<A>>
+declare function map<A, B>(option: Option<A>, mapFn: (value: A) => B): Option<B>
+declare function map<A, B>(mapFn: (value: A) => B): (option: Option<A>) => Option<B>
+const o1 = fromNullable(5 as number | null)
+const b = map(o1, x => x * 2)
+"#;
+    assert_eq!(
+        diag_count(source, 2362),
+        0,
+        "identity-alias `Some<A>` arm must infer A = number, leaving `x * 2` clean"
+    );
+    assert_eq!(
+        total_diags(source),
+        0,
+        "the whole program should type-check clean"
+    );
+}
+
+/// Without the data-last overload the single-signature form must also be clean:
+/// the trigger is the identity-alias arm, not the overload count.
+#[test]
+fn single_signature_identity_alias_arm_no_ts2362() {
+    let source = r#"
+type Some<A> = A
+type None = undefined | null
+type Option<A> = Some<A> | None
+declare function map<A, B>(o: Option<A>, f: (v: A) => B): Option<B>
+declare const o: Option<number>
+const b = map(o, x => x * 2)
+"#;
+    assert_eq!(diag_count(source, 2362), 0);
+    assert_eq!(total_diags(source), 0);
+}
+
+/// The rule is structural, not tied to the identifiers `Some`/`A`/`None`.
+#[test]
+fn renamed_binders_identity_alias_arm_no_ts2362() {
+    let source = r#"
+type Forward<Inner> = Inner
+type Nothing = undefined | null
+type Maybe<Inner> = Forward<Inner> | Nothing
+declare function lift<Inner, Out>(m: Maybe<Inner>, fn: (v: Inner) => Out): Maybe<Out>
+declare const m: Maybe<number>
+const r = lift(m, n => n * 2)
+"#;
+    assert_eq!(diag_count(source, 2362), 0);
+    assert_eq!(total_diags(source), 0);
+}
+
+/// A single-member `None` (just `undefined`) exercises the same partitioning.
+#[test]
+fn single_member_none_identity_alias_arm_no_ts2362() {
+    let source = r#"
+type Some<A> = A
+type Option<A> = Some<A> | undefined
+declare function map<A, B>(o: Option<A>, f: (v: A) => B): Option<B>
+declare const o: Option<number>
+const b = map(o, x => x * 2)
+"#;
+    assert_eq!(diag_count(source, 2362), 0);
+    assert_eq!(total_diags(source), 0);
+}
+
+/// The identity-alias arm also forwards a non-numeric element correctly: `A`
+/// must infer `string`, so a numeric use of the parameter is rejected (TS2362)
+/// — the peel preserves the *correct* element, it does not blanket-suppress.
+#[test]
+fn identity_alias_arm_forwards_string_still_reports_ts2362() {
+    let source = r#"
+type Some<A> = A
+type None = undefined | null
+type Option<A> = Some<A> | None
+declare function map<A, B>(o: Option<A>, f: (v: A) => B): Option<B>
+declare const o: Option<string>
+const b = map(o, x => x * 2)
+"#;
+    assert_eq!(
+        diag_count(source, 2362),
+        1,
+        "A must infer `string`; using it as the LHS of `* 2` is a real TS2362"
+    );
+}
+
+/// A non-identity alias whose body adds structure (`type Box<X> = { v: X }`)
+/// must NOT be peeled: the structured arm still drives inference and a property
+/// access through it remains well typed.
+#[test]
+fn structured_alias_arm_is_not_peeled() {
+    let source = r#"
+type Box<X> = { v: X }
+type None = undefined | null
+type Boxed<X> = Box<X> | None
+declare function unbox<X, R>(b: Boxed<X>, f: (b: { v: X }) => R): R
+declare const bx: Boxed<number>
+const out = unbox(bx, b => b.v * 2)
+"#;
+    assert_eq!(diag_count(source, 2362), 0);
+    assert_eq!(total_diags(source), 0);
+}

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -4,16 +4,18 @@
 //! that collects type constraints when inferring generic type parameters from
 //! argument types.
 
+use crate::def::DefId;
 use crate::inference::infer::InferenceContext;
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::operations::core::MAX_CONSTRAINT_STEPS;
 use crate::operations::{AssignabilityChecker, CallEvaluator, MAX_CONSTRAINT_RECURSION_DEPTH};
 use crate::types::{
     FunctionShape, IntrinsicKind, LiteralValue, ParamInfo, PropertyInfo, TemplateSpan, TypeData,
-    TypeId, TypeParamInfo, TypePredicate,
+    TypeId, TypeListId, TypeParamInfo, TypePredicate,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
+use std::sync::Arc;
 use tracing::{debug, trace};
 
 // Reusable scratch `FxHashSet<TypeId>` for the five `type_contains_placeholder`
@@ -83,6 +85,89 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // Decrement depth on return
         self.constraint_recursion_depth
             .set(self.constraint_recursion_depth.get() - 1);
+    }
+
+    /// Normalize a union's members for inference partitioning by peeling
+    /// transparent identity-alias applications (`type Some<X> = X`).
+    ///
+    /// A target arm like `Some<A>` is otherwise an opaque `Application` that
+    /// never registers as the naked inference variable `A`, so the single-naked
+    /// variable union strategy (`inferToMultipleTypes`) cannot route unmatched
+    /// source constituents into `A` and it collapses to its default. Peeling the
+    /// arm to its forwarded type fixes that; a peel that yields a union is
+    /// flattened one level so downstream partitioning sees the leaf members.
+    fn normalize_union_members_for_inference(&mut self, members: TypeListId) -> Arc<[TypeId]> {
+        let original = self.interner.type_list(members);
+        // Cheap pre-scan: only a `Lazy`-alias `Application` can be an identity
+        // alias. When the union has none — the overwhelming common case on this
+        // hot constraint path — return the interned list untouched, avoiding
+        // both a fresh allocation and any resolver work.
+        if !original
+            .iter()
+            .any(|&member| self.lazy_alias_application_def_id(member).is_some())
+        {
+            return original;
+        }
+        let mut out = Vec::with_capacity(original.len());
+        for &member in original.iter() {
+            let Some(peeled) = self.try_peel_identity_alias_application(member) else {
+                out.push(member);
+                continue;
+            };
+            if let Some(TypeData::Union(inner)) = self.interner.lookup(peeled) {
+                out.extend(self.interner.type_list(inner).iter().copied());
+            } else {
+                out.push(peeled);
+            }
+        }
+        out.into()
+    }
+
+    /// The alias `DefId` when `member` is an `Application` whose base is a `Lazy`
+    /// alias reference — the only shape `try_peel_identity_alias_application` can
+    /// peel. Resolver-free, so it doubles as the cheap pre-scan gate.
+    fn lazy_alias_application_def_id(&self, member: TypeId) -> Option<DefId> {
+        let TypeData::Application(app_id) = self.interner.lookup(member)? else {
+            return None;
+        };
+        let base = self.interner.type_application(app_id).base;
+        if base.is_intrinsic() {
+            return None;
+        }
+        match self.interner.lookup(base)? {
+            TypeData::Lazy(def_id) => Some(def_id),
+            _ => None,
+        }
+    }
+
+    /// If `member` applies a *transparent identity alias* — a type alias whose
+    /// body is exactly one of its own type parameters, e.g. `type Some<X> = X` —
+    /// expand it to the forwarded type argument.
+    ///
+    /// Returns `None` for any alias whose body adds structure
+    /// (`type Box<X> = { v: X }`, `type Opt<X> = X | undefined`): those must stay
+    /// opaque so structural union inference can still match against the wrapper.
+    fn try_peel_identity_alias_application(&mut self, member: TypeId) -> Option<TypeId> {
+        let def_id = self.lazy_alias_application_def_id(member)?;
+        // The alias body must be a bare type parameter declared by this very
+        // alias. Scope the resolver borrow so `expand_type_alias_application`
+        // (which needs `&mut self.checker`) can run afterwards.
+        let is_identity = {
+            let resolver = self.checker.type_resolver()?;
+            let type_params = resolver.get_lazy_type_params(def_id)?;
+            let body = resolver.resolve_lazy(def_id, self.interner)?;
+            match self.interner.lookup(body)? {
+                TypeData::TypeParameter(body_param) => {
+                    type_params.iter().any(|p| p.name == body_param.name)
+                }
+                _ => false,
+            }
+        };
+        if !is_identity {
+            return None;
+        }
+        let peeled = self.checker.expand_type_alias_application(member)?;
+        (peeled != member).then_some(peeled)
     }
 
     /// Inner implementation of `constrain_types`
@@ -543,8 +628,11 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 // against parameterized members. This implements TypeScript's inference
                 // filtering: for `T | undefined`, `undefined` in the source should match
                 // the fixed `undefined` in the target, not be inferred as T.
-                let s_members = self.interner.type_list(s_members);
-                let t_members_list = self.interner.type_list(t_members);
+                // Peel transparent identity-alias arms (`type Some<X> = X`) on
+                // both sides so an arm like `Some<A>` partitions as the naked
+                // inference variable `A` rather than an opaque application.
+                let s_members = self.normalize_union_members_for_inference(s_members);
+                let t_members_list = self.normalize_union_members_for_inference(t_members);
 
                 // Collect fixed target members (those without placeholders) once per
                 // target union for this inference pass. Fixed members are resolved and


### PR DESCRIPTION
Fixes #14251.

## Summary
When generic call inference partitions a union target whose arm is a
**transparent identity-alias application** — a type alias whose body is exactly
its own type parameter, e.g. `type Some&lt;X&gt; = X`, applied as `Some&lt;A&gt;` —
`tsc` treats the arm as the naked inference variable `A` and unions the
unmatched source constituents into it (`A = number`). tsz kept `Some&lt;A&gt;`
as an opaque `Application`, so the arm partitioned as a *structured* member
instead of a naked variable; the unmatched source constituents never reached
`A`, which collapsed to its `{}` default and leaked the `None` branch — a
spurious **TS2362** on `O.map(O.fromNullable(...), x => x * 2)` (mined from
ts-belt).

## Structural rule
When a union inference target has an arm that is a transparent identity-alias
application (`type Some&lt;X&gt; = X` applied as `Some&lt;A&gt;`), `tsc`
partitions it as the naked type variable `A`; tsz now does the same through the
solver's constraint walker by peeling the arm to its forwarded type before
partitioning. Aliases whose body adds structure (`Box&lt;X&gt; = { v: X }`,
`Opt&lt;X&gt; = X | undefined`) are left opaque so structural union matching
still applies.

## Owner layer
Solver — `crates/tsz-solver/src/operations/constraints/walker.rs`, the
union-union case of `constrain_types_impl` (the engine that drives generic
**call** inference). Both source and target member lists are normalized via a
new `normalize_union_members_for_inference`;
`try_peel_identity_alias_application` gates the peel to aliases whose resolved
body is a bare declared type parameter and reuses the existing
`expand_type_alias_application` boundary. A resolver-free pre-scan
(`lazy_alias_application_def_id`) keeps the common no-alias union on its
existing zero-allocation `Arc<[TypeId]>` path.

## Adjacent matrix (all match `tsc`)
- Reported overloaded ts-belt `map` repro → clean.
- Single-signature `map` (overload count is not the trigger) → clean.
- Renamed binders (`type Forward&lt;Inner&gt; = Inner`) → clean.
- Single-member `None` (`X | undefined`) → clean.
- Identity-alias forwarding `string` → **TS2362 still reported** (peel preserves
  the correct element; it does not blanket-suppress).
- Non-identity structured alias `Box&lt;X&gt; = { v: X }` → not peeled, stays
  clean.

## Anti-hardcoding
Structural: the peel triggers only when a `Lazy` alias's resolved body is a bare
type parameter it declares (compared by the alias's own parameter name, not any
user literal or file name). No printer/diagnostic string is read.

## Verification
- New regression suite `crates/tsz-checker/tests/identity_alias_union_arm_inference_tests.rs` (6 cases above) — all pass.
- Witness confirmed against `tsc`: baseline tsz emits TS2362, `tsc` is clean; with the fix tsz is clean.
- Adjacent suites green: `array_element_naked_inference_tests`, `recursive_array_utility_inference_tests`, `binding_pattern_inference_tests`, `issue_3768_generic_callback_outer_inference_tests`. The 5 failures in `generic_call_inference_tests` reproduce on `main` (pre-existing, unrelated).
- `cargo clippy -p tsz-solver` clean.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4
Effort: high