### PR TITLE
fix(checker): object-type-literal unique-symbol members keep identity via typeof (TS2322)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -36,6 +36,9 @@ stacker = "0.1.23"
 name = "as_const_object_property_inference_tests"
 path = "tests/as_const_object_property_inference_tests.rs"
 [[test]]
+name = "object_literal_unique_symbol_member_tests"
+path = "tests/object_literal_unique_symbol_member_tests.rs"
+[[test]]
 name = "top_level_await_grammar_diagnostics_tests"
 path = "tests/top_level_await_grammar_diagnostics_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/type_operators.rs
+++ b/crates/tsz-checker/src/types/computation/type_operators.rs
@@ -1,11 +1,11 @@
 //! Union, intersection, type operator, and keyof type computation.
 //! Also includes class-type helpers for brand property resolution.
 
-use super::super::unique_symbol_arena::has_declared_unique_symbol_owner;
+use super::super::unique_symbol_construction::unique_symbol_type_for_operator;
 use crate::query_boundaries::type_computation::complex as query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
-use tsz_solver::{SymbolRef, TypeId};
+use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     /// Get type from a union type node (A | B).
@@ -124,14 +124,8 @@ impl<'a> CheckerState<'a> {
 
             // Handle unique operator
             if operator == SyntaxKind::UniqueKeyword as u16 {
-                if inner_type == TypeId::SYMBOL
-                    && !has_declared_unique_symbol_owner(self.ctx.arena, idx)
-                {
-                    return self.ctx.types.unique_symbol(synthetic_unique_symbol_ref(
-                        &self.ctx.file_name,
-                        node.pos,
-                        node.end,
-                    ));
+                if inner_type == TypeId::SYMBOL {
+                    return unique_symbol_type_for_operator(&self.ctx, idx, node.pos, node.end);
                 }
                 return inner_type;
             }
@@ -308,17 +302,4 @@ impl<'a> CheckerState<'a> {
         self.get_class_decl_for_display_type(type_id)
             .map(|(class_idx, _)| self.get_class_name_from_decl(class_idx))
     }
-}
-
-fn synthetic_unique_symbol_ref(file_name: &str, pos: u32, end: u32) -> SymbolRef {
-    let mut hash = 0x811c_9dc5u32;
-    for byte in file_name.as_bytes() {
-        hash ^= u32::from(*byte);
-        hash = hash.wrapping_mul(0x0100_0193);
-    }
-    for value in [pos, end] {
-        hash ^= value;
-        hash = hash.wrapping_mul(0x0100_0193);
-    }
-    SymbolRef(hash | 0x8000_0000)
 }

--- a/crates/tsz-checker/src/types/mod.rs
+++ b/crates/tsz-checker/src/types/mod.rs
@@ -28,6 +28,7 @@ mod type_node_query_members;
 mod type_node_resolution;
 mod type_node_signature;
 pub(crate) mod unique_symbol_arena;
+pub(crate) mod unique_symbol_construction;
 pub(crate) mod utilities;
 pub(crate) mod window_global_this_annotation;
 

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -16,12 +16,12 @@ use super::type_node_helpers::{
     get_string_literal_from_type_index, is_type_query_in_non_flow_sensitive_signature_parameter,
     is_typeof_global_this_type_node,
 };
-use super::unique_symbol_arena::has_declared_unique_symbol_owner;
+use super::unique_symbol_construction::unique_symbol_type_for_operator;
 use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{SymbolRef, TypeId};
+use tsz_solver::TypeId;
 
 impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     // =========================================================================
@@ -83,14 +83,8 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
 
             // Handle unique operator
             if operator == SyntaxKind::UniqueKeyword as u16 {
-                if inner_type == TypeId::SYMBOL
-                    && !has_declared_unique_symbol_owner(self.ctx.arena, idx)
-                {
-                    return self.ctx.types.unique_symbol(synthetic_unique_symbol_ref(
-                        &self.ctx.file_name,
-                        node.pos,
-                        node.end,
-                    ));
+                if inner_type == TypeId::SYMBOL {
+                    return unique_symbol_type_for_operator(self.ctx, idx, node.pos, node.end);
                 }
                 return inner_type;
             }
@@ -1215,17 +1209,4 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         // Delegate to TypeLowering with extended resolvers (enum flags + lib search)
         self.lower_with_resolvers(idx, true, false)
     }
-}
-
-fn synthetic_unique_symbol_ref(file_name: &str, pos: u32, end: u32) -> SymbolRef {
-    let mut hash = 0x811c_9dc5u32;
-    for byte in file_name.as_bytes() {
-        hash ^= u32::from(*byte);
-        hash = hash.wrapping_mul(0x0100_0193);
-    }
-    for value in [pos, end] {
-        hash ^= value;
-        hash = hash.wrapping_mul(0x0100_0193);
-    }
-    SymbolRef(hash | 0x8000_0000)
 }

