### PR TITLE
test(solver): register architecture_guards + pin raw_symbol_fallback_def budget (#14344)

### DIFF
--- a/crates/tsz-solver/Cargo.toml
+++ b/crates/tsz-solver/Cargo.toml
@@ -36,6 +36,10 @@ workspace = true
 doctest = false
 
 [[test]]
+name = "architecture_guards"
+path = "tests/architecture_guards.rs"
+
+[[test]]
 name = "public_api_tests"
 path = "tests/public_api_tests.rs"
 

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -274,3 +274,68 @@ fn narrowing_engine_keeps_request_stage_boundary() {
         "narrowing/core.rs must not own the anonymous packed compiler-flags byte — use NarrowingOptions"
     );
 }
+
+// =============================================================================
+// Identity bridge guard — DefId-as-SymbolId raw-symbol fallback budget (#14344)
+// =============================================================================
+
+/// Guard the solver-side `DefId`-as-`SymbolId` reinterpretation surface.
+///
+/// `TypeEnvironment::raw_symbol_fallback_def` recovers a real `DefId` when a
+/// `Lazy(DefId)` actually wrapped a raw `SymbolId.0`. The two are independent
+/// identity spaces that happen to collide on a raw `u32` (see
+/// `crates/tsz-solver/src/def/resolver.rs` and
+/// `docs/architecture/DEFID_RAW_SYMBOL_FALLBACK_PRODUCERS.md`). It is a
+/// compatibility path for the non-canonical identity model tracked by
+/// tsz-org/tsz#14344, and the documented intent is to keep this fallback budget
+/// from growing.
+///
+/// This mirrors the checker's zero `.reference(...)` construction guard on the
+/// solver side: it pins the number of call sites that reinterpret a `DefId` as a
+/// `SymbolId` so the surface cannot GROW. The migration toward content-canonical
+/// identity (#14344) should ratchet `BUDGET` DOWN to 0 as callers are retired; it
+/// must never be raised. Counting `.raw_symbol_fallback_def(` (the method-call
+/// form) excludes the `fn` definition and doc comments.
+#[test]
+fn solver_raw_symbol_fallback_def_budget_does_not_grow() {
+    const BUDGET: usize = 4;
+    const PATTERN: &str = ".raw_symbol_fallback_def(";
+
+    let solver_src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    walk_rs_files(&solver_src, &mut files);
+
+    let mut sites = Vec::new();
+    for path in &files {
+        let rel = path
+            .strip_prefix(&solver_src)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        let src = match fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        for (line_num, line) in src.lines().enumerate() {
+            if line.trim_start().starts_with("//") {
+                continue;
+            }
+            if line.contains(PATTERN) {
+                sites.push(format!("  {}:{}", rel, line_num + 1));
+            }
+        }
+    }
+
+    assert!(
+        sites.len() <= BUDGET,
+        "Solver `raw_symbol_fallback_def` call sites grew to {} (budget {}). \
+         Each reinterprets a `DefId` as a `SymbolId`; this surface must not grow \
+         while the content-canonical identity migration (tsz-org/tsz#14344) is \
+         retiring it. New code should resolve a real `DefId` and `lazy(def_id)` \
+         instead. See docs/architecture/DEFID_RAW_SYMBOL_FALLBACK_PRODUCERS.md.\n\
+         Call sites:\n{}",
+        sites.len(),
+        BUDGET,
+        sites.join("\n"),
+    );
+}

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -13,14 +13,13 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 fn walk_rs_files(dir: &Path, files: &mut Vec<PathBuf>) {
-    let entries = match fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(_) => return,
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
     };
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
-            walk_rs_files(&path, &mut *files);
+            walk_rs_files(&path, files);
         } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
             files.push(path);
         }
