### PR TITLE
fix(solver): erase signature type params to any for generic conditional-rest arity (#14326)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -754,6 +754,9 @@ mod conditional_keyof_test;
 #[path = "tests/conditional_never_param_inference_tests.rs"]
 mod conditional_never_param_inference_tests;
 #[cfg(test)]
+#[path = "../tests/conditional_rest_arity_erasure_tests.rs"]
+mod conditional_rest_arity_erasure_tests;
+#[cfg(test)]
 #[path = "tests/const_asserted_return_type_tests.rs"]
 mod const_asserted_return_type_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/tests/conditional_rest_arity_erasure_tests.rs
+++ b/crates/tsz-checker/tests/conditional_rest_arity_erasure_tests.rs
@@ -1,0 +1,154 @@
+//! Tests for arity computation against a generic conditional/mapped rest tuple.
+//!
+//! When a signature's trailing rest parameter is a conditional tuple whose
+//! branch is selected by the signature's own (still-uninstantiated) type
+//! parameter — e.g. `...[opts]: [s] extends [PropertyKey] ? [opts?: Opts] :
+//! [opts: Opts]` — `tsc` computes call arity against the erased signature
+//! (type parameters → `any`). `[any] extends [PropertyKey]` is true, so the
+//! permissive `[opts?: Opts]` branch is chosen and the trailing argument is
+//! optional. tsz previously evaluated the conditional with `s` unresolved,
+//! collapsing it to the false/required branch `[opts: Opts]` and over-counting
+//! the minimum argument count → spurious TS2554. See issue #14326.
+
+use crate::test_utils::check_source_codes as get_error_codes;
+
+/// Repro from arktype: generic function-type value whose conditional rest tuple
+/// resolves to the optional branch under erasure. `fn([1, 2])` is one arg and
+/// must be accepted.
+#[test]
+fn test_generic_conditional_rest_optional_branch_function_type() {
+    let codes = get_error_codes(
+        r#"
+type Opts = { a?: number };
+type Fn = <s>(head: ReadonlyArray<s>, ...[opts]: [s] extends [PropertyKey] ? [opts?: Opts] : [opts: Opts]) => void;
+declare const fn: Fn;
+fn([1, 2]);
+"#,
+    );
+    assert!(
+        !codes.contains(&2554),
+        "Should not emit TS2554 for a generic conditional rest resolving to the optional branch, got: {codes:?}"
+    );
+}
+
+/// Same shape declared as a generic function declaration.
+#[test]
+fn test_generic_conditional_rest_optional_branch_declared_fn() {
+    let codes = get_error_codes(
+        r#"
+type Opts = { a?: number };
+declare function fn<s>(head: ReadonlyArray<s>, ...[opts]: [s] extends [PropertyKey] ? [opts?: Opts] : [opts: Opts]): void;
+fn([1, 2]);
+"#,
+    );
+    assert!(
+        !codes.contains(&2554),
+        "Should not emit TS2554 for a generic conditional rest declared fn, got: {codes:?}"
+    );
+}
+
+/// Explicit type argument that satisfies the conditional's true branch is also
+/// clean (this path already worked; guards against regressing it).
+#[test]
+fn test_generic_conditional_rest_explicit_type_arg() {
+    let codes = get_error_codes(
+        r#"
+type Opts = { a?: number };
+declare function fn<s>(head: ReadonlyArray<s>, ...[opts]: [s] extends [PropertyKey] ? [opts?: Opts] : [opts: Opts]): void;
+fn<number>([1, 2]);
+"#,
+    );
+    assert!(
+        !codes.contains(&2554),
+        "Should not emit TS2554 with an explicit type argument, got: {codes:?}"
+    );
+}
+
+/// A constrained type parameter behaves the same — erasure maps `s` to `any`,
+/// not to its constraint, so the permissive branch is still selected.
+#[test]
+fn test_generic_conditional_rest_constrained_param() {
+    let codes = get_error_codes(
+        r#"
+type Opts = { a?: number };
+declare function fn<s extends number>(head: ReadonlyArray<s>, ...[opts]: [s] extends [PropertyKey] ? [opts?: Opts] : [opts: Opts]): void;
+fn([1, 2]);
+"#,
+    );
+    assert!(
+        !codes.contains(&2554),
+        "Should not emit TS2554 for a constrained generic conditional rest, got: {codes:?}"
+    );
+}
+
+/// Negative control: a generic conditional rest whose BOTH branches are
+/// required must still over-count — erasure must not silence a genuinely
+/// required trailing argument.
+#[test]
+fn test_generic_conditional_rest_both_branches_required_still_2554() {
+    let codes = get_error_codes(
+        r#"
+type Opts = { a?: number };
+declare function fn<s>(head: ReadonlyArray<s>, ...[opts]: [s] extends [PropertyKey] ? [opts: Opts] : [opts: Opts]): void;
+fn([1, 2]);
+"#,
+    );
+    assert!(
+        codes.contains(&2554),
+        "Should still emit TS2554 when the trailing argument is required in both branches, got: {codes:?}"
+    );
+}
+
+/// Negative control: a plain generic required trailing parameter still reports
+/// TS2554 when omitted.
+#[test]
+fn test_generic_required_trailing_param_still_2554() {
+    let codes = get_error_codes(
+        r#"
+type Opts = { a?: number };
+declare function fn<s>(head: ReadonlyArray<s>, opts: Opts): void;
+fn([1, 2]);
+"#,
+    );
+    assert!(
+        codes.contains(&2554),
+        "Should emit TS2554 for a genuinely required trailing parameter, got: {codes:?}"
+    );
+}
+
+/// Non-generic arity (the common path threaded with an empty type-param slice)
+/// is unaffected: a required single-element rest tuple still demands one
+/// argument, so a zero-argument call reports TS2554.
+#[test]
+fn test_concrete_required_rest_tuple_still_2554() {
+    let codes = get_error_codes(
+        r#"
+type Opts = { a?: number };
+type D = (...args: [Opts]) => void;
+declare const d: D;
+d();
+"#,
+    );
+    assert!(
+        codes.contains(&2554),
+        "Should emit TS2554 for a required rest-tuple element with no arguments, got: {codes:?}"
+    );
+}
+
+/// Non-generic arity: an optional rest-tuple element accepts the zero-argument
+/// call (the empty type-param slice means no erasure round-trip).
+#[test]
+fn test_concrete_optional_rest_tuple_ok() {
+    let codes = get_error_codes(
+        r#"
+type Opts = { a?: number };
+type C = (...args: [opts?: Opts]) => void;
+declare const c: C;
+c();
+"#,
+    );
+    assert!(
+        !codes.contains(&2554),
+        "Should not emit TS2554 for an optional rest-tuple element, got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/operations/call_args.rs
+++ b/crates/tsz-solver/src/operations/call_args.rs
@@ -7,8 +7,9 @@
 //! - Contextual sensitivity analysis (`is_contextually_sensitive`)
 
 use super::{AssignabilityChecker, CallEvaluator, CallResult};
+use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type_cached};
 use crate::operations::iterators::{get_iterator_info, target_has_non_iterable_property_shape};
-use crate::types::{ParamInfo, TemplateSpan, TupleElement, TypeData, TypeId};
+use crate::types::{ParamInfo, TemplateSpan, TupleElement, TypeData, TypeId, TypeParamInfo};
 use crate::utils::{self, TupleRestExpansion};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
@@ -884,7 +885,44 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         self.param_type_contains_void(elem.type_id)
     }
 
-    pub(crate) fn arg_count_bounds(&mut self, params: &[ParamInfo]) -> (usize, Option<usize>) {
+    /// Erase the signature's own type parameters to `any` before arity-time
+    /// evaluation of a rest-parameter type, mirroring tsc's `getErasedSignature`
+    /// / `createTypeEraser`. tsc computes call arity against the
+    /// type-parameters→`any` signature, so a rest parameter whose tuple shape is
+    /// selected by a conditional/mapped type over a still-uninstantiated type
+    /// parameter — e.g. `...[opts]: [s] extends [PropertyKey] ? [opts?: Opts] :
+    /// [opts: Opts]` — takes the permissive (`[any] extends ...`) branch instead
+    /// of collapsing to the false/required branch and over-counting required
+    /// arguments (#14326). Inference then runs and the post-inference
+    /// assignability check reports any genuinely-missing argument.
+    fn erase_sig_type_params_to_any(
+        &self,
+        type_id: TypeId,
+        type_params: &[TypeParamInfo],
+    ) -> TypeId {
+        if type_params.is_empty() {
+            return type_id;
+        }
+        let mut subst = TypeSubstitution::new();
+        for tp in type_params {
+            subst.insert(tp.name, TypeId::ANY);
+        }
+        // Cached variant: arity is computed per call, so memoize the erased
+        // rest-parameter type across repeated calls to the same generic
+        // signature. `instantiate_type_cached` fast-paths intrinsics internally.
+        instantiate_type_cached(
+            self.interner.as_type_database(),
+            Some(self.interner),
+            type_id,
+            &subst,
+        )
+    }
+
+    pub(crate) fn arg_count_bounds(
+        &mut self,
+        params: &[ParamInfo],
+        type_params: &[TypeParamInfo],
+    ) -> (usize, Option<usize>) {
         // Count required parameters, treating trailing `void`-containing params as optional.
         // In TypeScript, a parameter of type `void` (or union containing void like `number | void`)
         // can be omitted at the call site, but only if all subsequent params are also optional/void.
@@ -908,6 +946,12 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         };
 
         let rest_param_type = self.unwrap_readonly(rest_param.type_id);
+        // Erase the signature's own type parameters to `any` before evaluating
+        // the rest-parameter type, matching tsc's erased-signature arity
+        // precheck so a generic conditional/mapped rest tuple does not collapse
+        // to its required branch before inference (#14326). No-op for
+        // non-generic signatures.
+        let rest_param_type = self.erase_sig_type_params_to_any(rest_param_type, type_params);
         // Evaluate Application/Conditional/Mapped types (e.g. Parameters<Fn>) to
         // their concrete Tuple form so arity checking works correctly.
         let rest_param_type = self.evaluate_rest_param_type(rest_param_type);

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -1460,7 +1460,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             };
 
         // Check argument count
-        let (min_args, max_args) = self.arg_count_bounds(&func.params);
+        let (min_args, max_args) = self.arg_count_bounds(&func.params, &func.type_params);
 
         if arg_types.len() < min_args {
             // For variadic tuple rest params (e.g. `...args: [...T[], Required]`),

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -202,7 +202,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 continue;
             };
             let source_shape = self.normalize_function_shape_params_for_context(&source_shape);
-            let (callback_min, callback_max) = self.arg_count_bounds(&source_shape.params);
+            let (callback_min, callback_max) =
+                self.arg_count_bounds(&source_shape.params, &source_shape.type_params);
 
             if rest_arg_count < callback_min || callback_max.is_some_and(|max| rest_arg_count > max)
             {
@@ -237,7 +238,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             .any(|arg| self.is_contextually_sensitive(arg));
         // Check argument count BEFORE type inference
         // This prevents false positive TS2554 errors for generic functions with optional/rest params
-        let (min_args, max_args) = self.arg_count_bounds(&func.params);
+        let (min_args, max_args) = self.arg_count_bounds(&func.params, &func.type_params);
 
         if arg_types.len() < min_args {
             return CallResult::ArgumentCountMismatch {

--- a/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
@@ -1012,7 +1012,9 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             })
             .collect();
         if !rest_param_from_constraint_fallback {
-            let (min_args, max_args) = self.arg_count_bounds(&instantiated_params);
+            // Params are already instantiated with the inferred type arguments,
+            // so the signature's type parameters are resolved — no erasure.
+            let (min_args, max_args) = self.arg_count_bounds(&instantiated_params, &[]);
             if arg_types.len() < min_args {
                 return CallResult::ArgumentCountMismatch {
                     expected_min: min_args,


### PR DESCRIPTION
Fixes #14326.

## Structural rule
When a generic signature's trailing rest parameter is a conditional/mapped tuple
whose branch is selected by the signature's **own** type parameter — e.g.
`...[opts]: [s] extends [PropertyKey] ? [opts?: Opts] : [opts: Opts]` — tsc
computes call arity against the **erased** signature (type parameters → `any`,
`getErasedSignature` / `createTypeEraser`). `[any] extends [PropertyKey]` is
true, so the rest is `[opts?: Opts]` (optional) and the call type-checks; only
afterward does inference resolve `s` and re-check arity post-instantiation.

tsz evaluated the conditional with `s` still uninstantiated, collapsing it to the
false/required branch `[opts: Opts]`, over-counting the minimum argument count
and emitting a spurious **TS2554**:

`When a signature's rest-parameter type is a conditional/mapped tuple selected by
that signature's own type parameter, tsc computes arity against the
type-parameters→any erased signature; tsz now erases the rest-parameter type the
same way before the arity gate, so the permissive branch is chosen and
optionality is computed pre-inference, with the genuine error (if any) surfaced
by the post-inference assignability check.`

So `fn([1, 2])` for
`type Fn = <s>(head: ReadonlyArray<s>, ...[opts]: [s] extends [PropertyKey] ? [opts?: Opts] : [opts: Opts]) => void`
no longer emits a false TS2554.

## Owner layer
Solver — `CallEvaluator::arg_count_bounds`
(`crates/tsz-solver/src/operations/call_args.rs`). A new
`erase_sig_type_params_to_any` helper maps the signature's type parameters to
`any` and instantiates the rest-parameter type (via the cached instantiation
path) **before** `evaluate_rest_param_type`. The four arity call sites thread the
signature's `type_params`:
- `core/call_resolution.rs` (non-generic path — slice is empty, no-op).
- `generic_call/resolve.rs` generic-call-before-inference gate (the fix path)
  and the contextual-callback arity check.
- `generic_call/resolve/finalize.rs` post-inference gate passes `&[]` — its
  params are already instantiated with the inferred type arguments, so erasure
  must not run.

## Fallback / safety
- Erasure maps each type parameter to `any` (matching tsc), **not** to its
  constraint, so a constrained `s` still selects the permissive branch.
- Non-rest parameter optionality is a declared `?` / trailing-`void` flag (read
  from `ParamInfo`, never type-evaluated), so it needs no erasure — the change is
  scoped to the one place a type is evaluated for arity.
- The guard returns early for non-generic signatures (empty `type_params`), so
  the common hot-path call pays nothing.
- Genuinely-required trailing args still report TS2554: a conditional whose
  **both** branches are required, and a plain required trailing parameter, are
  unaffected.

## Adjacent matrix
- Generic conditional rest resolving to `[opts?]` (function-type value + declared
  fn), explicit type argument, constrained type parameter, `ReadonlyArray`-wrapped
  check.
- Negative controls: conditional with both branches required → TS2554; plain
  generic required trailing param → TS2554; concrete required/optional rest tuple
  arity unchanged.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-checker --lib conditional_rest_arity_erasure` — new file,
  8 tests, registered in `lib.rs` (tsz-checker sets `autotests = false`): 8/8.
- Regression: `cargo test -p tsz-checker --lib -- void_param_optionality
  variadic_tuple rest_tuple spread_rest tuple_rest arg_count argument_count` →
  218/219; the single failure
  (`spread_rest_tests::test_array_like_rest_rejects_aggregate_rest_arguments`,
  "Cannot find global type 'NewableFunction'") reproduces unchanged on
  `origin/main` with this change stashed — a pre-existing local stale-lib
  artifact, not introduced here.
- `cargo test -p tsz-solver --lib -- arg_count arity rest_param min_arg` → 75/75.
- `cargo clippy -p tsz-solver` clean; `cargo fmt` applied.

https://claude.ai/code/session_01Sb7vnDe5rqrRLMEW3KMWp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sb7vnDe5rqrRLMEW3KMWp7)_