### PR TITLE
fix(cli): port tsc's directive walk-up + last-line block-comment registration (false TS2578)

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -122,8 +122,9 @@ fn build_export_signature_input(
             let mut aug_names: Vec<String> = file
                 .module_augmentations
                 .get(module.as_str())
-                .map(|augs| augs.iter().map(|a| a.name.clone()).collect())
-                .unwrap_or_default();
+                .map_or_else(Vec::new, |augs| {
+                    augs.iter().map(|a| a.name.clone()).collect()
+                });
             aug_names.sort();
             input.module_augmentations.push((module.clone(), aug_names));
         }
@@ -195,9 +196,10 @@ pub(super) fn convert_js_parse_diagnostics_to_ts8xxx(
             let is_method_optional = source_text.is_some_and(|src| {
                 let after_q = (diag.start + diag.length) as usize;
                 // Skip whitespace after `?` and check for `(`
-                src.get(after_q..)
-                    .map(|s| s.trim_start().starts_with('(') || s.trim_start().starts_with('<'))
-                    .unwrap_or(false)
+                src.get(after_q..).is_some_and(|s| {
+                    let s = s.trim_start();
+                    s.starts_with('(') || s.starts_with('<')
+                })
             });
             if is_method_optional {
                 out.push(Diagnostic::error(
@@ -1102,8 +1104,7 @@ fn line_trimmed<'a>(text: &'a str, line_map: &LineMap, line: u32) -> &'a str {
     let start = start as usize;
     let end = line_map
         .line_start(line as usize + 1)
-        .map(|next| next as usize)
-        .unwrap_or(text.len())
+        .map_or(text.len(), |next| next as usize)
         .min(text.len());
     if start >= end {
         return "";

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -1007,7 +1007,7 @@ struct TsDirective {
 fn directive_in_block_last_line(last_line: &str) -> Option<DirectiveKind> {
     let body = last_line
         .trim_start()
-        .trim_start_matches(|c| c == '/' || c == '*')
+        .trim_start_matches(['/', '*'])
         .trim_start();
     for (kind, text) in [
         (DirectiveKind::ExpectError, "@ts-expect-error"),

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -999,33 +999,58 @@ struct TsDirective {
     unused_diagnostic_length: u32,
 }
 
+/// Match `commentDirectiveRegExMultiLine`
+/// (`/^(?:\/|\*)*\s*@(ts-expect-error|ts-ignore)/`) against a block comment's
+/// last line. tsc only registers a block comment as a directive when its final
+/// line begins the directive, so `/* @ts-ignore */` qualifies but
+/// `/* @ts-ignore\n...*/` (directive on a non-final line) does not.
+fn directive_in_block_last_line(last_line: &str) -> Option<DirectiveKind> {
+    let body = last_line
+        .trim_start()
+        .trim_start_matches(|c| c == '/' || c == '*')
+        .trim_start();
+    for (kind, text) in [
+        (DirectiveKind::ExpectError, "@ts-expect-error"),
+        (DirectiveKind::Ignore, "@ts-ignore"),
+    ] {
+        if let Some(rest) = body.strip_prefix(text)
+            && (rest.is_empty() || is_directive_separator(rest.as_bytes()[0]))
+        {
+            return Some(kind);
+        }
+    }
+    None
+}
+
 /// Scan source text for `@ts-expect-error` and `@ts-ignore` directives in
 /// comments. `line_map` must be built from the same `text`.
+///
+/// tsc registers each directive on the line of the comment's end (`_tsc.js`
+/// `createCommentDirectivesMap`): single-line `//`/`///` comments match the
+/// whole comment; block comments are matched against their last line alone.
 fn find_ts_directives(text: &str, line_map: &LineMap) -> Vec<TsDirective> {
     let mut directives = Vec::new();
 
     for comment in tsz_common::comments::get_comment_ranges(text) {
-        let comment_text = comment.get_text(text);
-        let Some((kind, directive_offset)) = find_directive_in_text(comment_text) else {
-            continue;
+        let (kind, unused_diagnostic_start) = if comment.is_multi_line {
+            let close_line = line_map.line_index(comment.end.saturating_sub(1)) as usize;
+            let last_line_start = line_map
+                .line_start(close_line)
+                .unwrap_or(comment.pos)
+                .max(comment.pos);
+            let last_line = &text[last_line_start as usize..comment.end as usize];
+            let Some(kind) = directive_in_block_last_line(last_line) else {
+                continue;
+            };
+            (kind, last_line_start)
+        } else {
+            let Some((kind, _offset)) = find_directive_in_text(comment.get_text(text)) else {
+                continue;
+            };
+            (kind, comment.pos)
         };
 
-        let suppressed_line = if comment.is_multi_line {
-            let close_line = line_map.line_index(comment.end.saturating_sub(1));
-            close_line + 1
-        } else {
-            let comment_line = line_map.line_index(comment.pos);
-            comment_line + 1
-        };
-        let directive_start = comment.pos.saturating_add(directive_offset);
-        let directive_line = line_map.line_index(directive_start) as usize;
-        let directive_line_start = line_map.line_start(directive_line).unwrap_or(comment.pos);
-        let unused_diagnostic_start = if comment.is_multi_line && directive_line_start > comment.pos
-        {
-            directive_line_start
-        } else {
-            comment.pos
-        };
+        let suppressed_line = line_map.line_index(comment.end.saturating_sub(1)) + 1;
 
         directives.push(TsDirective {
             is_expect_error: kind == DirectiveKind::ExpectError,
@@ -1036,6 +1061,54 @@ fn find_ts_directives(text: &str, line_map: &LineMap) -> Vec<TsDirective> {
     }
 
     directives
+}
+
+/// Mirror tsc's `markPrecedingCommentDirectiveLine` (`_tsc.js`): starting from
+/// the line above `diag_line`, walk upward skipping blank lines and
+/// `//`-comment lines and return the first line that carries a directive. Stop
+/// (returning `None`) at the first line with non-comment content. Block-comment
+/// directive lines are caught before the content check so a `/* @ts-ignore */`
+/// line still suppresses across an intervening blank line.
+fn preceding_directive_line(
+    diag_line: u32,
+    directive_lines: &rustc_hash::FxHashSet<u32>,
+    text: &str,
+    line_map: &LineMap,
+) -> Option<u32> {
+    if diag_line == 0 {
+        return None;
+    }
+    let mut line = diag_line - 1;
+    loop {
+        if directive_lines.contains(&line) {
+            return Some(line);
+        }
+        let line_text = line_trimmed(text, line_map, line);
+        if !line_text.is_empty() && !line_text.starts_with("//") {
+            return None;
+        }
+        if line == 0 {
+            return None;
+        }
+        line -= 1;
+    }
+}
+
+/// The trimmed text of a single 0-based `line` in `text`.
+fn line_trimmed<'a>(text: &'a str, line_map: &LineMap, line: u32) -> &'a str {
+    let Some(start) = line_map.line_start(line as usize) else {
+        return "";
+    };
+    let start = start as usize;
+    let end = line_map
+        .line_start(line as usize + 1)
+        .map(|next| next as usize)
+        .unwrap_or(text.len())
+        .min(text.len());
+    if start >= end {
+        return "";
+    }
+    text[start..end].trim()
 }
 
 /// Apply `@ts-expect-error` and `@ts-ignore` directive suppression to diagnostics.
@@ -1059,9 +1132,18 @@ pub(super) fn apply_ts_directive_suppression(
     let has_ts_nocheck =
         tsz_common::comments::has_ts_directive_in_leading_trivia(source_text, "@ts-nocheck");
 
-    let mut directive_used = vec![false; directives.len()];
+    // Lines (0-based) carrying a directive. tsc keys directives by the line of
+    // the comment's end; `suppressed_line` is that line + 1.
+    let directive_lines: rustc_hash::FxHashSet<u32> = directives
+        .iter()
+        .map(|d| d.suppressed_line.saturating_sub(1))
+        .collect();
 
-    // Suppress diagnostics on directive-targeted lines.
+    // Directive lines that suppressed (or were touched by) at least one
+    // diagnostic. An unused `@ts-expect-error` line draws TS2578.
+    let mut used_directive_lines: rustc_hash::FxHashSet<u32> = rustc_hash::FxHashSet::default();
+
+    // Suppress diagnostics whose line resolves to a preceding directive.
     //
     // tsc applies `@ts-ignore` and `@ts-expect-error` uniformly across the
     // checking pipeline, including the JSDoc `@type` lookup that runs during
@@ -1077,13 +1159,13 @@ pub(super) fn apply_ts_directive_suppression(
     // used. Keep those diagnostics while recording the directive hit.
     diagnostics.retain(|diag| {
         let diag_line = line_map.line_index(diag.start);
-        for (idx, directive) in directives.iter().enumerate() {
-            if diag_line == directive.suppressed_line {
-                directive_used[idx] = true;
-                return is_ts_directive_unsuppressible_syntactic(diag.code);
+        match preceding_directive_line(diag_line, &directive_lines, source_text, &line_map) {
+            Some(dline) => {
+                used_directive_lines.insert(dline);
+                is_ts_directive_unsuppressible_syntactic(diag.code)
             }
+            None => true,
         }
-        true
     });
 
     // Emit TS2578 for unused @ts-expect-error directives.
@@ -1093,8 +1175,9 @@ pub(super) fn apply_ts_directive_suppression(
     // opener, while directives inside multiline block comments start at the
     // line containing the directive text.
     if !has_ts_nocheck {
-        for (idx, directive) in directives.iter().enumerate() {
-            if directive.is_expect_error && !directive_used[idx] {
+        for directive in &directives {
+            let dline = directive.suppressed_line.saturating_sub(1);
+            if directive.is_expect_error && !used_directive_lines.contains(&dline) {
                 diagnostics.push(Diagnostic::error(
                     file_name.to_string(),
                     directive.unused_diagnostic_start,

--- a/crates/tsz-cli/src/driver/check_utils/tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/tests.rs
@@ -243,6 +243,83 @@ fn ts_directive_suppresses_next_line_with_form_feed_spacing() {
     );
 }
 
+/// Build a single TS2304 diagnostic anchored at `bad_ref` within `source`.
+#[cfg(test)]
+fn bad_ref_diagnostic(source: &str) -> Vec<Diagnostic> {
+    let start = source.find("bad_ref").expect("source must contain bad_ref") as u32;
+    vec![Diagnostic::error(
+        "repro.ts".to_string(),
+        start,
+        "bad_ref".len() as u32,
+        "Cannot find name 'bad_ref'.".to_string(),
+        2304,
+    )]
+}
+
+#[test]
+fn ts_directive_suppresses_across_continuation_comment() {
+    // tsc walks up from the error line skipping `//`-comment lines, so a
+    // directive whose comment wraps onto a second explanatory line still
+    // suppresses the code below.
+    let source = "// @ts-expect-error - reason\n// continued reason\nbad_ref;\n";
+    let mut diagnostics = bad_ref_diagnostic(source);
+    apply_ts_directive_suppression("repro.ts", source, &mut diagnostics, false);
+    assert!(
+        diagnostics.is_empty(),
+        "directive must suppress across a continuation comment line, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn ts_directive_suppresses_across_blank_line() {
+    let source = "// @ts-expect-error\n\nbad_ref;\n";
+    let mut diagnostics = bad_ref_diagnostic(source);
+    apply_ts_directive_suppression("repro.ts", source, &mut diagnostics, false);
+    assert!(
+        diagnostics.is_empty(),
+        "directive must suppress across a blank line, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn ts_directive_walk_up_stops_at_real_code_line() {
+    // A real code line between the directive and the error stops the walk: the
+    // error survives and the unused directive is reported (TS2578).
+    let source = "// @ts-expect-error\nconst ok = 1;\nbad_ref;\n";
+    let mut diagnostics = bad_ref_diagnostic(source);
+    apply_ts_directive_suppression("repro.ts", source, &mut diagnostics, false);
+    let codes: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&2304),
+        "real error must survive a code line between directive and error, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&2578),
+        "directive that suppressed nothing must be reported unused, got: {codes:?}"
+    );
+}
+
+#[test]
+fn inert_multiline_block_directive_is_not_a_directive() {
+    // tsc registers a block-comment directive only when its LAST line begins the
+    // directive. `/* @ts-expect-error\nmore */` does not, so it neither
+    // suppresses the code below nor draws an unused-directive TS2578.
+    let source = "/* @ts-expect-error\nmore */\nbad_ref;\n";
+    assert_eq!(
+        find_ts_directives(source).len(),
+        0,
+        "a block comment whose last line lacks the directive must not register"
+    );
+    let mut diagnostics = bad_ref_diagnostic(source);
+    apply_ts_directive_suppression("repro.ts", source, &mut diagnostics, false);
+    let codes: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        vec![2304],
+        "inert block must leave the error and add no TS2578, got: {codes:?}"
+    );
+}
+
 #[test]
 fn ts_directive_scan_keeps_template_substitution_directives() {
     let directives =


### PR DESCRIPTION
Goal: green

## Summary
`@ts-ignore` / `@ts-expect-error` suppression in tsz only fired when the directive sat on the line **immediately** above the error. Any blank line or `//` comment line in between broke it: the real diagnostic leaked **and** a spurious `TS2578` ("Unused '@ts-expect-error' directive") fired. Witness: `remeda` (`packages/remeda/src`) has directives whose comments wrap onto a second explanatory line — 28 spurious `TS2578`.

tsc does not work by "directive → next line". It walks **up** from the error line, skipping blank and `//`-comment lines, until it finds a line carrying a directive or hits real content (`markPrecedingCommentDirectiveLine`, `_tsc.js`). This PR ports that algorithm into `apply_ts_directive_suppression`.

It also fixes directive **registration** to match tsc: a block comment registers as a directive only when its **last line** begins the directive (`commentDirectiveRegExMultiLine` is applied to the comment's last line in `appendIfCommentDirective`). So `/* @ts-ignore */` registers, but `/* @ts-ignore\n...*/` (directive on a non-final line) is **inert**. tsz previously registered the latter, which—combined with the new walk-up—would have over-suppressed.

Structural rule: when a diagnostic's line, walking up past blank/`//` lines, reaches a registered directive line, tsc suppresses it (and marks the directive used); a non-comment line stops the walk. Owner: `crates/tsz-cli/src/driver/check_utils.rs` (CLI directive layer; no checker/solver changes).

## Verification — byte-identical to tsc 6.0.3
- The authoritative conformance witness `checkJsFiles_skipDiagnostics` (`a.js`): tsz and tsc both report exactly `a.js(29,1)` and `a.js(35,1)` TS2349, nothing else. (My earlier attempt #14361 regressed this file; this is the correct fix and it is superseded.)
- Edge matrix, all `OK` (tsz codes == tsc codes): directive+continuation-comment, directive+blank, directive+comment+blank+comment, walk-up-stops-at-real-code (TS2304+TS2578), same-line directive (no suppress), directive-first-line, `@ts-ignore` across a gap, two-errors-one-suppressed, EOF unused directive (TS2578), block last-line directive (`/**\n @ts-ignore */`), inert multiline block (TS2304, no TS2578), JSDoc-empty-`//` continuation.
- `cargo nextest run -p tsz-cli --lib check_utils::tests::` — 83 passed (4 new). The 3 new behavior tests (`ts_directive_suppresses_across_continuation_comment`, `ts_directive_suppresses_across_blank_line`, `inert_multiline_block_directive_is_not_a_directive`) **fail on main** (confirmed by stashing the source change); the walk-up-stops control passes on both.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
