### PR TITLE
fix(checker): accept a flow-narrowed value-reference class-extends base (#14260)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -283,6 +283,9 @@ mod global_this_typeof_surface_tests;
 #[path = "tests/heritage_constraint_structural_name_lookup_arch_tests.rs"]
 mod heritage_constraint_structural_name_lookup_arch_tests;
 #[cfg(test)]
+#[path = "tests/heritage_flow_narrowed_base_tests.rs"]
+mod heritage_flow_narrowed_base_tests;
+#[cfg(test)]
 #[path = "../tests/heritage_type_only_tests.rs"]
 mod heritage_type_only_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/heritage.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage.rs
@@ -95,6 +95,25 @@ impl<'a> CheckerState<'a> {
         );
     }
 
+    /// Whether the *flow-narrowed* type of a heritage base expression (a value
+    /// reference) is a constructor at this location.
+    ///
+    /// tsc types a class `extends <expr>` base via `checkExpression`, which
+    /// applies control-flow narrowing. This mirrors that narrowing for the
+    /// constructor-validity check so a binding narrowed from `Ctor | undefined`
+    /// to `Ctor` (e.g. inside `klass ? class extends klass {} : null`) is
+    /// recognized as a valid base. Used only as a fallback *after* the declared
+    /// symbol type fails the constructor check, so it can only accept a base —
+    /// never introduce a new `TS2507`.
+    fn flow_narrowed_base_is_constructor(&mut self, expr_idx: NodeIndex) -> bool {
+        let node_type = self.get_type_of_node(expr_idx);
+        if node_type == TypeId::ERROR {
+            return false;
+        }
+        let evaluated = self.evaluate_type_for_assignability(node_type);
+        self.is_constructor_type(evaluated)
+    }
+
     /// Check heritage clauses (extends/implements) for unresolved names.
     /// Emits TS2304 when a referenced name cannot be resolved.
     /// Emits TS2689 when a class extends an interface.
