### PR TITLE
test(checker): lock in #13609 type-parameter default/const identity parity

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -607,6 +607,9 @@ mod ts7057_yield_implicit_any;
 #[path = "../tests/tuple_index_access_tests.rs"]
 mod tuple_index_access_tests;
 #[cfg(test)]
+#[path = "tests/type_parameter_default_identity_tests.rs"]
+mod type_parameter_default_identity_tests;
+#[cfg(test)]
 #[path = "../tests/typeof_operator_result_union_tests.rs"]
 mod typeof_operator_result_union_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/type_parameter_default_identity_tests.rs
+++ b/crates/tsz-checker/src/tests/type_parameter_default_identity_tests.rs
@@ -1,0 +1,142 @@
+//! Regression coverage for #13609: a type parameter's optional `default`
+//! annotation (and its `const` modifier) must not fragment relation/identity.
+//!
+//! `tsc` never distinguishes type parameters by their `default` or by `const`
+//! in relation or identity (`compareTypeParametersIdentical` compares only the
+//! constraint). tsz previously interned `TypeData::TypeParameter` over the whole
+//! `TypeParamInfo` — including `default` and `is_const` — so two structurally
+//! identical parameters that differed only in `default` (or only in `const`)
+//! received distinct `TypeId`s. A wrapping `Application`/`Conditional` then
+//! failed the relation's reflexive/identity short-circuit and fell into a
+//! resolver-state-dependent structural walk, surfacing as a false `TS2322`
+//! (#13609; the original ofetch / `$Fetch["raw"]`-vs-`onError` witness). The
+//! fix normalizes type-parameter identity in the solver canonicalizer:
+//! `canonical_type_param` canonicalizes the constraint and drops both `default`
+//! and `is_const`, while the interned parameter keeps its `default` so bare
+//! instantiation still applies it.
+//!
+//! These witnesses pin the user-facing parity end-to-end through the checker.
+//! Binder names are varied (never the canonical `R`/`T`/`U` spellings the
+//! original report used) so the rule follows the type-parameter *shape*, not a
+//! literal name — per the anti-hardcoding test discipline.
+
+use crate::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, diagnostic_codes, load_default_lib_files};
+
+fn codes(source: &str) -> Vec<u32> {
+    diagnostic_codes(&check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions::default(),
+        &load_default_lib_files(),
+    ))
+}
+
+fn assert_clean(source: &str) {
+    let found = codes(source);
+    assert!(
+        found.is_empty(),
+        "expected no diagnostics, got {found:?} for source:\n{source}"
+    );
+}
+
+fn assert_has_code(source: &str, code: u32) {
+    let found = codes(source);
+    assert!(
+        found.contains(&code),
+        "expected TS{code}, got {found:?} for source:\n{source}"
+    );
+}
+
+/// Two generic function types that differ *only* in whether their type
+/// parameter declares a `default` relate as identical in both directions.
+#[test]
+fn default_present_vs_absent_function_types_relate_both_ways() {
+    assert_clean(
+        r#"
+type Defaulted   = <Pick_ extends string = "json">(seed: Pick_) => Pick_;
+type Undefaulted = <Sift  extends string>(seed: Sift) => Sift;
+
+declare const withDefault: Defaulted;
+declare const without: Undefaulted;
+
+const toUndefaulted: Undefaulted = withDefault;
+const toDefaulted: Defaulted = without;
+"#,
+    );
+}
+
+/// A `const` type parameter and an otherwise-identical non-`const` parameter
+/// relate as identical: `tsc` ignores `const` in identity just like `default`.
+#[test]
+fn const_vs_non_const_type_params_relate_both_ways() {
+    assert_clean(
+        r#"
+type Constish    = <const Holder>(box: Holder) => Holder;
+type Plainish     = <Crate>(box: Crate) => Crate;
+
+declare const constish: Constish;
+declare const plainish: Plainish;
+
+const toPlain: Plainish = constish;
+const toConst: Constish = plainish;
+"#,
+    );
+}
+
+/// The `default` is still applied when the alias is referenced with no type
+/// argument: dropping `default` from identity must not drop it from defaulting.
+#[test]
+fn default_is_still_applied_on_bare_instantiation() {
+    assert_clean(
+        r#"
+type Channel<Mode extends string = "json"> = Mode;
+const stays: Channel = "json";
+"#,
+    );
+}
+
+/// ...and bare instantiation rejects a value outside the applied default,
+/// proving the default genuinely resolves to `"json"` (not erased to `string`).
+#[test]
+fn default_applied_on_bare_instantiation_rejects_off_default_value() {
+    assert_has_code(
+        r#"
+type Channel<Mode extends string = "json"> = Mode;
+const bad: Channel = "csv";
+"#,
+        2322,
+    );
+}
+
+/// A still-generic conditional whose check type is a type parameter relates to
+/// the same conditional reached through a parameter that differs only in its
+/// `default` — the shape closest to the original ofetch witness.
+#[test]
+fn deferred_conditional_over_param_differing_only_in_default_relates() {
+    assert_clean(
+        r#"
+type WhenDefaulted<Mode extends string = "json"> = Mode extends "json" ? 1 : 2;
+type WhenPlain<Kind extends string>               = Kind extends "json" ? 1 : 2;
+
+declare const defaulted: <Mode extends string = "json">() => WhenDefaulted<Mode>;
+const asPlain: <Kind extends string>() => WhenPlain<Kind> = defaulted;
+"#,
+    );
+}
+
+/// The default may itself reference an earlier type parameter; two such generic
+/// signatures that differ only in the presence of that defaulting clause still
+/// relate as identical.
+#[test]
+fn param_relative_default_does_not_fragment_identity() {
+    assert_clean(
+        r#"
+type WithRelDefault = <Seed, Echo extends Seed = Seed>(seed: Seed, echo: Echo) => Echo;
+type NoRelDefault   = <Root, Leaf extends Root>(seed: Root, echo: Leaf) => Leaf;
+
+declare const withRel: WithRelDefault;
+const asNoRel: NoRelDefault = withRel;
+"#,
+    );
+}


