### PR TITLE
fix(solver): remove void union member when narrowing by an undefined discriminator (TS2322)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1495,6 +1495,9 @@ mod variadic_tuple_tail_arity_inference_tests;
 #[path = "../tests/void_param_optionality_tests.rs"]
 mod void_param_optionality_tests;
 #[cfg(test)]
+#[path = "tests/void_undefined_discriminant_narrowing_tests.rs"]
+mod void_undefined_discriminant_narrowing_tests;
+#[cfg(test)]
 #[path = "tests/zod_type_query_regression_tests.rs"]
 mod zod_type_query_regression_tests;
 

--- a/crates/tsz-checker/src/tests/void_undefined_discriminant_narrowing_tests.rs
+++ b/crates/tsz-checker/src/tests/void_undefined_discriminant_narrowing_tests.rs
@@ -1,0 +1,198 @@
+//! Narrowing a union containing `void` by an undefined discriminator must
+//! remove the `void` member, matching tsc's `NEUndefined`/`EQUndefined` type
+//! facts: `void`'s sole inhabitant is `undefined`, so `x !== undefined`
+//! (and `typeof x !== "undefined"`, plus the symmetric `=== undefined` false
+//! branch) discards it.
+//!
+//! Regression for es-toolkit (`isEqualWith.ts`): a `() => boolean | void`
+//! callback result narrowed by `if (result !== undefined)` wrongly kept
+//! `void`, yielding a spurious TS2322 against a `boolean` return target.
+//! Binder names are varied across cases per the anti-hardcoding gate.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(diagnostics: &[Diagnostic]) -> Vec<u32> {
+    diagnostics.iter().map(|d| d.code).collect()
+}
+
+/// Strict `!== undefined` removes `void` from `boolean | void`.
+#[test]
+fn strict_ne_undefined_removes_void() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+declare const probe: () => boolean | void;
+function decide(): boolean {
+    const outcome = probe();
+    if (outcome !== undefined) {
+        return outcome;
+    }
+    return false;
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "`outcome` should narrow to `boolean`, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// Loose `!= undefined` (which also strips `null`) removes `void`.
+#[test]
+fn loose_ne_undefined_removes_void() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+declare const fetchFlag: () => boolean | void;
+function resolve(): boolean {
+    const flag = fetchFlag();
+    if (flag != undefined) {
+        return flag;
+    }
+    return true;
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "`flag` should narrow to `boolean`, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// `typeof x !== "undefined"` removes `void`.
+#[test]
+fn typeof_ne_undefined_removes_void() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+declare const compute: () => boolean | void;
+function pick(): boolean {
+    const value = compute();
+    if (typeof value !== "undefined") {
+        return value;
+    }
+    return false;
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "`value` should narrow to `boolean`, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// The symmetric `=== undefined` false branch removes `void`.
+#[test]
+fn eq_undefined_false_branch_removes_void() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+declare const gather: () => boolean | void;
+function evaluate(): boolean {
+    const collected = gather();
+    if (collected === undefined) {
+        return false;
+    }
+    return collected;
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "`collected` should narrow to `boolean`, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// Yoda form `undefined !== x` removes `void` too.
+#[test]
+fn yoda_ne_undefined_removes_void() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+declare const sample: () => boolean | void;
+function judge(): boolean {
+    const item = sample();
+    if (undefined !== item) {
+        return item;
+    }
+    return false;
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "`item` should narrow to `boolean`, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// The positive `=== undefined` branch keeps `void` (dual of the exclusion).
+#[test]
+fn eq_undefined_true_branch_keeps_void() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+declare const observe: () => boolean | void;
+function inspect(): void {
+    const reading = observe();
+    if (reading === undefined) {
+        const captured: void = reading;
+        return captured;
+    }
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "positive branch should keep `void`, got {:?}",
+        codes(&diagnostics)
+    );
+}
+
+/// Without a narrowing guard, the `void` member still triggers TS2322 — the
+/// fix must not introduce a false negative.
+#[test]
+fn unnarrowed_void_still_reports_ts2322() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+declare const yield_: () => boolean | void;
+function passthrough(): boolean {
+    const carried = yield_();
+    return carried;
+}
+"#,
+    );
+    assert_eq!(
+        codes(&diagnostics),
+        vec![2322],
+        "unnarrowed `boolean | void` must still fail against `boolean`"
+    );
+}
+
+/// Excluding a non-`undefined` type must not drop `void`.
+#[test]
+fn non_undefined_exclusion_keeps_void() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+declare const produce: () => boolean | void;
+function route(): boolean | void {
+    const slot = produce();
+    if (typeof slot === "boolean") {
+        return slot;
+    }
+    return slot;
+}
+"#,
+    );
+    assert_eq!(
+        diagnostics.len(),
+        0,
+        "non-undefined exclusion should keep `void`, got {:?}",
+        codes(&diagnostics)
+    );
+}

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -1772,7 +1772,7 @@ impl<'a> NarrowingContext<'a> {
                             .narrow_excluding_type(member, excluded_type)
                             .non_never();
                     }
