### PR TITLE
fix(solver): keep contextual-return as a hint for argument-pinned bare return params (#14262)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -809,6 +809,9 @@ path = "tests/contextual_tuple_tests.rs"
 name = "contextual_return_tuple_generic_member_tests"
 path = "tests/contextual_return_tuple_generic_member_tests.rs"
 [[test]]
+name = "contextual_return_value_arg_pinned_tests"
+path = "tests/contextual_return_value_arg_pinned_tests.rs"
+[[test]]
 name = "contextual_ts2345_conformance_tests"
 path = "tests/contextual_ts2345_conformance_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/call_context.rs
+++ b/crates/tsz-checker/src/checkers/call_context.rs
@@ -607,6 +607,22 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
+            // A naked value parameter whose type IS a return type parameter is
+            // pinned directly by this argument. When the argument is a concrete
+            // (non context-sensitive) value, argument inference owns that return
+            // type parameter, so the contextual-return type must be suppressed —
+            // even for an object literal that carries function members, which the
+            // generic function-member guard below would otherwise defer (#14262).
+            // Without this, `reduce(init, fn) as never` (where `reduce<T>(init: T,
+            // fn: (acc: T, k: string) => T): T`) clamps the callback's `acc`/return
+            // to `never` even though `init` already determines `T`.
+            if !is_contextually_sensitive(self, arg_idx)
+                && common::type_param_info(self.ctx.types, param_type)
+                    .is_some_and(|info| return_type_params.contains(&info.name))
+            {
+                return true;
+            }
+
             if is_contextually_sensitive(self, arg_idx)
                 || self.object_literal_contains_function_member(arg_idx)
             {

--- a/crates/tsz-checker/tests/contextual_return_value_arg_pinned_tests.rs
+++ b/crates/tsz-checker/tests/contextual_return_value_arg_pinned_tests.rs
@@ -1,0 +1,130 @@
+//! Regression tests for issue #14262.
+//!
+//! When a generic call's return type is a bare type parameter `T` that is ALSO
+//! directly seeded by a concrete value argument, `tsc` lets argument inference
+//! own `T` and treats an outer contextual-return type — including an `as`-cast
+//! target like `as never` or `as { ... }` — as a low-priority hint that cannot
+//! override argument inference. tsz previously constrained the bare placeholder
+//! against the contextual type as an upper bound (and propagated it into the
+//! callback's contextual signature), so `as never` clamped `T = never` and broke
+//! the value argument and callback (TS2322 / TS2769 / TS2698).
+//!
+//! Anti-hardcoding: the structural rule is "the return type parameter is the
+//! naked type of a value parameter pinned by a concrete argument", so the tests
+//! vary binder names and argument shapes rather than matching any specific
+//! identifier or rendered message.
+
+use tsz_checker::test_utils::{check_source_diagnostics, diagnostic_code_message_refs};
+
+const CLAMP_CODES: &[u32] = &[2322, 2345, 2769, 2698];
+
+fn assert_no_clamp(source: &str, context: &str) {
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|diagnostic| CLAMP_CODES.contains(&diagnostic.code)),
+        "{context}: expected no contextual-return clamp diagnostic, got {:#?}",
+        diagnostic_code_message_refs(&diagnostics),
+    );
+}
+
+fn assert_has_code(source: &str, code: u32, context: &str) {
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.iter().any(|diagnostic| diagnostic.code == code),
+        "{context}: expected TS{code}, got {:#?}",
+        diagnostic_code_message_refs(&diagnostics),
+    );
+}
+
+#[test]
+fn as_never_does_not_clamp_argument_pinned_return_param() {
+    // The original witness: `reduce`'s `T` is pinned by `init`, the callback adds
+    // a computed key. The outer `as never` must not clamp `T`.
+    assert_no_clamp(
+        r#"
+declare function reduce<T>(init: T, fn: (acc: T, key: string) => T): T
+const r = reduce({ x: 1 }, (acc, key) => ({ ...acc, [key]: 1 })) as never
+"#,
+        "as never over a value-pinned bare return parameter",
+    );
+}
+
+#[test]
+fn as_never_with_function_member_argument_does_not_clamp() {
+    // The pinning argument is an object literal that also carries a function
+    // member, which previously defeated the contextual-return suppression.
+    assert_no_clamp(
+        r#"
+declare function reduce<T>(init: T, fn: (acc: T, key: string) => T): T
+const r = reduce({ x: 1, m: () => 2 }, (acc, key) => ({ ...acc, [key]: 1 })) as never
+"#,
+        "function-member-bearing pinning argument",
+    );
+}
+
+#[test]
+fn as_narrower_object_cast_does_not_clamp() {
+    // `as SomeNarrower` is the same family: the cast target is an object type.
+    assert_no_clamp(
+        r#"
+declare function fold<S>(seed: S, step: (acc: S, k: string) => S): S
+const r = fold({ a: 1, m: () => 9 }, (acc, k) => ({ ...acc, [k]: 1 })) as { a: number }
+"#,
+        "as narrower-object over a value-pinned bare return parameter",
+    );
+}
+
+#[test]
+fn renamed_binders_do_not_clamp() {
+    // Anti-hardcoding: arbitrary binder names must behave identically.
+    assert_no_clamp(
+        r#"
+declare function QQ<ZZZ>(init: ZZZ, cb: (state: ZZZ, key: string) => ZZZ): ZZZ
+const out = QQ({ p: 1, fn: () => 7 }, (state, key) => ({ ...state, [key]: 1 })) as never
+"#,
+        "renamed binders over a value-pinned bare return parameter",
+    );
+}
+
+#[test]
+fn return_param_only_from_context_still_applies_cast() {
+    // Negative control: when `U` is seeded ONLY by the contextual type (no value
+    // argument pins it), the cast must still apply and narrow `U`.
+    assert_no_clamp(
+        r#"
+declare function make<U>(): U
+const r = make() as never
+const s: number = make<number>()
+"#,
+        "context-only return parameter keeps cast semantics",
+    );
+}
+
+#[test]
+fn literal_union_annotation_is_preserved_for_callback_only_return() {
+    // Regression guard: callback-only seeded return parameters still use the
+    // contextual type to preserve literal unions (the upper-bound path).
+    assert_no_clamp(
+        r#"
+declare function invoke<T>(f: () => T): T
+let x: 0 | 1 | 2 = invoke(() => 1)
+"#,
+        "literal-union contextual preserved for callback-only return",
+    );
+}
+
+#[test]
+fn assignment_to_never_is_still_a_real_error() {
+    // The fix must not silence a genuine assignment error: assigning the
+    // argument-inferred object type to a `never`-annotated binding still fails.
+    assert_has_code(
+        r#"
+declare function reduce<T>(init: T, fn: (acc: T, key: string) => T): T
+const r: never = reduce({ x: 1 }, (acc, key) => ({ ...acc, [key]: 1 }))
+"#,
+        2322,
+        "object inferred from arguments is not assignable to never",
+    );
+}

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -616,6 +616,12 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // Track bare return type placeholder for conditional seeding after Round 1
         let mut return_type_bare_var: Option<(crate::inference::infer::InferenceVar, TypeId)> =
             None;