--- a/crates/tsz-checker/src/types/unique_symbol_arena.rs
+++ b/crates/tsz-checker/src/types/unique_symbol_arena.rs
@@ -83,6 +83,50 @@ pub(crate) fn is_symbol_call_initializer(arena: &NodeArena, init_idx: NodeIndex)
         .is_some_and(|ident| ident.escaped_text == "Symbol")
 }
 
+/// Is the immediate owner of this `unique symbol` type-operator node (skipping
+/// enclosing parenthesized types) a `readonly` property signature — an interface
+/// or object-type-literal member?
+///
+/// Per tsc's `isValidESSymbolDeclaration`, such a member is a valid
+/// `unique symbol` owner and gets a `unique symbol` of its own — identically for
+/// interface and object-type-literal members. tsz must construct that unique
+/// symbol at this site rather than widening the member to plain `symbol`,
+/// otherwise `typeof obj.prop` loses the unique-symbol identity for
+/// object-type-literal members (the variable-declaration ancestor would
+/// otherwise make `has_declared_unique_symbol_owner` treat it as a declared
+/// owner and widen it).
+pub(crate) fn is_readonly_unique_symbol_property_signature(
+    arena: &NodeArena,
+    idx: NodeIndex,
+) -> bool {
+    let Some(parent_idx) = parenthesized_type_parent(arena, idx) else {
+        return false;
+    };
+    let Some(parent) = arena.get(parent_idx) else {
+        return false;
+    };
+    parent.kind == syntax_kind_ext::PROPERTY_SIGNATURE
+        && arena
+            .get_signature(parent)
+            .is_some_and(|sig| arena.has_modifier(&sig.modifiers, SyntaxKind::ReadonlyKeyword))
+}
+
+/// The non-parenthesized owner of `idx`, skipping any enclosing
+/// `(... )` parenthesized type wrappers (matching tsc's
+/// `walkUpParenthesizedTypes(node.parent)`).
+fn parenthesized_type_parent(arena: &NodeArena, idx: NodeIndex) -> Option<NodeIndex> {
+    let mut cursor = idx;
+    loop {
+        let parent_idx = arena.get_extended(cursor)?.parent;
+        let parent = arena.get(parent_idx)?;
+        if parent.kind == syntax_kind_ext::PARENTHESIZED_TYPE {
+            cursor = parent_idx;
+            continue;
+        }
+        return Some(parent_idx);
+    }
+}
+
 pub(crate) fn has_declared_unique_symbol_owner(arena: &NodeArena, idx: NodeIndex) -> bool {
     let Some(parent_ext) = arena.get_extended(idx) else {
         return false;

--- a/crates/tsz-checker/src/types/unique_symbol_construction.rs
+++ b/crates/tsz-checker/src/types/unique_symbol_construction.rs
@@ -1,0 +1,56 @@
+//! Construction of `unique symbol` types for `unique symbol` type-operator
+//! annotations, shared by the two `get_type_from_type_operator` entry points
+//! (`TypeNodeChecker` and `CheckerState`).
+
+use super::unique_symbol_arena::{
+    has_declared_unique_symbol_owner, is_readonly_unique_symbol_property_signature,
+};
+use crate::context::CheckerContext;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::{SymbolRef, TypeId};
+
+/// Resolve the type of a `unique symbol` type-operator annotation at `idx`,
+/// whose inner operand already resolved to plain `symbol`.
+///
+/// Mirrors tsc's `getESSymbolLikeTypeForNode`:
+/// - A `readonly` property signature (interface *or* object-type-literal
+///   member) is a valid ES-symbol declaration, so it owns a distinct
+///   `unique symbol`. Object-type literals previously missed this — they widened
+///   to plain `symbol`, dropping the identity recovered by `typeof obj.prop`.
+/// - A `const` variable / `static readonly` class property is also a declared
+///   owner, but its identity is recovered through the `typeof` read path keyed
+///   on the declaration symbol; the annotation lowers to plain `symbol` here so
+///   `symbol`-typed initializers are accepted at the declaration site.
+/// - Any other position synthesizes a source-position-stable identity.
+pub(crate) fn unique_symbol_type_for_operator(
+    ctx: &CheckerContext<'_>,
+    idx: NodeIndex,
+    pos: u32,
+    end: u32,
+) -> TypeId {
+    if is_readonly_unique_symbol_property_signature(ctx.arena, idx)
+        || !has_declared_unique_symbol_owner(ctx.arena, idx)
+    {
+        return ctx
+            .types
+            .unique_symbol(synthetic_unique_symbol_ref(&ctx.file_name, pos, end));
+    }
+    TypeId::SYMBOL
+}
+
+/// A source-position-stable `unique symbol` identity for a member whose
+/// declaration is not itself a binder symbol (interface and object-type-literal
+/// members are resolved structurally, not via `node_symbols`). The position
+/// hash is unique per declaration, so distinct members stay distinct.
+fn synthetic_unique_symbol_ref(file_name: &str, pos: u32, end: u32) -> SymbolRef {
+    let mut hash = 0x811c_9dc5u32;
+    for byte in file_name.as_bytes() {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    for value in [pos, end] {
+        hash ^= value;
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    SymbolRef(hash | 0x8000_0000)
+}

--- a/crates/tsz-checker/tests/object_literal_unique_symbol_member_tests.rs
+++ b/crates/tsz-checker/tests/object_literal_unique_symbol_member_tests.rs
@@ -1,0 +1,158 @@
+//! Object-type-literal `unique symbol` members must keep their unique-symbol
+//! identity when read back via `typeof`, matching interface members and tsc.
+//!
+//! Regression for the false-negative where a `unique symbol`-typed property in
+//! an *object type literal* widened to plain `symbol` via `typeof obj.prop`
+//! (or `(typeof obj)["prop"]`), so assigning a generic `symbol` was wrongly
+//! accepted (missed TS2322). Per tsc's `getESSymbolLikeTypeForNode`, a
+//! `readonly` property signature — interface *or* object-type-literal member —
+//! owns a `unique symbol` keyed on the member's own declaration symbol.
+
+use tsz_checker::context::CheckerOptions;
+
+fn check_strict(source: &str) -> Vec<(u32, String)> {
+    let options = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..Default::default()
+    };
+    tsz_checker::test_utils::check_source(source, "test.ts", options)
+        .into_iter()
+        .map(|d| (d.code, d.message_text))
+        .collect()
+}
+
+fn ts2322_count(diags: &[(u32, String)]) -> usize {
+    diags.iter().filter(|(c, _)| *c == 2322).count()
+}
+
+#[test]
+fn object_literal_member_via_property_access_emits_ts2322() {
+    let source = r#"
+declare const C: { readonly K: unique symbol };
+declare const s: symbol;
+const b1: typeof C.K = s;
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        ts2322_count(&diags),
+        1,
+        "object-type-literal member read via `typeof C.K` must reject generic symbol: {diags:?}"
+    );
+}
+
+#[test]
+fn object_literal_member_via_indexed_access_emits_ts2322() {
+    let source = r#"
+declare const C: { readonly K: unique symbol };
+declare const s: symbol;
+const b2: (typeof C)["K"] = s;
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        ts2322_count(&diags),
+        1,
+        "object-type-literal member read via `(typeof C)[\"K\"]` must reject generic symbol: {diags:?}"
+    );
+}
+
+#[test]
+fn matches_interface_and_const_variable_owners() {
+    // All four binding forms behave identically and reject a generic symbol.
+    let source = r#"
+declare const C: { readonly K: unique symbol };
+declare const s: symbol;
+const b1: typeof C.K = s;
+const b2: (typeof C)["K"] = s;
+interface I { readonly K: unique symbol }
+declare const D: I;
+const b3: typeof D.K = s;
+declare const E: unique symbol;
+const b4: typeof E = s;
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        ts2322_count(&diags),
+        4,
+        "interface, const, and object-literal forms must all emit TS2322: {diags:?}"
+    );
+}
+
+#[test]
+fn renamed_binders_behave_identically() {
+    // §25: the fix must not depend on user-chosen identifier names.
+    let source = r#"
+declare const aDifferentName: { readonly RENAMED_KEY: unique symbol };
+declare const someSym: symbol;
+const x: typeof aDifferentName.RENAMED_KEY = someSym;
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        ts2322_count(&diags),
+        1,
+        "renamed binders must still reject generic symbol: {diags:?}"
+    );
+}
+
+#[test]
+fn nested_object_literal_member() {
+    let source = r#"
+declare const C: { readonly inner: { readonly K: unique symbol } };
+declare const s: symbol;
+const x: typeof C.inner.K = s;
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        ts2322_count(&diags),
+        1,
+        "nested object-literal member must reject generic symbol: {diags:?}"
+    );
+}
+
+#[test]
+fn parenthesized_unique_symbol_member() {
+    let source = r#"
+declare const C: { readonly K: (unique symbol) };
+declare const s: symbol;
+const x: typeof C.K = s;
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        ts2322_count(&diags),
+        1,
+        "parenthesized `(unique symbol)` member must reject generic symbol: {diags:?}"
+    );
+}
+
+#[test]
+fn distinct_object_literals_have_distinct_unique_symbols() {
+    // Two structurally identical object-type-literal members are distinct
+    // unique symbols, so cross-assignment is rejected.
+    let source = r#"
+declare const A: { readonly K: unique symbol };
+declare const B: { readonly K: unique symbol };
+const x: typeof A.K = B.K;
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        ts2322_count(&diags),
+        1,
+        "distinct object-literal members must be distinct unique symbols: {diags:?}"
+    );
+}
+
+#[test]
+fn same_member_unique_symbol_is_assignable_to_itself() {
+    // The member's unique symbol must round-trip: assigning it to its own
+    // `typeof` type must not error.
+    let source = r#"
+declare const C: { readonly K: unique symbol };
+const ok: typeof C.K = C.K;
+"#;
+    let diags = check_strict(source);
+    assert_eq!(
+        ts2322_count(&diags),
+        0,
+        "a member's own unique symbol must be assignable to `typeof C.K`: {diags:?}"
+    );
+}


