### PR TITLE
fix(checker): kill declared nullishness on a non-nullish killing-definition (TS18048)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -278,6 +278,37 @@ impl<'a> FlowAnalyzer<'a> {
         for_node.kind == syntax_kind_ext::FOR_IN_STATEMENT
     }
 
+    /// Returns `true` when `assignment_node` is a simple killing definition
+    /// (`target = <rhs>`) whose right-hand side is *syntactically* a definitely
+    /// non-nullish expression (object/array literal, `new`, function/arrow/class
+    /// expression).
+    ///
+    /// Used by flow traversal as a soundness floor when
+    /// [`Self::get_assigned_type`] could not resolve the RHS type (cache miss
+    /// during deferred closure typing, and the syntactic fallback could not
+    /// rebuild a structural type — e.g. an object literal containing a method).
+    /// In that case the declared union must still drop `null`/`undefined` after
+    /// the write, matching tsc's `getAssignmentReducedType`, instead of keeping
+    /// the nullable declared type and reporting a false TS18048.
+    pub(crate) fn is_killing_definition_with_non_nullish_rhs(
+        &self,
+        assignment_node: NodeIndex,
+        target: NodeIndex,
+    ) -> bool {
+        let Some(node) = self.arena.get(assignment_node) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+            return false;
+        }
+        let Some(bin) = self.arena.get_binary_expr(node) else {
+            return false;
+        };
+        bin.operator_token == SyntaxKind::EqualsToken as u16
+            && self.is_matching_reference(bin.left, target)
+            && self.is_syntactically_non_nullish_expression(bin.right)
+    }
+
     pub(crate) fn get_assigned_type(
         &self,
         assignment_node: NodeIndex,

--- a/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
@@ -414,6 +414,32 @@ impl<'a> FlowAnalyzer<'a> {
         ty.filter(|&ty| !contains_free_type_parameters(self.interner, ty))
     }
 
+    /// Returns `true` when `expr` is a syntactic form that always evaluates to a
+    /// definitely non-nullish value, regardless of how (or whether) the full
+    /// checker pipeline managed to cache its type.
+    ///
+    /// These node kinds construct a fresh value on evaluation — an object/array
+    /// literal, a `new` expression, or a function/arrow/class expression — so the
+    /// result can never be `null` or `undefined`. Call expressions are excluded:
+    /// a call's return type is not knowable from syntax alone and may itself be
+    /// nullable (e.g. `t = maybeUndef()`), so killing-definition narrowing for
+    /// calls stays on the type-driven path.
+    pub(super) fn is_syntactically_non_nullish_expression(&self, expr: NodeIndex) -> bool {
+        let expr = self.skip_parens_and_assertions(expr);
+        let Some(node) = self.arena.get(expr) else {
+            return false;
+        };
+        matches!(
+            node.kind,
+            k if k == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                || k == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                || k == syntax_kind_ext::NEW_EXPRESSION
+                || k == syntax_kind_ext::FUNCTION_EXPRESSION
+                || k == syntax_kind_ext::ARROW_FUNCTION
+                || k == syntax_kind_ext::CLASS_EXPRESSION
+        )
+    }
+
     fn fallback_call_expression_type(&self, call_expr: NodeIndex) -> Option<TypeId> {
         self.reject_unresolved_generic_result(self.fallback_call_expression_type_inner(call_expr))
     }

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -741,6 +741,36 @@ impl<'a> FlowAnalyzer<'a> {
                                         declared_type,
                                         true,
                                     )
+                                } else if self.is_killing_definition_with_non_nullish_rhs(
+                                    flow.node, reference,
+                                ) {
+                                    // `target = <object/array literal | new | fn>` always
+                                    // writes a definitely non-nullish value, even when the
+                                    // RHS type could not be resolved (deferred closure typing
+                                    // plus an unreconstructable structural fallback). Drop
+                                    // `null`/`undefined` from the declared union so the killing
+                                    // definition matches tsc's `getAssignmentReducedType`
+                                    // instead of leaving a false TS18048 on a later read.
+                                    let declared_type =
+                                        symbol_id
+                                            .and_then(|sid| self.binder.get_symbol(sid))
+                                            .filter(|sym| sym.value_declaration.is_some())
+                                            .and_then(|sym| {
+                                                self.annotation_type_from_var_decl_node(
+                                                    sym.value_declaration,
+                                                )
+                                                .or_else(|| {
+                                                    self.node_types.and_then(|nt| {
+                                                        nt.get(&sym.value_declaration.0).copied()
+                                                    })
+                                                })
+                                            })
+                                            .unwrap_or(initial_type);
+                                    flow_boundary::narrow_destructuring_default(
+                                        self.interner.as_type_database(),
+                                        declared_type,
+                                        true,
+                                    )
                                 } else {
                                     current_type
                                 }


### PR DESCRIPTION
Goal: green

Clears a false **TS18048** where a `let t: T | undefined` reassigned to a syntactically non-nullish value inside a closure stays possibly-undefined.

## Structural rule
When a flow assignment is a simple killing definition (`t = <rhs>`, `EqualsToken`, `is_matching_reference(left, target)`) whose RHS is **syntactically** a definitely-non-nullish expression (object/array literal, `new`, function/arrow/class expression), tsc's `getAssignmentReducedType` strips `null`/`undefined` from the declared union. tsz failed to in closures: the RHS is typed in a deferred pass (so `node_types` misses during flow analysis) and `fallback_object_literal_type_from_syntax` returns `None` for a method-bearing literal, so `get_assigned_type` returned `None` and flow kept the declared `T | undefined`. The flow traversal now narrows the declared union by remove-nullish for such killing definitions, using the authoritative `initial_type`. **Calls are deliberately excluded** (a call may return nullable — keeps the negatives sound).

## Adjacent matrix
- `let t: M|undefined; t = { go(){} }; t.go()` (in a `forEach` closure) → clean (matches tsc); object/array/new/arrow RHS variants likewise.
- **Negatives (still error in both):** conditional `if (flag) { t = {...} } t.go()`; nullable-RHS `t = maybeUndef()`; no assignment. The fix does not blanket-strip undefined.

## Verification
- Repros clean and tsc-matched; all 3 negatives preserved.
- kysely project: TS18048 1→1, total 98→98 — the remaining kysely TS18048 is a `freeze({...})` **call**-RHS (intentionally excluded; a separate generic-call-return root). This PR clears the general object-literal killing-definition pattern, not the kysely-specific call form.
- Regression delta vs clean `main`: `--lib assignment` 9/9 (identical on clean main), `--lib narrow` 2/2, `--lib flow` 2/2, `--lib 18048` 24/24 pass — **zero new failures**. clippy clean.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
