### PR TITLE
fix(checker): type a value-reference class-extends base from its flow-narrowed type (#14260)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -283,6 +283,9 @@ mod global_this_typeof_surface_tests;
 #[path = "tests/heritage_constraint_structural_name_lookup_arch_tests.rs"]
 mod heritage_constraint_structural_name_lookup_arch_tests;
 #[cfg(test)]
+#[path = "tests/heritage_flow_narrowed_base_tests.rs"]
+mod heritage_flow_narrowed_base_tests;
+#[cfg(test)]
 #[path = "../tests/heritage_type_only_tests.rs"]
 mod heritage_type_only_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/heritage.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage.rs
@@ -616,10 +616,21 @@ impl<'a> CheckerState<'a> {
                             // needing full symbol type resolution here. Merged class/value
                             // symbols (like a user class colliding with lib `Symbol`) still need
                             // constructor validation because their value side may be non-newable.
-                            let skip_constructor_check =
-                                self.get_cross_file_symbol(sym_to_check).is_some_and(|s| {
-                                    s.has_any_flags(symbol_flags::CLASS)
-                                        && !s.has_any_flags(symbol_flags::VARIABLE)
+                            //
+                            // `use_flow_narrowed_base` is decided from the same symbol read:
+                            // a narrowable value binding (a `var`/`let`/`const`/parameter, not a
+                            // class/interface type declaration) is typed via its flow-narrowed
+                            // node type below, matching tsc's `checkExpression`.
+                            let (skip_constructor_check, use_flow_narrowed_base) = self
+                                .get_cross_file_symbol(sym_to_check)
+                                .map_or((false, false), |s| {
+                                    let skip = s.has_any_flags(symbol_flags::CLASS)
+                                        && !s.has_any_flags(symbol_flags::VARIABLE);
+                                    let flow_narrowed = s.has_any_flags(symbol_flags::VARIABLE)
+                                        && !s.has_any_flags(
+                                            symbol_flags::CLASS | symbol_flags::INTERFACE,
+                                        );
+                                    (skip, flow_narrowed)
                                 });
 
                             // When a user class shadows a lib variable of the same name
@@ -658,8 +669,16 @@ impl<'a> CheckerState<'a> {
                             }
 
                             if !skip_constructor_check {
+                                // A narrowable value binding is typed via its
+                                // flow-narrowed node type (tsc's `checkExpression`), so a
+                                // narrowing like `Ctor | undefined → Ctor` (e.g.
+                                // `klass ? class extends klass {} : null`) is honored
+                                // instead of falsely reporting TS2507. Class/interface
+                                // symbols keep their location-independent declared type.
                                 let symbol_type = if is_being_resolved {
                                     TypeId::ERROR
+                                } else if use_flow_narrowed_base {
+                                    self.get_type_of_node(expr_idx)
                                 } else {
                                     self.get_type_of_symbol(sym_to_check)
                                 };

--- a/crates/tsz-checker/src/tests/heritage_flow_narrowed_base_tests.rs
+++ b/crates/tsz-checker/src/tests/heritage_flow_narrowed_base_tests.rs
@@ -1,0 +1,100 @@
+//! Heritage base typed from the flow-narrowed reference, not the declared symbol.
+//!
+//! Structural rule: when a class `extends <expr>` and `<expr>` is a value
+//! reference (parameter/variable) whose control-flow-narrowed type at the
+//! heritage location is a constructor, tsc types the base via `checkExpression`
+//! (flow narrowing) and accepts it. tsz previously read the binding's *declared*
+//! type via `get_type_of_symbol` in the heritage constructor check, so a binding
+//! narrowed from `Ctor | undefined` to `Ctor` (e.g. inside `klass ? ... : ...`)
+//! was wrongly seen as possibly-undefined and emitted a false TS2507.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_with_options, diagnostic_count};
+
+fn strict() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+const CTOR: &str = "type Ctor = new (...args: any[]) => object;\n";
+
+#[test]
+fn conditional_narrowed_parameter_base_no_ts2507() {
+    let src = format!(
+        "{CTOR}export const make = (klass?: Ctor) => klass ? class extends klass {{}} : null;\n"
+    );
+    let diags = check_with_options(&src, strict());
+    assert_eq!(
+        diagnostic_count(&diags, 2507),
+        0,
+        "a base narrowed to a constructor by `klass ? ...` must not emit TS2507: {diags:?}"
+    );
+}
+
+#[test]
+fn if_guarded_narrowed_parameter_base_no_ts2507() {
+    let src = format!(
+        "{CTOR}export function make(klass?: Ctor) {{ if (klass) {{ return class extends klass {{}}; }} return null; }}\n"
+    );
+    let diags = check_with_options(&src, strict());
+    assert_eq!(
+        diagnostic_count(&diags, 2507),
+        0,
+        "a base narrowed to a constructor inside `if (klass)` must not emit TS2507: {diags:?}"
+    );
+}
+
+#[test]
+fn and_narrowed_parameter_base_no_ts2507() {
+    let src =
+        format!("{CTOR}export const make = (klass?: Ctor) => klass && class extends klass {{}};\n");
+    let diags = check_with_options(&src, strict());
+    assert_eq!(
+        diagnostic_count(&diags, 2507),
+        0,
+        "a base narrowed to a constructor by `klass && ...` must not emit TS2507: {diags:?}"
+    );
+}
+
+#[test]
+fn narrowed_local_variable_base_no_ts2507() {
+    // Vary the binder kind: a local `let` narrowed by assignment, not a parameter.
+    let src = format!(
+        "{CTOR}declare const base: Ctor | undefined;\nexport function make() {{ let local: Ctor | undefined = base; if (local) {{ return class extends local {{}}; }} return null; }}\n"
+    );
+    let diags = check_with_options(&src, strict());
+    assert_eq!(
+        diagnostic_count(&diags, 2507),
+        0,
+        "a local variable narrowed to a constructor must not emit TS2507: {diags:?}"
+    );
+}
+
+#[test]
+fn unnarrowed_optional_constructor_base_still_ts2507() {
+    // Negative control: an un-narrowed `Ctor | undefined` base is genuinely
+    // possibly-undefined and must still report TS2507.
+    let src =
+        format!("{CTOR}declare const base: Ctor | undefined;\nexport class C extends base {{}}\n");
+    let diags = check_with_options(&src, strict());
+    assert_eq!(
+        diagnostic_count(&diags, 2507),
+        1,
+        "an un-narrowed `Ctor | undefined` base must still report TS2507: {diags:?}"
+    );
+}
+
+#[test]
+fn non_constructor_narrowed_base_still_ts2507() {
+    // Negative control: narrowing away `undefined` from a non-constructor value
+    // still leaves a non-constructable base, which must report TS2507.
+    let src = "declare const base: number | undefined;\nexport function make() { if (base) { return class extends base {}; } return null; }\n";
+    let diags = check_with_options(src, strict());
+    assert_eq!(
+        diagnostic_count(&diags, 2507),
+        1,
+        "a narrowed non-constructor base must still report TS2507: {diags:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
Mined from **effect**. tsz emitted a false `TS2507` where tsc is clean: a class
`extends`-base that is a value reference (parameter/variable) was typed from the
binding's **declared** symbol type instead of its **flow-narrowed** type.

```ts
type Ctor = new (...args: any[]) => object;
export const make = (klass?: Ctor) => klass ? class extends klass {} : null;
// tsz: TS2507 'klass' is not a constructor function type (sees Ctor | undefined)
// tsc: clean (klass narrowed to Ctor inside the `klass ? ...` true branch)
```

## Structural rule
When a class extends a base expression that is a value reference whose
control-flow-narrowed type at the heritage location is a constructor, tsc types
the base via `checkExpression` (flow narrowing) and accepts it. tsz's
resolved-symbol heritage constructor check read the binding's declared type via
`get_type_of_symbol`, so a binding narrowed from `Ctor | undefined` to `Ctor`
was still seen as possibly-undefined and produced a false TS2507.

## Owner
Checker — `crates/tsz-checker/src/state/state_checking/heritage.rs`, the
resolved-symbol `extends` constructor check. For a **narrowable value binding**
(binder symbol with the `VARIABLE` flag and *not* `CLASS`/`INTERFACE`) the base
is now typed through the flow-narrowed node type (`get_type_of_node`), matching
tsc's `checkExpression`. Class/interface symbols and merged `INTERFACE+VARIABLE`
built-ins (`Array`, `Promise`) keep their location-independent declared type. The
flag read is folded into the pre-existing `skip_constructor_check` symbol lookup,
so no extra cross-file symbol resolution is introduced.

Anti-hardcoding: the gate is purely structural (binder symbol flags); no
identifier, alias, file-name, or printer-output string drives the decision.

## Adjacent cases (verified)
- `klass ? class extends klass {} : null` (conditional narrowing): clean.
- `if (klass) { return class extends klass {}; }` (if-guard narrowing): clean.
- `klass && class extends klass {}` (`&&` narrowing): clean.
- Renamed binder — a narrowed local `let local: Ctor | undefined` (binder-name
  variation, not a parameter): clean.
- Negative control: an un-narrowed `Ctor | undefined` base still reports TS2507.
- Negative control: a narrowed **non-constructor** base (`number | undefined`
  narrowed to `number`) still reports TS2507.

## Verification
- New regression file
  `crates/tsz-checker/src/tests/heritage_flow_narrowed_base_tests.rs`
  (6 tests: 4 narrowing cases + 2 negative controls; the 4 narrowing tests fail
  on main, all 6 pass after the fix).
- `cargo test -p tsz-checker --lib heritage_flow_narrowed_base` → 6 pass.
- No regression in `heritage` / `extends` / `constructor` / `mixin` lib suites,
  nor `ts2545_mixin_constructor_shape_tests`,
  `js_class_constructor_merge_tests`, `js_constructor_property_more_tests`,
  `cross_file_lib_interface_identity_tests` (the one pre-existing `heritage`
  failure, `delegate_cross_arena_source_interface_with_heritage_still_falls_back`,
  also fails on the untouched base branch).
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib -- -D warnings` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Closes #14260
