### PR TITLE
fix(checker): class extends a flow-narrowed value uses the narrowed base type (#14260)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1591,6 +1591,9 @@ path = "tests/class_expression_implements_display_tests.rs"
 name = "class_expression_heritage_ts2416_tests"
 path = "tests/class_expression_heritage_ts2416_tests.rs"
 [[test]]
+name = "class_extends_flow_narrowed_base_tests"
+path = "tests/class_extends_flow_narrowed_base_tests.rs"
+[[test]]
 name = "predicate_alias_generic_inference_tests"
 path = "tests/predicate_alias_generic_inference_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/heritage.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage.rs
@@ -747,6 +747,20 @@ impl<'a> CheckerState<'a> {
                                     let is_valid_base = if self.is_constructor_type(evaluated_type)
                                     {
                                         true
+                                    } else if self.heritage_base_is_constructor_via_flow_narrowing(
+                                        expr_idx,
+                                        symbol_type,
+                                    ) {
+                                        // The declared symbol type can be wider than the
+                                        // flow-narrowed type at the heritage position — e.g.
+                                        // `klass?: Ctor` narrowed to `Ctor` inside
+                                        // `klass ? class extends klass {} : null`. tsc types the
+                                        // base via the narrowed expression type, so a value whose
+                                        // declared type is `Ctor | undefined` still extends cleanly
+                                        // once narrowing removes the nullish arm (#14260). This is
+                                        // additive: it only accepts a base the narrowed type proves
+                                        // constructable, never introduces a new TS2507.
+                                        true
                                     } else {
                                         // For types that don't directly report as constructors,
                                         // let the general type system handle validation rather
@@ -1441,6 +1455,35 @@ impl<'a> CheckerState<'a> {
         }
 
         None
+    }
+
+    /// Whether the heritage base expression resolves to a constructor type once
+    /// flow narrowing is applied at its position.
+    ///
+    /// The declared type of the base symbol can be wider than the narrowed type
+    /// at the `extends` position. A class extending a guarded value
+    /// (`klass?: Ctor` used as `klass ? class extends klass {} : null`, or after
+    /// an early `if (!klass) return`) is constructable at that point even though
+    /// the declared type `Ctor | undefined` is not (#14260). tsc types the base
+    /// via the narrowed expression type; mirror that here. Returns `true` only
+    /// when the narrowed expression type is genuinely a constructor type and is
+    /// strictly narrower than `declared_type`, so this can never introduce a new
+    /// `TS2507` — it only suppresses a false positive the declared type caused.
+    fn heritage_base_is_constructor_via_flow_narrowing(
+        &mut self,
+        expr_idx: NodeIndex,
+        declared_type: TypeId,
+    ) -> bool {
+        let narrowed = self.get_type_of_node(expr_idx);
+        if narrowed == declared_type
+            || narrowed == TypeId::ERROR
+            || narrowed == TypeId::UNKNOWN
+            || narrowed == TypeId::ANY
+        {
+            return false;
+        }
+        let evaluated = self.evaluate_type_for_assignability(narrowed);
+        self.is_constructor_type(evaluated)
     }
 
     /// Check heritage clauses for primitive type keywords only (TS2863/TS2864).

--- a/crates/tsz-checker/tests/class_extends_flow_narrowed_base_tests.rs
+++ b/crates/tsz-checker/tests/class_extends_flow_narrowed_base_tests.rs
@@ -1,0 +1,90 @@
+//! A class expression whose `extends` base is a flow-narrowed value must use the
+//! narrowed type, not the wider declared type, for the TS2507 constructor check.
+//!
+//! Regression for #14260 (effect): `(klass?: Ctor) => klass ? class extends klass {} : null`
+//! narrows `klass` from `Ctor | undefined` to `Ctor` at the `extends` position, so the
+//! base is constructable and tsc accepts it. tsz used the declared `Ctor | undefined`
+//! and emitted a spurious TS2507. The fix is additive: a TS2507 is suppressed only when
+//! the flow-narrowed base type is genuinely a constructor type.
+
+use tsz_checker::test_utils::check_source_code_messages;
+
+fn ts2507_count(source: &str) -> usize {
+    check_source_code_messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2507)
+        .count()
+}
+
+#[test]
+fn ternary_narrowed_optional_ctor_base_no_ts2507() {
+    let src = r#"
+type Ctor<T = {}> = new (...args: Array<any>) => T;
+export const make = (klass?: Ctor) => (klass ? class extends klass {} : null);
+"#;
+    assert_eq!(
+        ts2507_count(src),
+        0,
+        "narrowed `Ctor` base in a ternary must not emit TS2507"
+    );
+}
+
+#[test]
+fn early_return_guard_narrowed_ctor_base_no_ts2507() {
+    let src = r#"
+type Ctor<T = {}> = new (...args: Array<any>) => T;
+export function make(klass?: Ctor) {
+    if (!klass) return null;
+    return class extends klass {};
+}
+"#;
+    assert_eq!(
+        ts2507_count(src),
+        0,
+        "narrowed `Ctor` base after an early-return guard must not emit TS2507"
+    );
+}
+
+// Binder-name variation: the fix is structural (flow narrowing of the base
+// expression), not keyed on any identifier. A renamed parameter behaves the same.
+#[test]
+fn ternary_narrowed_optional_ctor_base_renamed_binder_no_ts2507() {
+    let src = r#"
+type MakeNew<T = {}> = new (...args: Array<any>) => T;
+export const build = (factory?: MakeNew) =>
+    factory ? class extends factory {} : null;
+"#;
+    assert_eq!(
+        ts2507_count(src),
+        0,
+        "renamed binder narrowed base must not emit TS2507"
+    );
+}
+
+// Negative control: a non-constructor base still emits TS2507.
+#[test]
+fn extends_non_constructor_value_still_emits_ts2507() {
+    let src = r#"
+const n: number = 5;
+class C extends n {}
+"#;
+    assert!(
+        ts2507_count(src) >= 1,
+        "extending a number must still emit TS2507"
+    );
+}
+
+// Negative control: an un-narrowed `Ctor | undefined` base still emits TS2507,
+// because narrowing does not remove the nullish arm at the `extends` position.
+#[test]
+fn extends_unnarrowed_optional_ctor_still_emits_ts2507() {
+    let src = r#"
+type Ctor<T = {}> = new (...args: Array<any>) => T;
+declare const maybe: Ctor | undefined;
+class C extends maybe {}
+"#;
+    assert!(
+        ts2507_count(src) >= 1,
+        "extending an un-narrowed `Ctor | undefined` must still emit TS2507"
+    );
+}


### PR DESCRIPTION
Fixes #14260.

## Structural rule
When a class expression `extends` a value-reference expression, `tsc` types the base via the flow-narrowed expression type at the `extends` position. tsz used the declared symbol type, so a class extending a guarded value — `(klass?: Ctor) => klass ? class extends klass {} : null`, or `if (!klass) return; return class extends klass {}` — saw the declared `Ctor | undefined`, failed the construct-signature check, and emitted a spurious **TS2507** ("Type `Ctor<{}> | undefined` is not a constructor function type"). tsc narrows `klass` to `Ctor` there and accepts it.

## Owner layer
Checker — `state/state_checking/heritage.rs`. The TS2507 path computed the base type as `get_type_of_symbol(sym_to_check)` (declared) and never consulted flow narrowing. The fix adds an additive re-check `heritage_base_is_constructor_via_flow_narrowing(expr_idx, declared_type)`: before emitting TS2507 it evaluates the flow-narrowed base expression type (`get_type_of_node(expr_idx)`) and accepts the base only when that narrowed type is strictly narrower than the declared type **and** is genuinely a constructor type. This can never introduce a new TS2507 — it only suppresses a false positive the wider declared type caused.

## Adjacent-case matrix
- ternary narrowing `klass ? class extends klass {} : null` → clean (was TS2507)
- early-return guard `if (!klass) return null; return class extends klass {}` → clean (was TS2507)
- renamed binder (`factory?: MakeNew` → `factory ? class extends factory {} : null`) → clean (structural, not name-keyed)
- non-optional `klass: Ctor` (no narrowing needed) → clean (unchanged)
- **negative**: `class C extends n` where `n: number` → still TS2507
- **negative**: `declare const maybe: Ctor | undefined; class C extends maybe {}` (no narrowing removes the nullish arm) → still TS2507

## Verification
- `cargo nextest run -p tsz-checker --test class_extends_flow_narrowed_base_tests` — 5/5 (3 positive incl. renamed-binder, 2 negative controls).
- `cargo nextest run -p tsz-checker --test class_expression_heritage_ts2416_tests` — 6/6 (no regression in the adjacent heritage-construct path).
- `cargo clippy -p tsz-checker` — clean.
- Manual: the issue repro `(klass?: Ctor) => klass ? class extends klass {} : null` reports 0 errors; both negative controls still emit TS2507.
- Broad conformance/emit/fourslash: ready-review CI.

Goal: green

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: max