### PR TITLE
fix(checker): narrow structured conditional check operand in true branch (TS2344 #14167)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1940,6 +1940,9 @@ path = "tests/recursive_utility_alias_fanout_tests.rs"
 name = "recursive_conditional_alias_concrete_fixpoint_tests"
 path = "tests/recursive_conditional_alias_concrete_fixpoint_tests.rs"
 [[test]]
+name = "conditional_true_branch_substitution_tests"
+path = "tests/conditional_true_branch_substitution_tests.rs"
+[[test]]
 name = "issue_14123_repro_tests"
 path = "tests/issue_14123_repro_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_resolution/conditional_flow.rs
+++ b/crates/tsz-checker/src/state/type_resolution/conditional_flow.rs
@@ -25,8 +25,25 @@ impl CheckerState<'_> {
         node_idx: NodeIndex,
         type_arg: TypeId,
     ) -> TypeId {
+        // Two narrowing channels, both modelling `tsc`'s `getImpliedConstraint`:
+        //   * a naked type-parameter check operand (`T extends U ? …T… : …`)
+        //     narrows *occurrences* of `T` inside the type argument — a
+        //     name-keyed substitution;
+        //   * a structured check operand (`F<V> extends U ? …F<V>… : …`, where
+        //     the operand is not a bare parameter) narrows the type argument as a
+        //     whole when it *is* that operand — `tsc` compares the actual type
+        //     variable of the check type against the type itself, not only bare
+        //     parameters, so a generic-alias check operand narrows here too.
         let mut subst = TypeSubstitution::new();
-        let mut found = false;
+        // Accumulated `extends` narrowing for the whole-argument channel; stays
+        // `None` until a structured check operand matches (0 or 1 is the common
+        // case, so avoid a heap `Vec`).
+        let mut whole_constraint: Option<TypeId> = None;
+
+        let arg_actual = tsz_solver::type_queries::substitution_base_or_self(
+            self.ctx.types.as_type_database(),
+            type_arg,
+        );
 
         let mut child = node_idx;
         let mut parent = self
@@ -46,18 +63,35 @@ impl CheckerState<'_> {
             if parent_node.kind == syntax_kind_ext::CONDITIONAL_TYPE
                 && let Some(cond) = self.ctx.arena.get_conditional_type(parent_node)
                 && cond.true_type == child
-                && let Some(type_param) = self.naked_check_type_param_id(cond.check_type)
-                && let Some(info) =
-                    query_common::type_param_info(self.ctx.types.as_type_database(), type_param)
             {
-                let current = subst.get(info.name).unwrap_or(type_param);
-                let extends = self.get_type_from_type_node(cond.extends_type);
-                let constraint = self.ctx.types.intersection2(current, extends);
-                subst.insert(
-                    info.name,
-                    self.ctx.types.substitution(type_param, constraint),
-                );
-                found = true;
+                if let Some(type_param) = self.naked_check_type_param_id(cond.check_type)
+                    && let Some(info) =
+                        query_common::type_param_info(self.ctx.types.as_type_database(), type_param)
+                {
+                    let current = subst.get(info.name).unwrap_or(type_param);
+                    let extends = self.get_type_from_type_node(cond.extends_type);
+                    let constraint = self.ctx.types.intersection2(current, extends);
+                    subst.insert(
+                        info.name,
+                        self.ctx.types.substitution(type_param, constraint),
+                    );
+                } else {
+                    // Structured check operand: narrow the whole argument when it
+                    // is the conditional's check operand (compared by actual type
+                    // variable so a substitution on either side still matches).
+                    let check_t = self.get_type_from_type_node(cond.check_type);
+                    let check_actual = tsz_solver::type_queries::substitution_base_or_self(
+                        self.ctx.types.as_type_database(),
+                        check_t,
+                    );
+                    if check_actual == arg_actual {
+                        let extends = self.get_type_from_type_node(cond.extends_type);
+                        whole_constraint = Some(
+                            whole_constraint
+                                .map_or(extends, |c| self.ctx.types.intersection2(c, extends)),
+                        );
+                    }
+                }
             }
             child = parent;
             parent = self
@@ -67,11 +101,20 @@ impl CheckerState<'_> {
                 .map_or(NodeIndex::NONE, |info| info.parent);
         }
 
-        if found {
-            query_common::instantiate_type(self.ctx.types, type_arg, &subst)
-        } else {
-            type_arg
+        if subst.is_empty() && whole_constraint.is_none() {
+            return type_arg;
         }
+
+        let mut result = if subst.is_empty() {
+            type_arg
+        } else {
+            query_common::instantiate_type(self.ctx.types, type_arg, &subst)
+        };
+        if let Some(extends) = whole_constraint {
+            let constraint = self.ctx.types.intersection2(result, extends);
+            result = self.ctx.types.substitution(result, constraint);
+        }
+        result
     }
 
     /// Resolve a type node to the `TypeId` of the naked type parameter it names

