### PR TITLE
fix(solver): stack-growth guard on infer-match recursion so recursive-conditional infer degrades to TS2589 not SIGABRT (#14123)

### DIFF
--- a/crates/tsz-checker/tests/issue_14123_repro_tests.rs
+++ b/crates/tsz-checker/tests/issue_14123_repro_tests.rs
@@ -81,3 +81,104 @@ const bad: { id: 1 } = value;
         "mismatched target must report exactly one TS2322. Got: {c:?}"
     );
 }
+
+/// Reopened witness #1 (issue comment, 2026-06-20): a recursive conditional that
+/// unwraps `infer` through *nested generic-alias containers* — `Box<T> =
+/// Promise<Set<T>>` — used to SIGABRT because the `infer V` extraction from the
+/// alias-`Application` source minted a fresh `Application` each step and never
+/// recognized convergence. It must converge to `{ id: 0 }`. Binders renamed so
+/// the guard is structural.
+#[test]
+fn issue_14123_nested_alias_container_infer_converges() {
+    let c = codes(
+        r#"
+type Peel<K> =
+    K extends Promise<infer M> ? Peel<M> :
+    K extends Set<infer N> ? Peel<N> :
+    K;
+type Nested<W> = Promise<Set<W>>;
+type Out = Peel<Nested<{ id: 0 }>>;
+declare const out: Out;
+const ok: { id: 0 } = out;
+"#,
+    );
+    assert!(!c.contains(&2589), "must converge, no TS2589. Got: {c:?}");
+    assert!(
+        !c.contains(&2322),
+        "Out must equal {{ id: 0 }} (positive assignment holds). Got: {c:?}"
+    );
+}
+
+/// Reopened witness #2 (issue comment / #14330, 2026-06-21): the still-failing
+/// path was an un-guarded self-recursion in `match_infer_object_pattern` when
+/// matching an object `{ payload: infer P }` pattern against an alias-
+/// `Application` source — a *single* application `DeepUnwrap<AsyncBox<{id:0}>>`
+/// was enough to abort. The object-pattern `Application` arm now re-enters the
+/// guarded `match_infer_pattern`, so it must converge to `{ id: 0 }`.
+#[test]
+fn issue_14123_object_pattern_over_alias_application_converges() {
+    let c = codes(
+        r#"
+type DeepUnwrap<G> =
+    G extends Promise<infer H> ? DeepUnwrap<H> :
+    G extends { payload: infer J } ? DeepUnwrap<J> :
+    G;
+type AsyncBox<V> = Promise<{ payload: V }>;
+type Settled = DeepUnwrap<AsyncBox<{ id: 0 }>>;
+declare const settled: Settled;
+const ok: { id: 0 } = settled;
+"#,
+    );
+    assert!(!c.contains(&2589), "must converge, no TS2589. Got: {c:?}");
+    assert!(
+        !c.contains(&2322),
+        "Settled must equal {{ id: 0 }} (positive assignment holds). Got: {c:?}"
+    );
+}
+
+/// Mutually-recursive deferred conditionals (`A` evaluates to `B`, `B` to `A`)
+/// over an alias source must terminate through the `(source, pattern)` cycle
+/// guard rather than unwinding `A -> B -> A -> ...` until the stack aborts. This
+/// is the cycle the `match_infer_unwrapped_application` re-routing was added to
+/// break; the result resolves to the inner `{ id: 0 }`.
+#[test]
+fn issue_14123_mutually_recursive_alias_conditionals_terminate() {
+    let c = codes(
+        r#"
+type StepA<P> = P extends { a: infer X } ? StepB<X> : P;
+type StepB<Q> = Q extends { b: infer Y } ? StepA<Y> : Q;
+type Wrap<T> = { a: { b: T } };
+type Done = StepA<Wrap<{ id: 0 }>>;
+declare const done: Done;
+const ok: { id: 0 } = done;
+"#,
+    );
+    assert!(!c.contains(&2589), "must terminate, no TS2589. Got: {c:?}");
+    assert!(
+        !c.contains(&2322),
+        "Done must equal {{ id: 0 }} (positive assignment holds). Got: {c:?}"
+    );
+}
+
+/// Safety-net guard (issue #14123, fix direction 2): a genuinely non-convergent
+/// recursive conditional — each step *grows* the type, so no cycle is ever hit —
+/// must degrade to a bounded TS2589 diagnostic, never a process-aborting stack
+/// overflow. This exercises the depth budgets plus the `stacker::maybe_grow`
+/// stack-growth guard on the infer-match recursion: reaching this assertion at
+/// all proves the process did not SIGABRT.
+#[test]
+fn issue_14123_non_convergent_conditional_degrades_to_ts2589() {
+    let c = codes(
+        r#"
+type Grow<T> =
+    T extends (infer E)[] ? Grow<[E, E]> :
+    Grow<T[]>;
+type Y = Grow<{ id: 0 }>;
+declare const y: Y;
+"#,
+    );
+    assert!(
+        c.contains(&2589),
+        "non-convergent recursion must report TS2589 (and not crash). Got: {c:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -1710,10 +1710,43 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
+        // Cheap cycle guard first: re-entering the same `(source, pattern)` pair
+        // is a converged cycle and returns before any further work or stack
+        // growth.
         if !visited.insert((source, pattern)) {
             return true;
         }
+        // Defensive stack growth for the structural infer-match recursion in
+        // `match_infer_pattern_inner`. That recursion is already logically
+        // bounded — the `visited` cycle guard above plus `INFER_MATCH_EXPANSION_
+        // DEPTH` on alias expansion — so termination does not need the shared
+        // solver frame budget; capping it with one could flip a legitimately
+        // deep-but-terminating match to its bail default. But a deeply nested yet
+        // acyclic source/pattern pair (e.g. a recursive conditional that extracts
+        // `infer` through a chain of generic-alias wrappers) can still drive the
+        // native stack past its limit. `grow_solver_stack` grows the stack on
+        // demand without consuming a frame, so a pathological case degrades
+        // through its own depth budget to a bounded TS2589 instead of a
+        // process-aborting SIGABRT (issue #14123, fix direction 2: the
+        // conditional/infer evaluation path must never crash the process). This
+        // only grows the stack; it never changes a match result.
+        crate::recursion::grow_solver_stack(|| {
+            self.match_infer_pattern_inner(source, pattern, bindings, visited, checker)
+        })
+    }
 
+    /// Structural body of [`Self::match_infer_pattern`]. Split out so the public
+    /// entry can pair the `(source, pattern)` cycle guard with one
+    /// `stacker::maybe_grow` segment-grow per recursion level; all recursive
+    /// infer-matching re-enters through `match_infer_pattern`, never here.
+    fn match_infer_pattern_inner(
+        &self,
+        source: TypeId,
+        pattern: TypeId,
+        bindings: &mut FxHashMap<Atom, TypeId>,
+        visited: &mut InferPatternVisited,
+        checker: &mut SubtypeChecker<'_, R>,
+    ) -> bool {
         if source == TypeId::NEVER {
             return self.bind_infer_defaults(pattern, TypeId::NEVER, bindings, checker);
         }

--- a/crates/tsz-solver/src/recursion.rs
+++ b/crates/tsz-solver/src/recursion.rs
@@ -795,6 +795,23 @@ pub fn with_solver_frame<T>(body: impl FnOnce() -> T) -> Option<T> {
     ))
 }
 
