### PR TITLE
fix(checker): entity-name computed names are late-bindable for override (false TS4127)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -842,6 +842,9 @@ path = "tests/keyof_array_literal_diagnostic_tests.rs"
 name = "keyof_quoted_string_property_name_tests"
 path = "tests/keyof_quoted_string_property_name_tests.rs"
 [[test]]
+name = "override_computed_entity_name_ts4127_tests"
+path = "tests/override_computed_entity_name_ts4127_tests.rs"
+[[test]]
 name = "keyof_well_known_symbol_key_tests"
 path = "tests/keyof_well_known_symbol_key_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -923,7 +923,7 @@ impl<'a> CheckerState<'a> {
     /// Entity name expressions are simple identifiers or property access chains
     /// (e.g., `a`, `a.b`, `a.b.c`). These are always allowed as computed property
     /// names in class property declarations, regardless of their type.
-    fn is_entity_name_expression(&self, expr_idx: NodeIndex) -> bool {
+    pub(crate) fn is_entity_name_expression(&self, expr_idx: NodeIndex) -> bool {
         let Some(expr_node) = self.ctx.arena.get(expr_idx) else {
             return false;
         };

--- a/crates/tsz-checker/src/classes/class_member_info.rs
+++ b/crates/tsz-checker/src/classes/class_member_info.rs
@@ -100,6 +100,23 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
+        // Entity-name property accesses (`globalThis.Symbol.hasInstance`,
+        // `Consts.KEY`) are late-bindable when the expression's type is usable as
+        // a property name — a unique symbol or a string/number literal — matching
+        // tsc's `isLateBindableName`. A widened type (plain `string`) stays dynamic
+        // and falls through to the `true` below.
+        if kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            && self.is_entity_name_expression(expression_idx)
+        {
+            let expr_type = self.get_type_of_node(expression_idx);
+            if crate::query_boundaries::checkers::property::is_type_usable_as_property_name(
+                self.ctx.types,
+                expr_type,
+            ) {
+                return false;
+            }
+        }
+
         if kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
             && let Some(paren) = self.ctx.arena.get_parenthesized(expr_node)
         {

--- a/crates/tsz-checker/tests/override_computed_entity_name_ts4127_tests.rs
+++ b/crates/tsz-checker/tests/override_computed_entity_name_ts4127_tests.rs
@@ -1,0 +1,85 @@
+//! Regression tests for TS4127 on `override` members with computed names that
+//! are entity-name property-access chains.
+//!
+//! tsc's `isLateBindableName` treats a computed name whose expression is an
+//! entity-name expression (`a.b.c`) as a *static* (non-dynamic) name when the
+//! expression's type is usable as a property name — a `unique symbol` or a
+//! string/number literal. Such a member may carry `override`. tsz previously
+//! recognized only bare-identifier and `Symbol.<name>` forms, so a deeper chain
+//! such as `globalThis.Symbol.hasInstance` (seen in the wild in `runtypes`) was
+//! treated as dynamic, producing a spurious TS4127.
+//!
+//! The structural rule under test: a computed name `[a.b.c]` is non-dynamic iff
+//! `a.b.c` is an entity-name expression whose type is usable as a property name,
+//! independent of the chain depth or the binder names involved. A widened type
+//! (plain `string`) on the same entity-name shape stays dynamic.
+//!
+//! Note: a literal-typed property access is used as the positive witness here
+//! because it is lib-free and the test harness preserves literal property types
+//! through member access. The `unique symbol` analogue (`globalThis.Symbol.*`)
+//! is verified at the full-pipeline/CLI level; the unit harness's lib does not
+//! model `globalThis.Symbol.hasInstance` as a `unique symbol`, and a separate
+//! gap widens `unique symbol` read off an object property to `symbol`.
+
+use tsz_checker::test_utils::check_source_code_messages as compile_and_get_diagnostics;
+
+fn ts4127s(source: &str) -> Vec<(u32, String)> {
+    compile_and_get_diagnostics(source)
+        .into_iter()
+        .filter(|(c, _)| *c == 4127)
+        .collect()
+}
+
+/// A literal-typed entity-name property access (`Lit.k` where `Lit.k: "fixed"`)
+/// is late-bindable, so the override must not draw TS4127. This is the case the
+/// fix flips: before, the property-access expression fell through to the dynamic
+/// catch-all; after, the entity-name + usable-type check accepts it.
+#[test]
+fn override_literal_typed_entity_name_is_not_dynamic() {
+    let ts4127 = ts4127s(
+        r#"
+declare const Lit: { readonly k: "fixed" };
+class Base { [Lit.k](): void {} }
+class Sub extends Base { override [Lit.k](): void {} }
+"#,
+    );
+    assert!(
+        ts4127.is_empty(),
+        "entity-name literal-typed computed override must not be dynamic; got TS4127: {ts4127:#?}"
+    );
+}
+
+/// Proves the rule is not binder-name-specific: a differently named chain with a
+/// numeric-literal-typed leaf is likewise late-bindable.
+#[test]
+fn override_numeric_literal_entity_name_is_not_dynamic() {
+    let ts4127 = ts4127s(
+        r#"
+declare const Cfg: { readonly idx: 7 };
+class Base { [Cfg.idx](): void {} }
+class Sub extends Base { override [Cfg.idx](): void {} }
+"#,
+    );
+    assert!(
+        ts4127.is_empty(),
+        "entity-name numeric-literal computed override must not be dynamic; got TS4127: {ts4127:#?}"
+    );
+}
+
+/// Negative control: the same entity-name shape with a *widened* `string` type
+/// is genuinely dynamic, so `override` must still draw TS4127 — matching tsc.
+/// Guards the fix against over-broadening to all entity-name accesses.
+#[test]
+fn override_widened_string_entity_name_is_dynamic() {
+    let ts4127 = ts4127s(
+        r#"
+declare const W: { readonly n: string };
+class Base { [W.n](): void {} }
+class Sub extends Base { override [W.n](): void {} }
+"#,
+    );
+    assert!(
+        !ts4127.is_empty(),
+        "widened-string computed override must stay dynamic (TS4127); got none"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
A computed member name whose expression is an **entity-name** property-access chain — `globalThis.Symbol.hasInstance`, `Consts.KEY`, `Lit.k` — is **late-bindable** (non-dynamic) when the expression's type is usable as a property name: a `unique symbol` or a string/number literal. tsc's `isLateBindableName` permits `override` on such a member; tsz emitted a spurious **TS4127** ("This member cannot have an 'override' modifier because its name is dynamic").

Witness: `runtypes` declares `static override [globalThis.Symbol.hasInstance](...)`. tsz reported a false TS4127 there.

Structural rule: when a computed name `[a.b.c]` is an entity-name expression whose type is usable as a property name, tsc treats the name as static; tsz now does too via `is_computed_expression_dynamic` (`crates/tsz-checker/src/classes/class_member_info.rs`). Previously that function handled only bare identifiers, string/number literals, and parenthesized forms, so any property-access chain fell through to the dynamic catch-all. The new branch reuses `CheckerState::is_entity_name_expression` (promoted to `pub(crate)`) and the existing `is_type_usable_as_property_name` query — no new name/string heuristics. A widened type (plain `string`) on the same shape stays dynamic.

Owner layer: checker (computed-name dynamism classification); structural decision delegated to the solver `type_queries::is_type_usable_as_property_name`.

## Verification
- `cargo nextest run -p tsz-checker --test override_computed_entity_name_ts4127_tests` — 3 passed. The two positive tests (literal- and numeric-literal-typed entity-name override) **fail on main** (confirmed by stashing the two source changes: "0 passed; 1 failed"); the widened-`string` negative control passes on both, guarding against over-broadening.
- Related suites green: `keyof_well_known_symbol_key_tests`, `keyof_class_unique_symbol_key_tests`, `override_intersection_display_tests`, `accessor_pair_override_ts2416_tests`, `homomorphic_mapped_well_known_symbol_iterable_tests`, `destructuring_rest_computed_key_omit_tests` (51 tests).
- CLI vs tsc 6.0.3 on `class Sub extends Base { static override [globalThis.Symbol.hasInstance](x: unknown) {...} }`: both clean (exit 0). Negative `override [W.n]` with `W.n: string`: both emit TS4127.

### Known follow-up (not in scope)
tsz widens a `unique symbol` read off an *object-type property* (`Consts.KEY` where `readonly KEY: unique symbol`) to plain `symbol` (probe: `const y: typeof Consts.KEY = someSymbol` errors in tsc but not tsz). Because of that separate gap, the `unique symbol`-via-object-property override is not yet clean in tsz; the late-binding classifier added here is correct and will cover it once the access preserves the unique-symbol identity. Identifier-bound and lib well-known symbols already preserve identity and are covered.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
