### PR TITLE
fix(checker): as-assertion to a generic callable/constructable type recognizes overlap with a callable source (#14325)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1983,5 +1983,8 @@ path = "tests/nullable_union_missing_property_tests.rs"
 name = "partial_record_optional_index_assignability_tests"
 path = "tests/partial_record_optional_index_assignability_tests.rs"
 [[test]]
+name = "generic_callable_as_assertion_overlap_tests"
+path = "tests/generic_callable_as_assertion_overlap_tests.rs"
+[[test]]
 name = "function_type_predicate_typeof_param_tests"
 path = "tests/function_type_predicate_typeof_param_tests.rs"

--- a/crates/tsz-checker/src/dispatch/mod.rs
+++ b/crates/tsz-checker/src/dispatch/mod.rs
@@ -854,6 +854,41 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                             } else {
                                 (false, asserted_type)
                             };
+                            // A generic callable/constructable assertion target with its
+                            // OWN bound type parameters (`new <t extends object>(base: t) => t`,
+                            // `<T>(x: T) => T`) has no concrete shape to compare, so the
+                            // structural overlap check spuriously fails and emits TS2352 even
+                            // when the source is itself callable/constructable. tsc's
+                            // `isTypeComparableTo` instantiates the signature's type parameters
+                            // and finds the two callables/constructors overlap. Mirror that:
+                            // when the asserted type is a generic signature (bound — not free —
+                            // type parameters) and both the source and the target are
+                            // callable or constructable, treat them as overlapping (#14325). A
+                            // non-callable source (`"s" as <T>(x: T) => T`) is not
+                            // callable/constructable, so a real TS2352 is still emitted.
+                            let generic_callable_overlap = should_check
+                                && generic_query::contains_type_parameters(
+                                    self.checker.ctx.types,
+                                    effective_asserted,
+                                )
+                                && !generic_query::contains_free_type_parameters(
+                                    self.checker.ctx.types,
+                                    effective_asserted,
+                                )
+                                && (crate::query_boundaries::common::is_callable_type(
+                                    self.checker.ctx.types,
+                                    effective_asserted,
+                                ) || crate::query_boundaries::common::has_construct_signatures(
+                                    self.checker.ctx.types,
+                                    effective_asserted,
+                                ))
+                                && (crate::query_boundaries::common::is_callable_type(
+                                    self.checker.ctx.types,
+                                    expr_type,
+                                ) || crate::query_boundaries::common::has_construct_signatures(
+                                    self.checker.ctx.types,
+                                    expr_type,
+                                ));
                             if should_check {
                                 // TS2352 is emitted if neither type is assignable to the other
                                 // (i.e., the types don't "sufficiently overlap").
@@ -944,6 +979,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                                 if !source_to_target
                                     && !target_to_source
                                     && !generic_indexed_assertion_source
+                                    && !generic_callable_overlap
                                 {
                                     // TSC uses isTypeComparableTo which decomposes unions
                                     // and checks per-member overlap. For `X as A | B`, it

--- a/crates/tsz-checker/tests/generic_callable_as_assertion_overlap_tests.rs
+++ b/crates/tsz-checker/tests/generic_callable_as_assertion_overlap_tests.rs
@@ -1,0 +1,76 @@
+//! An `as`-assertion to a GENERIC callable/constructable type must recognize the
+//! overlap when the source is itself callable/constructable, instead of emitting
+//! a spurious TS2352.
+//!
+//! Regression for #14325 (arktype): `class {} as new <t extends object>(base: t) => t`
+//! casts a constructable anonymous class to a generic construct signature. The
+//! signature's own bound type parameter has no concrete shape, so the structural
+//! overlap check failed and emitted TS2352. tsc's `isTypeComparableTo`
+//! instantiates the generic signature and finds the two constructors overlap.
+//! A non-callable source (`"s" as <T>(v: T) => T`) is still a genuine mismatch
+//! and keeps TS2352.
+
+use tsz_checker::test_utils::check_source_code_messages;
+
+fn ts2352_count(source: &str) -> usize {
+    check_source_code_messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2352)
+        .count()
+}
+
+#[test]
+fn constructable_source_to_generic_construct_signature_no_ts2352() {
+    let src = r#"
+const B = class {} as new <t extends object>(base: t) => t;
+export { B };
+"#;
+    assert_eq!(
+        ts2352_count(src),
+        0,
+        "a constructable anonymous class cast to a generic construct signature must not emit TS2352"
+    );
+}
+
+#[test]
+fn callable_source_to_generic_call_signature_no_ts2352() {
+    let src = r#"
+const f = (() => 0) as <T>(v: T) => T;
+export { f };
+"#;
+    assert_eq!(
+        ts2352_count(src),
+        0,
+        "a callable source cast to a generic call signature must not emit TS2352"
+    );
+}
+
+// Binder-name variation: the fix is structural (both sides callable/constructable
+// + generic signature target), not keyed on any identifier.
+#[test]
+fn constructable_source_to_renamed_generic_construct_signature_no_ts2352() {
+    let src = r#"
+const Make = class {} as new <Elem extends object>(seed: Elem) => Elem;
+export { Make };
+"#;
+    assert_eq!(
+        ts2352_count(src),
+        0,
+        "renamed generic construct-signature target must not emit TS2352"
+    );
+}
+
+// Negative control: a non-callable source has no overlap with a generic callable
+// target, so TS2352 must still fire (the suppression is gated on the source being
+// callable/constructable).
+#[test]
+fn noncallable_source_to_generic_call_signature_still_ts2352() {
+    let src = r#"
+const x = "str" as <T>(v: T) => T;
+export { x };
+"#;
+    assert!(
+        ts2352_count(src) >= 1,
+        "a non-callable `string` source cast to a generic call signature must still emit TS2352"
+    );
+}


### PR DESCRIPTION
Fixes #14325.

## Structural rule
An `as`-assertion is allowed when the source and target "sufficiently overlap" (`isTypeComparableTo`). When the target is a **generic** callable or constructable type — `new <t extends object>(base: t) => t`, `<T>(v: T) => T` — its own bound type parameters have no concrete shape, so tszs structural overlap check failed and emitted a spurious **TS2352**, even though the source is itself callable/constructable (e.g. an anonymous class is constructable). tsc instantiates the generic signature for comparability and finds the two constructors/functions overlap.

## Owner layer
Checker — the TS2352 overlap gate in `dispatch/mod.rs`. It already suppresses the error for targets with **free** (outer-scope) type parameters (`structured_generic_assertion_target`), but a signature with its **own bound** type parameters is not "free", so it fell through to the structural overlap check, which cant evaluate bound params and failed. The fix adds `generic_callable_overlap`: when the asserted type has bound (not free) type parameters AND both the source and the asserted type are callable or constructable, treat them as overlapping. This is gated on the source being callable/constructable, so it never blanket-suppresses.

## Adjacent-case matrix
- `class {} as new <t extends object>(base: t) => t` → 0 errors (was TS2352)
- `(() => 0) as <T>(v: T) => T` (callable source → generic call sig) → 0 errors
- renamed type-param (`as new <Elem extends object>(seed: Elem) => Elem`) → 0 errors (structural, not name-keyed)
- `class {} as new (base: object) => object` (non-generic ctor) → 0 errors (unchanged)
- **negative**: `"str" as <T>(v: T) => T` — `string` is not callable/constructable, so no overlap and TS2352 still fires

## Verification
- `cargo nextest run -p tsz-checker --test generic_callable_as_assertion_overlap_tests` — 4/4 (3 positive incl. renamed-param, 1 negative control).
- `cargo clippy -p tsz-checker` — clean.
- Manual: the issue repro reports 0 errors; `"str" as <T>(v: T) => T` still emits TS2352.
- Broad conformance/emit/fourslash: ready-review CI.

Goal: green

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: max