### PR TITLE
fix(binder): a renamed re-export must not create an in-module local binding (TS2315/TS2552/TS2749) (#14216, #14255)

### DIFF
--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -598,49 +598,33 @@ impl BinderState {
                                             // alias name-agnostic at the module boundary: it
                                             // does NOT introduce a local binding named `exp`.
                                             //
-                                            // When the module already declares a DISTINCT
-                                            // local symbol under `exp` (e.g. `class Box {}`
-                                            // plus `export { box as Box }`), overwriting the
-                                            // scope/file-local slot would re-point every
-                                            // in-module reference to `exp` (type and value
-                                            // positions) at the aliased target, yielding
-                                            // spurious `TS2552`/`TS2749`. Detect that
-                                            // collision and route the export through the
-                                            // file's `module_exports` table directly, leaving
-                                            // local resolution of `exp` (the
-                                            // class/interface/var) intact.
-                                            let colliding_local = self
-                                                .current_scope()
-                                                .get(exp)
-                                                .or_else(|| self.file_locals.get(exp))
-                                                .filter(|&existing| existing != sym_id)
-                                                .filter(|&existing| {
-                                                    self.symbols.get(existing).is_some_and(|s| {
-                                                        !s.declarations.is_empty()
-                                                            && (s.flags & symbol_flags::ALIAS) == 0
-                                                    })
-                                                });
-                                            if colliding_local.is_some() {
-                                                // Seed the file's public export surface so
-                                                // cross-file `import { exp }` still resolves
-                                                // to the alias TARGET (`sym_id`, i.e. `box`),
-                                                // without disturbing the local declaration's
-                                                // scope slot. The export record must map the
-                                                // public name to the alias source symbol, not
-                                                // the local declaration, or the cross-file
-                                                // import would resolve to the wrong binding.
-                                                let current_file =
-                                                    self.debugger.current_file.clone();
-                                                Arc::make_mut(&mut self.module_exports)
-                                                    .entry(current_file)
-                                                    .or_default()
-                                                    .set(exp.to_string(), sym_id);
-                                            } else {
-                                                if let Some(table) = self.current_scope_mut() {
-                                                    table.set(exp.to_string(), sym_id);
-                                                }
-                                                self.file_locals.set(exp.to_string(), sym_id);
-                                            }
+                                            // Introducing a local `exp` binding re-points
+                                            // every in-module reference to `exp` (type and
+                                            // value positions) at the aliased target. That is
+                                            // wrong whenever `exp` also names a distinct local
+                                            // declaration (e.g. `class Box {}` plus
+                                            // `export { box as Box }`, yielding spurious
+                                            // `TS2552`/`TS2749`) or a lib intrinsic (e.g.
+                                            // `export { Local as Capitalize }` shadowing the
+                                            // intrinsic `Capitalize<S>`, yielding spurious
+                                            // `TS2315`). The local declaration may be bound
+                                            // after this export specifier, and lib intrinsics
+                                            // never appear in `file_locals`, so a
+                                            // collision-detection guard cannot reliably catch
+                                            // either case. Route the export through the file's
+                                            // `module_exports` table only, leaving in-module
+                                            // resolution of `exp` to fall through to its local
+                                            // declaration or the lib type.
+                                            //
+                                            // The export record maps the public name to the
+                                            // alias source symbol (`sym_id`, i.e. `box`), so
+                                            // cross-file `import { exp }` still resolves to the
+                                            // alias TARGET.
+                                            let current_file = self.debugger.current_file.clone();
+                                            Arc::make_mut(&mut self.module_exports)
+                                                .entry(current_file)
+                                                .or_default()
+                                                .set(exp.to_string(), sym_id);
                                         }
                                     }
                                 }

--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -9,4 +9,5 @@ mod indexed_access;
 mod membership_semantics;
 mod narrowing;
 mod optional_chain;
+mod renamed_export_no_local_binding;
 mod spread_param_constraint_2345;

