### PR TITLE
fix(checker): suppress three spurious did-you-mean suggestions to match tsc

### DIFF
--- a/crates/tsz-checker/src/error_reporter/name_resolution.rs
+++ b/crates/tsz-checker/src/error_reporter/name_resolution.rs
@@ -1564,12 +1564,15 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // A missing-namespace "did you mean?" candidate must itself carry a
+        // namespace meaning (`SymbolFlags.Namespace`: enum / value-module /
+        // namespace-module, or a symbol merged with one). tsc never offers a pure
+        // type (interface / class / type alias) as a namespace suggestion, so
+        // including `TYPE` here wrongly suggested e.g. the DOM `Node` interface for
+        // a missing `NodeJS` namespace (TS2833) where tsc emits plain TS2503.
         if !self.has_syntax_parse_errors()
-            && let Some(suggestions) = self.find_similar_identifiers(
-                name,
-                idx,
-                symbol_flags::NAMESPACE | symbol_flags::TYPE,
-            )
+            && let Some(suggestions) =
+                self.find_similar_identifiers(name, idx, symbol_flags::NAMESPACE)
             && let Some(suggestion) = suggestions.first()
         {
             self.error_at_node_msg(

--- a/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
+++ b/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
@@ -795,6 +795,15 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
+        // tsc only offers the "Did you mean to call '<obj>.get'?" hint (TS7052)
+        // when the get/set signature requires at least one argument
+        // (`getMinArgumentCount(s) >= 1`). A rest-only `get(..._: any)` or an
+        // optional leading param has min-arg-count 0, so tsc emits plain TS7053
+        // (witness: mobx `legacyobservablearray.ts` array-entry descriptors).
+        if !first.is_required() {
+            return false;
+        }
+
         self.element_access_method_suggestion_relation_outcome(index_type, first.type_id)
             .related
     }

--- a/crates/tsz-checker/src/error_reporter/suggestions.rs
+++ b/crates/tsz-checker/src/error_reporter/suggestions.rs
@@ -209,6 +209,13 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // ECMAScript private fields (`#foo`) are never reachable through a public
+        // member access, so tsc never offers one as a "did you mean?" candidate.
+        // Without this, an external `c.events` on a class with a `#event` field
+        // wrongly becomes TS2551 ("Did you mean '#event'?") instead of plain
+        // TS2339 (witness: msw).
+        property_names.retain(|name| !name.starts_with('#'));
+
         property_names
     }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -409,6 +409,9 @@ mod override_incompatibility_elaboration_tests;
 #[path = "../tests/override_intersection_display_tests.rs"]
 mod override_intersection_display_tests;
 #[cfg(test)]
+#[path = "tests/private_field_no_spelling_suggestion_tests.rs"]
+mod private_field_no_spelling_suggestion_tests;
+#[cfg(test)]
 #[path = "../tests/relation_boundary_tests.rs"]
 mod relation_boundary_tests;
 #[cfg(test)]
@@ -429,6 +432,9 @@ mod spread_rest_diagnostics_tests;
 #[cfg(test)]
 #[path = "../tests/spread_rest_tests.rs"]
 mod spread_rest_tests;
+#[cfg(test)]
+#[path = "tests/spurious_suggestion_suppression_tests.rs"]
+mod spurious_suggestion_suppression_tests;
 #[cfg(test)]
 #[path = "../tests/stability_validation_tests.rs"]
 mod stability_validation_tests;

