### PR TITLE
fix(checker): structural call/construct-signature overlap for both-callable as-assertions (TS2352)

### DIFF
--- a/crates/tsz-checker/src/dispatch/mod.rs
+++ b/crates/tsz-checker/src/dispatch/mod.rs
@@ -1063,55 +1063,18 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                                         }
                                     }
 
-                                    // Final fallback: check structural property overlap.
-                                    // Skip the comparable heuristic when both sides are
-                                    // Callable types (constructor/class types) because the
-                                    // property-overlap check is too permissive — shared
-                                    // `prototype` properties mask real mismatches between
-                                    // distinct generic instantiations. tsc uses a full
-                                    // structural relation (isTypeComparableTo) instead.
-                                    // Only skip for Callable; Object types need the check
-                                    // for legitimate assertions like `{a: 1} as {a: number}`.
+                                    // Final fallback: structural overlap of the
+                                    // deeply-evaluated source and target. When both sides
+                                    // are callable/constructor types this compares
+                                    // call/construct signatures (erasing the target's
+                                    // generic type parameters) instead of the too-permissive
+                                    // property-overlap heuristic; see
+                                    // `assertion_deep_types_overlap`.
                                     if !have_overlap {
-                                        let evaluated_expr =
-                                            self.checker.evaluate_type_for_assignability(expr_type);
-                                        let evaluated_asserted = self
-                                            .checker
-                                            .evaluate_type_for_assignability(effective_asserted);
-
-                                        // Deep-evaluate object property types so the
-                                        // solver's comparable check sees concrete types
-                                        // instead of Lazy(DefId) references.  Without
-                                        // this, nested interface properties (e.g.,
-                                        // `automation: Automation` inside `UserSettings`)
-                                        // appear as opaque Lazy refs that the solver
-                                        // cannot structurally compare, causing false
-                                        // TS2352 on valid assertions like
-                                        // `{mode: ""} as UserSettings`.
-                                        let deep_expr = self
-                                            .checker
-                                            .deep_evaluate_object_properties(evaluated_expr);
-                                        let deep_asserted = self
-                                            .checker
-                                            .deep_evaluate_object_properties(evaluated_asserted);
-
-                                        let both_callable = crate::query_boundaries::common::callable_shape_id(
-                                            self.checker.ctx.types,
-                                            deep_expr,
-                                        )
-                                        .is_some()
-                                            && crate::query_boundaries::common::callable_shape_id(
-                                                self.checker.ctx.types,
-                                                deep_asserted,
-                                            )
-                                            .is_some();
-                                        if !both_callable {
-                                            have_overlap = crate::query_boundaries::common::types_are_comparable_for_assertion(
-                                                self.checker.ctx.types,
-                                                deep_expr,
-                                                deep_asserted,
-                                            );
-                                        }
+                                        have_overlap = self.checker.assertion_deep_types_overlap(
+                                            expr_type,
+                                            effective_asserted,
+                                        );
                                     }
                                     // Per-property comparable check: the solver's
                                     // `types_are_comparable_for_assertion` can't resolve

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -493,6 +493,9 @@ mod ts2323_tests;
 #[path = "../tests/ts2347_tests.rs"]
 mod ts2347_tests;
 #[cfg(test)]
+#[path = "../tests/ts2352_both_callable_overlap_repro_tests.rs"]
+mod ts2352_both_callable_overlap_repro_tests;
+#[cfg(test)]
 #[path = "../tests/ts2352_constrained_type_param_target_tests.rs"]
 mod ts2352_constrained_type_param_target_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -1493,6 +1493,50 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    /// Final structural-overlap fallback for a `source as Target` assertion
