### PR TITLE
fix(checker): accept string-literal numeral keys in generic tuple index chain (TS2536) (#14254)

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -1114,6 +1114,14 @@ impl<'a> CheckerState<'a> {
                     && value >= 0.0
                     && (has_rest || (value as usize) < len);
             }
+            // A string-literal key that spells a canonical array index (`'0'`,
+            // `'1'`, …) indexes a tuple/array element exactly like its numeric
+            // form. Accept it within the same numeric domain so a generic index
+            // constrained to `'0' | '1'` stays a tuple element access rather than
+            // spuriously escaping to `TS2536`.
+            if let Some(index) = self.string_literal_numeric_index(member) {
+                return has_rest || index < len;
+            }
             false
         })
     }
@@ -1343,18 +1351,24 @@ impl<'a> CheckerState<'a> {
             .error(pos as u32, len as u32, message.to_string(), code);
     }
 
+    /// The canonical array-index a string-literal *type* spells (`'0'` -> `0`,
+    /// `'42'` -> `42`), or `None` when `index_type` is not a string-literal type
+    /// or its text is not a canonical unsigned-integer index string (`'01'`,
+    /// `'foo'`, `'+1'` are property names, not indices). `tsc` treats
+    /// `Base['0']` and `Base[0]` identically for tuple/array element lookup.
+    pub(super) fn string_literal_numeric_index(&self, index_type: TypeId) -> Option<usize> {
+        let prop_atom =
+            crate::query_boundaries::common::string_literal_value(self.ctx.types, index_type)?;
+        let property_name = self.ctx.types.resolve_atom_ref(prop_atom);
+        self.get_numeric_index_from_string(&property_name)
+    }
+
     pub(super) fn canonical_numeric_string_literal_valid_for_object(
         &self,
         index_type: TypeId,
         object_type: TypeId,
     ) -> bool {
-        let Some(prop_atom) =
-            crate::query_boundaries::common::string_literal_value(self.ctx.types, index_type)
-        else {
-            return false;
-        };
-        let property_name = self.ctx.types.resolve_atom(prop_atom);
-        self.get_numeric_index_from_string(&property_name)
+        self.string_literal_numeric_index(index_type)
             .is_some_and(|_| self.is_element_indexable(object_type, false, true))
     }
 

--- a/crates/tsz-checker/tests/concrete_tuple_generic_index_chain_ts2536_tests.rs
+++ b/crates/tsz-checker/tests/concrete_tuple_generic_index_chain_ts2536_tests.rs
@@ -158,9 +158,85 @@ type Nested<D1 extends 0 | 1> = Table[D1]["a"];
     );
 }
 
