### PR TITLE
fix(solver): compute call arity of generic conditional rest against erased signature (#14326)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -986,6 +986,9 @@ path = "tests/inline_mapped_array_return_tests.rs"
 name = "overload_inference_literal_preservation_tests"
 path = "tests/overload_inference_literal_preservation_tests.rs"
 [[test]]
+name = "generic_conditional_rest_arity_tests"
+path = "tests/generic_conditional_rest_arity_tests.rs"
+[[test]]
 name = "overload_spread_into_rest_ts2556_tests"
 path = "tests/overload_spread_into_rest_ts2556_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/generic_conditional_rest_arity_tests.rs
+++ b/crates/tsz-checker/tests/generic_conditional_rest_arity_tests.rs
@@ -1,0 +1,149 @@
+//! Call arity of a generic signature whose rest parameter is a conditional must
+//! be computed against the *erased* signature (type parameters → `any`), so a
+//! conditional whose check still references a free type parameter does not
+//! collapse to its required branch and over-count required arguments.
+//!
+//! Regression for #14326 (arktype): for
+//! `Fn = <s>(head: readonly s[], ...[opts]: [s] extends [PropertyKey] ?
+//! [opts?: Opts] : [opts: Opts]) => void`, the call `fn([1, 2])` produced a
+//! spurious TS2554 "Expected 2 arguments, but got 1". The arity computation
+//! evaluated the rest conditional with `s` unresolved, collapsing it to the
+//! false branch `[opts: Opts]` (one required element) → min 2 args. tsc computes
+//! arity from the erased signature (`[any] extends [PropertyKey]` → true →
+//! `[opts?: Opts]`) → min 1 arg, so the call is accepted and inference then
+//! resolves `s`.
+//!
+//! Structural rule (one sentence):
+//!
+//! > When a generic signature's rest parameter is a conditional whose check
+//! > still references a free type parameter, call-argument-count bounds are
+//! > computed with those type parameters erased to `any` (tsc
+//! > `getErasedSignature` parity); a conditional with no free type parameter is
+//! > resolved normally.
+//!
+//! Lib-free: `readonly s[]` and `string | number | symbol` stand in for
+//! `ReadonlyArray<s>` / `PropertyKey` so the cases resolve without the full lib.
+//! Every test varies user-chosen names so the fix is structural, not name-keyed.
+
+use tsz_checker::test_utils::check_source_code_messages;
+
+const TS2554: u32 = 2554;
+const TS2555: u32 = 2555;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_code_messages(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .filter(|c| *c != 0)
+        .collect()
+}
+
+// ───────────────────────── 1. reported repro ──────────────────────────────
+
+#[test]
+fn generic_conditional_rest_does_not_overcount_required_args() {
+    let src = r#"
+type Opts = { a?: number };
+type Fn = <s>(head: readonly s[], ...[opts]: [s] extends [string | number | symbol] ? [opts?: Opts] : [opts: Opts]) => void;
+declare const fn: Fn;
+fn([1, 2]);
+export {};
+"#;
+    assert_eq!(
+        codes(src),
+        Vec::<u32>::new(),
+        "a generic conditional rest must not over-count required args (no TS2554)"
+    );
+}
+
+// ───────────────────── 2. binder-name variation ───────────────────────────
+
+#[test]
+fn generic_conditional_rest_renamed_binders() {
+    let src = r#"
+type Cfg = { verbose?: boolean };
+type Handler = <T>(items: readonly T[], ...[cfg]: [T] extends [string | number | symbol] ? [cfg?: Cfg] : [cfg: Cfg]) => void;
+declare const h: Handler;
+h(["a", "b"]);
+export {};
+"#;
+    assert_eq!(
+        codes(src),
+        Vec::<u32>::new(),
+        "renamed generic conditional rest must not over-count required args"
+    );
+}
+
+// ───────────────────────── 3. negative controls ───────────────────────────
+
+/// A *concrete* (non-generic) conditional rest whose check has no free type
+/// parameter must resolve normally: when it picks the required branch, the
+/// missing argument still reports TS2554. This proves the erasure is gated on
+/// free type parameters, not on the mere presence of a conditional.
+#[test]
+fn concrete_conditional_rest_required_branch_still_ts2554() {
+    let src = r#"
+type Opts = { a?: number };
+type FnC = (head: readonly object[], ...[opts]: [object] extends [string | number | symbol] ? [opts?: Opts] : [opts: Opts]) => void;
+declare const fnc: FnC;
+fnc([{}]);
+export {};
+"#;
+    assert!(
+        codes(src).contains(&TS2554),
+        "a concrete conditional rest resolving to its required branch must still emit TS2554"
+    );
+}
+
+/// A genuinely-required (non-conditional) trailing parameter still reports
+/// TS2554 — the fix only relaxes generic conditional rests.
+#[test]
+fn genuinely_required_param_still_ts2554() {
+    let src = r#"
+type Opts = { a?: number };
+type Fn2 = <s>(head: readonly s[], opts: Opts) => void;
+declare const fn2: Fn2;
+fn2([1, 2]);
+export {};
+"#;
+    assert!(
+        codes(src).contains(&TS2554),
+        "a genuinely-required second parameter must still emit TS2554"
+    );
+}
+
+/// A non-conditional generic variadic rest (`...rest: T`) keeps its normal arity
+/// treatment: a required leading parameter still drives a too-few-args error.
+/// Guards against the erasure over-relaxing non-conditional generic rests.
+#[test]
+fn non_conditional_generic_rest_keeps_arity() {
+    let src = r#"
+function f3<T extends unknown[]>(first: string, ...rest: T): void {}
+f3("a");
+f3();
+export {};
+"#;
+    let got = codes(src);
+    assert!(
+        got.contains(&TS2555) || got.contains(&TS2554),
+        "a required leading param before a generic variadic rest must still flag the empty call; got {got:?}"
+    );
+}
+
+/// Control: a concrete conditional rest resolving to its *optional* branch is
+/// accepted (no error) — the optional-branch path is unaffected.
+#[test]
+fn concrete_conditional_rest_optional_branch_ok() {
+    let src = r#"
+type Opts = { a?: number };
+type FnK = (head: readonly string[], ...[opts]: [string] extends [string | number | symbol] ? [opts?: Opts] : [opts: Opts]) => void;
+declare const fnk: FnK;
+fnk(["x"]);
+export {};
+"#;
+    assert_eq!(
+        codes(src),
+        Vec::<u32>::new(),
+        "a concrete conditional rest resolving to its optional branch must be accepted"
+    );
+}

--- a/crates/tsz-solver/src/operations/call_args.rs
+++ b/crates/tsz-solver/src/operations/call_args.rs
@@ -908,6 +908,18 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         };
 
         let rest_param_type = self.unwrap_readonly(rest_param.type_id);
