### PR TITLE
fix(checker): unrelated array mutation must not re-widen another reference's narrowing

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1806,6 +1806,9 @@ path = "tests/flow_captured_let_memoization_tests.rs"
 [[test]]
 name = "flow_passthrough_run_narrowing_tests"
 path = "tests/flow_passthrough_run_narrowing_tests.rs"
+[[test]]
+name = "array_mutation_unrelated_narrowing_tests"
+path = "tests/array_mutation_unrelated_narrowing_tests.rs"
 
 [[test]]
 name = "public_package_unique_symbol_emit_tests"

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -959,22 +959,55 @@ impl<'a> FlowAnalyzer<'a> {
                 } else if affects_ref {
                     current_type
                 } else if let Some(&ant) = flow.antecedent.first() {
-                    if self.antecedent_requires_defer_cached(
-                        ant,
-                        reference,
-                        symbol_id,
-                        &mut defer_memos,
-                    ) && !visited.contains(&ant)
-                        && !results.contains_key(&ant)
-                    {
-                        defer_to_antecedent(worklist, in_worklist, ant, current_flow, current_type);
-                        continue;
+                    // This mutation targets a DIFFERENT array than `reference`, so it
+                    // is a pure value pass-through for `reference` and must NOT
+                    // re-derive its narrowing. Mirror the non-targeting ASSIGNMENT
+                    // pass-through: if the antecedent carries narrowing for
+                    // `reference` and has not been resolved yet, defer so the
+                    // narrowed type reaches the dependent reader instead of the
+                    // declared type. A bare `antecedent_requires_defer` is too
+                    // narrow here — it does not recognize a prior `ARRAY_MUTATION`
+                    // node (the mutation/evolution of `reference` itself) or a
+                    // non-targeting ASSIGNMENT chain that still carries the
+                    // assignment-narrowing of `reference` (e.g.
+                    // `a = a || []; a.push(1); b.push(1); a.pop()`), so the
+                    // unrelated mutation re-widens `a` to `T | undefined` and emits
+                    // a false `TS18048`.
+                    if let Some(&ant_type) = results.get(&ant) {
+                        ant_type
+                    } else if !visited.contains(&ant) {
+                        let ant_needs_defer = self.binder.flow_nodes.get(ant).is_some_and(|f| {
+                            f.has_any_flags(
+                                flow_flags::CONDITION
+                                    | flow_flags::CALL
+                                    | flow_flags::BRANCH_LABEL
+                                    | flow_flags::LOOP_LABEL
+                                    | flow_flags::ASSIGNMENT
+                                    | flow_flags::ARRAY_MUTATION
+                                    | flow_flags::SWITCH_CLAUSE
+                                    | flow_flags::AWAIT_POINT
+                                    | flow_flags::YIELD_POINT
+                                    | flow_flags::START,
+                            )
+                        });
+                        if ant_needs_defer {
+                            defer_to_antecedent(
+                                worklist,
+                                in_worklist,
+                                ant,
+                                current_flow,
+                                current_type,
+                            );
+                            continue;
+                        }
+                        if !in_worklist.contains(&ant) {
+                            worklist.push_back((ant, current_type));
+                            in_worklist.insert(ant);
+                        }
+                        *results.get(&ant).unwrap_or(&current_type)
+                    } else {
+                        current_type
                     }
-                    if !in_worklist.contains(&ant) && !visited.contains(&ant) {
-                        worklist.push_back((ant, current_type));
-                        in_worklist.insert(ant);
-                    }
-                    *results.get(&ant).unwrap_or(&current_type)
                 } else {
                     current_type
                 }

--- a/crates/tsz-checker/tests/array_mutation_unrelated_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/array_mutation_unrelated_narrowing_tests.rs
@@ -1,0 +1,170 @@
+//! Witness matrix for the `ARRAY_MUTATION` pass-through narrowing fix in the
+//! backward flow walk (`check_flow`'s `ARRAY_MUTATION` arm in
+//! `crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs`).
+//!
+//! Structural rule:
+//!
+//! > An `ARRAY_MUTATION` flow node for a mutating method call (`.push` / `.pop`
+//! > / `.unshift`) on array `B` must only affect the evolving-array narrowing of
+//! > `B` itself. For an unrelated reference `A` the node is a pure value
+//! > pass-through, so the walk must defer to the antecedent that carries `A`'s
+//! > narrowing instead of re-deriving (and re-widening) it. Previously the arm's
+//! > `!affects_ref` branch used a defer predicate that did not recognize a prior
+//! > `ARRAY_MUTATION` node (the mutation/evolution of `A` itself) nor a
+//! > non-targeting ASSIGNMENT chain still carrying `A`'s assignment-narrowing, so
+//! > the unrelated mutation re-widened `A` back to `T | undefined` and emitted a
+//! > false `TS18048` on a later read of `A`.
+//!
+//! `tsc` keeps `A` narrowed across an unrelated array mutation; all cases here
+//! are `tsc`-clean except the explicitly-cleared one. Each case uses distinct
+//! binder / parameter names so the behavior follows the structural shape, not
+//! any identifier spelling (CLAUDE.md anti-hardcoding gate).
+
+use tsz_checker::test_utils::check_source_codes;
+
+const TS18048_POSSIBLY_UNDEFINED: u32 = 18048;
+
+fn assert_no_possibly_undefined(source: &str) {
+    let diags = check_source_codes(source);
+    assert!(
+        !diags.contains(&TS18048_POSSIBLY_UNDEFINED),
+        "unrelated array mutation must not re-widen the narrowed reference \
+         (unexpected TS18048); got: {diags:?}",
+    );
+}
+
+fn assert_possibly_undefined(source: &str) {
+    let diags = check_source_codes(source);
+    assert!(
+        diags.contains(&TS18048_POSSIBLY_UNDEFINED),
+        "a genuinely possibly-undefined read must still report TS18048; got: {diags:?}",
+    );
+}
+
+// =========================================================================
+// Narrowing of A is PRESERVED across an unrelated array mutation of B.
+// =========================================================================
+
+/// `first` is narrowed by `= first || []`, referenced, then a DIFFERENT array
+/// `second` is mutated with `.push`. The later `first.pop()` must read the
+/// narrowed `number[]`, not the declared `number[] | undefined`. (The minimal
+/// repro of the bug; `tsc` is clean.)
+#[test]
+fn or_default_narrowing_survives_unrelated_push() {
+    assert_no_possibly_undefined(
+        r#"
+function withOrDefault(first: number[] | undefined, second: number[]) {
+    first = first || [];
+    first.push(1);
+    second.push(1);
+    first.pop();
+}
+"#,
+    );
+}
+
+/// Same shape narrowed via an `if (x === undefined) x = []` guard instead of
+/// `|| []`. Both produce a targeting ASSIGNMENT that the unrelated mutation
+/// must defer through.
+#[test]
+fn if_undefined_narrowing_survives_unrelated_push() {
+    assert_no_possibly_undefined(
+        r#"
+function withIfGuard(left: string[] | undefined, right: string[]) {
+    if (left === undefined) left = [];
+    left.push("a");
+    right.push("b");
+    left.pop();
+}
+"#,
+    );
+}
+
+/// The unrelated mutation uses `.unshift` rather than `.push`; still a pure
+/// pass-through for the narrowed array.
+#[test]
+fn narrowing_survives_unrelated_unshift() {
+    assert_no_possibly_undefined(
+        r#"
+function withUnshift(primary: number[] | undefined, secondary: number[]) {
+    primary = primary || [];
+    primary.push(1);
+    secondary.unshift(1);
+    primary.pop();
+}
+"#,
+    );
+}
+
+/// The unrelated mutation uses `.pop`; the narrowed array must stay narrowed.
+#[test]
+fn narrowing_survives_unrelated_pop() {
+    assert_no_possibly_undefined(
+        r#"
+function withPop(alpha: number[] | undefined, beta: number[]) {
+    alpha = alpha || [];
+    alpha.push(1);
+    beta.pop();
+    alpha.pop();
+}
+"#,
+    );
+}
+
+/// An element write (`other[0] = 1`) interleaved between the narrowed array's
+/// own mutation and a later read must not drop the narrowing either. This
+/// exercises the non-targeting ASSIGNMENT-after-ARRAY_MUTATION chain.
+#[test]
+fn narrowing_survives_unrelated_element_write() {
+    assert_no_possibly_undefined(
+        r#"
+function withElementWrite(head: number[] | undefined, other: number[]) {
+    head = head || [];
+    head.push(1);
+    other[0] = 1;
+    head.pop();
+}
+"#,
+    );
+}
+
+/// Two independently-narrowed arrays whose mutations interleave: each read must
+/// see its own narrowed type, unaffected by the other's mutation.
+#[test]
+fn two_narrowed_arrays_interleaved_mutations() {
+    assert_no_possibly_undefined(
+        r#"
+function withTwo(one: number[] | undefined, two: string[] | undefined) {
+    one = one || [];
+    two = two || [];
+    one.push(1);
+    two.push("x");
+    one.pop();
+    two.pop();
+}
+"#,
+    );
+}
+
+// =========================================================================
+// A genuinely-undefined read still reports TS18048 (no over-suppression).
+// =========================================================================
+
+/// No narrowing of `maybe` ever happens; the unrelated mutation must not
+/// fabricate a non-null narrowing. The `maybe[0]` read is still a true
+/// possibly-undefined access and must report TS18048. (Element access is used
+/// rather than a `.pop()` call so the read surfaces TS18048 independently of
+/// the minimal test-harness lib's `Array.prototype` member resolution; the CLI
+/// reports TS18048 on the `.pop()` form too.)
+#[test]
+fn unnarrowed_reference_still_reports_possibly_undefined() {
+    assert_possibly_undefined(
+        r#"
+function withoutGuard(maybe: number[] | undefined, present: number[]) {
+    present.push(1);
+    const value = maybe[0];
+    return value;
+}
+"#,
+    );
+}


### PR DESCRIPTION
Goal: green

## Structural rule
When a backward flow walk evaluates an `ARRAY_MUTATION` flow node for a mutating method call (`.push` / `.pop` / `.unshift`) on array `B`, that node must only affect the evolving-array narrowing of `B` itself; for an unrelated reference `A` it is a pure value pass-through, so tsz must defer to the antecedent that carries `A`'s narrowing rather than re-deriving (and re-widening) it — matching `tsc`.

Owner layer: `crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs`, the `ARRAY_MUTATION` arm's `!affects_ref` branch. It previously used `antecedent_requires_defer`, which does not recognize a prior `ARRAY_MUTATION` node (`A`'s own mutation/evolution) nor a non-targeting ASSIGNMENT chain still carrying `A`'s assignment-narrowing. So a mutation of `B` re-widened `A` back to its declared `T | undefined` and emitted a false `TS18048` on a later read of `A`. The fix mirrors the proven non-targeting-ASSIGNMENT pass-through: defer to the antecedent when it carries narrowing (`CONDITION`/`CALL`/`BRANCH_LABEL`/`LOOP_LABEL`/`ASSIGNMENT`/`ARRAY_MUTATION`/`SWITCH_CLAUSE`/`AWAIT_POINT`/`YIELD_POINT`/`START`) and is unresolved. The `affects_ref` (evolving-array) path is untouched, so array element-type evolution is preserved. No identifier/file/text hardcoding.

