### PR TITLE
fix(checker): narrow generic guard with bare target inferred from a nested param (TS2322)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1609,6 +1609,9 @@ path = "tests/class_expression_heritage_ts2416_tests.rs"
 name = "predicate_alias_generic_inference_tests"
 path = "tests/predicate_alias_generic_inference_tests.rs"
 [[test]]
+name = "predicate_bare_target_nested_param_inference_tests"
+path = "tests/predicate_bare_target_nested_param_inference_tests.rs"
+[[test]]
 name = "class_implements_predicate_inference_tests"
 path = "tests/class_implements_predicate_inference_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/flow/control_flow/predicate_resolution.rs
+++ b/crates/tsz-checker/src/flow/control_flow/predicate_resolution.rs
@@ -180,36 +180,72 @@ impl<'a> FlowAnalyzer<'a> {
             }
         }
 
-        // Case 2c: Structural inference for a type parameter nested inside the
-        // predicate target. The preceding cases bind a type parameter when it
-        // appears *directly* as a parameter type (`value: T`), as a bare member
-        // of a union parameter (`T | "x"`), or as a callback predicate target.
-        // A predicate target that is itself a bare type parameter (`value is T`)
-        // is also covered by the union-subtraction path (Case 3) below, which
-        // must keep ownership so the false branch narrows correctly — running
-        // general inference there would bind `T` to the whole argument union
-        // rather than the subtracted member.
+        // Case 2c: The predicate target is a bare type parameter whose corresponding
+        // parameter type is a *union* containing that type parameter (a wrapper such
+        // as `Result<T>` rather than just `T`). Case 1 failed because
+        // `param.type_id != pred_type`, and Case 2 failed because `param.type_id` is
+        // not directly a `TypeParameter`.
         //
-        // The remaining gap is a predicate target that is a *compound* type
-        // mentioning the type parameter — a generic application or wrapper such
-        // as `AsyncIterable<T>`, `Box<T>`, `Promise<T>`, or `Map<K, V>`, often
-        // reached through a parameter alias like
-        // `MaybeAsync<T> = T | AsyncIterable<T>`. None of the shortcuts fire for
-        // it, so the predicate is left generic. Narrowing then intersects the
-        // already-narrowed value with the generic target
-        // (`AsyncIterable<string> & AsyncIterable<any>`), over-constraining it.
+        // Handle the common pattern where the parameter type is a union containing
+        // the type parameter:
+        //   `function isSuccess<T>(result: T | "FAILURE"): result is T`
+        //   param type = T | "FAILURE", arg type = number | "FAILURE"
+        //   → infer T = number (subtract fixed union members from arg type)
         //
-        // Recover the bindings the same way call resolution does: structurally
-        // match each declared parameter type against its argument type. This is
-        // a solver concern, so it is answered through the inference query
-        // boundary rather than re-implemented here.
-        let predicate_target_is_bare_type_param =
-            flow_query::type_param_info(self.interner, pred_type).is_some();
-        let predicate_still_generic = !predicate_target_is_bare_type_param
-            && type_params.iter().any(|tp| {
-                substitution.get(tp.name).is_none()
-                    && flow_query::contains_type_parameter_named(self.interner, pred_type, tp.name)
-            });
+        // This union-subtraction path must run *before* the general structural
+        // inference below and keep ownership of the bare-union case: structural
+        // inference would bind `T` to the whole argument union (`number | "FAILURE"`)
+        // rather than the subtracted member (`number`), which would also leave the
+        // false branch narrowing wrong.
+        if let Some(pred_param_info) = flow_query::type_param_info(self.interner, pred_type) {
+            let pred_param_name = pred_param_info.name;
+            if type_params.iter().any(|tp| tp.name == pred_param_name) {
+                for (i, param) in params.iter().enumerate() {
+                    if let Some(&arg_idx) = args.get(i)
+                        && let Some(&arg_type) = node_types.get(&arg_idx.0)
+                        && let Some(inferred) = self.infer_type_param_from_union(
+                            param.type_id,
+                            arg_type,
+                            pred_param_name,
+                        )
+                    {
+                        return TypePredicate {
+                            type_id: Some(inferred),
+                            ..*predicate
+                        };
+                    }
+                }
+            }
+        }
+
+        // Case 2d: Structural inference for a type parameter that none of the earlier
+        // cases could bind. The preceding cases bind a type parameter when it appears
+        // *directly* as a parameter type (`value: T`), as a bare member of a union
+        // parameter (`T | "x"`, handled by Cases 1b/2c above), or as a callback
+        // predicate target.
+        //
+        // The remaining gap is a type parameter mentioned only from a *nested*
+        // parameter position. Two shapes reach here:
+        //   * the predicate target is a *compound* type mentioning the type parameter
+        //     — a generic application or wrapper such as `AsyncIterable<T>`, `Box<T>`,
+        //     `Promise<T>`, or `Map<K, V>`, often via an alias like
+        //     `MaybeAsync<T> = T | AsyncIterable<T>`; or
+        //   * the predicate target is a *bare* type parameter (`value is T`) whose `T`
+        //     is inferable only from another parameter's nested shape
+        //     (`witness: T[]`, `() => T`, a struct field).
+        // None of the shortcuts fire for these, so the predicate would otherwise be
+        // left generic and narrowing would intersect the value with the raw type
+        // parameter. The union-subtraction Case 2c already returned for bare targets
+        // reachable through a union parameter, so it does not preempt this fallback.
+        //
+        // Recover the bindings the same way call resolution does: structurally match
+        // each declared parameter type against its argument type. This is a solver
+        // concern, so it is answered through the inference query boundary rather than
+        // re-implemented here.
+        let predicate_still_generic = type_params.iter().any(|tp| {
+            substitution.get(tp.name).is_none()
+                && flow_query::contains_type_parameter_named(self.interner, pred_type, tp.name)
+        });
         if predicate_still_generic {
             let param_arg_pairs: Vec<(TypeId, TypeId)> = params
                 .iter()
@@ -241,37 +277,6 @@ impl<'a> FlowAnalyzer<'a> {
                     type_id: Some(evaluated),
                     ..*predicate
                 };
-            }
-        }
-
-        // Case 3: The predicate type is a TypeParameter whose corresponding
-        // parameter type is a wrapper (e.g., `Result<T>` instead of just `T`).
-        // Case 1 failed because param.type_id != pred_type, and Case 2 failed
-        // because param.type_id is not directly a TypeParameter.
-        //
-        // Handle the common pattern where the parameter type is a union
-        // containing the type parameter:
-        //   `function isSuccess<T>(result: T | "FAILURE"): result is T`
-        //   param type = T | "FAILURE", arg type = number | "FAILURE"
-        //   → infer T = number (subtract fixed union members from arg type)
-        if let Some(pred_param_info) = flow_query::type_param_info(self.interner, pred_type) {
-            let pred_param_name = pred_param_info.name;
-            if type_params.iter().any(|tp| tp.name == pred_param_name) {
-                for (i, param) in params.iter().enumerate() {
-                    if let Some(&arg_idx) = args.get(i)
-                        && let Some(&arg_type) = node_types.get(&arg_idx.0)
-                        && let Some(inferred) = self.infer_type_param_from_union(
-                            param.type_id,
-                            arg_type,
-                            pred_param_name,
-                        )
-                    {
-                        return TypePredicate {
-                            type_id: Some(inferred),
-                            ..*predicate
-                        };
-                    }
-                }
             }
         }
 

