### PR TITLE
perf(solver): memoize extract_type_params_from_type per TypeId (#14330)

### DIFF
--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -521,6 +521,26 @@ pub trait TypeSubstitutionConstruction {
     fn substitution(&self, base_type: TypeId, constraint: TypeId) -> TypeId;
 }
 
+/// Cache for the `extract_type_params_from_type` result keyed by `TypeId`.
+///
+/// The reachable type-parameter set of a type is a pure function of the
+/// immutable interned structure, so it can be memoized project-wide and reused
+/// across the many fresh evaluators created during instantiation. Kept separate
+/// from [`TypeDatabase`] so the broad query trait stays under its method cap
+/// (#8205); `TypeDatabase` re-exposes these via the supertrait bound, so
+/// `&dyn TypeDatabase` callers are unaffected.
+pub trait TypeExtractParamsCache {
+    /// Look up the memoized `extract_type_params_from_type` result for
+    /// `type_id`. Default `None` (no caching).
+    fn extract_type_params_memo(&self, _type_id: TypeId) -> Option<Arc<[TypeParamInfo]>> {
+        None
+    }
+
+    /// Record the `extract_type_params_from_type` result for `type_id`.
+    /// Default no-op.
+    fn set_extract_type_params_memo(&self, _type_id: TypeId, _params: Arc<[TypeParamInfo]>) {}
+}
+
 /// Query interface for the solver.
 ///
 /// This keeps solver components generic and prevents them from reaching
@@ -533,6 +553,7 @@ pub trait TypeDatabase:
     + TypeApplicationEvalCache
     + TypeWidenCache
     + TypeSubstitutionConstruction
+    + TypeExtractParamsCache
 {
     fn intern(&self, key: TypeData) -> TypeId;
     fn lookup(&self, id: TypeId) -> Option<TypeData>;
@@ -1035,6 +1056,16 @@ impl TypeWidenCache for TypeInterner {
 impl TypeSubstitutionConstruction for TypeInterner {
     fn substitution(&self, base_type: TypeId, constraint: TypeId) -> TypeId {
         Self::substitution(self, base_type, constraint)
+    }
+}
+
+impl TypeExtractParamsCache for TypeInterner {
+    fn extract_type_params_memo(&self, type_id: TypeId) -> Option<Arc<[TypeParamInfo]>> {
+        Self::extract_type_params_memo(self, type_id)
+    }
+
+    fn set_extract_type_params_memo(&self, type_id: TypeId, params: Arc<[TypeParamInfo]>) {
+        Self::set_extract_type_params_memo(self, type_id, params);
     }
 }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -7,8 +7,8 @@
 use crate::caches::application_eval_index::{self, ApplicationEvalDependencyIndex};
 use crate::caches::db::{
     QueryDatabase, TypeApplicationEvalCache, TypeCompilerOptions, TypeDatabase,
-    TypeDisplayProvenance, TypePredicateCache, TypeSubstitutionConstruction, TypeTupleLimitSignal,
-    TypeWidenCache,
+    TypeDisplayProvenance, TypeExtractParamsCache, TypePredicateCache,
+    TypeSubstitutionConstruction, TypeTupleLimitSignal, TypeWidenCache,
 };
 use crate::caches::instantiation_cache::{InstantiationCache, InstantiationCacheKey};
 use crate::caches::query_cache_statistics::{QueryCacheStatistics, RelationCacheStats};
@@ -966,6 +966,16 @@ impl TypeWidenCache for QueryCache<'_> {
 impl TypeSubstitutionConstruction for QueryCache<'_> {
     fn substitution(&self, base_type: TypeId, constraint: TypeId) -> TypeId {
         self.interner.substitution(base_type, constraint)
+    }
+}
+
+impl TypeExtractParamsCache for QueryCache<'_> {
+    fn extract_type_params_memo(&self, type_id: TypeId) -> Option<Arc<[TypeParamInfo]>> {
+        self.interner.extract_type_params_memo(type_id)
+    }
+
+    fn set_extract_type_params_memo(&self, type_id: TypeId, params: Arc<[TypeParamInfo]>) {
+        self.interner.set_extract_type_params_memo(type_id, params);
     }
 }
 

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -137,11 +137,30 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     }
 
     /// Extract type parameter infos from a type by scanning for `TypeParameter` types.