--- a/crates/tsz-checker/tests/conditional_true_branch_substitution_tests.rs
+++ b/crates/tsz-checker/tests/conditional_true_branch_substitution_tests.rs
@@ -1,0 +1,122 @@
+//! Regression for issue #14167: inside the true branch of a conditional type,
+//! the check operand must be narrowed by the `extends` type (`tsc`'s
+//! `getConditionalFlowTypeOfType` / `SubstitutionType`), so a dependent
+//! constraint check on a use of the operand passes.
+//!
+//! The previously-missing case is a *structured* (non-naked) check operand such
+//! as a generic-alias instantiation `F<V>`: `tsc`'s `getImpliedConstraint`
+//! compares the actual type variable of the whole check type, not only bare type
+//! parameters, so `F<V> extends string ? Capitalize<F<V>> : F<V>` narrows
+//! `F<V>` to `& string` in the true branch and the `Capitalize` constraint
+//! passes.
+//!
+//! Binder names and the string-mapping intrinsic are varied across cases so the
+//! guard follows structure, not identifier text. Negative controls confirm the
+//! narrowing is by the *actual* `extends` type and does not blanket-suppress.
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::check_source_with_libs_code_messages;
+
+fn codes(source: &str) -> Vec<u32> {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    let opts = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    check_source_with_libs_code_messages(source, "test.ts", opts, &libs)
+        .into_iter()
+        .map(|(c, _)| c)
+        .collect()
+}
+
+/// The mined witness: a deferred-conditional alias `Snake<V>` used as the check
+/// operand; in the true branch `Capitalize<Snake<V>>`'s `extends string`
+/// constraint must pass because `Snake<V>` is narrowed to `string`.
+#[test]
+fn structured_check_operand_narrowed_in_true_branch_no_ts2344() {
+    let c = codes(
+        r#"
+type Snake<Type> = Type extends string ? `snake_${Type}` : Type;
+type _Pascal<V> = Snake<V> extends string
+    ? Capitalize<Snake<V>>
+    : Snake<V>;
+export {};
+"#,
+    );
+    assert!(
+        !c.contains(&2344),
+        "no TS2344 expected — Snake<V> is narrowed to string in the true branch. Got: {c:?}"
+    );
+}
+
+/// Renamed binders + a different string-mapping intrinsic (`Uppercase`) must
+/// behave identically — the rule is structural.
+#[test]
+fn structured_check_operand_renamed_binders_uppercase_no_ts2344() {
+    let c = codes(
+        r#"
+type Wrap<Q> = Q extends string ? `wrap_${Q}` : Q;
+type _Out<W> = Wrap<W> extends string
+    ? Uppercase<Wrap<W>>
+    : Wrap<W>;
+export {};
+"#,
+    );
+    assert!(
+        !c.contains(&2344),
+        "no TS2344 expected with renamed binders / Uppercase. Got: {c:?}"
+    );
+}
+
+/// Negative control: when the operand is constrained by `number` (not
+/// `string`), a `Capitalize<...>` use in the true branch must STILL report
+/// TS2344 — the narrowing is by the actual `extends` type, not a blanket pass.
+#[test]
+fn structured_check_operand_wrong_constraint_still_ts2344() {
+    let c = codes(
+        r#"
+type Snake<Type> = Type extends string ? `snake_${Type}` : Type;
+type _Bad<V> = Snake<V> extends number
+    ? Capitalize<Snake<V>>
+    : Snake<V>;
+export {};
+"#,
+    );
+    assert!(
+        c.contains(&2344),
+        "TS2344 expected — Snake<V> narrowed to `& number` does not satisfy `string`. Got: {c:?}"
+    );
+}
+
+/// The classic naked-type-parameter operand must keep working: `T extends
+/// string ? Capitalize<T> : T` is clean.
+#[test]
+fn naked_type_parameter_operand_still_clean() {
+    let c = codes(
+        r#"
+type F<T> = T extends string ? Capitalize<T> : T;
+export {};
+"#,
+    );
+    assert!(
+        !c.contains(&2344),
+        "no TS2344 expected for a naked type-parameter check operand. Got: {c:?}"
+    );
+}
+
+/// A bare reference to the (unnarrowed) alias outside any conditional true
+/// branch must remain rejected, so the narrowing is scoped to the true branch.
+#[test]
+fn operand_outside_true_branch_still_ts2344() {
+    let c = codes(
+        r#"
+type Snake<Type> = Type extends string ? `snake_${Type}` : Type;
+type _Direct<V> = Capitalize<Snake<V>>;
+export {};
+"#,
+    );
+    assert!(
+        c.contains(&2344),
+        "TS2344 expected — outside a conditional true branch Snake<V> is not narrowed. Got: {c:?}"
+    );
+}

