### PR TITLE
fix(solver): reduce concrete-check this-relative conditional members before relating (TS2344)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -908,6 +908,9 @@ path = "tests/inline_conditional_infer_return_tests.rs"
 name = "inline_conditional_generic_ref_infer_false_branch_tests"
 path = "tests/inline_conditional_generic_ref_infer_false_branch_tests.rs"
 [[test]]
+name = "this_relative_infer_member_constraint_14385_tests"
+path = "tests/this_relative_infer_member_constraint_14385_tests.rs"
+[[test]]
 name = "conditional_alias_lib_application_tests"
 path = "tests/conditional_alias_lib_application_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/this_relative_infer_member_constraint_14385_tests.rs
+++ b/crates/tsz-checker/tests/this_relative_infer_member_constraint_14385_tests.rs
@@ -1,0 +1,151 @@
+//! Regression tests for #14385.
+//!
+//! Structural rule: when two object types are related and a `this`-relative
+//! member is an `infer`-introducing conditional over a deferred `this[...]`
+//! indexed access (e.g. `this["rawArgs"] extends infer a extends unknown[] ? a
+//! : never`), binding each member's `this` to its own receiver leaves the
+//! member as a deferred `Conditional` keyed on that receiver. The two members
+//! then differ only by receiver and the relation reports them as unrelated even
+//! though both reduce to the same concrete branch (here `never`). `tsc` reduces
+//! a conditional once its check type is concrete, so the members relate and the
+//! enclosing generic constraint is satisfied — no spurious TS2344.
+//!
+//! Mined from the higher-kinded-type `Fn` combinator pattern in `hotscript`,
+//! where `PartialApply extends Fn` is checked against an `Fn | unset`
+//! constraint.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn diagnostics(source: &str) -> Vec<(u32, String)> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+        &libs,
+    )
+    .iter()
+    .map(|diagnostic| (diagnostic.code, diagnostic.message_text.clone()))
+    .collect()
+}
+
+fn assert_clean(source: &str, label: &str) {
+    let diagnostics = diagnostics(source);
+    assert!(
+        diagnostics.is_empty(),
+        "[{label}] expected clean, got {diagnostics:?}"
+    );
+}
+
+/// The witnessed repro: an `infer`-bearing `this`-relative conditional member on
+/// a self-referential interface used as both heritage base and generic
+/// constraint. `tsc` accepts; tsz previously emitted TS2344.
+#[test]
+fn partial_apply_satisfies_fn_union_unset_constraint() {
+    let source = r#"
+declare const unsetSym: unique symbol;
+type unset = typeof unsetSym;
+
+interface Fn {
+  rawArgs: unknown;
+  args: this["rawArgs"] extends infer a extends unknown[] ? a : never;
+  return: unknown;
+}
+
+interface PartialApply<fn extends Fn, partialArgs extends unknown[]> extends Fn {
+  rawArgs: unknown;
+  return: never;
+}
+
+type Apply<fn extends Fn | unset, args> = fn extends Fn ? fn : never;
+type Get<K> = PartialApply<Fn, [K]>;
+type X = Apply<Get<"length">, []>;
+export {};
+"#;
+    assert_clean(source, "PartialApply<Fn> satisfies Fn | unset");
+}
+
+/// Same structural shape with every binder renamed — guards against any
+/// name-driven fast path (anti-hardcoding).
+#[test]
+fn renamed_binders_keep_the_constraint_clean() {
+    let source = r#"
+declare const NONE: unique symbol;
+
+interface Hkt {
+  raw: unknown;
+  out: this["raw"] extends infer r extends unknown[] ? r : never;
+  ret: unknown;
+}
+
+interface Bind<f extends Hkt, ps extends unknown[]> extends Hkt {
+  raw: unknown;
+  ret: never;
+}
+
+type Run<f extends Hkt | typeof NONE, a> = f extends Hkt ? f : never;
+type Pick1<K> = Bind<Hkt, [K]>;
+type Y = Run<Pick1<"size">, []>;
+export {};
+"#;
+    assert_clean(source, "renamed HKT binders stay clean");
+}
+
+/// The `this`-relative conditional member declared directly on the derived
+/// interface (not inherited) is also accepted.
+#[test]
+fn member_declared_on_derived_interface_is_clean() {
+    let source = r#"
+declare const unsetSym: unique symbol;
+type unset = typeof unsetSym;
+
+interface Fn {
+  rawArgs: unknown;
+  return: unknown;
+}
+
+interface PartialApply<fn extends Fn, partialArgs extends unknown[]> extends Fn {
+  rawArgs: unknown;
+  args: this["rawArgs"] extends infer a extends unknown[] ? a : never;
+  return: never;
+}
+
+type Apply<fn extends Fn | unset, args> = fn extends Fn ? fn : never;
+type Get<K> = PartialApply<Fn, [K]>;
+type X = Apply<Get<"length">, []>;
+export {};
+"#;
+    assert_clean(source, "member declared on derived interface");
+}
+
+/// Two independent instantiations of the same generic combinator both relate
+/// against the constraint — the reduction is per-receiver, not a one-shot
+/// cache artifact.
+#[test]
+fn two_instantiations_both_clean() {
+    let source = r#"
+declare const Sym: unique symbol;
+
+interface Fn {
+  rawArgs: unknown;
+  args: this["rawArgs"] extends infer a extends unknown[] ? a : never;
+  return: unknown;
+}
+
+interface PartialApply<fn extends Fn, partialArgs extends unknown[]> extends Fn {
+  rawArgs: unknown;
+  return: never;
+}
+
+type Apply<fn extends Fn | typeof Sym, args> = fn extends Fn ? fn : never;
+type Get<K> = PartialApply<Fn, [K]>;
+type X1 = Apply<Get<"a">, []>;
+type X2 = Apply<Get<"b">, []>;
+export {};
+"#;
+    assert_clean(source, "two instantiations both clean");
+}

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -32,6 +32,22 @@ pub(crate) use crate::limits::{
 };
 pub use crate::limits::{lazy_resolve_failure_count, reset_subtype_thread_local_state};
 
