### PR TITLE
fix(checker): keep named props between two union-distributed spreads (TS2322)

### DIFF
--- a/crates/tsz-checker/src/types/computation/object_literal/spread_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/spread_element.rs
@@ -253,6 +253,23 @@ impl<'a> CheckerState<'a> {
                 *has_union_spread = true;
                 let mut new_branches: Vec<FxHashMap<Atom, PropertyInfo>> = Vec::new();
 
+                // When earlier union spreads already produced branches, any
+                // named properties written since then accumulate in the main
+                // `properties` map (it was cleared after the previous union
+                // spread). Those intervening props are not present in the
+                // existing branches, and the post-union assembly only folds
+                // in props written after the LAST union spread — so without
+                // this snapshot they would vanish from every distributed
+                // branch. Capture them once (sorted by declaration order for
+                // determinism) and fold them into each existing branch below.
+                let intervening_props: Vec<PropertyInfo> = if union_spread_branches.is_empty() {
+                    Vec::new()
+                } else {
+                    let mut props: Vec<PropertyInfo> = properties.values().cloned().collect();
+                    props.sort_by_key(|p| p.declaration_order);
+                    props
+                };
+
                 // Collect properties from each union member for TS2783
                 // and branching.
                 let mut all_member_props: Vec<Vec<PropertyInfo>> = members
@@ -324,6 +341,11 @@ impl<'a> CheckerState<'a> {
                         // Subsequent union spread: cross-product with existing branches
                         for existing in union_spread_branches.iter() {
                             let mut branch = existing.clone();
+                            // Fold in named props written since the previous
+                            // union spread so they survive this distribution.
+                            for prop in &intervening_props {
+                                self.merge_spread_property(&mut branch, prop);
+                            }
                             for prop in &member_props {
                                 self.merge_spread_property(&mut branch, prop);
                             }

--- a/crates/tsz-checker/src/types/computation/object_literal/spread_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/spread_element.rs
@@ -260,14 +260,18 @@ impl<'a> CheckerState<'a> {
                 // existing branches, and the post-union assembly only folds
                 // in props written after the LAST union spread — so without
                 // this snapshot they would vanish from every distributed
-                // branch. Capture them once (sorted by declaration order for
-                // determinism) and fold them into each existing branch below.
-                let intervening_props: Vec<PropertyInfo> = if union_spread_branches.is_empty() {
+                // branch. Capture their names once (sorted by declaration
+                // order for determinism) and fold them into each existing
+                // branch below.
+                let intervening_prop_names: Vec<Atom> = if union_spread_branches.is_empty() {
                     Vec::new()
                 } else {
-                    let mut props: Vec<PropertyInfo> = properties.values().cloned().collect();
-                    props.sort_by_key(|p| p.declaration_order);
-                    props
+                    let mut props: Vec<(u32, Atom)> = properties
+                        .values()
+                        .map(|prop| (prop.declaration_order, prop.name))
+                        .collect();
+                    props.sort_by_key(|(declaration_order, _)| *declaration_order);
+                    props.into_iter().map(|(_, name)| name).collect()
                 };
 
                 // Collect properties from each union member for TS2783
@@ -343,8 +347,10 @@ impl<'a> CheckerState<'a> {
                             let mut branch = existing.clone();
                             // Fold in named props written since the previous
                             // union spread so they survive this distribution.
-                            for prop in &intervening_props {
-                                self.merge_spread_property(&mut branch, prop);
+                            for name in &intervening_prop_names {
+                                if let Some(prop) = properties.get(name) {
+                                    self.merge_spread_property(&mut branch, prop);
+                                }
                             }
                             for prop in &member_props {
                                 self.merge_spread_property(&mut branch, prop);


### PR DESCRIPTION
Goal: green

Clears false **TS2322** ("Property 'X' is missing") when a named property is written **between two union-distributed object spreads**.

## Structural rule
tsc keeps a named property written between two union spreads in every distributed branch. tsz cleared the main `properties` map after the first union spread and only re-folded *post-last-union* props during assembly (`finalize_object_literal_type`), so props written *between* spreads vanished from all branches → false TS2322. The subsequent-union-spread arm in `process_object_literal_spread_element` now folds the accumulated intervening props (snapshotted, sorted by `declaration_order` for determinism) into each existing branch via the existing `merge_spread_property` helper before cross-producting with the next union's members. Structural; no name/file checks.

## Adjacent matrix
- `{ ...(cond ? {rel,as} : {rel}), href: 'h', ...(co ? {co} : {}) }` against a target requiring `href` → clean (matches tsc).
- single union spread + trailing named prop → unchanged (clean); a prop written *after* the second union spread still survives; two union spreads with no intervening prop → unchanged.
- **Negative:** omit `href` entirely → still TS2322 in both.
- Deterministic output across repeated runs (props sorted by declaration order).

## Verification
- Repro + 4 adjacent/negative cases parity-matched and deterministic. (CI runs the full object_literal/spread/2322 unit filters + clippy + conformance — local run cut short by a transient disk-full from a concurrent build; the change is a single localized arm verified against the repro + adjacency matrix.)

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
