### PR TITLE
fix(solver): infer type args through indexed-access parameter types (#14261)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -860,6 +860,9 @@ path = "tests/contextual_ts2345_conformance_tests.rs"
 name = "co_contra_inference_tests"
 path = "tests/co_contra_inference_tests.rs"
 [[test]]
+name = "issue_14261_indexed_access_param_inference_tests"
+path = "tests/issue_14261_indexed_access_param_inference_tests.rs"
+[[test]]
 name = "keyof_type_param_target_diagnostic_tests"
 path = "tests/keyof_type_param_target_diagnostic_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/issue_14261_indexed_access_param_inference_tests.rs
+++ b/crates/tsz-checker/tests/issue_14261_indexed_access_param_inference_tests.rs
@@ -1,0 +1,154 @@
+//! Regression for issue #14261: a callee type argument must be inferable from
+//! an argument matched against an **indexed-access parameter type** whose object
+//! is a generic application carrying the type parameter (`Ord<A>['compare']`).
+//!
+//! Root cause: the generic-call constraint walker reduced an indexed-access
+//! target through the bare interner (`evaluate_index_access`), which has no
+//! resolver and therefore cannot expand a `Lazy`/`Application` object such as
+//! `Ord<A>` to its body. The access stayed unevaluated, so no candidate was ever
+//! collected for `A` and it collapsed to its default (`unknown`), surfacing as a
+//! callback whose parameters were `unknown` (false `TS2345`/`TS18046`). The
+//! walker now expands the object through the checker's resolver — which preserves
+//! the inference placeholder rather than collapsing it to its constraint — and
+//! re-indexes, so `Ord<A>['compare']` reduces to `(first: A, second: A) =>
+//! Ordering` and the argument contributes `A = string`.
+//!
+//! Each test varies the binder names so the fix is exercised structurally, not
+//! via any identifier/file-name predicate. Positive cases assert the inferred
+//! argument flows (no spurious error); negative cases assert the parameter was
+//! bound to the *concrete* inferred type (a mismatched annotation still reports
+//! exactly one `TS2322`), proving the value is not a permissive `any`/`unknown`
+//! that would suppress the error.
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::check_source_with_libs_code_messages;
+
+fn codes(source: &str) -> Vec<u32> {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    let opts = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    check_source_with_libs_code_messages(source, "test.ts", opts, &libs)
+        .into_iter()
+        .map(|(c, _)| c)
+        .collect()
+}
+
+/// The issue witness: a contextual return type (`Ord<string>`) fixes `A`, and
+/// the unannotated callback parameters must pick up `string` through the
+/// indexed-access parameter type `Ord<A>['compare']`.
+#[test]
+fn issue_14261_contextual_return_indexed_access_param_callback() {
+    let c = codes(
+        r#"
+type Ordering = -1 | 0 | 1
+interface Ord<A> { readonly compare: (first: A, second: A) => Ordering }
+declare const fromCompare: <A>(compare: Ord<A>['compare']) => Ord<A>
+export const fromBlock = (O: Ord<string>): Ord<string> =>
+  fromCompare((x, y) => { return x.length < y.length ? -1 : 1 })
+"#,
+    );
+    assert!(
+        c.is_empty(),
+        "callback params must be typed `string` via the indexed-access parameter; got {c:?}"
+    );
+}
+
+/// Pure inference (no contextual return): explicit `string` callback parameters
+/// must infer `A = string` through `Ord<A>['compare']`. The mismatched
+/// `Ord<number>` annotation proves `A` bound to `string`, not `unknown`.
+#[test]
+fn issue_14261_pure_inference_indexed_access_param() {
+    let c = codes(
+        r#"
+type Ordering = -1 | 0 | 1
+interface Ord<A> { readonly compare: (first: A, second: A) => Ordering }
+declare const f: <A>(c: Ord<A>['compare']) => Ord<A>
+const r = f((x: string, y: string) => 1)
+const ok: Ord<string> = r
+const bad: Ord<number> = r
+"#,
+    );
+    assert_eq!(
+        c.iter().filter(|&&x| x == 2322).count(),
+        1,
+        "A must infer to `string`: only the `Ord<number>` annotation mismatches. Got {c:?}"
+    );
+}
+
+/// Renamed binders, explicit callback parameters: the fix is structural, so the
+/// same inference holds when every identifier differs.
+#[test]
+fn issue_14261_renamed_binders_indexed_access_param() {
+    let c = codes(
+        r#"
+type Cmp = -1 | 0 | 1
+interface Comparator<Q> { readonly run: (a: Q, b: Q) => Cmp }
+declare const build: <Q>(run: Comparator<Q>['run']) => Comparator<Q>
+const made = build((zzz: string, www: string) => 1)
+const ok: Comparator<string> = made
+const bad: Comparator<number> = made
+"#,
+    );
+    assert_eq!(
+        c.iter().filter(|&&x| x == 2322).count(),
+        1,
+        "Q must infer to `string` regardless of binder names. Got {c:?}"
+    );
+}
+
+/// Nested indexed access (`Foo<A>['x']['y']`): reduction must descend through
+/// every index step to reach the callback inference site.
+#[test]
+fn issue_14261_nested_indexed_access_param() {
+    let c = codes(
+        r#"
+interface Foo<A> { x: { y: (v: A) => void } }
+declare const g: <A>(cb: Foo<A>['x']['y']) => A
+const r: string = g((v) => { const s: string = v })
+"#,
+    );
+    assert!(
+        c.is_empty(),
+        "nested indexed-access parameter must infer `A = string`; got {c:?}"
+    );
+}
+
+/// Indexed access over a mapped type (`Pick<Box<A>, 'make'>['make']`): the
+/// object expands through a mapped-type application and still exposes `A`.
+#[test]
+fn issue_14261_mapped_indexed_access_param() {
+    let c = codes(
+        r#"
+interface Box<A> { make: (x: A) => A; other: number }
+declare const h: <A>(fn: Pick<Box<A>, 'make'>['make']) => A
+const r: string = h((x) => { const s: string = x; return x })
+"#,
+    );
+    assert!(
+        c.is_empty(),
+        "mapped indexed-access parameter must infer `A = string`; got {c:?}"
+    );
+}
+
+/// A direct function parameter (no indexed access) already worked; pin it so the
+/// fix does not perturb the baseline path.
+#[test]
+fn issue_14261_direct_function_param_unaffected() {
+    let c = codes(
+        r#"
+type Ordering = -1 | 0 | 1
+interface Ord<A> { readonly compare: (first: A, second: A) => Ordering }
+declare const f: <A>(c: (first: A, second: A) => Ordering) => Ord<A>
+const r = f((x: string, y: string) => 1)
+const ok: Ord<string> = r
+const bad: Ord<number> = r
+"#,
+    );
+    assert_eq!(
+        c.iter().filter(|&&x| x == 2322).count(),
+        1,
+        "baseline direct-function-param inference must still bind `A = string`. Got {c:?}"
+    );
+}

--- a/crates/tsz-solver/src/operations/constraints/indexed_access.rs
+++ b/crates/tsz-solver/src/operations/constraints/indexed_access.rs
@@ -1,0 +1,49 @@
+//! Indexed-access helpers for generic inference constraints.
+
+use crate::operations::{AssignabilityChecker, CallEvaluator};
+use crate::types::TypeId;
+
+impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
+    /// Reduce an indexed-access type `object[index]` to its member type during
+    /// inference constraint collection.
+    ///
+    /// The bare-interner reduction (`evaluate_index_access`) cannot resolve an
+    /// object that is itself a `Lazy`/`Application` of a generic type, because it
+    /// runs without a resolver: `Ord<A>['compare']` (a parameter type during a
+    /// generic call) is left unevaluated, so the access never exposes its member
+    /// type and no candidate is collected for `A`, which then collapses to its
+    /// default (`unknown`) — the inference half of #14261.
+    ///
+    /// When the bare reduction makes no progress, expand the object through the
+    /// checker's resolver via [`AssignabilityChecker::expand_type_alias_application`],
+    /// which instantiates the generic body while *preserving* inference
+    /// placeholders (rather than collapsing them to their constraints, as a full
+    /// evaluation would), and re-index the expanded object. For `Ord<A>` this
+    /// yields `{ compare: (first: A, second: A) => Ordering }['compare']`, which
+    /// the bare reducer then resolves to `(first: A, second: A) => Ordering`,
+    /// exposing the inference site for `A`. Returns `original` unchanged when no
+    /// reduction is possible, matching the prior no-progress contract callers
+    /// already guard with `evaluated != original`.
+    pub(super) fn reduce_index_access_for_inference(
+        &mut self,
+        original: TypeId,
+        object_type: TypeId,
+        index_type: TypeId,
+    ) -> TypeId {
+        let evaluated = self.interner.evaluate_index_access(object_type, index_type);
+        if evaluated != original {
+            return evaluated;
+        }
+        if let Some(expanded_object) = self.checker.expand_type_alias_application(object_type)
+            && expanded_object != object_type
+        {
+            return self
+                .interner
+                .evaluate_index_access(expanded_object, index_type);
+        }
+        // No reduction was possible; return the unchanged indexed access (which
+        // equals `evaluated` here) so the caller's `!= original` guard reads it
+        // as no progress.
+        original
+    }
+}

