### PR TITLE
fix(checker): deferred-conditional operand overlap via comparability apparent type (TS2367) (#14253)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics/type_comparability.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics/type_comparability.rs
@@ -276,6 +276,29 @@ impl<'a> CheckerState<'a> {
         found_function_prop
     }
 
+    /// Apparent type used by the comparable relation, mirroring tsc's
+    /// `getApparentType` for instantiable operands.
+    ///
+    /// A bare type parameter resolves to its constraint (or `unknown`). A deferred
+    /// conditional (`T extends U ? X : Y`) resolves to its default constraint
+    /// (`getDefaultConstraintOfConditionalType`, the union of the inferred branch
+    /// results); if that constraint is itself a bare type parameter — as in
+    /// `Exclude<T, U>` whose constraint reduces to `T` — it is resolved one further
+    /// step to the parameter's apparent type so the comparable relation sees a
+    /// concrete value-space. Non-instantiable types are returned unchanged.
+    fn comparable_apparent_type(&mut self, ty: TypeId, is_type_param: bool) -> TypeId {
+        if is_type_param {
+            return self.get_type_param_apparent_type(ty);
+        }
+        match crate::query_boundaries::common::conditional_default_constraint(self.ctx.types, ty) {
+            Some(constraint) if is_type_parameter_like(self.ctx.types, constraint) => {
+                self.get_type_param_apparent_type(constraint)
+            }
+            Some(constraint) => constraint,
+            None => ty,
+        }
+    }
+
     /// Check if two types are comparable (overlap).
     ///
     /// Corresponds to TypeScript's `areTypesComparable`: returns true if the types
@@ -308,17 +331,13 @@ impl<'a> CheckerState<'a> {
             return self.type_params_are_comparable(source, target);
         }
 
-        // Resolve type parameter to apparent type (constraint or `unknown`)
-        let source_apparent = if source_is_tp {
-            self.get_type_param_apparent_type(source)
-        } else {
-            source
-        };
-        let target_apparent = if target_is_tp {
-            self.get_type_param_apparent_type(target)
-        } else {
-            target
-        };
+        // Resolve type parameter to apparent type (constraint or `unknown`), and a
+        // deferred conditional to its default constraint. tsc's `getApparentType`
+        // resolves instantiable types (type parameters and conditionals alike)
+        // before the comparable relation runs, so `Exclude<T, U>` overlaps with a
+        // literal exactly when its branch constraint does.
+        let source_apparent = self.comparable_apparent_type(source, source_is_tp);
+        let target_apparent = self.comparable_apparent_type(target, target_is_tp);
 
         let skip_signature_only_fast_path =
             self.are_pure_signature_objects(source_apparent, target_apparent);

--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -1015,21 +1015,24 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
+        // Deferred conditional operands (e.g. `Exclude<T, U>` = `T extends U ?
+        // never : T`) are instantiable types with no concrete value form until
+        // applied. tsc compares them through their apparent type: the default
+        // constraint (`getDefaultConstraintOfConditionalType`). Normalize that
+        // apparent type here, then keep using the overlap routine's existing
+        // primitive, union, intersection, callable, and object handling.
+        let apparent_left = self.conditional_overlap_apparent_type(left);
+        let apparent_right = self.conditional_overlap_apparent_type(right);
+        if apparent_left != left || apparent_right != right {
+            return self.types_have_no_overlap(apparent_left, apparent_right);
+        }
+
         // For type parameters, delegate to the comparability check which correctly handles:
         // - T vs {} → comparable (overlap exists, return false)
         // - T vs U (unrelated) → not comparable (no overlap, return true)
         // - T extends X vs Y → uses constraint resolution
-        //
-        // Deferred conditional operands (e.g. `Exclude<T, U>` = `T extends U ? never
-        // : T`) are instantiable types with no concrete value form until applied, so
-        // a direct assignability probe wrongly reports no overlap. tsc compares them
-        // through their apparent type — the default constraint
-        // (`getDefaultConstraintOfConditionalType`). The comparability gateway owns
-        // that resolution, so route a deferred conditional operand through it too.
         if is_type_parameter_like(self.ctx.types, left)
             || is_type_parameter_like(self.ctx.types, right)
-            || crate::query_boundaries::common::is_conditional_type(self.ctx.types, left)
-            || crate::query_boundaries::common::is_conditional_type(self.ctx.types, right)
         {
             return !self.is_type_comparable_to(left, right);
         }
@@ -1399,6 +1402,21 @@ impl<'a> CheckerState<'a> {
             classify_literal_type(self.ctx.types, type_id),
             LiteralTypeKind::NotLiteral
         ) || crate::query_boundaries::common::is_unique_symbol_type(self.ctx.types, type_id)
+    }
+
+    fn conditional_overlap_apparent_type(&mut self, type_id: TypeId) -> TypeId {
+        let Some(constraint) = crate::query_boundaries::common::conditional_default_constraint(
+            self.ctx.types,
+            type_id,
+        ) else {
+            return type_id;
+        };
+
+        if is_type_parameter_like(self.ctx.types, constraint) {
+            self.get_type_param_apparent_type(constraint)
+        } else {
+            constraint
+        }
     }
 
     pub(crate) fn are_pure_signature_objects(&mut self, left: TypeId, right: TypeId) -> bool {

--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -1019,8 +1019,17 @@ impl<'a> CheckerState<'a> {
         // - T vs {} → comparable (overlap exists, return false)
         // - T vs U (unrelated) → not comparable (no overlap, return true)
         // - T extends X vs Y → uses constraint resolution
+        //
+        // Deferred conditional operands (e.g. `Exclude<T, U>` = `T extends U ? never
+        // : T`) are instantiable types with no concrete value form until applied, so
+        // a direct assignability probe wrongly reports no overlap. tsc compares them
+        // through their apparent type — the default constraint
+        // (`getDefaultConstraintOfConditionalType`). The comparability gateway owns
+        // that resolution, so route a deferred conditional operand through it too.
         if is_type_parameter_like(self.ctx.types, left)
             || is_type_parameter_like(self.ctx.types, right)
+            || crate::query_boundaries::common::is_conditional_type(self.ctx.types, left)
+            || crate::query_boundaries::common::is_conditional_type(self.ctx.types, right)
         {
             return !self.is_type_comparable_to(left, right);
         }

--- a/crates/tsz-checker/tests/ts2367_comparison_overlap_tests.rs
+++ b/crates/tsz-checker/tests/ts2367_comparison_overlap_tests.rs
@@ -285,3 +285,69 @@ if (a === b) {}
         "Expected NO TS2367 for identical types"
     );
 }
