### PR TITLE
fix(checker): keep deferred conditional/indexed source spelling in TS2322 against a generic target

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -201,6 +201,36 @@ impl<'a> CheckerState<'a> {
         {
             return self.format_type_for_assignability_message(source);
         }
+        // A deferred meta-type source — a bare conditional (`T extends U ? X : Y`)
+        // or indexed-access (`T["x"]`), or an `Application` of a conditional/
+        // indexed-bodied alias (`T95<U>`) — that still carries free type
+        // parameters keeps its written spelling in tsc's assignability
+        // diagnostics: the relation compares the apparent (branch-union /
+        // constraint) form, but the displayed source type is the original. This
+        // mirrors the target-side conditional and indexed-access guards in
+        // `format_assignment_target_type_for_diagnostic`; without it the widening
+        // fallbacks below collapse the source to its apparent form (e.g. `T95<U>`
+        // rendered as `number | boolean`, `T["x"]` as `string | undefined`).
+        // Scoped to a generic target: tsc only keeps the source's written
+        // spelling when the target is itself generic (a deferred conditional or
+        // type-parameter-bearing type, e.g. `T95<U>` vs `T94<U>`, `T["x"]` vs
+        // `NonNullable<T["x"]>`). Against a *concrete* target tsc instead shows
+        // the source's apparent constraint — `IsArray<T>` rendered as `boolean`
+        // for `let t: true = x`, or `ReturnType<T[M]>` left to the established
+        // application path for `x: A` — both already handled by the fallbacks
+        // below, so this guard must not intercept them.
+        if crate::query_boundaries::common::contains_type_parameters(self.ctx.types, source)
+            && crate::query_boundaries::common::contains_type_parameters(self.ctx.types, target)
+            && (crate::query_boundaries::common::is_conditional_type(self.ctx.types, source)
+                || crate::query_boundaries::common::is_index_access_type(self.ctx.types, source)
+                || crate::query_boundaries::diagnostics::alias_application_body_reduces_through_conditional_or_indexed(
+                    self.ctx.types,
+                    &self.ctx.definition_store,
+                    source,
+                ))
+        {
+            return self.format_type_for_assignability_message(source);
+        }
         // For property-access source expressions whose underlying value type is
         // a `unique symbol` (e.g. `Symbol.toPrimitive`), tsc displays the source
         // as `typeof <expr>` rather than widening to `symbol`. Match that here

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -219,15 +219,12 @@ impl<'a> CheckerState<'a> {
         // for `let t: true = x`, or `ReturnType<T[M]>` left to the established
         // application path for `x: A` — both already handled by the fallbacks
         // below, so this guard must not intercept them.
-        if crate::query_boundaries::common::contains_type_parameters(self.ctx.types, source)
-            && crate::query_boundaries::common::contains_type_parameters(self.ctx.types, target)
-            && (crate::query_boundaries::common::is_conditional_type(self.ctx.types, source)
-                || crate::query_boundaries::common::is_index_access_type(self.ctx.types, source)
-                || crate::query_boundaries::diagnostics::alias_application_body_reduces_through_conditional_or_indexed(
-                    self.ctx.types,
-                    &self.ctx.definition_store,
-                    source,
-                ))
+        if crate::query_boundaries::diagnostics::generic_deferred_source_keeps_spelling_against_generic_target(
+            self.ctx.types,
+            &self.ctx.definition_store,
+            source,
+            target,
+        )
         {
             return self.format_type_for_assignability_message(source);
         }

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -141,6 +141,23 @@ pub(crate) fn alias_application_body_reduces_through_conditional_or_indexed(
         })
 }
 
