### PR TITLE
fix(checker): infer a bare-type-param predicate target from nested params (TS2345/TS2322)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/predicate_resolution.rs
+++ b/crates/tsz-checker/src/flow/control_flow/predicate_resolution.rs
@@ -180,36 +180,61 @@ impl<'a> FlowAnalyzer<'a> {
             }
         }
 
-        // Case 2c: Structural inference for a type parameter nested inside the
-        // predicate target. The preceding cases bind a type parameter when it
+        // Case 2c: Structural inference for a type parameter the earlier cases
+        // could not bind. The preceding cases bind a type parameter when it
         // appears *directly* as a parameter type (`value: T`), as a bare member
         // of a union parameter (`T | "x"`), or as a callback predicate target.
-        // A predicate target that is itself a bare type parameter (`value is T`)
-        // is also covered by the union-subtraction path (Case 3) below, which
-        // must keep ownership so the false branch narrows correctly — running
-        // general inference there would bind `T` to the whole argument union
-        // rather than the subtracted member.
         //
-        // The remaining gap is a predicate target that is a *compound* type
-        // mentioning the type parameter — a generic application or wrapper such
-        // as `AsyncIterable<T>`, `Box<T>`, `Promise<T>`, or `Map<K, V>`, often
-        // reached through a parameter alias like
-        // `MaybeAsync<T> = T | AsyncIterable<T>`. None of the shortcuts fire for
-        // it, so the predicate is left generic. Narrowing then intersects the
-        // already-narrowed value with the generic target
-        // (`AsyncIterable<string> & AsyncIterable<any>`), over-constraining it.
+        // Two gaps remain, both recovered here the same way call resolution
+        // does — structurally matching each declared parameter type against its
+        // argument type, answered through the inference query boundary rather
+        // than re-implemented here:
         //
-        // Recover the bindings the same way call resolution does: structurally
-        // match each declared parameter type against its argument type. This is
-        // a solver concern, so it is answered through the inference query
-        // boundary rather than re-implemented here.
+        // 1. A *compound* predicate target mentioning the type parameter — a
+        //    generic application or wrapper such as `AsyncIterable<T>`,
+        //    `Box<T>`, `Promise<T>`, or `Map<K, V>`, often reached through a
+        //    parameter alias like `MaybeAsync<T> = T | AsyncIterable<T>`. None
+        //    of the shortcuts fire, so the predicate is left generic and
+        //    narrowing intersects the already-narrowed value with the generic
+        //    target (`AsyncIterable<string> & AsyncIterable<any>`),
+        //    over-constraining it.
+        //
+        // 2. A *bare* type-parameter target (`value is G`) whose only binding
+        //    comes from a nested generic application parameter (`box: Box<G>`
+        //    matched against `condition: Box<C>`). Cases 1/1b/2/2b do not bind
+        //    `G` and the union-subtraction paths (Case 1b / Case 3) do not own
+        //    it because it is not a *direct union member* of any parameter, so
+        //    `value` would narrow to the uninstantiated `G` instead of `C`.
+        //
+        // Bare targets that *are* a direct union member of a parameter
+        // (`value: T | null`) must stay owned by the union-subtraction paths:
+        // subtracting the fixed members from the argument union is what narrows
+        // the false branch correctly, and general inference would bind the
+        // parameter to the whole argument union rather than the subtracted
+        // member. The `bare_target_is_union_member` guard preserves that
+        // ownership while still letting the nested-application case (2) run.
         let predicate_target_is_bare_type_param =
             flow_query::type_param_info(self.interner, pred_type).is_some();
-        let predicate_still_generic = !predicate_target_is_bare_type_param
-            && type_params.iter().any(|tp| {
-                substitution.get(tp.name).is_none()
-                    && flow_query::contains_type_parameter_named(self.interner, pred_type, tp.name)
+        let bare_target_is_union_member = predicate_target_is_bare_type_param
+            && params.iter().any(|param| {
+                let evaluated_param = if let Some(env) = &self.type_environment {
+                    let env_borrow = env.borrow();
+                    flow_query::evaluate_application_type(self.interner, &env_borrow, param.type_id)
+                } else {
+                    flow_query::evaluate_type_structure(self.interner, param.type_id)
+                };
+                union_members_for_type(self.interner, evaluated_param)
+                    .is_some_and(|members| members.contains(&pred_type))
             });
+        // Run structural inference for both a compound predicate target that
+        // mentions an unbound type parameter and a bare type-parameter target
+        // that the union-subtraction cases do not own (and that no earlier case
+        // already bound).
+        let predicate_still_generic = type_params.iter().any(|tp| {
+            substitution.get(tp.name).is_none()
+                && flow_query::contains_type_parameter_named(self.interner, pred_type, tp.name)
+        }) && (!predicate_target_is_bare_type_param
+            || !bare_target_is_union_member);
         if predicate_still_generic {
             let param_arg_pairs: Vec<(TypeId, TypeId)> = params
                 .iter()


### PR DESCRIPTION
Goal: green

Clears false **TS2345/TS2322** from a generic type-guard whose predicate target is a bare type parameter inferable only from a nested generic-application parameter (superstruct `coerce`/`is`).

## Structural rule
When a type-predicate target is a bare type parameter `G` (`value is G`) that none of Cases 1/1b/2/2b bound, that is still unbound in the substitution, and that is **not** a direct union member of any parameter's evaluated type, tsc recovers `G` by structurally inferring it from the parameters (`box: Box<G>` ← `condition: Box<C>` ⇒ `G = C`). tsz's `resolve_generic_predicate` Case 2c gate hard-disabled structural inference for *any* bare-type-param target, so `value` narrowed to the uninstantiated `G` (which, under a name-colliding guard param, renders as the caller's `T`) → false TS2345/TS2322 on a later assignment. The gate now adds a structural `bare_target_is_union_member` check and relaxes accordingly. Bare targets that **are** a direct union member of a parameter (`value: T | null`) stay owned by the union-subtraction paths (Case 1b / Case 3). Anti-hardcoding: flags + substitution membership + union-membership only.

## Adjacent matrix
- `is<G>(value, box: Box<G>): value is G` called with `condition: Box<C>` → `value` narrows to `C` (was leaked `G`); matches tsc.
- **Negatives (all parity-matched):** Case 1 direct param `isDirect<G>(v, sample: G): value is G`; non-generic `isStr(v): v is string`; aliased-union guard (pre-existing divergence, unchanged); **bare-param-as-direct-union-member** `isT<T>(value: T|null): value is T` → narrows to `T`, `null` still subtracted (Case 1b/3 ownership preserved, the un-narrowed assignment still errors).

## Verification
- Repro line-exact tsc-parity (`asC` clean, `asT` still errors), deterministic across 10 forced-parallel runs; all 4 negatives match tsc.
- superstruct: TS2345|TS2322 8→7 (`coercions.ts:25`), total 16→15, no new codes, 3-run-stable.
- Regression delta vs clean `main`: `--lib type_guard` 87/87, `--lib generic_predicate` 1/1, `--lib predicate` 145/146 (1 pre-existing arch test on other files), `--lib narrow` 311/313 (2 pre-existing) — **zero new failures** (all proven pre-existing via stash→rebuild→rerun). clippy clean; warn-ratchet pre-empted (0 hits in the file).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
