### PR TITLE
fix(checker): import named like a global constructor shadows the global in value position (TS2348)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -928,6 +928,9 @@ mod identifier_relation_routing_arch_tests;
 #[path = "tests/import_attributes_relation_routing_arch_tests.rs"]
 mod import_attributes_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/import_shadows_global_ctor_tests.rs"]
+mod import_shadows_global_ctor_tests;
+#[cfg(test)]
 #[path = "tests/imported_predicate_false_branch_tests.rs"]
 mod imported_predicate_false_branch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/test_utils.rs
+++ b/crates/tsz-checker/src/test_utils.rs
@@ -1113,7 +1113,8 @@ pub fn check_source_with_libs_code_messages(
 mod multi_file;
 pub use multi_file::{
     check_all_multi_file_with_global_index, check_multi_file, check_multi_file_with_global_index,
-    check_multi_file_with_libs, check_multi_file_with_type_params_cache,
+    check_multi_file_with_libs, check_multi_file_with_libs_stamped,
+    check_multi_file_with_type_params_cache,
 };
 
 #[cfg(test)]

--- a/crates/tsz-checker/src/test_utils/multi_file.rs
+++ b/crates/tsz-checker/src/test_utils/multi_file.rs
@@ -227,15 +227,56 @@ pub fn check_multi_file_with_libs(
     options: CheckerOptions,
     lib_files: &[Arc<LibFile>],
 ) -> Vec<Diagnostic> {
+    check_multi_file_with_libs_impl(files, entry_file, options, lib_files, false)
+}
+
+/// Like [`check_multi_file_with_libs`] but production-faithful with respect to
+/// per-file symbol provenance: each binder is given its file index *before*
+/// binding, so `BinderState::stamp_file_idx` records every module-local
+/// symbol's `decl_file_idx` exactly as the driver's bind-result reducer does.
+/// It also wires the `global_symbol_file_index`.
+///
+/// Tests that depend on `symbol_is_from_actual_or_cloned_lib` (which uses
+/// `decl_file_idx` to distinguish module-local symbols from lib globals) must
+/// use this helper: the plain [`check_multi_file_with_libs`] leaves
+/// `decl_file_idx == u32::MAX`, which makes a module-local symbol that shadows
+/// a lib global look like the lib symbol.
+pub fn check_multi_file_with_libs_stamped(
+    files: &[(&str, &str)],
+    entry_file: &str,
+    options: CheckerOptions,
+    lib_files: &[Arc<LibFile>],
+) -> Vec<Diagnostic> {
+    check_multi_file_with_libs_impl(files, entry_file, options, lib_files, true)
+}
+
+/// Shared body for [`check_multi_file_with_libs`] and
+/// [`check_multi_file_with_libs_stamped`]. When `stamp` is set, each binder is
+/// given its file index before binding (so `stamp_file_idx` records
+/// `decl_file_idx`) and the `global_symbol_file_index` is wired — matching the
+/// production driver. When unset, this is the lib-aware counterpart to
+/// [`check_multi_file`] that leaves `decl_file_idx == u32::MAX`.
+fn check_multi_file_with_libs_impl(
+    files: &[(&str, &str)],
+    entry_file: &str,
+    options: CheckerOptions,
+    lib_files: &[Arc<LibFile>],
+    stamp: bool,
+) -> Vec<Diagnostic> {
     let mut arenas = Vec::with_capacity(files.len());
     let mut binders = Vec::with_capacity(files.len());
     let mut roots = Vec::with_capacity(files.len());
     let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
 
-    for (name, source) in files {
+    for (file_idx, (name, source)) in files.iter().enumerate() {
         let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
         let root = parser.parse_source_file();
         let mut binder = BinderState::new();
+        if stamp {
+            // Stamp the driver-assigned file index before binding so that
+            // `stamp_file_idx` runs at bind end and records `decl_file_idx`.
+            binder.set_file_idx(file_idx as u32);
+        }
         if lib_files.is_empty() {
             binder.bind_source_file(parser.get_arena(), root);
         } else {
@@ -283,6 +324,20 @@ pub fn check_multi_file_with_libs(
         .ctx
         .set_resolved_module_paths(Arc::new(resolved_module_paths));
     checker.ctx.set_resolved_modules(resolved_modules);
+
+    if stamp {
+        // Build the immutable declaring-file index (SymbolId -> file_idx) like
+        // the driver's `build_global_symbol_file_index`.
+        let mut symbol_file_index = rustc_hash::FxHashMap::default();
+        for (file_idx, binder) in all_binders.iter().enumerate() {
+            for symbol in binder.symbols.iter() {
+                symbol_file_index.entry(symbol.id).or_insert(file_idx);
+            }
+        }
+        checker
+            .ctx
+            .set_global_symbol_file_index(Arc::new(symbol_file_index));
+    }
 
     checker.check_source_file(roots[entry_idx]);
     checker.ctx.diagnostics.clone()

--- a/crates/tsz-checker/src/tests/import_shadows_global_ctor_tests.rs
+++ b/crates/tsz-checker/src/tests/import_shadows_global_ctor_tests.rs
@@ -1,0 +1,167 @@
+//! Regression tests for false TS2348 when an imported value binding is named
+//! like a global constructor (`Promise`, `Map`, `Object`, ...).
+//!
+//! Structural rule: a module-scoped import binding lexically shadows the
+//! ambient global of the same name. When the imported binding is used in call
+//! position, tsc resolves to the *imported* value, not the global constructor.
+//! tsz previously let a known-global value-recovery override the import alias
+//! (the alias symbol carries `ALIAS` but not `VALUE`), so the call resolved to
+//! the non-callable global constructor and emitted a false TS2348.
+//!
+//! Mined from **typebox**. Issue:
+//! <https://github.com/tsz-org/tsz/issues/14263>
+
+use std::sync::{Arc, OnceLock};
+use tsz_binder::lib_loader::LibFile;
+use tsz_common::common::ModuleKind;
+
+use crate::CheckerOptions;
+use crate::test_utils::{check_multi_file_with_libs_stamped, load_default_lib_files};
+
+fn default_libs() -> &'static [Arc<LibFile>] {
+    static DEFAULT_LIBS: OnceLock<Vec<Arc<LibFile>>> = OnceLock::new();
+    DEFAULT_LIBS.get_or_init(load_default_lib_files)
+}
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        module: ModuleKind::ESNext,
+        ..CheckerOptions::default()
+    }
+}
+
+fn ts2348_count(files: &[(&str, &str)], entry: &str) -> usize {
+    check_multi_file_with_libs_stamped(files, entry, opts(), default_libs())
+        .iter()
+        .filter(|d| d.code == 2348)
+        .count()
+}
+
+const LIB: &str = "export function Promise(x: number): string { return \"\"; }\n\
+    export function Map(x: number): string { return \"\"; }\n\
+    export function Object(x: number): string { return \"\"; }\n";
+
+#[test]
+fn imported_value_named_like_global_ctor_shadows_global_in_call() {
+    let files = &[
+        ("lib.ts", LIB),
+        (
+            "main.ts",
+            "import { Promise, Map, Object } from \"./lib\";\n\
+             const a: string = Promise(1);\n\
+             const b: string = Map(2);\n\
+             const c: string = Object(3);\n\
+             export {};\n",
+        ),
+    ];
+    assert_eq!(
+        ts2348_count(files, "main.ts"),
+        0,
+        "imported value named like a global constructor must shadow the global in call position"
+    );
+}
+
+#[test]
+fn renamed_import_to_global_ctor_name_shadows_global_in_call() {
+    let files = &[
+        (
+            "lib.ts",
+            "export function p(x: number): string { return \"\"; }\n",
+        ),
+        (
+            "main.ts",
+            "import { p as Promise } from \"./lib\";\n\
+             const a: string = Promise(1);\n\
+             export {};\n",
+        ),
+    ];
+    assert_eq!(
+        ts2348_count(files, "main.ts"),
+        0,
+        "renamed import to a global-constructor name must shadow the global in call position"
+    );
+}
+
+#[test]
+fn reexported_import_to_global_ctor_name_shadows_global_in_call() {
+    let files = &[
+        (
+            "lib.ts",
+            "export function local(x: number): string { return \"\"; }\n",
+        ),
+        ("reexport.ts", "export { local as Map } from \"./lib\";\n"),
+        (
+            "main.ts",
+            "import { Map } from \"./reexport\";\n\
+             const b: string = Map(2);\n\
+             export {};\n",
+        ),
+    ];
+    assert_eq!(
+        ts2348_count(files, "main.ts"),
+        0,
+        "re-exported import to a global-constructor name must shadow the global in call position"
+    );
+}
+
+#[test]
+fn no_import_global_ctor_still_resolves_to_non_callable_global() {
+    // Negative control: without an import binding, `Promise` resolves to the
+    // global PromiseConstructor, which is not callable → genuine TS2348.
+    let files = &[("main.ts", "const a = Promise(1);\nexport {};\n")];
+    assert_eq!(
+        ts2348_count(files, "main.ts"),
+        1,
+        "without an import, the global Promise constructor is not callable (genuine TS2348)"
+    );
+}
+
+#[test]
+fn module_local_function_named_like_global_ctor_is_callable_in_same_module() {
+    // A module-local `export function Promise` shadows the global value even
+    // when referenced directly in the same module. The binder preserves the
+    // lib's `interface Promise` TYPE meaning, so the merged symbol carries
+    // INTERFACE+FUNCTION, but the value side is the user's function — not the
+    // non-callable PromiseConstructor.
+    let files = &[(
+        "main.ts",
+        "export function Promise(x: number): string { return \"\"; }\n\
+         const a: string = Promise(1);\n",
+    )];
+    assert_eq!(
+        ts2348_count(files, "main.ts"),
+        0,
+        "a module-local function named like a global constructor must be callable"
+    );
+}
+
+#[test]
+fn imported_value_named_like_global_ctor_returns_imported_value_type() {
+    // The imported binding's return type (`string`) must flow through, proving
+    // we resolved the imported function — not the global constructor.
+    let files = &[
+        (
+            "lib.ts",
+            "export function Promise(x: number): number { return x; }\n",
+        ),
+        (
+            "main.ts",
+            // Assigning the `number` result to a `string` annotation must fail
+            // with TS2322 — which only happens if `Promise(1)` typed as the
+            // imported function returning `number`.
+            "import { Promise } from \"./lib\";\nconst a: string = Promise(1);\nexport {};\n",
+        ),
+    ];
+    let diags = check_multi_file_with_libs_stamped(files, "main.ts", opts(), default_libs());
+    assert_eq!(
+        diags.iter().filter(|d| d.code == 2348).count(),
+        0,
+        "imported function must be callable (no TS2348)"
+    );
+    assert_eq!(
+        diags.iter().filter(|d| d.code == 2322).count(),
+        1,
+        "the imported function's `number` return must not assign to a `string` (TS2322)"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/identifier/resolved.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/resolved.rs
@@ -1057,16 +1057,6 @@ impl CheckerState<'_> {
                 constructor_name = %constructor_name,
                 "get_type_of_identifier: looking for *Constructor symbol"
             );
-            // Only a *true lib global* models its value side through a
-            // `*Constructor` companion. A module-local declaration named like a
-            // global (`export function Promise() {}`, including one reached
-            // through an import alias) carries the lib's INTERFACE meaning in
-            // the type namespace — the binder preserves it when the declaration
-            // shadows the global value — but its value side is the user's own
-            // function, so substituting the non-callable constructor would emit
-            // a false TS2348. Gate the override on lib provenance, the same
-            // predicate `lib_constructor_companion` above uses.
-            let symbol_is_lib_global = self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id);
             // Use find_value_symbol_in_libs (not resolve_global_value_symbol) to get
             // the correct VALUE symbol. resolve_global_value_symbol can return the
             // wrong symbol when there are name collisions in file_locals.
@@ -1089,15 +1079,8 @@ impl CheckerState<'_> {
                         value_type
                     } else if (flags & tsz_binder::symbol_flags::CLASS) != 0 {
                         self.merge_interface_types(value_type, constructor_type)
-                    } else if symbol_is_lib_global {
-                        // True lib global: the `*Constructor` companion is the
-                        // authoritative value-position type.
-                        constructor_type
                     } else {
-                        // Module-local declaration that merely shadows the global
-                        // (e.g. an imported `export function Promise`): keep its
-                        // own value type instead of the lib constructor.
-                        value_type
+                        constructor_type
                     };
                 }
             } else {

--- a/crates/tsz-checker/src/types/computation/identifier/resolved.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/resolved.rs
@@ -343,8 +343,17 @@ impl CheckerState<'_> {
         symbol_declarations: &[NodeIndex],
         is_umd_export: bool,
     ) -> Option<TypeId> {
+        // Recover a known-global value (`Promise`, `Map`, ...) for a symbol with
+        // no VALUE flag — this handles a type-only declaration merging with the
+        // lib's value side. Exclude import ALIASes: an import is a real local
+        // binding that lexically shadows the ambient global, so the recovery
+        // must not replace it with the non-callable global constructor (false
+        // TS2348). Type-only aliases are already handled in
+        // `resolved_identifier_pre_flag_meaning`, so any ALIAS reaching here is
+        // a value binding resolved downstream to the imported value's type.
         if !self.is_identifier_in_type_position(idx)
             && (flags & symbol_flags::VALUE) == 0
+            && (flags & symbol_flags::ALIAS) == 0
             && self.is_known_global_value_name(name)
         {
             let value_type = self.type_of_value_symbol_by_name(name);
@@ -1048,6 +1057,16 @@ impl CheckerState<'_> {
                 constructor_name = %constructor_name,
                 "get_type_of_identifier: looking for *Constructor symbol"
             );
+            // Only a *true lib global* models its value side through a
+            // `*Constructor` companion. A module-local declaration named like a
+            // global (`export function Promise() {}`, including one reached
+            // through an import alias) carries the lib's INTERFACE meaning in
+            // the type namespace — the binder preserves it when the declaration
+            // shadows the global value — but its value side is the user's own
+            // function, so substituting the non-callable constructor would emit
+            // a false TS2348. Gate the override on lib provenance, the same
+            // predicate `lib_constructor_companion` above uses.
+            let symbol_is_lib_global = self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id);
             // Use find_value_symbol_in_libs (not resolve_global_value_symbol) to get
             // the correct VALUE symbol. resolve_global_value_symbol can return the
             // wrong symbol when there are name collisions in file_locals.
