### PR TITLE
fix(solver): drop bare type-param union member under a Function type guard (#14320)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -662,6 +662,9 @@ path = "tests/array_isarray_mutual_subtype_narrowing_tests.rs"
 name = "typeof_const_member_conditional_tests"
 path = "tests/typeof_const_member_conditional_tests.rs"
 [[test]]
+name = "generic_union_function_guard_narrowing_tests"
+path = "tests/generic_union_function_guard_narrowing_tests.rs"
+[[test]]
 name = "typeof_function_like_flow_tests"
 path = "tests/typeof_function_like_flow_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/type_checking/declarations.rs
+++ b/crates/tsz-checker/src/types/type_checking/declarations.rs
@@ -503,27 +503,58 @@ impl<'a> CheckerState<'a> {
             return TypeId::ANY;
         }
 
+        // Anything assignable to the global `Function` interface that carries no
+        // call/construct signatures of its own is an untyped call returning
+        // `any` (tsc's `isUntypedFunctionCall`). Both witnesses below — the
+        // `bind`-member object probe and the intersection check — only apply
+        // when the callee has no own call signatures, so compute that once.
+        let callee_has_call_sigs = crate::query_boundaries::common::call_signatures_for_type(
+            self.ctx.types,
+            callee_type_for_call,
+        )
+        .is_some_and(|sigs| !sigs.is_empty());
+
         // Subtypes of Function (e.g., `interface SubFunc extends Function { prop: number }`)
         // are also callable, returning `any`. tsc's `isFunctionObjectType` checks if the
         // type has a `bind` member (inherited from Function) to identify Function-like types.
-        // Only check this when the type has no call signatures of its own.
-        {
-            let has_call_sigs = crate::query_boundaries::common::call_signatures_for_type(
+        if !callee_has_call_sigs {
+            let callee_resolved = self.resolve_lazy_type(callee_type_for_call);
+            let has_bind = crate::query_boundaries::common::find_property_in_object_by_str(
+                self.ctx.types,
+                callee_resolved,
+                "bind",
+            )
+            .is_some();
+            if has_bind {
+                return TypeId::ANY;
+            }
+        }
+
+        // Intersection containing the global `Function` interface (e.g. the
+        // `V & Function` synthesized when a generic union member is narrowed by
+        // a `value is Function` type guard). An intersection is assignable to
+        // `Function` as soon as one constituent is, so the per-member identity
+        // check is the structural witness for that. The `bind`-member probe
+        // above only inspects a single object shape and misses intersections
+        // (their members are not flattened into one shape), so handle them here.
+        if !callee_has_call_sigs
+            && let Some(members) = crate::query_boundaries::common::intersection_members(
                 self.ctx.types,
                 callee_type_for_call,
             )
-            .is_some_and(|sigs| !sigs.is_empty());
-            if !has_call_sigs {
-                let callee_resolved = self.resolve_lazy_type(callee_type_for_call);
-                let has_bind = crate::query_boundaries::common::find_property_in_object_by_str(
+        {
+            let has_construct_sigs =
+                crate::query_boundaries::common::construct_signatures_for_type(
                     self.ctx.types,
-                    callee_resolved,
-                    "bind",
+                    callee_type_for_call,
                 )
-                .is_some();
-                if has_bind {
-                    return TypeId::ANY;
-                }
+                .is_some_and(|sigs| !sigs.is_empty());
+            if !has_construct_sigs
+                && members
+                    .iter()
+                    .any(|&member| self.is_global_function_type(member))
+            {
+                return TypeId::ANY;
             }
         }
 

--- a/crates/tsz-checker/tests/generic_union_function_guard_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/generic_union_function_guard_narrowing_tests.rs
@@ -1,0 +1,118 @@
+//! Regression tests for narrowing a generic union by a `value is Function`
+//! (or built-in `Function`) type guard.
+//!
+//! tsc's `getNarrowedTypeWorker` keeps only the constituents structurally
+//! related to the predicate target; the per-member `T & target` intersection
+//! synthesis is a *fallback* reached only when no constituent is related. tsz
+//! used to synthesize `V & Function` eagerly for a bare type-parameter member
+//! and retain it next to the real function member, so the call site saw a
+//! non-callable `V & Function` and reported a spurious TS2349. When the fallback
+//! does legitimately apply (no function member in the union), the resulting
+//! `V & Function` must itself be callable as an untyped call (tsc's
+//! `isUntypedFunctionCall`).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs, load_default_lib_files};
+use tsz_common::diagnostics::Diagnostic;
+
+fn check(source: &str) -> Vec<Diagnostic> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs)
+}
+
+/// The reported repro (issue #14320, mined from radash): a generic union with
+/// a bare type parameter `V` plus a function member, narrowed by a user
+/// predicate `value is Function`. The function member is the only constituent
+/// related to `Function`, so `V` is dropped and the call type-checks.
+#[test]
+fn user_function_guard_drops_bare_type_param_member() {
+    let source = r#"
+declare const isFunction: (value: any) => value is Function;
+
+function pick<V>(values: V | ((idx: number) => V)): V {
+  if (isFunction(values)) {
+    return values(0);
+  }
+  return values;
+}
+"#;
+    let diags = check(source);
+    let not_callable: Vec<_> = diags.iter().filter(|d| d.code == 2349).collect();
+    assert!(
+        not_callable.is_empty(),
+        "function guard must keep only the callable member of `V | (fn)`; got: {diags:#?}"
+    );
+}
+
+/// Renamed binder + constrained type parameter must behave identically: the
+/// fix is structural, not keyed on the parameter name `V` or an unconstrained
+/// constraint.
+#[test]
+fn user_function_guard_renamed_and_constrained_type_param() {
+    let source = r#"
+declare const isFunction: (value: any) => value is Function;
+
+function renamed<Elem>(vals: Elem | ((i: number) => Elem)): Elem {
+  if (isFunction(vals)) {
+    return vals(0);
+  }
+  return vals;
+}
+
+function constrained<W extends object>(values: W | ((idx: number) => W)): W {
+  if (isFunction(values)) {
+    return values(0);
+  }
+  return values;
+}
+"#;
+    let diags = check(source);
+    let not_callable: Vec<_> = diags.iter().filter(|d| d.code == 2349).collect();
+    assert!(
+        not_callable.is_empty(),
+        "renamed/constrained type-param unions must narrow identically; got: {diags:#?}"
+    );
+}
+
+/// When the union has no function member, the fallback legitimately produces
+/// `V & Function`. tsc treats a callee assignable to the global `Function`
+/// interface with no own signatures as an untyped call returning `any`, so the
+/// call must type-check. (Bare `Function` and the intersection must both work.)
+#[test]
+fn function_guard_fallback_intersection_is_callable() {
+    let source = r#"
+declare const f: Function;
+const a = f(1, 2);
+
+declare const isFunction: (value: any) => value is Function;
+function h<V>(values: V | string): unknown {
+  if (isFunction(values)) {
+    return values(0);
+  }
+  return "";
+}
+"#;
+    let diags = check(source);
+    let not_callable: Vec<_> = diags.iter().filter(|d| d.code == 2349).collect();
+    assert!(
+        not_callable.is_empty(),
+        "`V & Function` and bare `Function` must be callable (untyped call); got: {diags:#?}"
+    );
+}
+
+/// Guard against over-permitting: an intersection callee with no `Function`
+/// constituent (and no call signatures) is still not callable.
+#[test]
+fn non_function_intersection_callee_still_not_callable() {
+    let source = r#"
+declare const n: number & { tag: 1 };
+n();
+"#;
+    let diags = check(source);
+    let not_callable: Vec<_> = diags.iter().filter(|d| d.code == 2349).collect();
+    assert_eq!(
+        not_callable.len(),
+        1,
+        "a non-Function intersection must remain non-callable; got: {diags:#?}"
+    );
+}

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -1279,9 +1279,6 @@ impl<'a> NarrowingContext<'a> {
             let mut matching: Vec<TypeId> = members
                 .iter()
                 .filter_map(|&member| {
-                    if let Some(narrowed) = self.narrow_type_param(member, target_type) {
-                        return Some(narrowed);
-                    }
                     if self.is_assignable_to(member, target_type) {
                         return Some(member);
                     }
@@ -1337,6 +1334,25 @@ impl<'a> NarrowingContext<'a> {
                     None
                 })
                 .collect();
+
+            // tsc parity (`getNarrowedTypeWorker`): the type-parameter
+            // intersection synthesis (`T & target`, via `narrow_type_param`) is
+            // only a *fallback*, reached when no declared constituent is
+            // structurally related to the candidate. tsc maps each constituent
+            // `t` to `target` (target <: t), `t` (t <: target), or `never`, and
+            // only when that whole map collapses to `never` does it re-map
+            // instantiable members to `t & target`. So when at least one
+            // constituent already matches structurally, a bare/unrelated
+            // type-parameter member is dropped rather than retained as
+            // `T & target`. Synthesizing it eagerly per member (the old
+            // behavior) kept a non-callable `V & Function` next to the function
+            // member, yielding spurious TS2349/TS2339.
+            if matching.is_empty() {
+                matching = members
+                    .iter()
+                    .filter_map(|&member| self.narrow_type_param(member, target_type))
+                    .collect();
+            }
             self.remove_redundant_intersection_members(&mut matching);
 
             if matching.is_empty() {


### PR DESCRIPTION
Fixes #14320.

## Structural rule
When a generic union like `V | ((idx: number) => V)` is narrowed by a `value is Function` type guard (or the built-in `Function`), tsc's `getNarrowedTypeWorker` maps each constituent `t` to `target` (when `target <: t`), `t` (when `t <: target`), or `never`, and only synthesizes the type-parameter intersection `T & target` as a **fallback** when that whole map collapses to `never`. So when at least one constituent already matches structurally (here the callable `(idx: number) => V` member), an unrelated bare type-parameter member `V` is **dropped**, not retained as `V & Function`.

tsz instead synthesized `T & target` eagerly per union member via `narrow_type_param`, keeping a non-callable `V & Function` next to the real function member. The call site then saw a non-callable constituent and emitted a spurious **TS2349** (and, in adjacent shapes, **TS2339**).

`When a union member is a bare type parameter unrelated to the guard target and another member is directly related, tsc drops it; tsz now does the same by moving the type-param intersection synthesis into a fallback in the solver's union-narrowing filter.`

## Owner layer
Solver — `narrowing/core.rs::narrow_to_type` union branch. The per-member filter now keeps only constituents directly related to the target (assignability either direction, plus the existing reverse-subtype and `instanceof Array` paths). The `narrow_type_param` intersection synthesis runs as a second pass **only when the first pass produced no matches**, mirroring tsc's `directlyRelated.isNever ? intersect-fallback : directlyRelated`.

Second, smaller change (checker — `replace_function_type_for_call`): when the fallback legitimately produces `X & Function` (a union with no callable member, e.g. `V | string`), that intersection must itself be callable. tsc's `isUntypedFunctionCall` treats a callee assignable to the global `Function` interface with no own call/construct signatures as an untyped call returning `any`. The existing `bind`-member probe only inspects a single object shape and misses intersections (their members are not flattened into one shape), so an intersection whose constituent is the global `Function` interface is now recognized as untyped-callable.

## Adjacent-case matrix
- `V | ((idx: number) => V)` under a user `value is Function` guard — unconstrained `V`: now clean (was TS2349).
- Renamed binder (`Elem`) and constrained `W extends object`: same, structural not name-keyed.
- Positive branch (`if (isFunction(values))`) and negative branch (`if (!isFunction(values))`): both clean.
- Union of only type parameters (`A | B` with no related member) → fallback still synthesizes `A & Function | B & Function` (unchanged).
- `V | string` (no function member) → fallback yields `V & Function`, now callable as an untyped call.
- Bare `Function` value → callable (unchanged).
- **Negatives:** a non-`Function` intersection callee (`number & { tag: 1 }`), a plain object call, and a `string` call still emit TS2349.

## Anti-hardcoding
Structural narrowing filter and structural untyped-call witness; no user-name/file-name literals, no rendered-type string predicate. Tests vary the binder names (`V`/`Elem`/`W`).

## Verification
- New regression suite `crates/tsz-checker/tests/generic_union_function_guard_narrowing_tests.rs` (4 tests: reported repro, renamed+constrained, fallback-intersection-callable, non-Function-intersection negative) — all pass.
- `cargo test -p tsz-checker --test typeof_function_like_flow_tests --test typeof_function_generic_alias_narrowing_tests --test distributive_callable_branch_tests --test callable_interface_index_tests --test generic_callable_interface_type_argument_display_tests` — all pass.
- `cargo test -p tsz-solver --lib narrow` — only the pre-existing `array_isarray_keeps_mutable_and_readonly_array_members` failure remains (fails identically on clean base; untouched `Array.isArray` path), zero new failures.
- CLI: the issue repro and adjacent/negative cases match tsc; genuine non-callables still emit TS2349.
- `cargo clippy -p tsz-checker -p tsz-solver` — clean; `cargo fmt --check` — clean.
- Broad conformance/emit/fourslash: ready-review CI.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01SovGyyo2EvvDPt97dvchKR)_