### PR TITLE
fix(solver): variadic rest spread distributes its element type, not the whole array

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1483,6 +1483,9 @@ mod variadic_tuple_elaboration_tests;
 #[path = "../tests/variadic_tuple_readonly_relation_tests.rs"]
 mod variadic_tuple_readonly_relation_tests;
 #[cfg(test)]
+#[path = "tests/variadic_tuple_spread_element_inference_tests.rs"]
+mod variadic_tuple_spread_element_inference_tests;
+#[cfg(test)]
 #[path = "../tests/variadic_tuple_tail_arity_inference_tests.rs"]
 mod variadic_tuple_tail_arity_inference_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/variadic_tuple_spread_element_inference_tests.rs
+++ b/crates/tsz-checker/src/tests/variadic_tuple_spread_element_inference_tests.rs
@@ -1,0 +1,92 @@
+//! Tests for issue #14175: inferring `T` from a parameter `T[]` against a
+//! variadic-tuple argument `[...End]` must infer the element type, not the whole
+//! constraint array.
+//!
+//! Structural rule: a variadic/rest spread `...End` (where `End extends string[]`)
+//! distributes the type obtained by number-indexing its operand — `string` — never
+//! the operand `End` itself. The element-type query
+//! (`rest_spread_element_type`) is the single owner of that rule, so indexed
+//! access (`[...End][number]`), generic-call inference (`head([...End])`), and
+//! best-common-type all agree.
+//!
+//! Binder names are varied across the cases to prove the fix is structural and not
+//! keyed on any identifier.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322_2345_codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .filter(|c| *c == 2322 || *c == 2345)
+        .collect()
+}
+
+/// The exact witness from the issue: `head([...End])` infers `T = string`, so
+/// `const s: string = x` is clean.
+#[test]
+fn head_of_variadic_spread_infers_element_type() {
+    let codes = ts2322_2345_codes(
+        r#"
+declare function head<T>(array: T[]): T;
+function probe<End extends string[]>(end: [...End]) {
+  const x = head(end);
+  const s: string = x;
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "expected no assignability errors, got: {codes:?}"
+    );
+}
+
+/// The element type of a variadic spread is observable directly through
+/// number-indexed access, independent of inference.
+#[test]
+fn number_index_of_variadic_spread_is_element_type() {
+    let codes = ts2322_2345_codes(
+        r#"
+function probe<Items extends string[]>(items: [...Items]) {
+  type E = (typeof items)[number];
+  const e: E = "ok";
+}
+"#,
+    );
+    assert!(codes.is_empty(), "expected E = string, got: {codes:?}");
+}
+
+/// Alias-wrapped array parameter (`Arr<T> = T[]`) reaches the same element rule.
+#[test]
+fn head_through_array_alias_infers_element_type() {
+    let codes = ts2322_2345_codes(
+        r#"
+type Arr<U> = U[];
+declare function head<T>(a: Arr<T>): T;
+function probe<Rest extends string[]>(rest: [...Rest]) {
+  const x = head(rest);
+  const s: string = x;
+}
+"#,
+    );
+    assert!(codes.is_empty(), "expected T = string, got: {codes:?}");
+}
+
+/// Negative control: a genuine mismatch (`number` target) must still be reported,
+/// proving the fix narrows the element type rather than blanket-suppressing.
+#[test]
+fn head_of_variadic_spread_still_rejects_real_mismatch() {
+    let codes = ts2322_2345_codes(
+        r#"
+declare function head<T>(array: T[]): T;
+function probe<End extends string[]>(end: [...End]) {
+  const x = head(end);
+  const n: number = x;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "expected TS2322 for string assigned to number, got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
@@ -8,7 +8,7 @@ use crate::types::{
     IntrinsicKind, LiteralValue, SymbolRef, TupleElement, TypeData, TypeId, TypeListId,
 };
 use crate::utils;
-use crate::visitor::{TypeVisitor, array_element_type, literal_number, tuple_list_id};
+use crate::visitor::{TypeVisitor, literal_number, tuple_list_id};
 
 use super::super::evaluate::{
     ARRAY_METHODS_RETURN_ANY, ARRAY_METHODS_RETURN_BOOLEAN, ARRAY_METHODS_RETURN_NUMBER,
@@ -186,26 +186,12 @@ impl TypeVisitor for ArrayKeyVisitor<'_> {
 
 /// Get the element type of a rest element, handling arrays and nested tuples.
 ///
-/// For arrays, returns the element type. For tuples, returns the union of all element types.
-/// Otherwise returns the type as-is.
+/// Delegates to the canonical [`crate::type_queries::rest_spread_element_type`],
+/// which distributes the number-indexed element of the spread operand (`...E[]` →
+/// `E`, `...[A, B]` → `A | B`, `...End` where `End extends string[]` → `string`)
+/// instead of leaking the whole array type.
 pub(super) fn rest_element_type(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    if let Some(elem) = array_element_type(db, type_id) {
-        return elem;
-    }
-    if let Some(elements) = tuple_list_id(db, type_id) {
-        let elements = db.tuple_list(elements);
-        let types: Vec<TypeId> = elements
-            .iter()
-            .map(|e| tuple_element_type_with_rest(db, e))
-            .collect();
-        if types.is_empty() {
-            TypeId::NEVER
-        } else {
-            db.union(types)
-        }
-    } else {
-        type_id
-    }
+    crate::type_queries::rest_spread_element_type(db, type_id)
 }
 
 /// Get the type of a tuple element, handling optional and rest elements.

--- a/crates/tsz-solver/src/inference/infer_bct.rs
+++ b/crates/tsz-solver/src/inference/infer_bct.rs
@@ -1218,16 +1218,7 @@ impl<'a> InferenceContext<'a> {
     }
 
     fn rest_element_type(&self, type_id: TypeId) -> TypeId {
-        if type_id == TypeId::ANY {
-            return TypeId::ANY;
-        }
-        if type_id.is_intrinsic() {
-            return type_id;
-        }
-        match self.interner.lookup(type_id) {
-            Some(TypeData::Array(elem)) => elem,
-            _ => type_id,
-        }
+        crate::type_queries::rest_spread_element_type(self.interner, type_id)
     }
 
     fn are_parameters_compatible(&self, source: TypeId, target: TypeId, bivariant: bool) -> bool {

--- a/crates/tsz-solver/src/operations/call_args.rs
+++ b/crates/tsz-solver/src/operations/call_args.rs
@@ -1202,13 +1202,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     }
 
     pub(crate) fn rest_element_type(&self, type_id: TypeId) -> TypeId {
-        if type_id.is_intrinsic() {
-            return type_id;
-        }
-        match self.interner.lookup(type_id) {
-            Some(TypeData::Array(elem)) => elem,
-            _ => type_id,
-        }
+        crate::type_queries::rest_spread_element_type(self.interner, type_id)
     }
 
     /// Element type of a tuple rest element when inferring against a plain array

--- a/crates/tsz-solver/src/type_queries/data/accessors.rs
+++ b/crates/tsz-solver/src/type_queries/data/accessors.rs
@@ -634,6 +634,69 @@ pub fn get_tuple_element_type_union(db: &dyn TypeDatabase, type_id: TypeId) -> O
     Some(db.union(members))
 }
 
+/// Element type contributed by a variadic/rest spread `...X`.
+///
+/// A spread element distributes the type obtained by number-indexing its operand,
+/// never the operand itself. This is the canonical "element type of an array-like
+/// spread" used wherever a tuple's rest element is unpacked (indexed access,
+/// constraint inference, best-common-type, signature relation):
+/// - `...E[]` / `...ReadonlyArray<E>` → `E`
+/// - `...[A, B, ...C[]]` → `A | B | C`
+/// - `...End` where `End extends string[]` (a type parameter / alias / application
+///   whose array-like form has element `string`) → `string`
+/// - `...End` where `End extends [A, B]` (a tuple constraint) → `A | B`
+///
+/// Anything that is not array-like is returned unchanged, mirroring tsc's
+/// `getElementTypeOfArrayType`. Without this a spread of a generic array-constrained
+/// parameter leaks the whole array type into element positions.
+pub fn rest_spread_element_type(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    rest_spread_element_type_inner(db, type_id, 0)
+}
+
+fn rest_spread_element_type_inner(db: &dyn TypeDatabase, type_id: TypeId, depth: usize) -> TypeId {
+    if type_id == TypeId::ANY {
+        return TypeId::ANY;
+    }
+    // Guard against self-referential constraints (`T extends T[]`-style chains).
+    if depth > 16 {
+        return type_id;
+    }
+
+    // Array-like form: `E[]`, `ReadonlyArray<E>`, or a type parameter / alias /
+    // application whose constraint or evaluation reduces to an `Array` element.
+    if let Some(elem) = get_array_element_type(db, type_id) {
+        return elem;
+    }
+
+    // Tuple operand (`...[A, B]`, `...[A, ...B[]]`, or a type parameter constrained
+    // to a tuple): union of each element's contribution, recursing through nested
+    // rest elements so they are unwrapped too. `get_tuple_elements` resolves
+    // readonly/type-parameter/alias wrappers down to the underlying tuple.
+    if let Some(elements) = get_tuple_elements(db, type_id) {
+        if elements.is_empty() {
+            return TypeId::NEVER;
+        }
+        let members: Vec<TypeId> = elements
+            .iter()
+            .map(|elem| {
+                let ty = if elem.rest {
+                    rest_spread_element_type_inner(db, elem.type_id, depth + 1)
+                } else {
+                    elem.type_id
+                };
+                if elem.optional {
+                    db.union2(ty, TypeId::UNDEFINED)
+                } else {
+                    ty
+                }
+            })
+            .collect();
+        return db.union(members);
+    }
+
+    type_id
+}
+
 /// Compute the `keyof` type for an object shape.
 ///
 /// Returns the union of string literal types for all property names in the object.

--- a/crates/tsz-solver/src/type_queries/data/tests.rs
+++ b/crates/tsz-solver/src/type_queries/data/tests.rs
@@ -897,6 +897,106 @@ fn deeply_any_for_nested_array_of_any() {
     assert!(is_type_deeply_any(&interner, outer));
 }
 
+fn make_array_constrained_param(interner: &TypeInterner, name: &str, element: TypeId) -> TypeId {
+    let constraint = interner.array(element);
+    interner.type_param(TypeParamInfo {
+        name: interner.intern_string(name),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    })
+}
+
+fn rest_elem(type_id: TypeId) -> crate::types::TupleElement {
+    crate::types::TupleElement {
+        type_id,
+        optional: false,
+        rest: true,
+        name: None,
+    }
+}
+
+fn fixed_elem(type_id: TypeId) -> crate::types::TupleElement {
+    crate::types::TupleElement {
+        type_id,
+        optional: false,
+        rest: false,
+        name: None,
+    }
+}
+
+#[test]
+fn rest_spread_element_of_plain_array_is_its_element() {
+    let interner = TypeInterner::new();
+    let arr = interner.array(TypeId::STRING);
+    assert_eq!(rest_spread_element_type(&interner, arr), TypeId::STRING);
+}
+
+#[test]
+fn rest_spread_element_of_array_constrained_param_is_constraint_element() {
+    // `...End` where `End extends string[]` contributes `string`, not `End`/`string[]`.
+    // Binder name is varied to prove the rule is structural, not name-driven.
+    let interner = TypeInterner::new();
+    for name in ["End", "Rest", "TItems", "_p0"] {
+        let param = make_array_constrained_param(&interner, name, TypeId::STRING);
+        assert_eq!(
+            rest_spread_element_type(&interner, param),
+            TypeId::STRING,
+            "spread of {name} extends string[] should contribute string"
+        );
+    }
+}
+
+#[test]
+fn rest_spread_element_of_tuple_constrained_param_unions_elements() {
+    // `...End` where `End extends [number, boolean]` contributes `number | boolean`.
+    let interner = TypeInterner::new();
+    let constraint = interner.tuple(vec![
+        fixed_elem(TypeId::NUMBER),
+        fixed_elem(TypeId::BOOLEAN),
+    ]);
+    let param = interner.type_param(TypeParamInfo {
+        name: interner.intern_string("Pair"),
+        constraint: Some(constraint),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    let expected = interner.union(vec![TypeId::NUMBER, TypeId::BOOLEAN]);
+    assert_eq!(rest_spread_element_type(&interner, param), expected);
+}
+
+#[test]
+fn rest_spread_element_of_nested_tuple_recurses_into_rest() {
+    // `...[A, ...B[]]` contributes `A | B`: the nested rest is unwrapped, not left
+    // as the inner array type.
+    let interner = TypeInterner::new();
+    let inner_array = interner.array(TypeId::NUMBER);
+    let tuple = interner.tuple(vec![fixed_elem(TypeId::STRING), rest_elem(inner_array)]);
+    let expected = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    assert_eq!(rest_spread_element_type(&interner, tuple), expected);
+}
+
+#[test]
+fn rest_spread_element_of_array_constrained_param_via_nested_rest() {
+    // The original bug witness: a single variadic spread `[...End]` of an
+    // array-constrained parameter, indexed for its element type, yields `string`.
+    let interner = TypeInterner::new();
+    let end = make_array_constrained_param(&interner, "End", TypeId::STRING);
+    let tuple = interner.tuple(vec![rest_elem(end)]);
+    assert_eq!(rest_spread_element_type(&interner, tuple), TypeId::STRING);
+}
+
+#[test]
+fn rest_spread_element_of_non_array_like_is_unchanged() {
+    let interner = TypeInterner::new();
+    assert_eq!(
+        rest_spread_element_type(&interner, TypeId::STRING),
+        TypeId::STRING
+    );
+}
+
 // =========================================================================
 // contains_application_in_structure
 // =========================================================================


### PR DESCRIPTION
Fixes #14175.

Goal: green

## Summary
A variadic/rest spread `...End` (where `End extends string[]`) must contribute the type obtained by number-indexing its operand — `string` — never the operand `End` itself. tsz carried **three inconsistent `rest_element_type` helpers**: the indexed-access one handled `Array`/`Tuple` but not array-constrained type parameters, while the call-inference and best-common-type copies handled only `Array`. As a result:

- `head<T>(array: T[])` called with `[...End]` inferred `T = End` (`string[]`) → false `TS2322` on `const s: string = x`.
- `[...End][number]` evaluated to `string[]` instead of `string`.

Both diverged from `tsc`.

## Structural rule
When the operand of a rest element is array-like in any form — `E[]`, `ReadonlyArray<E>`, a tuple, or a type parameter / alias / application whose constraint or evaluation reduces to one of those — the spread contributes its **number-indexed element**; otherwise the operand is returned unchanged. This mirrors tsc's `getElementTypeOfArrayType`.

`When a tuple rest element spreads an array-like operand, tsc contributes the operand's element type; tsz now does the same through the solver's rest_spread_element_type query.`

## Owner layer
Introduce a single canonical `rest_spread_element_type` query in `tsz_solver::type_queries` (next to `get_array_element_type` / `get_tuple_elements`) and route **all four** `rest_element_type` helpers through it:
- `evaluation::evaluate_rules::index_access_keys` (indexed access)
- `operations::call_args` (generic-call constraint walker)
- `inference::infer_bct` (best-common-type)
- `evaluation::evaluate_rules::index_access` (the `TypeEvaluator` shim, already a delegate)

So indexed access, generic-call inference, and BCT now agree on one rule. No checker/emitter changes — the fix lives entirely in the solver's query layer.

## Adjacent matrix (tested)
- plain `E[]`
- array-constrained type parameter, under **varied binder names** (`End`, `Rest`, `TItems`, `_p0`) to prove the rule is structural, not name-driven
- tuple-constrained type parameter (`A | B`)
- nested `[A, ...B[]]` rest (recurses into the inner spread)
- single `[...End]` witness (the issue repro) + alias-wrapped `Arr<T> = T[]`
- negative control: a real `number` mismatch still reports `TS2322`

## Non-goals
`head([string, number])` (a heterogeneous tuple → naked `T`) infers `T = string` in tsz today; this is a **pre-existing, separate** candidate-resolution limitation (it reproduces with no variadics at all) and is out of scope here.

## Verification
- `cargo test -p tsz-solver --lib rest_spread` — 6 new unit tests over the canonical query (varied binder names).
- `cargo test -p tsz-checker --lib variadic_tuple_spread_element_inference` — 4 new end-to-end checker tests (issue repro, index access, alias wrapper, negative control).
- `cargo test -p tsz-solver --lib tuple index_access rest` — existing tuple/index/rest suites pass.
- `cargo clippy -p tsz-solver` — clean.
- The 4 unrelated pre-existing solver lib failures were confirmed identical with the change stashed (not introduced here).
- Ready-review CI owns broad conformance/emit/fourslash.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Opus 4.8
Effort: high

https://claude.ai/code/session_01MeUiTEe4VuLAh3Rqcy44ak