@@ -1070,8 +1089,15 @@ impl CheckerState<'_> {
                         value_type
                     } else if (flags & tsz_binder::symbol_flags::CLASS) != 0 {
                         self.merge_interface_types(value_type, constructor_type)
-                    } else {
+                    } else if symbol_is_lib_global {
+                        // True lib global: the `*Constructor` companion is the
+                        // authoritative value-position type.
                         constructor_type
+                    } else {
+                        // Module-local declaration that merely shadows the global
+                        // (e.g. an imported `export function Promise`): keep its
+                        // own value type instead of the lib constructor.
+                        value_type
                     };
                 }
             } else {


### PR DESCRIPTION
Fixes #14263.

## Structural rule
When a module imports a value binding whose local name equals a global constructor/value (`Promise`/`Map`/`Object`/`Array`/`String`/`Date`/`Number`, including `import { orig as Name }` renames and `export { local as Name }` re-exports) and uses it in value/call position, `tsc` resolves to the imported value. The import lexically shadows the ambient global. tsz let known-global value recovery override an import alias, so the call resolved to the non-callable ambient constructor and emitted false `TS2348`.

`When a module value reference resolves to an import binding named like a global constructor, tsc uses the imported value; tsz now does too instead of recovering the ambient global constructor.`

## Owner layer
Checker, in resolved-identifier value typing: `crates/tsz-checker/src/types/computation/identifier/resolved.rs`.

The fix is intentionally narrow: `resolved_identifier_meaning_guards` no longer runs known-global value recovery when the resolved symbol is an `ALIAS`. Import aliases carry `ALIAS` but not `VALUE`, and type-only aliases are already handled earlier in `resolved_identifier_pre_flag_meaning`, so an `ALIAS` reaching this guard is a value binding that must resolve downstream to the imported value.

## Fallback / safety
- The merged-interface `*Constructor` companion path is unchanged from `main`; the conformance repair removed the broader provenance gate because CI exposed a Linux-only regression in `inferentialTypingWithFunctionTypeZip.ts`.
- The decision is based on symbol flags, not user-chosen names, file names, source text, or rendered diagnostic strings.

## Adjacent matrix
- Direct `import { Promise, Map, Object }` call.
- `import { p as Promise }` rename.
- `export { local as Map }` re-export consumed in a third file.
- Module-local `export function Promise` referenced in the same module.
- Imported function return type flows through (`number` return -> `TS2322` against a `string` annotation).
- Negative control: no import -> bare `Promise(1)` still reports genuine `TS2348`.

Goal: green

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high

## Verification
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter inferentialTypingWithFunctionTypeZip --verbose` -> 1/1 passed.
- `python3 scripts/arch/arch_guard.py` -> passed.
- `scripts/arch/check-checker-boundaries.sh` -> passed.
- `git diff --check` -> clean.
- CLI smokes with `.target/dist-fast/tsz --noEmit`: direct import, rename, re-export, same-module local function, imported return-type `TS2322`, and no-import `TS2348` negative control.
- Attempted `scripts/safe-run.sh cargo nextest run -p tsz-checker import_shadows_global`; blocked locally by `ENOSPC` while linking debug test binaries after the focused conformance build had passed.