+        // Name of a bare return type parameter that is also directly pinned by a
+        // concrete value argument (#14262). For such a parameter argument
+        // inference owns the result, so the contextual-return type must stay a
+        // low-priority hint: its return-context substitution is dropped below so
+        // it cannot clamp the argument-pinned callback/return.
+        let mut value_arg_seeded_bare_return_param: Option<tsz_common::Atom> = None;
         let mut round1_direct_seed_vars = FxHashSet::default();
         let mut pair_visited = FxHashSet::default();
 
@@ -689,6 +695,38 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             // Without this, `let x: 0|1|2 = invoke(() => 1)` would widen T to
             // `number` because the contextual `0|1|2` upper bound is never set.
             let return_is_bare_var = var_map.contains_key(&return_type_with_placeholders);
+            // When the return type is a bare type parameter `T` that is ALSO
+            // directly seeded by a concrete value argument (some parameter's
+            // type IS `T` and the corresponding argument is not a deferred,
+            // context-sensitive expression), argument inference owns `T`. tsc
+            // treats the contextual-return type — including an outer `as`-cast
+            // target like `as never` — as a low-priority `ReturnType` hint that
+            // cannot override the argument-pinned inference (#14262).
+            //
+            // We detect the *naked* value-parameter position (`init: T`), not
+            // any reachable occurrence, so the literal-widening upper bound is
+            // preserved for callback-return positions like `<T>(f: () => T): T`
+            // (`let x: 0|1|2 = invoke(() => 1)`), where `T` is only seeded
+            // through the callback's return type and the contextual type is the
+            // sole anchor that prevents widening. The matched type parameter's
+            // name is recorded so its return-context substitution is dropped
+            // below (it must not clamp the callback parameters / return type).
+            if let Some(rv) = var_map.get(&return_type_with_placeholders).copied() {
+                let pinned_by_value_arg = arg_types.iter().enumerate().any(|(i, &arg_type)| {
+                    self.param_type_for_arg_index(&instantiated_params, i, arg_types.len())
+                        .is_some_and(|param_type| var_map.get(&param_type).copied() == Some(rv))
+                        && !self.is_contextually_sensitive(arg_type)
+                });
+                if pinned_by_value_arg {
+                    value_arg_seeded_bare_return_param = func
+                        .type_params
+                        .iter()
+                        .zip(type_param_vars.iter())
+                        .find(|(_, v)| **v == rv)
+                        .map(|(tp, _)| tp.name);
+                }
+            }
+            let bare_return_var_value_arg_seeded = value_arg_seeded_bare_return_param.is_some();
             // When the contextual type is a generic function (has type parameters),
             // always seed from it regardless of coverage. Higher-order generic
             // patterns like `compose(list, box)` need the contextual type's
