### PR TITLE
fix(solver): preserve source literal through reverse-mapped filter conditional (#14226)

### DIFF
--- a/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
+++ b/crates/tsz-checker/tests/reverse_mapped_inference_tests.rs
@@ -859,3 +859,131 @@ const checked = checkShape<{ x: number; y: string }>()({
         ts2353[0].message_text
     );
 }
+
+// ---------------------------------------------------------------------------
+// "Filter" conditional idiom literal preservation (issue #14226).
+//
+// `{ [K in keyof T]: T[K] extends E ? T[K] : never }` (tsc's `Narrow` helper)
+// passes a source property that matches `E` straight through the true branch
+// and keeps it as a *regular* (non-widening) literal, while a plain
+// homomorphic copy `{ [K in keyof T]: T[K] }` widens the inferred literal.
+// The reverse-mapped reconstruction must reproduce that per-property split.
+// ---------------------------------------------------------------------------
+
+/// Helper: the structural TS2322 message produced by assigning the inferred
+/// reverse-mapped result to an incompatible primitive (`number`).
+fn ts2322_message(code: &str) -> String {
+    let diags = check_source_diagnostics(code);
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        !ts2322.is_empty(),
+        "expected a TS2322 diagnostic to force structural display, got: {diags:#?}"
+    );
+    ts2322
+        .iter()
+        .map(|d| d.message_text.clone())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn filter_conditional_preserves_source_literal() {
+    // `T[K] extends prim ? T[K] : never` with a matching source keeps `"there"`.
+    let code = r#"
+declare function narrow<T>(
+    x: { [K in keyof T]: T[K] extends (string | number | bigint | boolean) ? T[K] : never }
+): T;
+const r = narrow({ hi: "there" });
+const bad: number = r;
+"#;
+    let msg = ts2322_message(code);
+    assert!(
+        msg.contains("hi: \"there\""),
+        "filter conditional must preserve the source literal `\"there\"`, got: {msg}"
+    );
+}
+
+#[test]
+fn homomorphic_identity_widens_source_literal() {
+    // Plain `{ [K in keyof T]: T[K] }` (no filter) widens `"there"` to `string`.
+    let code = r#"
+declare function copy<T>(x: { [K in keyof T]: T[K] }): T;
+const r = copy({ hi: "there" });
+const bad: number = r;
+"#;
+    let msg = ts2322_message(code);
+    assert!(
+        msg.contains("hi: string"),
+        "plain homomorphic copy must widen the source literal to `string`, got: {msg}"
+    );
+}
+
+#[test]
+fn non_filter_conditional_widens_source_literal() {
+    // A conditional whose false branch is *not* `never` is a homomorphic copy,
+    // not a filter; tsc widens it like the identity mapping.
+    let code = r#"
+declare function copyCond<T>(
+    x: { [K in keyof T]: T[K] extends string ? T[K] : T[K] }
+): T;
+const r = copyCond({ hi: "there" });
+const bad: number = r;
+"#;
+    let msg = ts2322_message(code);
+    assert!(
+        msg.contains("hi: string"),
+        "conditional with non-`never` false branch must widen, got: {msg}"
+    );
+}
+
+#[test]
+fn filter_conditional_widens_property_that_fails_check() {
+    // Per-property: with `extends string`, the string property preserves its
+    // literal while the number property (which fails the check) widens.
+    let code = r#"
+declare function narrowStr<T>(
+    x: { [K in keyof T]: T[K] extends string ? T[K] : never }
+): T;
+const r = narrowStr({ s: "a", n: 1 });
+const bad: number = r;
+"#;
+    let msg = ts2322_message(code);
+    assert!(
+        msg.contains("s: \"a\"") && msg.contains("n: number"),
+        "filter must preserve the matching property and widen the failing one, got: {msg}"
+    );
+}
+
+#[test]
+fn filter_conditional_preserves_all_matching_properties() {
+    // With `extends string | number`, both properties match and are preserved.
+    let code = r#"
+declare function narrowSN<T>(
+    x: { [K in keyof T]: T[K] extends (string | number) ? T[K] : never }
+): T;
+const r = narrowSN({ s: "a", n: 1 });
+const bad: number = r;
+"#;
+    let msg = ts2322_message(code);
+    assert!(
+        msg.contains("s: \"a\"") && msg.contains("n: 1"),
+        "filter must preserve every matching literal property, got: {msg}"
+    );
+}
+
+#[test]
+fn filter_conditional_preserves_literal_with_renamed_binders() {
+    // Anti-hardcoding: the rule is structural, not tied to the `T`/`K` names.
+    let code = r#"
+declare function pick<Elem, Key extends keyof Elem = keyof Elem>(
+    x: { [P in keyof Elem]: Elem[P] extends string ? Elem[P] : never }
+): Elem;
+const r = pick({ label: "ok" });
+const bad: number = r;
+"#;
+    let msg = ts2322_message(code);
+    assert!(
+        msg.contains("label: \"ok\""),
+        "renamed binders must not change the filter literal-preservation rule, got: {msg}"
+    );
+}

--- a/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
+++ b/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
@@ -386,6 +386,20 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     crate::operations::widening::widen_type(self.interner, reversed_value);
             }
 