+/// #14254 (hkt-toolbelt): an inner/outer index constrained to *string-literal*
+/// numerals (`'0' | '1'`) addresses tuple elements exactly like the numeric
+/// form — `tsc` treats `Base['0']` and `Base[0]` identically for the element
+/// lookup, so the chain `T[A][B]` must not emit TS2536. Varied alias/param
+/// spellings prove the rule is structural.
+#[test]
+fn string_literal_numeral_constrained_chain_is_accepted() {
+    for (alias, a, b) in [("T", "A", "B"), ("Pairs", "Row", "Col"), ("Grid", "I", "J")] {
+        let src = format!(
+            r#"
+type {alias} = [['a', 'b'], ['c', 'd']];
+type Index<{a} extends '0' | '1', {b} extends '0' | '1'> = {alias}[{a}][{b}];
+"#
+        );
+        let diags = check(&src);
+        assert!(
+            !has_code(&diags, 2536),
+            "string-literal numeral chain (alias {alias}) must not emit TS2536, got: {:?}",
+            codes(&diags)
+        );
+    }
+}
+
+/// Mixed forms: an inner string-literal numeral with an outer numeric literal
+/// (and vice versa) resolve to the same element value — accepted.
+#[test]
+fn mixed_string_and_numeric_literal_chain_is_accepted() {
+    let diags = check(
+        r#"
+type T = [['a', 'b'], ['c', 'd']];
+type InnerStr<A extends '0' | '1', B extends 0 | 1> = T[A][B];
+type InnerNum<A extends 0 | 1, B extends '0' | '1'> = T[A][B];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536),
+        "mixed string/numeric literal chain must not emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+}
+
 // -------------------------------------------------------------------------
 // Negative controls: genuine TS2536 must still fire (no over-suppression).
 // -------------------------------------------------------------------------
+
+/// An inner string-literal numeral constraint with an out-of-range member
+/// (`'0' | '5'` over a 2-tuple) genuinely escapes the element-index domain —
+/// `tsc` emits TS2536, matching the numeric-literal control.
+#[test]
+fn out_of_range_inner_string_literal_still_errors() {
+    let diags = check(
+        r#"
+type T = [['a', 'b'], ['c', 'd']];
+type Bad<A extends '0' | '5', B extends '0' | '1'> = T[A][B];
+"#,
+    );
+    assert!(
+        has_code(&diags, 2536),
+        "out-of-range inner string literal must still emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// A non-canonical string key (`'foo'`, not a numeric index string) is not a
+/// tuple element index — `tsc` emits TS2536.
+#[test]
+fn non_canonical_string_key_inner_index_still_errors() {
+    let diags = check(
+        r#"
+type T = [['a', 'b'], ['c', 'd']];
+type Bad<A extends 'foo', B extends '0' | '1'> = T[A][B];
+"#,
+    );
+    assert!(
+        has_code(&diags, 2536),
+        "non-canonical string key must still emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+}
 
 /// An inner index constraint with an out-of-range literal (`0 | 1 | 2` over a
 /// 2-tuple) genuinely escapes the element-index domain — `tsc` emits TS2536.


### PR DESCRIPTION
Fixes #14254.

## Summary
Mined from **hkt-toolbelt**. When a concrete tuple is indexed by a generic
type-parameter chain `T[A][B]` whose index constraint is a *string-literal*
numeral union (`'0' | '1'`), tsz emitted a false **TS2536** on the outer index
where tsc is clean:

```ts
type T = [['a', 'b'], ['c', 'd']]
type Index<A extends '0' | '1', B extends '0' | '1'> = T[A][B]  // tsz: TS2536 on [B]; tsc: clean
```

The numeric-literal form `0 | 1` already worked; only the string-literal numeral
form failed.

## Structural rule
When a concrete tuple `Base` is indexed by a generic index `I extends C` and `C`
lies in the tuple's numeric element-index domain, tsc resolves `Base[I]` to the
element-value union `Base[number]`, whose key space accepts a chained index
`Base[I][J]`. `Base['0']` and `Base[0]` address the *same* tuple element, so a
string-literal numeral key (`'0'`, `'1'`, … canonical unsigned-integer index
string within the tuple length, or any non-negative index under an open rest
tail) is in-domain exactly like its numeric form. tsz's element-index domain
check (`index_within_tuple_element_domain`) only recognized `number` and numeric
literals, so a string-literal-numeral constraint escaped the domain, the chain
failed to resolve to the element union, and the outer index fell through to a
spurious TS2536.

## Owner layer
Checker — `crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs`.
`index_within_tuple_element_domain` now accepts a string-literal member whose
text is a canonical numeric index string within range, alongside the existing
`number` and numeric-literal branches. The string-literal→index conversion is
factored into a shared `string_literal_numeric_index` helper (reused by
`canonical_numeric_string_literal_valid_for_object`). The solver's value
resolution was already correct (`Index<'0','1'>` evaluates to `'b'`); only the
TS2536 diagnostic gate was wrong.

## Adjacent matrix (all verified against `tsc` 6.0.2)
- `T[A][B]` with `'0' | '1'` string-literal constraints, varied alias/param
  spellings → clean.
- Mixed inner string / outer numeric (and vice versa) → clean.
- Numeric-literal and `number` constraints → still clean (unchanged path).
- `'length'`, array methods, 3-level chains → clean.
- Negative: out-of-range numeral `'5'` over a 2-tuple → **TS2536 still emitted**
  (range-checked, chain stays deferred).
- Negative: non-canonical key `'foo'` / `'01'` → **TS2536 still emitted**.

## Anti-hardcoding
Structural: the domain check reads the string-literal's interned text and maps
it through the existing canonical-index parser (`get_numeric_index_from_string`),
gated by the actual tuple length. No user-name/file-name literal, no
printer/diagnostic string is consulted. Plain array bases (`tuple_elements`
returns `None`) are unaffected.

## Verification
- New regression cases in
  `crates/tsz-checker/tests/concrete_tuple_generic_index_chain_ts2536_tests.rs`
  (`string_literal_numeral_constrained_chain_is_accepted`,
  `mixed_string_and_numeric_literal_chain_is_accepted`, plus out-of-range and
  non-canonical negative controls) — full file 14/14 pass.
- Repro witness confirmed against `tsc` 6.0.2: baseline tsz emits TS2536, tsc is
  clean; with the fix both agree on the full positive/negative matrix.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_0156Rx8YzBn4nwTv2GMeymAc)_