### PR TITLE
fix(solver): infer a callee type argument from a generic type-parameter source's apparent type (TS2339) (#14321)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -959,6 +959,9 @@ path = "tests/program_context_tests.rs"
 name = "generic_call_inference_tests"
 path = "tests/generic_call_inference_tests.rs"
 [[test]]
+name = "generic_param_source_apparent_type_inference_tests"
+path = "tests/generic_param_source_apparent_type_inference_tests.rs"
+[[test]]
 name = "kysely_callback_context_tests"
 path = "tests/kysely_callback_context_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/generic_param_source_apparent_type_inference_tests.rs
+++ b/crates/tsz-checker/tests/generic_param_source_apparent_type_inference_tests.rs
@@ -1,0 +1,146 @@
+//! Regression tests for issue #14321.
+//!
+//! When inferring a callee's type argument and the argument's type is itself a
+//! generic type parameter we are *not* inferring (e.g. `obj: T` passed to
+//! `keyOf<K>(obj: Record<K, unknown>)`), `tsc` infers the callee parameter from
+//! the source's apparent type — its constraint. So `K` of `Record<K, unknown>`
+//! is inferred from a `T extends Record<string, unknown>` source as `string`,
+//! not the constraint default `PropertyKey`.
+//!
+//! tsz previously left such a `K` at its `PropertyKey` constraint default,
+//! producing an over-wide key and a downstream false `TS2339`/`TS2322` (mined
+//! from radash `lowerize`). These tests pin the corrected apparent-type
+//! inference for the `Record<K, V>` constructor form, the equivalent mapped
+//! `{ [P in K]: V }` form, and a concrete index-signature source, with binder
+//! names varied so no fix can key on a particular spelling.
+
+use tsz_checker::test_utils::check_source_code_messages as compile_and_get_diagnostics;
+
+fn ts2322_count(source: &str) -> usize {
+    compile_and_get_diagnostics(source)
+        .iter()
+        .filter(|(code, _)| *code == 2322)
+        .count()
+}
+
+// Self-contained `Record`/`PropertyKey` so the test runs without lib contexts.
+const PRELUDE: &str = r#"
+type PKey = string | number | symbol;
+type Rec<K extends PKey, V> = { [P in K]: V };
+"#;
+
+#[test]
+fn record_key_param_inferred_from_source_constraint_key() {
+    // `K` of `Rec<K, unknown>` must infer `string` from `T`'s constraint
+    // `Rec<string, unknown>`, so `const s: string = k` is clean.
+    let source = format!(
+        "{PRELUDE}
+declare function keyOf<K extends PKey>(obj: Rec<K, unknown>): K;
+function lowerize<T extends Rec<string, unknown>>(obj: T) {{
+  const k = keyOf(obj);
+  const s: string = k;
+}}
+"
+    );
+    assert_eq!(
+        ts2322_count(&source),
+        0,
+        "K should infer `string` from the source parameter's apparent type, not `PropertyKey`"
+    );
+}
+
+#[test]
+fn record_key_param_is_string_not_widened_to_propertykey() {
+    // The dual of the previous test: if `K` were `string`, assigning to a
+    // narrower `1` must still fail — proving `K` is `string`, not `1` and not a
+    // suppressed `any`.
+    let source = format!(
+        "{PRELUDE}
+declare function keyOf<K extends PKey>(obj: Rec<K, unknown>): K;
+function lowerize<T extends Rec<string, unknown>>(obj: T) {{
+  const k = keyOf(obj);
+  const bad: 1 = k;
+}}
+"
+    );
+    assert_eq!(
+        ts2322_count(&source),
+        1,
+        "K = string is not assignable to the literal `1`"
+    );
+}
+
+#[test]
+fn number_key_constraint_infers_number() {
+    // A `Rec<number, unknown>` constraint must infer `K = number`.
+    let source = format!(
+        "{PRELUDE}
+declare function keyOf<K extends PKey>(obj: Rec<K, unknown>): K;
+function f<Src extends Rec<number, unknown>>(obj: Src) {{
+  const k = keyOf(obj);
+  const n: number = k;
+  const bad: 1 = k;
+}}
+"
+    );
+    assert_eq!(
+        ts2322_count(&source),
+        1,
+        "K = number is clean against `number` but rejected against `1`"
+    );
+}
+
+#[test]
+fn propertykey_constraint_source_stays_propertykey() {
+    // Negative control: a source whose constraint key is the full `PKey` must
+    // keep `K = PKey`, so assigning to `string` *does* error.
+    let source = format!(
+        "{PRELUDE}
+declare function keyOf<K extends PKey>(obj: Rec<K, unknown>): K;
+function f<Src extends Rec<PKey, unknown>>(obj: Src) {{
+  const k = keyOf(obj);
+  const s: string = k;
+}}
+"
+    );
+    assert_eq!(
+        ts2322_count(&source),
+        1,
+        "a PropertyKey-constrained source must not be narrowed to `string`"
+    );
+}
+
+#[test]
+fn mapped_key_param_inferred_from_concrete_index_signature() {
+    // The mapped `{ [P in K]: V }` form over a concrete index-signature source
+    // infers `K` from the index key type.
+    let source = "
+declare function keyOf2<Key extends string | number | symbol>(obj: { [P in Key]: unknown }): Key;
+declare const o: { [x: string]: number };
+const k = keyOf2(o);
+const s: string = k;
+const bad: 1 = k;
+";
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "K should infer `string` from the source index-signature key, clean against `string`"
+    );
+}
+
+#[test]
+fn plain_generic_identity_inference_is_unchanged() {
+    // Guard against over-firing: a non-structured target still infers the
+    // source directly (`T = 5`), not its (absent) constraint.
+    let source = "
+declare function id<T>(x: T): T;
+const r = id(5);
+const ok: 5 = r;
+const bad: 6 = r;
+";
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "identity inference must keep T = 5 (only the `6` assignment fails)"
+    );
+}