+            // tsc's "filter" idiom `{ [K in keyof T]: T[K] extends E ? T[K] : never }`
+            // (e.g. `Narrow`) passes a matching source property straight through the
+            // true branch and keeps it as a *regular* (non-widening) literal rather
+            // than widening it. Mark the reconstructed property so the later
+            // fresh-literal deep-widen preserves the literal — but only when the
+            // source actually satisfies `E`, so the true branch is genuinely
+            // selected (when it fails `E` the `never` branch is taken and tsc
+            // widens the property as usual).
+            let non_widening = self.reverse_mapped_property_preserves_literal(
+                source_prop_type,
+                instantiated_template,
+                target_placeholder,
+            );
+
             // Reverse the mapped type's modifier directives to reconstruct T's modifiers.
             // If the mapped type adds a modifier, the reverse removes it (and vice versa).
             // If the mapped type has no modifier directive (None), it preserves the source's
@@ -423,7 +437,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 is_string_named: prop.is_string_named,
                 is_symbol_named: prop.is_symbol_named,
                 single_quoted_name: prop.single_quoted_name,
-                non_widening: false,
+                non_widening,
             });
         }
 
@@ -640,6 +654,68 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         Some((shape, true))
     }
 
+    /// Whether a reverse-mapped property reconstructed from `source_value`
+    /// through `template` must preserve its source literal instead of widening.
+    ///
+    /// This recognises tsc's "filter" conditional idiom
+    /// `A[K] extends E ? A[K] : never` (used by helpers like `Narrow`): when the
+    /// source property is assignable to `E`, the conditional's true branch — the
+    /// naked indexed access `A[K]` — passes the source straight through, and tsc
+    /// keeps it as a *regular* (non-widening) literal. We mirror that by flagging
+    /// the reconstructed property `non_widening`. The guard is exact:
+    /// - the false branch must be `never` (a genuine filter, not a homomorphic
+    ///   copy like `A[K] extends E ? A[K] : A[K]`, which tsc widens);
+    /// - the true branch must be the naked indexed access of the placeholder
+    ///   (a wrapped branch such as `[A[K]]` does not pass the source through);
+    /// - the concrete source must satisfy `E`, otherwise the `never` branch is
+    ///   taken and tsc widens the property as for a plain homomorphic copy.
+    fn reverse_mapped_property_preserves_literal(
+        &mut self,
+        source_value: TypeId,
+        template: TypeId,
+        target_placeholder: TypeId,
+    ) -> bool {
+        let Some(TypeData::Conditional(cond_id)) = self.interner.lookup(template) else {
+            return false;
+        };
+        let cond = self.interner.get_conditional(cond_id);
+        if cond.false_type != TypeId::NEVER {
+            return false;
+        }
+        // The true branch must be the naked indexed access of the placeholder
+        // (`A[K]`) so it reverses the source straight through — a wrapped branch
+        // such as `[A[K]]` does not pass the literal through.
+        if !self.index_access_targets_placeholder(cond.true_type, target_placeholder) {
+            return false;
+        }
+        self.checker
+            .is_assignable_to(source_value, cond.extends_type)
+    }
+
+    /// Whether `type_id` is an indexed access `A[K]` whose object `A` is the
+    /// reverse-mapped placeholder — directly, as an intersection member
+    /// (`is_placeholder_match`, e.g. `T & {}` from `LowInfer<T>`), or resolved
+    /// to the placeholder's constraint (when `evaluate_type` lowered
+    /// `T_placeholder[P]` to `Constraint[P]`). This is the "naked `T[K]` reverse
+    /// site" recognised by `reverse_infer_through_template`'s Case 1 and by the
+    /// conditional filter-idiom literal-preservation check.
+    fn index_access_targets_placeholder(
+        &self,
+        type_id: TypeId,
+        target_placeholder: TypeId,
+    ) -> bool {
+        let Some(TypeData::IndexAccess(obj, _)) = self.interner.lookup(type_id) else {
+            return false;
+        };
+        if self.is_placeholder_match(obj, target_placeholder) {
+            return true;
+        }
+        matches!(
+            self.interner.lookup(target_placeholder),
+            Some(TypeData::TypeParameter(info)) if info.constraint == Some(obj)
+        )
+    }
+
     /// Reverse-infer a single property value through a mapped type template.
     ///
     /// Given `source_value` (e.g., `Box<number>`) and `template` (e.g., `Box<T["a"]>`),
