### PR TITLE
fix(solver): resolve T[never] to the index source, not never (TS2345) (#14327)

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/types/indexed_access.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/indexed_access.rs
@@ -1792,3 +1792,72 @@ type Bad<K1 extends keyof T> = T[K1]["nope"];
          the concrete base.\nActual diagnostics: {diagnostics:#?}"
     );
 }
+
+// `T[never]` indexes an empty key set. `never` is assignable to every index
+// key, so `tsc` resolves the access to `T`'s index source — an array/tuple
+// element type or an index-signature value type — not `never`. Collapsing
+// `T[never]` to `never` made it the parameter type below, so a real argument
+// (a `string`/`number`/`boolean`) was rejected with a false TS2345. Mined from
+// arktype. Adjacent cases cover array, tuple, and index-signature bases with
+// varied binders.
+#[test]
+fn never_key_index_resolves_to_index_source_no_ts2345() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type ElemOfArray = (readonly string[])[never];
+declare function takeElem(value: ElemOfArray): void;
+takeElem("hello");
+        "#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2345),
+        "(readonly string[])[never] must resolve to the element type string.\nActual diagnostics: {diagnostics:#?}"
+    );
+
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type ElemOfTuple = [string, number][never];
+declare function takeTuple(slot: ElemOfTuple): void;
+takeTuple(42);
+takeTuple("world");
+        "#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2345),
+        "[string, number][never] must resolve to string | number.\nActual diagnostics: {diagnostics:#?}"
+    );
+
+    // Inline index-signature object (lib-independent stand-in for
+    // `Record<string, boolean>`): `T[never]` reads the string index value type.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type ValueOfRecord = { [k: string]: boolean }[never];
+declare function takeRecord(flag: ValueOfRecord): void;
+takeRecord(true);
+        "#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2345),
+        "{{ [k: string]: boolean }}[never] must resolve to the index value boolean.\nActual diagnostics: {diagnostics:#?}"
+    );
+}
+
+// Negative control: a plain object type with named properties only has no index
+// source, so `T[never]` stays `never`. Assigning a `string` to it must still
+// fail, exactly as `tsc` does — the fix must not over-broaden to a non-`never`
+// value type when there is no array element or index signature.
+#[test]
+fn never_key_index_on_plain_object_stays_never() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type NoIndexSource = { a: string; b: number }[never];
+const bad: NoIndexSource = "not never";
+        "#,
+    );
+
+    assert!(
+        has_error(&diagnostics, 2322),
+        "A plain object with named properties only has no index source, so T[never] is \
+         never and a string is not assignable.\nActual diagnostics: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -1771,6 +1771,62 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.evaluate(index_access)
     }
 
+    /// Evaluate `T[K]` for an empty (`never`) key set, mirroring tsc's
+    /// `getIndexedAccessType` over an empty key. `object_type` must already be
+    /// evaluated — the caller passes the evaluated object, and union members are
+    /// constituents of an evaluated union.
+    ///
+    /// `never` is assignable to every index key, so tsc reads `T`'s index
+    /// *sources*: the number index first (an array's element type, a tuple's
+    /// element union, or a numeric index signature), then the string and symbol
+    /// index signatures. The access collapses to `never` only when `T` exposes no
+    /// index source (e.g. a plain object type with named properties only, or a
+    /// primitive). Probing the concrete `number`/`string`/`symbol` keys reuses the
+    /// full per-shape index machinery (`readonly` unwrapping, `Lazy` resolution,
+    /// numeric-to-string index fallback); a missing index source surfaces as
+    /// `error`/`undefined`, which is treated as "no contribution".
+    fn evaluate_empty_key_index_access(&mut self, object_type: TypeId) -> TypeId {
+        if object_type == TypeId::NEVER {
+            return TypeId::NEVER;
+        }
+
+        // `(A | B)[never]` distributes to `A[never] | B[never]`, dropping members
+        // that contribute no index source (`union` of an empty set is `never`).
+        if let Some(members_id) = union_list_id(self.interner(), object_type) {
+            let members = self.interner().type_list(members_id);
+            let mut results = Vec::new();
+            for &member in members.iter() {
+                let contribution = self.evaluate_empty_key_index_access(member);
+                if contribution != TypeId::NEVER {
+                    results.push(contribution);
+                }
+            }
+            return self.interner().union(results);
+        }
+
+        // tsc priority: the number index (array/tuple element, numeric signature)
+        // first, then the string and symbol index signatures.
+        for key in [TypeId::NUMBER, TypeId::STRING, TypeId::SYMBOL] {
+            let value = self.recurse_index_access(object_type, key);
+            if value == TypeId::ERROR || value == TypeId::UNDEFINED || value == TypeId::NEVER {
+                continue;
+            }
+            // A deferred access that indexes straight back onto `object_type` made
+            // no progress for this key (e.g. a mapped type whose constraint does
+            // not admit `number`); skip it so a later key can still resolve the
+            // real index source (the mapped constraint `string`/`symbol`).
+            if matches!(
+                self.interner().lookup(value),
+                Some(TypeData::IndexAccess(obj, _)) if obj == object_type
+            ) {
+                continue;
+            }
+            return value;
+        }
+
+        TypeId::NEVER
+    }
+
     /// Evaluate an index access type: T[K]
     ///
     /// This resolves property access on object types.
