### PR TITLE
fix(checker): resolve qualified-type LHS through shadowed re-imported namespace (TS2503) (#14225)

### DIFF
--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -875,10 +875,16 @@ impl<'a> CheckerState<'a> {
                 {
                     return Some(local_namespace_sym_id);
                 }
+                // A qualified-type-name LHS resolves with namespace meaning: when
+                // a local `type`/`interface` shadows a same-named import alias
+                // whose target is a namespace, anchor on the import.
+                let anchor_src = self
+                    .namespace_anchor_alias_partner(sym_id, &lib_binders)
+                    .unwrap_or(sym_id);
                 let mut visited_aliases = AliasCycleTracker::new();
                 Some(
-                    self.resolve_alias_symbol(sym_id, &mut visited_aliases)
-                        .unwrap_or(sym_id),
+                    self.resolve_alias_symbol(anchor_src, &mut visited_aliases)
+                        .unwrap_or(anchor_src),
                 )
             }
             TypeSymbolResolution::ValueOnly(sym_id)
@@ -1174,171 +1180,6 @@ impl<'a> CheckerState<'a> {
             true
         };
 
-        let resolve_alias_type_position_result = |sym_id: SymbolId| {
-            let classify_target_resolution = |target_sym_id: SymbolId| {
-                let mut effective_target_id = target_sym_id;
-                let target_symbol_has_declared_type_meaning = |sym_id: SymbolId| {
-                    let Some(symbol) = self
-                        .get_cross_file_symbol(sym_id)
-                        .or_else(|| self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders))
-                    else {
-                        return false;
-                    };
-
-                    if !symbol.has_any_flags(symbol_flags::ALIAS)
-                        && symbol.has_any_flags(symbol_flags::TYPE)
-                    {
-                        return true;
-                    }
-
-                    symbol.declarations.iter().copied().any(|decl_idx| {
-                        let arena = self
-                            .ctx
-                            .resolve_symbol_file_index(sym_id)
-                            .and_then(|file_idx| self.ctx.get_binder_for_file(file_idx))
-                            .and_then(|binder| binder.get_arena_for_declaration(sym_id, decl_idx))
-                            .or_else(|| self.ctx.binder.get_arena_for_declaration(sym_id, decl_idx))
-                            .map_or(self.ctx.arena, |arena| arena.as_ref());
-
-                        arena.get(decl_idx).is_some_and(|node| {
-                            node.kind == syntax_kind_ext::INTERFACE_DECLARATION
-                                || node.kind == syntax_kind_ext::CLASS_DECLARATION
-                                || node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION
-                                || node.kind == syntax_kind_ext::ENUM_DECLARATION
-                        })
-                    })
-                };
-                let mut target_flags = self
-                    .get_cross_file_symbol(effective_target_id)
-                    .or_else(|| {
-                        self.ctx
-                            .binder
-                            .get_symbol_with_libs(effective_target_id, &lib_binders)
-                    })
-                    .map_or(0, |s| s.flags);
-
-                // Synthetic default-export symbols often exist as bare aliases
-                // with no direct TYPE/VALUE flags. Follow the alias before
-                // deciding whether the import is usable in type position.
-                if (target_flags & symbol_flags::ALIAS) != 0 {
-                    if target_symbol_has_declared_type_meaning(effective_target_id) {
-                        return TypeSymbolResolution::Type(effective_target_id);
-                    }
-                    let mut visited_target_aliases = AliasCycleTracker::new();
-                    if let Some(alias_target_id) =
-                        self.resolve_alias_symbol(effective_target_id, &mut visited_target_aliases)
-                        && alias_target_id != effective_target_id
-                    {
-                        effective_target_id = alias_target_id;
-                        target_flags = self
-                            .get_cross_file_symbol(effective_target_id)
-                            .or_else(|| {
-                                self.ctx
-                                    .binder
-                                    .get_symbol_with_libs(effective_target_id, &lib_binders)
-                            })
-                            .map_or(0, |s| s.flags);
-                    }
-                }
-
-                let target_is_namespace_module = (target_flags
-                    & (symbol_flags::MODULE
-                        | symbol_flags::NAMESPACE_MODULE
-                        | symbol_flags::VALUE_MODULE))
-                    != 0;
-                let target_has_type =
-                    (target_flags & (symbol_flags::TYPE | symbol_flags::TYPE_ALIAS)) != 0;
-                let target_has_value = (target_flags & symbol_flags::VALUE) != 0;
-                let target_is_value_only =
-                    target_has_value && !target_has_type && !target_is_namespace_module;
-
-                if target_is_value_only {
-                    TypeSymbolResolution::ValueOnly(effective_target_id)
-                } else {
-                    TypeSymbolResolution::Type(effective_target_id)
-                }
-            };
-
-            if let Some(alias_symbol) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)
-                && let Some(module_name) = alias_symbol.import_module()
-                && alias_symbol.import_name().is_some()
-            {
-                let expected_name = alias_symbol
-                    .import_name()
-                    .unwrap_or(alias_symbol.escaped_name.as_str());
-                let source_file_idx = self
-                    .ctx
-                    .resolve_symbol_file_index(sym_id)
-                    .unwrap_or(self.ctx.current_file_idx);
-                if let Some(target_sym_id) = self.resolve_cross_file_export_from_file(
-                    module_name,
-                    expected_name,
-                    Some(source_file_idx),
-                ) {
-                    let export_surface_meanings = (expected_name != "*")
-                        .then(|| {
-                            self.ctx
-                                .resolve_import_target_from_file(source_file_idx, module_name)
-                        })
-                        .flatten()
-                        .map(|target_file_idx| {
-                            let declarations = self.export_surface_declarations_in_file(
-                                target_file_idx,
-                                expected_name,
-                            );
-                            let has_type_position_meaning =
-                                declarations.iter().any(|(_, flags, _)| {
-                                    (*flags
-                                        & (symbol_flags::TYPE
-                                            | symbol_flags::NAMESPACE_MODULE
-                                            | symbol_flags::VALUE_MODULE))
-                                        != 0
-                                });
-                            let has_runtime_value = declarations
-                                .iter()
-                                .any(|(_, flags, _)| (*flags & symbol_flags::VALUE) != 0);
-                            (has_type_position_meaning, has_runtime_value)
-                        });
-                    if let Some((has_type_position_meaning, has_runtime_value)) =
-                        export_surface_meanings
-                        && !has_type_position_meaning
-                        && has_runtime_value
-                    {
-                        return Some(TypeSymbolResolution::ValueOnly(target_sym_id));
-                    }
-                    // Use get_cross_file_symbol first, then fall back to
-                    // get_symbol_with_libs. When the target comes from a
-                    // different binder (ambient module, cross-file export),
-                    // SymbolId values can collide with the current binder's
-                    // symbols, causing incorrect flag lookups.
-                    self.record_cross_file_symbol_if_needed(
-                        target_sym_id,
-                        expected_name,
-                        module_name,
-                    );
-                    return Some(classify_target_resolution(target_sym_id));
-                }
-            }
-            let mut visited_aliases = AliasCycleTracker::new();
-            self.resolve_alias_symbol(sym_id, &mut visited_aliases)
-                .map(|target_sym_id| {
-                    if let Some(alias_symbol) =
-                        self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)
-                        && let Some(module_name) = alias_symbol.import_module()
-                    {
-                        let expected_name = alias_symbol
-                            .import_name()
-                            .unwrap_or(alias_symbol.escaped_name.as_str());
-                        self.record_cross_file_symbol_if_needed(
-                            target_sym_id,
-                            expected_name,
-                            module_name,
-                        );
-                    }
-                    classify_target_resolution(target_sym_id)
-                })
-        };
-
         let should_preserve_alias_symbol_in_type_position = |sym_id: SymbolId| {
             let Some(symbol) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders) else {
                 return false;
@@ -1433,7 +1274,9 @@ impl<'a> CheckerState<'a> {
                     .referenced_symbols
                     .borrow_mut()
                     .insert(local_sym_id);
-                if let Some(resolved) = resolve_alias_type_position_result(local_sym_id) {
+                if let Some(resolved) =
+                    self.resolve_alias_type_position_result(local_sym_id, &lib_binders)
+                {
                     return resolved;
                 }
             }
@@ -1529,7 +1372,9 @@ impl<'a> CheckerState<'a> {
                 // and inserted into referenced_symbols by the caller. Without this,
                 // imports used only in type positions appear unused (false TS6133).
                 self.ctx.referenced_symbols.borrow_mut().insert(sym_id);
-                if let Some(resolved) = resolve_alias_type_position_result(sym_id) {
+                if let Some(resolved) =
+                    self.resolve_alias_type_position_result(sym_id, &lib_binders)
+                {
                     return resolved;
                 }
             }
@@ -1578,6 +1423,177 @@ impl<'a> CheckerState<'a> {
         }
 
         TypeSymbolResolution::NotFound
+    }
+
+    /// Resolve an import-alias symbol to its type-position target via cross-file
+    /// export resolution.
+    ///
+    /// This mirrors how an unshadowed `import { X } from "./m"` is resolved when
+    /// `X` is used in type position: it follows the alias to the exported target
+    /// in the source module, classifies the target's meaning (namespace/module,
+    /// type, or value-only), and follows synthetic default-export alias chains.
+    /// Returns `None` when `sym_id` is not an import alias or its target cannot
+    /// be resolved.
+    pub(crate) fn resolve_alias_type_position_result(
+        &self,
+        sym_id: SymbolId,
+        lib_binders: &[Arc<tsz_binder::BinderState>],
+    ) -> Option<TypeSymbolResolution> {
+        let classify_target_resolution = |target_sym_id: SymbolId| {
+            let mut effective_target_id = target_sym_id;
+            let target_symbol_has_declared_type_meaning = |sym_id: SymbolId| {
+                let Some(symbol) = self
+                    .get_cross_file_symbol(sym_id)
+                    .or_else(|| self.ctx.binder.get_symbol_with_libs(sym_id, lib_binders))
+                else {
+                    return false;
+                };
+
+                if !symbol.has_any_flags(symbol_flags::ALIAS)
+                    && symbol.has_any_flags(symbol_flags::TYPE)
+                {
+                    return true;
+                }
+
+                symbol.declarations.iter().copied().any(|decl_idx| {
+                    let arena = self
+                        .ctx
+                        .resolve_symbol_file_index(sym_id)
+                        .and_then(|file_idx| self.ctx.get_binder_for_file(file_idx))
+                        .and_then(|binder| binder.get_arena_for_declaration(sym_id, decl_idx))
+                        .or_else(|| self.ctx.binder.get_arena_for_declaration(sym_id, decl_idx))
+                        .map_or(self.ctx.arena, |arena| arena.as_ref());
+
+                    arena.get(decl_idx).is_some_and(|node| {
+                        node.kind == syntax_kind_ext::INTERFACE_DECLARATION
+                            || node.kind == syntax_kind_ext::CLASS_DECLARATION
+                            || node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+                            || node.kind == syntax_kind_ext::ENUM_DECLARATION
+                    })
+                })
+            };
+            let mut target_flags = self
+                .get_cross_file_symbol(effective_target_id)
+                .or_else(|| {
+                    self.ctx
+                        .binder
+                        .get_symbol_with_libs(effective_target_id, lib_binders)
+                })
+                .map_or(0, |s| s.flags);
+
+            // Synthetic default-export symbols often exist as bare aliases
+            // with no direct TYPE/VALUE flags. Follow the alias before
+            // deciding whether the import is usable in type position.
+            if (target_flags & symbol_flags::ALIAS) != 0 {
+                if target_symbol_has_declared_type_meaning(effective_target_id) {
+                    return TypeSymbolResolution::Type(effective_target_id);
+                }
+                let mut visited_target_aliases = AliasCycleTracker::new();
+                if let Some(alias_target_id) =
+                    self.resolve_alias_symbol(effective_target_id, &mut visited_target_aliases)
+                    && alias_target_id != effective_target_id
+                {
+                    effective_target_id = alias_target_id;
+                    target_flags = self
+                        .get_cross_file_symbol(effective_target_id)
+                        .or_else(|| {
+                            self.ctx
+                                .binder
+                                .get_symbol_with_libs(effective_target_id, lib_binders)
+                        })
+                        .map_or(0, |s| s.flags);
+                }
+            }
+
+            let target_is_namespace_module = (target_flags
+                & (symbol_flags::MODULE
+                    | symbol_flags::NAMESPACE_MODULE
+                    | symbol_flags::VALUE_MODULE))
+                != 0;
+            let target_has_type =
+                (target_flags & (symbol_flags::TYPE | symbol_flags::TYPE_ALIAS)) != 0;
+            let target_has_value = (target_flags & symbol_flags::VALUE) != 0;
+            let target_is_value_only =
+                target_has_value && !target_has_type && !target_is_namespace_module;
+
+            if target_is_value_only {
+                TypeSymbolResolution::ValueOnly(effective_target_id)
+            } else {
+                TypeSymbolResolution::Type(effective_target_id)
+            }
+        };
+
+        if let Some(alias_symbol) = self.ctx.binder.get_symbol_with_libs(sym_id, lib_binders)
+            && let Some(module_name) = alias_symbol.import_module()
+            && alias_symbol.import_name().is_some()
+        {
+            let expected_name = alias_symbol
+                .import_name()
+                .unwrap_or(alias_symbol.escaped_name.as_str());
+            let source_file_idx = self
+                .ctx
+                .resolve_symbol_file_index(sym_id)
+                .unwrap_or(self.ctx.current_file_idx);
+            if let Some(target_sym_id) = self.resolve_cross_file_export_from_file(
+                module_name,
+                expected_name,
+                Some(source_file_idx),
+            ) {
+                let export_surface_meanings = (expected_name != "*")
+                    .then(|| {
+                        self.ctx
+                            .resolve_import_target_from_file(source_file_idx, module_name)
+                    })
+                    .flatten()
+                    .map(|target_file_idx| {
+                        let declarations = self
+                            .export_surface_declarations_in_file(target_file_idx, expected_name);
+                        let has_type_position_meaning = declarations.iter().any(|(_, flags, _)| {
+                            (*flags
+                                & (symbol_flags::TYPE
+                                    | symbol_flags::NAMESPACE_MODULE
+                                    | symbol_flags::VALUE_MODULE))
+                                != 0
+                        });
+                        let has_runtime_value = declarations
+                            .iter()
+                            .any(|(_, flags, _)| (*flags & symbol_flags::VALUE) != 0);
+                        (has_type_position_meaning, has_runtime_value)
+                    });
+                if let Some((has_type_position_meaning, has_runtime_value)) =
+                    export_surface_meanings
+                    && !has_type_position_meaning
+                    && has_runtime_value
+                {
+                    return Some(TypeSymbolResolution::ValueOnly(target_sym_id));
+                }
+                // Use get_cross_file_symbol first, then fall back to
+                // get_symbol_with_libs. When the target comes from a
+                // different binder (ambient module, cross-file export),
+                // SymbolId values can collide with the current binder's
+                // symbols, causing incorrect flag lookups.
+                self.record_cross_file_symbol_if_needed(target_sym_id, expected_name, module_name);
+                return Some(classify_target_resolution(target_sym_id));
+            }
+        }
+        let mut visited_aliases = AliasCycleTracker::new();
+        self.resolve_alias_symbol(sym_id, &mut visited_aliases)
+            .map(|target_sym_id| {
+                if let Some(alias_symbol) =
+                    self.ctx.binder.get_symbol_with_libs(sym_id, lib_binders)
+                    && let Some(module_name) = alias_symbol.import_module()
+                {
+                    let expected_name = alias_symbol
+                        .import_name()
+                        .unwrap_or(alias_symbol.escaped_name.as_str());
+                    self.record_cross_file_symbol_if_needed(
+                        target_sym_id,
+                        expected_name,
+                        module_name,
+                    );
+                }
+                classify_target_resolution(target_sym_id)
+            })
     }
 
     // =========================================================================

--- a/crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs
@@ -129,6 +129,9 @@ impl<'a> CheckerState<'a> {
         sym_id: SymbolId,
         lib_binders: &[std::sync::Arc<tsz_binder::BinderState>],
     ) -> Option<SymbolId> {
+        // Bound the re-export walk; chains this long are pathological.
+        const MAX_REEXPORT_HOPS: usize = 32;
+
         if self.symbol_anchors_qualified_type_member(sym_id, lib_binders) {
             return None;
         }
@@ -154,13 +157,12 @@ impl<'a> CheckerState<'a> {
         // anchor nor a further module import (e.g. a plain `type` alias) stops
         // the walk with no anchor, so a real "not a namespace" diagnostic still
         // surfaces.
-        // Bound the re-export walk; chains this long are pathological.
-        const MAX_REEXPORT_HOPS: usize = 32;
         let mut current = alias;
         for _ in 0..MAX_REEXPORT_HOPS {
-            let resolved = match self.resolve_alias_type_position_result(current, lib_binders) {
-                Some(TypeSymbolResolution::Type(target)) => target,
-                _ => return None,
+            let Some(TypeSymbolResolution::Type(resolved)) =
+                self.resolve_alias_type_position_result(current, lib_binders)
+            else {
+                return None;
             };
             if resolved == current {
                 return None;

--- a/crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs
@@ -59,6 +59,123 @@ impl<'a> CheckerState<'a> {
         self.resolve_qualified_symbol_inner_in_type_position(idx, &mut visited_aliases, 0)
     }
 
+    /// Whether `sym_id` carries meaning that lets it anchor the left-hand side
+    /// of a qualified type name `X.Member` — a namespace/module, class, or enum,
+    /// or a namespace import alias (`import * as X`) that navigates into another
+    /// module. A bare `type X = ...` alias or interface does not. Aliases are
+    /// followed to their target before the flag check; a namespace import alias
+    /// resolves to itself, so it is recognized by its `*` import name.
+    pub(crate) fn symbol_anchors_qualified_type_member(
+        &self,
+        sym_id: SymbolId,
+        lib_binders: &[std::sync::Arc<tsz_binder::BinderState>],
+    ) -> bool {
+        let mut visited = AliasCycleTracker::new();
+        let resolved = self
+            .resolve_alias_symbol(sym_id, &mut visited)
+            .unwrap_or(sym_id);
+        self.get_cross_file_symbol(resolved)
+            .or_else(|| self.ctx.binder.get_symbol_with_libs(resolved, lib_binders))
+            .is_some_and(|symbol| {
+                symbol.has_any_flags(
+                    symbol_flags::MODULE
+                        | symbol_flags::CLASS
+                        | symbol_flags::REGULAR_ENUM
+                        | symbol_flags::CONST_ENUM,
+                ) || (symbol.has_any_flags(symbol_flags::ALIAS)
+                    && symbol.import_name() == Some("*"))
+            })
+    }
+
+    /// Whether `sym_id` is an import alias that targets another module by name —
+    /// i.e. has an `import_module` specifier. Namespace imports (`import * as X`),
+    /// named imports (`import { X }`), and default imports all qualify; the
+    /// distinction between them is made by the caller via `import_name`.
+    fn symbol_is_module_import_alias(
+        &self,
+        sym_id: SymbolId,
+        lib_binders: &[std::sync::Arc<tsz_binder::BinderState>],
+    ) -> bool {
+        self.ctx
+            .binder
+            .get_symbol_with_libs(sym_id, lib_binders)
+            .is_some_and(|symbol| {
+                symbol.has_any_flags(symbol_flags::ALIAS) && symbol.import_module().is_some()
+            })
+    }
+
+    /// Resolve the namespace anchor for a qualified-type-name LHS whose type-space
+    /// resolution cannot itself anchor member access.
+    ///
+    /// tsc resolves the LHS of a qualified type name with *namespace* meaning, so
+    /// neither a shadowing local `type`/`interface` declaration nor the surface
+    /// `import { X }` binding may hide the namespace that the import ultimately
+    /// targets. The import alias carrying that meaning is either:
+    /// - `sym_id` itself, when it is a named/default import whose target module
+    ///   re-exports a namespace (the local-declaration merge can leave the import
+    ///   alias as the resolved type-space symbol); or
+    /// - `sym_id`'s `alias_partner`, when `sym_id` is a same-named local
+    ///   `type`/`interface` declaration that shadows the import.
+    ///
+    /// In both cases the alias is resolved through the same cross-file machinery
+    /// the unshadowed case uses; the result is returned only when it genuinely
+    /// anchors qualified member access (namespace/module, class, enum, or a
+    /// namespace import). Returns `None` when the type-space symbol already
+    /// anchors, when no import alias is involved, or when the alias does not
+    /// resolve to a usable anchor — so a real "not a namespace" diagnostic still
+    /// surfaces.
+    pub(crate) fn namespace_anchor_alias_partner(
+        &self,
+        sym_id: SymbolId,
+        lib_binders: &[std::sync::Arc<tsz_binder::BinderState>],
+    ) -> Option<SymbolId> {
+        if self.symbol_anchors_qualified_type_member(sym_id, lib_binders) {
+            return None;
+        }
+        // The import alias that carries the namespace meaning: the symbol itself
+        // when it is a module import, otherwise its same-named alias partner.
+        let alias = if self.symbol_is_module_import_alias(sym_id, lib_binders) {
+            sym_id
+        } else {
+            let partner = self
+                .ctx
+                .alias_partner_for(self.ctx.binder, sym_id)
+                .or_else(|| self.ctx.alias_partner_reverse(self.ctx.binder, sym_id))
+                .filter(|&partner| partner != sym_id)?;
+            if !self.symbol_is_module_import_alias(partner, lib_binders) {
+                return None;
+            }
+            partner
+        };
+        // Follow the import alias through any re-export chain to its terminal
+        // target. Each `resolve_alias_type_position_result` hop advances one
+        // module boundary (`export { X } from "./m"`); a namespace import or a
+        // module/class/enum is the terminal anchor. A target that is neither an
+        // anchor nor a further module import (e.g. a plain `type` alias) stops
+        // the walk with no anchor, so a real "not a namespace" diagnostic still
+        // surfaces.
+        // Bound the re-export walk; chains this long are pathological.
+        const MAX_REEXPORT_HOPS: usize = 32;
+        let mut current = alias;
+        for _ in 0..MAX_REEXPORT_HOPS {
+            let resolved = match self.resolve_alias_type_position_result(current, lib_binders) {
+                Some(TypeSymbolResolution::Type(target)) => target,
+                _ => return None,
+            };
+            if resolved == current {
+                return None;
+            }
+            if self.symbol_anchors_qualified_type_member(resolved, lib_binders) {
+                return (resolved != sym_id).then_some(resolved);
+            }
+            if !self.symbol_is_module_import_alias(resolved, lib_binders) {
+                return None;
+            }
+            current = resolved;
+        }
+        None
+    }
+
     /// Inner implementation of qualified symbol resolution for type positions.
     pub(crate) fn resolve_qualified_symbol_inner_in_type_position(
         &self,
@@ -92,13 +209,19 @@ impl<'a> CheckerState<'a> {
                     if self.is_import_equals_type_anchor(sym_id, &lib_binders) {
                         return TypeSymbolResolution::Type(sym_id);
                     }
+                    // A qualified-type-name LHS resolves with namespace meaning:
+                    // when a local `type`/`interface` shadows a same-named import
+                    // alias whose target is a namespace, anchor on the import.
+                    let anchor_src = self
+                        .namespace_anchor_alias_partner(sym_id, &lib_binders)
+                        .unwrap_or(sym_id);
                     // Preserve unresolved alias symbols in type position.
                     // `import X = require("...")` aliases may not resolve to a concrete
                     // target symbol, but `X` is still a valid namespace-like type query
                     // anchor (e.g., `typeof X.Member`).
                     let resolved = self
-                        .resolve_alias_symbol(sym_id, visited_aliases)
-                        .unwrap_or(sym_id);
+                        .resolve_alias_symbol(anchor_src, visited_aliases)
+                        .unwrap_or(anchor_src);
                     TypeSymbolResolution::Type(resolved)
                 }
                 TypeSymbolResolution::ValueOnly(sym_id)

--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -148,6 +148,10 @@ name = "cross_binder_reexport_meaning_tests"
 path = "tests/cross_binder_reexport_meaning_tests.rs"
 
 [[test]]
+name = "qualified_type_namespace_shadow_tests"
+path = "tests/qualified_type_namespace_shadow_tests.rs"
+
+[[test]]
 name = "imported_infer_readonly_alias_cli_tests"
 path = "tests/imported_infer_readonly_alias_cli_tests.rs"
 

--- a/crates/tsz-cli/tests/qualified_type_namespace_shadow_tests.rs
+++ b/crates/tsz-cli/tests/qualified_type_namespace_shadow_tests.rs
@@ -1,0 +1,210 @@
+//! Qualified-type-name LHS resolution under a local-declaration shadow
+//! (issue #14225, mined from `ts-toolbelt`).
+//!
+//! tsc resolves the left side of a qualified type name `X.Member` with
+//! *namespace* meaning. When a module re-imports a namespace by name
+//! (`import { X }`, where the source re-exports an `import * as X`) **and**
+//! declares a same-named local `type X` / `interface X`, tsc keeps the local
+//! declaration for a bare `: X` reference but still resolves `X.Member` through
+//! the imported namespace. tsz previously gated namespace-anchor recognition on
+//! the *syntactic* `import * as` / `import =` form, so the shadowed re-import
+//! lost its namespace meaning and reported a spurious `TS2503`.
+//!
+//! These run the **real multi-file driver** in project mode. The bug only
+//! manifests once the program skeleton hoists each file's exports into the
+//! program-wide index and links the same-named local declaration and import
+//! alias via `program_alias_partners`; an entry-only checker harness resolves
+//! the re-export differently and does not reproduce it.
+//!
+//! Binder names and file names are varied across cases so the behaviour follows
+//! structure, not identifier text.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+/// Run `tsz -p tsconfig.json` over `files` (relative name, contents), returning
+/// combined stdout+stderr. The driver is invoked in project mode so the
+/// program-wide skeleton (and `program_alias_partners`) is built.
+fn run_tsz(files: &[(&str, &str)]) -> String {
+    let Some(tsz_bin) = find_tsz_binary() else {
+        return String::from("__SKIP__");
+    };
+    let dir = tempfile::tempdir().expect("temp dir");
+    for (name, contents) in files {
+        let path = dir.path().join(name);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dir");
+        }
+        std::fs::write(path, contents).expect("write file");
+    }
+    std::fs::write(
+        dir.path().join("tsconfig.json"),
+        r#"{ "compilerOptions": { "noEmit": true, "strict": true, "target": "esnext", "module": "esnext", "moduleResolution": "bundler", "skipLibCheck": true } }"#,
+    )
+    .expect("write tsconfig.json");
+
+    let output = Command::new(tsz_bin)
+        .args(["-p", "tsconfig.json", "--pretty", "false"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run tsz");
+
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    combined
+}
+
+/// The mined repro: `import * as T` re-exported under the same name, consumed by
+/// `import { T }` alongside a local `type T`. `T.Intersect<...>` must resolve
+/// through the imported namespace (tsc clean), not collapse onto the shadowing
+/// tuple alias and report `TS2503`/`TS2694`.
+#[test]
+fn type_alias_shadow_resolves_qualified_member_through_imported_namespace() {
+    let out = run_tsz(&[
+        ("lib.ts", "export type Intersect<A, B> = A & B;\n"),
+        ("index.ts", "import * as T from './lib';\nexport { T };\n"),
+        (
+            "use.ts",
+            "import { T } from './index';\ntype T = [1, 2, 3];\ntype R = T.Intersect<{ a: 1 }, { b: 2 }>;\nconst r: R = { a: 1, b: 2 };\nexport { r };\n",
+        ),
+    ]);
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("TS2503") && !out.contains("TS2694"),
+        "shadowed re-imported namespace must anchor T.Member, got:\n{out}"
+    );
+}
+
+/// A bare `: T` reference keeps the local `type T` (a tuple) — the qualified
+/// anchor redirect must not change the meaning of a non-qualified type
+/// reference. The tuple is assignable from the literal, so the whole file stays
+/// clean.
+#[test]
+fn bare_type_reference_keeps_local_alias_while_qualified_anchor_uses_namespace() {
+    let out = run_tsz(&[
+        ("lib.ts", "export type Intersect<A, B> = A & B;\n"),
+        ("index.ts", "import * as T from './lib';\nexport { T };\n"),
+        (
+            "use.ts",
+            "import { T } from './index';\ntype T = [1, 2, 3];\nconst local: T = [1, 2, 3];\ntype R = T.Intersect<{ a: 1 }, { b: 2 }>;\nconst r: R = { a: 1, b: 2 };\nexport { local, r };\n",
+        ),
+    ]);
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("TS2503") && !out.contains("TS2694") && !out.contains("TS2322"),
+        "bare `: T` keeps the local alias while `T.Member` uses the namespace, got:\n{out}"
+    );
+}
+
+/// An `interface` shadow (rather than a `type` alias) under the same name must
+/// also resolve the qualified member through the imported namespace. Binder and
+/// file names differ from the first case so the behaviour is structural.
+#[test]
+fn interface_shadow_resolves_qualified_member_through_imported_namespace() {
+    let out = run_tsz(&[
+        ("shapes.ts", "export type Pick2<A, B> = { a: A; b: B };\n"),
+        (
+            "barrel.ts",
+            "import * as Box from './shapes';\nexport { Box };\n",
+        ),
+        (
+            "consumer.ts",
+            "import { Box } from './barrel';\ninterface Box { z: number }\ntype R = Box.Pick2<1, 2>;\nconst r: R = { a: 1, b: 2 };\nexport { r };\n",
+        ),
+    ]);
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("TS2503") && !out.contains("TS2694"),
+        "interface shadow must anchor Box.Member on the namespace, got:\n{out}"
+    );
+}
+
+/// Renaming the namespace binder (`import * as Widget` re-exported, local
+/// `type Widget`) proves the fix is not keyed on any particular identifier.
+#[test]
+fn renamed_binder_shadow_resolves_qualified_member() {
+    let out = run_tsz(&[
+        (
+            "palette.ts",
+            "export type Pair<A, B> = { first: A; second: B };\n",
+        ),
+        (
+            "gateway.ts",
+            "import * as Widget from './palette';\nexport { Widget };\n",
+        ),
+        (
+            "screen.ts",
+            "import { Widget } from './gateway';\ntype Widget = [1];\ntype R = Widget.Pair<1, 2>;\nconst r: R = { first: 1, second: 2 };\nexport { r };\n",
+        ),
+    ]);
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("TS2503") && !out.contains("TS2694"),
+        "renamed binder shadow must anchor Widget.Member, got:\n{out}"
+    );
+}
+
+/// A deeper re-export chain (`leaf` -> `mid` -> `hub`) under a local shadow must
+/// still walk through to the terminal namespace.
+#[test]
+fn deep_reexport_chain_shadow_resolves_qualified_member() {
+    let out = run_tsz(&[
+        ("leaf.ts", "export type Pick2<A, B> = { a: A; b: B };\n"),
+        ("mid.ts", "import * as Ns from './leaf';\nexport { Ns };\n"),
+        ("hub.ts", "export { Ns } from './mid';\n"),
+        (
+            "entry.ts",
+            "import { Ns } from './hub';\ntype Ns = [1];\ntype R = Ns.Pick2<1, 2>;\nconst r: R = { a: 1, b: 2 };\nexport { r };\n",
+        ),
+    ]);
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("TS2503") && !out.contains("TS2694"),
+        "deep re-export chain shadow must anchor Ns.Member, got:\n{out}"
+    );
+}
+
+/// Negative control: when the named import is genuinely a *value* (not a
+/// namespace), a same-named local type does not invent a namespace anchor —
+/// `Token.Member` still reports `TS2503`, matching tsc.
+#[test]
+fn value_import_shadow_still_reports_cannot_find_namespace() {
+    let out = run_tsz(&[
+        ("runtime.ts", "export const Token = 1;\n"),
+        (
+            "client.ts",
+            "import { Token } from './runtime';\ntype Token = [1];\ntype R = Token.Member;\nexport type Exported = R;\n",
+        ),
+    ]);
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        out.contains("TS2503"),
+        "a value import shadowed by a local type must not become a namespace anchor, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes #14225.

## Summary
Mined from **ts-toolbelt** (`tests/List.ts`). When a module re-imports a namespace
by name (`import { T }`, where the source re-exports an `import * as T`) **and**
declares a same-named local `type T` / `interface T`, tsz emitted a spurious
`TS2503` at the qualified-type anchor `T.Member`. tsc is clean: the left side of a
qualified type name is resolved with **namespace** meaning, so the local type does
not hide the import's namespace at the anchor (while a bare `: T` still resolves
the local declaration).

## Structural rule
When the LHS of a qualified type name resolves, in type space, to a symbol that
cannot anchor member access (a local `type`/`interface`, not a namespace/module/
class/enum), tsc resolves the LHS with namespace meaning and uses the same-named
import alias whose target is a namespace. tsz gated namespace-anchor recognition
on the *syntactic* `import * as` / `import =` form only, so a re-imported
namespace shadowed by a local type lost its namespace meaning → spurious `TS2503`.

`When a qualified-type-name LHS resolves to a non-anchoring local declaration that
has a same-named module-import alias whose target resolves (through the re-export
chain) to a namespace/module/class/enum, tsc anchors X.Member on the import's
namespace; tsz now does X through the checker symbol resolver`
(`namespace_anchor_alias_partner`).

## Owner / fix direction
Checker — `crates/tsz-checker/src/symbols/`. The qualified-type anchor now
redirects to the import alias carrying the namespace meaning — the symbol itself
when it is a named/default module import, otherwise its `alias_partner` (the
same-named import alias the binder links to a local `type`/`interface`) — and
follows the re-export chain to the terminal namespace through the same cross-file
machinery the unshadowed case uses. The redirect is wired into both qualified-type
entry points: the generic path (`resolve_qualified_symbol_inner_in_type_position`)
and the non-generic anchor (`resolve_identifier_symbol_as_qualified_type_anchor`).
The shared cross-file alias-to-type-position resolution was extracted from an
inline closure into `resolve_alias_type_position_result` so both reuse it.

Anti-hardcoding: the decision keys only on declaration kind, resolved-target
symbol flags (`MODULE`/`CLASS`/`REGULAR_ENUM`/`CONST_ENUM`), the binder-computed
`alias_partner` link, and the binder's `*` namespace-import marker
(`import_name() == Some("*")`). No user identifier, alias, property, or file-name
string drives the logic; no rendered/printer output is read.

## Adjacent cases (verified vs tsc, all clean except the noted control)
- `import { T }` re-exporting `import * as T`, local `type T`: `T.Intersect<…>`
  resolves through the namespace (was `TS2503`).
- Bare `: T` keeps the local tuple alias while `T.Member` uses the namespace.
- Local shadow as `interface` (not just `type`).
- Renamed namespace binder (`import * as Widget`, local `type Widget`) — proves
  the fix is not keyed on identifier text.
- Deep re-export chain (`leaf → mid → hub`) under a local shadow.
- Negative control: when the named import is genuinely a **value**
  (`export const Token = 1`), a same-named local type does **not** invent a
  namespace anchor — `Token.Member` still reports `TS2503`, matching tsc.

Out of scope (pre-existing, verified unchanged from baseline): a `class T` shadow
forms a genuine `TS2440` conflict whose secondary diagnostic differs from tsc, and
a missing namespace member reports `TS2503` rather than `TS2694` (reproduces
without any shadow). Both are orthogonal and not introduced here.

## Verification
- New driver-level regression suite (runs the real `tsz` binary in project mode,
  the only path where the program skeleton + `program_alias_partners` reproduce
  the bug): `cargo test -p tsz-cli --test qualified_type_namespace_shadow_tests`
  — 6 tests pass; 5 of 6 fail on `main` (the negative control passes on both).
- Original repro and the adjacent matrix above checked against `tsc` (strict,
  `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, ES2022, ESNext,
  Bundler, `noEmit`): tsz now matches `tsc`.
- `cargo clippy -p tsz-checker -p tsz-cli --all-targets` clean;
  `cargo fmt -p tsz-checker -p tsz-cli --check` clean.
- Targeted checker suites pass (qualified / namespace / shadowing / reexport /
  import_alias / type_position); the cross-file lib/JSX/zod test failures present
  locally are environmental (no lib checkout) and identical on `main`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019VdYP4AeedLEez2g24XdZQ)_