--- a/crates/tsz-checker/tests/conformance_issues/types/renamed_export_no_local_binding.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/renamed_export_no_local_binding.rs
@@ -1,0 +1,68 @@
+//! A renamed re-export (`export { Orig as Exp }`, `Orig != Exp`) must NOT
+//! introduce an in-module local binding for `Exp` — it only contributes `Exp` to
+//! the module's export surface. tsz's binder was seeding `file_locals`/scope with
+//! the renamed name, so in-module references to `Exp` wrongly resolved to the
+//! export target instead of a sibling local declaration or a lib intrinsic.
+//! (#14216, #14255)
+
+use super::super::core::*;
+
+fn opts() -> tsz_checker::context::CheckerOptions {
+    tsz_checker::context::CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        module: tsz_common::common::ModuleKind::ESNext,
+        ..Default::default()
+    }
+}
+
+/// #14255 (TS2315): `export { Local as Capitalize }` must not shadow the lib
+/// `Capitalize` string-mapping intrinsic in-module. `Capitalize<S>` must keep its
+/// generic intrinsic meaning (no false "type is not generic").
+#[test]
+fn renamed_export_shadowing_intrinsic_no_ts2315() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+export type Cap<S extends string> = Capitalize<S>;
+interface Local { tag: 'kind' }
+export { Local as Capitalize };
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2315),
+        "no TS2315 expected — the renamed export `Capitalize` is recorded only on \
+         the export surface; in-module `Capitalize<S>` keeps the intrinsic meaning. \
+         Actual: {diagnostics:#?}"
+    );
+}
+
+/// #14216 (TS2552/TS2749): a module declaring a local `class Box` that also
+/// re-exports a distinct local binding under the same name via
+/// `export { box as Box }`. In-module references to `Box` must keep the local
+/// class meaning (value and type).
+#[test]
+fn renamed_export_collides_local_class_no_ts2552_ts2749() {
+    if !lib_files_available() {
+        return;
+    }
+    let files = &[(
+        "m.ts",
+        "class Box { constructor(public value: number) {} }\n\
+         const useType = (b: Box): number => b.value\n\
+         const useValue = (): Box => new Box(1)\n\
+         const box = (n: number) => new Box(n)\n\
+         export { box as Box }",
+    )];
+    let diagnostics =
+        compile_named_files_get_diagnostics_with_lib_and_options(files, "m.ts", opts());
+    assert!(
+        !has_error(&diagnostics, 2749),
+        "no TS2749 expected — in-module `Box` type positions resolve to the local \
+         class, not the export alias. Actual: {diagnostics:#?}"
+    );
+    assert!(
+        !has_error(&diagnostics, 2552),
+        "no TS2552 expected — in-module `Box` value positions resolve to the local \
+         class constructor. Actual: {diagnostics:#?}"
+    );
+}


### PR DESCRIPTION
Fixes two green-goal false positives by implementing tsc's structural rule that a
RENAMED re-export does not introduce an in-module local binding.

Goal: green

## Structural rule
`export { Orig as Exp }` (where `Orig != Exp`) contributes `Exp` only to the
module's **export surface** (`module_exports`); it does NOT create an in-module
binding for `Exp`. tsz's binder was seeding `file_locals`/scope with the renamed
name (the existing collision guard missed two cases: a local declaration bound
*after* the specifier, and a lib intrinsic that is never in `file_locals`). So
in-module references to `Exp` wrongly resolved to the export target.

The renamed-export path now routes `Exp -> sym_id` to `module_exports` only
(using the binder's existing namespace-re-export idiom), never `file_locals`/
`current_scope`. Cross-file `import { Exp }` still resolves via `module_exports`;
the same-name (`orig == exp`) and default-export paths are untouched.

This fixes:
- **#14216** (TS2552/TS2749): `export { box as Box }` no longer clobbers a sibling
  local `class Box` — in-module `: Box` / `new Box()` keep the class meaning.
- **#14255** (TS2315): `export { Local as Capitalize }` no longer shadows the lib
  `Capitalize` string-mapping intrinsic — in-module `Capitalize<S>` stays generic.

Owner: binder — `modules/import_export.rs`.

## Verification
- `cargo nextest run -p tsz-checker -j 2 renamed_export_no_local_binding` — both
  flips green (TS2315 single-file; TS2552/TS2749 multi-file with libs).
- CI gates: lint, unit-checker-integration, conformance-aggregate, emit-aggregate,
  fourslash-*, project-compile-guard, CI Summary. (Binder/module-binding has
  conformance surface — relying on CI to confirm no module-resolution regressions.)

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max