--- a/crates/tsz-checker/src/tests/private_field_no_spelling_suggestion_tests.rs
+++ b/crates/tsz-checker/src/tests/private_field_no_spelling_suggestion_tests.rs
@@ -1,0 +1,55 @@
+//! ECMAScript private (`#`) fields are never offered as "did you mean?" spelling
+//! suggestions on a public member access.
+//!
+//! Structural rule: a `#foo` field is unreachable through a public `obj.bar`
+//! access, so tsc never lists one as a TS2551 suggestion candidate — an external
+//! `c.events` on a class with a `#event` field is plain TS2339, not TS2551 "Did
+//! you mean '#event'?". tsz collected the private field into the candidate set.
+//! Owner: `error_reporter/suggestions.rs` `collect_accessible_type_property_names`.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+const TS2339: u32 = 2339; // Property does not exist.
+const TS2551: u32 = 2551; // Property does not exist. Did you mean '<x>'?
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+#[test]
+fn private_field_not_offered_as_suggestion() {
+    // `c.events` where the only near-name member is the private `#event` —
+    // tsc reports plain TS2339, no suggestion.
+    let codes = check_strict(
+        r#"
+class C { #event = 1; }
+declare const c: C;
+c.events;
+"#,
+    );
+    assert_eq!(count(&codes, TS2339), 1, "plain TS2339 expected: {codes:?}");
+    assert_eq!(
+        count(&codes, TS2551),
+        0,
+        "private `#event` must not be suggested: {codes:?}"
+    );
+}
+
+#[test]
+fn public_field_typo_still_suggested() {
+    // Control: a public near-name field still produces the TS2551 suggestion, so
+    // the fix only drops private candidates rather than disabling suggestions.
+    let codes = check_strict(
+        r#"
+class C { event = 1; }
+declare const c: C;
+c.events;
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS2551),
+        1,
+        "public `event` is still suggested: {codes:?}"
+    );
+    assert_eq!(count(&codes, TS2339), 0, "{codes:?}");
+}

--- a/crates/tsz-checker/src/tests/spurious_suggestion_suppression_tests.rs
+++ b/crates/tsz-checker/src/tests/spurious_suggestion_suppression_tests.rs
@@ -1,0 +1,95 @@
+//! tsz must not offer "did you mean?" suggestions in cases where tsc stays
+//! silent — matching tsc's candidate-meaning and min-argument-count rules.
+//!
+//! - Namespace (TS2833 vs TS2503): a missing-namespace suggestion candidate must
+//!   carry a namespace meaning (enum / value-module / namespace-module). A pure
+//!   type (interface/class/type alias) is never offered. Owner:
+//!   `error_reporter/name_resolution.rs` `error_cannot_find_namespace_with_suggestion`.
+//! - Method-call index hint (TS7052 vs TS7053): the "Did you mean to call
+//!   '<obj>.get'?" hint requires the get/set signature to need a leading argument
+//!   (`getMinArgumentCount >= 1`). A rest-only / optional-first param does not.
+//!   Owner: `error_reporter/properties/diagnostic_methods_tail.rs`
+//!   `signature_accepts_index_argument`.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+const TS2503: u32 = 2503; // Cannot find namespace 'X'.
+const TS2833: u32 = 2833; // Cannot find namespace 'X'. Did you mean 'Y'?
+const TS7052: u32 = 7052; // ... no index signature. Did you mean to call '...'?
+const TS7053: u32 = 7053; // Element implicitly has an 'any' type (no index sig).
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+#[test]
+fn type_is_not_offered_as_namespace_suggestion() {
+    // `Foobaz.X` near an `interface Foobar` (a pure type) — tsc emits plain
+    // TS2503, never suggesting the interface as a namespace.
+    let codes = check_strict(
+        r#"
+interface Foobar { x: number }
+type T = Foobaz.X;
+"#,
+    );
+    assert_eq!(count(&codes, TS2503), 1, "plain TS2503 expected: {codes:?}");
+    assert_eq!(
+        count(&codes, TS2833),
+        0,
+        "an interface must not be suggested as a namespace: {codes:?}"
+    );
+}
+
+#[test]
+fn real_namespace_is_still_suggested() {
+    // Control: a real `namespace` near-match still produces the TS2833 suggestion.
+    let codes = check_strict(
+        r#"
+namespace Foobar { export type X = number; }
+type T = Foobaz.X;
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS2833),
+        1,
+        "a real namespace is still suggested: {codes:?}"
+    );
+    assert_eq!(count(&codes, TS2503), 0, "{codes:?}");
+}
+
+#[test]
+fn rest_only_indexer_method_does_not_get_call_hint() {
+    // `o[sym]` where `get` takes only a rest param (min-arg-count 0) — tsc emits
+    // plain TS7053, not the "Did you mean to call 'o.get'?" TS7052 hint.
+    let codes = check_strict(
+        r#"
+declare const sym: unique symbol;
+const o = { get(..._: any): any { return 1; } };
+o[sym];
+"#,
+    );
+    assert_eq!(count(&codes, TS7053), 1, "plain TS7053 expected: {codes:?}");
+    assert_eq!(
+        count(&codes, TS7052),
+        0,
+        "rest-only get must not trigger the call hint: {codes:?}"
+    );
+}
+
+#[test]
+fn required_arg_indexer_method_still_gets_call_hint() {
+    // Control: a `get` with a required leading param still produces TS7052.
+    let codes = check_strict(
+        r#"
+declare const sym: unique symbol;
+const o = { get(k: symbol): any { return k; } };
+o[sym];
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS7052),
+        1,
+        "required-arg get still gets the call hint: {codes:?}"
+    );
+    assert_eq!(count(&codes, TS7053), 0, "{codes:?}");
+}


