### PR TITLE
fix(checker): recognize readonly arrays and array-constrained generics as ES5-iterable (false TS2802)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1985,3 +1985,6 @@ path = "tests/partial_record_optional_index_assignability_tests.rs"
 [[test]]
 name = "function_type_predicate_typeof_param_tests"
 path = "tests/function_type_predicate_typeof_param_tests.rs"
+[[test]]
+name = "es5_constrained_generic_array_iterability_tests"
+path = "tests/es5_constrained_generic_array_iterability_tests.rs"

--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -1038,7 +1038,9 @@ impl<'a> CheckerState<'a> {
         //   type is not array-like (TSC strips strings from union before checking array-likeness).
         // - Emit TS2495 if the type is neither an array nor a string (not iterable at all).
         if self.requires_array_like_iteration_for_es5_target() {
-            if self.is_array_or_tuple_or_string(expr_type) {
+            if self.is_array_or_tuple_or_string(expr_type)
+                || self.es5_constrained_generic_is_array_like(expr_type)
+            {
                 return true;
             }
             // Mirror TSC's logic: strip string-like members from union types.
@@ -1076,6 +1078,41 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Extra ES5 array-like recognition for the iterability checks: a **readonly**
+    /// array (`readonly T[]` / `ReadonlyArray<T>`) iterates as an array in ES5 —
+    /// no `--downlevelIteration` is needed — and a generic type parameter
+    /// constrained to an array/tuple (e.g. `A extends ReadonlyArray<number>`)
+    /// does too, so tsc emits no TS2802 for either. `is_array_or_tuple_type` does
+    /// not see readonly arrays or a parameter's apparent type, so check the
+    /// element type (which resolves readonly/array/tuple) and follow a type
+    /// parameter to its constraint.
+    fn es5_constrained_generic_is_array_like(&mut self, type_id: TypeId) -> bool {
+        let mut t = self.resolve_lazy_type(type_id);
+        let mut hops = 0;
+        loop {
+            if self.is_array_or_tuple_type(t)
+                || crate::query_boundaries::type_computation::complex::is_readonly_type(
+                    self.ctx.types,
+                    t,
+                )
+            {
+                return true;
+            }
+            hops += 1;
+            if hops > 16 {
+                return false;
+            }
+            let Some(constraint) = common::type_parameter_constraint(self.ctx.types, t) else {
+                return false;
+            };
+            let resolved = self.resolve_lazy_type(constraint);
+            if resolved == t {
+                return false;
+            }
+            t = resolved;
+        }
+    }
+
     /// Check iterability of a spread argument and emit TS2488 if not iterable.
     ///
     /// Used for spread in array literals and function call arguments.
@@ -1088,6 +1125,9 @@ impl<'a> CheckerState<'a> {
                 return true;
             }
 
+            if self.es5_constrained_generic_is_array_like(spread_type) {
+                return true;
+            }
             let resolved = self.resolve_lazy_type(spread_type);
             if self.is_array_or_tuple_type(resolved) || self.has_numeric_index_signature(resolved) {
                 return true;
@@ -1295,7 +1335,9 @@ impl<'a> CheckerState<'a> {
             {
                 return true;
             }
-            if self.is_array_or_tuple_type(resolved_type) {
+            if self.is_array_or_tuple_type(resolved_type)
+                || self.es5_constrained_generic_is_array_like(resolved_type)
+            {
                 return true;
             }
             // Destructuring never uses the "or a string type" variant (allows_strings = false).

--- a/crates/tsz-checker/tests/es5_constrained_generic_array_iterability_tests.rs
+++ b/crates/tsz-checker/tests/es5_constrained_generic_array_iterability_tests.rs
@@ -1,0 +1,77 @@
+//! Regression: under an ES5 target, iterating/spreading a **readonly** array
+//! (`readonly T[]` / `ReadonlyArray<T>`) or a generic type parameter constrained
+//! to an array/tuple/readonly-array must not emit TS2802 — these iterate as
+//! arrays in ES5 (no `--downlevelIteration` needed), matching tsc. The ES5
+//! array-like iterability checks recognized neither readonly arrays nor a type
+//! parameter's apparent type.
+//!
+//! Owner: `crates/tsz-checker/src/checkers/iterable_checker.rs`.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs, load_default_lib_files};
+use tsz_common::common::ScriptTarget;
+
+fn es5_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES5,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+#[test]
+fn es5_iterate_generic_constrained_to_readonly_array_no_ts2802() {
+    let codes = es5_codes(
+        r#"
+function iterate<A extends ReadonlyArray<number>>(a: A): number[] {
+  for (const v of a) { v.toFixed(); }
+  return [...a];
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2802),
+        "iterating a generic constrained to ReadonlyArray must not emit TS2802 in ES5; got {codes:?}"
+    );
+}
+
+#[test]
+fn es5_iterate_concrete_readonly_array_no_ts2802() {
+    let codes = es5_codes(
+        r#"
+function f(a: readonly number[], b: ReadonlyArray<string>) {
+  for (const x of a) { x.toFixed(); }
+  return [...b];
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2802),
+        "iterating a concrete readonly array must not emit TS2802 in ES5; got {codes:?}"
+    );
+}
+
+#[test]
+fn es5_iterate_generic_constrained_to_tuple_no_ts2802() {
+    let codes = es5_codes(
+        r#"
+function g<Items extends [number, string]>(items: Items) {
+  for (const v of items) { void v; }
+  return [...items];
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2802),
+        "iterating a generic constrained to a tuple must not emit TS2802 in ES5; got {codes:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
Under an ES5 target, iterating or spreading a **readonly array** (`readonly T[]`, `ReadonlyArray<T>`) or a **generic type parameter constrained to an array/tuple/readonly-array** (`A extends ReadonlyArray<number>`) wrongly emitted `TS2802` ("can only be iterated through when using `--downlevelIteration` or `--target es2015`"). These iterate as plain arrays in ES5, so tsc emits nothing.

Structural rule: When the ES5 array-like iterability check sees a readonly array, or a type parameter whose apparent type (constraint, transitively) is an array/tuple/readonly-array, the value is array-iterable in ES5 and no `TS2802` is warranted. tsz now recognizes both in `iterable_checker.rs` (for-of, spread, and array-destructuring paths).

## Root cause
`is_array_or_tuple_type` matches only `TypeData::Array`/tuple, so it missed readonly arrays (`TypeData::ReadonlyType`) and never resolved a type parameter's constraint. The new `es5_constrained_generic_is_array_like` helper resolves a parameter to its constraint and accepts arrays/tuples plus `is_readonly_type` (strict — readonly arrays/tuples only, never `Set`/custom iterables); it is added as a purely additive early-out in the three ES5 paths, so non-array types still emit `TS2802`.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test es5_constrained_generic_array_iterability_tests` — 3 passed. Previous branch evidence showed all three fail on main (`got [2802, 2802]`) and pass with the fix.
- CLI: `A extends ReadonlyArray<number>` for-of/spread, concrete `readonly number[]`/`ReadonlyArray<string>`, and `Items extends [number, string]` are now clean under `--target es5 --lib es2015`; a genuinely non-array constraint still errors.

Discovered via a deeper-pass canary sweep on io-ts (12 `TS2802` witnesses in `Codec.ts`/`Decoder.ts`/`index.ts` etc., all for-of/spread over a `ReadonlyArray`/tuple-constrained generic). Reduces false-positive churn (Fast-adjacent per #14102).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

