### PR TITLE
fix(cli): @ts-expect-error/@ts-ignore guards the next code line past comment-only continuations (TS2578)

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -999,12 +999,10 @@ struct TsDirective {
     unused_diagnostic_length: u32,
 }
 
-/// Whether `line` (0-based) is blank or a `//` line comment. Mirrors tsc's
-/// `markPrecedingCommentDirectiveLine`, which walks past empty lines and lines
-/// matching `^\s*//` when resolving the line a single-line directive guards. A
-/// block (`/* */`) comment line does not start with `//` and is therefore a
-/// barrier, not skipped.
-fn line_is_blank_or_line_comment(text: &str, line_map: &LineMap, line: usize) -> bool {
+/// Whether `line` (0-based) is trivia TypeScript's directive walk-up skips:
+/// empty or an ordinary `//` line. Block comments and `// @...` pragmas stop
+/// the walk.
+fn line_is_skippable_directive_trivia(text: &str, line_map: &LineMap, line: usize) -> bool {
     let Some(start) = line_map.line_start(line) else {
         return false;
     };
@@ -1012,8 +1010,14 @@ fn line_is_blank_or_line_comment(text: &str, line_map: &LineMap, line: usize) ->
     let end = line_map
         .line_start(line + 1)
         .map_or(text.len(), |next| next as usize);
-    let trimmed = text[start..end].trim();
-    trimmed.is_empty() || trimmed.starts_with("//")
+    let line_text = text[start..end].trim();
+    line_text.is_empty()
+        || (line_text.starts_with("//")
+            && !line_text
+                .trim_start_matches('/')
+                .trim_start()
+                .starts_with('@')
+            && find_directive_in_text(line_text).is_none())
 }
 
 /// Scan source text for `@ts-expect-error` and `@ts-ignore` directives in
@@ -1036,16 +1040,14 @@ fn find_ts_directives(text: &str, line_map: &LineMap) -> Vec<TsDirective> {
         };
         // For single-line (`//`/`///`) directives, tsc's
         // `markPrecedingCommentDirectiveLine` resolves the guarded line by
-        // walking past blank lines and other `//` comment lines (regex `^\s*//`)
-        // to the next line bearing real code, so a directive followed by `//`
-        // continuation comments still suppresses that code line (rather than
-        // leaking the error and reporting the directive unused -- TS2578).
-        // Block (`/* */`) directives suppress only the line immediately after
-        // the comment, with no skipping: a non-`//` line (including a
-        // block-comment line) is a barrier.
+        // walking past blank lines and ordinary `//` continuation comments to
+        // the next line bearing real code, so those directives do not leak the
+        // guarded error and then report unused (TS2578). Block directives
+        // suppress only the line immediately after the comment; block-comment
+        // lines and `// @...` pragmas are barriers.
         if !comment.is_multi_line {
             while line_map.line_start(suppressed_line as usize + 1).is_some()
-                && line_is_blank_or_line_comment(text, line_map, suppressed_line as usize)
+                && line_is_skippable_directive_trivia(text, line_map, suppressed_line as usize)
             {
                 suppressed_line += 1;
             }

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -999,6 +999,23 @@ struct TsDirective {
     unused_diagnostic_length: u32,
 }
 
+/// Whether `line` (0-based) is blank or a `//` line comment. Mirrors tsc's
+/// `markPrecedingCommentDirectiveLine`, which walks past empty lines and lines
+/// matching `^\s*//` when resolving the line a single-line directive guards. A
+/// block (`/* */`) comment line does not start with `//` and is therefore a
+/// barrier, not skipped.
+fn line_is_blank_or_line_comment(text: &str, line_map: &LineMap, line: usize) -> bool {
+    let Some(start) = line_map.line_start(line) else {
+        return false;
+    };
+    let start = start as usize;
+    let end = line_map
+        .line_start(line + 1)
+        .map_or(text.len(), |next| next as usize);
+    let trimmed = text[start..end].trim();
+    trimmed.is_empty() || trimmed.starts_with("//")
+}
+
 /// Scan source text for `@ts-expect-error` and `@ts-ignore` directives in
 /// comments. `line_map` must be built from the same `text`.
 fn find_ts_directives(text: &str, line_map: &LineMap) -> Vec<TsDirective> {
@@ -1010,13 +1027,29 @@ fn find_ts_directives(text: &str, line_map: &LineMap) -> Vec<TsDirective> {
             continue;
         };
 
-        let suppressed_line = if comment.is_multi_line {
+        let mut suppressed_line = if comment.is_multi_line {
             let close_line = line_map.line_index(comment.end.saturating_sub(1));
             close_line + 1
         } else {
             let comment_line = line_map.line_index(comment.pos);
             comment_line + 1
         };
+        // For single-line (`//`/`///`) directives, tsc's
+        // `markPrecedingCommentDirectiveLine` resolves the guarded line by
+        // walking past blank lines and other `//` comment lines (regex `^\s*//`)
+        // to the next line bearing real code, so a directive followed by `//`
+        // continuation comments still suppresses that code line (rather than
+        // leaking the error and reporting the directive unused -- TS2578).
+        // Block (`/* */`) directives suppress only the line immediately after
+        // the comment, with no skipping: a non-`//` line (including a
+        // block-comment line) is a barrier.
+        if !comment.is_multi_line {
+            while line_map.line_start(suppressed_line as usize + 1).is_some()
+                && line_is_blank_or_line_comment(text, line_map, suppressed_line as usize)
+            {
+                suppressed_line += 1;
+            }
+        }
         let directive_start = comment.pos.saturating_add(directive_offset);
         let directive_line = line_map.line_index(directive_start) as usize;
         let directive_line_start = line_map.line_start(directive_line).unwrap_or(comment.pos);

--- a/crates/tsz-cli/src/driver/check_utils/tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/tests.rs
@@ -209,6 +209,121 @@ fn ts_directive_scan_keeps_real_line_directives() {
 }
 
 #[test]
+fn ts_directive_skips_blank_and_non_directive_slash_comments() {
+    let source = "// @ts-ignore\n// rationale\n\nconst x: string = 1;\n";
+    let directives = find_ts_directives(source);
+    assert_eq!(directives.len(), 1);
+    assert!(!directives[0].is_expect_error);
+    assert_eq!(directives[0].suppressed_line, 3);
+
+    let mut diagnostics = vec![Diagnostic::error(
+        "slash-continuation.ts".to_string(),
+        source.find('1').unwrap() as u32,
+        1,
+        "Type 'number' is not assignable to type 'string'.".to_string(),
+        2322,
+    )];
+    apply_ts_directive_suppression("slash-continuation.ts", source, &mut diagnostics, false);
+
+    assert!(diagnostics.is_empty());
+}
+
+#[test]
+fn ts_directive_does_not_skip_block_comment_continuation() {
+    let source = "// @ts-ignore\n/* rationale */\nconst x: string = 1;\n";
+    let directives = find_ts_directives(source);
+    assert_eq!(directives.len(), 1);
+    assert!(!directives[0].is_expect_error);
+    assert_eq!(directives[0].suppressed_line, 1);
+
+    let mut diagnostics = vec![Diagnostic::error(
+        "block-continuation.ts".to_string(),
+        source.find('1').unwrap() as u32,
+        1,
+        "Type 'number' is not assignable to type 'string'.".to_string(),
+        2322,
+    )];
+    apply_ts_directive_suppression("block-continuation.ts", source, &mut diagnostics, false);
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].code, 2322);
+}
+
+#[test]
+fn ts_directive_does_not_skip_slash_at_pragma_continuation() {
+    let source = "// @ts-ignore\n// @another\n\nconst x: string = 1;\n";
+    let directives = find_ts_directives(source);
+    assert_eq!(directives.len(), 1);
+    assert!(!directives[0].is_expect_error);
+    assert_eq!(directives[0].suppressed_line, 1);
+
+    let mut diagnostics = vec![Diagnostic::error(
+        "slash-pragma-continuation.ts".to_string(),
+        source.find('1').unwrap() as u32,
+        1,
+        "Type 'number' is not assignable to type 'string'.".to_string(),
+        2322,
+    )];
+    apply_ts_directive_suppression(
+        "slash-pragma-continuation.ts",
+        source,
+        &mut diagnostics,
+        false,
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].code, 2322);
+}
+
+#[test]
+fn multiline_ts_directive_does_not_skip_following_blank_line() {
+    let source = "/* @ts-ignore\ncontinuation */\n\nconst x: string = 1;\n";
+    let directives = find_ts_directives(source);
+    assert_eq!(directives.len(), 1);
+    assert!(!directives[0].is_expect_error);
+    assert_eq!(directives[0].suppressed_line, 2);
+
+    let mut diagnostics = vec![Diagnostic::error(
+        "multiline-directive-blank.ts".to_string(),
+        source.find('1').unwrap() as u32,
+        1,
+        "Type 'number' is not assignable to type 'string'.".to_string(),
+        2322,
+    )];
+    apply_ts_directive_suppression(
+        "multiline-directive-blank.ts",
+        source,
+        &mut diagnostics,
+        false,
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].code, 2322);
+}
+
+#[test]
+fn stacked_expect_error_uses_nearest_directive_only() {
+    let source = "// @ts-expect-error\n// @ts-expect-error\nconst x: string = 1;\n";
+    let directives = find_ts_directives(source);
+    assert_eq!(directives.len(), 2);
+    assert_eq!(directives[0].suppressed_line, 1);
+    assert_eq!(directives[1].suppressed_line, 2);
+
+    let mut diagnostics = vec![Diagnostic::error(
+        "stacked.ts".to_string(),
+        source.find('1').unwrap() as u32,
+        1,
+        "Type 'number' is not assignable to type 'string'.".to_string(),
+        2322,
+    )];
+    apply_ts_directive_suppression("stacked.ts", source, &mut diagnostics, false);
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].code, 2578);
+    assert_eq!(diagnostics[0].start, 0);
+}
+
+#[test]
 fn ts_directive_scan_accepts_form_feed_before_directive() {
     let directives = find_ts_directives("//\x0C@ts-ignore\nconst x: string = 1;");
     assert_eq!(directives.len(), 1);


### PR DESCRIPTION
Goal: hold

## Structural rule
For `@ts-expect-error` / `@ts-ignore` directive suppression, tsz's CLI post-processing must match the checked-in TypeScript conformance oracle: a single-line `//` / `///` directive may advance past blank lines and ordinary `//` rationale comments to the guarded code line, but barrier trivia must stop that advance.

Barriers covered here are block-comment lines, multiline block directives, stacked directive comments, and `// @...` pragma-like comments such as `// @another` in `checkJsFiles_skipDiagnostics.ts`. Those lines must not let an earlier directive suppress a later diagnostic.

Owner: CLI directive layer (`crates/tsz-cli/src/driver/check_utils.rs`, `find_ts_directives`). This is diagnostic post-processing in the CLI, not checker or solver type semantics.

## Witness
The conformance aggregate failed because `TypeScript/tests/cases/compiler/checkJsFiles_skipDiagnostics.ts` no longer matched the checked-in `tsc` fingerprint set. The branch advanced directives too broadly and suppressed a `TS2349` that the conformance oracle expects to remain reported.

## Adjacent cases
- `//` directive directly above code -> unchanged.
- `//` directive + blank / ordinary `//` rationale continuation + erroring code -> suppresses the code line.
- `//` directive + `// @...` pragma-like line + code -> stops at the pragma-like comment; later diagnostic remains.
- Block (`/* */`) directive + following blank/comment + code -> does not advance past the immediate next line.
- Stacked `@ts-expect-error` comments -> nearest directive owns the guarded diagnostic; earlier expectation remains unused.

## Verification
- `cargo fmt --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli check_utils::tests --no-fail-fast`
- `scripts/safe-run.sh cargo build --target-dir .target --profile dist-fast -p tsz-cli -p tsz-conformance`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "checkJsFiles_skipDiagnostics" --verbose` -> `1/1 passed`, `Fingerprint-only: 0`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
