### PR TITLE
fix(bench): isolate failed shards so one error stub can't block benchmark publish (#14398)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1510,15 +1510,29 @@ jobs:
             printf '%s\n' "${json_files[@]}" | grep -Ev '/bench-results-bench-(canaries|applications)\.json$' || true
           )
           expected_shards=9
-          echo "json_count=${#required_files[@]}" >> "$GITHUB_OUTPUT"
+          # A required shard that exits non-zero writes only an error stub
+          # ({"results":[],"error":...}) per cloudbuild-bench-shard.yaml, which
+          # merge-results.mjs drops from the published artifact. Count required
+          # shards that actually produced result rows — not merely the stub
+          # files present — so a failed required shard yields complete=false
+          # instead of publishing silently-incomplete data marked complete.
+          required_present=0
+          for shard_json in "${required_files[@]}"; do
+            if node -e 'const fs=require("fs");try{const r=JSON.parse(fs.readFileSync(process.argv[1],"utf8")).results;process.exit(Array.isArray(r)&&r.length>0?0:1)}catch{process.exit(1)}' "${shard_json}"; then
+              required_present=$((required_present + 1))
+            else
+              echo "::warning::Required benchmark shard $(basename "${shard_json}") produced no result rows (failed/partial shard); excluding it from the required-shard completeness count."
+            fi
+          done
+          echo "json_count=${required_present}" >> "$GITHUB_OUTPUT"
           echo "expected_json_count=${expected_shards}" >> "$GITHUB_OUTPUT"
-          if [[ "${#required_files[@]}" -eq 0 ]]; then
-            echo "No required benchmark result JSON files found."
+          if [[ "${required_present}" -eq 0 ]]; then
+            echo "No required benchmark shard produced result rows."
             find bench-artifacts -maxdepth 2 -type f -print || true
             exit 1
           fi
-          if [[ "${#required_files[@]}" -ne "${expected_shards}" ]]; then
-            echo "::warning::Expected ${expected_shards} required benchmark shard JSON files, found ${#required_files[@]}; merging partial artifact for diagnosis, but public publish will fail."
+          if [[ "${required_present}" -ne "${expected_shards}" ]]; then
+            echo "::warning::Expected ${expected_shards} required benchmark shards with results, found ${required_present}; merging partial artifact for diagnosis, but public publish will fail."
             printf 'Found JSON files:\n'
             printf '  %s\n' "${json_files[@]}"
             find bench-artifacts -maxdepth 2 -type f -print || true

--- a/scripts/bench/merge-results.mjs
+++ b/scripts/bench/merge-results.mjs
@@ -48,6 +48,21 @@ function isNonEmptyStringArray(value) {
   return Array.isArray(value) && value.some(isNonEmptyString);
 }
 
