### PR TITLE
fix(binder): renamed top-level export must not clobber a same-named local

### DIFF
--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -588,15 +588,22 @@ impl BinderState {
                                                 clone_sym.is_type_only = true;
                                                 clone_sym.is_exported = true;
                                             }
-                                            if let Some(table) = self.current_scope_mut() {
-                                                table.set(exp.to_string(), clone_id);
+                                            // Renamed *top-level* exports go to the public
+                                            // surface only (see `seed_module_export`). Namespace
+                                            // member exports keep the scope/file-local seeding:
+                                            // their cross-references resolve through the
+                                            // namespace's own exports table, not `file_locals`.
+                                            if orig != exp && current_namespace_sym_id.is_none() {
+                                                self.seed_module_export(exp, clone_id);
+                                            } else {
+                                                self.set_scope_and_file_local(exp, clone_id);
                                             }
-                                            self.file_locals.set(exp.to_string(), clone_id);
                                         } else if orig != exp {
-                                            if let Some(table) = self.current_scope_mut() {
-                                                table.set(exp.to_string(), sym_id);
+                                            if current_namespace_sym_id.is_none() {
+                                                self.seed_module_export(exp, sym_id);
+                                            } else {
+                                                self.set_scope_and_file_local(exp, sym_id);
                                             }
-                                            self.file_locals.set(exp.to_string(), sym_id);
                                         }
                                     }
                                 }
@@ -800,11 +807,7 @@ impl BinderState {
                         }
                     } else {
                         // Regular namespace re-export — add to module exports
-                        let current_file = self.debugger.current_file.clone();
-                        Arc::make_mut(&mut self.module_exports)
-                            .entry(current_file)
-                            .or_default()
-                            .set(name.to_string(), sym_id);
+                        self.seed_module_export(name, sym_id);
                     }
                 }
             }
@@ -832,6 +835,35 @@ impl BinderState {
                 }
             }
         }
+    }
+
+    /// Record a public export `name -> sym_id` directly in the file's
+    /// `module_exports` surface, without creating an in-module lexical binding.
+    ///
+    /// Used by export forms that contribute a public name but must not seed a
+    /// `file_locals`/scope slot: `export * as ns from "mod"` and renamed
+    /// top-level specifiers (`export { orig as exp }`). For the latter, routing
+    /// through `module_exports` is load-bearing — writing the alias target into
+    /// the scope slot would clobber a colliding local declaration named `exp`
+    /// (for example a same-named `class`), producing spurious `TS2749` at
+    /// in-module type sites and `TS2552` at value sites, while cross-file
+    /// `import { exp }` must still resolve to the alias target.
+    fn seed_module_export(&mut self, name: &str, sym_id: crate::SymbolId) {
+        let current_file = self.debugger.current_file.clone();
+        Arc::make_mut(&mut self.module_exports)
+            .entry(current_file)
+            .or_default()
+            .set(name.to_string(), sym_id);
+    }
+
+    /// Seed a same-file lexical binding `name -> sym_id` into both the current
+    /// scope and `file_locals`. Used by export forms that legitimately create an
+    /// in-module name (namespace member exports, type-only export clones).
+    fn set_scope_and_file_local(&mut self, name: &str, sym_id: crate::SymbolId) {
+        if let Some(table) = self.current_scope_mut() {
+            table.set(name.to_string(), sym_id);
+        }
+        self.file_locals.set(name.to_string(), sym_id);
     }
 
     /// Existing re-export alias for `name` in the current scope, if any.

--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -590,18 +590,27 @@ impl BinderState {
                                                 clone_sym.is_exported = true;
                                             }
                                             // Renamed *top-level* exports go to the public
-                                            // surface only (see `seed_module_export`). Namespace
-                                            // member exports keep the scope/file-local seeding:
-                                            // their cross-references resolve through the
+                                            // surface only (see `seed_module_export`). The
+                                            // synthetic `default` slot is the exception: default
+                                            // import classification still consults the legacy
+                                            // file-local default path, and there is no user
+                                            // identifier named `default` to clobber. Namespace
+                                            // member exports also keep the scope/file-local
+                                            // seeding; their cross-references resolve through the
                                             // namespace's own exports table, not `file_locals`.
