### PR TITLE
fix(checker): preserve contextually-typed closure mark across return-type rollback (TS7006)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -455,6 +455,9 @@ path = "tests/ts2636_method_bivariance_tests.rs"
 name = "function_bivariance"
 path = "tests/function_bivariance.rs"
 [[test]]
+name = "curried_annotated_return_object_member_implicit_any_tests"
+path = "tests/curried_annotated_return_object_member_implicit_any_tests.rs"
+[[test]]
 name = "function_expression_excess_param_implicit_any_tests"
 path = "tests/function_expression_excess_param_implicit_any_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -40,16 +40,10 @@ impl<'a> CheckerState<'a> {
             node.kind,
             syntax_kind_ext::FUNCTION_EXPRESSION | syntax_kind_ext::ARROW_FUNCTION
         );
-        // An object-literal method shorthand (e.g. `{ m(x, y) { ... } }`) is
-        // contextually typed by the surrounding object literal, exactly like an
-        // arrow / function-expression property initializer. For implicit-any dedup
-        // — and especially the speculative-rollback mark preservation that keeps a
-        // contextually-typed member from re-emitting a spurious TS7006 on an
-        // authoritative re-check — it must be tracked the same way, even though it
-        // is not an `is_closure` node (which also drives narrowing depth and must
-        // stay arrow/function-expression only). Class methods are excluded: they
-        // are checked authoritatively via the class-member pass and do not suffer
-        // the speculative-only re-check.
+        // Track object-literal method shorthand for implicit-any like an
+        // arrow/function-expression member; `is_closure` (which also drives
+        // narrowing depth) stays arrow/function-expression only. Rationale and
+        // class-method exclusion: see `is_object_literal_method`.
         let tracks_implicit_any = is_closure || self.is_object_literal_method(idx);
         // Rule #42: Increment closure depth when entering a function expression or arrow function
         // This causes mutable variables (let/var) to lose narrowing inside the closure

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -40,6 +40,17 @@ impl<'a> CheckerState<'a> {
             node.kind,
             syntax_kind_ext::FUNCTION_EXPRESSION | syntax_kind_ext::ARROW_FUNCTION
         );
