### PR TITLE
test(checker): activate guards for fleet-fixed #14231/#14261 (regression-guard audit round 5)

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
@@ -267,7 +267,6 @@ export { a, b }
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "reproduces #14261"]
 fn issue_14261_contextual_return_binding_samename_typeparam_no_ts18046() {
     let diags = compile_and_get_diagnostics_with_lib_and_options(
         r#"
@@ -368,7 +367,6 @@ export { f };
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "reproduces #14231"]
 fn issue_14231_type_predicate_through_alias_no_ts2677() {
     let diags = compile_and_get_diagnostics_with_lib_and_options(
         r#"


### PR DESCRIPTION
Round 5 of the canary FP regression-guard audit. No compiler source changes —
parity-floor protection (`Goal: hold`).

Goal: hold

## What changed
Two more round-3 `#[ignore]`d witnesses whose issues have since closed were
re-checked against current `main` and now PASS — activated as regression guards:
- **#14231** (TS2677): type predicate through an alias head — relation runs on the
  resolved alias body.
- **#14261** (TS18046): contextual-return binding with a same-named type parameter
  no longer leaks `unknown`.

Both were fixed conformance-safely on `main` (a sister session also added dedicated
`issue_14261_indexed_access_param_inference_tests`). The guards lock the parity.

## Verification
- `cargo nextest run -p tsz-checker -j 2 issue_14231 issue_14261` — all pass
  (the 2 activated guards + the sibling #14261 inference suite).
- CI gates: lint, unit-checker-integration, conformance-aggregate, emit-aggregate,
  fourslash-*, project-compile-guard, CI Summary.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max