### PR TITLE
fix(checker): contextually type a function expression from the sole arity-viable union member (TS7006)

### DIFF
--- a/crates/tsz-checker/src/types/utilities/contextual_calls.rs
+++ b/crates/tsz-checker/src/types/utilities/contextual_calls.rs
@@ -68,4 +68,75 @@ impl<'a> CheckerState<'a> {
             _ => Some(self.ctx.types.factory().union_preserve_members(param_types)),
         }
     }
+
+    /// Whether a single callable union member can serve as the contextual
+    /// signature for a function expression that declares `arg_count`
+    /// parameters. Mirrors tsc's `isAritySmaller`: a call signature is viable
+    /// when it has a rest parameter or at least `arg_count` parameters.
+    /// Non-callable members are not viable.
+    pub(crate) fn callable_member_accepts_callback_arity(
+        &self,
+        member: TypeId,
+        arg_count: usize,
+    ) -> bool {
+        let accepts = |params: &[tsz_solver::ParamInfo]| {
+            params.iter().any(|param| param.rest) || params.len() >= arg_count
+        };
+        if let Some(shape) =
+            crate::query_boundaries::common::function_shape_for_type(self.ctx.types, member)
+        {
+            return accepts(&shape.params);
+        }
+        if let Some(signatures) =
+            crate::query_boundaries::common::call_signatures_for_type(self.ctx.types, member)
+        {
+            return signatures.iter().any(|sig| accepts(&sig.params));
+        }
+        false
+    }
+
+    /// Contextual type of parameter `index` taken from a single callable union
+    /// member, considering only call signatures that can accept a callback of
+    /// `arg_count` parameters (tsc's `isAritySmaller`). Returns `None` when no
+    /// viable signature covers the position. Complements
+    /// `contextual_mixed_overload_param_type_for_call`, which only handles
+    /// members carrying two or more mixed generic/non-generic overloads; this
+    /// covers the common case of a plain single-signature function member.
+    pub(crate) fn contextual_callable_member_param_type_for_call(
+        &mut self,
+        member: TypeId,
+        index: usize,
+        arg_count: usize,
+    ) -> Option<TypeId> {
+        let signature_params: Vec<Vec<tsz_solver::ParamInfo>> = if let Some(shape) =
+            crate::query_boundaries::common::function_shape_for_type(self.ctx.types, member)
+        {
+            vec![shape.params.clone()]
+        } else {
+            crate::query_boundaries::common::call_signatures_for_type(self.ctx.types, member)?
+                .into_iter()
+                .map(|sig| sig.params)
+                .collect()
+        };
+        for params in &signature_params {
+            let has_rest = params.iter().any(|param| param.rest);
+            if !has_rest && params.len() < arg_count {
+                continue;
+            }
+            if let Some(param) = params.get(index) {
+                return Some(if param.rest {
+                    self.rest_argument_element_type_with_env(param.type_id)
+                } else {
+                    self.evaluate_type_with_env(param.type_id)
+                });
+            }
+            if has_rest
+                && let Some(last) = params.last()
+                && last.rest
+            {
+                return Some(self.rest_argument_element_type_with_env(last.type_id));
+            }
+        }
+        None
+    }
 }

