### PR TITLE
fix(checker): assignment to shadowing local is not an import assignment (TS2632)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -454,11 +454,23 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        // TS2632: Check if this identifier is an import binding BEFORE resolving
-        // through imports. resolve_identifier follows aliases, so the resolved symbol
-        // would be the export target (e.g., `var x`) rather than the import binding.
-        // Import bindings are readonly in ESM — you cannot reassign them.
-        if let Some(local_sym_id) = self.ctx.binder.file_locals.get(name)
+        // TS2632: Check if this identifier's *innermost* binding is an import
+        // alias BEFORE resolving through imports. `resolve_identifier` follows
+        // aliases, so the fully-resolved symbol would be the export target
+        // (e.g. `var x`) rather than the import binding, losing the ALIAS flag.
+        // We therefore walk the scope chain to the innermost binding and inspect
+        // its raw flags: import bindings are readonly in ESM and cannot be
+        // reassigned. Crucially, a `let`/`const`/parameter that SHADOWS the
+        // import wins the scope walk, so assigning to the shadowing local must
+        // NOT report TS2632 (tsc parity).
+        let lib_binders = self.get_lib_binders();
+        let innermost_binding = self.ctx.binder.resolve_identifier_with_filter(
+            self.ctx.arena,
+            inner,
+            &lib_binders,
+            |_sym_id| true,
+        );
+        if let Some(local_sym_id) = innermost_binding
             && let Some(local_sym) = self.ctx.binder.get_symbol(local_sym_id)
             && local_sym.has_any_flags(symbol_flags::ALIAS)
         {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -667,6 +667,9 @@ mod as_const_nested_literal_display_tests;
 #[path = "tests/assertion_type_predicate_diagnostics_tests.rs"]
 mod assertion_type_predicate_diagnostics_tests;
 #[cfg(test)]
+#[path = "tests/assign_to_import_shadowing_local_tests.rs"]
+mod assign_to_import_shadowing_local_tests;
+#[cfg(test)]
 #[path = "../tests/bigint_target_ts2737_tests.rs"]
 mod bigint_target_ts2737_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/assign_to_import_shadowing_local_tests.rs
+++ b/crates/tsz-checker/src/tests/assign_to_import_shadowing_local_tests.rs
@@ -1,0 +1,193 @@
+//! Regression tests for false TS2632 ("Cannot assign to 'X' because it is an
+//! import") when a `let`/`const`/parameter lexically shadows a same-named
+//! module import and is used as an assignment target.
+//!
+//! Structural rule: an assignment whose target identifier resolves, in the
+//! innermost scope, to a local `let`/`const`/parameter that SHADOWS a same-named
+//! import must bind to the local. The "cannot assign to import" (TS2632) check
+//! applies only when the target genuinely resolves to the import binding. tsz
+//! previously consulted `file_locals` directly for the import alias, which
+//! always returned the module-scoped import even when an inner local shadowed
+//! it, producing a false TS2632.
+//!
+//! Owner: checker assignment-to-import check (`check_function_assignment`),
+//! which now walks the scope chain to the innermost raw binding before testing
+//! the ALIAS flag.
+//!
+//! Mined from **tanstack-router** (`router.ts`: a function-local `let redirect`
+//! shadows `import { redirect }`).
+
+use std::sync::{Arc, OnceLock};
+use tsz_binder::lib_loader::LibFile;
+use tsz_common::common::ModuleKind;
+
+use crate::CheckerOptions;
+use crate::test_utils::{check_multi_file_with_libs_stamped, load_default_lib_files};
+
+fn default_libs() -> &'static [Arc<LibFile>] {
+    static DEFAULT_LIBS: OnceLock<Vec<Arc<LibFile>>> = OnceLock::new();
+    DEFAULT_LIBS.get_or_init(load_default_lib_files)
+}
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        module: ModuleKind::ESNext,
+        ..CheckerOptions::default()
+    }
+}
+
+fn code_count(files: &[(&str, &str)], entry: &str, code: u32) -> usize {
+    check_multi_file_with_libs_stamped(files, entry, opts(), default_libs())
+        .iter()
+        .filter(|d| d.code == code)
+        .count()
+}
+
+const LIB: &str = "export const redirect = (n: number) => n;\n";
+
+#[test]
+fn function_scope_let_shadowing_import_is_not_an_import_assignment() {
+    let files = &[
+        ("lib.ts", LIB),
+        (
+            "main.ts",
+            "import { redirect } from \"./lib\";\n\
+             export function use() {\n\
+               let redirect: { x: number } | undefined;\n\
+               redirect = { x: 1 };\n\
+               return redirect.x;\n\
+             }\n\
+             export const _ = redirect;\n",
+        ),
+    ];
+    assert_eq!(
+        code_count(files, "main.ts", 2632),
+        0,
+        "a function-scope `let` shadowing an import binds the assignment to the local, not the import"
+    );
+}
+
+#[test]
+fn nested_block_let_shadowing_import_is_not_an_import_assignment() {
+    // Vary the binder name (`navigate`) to prove the fix is structural, not
+    // keyed on a specific identifier string.
+    let files = &[
+        ("lib.ts", "export const navigate = (n: number) => n;\n"),
+        (
+            "main.ts",
+            "import { navigate } from \"./lib\";\n\
+             export function go() {\n\
+               {\n\
+                 let navigate: { x: number } | undefined;\n\
+                 navigate = { x: 1 };\n\
+                 return navigate?.x;\n\
+               }\n\
+             }\n\
+             export const _ = navigate;\n",
+        ),
+    ];
+    assert_eq!(
+        code_count(files, "main.ts", 2632),
+        0,
+        "a nested-block `let` shadowing an import binds the assignment to the local, not the import"
+    );
+}
+
+#[test]
+fn nested_function_let_shadowing_import_is_not_an_import_assignment() {
+    let files = &[
+        ("lib.ts", "export const cursor = (n: number) => n;\n"),
+        (
+            "main.ts",
+            "import { cursor } from \"./lib\";\n\
+             export function outer() {\n\
+               function inner() {\n\
+                 let cursor: { x: number } | undefined;\n\
+                 cursor = { x: 1 };\n\
+                 return cursor.x;\n\
+               }\n\
+               return inner();\n\
+             }\n\
+             export const _ = cursor;\n",
+        ),
+    ];
+    assert_eq!(
+        code_count(files, "main.ts", 2632),
+        0,
+        "a `let` in a nested function shadowing an import binds the assignment to the local"
+    );
+}
+
+#[test]
+fn const_local_shadowing_import_reports_const_not_import() {
+    // Assigning to a shadowing `const` local must report TS2588 (constant),
+    // NOT TS2632 (import) — the assignment binds to the local.
+    let files = &[
+        ("lib.ts", "export const handle = (n: number) => n;\n"),
+        (
+            "main.ts",
+            "import { handle } from \"./lib\";\n\
+             export function use() {\n\
+               const handle: { x: number } = { x: 1 };\n\
+               handle = { x: 2 };\n\
+               return handle.x;\n\
+             }\n\
+             export const _ = handle;\n",
+        ),
+    ];
+    assert_eq!(
+        code_count(files, "main.ts", 2632),
+        0,
+        "assigning to a shadowing `const` local must not report TS2632"
+    );
+    assert_eq!(
+        code_count(files, "main.ts", 2588),
+        1,
+        "assigning to a shadowing `const` local reports TS2588 (constant)"
+    );
+}
+
+#[test]
+fn assigning_to_actual_import_without_shadow_still_reports_import() {
+    // Negative control: no shadowing local — the assignment target genuinely
+    // resolves to the import binding, so TS2632 must still fire.
+    let files = &[
+        ("lib.ts", "export const beacon = (n: number) => n;\n"),
+        (
+            "main.ts",
+            "import { beacon } from \"./lib\";\n\
+             export function use() {\n\
+               beacon = (() => 0) as any;\n\
+               return beacon;\n\
+             }\n",
+        ),
+    ];
+    assert_eq!(
+        code_count(files, "main.ts", 2632),
+        1,
+        "assigning to a genuine import binding (no shadow) must still report TS2632"
+    );
+}
+
+#[test]
+fn assigning_to_reexported_import_without_shadow_still_reports_import() {
+    // Negative control: a re-exported import is still an import binding at the
+    // use site, so assigning to it (no shadow) must report TS2632.
+    let files = &[
+        ("lib.ts", "export const anchor = (n: number) => n;\n"),
+        ("reexport.ts", "export { anchor } from \"./lib\";\n"),
+        (
+            "main.ts",
+            "import { anchor } from \"./reexport\";\n\
+             export function use() {\n\
+               anchor = (() => 0) as any;\n\
+             }\n",
+        ),
+    ];
+    assert_eq!(
+        code_count(files, "main.ts", 2632),
+        1,
+        "assigning to a re-exported import binding (no shadow) must still report TS2632"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary

A `let`/`const`/parameter that shadows a same-named module import wins lexical
scope resolution, so an assignment to that identifier must bind to the local —
not the import. tsz was reporting a false **TS2632** ("Cannot assign to 'X'
because it is an import") for such assignments.

Mined from **tanstack-router** (`router.ts`: a function-local `let redirect` at
2446 shadows `import { redirect }` at line 38; the assignment at 2587 was
wrongly flagged TS2632). `tsc` is clean.

## Structural rule

When an assignment's target identifier resolves, in the innermost scope, to a
local `let`/`const`/parameter that SHADOWS a same-named import, the assignment
binds to the local; `tsc` does X, and tsz now does X through the checker's
assignment-to-import check. The "cannot assign to import" (TS2632) check applies
only when the target genuinely resolves to the import binding.

Owner layer: checker `check_function_assignment`
(`crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs`).
The check previously consulted `binder.file_locals.get(name)` directly for the
import alias, which always returned the module-scoped import binding even when an
inner local shadowed it. It now walks the scope chain to the innermost raw
binding via `binder.resolve_identifier_with_filter` (which, unlike
`resolve_identifier`, does not follow import aliases and so preserves the raw
`ALIAS` flag) and tests the `ALIAS` flag on that symbol. A shadowing local wins
the scope walk → no TS2632; a genuine import binding still carries `ALIAS` →
TS2632 fires. No identifier/file/text hardcoding: the decision is driven by
binder scope order and the symbol `ALIAS` flag only.

Adjacent-case matrix (all verified against bundled `tsc --strict --noEmit`):
- function-scope `let` shadow → clean (was false TS2632)
- nested-block `let` shadow → clean
- `let` shadow in a nested function → clean
- `const` local shadow → TS2588 (constant), not TS2632
- negative: assign to the actual import (no shadow) → TS2632 still fires
- negative: assign to a re-exported import (no shadow) → TS2632 still fires
- negative: assign to a namespace-import member → TS2540 (read-only property)

## Verification

- New checker regression tests (binder names varied across cases):
  `cargo nextest run -p tsz-checker -E 'test(/assign_to_import_shadowing/)'` →
  6/6 pass.
- Repro parity vs bundled `tsc --strict --noEmit`: the 7-case matrix above
  matches `tsc` exactly.
- Conformance (filename-substring filters, vs cache baseline, 0 known failures):
  - `--filter import` → 281/281 (100%)
  - `--filter assign` → 194/194 (100%)
  - `--filter shadow` → 6/6 (100%)
  - `--filter scope` → 26/26 (100%)
  - `--filter moduleResolution` → 111/111 (100%)
  ZERO new regressions across all import/scope/assign-sensitive suites.
- Corpus (tanstack-router via `project-compile-guard.sh`): `router.ts` TS2632
  count 1 → 0 (cleared); no new diagnostics introduced (other families
  unchanged).
- Lib delta-gate vs clean `origin/main` parent
  (`-p tsz-checker -p tsz-binder --lib`, filters
  import/scope/2632/assign/shadow/resolution): net-new failures = 0 (the
  pre-existing local env-only failures are identical on the parent commit).
- clippy clean (`-p tsz-checker`, 0 warnings). All touched files < 2000 LOC.

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
