### PR TITLE
ci(track2): move unit + checker-integration to a 128GiB highmem Cloud Build pool

### DIFF
--- a/scripts/cloudbuild/cloudbuild-checker-integration.yaml
+++ b/scripts/cloudbuild/cloudbuild-checker-integration.yaml
@@ -27,7 +27,7 @@ steps:
 
 options:
   pool:
-    name: projects/tsz-ci/locations/us-central1/workerPools/tsz-ci-build-pool
+    name: projects/tsz-ci/locations/us-central1/workerPools/tsz-ci-build-pool-highmem
   logging: CLOUD_LOGGING_ONLY
 
 timeout: 1800s

--- a/scripts/cloudbuild/cloudbuild-unit.yaml
+++ b/scripts/cloudbuild/cloudbuild-unit.yaml
@@ -11,9 +11,11 @@
 # per-process peak, so there is no parallelism left to cut on Cloud Run.
 #
 # This config runs the same `scripts/ci/gcp-full-ci.sh unit` slice on the
-# larger `tsz-ci-build-pool` private worker pool, where memory is not the
-# constraint (the maintainer-endorsed path that `cloudbuild-checker-integration`
-# already uses successfully). `TSZ_CI_UNIT_SKIP_CHECKER_INTEGRATION=1` keeps the
+# dedicated `tsz-ci-build-pool-highmem` (e2-standard-32: 32 vCPU / 128 GiB)
+# private worker pool, so a single lib-test rustc peak >32 GiB now fits with
+# headroom (this OOM was the publishing-freeze recurrence engine). The bench
+# pool stays e2-highcpu-32 to preserve perf-timing parity.
+# `TSZ_CI_UNIT_SKIP_CHECKER_INTEGRATION=1` keeps the
 # checker integration slice on its own dedicated Cloud Build job.
 
 steps:
@@ -29,6 +31,10 @@ steps:
       - 'TSZ_CI_SKIP_HOST_APT=1'
       - 'TSZ_CI_DISABLE_SCCACHE=1'
       - 'TSZ_CI_UNIT_SKIP_CHECKER_INTEGRATION=1'
+      # 128 GiB pool: relax the OOM-driven 2-thread test cap. 4 lib-test threads
+      # at >16 GiB peak each (~64 GiB) fit with headroom; this was a SIGKILL on
+      # the old 32 GiB pool, which is exactly the constraint the highmem pool lifts.
+      - 'TSZ_CI_UNIT_TEST_THREADS=4'
     script: |
       #!/usr/bin/env bash
       set -euo pipefail
@@ -39,7 +45,7 @@ steps:
 
 options:
   pool:
-    name: projects/tsz-ci/locations/us-central1/workerPools/tsz-ci-build-pool
+    name: projects/tsz-ci/locations/us-central1/workerPools/tsz-ci-build-pool-highmem
   logging: CLOUD_LOGGING_ONLY
 
 timeout: 2700s


### PR DESCRIPTION
## Summary (Track 2: bigger-RAM machine class for the RAM-bound jobs)

Move the `unit` and `unit-checker-integration` Cloud Build jobs from the shared `tsz-ci-build-pool` (e2-highcpu-32 = 32 vCPU / **32 GiB**) to a new dedicated `tsz-ci-build-pool-highmem` (e2-standard-32 = 32 vCPU / **128 GiB**), and relax the OOM-driven test-thread cap (`UNIT_NEXTEST_TEST_THREADS` 2 → 4).

## Why

The unit lib-test `rustc` peaks **>32 GiB** on a single LLVM codegen unit (`tsz-checker`/`tsz-solver` lib-test), which SIGKILLs the 32 GiB pool — the **recurrence engine behind the publishing freeze** (unit OOM → "self-hosted runner lost communication" → main CI `cancelled` → bench skipped). 4× RAM removes the constraint and lets the test phase run 4-wide again (it was capped to 2 purely to dodge the OOM). The build also auto-scales more cargo jobs on the extra RAM (`CARGO_BUILD_JOBS` keys off live `MemAvailable`).

The **bench pool (`tsz-ci-build-pool`) is deliberately left unchanged** so bench perf timings keep their x86-64-v3 baseline — the new pool is for the RAM-bound compile/test jobs only.

## Changes

- **GCP (out-of-band, done):** created worker pool `tsz-ci-build-pool-highmem` (e2-standard-32, 128 GiB, 200 GB disk, PUBLIC_EGRESS). Quota-confirmed (`E2_CPUS` limit 600, ~0 used); smoke build on it succeeded.
- `cloudbuild-unit.yaml`: pool → highmem; `TSZ_CI_UNIT_TEST_THREADS=4`; updated rationale comment.
- `cloudbuild-checker-integration.yaml`: pool → highmem.

Goal: fast

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- Both cloudbuild YAMLs parse.
- New pool created + RUNNING + a trivial build succeeded on it.
- **The merge_group runs `unit` + `unit-checker-integration` on the new pool** (full CI runs in merge_group regardless of path classification) — green proves the pool works and there's no OOM at 4 test-threads *before* this can reach main. A misconfigured pool ejects the PR, it never lands broken.
- Bench pool untouched → perf-timing parity preserved.