### PR DESCRIPTION
Fixes #14372.

## Summary
A `unique symbol`-typed `readonly` property declared in an **object type literal**
lost its unique-symbol identity when read back via `typeof obj.prop` (or
`(typeof obj)["prop"]`): tsz widened it to plain `symbol`, so an assignment from a
generic `symbol` was **incorrectly accepted** (missed TS2322). Interface members
and top-level `unique symbol` consts were already handled correctly.

```ts
declare const C: { readonly K: unique symbol };
declare const s: symbol;
const b1: typeof C.K = s;        // tsc: TS2322 — tsz now: TS2322 (was MISSED)
const b2: (typeof C)["K"] = s;   // tsc: TS2322 — tsz now: TS2322 (was MISSED)
```

## Structural rule
When a `unique symbol` annotation is on a `readonly` property signature, tsc
(`getESSymbolLikeTypeForNode` / `isValidESSymbolDeclaration`) gives that member a
`unique symbol` of its own — **identically for interface and object-type-literal
members**. tsz previously routed object-literal members through
`has_declared_unique_symbol_owner`, whose property-signature walk found the
enclosing variable declaration (`const C: { ... }`) and treated the member as a
*declared owner*, widening it to plain `symbol`. Only `const` variables and
`static readonly` class properties are declared owners — their identity is
recovered through the `typeof` read path keyed on the declaration symbol; a
property signature is not.