## Adjacent matrix
All `tsc`-clean except the explicit negative; tsz now matches `tsc` on every row.
- `a = a || []; a.push(1); b.push(1); a.pop()` — narrowing preserved (was false TS18048). FIXED
- `if (a === undefined) a = []; a.push(1); b.push(1); a.pop()` — same via `=== undefined` guard. FIXED
- `b.unshift(1)` / `b.pop()` as the unrelated mutation — preserved.
- `b[0] = 1` element write interleaved between `a.push(1)` and `a.pop()` — preserved (non-targeting ASSIGNMENT-after-ARRAY_MUTATION chain).
- Two independently-narrowed arrays with interleaved mutations — each keeps its own narrowing.
- `let a = []; a.push(1); a.push("x")` — evolving-array element type still evolves (affects_ref path unchanged).
- Unnarrowed reference (`a: number[] | undefined`, no guard) still reports TS18048 — no over-suppression.
- Negatives that were already clean stay clean: non-mutating second-var method (`.indexOf`/`.length`), no prior reference to `a`, order swapped.

## Verification
- Minimal repro `/tmp/n2.ts` and `=== undefined` variant: tsz now exit 0, matches bundled `tsc` (clean); full adjacency matrix verified against `node TypeScript/bin/tsc` (all parity).
- New regression suite `crates/tsz-checker/tests/array_mutation_unrelated_narrowing_tests.rs` (7 tests, varied binder names per anti-hardcoding gate): 7/7 pass.
- Conformance (`scripts/conformance/conformance.sh run --filter ...`): narrowing 29/29, controlFlow 94/94, evolvingArray 2/2, arrayLiteral 19/19, assignment 161/161, flow 5/5, Array 254/254 — all 100%, zero regressions. evolvingArray (the key risk) stays green.
- Corpus mobx (canary, `project-compile-guard`): eq.ts TS18048 2 -> 0; total mobx diagnostics 36 (TS7006/TS7053/TS2683/TS2322 — pre-existing deep roots), zero TS18048, no new diagnostics.
- Delta-gate vs clean base `f8838692a5`: identical 17 pre-existing env-only failures (architecture-contract / structural-display / typebox / spread-rest / relation-overflow timeout) in `-p tsz-checker` narrow/flow/array/evolv/18048/mutation families before and after — net-new = 0. clippy `-p tsz-checker --tests` clean. Touched files under 2000 LOC.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
