### PR TITLE
fix(checker): seed typeof-param scope for function-type predicate signatures (TS2304) (#14229)

### DIFF
--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -1077,40 +1077,6 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             param_type
         };
 
-        // The asserted type and the parameter type can each be an alias head: a
-        // `Lazy(DefId)` alias reference or an unevaluated `Application` such as
-        // `Alias<T> = keyof T`. Left unresolved, the relation below compares two
-        // opaque heads and fails even when the alias bodies are assignable, which
-        // surfaces as a false `TS2677`. Resolve both through the environment
-        // (lazy-def resolve + application evaluate) before the relation, mirroring
-        // the index-signature-key resolution pattern used elsewhere in this file.
-        let resolved_predicate = {
-            let env = self.ctx.type_environment.borrow();
-            let lazy_resolved = crate::query_boundaries::flow::resolve_lazy_def_with_env(
-                self.ctx.types,
-                Some(&env),
-                resolved_predicate,
-            );
-            crate::query_boundaries::flow_analysis::evaluate_application_type(
-                self.ctx.types,
-                &env,
-                lazy_resolved,
-            )
-        };
-        let resolved_param = {
-            let env = self.ctx.type_environment.borrow();
-            let lazy_resolved = crate::query_boundaries::flow::resolve_lazy_def_with_env(
-                self.ctx.types,
-                Some(&env),
-                resolved_param,
-            );
-            crate::query_boundaries::flow_analysis::evaluate_application_type(
-                self.ctx.types,
-                &env,
-                lazy_resolved,
-            )
-        };
-
         let types = self.ctx.types;
         if !crate::query_boundaries::type_predicates::type_predicate_type_assignability_outcome(
             types,

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -868,10 +868,42 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         // union/intersection contexts) to match tsc's parser-level detection.
         self.check_nested_function_types_in_type(func_data.type_annotation);
 
+        // A signature's value parameters are in scope for every type position of
+        // that signature, including a type-predicate's asserted type. Seed
+        // `typeof_param_scope` from this function type's value parameters so that
+        // `typeof param` inside the asserted type (e.g.
+        // `type Guard = (a: { z: string }) => a is typeof a & { y: boolean }`)
+        // resolves to the parameter's declared type instead of fabricating a
+        // false `TS2304` during lowering. This mirrors
+        // `resolve_return_type_with_params_in_scope`, which seeds the scope when
+        // lowering an ordinary return-type annotation; the predicate's asserted
+        // type is just another type position of the same signature. The `this`
+        // parameter is skipped (its name node is not an identifier, so it is
+        // naturally excluded).
+        let mut seeded_typeof_params: Vec<(String, NodeIndex)> = Vec::new();
+        for &param_idx in &func_data.parameters.nodes {
+            if let Some(param_node) = self.ctx.arena.get(param_idx)
+                && let Some(param_data) = self.ctx.arena.get_parameter(param_node)
+                && param_data.type_annotation.is_some()
+                && let Some(name) = self.ctx.arena.get_identifier_text(param_data.name)
+                && name != "this"
+            {
+                seeded_typeof_params.push((name.to_string(), param_data.type_annotation));
+            }
+        }
+        for (name, annotation) in &seeded_typeof_params {
+            let param_type = self.check(*annotation);
+            self.ctx.typeof_param_scope.insert(name.clone(), param_type);
+        }
+
         // Delegate to TypeLowering with standard resolvers.
         // Enable qualified name resolution so return types like `Ns.Type<T>`
         // resolve correctly (QUALIFIED_NAME nodes need the extended resolver).
         let result = self.lower_with_resolvers(idx, true, true);
+
+        for (name, _) in &seeded_typeof_params {
+            self.ctx.typeof_param_scope.remove(name);
+        }
 
         // TS2677: Check that a type predicate's type is assignable to its parameter's type.
         self.check_type_predicate_assignability(idx, func_data.type_annotation, result);
@@ -1043,6 +1075,40 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             }
         } else {
             param_type
+        };
+
+        // The asserted type and the parameter type can each be an alias head: a
+        // `Lazy(DefId)` alias reference or an unevaluated `Application` such as
+        // `Alias<T> = keyof T`. Left unresolved, the relation below compares two
+        // opaque heads and fails even when the alias bodies are assignable, which
+        // surfaces as a false `TS2677`. Resolve both through the environment
+        // (lazy-def resolve + application evaluate) before the relation, mirroring
+        // the index-signature-key resolution pattern used elsewhere in this file.
+        let resolved_predicate = {
+            let env = self.ctx.type_environment.borrow();
+            let lazy_resolved = crate::query_boundaries::flow::resolve_lazy_def_with_env(
+                self.ctx.types,
+                Some(&env),
+                resolved_predicate,
+            );
+            crate::query_boundaries::flow_analysis::evaluate_application_type(
+                self.ctx.types,
+                &env,
+                lazy_resolved,
+            )
+        };
+        let resolved_param = {
+            let env = self.ctx.type_environment.borrow();
+            let lazy_resolved = crate::query_boundaries::flow::resolve_lazy_def_with_env(
+                self.ctx.types,
+                Some(&env),
+                resolved_param,
+            );
+            crate::query_boundaries::flow_analysis::evaluate_application_type(
+                self.ctx.types,
+                &env,
+                lazy_resolved,
+            )
         };
 
         let types = self.ctx.types;

