### PR TITLE
fix(checker): recognize a deferred conditional constraint as array-like in the spread gate (TS2345) (#14217)

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
@@ -37,6 +37,42 @@ fn type_param_variadic_tuple_spread(
     is_type_parameter_type(db, spread_type) && elems.iter().any(|elem| elem.rest)
 }
 
+/// Whether a type-parameter spread constraint is array- or tuple-like, so that
+/// `...params` (where `params: P`) is a safe variadic spread rather than a
+/// destructured argument list.
+///
+/// The direct constraint is tested first. When it is a *deferred* type
+/// expression — e.g. `P extends Parameters<F>`, whose constraint is an
+/// unevaluated alias application that resolves to a `Conditional` — the direct
+/// tuple/array probes both miss. The fallback evaluates the constraint to its
+/// structural form and, for a deferred conditional, resolves it to its apparent
+/// base constraint (the union of branches, tsc's
+/// `getDefaultConstraintOfConditionalType`) before re-probing. This only ever
+/// *recognizes more* array/tuple-like constraints; a non-array constraint
+/// (e.g. `T extends number`) still fails every probe, so a genuinely invalid
+/// spread keeps its diagnostic.
+fn constraint_is_array_or_tuple_like(
+    db: &dyn tsz_solver::construction::TypeDatabase,
+    constraint: TypeId,
+) -> bool {
+    let is_array_or_tuple = |ty: TypeId| {
+        array_element_type_for_type(db, ty).is_some() || tuple_elements_for_type(db, ty).is_some()
+    };
+    if is_array_or_tuple(constraint) {
+        return true;
+    }
+    // Resolve a deferred constraint (e.g. an unevaluated `Parameters<F>`
+    // application) to its structural form and re-probe.
+    let evaluated = crate::query_boundaries::common::evaluate_type(db, constraint);
+    if evaluated != constraint && is_array_or_tuple(evaluated) {
+        return true;
+    }
+    // A deferred conditional stays deferred after evaluation; use its apparent
+    // base constraint (union of branches) for the array/tuple probe.
+    crate::query_boundaries::common::conditional_default_constraint(db, evaluated)
+        .is_some_and(is_array_or_tuple)
+}
+
 impl<'a> CheckerState<'a> {
     fn generic_function_argument_has_own_type_params(&self, arg_idx: NodeIndex) -> bool {
         let arg_idx = self.ctx.arena.skip_parenthesized_and_assertions(arg_idx);
@@ -714,8 +750,7 @@ impl<'a> CheckerState<'a> {
                                 self.ctx.types,
                                 spread_type,
                             )
-                        && (array_element_type_for_type(self.ctx.types, constraint).is_some()
-                            || tuple_elements_for_type(self.ctx.types, constraint).is_some())
+                        && constraint_is_array_or_tuple_like(self.ctx.types, constraint)
                     {
                         // Wrap the spread type parameter in a variadic tuple
                         // marker [...U] so the solver can distinguish `f(...u)`

--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -8,3 +8,4 @@ mod indexed_access;
 mod membership_semantics;
 mod narrowing;
 mod optional_chain;
+mod spread_param_constraint_2345;

--- a/crates/tsz-checker/tests/conformance_issues/types/spread_param_constraint_2345.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/spread_param_constraint_2345.rs
@@ -1,0 +1,82 @@
+//! Spreading a type parameter whose constraint is a *deferred* array/tuple-like
+//! type (e.g. `P extends Parameters<F>`) must be treated as a variadic spread,
+//! not destructured against the target's parameters. `tsz` previously only
+//! recognized a *directly* array/tuple-like constraint, so `...params` where
+//! `params: P` and `P extends Parameters<F>` fell through to a per-element check
+//! that compared `any` against the rest parameter's `never` element, emitting a
+//! false TS2345 ("'any' is not assignable to 'never'"). The gate now resolves a
+//! deferred constraint (`Parameters<F>` -> its apparent base constraint) before
+//! probing for array/tuple shape. (#14217)
+
+use super::super::core::*;
+
+/// The witness: `P extends Parameters<F>` is a deferred conditional constraint
+/// (an unevaluated `Parameters` alias application). The spread `fn(...params)`
+/// must be recognized as a variadic spread, so no TS2345 fires.
+#[test]
+fn spread_param_extends_parameters_of_fn_no_ts2345() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type AnyFunction = (...params: never[]) => unknown;
+export function callIt<F extends AnyFunction, P extends Parameters<F>>(
+  fn: F,
+  params: P,
+): unknown {
+  return fn(...params);
+}
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2345),
+        "no TS2345 expected — `P extends Parameters<F>` is a deferred array/tuple-like \
+         constraint, so `fn(...params)` is a variadic spread, not a destructured arg \
+         list. Actual: {diagnostics:#?}"
+    );
+}
+
+/// Adjacent case: the constraint is a *directly* tuple-like deferred reference
+/// reached through a second type parameter (`P extends Q`, `Q extends [number]`).
+/// The fallback resolution must not regress the already-working direct-tuple
+/// path, so this stays clean too.
+#[test]
+fn spread_param_extends_indirect_tuple_constraint_no_ts2345() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+export function callIt<Q extends [number, number], P extends Q>(
+  fn: (a: number, b: number) => unknown,
+  params: P,
+): unknown {
+  return fn(...params);
+}
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2345),
+        "no TS2345 expected — `P extends Q`, `Q extends [number, number]` is a \
+         tuple-like spread. Actual: {diagnostics:#?}"
+    );
+}
+
+/// Negative control: a real argument-type mismatch on a tuple-constrained spread
+/// must still surface as TS2345. The spread is recognized as variadic, but the
+/// tuple element type (`string`) is incompatible with the target parameter
+/// (`number`), so the assignability error must fire — the fix only stops the
+/// false `any`-vs-`never` element check, never a real one.
+#[test]
+fn spread_tuple_param_with_wrong_element_type_still_ts2345() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+export function callIt<P extends [string, string]>(
+  fn: (a: number, b: number) => unknown,
+  params: P,
+): unknown {
+  return fn(...params);
+}
+"#,
+    );
+    assert!(
+        has_error(&diagnostics, 2345),
+        "TS2345 expected — the variadic spread of a `[string, string]` tuple into a \
+         `(number, number)` target is a real element-type mismatch. Actual: {diagnostics:#?}"
+    );
+}


