### PR TITLE
fix(checker): validate untyped-call type arguments as types, not values (spurious TS2693 on f<void>())

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1985,3 +1985,6 @@ path = "tests/partial_record_optional_index_assignability_tests.rs"
 [[test]]
 name = "function_type_predicate_typeof_param_tests"
 path = "tests/function_type_predicate_typeof_param_tests.rs"
+[[test]]
+name = "untyped_call_keyword_type_arg_tests"
+path = "tests/untyped_call_keyword_type_arg_tests.rs"

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -265,12 +265,14 @@ impl<'a> CheckerState<'a> {
                         crate::diagnostics::diagnostic_codes::UNTYPED_FUNCTION_CALLS_MAY_NOT_ACCEPT_TYPE_ARGUMENTS,
                     );
                     }
-                    // Resolve type arguments even though the call is untyped. Without
+                    // Validate type arguments even though the call is untyped. Without
                     // this, unresolved type names in arguments (e.g.
                     // `g<InvalidReference>()`) silently succeed — tsc still emits
-                    // TS2304 for them. Mirrors the matching block in generic_checker.
+                    // TS2304 for them. Use the type-node checker (not the value-context
+                    // `get_type_of_node`, which wrongly reports a keyword type such as
+                    // `void` as a value via TS2693): tsc emits only TS2347 here.
                     for &type_arg_idx in &type_args_list.nodes {
-                        self.get_type_of_node(type_arg_idx);
+                        self.check_type_node(type_arg_idx);
                     }
                 }
                 // Untyped calls accept ordinary args; callbacks still get their own context for TS7006.

--- a/crates/tsz-checker/tests/untyped_call_keyword_type_arg_tests.rs
+++ b/crates/tsz-checker/tests/untyped_call_keyword_type_arg_tests.rs
@@ -1,0 +1,69 @@
+//! Regression: an untyped (`any`) callee invoked with an explicit type argument
+//! that is a keyword type (e.g. `void`) must emit only `TS2347` ("Untyped
+//! function calls may not accept type arguments"), not a spurious `TS2693`
+//! ("'void' only refers to a type, but is being used as a value here"). The
+//! untyped-call path validated type arguments through the value-context
+//! `get_type_of_node`; it now uses the type-node checker.
+//!
+//! Owner: `crates/tsz-checker/src/types/computation/call/inner.rs`.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn untyped_call_with_void_type_arg_is_only_ts2347() {
+    let codes = codes(
+        r#"
+declare const f: any;
+export const x = f<void>(undefined);
+"#,
+    );
+    assert!(
+        codes.contains(&2347),
+        "untyped call with a type argument is TS2347; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2693),
+        "a `void` keyword type argument must not be reported as a value (TS2693); got {codes:?}"
+    );
+}
+
+#[test]
+fn untyped_call_with_other_keyword_type_args_no_ts2693() {
+    // `unknown`, `never`, `string` keyword type args likewise must not be
+    // reported as values.
+    let codes = codes(
+        r#"
+declare const g: any;
+export const a = g<unknown>();
+export const b = g<never>();
+export const c = g<string>();
+"#,
+    );
+    assert!(
+        !codes.contains(&2693),
+        "keyword type arguments on an untyped call must not emit TS2693; got {codes:?}"
+    );
+}
+
+#[test]
+fn untyped_call_with_unresolved_type_arg_still_ts2304() {
+    // Negative control: the loop's purpose — an unresolved type *name* in a type
+    // argument still emits TS2304 even though the call is untyped.
+    let codes = codes(
+        r#"
+declare const h: any;
+export const y = h<InvalidReference>();
+"#,
+    );
+    assert!(
+        codes.contains(&2304),
+        "an unresolved type name in a type argument still emits TS2304; got {codes:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
An untyped (`any`) callee invoked with an explicit **keyword** type argument (`f<void>(...)`, `g<unknown>()`, …) emitted a spurious `TS2693` ("'void' only refers to a type, but is being used as a value here"). tsc emits only `TS2347` ("Untyped function calls may not accept type arguments").

Structural rule: When an untyped (`any`) callee is invoked with type arguments, tsc validates the type-argument *type nodes* (still reporting `TS2304` for an unresolved type *name*) but reports nothing else. tsz validated them through the value-context `get_type_of_node`, which treats a keyword type node such as `void` as a value and emits `TS2693`.

## Root cause / fix
`crates/tsz-checker/src/types/computation/call/inner.rs` — the untyped-call type-argument loop called `self.get_type_of_node(type_arg_idx)` to catch unresolved names. `get_type_of_node` is a value-expression typer; on a `void` type node it produces `TS2693`. Switched to `self.check_type_node(type_arg_idx)`, the type-node checker, which still emits `TS2304` for an unresolved type name (recursing into array/union/etc.) but treats keyword types as types.

## Verification
- `f<void>(undefined)` (`f: any`) → `TS2347` only (was `TS2347` + spurious `TS2693`).
- `h<InvalidReference>()` (`h: any`) → `TS2347` + `TS2304` (the loop's purpose preserved).
- `cargo test -p tsz-checker --test untyped_call_keyword_type_arg_tests` — 3 passed (void; `unknown`/`never`/`string` keywords; unresolved-name TS2304 control).

Discovered via a differential canary sweep on fp-ts (`src`). Reduces false-positive churn (Fast-adjacent per #14102).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
