### PR TITLE
test(bench): map msw #core subpath imports via paths like upstream tsconfig

### DIFF
--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -777,7 +777,23 @@ tsz_write_valibot_config() {
 }
 
 tsz_write_msw_config() {
-  tsz_write_basic_external_project_config "$1" "src"
+  # msw's source imports its package-internal core via `#core` / `#core/*`
+  # subpath specifiers. Its real tsconfig.base.json resolves those through a
+  # TypeScript `paths` mapping (`"#core/*": ["./src/core/*"]`), NOT through the
+  # package.json `imports` field. The fixture clone runs no npm install, and the
+  # package.json `imports` targets are extensionless (`"./src/core/*"`), which
+  # `moduleResolution: bundler` does not probe with a `.ts` extension -- bundled
+  # tsc emits the same TS2307 on those specifiers without the `paths` mapping.
+  # Mirror upstream's `paths` so the fixture replicates msw's actual resolution
+  # setup; both tsc and tsz then bind `#core/...` to src/core sources. (External
+  # dependency specifiers such as `outvariant`/`@mswjs/interceptors` remain
+  # unresolved because the clone installs nothing, matching tsc.)
+  tsz_write_basic_external_project_config "$1" "src" \
+    '    "paths": {
+      "#core": ["./src/core"],
+      "#core/*": ["./src/core/*"]
+    },
+'
 }
 
 tsz_write_comlink_config() {


### PR DESCRIPTION
Goal: green

## Structural rule
When a benchmark fixture's source imports package-internal modules via `#`-prefixed
subpath specifiers (`#core` / `#core/*`), and the upstream project resolves them
through a TypeScript `paths` mapping rather than the `package.json` `imports` field,
the generated tsz-guard config must carry the same `paths` mapping. msw's real
`tsconfig.base.json` declares `"#core/*": ["./src/core/*"]` under `paths`; the
generated `tsconfig.tsz-guard.json` omitted it, so resolution fell back to the
`package.json` `imports` map whose targets are extensionless (`"./src/core/*"`).
`moduleResolution: bundler` does not append a `.ts` extension to those `imports`
targets, so the specifiers failed -- and bundled `tsc` emits the **identical**
TS2307 on that fallback. This was a fixture-config gap, not a tsz resolver bug.

## Investigation (ground truth)
- tsz already implements `package.json` `imports` subpath resolution
  (`crates/tsz-core/src/module_resolver/exports_imports.rs::resolve_package_imports`);
  a minimal repro with extensioned `imports` targets resolves cleanly in both
  tsz and tsc.
- Minimal repro with msw's exact extensionless `imports` shape + `moduleResolution: bundler`:
  bundled `tsc` AND tsz both emit TS2307 (parity). Adding `paths` makes BOTH resolve cleanly.
- On the real msw fixture: original guard config -> 125 TS2307 (42 of them `#core/...`).
  Patched config -> 0 `#core` TS2307 in both tsz and tsc; 83 residual TS2307 are
  uninstalled external packages (`outvariant`, `@mswjs/interceptors`, `graphql`,
  `rettime`, `headers-polyfill`, `strict-event-emitter`, `path-to-regexp`, ...),
  matching tsc (86), because the fixture clone runs no npm install.

## Adjacent matrix (minimal repro, tsc vs tsz)
- `#core/*` with extensioned `imports` target (`./src/core/*.ts`): both resolve. PASS
- `#core/*` with extensionless `imports` target (`./src/core/*`), no `paths`: both TS2307. PARITY (negative preserved)
- `#core/*` via `paths` (`["./src/core/*"]`): both resolve. PASS
- exact `#core` (no `*`) via `paths`: both resolve. PASS

## Verification
- `bash -n scripts/bench/project-fixtures.sh` (syntax OK)
- Regenerated config via `source scripts/bench/project-fixtures.sh; tsz_write_msw_config`
  is valid JSON and contains the `paths` block.
- End-to-end: `TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_FILTER=msw
  TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 scripts/ci/project-compile-guard.sh` regenerates
  the config with `paths`; remaining diagnostics are external-package TS2307 + downstream
  type errors, no `#core` TS2307.
- No Rust changed (`crates/**` untouched), so conformance/emit/fourslash are unaffected;
  this is a bench fixture-config change only.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
