### PR TITLE
fix(checker): preserve type meaning of declare class re-exported through 2+ hops (#14358)

### DIFF
--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -63,7 +63,12 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             .ctx
             .resolve_symbol_file_index(sym_id)
             .unwrap_or(self.ctx.current_file_idx);
-        self.resolve_import_alias_type_target_from_source(source_file_idx, module_name, import_name)
+        self.resolve_import_alias_type_target_from_source(
+            source_file_idx,
+            module_name,
+            import_name,
+            0,
+        )
     }
 
     /// Resolve a value/type import alias used in **type position** to the
@@ -82,6 +87,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         source_file_idx: usize,
         module_name: &str,
         import_name: &str,
+        depth: usize,
     ) -> Option<tsz_binder::SymbolId> {
         let target_file_idx = self
             .ctx
@@ -129,6 +135,28 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
 
         let target_symbol = target_binder.get_symbol(target_sym_id)?;
         if !target_symbol.has_any_flags(tsz_binder::symbol_flags::TYPE) {
+            // At 2+ re-export hops the single chase above can land on an
+            // intermediate re-export alias stub (it carries an `import_module`
+            // but no TYPE shape of its own) rather than the declaring
+            // class/interface, so the TYPE gate fails and the type reference
+            // wrongly falls back to the value (`typeof`) side (#14358). Follow
+            // the stub one more hop from its own file, bounded to avoid cycles.
+            if depth < 16
+                && let Some(stub_module) = target_symbol.import_module().map(str::to_string)
+            {
+                let stub_name = target_symbol
+                    .import_name()
+                    .unwrap_or(import_name)
+                    .to_string();
+                if stub_module != module_name || stub_name != import_name {
+                    return self.resolve_import_alias_type_target_from_source(
+                        resolved_file_idx,
+                        &stub_module,
+                        &stub_name,
+                        depth + 1,
+                    );
+                }
+            }
             return None;
         }
         self.ctx
@@ -169,7 +197,12 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             .ctx
             .get_file_idx_for_arena(decl_arena)
             .unwrap_or(self.ctx.current_file_idx);
-        self.resolve_import_alias_type_target_from_source(source_file_idx, module_name, import_name)
+        self.resolve_import_alias_type_target_from_source(
+            source_file_idx,
+            module_name,
+            import_name,
+            0,
+        )
     }
 
     pub(super) fn entity_name_text(&self, idx: NodeIndex) -> Option<String> {

--- a/crates/tsz-cli/tests/cross_binder_reexport_meaning_tests.rs
+++ b/crates/tsz-cli/tests/cross_binder_reexport_meaning_tests.rs
@@ -187,6 +187,121 @@ fn reexported_numeric_enum_typed_as_typeof_renamed_binders() {
     );
 }
 