### PR DESCRIPTION
Goal: green

## Summary

Three diagnostic-display false positives where tsz offered a "did you mean?" suggestion — and thus the suggestion-bearing TS code — at a location where tsc stays silent and emits the plain code.

## Structural rule + fixes

| # | tsz (wrong) | tsc | rule | owner |
|---|---|---|---|---|
| 1 | TS2551 "Did you mean '#event'?" | TS2339 | a private `#`-field is unreachable via a public member access, so it is never a spelling candidate | `error_reporter/suggestions.rs` `collect_accessible_type_property_names` (drop `#`-named candidates) |
| 2 | TS2833 "Did you mean 'Node'?" | TS2503 | a missing-namespace suggestion candidate must carry a namespace meaning (`SymbolFlags.Namespace` = enum / value-module / namespace-module), not a pure type | `error_reporter/name_resolution.rs` `error_cannot_find_namespace_with_suggestion` (pass `symbol_flags::NAMESPACE`, not `NAMESPACE \| TYPE`) |
| 3 | TS7052 "Did you mean to call 'o.get'?" | TS7053 | the index-call hint requires the get/set signature to need a leading argument (`getMinArgumentCount >= 1`); a rest-only / optional-first param does not | `error_reporter/properties/diagnostic_methods_tail.rs` `signature_accepts_index_argument` (require `first.is_required()`) |

## Adjacent-case matrix (verified vs tsc — each fix preserves the legitimate suggestion)
- #1: `c.events` with `#event` → TS2339 (was TS2551); control `event` public field → still TS2551.
- #2: `Foobaz.X` near `interface Foobar` → TS2503 (was TS2833); control near a real `namespace Foobar` → still TS2833. Merged interface/class+namespace symbols keep their namespace bit and are still suggested.
- #3: rest-only `get(..._: any)` → TS7053 (was TS7052); control required-arg `get(k: symbol)` → still TS7052.

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- Verified vs tsc: all three wrong codes become the plain code; all positive controls keep the suggestion.
- Canary witnesses cleared: msw `TS2551`→0 and `TS2833`→0; mobx `TS7052`→0 (mobx's remaining `TS2551`=3 are legitimate public-field suggestions, preserved).
- Conformance 100%: `spellingSuggestion` 7/7, `didYouMean` 3/3, `noImplicitAny` 37/37, `moduleResolution` 111/111, and the named baselines `primaryExpressionMods`, `invalidInstantiatedModule`, `importedModuleAddToGlobal`, `parserUnfinishedTypeNameBeforeKeyword1`, `noImplicitAnyStringIndexerOnObject` (all 1/1 — TS2833/TS7052 preserved for genuine cases).
- 6 new regression tests (each fix + a positive control). `arch_guard.py` pass, `cargo fmt --all --check` clean, `cargo clippy -p tsz-checker` clean. (Local nextest harness is hanging in this environment; the tests compile and run in CI.)

Found via a corpus wrong-diagnostic-code scan; the namespace and method-call rules were tsc-validated across 15+ variants by a verification workflow.