+pub(crate) fn generic_deferred_source_keeps_spelling_against_generic_target(
+    db: &dyn TypeDatabase,
+    definitions: &DefinitionStore,
+    source: TypeId,
+    target: TypeId,
+) -> bool {
+    super::common::contains_type_parameters(db, source)
+        && super::common::contains_type_parameters(db, target)
+        && (super::common::is_conditional_type(db, source)
+            || super::common::is_index_access_type(db, source)
+            || alias_application_body_reduces_through_conditional_or_indexed(
+                db,
+                definitions,
+                source,
+            ))
+}
+
 pub(crate) fn evaluated_alias_application_has_concrete_display(
     db: &dyn TypeDatabase,
     candidate: TypeId,

--- a/crates/tsz-checker/tests/conditional_application_display_tests.rs
+++ b/crates/tsz-checker/tests/conditional_application_display_tests.rs
@@ -14,13 +14,12 @@
 //! Verified against `tsc` 6.0.2. Binder names are varied across the matrix so the
 //! rule is proven structural, not keyed on a particular identifier.
 
-use tsz_checker::test_utils::check_source_diagnostics;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::{check_source_diagnostics, check_source_strict};
 
-/// Collect the rendered messages (primary + nested) for inspection.
-#[track_caller]
-fn messages(source: &str) -> Vec<String> {
+fn collect(diags: Vec<Diagnostic>) -> Vec<String> {
     let mut out = Vec::new();
-    for d in check_source_diagnostics(source) {
+    for d in diags {
         out.push(d.message_text.clone());
         for r in &d.related_information {
             out.push(r.message_text.clone());
@@ -29,9 +28,22 @@ fn messages(source: &str) -> Vec<String> {
     out
 }
 
+/// Collect the rendered messages (primary + nested) for inspection.
 #[track_caller]
-fn assert_any_contains(source: &str, needle: &str) {
-    let msgs = messages(source);
+fn messages(source: &str) -> Vec<String> {
+    collect(check_source_diagnostics(source))
+}
+
+/// As [`messages`], but under `strict` + `strictNullChecks` — required for the
+/// nullish-stripping cases (`NonNullable<…>`) whose mismatch only surfaces when
+/// `undefined` is a tracked member.
+#[track_caller]
+fn messages_strict(source: &str) -> Vec<String> {
+    collect(check_source_strict(source))
+}
+
+#[track_caller]
+fn assert_msgs_any_contains(msgs: &[String], needle: &str) {
     assert!(
         msgs.iter().any(|m| m.contains(needle)),
         "expected a diagnostic containing {needle:?}, got: {msgs:#?}",
@@ -39,12 +51,21 @@ fn assert_any_contains(source: &str, needle: &str) {
 }
 
 #[track_caller]
-fn assert_none_contains(source: &str, needle: &str) {
-    let msgs = messages(source);
+fn assert_msgs_none_contains(msgs: &[String], needle: &str) {
     assert!(
         !msgs.iter().any(|m| m.contains(needle)),
         "expected no diagnostic containing {needle:?}, got: {msgs:#?}",
     );
+}
+
+#[track_caller]
+fn assert_any_contains(source: &str, needle: &str) {
+    assert_msgs_any_contains(&messages(source), needle);
+}
+
+#[track_caller]
+fn assert_none_contains(source: &str, needle: &str) {
+    assert_msgs_none_contains(&messages(source), needle);
 }
 
 // ── Nested elaboration positions (rendered by the solver formatter) ──
@@ -127,4 +148,76 @@ type F<T> = T extends number ? string : boolean;
 function g<T>(p: F<T>): void { const y: number = p; }
 "#;
     assert_any_contains(source, "string | boolean");
+}
+
+// ── Source position against a generic target (the alias is preserved) ──
+//
+// tsc renders the *source* of a TS2322 with its written conditional/indexed
+// spelling — never its apparent branch-union / constraint — when the target is
+// itself generic (a deferred conditional or type-parameter-bearing type). The
+// relation still compares the apparent form; only the displayed source differs.
+// This is the mirror of the target-side conditional guard and of the
+// concrete-target case above (where the constraint IS shown).
+
+#[test]
+fn conditional_source_keeps_alias_against_generic_target() {
+    // `T95<U>` vs `T94<U>`: both deferred conditionals. tsc shows the source as
+    // `T95<U>`, not its branch union `number | boolean`. (Fixture
+    // `conditionalTypes1.ts`, `f45`.)
+    let source = r#"
+type T94<T> = T extends string ? true : 42;
+type T95<T> = T extends string ? boolean : number;
+function h<U>(value: T95<U>, sink: T94<U>) { sink = value; }
+"#;
+    assert_any_contains(source, "Type 'T95<U>' is not assignable to type 'T94<U>'.");
+    assert_none_contains(source, "number | boolean");
+}
+
+#[test]
+fn conditional_source_keeps_alias_against_generic_target_renamed_binders() {
+    // Same structural rule, different identifiers — proves it is not keyed on a
+    // particular alias/parameter name.
+    let source = r#"
+type Pick94<Q> = Q extends string ? true : 42;
+type Pick95<Q> = Q extends string ? boolean : number;
+function relay<W>(input: Pick95<W>, out: Pick94<W>) { out = input; }
+"#;
+    assert_any_contains(
+        source,
+        "Type 'Pick95<W>' is not assignable to type 'Pick94<W>'.",
+    );
+    assert_none_contains(source, "number | boolean");
+}
+
+#[test]
+fn indexed_access_source_keeps_spelling_against_generic_target() {
+    // A deferred indexed-access source `T["x"]` keeps its written form against a
+    // generic `NonNullable<T["x"]>` target, rather than collapsing to the
+    // constraint `string | undefined`. (Fixture `conditionalTypes1.ts`, `f4`.)
+    // `NonNullable` is defined locally (the unit harness does not load `lib.es5`)
+    // with tsc's `T & {}` body so the nullish-stripping target keeps its alias.
+    let source = r#"
+type NonNullable<T> = T & {};
+function pick<T extends { x: string | undefined }>(src: T["x"], dst: NonNullable<T["x"]>) {
+    dst = src;
+}
+"#;
+    let msgs = messages_strict(source);
+    assert_msgs_any_contains(&msgs, "Type 'T[\"x\"]' is not assignable to type");
+    assert_msgs_none_contains(&msgs, "Type 'string | undefined' is not assignable");
+}
+
+#[test]
+fn conditional_source_still_expands_against_concrete_target() {
+    // Negative boundary: against a *concrete* target tsc shows the source's
+    // apparent constraint, not the alias. `IsArray<T>` is rendered `boolean`
+    // for `let t: true = x`. (Fixture `distributiveConditionalTypeConstraints.ts`.)
+    let source = r#"
+type IsArray<T> = T extends unknown[] ? true : false;
+function f1<T extends object>(x: IsArray<T>) {
+    let t: true = x;
+}
+"#;
+    assert_any_contains(source, "Type 'boolean' is not assignable to type 'true'.");
+    assert_none_contains(source, "Type 'IsArray<T>'");
 }


### PR DESCRIPTION
## Summary

When the **source** of a `TS2322` is a deferred meta-type — a bare conditional (`T extends U ? X : Y`) or indexed-access (`T["x"]`), or an `Application` of a conditional/indexed-bodied alias (`T95<U>`) that still carries free type parameters — and the **target is itself generic**, `tsc` renders the source with its written spelling (`T95<U>`, `T["x"]`), not its apparent branch-union / constraint form. The relation still compares the apparent form; only the displayed source type is the original.

The source-formatting path (`format_assignment_source_type_for_diagnostic`) collapsed such a source to its apparent type via the widening fallback, producing `number | boolean` for `T95<U>` and `string | undefined` for `T["x"]`. The target-formatting path already carried a symmetric conditional / generic-index-access guard; this adds the matching guard on the source side.

## Structural rule

When the source of an assignability error is a deferred conditional / indexed-access (or an application of a conditional/indexed-bodied alias) bearing free type parameters **and the target is generic**, `tsc` shows the source's written spelling; `tsz` now does too, through the checker's assignment-source diagnostic formatter. Scoped to a generic target so the established behaviour against a **concrete** target is preserved — `IsArray<T>` still renders `boolean` for `let t: true = x`, and `ReturnType<T[M]>` still flows to the application path for a concrete object target.

## Owner layer

Checker error-reporter (`crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs`), display-only. The relation continues to use the prepared apparent constraint, so assignability outcomes are unchanged — only the rendered source type differs.

## Relation to #14141

This is one of the underlying display divergences masked by the `source_text.contains`-gated `rewrite_*_fingerprints` functions in `source_file.rs` tracked in #14141 (the `conditionalTypes1.ts` `f45` source line, `T95<U>`). The fingerprint rewrite is intentionally left in place; its remaining deltas for that fixture (assignment-narrowing of a generic indexed-access source, and conditional-resolution alias propagation in `TS2339` receiver display) are distinct follow-ups and are not removed here.

## Adjacent-case matrix (unit tests, renamed binders)

- Conditional source kept against a generic conditional target (`T95<U>` vs `T94<U>`), plus a renamed-binder twin (`Pick95<W>` / `Pick94<W>`).
- Indexed-access source kept against a generic `NonNullable<T["x"]>` target.
- Negative boundary: conditional source against a **concrete** target still expands to its constraint (`IsArray<T>` → `boolean`).
- Existing `deferred_generic_conditional_keeps_branch_union` (concrete target → branch union) still passes.

Goal: hold

## Verification

- `cargo test -p tsz-checker --test conditional_application_display_tests` → 10/10 pass (4 new + 6 existing).
- Related display suites green: `keyof_source_display_tests`, `bare_alias_display_tests`, `assignability_final_relation_gate_tests`.
- Conformance regression slice: a 711-file pinned-commit (TS 6.0.3) corpus spanning conditional / mapped / members / indexed-access / tuple cases, run with the checked-in `tsc-cache-full.json`. Result **708/711 PASS, byte-identical to the pre-change baseline** (the 3 pre-existing failures are unrelated multi-file cases); zero new failures, `conditionalTypes1.ts` still passes.
- Ready-review CI owns the full conformance / emit / fourslash suites.

## Provenance

Machine: cloud
Assistant: claude-code
Model: Claude Opus 4.8
Effort: high

https://claude.ai/code/session_01VnRu7TSS824p2ie5Tdyy9P

---
_Generated by [Claude Code](https://claude.ai/code/session_01VnRu7TSS824p2ie5Tdyy9P)_