+        // tsc computes call arity against the ERASED signature (its type
+        // parameters mapped to `any`, `getErasedSignature`). When a rest
+        // parameter is a conditional whose check still references a free type
+        // parameter — e.g. `...[opts]: [s] extends [PropertyKey] ? [opts?] :
+        // [opts]` — evaluating it with `s` unresolved collapses the conditional
+        // to its (false) required branch and over-counts required arguments,
+        // producing a spurious TS2554 (#14326). Erase the free type parameters
+        // of such a rest type to `any` for arity counting so the conditional
+        // resolves the branch tsc's erased-signature precheck picks. Gated to
+        // conditional-bearing rest types so bare type-parameter / `T[]` rests
+        // keep their existing arity treatment.
+        let rest_param_type = self.erase_conditional_rest_type_params_for_arity(rest_param_type);
         // Evaluate Application/Conditional/Mapped types (e.g. Parameters<Fn>) to
         // their concrete Tuple form so arity checking works correctly.
         let rest_param_type = self.evaluate_rest_param_type(rest_param_type);
@@ -923,6 +935,36 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             }
             _ => (required, None),
         }
+    }
+
+    /// Erase the free type parameters of a conditional-bearing rest-parameter
+    /// type to `any` for arity counting only (tsc `getErasedSignature` parity,
+    /// #14326). Returns the type unchanged when it carries no conditional or no
+    /// free type parameter, so non-generic and `T[]`/bare-`T` rests are
+    /// untouched. This is used only for argument-count bounds, never for the
+    /// real type of the rest parameter.
+    fn erase_conditional_rest_type_params_for_arity(&self, type_id: TypeId) -> TypeId {
+        use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
+        if !crate::type_queries::contains_conditional_type(self.interner, type_id) {
+            return type_id;
+        }
+        let free = crate::visitors::visitor_predicates::free_type_parameter_ids_in(
+            self.interner,
+            [type_id],
+        );
+        if free.is_empty() {
+            return type_id;
+        }
+        let mut sub = TypeSubstitution::new();
+        for id in free {
+            if let Some(TypeData::TypeParameter(info)) = self.interner.lookup(id) {
+                sub.insert(info.name, TypeId::ANY);
+            }
+        }
+        if sub.is_empty() {
+            return type_id;
+        }
+        instantiate_type(self.interner, type_id, &sub)
     }
 
     /// Look up the `ParamInfo` for a given argument index (non-rest only).


