### PR TITLE
perf(checker): route namespace "did you mean" suggestions through the memoized scan gateway

### DIFF
--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -479,16 +479,22 @@ pub struct NameResolutionDiagnostics {
     pub reported_nodes: FxHashSet<NodeIndex>,
 
     /// Memoized spelling-suggestion candidate scans keyed by the failing
-    /// reference `NodeIndex`. The full-symbol-universe Levenshtein walk in
-    /// `scan_similar_identifiers` is a pure function of the binder/lib tables
-    /// (stable within a file session) and the reference site, but demand-driven
-    /// type evaluation re-resolves the *same* unresolved type reference many
-    /// times (constraint/alias/conditional/indexed-access revisits). Without a
-    /// memo the scan re-runs per revisit — `O(references × identifier-table)`
-    /// instead of `O(unique-unresolved-references)`. Caching the result per node
-    /// collapses the repeats while emitting exactly the same suggestions.
+    /// reference `NodeIndex` together with the symbol-meaning mask the scan ran
+    /// under (`VALUE`/`TYPE` for ordinary name lookups, `NAMESPACE` for the
+    /// `Cannot find namespace` path). The full-symbol-universe Levenshtein walk
+    /// in `scan_similar_identifiers_for_meaning` is a pure function of the
+    /// binder/lib tables (stable within a file session), the reference site, and
+    /// the requested meaning, but demand-driven type evaluation re-resolves the
+    /// *same* unresolved reference many times (constraint/alias/conditional/
+    /// indexed-access revisits). Without a memo the scan re-runs per revisit —
+    /// `O(references × identifier-table)` instead of
+    /// `O(unique-unresolved-references)`. Caching the result per
+    /// `(node, meaning)` collapses the repeats while emitting exactly the same
+    /// suggestions. The meaning is part of the key so a node queried under two
+    /// distinct meanings (it never is today, but the gateway is shared) cannot
+    /// return a scan run for the wrong candidate set.
     /// Cleared at the file-session boundary alongside `reported_nodes`.
-    pub suggestion_scan_cache: RefCell<FxHashMap<NodeIndex, Vec<String>>>,
+    pub suggestion_scan_cache: RefCell<FxHashMap<(NodeIndex, u32), Vec<String>>>,
 }
 
 /// File-session memo tables shared by flow narrowing helpers.

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -478,21 +478,11 @@ pub struct NameResolutionDiagnostics {
     /// re-evaluation in generic/contextual typing contexts).
     pub reported_nodes: FxHashSet<NodeIndex>,
 
-    /// Memoized spelling-suggestion candidate scans keyed by the failing
-    /// reference `NodeIndex` together with the symbol-meaning mask the scan ran
-    /// under (`VALUE`/`TYPE` for ordinary name lookups, `NAMESPACE` for the
-    /// `Cannot find namespace` path). The full-symbol-universe Levenshtein walk
-    /// in `scan_similar_identifiers_for_meaning` is a pure function of the
-    /// binder/lib tables (stable within a file session), the reference site, and
-    /// the requested meaning, but demand-driven type evaluation re-resolves the
-    /// *same* unresolved reference many times (constraint/alias/conditional/
-    /// indexed-access revisits). Without a memo the scan re-runs per revisit —
-    /// `O(references × identifier-table)` instead of
-    /// `O(unique-unresolved-references)`. Caching the result per
-    /// `(node, meaning)` collapses the repeats while emitting exactly the same
-    /// suggestions. The meaning is part of the key so a node queried under two
-    /// distinct meanings (it never is today, but the gateway is shared) cannot
-    /// return a scan run for the wrong candidate set.
+    /// Memoized spelling-suggestion candidate scans keyed by failing reference
+    /// node and symbol-meaning mask (`VALUE`/`TYPE`/`NAMESPACE`). The
+    /// full-symbol-universe Levenshtein walk depends only on stable binder/lib
+    /// tables, reference site, and meaning; caching `(node, meaning)` collapses
+    /// repeated demand-driven revisits without reusing the wrong candidate set.
     /// Cleared at the file-session boundary alongside `reported_nodes`.
     pub suggestion_scan_cache: RefCell<FxHashMap<(NodeIndex, u32), Vec<String>>>,
 }

