### PR TITLE
fix(solver): typeof-function narrowing keeps object/empty-shape union members as Function (TS2339)

### DIFF
--- a/crates/tsz-checker/tests/typeof_function_like_flow_tests.rs
+++ b/crates/tsz-checker/tests/typeof_function_like_flow_tests.rs
@@ -195,3 +195,95 @@ function f(instance: Function | object) {
         "typeof === 'function' on `Function | object` must keep Function callable; got: {diags:#?}"
     );
 }
+
+/// Regression (issue #14324, mined from arktype): `typeof x === "function"`
+/// narrowing of a union whose members include the bare `object` type must
+/// narrow that member to `Function` (a subtype of `object`), not collapse the
+/// whole union to `never`. tsc reports no error; tsz previously emitted TS2339
+/// because the per-union-member narrowing dropped the `object` member while the
+/// scalar path kept it. Covers `object | symbol`, `object | string`, and the
+/// bare scalar `object` so the per-member and scalar paths stay aligned.
+#[test]
+fn typeof_function_narrows_object_union_member_to_function() {
+    let source = r#"
+function a(value: object | symbol) {
+  if (typeof value === "function") {
+    return value.name;
+  }
+  return "";
+}
+
+function b(value: object | string) {
+  if (typeof value === "function") {
+    return value.name;
+  }
+  return "";
+}
+
+function bare(value: object) {
+  if (typeof value === "function") {
+    return value.name;
+  }
+  return "";
+}
+"#;
+    let diags = check_source(source, "test.ts", CheckerOptions::default());
+    let property_missing: Vec<_> = diags.iter().filter(|d| d.code == 2339).collect();
+    assert!(
+        property_missing.is_empty(),
+        "typeof === 'function' on a union containing `object` must narrow that member to Function; got: {diags:#?}"
+    );
+}
+
+/// Regression (issue #14324, adjacent): the empty object shape `{}` is a
+/// supertype of `Function`, so a `{} | T` union member that is `{}` narrows to
+/// `Function` under `typeof === "function"` rather than being dropped. The
+/// generic `{} | T` form exercises the type-parameter member alongside `{}`.
+#[test]
+fn typeof_function_narrows_empty_object_union_member_to_function() {
+    let source = r#"
+function emptyShape(value: {} | symbol) {
+  if (typeof value === "function") {
+    return value.name;
+  }
+  return "";
+}
+
+function withTypeParam<T extends symbol>(value: {} | T) {
+  if (typeof value === "function") {
+    return value.name;
+  }
+  return "";
+}
+"#;
+    let diags = check_source(source, "test.ts", CheckerOptions::default());
+    let property_missing: Vec<_> = diags.iter().filter(|d| d.code == 2339).collect();
+    assert!(
+        property_missing.is_empty(),
+        "typeof === 'function' on a union containing `{{}}` must narrow that member to Function; got: {diags:#?}"
+    );
+}
+
+/// Negative control (issue #14324): a union with no function- or
+/// object-compatible member must still narrow to `never` under
+/// `typeof === "function"`, confirming the fix is scoped to `object`/empty-shape
+/// members and does not over-broadly keep scalars. The collapse-to-`never` is
+/// witnessed here through tsz's current property-access-on-`never` behavior
+/// (TS2339); the witness, not tsc parity for `never` access, is the point.
+#[test]
+fn typeof_function_negative_control_no_compatible_member_is_never() {
+    let source = r#"
+function c(value: string | symbol) {
+  if (typeof value === "function") {
+    return value.name;
+  }
+  return "";
+}
+"#;
+    let diags = check_source(source, "test.ts", CheckerOptions::default());
+    let property_missing: Vec<_> = diags.iter().filter(|d| d.code == 2339).collect();
+    assert!(
+        !property_missing.is_empty(),
+        "typeof === 'function' on `string | symbol` must collapse to never (no Function member); got: {diags:#?}"
+    );
+}