--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -9,4 +9,5 @@ mod indexed_access;
 mod membership_semantics;
 mod narrowing;
 mod optional_chain;
+mod predicate_alias_typeof_2677_2304;
 mod spread_param_constraint_2345;

--- a/crates/tsz-checker/tests/conformance_issues/types/predicate_alias_typeof_2677_2304.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/predicate_alias_typeof_2677_2304.rs
@@ -1,44 +1,9 @@
-//! Type-predicate signatures in function-type position must resolve the same way
-//! tsc resolves them: (1) an alias-typed predicate parameter is expanded before
-//! the predicate-assignability relation (TS2677), and (2) the signature's value
-//! parameters are in scope for `typeof <param>` in the predicate's asserted type
-//! (TS2304). Both were false positives in `tsz`. (#14231, #14229)
+//! A type-predicate signature's value parameters are in scope for every type
+//! position of that signature, including a `typeof <param>` inside the
+//! predicate's asserted type. `tsz` failed to seed the parameter scope before
+//! lowering the function-type node, so `typeof a` reported a false TS2304. (#14229)
 
 use super::super::core::*;
-
-/// #14231 (TS2677): when a type predicate's parameter type is an alias head
-/// (`Alias<T> = keyof T`), the predicate-assignability relation must run on the
-/// resolved alias body, not the opaque `Lazy`/`Application` reference. `tsz`
-/// previously related the unresolved head and wrongly reported TS2677.
-#[test]
-fn type_predicate_through_alias_no_ts2677() {
-    let diagnostics = compile_and_get_diagnostics(
-        r#"
-type Alias<T> = keyof T;
-let g: <T>(p: Alias<T>) => p is keyof T;
-type A = string;
-let g2: (p: A) => p is string;
-export {};
-"#,
-    );
-    assert!(
-        !has_error(&diagnostics, 2677),
-        "no TS2677 expected — the alias-typed predicate parameter must be resolved \
-         before the predicate-assignability relation. Actual: {diagnostics:#?}"
-    );
-    // Negative control: a predicate that genuinely doesn't assign must still error.
-    let neg = compile_and_get_diagnostics(
-        r#"
-let g3: (p: string) => p is number;
-export {};
-"#,
-    );
-    assert!(
-        has_error(&neg, 2677),
-        "TS2677 expected — `p is number` is not assignable to `p: string`. \
-         Actual: {neg:#?}"
-    );
-}
 
 /// #14229 (TS2304): `typeof <param>` inside a function-type alias's type-predicate
 /// asserted type must resolve the parameter, which is in scope for every type

