### PR TITLE
fix(checker): resolve self-referential annotated const arrow to its declared signature (#14234)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -292,6 +292,9 @@ path = "tests/optional_chain_literal_nullish_ts2339_tests.rs"
 name = "optional_chain_indexed_unknown_tests"
 path = "tests/optional_chain_indexed_unknown_tests.rs"
 [[test]]
+name = "recursive_annotated_arrow_self_reference_tests"
+path = "tests/recursive_annotated_arrow_self_reference_tests.rs"
+[[test]]
 name = "new_expression_regression_tests"
 path = "tests/new_expression_regression_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -597,6 +597,22 @@ impl<'a> CheckerState<'a> {
                     // Fall back to inferring from initializer
                     if var_decl.initializer.is_some() {
                         let mut inferred_type = self.get_type_of_node(var_decl.initializer);
+                        // A `const`/`let`/`var` bound to a fully-annotated arrow or
+                        // function expression that references itself in its own body
+                        // cycles through this very initializer node while the body is
+                        // being checked, so `get_type_of_node` returns ERROR. The
+                        // binding's type is its declared signature — computable from
+                        // the parameter and return annotations without analyzing the
+                        // body — so recover it here, mirroring `tsc`, which types a
+                        // fully-annotated function expression from its signature. A
+                        // non-arrow or un-annotated initializer yields `None` and the
+                        // ERROR is left untouched.
+                        if inferred_type == TypeId::ERROR
+                            && let Some(declared) =
+                                self.provisional_circular_variable_function_symbol_type(sym_id)
+                        {
+                            inferred_type = declared;
+                        }
                         // Eagerly evaluate Application types (e.g., merge<A, B>)
                         // to concrete types. Without this, long chains like
                         //   const o50 = merge(merge(merge(...)))

--- a/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/symbol_type_helpers.rs
@@ -4,7 +4,7 @@
 use crate::query_boundaries::common::{TypeEnvironment, type_param_info};
 use crate::state::CheckerState;
 use tsz_binder::{SymbolId, symbol_flags};
-use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
@@ -351,6 +351,123 @@ impl<'a> CheckerState<'a> {
             is_method: false,
         });
         Some(func_type)
+    }
+
+    /// Provisional self-reference type for a circular `const`/`let`/`var` bound
+    /// to an arrow or function expression whose parameters and return type are
+    /// all explicitly annotated.
+    ///
+    /// `tsc` resolves an in-body self-reference of such a binding to the
+    /// initializer's declared signature, which is computable from the
+    /// annotations alone without analyzing the body. Without a provisional,
+    /// the variable symbol — which is not a `FUNCTION` symbol, so
+    /// [`Self::provisional_circular_function_symbol_type`] does not apply —
+    /// collapses to `ERROR`/`unknown` during the cycle, so `param.map(self)`
+    /// degrades to `unknown[]` and yields a false `TS18046`/`TS2571`.
+    ///
+    /// Only fires when every parameter and the return type are annotated: an
+    /// un-annotated arrow genuinely needs body inference to determine its
+    /// signature, so it is left to the existing cycle behavior.
+    pub(crate) fn provisional_circular_variable_function_symbol_type(
+        &mut self,
+        sym_id: SymbolId,
+    ) -> Option<TypeId> {
+        use tsz_solver::FunctionShape;
+
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        // Plain value variables only; entities with their own provisional /
+        // lazy handling (functions, classes, interfaces, type aliases, enums,
+        // modules, aliases) are resolved elsewhere.
+        if !symbol.has_any_flags(symbol_flags::VARIABLE)
+            || symbol.has_any_flags(
+                symbol_flags::FUNCTION
+                    | symbol_flags::CLASS
+                    | symbol_flags::INTERFACE
+                    | symbol_flags::TYPE_ALIAS
+                    | symbol_flags::ENUM
+                    | symbol_flags::MODULE
+                    | symbol_flags::ALIAS,
+            )
+        {
+            return None;
+        }
+
+        let declarations = symbol.declarations.clone();
+        for decl_idx in declarations {
+            let Some(init_idx) = self.variable_declaration_function_initializer(decl_idx) else {
+                continue;
+            };
+            let Some(init_node) = self.ctx.arena.get(init_idx) else {
+                continue;
+            };
+            if init_node.kind != syntax_kind_ext::ARROW_FUNCTION
+                && init_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION
+            {
+                continue;
+            }
+            let Some(func) = self.ctx.arena.get_function(init_node) else {
+                continue;
+            };
+            if !self.function_has_explicit_param_and_return_annotations(func) {
+                continue;
+            }
+
+            let sig = self.call_signature_from_function(func, init_idx);
+            return Some(self.ctx.types.factory().function(FunctionShape {
+                type_params: sig.type_params,
+                params: sig.params,
+                this_type: sig.this_type,
+                return_type: sig.return_type,
+                type_predicate: sig.type_predicate,
+                is_constructor: false,
+                is_method: false,
+            }));
+        }
+        None
+    }
+
+    /// Resolve a symbol declaration node to the initializer of its enclosing
+    /// `VariableDeclaration`, when the binding carries no type annotation of its
+    /// own (an annotated binding uses that annotation, not the initializer's
+    /// inferred signature). Symbol declarations may point at the binding
+    /// identifier, so climb to the enclosing declaration when needed.
+    fn variable_declaration_function_initializer(&self, decl_idx: NodeIndex) -> Option<NodeIndex> {
+        let mut node_idx = decl_idx;
+        let mut node = self.ctx.arena.get(node_idx)?;
+        if node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
+            node_idx = self
+                .ctx
+                .arena
+                .get_extended(node_idx)
+                .map(|ext| ext.parent)?;
+            node = self.ctx.arena.get(node_idx)?;
+        }
+        if node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
+            return None;
+        }
+        let decl = self.ctx.arena.get_variable_declaration(node)?;
+        if decl.type_annotation != NodeIndex::NONE {
+            return None;
+        }
+        Some(decl.initializer)
+    }
+
+    /// Whether a function/arrow node has an explicit return-type annotation and
+    /// an explicit type annotation on every parameter.
+    fn function_has_explicit_param_and_return_annotations(
+        &self,
+        func: &tsz_parser::parser::node::FunctionData,
+    ) -> bool {
+        if func.type_annotation == NodeIndex::NONE {
+            return false;
+        }
+        func.parameters.nodes.iter().copied().all(|param_idx| {
+            self.ctx
+                .arena
+                .get(param_idx)
+                .and_then(|param_node| self.ctx.arena.get_parameter(param_node))
+                .is_some_and(|param| param.type_annotation != NodeIndex::NONE)
+        })
     }
 
     fn provisional_declaration_file_call_signature(

--- a/crates/tsz-checker/tests/recursive_annotated_arrow_self_reference_tests.rs
+++ b/crates/tsz-checker/tests/recursive_annotated_arrow_self_reference_tests.rs
@@ -1,0 +1,115 @@
+//! Regression matrix for a self-referential `const`/`let`/`var` bound to a
+//! fully-annotated arrow or function expression (issue #14234).
+//!
+//! When such a binding references itself inside its own body (for example
+//! `const f = (p: number[] | number): string => { ...; const r = p.map(f); ... }`),
+//! `tsc` resolves the in-body self-reference to the binding's *declared*
+//! signature — computable from the parameter and return annotations without
+//! analyzing the body. tsz previously collapsed the self-reference to
+//! `unknown` during the resolution cycle (the variable is not a `FUNCTION`
+//! symbol, so the existing function cycle-break did not apply), so
+//! `p.map(f)` degraded to `unknown[]` and produced a false `TS2571`/`TS18046`.
+//!
+//! These tests lock the parity. Per the anti-hardcoding gate, the binder name
+//! is varied across cases so a fix keyed on a specific spelling would fail.
+
+use tsz_checker::test_utils::{check_source_strict, diagnostic_count};
+
+const TS2571_OBJECT_IS_UNKNOWN: u32 = 2571;
+const TS18046_IS_OF_TYPE_UNKNOWN: u32 = 18046;
+
+/// Total `unknown`-object element-access diagnostics on a snippet (the two
+/// forms are mutually exclusive per access site).
+fn unknown_object_diags(source: &str) -> usize {
+    let diags = check_source_strict(source);
+    diagnostic_count(&diags, TS2571_OBJECT_IS_UNKNOWN)
+        + diagnostic_count(&diags, TS18046_IS_OF_TYPE_UNKNOWN)
+}
+
+/// The issue witness: a fully-annotated recursive const arrow whose body maps
+/// over itself. The mapped result must be `string[]`, so the trailing
+/// `.toUpperCase()` is well typed.
+#[test]
+fn recursive_const_arrow_self_reference_resolves_declared_signature() {
+    let source = r#"
+const consumer = (param: number[] | number): string => {
+  if (typeof param === 'number') return String(param);
+  const r = param.map(consumer);
+  return r[0]!.toUpperCase();
+};
+"#;
+    assert_eq!(
+        unknown_object_diags(source),
+        0,
+        "in-body self-reference must resolve to the declared `(param) => string` signature"
+    );
+}
+
+/// Same shape via a `function` expression rather than an arrow.
+#[test]
+fn recursive_const_function_expression_self_reference_resolves_declared_signature() {
+    let source = r#"
+const handler = function (items: number[] | number): string {
+  if (typeof items === 'number') return String(items);
+  const mapped = items.map(handler);
+  return mapped[0]!.toUpperCase();
+};
+"#;
+    assert_eq!(
+        unknown_object_diags(source),
+        0,
+        "function-expression form must behave identically to the arrow form"
+    );
+}
+
+/// Renamed binder — the fix must be structural, not keyed on a name.
+#[test]
+fn recursive_const_arrow_self_reference_is_not_name_keyed() {
+    let source = r#"
+const walkValue = (entry: number[] | number): string => {
+  if (typeof entry === 'number') return String(entry);
+  const collected = entry.map(walkValue);
+  return collected[0]!.toUpperCase();
+};
+"#;
+    assert_eq!(
+        unknown_object_diags(source),
+        0,
+        "the declared-signature recovery must not depend on the binder spelling"
+    );
+}
+
+/// `let`-bound recursive annotated arrow.
+#[test]
+fn recursive_let_arrow_self_reference_resolves_declared_signature() {
+    let source = r#"
+let visit = (node: string[] | string): string => {
+  if (typeof node === 'string') return node;
+  const parts = node.map(visit);
+  return parts[0]!.toUpperCase();
+};
+"#;
+    assert_eq!(
+        unknown_object_diags(source),
+        0,
+        "a `let`-bound recursive annotated arrow resolves to its declared signature"
+    );
+}
+
+/// Negative control: a genuinely `unknown` indexed access still errors, proving
+/// the recovery is scoped to the self-reference cycle and does not blanket-
+/// suppress the `unknown`-object diagnostics.
+#[test]
+fn unknown_object_index_still_reports() {
+    let source = r#"
+const reader = (value: unknown): string => {
+  const slot = (value as unknown)["k"];
+  return slot;
+};
+"#;
+    assert_eq!(
+        diagnostic_count(&check_source_strict(source), TS2571_OBJECT_IS_UNKNOWN),
+        1,
+        "indexing a genuine `unknown` base must still report TS2571"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes #14234. A `const`/`let`/`var` bound to a fully-annotated arrow or function expression that references itself in its own body resolved the in-body self-reference to `unknown`, producing a false `TS2571`/`TS18046`:

```ts
const consumer = (param: number[] | number): string => {
  if (typeof param === 'number') return String(param);
  const r = param.map(consumer);   // tsz: r was unknown[] (should be string[])
  return r[0]!.toUpperCase();       // tsz: false TS2571/TS18046; tsc: clean
};
```

Goal: green

## Structural rule
When a `const`/`let`/`var` is bound to an arrow/function expression that has explicit parameter **and** return-type annotations and references itself in its own body, `tsc` resolves the in-body self-reference to the binding's **declared** signature — computable from the annotations without analyzing the body. tsz cycled through the binding's own initializer node while checking the body (`get_type_of_node(initializer)` returns the in-progress `ERROR` placeholder), and because the binding is a `VARIABLE` symbol — not a `FUNCTION` symbol — the existing function cycle-break (`provisional_circular_function_symbol_type`, which is `FUNCTION`-only) never applied, so the self-reference collapsed to `ERROR`/`unknown`.

## Fix (owner layer: checker)
- Add `provisional_circular_variable_function_symbol_type` (solver-backed signature build via the existing `call_signature_from_function`): for a plain value variable whose initializer is an arrow/function expression with every parameter and the return type annotated, build the declared function signature.
- In the variable type computation (`computed/type_alias_variable_alias.rs`), when the initializer's inferred type is `ERROR` (the self-cycle), recover the declared signature. A non-arrow or un-annotated initializer yields `None` and the `ERROR` is left untouched, so the genuinely-needs-inference case is unaffected.

This is the layer where the cycle's `ERROR` is observable and recoverable; the symbol-level cycle hooks in `core.rs` are bypassed because the cycle is at the initializer *node* level.

## Adjacent-case matrix (verified vs `tsc`)
- arrow form (witness), `function`-expression form, renamed binder, `let`-bound arrow → all clean, matching `tsc`.
- generic recursive arrow (`<T>`) → clean (signature build threads type parameters).
- non-recursive annotated arrow + a real type error → unchanged (`TS2322` still fires).
- negative control: indexing a genuine `unknown` base still reports `TS2571`.

## Verification
- New regression matrix: `cargo test -p tsz-checker --test recursive_annotated_arrow_self_reference_tests` (5 cases, binder names varied per the anti-hardcoding gate) — passing.
- `cargo test -p tsz-cli --test recursive_const_arrow_dts_emit_tests` — passing (no DTS-emit regression).
- Manual parity on the witness + adjacent cases against `tsc` 6.0.2 (`--strict --noEmit`).
- Broad conformance/emit/fourslash: ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_0198BFfypke4JmrwX3HKB6FT

---
_Generated by [Claude Code](https://claude.ai/code/session_0198BFfypke4JmrwX3HKB6FT)_