+/// Run `body` on a (possibly freshly grown) stack **without** consuming a logical
+/// recursion frame.
+///
+/// This is the stack-growth half of [`with_solver_frame`] for recursion that is
+/// already bounded by its own logical guard (e.g. a `(source, pattern)` visited
+/// cycle break plus an expansion-depth budget) and therefore must not also be
+/// capped by the shared [`MAX_SOLVER_STACK_FRAMES`] budget — doing so could flip
+/// a legitimately deep-but-terminating match to its bail default. It only grows
+/// the native stack on demand using the same shared segment sizes, so a deeply
+/// nested case degrades through its own depth budget instead of overflowing the
+/// OS stack (SIGABRT). Use [`with_solver_frame`] instead whenever the recursion
+/// needs the frame budget as its termination guarantee.
+#[inline]
+pub fn grow_solver_stack<T>(body: impl FnOnce() -> T) -> T {
+    stacker::maybe_grow(STACK_RED_ZONE_BYTES, STACK_GROW_BYTES, body)
+}
+
 /// Current number of active solver recursion frames on this thread.
 ///
 /// Exposed for tests and diagnostics; normal callers use


### PR DESCRIPTION
Fixes #14123.

Goal: hold

## Structural rule
`When a recursive conditional extracts an infer variable through a chain of
generic-alias wrappers, tsc evaluates the infer match to a bounded fixpoint;
tsz now bounds the same recursion through the solver's shared stack-growth
machinery so a pathological depth degrades to a bounded TS2589 instead of a
process-aborting SIGABRT — owned by the solver infer-match entry
(match_infer_pattern).`

