### PR TITLE
fix(checker): name-merged type-alias+value import types value refs from the const (TS18048)

### DIFF
--- a/crates/tsz-checker/src/types/computation/identifier/core.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/core.rs
@@ -235,6 +235,40 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// Select the value-side declaration of a name-merged `TYPE_ALIAS` + value
+    /// symbol.
+    ///
+    /// When a `TYPE_ALIAS` is declared before its merged value (e.g.
+    /// `type Foo = ...; const Foo: any;`), the binder records the type-alias
+    /// node as `value_declaration`. Typing that type-alias node in value
+    /// position yields a possibly-undefined type. Return the first declaration
+    /// whose kind is not a type-alias declaration so the actual value
+    /// declaration drives value-position typing. Returns `None` when every
+    /// declaration is a type-alias (or none can be read from the target arena),
+    /// leaving the caller to fall back to the recorded `value_declaration`.
+    pub(crate) fn value_declaration_skipping_type_alias(
+        &self,
+        target: &tsz_binder::Symbol,
+        target_file_idx: usize,
+    ) -> Option<NodeIndex> {
+        // If the recorded value declaration is already a non-type-alias node,
+        // it is the value side; keep it (matches the const-first merge order).
+        let arena = self.ctx.get_arena_for_file(target_file_idx as u32);
+        let is_type_alias_node = |decl: NodeIndex| {
+            arena
+                .get(decl)
+                .is_some_and(|node| node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION)
+        };
+        if target.value_declaration.is_some() && !is_type_alias_node(target.value_declaration) {
+            return Some(target.value_declaration);
+        }
+        target
+            .declarations
+            .iter()
+            .copied()
+            .find(|&decl| decl.is_some() && !is_type_alias_node(decl))
+    }
+
     pub(crate) fn local_current_file_value_symbol_named(
         &self,
         name: &str,

--- a/crates/tsz-checker/src/types/computation/identifier/resolved.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/resolved.rs
@@ -797,7 +797,12 @@ impl CheckerState<'_> {
         // value-declaration via cross-file delegation so the call-site
         // sees the value-side type instead of the interface type that
         // `compute_type_of_symbol` returns by default.
-        let alias_target_merged_value_info: Option<(tsz_binder::SymbolId, NodeIndex, usize)> =
+        // `(target_sym_id, value_decl, file_idx, is_plain_value_type_alias)`.
+        // The final flag marks a name-merged plain `TYPE_ALIAS` (no `INTERFACE`,
+        // no `CLASS`) over a value, the only shape allowed to fall back to the
+        // symbol's own type when its value declaration lowers to a
+        // non-instantiable value-position type.
+        let alias_target_merged_value_info: Option<(tsz_binder::SymbolId, NodeIndex, usize, bool)> =
             ((flags & tsz_binder::symbol_flags::ALIAS) != 0)
                 .then(|| {
                     let mut target_sym_id =
@@ -851,16 +856,55 @@ impl CheckerState<'_> {
                         && target.import_module().is_none()
                         && target.value_declaration.is_some()
                     {
-                        let target_value_decl = target.value_declaration;
                         let target_file_idx = self.ctx.resolve_symbol_file_index(target_sym_id)?;
-                        Some((target_sym_id, target_value_decl, target_file_idx))
+                        // The value-position type must come from the *value*
+                        // declaration, not whichever declaration the binder
+                        // recorded as `value_declaration`. When a `TYPE_ALIAS` is
+                        // declared before its name-merged const/var (e.g.
+                        // `type Foo = ...; const Foo: any;`), the binder records
+                        // the type-alias node as `value_declaration`; typing that
+                        // type-alias node as a value yields a possibly-undefined
+                        // type and produces false TS18048/TS2722 on
+                        // `new Foo()` / `Foo()`. Prefer a declaration node whose
+                        // kind is not a type-alias so the const's declared value
+                        // type is used.
+                        //
+                        // Restrict this correction to a name-merged plain
+                        // `TYPE_ALIAS` (no `INTERFACE`, no `CLASS`) over a value.
+                        // `INTERFACE`+value (constructor companion) and `CLASS`
+                        // merges keep the recorded `value_declaration` untouched:
+                        // their value side is the companion declaration the
+                        // binder already records correctly.
+                        let is_plain_value_type_alias = (tflags
+                            & (tsz_binder::symbol_flags::INTERFACE
+                                | tsz_binder::symbol_flags::CLASS))
+                            == 0;
+                        let target_value_decl = if is_plain_value_type_alias {
+                            self.value_declaration_skipping_type_alias(target, target_file_idx)
+                                .unwrap_or(target.value_declaration)
+                        } else {
+                            target.value_declaration
+                        };
+                        Some((
+                            target_sym_id,
+                            target_value_decl,
+                            target_file_idx,
+                            is_plain_value_type_alias,
+                        ))
                     } else if (tflags
                         & (tsz_binder::symbol_flags::INTERFACE
                             | tsz_binder::symbol_flags::TYPE_ALIAS))
                         != 0
                         && (tflags & tsz_binder::symbol_flags::VALUE) == 0
                     {
+                        // `TYPE_ALIAS`/`INTERFACE` without a merged value: the
+                        // value side is a separate same-file symbol whose value
+                        // declaration models it correctly, so no symbol-type
+                        // fallback is needed.
                         self.same_file_value_symbol_for_type_symbol(target_sym_id)
+                            .map(|(value_sym_id, value_decl, value_file_idx)| {
+                                (value_sym_id, value_decl, value_file_idx, false)
+                            })
                     } else {
                         None
                     }
@@ -911,14 +955,43 @@ impl CheckerState<'_> {
             };
             let mut value_type = if let Some(constructor_type) = lib_constructor_companion {
                 constructor_type
-            } else if let Some((target_sym_id, target_value_decl, target_file_idx)) =
-                alias_target_merged_value_info
+            } else if let Some((
+                target_sym_id,
+                target_value_decl,
+                target_file_idx,
+                is_plain_value_type_alias,
+            )) = alias_target_merged_value_info
             {
-                self.type_of_value_declaration_for_cross_file_symbol(
+                let from_value_decl = self.type_of_value_declaration_for_cross_file_symbol(
                     target_sym_id,
                     target_value_decl,
                     target_file_idx,
-                )
+                );
+                // For a name-merged plain `TYPE_ALIAS` + value, the value
+                // declaration can still lower to a non-instantiable
+                // value-position type (e.g. `void`/`undefined` when a generic
+                // type-alias side shadows the const). Such a type is never a
+                // valid `new`/call target for a merged value symbol and yields
+                // false TS18048/TS2722. Fall back to the symbol's own type,
+                // which carries the const's declared value type. A usable value
+                // declaration is still preferred (e.g. `const matcher: symbol`
+                // keeps its `symbol` identity). `INTERFACE`/`CLASS` merges never
+                // take this fallback: their symbol type is the instance side.
+                if is_plain_value_type_alias
+                    && matches!(
+                        from_value_decl,
+                        TypeId::VOID | TypeId::UNDEFINED | TypeId::UNKNOWN | TypeId::ERROR
+                    )
+                {
+                    let from_symbol = self.get_type_of_symbol(target_sym_id);
+                    if matches!(from_symbol, TypeId::UNKNOWN | TypeId::ERROR) {
+                        from_value_decl
+                    } else {
+                        from_symbol
+                    }
+                } else {
+                    from_value_decl
+                }
             } else if let Some(file_idx) = self.ctx.resolve_symbol_file_index(sym_id)
                 && file_idx != self.ctx.current_file_idx
             {


### PR DESCRIPTION
Goal: green

Clears false **TS18048/TS2722** when a name-merged `export type Foo` + `export const Foo` is imported and used in value position.

## Structural rule
When a cross-file `ALIAS` resolves to a name-merged **plain `TYPE_ALIAS` over a value** (`TYPE_ALIAS` + `VALUE`, no `INTERFACE`, no `CLASS`), tsc types value-position references (`new Foo()`, `Foo()`) from the const's declared value type. tsz re-derived the value type from the binder's recorded `value_declaration`, which — when the type alias is declared *before* the const — points at the type-alias node and lowers to `void`/possibly-undefined → false TS18048/TS2722. The merged-value branch now, for a plain-value-`TYPE_ALIAS` target, selects the first non-`TYPE_ALIAS` declaration (the const/var); and if that still yields a non-instantiable type (the generic `type Foo<T=any>=any` case), falls back to `get_type_of_symbol`. Flag-gated to the plain-`TYPE_ALIAS` case so `INTERFACE`+value and `CLASS` merges are untouched.

## Adjacent matrix
- `declare module 'm' { export type Foo<T=any>=any; export const Foo: any }` + `import {Foo}; new Foo(x)` / `Foo(x)` → clean (matches tsc).
- **Negatives (parity-matched):** genuine `function f(o?:{go():void}){o.go()}` → still TS18048; interface+value ctor alias `interface Bar{x}; const Bar:{new():Bar}` → clean (path untouched); plain non-merged imported const → clean.
- **Preserves #14129:** `const matcher: symbol; type matcher = typeof matcher` keeps its `symbol` value type (the value-decl path is kept; only the degenerate non-instantiable case falls back).

## Verification
- Repro (new + call forms) + 3 negatives + #14129 matcher adjacent all tsc-parity.
- ts-rest project: `TS18048|TS2722` 1→0 (the `ZodError` possibly-undefined FP); after-codes a strict subset of before, no new codes.
- Regression delta vs clean `main`: `--lib merged` 61/0 (incl. the matcher test a naive fix would break), `--lib alias`/`--lib cross_file` zero new failures (the 2 deterministic cross_file failures are pre-existing on clean main). clippy clean.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