@@ -1841,10 +1897,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return TypeId::ERROR;
         }
 
-        // `T[never]` and `T[keyof T]` where the key set is empty index over no
-        // properties, so they evaluate to `never`. Keep this narrower than all
-        // indexes that simplify to `never`, because some mapped/utility-type
-        // paths rely on the existing concrete lookup fallback behavior.
+        // `T[never]` and `T[keyof T]` over an empty key set index over no named
+        // properties. `never` is assignable to every index key, so tsc resolves
+        // such an access to `T`'s *index source* — the number index (array/tuple
+        // element, numeric signature), then the string/symbol index signatures —
+        // collapsing to `never` only when `T` exposes no index source. Keep this
+        // narrower than all indexes that simplify to `never`, because some
+        // mapped/utility-type paths rely on the existing concrete lookup fallback
+        // behavior for deferred keys that happen to reduce to `never`.
         let is_empty_index_access = evaluated_index == TypeId::NEVER
             && (index_type == TypeId::NEVER
                 || matches!(
@@ -1856,7 +1916,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             || self.evaluate(inner) == evaluated_object
                 ));
         if is_empty_index_access {
-            return TypeId::NEVER;
+            return self.evaluate_empty_key_index_access(evaluated_object);
         }
 
         // Rule #38: Distribute over index union at the top level (Cartesian product expansion)

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -1771,62 +1771,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.evaluate(index_access)
     }
 
-    /// Evaluate `T[K]` for an empty (`never`) key set, mirroring tsc's
-    /// `getIndexedAccessType` over an empty key. `object_type` must already be
-    /// evaluated — the caller passes the evaluated object, and union members are
-    /// constituents of an evaluated union.
-    ///
-    /// `never` is assignable to every index key, so tsc reads `T`'s index
-    /// *sources*: the number index first (an array's element type, a tuple's
-    /// element union, or a numeric index signature), then the string and symbol
-    /// index signatures. The access collapses to `never` only when `T` exposes no
-    /// index source (e.g. a plain object type with named properties only, or a
-    /// primitive). Probing the concrete `number`/`string`/`symbol` keys reuses the
-    /// full per-shape index machinery (`readonly` unwrapping, `Lazy` resolution,
-    /// numeric-to-string index fallback); a missing index source surfaces as
-    /// `error`/`undefined`, which is treated as "no contribution".
-    fn evaluate_empty_key_index_access(&mut self, object_type: TypeId) -> TypeId {
-        if object_type == TypeId::NEVER {
-            return TypeId::NEVER;
-        }
-
-        // `(A | B)[never]` distributes to `A[never] | B[never]`, dropping members
-        // that contribute no index source (`union` of an empty set is `never`).
-        if let Some(members_id) = union_list_id(self.interner(), object_type) {
-            let members = self.interner().type_list(members_id);
-            let mut results = Vec::new();
-            for &member in members.iter() {
-                let contribution = self.evaluate_empty_key_index_access(member);
-                if contribution != TypeId::NEVER {
-                    results.push(contribution);
-                }
-            }
-            return self.interner().union(results);
-        }
-
-        // tsc priority: the number index (array/tuple element, numeric signature)
-        // first, then the string and symbol index signatures.
-        for key in [TypeId::NUMBER, TypeId::STRING, TypeId::SYMBOL] {
-            let value = self.recurse_index_access(object_type, key);
-            if value == TypeId::ERROR || value == TypeId::UNDEFINED || value == TypeId::NEVER {
-                continue;
-            }
-            // A deferred access that indexes straight back onto `object_type` made
-            // no progress for this key (e.g. a mapped type whose constraint does
-            // not admit `number`); skip it so a later key can still resolve the
-            // real index source (the mapped constraint `string`/`symbol`).
-            if matches!(
-                self.interner().lookup(value),
-                Some(TypeData::IndexAccess(obj, _)) if obj == object_type
-            ) {
-                continue;
-            }
-            return value;
-        }
-
-        TypeId::NEVER
-    }
-
     /// Evaluate an index access type: T[K]
     ///
     /// This resolves property access on object types.
