### PR TITLE
refactor(checker): remove dead recursiveTypeReferences1 diagnostic rewrite

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -757,7 +757,6 @@ impl CheckerState<'_> {
         }
         self.rewrite_conditional_types1_fingerprints(&sf.text);
         self.rewrite_variadic_tuples1_fingerprints(&sf.text);
-        self.rewrite_recursive_type_references1_fingerprints(&sf.text);
         self.align_awaited_type_instantiation_diagnostics(&sf.text);
         self.align_evolving_array_inference_diagnostics(&sf.text);
         self.align_type_inference_literal_union_diagnostics(&sf.text);
@@ -1027,113 +1026,6 @@ impl CheckerState<'_> {
                 message,
                 code,
             ));
-        }
-    }
-
-    fn rewrite_recursive_type_references1_fingerprints(&mut self, source_text: &str) {
-        use tsz_common::diagnostics::{Diagnostic, diagnostic_codes};
-
-        if !source_text.contains("type Box2 = Box<Box2 | number>")
-            || !source_text.contains("const b20: Box2 = 42;")
-            || !source_text.contains("type RecArray<T> = Array<T | RecArray<T>>")
-        {
-            return;
-        }
-
-        let expected_recursive_array_diagnostics = [
-            (
-                "flat([1, ['a']]);",
-                "flat([",
-                "Type 'number' is not assignable to type 'string | RecArray<string>'.",
-            ),
-            (
-                "flat1([1, ['a']]);",
-                "flat1([",
-                "Type 'number' is not assignable to type 'string | string[]'.",
-            ),
-            (
-                "flat2([1, ['a']]);",
-                "flat2([",
-                "Type 'number' is not assignable to type 'string | (string | string[])[]'.",
-            ),
-        ];
-        let mut callsite_rewrites = Vec::with_capacity(expected_recursive_array_diagnostics.len());
-        for (line_marker, prefix, message) in expected_recursive_array_diagnostics {
-            let Some(line_start) = source_text.find(line_marker) else {
-                return;
-            };
-            let start = line_start + prefix.len();
-            let line_end = source_text[line_start..]
-                .find('\n')
-                .map(|offset| line_start + offset)
-                .unwrap_or(source_text.len());
-            callsite_rewrites.push((line_start, line_end, start, message));
-        }
-
-        let recursive_array_extra_messages = [
-            "Type 'number' is not assignable to type 'string | RecArray<string>'.",
-            "Type 'string' is not assignable to type 'number | RecArray<number>'.",
-            "Type 'number' is not assignable to type 'string | string[]'.",
-            "Type 'number' is not assignable to type 'string'.",
-            "Type '1' is not assignable to type '\"a\" | \"a\"[]'.",
-            "Type 'number' is not assignable to type '\"a\"'.",
-            "Type 'string' is not assignable to type 'number'.",
-            "Type 'number' is not assignable to type 'string | (string | string[])[]'.",
-            "Type 'string' is not assignable to type 'number | number[]'.",
-            "Type 'string' is not assignable to type 'VibratePattern'.",
-            "Type '(ValueOrArray<number>)[]' is not assignable to type 'ValueOrArray<number>'.",
-        ];
-        let fixture_block = source_text
-            .find("type RecArray<T> = Array<T | RecArray<T>>")
-            .and_then(|start| {
-                source_text[start..]
-                    .find("type T10 = T10[];")
-                    .map(|offset| (start, start + offset))
-            });
-        self.ctx.diagnostics.retain(|diag| {
-            if diag.code != diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE {
-                return true;
-            }
-            let diag_start = diag.start as usize;
-            let in_rewrite_scope = callsite_rewrites
-                .iter()
-                .any(|(line_start, line_end, _, _)| {
-                    diag_start >= *line_start && diag_start < *line_end
-                })
-                || fixture_block
-                    .is_some_and(|(start, end)| diag_start >= start && diag_start < end);
-            if !in_rewrite_scope {
-                return true;
-            }
-            !recursive_array_extra_messages
-                .iter()
-                .any(|message| diag.message_text == *message)
-        });
-        let mut push_unique_diagnostic = |start: usize, code: u32, message: &str| {
-            let start_u32 = start as u32;
-            let len_u32 = 1u32;
-            if self.ctx.diagnostics.iter().any(|existing| {
-                existing.code == code
-                    && existing.start == start_u32
-                    && existing.length == len_u32
-                    && existing.message_text == message
-            }) {
-                return;
-            }
-            self.ctx.diagnostics.push(Diagnostic::error(
-                self.ctx.file_name.clone(),
-                start_u32,
-                len_u32,
-                message,
-                code,
-            ));
-        };
-        for (_, _, start, message) in callsite_rewrites {
-            push_unique_diagnostic(
-                start,
-                diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
-                message,
-            );
         }
     }
 


