### PR TITLE
fix(checker): default unfixed type params in new-expression callback contextual types (#14333)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -304,6 +304,9 @@ path = "tests/new_expression_regression_tests.rs"
 name = "new_generic_construct_signature_type_arg_display_tests"
 path = "tests/new_generic_construct_signature_type_arg_display_tests.rs"
 [[test]]
+name = "new_generic_callback_contextual_infer_tests"
+path = "tests/new_generic_callback_contextual_infer_tests.rs"
+[[test]]
 name = "noinfer_diagnostic_display_tests"
 path = "tests/noinfer_diagnostic_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/call_inference.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference.rs
@@ -377,6 +377,38 @@ impl<'a> CheckerState<'a> {
         filled
     }
 
+    /// Default any type parameter or `__infer_*` placeholder that round-1
+    /// inference could not fix to its default/constraint/`unknown` before the
+    /// contextual parameter type is pushed into a context-sensitive callback
+    /// argument. Without this, reading the callback parameter as a value (e.g.
+    /// assigning `res` out of `new Promise((res) => { resolve = res })`)
+    /// relates an un-fixed `(value: __infer_0 | ...) => void` and produces a
+    /// tsz-only false positive; `tsc` fixes the type parameter (e.g.
+    /// `T = unknown`) so the callback parameter becomes concrete. Shared by the
+    /// generic call and generic `new` round-2 contextual-typing paths so the
+    /// two cannot drift.
+    pub(crate) fn default_unfixed_sensitive_contextual_type_params(
+        &self,
+        is_sensitive: bool,
+        contextual: TypeId,
+        type_params: &[tsz_solver::TypeParamInfo],
+        substitution: &crate::query_boundaries::common::TypeSubstitution,
+    ) -> TypeId {
+        if is_sensitive
+            && (common::contains_type_parameters(self.ctx.types, contextual)
+                || common::contains_infer_types(self.ctx.types, contextual))
+        {
+            crate::query_boundaries::inference::instantiate_remaining_contextual_type_params(
+                self.ctx.types,
+                contextual,
+                type_params,
+                substitution,
+            )
+        } else {
+            contextual
+        }
+    }
+
     pub(crate) fn direct_round1_literal_conflict_type_params(
         &mut self,
         shape: &FunctionShape,

--- a/crates/tsz-checker/src/types/computation/call_inference/argument_context.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference/argument_context.rs
@@ -467,19 +467,12 @@ impl<'a> CheckerState<'a> {
                 } else {
                     self.evaluate_type_with_env(instantiated)
                 };
-                let evaluated = if is_sensitive
-                    && (common::contains_type_parameters(self.ctx.types, evaluated)
-                        || common::contains_infer_types(self.ctx.types, evaluated))
-                {
-                    crate::query_boundaries::inference::instantiate_remaining_contextual_type_params(
-                        self.ctx.types,
-                        evaluated,
-                        &shape.type_params,
-                        &contextual_substitution,
-                    )
-                } else {
-                    evaluated
-                };
+                let evaluated = self.default_unfixed_sensitive_contextual_type_params(
+                    is_sensitive,
+                    evaluated,
+                    &shape.type_params,
+                    &contextual_substitution,
+                );
                 Some(if is_rest_param {
                     self.rest_argument_element_type_with_env(evaluated)
                 } else {

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1341,6 +1341,20 @@ impl<'a> CheckerState<'a> {
                             } else {
                                 self.evaluate_type_with_env(instantiated)
                             };
+                            // Mirror the generic-call path: any type parameter that
+                            // round-1 inference could not fix (it stays a bare type
+                            // parameter or an `__infer_*` placeholder) is
+                            // back-substituted to its default/constraint/`unknown`
+                            // before the contextual parameter type is pushed into a
+                            // sensitive callback argument, so reading that parameter
+                            // out does not surface a leaked placeholder.
+                            let is_sensitive = sensitive_args.get(i).copied().unwrap_or(false);
+                            let contextual = self.default_unfixed_sensitive_contextual_type_params(
+                                is_sensitive,
+                                contextual,
+                                &shape.type_params,
+                                &round2_substitution,
+                            );
                             trace!(
                                 arg_index = i,
                                 param_type_display = %self.format_type(param_type),

--- a/crates/tsz-checker/tests/new_generic_callback_contextual_infer_tests.rs
+++ b/crates/tsz-checker/tests/new_generic_callback_contextual_infer_tests.rs
@@ -1,0 +1,108 @@
+//! Regression tests for back-substituting the fixed inference result into
+//! contextual callback-parameter types on the construct (`new`) path.
+//!
+//! When a generic construct signature's type parameter cannot be fixed from the
+//! arguments (no explicit type argument, callback body not yet analyzed), `tsc`
+//! defaults the parameter (e.g. `T = unknown`) before pushing the contextual
+//! parameter types into a callback argument. Previously tsz left the raw
+//! inference placeholder (`__infer_*`) in the callback's parameter type, so
+//! reading that parameter as a value produced a tsz-only `TS2322` and leaked the
+//! internal placeholder into the user-facing message.
+
+use tsz_checker::diagnostics::diagnostic_codes;
+use tsz_checker::test_utils::{check_source_diagnostics, diagnostic_codes as codes_of};
+
+/// The original witness, reproduced lib-free with the same executor shape as
+/// the real `Promise` constructor: `(value: T | PromiseLike<T>) => void`. With
+/// no contextual type `T` defaults to `unknown`, so reading `res` out against
+/// `(value: unknown) => void` is clean (rather than leaking `__infer_*`).
+#[test]
+fn promise_shaped_executor_resolve_assigned_out_is_clean() {
+    let source = r#"
+interface ThenableLike<T> { then(cb: (value: T) => void): void; }
+interface ThenableCtor {
+    new <T>(executor: (res: (value: T | ThenableLike<T>) => void) => void): ThenableLike<T>;
+}
+declare const Thenable: ThenableCtor;
+let resolve: (value: unknown) => void;
+new Thenable((res) => { resolve = res });
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.is_empty(),
+        "promise-shaped executor reading `res` out must be clean: {diagnostics:?}"
+    );
+}
+
+/// Not Promise-specific: a user-defined generic class whose constructor takes a
+/// callback that exposes the type parameter must default `T` the same way.
+#[test]
+fn user_generic_class_executor_callback_param_read_out_is_clean() {
+    let source = r#"
+class Box<T> {
+    constructor(executor: (res: (value: T) => void) => void) {}
+}
+let resolve: (value: unknown) => void;
+new Box((res) => { resolve = res });
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.is_empty(),
+        "user generic class executor reading `res` out must be clean: {diagnostics:?}"
+    );
+}
+
+/// The internal `__infer_*` placeholder atom must never surface in a
+/// user-facing diagnostic message, regardless of whether a diagnostic fires.
+#[test]
+fn construct_callback_never_leaks_infer_placeholder_into_messages() {
+    let source = r#"
+class Box<T> {
+    constructor(executor: (res: (value: T) => void) => void) {}
+}
+let resolve: (value: unknown) => void;
+new Box((res) => { resolve = res });
+"#;
+    for diag in check_source_diagnostics(source) {
+        assert!(
+            !diag.message_text.contains("__infer"),
+            "diagnostic leaked an inference placeholder: {diag:?}"
+        );
+    }
+}
+
+/// Back-substitution must not mask real errors: when the argument genuinely
+/// fixes `T` to a concrete type, body errors against that type still fire.
+#[test]
+fn concrete_construct_inference_still_reports_body_error() {
+    let source = r#"
+class Holder<T> {
+    constructor(cb: (x: T) => void, seed: T) {}
+}
+new Holder((x) => { x.toFixed(); }, "world");
+"#;
+    let codes = codes_of(&check_source_diagnostics(source));
+    assert!(
+        codes.contains(&diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE),
+        "expected TS2339 for `.toFixed()` on string-inferred T: {codes:?}"
+    );
+}
+
+/// An explicit type argument on a generic class fixes `T` directly; the
+/// callback parameter is concrete and assigning it out against the matching
+/// declared type is clean (the implicit two-pass inference path is bypassed).
+#[test]
+fn explicit_type_argument_construct_callback_is_clean() {
+    let source = r#"
+class Box<T> {
+    constructor(executor: (res: (value: T) => void) => void) {}
+}
+let resolve: (value: number) => void;
+new Box<number>((res) => { resolve = res });
+"#;
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.is_empty(),
+        "explicit `new Box<number>` executor must be clean: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
Fixes #14333.

## Structural rule
When a generic **construct** signature's type parameter cannot be fixed from the arguments (no explicit type argument; the callback body is not analyzed during round-1 inference), `tsc` defaults the parameter (e.g. `T = unknown`) before pushing the contextual parameter types into a callback argument; tsz did this on the **call** path but not the **construct (`new`)** path, so the raw inference placeholder (`__infer_*`) leaked into the callback's parameter type. Reading that parameter as a value (assigning `res` out of `new Promise((res) => { resolve = res })`) related an un-fixed `(value: __infer_0 | PromiseLike<__infer_0>) => void` against `(value: unknown) => void` and produced a tsz-only `TS2322`, also surfacing the internal placeholder in the user-facing message.

`When a generic construct signature leaves a type parameter unfixed after round-1 inference, tsc defaults it to its default/constraint/unknown before pushing contextual callback-parameter types; tsz now does X through crates/tsz-checker round-2 contextual typing (checker), shared between the call and new paths.`

## Owner layer
Checker — round-2 contextual typing for generic call/`new` arguments. The generic-call path already routed unresolved type parameters / inference placeholders through `instantiate_remaining_contextual_type_params`; the construct path did not. The shared guard + helper call is factored into `default_unfixed_sensitive_contextual_type_params` (in `call_inference.rs`) and used by **both** the call (`call_inference/argument_context.rs`) and `new` (`types/computation/complex.rs`) round-2 paths so they cannot drift again.

## Adjacent-case matrix (verified on a fresh binary)
| Case | Before | After |
|---|---|---|
| `new Promise((res) => { resolve = res })`, T inferred, `res` read out | TS2322 (leaked `__infer_0`) | clean |
| user generic **class** `new Box((res) => { resolve = res })`, T inferred | TS2322 (same leak) | clean |
| `new Promise<number>((res) => { resolve = res })` (explicit type arg) | clean | clean |
| `new Promise((res) => { res(123) })` (`res` only called) | clean | clean |
| user generic **function** `make((res) => { resolve = res })` (call path) | clean | clean |
| concrete inference `new Holder((x) => { x.toFixed() }, "world")` (T = string) | TS2339 | TS2339 (preserved) |

Not Promise-specific: it is the shared mechanism, so any generic constructor whose callback exposes an unfixed type parameter is fixed. Real argument-driven inference is unaffected — body errors against a concretely-inferred type parameter still fire.

## Fallback
When a parameter has no default/constraint, it resolves to `unknown` (matching `tsc`). An explicit type argument bypasses round-2 inference entirely and is unchanged. A separate, pre-existing leak on the explicit-type-argument path for *interface* construct signatures (`new Thenable<number>(...)` where the constructor is a Lazy interface type) is out of scope here and tracked separately.

## Goal
Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo nextest run -p tsz-checker --test new_generic_callback_contextual_infer_tests` (new regression suite: 5/5 pass — Promise-shaped executor, user generic class, no `__infer` leak in messages, concrete-inference body error still fires, explicit type arg clean)
- `cargo nextest run -p tsz-checker --test promise_callback_variance_tests --test promise_constructor_capability_tests --test new_expression_regression_tests --test new_generic_construct_signature_type_arg_display_tests --test construct_signature_boundary_matrix_tests --test checker_constructor_matrix_tests` (all pass)
- `cargo nextest run -p tsz-checker --test generic_call_inference_tests --test contextual_typing_tests --test context_sensitive_callback_inference_tests --test covariant_callbacks_tests --test indexed_access_callback_tests --test fresh_object_literal_arg_callback_param_variance_tests --test generic_callback_local_literal_widening_tests --test inference_placeholder_determinism_tests` (no new failures; the 5 `generic_call_inference_tests` failures are pre-existing on `main`, identical before/after this change)
- arch tests `call_context_relation_routing_arch_tests` + `libtype_structural_name_lookup_arch_tests` pass after the helper extraction
- `cargo clippy -p tsz-checker` clean

https://claude.ai/code/session_012h1YkSxsy82vVQr7YVtrUb

---
_Generated by [Claude Code](https://claude.ai/code/session_012h1YkSxsy82vVQr7YVtrUb)_