### PR TITLE
fix(solver): reject a primitive against a deferred any-constrained index map (#14220)

### DIFF
--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -479,6 +479,9 @@ mod narrowing_discriminant_tests;
 #[path = "../tests/numeric_keyof_tests.rs"]
 mod numeric_keyof_tests;
 #[cfg(test)]
+#[path = "../tests/primitive_mapped_index_subtype_tests.rs"]
+mod primitive_mapped_index_subtype_tests;
+#[cfg(test)]
 #[path = "../tests/property_helpers_tests.rs"]
 mod property_helpers_tests;
 #[cfg(test)]

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -87,6 +87,25 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
 
         if let Some(shape) = self.apparent_primitive_shape_for_type(source) {
+            // A deferred mapped target may be structurally a pure index-signature
+            // object — e.g. `{ [P in any]: V }` (the shape of `Record<any, V>` /
+            // `Record<PropertyKey, V>`) is equivalent to
+            // `{ [k: string]: V; [k: number]: V }`. Such a target is never
+            // expanded eagerly during evaluation (to keep error-message display
+            // stable), so `object_with_index_shape_id` reports `None` for it and
+            // the relation would otherwise fall through to the boxed-wrapper
+            // fallback below, wrongly accepting a primitive against a pure index
+            // signature (a primitive has no index signature; tsc rejects it).
+            // Expand it here so the pure-index guard in the
+            // `object_with_index_shape_id` arm owns the decision, exactly as it
+            // does for the written-out `{ [k: string]: V }` form.
+            let target = mapped_type_id(self.interner, target)
+                .and_then(|mapped_id| self.try_expand_mapped(mapped_id))
+                .filter(|&expanded| {
+                    object_shape_id(self.interner, expanded).is_some()
+                        || object_with_index_shape_id(self.interner, expanded).is_some()
+                })
+                .unwrap_or(target);
             if let Some(t_shape_id) = object_shape_id(self.interner, target) {
                 let t_shape = self.interner.object_shape(t_shape_id);
                 // Reset `in_intersection_member_check` for apparent primitive structural

--- a/crates/tsz-solver/tests/primitive_mapped_index_subtype_tests.rs
+++ b/crates/tsz-solver/tests/primitive_mapped_index_subtype_tests.rs
@@ -1,0 +1,121 @@
+//! Relation-path coverage for a primitive source against a deferred mapped type
+//! that is structurally a pure index-signature object.
+//!
+//! Structural rule: `{ [P in any]: V }` (the shape of `Record<any, V>` /
+//! `Record<PropertyKey, V>`) is equivalent to
+//! `{ [k: string]: V; [k: number]: V }` — a *pure* index-signature object with
+//! no named properties. A primitive (`string`, `number`, `boolean`, …) has no
+//! index signature, so tsc rejects `primitive <: { [P in any]: V }` even though
+//! the primitive's boxed wrapper would structurally satisfy the index signature.
+//!
+//! Such an `any`-constrained mapped type is intentionally NOT expanded by the
+//! eager evaluator (to keep error-message display stable), so it reaches the
+//! subtype checker as a raw `Mapped` node. The apparent-primitive dispatch must
+//! expand it (`try_expand_mapped`) so the pure-index guard owns the relation
+//! instead of falling through to the boxed-wrapper fallback. Regression guard
+//! for the zod false-positive TS2339 in issue #14220.
+
+use super::*;
+use crate::computation::SubtypeChecker;
+use crate::construction::TypeInterner;
+use crate::types::{MappedType, PropertyInfo, TypeParamInfo};
+
+/// Build a raw mapped type `{ [iter in any]: template }` without going through
+/// the eager evaluator, so the subtype checker sees the deferred `Mapped` node —
+/// exactly the form that reaches relations for `Record<any, V>`.
+fn any_constrained_mapped(interner: &TypeInterner, template: TypeId) -> TypeId {
+    let iter_param = TypeParamInfo {
+        name: interner.intern_string("P"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    };
+    interner.mapped(MappedType {
+        type_param: iter_param,
+        constraint: TypeId::ANY,
+        name_type: None,
+        template,
+        optional_modifier: None,
+        readonly_modifier: None,
+    })
+}
+
+#[test]
+fn string_is_not_subtype_of_record_any_any() {
+    let interner = TypeInterner::new();
+    let mapped = any_constrained_mapped(&interner, TypeId::ANY);
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        !checker.is_subtype_of(TypeId::STRING, mapped),
+        "primitive `string` must not satisfy a pure index-signature `{{ [P in any]: any }}`"
+    );
+}
+
+#[test]
+fn number_and_boolean_are_not_subtype_of_record_any_any() {
+    let interner = TypeInterner::new();
+    let mapped = any_constrained_mapped(&interner, TypeId::ANY);
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        !checker.is_subtype_of(TypeId::NUMBER, mapped),
+        "primitive `number` must not satisfy `{{ [P in any]: any }}`"
+    );
+    assert!(
+        !checker.is_subtype_of(TypeId::BOOLEAN, mapped),
+        "primitive `boolean` must not satisfy `{{ [P in any]: any }}`"
+    );
+}
+
+#[test]
+fn string_literal_is_not_subtype_of_record_any_any() {
+    let interner = TypeInterner::new();
+    let mapped = any_constrained_mapped(&interner, TypeId::ANY);
+    let lit = interner.literal_string("x");
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        !checker.is_subtype_of(lit, mapped),
+        "a string literal must not satisfy `{{ [P in any]: any }}`"
+    );
+}
+
+#[test]
+fn object_is_still_subtype_of_record_any_any() {
+    let interner = TypeInterner::new();
+    let mapped = any_constrained_mapped(&interner, TypeId::ANY);
+    let obj = interner.object(vec![
+        PropertyInfo::new(interner.intern_string("a"), TypeId::NUMBER),
+        PropertyInfo::new(interner.intern_string("b"), TypeId::STRING),
+    ]);
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        checker.is_subtype_of(obj, mapped),
+        "an object literal must still satisfy `Record<any, any>` (positive control)"
+    );
+}
+
+#[test]
+fn empty_object_is_still_subtype_of_record_any_any() {
+    let interner = TypeInterner::new();
+    let mapped = any_constrained_mapped(&interner, TypeId::ANY);
+    let empty = interner.object(vec![]);
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        checker.is_subtype_of(empty, mapped),
+        "an empty object must still satisfy `Record<any, any>` (positive control)"
+    );
+}
+
+#[test]
+fn string_is_not_subtype_of_record_any_string_value() {
+    // Narrow the value type: `{ [P in any]: string }`. A primitive must still be
+    // rejected — the relation hinges on the source being a primitive, not on the
+    // index value type.
+    let interner = TypeInterner::new();
+    let mapped = any_constrained_mapped(&interner, TypeId::STRING);
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        !checker.is_subtype_of(TypeId::STRING, mapped),
+        "primitive `string` must not satisfy `{{ [P in any]: string }}`"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #14220 (mined from **zod** `v4/mini`). A primitive was wrongly accepted as
a subtype of `Record<any, any>`, so a `Normalize` conditional gated on
`T extends Record<…>` took the wrong branch and a later narrowed property access
diverged (false TS2339; `tsc` clean).

```ts
type RAny = string extends Record<any, any> ? 1 : 0;   // tsc: 0 — tsz before: 1 (wrong)
const a: RAny = 0;                                     // tsz before: TS2322
```

Root cause: `{ [P in any]: V }` — the shape of `Record<any, V>` /
`Record<PropertyKey, V>` — is structurally a pure index-signature object
(`{ [k: string]: V; [k: number]: V }`), but the evaluator intentionally keeps an
`any`-constrained mapped type **deferred** (it is not expanded to an index object)
to keep error-message display stable, so `object_with_index_shape_id` reports
`None` for it. In the apparent-primitive subtype dispatch the existing pure-index
guard only fired for targets that were *already* an `object_with_index` shape, so
the deferred mapped target slipped past it and fell through to the boxed-wrapper
fallback — where the registered `String`/`Number` wrapper structurally satisfies
the index signature, wrongly making `string extends Record<any, any>` true. (`number`
already rejected because its boxed wrapper missed the number-only deferred shape;
the fix makes both directions correct and tsc-faithful.)

## Structural rule

`When the source is an apparent primitive and the target is a deferred mapped
type that expands to a pure index-signature object, tsc rejects the relation (a
primitive has no index signature); tsz now expands the mapped target through the
canonical `try_expand_mapped` so the existing pure-index guard owns the decision,
exactly as it already does for the written-out `{ [k: string]: V }` form.`

## Owner layer

Solver — `crates/tsz-solver/src/relations/subtype/core_dispatch.rs`, the
apparent-primitive block of `check_subtype_inner_impl`. The normalization reuses
`try_expand_mapped` (the same helper `check_source_to_mapped_expansion` already
uses), and only retains the expansion when it yields an object / object-with-index
shape, so non-expandable generic mapped targets and Application targets (e.g.
`Iterable<string>`) are untouched. No change to the evaluation/display path.

## Adjacent-case matrix (verified vs `tsc`)

| Relation | tsc / tsz |
|---|---|
| `string extends Record<any, any>` | `false` (was wrongly `true`) |
| `string extends { [P in any]: any }` | `false` (was wrongly `true`) |
| `string extends Record<PropertyKey, any>` | `false` |
| `number` / `boolean extends Record<any, any>` | `false` |
| `string extends Record<string, any>` / `{ [k: string]: any }` | `false` (already) |
| `Record<any, any> = "str" \| 42 \| true` | TS2322 (primitive value rejected) |
| `Record<any, any> = { a: 1 }` / `{}` | accepted (object / empty object) |
| `"x".length`, `for (const c of "abc")` | accepted (boxed member access) |
| `Iterable<string> = "hi"`, `ArrayLike<string> = "abc"` | accepted (boxed heritage) |

Anti-hardcoding: the rule is purely structural (apparent-primitive source vs a
mapped target expanding to a pure index signature); no identifier/file-name string
drives it. Adjacent positive/negative and value-narrowed (`{ [P in any]: string }`)
cases are covered.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-solver --lib primitive_mapped_index_subtype` — 6 new tests pass (primitive/literal rejection, object/empty-object acceptance, value-narrowed rejection).
- `cargo test -p tsz-solver --lib subtype` (1305) / `mapped` (399) / `index` (582) — green; full `-p tsz-solver --lib` matches base (only 4 pre-existing unrelated failures, identical before and after this change).
- CLI: issue repro → 0 diagnostics; `Record = <primitive>` → 6× TS2322; boxed heritage/member-access controls clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_017JDsifh1aagBVVUdSvzgqC)_