+// A benchmark shard that exits non-zero writes an explicit error stub
+// ({"schema_version":1,"results":[],"error":"..."}) instead of timing data
+// (scripts/cloudbuild/cloudbuild-bench-shard.yaml). A payload with no result
+// rows contributes nothing to the published artifact, so it carries no timing
+// data to publish — and nothing to forge — and must be excluded from the merge
+// rather than fail the runner-signature gate.
+function isFailedShardStub(payload) {
+  const results = Array.isArray(payload?.results) ? payload.results : [];
+  return results.length === 0;
+}
+
+function shardStubError(payload) {
+  return isNonEmptyString(payload?.error) ? payload.error.trim() : null;
+}
+
 function parseArgs(argv) {
   const [, , outFile, ...rest] = argv;
   const inputFiles = [];
@@ -556,14 +571,35 @@ function main() {
     process.exit(1);
   }
 
-  const payloads = inputFiles.map((file) => ({
+  const allPayloads = inputFiles.map((file) => ({
     file,
     payload: JSON.parse(fs.readFileSync(file, "utf8")),
   }));
 
-  if (payloads.length === 0) {
+  if (allPayloads.length === 0) {
     console.error("No benchmark JSON inputs found.");
     process.exit(1);
+  }
+
+  // Isolate failed/partial shards: a shard that wrote only the error stub (no
+  // result rows) must not abort the merge of the shards that succeeded. Crashing
+  // here on a single transient shard failure turned every such failure into a
+  // total benchmark-publish outage (issue #14398). Required-shard completeness
+  // is owned independently by the bench.yml shard gate and
+  // check-artifact-readiness.mjs, not by the runner-signature gate.
+  const payloads = [];
+  const droppedEmptyShards = [];
+  for (const entry of allPayloads) {
+    (isFailedShardStub(entry.payload) ? droppedEmptyShards : payloads).push(entry);
+  }
+
+  if (droppedEmptyShards.length > 0) {
+    console.warn(
+      "::warning::Excluding benchmark shard(s) that produced no result rows (failed/partial shard) from the merged artifact:",
+    );
+    for (const { file, payload } of droppedEmptyShards) {
+      console.warn(`  - ${path.basename(file)}: ${shardStubError(payload) ?? "no result rows"}`);
+    }
   }
 
   const results = mergeCompatibilityCanaries(
@@ -626,6 +662,10 @@ function main() {
       runner_environment_warnings: runnerEnvironmentWarnings,
       measurement_profile_warnings: measurementProfileWarnings,
       project_compatibility_advisory: compatAdvisory,
+      dropped_empty_shards: droppedEmptyShards.map(({ file, payload }) => ({
+        file: path.basename(file),
+        error: shardStubError(payload),
+      })),
     },
     ...(runnerEnvironment ? { runner_environment: runnerEnvironment } : {}),
     ...(measurementProfile ? { measurement_profile: measurementProfile } : {}),

--- a/scripts/bench/test-merge-results.mjs
+++ b/scripts/bench/test-merge-results.mjs
@@ -1095,6 +1095,87 @@ withTempDir((dir) => {
   assert.equal(merged.totals.green_tsgo_wins, 1);
 });
 
+// Issue #14398: a failed shard writes an error stub ({results:[], error}) per
+// cloudbuild-bench-shard.yaml. It carries no timing data, so a
+// --require-runner-signature merge must DROP it (with a warning) and keep
+// merging the shards that succeeded — a single transient shard failure must not
+// crash the whole benchmark publish on the signature gate.
+withTempDir((dir) => {
+  const signed = writeInput(dir, "bench-results-projects.json", [projectRow("standalone")], {
+    ...SAMPLE_RUN_METADATA,
+    runner_environment: SAMPLE_RUNNER_ENVIRONMENT,
+    shard: { label: "projects", filter: "projects" },
+    filter: "projects",
+  });
+  const stub = path.join(dir, "bench-results-project-hotspots.json");
+  fs.writeFileSync(
+    stub,
+    `${JSON.stringify({ schema_version: 1, results: [], error: "benchmark shard did not write results" })}\n`,
+    "utf8",
+  );
+  const result = runMergeInputs(dir, [signed, stub], ["--require-runner-signature"]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stderr,
+    /::warning::[\s\S]*bench-results-project-hotspots\.json: benchmark shard did not write results/,
+  );
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.ok(merged.results.some((r) => r.name === "standalone"), "the successful shard must survive the merge");
+  assert.deepEqual(
+    merged.merged_from,
+    ["bench-results-projects.json"],
+    "the dropped error stub must not appear in merged_from",
+  );
+  assert.equal(merged.totals.rows, 1, "the dropped stub must not contribute rows");
+  assert.equal(
+    merged.validation.hyperfine_exit_codes_required,
+    true,
+    "a dropped stub must not flip aggregate validation flags",
+  );
+  assert.ok(
+    merged.validation.dropped_empty_shards.some(
+      (s) => s.file === "bench-results-project-hotspots.json"
+        && s.error === "benchmark shard did not write results",
+    ),
+    "the dropped stub must be recorded in validation.dropped_empty_shards",
+  );
+});
+
+// A payload with no result rows is treated as a failed/partial shard and dropped
+// even when it carries no `error` and no signature: it contributes nothing, so it
+// is not subject to the runner-signature gate.
+withTempDir((dir) => {
+  const signed = writeInput(dir, "bench-results-a.json", [projectRow("standalone")], {
+    ...SAMPLE_RUN_METADATA,
+    runner_environment: SAMPLE_RUNNER_ENVIRONMENT,
+    shard: { label: "a", filter: "a" },
+    filter: "a",
+  });
+  const empty = path.join(dir, "bench-results-empty.json");
+  fs.writeFileSync(empty, `${JSON.stringify({ schema_version: 1, results: [] })}\n`, "utf8");
+  const result = runMergeInputs(dir, [signed, empty], ["--require-runner-signature"]);
+  assert.equal(result.status, 0, result.stderr);
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.deepEqual(merged.merged_from, ["bench-results-a.json"]);
+  assert.ok(
+    merged.validation.dropped_empty_shards.some((s) => s.file === "bench-results-empty.json" && s.error === null),
+  );
+});
+
+// Security boundary preserved: a shard that DOES contribute result rows but lacks
+// the runner signature must still hard-fail under --require-runner-signature — only
+// genuinely-empty shards are exempt (they carry no timing data to forge).
+withTempDir((dir) => {
+  const unsignedWithResults = writeInput(dir, "bench-results-unsigned.json", [projectRow("standalone")], {
+    ...SAMPLE_RUN_METADATA,
+    shard: { label: "unsigned", filter: "unsigned" },
+    filter: "unsigned",
+  });
+  const result = runMergeInputs(dir, [unsignedWithResults], ["--require-runner-signature"]);
+  assert.equal(result.status, 1, "an unsigned payload that contributes rows must still fail");
+  assert.match(result.stderr, /bench-results-unsigned\.json: missing runner_environment/);
+});
+
 // A perf-timed canary (the bench-canaries shard already measured it) must keep
 // its real tsz_ms/tsgo_ms and must NOT be stamped the "not timed" placeholder
 // status when its compile-guard compat is attached — otherwise isGreen() becomes


### PR DESCRIPTION
Goal: hold

Fixes #14398 — "Benchmark data is stale in Readme and website / Bench publish is not publishing."

## Root cause
Diagnosed from the failing scheduled `Bench` runs (e.g. 27911475782, 27908123145), confirmed by downloading the offending shard artifact:

- The `project-hotspots` shard exits `141` (SIGPIPE) inside Cloud Build (`BENCH_SHARD_STATUS=141`) and writes no results, so `scripts/cloudbuild/cloudbuild-bench-shard.yaml` emits its intentional error-stub sentinel: `{"schema_version":1,"results":[],"error":"benchmark shard did not write results"}`.
- The `bench-publish` job feeds *every* shard JSON — including that stub — into `scripts/bench/merge-results.mjs --require-runner-signature`, which hard-fails on the unsigned stub (`missing runner_environment`, `missing source_commit`, ...) and aborts the whole merge with exit 1.

So a single failed/partial shard takes down the entire benchmark publish: `latest.json` is never republished and the committed README image + website data drift stale.

## Structural rule
When a benchmark shard contributes **zero result rows** (the documented failed-shard sentinel), it carries no timing data to publish — and nothing to forge — so it must be excluded from the merge, not run through the runner-signature anti-forgery gate. The signature gate is for *untrusted timing data*; applying it to an empty stub converts one transient shard failure into a total publish outage. Required-shard completeness is owned by the `bench.yml` shard gate and `check-artifact-readiness.mjs`, not by the signature gate.

## Change
- `scripts/bench/merge-results.mjs`: drop any payload with zero result rows with a `::warning::` and record it in `validation.dropped_empty_shards`, instead of crashing the signature gate. A payload that **does** contribute result rows must still be fully signed (anti-forgery boundary preserved and tested). All aggregates (signature, runner env, measurement profile, totals, `merged_from`) are computed over contributing shards only.
- `.github/workflows/bench.yml`: count required shards that actually produced result rows toward the completeness floor, so a failed **required** shard yields `complete=false` (the existing graceful-withhold path, now with an accurate diagnostic) while a failed **optional** canary/application shard no longer blocks publishing.
- `scripts/bench/test-merge-results.mjs`: cover stub-drop under `--require-runner-signature`, a no-`error` empty payload, and the preserved signature boundary for payloads that contribute rows.

Adjacent shapes covered: standard error stub, silent `{results:[]}` with no error, and `{results:[row], <unsigned>}` (still hard-fails). The upstream `project-hotspots` SIGPIPE is a separate transient shard-infra issue; this change makes the publish pipeline degrade to the designed readiness/completeness gates instead of being a single point of failure.

## Verification
- `node scripts/bench/test-merge-results.mjs` — new + existing merge cases pass.
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs` — the merge-step workflow assertion (`expected_shards=9` … `complete=false` … `merge-results.mjs`) still matches.
- All `scripts/bench/test-*.mjs` (23 suites) pass.
- `.github/workflows/bench.yml` parses as valid YAML; the new `node -e` completeness predicate verified against a real shard JSON (contributing) and the captured error stub (dropped).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019XWEtXEmFKw9eGZaKEz3Qo)_