--- a/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
+++ b/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
@@ -849,6 +849,38 @@ impl<'a> CheckerState<'a> {
                 .iter()
                 .any(|(member, evaluated)| member != evaluated);
             if has_evaluated_members || !union_has_direct_call_signatures {
+                // tsc derives the contextual signature for a function expression
+                // from a union of function types by discarding members whose
+                // call signature is arity-smaller than the expression
+                // (`isAritySmaller`). When exactly one member can accept the
+                // callback's arity, the contextual signature -- and thus every
+                // parameter type -- comes solely from that member. Without this,
+                // a union of plain single-signature function types (e.g.
+                // `MethodDecorator | PropertyDecorator | ClassDecorator`, where
+                // only the 3-parameter `MethodDecorator` can accept a
+                // 3-parameter callback) yields no contextual type for any
+                // parameter and spuriously reports TS7006, because the
+                // per-member mixed-overload path below only handles members
+                // carrying two or more overload signatures. The 2-or-more
+                // survivor case is left to the existing per-member logic, which
+                // preserves tsc's "members must agree, else implicit any".
+                // `evaluated_member` already equals `member` when evaluation
+                // produced no change, so it is the effective member type.
+                let mut arity_viable_members: Vec<TypeId> = Vec::new();
+                for &(_, evaluated_member) in &evaluated_members {
+                    if self.callable_member_accepts_callback_arity(evaluated_member, arg_count) {
+                        arity_viable_members.push(evaluated_member);
+                    }
+                }
+                if arity_viable_members.len() == 1
+                    && let Some(param_type) = self.contextual_callable_member_param_type_for_call(
+                        arity_viable_members[0],
+                        index,
+                        arg_count,
+                    )
+                {
+                    return Some(param_type);
+                }
                 let contextual_members: Vec<_> = evaluated_members
                     .into_iter()
                     .filter_map(|(member, evaluated_member)| {

--- a/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
+++ b/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
@@ -884,10 +884,10 @@ impl<'a> CheckerState<'a> {
                 let contextual_members: Vec<_> = evaluated_members
                     .into_iter()
                     .filter_map(|(member, evaluated_member)| {
-                        let target_member = if evaluated_member != member {
-                            evaluated_member
-                        } else {
+                        let target_member = if evaluated_member == member {
                             member
+                        } else {
+                            evaluated_member
                         };
                         if evaluated_member != member {
                             self.contextual_parameter_type_for_call_with_env_from_expected(


### PR DESCRIPTION
Goal: green

## Structural rule
When a function expression with N parameters is contextually typed against a
union of function types, tsc discards union members whose call signature is
arity-smaller than N (`isAritySmaller`); when exactly one member can accept N
parameters, that member alone supplies the contextual signature, and therefore
every parameter type.

tsz's union contextual-parameter path
(`contextual_parameter_type_for_call_with_env_from_expected`) routed plain
single-signature function members exclusively through
`contextual_mixed_overload_param_type_for_call`, which only handles members
carrying two or more mixed generic/non-generic overload signatures. So a union
such as `MethodDecorator | PropertyDecorator | ClassDecorator` -- where only the
3-parameter `MethodDecorator` can accept a 3-parameter callback -- produced no
contextual type for any parameter, and every parameter fell back to implicit
`any` (false `TS7006`).

Owner: checker contextual-parameter resolution
(`crates/tsz-checker/src/types/utilities/contextual_parameters.rs`, with two
helpers in `contextual_calls.rs`). The arity decision stays in the checker
contextual layer; solver contextual-signature synthesis is unchanged.

## Witness
type-graphql canary `src/decorators/Extensions.ts:10`: a 3-parameter arrow is
returned where the declared return type is
`MethodDecorator | PropertyDecorator | ClassDecorator` (arities 3/2/1). tsc
keeps only the 3-parameter `MethodDecorator` and contextually types the
parameters; tsz emitted a false TS7006.

## Adjacent cases
- Exactly one arity-viable member -> its parameter types (the fix).
- Two or more arity-viable members -> left to the existing per-member logic,
  preserving tsc's "members must agree, else implicit any". E.g. `Big | Sm`
  with an arity-1 callback (both members viable, signatures differ) correctly
  stays `TS7006`, matching tsc.
- Arity-smaller members dropped; a rest parameter is treated as open-ended.
- Both bare function types (`function_shape_for_type`) and object types with
  call signatures (`call_signatures_for_type`) handled.

## Verification
- type-graphql canary: false TS7006 at `Extensions.ts:10` cleared (8 -> 7
  tsz-only diagnostics; remaining 7 are unrelated families).
- Byte-parity sweep, baseline (origin/main `8755a6a4`) vs fixed, across all 28
  canary guards: 3 canaries changed, ALL toward tsc-parity, ZERO regressions:
  - type-graphql 8->7 (target TS7006 cleared)
  - fp-ts 1305->1303 (2 TS7006 cleared; tsc-clean at those lines)
  - superstruct 15->18 (3 TS7053 ADDED that tsc ALSO emits -- the corrected
    contextual type now resolves so the index error correctly fires; tsz was
    leniently missing them).
- Regression guards (`Big | Sm`): arity-3 callback clears (tsc=0), arity-1
  callback stays TS7006 (tsc=1).
- Conformance: validated by ready-review CI (the TypeScript submodule is not
  checked out locally, per repo guidance). The 28-project byte-parity sweep
  above exercises broad real-world contextual typing with zero regressions.
- cargo fmt clean; clippy (tsz-checker) clean.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
