### PR TITLE
fix(solver): waive any-valued number index for single object types, not just named (#14220)

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
@@ -286,13 +286,23 @@ export const fromBlock = <A>(O: Ord<A>): Ord<A[]> =>
 }
 
 // ---------------------------------------------------------------------------
-// #14220 — TS2339: primitive string wrongly satisfies Record<any, any> in a
-// conditional check (zod).
+// #14220 — TS2339: an object interface wrongly fails `extends Record<any, any>`,
+// collapsing a `Normalize<T>` conditional to `never` (zod).
+//
+// Real root (verified against tsc 6.0.2): the conditional check `T extends
+// Record<any, any>` must hold for the object constituent `Params`.
+// `Record<any, any>` expands to a single anonymous `{ [k: string]: any; [k:
+// number]: any }` whose `any`-valued number index is *waived* by its co-present
+// `any`-valued string index, so a named interface with no numeric index still
+// satisfies it. tsz only applied that waiver to NAMED targets, so the expanded
+// `Record<any, any>` (anonymous) rejected `Params`, the conditional took its
+// `never` branch, and `params.case` reported a false TS2339. Fixed in
+// `relations/subtype/rules/objects.rs` (number-index waiver gated on
+// `!INTERSECTION_MERGED`, requiring both index values to be `any`).
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "reproduces #14220 (issue closed but minimal repro still emits TS2339)"]
-fn issue_14220_primitive_not_record_conditional_branch_no_ts2339() {
+fn issue_14220_object_satisfies_record_any_conditional_branch_no_ts2339() {
     let diags = compile_and_get_diagnostics_with_lib_and_options(
         r#"
 type Flatten<T> = { [k in keyof T]: T[k] };
@@ -313,7 +323,45 @@ export { f };
     );
     assert!(
         !has_error(&diags, 2339),
-        "no TS2339 — `string` must not satisfy `Record<any, any>`, so the conditional takes the narrowable branch. Actual: {diags:#?}"
+        "no TS2339 — an object interface must satisfy `Record<any, any>`, so the conditional keeps its narrowable branch. Actual: {diags:#?}"
+    );
+}
+
+// #14220 (adjacent, name-varied): a named interface with no numeric index is
+// directly assignable to the dual-`any`-index `Record<any, any>` target, while a
+// `Record<number, any>` (number index only) is still correctly rejected — and an
+// intersection of two single-index aliases stays rejected (per-member relation).
+#[test]
+fn issue_14220_named_object_vs_record_any_index_matrix() {
+    let diags = compile_and_get_diagnostics_with_lib_and_options(
+        r#"
+interface Widget { label?: "a" | "b"; size?: number; }
+declare const w: Widget;
+const ok1: Record<any, any> = w;
+const ok2: { [k: string]: any; [k: number]: any } = w;
+const ok3: Record<string, any> = w;
+export { ok1, ok2, ok3 };
+"#,
+        strict_opts(),
+    );
+    assert!(
+        !has_error(&diags, 2322),
+        "no TS2322 — a named interface satisfies dual-`any`-index targets. Actual: {diags:#?}"
+    );
+
+    let neg = compile_and_get_diagnostics_with_lib_and_options(
+        r#"
+interface Gadget { label?: "a" | "b"; }
+declare const g: Gadget;
+const bad1: Record<number, any> = g;
+const bad2: { [k: string]: string; [k: number]: any } = g;
+export { bad1, bad2 };
+"#,
+        strict_opts(),
+    );
+    assert!(
+        has_error(&neg, 2322),
+        "TS2322 expected — number-index-only and narrower-string-value targets still reject a named source. Actual: {neg:#?}"
     );
 }
 

--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
@@ -363,6 +363,27 @@ export { bad1, bad2 };
         has_error(&neg, 2322),
         "TS2322 expected — number-index-only and narrower-string-value targets still reject a named source. Actual: {neg:#?}"
     );
