### PR TITLE
fix(checker): recognize named import of `export * as NS` as a type-position namespace anchor (TS2503)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -587,6 +587,9 @@ path = "tests/ambient_module_value_export_tests.rs"
 name = "export_star_module_augmentation_tests"
 path = "tests/export_star_module_augmentation_tests.rs"
 [[test]]
+name = "export_star_as_named_import_type_anchor_tests"
+path = "tests/export_star_as_named_import_type_anchor_tests.rs"
+[[test]]
 name = "deferred_conditional_arithmetic_operand_tests"
 path = "tests/deferred_conditional_arithmetic_operand_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1431,6 +1431,99 @@ impl<'a> CheckerContext<'a> {
             })
     }
 
+    /// When `alias_id` is a *named* import bound to an `export * as NS from '<m>'`
+    /// namespace re-export, return the file index of the re-exported module `<m>`
+    /// — the backing module whose exports are the anchor's members. Returns
+    /// `None` for any other alias shape.
+    ///
+    /// `tsc` treats such a named import as a type-position namespace anchor whose
+    /// members are the exports of `<m>`. Because the member is not part of the
+    /// *importing* module's own export surface, the ordinary re-export member
+    /// lookup misses it; [`Self::resolve_member_via_namespace_reexport`] resolves
+    /// the member through this backing file instead. The hop is keyed by file
+    /// index + module specifier (never raw `SymbolId`), so cross-binder id
+    /// collisions cannot interfere. This is also the structural predicate behind
+    /// the "missing member is TS2694, not TS2503" diagnostic.
+    pub(crate) fn namespace_reexport_anchor_backing_file(
+        &self,
+        alias_id: tsz_binder::SymbolId,
+    ) -> Option<usize> {
+        let alias = self.binder.get_symbol(alias_id)?;
+        if !alias.has_any_flags(tsz_binder::symbol_flags::ALIAS) {
+            return None;
+        }
+        // A whole-namespace import (`import * as NS`) is handled by the ordinary
+        // re-export path; this targets a *named* binding (`import { NS }` /
+        // `import { NS as X }`) of an `export * as NS` re-export. Check before
+        // allocating below so the common star-import case stays allocation-free.
+        let import_name = alias.import_name()?;
+        if import_name == "*" {
+            return None;
+        }
+        let import_module = alias.import_module()?.to_string();
+        let import_name = import_name.to_string();
+        // The alias's declaring file is the base for resolving the relative
+        // `import_module` specifier. `resolve_symbol_file_index` can be polluted
+        // by an earlier cross-file `register_symbol_file_target` (it pins the
+        // importing alias to the *target* file), and a named import is local to
+        // the current file anyway, so try the current file first and fall back to
+        // the recorded index when it differs.
+        let recorded = self
+            .resolve_symbol_file_index(alias_id)
+            .filter(|&recorded| recorded != self.current_file_idx);
+        std::iter::once(self.current_file_idx)
+            .chain(recorded)
+            .find_map(|source_file_idx| {
+                self.namespace_reexport_anchor_backing_file_from(
+                    source_file_idx,
+                    &import_module,
+                    &import_name,
+                )
+            })
+    }
+
+    /// Resolve `NS.member` to its target `SymbolId` when `NS` (`alias_id`) is a
+    /// named import bound to an `export * as NS` namespace re-export. Returns
+    /// `None` when `alias_id` is not such an anchor or the module has no such
+    /// member. Shared by the qualified-name type resolvers so the
+    /// backing-file + export lookup lives in one place.
+    pub(crate) fn resolve_member_via_namespace_reexport(
+        &self,
+        alias_id: tsz_binder::SymbolId,
+        member_name: &str,
+    ) -> Option<tsz_binder::SymbolId> {
+        let backing_idx = self.namespace_reexport_anchor_backing_file(alias_id)?;
+        let mut visited = rustc_hash::FxHashSet::default();
+        self.resolve_export_in_target_file(backing_idx, member_name, &mut visited)
+    }
+
+    /// One attempt of [`Self::namespace_reexport_anchor_backing_file`] using
+    /// `source_file_idx` as the base for the relative `import_module` specifier.
+    fn namespace_reexport_anchor_backing_file_from(
+        &self,
+        source_file_idx: usize,
+        import_module: &str,
+        import_name: &str,
+    ) -> Option<usize> {
+        let target_idx = self.resolve_import_target_from_file(source_file_idx, import_module)?;
+        let target_binder = self.get_binder_for_file(target_idx)?;
+        let target_arena = self.get_arena_for_file(target_idx as u32);
+        let target_file_name = target_arena.source_files.first()?.file_name.clone();
+        let ns_sym_id = self
+            .module_exports_for_module(target_binder, &target_file_name)
+            .and_then(|exports| exports.get(import_name))?;
+        let ns_sym = target_binder.get_symbol(ns_sym_id)?;
+        // Only an `export * as NS` namespace re-export qualifies: it carries an
+        // import module and the wildcard `*` import name.
+        if !ns_sym.has_any_flags(tsz_binder::symbol_flags::ALIAS)
+            || ns_sym.import_name() != Some("*")
+        {
+            return None;
+        }
+        let ns_module = ns_sym.import_module()?;
+        self.resolve_import_target_from_file(target_idx, ns_module)
+    }
+
     /// Extract the persistent cache from this context.
     /// This allows saving type checking results for future queries.
     pub fn extract_cache(self) -> TypeCache {

--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -441,7 +441,14 @@ impl<'a> CheckerState<'a> {
                 // find namespace"). Accept the UMD alias here so the
                 // member-resolution failure below routes through the TS2694
                 // branch.
-                || symbol.is_umd_export)
+                || symbol.is_umd_export
+                // A named import bound to an `export * as NS` re-export is a
+                // type-position namespace anchor too: a missing member is
+                // TS2694, not TS2503.
+                || self
+                    .ctx
+                    .namespace_reexport_anchor_backing_file(left_sym_id)
+                    .is_some())
         {
             // If the left symbol is a pure interface (no namespace meaning) and a
             // local declaration shadows an outer namespace, the member might exist
@@ -778,6 +785,18 @@ impl<'a> CheckerState<'a> {
                 && let Some(resolved) =
                     self.ctx
                         .resolve_alias_import_member(alias_id, module_specifier, member_name)
+            {
+                return Some(resolved);
+            }
+            // Named import bound to an `export * as NS` namespace re-export: the
+            // member lives in the re-exported module, not in the importing
+            // module's own export surface, so neither lookup above can find it.
+            // Follow the named export to the namespace re-export and resolve the
+            // member through its backing module.
+            if let Some(alias_id) = sym_id
+                && let Some(resolved) = self
+                    .ctx
+                    .resolve_member_via_namespace_reexport(alias_id, member_name)
             {
                 return Some(resolved);
             }

--- a/crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs
@@ -502,6 +502,38 @@ impl<'a> CheckerState<'a> {
             return TypeSymbolResolution::Type(augmented_sym);
         }
 
+        // Named import bound to an `export * as NS from '<m>'` namespace
+        // re-export: the member lives in the re-exported module `<m>`, not in the
+        // importing module's own export surface, so every lookup above misses.
+        // Resolve the member through the namespace's backing module here, on the
+        // symbol-resolution path, so its type materializes the same way a
+        // whole-namespace import (`import * as NS`) does — rather than letting
+        // the caller fall back to the raw-`SymbolId`-sensitive
+        // `resolve_qualified_name` path, which mis-resolves cross-file members
+        // whose ids collide with the local import alias.
+        if !left_has_local_namespace_conflict
+            && let Some(member_sym) = self
+                .ctx
+                .resolve_member_via_namespace_reexport(original_left_sym, right_name)
+                .or_else(|| {
+                    self.ctx
+                        .resolve_member_via_namespace_reexport(left_sym, right_name)
+                })
+        {
+            let member_sym =
+                self.propagate_cross_file_member_target(left_sym, member_sym, right_name);
+            let is_value_only = (self.alias_resolves_to_value_only(member_sym, Some(right_name))
+                || self.symbol_is_value_only(member_sym, Some(right_name)))
+                && !self.symbol_is_type_only(member_sym, Some(right_name));
+            if is_value_only {
+                return TypeSymbolResolution::ValueOnly(member_sym);
+            }
+            return TypeSymbolResolution::Type(
+                self.resolve_alias_symbol(member_sym, visited_aliases)
+                    .unwrap_or(member_sym),
+            );
+        }
+
         TypeSymbolResolution::NotFound
     }
 

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -306,6 +306,15 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         .or_else(|| target_binder.resolve_import_with_reexports(module, segment))
                         .or_else(|| target_binder.file_locals.get(segment))
                         .inspect(|sym_id| self.ctx.register_symbol_file_target(*sym_id, target_idx))
+                })
+                .or_else(|| {
+                    // Named import bound to an `export * as NS from '<m>'`
+                    // namespace re-export: the member lives in the re-exported
+                    // module `<m>`, not in the importing module's own export
+                    // surface, so every branch above misses. Resolve `segment`
+                    // through the namespace's backing module.
+                    self.ctx
+                        .resolve_member_via_namespace_reexport(current_sym, segment)
                 })?;
         }
 