@@ -616,10 +635,21 @@ impl<'a> CheckerState<'a> {
                             // needing full symbol type resolution here. Merged class/value
                             // symbols (like a user class colliding with lib `Symbol`) still need
                             // constructor validation because their value side may be non-newable.
-                            let skip_constructor_check =
-                                self.get_cross_file_symbol(sym_to_check).is_some_and(|s| {
-                                    s.has_any_flags(symbol_flags::CLASS)
-                                        && !s.has_any_flags(symbol_flags::VARIABLE)
+                            //
+                            // `use_flow_narrowed_base` is decided from the same symbol read:
+                            // a narrowable value binding (a `var`/`let`/`const`/parameter, not a
+                            // class/interface type declaration) is typed via its flow-narrowed
+                            // node type below, matching tsc's `checkExpression`.
+                            let (skip_constructor_check, use_flow_narrowed_base) = self
+                                .get_cross_file_symbol(sym_to_check)
+                                .map_or((false, false), |s| {
+                                    let skip = s.has_any_flags(symbol_flags::CLASS)
+                                        && !s.has_any_flags(symbol_flags::VARIABLE);
+                                    let flow_narrowed = s.has_any_flags(symbol_flags::VARIABLE)
+                                        && !s.has_any_flags(
+                                            symbol_flags::CLASS | symbol_flags::INTERFACE,
+                                        );
+                                    (skip, flow_narrowed)
                                 });
 
                             // When a user class shadows a lib variable of the same name
@@ -746,6 +776,19 @@ impl<'a> CheckerState<'a> {
                                     // constructor type by checking through the solver's relation logic.
                                     let is_valid_base = if self.is_constructor_type(evaluated_type)
                                     {
+                                        true
+                                    } else if use_flow_narrowed_base
+                                        && self.flow_narrowed_base_is_constructor(expr_idx)
+                                    {
+                                        // The declared type of a value reference is not (yet) a
+                                        // constructor, but tsc types the heritage base via
+                                        // `checkExpression`, applying control-flow narrowing at
+                                        // this location. A binding narrowed from `Ctor | undefined`
+                                        // to `Ctor` (e.g. `klass ? class extends klass {} : null`)
+                                        // is a valid base. This only ever *accepts* a base the
+                                        // declared-type check rejected — it never introduces a new
+                                        // TS2507 — so an `any`/already-constructor declared type is
+                                        // unaffected.
                                         true
                                     } else {
                                         // For types that don't directly report as constructors,

--- a/crates/tsz-checker/src/tests/heritage_flow_narrowed_base_tests.rs
+++ b/crates/tsz-checker/src/tests/heritage_flow_narrowed_base_tests.rs
@@ -1,0 +1,117 @@
+//! Heritage base typed from the flow-narrowed reference, not the declared symbol.
+//!
+//! Structural rule: when a class `extends <expr>` and `<expr>` is a value
+//! reference (parameter/variable) whose control-flow-narrowed type at the
+//! heritage location is a constructor, tsc types the base via `checkExpression`
+//! (flow narrowing) and accepts it. tsz previously read the binding's *declared*
+//! type via `get_type_of_symbol` in the heritage constructor check, so a binding
+//! narrowed from `Ctor | undefined` to `Ctor` (e.g. inside `klass ? ... : ...`)
+//! was wrongly seen as possibly-undefined and emitted a false TS2507.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_with_options, diagnostic_count};
+
+fn strict() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+const CTOR: &str = "type Ctor = new (...args: any[]) => object;\n";
+
+#[test]
+fn conditional_narrowed_parameter_base_no_ts2507() {
+    let src = format!(
+        "{CTOR}export const make = (klass?: Ctor) => klass ? class extends klass {{}} : null;\n"
+    );
+    let diags = check_with_options(&src, strict());
+    assert_eq!(
+        diagnostic_count(&diags, 2507),
+        0,
+        "a base narrowed to a constructor by `klass ? ...` must not emit TS2507: {diags:?}"
+    );
+}
+
+#[test]
+fn if_guarded_narrowed_parameter_base_no_ts2507() {
+    let src = format!(
+        "{CTOR}export function make(klass?: Ctor) {{ if (klass) {{ return class extends klass {{}}; }} return null; }}\n"
+    );
+    let diags = check_with_options(&src, strict());
+    assert_eq!(
+        diagnostic_count(&diags, 2507),
+        0,
+        "a base narrowed to a constructor inside `if (klass)` must not emit TS2507: {diags:?}"
+    );
+}
+
+#[test]
+fn and_narrowed_parameter_base_no_ts2507() {
+    let src =
+        format!("{CTOR}export const make = (klass?: Ctor) => klass && class extends klass {{}};\n");
+    let diags = check_with_options(&src, strict());
+    assert_eq!(
+        diagnostic_count(&diags, 2507),
+        0,
+        "a base narrowed to a constructor by `klass && ...` must not emit TS2507: {diags:?}"
+    );
+}
+
+#[test]
+fn narrowed_local_variable_base_no_ts2507() {
+    // Vary the binder kind: a local `let` narrowed by assignment, not a parameter.
+    let src = format!(
+        "{CTOR}declare const base: Ctor | undefined;\nexport function make() {{ let local: Ctor | undefined = base; if (local) {{ return class extends local {{}}; }} return null; }}\n"
+    );
+    let diags = check_with_options(&src, strict());
+    assert_eq!(
+        diagnostic_count(&diags, 2507),
+        0,
+        "a local variable narrowed to a constructor must not emit TS2507: {diags:?}"
+    );
+}
+
+#[test]
+fn unnarrowed_optional_constructor_base_still_ts2507() {
+    // Negative control: an un-narrowed `Ctor | undefined` base is genuinely
+    // possibly-undefined and must still report TS2507.
+    let src =
+        format!("{CTOR}declare const base: Ctor | undefined;\nexport class C extends base {{}}\n");
+    let diags = check_with_options(&src, strict());
+    assert_eq!(
+        diagnostic_count(&diags, 2507),
+        1,
+        "an un-narrowed `Ctor | undefined` base must still report TS2507: {diags:?}"
+    );
+}
+
+#[test]
+fn non_constructor_narrowed_base_still_ts2507() {
+    // Negative control: narrowing away `undefined` from a non-constructor value
+    // still leaves a non-constructable base, which must report TS2507.
+    let src = "declare const base: number | undefined;\nexport function make() { if (base) { return class extends base {}; } return null; }\n";
+    let diags = check_with_options(src, strict());
+    assert_eq!(
+        diagnostic_count(&diags, 2507),
+        1,
+        "a narrowed non-constructor base must still report TS2507: {diags:?}"
+    );
+}
+
+#[test]
+fn hoisted_var_shadowing_outer_class_base_no_ts2507() {
+    // Monotonicity guard (TS conformance `classWithStaticFieldInParameterInitializer.3`,
+    // microsoft/TypeScript#36295): a class `extends C` inside a parameter
+    // initializer where the arrow body hoists `var C`. The flow-narrowed value
+    // type of that binding is not a constructor, but the declared type already
+    // is — accepting the base must dominate. The flow-narrowed path is only a
+    // *fallback*, so it must never turn an already-accepted base into TS2507.
+    let src = "class C {}\n((b = class extends C { static x = 1 }) => { var C; })();\n";
+    let diags = check_with_options(src, strict());
+    assert_eq!(
+        diagnostic_count(&diags, 2507),
+        0,
+        "a hoisted-var heritage base whose declared type is a constructor must not emit TS2507: {diags:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

Supersedes #14287 (closed: branch force-pushed with the monotonicity fix below, GitHub blocked reopen).

## Summary
Mined from **effect**. tsz emitted a false `TS2507` where tsc is clean: a class
extends-base that is a value reference (parameter/variable) was typed only from
the binding's **declared** symbol type, dropping control-flow narrowing.

```ts
type Ctor = new (...args: any[]) => object;
export const make = (klass?: Ctor) => klass ? class extends klass {} : null;
// tsz: TS2507 'klass' is not a constructor function type (sees Ctor | undefined)
// tsc: clean (klass narrowed to Ctor inside the `klass ? ...` true branch)
```

## Structural rule
When a class extends a base expression that is a value reference whose
control-flow-narrowed type at the heritage location is a constructor, tsc types
the base via `checkExpression` (flow narrowing) and accepts it. tsz's
resolved-symbol heritage constructor check read the binding's declared type via
`get_type_of_symbol`, so a binding narrowed from `Ctor | undefined` to `Ctor`
was still seen as possibly-undefined and produced a false TS2507.

## Owner
Checker — `crates/tsz-checker/src/state/state_checking/heritage.rs`, the
resolved-symbol `extends` constructor check. For a **narrowable value binding**
(binder symbol with the `VARIABLE` flag and *not* `CLASS`/`INTERFACE`) the check
now falls back to the flow-narrowed node type (`get_type_of_node` via
`flow_narrowed_base_is_constructor`) **after** the declared type fails.

**The rule is monotonic**: the flow-narrowed path is an *accept-only* fallback —
it can only clear a TS2507 the declared-type check would have emitted, never
introduce a new one. So an `any`/already-constructor declared type is
unaffected. This is what keeps the fix from regressing the hoisted-`var`
heritage edge case (microsoft/TypeScript#36295,
`classWithStaticFieldInParameterInitializer.3`): there a base resolves to an
untyped function-scoped `var` whose declared `any` is constructor-like but whose
flow type is `undefined`; the declared-type accept dominates.

Anti-hardcoding: the gate is purely structural (binder symbol flags); no
identifier, alias, file-name, or printer-output string drives the decision. The
flag read is folded into the pre-existing `skip_constructor_check` symbol lookup,
so no extra cross-file symbol resolution is introduced.

## Adjacent cases (verified)
- `klass ? class extends klass {} : null` (conditional narrowing): clean.
- `if (klass) { return class extends klass {}; }` (if-guard narrowing): clean.
- `klass && class extends klass {}` (`&&` narrowing): clean.
- Renamed binder — a narrowed local `let local: Ctor | undefined` (binder-name
  variation, not a parameter): clean.
- Monotonicity guard — `class C {}` / `((b = class extends C { static x = 1 }) => { var C; })()`
  (hoisted `var C` shadows outer class in a parameter initializer): no TS2507.
- Negative control: an un-narrowed `Ctor | undefined` base still reports TS2507.
- Negative control: a narrowed **non-constructor** base (`number | undefined`
  narrowed to `number`) still reports TS2507.

## Verification
- New regression file
  `crates/tsz-checker/src/tests/heritage_flow_narrowed_base_tests.rs`
  (7 tests: 4 narrowing cases + hoisted-var monotonicity guard + 2 negative
  controls). The 4 narrowing tests fail on main; all 7 pass after the fix.
- `cargo test -p tsz-checker --lib heritage_flow_narrowed_base` → 7 pass.
- Reproduced the prior #14287 conformance failure locally
  (`classWithStaticFieldInParameterInitializer.3`: `[2507]` before fix → `[]`
  after) and confirmed `inferentialTypingWithFunctionTypeZip` is byte-identical
  with and without the change (no heritage clause — independent of this PR).
- No regression in `heritage` / `extends` / `constructor` / `mixin` lib suites
  (the one pre-existing `heritage` failure,
  `delegate_cross_arena_source_interface_with_heritage_still_falls_back`, also
  fails on the untouched base branch).
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib -- -D warnings` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Closes #14260


---
_Generated by [Claude Code](https://claude.ai/code/session_01NM2w8HnAu2j9vs8gqNhXKe)_