@@ -671,20 +747,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // its constraint (e.g., `T extends object` → IndexAccess(object, P) instead of
         // IndexAccess(T_placeholder, P)), we recognize that the IndexAccess object type
         // is the constraint of the target placeholder and still accept the match.
-        if let Some(TypeData::IndexAccess(obj, _idx)) = self.interner.lookup(template) {
-            if self.is_placeholder_match(obj, target_placeholder) {
-                return Some(source_value);
-            }
-            // Check if obj is the constraint of the target placeholder.
-            // This happens when evaluate_type resolves T_placeholder[P] through T's
-            // constraint, producing constraint[P]. We should still treat this as a
-            // placeholder match for reverse mapped inference.
-            if let Some(TypeData::TypeParameter(info)) = self.interner.lookup(target_placeholder)
-                && let Some(constraint) = info.constraint
-                && obj == constraint
-            {
-                return Some(source_value);
-            }
+        if self.index_access_targets_placeholder(template, target_placeholder) {
+            return Some(source_value);
         }
 
         // Case 1b: template is an array/readonly wrapper around the indexed


### PR DESCRIPTION
## Summary

Fixes #14226. Reverse-mapped homomorphic inference widened a fresh source literal even when the mapped template was tsc's "filter" conditional idiom `{ [K in keyof T]: T[K] extends E ? T[K] : never }` (helpers like `Narrow`). tsz inferred `T = { hi: string }` where tsc infers `T = { hi: "there" }`, producing spurious TS2416/TS2322 downstream (mined from **ts-toolbelt**).

```ts
declare function f1<T>(x: { [K in keyof T]: T[K] extends (string|number|bigint|boolean) ? T[K] : never }): T;
const r1 = f1({ hi: 'there' });
const b1: number = r1;   // before: { hi: string }  →  after: { hi: "there" } (matches tsc)
```

## Structural rule

`When reversing a source property through a conditional template `A[K] extends E ? A[K] : never` whose false branch is `never`, whose true branch is the naked indexed access of the placeholder, and whose concrete source value satisfies `E` (so the true branch is genuinely selected), tsc keeps the source as a regular (non-widening) literal; tsz now reconstructs that property as `non_widening` through the solver's reverse-mapped constraint walker.`

The decision is **per-property**, mirroring tsc's per-property freshness: when the source fails `E` the `never` branch is taken and the property still widens; a plain homomorphic copy (false branch not `never`, e.g. `A[K] extends E ? A[K] : A[K]`) also still widens.

## Owner layer

Solver — `crates/tsz-solver/src/operations/constraints/reverse_mapped.rs`, `constrain_reverse_mapped_type` (the `CallEvaluator` constraint-walker path that a generic call actually uses, not `infer_matching.rs`). Preservation rides the existing per-property `non_widening` flag, which `widen_type_for_inference` already honors. The naked-indexed-access placeholder match is factored into a shared `index_access_targets_placeholder` helper reused by `reverse_infer_through_template`'s Case 1.

## Adjacent-case matrix (verified against `tsc` 5.x)

| Template | source | tsc / tsz |
|---|---|---|
| `T[K]` (identity) | `{hi:'there'}` | `{ hi: string }` (widen) |
| `T[K] extends prim ? T[K] : never` | `{hi:'there'}` | `{ hi: "there" }` (preserve) |
| `T[K] extends string ? T[K] : T[K]` | `{hi:'there'}` | `{ hi: string }` (widen — not a filter) |
| `T[K] extends object ? T[K] : never` | `{hi:'there'}` | `{ hi: string }` (source fails `E` → widen) |
| `T[K] extends string ? T[K] : never` | `{s:'a', n:1}` | `{ s: "a"; n: number }` (per-property) |
| `T[K] extends (string\|number) ? T[K] : never` | `{s:'a', n:1}` | `{ s: "a"; n: 1 }` (both preserved) |

Anti-hardcoding: the rule is structural (conditional shape + assignability), driven by no identifier/file-name string; a renamed-binder test (`Elem`/`Key`/`P`) is included.

## Verification

- `cargo test -p tsz-checker --test reverse_mapped_inference_tests` — 34 passed (6 new: filter preserve, identity widen, non-filter widen, per-property split, all-match preserve, renamed binders).
- `cargo test -p tsz-solver --lib inference` — 570 passed.
- Adjacent checker suites green: `homomorphic_mapped_union_distribution_tests`, `mapped_type_errors_conformance_tests`, `cross_file_generic_interface_mapped_filter_tests`, `as_const_object_property_inference_tests`, `homomorphic_mapped_index_display_tests`.
- `cargo clippy -p tsz-solver --all-targets` clean.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_015TiwVw9YQkPZStny2P2Npc)_