+/// Whether the relation reduces two deferred `Conditional` operands whose check
+/// types are concrete (the branch is decidable) and relates the reduced forms
+/// before falling back to the raw deferred-conditional comparison.
+///
+/// Default-on; `TSZ_DISABLE_RELATION_CONDITIONAL_REDUCTION=1` is the kill switch
+/// that restores the prior behavior, where two `this`-relative conditional
+/// members that only reduce once their receivers are concrete stay divergent
+/// and produce a spurious non-subtype verdict (issue #14385).
+fn relation_conditional_reduction_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| {
+        !std::env::var("TSZ_DISABLE_RELATION_CONDITIONAL_REDUCTION").is_ok_and(|v| v == "1")
+    })
+}
+
 /// One recorded `Ternary.Maybe`-style relation outcome awaiting validation by
 /// the outermost frame of its checker instance (tsc `maybeKeys` parity).
 ///
@@ -743,6 +759,53 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 finish_frame!(SubtypeResult::True);
                 leave_global!();
                 return SubtypeResult::True;
+            }
+        }
+
+        // Two deferred conditionals whose CHECK types are concrete (no free type
+        // parameters and no unsubstituted `this`) have a decidable branch, so tsc
+        // reduces each to its concrete branch and relates those. This is the
+        // `this`-relative member case: a member typed
+        // `this[K] extends infer a extends unknown[] ? a : never` is bound to its
+        // source and target receivers by `bind_property_receiver_this`, which
+        // substitutes `this` but leaves the conditional deferred. The two members
+        // then differ only by receiver (distinct `Conditional` ids over different
+        // indexed-access check types) and the raw deferred-conditional path below
+        // reports them unrelated, even though both reduce to the same branch (often
+        // `never`). Reduce both and relate the results; only conclude `True` here —
+        // a non-relating reduction falls through to the existing paths unchanged, so
+        // this can only add tsc-aligned successes, never new rejections. The check
+        // types being concrete keeps the reduction safe from the infer-binding
+        // over-acceptance the raw path below guards against (issue #14385).
+        // Kill switch: `TSZ_DISABLE_RELATION_CONDITIONAL_REDUCTION=1`.
+        if !self.bypass_evaluation
+            && let Some(source_cond_id) = conditional_type_id(self.interner, source)
+            && let Some(target_cond_id) = conditional_type_id(self.interner, target)
+            && relation_conditional_reduction_enabled()
+        {
+            let source_check = self.interner.get_conditional(source_cond_id).check_type;
+            let target_check = self.interner.get_conditional(target_cond_id).check_type;
+            let check_decidable = |check: TypeId| {
+                !crate::visitor::contains_type_parameters(self.interner, check)
+                    && !contains_this_type(self.interner, check)
+            };
+            if check_decidable(source_check) && check_decidable(target_check) {
+                let source_eval = self.evaluate_type(source);
+                let target_eval = self.evaluate_type(target);
+                if source_eval != source
+                    && target_eval != target
+                    && conditional_type_id(self.interner, source_eval).is_none()
+                    && conditional_type_id(self.interner, target_eval).is_none()
+                    && self.check_subtype(source_eval, target_eval).is_true()
+                {
+                    if let Some(dp) = def_entered {
+                        self.def_guard.leave(dp);
+                    }
+                    self.guard.leave(pair);
+                    finish_frame!(SubtypeResult::True);
+                    leave_global!();
+                    return SubtypeResult::True;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Structural rule: **when two object types are related and a `this`-relative member is an `infer`-bearing conditional over a deferred `this[...]` indexed access (e.g. `this["rawArgs"] extends infer a extends unknown[] ? a : never`), tsc reduces each member once its receiver makes the check type concrete (both collapse to the same branch, here `never`) and relates them; tsz left them as divergent `Conditional`s keyed on different receivers and reported a non-subtype, emitting a spurious TS2344.**

Mined from the higher-kinded-type `Fn` combinator pattern in **hotscript**: `PartialApply extends Fn` checked against an `Fn | unset` constraint (`Tuples.Map<…>`). Repro (tsc 6.0.2 clean, tsz previously `TS2344`):

```ts
declare const unsetSym: unique symbol;
type unset = typeof unsetSym;
interface Fn {
  rawArgs: unknown;
  args: this["rawArgs"] extends infer a extends unknown[] ? a : never;
  return: unknown;
}
interface PartialApply<fn extends Fn, partialArgs extends unknown[]> extends Fn {
  rawArgs: unknown;
  return: never;
}
type Apply<fn extends Fn | unset, args> = fn extends Fn ? fn : never;
type Get<K> = PartialApply<Fn, [K]>;
type X = Apply<Get<"length">, []>;   // tsz: TS2344; tsc: clean
```

## Root cause / owner

Owner layer: **solver** — `crates/tsz-solver/src/relations/subtype/cache.rs` (`check_subtype`).

`bind_property_receiver_this` (`relations/subtype/rules/objects.rs`) substitutes each member's `this` with its own receiver but leaves the conditional deferred. The two members then differ only by receiver (distinct `Conditional` ids over different indexed-access check types). The structural compare fails, but both members `evaluate_type` to `never`. `check_subtype` skips meta-type reduction while `bypass_evaluation` is set (it runs inside the evaluator), so the divergent `Conditional`s never collapse and the constraint validation reports the type argument as not satisfying its constraint.

## Fix

Add a pre-pass in `check_subtype`: when **both** operands are conditionals whose **check types are concrete** (no free type parameters and no unsubstituted `this`, so the branch is decidable), reduce both and relate the reduced forms — concluding only `True`. A non-relating reduction falls through to the existing paths unchanged, so this can only add tsc-aligned successes, never new rejections. The concrete-check gate keeps the reduction safe from the infer-binding over-acceptance the adjacent raw deferred-conditional path guards against. Gated by the `TSZ_DISABLE_RELATION_CONDITIONAL_REDUCTION=1` kill switch.

This is structural (no name/file/source-text predicates): it keys only on `conditional_type_id`, `contains_type_parameters`, `contains_this_type`, and the relation outcome of the reduced forms.

Closes #14385.

## Adjacent-case matrix

All clean in both tsc and tsz with the fix (see new test file):
- inherited `infer` member on the heritage base (the bug);
- the same member **declared on the derived interface**;
- **every binder renamed** (anti-hardcoding — no name-driven path);
- **two independent instantiations** both satisfy the constraint (reduction is per-receiver, not a one-shot cache artifact).

## Goal
Goal: green

## Verification
- New regression suite `this_relative_infer_member_constraint_14385_tests` (4 cases): `cargo test -p tsz-checker --test this_relative_infer_member_constraint_14385_tests` → 4 passed.
- Repro `min3.ts` flips tsz `TS2344` → clean; `TSZ_DISABLE_RELATION_CONDITIONAL_REDUCTION=1` reverts it (kill-switch attribution).
- `cargo fmt -p tsz-solver -p tsz-checker -- --check` clean; `cargo clippy -p tsz-solver` clean.
- Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01KeRWcSHqjGaqg1CzeRhpcd

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeRWcSHqjGaqg1CzeRhpcd)_