--- a/crates/tsz-checker/src/error_reporter/name_resolution.rs
+++ b/crates/tsz-checker/src/error_reporter/name_resolution.rs
@@ -1220,20 +1220,6 @@ impl<'a> CheckerState<'a> {
     /// (it does not re-apply the suppression predicates or touch the cap
     /// counter), and only when a diagnostic is actually being emitted.
     pub(crate) fn scan_similar_identifiers(&self, name: &str, idx: NodeIndex) -> Vec<String> {
-        // Memoize per reference site: the same unresolved reference is
-        // re-resolved many times under demand-driven evaluation, and each
-        // revisit would otherwise repeat the full-symbol-universe scan below.
-        // See `NameResolutionDiagnostics::suggestion_scan_cache`.
-        if let Some(cached) = self
-            .ctx
-            .name_resolution_diagnostics
-            .suggestion_scan_cache
-            .borrow()
-            .get(&idx)
-        {
-            return cached.clone();
-        }
-
         // Determine spelling suggestion meaning based on context.
         // In type positions (type annotations, implements clauses, type references),
         // only suggest TYPE-meaning symbols. In value positions, suggest VALUE symbols.
@@ -1244,15 +1230,52 @@ impl<'a> CheckerState<'a> {
             tsz_binder::symbol_flags::VALUE
         };
 
+        self.scan_similar_identifiers_for_meaning(name, idx, suggestion_meaning)
+    }
+
+    /// Memoized full-symbol-universe candidate scan for an explicit symbol
+    /// meaning. This is the single owner of `find_similar_identifiers`: every
+    /// spelling-suggestion call site (ordinary `VALUE`/`TYPE` name lookups via
+    /// `scan_similar_identifiers`, and the `Cannot find namespace` path via
+    /// `error_cannot_find_namespace_with_suggestion`) routes through here so the
+    /// expensive Levenshtein walk is memoized exactly once per
+    /// `(reference site, meaning)`.
+    ///
+    /// Before this consolidation the namespace path called
+    /// `find_similar_identifiers` directly, bypassing the memo, so a missing
+    /// namespace re-resolved during demand-driven evaluation re-ran the whole
+    /// scan on every revisit (issue #14349). Callers that need cap/suppression
+    /// gating must still consult `suggestion_scan_eligible` first; this method
+    /// only owns the candidate scan and its cache.
+    pub(crate) fn scan_similar_identifiers_for_meaning(
+        &self,
+        name: &str,
+        idx: NodeIndex,
+        meaning: u32,
+    ) -> Vec<String> {
+        // Memoize per (reference site, meaning): the same unresolved reference is
+        // re-resolved many times under demand-driven evaluation, and each
+        // revisit would otherwise repeat the full-symbol-universe scan below.
+        // See `NameResolutionDiagnostics::suggestion_scan_cache`.
+        if let Some(cached) = self
+            .ctx
+            .name_resolution_diagnostics
+            .suggestion_scan_cache
+            .borrow()
+            .get(&(idx, meaning))
+        {
+            return cached.clone();
+        }
+
         let suggestions = self
-            .find_similar_identifiers(name, idx, suggestion_meaning)
+            .find_similar_identifiers(name, idx, meaning)
             .unwrap_or_default();
 
         self.ctx
             .name_resolution_diagnostics
             .suggestion_scan_cache
             .borrow_mut()
-            .insert(idx, suggestions.clone());
+            .insert((idx, meaning), suggestions.clone());
 
         suggestions
     }
@@ -1570,10 +1593,16 @@ impl<'a> CheckerState<'a> {
         // type (interface / class / type alias) as a namespace suggestion, so
         // including `TYPE` here wrongly suggested e.g. the DOM `Node` interface for
         // a missing `NodeJS` namespace (TS2833) where tsc emits plain TS2503.
+        // Route through the shared memoized scan gateway (keyed by node +
+        // `NAMESPACE` meaning) so a missing namespace re-resolved during
+        // demand-driven evaluation does not re-run the full-symbol-universe
+        // walk on every revisit (issue #14349). An empty result means no
+        // close-enough namespace candidate, so we fall through to plain TS2503 —
+        // identical to the previous `Option`-returning direct call.
         if !self.has_syntax_parse_errors()
-            && let Some(suggestions) =
-                self.find_similar_identifiers(name, idx, symbol_flags::NAMESPACE)
-            && let Some(suggestion) = suggestions.first()
+            && let Some(suggestion) = self
+                .scan_similar_identifiers_for_meaning(name, idx, symbol_flags::NAMESPACE)
+                .first()
         {
             self.error_at_node_msg(
                 idx,

--- a/crates/tsz-checker/src/tests/spurious_suggestion_suppression_tests.rs
+++ b/crates/tsz-checker/src/tests/spurious_suggestion_suppression_tests.rs
@@ -58,6 +58,31 @@ type T = Foobaz.X;
 }
 
 #[test]
+fn namespace_suggestion_stable_across_repeated_references() {
+    // The `Cannot find namespace` suggestion path is memoized per
+    // (reference site, NAMESPACE meaning) so a missing namespace re-resolved
+    // many times under demand-driven evaluation does not re-run the
+    // full-symbol-universe scan (issue #14349). Referencing the same missing
+    // namespace from several distinct sites must still yield one TS2833 per
+    // site with the correct suggestion and no spurious TS2503 — i.e. the memo
+    // never returns a stale/empty scan for a namespace lookup.
+    let codes = check_strict(
+        r#"
+namespace Foobar { export type X = number; }
+type A = Foobaz.X;
+type B = Foobaz.X;
+type C = Foobaz.X;
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS2833),
+        3,
+        "each missing-namespace site still gets its suggestion: {codes:?}"
+    );
+    assert_eq!(count(&codes, TS2503), 0, "{codes:?}");
+}
+
+#[test]
 fn rest_only_indexer_method_does_not_get_call_hint() {
     // `o[sym]` where `get` takes only a rest param (min-arg-count 0) — tsc emits
     // plain TS7053, not the "Did you mean to call 'o.get'?" TS7052 hint.


### PR DESCRIPTION
Goal: fast

Closes #14349 (the namespace residual leak; the broader spelling-suggestion-scan root was already mitigated by #13962/#14103).

## Structural rule
When a name-resolution MISS needs a spelling suggestion, `tsc` runs the
full-symbol-universe candidate scan once and reuses it; `tsz` does the same through
the per-`(reference site)` `suggestion_scan_cache` memo — **except** the
`Cannot find namespace` path (`error_cannot_find_namespace_with_suggestion`)
called `find_similar_identifiers` directly, bypassing the memo. Under demand-driven
type evaluation the same missing namespace is re-resolved many times, so each revisit
re-ran the whole `O(symbol-universe)` Levenshtein walk — making a failing miss as
expensive as success on exactly the projects that fail.

## Owner layer
checker (`error_reporter`). The fix generalizes the memoized scan into
`scan_similar_identifiers_for_meaning(name, idx, meaning)`, keyed by
`(NodeIndex, meaning)`, and makes it the **single owner** of
`find_similar_identifiers`. Both call sites now route through it:

- ordinary `VALUE`/`TYPE` name lookups via `scan_similar_identifiers` (a thin
  wrapper that derives the meaning from syntactic context), and
- the `NAMESPACE` path via `error_cannot_find_namespace_with_suggestion`.

`find_similar_identifiers` now has exactly one caller (the gateway), so every
spelling-suggestion site is memoized exactly once per `(reference site, meaning)`.
The meaning is part of the cache key so scans run under different candidate sets
cannot collide.

## Parity / scope
Diagnostic-neutral. The namespace path still emits the same TS2833 (did-you-mean)
/ TS2503 (plain) and still does **not** charge the suggestion-cap counter — the
cap-charging unification flagged in #14349 is a separate, parity-sensitive change
(it can shift which later suggestions are suppressed; TS2833/TS2503/TS2552 baselines
would need validation) and is intentionally left out of this PR. An empty scan result
is treated identically to the previous `Option::None` (falls through to plain TS2503).

## Adjacent-case matrix
- value-position miss (existing `scan_similar_identifiers` path) — unchanged, memoized.
- type-position miss — unchanged, memoized (TYPE meaning).
- namespace miss with a real near-match namespace → TS2833 (existing
  `real_namespace_is_still_suggested`).
- namespace miss whose near-match is a pure type (interface/class/alias) → plain
  TS2503, no suggestion (existing `type_is_not_offered_as_namespace_suggestion`).
- **new**: same missing namespace referenced from several sites → one TS2833 per
  site, no spurious TS2503, exercising the shared `(idx, NAMESPACE)` cache
  (`namespace_suggestion_stable_across_repeated_references`).

## Anti-hardcoding
No identifier/file-name/message-string predicates added. The gateway keys on a
structural `(NodeIndex, symbol-meaning-mask)` tuple; the namespace meaning is the
existing `symbol_flags::NAMESPACE`.

## Verification
- `cargo build -p tsz-checker` — clean.
- `cargo clippy -p tsz-checker` — clean (no warnings).
- `cargo test -p tsz-checker --lib -- name_resolution suggestion` — 76 passed,
  0 failed (includes the new regression test).
- Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

https://claude.ai/code/session_013W1FQizbZeg4yD9JFTyvnc

---
_Generated by [Claude Code](https://claude.ai/code/session_013W1FQizbZeg4yD9JFTyvnc)_