### PR DESCRIPTION
Goal: hold

Closes part of #14141 (one of the five `source_text.contains` fixture rewrites).

## What

Removes `rewrite_recursive_type_references1_fingerprints` and its dispatch from
`crates/tsz-checker/src/state/state_checking/source_file.rs` (108 lines).

This function is one of the five fixture-text-gated diagnostic rewrites called
out by the Anti-Hardcoding Gate in #14141. It gated on
`source_text.contains("type Box2 = Box<Box2 | number>")` (and two more
snippets), then dropped/pushed diagnostics by matching hardcoded message
sentences embedding user identifiers (`RecArray`, `Box2`, …) — tripping four
of the gate's prohibitions at once.

## Structural rule

When a recursive type reference (`type Box2 = Box<Box2 | number>`,
`RecArray<T> = Array<T | RecArray<T>>`) is assigned an incompatible value, tsc
reports `TS2322` with the recursive target type displayed; tsz now reports this
through the solver's relation → reason → diagnostic path natively, so the
fixture rewrite is a complete no-op.

The solver caught up since the rewrite was written. The rewrite no longer
changes any output: every diagnostic it would push is already produced by the
native path at the same position, and every message it would drop is no longer
produced.

## Why it's safe

The rewrite is gated on long fixture-specific marker strings, so it can only
affect files containing those exact snippets — i.e. only this fixture. I
verified deadness empirically against the pinned TypeScript submodule commit
(`050880c`, TS 6.0.3):

- Ran `recursiveTypeReferences1.ts` with the rewrite enabled vs. disabled:
  **byte-identical** diagnostic output.
- Output matches the tsc `recursiveTypeReferences1.errors.txt` baseline exactly
  (13 diagnostics: 4 × `TS2322`, 9 × `TS2304`).
- Compared the unique diagnostic-fingerprint set (code + line + column +
  normalized message — what the conformance harness compares) before vs. after
  the change for all five rewrite fixtures: **unchanged** for every one
  (recursive 13, conditional 20, variadic 22, indexSignatures 52, inferGeneric
  2 — all equal to their tsc baselines).
- `crates/tsz-checker/tests/recursive_array_utility_inference_tests.rs` (which
  exercises the native path with renamed binders, including
  `renamed_binders_behave_identically`) passes — confirming the native result
  is binder-agnostic, not a second hardcoding.

The other four rewrites (`conditional_types1`, `variadic_tuples1`,
`index_signatures1`, `infer_generic_return`) are still load-bearing — the solver
genuinely diverges from tsc on those fixtures (e.g. variadic-tuple relation
gaps, conditional-type display of `DeepReadonly` vs `DeepReadonlyObject`,
contextual-inference through `Promise.all`). They require real semantic fixes
and are left for follow-up PRs per the issue's one-PR-per-fixture decomposition.

## Verification

- `cargo build -p tsz-cli` — clean.
- `cargo clippy -p tsz-checker --lib` — no warnings.
- `cargo test -p tsz-checker --test recursive_array_utility_inference_tests` —
  5/5 pass.
- Fingerprint-set parity (rewrite enabled vs. removed) across all five fixtures
  — unchanged.
- ready-review CI conformance/emit/fourslash suites own broad parity.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVH82ZN7NRrK8YRP9JMg8k)_