### PR TITLE
fix(checker): anchor a re-imported namespace through the import chain (#14225)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -3,6 +3,7 @@
 use crate::state::CheckerState;
 use crate::symbol_resolver::TypeSymbolResolution;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
+use rustc_hash::FxHashSet;
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -401,6 +402,14 @@ impl<'a> CheckerState<'a> {
                                     .or_else(|| {
                                         self.resolve_effective_module_exports(module)
                                             .and_then(|e| e.get(&right_name))
+                                    })
+                                    .or_else(|| {
+                                        self.resolve_member_through_namespace_import_chain(
+                                            alias_sym.import_module(),
+                                            alias_sym.import_name(),
+                                            alias_sym.escaped_name.as_str(),
+                                            &right_name,
+                                        )
                                     });
                             }
                         }
@@ -644,6 +653,73 @@ impl<'a> CheckerState<'a> {
             self.error_cannot_find_namespace_with_suggestion(ident.escaped_text.as_str(), qn.left);
         }
         TypeId::ERROR
+    }
+
+    /// Resolve `member_name` for a qualified-type-name anchor that is an import
+    /// alias re-importing a namespace (`import * as Ns`), walking the import
+    /// chain across module boundaries by `(file, name)` rather than by raw
+    /// `SymbolId` (which is only unique within a single file's binder).
+    ///
+    /// `import { Ns } from "./reexporter"` where `./reexporter` has
+    /// `import * as Ns from "./ns"; export { Ns }` makes `Ns` the namespace of
+    /// `./ns`, so `Ns.Member` resolves `Member` from `./ns`'s exports even when a
+    /// same-named local `type`/`interface` shadows `Ns` in type space. The walk
+    /// is purely file-and-name based so it is immune to per-binder `SymbolId`
+    /// collisions when the same numeric id denotes different symbols in two
+    /// files.
+    pub(crate) fn resolve_member_through_namespace_import_chain(
+        &self,
+        import_module: Option<&str>,
+        import_name: Option<&str>,
+        alias_escaped_name: &str,
+        member_name: &str,
+    ) -> Option<SymbolId> {
+        // Bound the re-export walk; chains this long are pathological (mirrors
+        // `namespace_anchor_alias_partner`'s guard).
+        const MAX_REEXPORT_HOPS: usize = 32;
+
+        let mut module = import_module?.to_string();
+        let mut name = import_name.unwrap_or(alias_escaped_name).to_string();
+        let mut cur_file = self.ctx.current_file_idx;
+        let mut visited: FxHashSet<(usize, String)> = FxHashSet::default();
+        for _ in 0..MAX_REEXPORT_HOPS {
+            let target_file = self
+                .ctx
+                .resolve_import_target_from_file(cur_file, &module)?;
+            let mut visited_exports = FxHashSet::default();
+            if name == "*" {
+                // The current binding is the whole namespace of `target_file`'s
+                // module, so the member is a direct (re-)export of that module.
+                return self.ctx.resolve_export_in_target_file(
+                    target_file,
+                    member_name,
+                    &mut visited_exports,
+                );
+            }
+            if !visited.insert((target_file, name.clone())) {
+                return None;
+            }
+            let export_sym =
+                self.ctx
+                    .resolve_export_in_target_file(target_file, &name, &mut visited_exports)?;
+            // Read the resolved export's import metadata from ITS OWN binder: the
+            // symbol id is only meaningful within the file it was resolved in.
+            let export_file = self
+                .ctx
+                .resolve_symbol_file_index(export_sym)
+                .unwrap_or(target_file);
+            let export_binder = self.ctx.get_binder_for_file(export_file)?;
+            let export_symbol = export_binder.get_symbol(export_sym)?;
+            // Only an import alias can carry the walk to a further module; a
+            // concrete declaration is not a namespace anchor for `Member`.
+            name = export_symbol
+                .import_name()
+                .unwrap_or(export_symbol.escaped_name.as_str())
+                .to_string();
+            module = export_symbol.import_module()?.to_string();
+            cur_file = export_file;
+        }
+        None
     }
 
     /// Walk a qualified-name chain leftward to find the root identifier and return

--- a/crates/tsz-checker/tests/conformance_issues/modules/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/mod.rs
@@ -4,3 +4,4 @@ mod declare_global;
 mod export_alias_local_collision;
 mod file_formats;
 mod package_resolution;
+mod reimported_namespace_qualifier;