--- a/crates/tsz-checker/tests/export_star_as_named_import_type_anchor_tests.rs
+++ b/crates/tsz-checker/tests/export_star_as_named_import_type_anchor_tests.rs
@@ -1,0 +1,145 @@
+//! Coverage for #14228: a named import bound to an `export * as NS` re-export
+//! must be recognized as a type-position namespace anchor.
+//!
+//! Structural rule: when a named import binds a namespace produced by
+//! `export * as NS from '...'` and `NS` is used as a qualified type
+//! (`NS.Type`), `tsc` treats `NS` as a type-position namespace anchor whose
+//! members are the exports of the re-exported module. tsz used to only accept
+//! whole-namespace imports (`import * as NS`), so the named-import indirection
+//! through `export * as` surfaced a false TS2503 ("Cannot find namespace").
+//!
+//! The members are resolved by following the named export to the `export * as`
+//! re-export and resolving through its backing module — keyed by file index +
+//! module specifier so cross-binder raw `SymbolId` collisions cannot interfere.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file;
+
+fn diagnostics(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn count_code(diags: &[(u32, String)], expected: u32) -> usize {
+    diags.iter().filter(|(code, _)| *code == expected).count()
+}
+
+/// Shared scaffold: `globals` declares the type/interface, `index` re-exports
+/// it as the `NS` namespace, and `consumer` is the file under test.
+fn check_consumer(consumer: &str) -> Vec<(u32, String)> {
+    diagnostics(
+        &[
+            (
+                "g/globals.ts",
+                "export interface Foo { a: number }\nexport type Bar = { b: string };\n",
+            ),
+            ("g/index.ts", "export * as NS from './globals';\n"),
+            ("consumer.ts", consumer),
+        ],
+        "consumer.ts",
+    )
+}
+
+/// The repro from #14228: `export * as NS` consumed via a named import, used as
+/// a qualified type in parameter and return position. No TS2503.
+#[test]
+fn named_import_of_export_star_as_namespace_is_type_anchor() {
+    let diags = check_consumer("import { NS } from './g/index';\nlet v: NS.Foo = { a: 1 };\nv;\n");
+    assert_eq!(
+        count_code(&diags, 2503),
+        0,
+        "unexpected TS2503; got {diags:#?}"
+    );
+}
+
+/// The qualified type must resolve to the actual member type, not silently to
+/// `any`/error: assigning the wrong shape still reports TS2322. This mirrors the
+/// issue's reported shape (`export type TTypeArray = ...`), a type-alias member.
+#[test]
+fn named_import_of_export_star_as_namespace_resolves_member_type() {
+    let diags =
+        check_consumer("import { NS } from './g/index';\nlet v: NS.Bar = { b: 123 };\nv;\n");
+    assert_eq!(
+        count_code(&diags, 2503),
+        0,
+        "unexpected TS2503; got {diags:#?}"
+    );
+    assert_eq!(
+        count_code(&diags, 2322),
+        1,
+        "expected TS2322 proving NS.Bar resolved to {{ b: string }}; got {diags:#?}"
+    );
+}
+
+/// Renamed binder: the named import is aliased to a different local name. The
+/// fix keys on the namespace-only resolution of the chain, not the textual
+/// identifier.
+#[test]
+fn renamed_named_import_of_export_star_as_namespace_is_type_anchor() {
+    let diags = check_consumer(
+        "import { NS as Guard } from './g/index';\nlet v: Guard.Foo = { a: 1 };\nv;\n",
+    );
+    assert_eq!(
+        count_code(&diags, 2503),
+        0,
+        "unexpected TS2503 on renamed binder; got {diags:#?}"
+    );
+}
+
+/// The namespace anchor consumed as a type-alias body.
+#[test]
+fn named_import_of_export_star_as_namespace_in_type_alias_body() {
+    let diags = check_consumer(
+        "import { NS } from './g/index';\ntype T = NS.Bar;\nlet v: T = { b: 'ok' };\nv;\n",
+    );
+    assert_eq!(
+        count_code(&diags, 2503),
+        0,
+        "unexpected TS2503 in type-alias body; got {diags:#?}"
+    );
+}
+
+/// A missing member through the anchor is TS2694 ("no exported member"), not
+/// TS2503 — proving the anchor is recognized as a namespace.
+#[test]
+fn missing_member_through_export_star_as_namespace_anchor_emits_2694() {
+    let diags = check_consumer("import { NS } from './g/index';\ntype T = NS.Nope;\n");
+    assert_eq!(
+        count_code(&diags, 2503),
+        0,
+        "should not emit TS2503 when anchor resolves; got {diags:#?}"
+    );
+    assert_eq!(
+        count_code(&diags, 2694),
+        1,
+        "expected TS2694 for missing member; got {diags:#?}"
+    );
+}
+
+/// Baseline: a direct `import * as NS` of the same module already works and
+/// must keep working (no regression on the whole-namespace import path).
+#[test]
+fn direct_namespace_import_baseline_still_resolves() {
+    let diags =
+        check_consumer("import * as NS from './g/globals';\nlet v: NS.Foo = { a: 1 };\nv;\n");
+    assert_eq!(
+        count_code(&diags, 2503),
+        0,
+        "unexpected TS2503; got {diags:#?}"
+    );
+    let diags_missing = check_consumer("import * as NS from './g/globals';\ntype T = NS.Nope;\n");
+    assert_eq!(
+        count_code(&diags_missing, 2694),
+        1,
+        "expected TS2694 for missing member on direct import; got {diags_missing:#?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #14228. A named import bound to an `export * as NS` re-export was not
recognized as a type-position namespace anchor, so `NS.Type` emitted a false
`TS2503` ("Cannot find namespace 'NS'").

```ts
// g/globals.ts
export type TTypeArray = Int8Array | Uint8Array
// g/index.ts
export * as GlobalsGuard from './globals'
// consumer.ts
import { GlobalsGuard } from './g/index'
function f(v: GlobalsGuard.TTypeArray): GlobalsGuard.TTypeArray { return v }  // tsc: 0, tsz: 2× TS2503
```

## Structural rule

When an alias chain is `import { NS } from 'barrel'` → `export * as NS from './m'`,
the members of `NS` are the exports of `./m` — `tsc` treats `NS` as a
type-position namespace anchor. The member is **not** part of the importing
barrel's own export surface, so the ordinary re-export member lookup (which only
inspects that surface) misses it. tsz previously only accepted whole-namespace
imports whose own alias carries `import_name == "*"` (`import * as NS`), missing
the `export * as` indirection.

## Owner layer

Checker — qualified-name type-position resolvers (solver-free symbol resolution).

- New `CheckerContext::namespace_reexport_anchor_backing_file(alias_id)` — the
  structural predicate: resolves a named import bound to `export * as NS` to the
  file index of the backing module `./m`. Keyed by file index + module specifier
  (never raw `SymbolId`) so cross-binder id collisions cannot interfere.
- New `CheckerContext::resolve_member_via_namespace_reexport(alias_id, member)` —
  resolves a member through that backing file; shared by all consumers.
- Wired as a fallback into the existing qualified-name resolvers
  (`resolve_entity_name_text_symbol`,
  `resolve_qualified_symbol_inner_in_type_position`,
  `resolve_qualified_name`'s member path), mirroring the `import * as NS`
  case each already special-cases.
- A missing member through such an anchor now emits `TS2694` ("no exported
  member") instead of `TS2503`.

## Adjacent-case matrix

- `export * as NS` consumed via named import, used as a qualified type (the bug) — fixed.
- Renamed binder (`import { NS as Guard }`) — fixed (keys on the chain, not the textual name).
- Type-alias member resolves to its real type (wrong assignment still flags `TS2322`) — fixed.
- Qualified type in a type-alias body (`type T = NS.Bar`) — fixed.
- Missing member (`NS.Nope`) → `TS2694`, not `TS2503` — fixed.
- Fallback: direct `import * as NS` baseline (whole-namespace import) unchanged.

## Anti-hardcoding

No user-name/file-name literals; resolution keys on the `export * as`
(`import_name == "*"`) re-export shape and module specifiers, looked up through
binder/program structural helpers. Test varies the binder name (`GlobalsGuard`,
`NS`, `Guard`).

## Verification

- New: `cargo nextest run -p tsz-checker --test export_star_as_named_import_type_anchor_tests` — 6/6 pass.
- Regression: `conformance_issues_modules`, `cross_module_nested_interface_tests`,
  `export_star_module_augmentation_tests`, `class_interface_namespace_merge_tests`,
  `ambient_module_value_export_tests` — no new failures (pre-existing failures
  verified identical on base via stash A/B).
- `cargo clippy -p tsz-checker --tests` — clean.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude Opus 4.8
Effort: high