--- a/crates/tsz-solver/src/operations/constraints/mod.rs
+++ b/crates/tsz-solver/src/operations/constraints/mod.rs
@@ -5,6 +5,7 @@
 //! recursive traversal of complex type structures (objects, functions, tuples,
 //! conditionals, mapped types, etc.) to extract inference candidates.
 
+mod indexed_access;
 mod reverse_mapped;
 mod signatures;
 mod walker;

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -127,49 +127,6 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         }
     }
 
-    /// Reduce an indexed-access type `object[index]` to its member type during
-    /// inference constraint collection.
-    ///
-    /// The bare-interner reduction (`evaluate_index_access`) cannot resolve an
-    /// object that is itself a `Lazy`/`Application` of a generic type, because it
-    /// runs without a resolver: `Ord<A>['compare']` (a parameter type during a
-    /// generic call) is left unevaluated, so the access never exposes its member
-    /// type and no candidate is collected for `A`, which then collapses to its
-    /// default (`unknown`) — the inference half of #14261.
-    ///
-    /// When the bare reduction makes no progress, expand the object through the
-    /// checker's resolver via [`AssignabilityChecker::expand_type_alias_application`],
-    /// which instantiates the generic body while *preserving* inference
-    /// placeholders (rather than collapsing them to their constraints, as a full
-    /// evaluation would), and re-index the expanded object. For `Ord<A>` this
-    /// yields `{ compare: (first: A, second: A) => Ordering }['compare']`, which
-    /// the bare reducer then resolves to `(first: A, second: A) => Ordering`,
-    /// exposing the inference site for `A`. Returns `original` unchanged when no
-    /// reduction is possible, matching the prior no-progress contract callers
-    /// already guard with `evaluated != original`.
-    fn reduce_index_access_for_inference(
-        &mut self,
-        original: TypeId,
-        object_type: TypeId,
-        index_type: TypeId,
-    ) -> TypeId {
-        let evaluated = self.interner.evaluate_index_access(object_type, index_type);
-        if evaluated != original {
-            return evaluated;
-        }
-        if let Some(expanded_object) = self.checker.expand_type_alias_application(object_type)
-            && expanded_object != object_type
-        {
-            return self
-                .interner
-                .evaluate_index_access(expanded_object, index_type);
-        }
-        // No reduction was possible; return the unchanged indexed access (which
-        // equals `evaluated` here) so the caller's `!= original` guard reads it
-        // as no progress.
-        original
-    }
-
     /// Normalize a union's members for inference partitioning by peeling
     /// transparent identity-alias applications (`type Some<X> = X`).
     ///

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -127,6 +127,49 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         }
     }
 
