### PR TITLE
fix(checker): key namespace-qualified unique-symbol computed members by canonical identity (TS7053)

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
+++ b/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
@@ -265,6 +265,24 @@ impl<'a> CheckerState<'a> {
         {
             return Some(self.ctx.types.resolve_atom_ref(name).to_string());
         }
+        // A computed name `[base.s]` whose qualified expression resolves to a
+        // binding with unique-symbol identity (e.g. a namespace-import-qualified
+        // `Symbol.for(...)` const reached through `import * as base`) keys the
+        // member under the canonical `__unique_<id>` binding-identity atom. The
+        // shared `computed_identifier_unique_symbol_property_ref` resolver
+        // (identifier OR qualified entity name) runs the result through
+        // `follow_import_aliases`, so the declaration-side member key here agrees
+        // with the SAME atom the index-side element access derives from the
+        // `unique symbol` index type. Without this leg the value-position
+        // evaluation below cannot type a cross-module namespace member during
+        // interface-member precomputation (it widens to `unknown`), the member is
+        // keyed under its syntactic fallback name, and the canonical
+        // `__unique_<id>` lookup misses -> false TS7053.
+        if let Some(sym_ref) =
+            self.computed_identifier_unique_symbol_property_ref(computed.expression)
+        {
+            return Some(format!("__unique_{}", sym_ref.0));
+        }
         let prev = self.ctx.checking_computed_property_name;
         self.ctx.checking_computed_property_name = Some(name_idx);
         let prev_preserve = self.ctx.preserve_literal_types;

--- a/crates/tsz-checker/src/types/computed_names.rs
+++ b/crates/tsz-checker/src/types/computed_names.rs
@@ -282,6 +282,17 @@ fn any_declaration_matches(
     // declaration was never inspected and `unique symbol` identity queries
     // silently returned `false`.
     let decl_is_current_file = symbol.decl_file_idx as usize == ctx.current_file_idx;
+    // The arena that actually holds the symbol's declaration nodes. For a
+    // cross-file import copy (`import * as ns` / a named import of the same
+    // const reached from another file) the per-binder `declaration_arenas` /
+    // `symbol_arenas` maps were populated only in the importing binder, not in
+    // the binder of the file recorded as `decl_file_idx`; consulting the
+    // owner file's arena directly recovers the original declaration
+    // (e.g. the `Symbol.for(...)` initializer of a re-imported `unique symbol`
+    // const) so identity queries do not silently return `false` when the
+    // declaration is reached through an import alias.
+    let owner_file_arena =
+        (symbol.decl_file_idx != u32::MAX).then(|| ctx.get_arena_for_file(symbol.decl_file_idx));
     symbol.all_declarations().into_iter().any(|decl_idx| {
         let mut candidate_arenas: Vec<&NodeArena> = Vec::new();
         if let Some(arenas) = owner_binder.declaration_arenas.get(&(sym_id, decl_idx)) {
@@ -289,6 +300,9 @@ fn any_declaration_matches(
         }
         if let Some(symbol_arena) = owner_binder.symbol_arenas.get(&sym_id) {
             candidate_arenas.push(symbol_arena.as_ref());
+        }
+        if let Some(arena) = owner_file_arena {
+            candidate_arenas.push(arena);
         }
         if decl_is_current_file || std::ptr::eq(owner_binder, ctx.binder) {
             candidate_arenas.push(ctx.arena);

--- a/crates/tsz-checker/src/types/queries/core_names.rs
+++ b/crates/tsz-checker/src/types/queries/core_names.rs
@@ -317,7 +317,7 @@ impl<'a> CheckerState<'a> {
         Some(self.ctx.types.unique_symbol(sym_ref))
     }
 
-    fn computed_identifier_unique_symbol_property_ref(
+    pub(crate) fn computed_identifier_unique_symbol_property_ref(
         &self,
         expr_idx: NodeIndex,
     ) -> Option<SymbolRef> {


### PR DESCRIPTION
Goal: green

Clears a false **TS7053** in ts-pattern, where a namespace-import-qualified `unique symbol` (a `Symbol.for(...)` const) used as a computed index key resolved to a member the interface could not find.

## Structural rule
When a computed property name `[base.s]` resolves (identifier or qualified entity name) to a binding with unique-symbol identity, tsc keys the member by that single symbol's identity; tsz must produce the canonical `__unique_<id>` atom on **both** the declaration side and the index side. Owner: `CheckerState` computed-property-name resolution + the `computed_names` identity helper (solver-backed via `SymbolRef`).

Two compounding cross-file `unique symbol` identity failures (verified by tracing):
1. The **index** side (`x[symbols.isVariadic]`) builds key `__unique_3773` from the unique-symbol type unconditionally (Symbol.for const). The **declaration** side (`[symbols.isVariadic]?` in the imported interface) ran through `resolve_local_computed_property_name`, which had **no leg** for a namespace-qualified unique symbol → value-position eval widened to `unknown` → the member was keyed under its syntactic fallback name, not `__unique_3773` → the index lookup missed.
2. Even when the declaration side resolved symbol 3773, `symbol_is_unique_symbol_binding(3773)` returned **false**: `any_declaration_matches` resolved no candidate arena because the cross-file import-copy's `decl_file_idx` points at the *importing* file, whose binder lacks the `Symbol.for` declaration arena (the real decl lives in the declaring file).

## The fix (3 files, +33/-1 — canonical `SymbolId`/`SymbolRef` identity, no name strings)
- `state/type_resolution/computed_property_names.rs`: added a binding-identity leg in `resolve_local_computed_property_name` using the shared `computed_identifier_unique_symbol_property_ref` (handles qualified names, runs `follow_import_aliases`), so the declaration-side key matches the index side.
- `types/computed_names.rs`: `any_declaration_matches` now also consults the symbol's owner-file arena (`get_arena_for_file(decl_file_idx)`), recovering the original declaration of a cross-file import copy.
- `types/queries/core_names.rs`: exposed `computed_identifier_unique_symbol_property_ref` as `pub(crate)`. Both legs are required (A/B-confirmed neither alone fixes the repro).

## Adjacent matrix
- namespace-qualified unique symbol both sides → clean (was false TS7053).
- named-import both sides → clean both (unchanged).
- absent key → TS7053 in both tsz and tsc.
- two distinct `Symbol.for` symbols → not conflated (distinct boolean vs string types; bad cross-assignment yields TS2322 in both).

## Verification
- Repro: tsz clean, bundled `tsc` clean — parity. Negatives all match tsc.
- ts-pattern project: TS7053 **1 → 0**, total **2 → 1**, no new codes (remaining TS2345 pre-existing/unrelated).
- Regression delta vs clean `main`: unique_symbol 61/62, computed 179/180, 7053 21/21, symbol 293/298, order 52/54 — every failure confirmed identical on clean baseline (lib/env `PropertyKey`/`Symbol` + unrelated inference). **Zero new failures.**
- Determinism: forced-parallel (`TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK=1 RAYON_NUM_THREADS=16`) — repro 5× identical md5, ts-pattern TS7053=0 across 3 runs. Order-independent.
- clippy `-p tsz-checker` clean.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