--- a/crates/tsz-checker/tests/generic_param_source_apparent_type_inference_tests.rs
+++ b/crates/tsz-checker/tests/generic_param_source_apparent_type_inference_tests.rs
@@ -16,11 +16,19 @@
 
 use tsz_checker::test_utils::check_source_code_messages as compile_and_get_diagnostics;
 
-fn ts2322_count(source: &str) -> usize {
+fn diagnostic_count(source: &str, expected_code: u32) -> usize {
     compile_and_get_diagnostics(source)
         .iter()
-        .filter(|(code, _)| *code == 2322)
+        .filter(|(code, _)| *code == expected_code)
         .count()
+}
+
+fn ts2322_count(source: &str) -> usize {
+    diagnostic_count(source, 2322)
+}
+
+fn ts2345_count(source: &str) -> usize {
+    diagnostic_count(source, 2345)
 }
 
 // Self-contained `Record`/`PropertyKey` so the test runs without lib contexts.
@@ -107,6 +115,39 @@ function f<Src extends Rec<PKey, unknown>>(obj: Src) {{
         ts2322_count(&source),
         1,
         "a PropertyKey-constrained source must not be narrowed to `string`"
+    );
+}
+
+#[test]
+fn nullable_union_constraint_does_not_hide_narrowed_undefined() {
+    // `x` is narrowed to `undefined` in both error branches. Apparent-type
+    // inference must not mine `Box<T>` out of the declared nullable union
+    // constraint and make `unbox(x)` appear valid.
+    let source = "
+interface Box<T> {
+    item: T;
+}
+
+declare function isBox(x: unknown): x is Box<unknown>;
+declare function isUndefined(x: unknown): x is undefined;
+declare function unbox<T>(x: Box<T>): T;
+
+function g3<T extends Box<T> | undefined>(x: T) {
+    if (!isBox(x)) {
+        unbox(x);
+    }
+}
+
+function g4<T extends Box<T> | undefined>(x: T) {
+    if (isUndefined(x)) {
+        unbox(x);
+    }
+}
+";
+    assert_eq!(
+        ts2345_count(source),
+        2,
+        "narrowed undefined branches must still reject calls to unbox"
     );
 }
 

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -420,24 +420,10 @@ impl<'a> InferenceContext<'a> {
                 self.infer_from_mapped_type_array(source_elem, mapped_id, priority)?;
             }
 
-            // Source is a generic type parameter that is NOT one we're
-            // inferring (Case 2 returns for inference variables) matched
-            // against a structured generic target — a type constructor like
-            // `Record<K, V>` or a mapped type. A bare type parameter cannot
-            // match such a target structurally, so — like tsc — infer from its
-            // apparent type (its constraint): `K` of `Record<K, any>` is then
-            // inferred from the source constraint's key component
-            // (`Record<string, any>` ⇒ `string`) instead of falling back to
-            // `K`'s constraint default (`PropertyKey`), which produces a
-            // spurious over-wide key and downstream TS2339 (radash `lowerize`).
-            //
-            // Guarded on the target actually carrying an inference variable so a
-            // fully concrete structured target stays a no-op, and on the
-            // constraint differing from the source to avoid self-recursion. A
-            // bare-type-parameter target is handled earlier (Case 1: the source
-            // becomes the candidate directly), and a naked parameter inside a
-            // union target keeps its direct `K = T` inference via the union
-            // decomposition arm, so neither is reached here.
+            // When a non-inferred source type parameter faces a structured
+            // generic target (`Record<K, V>`/mapped type), infer from the
+            // source's apparent type (its constraint) so target placeholders
+            // get the constraint's components instead of their defaults.
             (
                 Some(TypeData::TypeParameter(ref param_info)),
                 Some(TypeData::Application(_) | TypeData::Mapped(_)),

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -423,13 +423,16 @@ impl<'a> InferenceContext<'a> {
             // When a non-inferred source type parameter faces a structured
             // generic target (`Record<K, V>`/mapped type), infer from the
             // source's apparent type (its constraint) so target placeholders
-            // get the constraint's components instead of their defaults.
+            // get the constraint's components instead of their defaults. Do
+            // not lift nullable union constraints: their nullish constituent
+            // must remain visible to the final argument check.
             (
                 Some(TypeData::TypeParameter(ref param_info)),
                 Some(TypeData::Application(_) | TypeData::Mapped(_)),
             ) => {
                 if let Some(constraint) = param_info.constraint
                     && constraint != source
+                    && !self.constraint_is_nullable_union(constraint)
                     && self.target_contains_inference_param(target)
                 {
                     self.infer_from_types(constraint, target, priority)?;
@@ -1633,6 +1636,16 @@ impl<'a> InferenceContext<'a> {
     /// instead of structurally matching `Foo<V>`.
     fn target_contains_inference_param(&self, target: TypeId) -> bool {
         self.target_contains_inference_param_inner(target, &mut std::collections::HashSet::new())
+    }
+
+    fn constraint_is_nullable_union(&self, constraint: TypeId) -> bool {
+        let Some(TypeData::Union(members)) = self.interner.lookup(constraint) else {
+            return false;
+        };
+        self.interner
+            .type_list(members)
+            .iter()
+            .any(|&member| member.is_nullable())
     }
 
     fn target_contains_inference_param_inner(

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -22,6 +22,7 @@ use rustc_hash::FxHashMap;
 use tsz_common::interner::Atom;
 
 use super::infer::{InferenceContext, InferenceError, InferenceVar};
+use super::infer_matching_helpers::constraint_is_nullable_union;
 use super::template_anchor::{find_leftmost_occurrence, find_next_anchor_alternatives};
 use super::template_segment_prefix::match_template_segment_prefix;
 
@@ -432,7 +433,7 @@ impl<'a> InferenceContext<'a> {
             ) => {
                 if let Some(constraint) = param_info.constraint
                     && constraint != source
-                    && !self.constraint_is_nullable_union(constraint)
+                    && !constraint_is_nullable_union(self.interner, constraint)
                     && self.target_contains_inference_param(target)
                 {
                     self.infer_from_types(constraint, target, priority)?;
@@ -1636,16 +1637,6 @@ impl<'a> InferenceContext<'a> {
     /// instead of structurally matching `Foo<V>`.
     fn target_contains_inference_param(&self, target: TypeId) -> bool {
         self.target_contains_inference_param_inner(target, &mut std::collections::HashSet::new())
-    }
-
-    fn constraint_is_nullable_union(&self, constraint: TypeId) -> bool {
-        let Some(TypeData::Union(members)) = self.interner.lookup(constraint) else {
-            return false;
-        };
-        self.interner
-            .type_list(members)
-            .iter()
-            .any(|&member| member.is_nullable())
     }
 
     fn target_contains_inference_param_inner(

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -420,6 +420,36 @@ impl<'a> InferenceContext<'a> {
                 self.infer_from_mapped_type_array(source_elem, mapped_id, priority)?;
             }
 
+            // Source is a generic type parameter that is NOT one we're
+            // inferring (Case 2 returns for inference variables) matched
+            // against a structured generic target — a type constructor like
+            // `Record<K, V>` or a mapped type. A bare type parameter cannot
+            // match such a target structurally, so — like tsc — infer from its
+            // apparent type (its constraint): `K` of `Record<K, any>` is then
+            // inferred from the source constraint's key component
+            // (`Record<string, any>` ⇒ `string`) instead of falling back to
+            // `K`'s constraint default (`PropertyKey`), which produces a
+            // spurious over-wide key and downstream TS2339 (radash `lowerize`).
+            //
+            // Guarded on the target actually carrying an inference variable so a
+            // fully concrete structured target stays a no-op, and on the
+            // constraint differing from the source to avoid self-recursion. A
+            // bare-type-parameter target is handled earlier (Case 1: the source
+            // becomes the candidate directly), and a naked parameter inside a
+            // union target keeps its direct `K = T` inference via the union
+            // decomposition arm, so neither is reached here.
+            (
+                Some(TypeData::TypeParameter(ref param_info)),
+                Some(TypeData::Application(_) | TypeData::Mapped(_)),
+            ) => {
+                if let Some(constraint) = param_info.constraint
+                    && constraint != source
+                    && self.target_contains_inference_param(target)
+                {
+                    self.infer_from_types(constraint, target, priority)?;
+                }
+            }
+
             // TypeApplication source: expand type alias and recurse.
             // When a source type is a type alias application (e.g., `Mapper<string, number>`),
             // expand it to its structural form so inference can match structurally against

--- a/crates/tsz-solver/src/inference/infer_matching_helpers.rs
+++ b/crates/tsz-solver/src/inference/infer_matching_helpers.rs
@@ -1,0 +1,11 @@
+use crate::caches::db::TypeDatabase;
+use crate::types::{TypeData, TypeId};
+
+pub(super) fn constraint_is_nullable_union(db: &dyn TypeDatabase, constraint: TypeId) -> bool {
+    let Some(TypeData::Union(members)) = db.lookup(constraint) else {
+        return false;
+    };
+    db.type_list(members)
+        .iter()
+        .any(|&member| member.is_nullable())
+}

--- a/crates/tsz-solver/src/inference/mod.rs
+++ b/crates/tsz-solver/src/inference/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod infer;
 pub(crate) mod infer_bct;
 pub(crate) mod infer_candidate_kinds;
 pub(crate) mod infer_matching;
+mod infer_matching_helpers;
 pub(crate) mod infer_matching_tuples;
 pub(crate) mod infer_resolve;
 pub(crate) mod infer_variance;

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -275,19 +275,21 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             // over-wide key and a downstream TS2339 (radash `lowerize`).
             //
             // Guarded on the target actually carrying an inference placeholder
-            // so a fully concrete structured target stays a no-op, and on the
-            // constraint differing from the source; the `constraint_pairs`
-            // visited set and recursion-depth bound own termination. A
-            // bare-placeholder target is handled earlier (lower-bound
-            // candidate), and a naked parameter inside a union/conditional
-            // target keeps its direct inference through the dedicated arms, so
-            // neither is reached here.
+            // so a fully concrete structured target stays a no-op, on the
+            // constraint differing from the source, and on the constraint not
+            // being a nullable union whose nullish member must still be checked.
+            // The `constraint_pairs` visited set and recursion-depth bound own
+            // termination. A bare-placeholder target is handled earlier
+            // (lower-bound candidate), and a naked parameter inside a
+            // union/conditional target keeps its direct inference through the
+            // dedicated arms, so neither is reached here.
             (
                 Some(TypeData::TypeParameter(ref param_info)),
                 Some(TypeData::Application(_) | TypeData::Mapped(_)),
             ) => {
                 if let Some(constraint) = param_info.constraint
                     && constraint != source
+                    && !self.constraint_is_nullable_union(constraint)
                     && with_placeholder_visited(|visited| {
                         self.type_contains_placeholder(target, var_map, visited)
                     })
@@ -2147,5 +2149,15 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             }
             _ => {}
         }
+    }
+
+    fn constraint_is_nullable_union(&self, constraint: TypeId) -> bool {
+        let Some(TypeData::Union(members)) = self.interner.lookup(constraint) else {
+            return false;
+        };
+        self.interner
+            .type_list(members)
+            .iter()
+            .any(|&member| member.is_nullable())
     }
 }

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -263,6 +263,38 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         }
 
         match (source_key, target_key) {
+            // A source that is a generic type parameter we are NOT inferring
+            // (source placeholders are handled above) cannot match a structured
+            // generic target — a type constructor like `Record<K, V>` or a
+            // mapped type — directly. Mirror tsc and infer from its apparent
+            // type (its constraint), so a target inference variable is seeded
+            // from the constraint's corresponding component: `K` of
+            // `Record<K, any>` is inferred from a `T extends Record<string,
+            // any>` source as `string`, instead of falling back to `K`'s
+            // constraint default (`PropertyKey`), which yields a spurious
+            // over-wide key and a downstream TS2339 (radash `lowerize`).
+            //
+            // Guarded on the target actually carrying an inference placeholder
+            // so a fully concrete structured target stays a no-op, and on the
+            // constraint differing from the source; the `constraint_pairs`
+            // visited set and recursion-depth bound own termination. A
+            // bare-placeholder target is handled earlier (lower-bound
+            // candidate), and a naked parameter inside a union/conditional
+            // target keeps its direct inference through the dedicated arms, so
+            // neither is reached here.
+            (
+                Some(TypeData::TypeParameter(ref param_info)),
+                Some(TypeData::Application(_) | TypeData::Mapped(_)),
+            ) => {
+                if let Some(constraint) = param_info.constraint
+                    && constraint != source
+                    && with_placeholder_visited(|visited| {
+                        self.type_contains_placeholder(target, var_map, visited)
+                    })
+                {
+                    self.constrain_types(ctx, var_map, constraint, target, priority);
+                }
+            }
             (Some(TypeData::ReadonlyType(s_inner)), Some(TypeData::ReadonlyType(t_inner))) => {
                 let prev_ro = ctx.in_readonly_source_context;
                 ctx.in_readonly_source_context = true;
@@ -575,6 +607,35 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                                 crate::types::InferencePriority::MappedType,
                             );
                             return;
+                        }
+
+                        // Simple mapped target `{ [P in K]: V }` over a source
+                        // carrying index signatures: infer the constraint `K`
+                        // from the index key type(s) (`string`/`number`),
+                        // mirroring tsc inferring `K = string` for a
+                        // `Record<string, …>` / `{ [x: string]: … }` source.
+                        // Guarded on `K` being a bare inference placeholder so
+                        // homomorphic (`keyof T`) mapped types keep their
+                        // reverse-mapped inference path untouched.
+                        if has_index_sigs && var_map.contains_key(&mapped.constraint) {
+                            let key_types: Vec<TypeId> =
+                                [&source_obj.string_index, &source_obj.number_index]
+                                    .into_iter()
+                                    .flatten()
+                                    .map(|idx| idx.key_type)
+                                    .collect();
+                            if !key_types.is_empty() {
+                                let keys_union =
+                                    crate::utils::union_or_single(self.interner, key_types);
+                                self.constrain_types(
+                                    ctx,
+                                    var_map,
+                                    keys_union,
+                                    mapped.constraint,
+                                    crate::types::InferencePriority::MappedType,
+                                );
+                                return;
+                            }
                         }
                     }
                     if !has_properties


### PR DESCRIPTION
## Summary

Fixes #14321 (mined from **radash** `lowerize`).

When inferring a callee's type argument and the argument's type is itself a
generic type parameter we are **not** inferring, `tsc` infers the callee
parameter from the source's **apparent type** (its constraint). tsz instead left
such a parameter at its constraint **default**, producing an over-wide key and a
downstream false `TS2339`/`TS2322`:

```ts
declare function keyOf<K extends PropertyKey>(obj: Record<K, any>): K
function lowerize<T extends Record<string, any>>(obj: T) {
  const k = keyOf(obj);   // tsc: K = string ;  tsz (before): K = PropertyKey
  return obj[k];          // over-wide key -> downstream TS2339
}
```

## Structural rule

When the inference source is a non-inferred generic type parameter matched
against a structured generic target — an `Application` type constructor like
`Record<K, V>` or a mapped type — it cannot match structurally, so tsz now
recurses the inference into the source's **constraint** (apparent type). A target
inference variable is then seeded from the constraint's corresponding component:
`K` of `Record<K, any>` is inferred from a `T extends Record<string, any>`
source as `string`, instead of falling back to `K`'s constraint default
(`PropertyKey`).

## Owner layer

Solver inference. The fix lives in the two engines that drive type-argument
inference:
- `crates/tsz-solver/src/operations/constraints/walker.rs` — `constrain_types`,
  the main call type-argument inference (placeholder-based). Adds the
  constraint-lifting arm, plus inference of a simple `{ [P in K]: V }` mapped
  constraint from a source index signature's key type.
- `crates/tsz-solver/src/inference/infer_matching.rs` — `infer_from_types`, the
  predicate inference path. Adds the identical constraint-lifting arm.

Guarded on the target carrying an inference placeholder (concrete targets stay a
no-op) and on the constraint differing from the source (termination is owned by
the existing visited-set / depth bounds). Bare-placeholder targets keep their
direct lower-bound candidate, and a naked parameter inside a union/conditional
keeps its direct inference, so neither is reached by the new arm.

## Adjacent-case matrix

Covered by `crates/tsz-checker/tests/generic_param_source_apparent_type_inference_tests.rs`
(binder names varied so the fix cannot key on a spelling):
- `Record<K, V>` constructor target — `K = string` (clean) and not widened
  (rejected against `1`).
- number-key constraint — `K = number`.
- mapped `{ [P in K]: V }` target over a concrete index-signature source.
- negative control: a `Record<PropertyKey, any>`-constrained source keeps
  `K = PropertyKey`.
- fallback control: plain `id<T>(x: T)` identity inference is unchanged
  (`T = 5`, not its constraint).

## Anti-hardcoding

Structural constraint-based inference keyed on `TypeData` shape; no
identifier/file-name/printer-string checks. Tests vary the binder names.

## Verification

- `cargo test -p tsz-checker --test generic_param_source_apparent_type_inference_tests` — 6/6 pass.
- `cargo test -p tsz-solver --lib inference` — 570 pass; `… constraints` — 82 pass (no new failures; the 4 pre-existing `tsz-solver --lib` failures reproduce on `main` unchanged).
- `cargo clippy -p tsz-solver --lib` — clean.
- Repro: `keyOf(obj)` now infers `K = string` (was `PropertyKey`); TS2339/TS2322 false positive gone.
- Ready-review CI owns the broad conformance/emit suites.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHozHYQvWtd63HoCEsSCpq)_