+        // An object-literal method shorthand (e.g. `{ m(x, y) { ... } }`) is
+        // contextually typed by the surrounding object literal, exactly like an
+        // arrow / function-expression property initializer. For implicit-any dedup
+        // — and especially the speculative-rollback mark preservation that keeps a
+        // contextually-typed member from re-emitting a spurious TS7006 on an
+        // authoritative re-check — it must be tracked the same way, even though it
+        // is not an `is_closure` node (which also drives narrowing depth and must
+        // stay arrow/function-expression only). Class methods are excluded: they
+        // are checked authoritatively via the class-member pass and do not suffer
+        // the speculative-only re-check.
+        let tracks_implicit_any = is_closure || self.is_object_literal_method(idx);
         // Rule #42: Increment closure depth when entering a function expression or arrow function
         // This causes mutable variables (let/var) to lose narrowing inside the closure
         if is_closure {
@@ -163,7 +174,7 @@ impl<'a> CheckerState<'a> {
         let mut pushed_this_type = false;
         let this_atom = self.ctx.types.intern_string("this");
         let mut closure_already_checked =
-            is_closure && self.ctx.implicit_any_checked_closures.contains(&idx);
+            tracks_implicit_any && self.ctx.implicit_any_checked_closures.contains(&idx);
         let (
             contextual_helper_type,
             contextual_signature_type_params,
@@ -475,7 +486,7 @@ impl<'a> CheckerState<'a> {
                     required_non_this_param_count,
                 )
             });
-        if is_closure && !contextual_signature_accepts_required_arity {
+        if tracks_implicit_any && !contextual_signature_accepts_required_arity {
             self.ctx.implicit_any_checked_closures.remove(&idx);
             self.ctx.implicit_any_contextual_closures.remove(&idx);
             closure_already_checked = false;
@@ -960,7 +971,7 @@ impl<'a> CheckerState<'a> {
                 let binding_context_type = (has_external_binding_context
                     || cached_param_type.is_some())
                 .then_some(type_id);
-                if is_closure && suppresses_implicit_any_context {
+                if tracks_implicit_any && suppresses_implicit_any_context {
                     self.ctx.implicit_any_contextual_closures.insert(idx);
                     _any_param_contextually_typed = true;
                 }
@@ -1262,7 +1273,7 @@ impl<'a> CheckerState<'a> {
         // Only mark as "checked" in statement-checking mode or when a contextual type was
         // available. Closures skipped in build_type_environment due to no contextual type
         // need a second chance in the statement-checking pass — don't pre-emptively lock them.
-        if is_closure
+        if tracks_implicit_any
             && !closure_already_checked
             && (self.ctx.is_checking_statements
                 || (ctx_helper.is_some() && contextual_signature_accepts_required_arity))

--- a/crates/tsz-checker/src/types/function_type_helpers.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers.rs
@@ -101,6 +101,26 @@ struct DirectExpressionBodyReturnMismatchCtx {
 }
 
 impl<'a> CheckerState<'a> {
+    /// Whether `idx` is an object-literal method shorthand (e.g. `{ m() {} }`).
+    /// The class-vs-object distinction for method declarations is decided by the
+    /// parent node kind: a method's parent is the class or object-literal node
+    /// directly. Object-literal methods are contextually typed by the enclosing
+    /// object literal, so for implicit-any tracking they behave like arrow /
+    /// function-expression property initializers even though they are not
+    /// `is_closure` nodes.
+    pub(crate) fn is_object_literal_method(&self, idx: NodeIndex) -> bool {
+        self.ctx
+            .arena
+            .get(idx)
+            .is_some_and(|node| node.kind == syntax_kind_ext::METHOD_DECLARATION)
+            && self
+                .ctx
+                .arena
+                .get_extended(idx)
+                .and_then(|ext| self.ctx.arena.get(ext.parent))
+                .is_some_and(|parent| parent.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION)
+    }
+
     pub(crate) fn function_contextual_type_context(
         &mut self,
         idx: NodeIndex,

--- a/crates/tsz-checker/src/types/function_type_helpers_async_promise.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers_async_promise.rs
@@ -130,12 +130,7 @@ impl<'a> CheckerState<'a> {
         };
         match node.kind {
             syntax_kind_ext::FUNCTION_EXPRESSION | syntax_kind_ext::ARROW_FUNCTION => true,
-            syntax_kind_ext::METHOD_DECLARATION => self
-                .ctx
-                .arena
-                .get_extended(func_idx)
-                .and_then(|ext| self.ctx.arena.get(ext.parent))
-                .is_some_and(|parent| parent.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION),
+            syntax_kind_ext::METHOD_DECLARATION => self.is_object_literal_method(func_idx),
             _ => false,
         }
     }

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -755,10 +755,31 @@ impl<'a> CheckerState<'a> {
         // TypeQuery(SymbolRef), which correctly resolves to the constructor type.
         let result = self.resolve_lazy_class_to_constructor(result);
 
-        // Before rollback, identify closures that had TS7006 emitted during this
-        // speculation. After rollback, these diagnostics will be lost. Record the
-        // closures so `recheck_deferred_implicit_any_closures` can re-emit TS7006
-        // for any that truly lack contextual parameter types.
+        // Closures newly added to `implicit_any_checked_closures` during this
+        // speculation. The rollback below restores the set to its pre-speculation
+        // snapshot, so each of these marks must be handled explicitly across the
+        // rollback boundary. The membership in `implicit_any_contextual_closures`
+        // (which is not speculation-scoped and survives the rollback) partitions
+        // them:
+        //   - NOT contextually typed -> recorded so
+        //     `recheck_deferred_implicit_any_closures` can re-emit the TS7006 that
+        //     the rollback discards, but only if they truly lack contextual types.
+        //   - contextually typed -> their "already checked" mark is re-applied
+        //     after the rollback, so an authoritative re-check that re-enters the
+        //     closure WITHOUT re-deriving its contextual signature (e.g. the inner
+        //     method of a curried `(a) => (): T => ({ m: (x, y) => ... })`, whose
+        //     contextual type comes from the inner arrow's annotation but is not
+        //     re-established on the outer arrow's authoritative body pass) does not
+        //     spuriously re-emit TS7006. A closure's contextual typing is
+        //     independent of the speculative return context, so preserving the mark
+        //     is sound and mirrors tsc, which resolves a node's contextual type
+        //     once and caches it.
+        let newly_checked_closures: Vec<_> = self
+            .ctx
+            .implicit_any_checked_closures
+            .difference(&snap.full.implicit_any_checked_closures)
+            .copied()
+            .collect();
         {
             use crate::diagnostics::diagnostic_codes;
             let speculative_diags = self
@@ -771,21 +792,20 @@ impl<'a> CheckerState<'a> {
                     || d.code == diagnostic_codes::PARAMETER_HAS_A_NAME_BUT_NO_TYPE_DID_YOU_MEAN
             });
             if has_implicit_any_diags {
-                // Find closures checked during this speculation that did NOT receive
-                // contextual parameter types. These are candidates for TS7006 re-emission.
-                let new_checked: Vec<_> = self
-                    .ctx
-                    .implicit_any_checked_closures
-                    .difference(&snap.full.implicit_any_checked_closures)
-                    .filter(|idx| !self.ctx.implicit_any_contextual_closures.contains(idx))
-                    .copied()
-                    .collect();
-                self.ctx
-                    .speculative_implicit_any_closures
-                    .extend(new_checked);
+                self.ctx.speculative_implicit_any_closures.extend(
+                    newly_checked_closures
+                        .iter()
+                        .copied()
+                        .filter(|idx| !self.ctx.implicit_any_contextual_closures.contains(idx)),
+                );
             }
         }
         snap.rollback(&mut self.ctx.speculation_state());
+        for idx in newly_checked_closures {
+            if self.ctx.implicit_any_contextual_closures.contains(&idx) {
+                self.ctx.implicit_any_checked_closures.insert(idx);
+            }
+        }
 
         // Widening of inferred return types is performed per-return-expression
         // during collection (`maybe_widen_return_contribution`), so that

--- a/crates/tsz-checker/tests/curried_annotated_return_object_member_implicit_any_tests.rs
+++ b/crates/tsz-checker/tests/curried_annotated_return_object_member_implicit_any_tests.rs
@@ -1,0 +1,177 @@
+//! Regression tests for a false-positive TS7006 (implicit-`any`) on the
+//! parameters of an object-literal member returned by the inner arrow of a
+//! curried `(a) => (): T => ({ m: (x, y) => ... })`.
+//!
+//! Structural rule: when an expression-bodied arrow with an explicit return
+//! annotation returns an object literal, that annotation contextually types the
+//! object literal's members, so a member function/method's parameters are
+//! contextually typed and must NOT raise TS7006. `tsc` reports nothing for the
+//! members below.
+//!
+//! tsz previously emitted TS7006 only for the *curried/nested* form: the outer
+//! (unannotated) arrow runs speculative return-type inference over its body,
+//! which checks the inner member WITH its contextual type but then rolls back
+//! the `implicit_any_checked_closures` mark; the authoritative re-check re-enters
+//! the member WITHOUT re-deriving the contextual signature and re-emits TS7006.
+//! The fix preserves the contextually-validated mark across the speculative
+//! rollback (and tracks object-literal method shorthand the same way arrows and
+//! function-expression initializers were already tracked).
+//!
+//! Every case varies its binder names (interface, alias, variable, and parameter
+//! identifiers) so the behavior cannot be keyed to a particular spelling, and
+//! each genuine-implicit-any counterpart is checked to confirm the fix does not
+//! over-suppress.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn strict_options() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..Default::default()
+    }
+}
+
+fn count_7006(source: &str) -> usize {
+    check_source(source, "test.ts", strict_options())
+        .iter()
+        .filter(|d| d.code == 7006)
+        .count()
+}
+
+#[test]
+fn curried_annotated_arrow_returns_object_with_arrow_member() {
+    // tsc: clean. The inner arrow's `: Algebra` annotation contextually types
+    // the returned object literal, so `meet`'s `(x, y)` are `number`.
+    let source = r#"
+        interface Algebra { readonly meet: (x: number, y: number) => number }
+        export const f =
+          (base: number) =>
+          (): Algebra => ({
+            meet: (x, y) => base + x + y
+          });
+    "#;
+    assert_eq!(count_7006(source), 0);
+}
+
+#[test]
+fn curried_annotated_arrow_returns_object_with_method_shorthand() {
+    // Same root cause as the arrow form, but the member is a method shorthand
+    // (`meet(x, y) { ... }`), which is not an `is_closure` node yet is still
+    // contextually typed by the surrounding object literal.
+    let source = r#"
+        interface Algebra { readonly meet: (x: number, y: number) => number }
+        export const f =
+          (base: number) =>
+          (): Algebra => ({
+            meet(x, y) { return base + x + y; }
+          });
+    "#;
+    assert_eq!(count_7006(source), 0);
+}
+
+#[test]
+fn curried_annotated_arrow_renamed_binders_no_false_positive() {
+    // Renamed interface / alias / variable / parameter spellings: the fix is
+    // structural, not keyed to identifier names.
+    let source = r#"
+        interface Ring { readonly combine: (alpha: string, beta: string) => string }
+        type RingFactory = (seed: string) => () => Ring;
+        export const build: RingFactory =
+          (seed) =>
+          () => ({
+            combine: (alpha, beta) => seed + alpha + beta
+          });
+    "#;
+    assert_eq!(count_7006(source), 0);
+}
+
+#[test]
+fn deeply_curried_annotated_arrow_no_false_positive() {
+    // Three levels of currying still resolve the inner member's contextual type.
+    let source = r#"
+        interface Algebra { readonly meet: (x: number, y: number) => number }
+        export const f =
+          (a: number) =>
+          (b: number) =>
+          (): Algebra => ({
+            meet: (x, y) => a + b + x + y
+          });
+    "#;
+    assert_eq!(count_7006(source), 0);
+}
+
+#[test]
+fn conditional_body_returning_annotated_object_no_false_positive() {
+    // The inner arrow returns `Algebra | null`; the `Algebra` arm still
+    // contextually types the object literal's member parameters.
+    let source = r#"
+        interface Algebra { readonly meet: (p: number, q: number) => number }
+        export const make =
+          (flag: boolean) =>
+          (n: number): Algebra | null =>
+            flag ? { meet: (p, q) => p + q + n } : null;
+    "#;
+    assert_eq!(count_7006(source), 0);
+}
+
+#[test]
+fn curried_unannotated_inner_arrow_still_reports_implicit_any() {
+    // Negative case: with no return annotation on the inner arrow there is no
+    // contextual type for the object literal, so tsc DOES report TS7006 for the
+    // member's parameters. The fix must not suppress this.
+    let source = r#"
+        export const f =
+          (base: number) =>
+          () => ({
+            meet: (x, y) => base + x + y
+          });
+    "#;
+    assert_eq!(count_7006(source), 2);
+}
+
+#[test]
+fn curried_unannotated_inner_arrow_method_shorthand_still_reports_implicit_any() {
+    // Method-shorthand counterpart of the negative case.
+    let source = r#"
+        export const f =
+          (base: number) =>
+          () => ({
+            meet(x, y) { return base + x + y; }
+          });
+    "#;
+    assert_eq!(count_7006(source), 2);
+}
+
+#[test]
+fn annotated_member_body_keeps_real_property_access_error() {
+    // The contextual typing makes `y` a `number`, so the body raises TS2339
+    // (`toUpperCase` does not exist on `number`) — and only that, with no
+    // spurious TS7006 masking it.
+    let source = r#"
+        interface Algebra { readonly meet: (x: number, y: number) => number }
+        export const f =
+          (base: number) =>
+          (): Algebra => ({
+            meet: (x, y) => y.toUpperCase()
+          });
+    "#;
+    let diagnostics = check_source(source, "test.ts", strict_options());
+    assert_eq!(
+        diagnostics.iter().filter(|d| d.code == 7006).count(),
+        0,
+        "no spurious TS7006: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| format!("TS{}: {}", d.code, d.message_text))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2339),
+        "expected TS2339 from `number.toUpperCase()` to survive: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| format!("TS{}: {}", d.code, d.message_text))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Fixes #14213

## Goal
Goal: green

## Summary
A curried `(a) => (): T => ({ m: (x, y) => ... })` emitted a spurious **TS7006**
(`Parameter implicitly has an 'any' type`) on the parameters of the object-literal
member returned by the inner annotated arrow, where `tsc` is clean. Mined from
**fp-ts** (`src/function.ts` `getBooleanAlgebra`, `src/Magma.ts` `filterFirst`).

Strict, dependency-free repro:
```ts
interface Algebra { readonly meet: (x: number, y: number) => number }
export const f =
  (base: number) =>
  (): Algebra => ({
    meet: (x, y) => base + x + y   // was: TS7006 on x, y; tsc: clean
  })
```

## Structural rule
When the outer (unannotated) arrow of a curried function infers its return type,
tsz runs **speculative return-type inference** over its body. During that pass the
inner member is checked WITH its contextual signature (derived from the inner
arrow's `: T` annotation), so no TS7006 is produced and the member is recorded in
`implicit_any_checked_closures`. The speculative rollback then restores that set to
its pre-speculation snapshot, **dropping the mark**. The authoritative re-check
re-enters the member WITHOUT re-deriving the contextual signature and re-emits
TS7006.

`When a closure is checked with a genuine contextual parameter signature during a
speculative return-type inference, tsc resolves and caches that contextual type
once; tsz must keep the "implicit-any already checked" mark across the speculative
rollback so an authoritative re-check does not re-derive implicit-any.` Owner:
checker — `infer_return_type_from_body` (solver-backed return-type inference) plus
the implicit-any tracking gate in `get_type_of_function`.

## Fix
1. **`utilities/return_type.rs`** — in `infer_return_type_from_body`, partition the
   closures newly added to `implicit_any_checked_closures` during the speculation
   by their `implicit_any_contextual_closures` membership (which is *not*
   speculation-scoped and survives the rollback):
   - **not** contextually typed → existing `speculative_implicit_any_closures`
     deferred-re-emit path (re-emits TS7006 only for closures that truly lack a
     contextual type);
   - contextually typed → re-apply the checked-mark **after** the rollback, so the
     authoritative pass treats them as already resolved. Symmetric to the existing
     negative-case handling; the difference is now computed once instead of twice.
2. **`function_type.rs` / `function_type_helpers.rs`** — object-literal method
   shorthand (`{ m(x, y) {} }`) is contextually typed by the enclosing object
   literal exactly like arrow / function-expression property initializers, but is
   not an `is_closure` node, so it was never tracked in the implicit-any sets. Add
   `is_object_literal_method` (extracted from the existing async-promise
   detection, now shared) and gate the four implicit-any tracking sites on
   `is_closure || is_object_literal_method`. `is_closure` still solely drives
   narrowing depth; class methods are excluded (checked authoritatively via the
   class-member pass).

No hardcoding: the fix is keyed on node kind / contextual-typing state, never on
identifier, type, or file-name strings.

## Adjacent matrix (verified vs `tsc`)
| case | tsc | tsz |
|---|---|---|
| curried arrow member (repro) | clean | clean |
| curried **method-shorthand** member | clean | clean |
| renamed binders (interface/alias/var/params) | clean | clean |
| 3-level currying | clean | clean |
| conditional body `Algebra \| null` | clean | clean |
| **unannotated** inner arrow member (negative) | TS7006 x2 | TS7006 x2 |
| unannotated inner **method** member (negative) | TS7006 x2 | TS7006 x2 |
| member body `y.toUpperCase()` | TS2339 only | TS2339 only |
| `(x:number)=>number = (x,y)=>...` arity mismatch | TS2322 + TS7006 x2 | TS2322 + TS7006 x2 |
| class method, no context (unaffected) | TS7006 x2 | TS7006 x2 |

### Known follow-up (out of scope, pre-existing)
The same curried shape also pre-existingly **masks** genuine errors on the inner
annotated arrow's body (e.g. excess-property TS2353 on `{ extra: 1 }`, and a
return-type TS2322 for `(): number => "hello"`), because that body is only ever
checked inside speculative return-type passes that roll back their diagnostics, and
the authoritative pass loses the contextual type. This is a separate architectural
issue (no authoritative contextual body check for the inner annotated arrow); it is
unchanged by this PR (confirmed on `main`) and not a regression. This PR removes the
false **positive** TS7006.

## Verification
- New regression suite (binder-name-varied, positive + negative):
  `cargo test -p tsz-checker --test curried_annotated_return_object_member_implicit_any_tests`
  -> 8 passed.
- Targeted no-regression run: `function_expression_excess_param_implicit_any_tests`,
  `class_arrow_property_type_inference_tests`,
  `contextual_method_index_signature_tests`, `contextual_return_tuple_generic_member_tests`,
  `curry_recursive_conditional_infer_tests`,
  `fresh_object_literal_arg_callback_param_variance_tests`,
  `generic_multi_prop_object_literal_tests`, `contextual_ts2345_conformance_tests`,
  `contextual_tuple_tests`, `window_indexed_access_callback_contextual_typing_tests`
  -> all green. (`nonnull_contextual_type_arg_inference_tests::contextual_return_can_refine_transparent_wrapper_inference`
  fails identically on `main` — pre-existing, unrelated.)
- `cargo clippy -p tsz-checker --lib` -> clean.
- CLI repro + adjacent matrix above compared directly against `tsc 6.x`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4.8
Effort: high