## Owner layer
Solver-backed checker type construction. The `unique symbol` type operator now
routes `readonly` property-signature members (interface or object type literal)
to a synthesized, position-stable unique-symbol identity — the same path
interfaces already used — *before* consulting `has_declared_unique_symbol_owner`.
Interface and object-type-literal members are resolved structurally (no binder
`node_symbols` entry), so a source-position-stable synthetic ref is the existing
mechanism for both; this change simply applies it uniformly. The duplicated
`synthetic_unique_symbol_ref` helper (previously copied in `type_node_advanced`
and `computation/type_operators`) is consolidated into a shared
`unique_symbol_construction` module.

## Adjacent-case matrix (`object_literal_unique_symbol_member_tests`)
- property access (`typeof C.K`) and indexed access (`(typeof C)["K"]`)
- interface / `const` / object-literal forms all emit TS2322
- renamed binders (no identifier-name dependence)
- nested object literal (`C.inner.K`)
- parenthesized `(unique symbol)`
- distinct object literals produce distinct unique symbols (cross-assign rejected)
- a member's own unique symbol round-trips (`typeof C.K = C.K` is accepted)

## Anti-hardcoding
No user-name/file-name literals drive logic; the decision is the structural
"`readonly` property signature owner" shape. Tests vary binder names.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-checker --test object_literal_unique_symbol_member_tests` (8 new tests, all pass)
- No regressions across unique-symbol suites:
  `static_readonly_unique_symbol_tests`, `merged_unique_symbol_factory_value_identity_tests`,
  `keyof_well_known_symbol_key_tests`, `ts2490_unique_symbol_iterator_tests`,
  `unique_symbol_discriminant_narrowing_tests`, `wide_symbol_equality_no_unique_narrowing_tests`,
  `computed_property_name_type_position_no_ts2454_tests`,
  `ts2353_cross_module_symbol_computed_key_tests`,
  `ts7053_unique_symbol_constrained_type_param_index_tests`
- Pre-existing failures in `conditional_infer_tests` (3), `lib_global_namespace_shadowing_tests` (1),
  and `ts2322_tests` (6) confirmed identical on the base commit (unrelated to this change).
- `cargo clippy -p tsz-checker` clean.
- Ready-review CI owns the broad conformance/emit/fourslash suites.

https://claude.ai/code/session_019nWswpzDajCtF6WgcXiUmM

---
_Generated by [Claude Code](https://claude.ai/code/session_019nWswpzDajCtF6WgcXiUmM)_