+    /// Reduce an indexed-access type `object[index]` to its member type during
+    /// inference constraint collection.
+    ///
+    /// The bare-interner reduction (`evaluate_index_access`) cannot resolve an
+    /// object that is itself a `Lazy`/`Application` of a generic type, because it
+    /// runs without a resolver: `Ord<A>['compare']` (a parameter type during a
+    /// generic call) is left unevaluated, so the access never exposes its member
+    /// type and no candidate is collected for `A`, which then collapses to its
+    /// default (`unknown`) — the inference half of #14261.
+    ///
+    /// When the bare reduction makes no progress, expand the object through the
+    /// checker's resolver via [`AssignabilityChecker::expand_type_alias_application`],
+    /// which instantiates the generic body while *preserving* inference
+    /// placeholders (rather than collapsing them to their constraints, as a full
+    /// evaluation would), and re-index the expanded object. For `Ord<A>` this
+    /// yields `{ compare: (first: A, second: A) => Ordering }['compare']`, which
+    /// the bare reducer then resolves to `(first: A, second: A) => Ordering`,
+    /// exposing the inference site for `A`. Returns `original` unchanged when no
+    /// reduction is possible, matching the prior no-progress contract callers
+    /// already guard with `evaluated != original`.
+    fn reduce_index_access_for_inference(
+        &mut self,
+        original: TypeId,
+        object_type: TypeId,
+        index_type: TypeId,
+    ) -> TypeId {
+        let evaluated = self.interner.evaluate_index_access(object_type, index_type);
+        if evaluated != original {
+            return evaluated;
+        }
+        if let Some(expanded_object) = self.checker.expand_type_alias_application(object_type)
+            && expanded_object != object_type
+        {
+            return self
+                .interner
+                .evaluate_index_access(expanded_object, index_type);
+        }
+        // No reduction was possible; return the unchanged indexed access (which
+        // equals `evaluated` here) so the caller's `!= original` guard reads it
+        // as no progress.
+        original
+    }
+
     /// Normalize a union's members for inference partitioning by peeling
     /// transparent identity-alias applications (`type Some<X> = X`).
     ///
