### PR TITLE
fix(solver): recursive conditional-alias over alias-wrapped Promise converges instead of re-entering reduction (#14417)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1931,6 +1931,9 @@ path = "tests/recursive_conditional_alias_concrete_fixpoint_tests.rs"
 name = "issue_14123_repro_tests"
 path = "tests/issue_14123_repro_tests.rs"
 [[test]]
+name = "issue_14417_repro_tests"
+path = "tests/issue_14417_repro_tests.rs"
+[[test]]
 name = "recursive_alias_counter_convergence_ts2589_tests"
 path = "tests/recursive_alias_counter_convergence_ts2589_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/issue_14417_repro_tests.rs
+++ b/crates/tsz-checker/tests/issue_14417_repro_tests.rs
@@ -1,0 +1,192 @@
+//! Regression for issue #14417: a self-recursive conditional whose check type
+//! is a **generic/concrete type alias that resolves to `Promise<…>`** must
+//! reduce through the alias indirection and converge to the same type `tsc`
+//! computes, instead of failing to canonicalize and leaving an opaque result
+//! (or, schedule-dependently, non-terminating).
+//!
+//! Root cause: the reduced result of the recursive conditional records a
+//! `display_alias` back-reference from its concrete value (`{ id: 0 }`) to the
+//! recursive alias application (`Deep<AB<{ id: 0 }>>`).
+//! `reduce_alias_body_to_application_form` treated that diagnostic-only
+//! back-reference as a structural reduction handle and followed it back into
+//! `Deep`, re-entering the recursion that produced the value — an unbounded
+//! re-evaluation (the non-crash residual left after the #14123 crash fix). The
+//! reducer now refuses to follow a `display_alias` whose application base is a
+//! *recursive* alias (its body re-references its own `DefId`), mirroring the
+//! `result_has_residual_recursive_alias` cache-poison guard; recoveries to a
+//! non-recursive alias (e.g. the structural `Promise` body back to `Promise<…>`)
+//! are still followed so the conditional `infer` slot binds.
+//!
+//! Each test asserts convergence (no TS2589) AND the exact `tsc` result via a
+//! positive assignment plus a mismatched-target TS2322. Binder names are varied
+//! per case so the guard is structural, not identifier-driven.
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::check_source_with_libs_code_messages;
+
+fn codes(source: &str) -> Vec<u32> {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    let opts = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    check_source_with_libs_code_messages(source, "test.ts", opts, &libs)
+        .into_iter()
+        .map(|(c, _)| c)
+        .collect()
+}
+
+/// The minimal witness from the issue: recursion in the true branch + a
+/// `Promise` check + the check type reaching the conditional through a *generic*
+/// alias (`AB<S> = Promise<S>`). The conditional must bind `infer U = { id: 0 }`
+/// and `Deep<{ id: 0 }>` must converge to `{ id: 0 }`.
+#[test]
+fn issue_14417_recursive_generic_alias_promise_converges() {
+    let c = codes(
+        r#"
+type Deep<K> = K extends Promise<infer U> ? Deep<U> : K;
+type AB<S> = Promise<S>;
+type Out = Deep<AB<{ id: 0 }>>;
+declare const o: Out;
+const ok: { id: 0 } = o;
+"#,
+    );
+    assert!(!c.contains(&2589), "must converge, no TS2589. Got: {c:?}");
+    assert!(
+        !c.contains(&2322),
+        "Out must equal {{ id: 0 }} (positive assignment holds). Got: {c:?}"
+    );
+}
+
+/// Same shape, renamed binders, mismatched target: the reduced `Out` equals
+/// `{ id: 0 }`, so assigning it to `{ id: 1 }` reports exactly one TS2322 —
+/// proving the recursion converged to a concrete value, not an opaque/`any`
+/// placeholder (which would suppress the error).
+#[test]
+fn issue_14417_recursive_generic_alias_promise_reports_mismatch() {
+    let c = codes(
+        r#"
+type Unwrap<Q> = Q extends Promise<infer A> ? Unwrap<A> : Q;
+type Wrapper<S> = Promise<S>;
+type Result = Unwrap<Wrapper<{ id: 0 }>>;
+declare const value: Result;
+const bad: { id: 1 } = value;
+"#,
+    );
+    assert!(!c.contains(&2589), "must converge, no TS2589. Got: {c:?}");
+    assert_eq!(
+        c.iter().filter(|&&x| x == 2322).count(),
+        1,
+        "mismatched target must report exactly one TS2322. Got: {c:?}"
+    );
+}
+
+/// Recursive + *concrete* (non-generic) alias: `Box = Promise<{ tag: 7 }>`.
+/// The check type still reaches the conditional through an alias indirection.
+#[test]
+fn issue_14417_recursive_concrete_alias_promise_converges() {
+    let c = codes(
+        r#"
+type Peel<T> = T extends Promise<infer R> ? Peel<R> : T;
+type Box = Promise<{ tag: 7 }>;
+type Out = Peel<Box>;
+declare const o: Out;
+const ok: { tag: 7 } = o;
+const bad: { tag: 8 } = o;
+"#,
+    );
+    assert!(!c.contains(&2589), "must converge, no TS2589. Got: {c:?}");
+    assert_eq!(
+        c.iter().filter(|&&x| x == 2322).count(),
+        1,
+        "concrete-alias result must equal {{ tag: 7 }}; one mismatch TS2322. Got: {c:?}"
+    );
+}
+
+/// Recursive + generic alias wrapping a structural payload:
+/// `Carrier<S> = Promise<{ payload: S }>`. The conditional binds
+/// `infer U = { payload: { id: 0 } }`, recurses once on a non-`Promise`, and
+/// settles on `{ payload: { id: 0 } }`.
+#[test]
+fn issue_14417_recursive_generic_alias_payload_wrapper_converges() {
+    let c = codes(
+        r#"
+type Dig<X> = X extends Promise<infer Y> ? Dig<Y> : X;
+type Carrier<S> = Promise<{ payload: S }>;
+type Out = Dig<Carrier<{ id: 0 }>>;
+declare const o: Out;
+const ok: { payload: { id: 0 } } = o;
+const bad: { payload: { id: 1 } } = o;
+"#,
+    );
+    assert!(!c.contains(&2589), "must converge, no TS2589. Got: {c:?}");
+    assert_eq!(
+        c.iter().filter(|&&x| x == 2322).count(),
+        1,
+        "payload-wrapper result must equal {{ payload: {{ id: 0 }} }}; one mismatch TS2322. \
+         Got: {c:?}"
+    );
+}
+
+/// Non-regression for the passing rows of the issue's matrix: the fix must not
+/// disturb the already-correct cases.
+/// * base: `Deep<{ id: 0 }>`            → `{ id: 0 }`
+/// * inline Promise: `Deep<Promise<…>>` → `{ id: 0 }`
+/// * non-recursive + alias              → `{ id: 0 }`
+#[test]
+fn issue_14417_baseline_cases_unaffected() {
+    let base = codes(
+        r#"
+type Sink<K> = K extends Promise<infer U> ? Sink<U> : K;
+type Out = Sink<{ id: 0 }>;
+declare const o: Out;
+const ok: { id: 0 } = o;
+const bad: { id: 1 } = o;
+"#,
+    );
+    assert!(!base.contains(&2589), "base must converge. Got: {base:?}");
+    assert_eq!(
+        base.iter().filter(|&&x| x == 2322).count(),
+        1,
+        "base: one mismatch TS2322. Got: {base:?}"
+    );
+
+    let inline = codes(
+        r#"
+type Drain<K> = K extends Promise<infer U> ? Drain<U> : K;
+type Out = Drain<Promise<{ id: 0 }>>;
+declare const o: Out;
+const ok: { id: 0 } = o;
+const bad: { id: 1 } = o;
+"#,
+    );
+    assert!(
+        !inline.contains(&2589),
+        "inline must converge. Got: {inline:?}"
+    );
+    assert_eq!(
+        inline.iter().filter(|&&x| x == 2322).count(),
+        1,
+        "inline Promise: one mismatch TS2322. Got: {inline:?}"
+    );
+
+    let non_recursive = codes(
+        r#"
+type Once<K> = K extends Promise<infer U> ? U : K;
+type AB<S> = Promise<S>;
+type Out = Once<AB<{ id: 0 }>>;
+declare const o: Out;
+const ok: { id: 0 } = o;
+const bad: { id: 1 } = o;
+"#,
+    );
+    assert!(
+        !non_recursive.contains(&2589),
+        "non-recursive must converge. Got: {non_recursive:?}"
+    );
+    assert_eq!(
+        non_recursive.iter().filter(|&&x| x == 2322).count(),
+        1,
+        "non-recursive + alias: one mismatch TS2322. Got: {non_recursive:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/application_reduction.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/application_reduction.rs
@@ -24,6 +24,46 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             .is_some_and(|alias| matches!(interner.lookup(alias), Some(TypeData::Application(_))))
     }
 
+    /// Whether `ty` is an `Application` whose base resolves to a *self-recursive
+    /// conditional alias* — a def whose resolved body is a `Conditional` that
+    /// re-references its own `DefId` (e.g.
+    /// `Deep<K> = K extends Promise<infer U> ? Deep<U> : K`).
+    ///
+    /// Such an application cannot serve as a structural reduction step: peeling
+    /// it ([`alias_application_substituted_body`](Self::alias_application_substituted_body))
+    /// yields the conditional body, and simulating that conditional re-enters
+    /// the same recursion, so
+    /// [`reduce_alias_body_to_application_form`](Self::reduce_alias_body_to_application_form)
+    /// must not follow a diagnostic-only `display_alias` back-reference to one.
+    ///
+    /// The body must be a `Conditional` specifically: a self-referential
+    /// *interface* body (e.g. `Promise`, whose `then`/`catch` return
+    /// `Promise<…>`) or a recursive *structural* alias body (object/union/
+    /// intersection) is not a hazard — peeling it produces a non-`Application`,
+    /// non-`Conditional` shape that terminates the reduction loop. Gating on the
+    /// conditional body (rather than the broad self-reference test used by
+    /// [`result_has_residual_recursive_alias`](Self::result_has_residual_recursive_alias)
+    /// for cache poisoning) keeps the legitimate `Promise<…>` recovery working.
+    pub(super) fn application_is_recursive_alias(&self, ty: TypeId) -> bool {
+        let Some(TypeData::Application(app_id)) = self.interner().lookup(ty) else {
+            return false;
+        };
+        let base = self.interner().type_application(app_id).base;
+        let Some(def_id) = (match self.interner().lookup(base) {
+            Some(TypeData::Lazy(def_id)) => Some(def_id),
+            Some(TypeData::TypeQuery(sym_ref)) => self.resolver().symbol_to_def_id(sym_ref),
+            _ => None,
+        }) else {
+            return false;
+        };
+        self.resolver()
+            .resolve_lazy(def_id, self.interner())
+            .is_some_and(|body| {
+                matches!(self.interner().lookup(body), Some(TypeData::Conditional(_)))
+                    && crate::visitor::contains_lazy_def_id(self.interner(), body, def_id)
+            })
+    }
+
     /// Reduce `ty` to its underlying `Application(...)` form by walking one
     /// alias step (Application body) or simulating one infer-match step
     /// (Conditional body with `infer` in `extends`). When `ty` isn't itself
@@ -36,7 +76,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     ) -> Option<TypeId> {
         let mut current = ty;
         for _ in 0..Self::MAX_ALIAS_REDUCTION_STEPS {
-            if let Some(alias) = self.try_recover_application_from_display_alias(current) {
+            // A `display_alias` back-reference whose application base is a
+            // *self-recursive conditional alias* (its resolved body is a
+            // `Conditional` that re-references its own `DefId`) is a
+            // diagnostic-only label, not a structural reduction handle:
+            // peeling/simulating it re-enters the very recursion that produced
+            // `current`, never reaching an `Application(interface)` form to read
+            // the infer slot from. For example a self-recursive
+            // `Deep<K> = K extends Promise<infer U> ? Deep<U> : K` records
+            // `{ id: 0 } -> Deep<AB<{ id: 0 }>>` on its reduced result; following
+            // that back into `Deep` spins forever (#14123/#14417). Recoveries to
+            // a non-recursive alias — including the structural `Promise` body
+            // back to `Promise<…>`, the legitimate reduction — are still
+            // followed.
+            if let Some(alias) = self.try_recover_application_from_display_alias(current)
+                && !self.application_is_recursive_alias(alias)
+            {
                 current = alias;
             }
 
@@ -70,6 +125,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     let result = self.evaluate(result);
                     let result = self
                         .try_recover_application_from_display_alias(result)
+                        .filter(|&recovered| !self.application_is_recursive_alias(recovered))
                         .unwrap_or(result);
                     if result == current {
                         break;


### PR DESCRIPTION
Fixes #14417.

## Summary
A self-recursive conditional alias applied through an alias-wrapped `Promise` —
```ts
type Deep<K> = K extends Promise<infer U> ? Deep<U> : K;
type AB<S> = Promise<S>;
type Out = Deep<AB<{ id: 0 }>>;   // tsc: { id: 0 }
const bad: string = ({} as Out);  // tsc: TS2322
```
reduced `Out` to its concrete value `{ id: 0 }`, but that value records a
**diagnostic-only `display_alias` back-reference** to the recursive application
`Deep<AB<{ id: 0 }>>`. `reduce_alias_body_to_application_form` followed that
back-reference as if it were a *structural reduction handle*, peeled the
recursive conditional body again, and re-entered the recursion that produced the
value — leaving an opaque/`any` result, or (schedule-dependently, under the
test-harness multi-pass resolver) non-terminating. This is the non-crash
residual left after the #14123 crash fix.

## Structural rule
When reducing a check type to its `Application(Base, Args)` canonical form so
conditional `infer` extraction can read the argument slot, a `display_alias`
whose base resolves to a **self-recursive conditional alias** (its resolved body
is a `Conditional` that re-references its own `DefId`) is not a reduction step —
peeling it only re-enters the recursion. tsz must not treat that diagnostic-only
label as a reduction handle.

## Owner layer
Solver `evaluation` reduction — `reduce_alias_body_to_application_form` and its
two `try_recover_application_from_display_alias` recovery points
(`crates/tsz-solver/src/evaluation/evaluate_rules/conditional/application_reduction.rs`).
The new `application_is_recursive_alias` predicate mirrors the existing
`result_has_residual_recursive_alias` cache-poison guard.

Recoveries to a **non-recursive** alias — including the structural `Promise`
body back to `Promise<…>`, the legitimate reduction — are still followed, so the
`infer` slot binds and the recursion converges to the `tsc` result. Gating on a
`Conditional` body (not the broad self-reference test) keeps self-referential
*interface* bodies (`Promise.then`/`catch` return `Promise<…>`) and recursive
*structural* aliases working: peeling those yields a non-`Application` shape that
terminates the loop.

## Adjacent-case matrix (regression tests)
`crates/tsz-checker/tests/issue_14417_repro_tests.rs`, varied binder names,
positive assignment + mismatched-target TS2322, all assert no TS2589:
- recursive + generic alias `AB<S> = Promise<S>` → `{ id: 0 }`
- recursive + concrete alias `Box = Promise<{ tag: 7 }>` → `{ tag: 7 }`
- recursive + generic payload wrapper `Carrier<S> = Promise<{ payload: S }>` → `{ payload: { id: 0 } }`
- non-regression rows (base `Deep<{id:0}>`, inline `Deep<Promise<…>>`, non-recursive `Once<AB<…>>`) still reduce to `{ id: 0 }`

## Verification
- `cargo nextest run -p tsz-checker --test issue_14417_repro_tests` — 5/5 pass
- `cargo nextest run -p tsz-checker --test issue_14123_repro_tests` — 2/2 pass (sibling guard, no hang)
- `cargo nextest run -p tsz-checker --test conditional_alias_lib_application_tests --test awaited_generic_application_fold_tests --test recursive_conditional_alias_concrete_fixpoint_tests --test conditional_alias_source_display_tests --test curry_recursive_conditional_infer_tests --test recursive_conditional_infer_depth_tests --test recursive_conditional_mapped_infer_tests --test async_return_promise_identity_tests --test conditional_application_display_tests` — no new failures
- `cargo nextest run -p tsz-solver -E 'test(conditional) or test(infer) or test(reduce_alias) or test(application_reduction) or test(recursive) or test(alias)'` — only one **pre-existing** failure on `main` (`test_conditional_infer_optional_property_present_distributive`, unrelated; reproduced on base)
- `cargo clippy -p tsz-solver --lib` — clean
- CLI repro `tsz --strict`: `Out` now displays/reduces as `{ id: 0; }` and reports the expected TS2322

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKHUUWyHDj4M9kQR1oHABv)_