### PR TITLE
refactor(checker): unify dual-env write discipline into one shared path

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -4,6 +4,7 @@
 //! references, type parameter registration, and resolved-type registration
 //! in the `TypeEnvironment`.
 
+use std::cell::RefCell;
 use std::sync::Arc;
 
 use crate::query_boundaries::common::TypeResolver;
@@ -32,6 +33,65 @@ fn eager_warm_local_caches() -> bool {
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false)
     })
+}
+
+// --- Shared dual-environment write discipline ---
+//
+// The context owns two `TypeEnvironment` instances behind separate `RefCell`s:
+// the authoritative evaluator env (`type_env`) and the flow-analyzer env
+// (`type_environment`). They are kept separate so a re-entrant evaluator can
+// publish-and-read freshly resolved `DefId -> TypeId` bodies into `type_env`
+// while the flow analyzer holds `type_environment` borrowed for narrowing. Both
+// envs share *one* race-safe write discipline, expressed once below and reused
+// for each (env, deferred-queue) pair rather than hand-duplicated per env.
+
+/// Apply `op` to `env`, or queue it on `queue` when `env` is already borrowed.
+///
+/// A registration can race with a live borrow during recursive resolution
+/// (which can hold either env, including the target itself). On a successful
+/// borrow this first drains any previously-deferred writes (in order) so the env
+/// catches up, then applies `op`; on a borrow conflict it queues `op` for later
+/// replay rather than dropping it. Dropping an authoritative write would also
+/// drop the shared `DefinitionStore` write-through that lives inside the env
+/// mutator, collapsing a def / class-instance body to `never` for every later
+/// consumer.
+fn apply_or_defer_env_write(
+    env: &RefCell<TypeEnvironment>,
+    queue: &RefCell<Vec<DeferredFlowEnvWrite>>,
+    op: DeferredFlowEnvWrite,
+) {
+    match env.try_borrow_mut() {
+        Ok(mut env) => {
+            drain_env_write_queue_into(queue, &mut env);
+            op.apply(&mut env);
+        }
+        Err(_) => queue.borrow_mut().push(op),
+    }
+}
+
+/// Replay every queued deferred write into an already-borrowed env, clearing the
+/// queue. A single `take` leaves an empty queue, so the loop is a no-op when
+/// nothing was deferred.
+fn drain_env_write_queue_into(
+    queue: &RefCell<Vec<DeferredFlowEnvWrite>>,
+    env: &mut TypeEnvironment,
+) {
+    let pending = std::mem::take(&mut *queue.borrow_mut());
+    for op in pending {
+        op.apply(env);
+    }
+}
+
+/// Replay any deferred writes for `env` that lost the borrow race, if it is
+/// momentarily borrowable. A no-op when nothing was deferred or the env is not
+/// borrowable (the next successful write drains the backlog).
+fn flush_env_write_queue(
+    env: &RefCell<TypeEnvironment>,
+    queue: &RefCell<Vec<DeferredFlowEnvWrite>>,
+) {
+    if let Ok(mut env) = env.try_borrow_mut() {
+        drain_env_write_queue_into(queue, &mut env);
+    }
 }
 
 impl CheckerContext<'_> {
@@ -758,56 +818,20 @@ impl CheckerContext<'_> {
         self.mirror_to_flow_env(op);
     }
 
-    /// Apply (or defer) one registration to the authoritative evaluator env.
+    /// Apply (or defer) one registration to the authoritative evaluator env
+    /// (`type_env`), through the shared race-safe write discipline.
     fn apply_to_eval_env(&self, op: DeferredFlowEnvWrite) {
-        match self.type_env.try_borrow_mut() {
-            Ok(mut env) => {
-                self.drain_deferred_eval_env_writes_into(&mut env);
-                op.apply(&mut env);
-            }
-            Err(_) => {
-                self.deferred_eval_env_writes.borrow_mut().push(op);
-            }
-        }
+        apply_or_defer_env_write(&self.type_env, &self.deferred_eval_env_writes, op);
     }
 