--- a/crates/tsz-checker/tests/conformance_issues/types/predicate_alias_typeof_2677_2304.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/predicate_alias_typeof_2677_2304.rs
@@ -1,0 +1,72 @@
+//! Type-predicate signatures in function-type position must resolve the same way
+//! tsc resolves them: (1) an alias-typed predicate parameter is expanded before
+//! the predicate-assignability relation (TS2677), and (2) the signature's value
+//! parameters are in scope for `typeof <param>` in the predicate's asserted type
+//! (TS2304). Both were false positives in `tsz`. (#14231, #14229)
+
+use super::super::core::*;
+
+/// #14231 (TS2677): when a type predicate's parameter type is an alias head
+/// (`Alias<T> = keyof T`), the predicate-assignability relation must run on the
+/// resolved alias body, not the opaque `Lazy`/`Application` reference. `tsz`
+/// previously related the unresolved head and wrongly reported TS2677.
+#[test]
+fn type_predicate_through_alias_no_ts2677() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type Alias<T> = keyof T;
+let g: <T>(p: Alias<T>) => p is keyof T;
+type A = string;
+let g2: (p: A) => p is string;
+export {};
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2677),
+        "no TS2677 expected — the alias-typed predicate parameter must be resolved \
+         before the predicate-assignability relation. Actual: {diagnostics:#?}"
+    );
+    // Negative control: a predicate that genuinely doesn't assign must still error.
+    let neg = compile_and_get_diagnostics(
+        r#"
+let g3: (p: string) => p is number;
+export {};
+"#,
+    );
+    assert!(
+        has_error(&neg, 2677),
+        "TS2677 expected — `p is number` is not assignable to `p: string`. \
+         Actual: {neg:#?}"
+    );
+}
+
+/// #14229 (TS2304): `typeof <param>` inside a function-type alias's type-predicate
+/// asserted type must resolve the parameter, which is in scope for every type
+/// position of the signature. `tsz` failed to seed the parameter scope before
+/// lowering the function-type node, so `typeof a` reported a false TS2304.
+#[test]
+fn typeof_param_in_predicate_asserted_type_no_ts2304() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type Guard = (a: { z: string }) => a is typeof a & { y: boolean };
+export {};
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2304),
+        "no TS2304 expected — the signature's value parameter `a` is in scope for \
+         the predicate's asserted type (`typeof a`). Actual: {diagnostics:#?}"
+    );
+    // Negative control: an undeclared name in the asserted type must still error.
+    let neg = compile_and_get_diagnostics(
+        r#"
+type Guard2 = (a: { z: string }) => a is typeof undeclared & { y: boolean };
+export {};
+"#,
+    );
+    assert!(
+        has_error(&neg, 2304),
+        "TS2304 expected — `typeof undeclared` references an undeclared name. \
+         Actual: {neg:#?}"
+    );
+}


### PR DESCRIPTION
Fixes a green-goal false positive (TS2304). Contained, additive checker-side
scope-seeding.

Goal: green

## Structural rule
A signature's value parameters are in scope for every type position of that
signature, including a type predicate's asserted type. `get_type_from_function_type`
lowered the function-type node without seeding `typeof_param_scope`, so `typeof a`
in `type Guard = (a: { z: string }) => a is typeof a & { y: boolean }` could not
resolve `a` and reported a false TS2304. The fix seeds the parameter scope
(name -> type) before lowering and removes it after — mirroring
`resolve_return_type_with_params_in_scope` for real signatures. An undeclared name
(`typeof undeclared`) still errors.

Owner: checker — `types/type_node.rs`.

(NOTE: this PR originally also carried a #14231 alias-resolution change; that was
reverted because it regressed `strictSubtypeAndNarrowing` / `styledComponents`
conformance — the contained #14229 scope-seeding is kept.)

## Verification
- `cargo nextest run -p tsz-checker -j 2 typeof_param_in_predicate` — flip +
  negative control green.
- CI gates: lint, unit-checker-integration, conformance-aggregate, emit-aggregate,
  fourslash-*, project-compile-guard, CI Summary.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max