--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -268,7 +268,7 @@ impl<'a> NarrowingContext<'a> {
             let members = self.db.type_list(members);
             let mut functions: Option<Vec<TypeId>> = None;
             for (index, &member) in members.iter().enumerate() {
-                let narrowed = self.narrow_union_member_to_function(member);
+                let narrowed = self.narrow_single_to_function(member);
 
                 match (narrowed, &mut functions) {
                     (Some(result), Some(functions)) => functions.push(result),
@@ -295,36 +295,58 @@ impl<'a> NarrowingContext<'a> {
             return union_or_single(self.db, functions);
         }
 
-        if let Some(narrowed) = self.narrow_type_param_to_function(source_type) {
-            return narrowed;
-        }
+        // Scalar (non-union) source: a member that classifies to nothing
+        // narrows to `never`.
+        self.narrow_single_to_function(source_type)
+            .unwrap_or(TypeId::NEVER)
+    }
 
-        if self.is_function_type(source_type) {
-            source_type
-        } else if source_type == TypeId::OBJECT {
-            self.function_type()
-        } else if let Some(shape_id) = object_shape_id(self.db, source_type) {
+    /// Classify a single resolved type for the `typeof x === "function"` guard.
+    ///
+    /// Returns `None` when `ty` is not a directly recognizable function /
+    /// object / indexed-access form (the caller should then try alias
+    /// resolution). Returns `Some(Function)` for a type that is a supertype of
+    /// `Function` (bare `object` or an empty object shape), `Some(ty)` when `ty`
+    /// is already callable, `Some(ty & Function)` for an indexed access, and
+    /// `Some(never)` for an object shape that has no function-compatible form.
+    ///
+    /// Mirrors `tsc`: `Function` is assignable to `object` and to `{}`, so the
+    /// function-narrowing keeps those members as `Function` rather than
+    /// collapsing them away.
+    fn classify_concrete_to_function(&self, ty: TypeId) -> Option<TypeId> {
+        if self.is_function_type(ty) {
+            return Some(ty);
+        }
+        if ty == TypeId::OBJECT {
+            return Some(self.function_type());
+        }
+        if let Some(shape_id) = object_shape_id(self.db, ty) {
             let shape = self.db.object_shape(shape_id);
-            if shape.properties.is_empty() {
-                self.function_type()
-            } else {
-                TypeId::NEVER
-            }
-        } else if let Some(shape_id) = object_with_index_shape_id(self.db, source_type) {
+            return Some(self.empty_shape_to_function(shape.properties.is_empty()));
+        }
+        if let Some(shape_id) = object_with_index_shape_id(self.db, ty) {
             let shape = self.db.object_shape(shape_id);
-            if shape.properties.is_empty()
-                && shape.string_index.is_none()
-                && shape.number_index.is_none()
-            {
-                self.function_type()
-            } else {
-                TypeId::NEVER
-            }
-        } else if index_access_parts(self.db, source_type).is_some() {
-            // For indexed access types like T[K], narrow to T[K] & Function
-            // This handles cases like: typeof obj[key] === 'function'
+            return Some(self.empty_shape_to_function(
+                shape.properties.is_empty()
+                    && shape.string_index.is_none()
+                    && shape.number_index.is_none(),
+            ));
+        }
+        if index_access_parts(self.db, ty).is_some() {
+            // For indexed access types like T[K], narrow to T[K] & Function.
+            // This handles cases like: typeof obj[key] === 'function'.
             let function_type = self.function_type();
-            self.db.intersection2(source_type, function_type)
+            return Some(self.db.intersection2(ty, function_type));
+        }
+        None
+    }
+
+    /// An object shape narrowed by `typeof === "function"`: `Function` when the
+    /// shape contributes no members (a supertype of `Function`, e.g. bare
+    /// `object` or `{}`), otherwise `never`.
+    fn empty_shape_to_function(&self, is_empty: bool) -> TypeId {
+        if is_empty {
+            self.function_type()
         } else {
             TypeId::NEVER
         }
@@ -336,30 +358,35 @@ impl<'a> NarrowingContext<'a> {
         is_function_type_through_type_constraints(self.db, type_id)
     }
 
-    /// Narrow a single union member for the `typeof === "function"` guard.
+    /// Narrow a single (non-union) type for the `typeof x === "function"` guard.
     ///
-    /// Returns the constituent to keep (`Some`), or `None` to drop the member.
-    /// Handles three cases the raw structural visitor cannot:
+    /// Returns the constituent to keep (`Some`), or `None` to drop it (the
+    /// scalar caller maps `None` to `never`; the union caller drops the member).
+    /// Shared by the scalar path and the per-member union path so both classify
+    /// `object`, `{}`, indexed accesses, type parameters, and alias references
+    /// identically. Handles the cases the raw structural visitor cannot:
     /// - type parameters (`narrow_type_param_to_function`);
-    /// - a member that is directly callable (kept as-is to preserve identity);
-    /// - a member that is a `Lazy`/`Application` alias which resolves to a
-    ///   callable type or to a nested union with callable constituents.
+    /// - directly callable types and supertypes of `Function` (bare `object`
+    ///   and empty object shapes), kept/narrowed by
+    ///   `classify_concrete_to_function`;
+    /// - a `Lazy`/`Application` alias which resolves to a concrete callable /
+    ///   object type or to a nested union with callable constituents.
     ///
     /// The structural `is_function_type` visitor runs over raw `TypeData` and
-    /// cannot see through an unresolved alias reference (e.g. a union member that
-    /// is itself a callable type alias, or one produced by an instantiated
-    /// generic alias whose body has not yet been collapsed). The narrowing
-    /// context owns a resolver, so resolve before classifying. When the member
-    /// is itself directly callable the original member is kept so display and
-    /// identity are unchanged; only members hidden behind an alias are replaced
-    /// by their resolved/recursively-narrowed callable form.
-    fn narrow_union_member_to_function(&self, member: TypeId) -> Option<TypeId> {
+    /// cannot see through an unresolved alias reference (e.g. a member that is
+    /// itself a callable type alias, or one produced by an instantiated generic
+    /// alias whose body has not yet been collapsed). The narrowing context owns
+    /// a resolver, so resolve before classifying. When the member is itself
+    /// directly callable the original member is kept so display and identity are
+    /// unchanged; only members hidden behind an alias are replaced by their
+    /// resolved/recursively-narrowed form.
+    fn narrow_single_to_function(&self, member: TypeId) -> Option<TypeId> {
         if let Some(narrowed) = self.narrow_type_param_to_function(member) {
             return narrowed.non_never();
         }
 
-        if self.is_function_type(member) {
-            return Some(member);
+        if let Some(result) = self.classify_concrete_to_function(member) {
+            return result.non_never();
         }
 
         let resolved = self.resolve_type(member);
@@ -367,8 +394,8 @@ impl<'a> NarrowingContext<'a> {
             return None;
         }
 
-        if self.is_function_type(resolved) {
-            return Some(resolved);
+        if let Some(result) = self.classify_concrete_to_function(resolved) {
+            return result.non_never();
         }
 
         // The alias resolved to a nested union (e.g. `Inner<T>` ->


### PR DESCRIPTION
## Summary
Fixes #14324 (mined from arktype). `typeof x === "function"` narrowing of a
union whose members include the bare `object` type collapsed to `never`,
producing a spurious TS2339 where tsc is clean:

```ts
function a(value: object | symbol) {
  if (typeof value === "function") return value.name; // tsz: TS2339; tsc: ok (Function)
  return "";
}
```

## Structural rule
When narrowing a union by `typeof x === "function"`, a member that is the bare
`object` type or an empty object shape (`{}`) is a supertype of `Function`, so
`tsc` narrows it to `Function` and keeps it (dropping non-function members).
tsz applied that promotion only on the scalar (non-union) path; the
per-union-member path dropped such members, collapsing `object | symbol`
(and `object | string`, `{} | T`, ...) to `never`.

Owner layer: solver — `narrowing/core/helpers.rs` (`narrow_to_function`).
The scalar path and the per-union-member path are unified behind a shared
`narrow_single_to_function` + `classify_concrete_to_function`, so both classify
`object`, `{}`, indexed accesses, type parameters, and alias references
identically. A non-function object shape still narrows to `never`.

## Adjacent-case matrix
- `object | symbol`, `object | string` — promoted member → `Function` (true branch ok).
- bare scalar `object` — unchanged (already correct).
- `{} | symbol`, `{} | T` (generic) — empty shape member → `Function`.
- Generic object alias `Box<A> = { value: A }` — non-empty shape → `never` (negative guard, unchanged).
- Negative control `string | symbol` — no function/object member → still `never`.
- Boxed `Function | object`, generic-function-alias, alias-to-union-with-function-arm — unchanged (existing tests still pass).

## Anti-hardcoding
Per-member structural narrowing only; no identifier/file-name/printer-string
checks. New tests vary binder names from the corpus witness.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-checker --test typeof_function_like_flow_tests` (8 pass, incl. 3 new: `typeof_function_narrows_object_union_member_to_function`, `typeof_function_narrows_empty_object_union_member_to_function`, `typeof_function_negative_control_no_compatible_member_is_never`).
- `cargo test -p tsz-checker --test typeof_function_generic_alias_narrowing_tests` (3 pass — object-alias negative guard unchanged).
- `cargo test -p tsz-solver --lib narrow` (no new failures; one pre-existing unrelated `array_isarray_keeps_mutable_and_readonly_array_members` failure present on `main` before this change).
- `cargo clippy -p tsz-solver --lib` clean.
- Ready-review CI owns the broad conformance/emit/fourslash suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_014xZPihUogMKvguxTWGeBUc)_