### PR TITLE
perf(solver): share class-check-context relation verdicts via a discriminating cache bit (#13828)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -334,18 +334,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             None
         };
         let this_context = this_binding.unwrap_or(TypeId::NONE);
-        // Class-symbol classification is also context-dependent: the callback
-        // can make the same object shape behave as a named class/interface in
-        // one checker and as a plain structural object in another. Since the
-        // relation cache key cannot encode an arbitrary predicate, those answers
-        // are excluded from the cross-checker shared cache and served by the
-        // instance-local fallback memo, whose `is_class_symbol` closure is fixed
-        // for the checker's lifetime.
-        let has_class_check_context = self.is_class_symbol.is_some();
+        // Class-symbol classification is also behavior-affecting (it can make a
+        // class-flagged symbol that has no resolvable `DefId` behave nominally),
+        // but it is no longer a cache bypass: the classifier is a pure function
+        // of the program binder, fixed for the whole compilation, so whether it
+        // is active is encoded as a single discriminating bit in the relation
+        // cache key via `RelationFlags::CLASS_CHECK_CONTEXT` (issue #13828).
+        // Class-context verdicts then share the cross-checker cache in their own
+        // partition and cannot poison the class-agnostic regime (whose keys keep
+        // the bit clear).
+        //
         // A `this`-bearing pair is shareable once keyed by its resolved binding;
-        // without a binding (or inside a class-check context) it stays local.
-        let can_use_shared_relation_cache =
-            !has_class_check_context && (!has_this_type || this_binding.is_some());
+        // without a binding it stays on the instance-local fallback memo.
+        let can_use_shared_relation_cache = !has_this_type || this_binding.is_some();
         // The `in_callback_param_check` state is encoded in
         // `RelationFlags::IN_CALLBACK_PARAM_CHECK` via `make_cache_key`, so
         // callback-mode results live in a separate cache slot from