--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_b.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_b.rs
@@ -199,9 +199,9 @@ export { f };
 
 /// Inside the true branch of `CamelCase<V> extends string ? ...`, the operand
 /// `CamelCase<V>` must be seen as narrowed to `string` so `Capitalize<...>`'s
-/// constraint passes. tsz lacks a `SubstitutionType` model -> false TS2344.
+/// constraint passes. The fix wraps the structured check operand in a
+/// `SubstitutionType`. Kept as a live regression guard.
 #[test]
-#[ignore = "reproduces #14167: conditional true-branch check operand not constrained (missing SubstitutionType) -> false TS2344"]
 fn issue_14167_conditional_true_branch_constrains_check_operand() {
     if !lib_files_available() {
         return;

--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
@@ -205,8 +205,10 @@ export const f =
 // type in the true branch (SubstitutionType missing). TS2344.
 // ---------------------------------------------------------------------------
 
+// Fixed: conditional true-branch narrowing now wraps a structured (non-naked)
+// check operand in a `SubstitutionType`, so `Capitalize<CamelCase<V>>`'s
+// constraint passes. Kept as a live regression guard.
 #[test]
-#[ignore = "reproduces #14167 (issue closed but minimal repro still emits TS2344)"]
 fn issue_14167_conditional_true_branch_substitution_no_ts2344() {
     let diags = compile_and_get_diagnostics_with_lib_and_options(
         r#"


### PR DESCRIPTION
## Summary

Fixes the residual false positive in #14167 (closed-but-reproducing): a deferred
conditional's check operand is not constrained to its checked type inside the
true branch when the operand is a **structured** type (a generic-alias
instantiation), so a dependent constraint check falsely reports **TS2344**.

Minimal witness (tsc clean, tsz `TS2344` before this change):

```ts
type CamelCase<Type> = Type extends string ? `camel${Type}` : Type;
type _PascalCase<V> = CamelCase<V> extends string
	? Capitalize<CamelCase<V>>   // tsz: TS2344 'CamelCase<V>' does not satisfy 'string'
	: CamelCase<V>;
```

Goal: green

## Structural rule

When the type argument under generic-constraint validation **is** the check
operand of an enclosing conditional whose true branch contains it, tsc records
that operand as `operand & extends` (a `SubstitutionType`), so the narrowed form
satisfies a dependent constraint (here `Capitalize<…> extends string`). tsz did
this only for a *naked type-parameter* check operand; a structured operand such
as `F<V>` (a `TYPE_REFERENCE` with type arguments) made `naked_check_type_param_id`
return `None`, so no `SubstitutionType` was introduced and the constraint check
failed.

`tsc`'s `getImpliedConstraint` compares the **actual type variable** of the whole
check type against the type itself — it is not limited to bare parameters — so a
generic-alias check operand must narrow too.

## Owner layer

Checker — `apply_conditional_flow_to_type_arg`
(`crates/tsz-checker/src/state/type_resolution/conditional_flow.rs`), the
type-argument-validation entry point that mirrors tsc's
`getConditionalFlowTypeOfType`. The narrowing stays at the checker layer (the
solver evaluates already-instantiated conditionals where the check type is
concrete and narrowing is implicit), preserving the function's "intentionally
narrower than lowering every true-branch type reference" contract.

## Fix

Add a second narrowing channel alongside the existing naked-parameter one: when
the argument's actual type variable (`substitution_base_or_self`) equals the
check operand's, accumulate the `extends` constraint and wrap the result in
`substitution(result, result & extends)`. Name-agnostic and structural — no
identifier/intrinsic-name allowlist; the existing `substitution()` constructor
collapses the wrapper once the base/constraint are concrete.

## Adjacent matrix / fallback

- Structured operand narrows (`F<V> extends string ? Capitalize<F<V>> : F<V>`).
- Renamed binders + a different intrinsic (`Uppercase`) behave identically.
- Naked-type-parameter operand still narrows (unchanged channel).
- **Negative control:** operand constrained by `number` still fails a `string`
  constraint — narrowing is by the actual `extends` type, not a blanket pass.
- **Scope control:** a use outside any conditional true branch is not narrowed
  (still TS2344).

## Verification

- `cargo test -p tsz-checker --test conditional_true_branch_substitution_tests` — 5/5 pass (incl. both negative controls).
- `cargo test -p tsz-checker --test conformance_issues_types -- --ignored issue_14167` — both previously `#[ignore]`d #14167 guards pass; activated as live regression guards.
- CLI repro now clean; `extends number` negative repro still emits TS2344.
- No new failures in `conformance_issues_types` / `conditional_infer_tests` (the 3 + 3 reds present are pre-existing on `main`, verified by `git stash`).
- `cargo clippy -p tsz-checker --tests` clean; `cargo fmt` applied.
- Broad CI suites (conformance/emit/fourslash) owned by ready-review per repo policy.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01PikBFuru5X3zfmi9A59v7V)_