+
+    // The waiver is for a *single* object type. An intersection of two named
+    // single-index interfaces (`StringTo<any> & NumberTo<any>`) is related
+    // member-by-member by tsc, so the `NumberTo<any>` member alone still demands
+    // a numeric index and the named source is rejected — mirrors the
+    // `objectTypeWithStringAndNumberIndexSignatureToAny.ts` conformance `f2`.
+    let intersection = compile_and_get_diagnostics_with_lib_and_options(
+        r#"
+interface Gadget { label?: "a" | "b"; }
+interface StringTo<T> { [k: string]: T; }
+interface NumberTo<T> { [k: number]: T; }
+declare const g: Gadget;
+const bad: StringTo<any> & NumberTo<any> = g;
+export { bad };
+"#,
+        strict_opts(),
+    );
+    assert!(
+        has_error(&intersection, 2322),
+        "TS2322 expected — an intersection of single-index interfaces relates per-member, so the numeric member still demands a numeric index. Actual: {intersection:#?}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tsz-solver/src/intern/intersection.rs
+++ b/crates/tsz-solver/src/intern/intersection.rs
@@ -780,9 +780,19 @@ impl TypeInterner {
         let mut prop_index: rustc_hash::FxHashMap<Atom, usize> = rustc_hash::FxHashMap::default();
         let mut merged_string_index: Option<IndexSignature> = None;
         let mut merged_number_index: Option<IndexSignature> = None;
+        // Which member first contributed each index signature. When the string
+        // and number index come from *different* members the merge collapses a
+        // genuine intersection (`StringTo<any> & NumberTo<any>`) into a single
+        // dual-index shape that interns identically to a plain `{ [s]: any; [n]:
+        // any }` — but tsc relates the intersection member-by-member (the
+        // `NumberTo<any>` member alone still demands a numeric index). We stamp
+        // such a merge `INTERSECTION_MERGED` below so the relation/diagnostics can
+        // recover the per-member view even for named members.
+        let mut string_index_from: Option<usize> = None;
+        let mut number_index_from: Option<usize> = None;
         let mut merged_fresh = true;
 
-        for obj in &objects {
+        for (member_idx, obj) in objects.iter().enumerate() {
             // Freshness is only preserved when *all* intersected object members are fresh.
             if !obj.flags.contains(ObjectFlags::FRESH_LITERAL) {
                 merged_fresh = false;
@@ -870,6 +880,7 @@ impl TypeInterner {
             // Merge index signatures
             match (&obj.string_index, &merged_string_index) {
                 (Some(idx), None) => {
+                    string_index_from = Some(member_idx);
                     merged_string_index = Some(IndexSignature {
                         key_type: idx.key_type,
                         value_type: idx.value_type,
@@ -894,6 +905,7 @@ impl TypeInterner {
 
             match (&obj.number_index, &merged_number_index) {
                 (Some(idx), None) => {
+                    number_index_from = Some(member_idx);
                     merged_number_index = Some(IndexSignature {
                         key_type: idx.key_type,
                         value_type: idx.value_type,
@@ -957,12 +969,21 @@ impl TypeInterner {
         // Otherwise the merged object is a distinct identity diagnostics can
         // recognize as an intersection target — the disambiguation the display
         // alias alone cannot provide, since a merged object otherwise interns
-        // identically to a plain object of that shape. Only an anonymous merge
-        // can be flagged, so the properties are copied for the (rare) flagged
-        // re-intern only in that case; nominal merges consume `merged_props`
-        // with no copy.
+        // identically to a plain object of that shape.
+        //
+        // An anonymous object intersection (`{ a } & { b }`) is flagged as
+        // before. A merge whose string and number index signatures came from
+        // *different* members is ALSO flagged even when the members are named
+        // (`StringTo<any> & NumberTo<any>`): the per-member index relation tsc
+        // keeps would otherwise be lost to a shape indistinguishable from a
+        // single `{ [s]: any; [n]: any }` type. Properties are copied for the
+        // (rare) flagged re-intern in those cases; other merges consume
+        // `merged_props` with no copy.
         let all_anonymous = objects.iter().all(|obj| obj.symbol.is_none());
-        let flag_properties = all_anonymous.then(|| merged_props.clone());
+        let split_index_merge = string_index_from.is_some()
+            && number_index_from.is_some()
+            && string_index_from != number_index_from;
+        let flag_properties = (all_anonymous || split_index_merge).then(|| merged_props.clone());
         let plain_result = intern_shape(self, base_flags, merged_props);
         let result = match flag_properties {
             Some(properties) if !members.contains(&plain_result) => intern_shape(

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -1007,6 +1007,38 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         !self.disable_method_bivariance && value_type.is_any()
     }
 
+    /// Whether an `any`-valued number index signature on `target` imposes no
+    /// requirement on a source that declares no numeric index, because `target`
+    /// also carries an `any`-valued (non-symbol) string index. The numeric
+    /// mirror of [`Self::target_string_index_any_waives_missing_index`]: `tsc`'s
+    /// `indexSignaturesRelatedTo` short-circuit accepts a named class/interface
+    /// against `{ [k: string]: any; [k: number]: any }` (e.g. `Record<any, any>`,
+    /// `{ [P in any]: any }`) even though `{ [k: number]: any }` alone rejects it.
+    ///
+    /// Both index values must be exactly `any` — a narrower number value
+    /// (`{ ...; [k: number]: string }`) or string value
+    /// (`{ [k: string]: string; [k: number]: any }`) falls back to the
+    /// per-property numeric check. An eagerly-merged intersection
+    /// (`ObjectFlags::INTERSECTION_MERGED`, e.g. `StringTo<any> & NumberTo<any>`)
+    /// is excluded: `tsc` relates each intersection member separately, so the
+    /// numeric member alone still demands a numeric index. A TS legacy
+    /// `any`-propagation quirk, disabled with method bivariance in Sound Mode.
+    pub(crate) fn target_dual_any_index_waives_missing_number_index(
+        &self,
+        target: &ObjectShape,
+    ) -> bool {
+        !self.disable_method_bivariance
+            && target
+                .number_index
+                .as_ref()
+                .is_some_and(|idx| idx.value_type.is_any())
+            && target
+                .string_index
+                .as_ref()
+                .is_some_and(|idx| idx.key_type != TypeId::SYMBOL && idx.value_type.is_any())
+            && !target.flags.contains(ObjectFlags::INTERSECTION_MERGED)
+    }
+
     /// Check string index signature compatibility between source and target.
     ///
     /// Validates that string index signatures are compatible, handling:
@@ -1179,23 +1211,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return SubtypeResult::True; // Target has no number index constraint
         };
 
-        // tsc: `indexSignaturesRelatedTo` short-circuit (checker.ts ~24828):
-        //   if THIS target index info maps to `any` AND the target ALSO has a
-        //   string index signature, the source need not declare a matching
-        //   number index. Gated on a NAMED target (`target.symbol.is_some()`)
-        //   so we don't loosen merged-intersection synthetic shapes whose
-        //   indexes come from distinct intersection members; tsc relates each
-        //   intersection member separately, while our interner eagerly merges
-        //   them. Without this gate, `Obj <: StringTo<any> & NumberTo<any>`
-        //   would incorrectly succeed.
-        if !self.disable_method_bivariance
-            && t_number_idx.value_type.is_any()
-            && target
-                .string_index
-                .as_ref()
-                .is_some_and(|idx| idx.key_type != TypeId::SYMBOL)
-            && target.symbol.is_some()
-        {
+        // tsc: `indexSignaturesRelatedTo` short-circuit (checker.ts ~24828) — an
+        // `any`-valued number index is waived by a co-present `any`-valued string
+        // index on the same single object type (`Record<any, any>` accepts a
+        // named source). See the helper for the full rule and intersection guard.
+        if self.target_dual_any_index_waives_missing_number_index(target) {
             return SubtypeResult::True;
         }
 

--- a/crates/tsz-solver/tests/index_signature_tests.rs
+++ b/crates/tsz-solver/tests/index_signature_tests.rs
@@ -681,15 +681,14 @@ fn test_named_source_with_props_assignable_to_dual_any_index_named_target() {
     );
 }
 
-/// Anonymous synthetic targets (e.g. shape produced by interner-side intersection
-/// merging of `StringTo<any> & NumberTo<any>`) must NOT trigger the number-index
-/// short-circuit. The shape has `target.symbol == None` and its two indexes
-/// originated from distinct intersection members. tsc would relate the source
-/// against each intersection member independently, and the `NumberTo<any>`
-/// member alone (no string index) rejects a class/interface source without a
-/// number index.
+/// A shape produced by interner-side intersection merging of
+/// `StringTo<any> & NumberTo<any>` (stamped `ObjectFlags::INTERSECTION_MERGED`)
+/// must NOT trigger the number-index short-circuit: its two indexes originated
+/// from distinct intersection members. tsc relates the source against each
+/// intersection member independently, and the `NumberTo<any>` member alone (no
+/// string index) rejects a class/interface source without a number index.
 #[test]
-fn test_anonymous_dual_any_index_target_still_rejects_named_source() {
+fn test_intersection_merged_dual_any_index_target_still_rejects_named_source() {
     use tsz_binder::SymbolId;
 
     let interner = TypeInterner::new();
@@ -706,7 +705,58 @@ fn test_anonymous_dual_any_index_target_still_rejects_named_source() {
         Some(SymbolId(81)),
     );
 
-    // Anonymous merged-intersection shape (target.symbol = None).
+    // Merged-intersection shape: both indexes came from distinct members, so the
+    // shape carries `INTERSECTION_MERGED` (how `intern/intersection.rs` stamps an
+    // anonymous widening merge).
+    let target = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::INTERSECTION_MERGED,
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::ANY,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: Some(IndexSignature {
+            key_type: TypeId::NUMBER,
+            value_type: TypeId::ANY,
+            readonly: false,
+            param_name: None,
+        }),
+    });
+
+    assert!(
+        !checker.is_subtype_of(source, target),
+        "Named class without numeric members must NOT satisfy an INTERSECTION_MERGED \
+         dual-index `any` target (preserves tsc's per-member intersection behavior)"
+    );
+}
+
+/// A genuine single anonymous object type literal `{ [k: string]: any; [k:
+/// number]: any }` (NOT an intersection merge — no `INTERSECTION_MERGED` flag)
+/// DOES accept a named class/interface source with no numeric index. tsc relates
+/// the source against this one type's index infos together, so the `any`-valued
+/// number index is waived by the co-present `any`-valued string index. This is
+/// the `Record<any, any>` / `{ [P in any]: any }` shape (issue #14220).
+#[test]
+fn test_anonymous_dual_any_index_literal_accepts_named_source() {
+    use tsz_binder::SymbolId;
+
+    let interner = TypeInterner::new();
+    let class_symbols = [crate::SymbolRef(81)];
+    let is_class = |s: crate::SymbolRef| class_symbols.contains(&s);
+    let mut checker = SubtypeChecker::new(&interner).with_class_check(&is_class);
+
+    let source = interner.object_with_flags_and_symbol(
+        vec![
+            PropertyInfo::new(interner.intern_string("hello"), TypeId::STRING),
+            PropertyInfo::new(interner.intern_string("world"), TypeId::NUMBER),
+        ],
+        ObjectFlags::empty(),
+        Some(SymbolId(81)),
+    );
+
     let target = interner.object_with_index(ObjectShape {
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -726,9 +776,55 @@ fn test_anonymous_dual_any_index_target_still_rejects_named_source() {
     });
 
     assert!(
+        checker.is_subtype_of(source, target),
+        "Named class must satisfy a single anonymous `{{ [k: string]: any; [k: number]: any }}` \
+         literal target (number-index waiver fires; tsc accepts `Record<any, any>`)"
+    );
+}
+
+/// The number-index waiver requires BOTH index values to be exactly `any`. A
+/// single anonymous literal whose string index is narrower than `any`
+/// (`{ [k: string]: string; [k: number]: any }`) must still reject a named source
+/// that lacks a numeric index — tsc falls back to the per-property numeric check.
+#[test]
+fn test_anonymous_dual_index_narrow_string_value_rejects_named_source() {
+    use tsz_binder::SymbolId;
+
+    let interner = TypeInterner::new();
+    let class_symbols = [crate::SymbolRef(81)];
+    let is_class = |s: crate::SymbolRef| class_symbols.contains(&s);
+    let mut checker = SubtypeChecker::new(&interner).with_class_check(&is_class);
+
+    let source = interner.object_with_flags_and_symbol(
+        vec![PropertyInfo::new(
+            interner.intern_string("hello"),
+            TypeId::STRING,
+        )],
+        ObjectFlags::empty(),
+        Some(SymbolId(81)),
+    );
+
+    let target = interner.object_with_index(ObjectShape {
+        symbol: None,
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::STRING,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: Some(IndexSignature {
+            key_type: TypeId::NUMBER,
+            value_type: TypeId::ANY,
+            readonly: false,
+            param_name: None,
+        }),
+    });
+
+    assert!(
         !checker.is_subtype_of(source, target),
-        "Named class without numeric members must NOT satisfy an anonymous synthetic \
-         dual-index `any` target (preserves tsc's per-member intersection behavior)"
+        "Waiver must not fire when the string index value is narrower than `any`"
     );
 }
 


### PR DESCRIPTION
Goal: green

Fixes #14220.

## Summary
A named class/interface with no numeric index signature is assignable to a single object type that carries **both** an `any`-valued string index and an `any`-valued number index — `{ [k: string]: any; [k: number]: any }`, i.e. `Record<any, any>` / `{ [P in any]: any }`. This is `tsc`'s `indexSignaturesRelatedTo` short-circuit: the missing numeric index is waived when the same type also has an `any`-valued string index.

`tsz` gated that waiver on `target.symbol.is_some()` (a **named** target), so the anonymous shape produced by expanding `Record<any, any>` rejected an interface source. In zod's `Normalize<T>` (`T extends Record<any, any> ? … : never`) the object constituent failed the conditional check, the alias collapsed to `never`, and a downstream property read reported a false `TS2339`.

## Structural rule
When relating a source that declares no numeric index to a target whose number index value is `any` and which **also** carries a non-symbol string index whose value is `any`, `tsc` waives the numeric-index requirement — for any *single* object type (named OR an anonymous type literal / expanded mapped type), but **NOT** for an **intersection** of single-index types (`StringTo<any> & NumberTo<any>`), which `tsc` relates member-by-member (the `NumberTo<any>` member alone demands a numeric index).

Two coordinated changes:

1. **`relations/subtype/rules/objects.rs`** — the number-index waiver (`check_number_index_compatibility`) now gates on `!ObjectFlags::INTERSECTION_MERGED` instead of named-ness, and additionally requires the **string** index value to be exactly `any` (`tsc` rejects a narrower string or number index value). Factored into `target_dual_any_index_waives_missing_number_index`, the numeric mirror of the existing `target_string_index_any_waives_missing_index`.

2. **`intern/intersection.rs`** — `tsz` eagerly merges an object intersection into one shape, which interned identically to a plain dual-index literal, so the relation could not tell `StringTo<any> & NumberTo<any>` apart from a single type. `ObjectFlags::INTERSECTION_MERGED` (the existing "lost the structural intersection view" marker) was only stamped for fully-anonymous merges; it is now **also** stamped when the merge draws its string and number index signatures from **different members** — the precise case where the merged single shape diverges from `tsc`'s per-member index relation — so named-interface intersections are flagged too.

Owner layer: solver subtype relation + intersection interning.

## Adjacent matrix (all verified against tsc 6.0.2)
- `interface I {…}` ≤ `Record<any, any>` / `{ [k:string]:any; [k:number]:any }` / `{ [P in any]: any }` — **accepted** (was false `TS2322`/`TS2339`).
- `interface I {…}` ≤ `Record<number, any>` / `{ [k: number]: any }` (number index only) — still **rejected**.
- `interface I {…}` ≤ `{ [k:string]:string; [k:number]:any }` / `{ [k:string]:any; [k:number]:string }` (narrower value) — still **rejected**.
- `Obj` ≤ `StringTo<any> & NumberTo<any>` (intersection) — still **rejected** (per-member relation; `INTERSECTION_MERGED`); `Obj` ≤ `StringAndNumberTo<any>` (one interface extending both) — **accepted**.
- Class source and renamed binders behave identically; anonymous type literals already passed and continue to.
- The full `objectTypeWithStringAndNumberIndexSignatureToAny.ts` conformance test (`f1`/`f2`/`f3`) now matches `tsc 6.0.2` error-for-error.

No anti-hardcoding concerns: structural object-shape flag checks, not identifier/file-name/printer-string predicates.

## Verification
- `objectTypeWithStringAndNumberIndexSignatureToAny.ts` reconstructed locally — `tsz` and `tsc 6.0.2` produce identical diagnostics (13 errors, same positions).
- `#14220` repro + named/anonymous-literal/intersection/narrow-value matrix — byte-for-byte parity with `tsc 6.0.2`.
- `cargo test -p tsz-solver` index + intersection suites (653) pass, incl. 3 new structural guards (intersection-merged rejects, anonymous-literal accepts, narrow-string-value rejects).
- `cargo test -p tsz-checker --test conformance_issues_types issue_14220` — the committed `#14220` witness activated as a regression guard, plus a name-varied direct-assignment + intersection matrix.
- `cargo clippy -p tsz-solver` (+ test targets) clean. Pre-existing failures in the solver/checker suites are unchanged (confirmed identical on clean `main`).
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high