--- a/crates/tsz-checker/tests/conformance_issues/modules/reimported_namespace_qualifier.rs
+++ b/crates/tsz-checker/tests/conformance_issues/modules/reimported_namespace_qualifier.rs
@@ -1,0 +1,140 @@
+//! Regression tests for a re-imported namespace used as a qualified-type-name
+//! anchor (`Ns.Member`) when a same-named local `type` alias shadows it.
+//!
+//! Structural rule: tsc resolves the left-hand side of a qualified type name
+//! with *namespace* meaning, following the full alias chain. A named/default
+//! import that re-imports an `import * as Ns` namespace (forwarded through an
+//! `export { Ns }`) therefore stays a valid namespace anchor even when a
+//! same-named local `type`/`interface` shadows the binding in type space. tsz
+//! previously bailed because the re-exported namespace import classifies as
+//! value-only at the flag level, so `namespace_anchor_alias_partner` (which only
+//! accepted a `Type` re-export hop) dropped the anchor and emitted a spurious
+//! `TS2503` ("Cannot find namespace"). Mined from ts-toolbelt (issue #14225).
+//!
+//! Binder names vary across the cases so the behavior follows the alias-chain
+//! shape, not a spelling.
+
+use super::super::core::*;
+
+/// The minimal #14225 witness: `import * as Ns` re-exported via `export { Ns }`,
+/// re-imported and shadowed by a local `type`. `Ns.Member` must anchor through
+/// the namespace, with no TS2503.
+#[test]
+fn reimported_namespace_with_local_type_shadow_anchors_qualified_type() {
+    if !lib_files_available() {
+        return;
+    }
+    let files = &[
+        ("lib.ts", "export type Intersect<A, B> = A & B\n"),
+        ("index.ts", "import * as T from './lib'\nexport { T }\n"),
+        (
+            "use.ts",
+            r#"
+import { T } from './index'
+type T = [1, 2, 3]
+type R = T.Intersect<{ a: 1 }, { b: 2 }>
+const r: R = { a: 1, b: 2 }
+export { r }
+"#,
+        ),
+    ];
+    let diags = compile_named_files_get_diagnostics_with_lib_and_options(files, "use.ts", opts());
+    assert!(
+        !has_error(&diags, 2503),
+        "no TS2503 — re-imported namespace `T` must anchor `T.Intersect` despite the local `type T`. Actual: {diags:#?}"
+    );
+}
+
+/// Name-agnostic variant: rename every binder. The fix must follow the alias
+/// chain by shape, never by the spelling `T`/`Intersect`.
+#[test]
+fn reimported_namespace_renamed_binders_anchors_qualified_type() {
+    if !lib_files_available() {
+        return;
+    }
+    let files = &[
+        ("a.ts", "export type Combine<X, Y> = X & Y\n"),
+        ("b.ts", "import * as Space from './a'\nexport { Space }\n"),
+        (
+            "c.ts",
+            r#"
+import { Space } from './b'
+type Space = readonly [0]
+type Out = Space.Combine<{ p: 1 }, { q: 2 }>
+const out: Out = { p: 1, q: 2 }
+export { out }
+"#,
+        ),
+    ];
+    let diags = compile_named_files_get_diagnostics_with_lib_and_options(files, "c.ts", opts());
+    assert!(
+        !has_error(&diags, 2503),
+        "no TS2503 — renamed re-imported namespace must still anchor. Actual: {diags:#?}"
+    );
+}
+
+/// Deep re-export chain: the namespace is forwarded across two modules before
+/// being re-imported and shadowed. Each hop must be followed.
+#[test]
+fn deep_reexport_chain_namespace_with_local_shadow_anchors() {
+    if !lib_files_available() {
+        return;
+    }
+    let files = &[
+        ("root.ts", "export type Pair<A, B> = [A, B]\n"),
+        ("mid1.ts", "import * as NS from './root'\nexport { NS }\n"),
+        ("mid2.ts", "export { NS } from './mid1'\n"),
+        (
+            "leaf.ts",
+            r#"
+import { NS } from './mid2'
+type NS = 0
+type R = NS.Pair<1, 2>
+const r: R = [1, 2]
+export { r }
+"#,
+        ),
+    ];
+    let diags = compile_named_files_get_diagnostics_with_lib_and_options(files, "leaf.ts", opts());
+    assert!(
+        !has_error(&diags, 2503),
+        "no TS2503 — a deep re-export chain of a namespace must anchor `NS.Pair`. Actual: {diags:#?}"
+    );
+}
+
+/// Negative control: a re-imported *value* (`export const`) shadowed by a local
+/// `type` is genuinely not a namespace, so `Val.Member` must still diagnose
+/// TS2503. The fix must not over-accept value-only re-exports.
+#[test]
+fn reimported_value_with_local_shadow_still_reports_ts2503() {
+    if !lib_files_available() {
+        return;
+    }
+    let files = &[
+        ("v.ts", "export const Val = 1\n"),
+        ("w.ts", "import { Val } from './v'\nexport { Val }\n"),
+        (
+            "u.ts",
+            r#"
+import { Val } from './w'
+type Val = [1]
+type R = Val.Member
+export type { R }
+"#,
+        ),
+    ];
+    let diags = compile_named_files_get_diagnostics_with_lib_and_options(files, "u.ts", opts());
+    assert!(
+        has_error(&diags, 2503),
+        "TS2503 expected — a re-imported `const` is not a namespace. Actual: {diags:#?}"
+    );
+}
+
+fn opts() -> tsz_checker::context::CheckerOptions {
+    tsz_checker::context::CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        module: tsz_common::common::ModuleKind::ESNext,
+        ..Default::default()
+    }
+}

