### PR TITLE
fix(cli): @ts-expect-error skips comment/blank lines to the next code line (false TS2578)

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1004,19 +1004,28 @@ struct TsDirective {
 fn find_ts_directives(text: &str, line_map: &LineMap) -> Vec<TsDirective> {
     let mut directives = Vec::new();
 
-    for comment in tsz_common::comments::get_comment_ranges(text) {
+    let comments = tsz_common::comments::get_comment_ranges(text);
+    let comment_spans: Vec<(u32, u32)> = comments.iter().map(|c| (c.pos, c.end)).collect();
+
+    for comment in &comments {
         let comment_text = comment.get_text(text);
         let Some((kind, directive_offset)) = find_directive_in_text(comment_text) else {
             continue;
         };
 
-        let suppressed_line = if comment.is_multi_line {
+        let initial_suppressed_line = if comment.is_multi_line {
             let close_line = line_map.line_index(comment.end.saturating_sub(1));
             close_line + 1
         } else {
             let comment_line = line_map.line_index(comment.pos);
             comment_line + 1
         };
+        // tsc applies the directive to the next line that bears a real token,
+        // skipping intervening comment-only and blank lines: a `@ts-expect-error`
+        // whose comment wraps onto further explanatory comment lines still
+        // suppresses the code beneath them (and stays "used").
+        let suppressed_line =
+            first_real_token_line(text, line_map, &comment_spans, initial_suppressed_line);
         let directive_start = comment.pos.saturating_add(directive_offset);
         let directive_line = line_map.line_index(directive_start) as usize;
         let directive_line_start = line_map.line_start(directive_line).unwrap_or(comment.pos);
@@ -1036,6 +1045,42 @@ fn find_ts_directives(text: &str, line_map: &LineMap) -> Vec<TsDirective> {
     }
 
     directives
+}
+
+/// Advance to the first line at or after `from_line` that bears a real token,
+/// skipping comment-only and blank lines. `comment_spans` are `(start, end)`
+/// byte offsets of every comment in the file. tsc applies a `@ts-expect-error` /
+/// `@ts-ignore` directive to that line, so a directive comment followed by
+/// further comment or blank lines still targets the code beneath them rather
+/// than the next physical line.
+fn first_real_token_line(
+    text: &str,
+    line_map: &LineMap,
+    comment_spans: &[(u32, u32)],
+    from_line: u32,
+) -> u32 {
+    let bytes = text.as_bytes();
+    let Some(start) = line_map.line_start(from_line as usize) else {
+        return from_line;
+    };
+    let mut offset = start as usize;
+    while offset < bytes.len() {
+        let c = bytes[offset];
+        if c == b' ' || c == b'\t' || c == b'\r' || c == b'\n' {
+            offset += 1;
+            continue;
+        }
+        let pos = offset as u32;
+        if let Some(&(_, end)) = comment_spans
+            .iter()
+            .find(|&&(start, end)| pos >= start && pos < end)
+        {
+            offset = end as usize;
+            continue;
+        }
+        return line_map.line_index(pos);
+    }
+    from_line
 }
 
 /// Apply `@ts-expect-error` and `@ts-ignore` directive suppression to diagnostics.

--- a/crates/tsz-cli/src/driver/check_utils/tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/tests.rs
@@ -1576,3 +1576,55 @@ fn apply_suppression_real_syntax_error_codes_are_never_suppressed() {
         );
     }
 }
+
+#[test]
+fn directive_suppresses_code_after_continuation_comment() {
+    // `@ts-expect-error` on line 1, an explanatory comment on line 2, then the
+    // erroring code on line 3. tsc suppresses the line-3 error and the directive
+    // stays "used" (no TS2578). Previously tsz targeted line 2 (the comment),
+    // failing to suppress and emitting a spurious TS2578.
+    let source = "// @ts-expect-error\n// explanatory continuation\ncode_here;\n";
+    let line_starts = line_starts_of(source);
+    let mut diagnostics = vec![Diagnostic::error(
+        "test.ts".to_string(),
+        line_starts[2],
+        1,
+        "diag 2304".to_string(),
+        2304,
+    )];
+    apply_ts_directive_suppression("test.ts", source, &mut diagnostics, false);
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 2304),
+        "the directive must suppress the error on the code line after a continuation comment; got {diagnostics:#?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 2578),
+        "the directive is used (it suppressed a real error), so no TS2578; got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn directive_does_not_skip_a_real_code_line() {
+    // `@ts-expect-error` on line 1, a real (non-comment) code line on line 2, then
+    // erroring code on line 3. tsc targets line 2 (the first real token) — so the
+    // directive is unused (TS2578) and the line-3 error survives. The skip is for
+    // comment-only/blank lines only.
+    let source = "// @ts-expect-error\nconst ok = 1;\nbad_here;\n";
+    let line_starts = line_starts_of(source);
+    let mut diagnostics = vec![Diagnostic::error(
+        "test.ts".to_string(),
+        line_starts[2],
+        1,
+        "diag 2304".to_string(),
+        2304,
+    )];
+    apply_ts_directive_suppression("test.ts", source, &mut diagnostics, false);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2304),
+        "an error one line below a real code line must NOT be suppressed; got {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2578),
+        "a directive whose target line has no error is unused (TS2578); got {diagnostics:#?}"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
A `@ts-expect-error` / `@ts-ignore` directive whose comment wraps onto further explanatory comment lines (or is followed by blank lines) targeted the next **physical** line instead of the next line bearing a **real token**. The real error on the code line below went unsuppressed, and a spurious `TS2578` ("Unused '@ts-expect-error' directive") fired.

Structural rule: tsc applies the directive to the next line with a real token, **skipping comment-only and blank lines** (but not skipping a real code line). tsz now advances the suppressed line the same way in `find_ts_directives` (`crates/tsz-cli/src/driver/check_utils.rs`).

## Verification — matches tsc 6.0.3 on all cases
| Source | tsc / tsz now |
|---|---|
| directive, comment, code | clean (suppressed) |
| directive, blank, code | clean (suppressed) |
| directive, code, code | `TS2578` + the line-3 error (does **not** skip code) |
| directive, code(err) immediately | clean |
| directive, no error anywhere | `TS2578` |

- `cargo test -p tsz-cli --lib check_utils::tests::directive_` — 2 passed; `directive_suppresses_code_after_continuation_comment` **fails on main** and passes with the fix (confirmed by stash-and-build); the control `directive_does_not_skip_a_real_code_line` passes on both.

Discovered via a deeper-pass canary sweep on remeda (28 spurious `TS2578` in `packages/remeda/src`, e.g. `funnel.ts` directives whose comments wrap onto a second explanatory line). Reduces false-positive churn (Fast-adjacent per #14102).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
