### PR TITLE
fix(checker): type a class-extends value base via flow narrowing (TS2507) (#14260)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/heritage.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage.rs
@@ -658,8 +658,25 @@ impl<'a> CheckerState<'a> {
                             }
 
                             if !skip_constructor_check {
+                                // A `class extends <value>` whose base is a plain
+                                // parameter/variable (not a class/interface, and not a
+                                // merged class+value with its own handling above) is
+                                // typed by its FLOW-NARROWED type at the heritage
+                                // location — tsc uses `checkExpression`, so
+                                // `klass ? class extends klass {} : …` sees the narrowed
+                                // `Ctor`, not the declared `Ctor | undefined` (false
+                                // TS2507, effect). (#14260)
+                                let base_is_flow_narrowable_value =
+                                    self.get_cross_file_symbol(sym_to_check).is_some_and(|s| {
+                                        s.has_any_flags(symbol_flags::VARIABLE)
+                                            && !s.has_any_flags(
+                                                symbol_flags::CLASS | symbol_flags::INTERFACE,
+                                            )
+                                    });
                                 let symbol_type = if is_being_resolved {
                                     TypeId::ERROR
+                                } else if base_is_flow_narrowable_value {
+                                    self.get_type_of_node(expr_idx)
                                 } else {
                                     self.get_type_of_symbol(sym_to_check)
                                 };

--- a/crates/tsz-checker/tests/conformance_issues/types/class_extends_flow_narrowed_base.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/class_extends_flow_narrowed_base.rs
@@ -1,0 +1,46 @@
+//! `class extends <value>` types the base via flow-narrowing, not the declared
+//! symbol type (TS2507). Mined from effect. (#14260)
+
+use super::super::core::*;
+
+/// A `class extends <param>` whose base parameter is flow-narrowed to a
+/// constructor (here inside a truthy `klass ? … : …`) must be accepted — tsc
+/// types the base via `checkExpression`. tsz previously read the declared
+/// `Ctor | undefined` symbol type and reported a false TS2507. Binder name
+/// varied to confirm the fix is structural.
+#[test]
+fn class_extends_flow_narrowed_value_base_no_ts2507() {
+    for klass in ["klass", "Base", "ctor"] {
+        let source = format!(
+            r#"
+type Ctor<T = {{}}> = new (...args: Array<any>) => T;
+export const make = ({klass}?: Ctor) => ({klass} ? class extends {klass} {{}} : null);
+"#
+        );
+        let diagnostics = compile_and_get_diagnostics(&source);
+        assert!(
+            !has_error(&diagnostics, 2507),
+            "[{klass}] a flow-narrowed `Ctor` base must be accepted; got TS2507. \
+             Diagnostics: {diagnostics:#?}"
+        );
+    }
+}
+
+/// Negative control: an un-narrowed `Ctor | undefined` base must STILL report
+/// TS2507 — the fix uses the flow-narrowed expression type, which here is still
+/// `Ctor | undefined` (not a constructor), so the error is preserved.
+#[test]
+fn class_extends_unnarrowed_optional_base_still_ts2507() {
+    let diagnostics = compile_and_get_diagnostics(
+        r"
+type Ctor<T = {}> = new (...args: Array<any>) => T;
+declare const maybe: Ctor | undefined;
+class C extends maybe {}
+        ",
+    );
+    assert!(
+        has_error(&diagnostics, 2507),
+        "an un-narrowed `Ctor | undefined` base must still report TS2507. \
+         Diagnostics: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -1,3 +1,4 @@
+mod class_extends_flow_narrowed_base;
 mod const_initializer_widening;
 mod cross_module_unique_symbol;
 mod defaults;


### PR DESCRIPTION
Closes #14260.

## Structural rule
When a class `extends <expr>` and the base is a plain parameter/variable whose **flow-narrowed** type at the heritage location is a constructor, `tsc` types the base via `checkExpression` and accepts it. `tsz` read the binding's **declared** type via `get_type_of_symbol`, so a base narrowed from `Ctor | undefined` to `Ctor` (e.g. inside `klass ? class extends klass {} : ...`) was wrongly seen as possibly-undefined → false **TS2507** (effect).

## Owner layer
Checker heritage constructor check in `crates/tsz-checker/src/state/state_checking/heritage.rs`. When the base symbol is a plain variable/parameter (`VARIABLE` and **not** `CLASS`/`INTERFACE` — so merged class/value and interface bases keep the declared path with their own existing handling), type the base through the **flow-narrowed expression type** (`get_type_of_node`) instead of the declared symbol type. Narrow blast radius — only `class extends <variable>`.

## Adjacent-case matrix
- `klass ? class extends klass {} : null` (binder-varied `klass`/`Base`/`ctor`) → no TS2507.
- **Negative control:** an un-narrowed `Ctor | undefined` base still reports **TS2507** (the flow-narrowed type is still the union — not over-permitted).

## Verification
- New tests in `conformance_issues/types/class_extends_flow_narrowed_base.rs` (witness ×3 + negative control) — verified locally with `-j 2`: the witness **flips** (flow-narrowing reaches the heritage expr) and the negative control holds.
- One local failure (`delegate_cross_arena_source_interface_with_heritage_still_falls_back`) is a global perf-counter assertion in the cross-arena **interface direct-lowering** path — a different code path from this class-extends change (gated to value bases), a known Mac-cluster cross-file counter test. CI (Linux) runs the full checker suite + project-compile-guard as the authoritative gate.

Goal: green

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max