### PR TITLE
fix(solver): structural constructor-narrowing matches tsc (TS2407/TS2698/TS2578)

### DIFF
--- a/crates/tsz-solver/src/narrowing/instanceof.rs
+++ b/crates/tsz-solver/src/narrowing/instanceof.rs
@@ -1001,28 +1001,126 @@ impl<'a> NarrowingContext<'a> {
         )
         .entered();
 
+        let resolved_instance = self.resolve_type(instance_type);
+
+        // tsc's `narrowTypeByConstructor` does NOT narrow when the constructor's
+        // prototype/instance type is the global `Object` or `Function` interface
+        // (every value's `.constructor` could legitimately be `Object`/`Function`).
+        // `({} as T).constructor === Object` therefore keeps `T` for every `T`,
+        // including primitives and nominal-class union members.
+        if self.is_global_object_or_function_instance(resolved_instance) {
+            return source_type;
+        }
+
+        // For `any` / `unknown` sources every type is a subtype of the source,
+        // so the result is exactly the constructor's instance type.
         if source_type == TypeId::ANY || source_type == TypeId::UNKNOWN {
             return instance_type;
         }
-
-        let resolved_instance = self.resolve_type(instance_type);
 
         if let Some(members_list) = union_list_id(self.db, source_type) {
             let members = self.db.type_list(members_list);
             let matching: Vec<TypeId> = members
                 .iter()
                 .copied()
-                .filter(|&m| self.types_match_nominally(m, instance_type, resolved_instance))
+                .filter(|&m| self.constructor_member_retained(m, instance_type, resolved_instance))
                 .collect();
             trace!(matched = matching.len(), total = members.len());
             return super::union_or_single_preserve(self.db, matching);
         }
 
-        if self.types_match_nominally(source_type, instance_type, resolved_instance) {
+        if self.constructor_member_retained(source_type, instance_type, resolved_instance) {
             source_type
         } else {
             TypeId::NEVER
         }
+    }
+
+    /// Is `resolved_instance` the global `Object` or `Function` interface?
+    ///
+    /// Mirrors the `candidate === globalObjectType || candidate === globalFunctionType`
+    /// short-circuit in tsc's `narrowTypeByConstructor`, which disables
+    /// constructor-identity narrowing because those constructors match any value.
+    ///
+    /// Uses the **identity** tier of the boxed-type registry exclusively (tsc
+    /// compares `candidate` by reference identity). The structural shape
+    /// fallback is intentionally avoided here: an interface like `Array` carries
+    /// `Object`'s members and could trip a member-name sniff, which would
+    /// wrongly disable `=== Array` narrowing.
+    fn is_global_object_or_function_instance(&self, resolved_instance: TypeId) -> bool {
+        let db = self.db.as_type_database();
+        if let Some(resolver) = self.resolver {
+            crate::type_queries::is_global_interface_by_identity_with_resolver(
+                db,
+                resolver,
+                resolved_instance,
+                crate::types::IntrinsicKind::Object,
+            ) || crate::type_queries::is_global_interface_by_identity_with_resolver(
+                db,
+                resolver,
+                resolved_instance,
+                crate::types::IntrinsicKind::Function,
+            )
+        } else {
+            crate::type_queries::is_global_interface_by_identity(
+                db,
+                resolved_instance,
+                crate::types::IntrinsicKind::Object,
+            ) || crate::type_queries::is_global_interface_by_identity(
+                db,
+                resolved_instance,
+                crate::types::IntrinsicKind::Function,
+            )
+        }
+    }
+
+    /// Decide whether a single source type (or union member) survives a
+    /// `x.constructor === Ctor` true-branch narrowing, mirroring tsc's
+    /// `isConstructedBy`.
+    ///
+    /// - **When either the member or the constructor's instance type is a
+    ///   nominal class** (`class C {}`), `tsc` requires exact constructor
+    ///   identity (`source.symbol === target.symbol`). `Dog.constructor === Animal`
+    ///   is `false` even though `Dog extends Animal`, so we narrow by exact
+    ///   nominal match ([`Self::types_match_nominally`]); a non-match drops the
+    ///   member (the single-source case narrows to `never`).
+    /// - **Otherwise** (object literals, `{}`, `object`, interfaces, and
+    ///   primitives — none of which carry a class-private constructor identity),
+    ///   `tsc` keeps the member iff it is a subtype of the constructor's instance
+    ///   type (e.g. `=== Array` keeps `number[]` but drops `{}` and `number`).
+    ///
+    /// The nominal/structural split is driven purely by binder-backed
+    /// [`Self::get_class_def_id`] (a `DefKind::Class` check), never by names or
+    /// printed shapes.
+    fn constructor_member_retained(
+        &self,
+        member: TypeId,
+        instance_type: TypeId,
+        resolved_instance: TypeId,
+    ) -> bool {
+        // If either side is a nominal class, use exact constructor identity.
+        // This keeps `Dog.constructor === Animal` narrowing to `never` and
+        // discriminates `A | B` unions by the exact constructor.
+        if self.get_class_def_id(member).is_some() || self.get_class_def_id(instance_type).is_some()
+        {
+            return self.types_match_nominally(member, instance_type, resolved_instance);
+        }
+
+        // Exact-identity fast path also covers a structural source whose
+        // instance type happens to be the same interned type.
+        if self.types_match_nominally(member, instance_type, resolved_instance) {
+            return true;
+        }
+
+        // Structural sources (interfaces, `{}`, `object`, anonymous objects,
+        // and primitives) have no private constructor identity. `tsc` keeps the
+        // source iff it is a subtype of the constructor's instance type.
+        let resolved_member = self.resolve_type(member);
+        crate::relations::subtype::is_subtype_of_with_db(
+            self.db,
+            resolved_member,
+            resolved_instance,
+        )
     }
 
     /// Narrow by `x.constructor !== SomeClass` (false branch).

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs
@@ -479,6 +479,68 @@ fn test_constructor_identity_false_branch_does_not_exclude_instance() {
     );
 }
 