+    ///
+    /// The reachable type-parameter set is a pure function of the immutable
+    /// interned structure of `type_id` (the walk never consults the resolver or
+    /// the substitution environment), so the result is memoized per `TypeId` on
+    /// the shared interner. The conditional evaluator extracts the params of
+    /// both the check and extends operands on every deferred-conditional
+    /// reduction; a recursive conditional re-applied over an alias `Application`
+    /// drives that re-walk thousands of times because each unwrap step mints a
+    /// fresh `TypeId`. The memo collapses the repeats to O(1) and is shared
+    /// across the many fresh evaluators created during instantiation (#14330).
     pub(crate) fn extract_type_params_from_type(&self, type_id: TypeId) -> Vec<TypeParamInfo> {
+        // Bare intrinsics carry no type parameters; skip the memo round-trip.
+        if type_id.is_intrinsic() {
+            return Vec::new();
+        }
+        if let Some(cached) = self.interner.extract_type_params_memo(type_id) {
+            return cached.to_vec();
+        }
         let mut seen_params = FxHashSet::default();
         let mut visited = FxHashSet::default();
         let mut params = Vec::new();
         self.collect_type_params(type_id, &mut visited, &mut seen_params, &mut params);
+        self.interner
+            .set_extract_type_params_memo(type_id, std::sync::Arc::from(params.as_slice()));
         params
     }
 
@@ -1837,5 +1856,57 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         } else {
             self.interner.array(evaluated)
         }