All recursive `infer`-pattern matching flows through one chokepoint,
`match_infer_pattern` (`crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs`).
Every sibling helper (`match_infer_object_pattern`,
`match_infer_object_with_index_pattern`, `match_infer_callable_pattern`,
`match_tuple_elements`, `match_infer_pattern_union_members`,
`match_infer_unwrapped_application`, …) re-enters through it rather than
recursing around it. That recursion was logically bounded — the
`(source, pattern)` visited cycle guard plus `INFER_MATCH_EXPANSION_DEPTH=100`
on alias expansion — but, unlike the sibling `evaluate` and structural-subtype
recursion entries, it had **no native stack-growth guard**. A deeply nested yet
acyclic source/pattern pair (e.g. `D<Box<{id:0}>>` with
`Box<T> = Promise<{ payload: T[] }>`) could still drive the OS stack to a
SIGABRT (exit 134). This is fix-direction 2 of the issue: the conditional/infer
evaluation path must never crash the process.

## Owner layer
Solver. `match_infer_pattern` is split into a thin public entry (cheap
`visited` cycle guard, then the growth wrapper) and `match_infer_pattern_inner`
(the original body). A new shared `recursion::grow_solver_stack` helper grows
the native stack on demand using the same segment sizes as `with_solver_frame`
— but **without** consuming a logical frame. The infer-match recursion already
owns its termination guarantee, so coupling it to the shared
`MAX_SOLVER_STACK_FRAMES` budget could flip a legitimately deep-but-terminating
match to its bail default (a parity risk); pure stack growth changes no match
result, it only prevents the crash. The cycle guard stays outside the growth
wrapper so cycle hits return without paying the stack check.

## Adjacent matrix (regression guards, varied binders)
Locks in the original witness **plus the two reopened ones** that had no guard
(the documented re-regression vector):
- nested generic-alias containers `Promise<Set<T>>` → converges to `{ id: 0 }`;
- single-application object-pattern path `DeepUnwrap<AsyncBox<{id:0}>>`
  (the #14330 root-cause site) → converges to `{ id: 0 }`;
- mutually-recursive deferred conditionals `A→B→A` over an alias → terminates;
- non-convergent (`Grow`) recursion → bounded **TS2589**, no SIGABRT;
- existing positive/negative (`TS2322`) fixpoint cases retained.
Binder names are varied across cases so the guards are structural, not
identifier-driven.

## Fallback
On exhausted alias-expansion budget the infer match already returns
"no match" (the conditional stays deferred / takes its false branch), and a
genuinely non-convergent recursion is caught by the existing depth budgets as
TS2589. `grow_solver_stack` only adds headroom for the bounded recursion; it
introduces no new logical bound and no new bail path.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-checker --test issue_14123_repro_tests` → 6/6 pass
  (4 new + 2 existing).
- Rebuilt `tsz` CLI: all convergent repros from the issue + adversarial
  variants exit 0; non-convergent cases exit 2 (TS2589) with no SIGABRT.
- `cargo clippy -p tsz-solver` clean.
- Regression sweep of related infer/conditional checker suites
  (`recursive_conditional_infer_depth_tests`,
  `infer_match_recursive_wrapper_termination_tests`,
  `variadic_infer_element_tests`, `recursive_conditional_mapped_infer_tests`,
  `tuple_infer_mapped_recursive_tests`, `variadic_tuple_recursive_zip_tests`,
  `template_literal_recursive_replace_tests`,
  `recursive_alias_counter_convergence_ts2589_tests`) — no new failures
  (3 failures in `conditional_infer_tests` are pre-existing on `main`,
  unrelated to this change).
- Broad conformance/emit/fourslash owned by ready-review CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Etu8sdNv52Tr25bz2eHRMx)_