### PR TITLE
fix(bench): resolve app compat CI runs without gh

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1422,7 +1422,7 @@ jobs:
       - id: app-compat-source
         name: Resolve application compile compatibility CI run
         env:
-          GH_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1443,15 +1443,47 @@ jobs:
                 break
               fi
             done < <(
-              gh run list \
-                --repo "${GITHUB_REPOSITORY}" \
-                --workflow CI \
-                --branch main \
-                --event push \
-                --status success \
-                --limit 50 \
-                --json databaseId,headSha,url \
-                --jq '.[] | [.databaseId, .headSha, .url] | @tsv'
+              node -e '
+                const https = require("node:https");
+                const repo = process.env.GITHUB_REPOSITORY;
+                const token = process.env.GITHUB_TOKEN;
+                if (!repo) {
+                  console.error("GITHUB_REPOSITORY is required to resolve CI runs");
+                  process.exit(1);
+                }
+                const requestPath = `/repos/${repo}/actions/runs?branch=main&event=push&status=success&per_page=50`;
+                const request = https.request({
+                  hostname: "api.github.com",
+                  path: requestPath,
+                  method: "GET",
+                  headers: {
+                    "Accept": "application/vnd.github+json",
+                    "User-Agent": "tsz-bench-publish",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                    ...(token ? { "Authorization": `Bearer ${token}` } : {}),
+                  },
+                }, (response) => {
+                  let body = "";
+                  response.setEncoding("utf8");
+                  response.on("data", (chunk) => body += chunk);
+                  response.on("end", () => {
+                    if (response.statusCode < 200 || response.statusCode >= 300) {
+                      console.error(`GitHub Actions runs API returned ${response.statusCode}: ${body}`);
+                      process.exit(1);
+                    }
+                    const payload = JSON.parse(body);
+                    for (const run of payload.workflow_runs || []) {
+                      if (run.name !== "CI") continue;
+                      console.log([run.id, run.head_sha, run.html_url].join("\t"));
+                    }
+                  });
+                });
+                request.on("error", (error) => {
+                  console.error(error.message);
+                  process.exit(1);
+                });
+                request.end();
+              '
             )
 
             if [[ -z "${run_id}" ]]; then

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -237,8 +237,13 @@ assert.match(
 
 assert.match(
   workflow,
-  /- id: app-compat-source[\s\S]+if \[\[ "\$\{\{ github\.event_name \}\}" == "workflow_run" \]\]; then[\s\S]+run_id="\$\{\{ github\.event\.workflow_run\.id \}\}"[\s\S]+if \[\[ "\$\{candidate_sha\}" == "\$\{target_sha\}" \]\]; then[\s\S]+run_id="\$\{candidate_id\}"[\s\S]+gh run list[\s\S]+--workflow CI[\s\S]+--branch main[\s\S]+--event push[\s\S]+--status success/,
-  "bench publish should resolve application compatibility from the triggering CI or an exact-SHA successful main CI",
+  /- id: app-compat-source[\s\S]+GITHUB_TOKEN: \$\{\{ github\.token \}\}[\s\S]+run_id="\$\{\{ github\.event\.workflow_run\.id \}\}"[\s\S]+run_id="\$\{candidate_id\}"/,
+  "bench publish should resolve application compatibility from the triggering CI or an exact-SHA successful main CI without requiring gh on the publish runner",
+);
+assert.match(
+  workflow,
+  /- id: app-compat-source[\s\S]+node -e[\s\S]+actions\/runs\?branch=main&event=push&status=success&per_page=50[\s\S]+hostname: "api\.github\.com"[\s\S]+run\.name !== "CI"/,
+  "bench publish should query successful main CI runs through the GitHub API instead of shelling out to gh",
 );
 assert.match(
   workflow,


### PR DESCRIPTION
Goal: hold

## Summary

Recent Bench publishes can still miss application compatibility after the app-row fixes because the `bench-publish` job resolves the matching CI run with `gh run list`. The publish job runs on the self-hosted Cloud Run runner, where recent logs showed `gh: command not found`; that leaves `run_id` empty, skips the exact-SHA compatibility artifact downloads, and can either render application rows gray or fail the readiness gate that requires application compatibility.

This PR keeps the same structural rule: application compatibility must come from the triggering CI run or a successful main CI run for the exact benchmark target SHA. The owner stays in the benchmark workflow publish step; only the transport changes from the local `gh` binary to the GitHub Actions REST API using `${{ github.token }}`.

## Change

- Replace the `gh run list --workflow CI ...` lookup in `bench-publish` with a small `node -e` API query against `/actions/runs`, filtering to successful main push runs whose workflow name is `CI`.
- Keep exact SHA matching before setting `run_id`, so a missing or mismatched artifact still refuses to publish gray app rows.
- Update the workflow smoke assertion so this no-`gh` path is guarded.

## Verification

- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `git diff --check`
- Live read-only API smoke: `GITHUB_REPOSITORY=tsz-org/tsz node -e '<bench-publish lookup snippet>' | head -3` returned tab-separated `run_id`, `head_sha`, and run URL rows.
- CI owns the full workflow and PR body gates.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