+
+// ── Deferred conditional operands (§ default constraint) ─────────────────────
+//
+// A deferred conditional (`Exclude`/`Extract`, or a bare `T extends U ? X : Y`)
+// has no value form until instantiated; tsc decides overlap through its default
+// constraint (`getDefaultConstraintOfConditionalType`). tsz must do the same and
+// must not treat the unresolved conditional as having empty overlap.
+
+#[test]
+fn test_exclude_conditional_vs_literal_no_ts2367() {
+    assert!(
+        !has_ts2367(
+            r#"
+function noTrue<T extends boolean>(subject: Exclude<T, false>): void {
+  if (subject === true) throw new TypeError("subject is true");
+}
+"#
+        ),
+        "Expected NO TS2367: Exclude<T, false> constraint (boolean) overlaps with true"
+    );
+}
+
+#[test]
+fn test_extract_conditional_vs_literal_no_ts2367() {
+    assert!(
+        !has_ts2367(
+            r#"
+function noFalse<U extends boolean>(subject: Extract<U, boolean>): void {
+  if (subject === false) throw new TypeError("subject is false");
+}
+"#
+        ),
+        "Expected NO TS2367: Extract<U, boolean> constraint (boolean) overlaps with false"
+    );
+}
+
+#[test]
+fn test_bare_deferred_conditional_vs_literal_no_ts2367() {
+    // Binder-name variation: type parameter renamed to `Elem`, no utility alias.
+    assert!(
+        !has_ts2367(
+            r#"
+function pick<Elem extends number>(value: Elem extends 0 ? never : Elem): void {
+  if (value === 1) {}
+}
+"#
+        ),
+        "Expected NO TS2367: (Elem extends 0 ? never : Elem) constraint (number) overlaps with 1"
+    );
+}
+
+#[test]
+fn test_deferred_conditional_disjoint_constraint_keeps_ts2367() {
+    // Negative control: the conditional's default constraint (number) is genuinely
+    // disjoint from a string literal, so TS2367 must still fire.
+    assert!(
+        has_ts2367(
+            r#"
+function f<T>(value: T extends string ? number : 1): void {
+  if (value === ("foo" as "foo")) {}
+}
+"#
+        ),
+        "Expected TS2367: number constraint does not overlap with \"foo\""
+    );
+}


