### PR TITLE
fix(solver): defer type-param-default conditional with unresolved Lazy/Recursive in check/extends

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -587,6 +587,9 @@ path = "tests/export_star_module_augmentation_tests.rs"
 name = "deferred_conditional_arithmetic_operand_tests"
 path = "tests/deferred_conditional_arithmetic_operand_tests.rs"
 [[test]]
+name = "keyof_type_param_default_conditional_repro"
+path = "tests/keyof_type_param_default_conditional_repro.rs"
+[[test]]
 name = "hkt_self_augmentation_keyof_repro"
 path = "tests/hkt_self_augmentation_keyof_repro.rs"
 [[test]]

--- a/crates/tsz-checker/tests/keyof_type_param_default_conditional_repro.rs
+++ b/crates/tsz-checker/tests/keyof_type_param_default_conditional_repro.rs
@@ -1,0 +1,164 @@
+//! Repro + adjacent matrix for the ts-rest `ClientInferRequestBase`
+//! false-positive: a type-parameter *default* of the form
+//! `H = 'k' extends keyof T ? X : never` must resolve its `keyof T` against the
+//! supplied argument for `T`, even when that argument is held as an unresolved
+//! semantic ref (`Lazy(DefId)`), so the conditional picks the true branch and the
+//! defaulted member survives a surrounding key-remapping mapped type (`Without`).
+//!
+//! Structural rule: when a generic type alias' parameter default is a conditional
+//! whose `check`/`extends` still holds an unresolved `Lazy(DefId)`/`Recursive`
+//! ref after substitution (e.g. `keyof T` with `T := Lazy(Route)`), tsc resolves
+//! the alias and picks the branch through the resolver; tsz must NOT pick the
+//! branch with the resolver-less subtype check used during default resolution
+//! (which silently answers `false` and bakes the false branch into the default).
+//! The owner is `maybe_evaluate_concrete_conditional`
+//! (`crates/tsz-solver/src/instantiation/instantiate/api.rs`), which now defers
+//! such conditionals so the later resolver-aware evaluator picks the branch.
+//!
+//! Kill switch: `TSZ_DISABLE_DEFER_LAZY_DEFAULT_CONDITIONAL=1` restores the prior
+//! eager (resolver-less) behavior.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "repro.ts",
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+fn count_code(diags: &[u32], expected: u32) -> usize {
+    diags.iter().filter(|&&c| c == expected).count()
+}
+
+/// Core witness: the defaulted `headers` member (`H = 'headers' extends keyof T
+/// ? { h: 1 } : never`) must survive the `Without` mapped type. Destructuring it
+/// off the alias must NOT raise TS2339.
+#[test]
+fn keyof_default_conditional_member_survives_without() {
+    let diags = codes(
+        r#"
+type Without<S, V> = { [Q in keyof S as S[Q] extends V ? never : Q]: S[Q] };
+type Prettify<U> = { [W in keyof U]: U[W] } & {};
+interface Route { body: { x: number }; method: 'POST'; headers?: unknown }
+type CIB<
+  T extends Route,
+  H = 'headers' extends keyof T ? { h: 1 } : never
+> = Prettify<
+  Without<
+    { body: T extends { method: 'POST' } ? T['body'] : never; query: never; headers: H },
+    never
+  >
+>;
+declare const inputArgs: CIB<Route> | undefined;
+const { body, headers } = (inputArgs as CIB<Route> & { next?: any }) || {};
+body; headers;
+"#,
+    );
+    assert_eq!(
+        count_code(&diags, 2339),
+        0,
+        "defaulted `headers` member must survive `Without`; got {diags:#?}"
+    );
+}
+
+/// Anti-hardcoding: rename every binder (alias names, parameters, the probed
+/// key, the kept member). The rule is structural, not name-driven.
+#[test]
+fn keyof_default_conditional_rule_is_binder_name_independent() {
+    let diags = codes(
+        r#"
+type Strip<Src, Drop> = { [Idx in keyof Src as Src[Idx] extends Drop ? never : Idx]: Src[Idx] };
+type Flatten<Whole> = { [Field in keyof Whole]: Whole[Field] } & {};
+interface Endpoint { payload: { y: string }; verb: 'PUT'; meta?: unknown }
+type Shape<
+  E extends Endpoint,
+  Tag = 'meta' extends keyof E ? { tag: 1 } : never
+> = Flatten<
+  Strip<
+    { payload: E extends { verb: 'PUT' } ? E['payload'] : never; nope: never; meta: Tag },
+    never
+  >
+>;
+declare const raw: Shape<Endpoint> | undefined;
+const { payload, meta } = (raw as Shape<Endpoint> & { trailer?: any }) || {};
+payload; meta;
+"#,
+    );
+    assert_eq!(
+        count_code(&diags, 2339),
+        0,
+        "renamed-binder form must also keep the defaulted member; got {diags:#?}"
+    );
+}
+
+/// The same default-conditional kept member must survive `Without` even when the
+/// mapped source is an intersection `{obj} & Application` (the original ts-rest
+/// `& ExtractExtraParametersFromClientArgs<...>` shape).
+#[test]
+fn keyof_default_conditional_member_survives_without_over_intersection() {
+    let diags = codes(
+        r#"
+type Without<S, V> = { [Q in keyof S as S[Q] extends V ? never : Q]: S[Q] };
+type Prettify<U> = { [W in keyof U]: U[W] } & {};
+interface Box<P> { boxed: P }
+interface Route { body: { x: number }; method: 'POST'; headers?: unknown }
+type CIB<
+  T extends Route,
+  H = 'headers' extends keyof T ? { h: 1 } : never
+> = Prettify<
+  Without<
+    { body: T['body']; headers: H } & Box<number>,
+    never
+  >
+>;
+declare const inputArgs: CIB<Route> | undefined;
+const { body, headers, boxed } = (inputArgs as CIB<Route> & { next?: any }) || {};
+body; headers; boxed;
+"#,
+    );
+    assert_eq!(
+        count_code(&diags, 2339),
+        0,
+        "defaulted member must survive `Without` over an intersection w/ Application; got {diags:#?}"
+    );
+}
+
+/// Negative control: a member whose value is genuinely `never` must STILL be
+/// filtered out by `Without`, so destructuring it raises TS2339 (matching tsc).
+/// The deferral must not resurrect a correctly-dropped member.
+#[test]
+fn never_valued_member_is_still_filtered_by_without() {
+    let diags = codes(
+        r#"
+type Without<S, V> = { [Q in keyof S as S[Q] extends V ? never : Q]: S[Q] };
+type Prettify<U> = { [W in keyof U]: U[W] } & {};
+interface Route { body: { x: number }; method: 'POST'; headers?: unknown }
+type CIB<
+  T extends Route,
+  H = 'headers' extends keyof T ? { h: 1 } : never
+> = Prettify<
+  Without<
+    { body: T['body']; headers: H; gone: never },
+    never
+  >
+>;
+declare const inputArgs: CIB<Route> | undefined;
+const { body, gone } = (inputArgs as CIB<Route> & { next?: any }) || {};
+body; gone;
+"#,
+    );
+    assert_eq!(
+        count_code(&diags, 2339),
+        1,
+        "the `never`-valued member must remain filtered out (exactly one TS2339); got {diags:#?}"
+    );
+}

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -1481,6 +1481,20 @@ pub(super) fn index_access_operand_needs_resolver(
 /// the branch unevaluated ensures that the substitution carries the same interned
 /// `Map<string,number>` `Application` `TypeId` that the checker produces for the
 /// source expression, so the subtype comparison succeeds without structural expansion.
+/// Whether deferral of type-parameter-default conditionals whose `check`/`extends`
+/// still hold an unresolved `Lazy(DefId)`/`Recursive` ref is active.
+///
+/// Default-on; `TSZ_DISABLE_DEFER_LAZY_DEFAULT_CONDITIONAL=1` is the kill switch
+/// that restores the prior eager (resolver-less) branch selection. See
+/// [`maybe_evaluate_concrete_conditional`].
+fn defer_lazy_default_conditional_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| {
+        !std::env::var("TSZ_DISABLE_DEFER_LAZY_DEFAULT_CONDITIONAL").is_ok_and(|v| v == "1")
+    })
+}
+
 pub(super) fn maybe_evaluate_concrete_conditional(
     interner: &dyn TypeDatabase,
     type_id: TypeId,
@@ -1505,6 +1519,37 @@ pub(super) fn maybe_evaluate_concrete_conditional(
     // would produce a union of branch results which requires the full evaluator.
     if cond.is_distributive && matches!(interner.lookup(cond.check_type), Some(TypeData::Union(_)))
     {
+        return type_id;
+    }
+    // The branch is picked by a *resolver-less* subtype check (no `query_db`),
+    // so it cannot follow a semantic ref. When `check_type` or `extends_type`
+    // contains a `Lazy(DefId)`/`Recursive` ref — for example a type-parameter
+    // default whose `extends` is `keyof T` and `T` was substituted with the
+    // unresolved `Lazy(Route)` form, leaving `keyof Lazy(Route)` — the relation
+    // sees a deferred meta-type over an unresolved alias and silently answers
+    // `false`, picking the wrong (false) branch and baking it into the default.
+    // That is how ts-rest's `ClientInferRequestBase` third-parameter default
+    // (`'headers' extends keyof T ? Prettify<...> : never`) collapses to `never`
+    // and the surrounding `Without<...>` mapped type can no longer surface
+    // `headers`. Leave such conditionals deferred so the later resolver-aware
+    // evaluator (reached on property access / mapped-type expansion) resolves
+    // the alias and picks the branch correctly. `Application` bases are
+    // intentionally NOT disqualifying here: the documented
+    // `K extends string ? Map<K, V> : Map<string, V>` case keeps its concrete
+    // `string extends string` check/extends and must still resolve eagerly to
+    // preserve the branch `Application` `TypeId` identity.
+    // Kill switch: `TSZ_DISABLE_DEFER_LAZY_DEFAULT_CONDITIONAL=1` restores the
+    // prior eager (resolver-less) branch selection.
+    if defer_lazy_default_conditional_enabled()
+        && (crate::type_queries::contains_lazy_or_recursive_db(interner, cond.check_type)
+            || crate::type_queries::contains_lazy_or_recursive_db(interner, cond.extends_type))
+    {
+        tracing::trace!(
+            type_id = type_id.0,
+            check = cond.check_type.0,
+            extends = cond.extends_type.0,
+            "maybe_evaluate_concrete_conditional: deferring (check/extends holds Lazy/Recursive ref)"
+        );
         return type_id;
     }
     // Both check and extends are concrete. Use a subtype check to pick the branch


### PR DESCRIPTION
## Summary

Fixes a false positive in type-parameter **default** resolution: a generic alias whose default is a conditional like `'headers' extends keyof T ? X : never` collapsed to the wrong (`never`) branch when `T` was substituted with an unresolved `Lazy(DefId)` ref, leaving the surrounding key-remapping mapped type unable to surface the kept member.

## Wrong operation

`maybe_evaluate_concrete_conditional` (`instantiation/instantiate/api.rs`, sole caller = `TypeSubstitution::from_args` Phase-3 default resolution) picks the conditional branch with a **resolver-less** `is_subtype_of` (no `query_db`). When `check_type`/`extends_type` still holds a `Lazy(DefId)`/`Recursive` after substitution — e.g. `'headers' extends keyof T` with `T := Lazy(Route)`, leaving `keyof Lazy(Route)` — the relation cannot follow the semantic ref, silently answers `false`, and bakes the false branch into the default.

## Structural rule

When a type-parameter default is a conditional whose `check`/`extends` still holds an unresolved `Lazy(DefId)`/`Recursive` ref after substitution, `tsc` resolves the alias through its resolver and picks the branch; tsz was eagerly picking the false branch via the resolver-less default-resolution subtype check. Fix: leave such conditionals **deferred** so the later resolver-aware evaluator (reached on property access / mapped-type expansion) picks the branch correctly.

## Owner layer

Solver (instantiation / conditional evaluation). `Application` bases are intentionally **not** disqualifying — the documented `K extends string ? Map<K,V> : Map<string,V>` default keeps its concrete `string extends string` check/extends and must still resolve eagerly to preserve branch `Application` `TypeId` identity.

## Adjacent-case matrix (new regression test, 4 cases)

`keyof T`-default conditional: positive (member kept), renamed type-parameter binder (anti-hardcoding), intersection-with-`Application` source, and negative (`never`-filtered member correctly absent).

## Honesty note

This is a **resolver-less / single-file / LSP-context** parity fix. It does **not** move the ts-rest project-compile row: in multi-file project mode the global index resolves the alias before the default is evaluated, so the bug does not manifest there. The residual ts-rest row FPs (`params`/`body` TS2339) have a separate, deeper root (Without body-property conditionals over the deeply-`Lazy` `AppRouteCommon` intersection) — filed separately.

Goal: hold

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New regression test `keyof_type_param_default_conditional_repro` (registered as `[[test]]`): 4/4 pass.
- Kill-switch `TSZ_DISABLE_DEFER_LAZY_DEFAULT_CONDITIONAL=1` restores prior behavior (FP returns) — confirms the fix is the cause.
- Focused solver suites (conditional/mapped/default) pass (one pre-existing failure on clean branch, unrelated).
- Byte-parity sanity: `Pick`/`Partial`/`Record`/`Omit` and 7 repro variants match tsc with the change on/off.
- `clippy -p tsz-solver` clean.
- Full conformance/emit/fourslash via CI (this is an evaluation-path change).