--- a/crates/tsz-checker/tests/predicate_bare_target_nested_param_inference_tests.rs
+++ b/crates/tsz-checker/tests/predicate_bare_target_nested_param_inference_tests.rs
@@ -1,0 +1,115 @@
+//! Regression tests for issue #14359: a generic type guard whose predicate
+//! target is a *bare* type parameter (`value is T`) where `T` is inferable only
+//! from another parameter's *nested* shape.
+//!
+//! For `declare function is<T>(value: unknown, witness: T[]): value is T`, the
+//! call's `T` is inferred from the `witness` argument (`string[]` -> `T = string`),
+//! but the narrowing kept the uninstantiated predicate target `T` instead of the
+//! inferred type. tsc narrows the guarded value to the inferred `T`.
+//!
+//! The structural rule: when a predicate target is a bare type parameter that is
+//! not bound by a direct (`value: T`) or union-member (`T | "x"`) parameter, the
+//! same structural inference that resolves the call's type arguments must also
+//! resolve the predicate target. The union-subtraction path keeps ownership of
+//! the union-member case (so its false branch narrows to the subtracted member);
+//! the structural fallback only fires for the genuinely nested shapes.
+//!
+//! Every binder name (function, value, witness, type parameter) is varied across
+//! cases so a fix that special-cases one spelling fails the suite. The witness
+//! position is varied across the nested shapes tsc handles: array element,
+//! return position of a callback, and a generic struct field.
+
+use tsz_checker::test_utils::{check_source_diagnostics, diagnostic_messages_with_code};
+
+const TS2322: u32 = 2322;
+
+/// The narrowed value must be the inferred concrete type, so a deliberate
+/// `never` mismatch reports that concrete type (and never the raw parameter).
+fn assert_narrows_to(source: &str, expected_fragment: &str) {
+    let diagnostics = check_source_diagnostics(source);
+    let messages = diagnostic_messages_with_code(&diagnostics, TS2322);
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one TS2322 (the `never` annotation), got: {diagnostics:#?}"
+    );
+    assert!(
+        messages[0].contains(expected_fragment),
+        "narrowed value should be `{expected_fragment}`, got: {}",
+        messages[0]
+    );
+}
+
+#[test]
+fn bare_target_inferred_from_array_witness() {
+    // The witness arg fixes `T = string`; `value` must narrow to `string`.
+    let source = r"
+declare function is<T>(value: unknown, witness: T[]): value is T;
+function check(value: unknown, witness: string[]) {
+  if (is(value, witness)) {
+    const x: never = value;
+  }
+}
+";
+    assert_narrows_to(source, "string");
+}
+
+#[test]
+fn bare_target_inferred_from_array_witness_renamed_binders() {
+    // Identical shape, every binder renamed and a different element type.
+    let source = r"
+declare function matches<Elem>(candidate: unknown, sample: Elem[]): candidate is Elem;
+function inspect(candidate: unknown, sample: number[]) {
+  if (matches(candidate, sample)) {
+    const wrong: never = candidate;
+  }
+}
+";
+    assert_narrows_to(source, "number");
+}
+
+#[test]
+fn bare_target_inferred_from_callback_return_witness() {
+    // `T` appears only in the return position of a callback parameter.
+    let source = r"
+declare function holds<T>(value: unknown, make: () => T): value is T;
+function check(value: unknown, make: () => boolean) {
+  if (holds(value, make)) {
+    const wrong: never = value;
+  }
+}
+";
+    assert_narrows_to(source, "boolean");
+}
+
+#[test]
+fn bare_target_inferred_from_generic_struct_field_witness() {
+    // `T` appears nested inside a generic struct parameter.
+    let source = r"
+interface Struct<T> { field: T; }
+declare function is<T>(value: unknown, witness: Struct<T>): value is T;
+function check(value: unknown, witness: Struct<string>) {
+  if (is(value, witness)) {
+    const wrong: never = value;
+  }
+}
+";
+    assert_narrows_to(source, "string");
+}
+
+/// The union-member case must keep its dedicated subtraction path: the predicate
+/// target is a bare `T` that appears as a union member of the parameter, so `T`
+/// is the *subtracted* member (`number`), not the whole argument union.
+#[test]
+fn bare_target_union_member_still_subtracts() {
+    let source = r#"
+declare function isValue<T>(result: T | "FAILURE"): result is T;
+declare const r: number | "FAILURE";
+function probe() {
+  if (isValue(r)) {
+    const wrong: never = r;
+  }
+}
+"#;
+    assert_narrows_to(source, "number");
+}