+    /// (`TS2352`), operating on the raw source/target types.
+    ///
+    /// Both sides are deeply evaluated so the comparable check sees concrete
+    /// property types instead of `Lazy(DefId)` references (otherwise nested
+    /// interface properties appear as opaque refs and produce false `TS2352`
+    /// on valid assertions such as `{ mode: "" } as UserSettings`).
+    ///
+    /// When both sides are callable/constructor types, overlap is decided by
+    /// structurally comparing their call/construct signatures (erasing the
+    /// target's generic type parameters) via `both_callable_types_overlap`. The
+    /// generic property-overlap heuristic is too permissive there — shared
+    /// `prototype` properties mask real mismatches between distinct constructor
+    /// instantiations — while skipping the check entirely is too strict. All
+    /// other shapes use the structural comparable-for-assertion relation, which
+    /// legitimate object assertions like `{ a: 1 } as { a: number }` rely on.
+    pub(crate) fn assertion_deep_types_overlap(
+        &mut self,
+        expr_type: TypeId,
+        asserted_type: TypeId,
+    ) -> bool {
+        let evaluated_expr = self.evaluate_type_for_assignability(expr_type);
+        let evaluated_asserted = self.evaluate_type_for_assignability(asserted_type);
+        let deep_expr = self.deep_evaluate_object_properties(evaluated_expr);
+        let deep_asserted = self.deep_evaluate_object_properties(evaluated_asserted);
+
+        let both_callable =
+            crate::query_boundaries::common::callable_shape_id(self.ctx.types, deep_expr).is_some()
+                && crate::query_boundaries::common::callable_shape_id(
+                    self.ctx.types,
+                    deep_asserted,
+                )
+                .is_some();
+        if both_callable {
+            self.both_callable_types_overlap(deep_expr, deep_asserted)
+        } else {
+            crate::query_boundaries::common::types_are_comparable_for_assertion(
+                self.ctx.types,
+                deep_expr,
+                deep_asserted,
+            )
+        }
+    }
+
     /// Check if both types are callable/function types that overlap.
     ///
     /// Two callable types overlap if there exists at least one (src, tgt) call-

--- a/crates/tsz-checker/tests/ts2352_both_callable_overlap_repro_tests.rs
+++ b/crates/tsz-checker/tests/ts2352_both_callable_overlap_repro_tests.rs
@@ -1,0 +1,104 @@
+//! TS2352 false-positive: a both-callable `as`-assertion skips the
+//! construct/call-signature structural overlap (#14325, mined from arktype).
+//!
+//! When an `as`-assertion has a callable/constructor source and a
+//! callable/constructor target and neither is assignable to the other, tsc
+//! decides overlap by structurally comparing call/construct signatures
+//! (erasing the target's generic type parameters). tsz short-circuited via a
+//! `both_callable` guard that skipped the comparison, leaving overlap false →
+//! a spurious TS2352.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+fn ts2352(source: &str) -> Vec<u32> {
+    check_strict(source)
+        .into_iter()
+        .filter(|c| *c == 2352)
+        .collect()
+}
+
+/// The arktype witness: an anonymous class source asserted to a construct
+/// signature returning a concrete object type. `{}` is not assignable to the
+/// target instance and the constructor arities differ, so neither side is
+/// assignable to the other — but the construct signatures structurally
+/// overlap, so tsc is clean.
+#[test]
+fn anon_class_to_concrete_construct_sig_no_ts2352() {
+    let source = r#"
+type T = { x: number };
+const B = class {} as new (base: T) => T;
+export { B };
+"#;
+    assert!(
+        ts2352(source).is_empty(),
+        "no TS2352 expected — construct signatures overlap. Got: {:?}",
+        check_strict(source)
+    );
+}
+
+/// Construct-signature target carrying its own generic type parameter. tsc
+/// erases the target's type parameter when computing overlap.
+#[test]
+fn anon_class_to_generic_construct_sig_no_ts2352() {
+    let source = r#"
+const B = class {} as new <U>(base: U) => U;
+export { B };
+"#;
+    assert!(
+        ts2352(source).is_empty(),
+        "no TS2352 expected — generic construct signatures overlap after erasure. Got: {:?}",
+        check_strict(source)
+    );
+}
+
+/// Construct-signature target whose return type is a wider object than the
+/// source instance. The empty-class instance `{}` is not assignable to the
+/// richer instance, and the constructor arities differ, so neither side is
+/// assignable to the other — but the construct return types are mutually
+/// comparable, so tsc is clean.
+#[test]
+fn anon_class_to_richer_construct_sig_no_ts2352() {
+    let source = r#"
+interface Node { kind: number; next: Node | null }
+const B = class {} as new (base: Node) => Node;
+export { B };
+"#;
+    assert!(
+        ts2352(source).is_empty(),
+        "no TS2352 expected — construct signatures overlap. Got: {:?}",
+        check_strict(source)
+    );
+}
+
+/// Negative control: a plain function value (call signature only) asserted to
+/// a construct signature has no comparable signature, so TS2352 must remain.
+#[test]
+fn plain_function_to_construct_sig_still_emits_ts2352() {
+    let source = r#"
+type T = { x: number };
+declare const f: (base: number) => number;
+const c = f as new (base: number) => T;
+export { c };
+"#;
+    assert!(
+        !ts2352(source).is_empty(),
+        "TS2352 expected — a call-only function is not comparable to a construct signature. Got: {:?}",
+        check_strict(source)
+    );
+}
+
+/// Negative control: construct signatures whose return types genuinely do not
+/// overlap (disjoint primitives) must still error.
+#[test]
+fn construct_sig_disjoint_returns_still_emits_ts2352() {
+    let source = r#"
+declare const a: new (base: number) => number;
+const b = a as new (base: number) => string;
+export { b };
+"#;
+    assert!(
+        !ts2352(source).is_empty(),
+        "TS2352 expected — `number` and `string` construct returns do not overlap. Got: {:?}",
+        check_strict(source)
+    );
+}