-                    if self.is_assignable_to(member, excluded_type) {
+                    if self.member_excluded_by(member, excluded_type) {
                         None
                     } else {
                         Some(member)
@@ -1846,11 +1846,29 @@ impl<'a> NarrowingContext<'a> {
         }
 
         // If source is assignable to excluded, return never
-        if self.is_assignable_to(source_type, excluded_type) {
+        if self.member_excluded_by(source_type, excluded_type) {
             TypeId::NEVER
         } else {
             source_type
         }
+    }
+
+    /// Whether `member` is removed when narrowing `source` by excluding
+    /// `excluded_type` (e.g. the true branch of `x !== undefined`).
+    ///
+    /// Beyond ordinary assignability, `void`'s sole inhabitant is `undefined`,
+    /// so excluding `undefined` removes a `void` member. This mirrors tsc's
+    /// `NEUndefined`/`EQUndefined` type facts, where `void` carries
+    /// `EQUndefined` but not `NEUndefined`: a `void` value can equal
+    /// `undefined`, so `x !== undefined` (and `typeof x !== "undefined"`, plus
+    /// the symmetric `=== undefined` false branch) discards it. Without this,
+    /// `boolean | void` stays `boolean | void` after `x !== undefined`,
+    /// producing a spurious TS2322 against a `boolean` target.
+    fn member_excluded_by(&self, member: TypeId, excluded_type: TypeId) -> bool {
+        if excluded_type == TypeId::UNDEFINED && member == TypeId::VOID {
+            return true;
+        }
+        self.is_assignable_to(member, excluded_type)
     }
 
     /// Narrow a type by excluding multiple types at once (batched version).
@@ -1917,9 +1935,10 @@ impl<'a> NarrowingContext<'a> {
 
                     // Slow path: check assignability for complex cases
                     // This handles cases where the member isn't identical to an excluded type
-                    // but might still be assignable to one (e.g., literal subtypes)
+                    // but might still be assignable to one (e.g., literal subtypes), and the
+                    // `void`-vs-`undefined` exclusion (see `member_excluded_by`).
                     for &excluded in &excluded_set {
-                        if self.is_assignable_to(member, excluded) {
+                        if self.member_excluded_by(member, excluded) {
                             return None;
                         }
                     }
@@ -1942,7 +1961,7 @@ impl<'a> NarrowingContext<'a> {
 
         // Check assignability for single type
         for &excluded in &excluded_set {
-            if self.is_assignable_to(source_type, excluded) {
+            if self.member_excluded_by(source_type, excluded) {
                 return TypeId::NEVER;
             }
         }


### PR DESCRIPTION
## Summary

Fixes #14316. Mined from **es-toolkit** (`isEqualWith.ts`): tsz emitted a spurious **TS2322** where tsc is clean when a union containing `void` is narrowed by an undefined discriminator.

```ts
declare const cb: () => boolean | void;
function f(): boolean {
  const result = cb();
  if (result !== undefined) { return result; }  // was: TS2322 'boolean | void' not assignable to 'boolean'
  return false;
}
```

## Structural rule

When a union containing a `void` member is narrowed by an undefined discriminator, `tsc` removes `void` because its only inhabitant is `undefined` (the `NEUndefined`/`EQUndefined` type facts: `void` carries `EQUndefined` but not `NEUndefined`). tsz keeps `void` because `is_assignable_to(void, undefined)` is `false`, so the exclusion filter never drops it, leaving `boolean | void` after the guard.

`When a union member is `void` and the excluded type is `undefined`, tsc narrows it away; tsz now does the same through the solver narrowing exclusion gateway.`

## Owner layer

Solver narrowing — `crates/tsz-solver/src/narrowing/core.rs`. The exclusion predicate is centralized in a new `member_excluded_by` helper, and all four union/non-union exclusion filters in `narrow_excluding_type` and the batched `narrow_excluding_types` route through it. The dual `=== undefined` **positive** branch is unaffected (it keeps `void` via `is_assignable_to`).

## Adjacent matrix

- Strict `!== undefined`, loose `!= undefined` (also strips `null`), `typeof x !== "undefined"`, symmetric `=== undefined` false branch, and yoda `undefined !== x` — all drop `void`.
- Positive `=== undefined` true branch **keeps** `void` (dual preserved).
- Un-narrowed `boolean | void` still reports TS2322 (no false negative introduced).
- Excluding a non-`undefined` type keeps `void`.
- Binder names varied across the eight regression tests per the anti-hardcoding gate.

## Verification

- New `crates/tsz-checker/src/tests/void_undefined_discriminant_narrowing_tests.rs` (8 cases): `cargo test -p tsz-checker --lib void_undefined_discriminant` → 8 passed.
- Repro `tsz --noEmit` on the witness and all adjacent forms: clean; un-narrowed case still TS2322.
- Full `cargo test -p tsz-solver --lib` and checker narrowing suites: no new failures versus the pre-change baseline (the handful of failures present are pre-existing in this sandbox and identical with/without the change).
- ready-review CI owns the broad conformance/emit/fourslash suites.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4
Effort: high

https://claude.ai/code/session_017jA6eQi2iog6hTaBEGL7GE

---
_Generated by [Claude Code](https://claude.ai/code/session_017jA6eQi2iog6hTaBEGL7GE)_