--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026.rs
@@ -86,7 +86,6 @@ fn issue_14228_export_star_as_namespace_type_qualifier_no_ts2503() {
 /// (`T.Intersect<...>`) even when a same-named local *type* `T` shadows in type
 /// space. Using `T.Intersect` must not report TS2503.
 #[test]
-#[ignore = "reproduces #14225; FP still present (TS2503 'Cannot find namespace T' on a re-exported namespace import shadowed by a local `type T`; also emits a downstream TS2661)"]
 fn issue_14225_reexported_namespace_qualifier_with_local_type_shadow_no_ts2503() {
     if !lib_files_available() {
         return;

--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
@@ -149,7 +149,6 @@ export type { A };
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "reproduces #14225 (issue closed but minimal repro still emits TS2503)"]
 fn issue_14225_reimported_namespace_qualified_type_no_ts2503() {
     if !lib_files_available() {
         return;


### PR DESCRIPTION
## Summary
Fixes #14225 (closed-but-reproducing; reopened). A qualified type name
`Ns.Member` whose left-hand side is a named/default import re-importing an
`import * as Ns` namespace (forwarded through `export { Ns }`) emitted a
spurious **TS2503 "Cannot find namespace"** when a same-named local
`type`/`interface` shadowed `Ns` in type space. `tsc` reports 0.

## Structural rule
`tsc` resolves a qualified-type LHS with **namespace meaning through the full
alias chain**, so neither a same-named local `type`/`interface` shadow nor the
surface import syntax may hide the namespace the import ultimately targets.
When `import { Ns } from "./reexporter"` re-imports an `import * as Ns from
"./ns"; export { Ns }` namespace, `Ns.Member` resolves `Member` from `./ns`'s
exports. A genuinely value-only re-import (a re-imported `const`/`function`) is
not a namespace and still diagnoses TS2503.

## Root cause
The LHS resolves to the local `type` shadow; its `alias_partner` is the
re-import. Resolving the member through that alias failed because:
1. a re-exported namespace import classifies as `ValueOnly`, so
   `namespace_anchor_alias_partner`'s `Type`-only re-export hop dropped the
   anchor, and
2. the `SymbolId`-based anchor walk hit its `resolved == current` self-loop
   guard — the cross-file namespace import collides numerically with the local
   re-import's `SymbolId` (ids are only unique within a single file's binder).

## Owner / fix
Checker — `crates/tsz-checker/src/state/type_analysis/qualified_names.rs`. Adds
`resolve_member_through_namespace_import_chain`, a member-resolution fallback in
`resolve_qualified_name` that walks the import chain across module boundaries by
`(file, name)` rather than raw `SymbolId`. It follows re-exported `import * as`
namespaces of any depth and is immune to per-binder id collisions, reading each
hop's import metadata from its own binder. Purely structural — no
name/file-string checks, no printer-output inspection.

## Adjacent-case matrix (name-agnostic, all green)
- type-alias shadow (the witness),
- renamed binders (no name fast-path),
- deep re-export chain (`leaf → mid2 → mid1 → root`),
- value-only negative control (`export const T = 1`) still reports TS2503.

The two committed `#[ignore]`d #14225 witnesses are un-ignored and now pass as
regression guards.

## Scope note
This fixes the TS2503 namespace-anchor defect. The separate downstream TS2661
on `export { r }` is a distinct, pre-existing export-checker FP (present on
`main` independently of this change) and is left for a follow-up.

## Verification
- `cargo nextest`/`cargo test -p tsz-checker --test conformance_issues_types -- issue_14225` → 2 pass (un-ignored witnesses).
- `cargo test -p tsz-checker --test conformance_issues_modules -- reimported_namespace` → 4 pass (adjacent matrix + negative control).
- Full `conformance_issues_types` and `conformance_issues_modules` suites: no new failures vs `main` (the 9 pre-existing local failures reproduce identically with the change stashed).
- ready-review CI owns the broad conformance/emit/fourslash/project-compile gates.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01FLhF4fKeBMRkvmaYcAjvNE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLhF4fKeBMRkvmaYcAjvNE)_