### PR TITLE
fix(solver): cap fixed-arity infer function pattern by source required arity (TS2322 #14323)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs
@@ -188,6 +188,34 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             pattern_params.len()
         };
 
+        // Arity gate, mirroring `compareSignaturesRelated`'s parameter-count
+        // check (see `check_params_compatible`): for the extends relation to
+        // hold, the source must be callable with the pattern's parameter list.
+        // A source signature with no rest parameter whose required-argument
+        // count exceeds a fixed-arity (no trailing rest) pattern's parameter
+        // count demands more arguments than the pattern supplies, so tsc fails
+        // the relation and the conditional takes the false branch. Without this
+        // guard tsz truncates the source to the pattern prefix and wrongly
+        // matches a higher-arity source (e.g. `(a, b) => {}` against
+        // `(p0: infer P0) => any`). A trailing rest in the pattern absorbs extra
+        // source params, so the cap only applies to fixed-arity patterns.
+        if trailing_rest_param.is_none() && !source_params.last().is_some_and(|param| param.rest) {
+            let source_required = checker.required_param_count(source_params);
+            // tsc's `getMinArgumentCount` treats trailing parameters whose type
+            // includes `void` as optional for arity, so a source like
+            // `(a: string, b: void) => …` still satisfies a 1-arg pattern; only
+            // a non-void extra required parameter fails the relation.
+            if source_required > fixed_param_count
+                && source_params
+                    .iter()
+                    .skip(fixed_param_count)
+                    .take(source_required - fixed_param_count)
+                    .any(|param| !checker.param_type_contains_void(param.type_id))
+            {
+                return false;
+            }
+        }
+
         // A source callable with fewer parameters is still assignable to the
         // inference pattern (extra trailing positions are ignored at the call
         // site); tsc takes the true branch and defaults the unmatched `infer`

--- a/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_functions.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_functions.rs
@@ -1460,3 +1460,244 @@ fn test_conditional_infer_readonly_array_element_non_distributive_union_branch()
 
     assert_eq!(result, TypeId::NEVER);
 }
