### PR TITLE
fix(checker): defer TS2488 for a rest binding pattern typed by a deferred conditional

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1985,3 +1985,6 @@ path = "tests/partial_record_optional_index_assignability_tests.rs"
 [[test]]
 name = "function_type_predicate_typeof_param_tests"
 path = "tests/function_type_predicate_typeof_param_tests.rs"
+[[test]]
+name = "destructuring_deferred_conditional_iterability_tests"
+path = "tests/destructuring_deferred_conditional_iterability_tests.rs"

--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -1345,6 +1345,20 @@ impl<'a> CheckerState<'a> {
         // ES5 with `downlevelIteration=false` reads the numeric index signature
         // path, and that case is already handled above when `target.is_es5()`.
 
+        // Conditional/IndexAccess/Application types containing free type parameters
+        // cannot have iterability proven at the generic boundary — tsc defers TS2488
+        // to instantiation time for these deferred generic types. For a rest binding
+        // pattern typed by e.g. `{} extends T ? [a?: string] : [a: string]`, both
+        // branches are tuples, so no error is ever produced. Mirrors the guard in
+        // `check_spread_argument_iterability`.
+        if (common::is_conditional_type(self.ctx.types, resolved_type)
+            || common::is_index_access_type(self.ctx.types, resolved_type)
+            || common::is_generic_type(self.ctx.types, resolved_type))
+            && common::contains_free_type_parameters(self.ctx.types, resolved_type)
+        {
+            return true;
+        }
+
         // Not iterable - emit TS2488
         self.emit_ts2488_not_iterable(pattern_type, pattern_idx, is_assignment_array_target, None);
         false

--- a/crates/tsz-checker/tests/destructuring_deferred_conditional_iterability_tests.rs
+++ b/crates/tsz-checker/tests/destructuring_deferred_conditional_iterability_tests.rs
@@ -1,0 +1,65 @@
+//! Regression: a rest parameter with an array binding pattern typed by a
+//! *deferred* conditional (its `extends` operand is a free type parameter, both
+//! branches tuples) must not emit TS2488 — tsc defers iterability to
+//! instantiation. The destructuring iterability check lacked the deferred-generic
+//! guard that `check_spread_argument_iterability` already has.
+//!
+//! Owner: `crates/tsz-checker/src/checkers/iterable_checker.rs`.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn rest_binding_deferred_conditional_no_ts2488() {
+    let codes = codes(
+        r#"
+export class C<T extends object> {
+  constructor(...[opts]: {} extends T ? [a?: string] : [a: string]) {
+    void opts;
+  }
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2488),
+        "a deferred-conditional rest binding pattern must not emit TS2488; got {codes:?}"
+    );
+}
+
+#[test]
+fn rest_binding_deferred_conditional_function_no_ts2488() {
+    // Same defect outside a constructor, with a binder-name variation.
+    let codes = codes(
+        r#"
+declare function make<Value extends object>(
+  ...[config]: {} extends Value ? [c?: number] : [c: number]
+): void;
+"#,
+    );
+    assert!(
+        !codes.contains(&2488),
+        "a deferred-conditional rest binding pattern in a function must not emit TS2488; got {codes:?}"
+    );
+}
+
+#[test]
+fn genuinely_non_iterable_destructuring_still_ts2488() {
+    // Negative control: a concrete non-iterable type still emits TS2488.
+    let codes = codes(
+        r#"
+declare const o: object;
+const [a] = o;
+void a;
+"#,
+    );
+    assert!(
+        codes.contains(&2488),
+        "destructuring a non-iterable concrete type still emits TS2488; got {codes:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
A rest parameter using an array binding pattern (`...[opts]`) typed by a **deferred conditional** — one whose `extends` operand is a free type parameter and whose branches are tuples — wrongly emitted `TS2488` ("must have a `[Symbol.iterator]()` method"). tsc defers iterability to instantiation time for deferred generic types, so no error is produced.

Structural rule: When a destructuring target type is a conditional/indexed-access/application type containing free type parameters, tsc cannot prove iterability at the generic boundary and defers `TS2488` to instantiation. tsz now applies the same defer-guard in `check_destructuring_iterability` (`crates/tsz-checker/src/checkers/iterable_checker.rs`).

## Root cause
The sibling spread-argument path (`check_spread_argument_iterability`) already guards `(is_conditional_type || is_index_access_type || is_generic_type) && contains_free_type_parameters` and returns iterable. The destructuring path lacked this guard, so a deferred conditional fell through to the final `TS2488` emit. This mirrors the existing guard exactly.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test destructuring_deferred_conditional_iterability_tests` — 3 passed after merging `origin/main`.
- `git diff --check origin/main...HEAD`
- Behavioral coverage: constructor and function rest binding deferred conditionals produce no `TS2488`; concrete `object` destructuring still produces `TS2488`.

Discovered via a deeper-pass canary sweep on arktype (`ark/util/functions.ts`, `class Callable` constructor). Reduces false-positive churn (Fast-adjacent per #14102).

## Provenance
Machine: MacBookPro
Assistant: codex
Model: gpt-5
Effort: medium
