### PR TITLE
fix(solver): defer infer-conditional over an unresolved-interface indexed access (TS2349, #14164)

### DIFF
--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -580,19 +580,33 @@ impl<'a> CheckerState<'a> {
         // deferred form (`type G = Atom['read']; function f(g: G) { g() }`):
         // unlike a `const`, a parameter keeps its annotation lazy, so the call
         // path — not the declaration — must reduce it. tsc classifies calls on
-        // the apparent type, so fully evaluate the callee and re-classify. The
-        // evaluation is *uncached* on purpose: an opaque result may have been
-        // interned earlier while a referenced interface was still unresolved, and
-        // the uncached walk forces that interface's type and recomputes the
-        // reduction. Only adopt the result when it actually reveals signatures,
-        // leaving genuinely uncallable and still-deferred-generic callees
-        // untouched (intrinsics can never become callable, so skip them).
+        // the apparent type, so fully evaluate the callee and re-classify.
+        //
+        // Readying the callee's relation inputs first is load-bearing (#14164):
+        // a callee like `Parameters<Atom<unknown>['read']>[0]` only reduces once
+        // the user interface `Atom`'s `DefId -> TypeId` is registered in the
+        // `TypeEnvironment` — a user interface, unlike a force-eligible lib def,
+        // is not materialized on a `resolve_lazy` miss, and this path is reached
+        // while still inside symbol resolution (a function-body return-inference
+        // path) where the environment evaluator skips its own readiness step.
+        // The conditional evaluator keeps such a callee deferred (rather than
+        // collapsing to `never`) precisely so this readiness step + the uncached
+        // re-evaluation below can resolve it. Readying is the same step the
+        // relation path runs, which is why the identical type relates as callable
+        // but the call path did not. The evaluation is *uncached* on purpose: an
+        // opaque result may have been interned earlier while a referenced
+        // interface was still unresolved, so the uncached walk recomputes the
+        // reduction over the now-registered bodies. Only adopt the result when it
+        // actually reveals signatures, leaving genuinely uncallable and
+        // still-deferred-generic callees untouched (intrinsics can never become
+        // callable, so skip them).
         let original_callee_is_union =
             common::is_union_type(self.ctx.types, resolved_for_classification);
         if matches!(classification, query::CallSignaturesKind::NoSignatures)
             && !original_callee_is_union
             && !callee_type_for_resolution.is_intrinsic()
         {
+            self.ensure_relation_input_ready(callee_type_for_resolution);
             let fully_evaluated = self.evaluate_type_with_env_uncached(callee_type_for_resolution);
             let fully_evaluated = self.resolve_lazy_type(fully_evaluated);
             let fully_classification =

--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_b.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_b.rs
@@ -59,9 +59,13 @@ export { c }
 
 /// Repro B (jotai): a method extracted via `Interface['method']` must keep its
 /// call signature so it stays callable. tsz yielded a function type with zero
-/// call signatures -> false TS2349 "not callable".
+/// call signatures -> false TS2349 "not callable". Fixed: a conditional whose
+/// check type referenced an unresolved user-interface `Lazy` (here the `Atom`
+/// base of `Atom<unknown>['read']`) collapsed to its `never` false branch
+/// instead of deferring, so `Parameters<…>` reduced to `never`; the call path
+/// now readies the callee's refs and the conditional defers rather than
+/// collapsing (#14164).
 #[test]
-#[ignore = "reproduces #14164 (Repro B): indexed method loses its call signature -> false TS2349"]
 fn issue_14164_indexed_method_type_stays_callable() {
     if !lib_files_available() {
         return;

--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
@@ -52,7 +52,6 @@ export { c }
 }
 
 #[test]
-#[ignore = "reproduces #14164"]
 fn issue_14164_extracted_method_callable_no_ts2349() {
     let diags = compile_and_get_diagnostics_with_lib_and_options(
         r#"
@@ -68,6 +67,56 @@ export { viaIndex }
     assert!(
         !has_error(&diags, 2349),
         "no TS2349 — extracted method type must keep its call signature. Actual: {diags:#?}"
+    );
+}
+
+// #14164 adjacent matrix: the defect is a conditional whose check type references
+// an unresolved user-interface `Lazy` collapsing to its false branch. Vary the
+// binders/shape to prove the fix is structural, not witness-shaped, and pin the
+// negative control so a genuinely non-callable member still reports TS2349.
+
+/// Renamed binders + a non-generic extracted method (no `<V>` on the callback
+/// alias). Still routes through `Parameters<Store<unknown>['select']>[0]` whose
+/// `Store` base is an unresolved `Lazy` while the enclosing function's type is
+/// computed; the call must stay callable.
+#[test]
+fn issue_14164_extracted_method_non_generic_renamed_callable() {
+    let diags = compile_and_get_diagnostics_with_lib_and_options(
+        r#"
+interface Store<State> { select: (read: Reader) => State }
+type Reader = (store: Store<number>) => number
+declare const s: Store<number>
+type ReaderFromIndex = Parameters<Store<unknown>['select']>[0]
+function viaIndex(read: ReaderFromIndex) { return read(s) }
+export { viaIndex }
+"#,
+        strict_opts(),
+    );
+    assert!(
+        !has_error(&diags, 2349),
+        "no TS2349 — non-generic extracted method (renamed binders) stays callable. Actual: {diags:#?}"
+    );
+}
+
+/// Negative control: an extracted member that is genuinely NOT callable (a
+/// `number`-typed property reached the same way) must still report TS2349 —
+/// the deferral only applies while a referenced `Lazy` is unresolved, never to
+/// a resolved non-callable member.
+#[test]
+fn issue_14164_extracted_non_callable_member_still_ts2349() {
+    let diags = compile_and_get_diagnostics_with_lib_and_options(
+        r#"
+interface Atom<Value> { read: (get: Getter) => Value; size: number }
+type Getter = <V>(atom: Atom<V>) => V
+declare const sz: Atom<unknown>['size']
+const r = sz()
+export { r }
+"#,
+        strict_opts(),
+    );
+    assert!(
+        has_error(&diags, 2349),
+        "TS2349 expected — a number-typed indexed member is not callable. Actual: {diags:#?}"
     );
 }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -224,6 +224,43 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         crate::visitors::visitor_predicates::is_tuple_type(self.interner(), extends_type)
     }
 
+    /// Whether `check_type` is a *non-generic* `IndexAccess` whose object is a
+    /// reference to a user interface the active resolver cannot resolve yet.
+    ///
+    /// Such a check type — e.g. `Atom<unknown>['read']` while the user interface
+    /// `Atom`'s `DefId -> TypeId` is not yet registered in this evaluation
+    /// context (the resolution-order window of #13980) — survives evaluation
+    /// unreduced. Matching an infer pattern (`Parameters<…>`'s
+    /// `(...args: infer P) => any`) against it then fails, and because the check
+    /// type carries no type parameters none of the generic-deferral guards apply,
+    /// so the conditional would collapse to its `never` false branch. That
+    /// `false` is schedule-dependent: the identical conditional matches its true
+    /// branch once the interface is registered (the consuming call/relation path
+    /// readies it). So the caller defers instead, the infer-path analogue of the
+    /// existing `UnresolvedTypeName` / unresolved-`Application` deferrals (#14164).
+    ///
+    /// The gate is deliberately narrow — a *concrete* `IndexAccess` over a single
+    /// unresolvable interface reference — so it never touches a generic indexed
+    /// access (handled by the generic guards) nor a recursive `Application` /
+    /// `Conditional` check type whose definitive branch is correct.
+    fn index_access_blocks_on_unresolved_interface(&self, check_type: TypeId) -> bool {
+        let Some(TypeData::IndexAccess(object, _)) = self.interner().lookup(check_type) else {
+            return false;
+        };
+        if crate::visitor::contains_free_type_parameters(self.interner(), object) {
+            return false;
+        }
+        // The interface reference is the index object itself (`I['k']`) or the
+        // base of an application of it (`I<…>['k']`).
+        let interface_ref = get_application_base(self.interner(), object).unwrap_or(object);
+        let Some(def_id) = crate::visitor::lazy_def_id(self.interner(), interface_ref) else {
+            return false;
+        };
+        self.resolver()
+            .resolve_lazy(def_id, self.interner())
+            .is_none()
+    }
+
     /// Evaluate a conditional type: T extends U ? X : Y
     ///
     /// Algorithm:
@@ -1024,6 +1061,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         false_type: cond.false_type,
                         is_distributive: cond.is_distributive,
                     });
+                }
+
+                // Infer match failed, but the (non-generic) check type is an
+                // indexed access whose interface base the resolver cannot resolve
+                // yet — an unregistered user interface in this evaluation context
+                // (the resolution-order window of #13980). The pattern was matched
+                // against an unreduced meta-type, so the `false` is
+                // schedule-dependent: the identical conditional matches its true
+                // branch once the interface is registered by a consuming
+                // call/relation path. Defer instead of collapsing to the false
+                // branch (#14164). The depth-detection pass is exempt for the same
+                // reason as the generic guard above.
+                if !self.is_depth_detection_pass()
+                    && self.index_access_blocks_on_unresolved_interface(check_type)
+                {
+                    return self.deferred_conditional(cond, check_type, extends_type);
                 }
 
                 // Infer match failed — take the false branch.


### PR DESCRIPTION
Goal: green

## Summary

Fixes #14164 Repro B (jotai): an interface method extracted via
`Parameters<I<…>['method']>[0]` lost its call signature, so

```ts
interface Atom<Value> { read: (get: Getter) => Value }
type Getter = <V>(atom: Atom<V>) => V
declare const a: Atom<number>
type GetterFromIndex = Parameters<Atom<unknown>['read']>[0]
function viaIndex(get: GetterFromIndex) { return get(a) } // tsz: false TS2349
```

emitted a false `TS2349` ("This expression is not callable"). `tsc` is clean.
(Repro A — the hybrid-interface `TS2344` case — was already fixed and is left
unchanged.)

## Root cause

`GetterFromIndex` is evaluated during the function body's return-type inference,
which runs **inside symbol resolution**. There the environment evaluator skips
its own ref-readiness step, so the user interface `Atom`'s `DefId -> TypeId` is
not registered in the `TypeEnvironment` (a user interface, unlike a
force-eligible lib def, is not materialized on a `resolve_lazy` miss).
`Atom<unknown>['read']` therefore survives evaluation as an unreduced
`IndexAccess`; the `Parameters` infer-conditional fails to match its
`(...args: infer P) => any` pattern; and because the check type carries no type
parameters, none of the generic-deferral guards apply, so the conditional
collapses to its `never` false branch — which is cached. `never[0]` then stays a
deferred `IndexAccess` with no call signatures, so the call classifies as not
callable.

## Structural rule

When a conditional's check type is a concrete `IndexAccess` over an interface
the resolver cannot resolve yet, `tsc` keeps the conditional deferred; tsz
collapsed it to the false branch. The fix defers in that case (the infer-path
analogue of the existing `UnresolvedTypeName` / unresolved-`Application`
deferrals), and the call consumer readies its callee's relation inputs before
re-classifying, so the now-registered interface lets the deferred form reduce to
the callable method — the same readiness step the relation path already runs
(which is why the identical type already *relates* as callable).

## Owner layer

- solver: `crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs`
  (infer-path deferral; reuses `get_application_base` / `lazy_def_id` /
  `contains_free_type_parameters` / `deferred_conditional`).
- checker: `crates/tsz-checker/src/types/computation/call/inner.rs`
  (call-signature readiness, gated to the `NoSignatures` fallback only).

## Adjacent matrix

- generic extracted method (`<V>` `Getter`) — the canary witness.
- non-generic extracted method with renamed binders (`Store` / `Reader`).
- negative control: a `number`-typed indexed member still reports `TS2349`
  (deferral only applies while a referenced `Lazy` is unresolved).
- Repro A hybrid-interface `connect` guards unchanged.

## Anti-hardcoding

Structural rule — no identifier/file-name/printer-string predicates. The guard
is gated to a non-generic indexed access over an interface `resolve_lazy`
cannot resolve, and the adjacent tests vary the binder names.

## Verification

- `cargo test -p tsz-checker --test conformance_issues_types issue_14164` — the
  two previously-`#[ignore]`d Repro B witnesses now pass as active guards, plus
  the two new adjacent-matrix tests; Repro A guards unchanged (6/6 pass).
- `cargo nextest run -p tsz-solver` (conditional/evaluation/subtype/canonicalize)
  — no new failures.
- `cargo clippy -p tsz-solver -p tsz-checker --lib` — clean.
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01TpEEQeZ7S44itw6pAK1G1a

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpEEQeZ7S44itw6pAK1G1a)_