### PR TITLE
fix(solver): resolve false branch for concrete-check vs generic-extends conditionals

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1967,3 +1967,7 @@ path = "tests/nullable_union_missing_property_tests.rs"
 [[test]]
 name = "partial_record_optional_index_assignability_tests"
 path = "tests/partial_record_optional_index_assignability_tests.rs"
+
+[[test]]
+name = "conditional_concrete_check_generic_extends_tests"
+path = "tests/conditional_concrete_check_generic_extends_tests.rs"

--- a/crates/tsz-checker/tests/conditional_concrete_check_generic_extends_tests.rs
+++ b/crates/tsz-checker/tests/conditional_concrete_check_generic_extends_tests.rs
@@ -1,0 +1,149 @@
+//! Tests for conditional types whose check type is concrete but whose extends
+//! type carries a type parameter.
+//!
+//! Issue #14232 (mined from ts-essentials): when a conditional's relation fails
+//! and the extends type is generic but the check type is concrete, tsc resolves
+//! eagerly — it takes the false branch as soon as the relation *also* fails
+//! under the permissive instantiation (every type parameter replaced by `any`,
+//! tsc's `getPermissiveInstantiation` gate). tsz previously deferred
+//! unconditionally whenever the extends type carried a type parameter, leaving
+//! the conditional opaque and reporting a spurious TS2322 at the use site.
+//!
+//! The structural rule:
+//!   When `Concrete extends GenericExtends ? X : Y` fails the relation and
+//!   `Concrete` has no free type parameters, take `Y` iff the relation also
+//!   fails for `GenericExtends[params -> any]`; otherwise defer.
+//!
+//! These cases vary the binder name and the shape (tuple, object, array) so the
+//! behavior is structural, not tied to any particular identifier.
+
+use tsz_checker::test_utils::{check_source_strict, diagnostic_count, diagnostics_without_codes};
+
+fn ts2322_count(source: &str) -> usize {
+    diagnostic_count(&check_source_strict(source), 2322)
+}
+
+/// No diagnostics other than TS2318 (missing global lib types in the no-stdlib
+/// unit harness).
+fn has_no_errors(source: &str) -> bool {
+    diagnostics_without_codes(&check_source_strict(source), &[2318]).is_empty()
+}
+
+// ── The canonical repro: empty tuple vs one-or-more generic tuple ─────────
+
+#[test]
+fn empty_tuple_never_satisfies_one_or_more_generic_tuple() {
+    // `[] extends [T, ...T[]]` can never hold for any `T`: the empty tuple has
+    // length 0 while `[T, ...T[]]` requires at least one element. The false
+    // branch is permissively definitive, so `A` resolves to `"no"`.
+    assert!(
+        has_no_errors(
+            r#"
+function f<T>() {
+  type A = [] extends [T, ...T[]] ? "yes" : "no";
+  const a: A = "no";
+}
+export {};
+"#
+        ),
+        "empty tuple vs `[T, ...T[]]` must resolve to the false branch"
+    );
+}
+
+#[test]
+fn empty_tuple_one_or_more_generic_tuple_rejects_true_branch_literal() {
+    // The conditional resolved to `"no"`, so assigning `"yes"` must still error.
+    assert_eq!(
+        ts2322_count(
+            r#"
+function f<T>() {
+  type A = [] extends [T, ...T[]] ? "yes" : "no";
+  const a: A = "yes";
+}
+export {};
+"#
+        ),
+        1,
+        "`\"yes\"` is not assignable to the resolved false branch `\"no\"`"
+    );
+}
+
+// Binder name must not matter — same structure, different type-parameter name.
+#[test]
+fn empty_tuple_one_or_more_generic_tuple_renamed_param() {
+    assert!(
+        has_no_errors(
+            r#"
+function f<Element>() {
+  type A = [] extends [Element, ...Element[]] ? "yes" : "no";
+  const a: A = "no";
+}
+export {};
+"#
+        ),
+        "renamed type parameter must behave identically"
+    );
+}
+
+// ── Object shape: a missing required key is permissively definitive ───────
+
+#[test]
+fn object_missing_required_key_takes_false_branch() {
+    // `{ a: 1 }` is missing `b`, so it can never satisfy `{ a: 1; b: T }` for
+    // any `T`. The false branch is definitive.
+    assert!(
+        has_no_errors(
+            r#"
+function f<T>() {
+  type A = { a: 1 } extends { a: 1; b: T } ? "yes" : "no";
+  const a: A = "no";
+}
+export {};
+"#
+        ),
+        "object missing a required key must resolve to the false branch"
+    );
+}
+
+// ── Deferral must be preserved when the permissive form could still match ──
+
+#[test]
+fn concrete_tuple_vs_single_generic_element_stays_deferred() {
+    // `[string] extends [T]` could be true (`T = string`) or false, so tsc keeps
+    // the conditional deferred. Neither `"yes"` nor `"no"` is assignable to the
+    // opaque conditional, so both assignments error (two TS2322).
+    assert_eq!(
+        ts2322_count(
+            r#"
+function f<T>() {
+  type A = [string] extends [T] ? "yes" : "no";
+  const a: A = "yes";
+  const b: A = "no";
+}
+export {};
+"#
+        ),
+        2,
+        "permissively-matchable conditional must stay deferred (both assignments error)"
+    );
+}
+
+// ── True branch when the relation holds regardless of instantiation ───────
+
+#[test]
+fn identical_generic_tuple_takes_true_branch() {
+    // `[T] extends [T]` holds for every `T`, so `A` resolves to `"yes"`.
+    assert_eq!(
+        ts2322_count(
+            r#"
+function f<T>() {
+  type A = [T] extends [T] ? "yes" : "no";
+  const a: A = "no";
+}
+export {};
+"#
+        ),
+        1,
+        "`[T] extends [T]` resolves to the true branch `\"yes\"`, so `\"no\"` errors"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -172,20 +172,33 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         extends_type: TypeId,
     ) -> bool {
         use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
-        let mut params = self.extract_type_params_from_type(check_type);
-        for param in self.extract_type_params_from_type(extends_type) {
-            if !params.iter().any(|existing| existing.name == param.name) {
-                params.push(param);
-            }
-        }
-        if params.is_empty() {
-            // No named parameters to widen: the failed relation already used
-            // the most permissive forms available.
+        // Widen every *free* type parameter (and `infer` variable) that occurs
+        // anywhere in either operand to `any` — tsc's
+        // `getPermissiveInstantiation`. Use the canonical free-parameter walker
+        // rather than `extract_type_params_from_type`: the walker reaches
+        // parameters nested in any shape (tuple elements, index signatures,
+        // string-intrinsic arguments, …), whereas
+        // `extract_type_params_from_type` is positional-arity machinery for
+        // instantiation and deliberately reports a narrower set. Missing a
+        // nested parameter here would make a generic operand look concrete and
+        // wrongly mark the false branch definitive (e.g. `[] extends
+        // [T, ...T[]]`, whose `T` lives inside a tuple).
+        let param_ids = crate::visitors::visitor_predicates::free_type_parameter_ids_in(
+            self.interner(),
+            [check_type, extends_type],
+        );
+        if param_ids.is_empty() {
+            // No free parameters to widen: the failed relation already used the
+            // most permissive forms available.
             return true;
         }
         let mut substitution = TypeSubstitution::new();
-        for param in &params {
-            substitution.insert(param.name, TypeId::ANY);
+        for &param_id in &param_ids {
+            if let Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) =
+                self.interner().lookup(param_id)
+            {
+                substitution.insert(info.name, TypeId::ANY);
+            }
         }
         let permissive_check =
             self.evaluate(instantiate_type(self.interner(), check_type, &substitution));
@@ -1068,14 +1081,34 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             let result_branch = if is_sub {
                 // T <: U -> true branch
                 cond.true_type
-            } else if extends_has_type_params
-                // tsc parity (`getConditionalType`): a conditional whose
-                // effective check type is still generic — instantiable flags,
-                // or a type reference/tuple/template whose arguments are
-                // generic — only resolves to the false branch when the
-                // relation also fails under the permissive instantiation
-                // (every type parameter replaced by `any`, tsc's
-                // `getPermissiveInstantiation` gate); otherwise it stays
+            } else if (extends_has_type_params
+                // tsc parity (`getConditionalType`): when the relation fails
+                // and the extends type carries a type parameter, the failure is
+                // only indeterminate while instantiation could still flip it.
+                //   * Depth-detection pass: keep deferring so unconditionally
+                //     recursive aliases still drive their recursive branch and
+                //     surface TS2589.
+                //   * Generic check type: instantiation could change the check
+                //     side too (`checkTypeInstantiable` in tsc never resolves),
+                //     so defer.
+                //   * Concrete check type: resolve to the false branch as soon
+                //     as the relation *also* fails under the permissive
+                //     instantiation (every type parameter replaced by `any`,
+                //     tsc's `getPermissiveInstantiation` gate). The empty tuple
+                //     can never satisfy `[T, ...T[]]` for any `T`, and an object
+                //     missing a required key can never satisfy `{ …; k: T }`, so
+                //     tsc takes the false branch instead of leaving the
+                //     conditional opaque. Only when the permissive form could
+                //     still match (`[string] extends [T]`) does it stay deferred.
+                && (self.is_depth_detection_pass()
+                    || crate::type_queries::is_generic_conditional_check_type(
+                        self.interner(),
+                        check_type,
+                    )
+                    || !self.permissive_false_branch_is_definitive(check_type, extends_type)))
+                // A conditional whose effective check type is still generic only
+                // resolves to the false branch when the relation also fails
+                // under the permissive instantiation; otherwise it stays
                 // deferred until instantiation makes the check type concrete.
                 // This also covers deferred wrappers over *unresolved*
                 // references (`keyof Lazy(D)`), which under parallel fresh


### PR DESCRIPTION
Fixes #14232.

## Summary
A conditional `C extends E ? X : Y` whose relation fails was deferred
unconditionally whenever the **extends** type `E` carried a type parameter —
even when the **check** type `C` was concrete. That left the conditional opaque
and produced a spurious **TS2322** at the use site:

```ts
function f<T>() {
  type A = [] extends [T, ...T[]] ? "yes" : "no";
  const a: A = "no"; // tsz: TS2322 (was); tsc: ok (A = "no")
}
```

The empty tuple can never satisfy `[T, ...T[]]` for *any* `T`, so `tsc`
resolves the false branch eagerly.

## Structural rule
When `C extends E ? X : Y` fails the relation and `E` is generic but `C` is
concrete (no free type parameters), `tsc` (`getConditionalType`) resolves the
false branch as soon as the relation **also fails under the permissive
instantiation** — every free type parameter replaced by `any`
(`getPermissiveInstantiation`). It only stays deferred when the permissive form
could still match (`[string] extends [T]`). When the check type is *itself*
generic, `tsc` never resolves (`checkTypeInstantiable`), so that case continues
to defer.

`When the relation fails and the check type is concrete, tsc resolves the false
branch iff the permissive (params → any) instantiation also fails; tsz now does
this through the solver's conditional-evaluation gate.`

## Owner layer
Solver — `evaluation/evaluate_rules/conditional.rs`:
- The `extends_has_type_params` deferral branch is now gated on
  `is_depth_detection_pass() || is_generic_conditional_check_type(check) ||
  !permissive_false_branch_is_definitive(...)`, so a concrete check with a
  permissively-definitive false branch resolves instead of deferring.
- `permissive_false_branch_is_definitive` now collects the parameters to widen
  via the canonical `free_type_parameter_ids_in` walker instead of
  `extract_type_params_from_type`. The latter is positional-arity machinery for
  instantiation and does not descend into tuple elements / index signatures /
  string-intrinsic arguments, so the gate previously treated tuple-shaped
  extends types as concrete and mis-classified the false branch as definitive.
  Routing the widening through the comprehensive walker fixes every shape at
  once and leaves the instantiation callers of `extract_type_params_from_type`
  untouched.

## Adjacent matrix (covered by the new test file)
- `[] extends [T, ...T[]]` → false branch (the bug); renamed binder identical.
- `{ a: 1 } extends { a: 1; b: T }` → false branch (missing key, definitive).
- `[string] extends [T]` → still deferred (permissive form matches).
- `[T] extends [T]` → true branch (holds for every `T`).

## Anti-hardcoding
Structural conditional-resolution rule driven by relation + permissive
instantiation; no identifier/file-name/printer-output checks. Tests vary the
type-parameter name.

## Verification
- New: `crates/tsz-checker/tests/conditional_concrete_check_generic_extends_tests.rs` (6 cases) — all pass.
- Repro `function f<T>() { type A = [] extends [T, ...T[]] ? "yes" : "no"; const a: A = "no"; }` — tsz 0 errors, matches `tsc` 6.0.2.
- `cargo test -p tsz-solver --lib -- --test-threads=1`: 6863 passed; only 4 pre-existing failures (confirmed identical on the base commit), 0 new.
- `cargo clippy -p tsz-solver` and `cargo fmt --check` clean.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high