+    }
+}
+
+#[cfg(test)]
+mod extract_type_params_memo_tests {
+    use super::TypeEvaluator;
+    use crate::intern::TypeInterner;
+    use crate::types::{TypeId, TypeParamInfo, TypeParamOrigin};
+
+    #[test]
+    fn memoizes_extract_type_params_per_type_id() {
+        let interner = TypeInterner::new();
+        let t_atom = interner.intern_string("T");
+        let t_param = interner.type_param(TypeParamInfo {
+            name: t_atom,
+            constraint: None,
+            default: None,
+            is_const: false,
+            origin: TypeParamOrigin::User,
+        });
+        // `T[]` forces the walk to descend one structural level before
+        // collecting the parameter, so the memo covers a non-leaf type.
+        let arr = interner.array(t_param);
+
+        // Nothing cached before the first extraction.
+        assert!(interner.extract_type_params_memo(arr).is_none());
+
+        let ev = TypeEvaluator::new(&interner);
+        let first = ev.extract_type_params_from_type(arr);
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].name, t_atom);
+
+        // The first extraction populated the shared interner memo.
+        let cached = interner
+            .extract_type_params_memo(arr)
+            .expect("memo populated after first extraction");
+        assert_eq!(cached.len(), 1);
+        assert_eq!(cached[0].name, t_atom);
+
+        // A second extraction (served from the memo) is identical.
+        let second = ev.extract_type_params_from_type(arr);
+        assert_eq!(second.len(), first.len());
+        assert_eq!(second[0].name, first[0].name);
+    }
+
+    #[test]
+    fn intrinsic_types_bypass_the_memo() {
+        let interner = TypeInterner::new();
+        let ev = TypeEvaluator::new(&interner);
+        assert!(ev.extract_type_params_from_type(TypeId::NUMBER).is_empty());
+        // Intrinsics short-circuit before touching the cache.
+        assert!(interner.extract_type_params_memo(TypeId::NUMBER).is_none());
     }
 }

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -247,6 +247,22 @@ pub struct TypeInterner {
     /// `widen_type_deep`/display variants compute different results for the same
     /// `TypeId` and must not share it.
     pub(super) widen_type_cache: DashMap<TypeId, TypeId, FxBuildHasher>,
+    /// Result memo for `extract_type_params_from_type`, keyed by `TypeId`.
+    ///
+    /// The set of `TypeParameter`/signature-owned type parameters reachable
+    /// from a type is a pure function of the immutable interned type structure
+    /// — it never consults the resolver or substitution environment. The
+    /// evaluator nonetheless recomputes it on every conditional reduction
+    /// (`permissive_false_branch_is_definitive` extracts the params of both the
+    /// check and extends operands) and on every keyof / application expansion,
+    /// each time allocating two `FxHashSet`s and re-walking the whole subtree.
+    /// A recursive conditional that re-applies itself over an alias
+    /// `Application` (e.g. `DeepUnwrap<AsyncBox<…>>`) drives this walk thousands
+    /// of times per query because every unwrap step mints a fresh, structurally
+    /// distinct `Application` `TypeId`. Memoizing the result per `TypeId`
+    /// collapses the repeats to O(1) and is shared across the many fresh
+    /// `TypeEvaluator` instances created during instantiation (#14330).
+    pub(super) extract_type_params_cache: DashMap<TypeId, Arc<[TypeParamInfo]>, FxBuildHasher>,
     /// Packed per-`TypeId` caches for immutable structural content predicates.
     ///
     /// Each bit records one predicate's known/truthy state. This preserves the
@@ -534,6 +550,7 @@ impl TypeInterner {
             identity_comparable_cache: DashMap::with_hasher(FxBuildHasher),
             predicate_cache: DashMap::with_hasher(FxBuildHasher),
             widen_type_cache: DashMap::with_hasher(FxBuildHasher),
+            extract_type_params_cache: DashMap::with_hasher(FxBuildHasher),
             union_normalize_cache: DashMap::with_hasher(FxBuildHasher),
             array_base_type: AtomicU32::new(u32::MAX),
             array_display_base_type: AtomicU32::new(u32::MAX),
@@ -790,6 +807,20 @@ impl TypeInterner {
     #[inline]
     pub fn set_widen_type_memo(&self, type_id: TypeId, result: TypeId) {
         self.widen_type_cache.insert(type_id, result);
+    }
+
+    /// Look up the memoized `extract_type_params_from_type` result for `type_id`.
+    #[inline]
+    pub fn extract_type_params_memo(&self, type_id: TypeId) -> Option<Arc<[TypeParamInfo]>> {
+        self.extract_type_params_cache
+            .get(&type_id)
+            .map(|v| Arc::clone(&v))
+    }
+
+    /// Record the `extract_type_params_from_type` result for `type_id`.
+    #[inline]
+    pub fn set_extract_type_params_memo(&self, type_id: TypeId, params: Arc<[TypeParamInfo]>) {
+        self.extract_type_params_cache.insert(type_id, params);
     }
 
     /// Intern a string into an Atom.


### PR DESCRIPTION
Goal: fast

Fixes the per-case recursive-conditional cost tracked in #14330 (the crash there is already fixed on `main`; what remains is the ~58–87 ms/case slowdown on the `conditional-infer-hotspot` row).

## Structural rule

When the evaluator needs the set of type parameters reachable from a type, `tsc` treats that as a pure, structural fact; tsz computes it through `TypeEvaluator::extract_type_params_from_type` (`evaluation/evaluate/support.rs`), which walks the immutable interned structure and **never** consults the resolver or the substitution environment. It is therefore a pure function of `(interner, TypeId)`, but it was recomputed — two `FxHashSet` allocations plus a full subtree walk — on every call:

- `permissive_false_branch_is_definitive` extracts the params of **both** the check and extends operands on every deferred-conditional reduction (`conditional.rs:178-179`),
- the lite-resolver application path (`application.rs:412`),
- `keyof` / index-access constraint resolution (`keyof.rs:835`, `conditional.rs:1355`).

A recursive conditional re-applied over an alias `Application` — `DeepUnwrap<AsyncBox<…>>` in the hotspot — drives this walk thousands of times per query because every unwrap step mints a fresh, structurally-distinct `Application` `TypeId`, so no two repeats share an args-keyed `application_eval_cache` entry, and the per-step work is redone from scratch.

## Fix (owner layer: solver / interner cache)

Memoize the result per `TypeId` on the shared interner, mirroring the established `widen_type_cache` / `TypeWidenCache` idiom (per-`TypeId` memo of a pure function over immutable interned structure):

- `intern/core/interner.rs`: new `extract_type_params_cache: DashMap<TypeId, Arc<[TypeParamInfo]>>` field + inherent `extract_type_params_memo` / `set_extract_type_params_memo`.
- `caches/db.rs`: new narrow `TypeExtractParamsCache` capability trait, re-exposed through the `TypeDatabase` supertrait bound (keeps `TypeDatabase` under its method cap, #8205), impl'd for `TypeInterner`.
- `caches/query_cache.rs`: `QueryCache` delegate forwarding to the interner.
- `evaluation/evaluate/support.rs`: `extract_type_params_from_type` consults the memo (intrinsic fast-path → lookup → compute → store).

Because the memo lives on the universe-shared interner, it is reused across the many fresh `TypeEvaluator` instances created during instantiation, so the win is **broad** — every conditional/keyof-heavy file benefits, not just the synthetic row. No invalidation needed: the interner is append-only and the cached value is a pure structural fact, matching the lifetime of `widen_type_cache` / `identity_comparable_cache`.

This is one safe, broad per-conditional lever; it does not fully close the 40–65× gap. The deeper convergence/canonicalization lever (per-step conditional reduction across alias re-application, tied to #14123 / #13894) remains open and is intentionally out of scope here to keep this change low-risk.

## Verification

- New unit tests (`evaluation::evaluate::support::extract_type_params_memo_tests`): memo is populated after the first extraction, second extraction matches, intrinsics bypass the cache. Both pass.
- `cargo build -p tsz-solver` and `cargo clippy -p tsz-solver` clean.
- `cargo test -p tsz-solver --lib`: 6872 pass; the only 4 failures (`literal_mask_preserves_object_vs_literal_reduction`, `array_isarray_keeps_mutable_and_readonly_array_members`, `test_conditional_infer_optional_property_present_distributive`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`) reproduce identically on `main` with the change stashed — pre-existing in this environment, not introduced here.
- Hotspot generator shape (debug CLI, `--strict --noEmit`): correctness unchanged (`rc=0`, 0 diagnostics at N ∈ {1, 25, 100}); N=25 wall-clock **70.8 s → 59.2 s** (per-case 2.82 s → 2.33 s, ~17% faster). Debug-build absolute numbers are inflated; the ratio is the signal.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Tz2E9YG1bvMgshXh8NC54f

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tz2E9YG1bvMgshXh8NC54f)_