@@ -42,6 +41,18 @@ fn walk_rs_files(dir: &Path, files: &mut Vec<PathBuf>) {
 /// APIs that perform semantic validation.
 #[test]
 fn emitter_must_not_use_semantic_validation_apis() {
+    // These are solver relation/compatibility APIs that the emitter must never use.
+    // Using them would mean the emitter is performing semantic type validation.
+    const FORBIDDEN_PATTERNS: &[&str] = &[
+        "CompatChecker",
+        "SubtypeChecker",
+        "is_assignable",
+        "is_subtype_of",
+        "RelationResult",
+        "check_assignability",
+        "tsz_checker::",
+    ];
+
     let emitter_src = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
@@ -55,18 +66,6 @@ fn emitter_must_not_use_semantic_validation_apis() {
     let mut files = Vec::new();
     walk_rs_files(&emitter_src, &mut files);
 
-    // These are solver relation/compatibility APIs that the emitter must never use.
-    // Using them would mean the emitter is performing semantic type validation.
-    const FORBIDDEN_PATTERNS: &[&str] = &[
-        "CompatChecker",
-        "SubtypeChecker",
-        "is_assignable",
-        "is_subtype_of",
-        "RelationResult",
-        "check_assignability",
-        "tsz_checker::",
-    ];
-
     let mut violations = Vec::new();
 
     for path in &files {
@@ -76,9 +75,8 @@ fn emitter_must_not_use_semantic_validation_apis() {
             .to_string_lossy()
             .replace('\\', "/");
 
-        let src = match fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(_) => continue,
+        let Ok(src) = fs::read_to_string(path) else {
+            continue;
         };
 
         for (line_num, line) in src.lines().enumerate() {
@@ -124,6 +122,13 @@ fn emitter_must_not_use_semantic_validation_apis() {
 /// a source-level belt-and-suspenders check and clearer error messages.
 #[test]
 fn binder_must_not_import_solver_or_checker() {
+    const FORBIDDEN_IMPORTS: &[&str] = &[
+        "tsz_solver::",
+        "tsz_checker::",
+        "use tsz_solver",
+        "use tsz_checker",
+    ];
+
     let binder_src = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .unwrap()
@@ -136,13 +141,6 @@ fn binder_must_not_import_solver_or_checker() {
     let mut files = Vec::new();
     walk_rs_files(&binder_src, &mut files);
 
-    const FORBIDDEN_IMPORTS: &[&str] = &[
-        "tsz_solver::",
-        "tsz_checker::",
-        "use tsz_solver",
-        "use tsz_checker",
-    ];
-
     let mut violations = Vec::new();
 
     for path in &files {
@@ -152,9 +150,8 @@ fn binder_must_not_import_solver_or_checker() {
             .to_string_lossy()
             .replace('\\', "/");
 
-        let src = match fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(_) => continue,
+        let Ok(src) = fs::read_to_string(path) else {
+            continue;
         };
 
         for (line_num, line) in src.lines().enumerate() {
@@ -312,9 +309,8 @@ fn solver_raw_symbol_fallback_def_budget_does_not_grow() {
             .unwrap_or(path)
             .to_string_lossy()
             .replace('\\', "/");
-        let src = match fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(_) => continue,
+        let Ok(src) = fs::read_to_string(path) else {
+            continue;
         };
         for (line_num, line) in src.lines().enumerate() {
             if line.trim_start().starts_with("//") {

--- a/docs/architecture/DEFID_RAW_SYMBOL_FALLBACK_PRODUCERS.md
+++ b/docs/architecture/DEFID_RAW_SYMBOL_FALLBACK_PRODUCERS.md
@@ -1,6 +1,7 @@
 # DefId Raw-Symbol Fallback Producer Map
 
-**Status**: Updated after #7717, #7756, and #7758
+**Status**: Updated after #7717, #7756, and #7758; solver caller budget guarded
+for the content-canonical identity migration (tsz-org/tsz#14344).
 **Scope**: `Lazy(DefId)` fallback paths that still recover from
 `interner.reference(SymbolRef(N))`-style construction.
 
@@ -28,6 +29,24 @@ No active non-test checker producers remain. The architecture guard
 `test_checker_raw_symbol_reference_construction_budget` allows zero raw
 `.reference(...)` construction calls in checker sources, and focused guards cover
 the previously migrated `instanceof` and `ArrayBuffer.isView` branches.
+
+## Solver Fallback Budget Guard
+
+The solver-side `TypeEnvironment::resolve_lazy` compatibility path reinterprets a
+`DefId` as a `SymbolId` through `raw_symbol_fallback_def`. Previously this surface
+had only a runtime signal (`identity.type_environment_raw_symbol_lazy_fallbacks`)
+and no static budget, so it could grow silently. The architecture guard
+`solver_raw_symbol_fallback_def_budget_does_not_grow` (in
+`crates/tsz-solver/tests/architecture_guards.rs`) now pins the number of
+`raw_symbol_fallback_def` call sites at a non-growing budget (currently **4**:
+`def/resolver.rs:1524,1553,1562,1689`), mirroring the checker's zero
+`.reference(...)` budget.
+
+**Removal condition**: this is migration scaffolding for tsz-org/tsz#14344
+(content-canonical identity). As the canonical-identity work retires these
+callers, ratchet the budget DOWN; the guard and budget are deleted entirely once
+the `DefId`/`SymbolId` spaces no longer collide on a raw `u32`. The budget must
+never be raised.
 
 ## Deprecated API Surface
 
@@ -78,4 +97,6 @@ The following nearby paths should not be counted as remaining producers:
 3. Once runtime hits are understood, narrow or retire the checker/solver
    `resolve_lazy` raw-symbol compatibility paths.
 4. Keep the zero-budget architecture guard in place so new checker code cannot
-   reintroduce raw `SymbolRef` lazy construction.
+   reintroduce raw `SymbolRef` lazy construction, and keep the solver
+   `solver_raw_symbol_fallback_def_budget_does_not_grow` guard pinning the
+   solver-side caller budget. Ratchet both toward 0 under tsz-org/tsz#14344.


### PR DESCRIPTION
Goal: hold

First landable, parity-safe slice of the content-canonical identity campaign (#14344), surfaced by the architectural root-cause review (#14351).

## What this does

1. **Registers the orphaned solver architecture guards.** `crates/tsz-solver/tests/architecture_guards.rs` was never running: the crate sets `autotests = false` and the file was absent from the `[[test]]` list. Its guards — emitter-must-not-use-semantic-validation, binder-must-not-import-solver/checker, and the evaluation/narrowing request-stage boundaries — had silently stopped being enforced. This PR adds the `[[test]]` registration so they run again (all pass).
2. **Adds `solver_raw_symbol_fallback_def_budget_does_not_grow`.** The solver-side `TypeEnvironment::resolve_lazy` compatibility path reinterprets a `DefId` as a `SymbolId` via `raw_symbol_fallback_def` — independent identity spaces that collide on a raw `u32` (root sin #14344). This previously had only a runtime counter (`identity.type_environment_raw_symbol_lazy_fallbacks`) and no static budget, so it could grow silently. The guard pins the caller count at a non-growing budget (currently **4**: `def/resolver.rs:1524,1553,1562,1689`), mirroring the checker's existing zero `.reference(...)` budget.
3. **Documents the staged plan + removal condition** in `docs/architecture/DEFID_RAW_SYMBOL_FALLBACK_PRODUCERS.md`.

## Architectural invariant guarded

When new code needs a `Lazy` type from a symbol, `tsc` resolves a real declaration identity; `tsz` must resolve a real `DefId` and `lazy(def_id)` rather than reinterpreting a `SymbolId` as a `DefId`. The `DefId`/`SymbolId` raw-`u32` reinterpretation surface must not grow while the canonical-identity migration (#14344) retires it. The budget ratchets DOWN to 0 and must never be raised; the guard is deleted entirely once the two spaces no longer collide.

## Why parity-safe

Tests + docs only. No `crates/tsz-solver/src` (or any compiler) source changed — no relation/inference/narrowing/eval/emit path is touched, and no diagnostics change. Registering the previously-dead guards is behavior-neutral for production (they assert on source structure, not runtime). Conformance/emit/fourslash are unaffected.

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

```
cargo nextest run -p tsz-solver --test architecture_guards
# Summary [0.524s] 5 tests run: 5 passed, 0 skipped
#   PASS solver_raw_symbol_fallback_def_budget_does_not_grow   (new)
#   PASS emitter_must_not_use_semantic_validation_apis         (revived)
#   PASS binder_must_not_import_solver_or_checker              (revived)
#   PASS evaluation_engine_keeps_request_stage_boundary        (revived)
#   PASS narrowing_engine_keeps_request_stage_boundary         (revived)
```

`tsz-solver` builds clean. Ready-review CI owns the broad conformance/emit/fourslash suites (no source change, so no expected drift).
