### PR TITLE
fix(solver): resolve concrete-check conditional with a generic extends type via permissive instantiation (TS2322) (#14232)

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/types/conditional_concrete_check_generic_extends_2322.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/conditional_concrete_check_generic_extends_2322.rs
@@ -1,0 +1,52 @@
+//! A conditional type whose CHECK type is concrete (`[]`) but whose EXTENDS type
+//! carries a type parameter (`[T, ...T[]]`) must not be left deferred when the
+//! false branch is definitive under permissive instantiation (T -> any). tsc
+//! resolves `[] extends [T, ...T[]] ? "yes" : "no"` to its false branch (`"no"`);
+//! tsz previously deferred (because the extends type carried `T`), leaving the
+//! alias opaque so a later `"no"` assignment produced a false TS2322. (#14232)
+
+use super::super::core::*;
+
+/// The witness: `A = [] extends [T, ...T[]] ? "yes" : "no"` resolves to `"no"`
+/// (an empty tuple is never a non-empty tuple, even under `T -> any`), so
+/// `const a: A = "no"` type-checks with no TS2322.
+#[test]
+fn concrete_check_generic_extends_resolves_false_branch_no_ts2322() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+function f<T>() {
+  type A = [] extends [T, ...T[]] ? "yes" : "no";
+  const a: A = "no";
+  return a;
+}
+export { f };
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2322),
+        "no TS2322 expected — `[] extends [T, ...T[]]` resolves to its false branch \
+         (`\"no\"`) under permissive instantiation. Actual: {diagnostics:#?}"
+    );
+}
+
+/// Negative control: the conditional genuinely resolves to `"no"`, so assigning
+/// the *true*-branch literal `"yes"` must still error — the fix resolves the
+/// branch, it does not blanket-suppress assignability.
+#[test]
+fn concrete_check_generic_extends_true_branch_value_still_ts2322() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+function f<T>() {
+  type A = [] extends [T, ...T[]] ? "yes" : "no";
+  const a: A = "yes";
+  return a;
+}
+export { f };
+"#,
+    );
+    assert!(
+        has_error(&diagnostics, 2322),
+        "TS2322 expected — `A` resolves to `\"no\"`, so `\"yes\"` is not assignable. \
+         Actual: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -1,4 +1,5 @@
 mod computed_property_names;
+mod conditional_concrete_check_generic_extends_2322;
 mod const_initializer_widening;
 mod cross_module_unique_symbol;
 mod defaults;

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -1087,6 +1087,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // T <: U -> true branch
                 cond.true_type
             } else if extends_has_type_params
+                && (crate::type_queries::is_generic_conditional_check_type(
+                    self.interner(),
+                    check_type,
+                ) || (!self.is_depth_detection_pass()
+                    && !self.permissive_false_branch_is_definitive(check_type, extends_type)))
                 // tsc parity (`getConditionalType`): a conditional whose
                 // effective check type is still generic — instantiable flags,
                 // or a type reference/tuple/template whose arguments are


### PR DESCRIPTION
Fixes a green-goal false positive (TS2322). Contained change to the conditional
result-branch decision: it narrows *when* `tsz` defers a conditional, matching
tsc's `getConditionalType` permissive-instantiation gate.

Goal: green

## Structural rule
In `evaluate_conditional`, when the EXTENDS type carries a type parameter
(`extends_has_type_params`), `tsz` unconditionally deferred the conditional —
even when the CHECK type is concrete. So `[] extends [T, ...T[]] ? "yes" : "no"`
stayed deferred, the alias `A` resolved to an opaque/`unknown`-like type, and a
later `const a: A = "no"` produced a false TS2322.

tsc (`getConditionalType`) only keeps such a conditional deferred when either the
check type is *itself* generic, or the false branch is *not* definitive under the
permissive instantiation (every type parameter replaced by `any`,
`getPermissiveInstantiation`). For a concrete check type whose false branch is
definitive — `[]` is never `[any, ...any[]]` — the conditional resolves to the
false branch.

This change adds that gate: defer only when
`extends_has_type_params && (is_generic_conditional_check_type(check) || !permissive_false_branch_is_definitive(check, extends))`,
preserving the existing deferred-wrapper / depth-detection tail unchanged.

Owner: solver — `evaluation/evaluate_rules/conditional.rs`.

## Adjacent cases (test file)
- Witness: `[] extends [T, ...T[]] ? "yes" : "no"` resolves to `"no"`;
  `const a: A = "no"` → no TS2322 (flip).
- Negative control: assigning the *true*-branch literal `"yes"` to `A` (which is
  `"no"`) still emits TS2322 — the fix resolves the branch, it does not
  blanket-suppress assignability.

## Verification
- `cargo nextest run -p tsz-checker -j 2 conditional_concrete_check_generic_extends`
  — flip + negative control green (verified with only `conditional.rs` changed).
- CI gates: lint, unit-checker-integration, conformance-aggregate, emit-aggregate,
  fourslash-*, project-compile-guard, CI Summary.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