+
+/// Helper: build `(params...) => return_type` as a `Function` type.
+fn make_fn(interner: &TypeInterner, params: Vec<ParamInfo>, return_type: TypeId) -> TypeId {
+    interner.function(FunctionShape {
+        params,
+        this_type: None,
+        return_type,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    })
+}
+
+/// Regression (issue #14323, mined from type-zoo): a fixed-arity `infer`
+/// function pattern (no trailing rest) must not match a higher-arity source.
+///
+/// ```ts
+/// type ParamTypes<F> =
+///   F extends (p0: infer P0) => any ? [P0]
+///   : F extends (p0: infer P0, p1: infer P1) => any ? [P0, P1] : never;
+/// // F = (a: string, b: number) => {}  =>  [string, number]
+/// ```
+///
+/// `tsc` fails `(a, b) => {}` against the 1-arg pattern (the source demands
+/// more arguments than the pattern supplies), so the conditional falls through
+/// to the 2-arg pattern. Before the arity gate, tsz truncated the source to the
+/// pattern prefix and wrongly picked `[string]`.
+#[test]
+fn test_conditional_infer_fixed_arity_rejects_higher_arity_source() {
+    let interner = TypeInterner::new();
+
+    let a = interner.intern_string("a");
+    let b = interner.intern_string("b");
+    let (_p0, infer_p0) = test_infer_param(&interner, "P0");
+    let (_p1, infer_p1) = test_infer_param(&interner, "P1");
+
+    // Source: (a: string, b: number) => {}
+    let source = make_fn(
+        &interner,
+        vec![
+            ParamInfo::required(a, TypeId::STRING),
+            ParamInfo::required(b, TypeId::NUMBER),
+        ],
+        TypeId::VOID,
+    );
+
+    // Pattern 1: (p0: infer P0) => any  ->  [P0]
+    let pattern1 = make_fn(&interner, vec![ParamInfo::required(a, infer_p0)], TypeId::ANY);
+    let true1 = interner.tuple(vec![TupleElement::fixed(infer_p0)]);
+
+    // Pattern 2: (p0: infer P0, p1: infer P1) => any  ->  [P0, P1]
+    let pattern2 = make_fn(
+        &interner,
+        vec![
+            ParamInfo::required(a, infer_p0),
+            ParamInfo::required(b, infer_p1),
+        ],
+        TypeId::ANY,
+    );
+    let true2 = interner.tuple(vec![
+        TupleElement::fixed(infer_p0),
+        TupleElement::fixed(infer_p1),
+    ]);
+
+    let inner = interner.conditional(ConditionalType {
+        check_type: source,
+        extends_type: pattern2,
+        true_type: true2,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    });
+    let outer = ConditionalType {
+        check_type: source,
+        extends_type: pattern1,
+        true_type: true1,
+        false_type: inner,
+        is_distributive: false,
+    };
+
+    let result = evaluate_conditional(&interner, &outer);
+    let expected = interner.tuple(vec![
+        TupleElement::fixed(TypeId::STRING),
+        TupleElement::fixed(TypeId::NUMBER),
+    ]);
+    assert_eq!(result, expected);
+}
+
+/// Adjacent: an exact-arity source still matches the fixed-arity pattern.
+#[test]
+fn test_conditional_infer_fixed_arity_matches_exact_arity_source() {
+    let interner = TypeInterner::new();
+
+    let a = interner.intern_string("a");
+    let (_p0, infer_p0) = test_infer_param(&interner, "P0");
+
+    // Source: (a: string) => void
+    let source = make_fn(&interner, vec![ParamInfo::required(a, TypeId::STRING)], TypeId::VOID);
+    // Pattern: (p0: infer P0) => any -> P0
+    let pattern = make_fn(&interner, vec![ParamInfo::required(a, infer_p0)], TypeId::ANY);
+
+    let cond = ConditionalType {
+        check_type: source,
+        extends_type: pattern,
+        true_type: infer_p0,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    assert_eq!(evaluate_conditional(&interner, &cond), TypeId::STRING);
+}
+
+/// Adjacent: a fixed-arity source with fewer params than the pattern still
+/// matches (extra positions default to `unknown`), matching `tsc`.
+#[test]
+fn test_conditional_infer_fixed_arity_matches_lower_arity_source() {
+    let interner = TypeInterner::new();
+
+    let a = interner.intern_string("a");
+    let b = interner.intern_string("b");
+    let (_p0, infer_p0) = test_infer_param(&interner, "P0");
+    let (_p1, infer_p1) = test_infer_param(&interner, "P1");
+
+    // Source: (a: string) => void
+    let source = make_fn(&interner, vec![ParamInfo::required(a, TypeId::STRING)], TypeId::VOID);
+    // Pattern: (p0: infer P0, p1: infer P1) => any -> [P0, P1]
+    let pattern = make_fn(
+        &interner,
+        vec![
+            ParamInfo::required(a, infer_p0),
+            ParamInfo::required(b, infer_p1),
+        ],
+        TypeId::ANY,
+    );
+    let true_branch = interner.tuple(vec![
+        TupleElement::fixed(infer_p0),
+        TupleElement::fixed(infer_p1),
+    ]);
+
+    let cond = ConditionalType {
+        check_type: source,
+        extends_type: pattern,
+        true_type: true_branch,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let result = evaluate_conditional(&interner, &cond);
+    let expected = interner.tuple(vec![
+        TupleElement::fixed(TypeId::STRING),
+        TupleElement::fixed(TypeId::UNKNOWN),
+    ]);
+    assert_eq!(result, expected);
+}
+
+/// Adjacent: a trailing-rest pattern imposes no arity cap, so a higher-arity
+/// source still matches `(...args: infer P) => any`.
+#[test]
+fn test_conditional_infer_rest_pattern_matches_higher_arity_source() {
+    let interner = TypeInterner::new();
+
+    let a = interner.intern_string("a");
+    let b = interner.intern_string("b");
+    let args = interner.intern_string("args");
+    let (_p, infer_p) = test_infer_param(&interner, "P");
+
+    // Source: (a: string, b: number) => void
+    let source = make_fn(
+        &interner,
+        vec![
+            ParamInfo::required(a, TypeId::STRING),
+            ParamInfo::required(b, TypeId::NUMBER),
+        ],
+        TypeId::VOID,
+    );
+    // Pattern: (...args: infer P) => any -> P
+    let pattern = make_fn(
+        &interner,
+        vec![ParamInfo {
+            name: Some(args),
+            type_id: infer_p,
+            optional: false,
+            rest: true,
+        }],
+        TypeId::ANY,
+    );
+
+    let cond = ConditionalType {
+        check_type: source,
+        extends_type: pattern,
+        true_type: infer_p,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    // The rest pattern absorbs both source params, so the true branch is taken
+    // (`P` binds to the `[string, number]` parameter tuple). The exact tuple
+    // reification (element names/readonly) is not what this case guards — only
+    // that the arity cap does not fire for a trailing-rest pattern.
+    let result = evaluate_conditional(&interner, &cond);
+    assert_ne!(result, TypeId::NEVER);
+    assert!(matches!(interner.lookup(result), Some(TypeData::Tuple(_))));
+}
+
+/// Adjacent: an optional trailing param does not count toward required arity,
+/// so `(a, b?) => {}` still matches the 1-arg pattern.
+#[test]
+fn test_conditional_infer_fixed_arity_optional_trailing_param_matches() {
+    let interner = TypeInterner::new();
+
+    let a = interner.intern_string("a");
+    let b = interner.intern_string("b");
+    let (_p0, infer_p0) = test_infer_param(&interner, "P0");
+
+    // Source: (a: string, b?: number) => void  (1 required param)
+    let source = make_fn(
+        &interner,
+        vec![
+            ParamInfo::required(a, TypeId::STRING),
+            ParamInfo {
+                name: Some(b),
+                type_id: TypeId::NUMBER,
+                optional: true,
+                rest: false,
+            },
+        ],
+        TypeId::VOID,
+    );
+    // Pattern: (p0: infer P0) => any -> P0
+    let pattern = make_fn(&interner, vec![ParamInfo::required(a, infer_p0)], TypeId::ANY);
+
+    let cond = ConditionalType {
+        check_type: source,
+        extends_type: pattern,
+        true_type: infer_p0,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    assert_eq!(evaluate_conditional(&interner, &cond), TypeId::STRING);
+}


### PR DESCRIPTION
## Summary

Fixes #14323 (mined from **type-zoo**). A conditional `infer` over a
fixed-arity function pattern wrongly matched a higher-arity source, so tsz
emitted a false-positive `TS2322` where `tsc` is clean:

```ts
type ParamTypes<F> =
  F extends (p0: infer P0) => any ? [P0]
  : F extends (p0: infer P0, p1: infer P1) => any ? [P0, P1] : never;
const fn = (a: string, b: number) => {};
const pts: [string, number] = (null as any as ParamTypes<typeof fn>);
// tsz picked [P0] -> TS2322; tsc picks [P0, P1]
```

tsz truncated the source to the pattern prefix and took the true branch, so a
2-arg function matched the 1-arg pattern.

## Structural rule

When a conditional `T extends (p0..pN) => Ret ? A : B` has a **fixed-arity**
function pattern (no trailing rest) and the source function's count of required
(non-optional, non-rest) parameters exceeds N, `tsc` fails the extends relation
and takes the false branch. tsz now does the same.

`When a function source with no rest parameter has more required parameters
than a fixed-arity (no trailing rest) infer function pattern supplies, tsc
fails the extends relation; tsz does X through the solver's
match_signature_params_for_infer arity gate.`

## Owner layer

Solver — conditional/function infer-pattern matching. The gate lives in
`match_signature_params_for_infer`
(`crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs`),
the single chokepoint shared by `match_infer_function_pattern` (all its
function/callable branches) and `match_infer_signature_pair` (callable
signatures). It mirrors `compareSignaturesRelated`'s parameter-count check
already used by the subtype rule `check_params_compatible`: when the pattern
has no trailing rest and the source has no rest, fail if the source's
required-parameter count exceeds the pattern's parameter count. Trailing
`void`-typed source params stay optional for arity, matching
`getMinArgumentCount`. The constructor path (`match_signature_params`) already
rejects higher-arity sources via its exact-length check, so it is unaffected.

## Adjacent-case matrix

Added solver unit tests in `conditional_infer_functions.rs`:
- 1-arg pattern vs 2-arg source (the bug) → falls through to the 2-arg
  pattern, yields `[string, number]`.
- exact arity (1 vs 1) → matches, yields `string`.
- lower-arity source (1 vs 2-arg pattern) → matches, unmatched infer slot
  defaults to `unknown`.
- trailing-rest pattern (`(...args: infer P) => any`) → no arity cap, matches
  the 2-arg source.
- optional trailing source param (`(a, b?) => {}`) → not counted toward
  required arity, matches the 1-arg pattern.

## Anti-hardcoding

Structural arity guard via the shared `required_param_count` /
`param_type_contains_void` helpers — no identifier, alias, file-name, or
rendered-string checks.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo nextest run -p tsz-solver --lib fixed_arity rest_pattern_matches_higher` — 5/5 pass.
- Full `cargo nextest run -p tsz-solver` — only the 5 failures that are
  pre-existing on `origin/main` remain (confirmed by detached-HEAD run);
  this change introduces no new failures.
- `cargo clippy -p tsz-solver --lib` — clean.
- End-to-end: `tsz --strict --target es2020 --lib es2020` on the issue repro
  now reports no diagnostics (matches `tsc`).

---
_Generated by [Claude Code](https://claude.ai/code/session_015k4uArUcdE8YAknpTVnhHw)_