### PR DESCRIPTION
## Summary

Adds the adjacent-case, binder-name-varied regression coverage that #13609's
acceptance criteria require, pinning the user-facing parity of the
type-parameter identity-non-fragmentation fix end-to-end through the checker.

`tsc` never distinguishes type parameters by their optional `default` (nor by
the `const` modifier) in relation/identity — `compareTypeParametersIdentical`
compares only the constraint. tsz previously interned
`TypeData::TypeParameter` over the whole `TypeParamInfo` (including `default`
and `is_const`), so two structurally identical parameters differing only in
`default` got distinct `TypeId`s; a wrapping `Application`/`Conditional` then
missed the relation's reflexive/identity short-circuit and fell into a
resolver-state-dependent structural walk → false `TS2322` (the original ofetch
/ `$Fetch["raw"]`-vs-`onError` witness).

The behavioral fix already landed in the solver canonicalizer:
`canonical_type_param` canonicalizes the constraint and drops both `default`
and `is_const`, while the interned parameter keeps its `default` so bare
instantiation still applies it. This PR is the **coverage half** the issue
called for, so #13609 can be closed with a guarded floor.

## Structural rule

When two type parameters share a name and constraint shape but differ only in
their optional `default` (or only in `const`), `tsc` relates/identifies them as
the same parameter; tsz must too. Owner layer: solver canonicalizer
(`canonical_type_param`). The `default` is still consumed by instantiation when
no type argument is supplied.

## Adjacent matrix (binder names varied per the anti-hardcoding discipline)

- default-present vs default-absent generic function types relate both ways;
- `const` vs non-`const` type params relate both ways;
- `default` is still applied on bare instantiation, and rejects an off-default
  value (proving it resolves to the literal, not widened to `string`);
- a deferred conditional over a param differing only in `default` relates;
- a param-relative `default` (`<Seed, Echo extends Seed = Seed>`) does not
  fragment identity.

## Verification

- `cargo nextest run -p tsz-checker --lib type_parameter_default_identity` →
  6/6 pass.
- Behavior cross-checked against `tsc` semantics for each witness (only the
  intentional off-default assignment reports `TS2322`).
- Ready-review CI owns the broad conformance/emit/fourslash floors.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019KFaKQKa4QCZbbikAXTyzR)_