+/// Repro C (#14358): a `declare class` re-exported through two or more
+/// `export { C } from '...'` hops keeps its **type** meaning, so `readonly C[]`
+/// in type position resolves to the class instance type (member access on an
+/// element succeeds) rather than falling back to the constructor value
+/// `typeof C` and reporting TS2339.
+///
+/// The single-step re-export chase lands on the first re-export *stub* (a symbol
+/// carrying an import-module reference but no TYPE shape of its own) at 2+ hops;
+/// the type reference then wrongly used the value side. tsz now re-chases the
+/// stub to the declaring module so the type meaning is preserved.
+#[test]
+fn reexported_declare_class_keeps_type_meaning_through_two_hops() {
+    let out = run_tsz(
+        &[
+            ("a.ts", "export declare class C { m: string; }\n"),
+            ("b.ts", "export { C } from './a';\n"),
+            ("c.ts", "export { C } from './b';\n"),
+            (
+                "use.ts",
+                "import { C } from './c';\nexport function f(d: readonly C[]) { return d[0].m; }\n",
+            ),
+        ],
+        "use.ts",
+    );
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("TS2339"),
+        "2-hop re-exported declare class must keep its type meaning (no TS2339), got:\n{out}"
+    );
+}
+
+/// Three hops, with all user-chosen names varied (class, member, file stems), so
+/// the re-chase follows structure rather than identifier text and is not capped
+/// at a single extra hop.
+#[test]
+fn reexported_declare_class_keeps_type_meaning_through_three_hops_renamed() {
+    let out = run_tsz(
+        &[
+            (
+                "widget.ts",
+                "export declare class Widget { label: string; }\n",
+            ),
+            ("mid.ts", "export { Widget } from './widget';\n"),
+            ("barrel.ts", "export { Widget } from './mid';\n"),
+            ("top.ts", "export { Widget } from './barrel';\n"),
+            (
+                "consumer.ts",
+                "import { Widget } from './top';\nexport function g(items: readonly Widget[]) { return items[0].label; }\n",
+            ),
+        ],
+        "consumer.ts",
+    );
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        !out.contains("TS2339"),
+        "3-hop renamed re-exported declare class must keep its type meaning (no TS2339), got:\n{out}"
+    );
+}
+
+/// Parity guard: a value-only declaration (`declare const`) re-exported through
+/// two hops and used in a type position must STILL report TS2749 — the re-chase
+/// only preserves a TYPE-bearing target, so a value never becomes a type.
+#[test]
+fn reexported_value_in_type_position_still_errors_through_hops() {
+    let out = run_tsz(
+        &[
+            ("av.ts", "export declare const V: number;\n"),
+            ("bv.ts", "export { V } from './av';\n"),
+            ("cv.ts", "export { V } from './bv';\n"),
+            (
+                "usev.ts",
+                "import { V } from './cv';\nexport function f(d: readonly V[]) { return d; }\n",
+            ),
+        ],
+        "usev.ts",
+    );
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        out.contains("TS2749"),
+        "a 2-hop re-exported value used as a type must still report TS2749, got:\n{out}"
+    );
+}
+
+/// Parity guard: a genuinely absent member on the re-exported class instance
+/// still reports TS2339 — the fix resolves the type, it does not suppress real
+/// missing-property errors.
+#[test]
+fn reexported_declare_class_missing_member_still_errors() {
+    let out = run_tsz(
+        &[
+            ("ac.ts", "export declare class C { m: string; }\n"),
+            ("bc.ts", "export { C } from './ac';\n"),
+            ("cc.ts", "export { C } from './bc';\n"),
+            (
+                "usec.ts",
+                "import { C } from './cc';\nexport function f(d: readonly C[]) { return d[0].nope; }\n",
+            ),
+        ],
+        "usec.ts",
+    );
+    if out == "__SKIP__" {
+        return;
+    }
+    assert!(
+        out.contains("TS2339"),
+        "a genuinely absent member on the resolved class instance must still report TS2339, got:\n{out}"
+    );
+}
+
 /// Parity guard: a genuinely absent enum member on a re-exported enum still
 /// reports TS2339 — the fix must not blanket-suppress member errors.
 #[test]


### PR DESCRIPTION
Fixes #14358.

## Structural rule
When an import alias resolves to a re-export **stub** (a symbol carrying an
import-module reference but lacking the `TYPE` flag) and that stub points at a
*different* module/name than the one currently being chased, `tsc` follows the
stub to the next module and keeps resolving until it reaches the type-bearing
declaration. tsz stopped at the first stub, so a `declare class` re-exported
through 2+ `export { C } from '...'` hops lost its TYPE meaning in type
position: `readonly C[]` fell back to the constructor value `typeof C` and
member access on an element reported a spurious **TS2339**.

## Owner layer
Checker type-node resolution. `TypeNodeChecker::resolve_import_alias_type_target_from_source`
(`crates/tsz-checker/src/types/type_node_resolution.rs`) now takes a `depth`
parameter and, when the chased target fails the `symbol_flags::TYPE` gate but is
itself a re-export stub (`import_module()` present, pointing elsewhere),
re-chases from the stub's own file — bounded to 16 hops to avoid cycles. The
final `TYPE` gate is unchanged, so a value-only re-export never becomes a type.

This is an additive guard: it only fires on the previously-`None` path, so it
cannot introduce a new diagnostic on inputs that already resolved.

## Why the unit (`check_multi_file`) harness can't cover this
A class is *both* a value and a type. Resolving its **type** meaning in
`readonly C[]` requires the program-skeleton export hoisting that only the
real project-mode driver performs (the same reason the sibling #14168
namespace/enum regressions are pinned as CLI tests). In `check_multi_file` a
direct `import { C }` class already resolves to `typeof C`, so a unit test there
passes with *and* without the fix — vacuous coverage. The tests therefore live
in the real-CLI-driver suite, where a revert-test confirms they are real:
without the fix the two `declare class` cases fail (TS2339); with it all pass.

## Adjacent-case matrix (`crates/tsz-cli/tests/cross_binder_reexport_meaning_tests.rs`)
- 2-hop re-exported `declare class` in `readonly C[]` → no TS2339 (repro).
- 3-hop, all binder/file names varied → no TS2339 (structural, multi-hop).
- Negative: value-only `declare const` re-exported 2 hops in type position → still **TS2749**.
- Negative: absent member on the resolved class instance → still **TS2339**.
- Pre-existing namespace/enum cases (#14168) unchanged.

Goal: green

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo nextest run -p tsz-cli --test cross_binder_reexport_meaning_tests` → 9/9 pass.
- Revert-test (stash the source fix, rebuild): the two `declare class` tests fail with TS2339; all pass once restored — confirms the tests cover the change.
- `cargo clippy -p tsz-checker -p tsz-cli --tests` → clean.

Signed-off-by: M1FableArchitect