+#[test]
+fn test_constructor_identity_keeps_structural_subtype_source() {
+    // `x.constructor === Ctor` true-branch: a structural (non-class) source
+    // that is a subtype of the constructor's instance type must be preserved,
+    // not narrowed to `never`. Mirrors tsc's `isConstructedBy` falling through
+    // to `isTypeSubtypeOf` for non-class types (e.g. `({a}).constructor === C`
+    // where the source already matches `C`'s instance shape).
+    let interner = TypeInterner::new();
+    let a = interner.intern_string("a");
+    let b = interner.intern_string("b");
+
+    // instance shape: { a: number }
+    let instance = interner.object(vec![PropertyInfo::new(a, TypeId::NUMBER)]);
+    // source: { a: number, b: string } <: { a: number }
+    let source = interner.object(vec![
+        PropertyInfo::new(a, TypeId::NUMBER),
+        PropertyInfo::new(b, TypeId::STRING),
+    ]);
+    let ctx = NarrowingContext::new(&interner);
+
+    let narrowed = ctx.narrow_type(
+        source,
+        &TypeGuard::Constructor(instance),
+        GuardSense::Positive,
+    );
+
+    assert_eq!(
+        narrowed, source,
+        "structural source that is a subtype of the constructor instance type \
+         must be preserved, not narrowed to `never`"
+    );
+}
+
+#[test]
+fn test_constructor_identity_drops_structural_non_subtype_source() {
+    // A structural source that is NOT a subtype of the instance type narrows to
+    // `never` (e.g. a disjoint object shape). This preserves the `never` outcome
+    // for cases like `({} as {}).constructor === Array`.
+    let interner = TypeInterner::new();
+    let a = interner.intern_string("a");
+    let req = interner.intern_string("required");
+
+    // instance shape requires `required: number`
+    let instance = interner.object(vec![PropertyInfo::new(req, TypeId::NUMBER)]);
+    // source lacks `required`, so `source` is not a subtype of `instance`.
+    let source = interner.object(vec![PropertyInfo::new(a, TypeId::STRING)]);
+    let ctx = NarrowingContext::new(&interner);
+
+    let narrowed = ctx.narrow_type(
+        source,
+        &TypeGuard::Constructor(instance),
+        GuardSense::Positive,
+    );
+
+    assert_eq!(
+        narrowed,
+        TypeId::NEVER,
+        "structural source that is not a subtype of the constructor instance \
+         type narrows to `never`"
+    );
+}
+
 // =============================================================================
 // Typeof Narrowing Tests
 // =============================================================================


### PR DESCRIPTION
Goal: green

Clears false **TS2407/TS2698/TS2578** where `x.constructor === Object` (or any constructor comparison) narrows a structural source to `never`.

## Structural rule
Grounded in tsc's `narrowTypeByConstructor`: in the `x.constructor === Ctor` true branch, if `Ctor`'s instance type is the global `Object`/`Function`, keep the source unchanged; otherwise, for each source/union member, require exact nominal identity **only** when either it or the instance type is a nominal class (`DefKind::Class`), else keep it iff it is a subtype of the instance type. tsz previously used exact nominal identity for *all* sources, narrowing a structural `{}`/`object`/interface to `never` (so a later `{...x}` spread → TS2698, `for (const k in x)` → TS2407). Adds `is_global_object_or_function_instance` (identity-tier registry check, not a structural shape sniff that would mis-fire on `Array`) + `constructor_member_retained` (structural arm reuses `is_subtype_of_with_db`). Anti-hardcoding-clean.

## Adjacent matrix
- `(x:{})/(x:object) if (x.constructor===Object) { for (k in x) }` → clean (was TS2407); `{...value1}` spread idiom clean.
- `interface Foo{a} (x:Foo) if (x.constructor===Object) { const p:1=x }` → now emits TS2322 (keeps `Foo`), matching tsc.
- **Negatives (parity-matched):** `class A|B` `===A` → keeps `A` (nominal); `{}`/`{a:number}`/primitive `===Array` → `never`; subclass `Dog` `===Animal` → `never`.

## Verification
- Repro + all negatives tsc-parity; `--lib narrow` 323/324, `narrowing::` 199/200, `instanceof` 23/23, `constructor` 185/185 — the 1 failure (`array_isarray_keeps_mutable_and_readonly_array_members`) is pre-existing on clean main (untouched `Array.isArray` path); zero new failures; +2 locking tests. clippy clean, warn-ratchet 0 hits.
- (valibot's row itself times out — deep-perf — so this is a general constructor-narrowing parity fix, not a row win.)

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