### PR DESCRIPTION
Fixes #14253 (mined from type-plus).

## Structural rule
When an operand of an equality comparison (`===`/`!==`) is a **deferred conditional** type - `Exclude`/`Extract`, or a bare `T extends U ? X : Y` whose check type is still instantiable - `tsc` decides TS2367 overlap through the conditional's **apparent type**: its default constraint (`getDefaultConstraintOfConditionalType`, the union of the inferred true/false branch results). tsz treated the unresolved conditional as having empty overlap and wrongly emitted `TS2367`, e.g. `Exclude<T, false> === true` (clean in `tsc`).

`When an operand of an equality/comparable check is a deferred conditional, tsc compares it through its default-constraint apparent type; tsz now normalizes deferred conditional operands to that apparent type at the checker overlap boundary, while the comparability gateway applies the same apparent-type rule for direct comparable checks.`

## Owner layer
Checker - the TS2367 overlap boundary plus the comparability gateway, both using the existing solver-backed `conditional_default_constraint` query boundary.

- `assignability/.../type_comparability.rs::is_type_comparable_to`: `comparable_apparent_type` resolves a deferred-conditional operand to its default constraint (`conditional_default_constraint` query boundary), and one step further to the parameter's apparent type when that constraint reduces to a bare `T` (the `Exclude<T, U>` shape). Type-parameter resolution is unchanged.
- `types/utilities/enum_utils.rs::types_have_no_overlap`: deferred-conditional operands are normalized to their default-constraint apparent type and then continue through the existing overlap machinery. Bare type parameters still delegate to `is_type_comparable_to`; conditional operands are not broadly rerouted through the comparability gateway.

No name/text predicates; resolution is purely structural via existing solver query boundaries.

## Adjacent-case matrix
- `Exclude<T, false> === true` (constraint `boolean`) -> no TS2367
- `Extract<U, boolean> === false` -> no TS2367
- bare `Elem extends 0 ? never : Elem === 1` (renamed param, no utility alias) -> no TS2367
- negative control: `(T extends string ? number : 1) === "foo"` (constraint `number`, disjoint from string literal) -> still TS2367
- regression guards: existing concrete-conditional cases (`MyExtract`/`MyExclude` over concrete unions, including the all-`never` branch) unchanged

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts2367_comparison_overlap_tests` -> 22/22.
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter inferentialTypingWithFunctionTypeZip --verbose` -> 1/1.
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --workers 8 --shard 2/4 --shard-strategy weighted --shard-weights scripts/conformance/conformance-shard-weights.json --offset 2850 --max 50 --verbose` -> 50/50.
- `git diff --check` -> clean.
- Broad conformance/emit/fourslash owned by ready-review CI.

Goal: green

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5-codex
Effort: high