### PR DESCRIPTION
Goal: green

Closes #14325

## Summary
Mined from **arktype**. A both-callable `as`-assertion emitted a spurious **TS2352** where tsc is clean:
```ts
const B = class {} as new (base: t) => t;   // tsz: TS2352; tsc: 0
export { B };
```

## Structural rule
When a `source as Target` assertion has a callable/constructor source and a callable/constructor target and neither is assignable to the other, tsc decides overlap by structurally comparing the call/construct signatures (erasing the target's generic type parameters). tsz short-circuited via a `both_callable` guard in the expression dispatcher that *skipped* the signature comparison whenever both sides were callable, leaving overlap false → TS2352.

`When both sides of an as-assertion are callable/constructor types and neither is assignable to the other, tsc decides overlap by structural call/construct-signature comparison (with target type-parameter erasure); tsz now does the same through the checker's assertion-overlap boundary.`

## Fix / owner layer
Checker — the TS2352 assertion-overlap path in `dispatch/mod.rs`.

- The deeply-evaluated overlap fallback now routes through a single checker method, `CheckerState::assertion_deep_types_overlap` (`types/utilities/enum_utils.rs`).
- When both sides are callable/constructor, it reuses the existing `both_callable_types_overlap` helper, which compares call/construct signatures via `any_signatures_comparable` (generic signatures resolve to apparent types — the target type-parameter erasure tsc performs). All other shapes keep the structural `types_are_comparable_for_assertion` relation that legitimate object assertions like `{ a: 1 } as { a: number }` rely on.
- This also lifts ~55 lines of deeply-nested deep-evaluation logic out of the dispatcher into the solver-backed checker boundary (no behavior change for non-callable shapes).

No hardcoding: the decision is keyed on structural callable-shape presence and signature comparability, never on identifier / alias / file-name strings or rendered diagnostic text.

## Adjacent-case matrix (regression tests added)
| case | expected |
|---|---|
| anon `class {}` → concrete `new (base: T) => T` (`{}` not assignable to `T`, arities differ) | no TS2352 |
| anon `class {}` → generic `new <U>(base: U) => U` (target type-param erasure) | no TS2352 |
| anon `class {}` → recursive-interface `new (base: Node) => Node` | no TS2352 |
| **negative:** plain function `(base: number) => number` → `new (base: number) => T` (call-only vs construct-only) | TS2352 preserved |
| **negative:** `new (base: number) => number` → `new (base: number) => string` (disjoint construct returns) | TS2352 preserved |

## Verification
- `cargo nextest run -p tsz-checker --lib ts2352_both_callable_overlap_repro` → 5/5 pass (3 positives that previously emitted spurious TS2352, 2 negative controls that still error).
- No regressions: every failing test in a full `--lib` run is pre-existing on the rebased base (the local checkout has no TypeScript submodule, so lib-dependent suites — Promise/Symbol/ReadonlyArray globals — fail identically with and without this change; confirmed by a stashed-baseline diff). Ready-review CI owns the broad suites with the full lib environment.
- `cargo fmt --all --check` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_013V42iA2ukZaLBE3tse2vbe

---
_Generated by [Claude Code](https://claude.ai/code/session_013V42iA2ukZaLBE3tse2vbe)_