### PR TITLE
fix(solver): distribute 'in'-narrowing into nested-union members (TS2339)

### DIFF
--- a/crates/tsz-solver/src/narrowing/property.rs
+++ b/crates/tsz-solver/src/narrowing/property.rs
@@ -203,6 +203,31 @@ impl<'a> NarrowingContext<'a> {
                     // CRITICAL: Resolve Lazy types for each member
                     let resolved_member = self.resolve_type(member);
 
+                    // A constituent may itself resolve to a *nested* union — most
+                    // commonly a generic alias such as
+                    // `Resp<T> = ErrorResponse | SuccessResponse<T>` reaching here
+                    // as an `Application`. tsc's `narrowTypeByInKeyword` filters the
+                    // constituents of the *fully flattened* union, so the `in`
+                    // narrowing must distribute into the nested union rather than
+                    // applying a single keep/drop decision to the alias as a whole.
+                    // Without this, the negative branch keeps the entire alias (its
+                    // `error`-bearing arm makes the property *not required* overall),
+                    // so a later `.result` access wrongly sees the still-present
+                    // `ErrorResponse` arm (false TS2339); the positive branch
+                    // symmetrically keeps the `error`-only arm. Recurse so each
+                    // nested constituent is filtered independently. `resolve_type`
+                    // is identity/cycle-guarded and the nested constituents resolve
+                    // to non-union structural forms, so the recursion is bounded by
+                    // the (finite) alias-nesting depth.
+                    if union_list_id(self.db, resolved_member).is_some() {
+                        let narrowed = self.narrow_by_property_presence(
+                            resolved_member,
+                            property_name,
+                            present,
+                        );
+                        return (narrowed != TypeId::NEVER).then_some(narrowed);
+                    }
+
                     let has_property = self.type_has_property(resolved_member, property_name);
                     if present {
                         // Positive: "prop" in member


### PR DESCRIPTION
Goal: green

Clears false **TS2339** ("Property 'X' does not exist") when an `in`-narrowing must distribute into a union member that itself resolves to a union (a generic alias whose body is a union).

## Structural rule
When `'prop' in x` narrows a union and a constituent resolves to **another** union — e.g. `Resp<T> = ErrorResponse | SuccessResponse<T>` arriving as a `TypeData::Application` — tsc filters the constituents of the *fully flattened* union. tsz applied a single binary keep/drop to the whole alias (`is_property_required_uncached` has no `Union` arm → returns false for a union-typed member), so the negative branch kept the entire alias and a later `.result` access still saw the `ErrorResponse` arm → false TS2339. `narrow_by_property_presence`'s union-member loop now recurses when a resolved member is itself a `Union` (`union_list_id(...).is_some()`), pushing the narrowed result (dropped when `NEVER`). Bounded by finite alias nesting; cycle-guarded `resolve_type`.

## Adjacent matrix
- `if ('error' in response) {...} return response.result` where `response: Resp<TOutput> | ErrorResponse` → `.result` resolves (matches tsc).
- **Negatives (still error in both):** `error` required on every arm → negative branch is `never`, `.result` errors (`'never'`); a non-union member alongside the union member distributes and re-joins correctly; positive `'result' in response` works.

## Verification
- Repro + 3 negatives parity-matched; trpc TS2339 11→7 (the 4 `transformer.ts` FPs), total 147→144, no new codes.
- `tsz-solver --lib narrow` 323 pass / 1 pre-existing fail (identical on clean main). (CI runs the full property/2339 filters + clippy + conformance — local run was cut short by a transient disk-full from a concurrent build.)

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