-    /// Replay queued evaluator-env writes into an already-borrowed env.
-    fn drain_deferred_eval_env_writes_into(&self, env: &mut TypeEnvironment) {
-        let pending = std::mem::take(&mut *self.deferred_eval_env_writes.borrow_mut());
-        for op in pending {
-            op.apply(env);
-        }
-    }
-
-    /// Apply (or defer) a single registration to the flow-analyzer env.
-    ///
-    /// On a successful borrow, first replays any previously-deferred writes (in
-    /// order) so the env catches up, then applies `op`. On a borrow conflict,
-    /// `op` is queued for later replay.
+    /// Apply (or defer) a single registration to the flow-analyzer env
+    /// (`type_environment`), through the shared race-safe write discipline.
     ///
     /// Exposed `pub(crate)` so the `get_type_of_symbol` caching path can mirror
     /// its `DefId` writes through this race-safe queue instead of a direct
     /// `try_borrow_mut` that silently drops on contention (#13086/#13944).
     pub(crate) fn mirror_to_flow_env(&self, op: DeferredFlowEnvWrite) {
-        match self.type_environment.try_borrow_mut() {
-            Ok(mut env) => {
-                self.drain_deferred_flow_env_writes_into(&mut env);
-                op.apply(&mut env);
-            }
-            Err(_) => {
-                self.deferred_flow_env_writes.borrow_mut().push(op);
-            }
-        }
-    }
-
-    /// Replay every queued deferred write into an already-borrowed flow-analyzer
-    /// env, clearing the queue. A single borrow: `take` leaves an empty queue,
-    /// so the loop is a no-op when nothing was deferred.
-    fn drain_deferred_flow_env_writes_into(&self, env: &mut TypeEnvironment) {
-        let pending = std::mem::take(&mut *self.deferred_flow_env_writes.borrow_mut());
-        for op in pending {
-            op.apply(env);
-        }
+        apply_or_defer_env_write(&self.type_environment, &self.deferred_flow_env_writes, op);
     }
 
     /// Replay any deferred flow-analyzer-env writes that lost the borrow race.
@@ -817,9 +841,7 @@ impl CheckerContext<'_> {
     /// analysis reads it. A no-op when nothing was deferred and when the env is
     /// momentarily unborrowable (the next successful mirror-write drains it).
     pub fn flush_deferred_flow_env_writes(&self) {
-        if let Ok(mut env) = self.type_environment.try_borrow_mut() {
-            self.drain_deferred_flow_env_writes_into(&mut env);
-        }
+        flush_env_write_queue(&self.type_environment, &self.deferred_flow_env_writes);
     }
 
     /// Replay any deferred evaluator-env (`type_env`) writes that lost the
@@ -829,9 +851,7 @@ impl CheckerContext<'_> {
     /// consumer (method-body checking, `overlay_missing_from`) reads it. A no-op
     /// when nothing was deferred or `type_env` is momentarily unborrowable.
     pub fn flush_deferred_eval_env_writes(&self) {
-        if let Ok(mut env) = self.type_env.try_borrow_mut() {
-            self.drain_deferred_eval_env_writes_into(&mut env);
-        }
+        flush_env_write_queue(&self.type_env, &self.deferred_eval_env_writes);
     }
 
     /// Number of registrations still waiting to be mirrored into the

--- a/crates/tsz-checker/src/context/def_mapping_tests.rs
+++ b/crates/tsz-checker/src/context/def_mapping_tests.rs
@@ -355,6 +355,85 @@ fn eval_env_backlog_drains_on_next_successful_write() {
     );
 }
 