@@ -1897,25 +1841,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return TypeId::ERROR;
         }
 
-        // `T[never]` and `T[keyof T]` over an empty key set index over no named
-        // properties. `never` is assignable to every index key, so tsc resolves
-        // such an access to `T`'s *index source* — the number index (array/tuple
-        // element, numeric signature), then the string/symbol index signatures —
-        // collapsing to `never` only when `T` exposes no index source. Keep this
-        // narrower than all indexes that simplify to `never`, because some
-        // mapped/utility-type paths rely on the existing concrete lookup fallback
-        // behavior for deferred keys that happen to reduce to `never`.
-        let is_empty_index_access = evaluated_index == TypeId::NEVER
-            && (index_type == TypeId::NEVER
-                || matches!(
-                    self.interner().lookup(index_type),
-                    Some(TypeData::KeyOf(inner))
-                        if inner == object_type
-                            || inner == evaluated_object
-                            || self.evaluate(inner) == object_type
-                            || self.evaluate(inner) == evaluated_object
-                ));
-        if is_empty_index_access {
+        if self.is_empty_key_index_access(
+            object_type,
+            evaluated_object,
+            index_type,
+            evaluated_index,
+        ) {
             return self.evaluate_empty_key_index_access(evaluated_object);
         }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_empty_key.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_empty_key.rs
@@ -6,7 +6,7 @@ use crate::visitor::union_list_id;
 
 use super::super::evaluate::TypeEvaluator;
 
-impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+impl<R: TypeResolver> TypeEvaluator<'_, R> {
     /// True for the narrow `T[never]` / empty `T[keyof T]` path.
     pub(crate) fn is_empty_key_index_access(
         &mut self,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_empty_key.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_empty_key.rs
@@ -1,0 +1,80 @@
+//! Empty-key indexed access support.
+
+use crate::relations::subtype::TypeResolver;
+use crate::types::{TypeData, TypeId};
+use crate::visitor::union_list_id;
+
+use super::super::evaluate::TypeEvaluator;
+
+impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+    /// True for the narrow `T[never]` / empty `T[keyof T]` path.
+    pub(crate) fn is_empty_key_index_access(
+        &mut self,
+        object_type: TypeId,
+        evaluated_object: TypeId,
+        index_type: TypeId,
+        evaluated_index: TypeId,
+    ) -> bool {
+        evaluated_index == TypeId::NEVER
+            && (index_type == TypeId::NEVER
+                || matches!(
+                    self.interner().lookup(index_type),
+                    Some(TypeData::KeyOf(inner))
+                        if inner == object_type
+                            || inner == evaluated_object
+                            || self.evaluate(inner) == object_type
+                            || self.evaluate(inner) == evaluated_object
+                ))
+    }
+
+    /// Evaluate `T[K]` for an empty (`never`) key set, mirroring tsc's
+    /// `getIndexedAccessType` over an empty key. `object_type` must already be
+    /// evaluated; union members are constituents of an evaluated union.
+    ///
+    /// `never` is assignable to every index key, so tsc reads `T`'s index
+    /// *sources*: the number index first (an array's element type, a tuple's
+    /// element union, or a numeric index signature), then the string and symbol
+    /// index signatures. The access collapses to `never` only when `T` exposes no
+    /// index source. Probing the concrete `number`/`string`/`symbol` keys reuses
+    /// the full per-shape index machinery; a missing index source surfaces as
+    /// `error`/`undefined`, which is treated as "no contribution".
+    pub(crate) fn evaluate_empty_key_index_access(&mut self, object_type: TypeId) -> TypeId {
+        if object_type == TypeId::NEVER {
+            return TypeId::NEVER;
+        }
+
+        // `(A | B)[never]` distributes to `A[never] | B[never]`, dropping members
+        // that contribute no index source (`union` of an empty set is `never`).
+        if let Some(members_id) = union_list_id(self.interner(), object_type) {
+            let members = self.interner().type_list(members_id);
+            let mut results = Vec::new();
+            for &member in members.iter() {
+                let contribution = self.evaluate_empty_key_index_access(member);
+                if contribution != TypeId::NEVER {
+                    results.push(contribution);
+                }
+            }
+            return self.interner().union(results);
+        }
+
+        // tsc priority: the number index (array/tuple element, numeric signature)
+        // first, then the string and symbol index signatures.
+        for key in [TypeId::NUMBER, TypeId::STRING, TypeId::SYMBOL] {
+            let value = self.recurse_index_access(object_type, key);
+            if value == TypeId::ERROR || value == TypeId::UNDEFINED || value == TypeId::NEVER {
+                continue;
+            }
+            // A deferred access that indexes straight back onto `object_type` made
+            // no progress for this key; skip it so a later key can still resolve.
+            if matches!(
+                self.interner().lookup(value),
+                Some(TypeData::IndexAccess(obj, _)) if obj == object_type
+            ) {
+                continue;
+            }
+            return value;
+        }
+
+        TypeId::NEVER
+    }
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
@@ -17,6 +17,7 @@ pub mod apparent;
 pub mod conditional;
 pub mod index_access;
 mod index_access_callable;
+mod index_access_empty_key;
 mod index_access_keys;
 mod index_access_object_with_index;
 mod index_access_tuple_literal;

--- a/crates/tsz-solver/tests/index_access_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/index_access_comprehensive_tests.rs
@@ -462,6 +462,143 @@ fn test_index_access_keyof_empty_object_is_never() {
     assert_eq!(result, TypeId::NEVER, "{{}}[keyof {{}}] should be never");
 }
 
+#[test]
+fn test_index_access_never_key_on_array_is_element_type() {
+    // `never` is assignable to every index key, so tsc resolves `T[never]` to
+    // `T`'s index source. For an array that is the element type, not `never`.
+    let interner = TypeInterner::new();
+
+    let array = interner.array(TypeId::STRING);
+    let index_access = interner.index_access(array, TypeId::NEVER);
+
+    let result = evaluate_type(&interner, index_access);
+    assert_eq!(
+        result,
+        TypeId::STRING,
+        "string[][never] should be the element type string"
+    );
+}
+
+#[test]
+fn test_index_access_never_key_on_tuple_is_element_union() {
+    let interner = TypeInterner::new();
+
+    let tuple = interner.tuple(vec![
+        TupleElement {
+            type_id: TypeId::STRING,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: TypeId::NUMBER,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+    let index_access = interner.index_access(tuple, TypeId::NEVER);
+
+    let result = evaluate_type(&interner, index_access);
+    let expected = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    assert_eq!(
+        result, expected,
+        "[string, number][never] should be the element union string | number"
+    );
+}
+
+#[test]
+fn test_index_access_never_key_on_string_index_signature() {
+    // `Record<string, number>`-shaped object: `T[never]` picks up the string
+    // index signature value type.
+    let interner = TypeInterner::new();
+
+    let obj = interner.object_with_index(crate::types::ObjectShape {
+        symbol: None,
+        flags: crate::types::ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(crate::types::IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+    });
+    let index_access = interner.index_access(obj, TypeId::NEVER);
+
+    let result = evaluate_type(&interner, index_access);
+    assert_eq!(
+        result,
+        TypeId::NUMBER,
+        "{{ [k: string]: number }}[never] should be the index value type number"
+    );
+}
+
+#[test]
+fn test_index_access_never_key_on_readonly_array_is_element_type() {
+    let interner = TypeInterner::new();
+
+    let array = interner.array(TypeId::NUMBER);
+    let readonly_array = interner.readonly_type(array);
+    let index_access = interner.index_access(readonly_array, TypeId::NEVER);
+
+    let result = evaluate_type(&interner, index_access);
+    assert_eq!(
+        result,
+        TypeId::NUMBER,
+        "(readonly number[])[never] should be the element type number"
+    );
+}
+
+#[test]
+fn test_index_access_never_key_on_string_mapped_is_value_type() {
+    // `Record<string, boolean>` expands to `{ [P in string]: boolean }`. Indexing
+    // it by `never` reads the (implicit string) index signature value type.
+    let interner = TypeInterner::new();
+
+    let mapped_type_param = TypeParamInfo {
+        name: interner.intern_string("P"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    };
+    let mapped = interner.mapped(MappedType {
+        type_param: mapped_type_param,
+        constraint: TypeId::STRING,
+        name_type: None,
+        template: TypeId::BOOLEAN,
+        optional_modifier: None,
+        readonly_modifier: None,
+    });
+
+    let index_access = interner.index_access(mapped, TypeId::NEVER);
+    let result = evaluate_type(&interner, index_access);
+    assert_eq!(
+        result,
+        TypeId::BOOLEAN,
+        "{{ [P in string]: boolean }}[never] should be the index value type boolean"
+    );
+}
+
+#[test]
+fn test_index_access_never_key_on_array_union_distributes() {
+    let interner = TypeInterner::new();
+
+    let string_array = interner.array(TypeId::STRING);
+    let number_array = interner.array(TypeId::NUMBER);
+    let union = interner.union(vec![string_array, number_array]);
+    let index_access = interner.index_access(union, TypeId::NEVER);
+
+    let result = evaluate_type(&interner, index_access);
+    let expected = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    assert_eq!(
+        result, expected,
+        "(string[] | number[])[never] should distribute to string | number"
+    );
+}
+
 // =============================================================================
 // Multiple Index Access Tests
 // =============================================================================


### PR DESCRIPTION
## Summary
Fixes #14327. tsz emitted a false **TS2345** where tsc is clean because `T[never]` collapsed to `never`.

`never` is assignable to every index key, so tsc resolves `T[K]` over an empty key set (`K = never`) to `T`'s **index source** — the number index (an array's element type, a tuple's element union, or a numeric index signature) first, then the string and symbol index signatures — mirroring `getIndexedAccessType` over an empty key. It collapses to `never` only when `T` exposes no index source. tsz collapsed `T[never]` to `never` unconditionally, dropping the array element / index-signature value type; when that type became a function parameter, a real argument was rejected with a false TS2345 (mined from **arktype**).

## Structural rule
When the index type of `T[K]` evaluates to `never` (empty key set), `tsc` returns the union of `T`'s applicable string/number/symbol index-signature value types and, for arrays/tuples, the element type — `never` only when `T` has no index source. tsz now does the same through the solver's indexed-access evaluation.

## Owner / fix direction
Solver — indexed-access evaluation (`crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs`). The empty-key branch of `evaluate_index_access` previously hard-returned `never`; it now delegates to a new `evaluate_empty_key_index_access` helper. The helper probes the concrete `number`/`string`/`symbol` keys through the existing per-shape index machinery (reusing `readonly` unwrapping, `Lazy` resolution, numeric-to-string index fallback), distributes over object unions, and treats a missing index source (`error`/`undefined`/no-progress deferral) as "no contribution" — so it yields `never` only when `T` has no index source. The gating condition is unchanged, so deferred keys that merely reduce to `never` still fall through to the existing lookup path.

### Anti-hardcoding
No identifier/file-name/printer-string checks. The decision is purely structural: it reuses the shared per-key index evaluation and the interner's union normalization. No formatted-diagnostic predicate.

## Adjacent cases (covered by tests)
- `T[never]` over an array → element type; over a tuple → element union; over an index-signature object / mapped `{ [P in string]: V }` → value type; over a `readonly` array; distributing over an array union.
- Negative control: a plain object with named properties only (`{ a; b }[never]`) and `{}[keyof {}]` stay `never`.

## Verification
- New solver unit tests in `crates/tsz-solver/tests/index_access_comprehensive_tests.rs` (array, tuple, string-index, readonly-array, union, string-mapped) — pass; existing `test_index_access_never_key` / `test_index_access_keyof_empty_object_is_never` still pass.
- New checker regression tests in `crates/tsz-checker/tests/conformance_issues/types/indexed_access.rs` (`never_key_index_resolves_to_index_source_no_ts2345`, `never_key_index_on_plain_object_stays_never`) — pass.
- `cargo test -p tsz-solver --lib index_access` → 143 passed; `cargo test -p tsz-checker --test conformance_issues_types` green except two pre-existing, lib-dependent failures (`*_preserves_ts2322`) that also fail on the clean tree in this no-submodule environment (`Cannot find name 'Pick'`) — unrelated to this change.
- CLI smoke (`tsz` with full lib) on the repro reports no diagnostics.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_013Evasm5r4n7MLUbxLNKoaj)_