@@ -373,18 +374,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     }
                 }
             } else if !self.local_relation_cache.is_empty() {
-                // Context-dependent pair (polymorphic `this` / class-check
-                // context): excluded from the cross-checker shared cache, but
-                // memoizable for this checker instance's lifetime (issue
-                // #13828). The context — the resolver's `this` binding and the
-                // `is_class_symbol` closure — is fixed for the instance, so a
-                // definitive verdict for this pair holds for every repeat of it
-                // in the same query's recursive structural walk. The memo is
-                // dropped with the checker (and cleared by `reset`), so it can
-                // never serve a verdict to a later query under a different
-                // context. A non-empty memo implies `query_db` was present at
-                // write time (and it never reverts to `None`), so no `query_db`
-                // recheck is needed before building the key below.
+                // Unbindable polymorphic-`this` pair: excluded from the
+                // cross-checker shared cache, but memoizable for this checker
+                // instance's lifetime (issue #13828). The resolver's `this`
+                // binding is fixed for the instance, so a definitive verdict for
+                // this pair holds for every repeat of it in the same query's
+                // recursive structural walk. The memo is dropped with the checker
+                // (and cleared by `reset`), so it can never serve a verdict to a
+                // later query under a different binding. A non-empty memo implies
+                // `query_db` was present at write time (and it never reverts to
+                // `None`), so no `query_db` recheck is needed before building the
+                // key below.
                 let key = self.make_cache_key(source, target);
                 if let Some(&related) = self.local_relation_cache.get(&key) {
                     return if related {
@@ -1215,17 +1215,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
     /// Record a definitive subtype verdict for later reuse.
     ///
-    /// Context-independent pairs are written to the cross-checker shared
-    /// `QueryCache`. Context-dependent pairs — those carrying a polymorphic
-    /// `this` or checked inside a class-check context, for which
-    /// `can_use_shared_relation_cache` is `false` — are written to the
-    /// instance-local fallback memo instead (issue #13828): their verdict
-    /// depends on the resolver's current `this` binding and on the
-    /// `is_class_symbol` closure, neither of which the flag-agnostic
-    /// [`RelationCacheKey`] encodes, so sharing them across checker instances
-    /// could poison sibling checks. Both inputs are fixed for the lifetime of
-    /// one checker instance, so the local memo safely serves repeats of the
-    /// same pair within one query and is dropped when the instance (or its
+    /// Most pairs are written to the cross-checker shared `QueryCache`. A
+    /// class-check context is no longer excluded: it is encoded in the key via
+    /// `RelationFlags::CLASS_CHECK_CONTEXT`, so class-context verdicts share the
+    /// cache in their own partition (issue #13828). The only pairs still routed
+    /// to the instance-local fallback memo — when `can_use_shared_relation_cache`
+    /// is `false` — are those carrying a polymorphic `this` with no resolvable
+    /// receiver binding: the binding the verdict depends on is not available to
+    /// encode in the [`RelationCacheKey`], so sharing them across checker
+    /// instances could poison sibling checks. The `this` binding is fixed for the
+    /// lifetime of one checker instance, so the local memo safely serves repeats
+    /// of the same pair within one query and is dropped when the instance (or its
     /// `reset`) ends.
     ///
     /// Only definitive `True`/`False` verdicts are recorded; `CycleDetected` /

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -324,23 +324,24 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// Instance-local fallback memo for definitive relation verdicts that the
     /// cross-checker shared cache must skip (issue #13828).
     ///
-    /// A pair whose source/target carries a polymorphic `this`, or that is
-    /// checked inside a class-check context (`is_class_symbol` set), is
-    /// context-dependent: its verdict depends on the resolver's current `this`
-    /// binding (`resolve_this_type`) and on the class-symbol classification
-    /// callback. Those inputs cannot be encoded in the flag-agnostic
-    /// [`RelationCacheKey`], so such verdicts are excluded from the shared
-    /// `QueryCache` to avoid cross-checker poisoning.
+    /// The only verdicts routed here are those for a pair whose source/target
+    /// carries a polymorphic `this` for which no concrete receiver binding can
+    /// be resolved (`resolve_this_type` returns `None`): the binding the verdict
+    /// depends on cannot be encoded in the [`RelationCacheKey`], so the verdict
+    /// is excluded from the shared `QueryCache` to avoid cross-checker poisoning.
+    /// (A class-check context is no longer excluded — it is discriminated in the
+    /// key by `RelationFlags::CLASS_CHECK_CONTEXT` and shared; a `this`-bearing
+    /// pair *with* a resolvable binding is discriminated by
+    /// [`RelationCacheKey::this_context`] and shared.)
     ///
-    /// They are, however, stable for the lifetime of one [`SubtypeChecker`]
-    /// instance: a fresh checker is built per top-level relation query, the
-    /// resolver is borrowed immutably for that whole lifetime (so the
-    /// `this` binding cannot shift mid-query), and the `is_class_symbol`
-    /// closure is fixed at construction. Memoizing them here therefore serves
-    /// the repeated comparisons of the same pair inside one query's recursive
-    /// structural walk (the dominant redundancy on class-heavy code such as
-    /// `ts-morph`) without ever leaking a context-bound verdict to a later
-    /// query under a different context. Cleared by [`SubtypeChecker::reset`].
+    /// Such verdicts are, however, stable for the lifetime of one
+    /// [`SubtypeChecker`] instance: a fresh checker is built per top-level
+    /// relation query and the resolver is borrowed immutably for that whole
+    /// lifetime, so the `this` binding cannot shift mid-query. Memoizing them
+    /// here therefore serves the repeated comparisons of the same pair inside one
+    /// query's recursive structural walk without ever leaking a context-bound
+    /// verdict to a later query under a different context. Cleared by
+    /// [`SubtypeChecker::reset`].
     pub(crate) local_relation_cache: FxHashMap<RelationCacheKey, bool>,
     /// Configured work budget for one failure-explanation traversal (issue
     /// #13243). Defaults to [`super::explain::EXPLAIN_EVAL_BUDGET`]; lowered in

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -307,6 +307,14 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if self.assume_related_on_cycle {
             flags |= RelationFlags::ASSUME_RELATED_ON_CYCLE;
         }
+        // The class-symbol classifier is behavior-affecting (it can make a
+        // no-`DefId` class-flagged symbol nominal), so discriminate verdicts
+        // computed with it active from class-agnostic ones (issue #13828). The
+        // classifier is a pure function of the program binder, fixed for the
+        // whole compilation, so this single bit fully partitions the regimes.
+        if self.is_class_symbol.is_some() {
+            flags |= RelationFlags::CLASS_CHECK_CONTEXT;
+        }
 
         RelationPolicy::from_relation_flags(flags)
             .with_any_propagation_mode(self.any_propagation)

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -344,6 +344,21 @@ bitflags::bitflags! {
         /// `strict_readonly_identity` field on `SubtypeChecker` for the
         /// rationale and toggle site.
         const STRICT_READONLY_IDENTITY      = 1 << 15;
+        /// A class-symbol classifier is active for this relation check (the
+        /// solver was configured via `with_class_check`).
+        ///
+        /// The classifier makes a class-flagged symbol that has no resolvable
+        /// `DefId` behave nominally — it then needs an explicit declared index
+        /// signature (`requires_explicit_declared_index_signature`) and gains
+        /// the both-classes nominal-heritage shortcut (`nominal_heritage_subtype`)
+        /// — whereas absent the classifier the same shape is judged purely
+        /// structurally. Those two verdicts genuinely differ, so they must not
+        /// share a cache slot. The classifier itself is a pure function of the
+        /// program's binder `CLASS` flags, fixed for the whole compilation, so a
+        /// single discriminating bit fully partitions the two regimes and lets
+        /// class-context verdicts live in the cross-checker shared cache without
+        /// poisoning the class-agnostic regime (issue #13828).
+        const CLASS_CHECK_CONTEXT           = 1 << 16;
     }
 }
 

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/class_context_partitioning.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/class_context_partitioning.rs
@@ -1,4 +1,13 @@
-//! Context-dependent class-check cache tests.
+//! Class-check relation cache partitioning tests.
+//!
+//! A class-symbol classifier is behavior-affecting: it can make a class-flagged
+//! symbol that has no resolvable `DefId` behave nominally (it then needs an
+//! explicit declared index signature) where, absent the classifier, the same
+//! shape is judged purely structurally. Those verdicts must never share a cache
+//! slot, but they *can* both live in the cross-checker shared cache once the key
+//! is discriminated by `RelationFlags::CLASS_CHECK_CONTEXT` (issue #13828). The
+//! classifier is a pure function of the program binder, fixed for the whole
+//! compilation, so a single discriminating bit fully partitions the regimes.
 
 use crate::caches::db::QueryDatabase;
 use crate::caches::query_cache::QueryCache;
@@ -9,16 +18,12 @@ use crate::relations::relation_queries::{
 use crate::relations::subtype::SubtypeChecker;
 use crate::types::{IndexSignature, ObjectFlags, ObjectShape, PropertyInfo, TypeId};
 
-#[test]
-fn subtype_cache_skips_class_check_context() {
-    use tsz_binder::SymbolId;
-
-    let interner = TypeInterner::new();
-    let db = QueryCache::new(&interner);
-    let source_symbol = SymbolId(42);
-    let class_ref = crate::SymbolRef(source_symbol.0);
-    let is_class = |symbol: crate::SymbolRef| symbol == class_ref;
-
+/// Build the `{a: number, b: number}` (symbol-tagged) source and the
+/// `{[s: string]: number}` index-signature target shared by these tests.
+fn nominal_vs_index_pair(
+    interner: &TypeInterner,
+    source_symbol: tsz_binder::SymbolId,
+) -> (TypeId, TypeId) {
     let source = interner.object_with_flags_and_symbol(
         vec![
             PropertyInfo::new(interner.intern_string("a"), TypeId::NUMBER),
@@ -39,42 +44,59 @@ fn subtype_cache_skips_class_check_context() {
         }),
         number_index: None,
     });
+    (source, target)
+}
 
+#[test]
+fn class_and_structural_contexts_use_distinct_cache_keys() {
+    use tsz_binder::SymbolId;
+
+    let interner = TypeInterner::new();
+    let source_symbol = SymbolId(42);
+    let class_ref = crate::SymbolRef(source_symbol.0);
+    let is_class = |symbol: crate::SymbolRef| symbol == class_ref;
+    let (source, target) = nominal_vs_index_pair(&interner, source_symbol);
+
+    // The two regimes still disagree on the verdict: the class-tagged source
+    // needs an explicit string index signature, the structural one does not.
     let mut class_uncached = SubtypeChecker::new(&interner).with_class_check(&is_class);
     assert!(
         !class_uncached.is_subtype_of(source, target),
         "named class/interface sources need an explicit string index signature",
     );
-
     let mut structural_uncached = SubtypeChecker::new(&interner);
     assert!(
         structural_uncached.is_subtype_of(source, target),
         "without class-symbol context the same shape is an ordinary structural object",
     );
 
-    let mut class_cached = SubtypeChecker::new(&interner)
-        .with_query_db(&db)
-        .with_class_check(&is_class);
-    let class_key = class_cached.debug_cache_key_for(source, target);
-    assert!(
-        !class_cached.is_subtype_of(source, target),
-        "cached class-context relation should preserve the uncached class-context answer",
+    // Because the verdicts differ, the keys must differ so they never collide.
+    let class_key = SubtypeChecker::new(&interner)
+        .with_class_check(&is_class)
+        .debug_cache_key_for(source, target);
+    let structural_key = SubtypeChecker::new(&interner).debug_cache_key_for(source, target);
+    assert_ne!(
+        class_key, structural_key,
+        "class-context and class-agnostic keys must occupy different cache slots",
     );
-    assert_eq!(
-        db.lookup_subtype_cache(class_key),
-        None,
-        "class-check context is behavior-affecting and must not populate a shared class-agnostic slot",
-    );
-
-    let mut structural_cached = SubtypeChecker::new(&interner).with_query_db(&db);
     assert!(
-        structural_cached.is_subtype_of(source, target),
-        "a class-context result must not be reused by a structural checker without class context",
+        class_key
+            .config
+            .flags
+            .contains(crate::types::RelationFlags::CLASS_CHECK_CONTEXT),
+        "the class-context key must carry the CLASS_CHECK_CONTEXT discriminator",
+    );
+    assert!(
+        !structural_key
+            .config
+            .flags
+            .contains(crate::types::RelationFlags::CLASS_CHECK_CONTEXT),
+        "the class-agnostic key must keep the CLASS_CHECK_CONTEXT bit clear",
     );
 }
 
 #[test]
-fn class_check_context_verdict_uses_instance_local_memo_not_shared_cache() {
+fn class_context_verdict_is_shared_cross_checker_in_its_own_partition() {
     use tsz_binder::SymbolId;
 
     let interner = TypeInterner::new();
@@ -82,69 +104,52 @@ fn class_check_context_verdict_uses_instance_local_memo_not_shared_cache() {
     let source_symbol = SymbolId(44);
     let class_ref = crate::SymbolRef(source_symbol.0);
     let is_class = |symbol: crate::SymbolRef| symbol == class_ref;
+    let (source, target) = nominal_vs_index_pair(&interner, source_symbol);
 
-    let source = interner.object_with_flags_and_symbol(
-        vec![
-            PropertyInfo::new(interner.intern_string("a"), TypeId::NUMBER),
-            PropertyInfo::new(interner.intern_string("b"), TypeId::NUMBER),
-        ],
-        ObjectFlags::empty(),
-        Some(source_symbol),
-    );
-    let target = interner.object_with_index(ObjectShape {
-        symbol: None,
-        flags: ObjectFlags::empty(),
-        properties: vec![],
-        string_index: Some(IndexSignature {
-            key_type: TypeId::STRING,
-            value_type: TypeId::NUMBER,
-            readonly: false,
-            param_name: None,
-        }),
-        number_index: None,
-    });
-
-    let mut checker = SubtypeChecker::new(&interner)
+    // First class-context checker populates the shared cache under the
+    // class-context-discriminated key — not the instance-local memo (the
+    // class-check bypass is gone, issue #13828).
+    let mut first = SubtypeChecker::new(&interner)
         .with_query_db(&db)
         .with_class_check(&is_class);
-    let key = checker.debug_cache_key_for(source, target);
-
-    // A class-context verdict is excluded from the cross-checker shared cache
-    // (it depends on the `is_class_symbol` closure), so the first check
-    // populates the instance-local fallback memo instead (issue #13828).
-    assert!(!checker.is_subtype_of(source, target));
+    let class_key = first.debug_cache_key_for(source, target);
+    assert!(!first.is_subtype_of(source, target));
     assert_eq!(
-        db.lookup_subtype_cache(key),
-        None,
-        "class-context verdict must not populate the shared class-agnostic slot",
+        db.lookup_subtype_cache(class_key),
+        Some(false),
+        "class-context verdict must be recorded in the shared cache under its discriminated key",
     );
-    assert_eq!(
-        checker.local_relation_cache.get(&key),
-        Some(&false),
-        "class-context verdict must be memoized in the instance-local fallback",
-    );
-
-    // A repeat comparison on the same instance is served from the local memo
-    // and preserves the verdict.
-    assert!(!checker.is_subtype_of(source, target));
-
-    // `reset` clears the instance-local memo so a reused checker never carries a
-    // context-bound verdict into a fresh context.
-    checker.reset();
     assert!(
-        checker.local_relation_cache.is_empty(),
-        "reset must clear the instance-local relation memo",
+        first.local_relation_cache.is_empty(),
+        "class-context verdict must no longer route to the instance-local memo",
     );
 
-    // A separate structural checker (no class context) computes the ordinary
-    // structural answer, unaffected by the per-instance memo — the verdict is
-    // never shared across instances.
+    // A second, independent class-context checker reads that shared verdict —
+    // the cross-checker reuse #13828 is about.
+    let mut second = SubtypeChecker::new(&interner)
+        .with_query_db(&db)
+        .with_class_check(&is_class);
+    assert!(!second.is_subtype_of(source, target));
+
+    // A class-agnostic checker keys to a *different* slot (bit clear), so it is
+    // never served the nominal verdict — it computes the structural answer.
+    let structural_key = SubtypeChecker::new(&interner)
+        .with_query_db(&db)
+        .debug_cache_key_for(source, target);
     let mut structural = SubtypeChecker::new(&interner).with_query_db(&db);
-    assert!(structural.is_subtype_of(source, target));
+    assert!(
+        structural.is_subtype_of(source, target),
+        "a class-context verdict must never poison the class-agnostic regime",
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(structural_key),
+        Some(true),
+        "the structural regime records its own verdict in its own slot",
+    );
 }
 
 #[test]
-fn assignability_relation_context_propagates_class_check_without_shared_cache() {
+fn assignability_relation_context_partitions_class_check_in_shared_cache() {
     use tsz_binder::SymbolId;
 
     let interner = TypeInterner::new();
@@ -152,38 +157,14 @@ fn assignability_relation_context_propagates_class_check_without_shared_cache() 
     let source_symbol = SymbolId(43);
     let class_ref = crate::SymbolRef(source_symbol.0);
     let is_class = |symbol: crate::SymbolRef| symbol == class_ref;
+    let (source, target) = nominal_vs_index_pair(&interner, source_symbol);
 
-    let source = interner.object_with_flags_and_symbol(
-        vec![
-            PropertyInfo::new(interner.intern_string("a"), TypeId::NUMBER),
-            PropertyInfo::new(interner.intern_string("b"), TypeId::NUMBER),
-        ],
-        ObjectFlags::empty(),
-        Some(source_symbol),
-    );
-    let target = interner.object_with_index(ObjectShape {
-        symbol: None,
-        flags: ObjectFlags::empty(),
-        properties: vec![],
-        string_index: Some(IndexSignature {
-            key_type: TypeId::STRING,
-            value_type: TypeId::NUMBER,
-            readonly: false,
-            param_name: None,
-        }),
-        number_index: None,
-    });
+    // Class-context assignability preserves the nominal index-signature rule.
     let class_context = RelationContext {
         query_db: Some(&db),
         class_check: Some(&is_class),
         ..RelationContext::default()
     };
-
-    let class_key = SubtypeChecker::new(&interner)
-        .with_query_db(&db)
-        .with_class_check(&is_class)
-        .debug_cache_key_for(source, target);
-
     assert!(
         !query_relation(
             &interner,
@@ -196,12 +177,10 @@ fn assignability_relation_context_propagates_class_check_without_shared_cache() 
         .is_related(),
         "assignability relation context must preserve class/interface index-signature rules",
     );
-    assert_eq!(
-        db.lookup_subtype_cache(class_key),
-        None,
-        "class-check assignability context must not populate a shared class-agnostic subtype slot",
-    );
 
+    // The class-agnostic assignability of the same pair is unaffected by any
+    // shared-cache entry the class-context run left behind: it keys to a
+    // different slot and computes the structural answer.
     assert!(
         query_relation(
             &interner,

--- a/docs/how-tsz-works/internals/solver-relations.md
+++ b/docs/how-tsz-works/internals/solver-relations.md
@@ -268,9 +268,13 @@ dispatch. It runs, in order:
    keyed by a `RelationCacheKey`. Three values: `True`, `False`, and the
    budget-conditional `LimitTrue { fuel_band }` (honest only when the current
    `remaining_global_subtype_fuel() <= fuel_band`). Skipped under
-   `identity_cycle_check` (the key cannot encode identity mode) and for
-   context-dependent pairs (polymorphic `this`, class-check context), which use
-   the instance-local `local_relation_cache` instead.
+   `identity_cycle_check` (the key cannot encode identity mode) and for a
+   polymorphic-`this` pair with no resolvable receiver binding, which uses the
+   instance-local `local_relation_cache` instead. A class-check context is *not*
+   skipped: it is discriminated in the key by `RelationFlags::CLASS_CHECK_CONTEXT`
+   and a `this`-bearing pair with a resolvable binding by
+   `RelationCacheKey::this_context`, so both share the cross-checker cache in
+   their own partition (#13828).
 4. **Structural-identity fast path** — `QueryDatabase::canonical_id(source) ==
    canonical_id(target)` ⇒ `True` (graph-isomorphism canonicalization, after
    the cheap cache check).
@@ -506,8 +510,8 @@ solver lacks, so the checker injects them through the
 
 | Cache | Scope / owner | Key | Invalidation |
 | --- | --- | --- | --- |
-| Cross-checker relation cache | shared `QueryDatabase` | `RelationCacheKey` (source, target, behavior flags, `this_context`) | dropped with the query DB; never written for undetermined or context-dependent results |
-| `local_relation_cache` | one `SubtypeChecker` instance | `RelationCacheKey` | cleared by `reset`; for polymorphic-`this` / class-check pairs only |
+| Cross-checker relation cache | shared `QueryDatabase` | `RelationCacheKey` (source, target, behavior flags incl. `CLASS_CHECK_CONTEXT`, `this_context`) | dropped with the query DB; never written for undetermined results |
+| `local_relation_cache` | one `SubtypeChecker` instance | `RelationCacheKey` | cleared by `reset`; for polymorphic-`this` pairs with no resolvable receiver binding only |
 | `eval_cache` | one `SubtypeChecker` instance | `(TypeId, no_unchecked_indexed_access)` | cleared by `reset`; memoizes `evaluate_type` results + stability |
 | `CompatChecker::cache` | one `CompatChecker` | `(TypeId, TypeId)` | cleared by every policy-affecting setter |
 | `DefaultJudge::subtype_cache` / `eval_cache` | one `DefaultJudge` | `(TypeId, TypeId)` / `TypeId` | `clear_caches` |
@@ -523,13 +527,18 @@ Several **cache-honesty invariants** are essential to tsc parity:
 - **Weak-sensitivity is never cached across enforcement states.** The
   flag-agnostic `RelationCacheKey` cannot encode weak-type enforcement, so a
   result whose computation read `note_weak_type_sensitivity` is excluded.
-- **Context-dependent pairs stay local.** A pair carrying polymorphic `this`, or
-  checked inside a class-check context, depends on the resolver's current `this`
-  binding and the `is_class_symbol` closure — neither is in the key — so it uses
-  the instance-local memo, valid only for the checker's lifetime (one top-level
-  query). When a concrete `this` binding *is* available, `make_cache_key`
-  discriminates the shared key by it (`RelationCacheKey::this_context`,
-  issue 13828) so the pair can safely re-enter the shared cache.
+- **Context-dependent pairs are discriminated, not dropped.** A class-check
+  context is a behavior-affecting input (the `is_class_symbol` classifier can
+  make a no-`DefId` class-flagged symbol nominal), but it is a pure function of
+  the program binder, fixed for the whole compilation, so whether it is active is
+  encoded as one bit in the key (`RelationFlags::CLASS_CHECK_CONTEXT`, issue
+  13828); class-context verdicts then share the cross-checker cache in their own
+  partition. A pair carrying polymorphic `this` depends on the resolver's current
+  `this` binding; when a concrete binding is available `make_cache_key`
+  discriminates the shared key by it (`RelationCacheKey::this_context`, issue
+  13828) so the pair re-enters the shared cache. Only a `this`-bearing pair with
+  *no* resolvable receiver binding stays on the instance-local memo, valid for
+  the checker's lifetime (one top-level query).
 - **`maybe_keys` (tsc `maybeKeys` parity, issue 13241).** A
   `CycleDetected`/`DepthExceeded` verdict is a *Maybe*: it is recorded in the
   `maybe_keys` stack and only **promoted** to a definitive cache entry when the


### PR DESCRIPTION
Goal: fast

Closes the **class-check-context** half of #13828 (the `has_this_type` half landed in #14030). The `ts-morph` canary times out because class-heavy code re-runs the same structural subtype comparisons from scratch on every top-level query — the cross-checker shared relation cache was bypassed entirely whenever a class-symbol classifier was active.

## The bypass (before)

`crates/tsz-solver/src/relations/subtype/cache.rs`:

```rust
let has_class_check_context = self.is_class_symbol.is_some();
let can_use_shared_relation_cache =
    !has_class_check_context && (!has_this_type || this_binding.is_some());
```

When the classifier was set (`with_class_check`, used by the checker's `is_subtype_of` path), every verdict was routed to the per-instance `local_relation_cache`, which is dropped at the end of each query. So the same generic-signature comparisons were re-instantiated and re-compared on every later query — the redundant structural recompute the issue profile attributes the hang to.

## Structural rule

> When a subtype `(source, target)` pair is checked with a class-symbol classifier active, `tsc` may treat a class-flagged symbol that has no resolvable `DefId` nominally (it then needs an explicit declared index signature, and gains the both-classes nominal-heritage shortcut), where absent the classifier the same shape is judged structurally. The classifier is a pure function of the program binder's `CLASS` flags, fixed for the whole compilation, so tsz now discriminates the two regimes with one cache-key bit and shares both through the cross-checker relation cache.

So whether the classifier is active is a single behavior-affecting input, not an arbitrary unhashable predicate. Encoding it as one bit fully partitions the two regimes.

## Owner layer

Solver relation cache (`crates/tsz-solver/src/relations/subtype/{cache.rs, core.rs, helpers.rs}`, `types.rs`).

- `RelationFlags` gains `CLASS_CHECK_CONTEXT = 1 << 16`, set in `cache_policy()` when `self.is_class_symbol.is_some()` — exactly how the existing solver-instance bits `IN_CALLBACK_PARAM_CHECK` and `STRICT_READONLY_IDENTITY` are set. It is not a `field_owned_bits` member, so it flows through `cache_config_with_cached_any_mode` into the key untouched.
- The shared-cache gate drops the `!has_class_check_context` factor: `can_use_shared_relation_cache = !has_this_type || this_binding.is_some()`.

## Soundness / what stays local (unchanged)

- **Class-agnostic pairs** keep the `CLASS_CHECK_CONTEXT` bit clear, so their keys are byte-identical to before and share their existing slots. A class-context verdict (bit set) can never be served to a class-agnostic checker, or vice versa.
- The production classifier (`crates/tsz-checker/src/assignability/subtype_identity_checker.rs`) is `binder.get_symbol(sym).has_any_flags(CLASS)` — canonical per compilation — so a single "classifier active" bit is a complete discriminator.
- A **polymorphic-`this` pair with no resolvable receiver binding** still stays on the instance-local memo (its binding can't be encoded in the key); a `this`-bearing pair *with* a binding stays discriminated by `this_context` (#14030).

## Anti-hardcoding

The discriminator is a structural bit derived from `is_class_symbol.is_some()`, not any identifier, file-name, or printer string. New tests vary the binder symbol id and assert on cache-slot identity and verdicts, never on names.

## Verification

- New/rewritten regression tests in `relation_policy_cache_agreement_tests::class_context_partitioning` (3): class-context and class-agnostic pairs key to distinct slots; a class-context verdict is shared cross-checker in its own partition; it never poisons the class-agnostic regime (which records its own structural verdict in its own slot). All pass.
- `cargo test -p tsz-solver --lib`: 6901 passed, 5 failed — the **same 5** failures present on clean base (verified via `git stash`; they are pre-existing main drift, incl. the `mapped.rs` file-size baseline). +3 new passing tests, **0 new failures**.
- `cargo fmt -p tsz-solver --check` clean; `cargo clippy -p tsz-solver --lib` clean; `architecture_guards` pass; `tsz-checker` lib builds.
- Broad conformance / emit / fourslash and the `ts-morph` timing owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Q7jAGGNe9Ba3SUY26eY1bV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7jAGGNe9Ba3SUY26eY1bV)_