### PR TITLE
fix(checker): namespace-member merged value+type resolves VALUE side (TS2464/TS2722)

### DIFF
--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -677,6 +677,30 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // For merged TYPE_ALIAS + value symbols (`export const X = ...` paired
+        // with `export type X = typeof X`), `get_type_of_symbol` enters the
+        // TYPE_ALIAS branch and returns the type-alias body. In namespace
+        // member access (value position — e.g. a computed property key
+        // `[ns.X]`), the VALUE side is required so the key resolves to the
+        // const's literal type instead of an unevaluated `typeof X`, which
+        // would otherwise raise a spurious TS2464 (and a follow-on TS2722 once
+        // the key fails to register as a member) (#14130). Mirrors the
+        // `is_merged_interface_value` branch above and the same-file identifier
+        // path in `resolved_identifier_flow_result`; the value side is resolved
+        // through the same helpers `reexported_merged_alias_value_type` uses,
+        // reusing the `value_decl` already fetched above.
+        if (flags & symbol_flags::TYPE_ALIAS) != 0
+            && (flags & (symbol_flags::VARIABLE | symbol_flags::FUNCTION)) != 0
+            && (flags & symbol_flags::INTERFACE) == 0
+            && (flags & symbol_flags::CLASS) == 0
+            && (flags & symbol_flags::ENUM) == 0
+            && let Some(value_type) = self
+                .compute_value_type_for_merged_alias(resolved_member_id)
+                .or_else(|| self.cross_file_merged_alias_value_type(resolved_member_id, value_decl))
+        {
+            return Some(value_type);
+        }
+
         Some(self.get_type_of_symbol(resolved_member_id))
     }
 

--- a/crates/tsz-cli/tests/symbol_keyed_member_cross_arena_cli_tests.rs
+++ b/crates/tsz-cli/tests/symbol_keyed_member_cross_arena_cli_tests.rs
@@ -56,12 +56,14 @@ fn compile_in_order(files: &[(&str, &str)], root_order: &[&str]) -> Vec<Diagnost
 }
 
 /// Diagnostics that this family produces as false positives: assignability
-/// mismatches (TS2322/TS2345/TS2353) and the invalid-computed-key error
-/// (TS2464) that the degraded value type triggers.
+/// mismatches (TS2322/TS2345/TS2353), the invalid-computed-key error (TS2464)
+/// that the degraded value type triggers, and the possibly-`undefined`-callee
+/// error (TS2722) raised when the unresolved key fails to register the member
+/// so its access falls back to a `… | undefined` index lookup.
 fn family_false_positives(diagnostics: &[Diagnostic]) -> Vec<(u32, String)> {
     diagnostics
         .iter()
-        .filter(|d| matches!(d.code, 2322 | 2345 | 2353 | 2464 | 2536))
+        .filter(|d| matches!(d.code, 2322 | 2345 | 2353 | 2464 | 2536 | 2722))
         .map(|d| (d.code, d.message_text.clone()))
         .collect()
 }
@@ -331,6 +333,113 @@ export const bad: I = { [m]: 123 };
             .iter()
             .any(|d| matches!(d.code, 2322 | 2345 | 2418 | 2353)),
         "expected an assignability error for the wrong computed-property value through a barrel, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// #14130 (ts-pattern witness): the merged value+type-alias symbol is consumed