@@ -743,7 +781,20 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         && func.params.iter().zip(instantiated_params.iter()).all(
                             |(original, instantiated)| original.type_id == instantiated.type_id,
                         );
-                if return_is_union_with_placeholder || constructor_params_lack_type_params {
+                if bare_return_var_value_arg_seeded {
+                    // Argument inference owns `T`: record the contextual type as a
+                    // low-priority `ReturnType` candidate (a hint) rather than an
+                    // upper bound. Argument candidates carry a higher priority
+                    // (`NakedTypeVariable`) and win during candidate filtering, so
+                    // an outer `as never` / `as SomeNarrower` cannot clamp `T`.
+                    if let Some(&var) = var_map.get(&return_type_with_placeholders) {
+                        infer_ctx.add_candidate(
+                            var,
+                            ctx_type,
+                            crate::types::InferencePriority::ReturnType,
+                        );
+                    }
+                } else if return_is_union_with_placeholder || constructor_params_lack_type_params {
                     self.constrain_types(
                         &mut infer_ctx,
                         &var_map,
@@ -885,8 +936,16 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             }
         }
 
-        let structural_return_subst =
+        let mut structural_return_subst =
             self.compute_return_context_substitution(func, self.contextual_type);
+        // Drop the return-context substitution for a bare return type parameter
+        // that a concrete value argument already pins (#14262). Argument
+        // inference owns the parameter, so the contextual-return type (e.g. an
+        // outer `as never`) must remain a low-priority hint and never reach the
+        // callback parameters, return type, or fixed substitution as a clamp.
+        if let Some(name) = value_arg_seeded_bare_return_param {
+            structural_return_subst.remove(name);
+        }
         // Add literal-containing upper bounds from the return context
         // substitution to prevent incorrect widening. When TResult1 has a
         // return context of DooDad = "SOMETHING" | "ELSE", the literal "ELSE"


### PR DESCRIPTION
Fixes #14262.

Goal: green

Clears false **TS2322 / TS2345 / TS2769 / TS2698** when an outer contextual-return type (e.g. an `as never` / `as { ... }` cast) is applied to a generic call whose bare return type parameter is already pinned by a value argument.

## Structural rule
When a generic call's return type is a bare type parameter `T` that is **also directly seeded by a concrete value argument** (some parameter's type IS `T` and its argument is a non-context-sensitive value), `tsc` lets argument inference own `T` and treats the contextual-return type — including an outer `as`-cast target like `as never` — as a low-priority hint that cannot override argument inference. tsz constrained the bare placeholder against the contextual type as an **upper bound** and propagated it into the callback's contextual signature, so `as never` clamped `T = never`, breaking the value argument and the callback:

