### PR TITLE
test(checker): activate guards for fleet-fixed #14213/#14232 + note 4 closed-but-reproducing FPs

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
@@ -149,7 +149,7 @@ export type { A };
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "reproduces #14225"]
+#[ignore = "reproduces #14225 (issue closed but minimal repro still emits TS2503)"]
 fn issue_14225_reimported_namespace_qualified_type_no_ts2503() {
     if !lib_files_available() {
         return;
@@ -182,7 +182,6 @@ export { r }
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "reproduces #14213"]
 fn issue_14213_curried_arrow_return_annotation_contextual_no_ts7006() {
     let diags = compile_and_get_diagnostics_with_lib_and_options(
         r#"
@@ -207,7 +206,7 @@ export const f =
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "reproduces #14167"]
+#[ignore = "reproduces #14167 (issue closed but minimal repro still emits TS2344)"]
 fn issue_14167_conditional_true_branch_substitution_no_ts2344() {
     let diags = compile_and_get_diagnostics_with_lib_and_options(
         r#"
@@ -231,7 +230,7 @@ export {};
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "reproduces #14263"]
+#[ignore = "reproduces #14263 (issue closed but minimal repro still emits TS2348)"]
 fn issue_14263_imported_value_shadows_global_ctor_no_ts2348() {
     if !lib_files_available() {
         return;
@@ -292,7 +291,7 @@ export const fromBlock = <A>(O: Ord<A>): Ord<A[]> =>
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "reproduces #14220"]
+#[ignore = "reproduces #14220 (issue closed but minimal repro still emits TS2339)"]
 fn issue_14220_primitive_not_record_conditional_branch_no_ts2339() {
     let diags = compile_and_get_diagnostics_with_lib_and_options(
         r#"
@@ -345,7 +344,6 @@ export { Local as Capitalize }
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "reproduces #14232"]
 fn issue_14232_concrete_check_generic_extends_false_branch_no_ts2322() {
     let diags = compile_and_get_diagnostics_with_lib_and_options(
         r#"


### PR DESCRIPTION
Round 4 of the canary FP regression-guard audit (follow-up to #14384, now merged).
No compiler source changes — parity-floor protection (`Goal: hold`).

Goal: hold

## What changed
Re-checked the 6 round-3 `#[ignore]`d witnesses whose issues have since closed, by
un-ignoring them and building against current `main`:

**Genuinely FIXED -> activated as passing regression guards:**
- **#14213** (TS7006): curried-arrow annotated-return contextual typing.
- **#14232** (TS2322): concrete-check conditional with a generic `extends` resolves
  its false branch (fixed conformance-safely on main).

**Issue CLOSED but minimal repro STILL reproduces -> kept `#[ignore]`d, notes
updated** (closed as duplicate/superseded, or the fix changed the witness):
#14167 (TS2344), #14220 (TS2339), #14225 (TS2503), #14263 (TS2348). These remain
documented witnesses; they'll flip to guards when actually fixed.

## Verification
- `cargo nextest run -p tsz-checker -j 2 fp_repro_audit_2026_c` — 6 active guards
  pass; reproducing/closed-but-present witnesses skipped (`#[ignore]`); suite green.
- CI gates: lint, unit-checker-integration, conformance-aggregate, emit-aggregate,
  fourslash-*, project-compile-guard, CI Summary.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max