### PR TITLE
fix(checker): accept readonly literal initializers on ambient class properties

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1985,3 +1985,6 @@ path = "tests/partial_record_optional_index_assignability_tests.rs"
 [[test]]
 name = "function_type_predicate_typeof_param_tests"
 path = "tests/function_type_predicate_typeof_param_tests.rs"
+[[test]]
+name = "ambient_readonly_literal_initializer_tests"
+path = "tests/ambient_readonly_literal_initializer_tests.rs"

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -304,11 +304,31 @@ impl<'a> CheckerState<'a> {
                         })
                     });
                 if !has_es_decorator_on_declare {
-                    self.error_at_node(
-                        prop.initializer,
-                        diagnostic_messages::INITIALIZERS_ARE_NOT_ALLOWED_IN_AMBIENT_CONTEXTS,
-                        diagnostic_codes::INITIALIZERS_ARE_NOT_ALLOWED_IN_AMBIENT_CONTEXTS,
-                    );
+                    // A `readonly` class property (incl. `static readonly`) behaves
+                    // like a `const` in an ambient context: a string/numeric/negated-
+                    // numeric literal initializer is accepted (it is preserved), while
+                    // a non-literal initializer is TS1254. A non-readonly property — or
+                    // a readonly property carrying an explicit type annotation — is
+                    // TS1039. Mirrors the ambient *variable* path in `statement_checks`.
+                    let is_readonly = self
+                        .ctx
+                        .arena
+                        .has_modifier(&prop.modifiers, tsz_scanner::SyntaxKind::ReadonlyKeyword);
+                    if is_readonly && prop.type_annotation.is_none() {
+                        if !self.is_valid_const_initializer(prop.initializer) {
+                            self.error_at_node(
+                                prop.initializer,
+                                diagnostic_messages::A_CONST_INITIALIZER_IN_AN_AMBIENT_CONTEXT_MUST_BE_A_STRING_OR_NUMERIC_LITERAL_OR,
+                                diagnostic_codes::A_CONST_INITIALIZER_IN_AN_AMBIENT_CONTEXT_MUST_BE_A_STRING_OR_NUMERIC_LITERAL_OR,
+                            );
+                        }
+                    } else {
+                        self.error_at_node(
+                            prop.initializer,
+                            diagnostic_messages::INITIALIZERS_ARE_NOT_ALLOWED_IN_AMBIENT_CONTEXTS,
+                            diagnostic_codes::INITIALIZERS_ARE_NOT_ALLOWED_IN_AMBIENT_CONTEXTS,
+                        );
+                    }
                 }
             }
         }

--- a/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/statement_checks.rs
@@ -189,7 +189,7 @@ impl<'a> CheckerState<'a> {
 
     /// Check if a node is a valid const initializer in an ambient context.
     /// Valid initializers are string literals, numeric literals, or negative numeric literals.
-    fn is_valid_const_initializer(&self, init_idx: NodeIndex) -> bool {
+    pub(crate) fn is_valid_const_initializer(&self, init_idx: NodeIndex) -> bool {
         self.is_valid_ambient_const_initializer(init_idx)
     }
 

--- a/crates/tsz-checker/tests/ambient_readonly_literal_initializer_tests.rs
+++ b/crates/tsz-checker/tests/ambient_readonly_literal_initializer_tests.rs
@@ -1,0 +1,86 @@
+//! Regression: a `readonly` class property (incl. `static readonly`) in an
+//! ambient context (`declare class` / `.d.ts`) behaves like an ambient `const`
+//! — a string/numeric/negated-numeric literal initializer is accepted, a
+//! non-literal initializer is `TS1254`, and a non-readonly property is `TS1039`.
+//! tsz previously emitted `TS1039` unconditionally for any initialized ambient
+//! class property.
+//!
+//! Owner: `crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs`
+//! (mirrors the ambient *variable* path in `statement_checks.rs`).
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn readonly_literal_initializers_accepted_in_ambient_class() {
+    let codes = codes(
+        r#"
+declare class C {
+  static readonly A = "x";
+  readonly B = 1;
+  readonly E = -1;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1039) && !codes.contains(&1254),
+        "readonly literal initializers are valid in an ambient class; got {codes:?}"
+    );
+}
+
+#[test]
+fn non_readonly_initializer_still_ts1039() {
+    // Negative control: a non-readonly property keeps TS1039.
+    let codes = codes(
+        r#"
+declare class C {
+  static prefix = 5;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1039),
+        "a non-readonly ambient property initializer is TS1039; got {codes:?}"
+    );
+}
+
+#[test]
+fn readonly_non_literal_initializer_is_ts1254() {
+    // Negative control: readonly but a non-literal initializer is TS1254, not
+    // accepted and not TS1039.
+    let codes = codes(
+        r#"
+declare class C {
+  readonly sum = 1 + 2;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&1254) && !codes.contains(&1039),
+        "a readonly non-literal ambient initializer is TS1254; got {codes:?}"
+    );
+}
+
+#[test]
+fn readonly_literal_initializers_accepted_binder_variation() {
+    // Binder-name variation to keep the check structural rather than name-driven.
+    let codes = codes(
+        r#"
+declare class Widget {
+  static readonly version = 2;
+  readonly label = "w";
+  protected readonly flag = -3;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&1039) && !codes.contains(&1254),
+        "readonly literal initializers are valid regardless of binder name; got {codes:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
A `readonly` (incl. `static readonly`/`protected readonly`) class property in an ambient context (`declare class` / `.d.ts`) may carry a literal initializer, matching tsc. tsz emitted a spurious `TS1039` ("Initializers are not allowed in ambient contexts") for **every** initialized ambient class property.

Structural rule: When a class property in an ambient context has an initializer, tsc accepts it without error if the property is `readonly` and the initializer is a string/numeric/negated-numeric literal; a `readonly` property with a non-literal initializer is `TS1254`; a non-readonly property is `TS1039`. tsz now applies the same rule in the class-property grammar check (`crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs`), mirroring the existing ambient-*variable* logic.

## Root cause
The class-property check emitted `TS1039` whenever `initializer.is_some() && (has_declare || in_declared_class)`, with no `readonly`/literal gating. The correct logic already existed for the variable path in `statement_checks.rs` (`is_const + is_valid_const_initializer -> TS1254 else TS1039`); this reuses its `is_valid_const_initializer` helper (made `pub(crate)`).

## Verification
- Boundary probe matches tsc 6.0.3 exactly:
  - `static readonly A = "x"`, `readonly B = 1`, `readonly E = -1` → accepted (was 3× false `TS1039`).
  - `static prefix = 5` (non-readonly) → `TS1039`.
  - `readonly D = 1 + 2` (readonly, non-literal) → `TS1254`.
- `cargo test -p tsz-checker --test ambient_readonly_literal_initializer_tests` — 4 passed (positive + the two negative controls + a binder-name variation).

Discovered via a differential canary sweep on ts-morph (`packages/ts-morph/src`), which uses `static readonly` literal members in ambient declarations. Reduces false-positive churn (Fast-adjacent per #14102).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