+/// Both type environments share one race-safe write discipline
+/// (`apply_or_defer_env_write`). When a single dual-env registration races
+/// *both* cells at once — the exact recursive-resolution scenario where the flow
+/// analyzer holds `type_environment` while the re-entrant evaluator holds
+/// `type_env` — neither write may be dropped: each must defer onto its own queue
+/// and replay symmetrically on flush.
+#[test]
+fn both_envs_defer_then_replay_under_simultaneous_borrow() {
+    use tsz_common::interner::Atom;
+    use tsz_solver::TypeId;
+    use tsz_solver::def::DefinitionInfo;
+
+    let (arena, binder, types) = minimal_checker_ctx();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    let child = ctx.definition_store.register(DefinitionInfo::type_alias(
+        Atom::default(),
+        vec![],
+        TypeId::UNKNOWN,
+    ));
+    let parent = ctx.definition_store.register(DefinitionInfo::type_alias(
+        Atom::default(),
+        vec![],
+        TypeId::UNKNOWN,
+    ));
+
+    // Hold both cells borrowed, so the evaluator write *and* the flow mirror
+    // each lose the borrow race. `class_extends` is env-local with no shared
+    // store fallback, so the reads below isolate the per-env map.
+    {
+        let held_eval = ctx.type_env.borrow();
+        let held_flow = ctx.type_environment.borrow();
+        ctx.register_class_extends_in_envs(child, parent);
+
+        assert_eq!(
+            held_eval.get_class_extends_def(child),
+            None,
+            "evaluator env must not yet have the deferred write"
+        );
+        assert_eq!(
+            held_flow.get_class_extends_def(child),
+            None,
+            "flow-analyzer env must not yet have the deferred write"
+        );
+        assert_eq!(
+            ctx.deferred_eval_env_write_count(),
+            1,
+            "the lost evaluator write must be queued for replay"
+        );
+        assert_eq!(
+            ctx.deferred_flow_env_write_count(),
+            1,
+            "the lost flow mirror must be queued for replay"
+        );
+    }
+
+    // Both queues drain symmetrically once the cells are borrowable again.
+    ctx.flush_deferred_eval_env_writes();
+    ctx.flush_deferred_flow_env_writes();
+    assert_eq!(ctx.deferred_eval_env_write_count(), 0);
+    assert_eq!(ctx.deferred_flow_env_write_count(), 0);
+    assert_eq!(
+        ctx.type_env.borrow().get_class_extends_def(child),
+        Some(parent),
+        "evaluator env must receive the replayed write"
+    );
+    assert_eq!(
+        ctx.type_environment.borrow().get_class_extends_def(child),
+        Some(parent),
+        "flow-analyzer env must receive the replayed write"
+    );
+}
+
 /// Regression for #13944 / #13086: a `DefId -> TypeId` body re-published by the
 /// lazy-resolution path (`register_resolved_def_in_envs`, the gateway
 /// `try_insert_def_in_type_env` now uses) must travel the race-safe deferred


### PR DESCRIPTION
Goal: hold

## Summary

Migration **step 1** for #14348 (`ROBUSTNESS_AUDIT` item #3, "dual `TypeEnvironment`"): a behavior-preserving consolidation of the dual-environment write discipline. No semantic change — this shrinks the surface the eventual single-authoritative-env collapse must touch.

The checker owns two `TypeEnvironment` instances behind separate `RefCell`s:
- `type_env` — the authoritative evaluator env
- `type_environment` — the flow-analyzer env

They are deliberately separate so a **re-entrant evaluator can publish-and-read** freshly resolved `DefId -> TypeId` bodies into `type_env` while the flow analyzer holds `type_environment` borrowed for narrowing. Each env had its own hand-duplicated borrow-or-defer / drain / flush helpers (six near-identical methods).

This PR collapses those onto three shared free functions parameterized by the `(env, deferred-queue)` pair:
- `apply_or_defer_env_write`
- `drain_env_write_queue_into`
- `flush_env_write_queue`

so both envs run exactly **one** race-safe write discipline.

## Why not the full collapse?

The audit's end-state (make `type_environment` a read-only snapshot, delete the deferred-write machinery) is **not** parity-safe in one shot: a single `RefCell` would force a re-entrant publish-then-read to defer, and deferred replay cannot make a write visible mid-borrow within the same narrowing op. That step needs full-conformance validation against the borrow-race witnesses (#13741 / #13944 / #13951 / #13952) and is a follow-up. This PR is the safe, independently-shippable precursor.

## Structural rule

When a `DefId`-keyed registration races a live `RefCell` borrow during recursive resolution, tsz defers the write onto a per-env queue and replays it (never drops it) — for **both** envs, now through one shared helper owned by the checker `context` layer. A dropped authoritative write would also drop the shared `DefinitionStore` write-through that rides the env mutator, collapsing a def / class-instance body to `never` for later consumers; that invariant is preserved.

## Anti-hardcoding

Pure consolidation: no name/file-string predicates, no printer-output reads, no behavior gated on identifiers. The new test registers synthetic defs (binder-name independent).

## Verification

- `cargo test -p tsz-checker --lib context::def_mapping::tests` — 8/8 pass: the 7 pre-existing dual-env regression tests (behavior preserved) plus a new `both_envs_defer_then_replay_under_simultaneous_borrow` covering the simultaneous-both-borrowed race (flow analyzer holds `type_environment` while the evaluator holds `type_env`).
- `cargo clippy -p tsz-checker --lib` — clean.
- Full conformance / emit / fourslash: deferred to ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: medium

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkGtVGfPdnBAPByRzXU27s)_