### PR TITLE
fix(checker): keep the alias for unconstrained named deferred conditionals in assignability messages

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker_generic_display_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_generic_display_tests.rs
@@ -94,3 +94,38 @@ const x: string = o;
         "concrete generic interface source should keep its concrete argument, got: {diag:?}"
     );
 }
+
+/// A *named* generic conditional alias used as the source of an assignability
+/// error must display by its alias application (`Branch<U>`), not collapse to
+/// the union of its branches. `tsc` keeps the alias spelling for a deferred
+/// conditional that carries its own `aliasSymbol`; only an anonymous deferred
+/// conditional renders as the branch union. Binder names are deliberately
+/// non-canonical so the assertion checks structure, not spellings. Regression
+/// for the `conditionalTypes1` fixture (#14141): `T95<U>` was rendered as
+/// `number | boolean`.
+#[test]
+fn named_conditional_alias_source_display_keeps_alias_not_branch_union() {
+    let diagnostics = diagnostics_for(
+        r#"
+type Target<Q> = Q extends string ? true : 42;
+type Branch<Q> = Q extends string ? boolean : number;
+function f<U>(value: Branch<U>): Target<U> {
+    return value;
+}
+"#,
+    );
+
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .expect("expected TS2322");
+    assert!(
+        diag.message_text
+            .contains("Type 'Branch<U>' is not assignable to type 'Target<U>'."),
+        "named conditional alias source should display its alias application, got: {diag:?}"
+    );
+    assert!(
+        !diag.message_text.contains("number | boolean"),
+        "named conditional alias source must not collapse to its branch union, got: {diag:?}"
+    );
+}

--- a/crates/tsz-checker/src/error_reporter/core_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core_alias_display.rs
@@ -143,6 +143,29 @@ impl<'a> CheckerState<'a> {
         if !branches_are_concrete {
             return None;
         }
+        // A *named* generic conditional alias deferred on an UNCONSTRAINED type
+        // parameter (`T95<U>` from `type T95<T> = T extends string ? boolean :
+        // number`) keeps its alias spelling in tsc. The branch union is shown
+        // only for an anonymous conditional or one whose check parameter carries
+        // a real constraint that makes the branch genuinely ambiguous
+        // (`IsArray<T extends object>` → `boolean`). Defer such named,
+        // unconstrained applications to the alias-application display instead of
+        // collapsing them to their branch union.
+        let check_param_unconstrained = param_info
+            .constraint
+            .is_none_or(|c| c == TypeId::UNKNOWN || c == TypeId::ANY);
+        if check_param_unconstrained
+            && self.ctx.types.get_display_alias(ty).is_some_and(|alias| {
+                crate::query_boundaries::diagnostics::type_application(self.ctx.types, alias)
+                    .is_some()
+                    && crate::query_boundaries::diagnostics::contains_type_parameters(
+                        self.ctx.types,
+                        alias,
+                    )
+            })
+        {
+            return None;
+        }
         let constraint = match param_info.constraint {
             Some(c) => c,
             None => return Some(self.ctx.types.union2(cond.true_type, cond.false_type)),


### PR DESCRIPTION
## Summary

The assignability-message formatter collapsed an "ambiguous" distributive
conditional to the union of its branches even when the conditional is a *named*
alias deferred on an **unconstrained** type parameter. For
`T95<U>` from `type T95<T> = T extends string ? boolean : number`, `tsc` renders
the name `T95<U>`, but tsz leaked the branch union `number | boolean`.

`compute_ambiguous_conditional_display` now keeps the alias for such named,
unconstrained applications. The branch union is still shown for:
- an anonymous deferred conditional, and
- one whose check parameter carries a **real constraint** that makes the branch
  genuinely ambiguous — `IsArray<T extends object>` → `boolean`,
  `Foo<T extends string>` → `boolean`.

That constraint distinction is the discriminator and is exactly what keeps
`distributiveConditionalTypeConstraints.ts` matching `tsc` (it expects `boolean`
for the constrained cases and `IsArray<T>` for the definitively-deferred ones).

**Structural rule:** When the source/target of an assignability error is a
distributive conditional whose check type is an *unconstrained* free type
parameter and which carries a generic alias application with a free-type-param
argument, `tsc` displays the alias application (`T95<U>`); tsz now does the same,
owned by the error reporter (`compute_ambiguous_conditional_display`). The shape
queries route through `query_boundaries::diagnostics` to respect the checker
boundary ratchet.

This makes the `number | boolean` vs `T95<U>` divergence masked by the
`conditionalTypes1` fixture rewrite (#14141) correct natively.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New regression unit test
  `named_conditional_alias_source_display_keeps_alias_not_branch_union`
  (`assignment_checker_generic_display_tests.rs`) — passes; binder names are
  deliberately non-canonical so the assertion checks structure, not spellings.
- `cargo test -p tsz-checker --lib assignability_domain::assignment_checker` —
  new test passes, **zero new failures** vs the branch base (7 pre-existing,
  unrelated, environment-specific failures unchanged).
- Conformance (project/batch mode, pinned tsc 6.0.3 cache): the regressed
  `distributiveConditionalTypeConstraints.ts` now passes again, and the four
  #14141 rewrite fixtures (`conditionalTypes1`, `variadicTuples1`,
  `indexSignatures1`, `inferFromGenericFunctionReturnTypes3`) still pass — the
  `T95<U>` case is now correct natively.
- `clippy -p tsz-checker` and `scripts/arch/arch_guard.py` both clean locally.

## Remaining `conditionalTypes1` divergences (still rewrite-masked, #14141)
Out of scope here — each is a deeper, higher-blast-radius solver change:
- TS2322 `T["x"]` not assignable to `NonNullable<T["x"]>` (L30): assignment-
  narrowing of a non-union deferred indexed-access parameter.
- TS2339 `DeepReadonly<Part>` vs `DeepReadonlyObject<Part>` (L138): the resolved
  conditional's branch-alias `display_alias` is mode-dependent (correct in CLI
  file mode, outer alias in project/batch mode) — a solver caching/ordering
  issue.

https://claude.ai/code/session_01KuG2boNMfqkDbUV38jhjfT