### PR TITLE
fix(checker): export-default merged interface keeps class-heritage members (TS2339)

### DIFF
--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -837,6 +837,43 @@ impl<'a> CheckerState<'a> {
                     &lib_contexts,
                     Some(self.ctx.arena),
                 );
+                let interface_canonical_sym_id = canonical_interface_symbol_id(
+                    &self.ctx,
+                    name,
+                    sym_id,
+                    selected_from_lib_context,
+                );
+                // Structural guard: a NON-lib (user/program-file) interface that
+                // declares `extends` heritage must not have its heritage-LESS
+                // lowering published here as the canonical body. `resolve_lib_type_
+                // by_name` lowers only the interface's own members; the
+                // class/interface-inherited members are merged later by the
+                // interface-type path. Publishing the bare body shadows that merged
+                // form for a merged interface+value symbol that is `export default`-
+                // ed (the value-side path re-enters this resolution mid-merge),
+                // dropping class-inherited members (false TS2339). Real lib
+                // interfaces (`Array extends ReadonlyArray`) keep the existing path:
+                // their heritage is reconciled through `merge_lib_interface_heritage`
+                // on both sides. For the guarded case, hand back the symbol's lazy
+                // reference so consumers resolve to the heritage-complete body once
+                // the interface-type path computes it. The lazy ref is captured here
+                // under a mutable borrow that ends before the lowering closures
+                // below (which hold an immutable `self.ctx` borrow).
+                let user_interface_has_heritage = !selected_from_lib_context
+                    && !self.ctx.symbol_is_from_lib(sym_id)
+                    && !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
+                    && decls_with_arenas.iter().any(|&(decl_idx, decl_arena)| {
+                        decl_arena
+                            .get(decl_idx)
+                            .and_then(|node| decl_arena.get_interface(node))
+                            .and_then(|iface| iface.heritage_clauses.as_ref())
+                            .is_some_and(|clauses| !clauses.nodes.is_empty())
+                    });
+                let user_interface_heritage_lazy_ref = if user_interface_has_heritage {
+                    Some(self.ctx.create_lazy_type_ref(interface_canonical_sym_id))
+                } else {
+                    None
+                };
                 let mut prewarmed_lazy_type_params = rustc_hash::FxHashMap::default();
                 for (decl_idx, decl_arena) in &decls_with_arenas {
                     let mut stack = vec![*decl_idx];
@@ -949,36 +986,39 @@ impl<'a> CheckerState<'a> {
 
                     if !is_type_alias {
                         let deduped = dedup_decl_arenas(&decls_with_arenas);
-                        let interface_sym_id = canonical_interface_symbol_id(
-                            &self.ctx,
-                            name,
-                            sym_id,
-                            selected_from_lib_context,
-                        );
 
-                        // Use lower_merged_interface_declarations for proper multi-arena support.
-                        // Pass sym_id so the resulting Object type gets stamped with the
-                        // interface's symbol — this allows the formatter to display the
-                        // named form (e.g., "Num") instead of the structural expansion.
-                        let (ty, params) = lowering
-                            .lower_merged_interface_declarations_with_symbol(
-                                &deduped,
-                                Some(interface_sym_id),
-                            );
+                        // Skip publishing the heritage-LESS body for a user interface
+                        // with `extends` heritage; push its lazy reference (captured
+                        // above, see `user_interface_heritage_lazy_ref`) so consumers
+                        // resolve the heritage-complete body computed by the
+                        // interface-type path instead.
+                        if let Some(lazy_ref) = user_interface_heritage_lazy_ref {
+                            lib_types.push(lazy_ref);
+                        } else {
+                            // Use lower_merged_interface_declarations for proper multi-arena support.
+                            // Pass sym_id so the resulting Object type gets stamped with the
+                            // interface's symbol — this allows the formatter to display the
+                            // named form (e.g., "Num") instead of the structural expansion.
+                            let (ty, params) = lowering
+                                .lower_merged_interface_declarations_with_symbol(
+                                    &deduped,
+                                    Some(interface_canonical_sym_id),
+                                );
 
-                        // If lowering succeeded (not ERROR), use the result
-                        if ty != TypeId::ERROR {
-                            // Register DefId, type params, and body in one step.
-                            register_selected_lib_def_resolved(
-                                &self.ctx,
-                                name,
-                                sym_id,
-                                selected_from_lib_context,
-                                ty,
-                                params,
-                            );
+                            // If lowering succeeded (not ERROR), use the result
+                            if ty != TypeId::ERROR {
+                                // Register DefId, type params, and body in one step.
+                                register_selected_lib_def_resolved(
+                                    &self.ctx,
+                                    name,
+                                    sym_id,
+                                    selected_from_lib_context,
+                                    ty,
+                                    params,
+                                );
 
-                            lib_types.push(ty);
+                                lib_types.push(ty);
+                            }
                         }
                     }
 


### PR DESCRIPTION
Goal: green

Parity fix: a false **TS2339** when an interface that extends a **class** is merged with a same-named annotated const and `export default`-ed, dropping the class-inherited members.

## Structural rule
When a non-lib interface declares `extends <Class>` heritage and is reached through `resolve_lib_type_by_name` — which happens when a merged interface+value symbol is `export default`-ed and the value-side path re-enters lib-name resolution mid-merge — tsz lowered and published the interface's **heritage-less own-member body** into the shared `DefinitionStore`, shadowing the merged form for later `f: Foo` reads and dropping class-inherited members (false TS2339). The fix detects this structurally (non-lib symbol + interface decl with non-empty heritage clauses) and returns the symbol's `Lazy(DefId)` reference instead of publishing the partial body, so consumers resolve to the heritage-complete type computed by the interface-type path. Real lib interfaces (`Array extends ReadonlyArray`, DOM `Element extends Node`) are excluded via the lib-context check and keep their existing `merge_lib_interface_heritage` path.

## Adjacent matrix
- `interface Foo extends Runtype<string> {}` + `const Foo: Foo = ...` + `export default Foo`, then `f.inspect()` → now clean (matches tsc).
- **Negatives (all unchanged, tsc-parity):** `export const Foo: Foo` (not default); cast `({} as Foo)` (no `: Foo` annotation); interface-base (not class); no-heritage interface; cross-file import of the type. Plus a recursive self-referential `interface Node { next: Node }` still resolves (the seed's original purpose preserved). Lib heritage (Array/ReadonlyArray, HTMLElement/Node, Map) intact.

## Verification
- Witness clean and tsc-matched; all 5 negatives + recursive-interface + lib-heritage checks unchanged. Scope note: this is a narrow parity fix for the witnessed pattern — the runtypes corpus snapshot is unchanged (its bulk FPs are a separate polymorphic-`this`/unique-symbol deep root), so this does not move that row.
- Regression delta vs clean `main`: `--lib interface/heritage/merged/export_default` — zero new failures (the one `delegate_cross_arena_source_interface_with_heritage_still_falls_back` fails identically on clean main); 89 lib_resolution tests pass. clippy clean.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