### PR DESCRIPTION
Fixes a green-goal canary false positive (TS2345) with a contained, **additive**
checker-side boundary extension — it only suppresses the false positive and can
never introduce a new diagnostic.

Goal: green

## Structural rule
When the spread-of-type-parameter gate decides whether a spread argument
(`fn(...params)` where `params: P`) is variadic, it tested only the **direct**
constraint of `P` for array/tuple-likeness. For `P extends Parameters<F>` the
constraint is a *deferred conditional* (an unevaluated `Parameters` alias
application), so the gate fell through to a per-element check that compared `any`
against the rest parameter's `never` element and emitted a false TS2345
(`'any' is not assignable to 'never'`).

tsc relates such a spread through the constraint's **default constraint** (the
union of the conditional's branches, `getDefaultConstraintOfConditionalType`).
This change resolves the constraint via `evaluate_type` +
`conditional_default_constraint` before probing for array/tuple shape, so a
deferred-but-array-like constraint is recognized as variadic.

Owner: checker — `checkers/call_checker/candidate_collection.rs` (new
`constraint_is_array_or_tuple_like` helper gating the spread check). Strictly
additive: a non-array constraint (`T extends number`) evaluates to `number`,
`conditional_default_constraint` returns `None`, the helper returns `false`, and
real spread errors are preserved.

## Adjacent cases (all covered by the test file)
- Witness: `P extends Parameters<F>` → no TS2345 (flip).
- Indirect: `P extends Q`, `Q extends [number, number]` → still clean (direct
  tuple path not regressed).
- Negative control: a real element-type mismatch (`[string, string]` spread into
  `(number, number)`) still emits TS2345 — the fix stops only the false
  `any`-vs-`never` element check, never a real assignability error.

## Verification
- `cargo nextest run -p tsz-checker -j 2 spread_param_constraint` — 3 tests
  (1 flip + 2 negative/adjacent controls) green.
- CI: lint, unit-checker-integration, conformance-aggregate, emit-aggregate,
  fourslash-*, project-compile-guard, CI Summary.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