`When the return type parameter is the naked type of a value parameter that a non-context-sensitive argument pins, tsc keeps the contextual-return type as a low-priority hint; tsz now records it as a low-priority ReturnType candidate and drops it from the return-context substitution, instead of an upper-bound clamp.`

So `reduce({ x: 1 }, (acc, key) => ({ ...acc, [key]: 1 })) as never` (where `reduce<T>(init: T, fn: (acc: T, key: string) => T): T`) is clean.

## Owner layer
- **Solver — generic-call inference** (`crates/tsz-solver/src/operations/generic_call/resolve.rs`): detect a bare return parameter pinned by a concrete value argument (matching the *naked* value-parameter position, not any reachable occurrence). For it, (a) record the contextual type as a low-priority `ReturnType` candidate rather than an upper bound, so argument candidates (`NakedTypeVariable`) win during priority filtering, and (b) drop that parameter's entry from `structural_return_subst` so it cannot clamp the callback parameters, return type, or fixed substitution.
- **Checker — `suppress_generic_return_context_for_direct_arg_overlap`** (`crates/tsz-checker/src/checkers/call_context.rs`): suppress the contextual-return type when a naked value parameter whose type IS a return type parameter receives a non-context-sensitive argument, even when the object literal carries function members — closing the gap that let the callback contextual signature clamp through.

## Fallback / safety
The literal-widening upper bound is preserved for callback-return positions like `<T>(f: () => T): T` (`let x: 0|1|2 = invoke(() => 1)`), where `T` is seeded only through the callback's return and the contextual type is the sole anchor that prevents widening. The detection matches the *naked* value-parameter position only, so these callback-return cases keep the existing upper-bound path.

## Adjacent matrix
New regression file `contextual_return_value_arg_pinned_tests.rs` (7 tests, registered):
- `as never` over a value-pinned bare return parameter; pinning argument with a function member (defeats the old suppression); `as { ... }` narrower-object cast; renamed binders (anti-hardcoding).
- **Negative controls:** return parameter seeded ONLY by the contextual type still applies the cast; literal-union annotation still preserved for callback-only returns (`invoke(() => 1)`); assigning the argument-inferred object type to a `never`-annotated binding is still a real TS2322.

## Anti-hardcoding
Structural inference-priority rule keyed on the *naked value-parameter* position and contextual sensitivity — no identifier/file-name/printer-output checks. Tests vary binder names.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo nextest run -p tsz-checker --test contextual_return_value_arg_pinned_tests` → 7/7 pass.
- `cargo nextest run -p tsz-solver` → 6870 pass; the 4 failures are pre-existing on clean `main` (reproduce with this change reverted) and are debug-build/env-only artifacts (main is green via the merge queue).
- Manual repro + adjacent + negative cases vs documented `tsc` results; `cargo clippy -p tsz-solver -p tsz-checker --tests` clean; `cargo fmt --check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_0111XeZDkQZamHz2kFuicioW)_