+/// through a **namespace import** (`import * as symbols`) and keyed as
+/// `[symbols.matcher]` — a *property-access* computed name rather than a bare
+/// identifier. The const value here is a plain **string literal**
+/// (`'@ts-pattern/matcher'`), not `Symbol.for(...)`, so the key is a
+/// string-literal late-bound name. Resolving `symbols.matcher` in value
+/// position must surface the const's literal VALUE, not the unevaluated
+/// `typeof matcher` type-alias body; otherwise the interface member key fails
+/// (false TS2464), the member never registers, and invoking the result of the
+/// element access reports a spurious TS2722.
+#[test]
+fn cross_file_namespace_import_string_literal_merge_computed_key() {
+    assert_clean_both_orders(&[
+        (
+            "symbols.ts",
+            r#"
+export const matcher = '@ts-pattern/matcher';
+export type matcher = typeof matcher;
+"#,
+        ),
+        (
+            "helpers.ts",
+            r#"
+import * as symbols from './symbols';
+export interface Matchable {
+  [symbols.matcher](): { match: (v: unknown) => boolean };
+}
+declare function isMatchable(x: unknown): x is Matchable;
+export function matchPattern(pattern: unknown, value: unknown) {
+  if (isMatchable(pattern)) {
+    return pattern[symbols.matcher]().match(value);
+  }
+}
+"#,
+        ),
+    ]);
+}
+
+/// Renamed-binder variant of the namespace-import case: the rule follows the
+/// merged binding's value side, not the `matcher` identifier text or the
+/// `symbols` namespace alias name.
+#[test]
+fn cross_file_namespace_import_string_literal_merge_computed_key_renamed() {
+    assert_clean_both_orders(&[
+        (
+            "keys.ts",
+            r#"
+export const wireTag = '@demo/wire-tag';
+export type wireTag = typeof wireTag;
+export const seq = 7;
+export type seq = typeof seq;
+"#,
+        ),
+        (
+            "use.ts",
+            r#"
+import * as ns from './keys';
+export interface Wire {
+  [ns.wireTag](): string;
+  [ns.seq](): number;
+}
+declare const w: Wire;
+export const a: string = w[ns.wireTag]();
+export const b: number = w[ns.seq]();
+const lit = { [ns.wireTag]: () => "x", [ns.seq]: () => 1 };
+export const ok: Wire = lit;
+"#,
+        ),
+    ]);
+}
+
+/// Negative control for the namespace-import form: the key resolves correctly,
+/// so a wrong value against the declared member type must still be rejected —
+/// the fix surfaces the value side without silencing real diagnostics.
+#[test]
+fn cross_file_namespace_import_string_literal_merge_wrong_value_still_errors() {
+    let files = &[
+        (
+            "symbols.ts",
+            r#"
+export const matcher = '@ts-pattern/matcher';
+export type matcher = typeof matcher;
+"#,
+        ),
+        (
+            "helpers.ts",
+            r#"
+import * as symbols from './symbols';
+export interface Matchable { [symbols.matcher](): number; }
+export const bad: Matchable = { [symbols.matcher]: 123 };
+"#,
+        ),
+    ];
+    let names: Vec<&str> = files.iter().map(|(name, _)| *name).collect();
+    let diags = compile_in_order(files, &names);
+    assert!(
+        diags
+            .iter()
+            .any(|d| matches!(d.code, 2322 | 2345 | 2418 | 2353)),
+        "expected an assignability error for the wrong computed-property value through a namespace import, got: {:?}",
         diags
             .iter()
             .map(|d| (d.code, &d.message_text))


### PR DESCRIPTION
## Summary
Fixes #14130. A module that exports a value and a type alias under one name
(`export const X = ...; export type X = typeof X`) and is consumed through a
**namespace import** (`import * as ns from "./x"`) surfaced its member `ns.X`
in value position as the unevaluated `typeof X` type-alias body instead of the
const's own VALUE. A computed property key `[ns.X]` then failed the
computed-property-name check with a spurious **TS2464**, the member never
registered on the interface, and invoking the element-access result reported a
follow-on **TS2722** ("Cannot invoke an object which is possibly 'undefined'").
This is the ts-pattern `helpers.ts` false-positive family in the issue.

The same-file identifier path (`resolved_identifier_flow_result`) and the
named-import / re-export paths (`imported_merged_type_alias_value_type` /
`reexported_merged_alias_value_type`) already resolved the VALUE side for these
merges; only the namespace-member path was missing it.

## Structural rule
When a namespace member is a name-merged `TYPE_ALIAS` + value symbol, tsc
resolves it to the value (the const's literal) in value position; tsz now does
the same through the checker's namespace-member value-position owner
`get_validated_member_type`. The branch sits next to the existing merged
`INTERFACE` + value branch, is gated on the same flag shape
(`TYPE_ALIAS` + `VARIABLE|FUNCTION`, excluding `INTERFACE`/`CLASS`/`ENUM` so
those keep their dedicated handling), and resolves the value side through the
existing `compute_value_type_for_merged_alias` /
`cross_file_merged_alias_value_type` helpers — reusing the member's
already-fetched value declaration (no new helper, no extra symbol lookup).

## Adjacent matrix
- Namespace import, string-literal const (the #14130 witness) — both root files
  and consumer-first ordering.
- Renamed binders (`wireTag`, `seq`, namespace aliased as `ns`) — follows the
  binding's value side, not the identifier/namespace text.
- Numeric-literal merged key, object-literal construction, element + call.
- Negative controls: a wrong member value (`123` vs a method type) is still
  rejected; a genuinely invalid object-typed computed name still reports TS2464.

## Goal
Goal: green

## Verification
- `cargo test -p tsz-cli --lib symbol_keyed_member_cross_arena` — 12 passed
  (3 new namespace-import regression tests + 9 existing).
- `cargo test -p tsz-checker --test ts2353_cross_module_symbol_computed_key_tests` — 3 passed.
- `cargo test -p tsz-checker --lib cross_file_merged_symbol_value_computed_key` — 8 passed.
- Manual: the issue's ts-pattern `helpers.ts` shape (`import * as symbols`,
  `[symbols.matcher]()`, guard + call) compiles clean; pre-existing merged/
  computed-key suites unaffected.
- `cargo clippy -p tsz-checker` — clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_012V5NdDsTHSvqGgSDw9S8sJ)_