### PR TITLE
fix(checker): narrow `??` right operand by optionality on discriminated unions

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -904,17 +904,39 @@ impl<'a> FlowAnalyzer<'a> {
                         );
                     }
                 }
-                // Handle truthiness discriminant narrowing for properties
+                // When the access is the left operand of a `??`/`??=`, the
+                // branches gate on the value being *nullish*, not *falsy* — tsc
+                // routes such a condition through `narrowTypeByOptionality`
+                // instead of `narrowTypeByTruthiness`. This matters for a
+                // discriminated-union receiver: `r.fullPath ?? r.from` reaches
+                // `r.from` on the branch where `r.fullPath` is nullish, which
+                // discriminates `r` to the member whose `fullPath` is `undefined`
+                // (a falsy-but-non-nullish `string` value must NOT keep that
+                // member). Truthiness narrowing would keep both members and leak
+                // `undefined` into the result type (false TS2322).
+                let coalesce_left = self.condition_is_nullish_coalesce_left(condition_idx);
+
+                // Handle discriminant narrowing for properties.
                 // For `if (x.flag)` where x is a discriminated union like
                 // `{flag: "hello"; data: string} | {flag: ""; data: number}`,
-                // narrow x based on whether `flag` is truthy or falsy.
+                // narrow x based on whether `flag` is truthy or falsy (or, for a
+                // `??` left, non-nullish or nullish).
                 if let Some(property_path) = self.discriminant_property(condition_idx, target) {
-                    let narrowed = flow_query::narrow_by_property_truthiness_in_context(
-                        &narrowing,
-                        type_id,
-                        &property_path,
-                        is_true_branch,
-                    );
+                    let narrowed = if coalesce_left {
+                        flow_query::narrow_by_property_nullishness_in_context(
+                            &narrowing,
+                            type_id,
+                            &property_path,
+                            is_true_branch,
+                        )
+                    } else {
+                        flow_query::narrow_by_property_truthiness_in_context(
+                            &narrowing,
+                            type_id,
+                            &property_path,
+                            is_true_branch,
+                        )
+                    };
                     // For union types, NEVER means all members were filtered out
                     // (no member has a truthy/falsy property), which is valid.
                     // For non-union types (class, mapped, generic), NEVER often
@@ -930,6 +952,19 @@ impl<'a> FlowAnalyzer<'a> {
                 // Handle truthiness narrowing for property/element access: if (y.a)
                 let condition_ref = self.arena.skip_parenthesized_and_assertions(condition_idx);
                 if self.is_matching_reference(condition_ref, target) {
+                    if coalesce_left {
+                        // `??` left: keep only the non-nullish part (true/short-
+                        // circuit branch) or the nullish part (false/right
+                        // branch), matching tsc's `narrowTypeByOptionality`
+                        // matching-reference arm (`NEUndefinedOrNull` /
+                        // `EQUndefinedOrNull`).
+                        let (non_nullish, nullish) = tsz_solver::narrowing::split_nullish_type(
+                            self.interner.as_type_database(),
+                            type_id,
+                        );
+                        let part = if is_true_branch { non_nullish } else { nullish };
+                        return part.unwrap_or(TypeId::NEVER);
+                    }
                     if is_true_branch {
                         // Full truthiness narrowing (same as a symbol reference):
                         // tsc's narrowTypeByTruthiness does not special-case
@@ -956,6 +991,19 @@ impl<'a> FlowAnalyzer<'a> {
                 let condition_ref = self.arena.skip_parenthesized_and_assertions(condition_idx);
                 let matches = self.is_matching_reference(condition_ref, target);
                 if matches {
+                    // A bare-identifier `??`/`??=` left gates the right operand
+                    // on nullishness, not truthiness (tsc's
+                    // `narrowTypeByOptionality` matching-reference arm). e.g.
+                    // `x ?? x.foo` with `x: T | undefined` sees `x: T` only when
+                    // `x` is non-nullish.
+                    if self.condition_is_nullish_coalesce_left(condition_idx) {
+                        let (non_nullish, nullish) = tsz_solver::narrowing::split_nullish_type(
+                            self.interner.as_type_database(),
+                            type_id,
+                        );
+                        let part = if is_true_branch { non_nullish } else { nullish };
+                        return part.unwrap_or(TypeId::NEVER);
+                    }
                     return flow_query::narrow_to_truthy_in_context(
                         &narrowing,
                         type_id,

--- a/crates/tsz-checker/src/flow/control_flow/narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/narrowing.rs
@@ -1153,6 +1153,45 @@ impl<'a> FlowAnalyzer<'a> {
         None
     }
 
+    /// Whether `condition_idx` is the left operand of a plain `??` binary
+    /// expression. Mirrors tsc's `narrowType` gate
+    /// (`isBinaryExpression(expr.parent) && ... === QuestionQuestionToken &&
+    /// expr.parent.left === expr`): when narrowing flows from the right operand
+    /// of `??`, the branches gate on the left being *nullish*, not *falsy*, so
+    /// such a condition narrows by optionality (`narrowTypeByOptionality`)
+    /// rather than truthiness. The right operand of `??` is reached through a
+    /// `FALSE_CONDITION` flow node recorded by the binder on the left operand,
+    /// so the condition node is exactly that left operand.
+    ///
+    /// The compound `??=` form is deliberately excluded: its post-assignment
+    /// flow type is produced through tsz's dedicated logical-assignment flow
+    /// path (a flow-assignment node plus `fallback_binary_expression_type`),
+    /// which already removes nullish from the left operand correctly. Routing
+    /// the `??=` left operand through optionality narrowing here would re-narrow
+    /// the assignment target while its own flow type is being computed, leaving
+    /// a residual self-reference in the post-assignment type. (tsc reaches the
+    /// same `narrowTypeByOptionality` result for `??=` through a different flow
+    /// shape, so excluding it here keeps parity without that interference.)
+    pub(crate) fn condition_is_nullish_coalesce_left(&self, condition_idx: NodeIndex) -> bool {
+        let Some(ext) = self.arena.get_extended(condition_idx) else {
+            return false;
+        };
+        let parent_idx = ext.parent;
+        if parent_idx.is_none() {
+            return false;
+        }
+        let Some(parent_node) = self.arena.get(parent_idx) else {
+            return false;
+        };
+        if parent_node.kind != syntax_kind_ext::BINARY_EXPRESSION {
+            return false;
+        }
+        let Some(bin) = self.arena.get_binary_expr(parent_node) else {
+            return false;
+        };
+        bin.operator_token == SyntaxKind::QuestionQuestionToken as u16 && bin.left == condition_idx
+    }
+
     pub(crate) fn discriminant_property(
         &self,
         expr: NodeIndex,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1189,6 +1189,9 @@ mod nonunique_symbol_property_access_tests;
 #[path = "tests/nullable_union_callback_variance_tests.rs"]
 mod nullable_union_callback_variance_tests;
 #[cfg(test)]
+#[path = "../tests/nullish_coalescing_discriminated_union_tests.rs"]
+mod nullish_coalescing_discriminated_union_tests;
+#[cfg(test)]
 #[path = "../tests/nullish_coalescing_unknown_result_tests.rs"]
 mod nullish_coalescing_unknown_result_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -448,6 +448,22 @@ pub(crate) fn narrow_by_property_truthiness_in_context(
     narrowing.narrow_by_property_truthiness(type_id, property_path, is_true_branch)
 }
 
+/// Narrow a union flow type by a discriminant property's *nullishness* using the
+/// caller's active flow narrowing context.
+///
+/// Mirrors tsc's `narrowTypeByOptionality` discriminant arm. The checker owns
+/// recognizing that the discriminant access is the left operand of a `??`/`??=`
+/// (so its branches gate on nullishness, not truthiness); the solver owns
+/// filtering union members by whether the property can be (non-)nullish.
+pub(crate) fn narrow_by_property_nullishness_in_context(
+    narrowing: &NarrowingContext<'_>,
+    type_id: TypeId,
+    property_path: &[tsz_common::interner::Atom],
+    is_true_branch: bool,
+) -> TypeId {
+    narrowing.narrow_by_property_nullishness(type_id, property_path, is_true_branch)
+}
+
 /// Exclude known values from a flow type using the caller's active flow
 /// narrowing context.
 ///

--- a/crates/tsz-checker/tests/nullish_coalescing_discriminated_union_tests.rs
+++ b/crates/tsz-checker/tests/nullish_coalescing_discriminated_union_tests.rs
@@ -1,0 +1,132 @@
+//! Checker result-type tests for `a ?? b` where the receiver is a
+//! discriminated union and both operands are discriminant property accesses.
+//!
+//! Structural rule:
+//!
+//! > The right operand of `a ?? b` is checked on the control-flow path where
+//! > `a` is *nullish* (tsc's `narrowTypeByOptionality`, not
+//! > `narrowTypeByTruthiness`). When `a` is a discriminant property access on a
+//! > union `r`, that nullish fact discriminates `r` to the member(s) whose
+//! > discriminant property can be `undefined`/`null`, so `b` (another property
+//! > of `r`) is narrowed accordingly.
+//!
+//! Witness: tanstack-router `new-process-route-tree.ts` has
+//! `{ fullPath: string; from?: never } | { fullPath?: never; from: string }`
+//! and writes `r.fullPath ?? r.from` into a `string`. Before the fix, the `??`
+//! right operand stayed `string | undefined` (the union was filtered by
+//! *falsiness*, keeping both members), leaking `undefined` into the result and
+//! raising a false TS2322. tsc narrows the right operand to `string`.
+//!
+//! Binder names below deliberately differ from the witness to keep the test
+//! free of identifier/file-name coupling.
+
+use crate::test_utils::check_source_strict_codes as check_strict;
+
+/// The reported witness shape: `r.head ?? r.tail` over a two-branch
+/// discriminated union whose discriminant is an optional `never` property.
+/// The result is `string`, assignable to `string` (no TS2322).
+#[test]
+fn discriminated_union_coalesce_property_access_yields_non_nullish() {
+    let source = r#"
+declare const rec:
+    | { head: string; tail?: never }
+    | { head?: never; tail: string };
+const out: string = rec.head ?? rec.tail;
+"#;
+    let codes = check_strict(source);
+    assert!(
+        !codes.contains(&2322),
+        "`rec.head ?? rec.tail` over a discriminated union must be `string`, got: {codes:?}"
+    );
+}
+
+/// Element-access form narrows identically to property-access form.
+#[test]
+fn discriminated_union_coalesce_element_access_yields_non_nullish() {
+    let source = r#"
+declare const rec:
+    | { head: string; tail?: never }
+    | { head?: never; tail: string };
+const out: string = rec["head"] ?? rec["tail"];
+"#;
+    let codes = check_strict(source);
+    assert!(
+        !codes.contains(&2322),
+        "`rec[\"head\"] ?? rec[\"tail\"]` must be `string`, got: {codes:?}"
+    );
+}
+
+/// Two operands suffice to collapse: the right operand `rec.tail` of a single
+/// `??` is re-narrowed through the discriminant, matching tsc. A three-branch
+/// *chain* (`a ?? b ?? c`) does NOT further collapse in tsc — the intermediate
+/// `a ?? b` result is no longer a discriminant access on `rec`, so `?? c`
+/// cannot re-narrow `rec`; tsc leaves `string | undefined` there. This test
+/// pins that parity: the chain keeps `undefined`, so assigning to `string`
+/// raises TS2322 in both tsc and tsz (the fix must not over-eagerly collapse
+/// chains).
+#[test]
+fn discriminated_union_coalesce_chain_matches_tsc_keeps_undefined() {
+    let source = r#"
+declare const rec:
+    | { a: string; b?: never; c?: never }
+    | { a?: never; b: string; c?: never }
+    | { a?: never; b?: never; c: string };
+const out: string = rec.a ?? rec.b ?? rec.c;
+"#;
+    let codes = check_strict(source);
+    assert!(
+        codes.contains(&2322),
+        "`rec.a ?? rec.b ?? rec.c` stays `string | undefined` in tsc, expected TS2322, got: {codes:?}"
+    );
+}
+
+/// Negative guard: when the left discriminant value genuinely keeps a
+/// non-nullish union member (a `string | number` value, not a falsy-only one),
+/// the `??` result must still include that member — the fix must not over-strip.
+/// `m.v ?? m.w` is `string | number | boolean`, which assigns to that target
+/// (no TS2322) but does NOT assign to `string` (a TS2322 we assert is present).
+#[test]
+fn discriminated_union_coalesce_keeps_genuine_union_member() {
+    let ok = r#"
+declare const m:
+    | { v: string | number; w?: never }
+    | { v?: never; w: boolean };
+const out: string | number | boolean = m.v ?? m.w;
+"#;
+    let codes_ok = check_strict(ok);
+    assert!(
+        !codes_ok.contains(&2322),
+        "`m.v ?? m.w` must be `string | number | boolean` (assignable), got: {codes_ok:?}"
+    );
+
+    let bad = r#"
+declare const m:
+    | { v: string | number; w?: never }
+    | { v?: never; w: boolean };
+const out: string = m.v ?? m.w;
+"#;
+    let codes_bad = check_strict(bad);
+    assert!(
+        codes_bad.contains(&2322),
+        "`m.v ?? m.w` keeps `number | boolean`, so assigning to `string` must raise TS2322, got: {codes_bad:?}"
+    );
+}
+
+/// Negative guard: `||` (logical OR, not `??`) is unchanged. Because `""` is a
+/// non-nullish *falsy* `string`, `t.val || t.alt` keeps both members and is
+/// `string | undefined`, raising TS2322 against `string` in tsc as well. The
+/// fix must only affect `??`, never `||`.
+#[test]
+fn discriminated_union_logical_or_unchanged() {
+    let source = r#"
+declare const t:
+    | { val: string; alt?: never }
+    | { val?: never; alt: string };
+const out: string = t.val || t.alt;
+"#;
+    let codes = check_strict(source);
+    assert!(
+        codes.contains(&2322),
+        "`t.val || t.alt` stays `string | undefined` (matching tsc), expected TS2322, got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/narrowing/discriminants.rs
+++ b/crates/tsz-solver/src/narrowing/discriminants.rs
@@ -14,7 +14,20 @@ use std::sync::Arc;
 use crate::TypeData;
 use rustc_hash::FxHashMap;
 
-use super::{CachedPropertyType, DiscriminantInfo, NarrowingContext, union_or_single_preserve};
+use super::{
+    CachedPropertyType, DiscriminantInfo, NarrowingContext, NullishFilter, union_or_single_preserve,
+};
+
+/// Selects which fact a discriminant-property filter narrows on: the *truthy*
+/// fact (`if (x.prop)`) or the *nullish* fact (`x.prop ?? ...`). The two agree
+/// for `null`/`undefined` discriminant values but differ on the non-nullish
+/// falsy values (`""`, `0`, `false`, `0n`, `NaN`), which `??` keeps but a
+/// truthiness check would drop.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DiscriminantPropertyFilter {
+    Truthiness,
+    Nullishness,
+}
 use crate::operations::property::{PropertyAccessEvaluator, PropertyAccessResult};
 use crate::type_queries::{
     LiteralValueKind, TypeParameterConstraintKind, UnionMembersKind, classify_for_literal_value,
@@ -796,6 +809,55 @@ impl<'a> NarrowingContext<'a> {
         property_path: &[Atom],
         sense: bool,
     ) -> TypeId {
+        self.narrow_by_property_filter(
+            union_type,
+            property_path,
+            DiscriminantPropertyFilter::Truthiness,
+            sense,
+        )
+    }
+
+    /// Narrows a union type based on whether a property is (or is not) nullish.
+    ///
+    /// Mirrors tsc's `narrowTypeByOptionality` discriminant arm, which filters
+    /// union members with `getTypeWithFacts(t, NEUndefinedOrNull)` (true /
+    /// "present" branch) or `EQUndefinedOrNull` (false / "absent" branch).
+    ///
+    /// This differs from [`Self::narrow_by_property_truthiness`] precisely on
+    /// the non-nullish-but-falsy values (`""`, `0`, `false`, `0n`, `NaN`): the
+    /// `??` operator and optional-chain roots gate on *nullishness*, not
+    /// *falsiness*, so a discriminant whose value is `string` (non-nullish) must
+    /// be excluded from the nullish/false branch even though `string` is
+    /// falsy-compatible. Used for the right operand of `a ?? b` (and `??=`):
+    /// when `a` is a discriminant property access on a union, the right operand
+    /// flows from `a` being nullish, discriminating the union to that branch.
+    pub fn narrow_by_property_nullishness(
+        &self,
+        union_type: TypeId,
+        property_path: &[Atom],
+        sense: bool,
+    ) -> TypeId {
+        self.narrow_by_property_filter(
+            union_type,
+            property_path,
+            DiscriminantPropertyFilter::Nullishness,
+            sense,
+        )
+    }
+
+    /// Shared discriminant-property filter for truthiness (`if (x.prop)`) and
+    /// nullishness (`x.prop ?? ...`) narrowing. `sense` selects the branch: for
+    /// truthiness, `true` keeps members where the property can be truthy and
+    /// `false` keeps members where it can be falsy; for nullishness, `true`
+    /// keeps members where the property can be non-nullish and `false` keeps
+    /// members where it can be nullish.
+    fn narrow_by_property_filter(
+        &self,
+        union_type: TypeId,
+        property_path: &[Atom],
+        filter: DiscriminantPropertyFilter,
+        sense: bool,
+    ) -> TypeId {
         use crate::type_queries::{
             TypeParameterConstraintKind, classify_for_type_parameter_constraint,
         };
@@ -806,7 +868,7 @@ impl<'a> NarrowingContext<'a> {
             && constraint != union_type
         {
             let narrowed_constraint =
-                self.narrow_by_property_truthiness(constraint, property_path, sense);
+                self.narrow_by_property_filter(constraint, property_path, filter, sense);
             if narrowed_constraint != constraint {
                 return self.db.intersection2(union_type, narrowed_constraint);
             }
@@ -814,7 +876,7 @@ impl<'a> NarrowingContext<'a> {
 
         let _span = span!(
             Level::TRACE,
-            "narrow_by_property_truthiness",
+            "narrow_by_property_filter",
             union_type = union_type.0,
             property_path_len = property_path.len(),
             sense
@@ -853,15 +915,23 @@ impl<'a> NarrowingContext<'a> {
                 };
 
                 let resolved_prop_type = self.resolve_type(prop_type);
-                // If it's the true branch, check if the property can be truthy
-                // If it's the false branch, check if the property can be falsy
-                if sense {
-                    let narrowed = self.narrow_by_truthiness(resolved_prop_type);
-                    narrowed != TypeId::NEVER
-                } else {
-                    let narrowed = self.narrow_to_falsy(resolved_prop_type);
-                    narrowed != TypeId::NEVER
-                }
+                // For the positive branch, check if the property can satisfy the
+                // fact (truthy / non-nullish); for the negative branch, check if
+                // it can satisfy the complement (falsy / nullish).
+                let narrowed = match (filter, sense) {
+                    (DiscriminantPropertyFilter::Truthiness, true) => {
+                        self.narrow_by_truthiness(resolved_prop_type)
+                    }
+                    (DiscriminantPropertyFilter::Truthiness, false) => {
+                        self.narrow_to_falsy(resolved_prop_type)
+                    }
+                    (DiscriminantPropertyFilter::Nullishness, true) => self
+                        .narrow_by_nullishness(resolved_prop_type, NullishFilter::ExcludeNullish),
+                    (DiscriminantPropertyFilter::Nullishness, false) => {
+                        self.narrow_by_nullishness(resolved_prop_type, NullishFilter::KeepNullish)
+                    }
+                };
+                narrowed != TypeId::NEVER
             };
 
             let matches = if let Some(ref intersection) = intersection_members {

--- a/crates/tsz-solver/tests/narrowing_discriminant_tests.rs
+++ b/crates/tsz-solver/tests/narrowing_discriminant_tests.rs
@@ -1173,6 +1173,78 @@ fn property_truthiness_false_branch() {
 }
 
 // =============================================================================
+// Property Nullishness Narrowing (the `a.prop ?? b` discriminant path)
+// =============================================================================
+
+/// The witness shape: `{ p: string; q?: never } | { p?: never; q: string }`.
+/// Narrowing by `p` being *nullish* (the right-operand branch of `p ?? q`)
+/// keeps only the member whose `p` is `undefined` — the second member. This is
+/// where nullishness differs from truthiness: a falsy-but-non-nullish `string`
+/// `p` is EXCLUDED from the nullish branch (truthiness would keep it).
+#[test]
+fn property_nullishness_false_branch_excludes_non_nullish_string() {
+    let interner = TypeInterner::new();
+    let ctx = NarrowingContext::new(&interner);
+
+    let p = interner.intern_string("p");
+    let q = interner.intern_string("q");
+
+    // member1: { p: string; q?: never } — accessing `p` yields `string`.
+    // member2: { p?: never; q: string } — accessing `p` yields `undefined`.
+    let member1 = interner.object(vec![
+        PropertyInfo::new(p, TypeId::STRING),
+        PropertyInfo::opt(q, TypeId::NEVER),
+    ]);
+    let member2 = interner.object(vec![
+        PropertyInfo::opt(p, TypeId::NEVER),
+        PropertyInfo::new(q, TypeId::STRING),
+    ]);
+    let union = interner.union(vec![member1, member2]);
+
+    // False (nullish) branch: keep members where `p` can be nullish → member2.
+    let nullish_branch = ctx.narrow_by_property_nullishness(union, &[p], false);
+    assert_eq!(
+        nullish_branch, member2,
+        "nullish `p` keeps only the member whose `p` is undefined"
+    );
+
+    // Truthiness false branch keeps BOTH (string can be ""), proving the two
+    // filters diverge on a non-nullish falsy discriminant.
+    let falsy_branch = ctx.narrow_by_property_truthiness(union, &[p], false);
+    assert_eq!(
+        falsy_branch, union,
+        "falsy `p` keeps both members; nullishness must be stricter"
+    );
+}
+
+/// True (non-nullish) branch keeps only the member whose `p` is definitely
+/// present (non-nullish): member1.
+#[test]
+fn property_nullishness_true_branch_keeps_non_nullish_member() {
+    let interner = TypeInterner::new();
+    let ctx = NarrowingContext::new(&interner);
+
+    let p = interner.intern_string("p");
+    let q = interner.intern_string("q");
+
+    let member1 = interner.object(vec![
+        PropertyInfo::new(p, TypeId::STRING),
+        PropertyInfo::opt(q, TypeId::NEVER),
+    ]);
+    let member2 = interner.object(vec![
+        PropertyInfo::opt(p, TypeId::NEVER),
+        PropertyInfo::new(q, TypeId::STRING),
+    ]);
+    let union = interner.union(vec![member1, member2]);
+
+    let non_nullish_branch = ctx.narrow_by_property_nullishness(union, &[p], true);
+    assert_eq!(
+        non_nullish_branch, member1,
+        "non-nullish `p` keeps only the member whose `p` is `string`"
+    );
+}
+
+// =============================================================================
 // Discriminant via TypeGuard
 // =============================================================================
 


### PR DESCRIPTION
Goal: green

## Summary

`a ?? b` where the receiver is a discriminated union computed `T | undefined`
instead of `T`, producing a false TS2322. For
`r: { fullPath: string; from?: never } | { fullPath?: never; from: string }`,
`r.fullPath ?? r.from` is `string` in `tsc` but was `string | undefined` in
`tsz`.

## Structural rule

When the left operand of a plain `??` is a discriminant property access on a
union, `tsc` checks the right operand on the flow path where the left is
*nullish* (`narrowTypeByOptionality`, `EQ/NEUndefinedOrNull`), not merely
*falsy* (`narrowTypeByTruthiness`). `tsz` routed the `??` right operand through
truthiness narrowing, which keeps a discriminant member whose value is a
non-nullish *falsy* `string` — leaking `undefined` into the result.

Owner: solver narrowing (`NarrowingContext::narrow_by_property_nullishness`,
new sibling of `narrow_by_property_truthiness` factored through a shared
`narrow_by_property_filter`) plus the checker flow boundary that recognizes a
`??`-left condition node (`condition_is_nullish_coalesce_left`) and routes its
discriminant / matching-reference narrowing through nullishness rather than
truthiness. No identifier/file/text hardcoding; the gate keys only off the
`QuestionQuestionToken` operator and `parent.left === expr`.

The compound `??=` form is deliberately excluded: its post-assignment flow type
is produced through `tsz`'s dedicated logical-assignment path (flow-assignment
node + `fallback_binary_expression_type`), which already removes nullish from
the left correctly; routing `??=` here re-narrowed the assignment target
mid-computation and left a residual self-reference (regression witnessed by
`test_typeof_after_logical_assignment_local_and_parameter_scopes`).

## Adjacent-case matrix

- Discriminated-union receiver `r.fullPath ?? r.from` -> `string` (fixed).
- Element-access form `r["fullPath"] ?? r["from"]` -> `string`.
- Plain `string | undefined ?? "x"` and `string | null ?? "x"` -> unchanged.
- `??=` discriminated-union (`obj.a ??= obj.b`) -> unchanged, correct.
- Three-branch chain `a ?? b ?? c` -> stays `string | undefined` (parity: the
  intermediate `a ?? b` is no longer a discriminant access on `r`; `tsc` agrees).
- Negative (no over-strip): `m.v ?? m.w` where `m.v: string | number` keeps the
  genuine union member -> result is `string | number | boolean`.
- Negative (`||` unchanged): `t.val || t.alt` stays `string | undefined`
  (matches `tsc`; `""` is non-nullish falsy).

## Verification

- Repro `/tmp/c3.ts`: `tsz` clean (exit 0), matches `tsc` exit 0.
- Conformance (no new regressions): `nullishCoalescing` 20/20, `binary` 80/80,
  `controlFlow` 94/94, broad `nullish` 12584/12585 (the single failure,
  `deeplyNestedMappedTypes.ts`, has zero `??` and fails identically on clean
  `origin/main` — confirmed by revert+rebuild).
- New tests: `nullish_coalescing_discriminated_union_tests` (5, checker) and
  `property_nullishness_*` (2, solver); binder names varied from the witness.
- Delta-gate vs clean `origin/main`: `tsz-solver` + `tsz-checker` `--lib`
  net-new failures = 0 (the ~19 checker + 1 solver pre-existing env/lib
  failures are identical on clean main). `clippy` clean; all files < 2000 LOC.
- Corpus (tanstack-router `new-process-route-tree.ts`): 46 -> 28 diagnostics;
  TS2322 4 -> 3 (line 411 `route.fullPath ?? route.from` cleared), cascaded
  TS18048 10 -> 1, TS2345 13 -> 5; no new diagnostics. `tsc` is clean (0) for
  this file.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: max