### PR DESCRIPTION
Fixes #14326.

## Structural rule
When a generic signature's rest parameter is a conditional whose check still
references a free type parameter, call-argument-count bounds are computed with
those type parameters erased to `any` (tsc `getErasedSignature` parity); a
conditional with no free type parameter is resolved normally.

## What was wrong
For
```ts
type Opts = { a?: number };
type Fn = <s>(head: ReadonlyArray<s>, ...[opts]: [s] extends [PropertyKey] ? [opts?: Opts] : [opts: Opts]) => void;
declare const fn: Fn;
fn([1, 2]); // tsz: spurious TS2554 "Expected 2 arguments, but got 1"
```
`arg_count_bounds` evaluated the rest conditional with `s` unresolved, collapsing
it to the false branch `[opts: Opts]` (one required element) → min 2 args. tsc
computes arity from the erased signature: `[any] extends [PropertyKey]` is true →
`[opts?: Opts]` → min 1 arg, the call is accepted, and inference then resolves
`s`.

## Owner layer
Solver — `SolverChecker::arg_count_bounds` (`crates/tsz-solver/src/operations/call_args.rs`).
A new `erase_conditional_rest_type_params_for_arity` erases the free type
parameters of a conditional-bearing rest type to `any` **for arity counting
only** (never for the real rest-parameter type), reusing the existing
`free_type_parameter_ids_in` + `instantiate_type` helpers. Gated on
`contains_conditional_type` + non-empty free type parameters, so non-generic
rests, `T[]`, and bare-`T` rests are untouched. Additive: it only changes the
computed min/max for generic conditional rests.

## Adjacent-case matrix (`generic_conditional_rest_arity_tests.rs`, 6 tests; lib-free `readonly s[]` / `string | number | symbol`)
- Repro: generic conditional rest, true branch via inference → no TS2554.
- Binder-name variation (renamed type param / conditional / members).
- Negative: a **concrete** conditional rest resolving to its required branch → still TS2554 (proves the free-type-param gate).
- Negative: a genuinely-required (non-conditional) trailing param → still TS2554.
- Negative: a non-conditional generic variadic rest (`...rest: T`) keeps its arity (empty call still flagged).
- Control: a concrete conditional rest resolving to its optional branch → accepted.

Goal: green

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo nextest run -p tsz-checker --test generic_conditional_rest_arity_tests` → 6/6 pass.
- Revert-test (stash the source fix, rebuild): the two generic-conditional repro tests fail with TS2554; all pass once restored — confirms coverage.
- Regression suites green: checker `variadic_tuple_spread_arity_ts2556_tests`, `rest_tuple_conditional_arg_tests`, `variadic_tuple_arity_inference_tests`, `tuple_arity_elaboration_tests`, `unannotated_callback_arity_tests`, `overload_spread_into_rest_ts2556_tests` (87 tests); solver `conditional_deferred_return_tests`, `conditional_infer_tuple_numeric_key_tests` (10 tests).
- Pinpointed root-cause analysis posted on #14326 (4-layer trace to `arg_count_bounds`).

Signed-off-by: M1FableArchitect
