### PR TITLE
fix(solver): callable `as T` overlaps a function-union type-parameter constraint (TS2352) (#14318)

### DIFF
--- a/crates/tsz-checker/tests/ts2352_constrained_type_param_target_tests.rs
+++ b/crates/tsz-checker/tests/ts2352_constrained_type_param_target_tests.rs
@@ -331,3 +331,129 @@ function f<T extends null | undefined>() {
         "TS2352 expected — `{{}}` has no overlap with `null | undefined`. Got: {codes:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Callable source asserted to a type parameter with a function-union
+// constraint (#14318, mined from es-toolkit `once.ts`). tsc resolves the bare
+// type-parameter target to its constraint and treats the assertion as
+// overlapping iff the callable is comparable to any union member.
+// ---------------------------------------------------------------------------
+
+/// A concrete function asserted to `F` whose constraint is a union of function
+/// types must NOT emit TS2352. Binder names are varied to keep the rule
+/// structural rather than name-driven.
+#[test]
+fn callable_as_function_union_constrained_type_param_no_ts2352() {
+    for (f_name, p_name) in [("F", "fn"), ("Fun", "callback"), ("G", "handler")] {
+        let source = format!(
+            r#"
+function wrap<{f_name} extends ((...args: any[]) => any) | ((...args: any[]) => void)>(
+    {p_name}: (x: number) => string,
+): {f_name} {{
+    return {p_name} as {f_name};
+}}
+"#
+        );
+        let codes = check_strict(&source);
+        let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+        assert!(
+            ts2352.is_empty(),
+            "[{f_name}/{p_name}] no TS2352 expected — a callable overlaps a \
+             function-union constraint. Got: {codes:?}"
+        );
+    }
+}
+
+/// The constraint may be a union of *distinct* function shapes; overlap holds
+/// when the source is comparable to at least one member.
+#[test]
+fn callable_as_union_of_distinct_function_shapes_no_ts2352() {
+    let source = r#"
+function pick<F extends ((a: number) => number) | ((b: string) => string)>(
+    fn: (x: number) => number,
+): F {
+    return fn as F;
+}
+"#;
+    let codes = check_strict(source);
+    let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+    assert!(
+        ts2352.is_empty(),
+        "no TS2352 expected — `(x: number) => number` overlaps the first union member. \
+         Got: {codes:?}"
+    );
+}
+
+/// A construct-signature source asserted to a type parameter whose constraint
+/// is a union of construct signatures overlaps as well.
+#[test]
+fn constructor_as_constructor_union_constrained_type_param_no_ts2352() {
+    let source = r#"
+function make<F extends (new () => object) | (new (x: number) => object)>(
+    k: new () => object,
+): F {
+    return k as F;
+}
+"#;
+    let codes = check_strict(source);
+    let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+    assert!(
+        ts2352.is_empty(),
+        "no TS2352 expected — a constructor overlaps a construct-signature-union \
+         constraint. Got: {codes:?}"
+    );
+}
+
+/// A single-function constraint (not a union) already accepts a callable source
+/// — guard against regressing the non-union path.
+#[test]
+fn callable_as_single_function_constrained_type_param_no_ts2352() {
+    let source = r#"
+function once<F extends (...args: any[]) => any>(fn: () => number): F {
+    return fn as F;
+}
+"#;
+    let codes = check_strict(source);
+    let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+    assert!(
+        ts2352.is_empty(),
+        "no TS2352 expected — single-function constraint accepts a callable. Got: {codes:?}"
+    );
+}
+
+/// Negative control: a primitive source stays incomparable to a
+/// function-union constraint, so TS2352 must still fire.
+#[test]
+fn primitive_as_function_union_constrained_type_param_emits_ts2352() {
+    let source = r#"
+function bad<F extends (() => void) | ((x: number) => number)>(s: number): F {
+    return s as F;
+}
+"#;
+    let codes = check_strict(source);
+    let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+    assert!(
+        !ts2352.is_empty(),
+        "TS2352 expected — `number` does not overlap a function-union constraint. \
+         Got: {codes:?}"
+    );
+}
+
+/// Negative control: a callable source vs a type parameter constrained to a
+/// non-callable object shape must still emit TS2352 (the resolution is gated on
+/// a callable on the other side, so this does not over-permit).
+#[test]
+fn callable_as_object_constrained_type_param_emits_ts2352() {
+    let source = r#"
+function bad<F extends { a: number }>(fn: () => void): F {
+    return fn as F;
+}
+"#;
+    let codes = check_strict(source);
+    let ts2352: Vec<&u32> = codes.iter().filter(|c| **c == 2352).collect();
+    assert!(
+        !ts2352.is_empty(),
+        "TS2352 expected — `() => void` does not overlap an object constraint. \
+         Got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/type_queries/flow/comparability.rs
+++ b/crates/tsz-solver/src/type_queries/flow/comparability.rs
@@ -244,6 +244,34 @@ pub(in crate::type_queries) fn types_are_comparable_for_assertion_inner(
         return true;
     }
 
+    // A callable asserted to a bare type parameter whose constraint is (or
+    // includes) function types overlaps iff the callable is assertion-comparable
+    // to that constraint. tsc resolves the bare type-parameter target to its
+    // base constraint and runs the per-member overlap decomposition; resolving
+    // it here lets the union handling above and the callable-signature overlap
+    // below apply (e.g. `(fn as F)` where
+    // `F extends ((...a: any[]) => any) | ((...a: any[]) => void)`). Gating on a
+    // *direct callable* on the other side keeps this from over-permitting
+    // object/primitive sources against a type-parameter constraint (which the
+    // narrower object-without-required-members rule above already governs), and
+    // preserves the negative control: a `string` source stays incomparable to a
+    // function-union constraint. The symmetric source case covers a generic
+    // source asserted to a concrete callable.
+    if is_direct_callable_for_assertion(db, source)
+        && let Some(TypeData::TypeParameter(info)) = target_data
+        && let Some(constraint) = informative_type_param_constraint(info.constraint)
+        && types_are_comparable_for_assertion_inner(db, source, constraint, depth + 1, nested)
+    {
+        return true;
+    }
+    if is_direct_callable_for_assertion(db, target)
+        && let Some(TypeData::TypeParameter(info)) = source_data
+        && let Some(constraint) = informative_type_param_constraint(info.constraint)
+        && types_are_comparable_for_assertion_inner(db, constraint, target, depth + 1, nested)
+    {
+        return true;
+    }
+
     // A deferred conditional (or an indexed access whose object base is a
     // deferred conditional) has no extractable properties, so it would fall
     // through to the property-overlap check and report a false TS2352. tsc
@@ -338,13 +366,17 @@ fn type_param_primitive_comparable_with_constraint(
     let Some(TypeData::TypeParameter(info)) = db.lookup(type_param) else {
         return false;
     };
-    let Some(constraint) = info
-        .constraint
-        .filter(|&c| c != TypeId::ANY && c != TypeId::UNKNOWN)
-    else {
+    let Some(constraint) = informative_type_param_constraint(info.constraint) else {
         return false;
     };
     is_primitive_comparable(db, other, constraint) || is_primitive_comparable(db, constraint, other)
+}
+
+/// A type parameter's assertion-relevant base constraint: its declared
+/// constraint, unless that constraint is the uninformative `any`/`unknown`
+/// (which carries no structural overlap signal for the TS2352 check).
+fn informative_type_param_constraint(constraint: Option<TypeId>) -> Option<TypeId> {
+    constraint.filter(|&c| c != TypeId::ANY && c != TypeId::UNKNOWN)
 }
 
 fn callable_signatures_overlap_for_assertion(


### PR DESCRIPTION
## Summary
Fixes #14318 (mined from es-toolkit `once.ts`). tsz emitted a false **TS2352** for a callable asserted `as F` where `F` is a bare type parameter whose concrete constraint is a **union of function types**.

```ts
function wrap<F extends ((...a: any[]) => any) | ((...a: any[]) => void)>(fn: (x: number) => string): F {
  return fn as F;   // tsz before: TS2352;  tsc: ok
}
```

## Structural rule
When a callable source is asserted `as T` and `T` is a type parameter, `tsc`'s `isTypeComparableTo` resolves the bare type-parameter target to its base constraint and treats the assertion as overlapping iff the source is assertion-comparable to at least one constraint member. tsz's `types_are_comparable_for_assertion_inner` had per-source-kind constraint resolution for **primitive** and **object-without-required-members** sources, but not for **callable** sources, so a function source never reached the existing union + callable-signature overlap decomposition → false TS2352.

## Owner / fix
Solver — `types_are_comparable_for_assertion_inner` (`crates/tsz-solver/src/type_queries/flow/comparability.rs`). Resolve a bare type-parameter side to its (non-`any`/`unknown`) constraint and recurse, so the existing union decomposition and `callable_signatures_overlap_for_assertion` apply. The resolution is **gated on a direct callable (`Function`/`Callable`) on the other side** — matching the existing per-kind gating — so object/primitive sources are not over-permitted against a type-parameter constraint (the general unwrap would regress `B as T extends A` / `genericTypeAssertions4.ts`, where `B`'s required members must still report TS2352). The shared `any`/`unknown` constraint filter is factored into `informative_type_param_constraint`, reused by the existing primitive path.

Anti-hardcoding: structural constraint resolution + union decomposition; no name/text predicates. The change is purely additive (only returns "comparable" in more cases), so it cannot introduce a new TS2352.

## Adjacent matrix
- ✅ concrete function source vs function-union constraint — clean
- ✅ union of *distinct* function shapes — clean (overlap iff comparable to any member)
- ✅ construct-signature union constraint — clean
- ✅ single-function (non-union) constraint — clean (regression guard)
- ✅ binder names varied (`F`/`Fun`/`G`, `fn`/`callback`/`handler`)
- ⛔ negative control: `string` source vs function-union constraint — still TS2352
- ⛔ negative control: callable source vs `{ a: number }` constraint — still TS2352

## Verification
- New regression tests in `crates/tsz-checker/tests/ts2352_constrained_type_param_target_tests.rs` (6 cases incl. 2 negative controls).
- Targeted suites pass locally: `cargo test -p tsz-checker --lib -- ts2352 assertion_overlap comparab` and `cargo test -p tsz-solver --lib -- comparab assertion` (0 failed), plus the `ts2352_*` / `assertion_*` integration targets.
- CLI repro: the witness now compiles clean; negative controls still emit TS2352.
- Broad conformance/emit/fourslash owned by ready-review CI.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01LafhhTjbxXuEuBzBUwkSRL

---
_Generated by [Claude Code](https://claude.ai/code/session_01LafhhTjbxXuEuBzBUwkSRL)_