@@ -472,13 +515,13 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 let _ = ctx.infer_from_types(source, target, priority);
             }
             (Some(TypeData::IndexAccess(s_obj, s_idx)), _) => {
-                let evaluated = self.interner.evaluate_index_access(s_obj, s_idx);
+                let evaluated = self.reduce_index_access_for_inference(source, s_obj, s_idx);
                 if evaluated != source {
                     self.constrain_types(ctx, var_map, evaluated, target, priority);
                 }
             }
             (_, Some(TypeData::IndexAccess(t_obj, t_idx))) => {
-                let evaluated = self.interner.evaluate_index_access(t_obj, t_idx);
+                let evaluated = self.reduce_index_access_for_inference(target, t_obj, t_idx);
                 if evaluated != target {
                     self.constrain_types(ctx, var_map, source, evaluated, priority);
                 }


### PR DESCRIPTION
Fixes #14261.

## Structural rule
When a generic call's parameter type is an **indexed-access type whose object
is a generic application carrying a type parameter** (e.g. `Ord<A>['compare']`),
`tsc` reduces the access to its member type (`(first: A, second: A) => Ordering`)
and infers `A` from the matching argument. tsz did this through the
constraint-walker's `evaluate_index_access`, but that bare-interner reduction
runs **without a resolver**, so it cannot expand a `Lazy`/`Application` object.
The access stayed unreduced, no candidate was collected for `A`, and it
collapsed to its default (`unknown`) — surfacing as a callback with `unknown`
parameters and a false `TS2345`/`TS18046`.

## Owner layer
Solver — generic-call inference constraint walker
(`crates/tsz-solver/src/operations/constraints/walker.rs`,
`constrain_types_impl` indexed-access arms).

## Fix
A new `reduce_index_access_for_inference` helper: try the cheap bare reduction
first; when it makes no progress, expand the indexed-access **object** through
the checker's resolver via `expand_type_alias_application` — which instantiates
the generic body while *preserving* inference placeholders instead of
collapsing them to their constraints, exactly as a full evaluation would — then
re-index. `Ord<A>['compare']` becomes
`{ compare: (first: A, second: A) => Ordering }['compare']` → `(first: A,
second: A) => Ordering`, exposing the inference site for `A`. This mirrors the
walker's existing Application source/target arms, which already use the
checker's resolver (`evaluate_type` / `expand_type_alias_application`) for the
same reason. Applied symmetrically to the indexed-access **source** and
**target** arms.

Anti-hardcoding: structural reduction via the resolver; no identifier,
file-name, or printer-string predicates. The resolver path is taken only on the
no-progress fallback, so concrete index accesses keep the cheap path.

## Adjacent matrix (regression test)
`crates/tsz-checker/tests/issue_14261_indexed_access_param_inference_tests.rs`,
binder names varied per case so the fix is exercised structurally:
- contextual-return witness (the issue repro) — clean
- pure inference (explicit callback params) — `A = string`, only the
  `Ord<number>` annotation mismatches (`TS2322`)
- renamed binders (`Comparator<Q>['run']`) — same
- nested indexed access `Foo<A>['x']['y']` — clean
- mapped indexed access `Pick<Box<A>, 'make'>['make']` — clean
- direct-function-param baseline (no indexed access) — unchanged

## Verification
- `cargo test -p tsz-checker --test issue_14261_indexed_access_param_inference_tests` — 6/6 pass
- `cargo test -p tsz-solver --lib constrain` — 436 pass; `index_access` — 144 pass; `generic_call` — 32 pass
- `cargo test -p tsz-checker --lib call_inference` — 9 pass; `contextual` — 245 pass (1 pre-existing failure unrelated to this change, present on the clean tree)
- Manual: the issue witness now reports 0 diagnostics (was a false `TS2345`); `tsc` is clean.
- Broad conformance/emit/fourslash owned by ready-review CI.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kx4KxaunagN4CdZfR6BB3M)_