### PR TITLE
fix(checker): substitute receiver type args for cross-arena lib generic interface member access (#14235)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -174,6 +174,9 @@ path = "tests/for_await_type_parameter_iterability_tests.rs"
 name = "async_iterable_type_param_element_tests"
 path = "tests/async_iterable_type_param_element_tests.rs"
 [[test]]
+name = "generic_generator_member_substitution_tests"
+path = "tests/generic_generator_member_substitution_tests.rs"
+[[test]]
 name = "array_element_naked_inference_tests"
 path = "tests/array_element_naked_inference_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_environment/application.rs
+++ b/crates/tsz-checker/src/state/type_environment/application.rs
@@ -54,6 +54,15 @@ impl<'a> CheckerState<'a> {
                 tsz_solver::def::DefKind::Interface | tsz_solver::def::DefKind::Class
             )
         {
+            // A cross-arena lib interface (e.g. `Generator<Y, R>`) whose
+            // type-parameter push collided with the current file arena cannot be
+            // substituted by the shared evaluator; recover before delegating. See
+            // `recover_arena_collided_application_for_property_access`.
+            if let Some(recovered) =
+                self.recover_arena_collided_application_for_property_access(type_id)
+            {
+                return recovered;
+            }
             return self.evaluate_application_type(type_id);
         }
         let Some(ApplicationBaseBody {
@@ -70,16 +79,38 @@ impl<'a> CheckerState<'a> {
         if type_params.is_empty() {
             return body_type;
         }
+        self.instantiate_application_body_for_property_access(
+            body_type,
+            &type_params,
+            &args,
+            type_id,
+        )
+    }
 
+    /// Instantiate a generic interface/class body with its type parameters bound
+    /// to an application's arguments, then env-evaluate the result.
+    ///
+    /// The arguments are env-evaluated, substituted into `body_type`, polymorphic
+    /// `this` is rebound to `application`, and the result is env-evaluated;
+    /// evaluation that collapses to `ERROR` falls back to the pre-evaluation
+    /// instantiation. Shared by `evaluate_application_type_for_property_access`
+    /// and the arena-collision recovery so the two stay in lock-step.
+    fn instantiate_application_body_for_property_access(
+        &mut self,
+        body_type: TypeId,
+        type_params: &[TypeParamInfo],
+        args: &[TypeId],
+        application: TypeId,
+    ) -> TypeId {
         let evaluated_args: Vec<TypeId> = args
             .iter()
             .map(|&arg| self.evaluate_type_with_env(arg))
             .collect();
         let substitution =
-            query::TypeSubstitution::from_args(self.ctx.types, &type_params, &evaluated_args);
+            query::TypeSubstitution::from_args(self.ctx.types, type_params, &evaluated_args);
         let mut instantiated = query::instantiate_type(self.ctx.types, body_type, &substitution);
         if query::contains_this_type(self.ctx.types, instantiated) {
-            instantiated = query::substitute_this_type(self.ctx.types, instantiated, type_id);
+            instantiated = query::substitute_this_type(self.ctx.types, instantiated, application);
         }
         let evaluated = self.evaluate_type_with_env(instantiated);
         if evaluated == TypeId::ERROR {
@@ -87,6 +118,68 @@ impl<'a> CheckerState<'a> {
         } else {
             evaluated
         }
+    }
+
+    /// Recover a property-access receiver whose cross-arena type-parameter push
+    /// collided with the current file arena, leaving the shared
+    /// `evaluate_application_type` unable to substitute its arguments.
+    ///
+    /// `type_reference_symbol_type_with_params` pushes a lib interface's
+    /// type-parameter nodes against the *current file* arena; when the owner
+    /// arena differs the `NodeIndex`es collide with unrelated current-file nodes,
+    /// so the pushed set disagrees in arity with the application arguments and the
+    /// shared evaluator's substitution against that same body is a no-op (the
+    /// interface's own parameters leak — false TS2322 on `Generator<Y,
+    /// R>.next().value`). Detect that arity mismatch and re-instantiate the
+    /// (identical) body with the symbol's canonical parameters, which match the
+    /// body's identities. Returns `None` for every well-formed application so the
+    /// caller keeps the shared evaluator.
+    pub(crate) fn recover_arena_collided_application_for_property_access(
+        &mut self,
+        type_id: TypeId,
+    ) -> Option<TypeId> {
+        let (base, args) = query::application_info(self.ctx.types, type_id)?;
+        if args.is_empty() {
+            return None;
+        }
+        // Cheap gate before the heavier interface re-lowering below: the arena
+        // collision only affects a cross-file interface/class base, whose
+        // type-parameter nodes live in a different arena than the push reads.
+        // Same-file generics and type-alias applications (`Partial`, `Pick`,
+        // `Record`, …) push against their own arena and never collide, so they
+        // keep the shared evaluator without paying the probe.
+        let base_def_id = query::lazy_def_id(self.ctx.types, base)?;
+        let base_def_info = self.ctx.definition_store.get(base_def_id)?;
+        if base_def_info
+            .file_id
+            .is_none_or(|file_id| file_id == self.ctx.current_file_idx as u32)
+            || !matches!(
+                base_def_info.kind,
+                tsz_solver::def::DefKind::Interface | tsz_solver::def::DefKind::Class
+            )
+        {
+            return None;
+        }
+        let sym_id = self.ctx.resolve_type_to_symbol_id(base)?;
+        // The body and pushed parameters come from the same query the shared
+        // evaluator uses, so the arity comparison is exactly its substitution
+        // input. A matching arity means the shared evaluator already substitutes
+        // correctly; bail and leave it untouched.
+        let (body_type, pushed_params) = self.type_reference_symbol_type_with_params(sym_id);
+        if pushed_params.len() == args.len()
+            || body_type == TypeId::ANY
+            || body_type == TypeId::ERROR
+        {
+            return None;
+        }
+        let canonical = self.get_type_params_for_symbol(sym_id);
+        if canonical.len() != args.len() {
+            return None;
+        }
+        let instantiated = self.instantiate_application_body_for_property_access(
+            body_type, &canonical, &args, type_id,
+        );
+        (instantiated != body_type).then_some(instantiated)
     }
 
     pub(crate) fn resolve_application_base_body(

--- a/crates/tsz-checker/src/types/property_access_type/helpers.rs
+++ b/crates/tsz-checker/src/types/property_access_type/helpers.rs
@@ -918,6 +918,24 @@ impl<'a> CheckerState<'a> {
             .get_flow_type(receiver_idx, read_type, flow_node)
     }
 
+    pub(crate) fn receiver_has_definite_assignment_error(
+        &self,
+        property_access_idx: NodeIndex,
+        receiver_idx: NodeIndex,
+    ) -> bool {
+        let (receiver_start, receiver_end) = self
+            .ctx
+            .arena
+            .get(receiver_idx)
+            .map(|node| (node.pos, node.end))
+            .unwrap_or((u32::MAX, u32::MAX));
+        self.ctx.daa_error_nodes.contains(&receiver_idx.0)
+            || self.ctx.daa_error_nodes.contains(&property_access_idx.0)
+            || self.ctx.diagnostics.iter().any(|diag| {
+                diag.code == 2454 && diag.start >= receiver_start && diag.start < receiver_end
+            })
+    }
+
     pub(crate) fn write_receiver_type_for_property_access(
         &mut self,
         property_access_idx: NodeIndex,

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -396,6 +396,14 @@ impl<'a> CheckerState<'a> {
             original_object_type
         } else if receiver_needs_env_fallback {
             self.evaluate_property_access_receiver_type(original_object_type)
+        } else if let Some(recovered) =
+            self.recover_arena_collided_application_for_property_access(original_object_type)
+        {
+            // Recover a cross-arena lib interface receiver (e.g. `g: Generator<Y,
+            // R>`) whose type-parameter push collided with the current file arena;
+            // see `recover_arena_collided_application_for_property_access`. Returns
+            // `None` (and falls through) for every well-formed receiver.
+            recovered
         } else {
             self.evaluate_application_type(original_object_type)
         };

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -510,29 +510,8 @@ impl<'a> CheckerState<'a> {
         {
             object_type = literal_type;
         }
-        let (receiver_start, receiver_end) = self
-            .ctx
-            .arena
-            .get(access.expression)
-            .map(|node| (node.pos, node.end))
-            .unwrap_or((u32::MAX, u32::MAX));
-        // A receiver "has a DAA error" when:
-        //   1. The receiver expression node itself was flagged with TS2454, or
-        //   2. The property-access node was flagged, or
-        //   3. Any TS2454 diagnostic falls within the receiver's [pos, end) span.
-        //
-        // Case (3) covers composite receivers like `get(foo)` where the
-        // identifier `foo` is a sub-expression of the receiver (not the
-        // receiver itself) and was the DAA-flagged node. tsc suppresses
-        // TS18047/TS18048/TS18049 (and the legacy TS2531/TS2532/TS2533) on
-        // property access whenever the receiver expression contains a
-        // definite-assignment failure, because the cascade is meaningless
-        // once we already reported that the underlying variable has no value.
-        let receiver_has_daa_error = self.ctx.daa_error_nodes.contains(&access.expression.0)
-            || self.ctx.daa_error_nodes.contains(&idx.0)
-            || self.ctx.diagnostics.iter().any(|diag| {
-                diag.code == 2454 && diag.start >= receiver_start && diag.start < receiver_end
-            });
+        let receiver_has_daa_error =
+            self.receiver_has_definite_assignment_error(idx, access.expression);
         if !skip_flow_narrowing
             // When TS2454 already forced the receiver read back to its declared type,
             // keep property access on that declared type so member lookup and call

--- a/crates/tsz-checker/tests/generic_generator_member_substitution_tests.rs
+++ b/crates/tsz-checker/tests/generic_generator_member_substitution_tests.rs
@@ -1,0 +1,145 @@
+//! Regression tests for issue #14235: a generic lib interface declared in its
+//! own lib file (`Generator` in es2015.generator.d.ts, `AsyncGenerator` in
+//! es2018.asyncgenerator.d.ts) must substitute the receiver's type arguments
+//! when a member is accessed through a still-generic application.
+//!
+//! Root cause: `type_reference_symbol_type_with_params` pushed the interface's
+//! type-parameter nodes against the *current file* arena. For a cross-arena lib
+//! interface the `NodeIndex`es collided with unrelated current-file nodes, so
+//! `Generator<T, TReturn, TNext>` referenced inside `take<Y, R>(...)` resolved
+//! to a single bogus `R` instead of its three parameters. The merged body kept
+//! the owner-arena parameter identities, so the substitution built from the
+//! mismatched parameters was a no-op and `g.next().value` leaked the
+//! interface's own `T | TReturn` — a false TS2322 against the declared `Y | R`.
+
+use std::sync::Arc;
+
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs, load_default_lib_files};
+use tsz_common::common::{ModuleKind, ScriptTarget};
+
+fn diagnostics(
+    source: &str,
+    target: ScriptTarget,
+    lib_files: &[Arc<LibFile>],
+) -> Vec<(u32, String)> {
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target,
+            module: ModuleKind::CommonJS,
+            strict: true,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+        lib_files,
+    )
+    .into_iter()
+    .map(|diagnostic| (diagnostic.code, diagnostic.message_text))
+    .collect()
+}
+
+/// `g.next().value` on a generic `Generator<Y, R>` resolves to `Y | R`, so the
+/// declared return type is satisfied and tsc emits nothing.
+#[test]
+fn generic_generator_next_value_substitutes_receiver_type_args() {
+    let lib_files = load_default_lib_files();
+    if lib_files.is_empty() {
+        return;
+    }
+    let diags = diagnostics(
+        "export function take<Y, R>(g: Generator<Y, R>): Y | R { return g.next().value; }",
+        ScriptTarget::ES2015,
+        &lib_files,
+    );
+    assert!(
+        diags.iter().all(|(code, _)| *code != 2322),
+        "generic Generator<Y, R>.next().value must resolve to Y | R, got: {diags:?}",
+    );
+}
+
+/// `return` and `throw` share the same `IteratorResult<T, TReturn>` member
+/// shape and must substitute identically.
+#[test]
+fn generic_generator_return_value_substitutes_receiver_type_args() {
+    let lib_files = load_default_lib_files();
+    if lib_files.is_empty() {
+        return;
+    }
+    let diags = diagnostics(
+        "export function take<Y, R>(g: Generator<Y, R>): Y | R { return g.return(undefined as any).value; }",
+        ScriptTarget::ES2015,
+        &lib_files,
+    );
+    assert!(
+        diags.iter().all(|(code, _)| *code != 2322),
+        "generic Generator<Y, R>.return().value must resolve to Y | R, got: {diags:?}",
+    );
+}
+
+/// The binder names must not drive the fix: renaming `Y, R` to `A, B, C` keeps
+/// the result clean.
+#[test]
+fn generic_generator_renamed_binders_substitute() {
+    let lib_files = load_default_lib_files();
+    if lib_files.is_empty() {
+        return;
+    }
+    let diags = diagnostics(
+        "export function take<A, B, C>(g: Generator<A, B, C>): A | B { return g.next().value; }",
+        ScriptTarget::ES2015,
+        &lib_files,
+    );
+    assert!(
+        diags.iter().all(|(code, _)| *code != 2322),
+        "renamed-binder generic Generator must resolve correctly, got: {diags:?}",
+    );
+}
+
+/// `AsyncGenerator` (declared in its own es2018.asyncgenerator.d.ts file) is the
+/// same cross-arena shape and must substitute the receiver type args too.
+#[test]
+fn generic_async_generator_next_value_substitutes_receiver_type_args() {
+    let lib_files = load_default_lib_files();
+    if lib_files.is_empty() {
+        return;
+    }
+    let diags = diagnostics(
+        "export async function take<Y, R>(g: AsyncGenerator<Y, R>): Promise<Y | R> { return (await g.next()).value; }",
+        ScriptTarget::ESNext,
+        &lib_files,
+    );
+    assert!(
+        diags.iter().all(|(code, _)| *code != 2322),
+        "generic AsyncGenerator<Y, R>.next().value must resolve to Y | R, got: {diags:?}",
+    );
+}
+
+/// Negative control: a genuinely wrong annotation must still report TS2322, and
+/// the diagnostic must show the *substituted* `Y | R` source (proving the
+/// member type was instantiated), not the leaked `T | TReturn`.
+#[test]
+fn generic_generator_genuine_mismatch_still_errors_with_substituted_source() {
+    let lib_files = load_default_lib_files();
+    if lib_files.is_empty() {
+        return;
+    }
+    let diags = diagnostics(
+        "export function take<Y, R>(g: Generator<Y, R>): boolean { return g.next().value; }",
+        ScriptTarget::ES2015,
+        &lib_files,
+    );
+    let ts2322: Vec<&(u32, String)> = diags.iter().filter(|(code, _)| *code == 2322).collect();
+    assert!(
+        !ts2322.is_empty(),
+        "assigning Generator<Y, R>.next().value to boolean must report TS2322, got: {diags:?}",
+    );
+    assert!(
+        ts2322
+            .iter()
+            .any(|(_, msg)| msg.contains("Y | R") && !msg.contains("TReturn")),
+        "TS2322 source must be the substituted `Y | R`, not the leaked `T | TReturn`, got: {ts2322:?}",
+    );
+}


### PR DESCRIPTION
Closes #14235.

Goal: green

## Structural rule
When a generic lib interface declared in its **own** lib file is referenced in
type position (`g: Generator<Y, R>`, lowered to `Application(Lazy(def), [Y, R,
any])`), member access must substitute the receiver's type arguments for the
interface's type parameters: `g.next().value` is `Y | R`, not the interface's
own `T | TReturn`.

`When a generic interface application's member is accessed, tsc instantiates the
member with the receiver's type arguments; tsz now does so even when the
interface's owner arena differs from the access site's arena.`

## The defect (#14235, neverthrow)
`take<Y, R>(g: Generator<Y, R>): Y | R { return g.next().value; }` (under
`--lib es2015`) wrongly reported `TS2322: Type 'TReturn | T' is not assignable
to type 'Y | R'`. `tsc` is clean. `Iterator`/`IteratorObject` (declared in the
same `es2015.iterable.d.ts` file) were unaffected; `Generator`
(es2015.generator.d.ts) and `AsyncGenerator` (es2018.asyncgenerator.d.ts), each
in its own file, leaked.

Root cause: `type_reference_symbol_type_with_params` calls
`push_type_parameters` on the interface's type-parameter nodes against the
**current file** arena. For an owner-arena interface those `NodeIndex`es collide
with unrelated current-file nodes, so the pushed set is a single bogus parameter
(`["R"]`, the enclosing `take<Y, R>`'s parameter) instead of the three real
parameters. The merged body keeps the owner-arena parameter identities, so the
substitution built from the mismatched set is a no-op and the interface's own
`T`/`TReturn` survive into `g.next()`'s `IteratorResult<T, TReturn>`.

## Owner layer & approach
The contamination cannot be repaired in the shared resolution path. The
contextual-generator return-inference path (gcye3 #13726) relies on the deferred
raw body, and the existing `same_arity_collision` repair in
`type_reference_symbol_type_with_params` **deliberately** leaves the
arity-mismatch case alone for exactly that reason (documented at
`symbol_types.rs:1690-1695`). Changing the shared `evaluate_application_type`
regresses `yield_star_nested_generic_call_preserves_generator_return_context`.

- **checker `state/type_environment/application.rs`** — new
  `recover_arena_collided_application_for_property_access`: detect the
  contamination signature (the arena-pushed parameter arity disagrees with the
  application argument arity while the symbol's canonical parameters match) and
  re-instantiate the identical body with the canonical parameters, which share
  the body's identities. Gated to **cross-file Interface/Class** bases, so
  same-file generics and type-alias applications (`Partial`, `Pick`, `Record`, …)
  skip the probe and keep the shared evaluator. The instantiate-and-evaluate tail
  is extracted into `instantiate_application_body_for_property_access`, shared
  with `evaluate_application_type_for_property_access`.
- **checker `types/property_access_type/resolve.rs`** — route the property-access
  expression receiver through the recovery before the shared evaluator (the
  element-access path already flows through
  `evaluate_application_type_for_property_access`).

## Anti-hardcoding
Purely structural: keyed on the application's parameter-arity mismatch plus the
def's cross-file Interface/Class provenance via existing solver/checker helpers —
no identifier, alias, file-name, or rendered-type-string checks. Verified with
renamed binders (`take<A, B, C>(g: Generator<A, B, C>)`).

## Adjacent matrix (verified)
Accept (no TS2322):
- `Generator<Y, R>.next().value` / `.return(...).value` → `Y | R`;
- `AsyncGenerator<Y, R>.next()` awaited → `Y | R`;
- renamed binders `Generator<A, B, C>`;
- partial type args `Generator<Y>`, self `[Symbol.iterator]()`, for-of over a
  generic `Generator<T>`.

Negative controls (still error, with the **substituted** source):
- `Generator<Y, R>.next().value` assigned to `boolean` → TS2322 source `Y | R`
  (proves instantiation happened; previously leaked `TReturn | T`).

No regression:
- `Iterator`/`IteratorObject`, `Map`/`Set` iteration, `Promise.then`,
  `Array.map`, same-file user generic interfaces;
- the gcye3 #13726 contextual-generator path (`number`, not `never`).

## Verification
- New suite `crates/tsz-checker/tests/generic_generator_member_substitution_tests.rs`
  (5 tests, registered in `Cargo.toml`):
  `cargo test -p tsz-checker --test generic_generator_member_substitution_tests` → **5 passed**.
- `cargo test -p tsz-checker --test generic_call_inference_tests` → 198 passed;
  the 5 pre-existing failures (compiled-lib harness artifacts) are identical on
  the stashed base — `yield_star_nested_generic_call_preserves_generator_return_context`
  passes (no gcye3 regression).
- Neighbour suites green: `for_await_type_parameter_iterability_tests`,
  `async_iterable_type_param_element_tests`,
  `cross_file_generic_interface_mapped_filter_tests`,
  `reexport_generic_typeref_instantiation_tests`,
  `qualified_namespace_generic_substitution_tests`,
  `for_await_promise_array_tests`.
- `cargo build` clean; `cargo clippy -p tsz-checker` clean.
- Reviewed with `/simplify` (helper extraction, cheap cross-arena gate, redundant
  guard removal applied). Broad conformance/emit/fourslash: delegated to
  ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01VLi33SEwYEQtwmrwRTcXmk

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLi33SEwYEQtwmrwRTcXmk)_