-                                            if orig != exp && current_namespace_sym_id.is_none() {
+                                            if orig != exp
+                                                && exp != "default"
+                                                && current_namespace_sym_id.is_none()
+                                            {
                                                 self.seed_module_export(exp, clone_id);
                                             } else {
                                                 self.set_scope_and_file_local(exp, clone_id);
                                             }
                                             exported_sym_id = clone_id;
                                         } else if orig != exp {
-                                            if current_namespace_sym_id.is_none() {
+                                            if exp != "default"
+                                                && current_namespace_sym_id.is_none()
+                                            {
                                                 self.seed_module_export(exp, sym_id);
                                             } else {
                                                 self.set_scope_and_file_local(exp, sym_id);

--- a/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
+++ b/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
@@ -527,6 +527,32 @@ let ns = { a: 1 };
 }
 
 #[test]
+fn renamed_default_export_updates_synthetic_default_slot() {
+    let source = r#"
+export default interface zzz {
+    x: string;
+}
+import zzz from "./b";
+export { zzz as default };
+"#;
+    let (binder, _parser) = parse_and_bind(source);
+
+    let default_id = binder
+        .file_locals
+        .get("default")
+        .expect("expected synthetic default export slot");
+    let default_symbol = binder
+        .symbols
+        .get(default_id)
+        .expect("expected default symbol data");
+
+    assert_ne!(default_symbol.flags & symbol_flags::ALIAS, 0);
+    assert!(!default_symbol.is_type_only);
+    assert_eq!(default_symbol.import_module(), Some("./b"));
+    assert_eq!(default_symbol.import_name(), Some("default"));
+}
+
+#[test]
 fn type_alias_after_namespace_reexport_keeps_alias_partner() {
     let source = r"
 export * as Foo from './mod';

--- a/crates/tsz-checker/tests/conformance_issues/modules/export_alias_local_collision.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/export_alias_local_collision.rs
@@ -1,0 +1,182 @@
+//! Regression tests for `export { local as Name }` where `Name` collides with a
+//! distinct local declaration.
+//!
+//! Structural rule: a renamed export specifier (`export { orig as exp }`)
+//! contributes only to the module's public export surface. tsc keeps any
+//! in-module declaration named `exp` (for example a same-named `class`) intact
+//! for value and type references and re-aliases solely at the export boundary.
+//! tsz previously overwrote the scope / file-local slot for `exp` with the alias
+//! source, producing spurious `TS2749` at in-module type sites and `TS2552` at
+//! value sites, while cross-file `import { exp }` still had to resolve to the
+//! alias target. Mined from purify-ts (`Either.ts` / `Maybe.ts`).
+
+use super::super::core::*;
+
+/// `export { box as Box }` next to a local `class Box`: in-module value/type
+/// references to `Box` must keep resolving to the class, not the lowercased
+/// alias source. No `TS2749` / `TS2552`.
+#[test]
+fn test_export_alias_does_not_clobber_same_named_local_class() {
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        r#"
+class Box { constructor(public value: number) {} }
+const useType = (b: Box): number => b.value;
+const useValue = (): Box => new Box(1);
+const box = (n: number) => new Box(n);
+export { box as Box };
+"#,
+        CheckerOptions {
+            strict: true,
+            module: ModuleKind::ES2020,
+            target: ScriptTarget::ES2020,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|(code, _)| *code == 2749 || *code == 2552),
+        "Expected no TS2749/TS2552 from an export-alias colliding with a local class.\nActual: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.is_empty(),
+        "Expected no diagnostics.\nActual: {diagnostics:#?}"
+    );
+}
+
+/// Renamed binders: the same collision over a local `function`, with a different
+/// identifier, must behave identically (anti-hardcoding: not keyed on `Box`).
+#[test]
+fn test_export_alias_does_not_clobber_same_named_local_function() {
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        r#"
+function Widget(input: number): number { return input; }
+const useValue = (): number => Widget(1);
+const make = (n: number) => n;
+export { make as Widget };
+"#,
+        CheckerOptions {
+            strict: true,
+            module: ModuleKind::ES2020,
+            target: ScriptTarget::ES2020,
+            ..Default::default()
+        },
+    );
+
+    // `Widget` in `Widget(1)` resolves to the local function (returns number),
+    // never to the lowercased `make`. No TS2552 / TS2304.
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|(code, _)| *code == 2552 || *code == 2304),
+        "Expected no TS2552/TS2304 from an export-alias colliding with a local function.\nActual: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.is_empty(),
+        "Expected no diagnostics.\nActual: {diagnostics:#?}"
+    );
+}
+
+/// The module's public export surface must map the *alias name* (`Box`) to the
+/// alias source, never the local declaration name. Cross-file:
+/// - `import { Box }` resolves (the renamed public export);
+/// - `import { box }` is `TS2460` (the local is exported only under `Box`);
+/// - `import { Nonexistent }` is `TS2305`.
+///
+/// This proves the fix seeds `module_exports[Box] -> box` without leaking `box`
+/// itself into the public surface or clobbering the producer's `class Box`.
+#[test]
+fn test_export_alias_cross_file_resolves_to_alias_target() {
+    let files = [
+        (
+            "/m.ts",
+            r#"
+class Box { constructor(public value: number) {} }
+const useType = (b: Box): number => b.value;
+const useValue = (): Box => new Box(1);
+const box = (n: number) => new Box(n);
+export { box as Box };
+"#,
+        ),
+        (
+            "/consumer.ts",
+            r#"
+import { Box } from "./m";
+import { box } from "./m";
+import { Nonexistent } from "./m";
+"#,
+        ),
+    ];
+
+    let diagnostics = compile_named_files_get_diagnostics_with_options_and_import_reporting(
+        &files,
+        "/consumer.ts",
+        CheckerOptions {
+            strict: true,
+            module: ModuleKind::ES2020,
+            target: ScriptTarget::ES2020,
+            ..Default::default()
+        },
+        true,
+    );
+
+    // `import { box }` -> TS2460: the local is exported only under the alias `Box`.
+    assert!(
+        diagnostics
+            .iter()
+            .any(|(code, msg)| *code == 2460 && msg.contains("'box'") && msg.contains("'Box'")),
+        "Expected TS2460 for `import {{ box }}` (exported only as `Box`).\nActual: {diagnostics:#?}"
+    );
+    // `import { Nonexistent }` -> TS2305.
+    assert!(
+        diagnostics.iter().any(|(code, _)| *code == 2305),
+        "Expected TS2305 for a name that is not exported.\nActual: {diagnostics:#?}"
+    );
+    // `import { Box }` must resolve cleanly: no TS2305/TS2460 mentioning `Box`
+    // as the *missing/renamed* member.
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|(code, msg)| *code == 2305 && msg.contains("'Box'")),
+        "Expected `import {{ Box }}` to resolve to the alias target.\nActual: {diagnostics:#?}"
+    );
+}
+
+/// A renamed export with no colliding local must keep resolving cross-file
+/// (guards against the fix dropping the public mapping entirely).
+#[test]
+fn test_renamed_export_without_collision_still_resolves_cross_file() {
+    let files = [
+        (
+            "/m.ts",
+            r#"
+const internalName = (n: number) => n + 1;
+export { internalName as publicName };
+"#,
+        ),
+        (
+            "/consumer.ts",
+            r#"
+import { publicName } from "./m";
+const r: number = publicName(3);
+"#,
+        ),
+    ];
+
+    let diagnostics = compile_named_files_get_diagnostics_with_options(
+        &files,
+        "/consumer.ts",
+        CheckerOptions {
+            strict: true,
+            module: ModuleKind::ES2020,
+            target: ScriptTarget::ES2020,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "Expected no diagnostics for a non-colliding renamed export.\nActual: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/conformance_issues/modules/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/mod.rs
@@ -1,5 +1,6 @@
 mod context;
 mod declaration_module_emit;
 mod declare_global;
+mod export_alias_local_collision;
 mod file_formats;
 mod package_resolution;


### PR DESCRIPTION
## Summary

Fixes #14216 (mined from purify-ts). A renamed top-level export specifier
(`export { orig as exp }`) was overwriting the in-module lexical binding for
`exp` by seeding `current_scope[exp]`/`file_locals[exp]` with the alias
source. When a distinct local declaration named `exp` already existed, in-module
value/type references could resolve to the alias source instead of the local
symbol. `tsc` keeps the local declaration intact and re-aliases only at the
export boundary.

Follow-up after the conflict refresh: renamed top-level `default` exports keep
the synthetic default slot path because default import classification consults
that legacy slot and there is no user identifier named `default` to clobber.

## Structural rule

When a module declares a local symbol `Name` and re-exports a distinct local
binding under that name via a renamed top-level specifier (`export { orig as
Name }`), `tsc` keeps the local declaration for all in-module references and
re-aliases only at the export boundary. tsz routes ordinary renamed top-level
exports through the public `module_exports` surface directly instead of
clobbering the scope/file-local slot. Namespace member exports keep the legacy
scope/file-local seeding because their cross-references resolve through the
namespace's own exports table. Renamed `default` keeps the synthetic default
slot so `export default interface T; export { T as default }` can merge a type
default with a value default like `tsc`.

Owner layer: binder (`crates/tsz-binder/src/modules/import_export.rs`, local
export-specifier handling).

## Adjacent matrix

- `export { box as Box }` with local `class Box` — no TS2749/TS2552.
- Same collision over a local `function` with a different identifier.
- Cross-file: `import { Box }` resolves to the alias target; `import { box }`
  remains TS2460; `import { Nonexistent }` remains TS2305.
- Type-only rename (`export type { ... as ... }`) keeps per-export type-only
  semantics.
- Renamed export with no colliding local still resolves cross-file.
- Renamed `default` preserves the value default slot for
  `allowImportClausesToMergeWithTypes.ts` and still reports the expected TS2749
  for value-only `originalZZZ` used as a type.

Fallback: ordinary non-default renamed top-level exports still avoid creating an
in-module binding under the exported name.

## Verification

- `scripts/safe-run.sh cargo nextest run -p tsz-binder renamed_default_export_updates_synthetic_default_slot` — 1/1 passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-cli compile_allow_import_clauses_to_merge_with_types_fixture_has_no_default_export_conflict` — 1/1 passed.
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "allowImportClausesToMergeWithTypes" --verbose` — 1/1 passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test conformance_issues_modules export_alias_local_collision` — 4/4 passed.
- Prior conflict-refresh checks on this PR: `scripts/safe-run.sh cargo nextest run -p tsz-checker -E 'binary(commonjs_module_export_alias_tests) | binary(ambient_module_renamed_export_ts2460_tests)'` — 35/35 passed; `scripts/safe-run.sh cargo nextest run -p tsz-binder` — 557/557 passed.

Goal: green

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