### PR DESCRIPTION
Fixes #14359.

## Structural rule
When a generic type guard `value is T` has its predicate target `T` reachable
only from a **nested** parameter position (`witness: T[]`, `() => T`, a generic
struct field), `tsc` narrows the guarded value to the inferred `T`; tsz left the
narrowing target as the raw type parameter `T`, so the guarded value narrowed to
`T` and produced a false-positive `TS2322`/`TS2345`. This is owned by the checker
flow layer (`resolve_generic_predicate`), which delegates the actual inference to
the solver inference query boundary.

## Wrong operation
`crates/tsz-checker/src/flow/control_flow/predicate_resolution.rs` —
`resolve_generic_predicate` gated its general structural-inference fallback
behind `!predicate_target_is_bare_type_param`. That exclusion existed so the
union-subtraction path (which yields the *subtracted* member and the correct
false-branch narrowing) keeps ownership of bare targets reachable through a
**union** parameter (`result: T | "FAILURE"`). But the exclusion was too broad: a
bare target whose `T` is inferable only from another parameter's nested shape
hit none of the earlier cases and returned the unmodified, still-generic
predicate.

## Fix
- Reorder so the union-subtraction case runs **before** the structural-inference
  fallback and returns early for the union shape (preserving its ownership and
  the subtracted-member / false-branch behavior).
- Drop the bare-target exclusion from the fallback gate. Bare targets reachable
  only through a nested parameter position now recover `T` via the same solver
  inference query (`infer_type_arguments_from_param_args`) that already resolves
  the call's type arguments.
- Renumber the in-source case labels so they read in execution order
  (`1, 1b, 2, 2b, 2c, 2d`).

No new user-name/file-name literals, no diagnostic-string predicates; the
decision is purely structural (bare type parameter + nested parameter shape) and
answered through the solver query boundary.

## Adjacent-case matrix
New regression test `predicate_bare_target_nested_param_inference_tests.rs`
varies the witness shape and every binder name:
- bare target inferred from an array-element witness (`witness: T[]`);
- same shape, all binders renamed, different element type;
- bare target inferred from a callback return position (`() => T`);
- bare target inferred from a generic struct field (`Struct<T>`);
- the union-member case (`T | "FAILURE"`) still subtracts to the member
  (guards that the reorder did not regress the union-subtraction owner).

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo build --bin tsz`, then the issue repro narrows `value` to `string`
  (matches `tsc`): `error TS2322: Type 'string' is not assignable to type 'never'.`
- `cargo test -p tsz-checker --test predicate_bare_target_nested_param_inference_tests`
  — 5 passed.
- `cargo test -p tsz-checker --test predicate_alias_generic_inference_tests`
  — 3 passed (the nested-compound `AsyncIterable<T>` precedent is unaffected).
- Ran the broader predicate/narrowing checker test binaries; the only failures
  (`ts2339_user_defined_predicate_primitive_or_object_tests::case_9/case_10`,
  `array_isarray_mutual_subtype_narrowing_tests::array_isarray_preserves_concrete_array_element_types`)
  reproduce on `main` with this change reverted, i.e. pre-existing and unrelated.
- Ready-review CI owns the broad conformance/emit/fourslash suites.


---
_Generated by [Claude Code](https://claude.ai/code/session_015bsuk4S2Fu9rTvEwZWK8Gn)_