### PR TITLE
fix(solver): keyless object source infers Record/mapped params as never (TS2345)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -500,6 +500,9 @@ path = "tests/this_type_indexed_access_receiver_tests.rs"
 name = "this_rooted_discriminant_narrowing_tests"
 path = "tests/this_rooted_discriminant_narrowing_tests.rs"
 [[test]]
+name = "keyless_object_record_inference_tests"
+path = "tests/keyless_object_record_inference_tests.rs"
+[[test]]
 name = "ts2725_tests"
 path = "tests/ts2725_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/keyless_object_record_inference_tests.rs
+++ b/crates/tsz-checker/tests/keyless_object_record_inference_tests.rs
@@ -1,0 +1,133 @@
+//! Regression coverage for inferring a generic `Record<K, T>` / mapped-type
+//! parameter from a **keyless object source** — the intrinsic `object` type and
+//! the empty object literal `{}`.
+//!
+//! Structural rule (matches TypeScript 6.0.x `inferToMappedType`): a non-
+//! homomorphic mapped type `{ [P in K]: T }` (the body of `Record<K, T>`) is
+//! inferred from a source by its enumerable keys. A keyless source has
+//! `keyof source === never`, so the key space — and, because there are no
+//! values, the template space — collapse to `never`: `K = never`, `T = never`.
+//! `Record<never, never>` is `{}`, which the source satisfies, so the call is
+//! accepted.
+//!
+//! Previously tsz produced no inference candidates for the intrinsic `object`
+//! against the mapped target, so `K` fell back to its constraint (`PropertyKey`)
+//! and `T` to `unknown`/`object`. The resulting `Record<PropertyKey, …>` has a
+//! required index signature that the bare `object` does not satisfy, yielding a
+//! false `TS2345`/`TS2322`. tsc accepts every positive case below.
+//!
+//! Binder names (type-parameter and value identifiers) are varied per case so
+//! the coverage is structural, not keyed to a particular name.
+
+use tsz_checker::test_utils::{
+    check_source_with_libs_code_messages, load_default_lib_files, strict_checker_options,
+};
+
+const TS2322: u32 = 2322; // Type not assignable
+const TS2345: u32 = 2345; // Argument not assignable to parameter
+
+fn codes(source: &str) -> Vec<u32> {
+    // The default libs supply `Record`, `PropertyKey`, and `Array.isArray`, and
+    // narrow `unknown` the way the real compiler does.
+    let libs = load_default_lib_files();
+    check_source_with_libs_code_messages(source, "test.ts", strict_checker_options(), &libs)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases — tsc is clean on all of these.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_param_inferred_from_intrinsic_object_argument() {
+    // The ts-pattern `recordEvery` witness, reduced: a `Record<K, T>` parameter
+    // called with an `object`-typed argument. K = never, T = never.
+    let diags = codes(
+        r#"
+declare const everyEntry: <K extends PropertyKey, V>(
+  table: Record<K, V>,
+  predicate: (key: K, value: V) => boolean
+) => boolean;
+
+function run(value: object): void {
+  everyEntry(value, (k, v) => true);
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2345),
+        "`Record<K, V>` param inferred from `object` must accept the argument, got {diags:?}"
+    );
+}
+
+#[test]
+fn record_param_inferred_from_empty_object_literal_type() {
+    // The empty object literal type is also keyless.
+    let diags = codes(
+        r#"
+declare const forEachKey: <Key extends PropertyKey, Val>(
+  dict: Record<Key, Val>
+) => void;
+
+function go(empty: {}): void {
+  forEachKey(empty);
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2345),
+        "empty object literal type must infer `Record<never, never>`, got {diags:?}"
+    );
+}
+
+#[test]
+fn mapped_type_alias_param_inferred_from_object() {
+    // A user-defined non-homomorphic mapped-type alias behaves like `Record`.
+    let diags = codes(
+        r#"
+type Dictionary<Key extends PropertyKey, Value> = { [Entry in Key]: Value };
+declare const sizeOf: <Key extends PropertyKey, Value>(
+  source: Dictionary<Key, Value>
+) => number;
+
+function measure(thing: object): number {
+  return sizeOf(thing);
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2345) && !diags.contains(&TS2322),
+        "mapped-type alias param inferred from `object` must be accepted, got {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative control — the assignability rule itself is unchanged. With explicit
+// type arguments (no inference), `object` is NOT assignable to a populated
+// `Record`, exactly as in tsc.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn explicit_record_type_args_still_reject_object() {
+    // `object` is not assignable to `Record<PropertyKey, unknown>`; supplying
+    // the type arguments explicitly must still surface the mismatch (tsc emits
+    // TS2345 here too). The inference fix must not weaken this.
+    let diags = codes(
+        r#"
+declare const everyEntry: <K extends PropertyKey, V>(
+  table: Record<K, V>,
+  predicate: (key: K, value: V) => boolean
+) => boolean;
+
+function run(value: object): void {
+  everyEntry<PropertyKey, unknown>(value, (k, v) => true);
+}
+"#,
+    );
+    assert!(
+        diags.contains(&TS2345),
+        "explicit `Record<PropertyKey, unknown>` must still reject `object`, got {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -87,6 +87,46 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             .set(self.constraint_recursion_depth.get() - 1);
     }
 
+    /// Constrain a mapped type's parameters from a source whose key space is
+    /// empty — the intrinsic `object` type, or an empty object literal `{}`.
+    ///
+    /// `keyof <keyless source>` is `never`, so the mapped key space collapses to
+    /// `never`. For a non-homomorphic mapped type (`{ [P in K]: T }`, whose
+    /// constraint is a plain key set rather than `keyof <param>`) the value space
+    /// is empty as well, so the template type parameter is inferred as `never`.
+    /// This matches tsc's `inferToMappedType`, which infers `[never, never]` for
+    /// both `rec(object)` and `rec({})` against
+    /// `<K extends PropertyKey, T>(r: Record<K, T>)`. Homomorphic mapped types
+    /// (constraint `keyof <param>`) keep only the key-space collapse, preserving
+    /// their reverse-mapped candidate handling.
+    fn constrain_empty_keyspace_mapped(
+        &mut self,
+        ctx: &mut InferenceContext,
+        var_map: &FxHashMap<TypeId, crate::inference::infer::InferenceVar>,
+        mapped: &crate::types::MappedType,
+        priority: crate::types::InferencePriority,
+    ) {
+        self.constrain_types(ctx, var_map, TypeId::NEVER, mapped.constraint, priority);
+        // Only a homomorphic mapped type (`{ [P in keyof T]: … }` over an
+        // inference placeholder) has a reverse-mapped candidate path to
+        // preserve. For any other (non-homomorphic) mapped type the value space
+        // is empty too, so the template type parameter is inferred as `never`.
+        if self
+            .find_keyof_inference_target(mapped.constraint, var_map)
+            .is_none()
+        {
+            let subst = TypeSubstitution::single(mapped.type_param.name, TypeId::NEVER);
+            let instantiated_template = instantiate_type(self.interner, mapped.template, &subst);
+            self.constrain_types(
+                ctx,
+                var_map,
+                TypeId::NEVER,
+                instantiated_template,
+                crate::types::InferencePriority::MappedType,
+            );
+        }
+    }
+
     /// Normalize a union's members for inference partitioning by peeling
     /// transparent identity-alias applications (`type Some<X> = X`).
     ///
@@ -644,15 +684,22 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                         && !has_index_sigs
                         && !crate::is_primitive_type(self.interner, source)
                     {
-                        self.constrain_types(
-                            ctx,
-                            var_map,
-                            TypeId::NEVER,
-                            mapped.constraint,
-                            priority,
-                        );
+                        self.constrain_empty_keyspace_mapped(ctx, var_map, &mapped, priority);
                         return;
                     }
+                }
+                // Keyless object-like source with no `ObjectShape` (the intrinsic
+                // `object` type). `keyof object` is `never`, so the mapped key
+                // space — and, for a non-homomorphic `{ [P in K]: T }`, the value
+                // space — collapse to `never`, inferring `K = never`, `T = never`.
+                // This matches tsc's `inferToMappedType` (`object` has no
+                // enumerable keys). Without it the intrinsic `object` produces no
+                // candidates, so `K` falls back to its constraint (e.g.
+                // `PropertyKey`) and `object` is wrongly rejected against
+                // `Record<K, T>`.
+                if matches!(source_key, Some(TypeData::Intrinsic(IntrinsicKind::Object))) {
+                    self.constrain_empty_keyspace_mapped(ctx, var_map, &mapped, priority);
+                    return;
                 }
                 // Handle Tuple sources against mapped types for reverse-mapped inference.
                 // Tuples like [string, number] have numeric keys "0", "1", etc.


### PR DESCRIPTION
Goal: hold

## What

Inferring a generic `Record<K, T>` / non-homomorphic mapped-type parameter `{ [P in K]: T }` from a **keyless object source** — the intrinsic `object` type or the empty object literal `{}` — wrongly fell back to the type parameters' constraints, producing `Record<PropertyKey, …>` and a false `TS2345`. `tsc`/`tsgo`: 0.

```ts
declare const everyEntry: <K extends PropertyKey, V>(
  table: Record<K, V>,
  predicate: (key: K, value: V) => boolean
) => boolean;

function run(value: object): void {
  everyEntry(value, (k, v) => true); // before: TS2345; tsc: 0
}
```

Fixes #14425.

## Structural rule

When a generic non-homomorphic mapped type `{ [P in K]: T }` (the body of `Record<K, T>`) is inferred from a keyless object source (`keyof source === never`: the intrinsic `object`, or `{}`), `tsc`'s `inferToMappedType` infers `K = never`, `T = never` (`rec(object)` ⇒ `[never, never]`, verified against `tsc` 6.0). `Record<never, never>` is `{}`, which `object` satisfies. tsz must do the same instead of falling back to the constraints; tsz owns this in the solver constraint walker.

## Owner layer

Solver constraint walker — `crates/tsz-solver/src/operations/constraints/walker.rs`, the `(_, Mapped)` inference arm. The empty-object-shape `{}` branch (which inferred only `K = never`) and a new intrinsic-`object` branch now route through a shared `constrain_empty_keyspace_mapped` helper that infers `K = never` (constraint) and, for non-homomorphic mapped types, `T = never` (template). Homomorphic detection reuses the arm's existing `find_keyof_inference_target`, so `{ [P in keyof T]: … }` over an inference placeholder keeps its reverse-mapped candidate path untouched.

## Adjacent-case matrix

- Positive: intrinsic `object`; empty `{}` object-literal type; a user-defined non-homomorphic mapped-type alias `{ [Entry in Key]: Value }` — all inferred as `never`/`never` and accepted (binder names varied per case, anti-hardcoding gate).
- Negative/fallback control: explicit `Record<PropertyKey, unknown>` type arguments still reject `object` (`TS2345`) — the assignability rule is unchanged; only inference candidate generation changed.
- Homomorphic mapped types and empty-shape reverse-mapping are preserved (gated on `find_keyof_inference_target`).

## Verification

- New: `cargo test -p tsz-checker --test keyless_object_record_inference_tests` — 4 cases pass (3 positive + 1 negative control).
- `cargo test -p tsz-solver --lib` — no new failures (the 5 reds pre-exist on `main`).
- Targeted checker suites unaffected: `union_target_inference_tests`, `class_field_mapped_type_indexed_access_tests`, `array_element_naked_inference_tests`, `binding_pattern_inference_tests` — all green.
- `cargo clippy -p tsz-solver` — clean.
- Broad conformance/emit/fourslash owned by ready-review CI.

Out of scope: the ts-pattern (`c92ca435`) project-scale instance at `src/patterns.ts:475` additionally depends on `Record` expanding to its mapped body in the relevant arena (cross-arena resolver-availability), so that specific row is not fully cleared by this change; the standalone inference defect is.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
