### PR TITLE
fix(checker): resolve cross-file declare-global computed-const augmentation keys

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
+++ b/crates/tsz-checker/src/state/type_resolution/computed_property_names.rs
@@ -229,6 +229,23 @@ impl<'a> CheckerState<'a> {
         {
             return Some(name);
         }
+        // A computed key `[K]` whose `K` is a string/number `const` — `const K =
+        // '$_TSR'` or `declare const K: '$R'` — keys the member under the literal
+        // value, exactly as the current-file value-position path
+        // (`resolve_local_computed_property_name`) does through type evaluation.
+        // The cross-arena path cannot run `get_type_of_node` against a foreign
+        // arena, so resolve the binding in the AUGMENTATION arena's own binder
+        // (where `[K]` is written) and read the literal syntactically from the
+        // declaration, following an import-type alias to its declaring file.
+        // Without this leg a `declare global { interface Window { [K]?: T } }`
+        // augmentation declared in one file drops its computed-const member when
+        // the member is accessed from a DIFFERENT file (false TS2339 on
+        // `self.$_TSR` / `window.$_TSR`).
+        if let Some(literal_name) =
+            self.cross_arena_const_literal_key_name(arena, computed.expression)
+        {
+            return Some(literal_name);
+        }
         let sym_id = self.resolve_computed_property_symbol_in_arena(arena, computed.expression)?;
         // Canonicalize to the declaring binder's symbol id so a cross-file
         // interface member keyed here agrees with the same `const`'s key reached
@@ -381,6 +398,91 @@ impl<'a> CheckerState<'a> {
             return crate::types_domain::queries::core::get_literal_property_name(arena, expr_idx);
         }
         None
+    }
+
+    /// Resolve a bare-identifier computed-key expression `[K]` written in
+    /// `arena` (the augmentation's own, possibly cross-file, arena) to the
+    /// string/number literal name of the `const` it binds. The identifier is
+    /// resolved in `arena`'s own binder — not the checker's current-file binder —
+    /// then an import-type alias is followed to the declaring file, and the
+    /// literal is read from THAT file's own arena. Handles both an initializer
+    /// literal (`const K = '$_TSR'`) and a declared literal-type annotation
+    /// (`declare const K: '$R'`). Returns `None` for non-`const` bindings,
+    /// non-identifier expressions, or keys that do not denote a string/number
+    /// literal — those fall through to the symbol-identity (`__unique_<id>`)
+    /// path, matching tsc, which keys such members by literal name only when the
+    /// key type is a string/number literal.
+    fn cross_arena_const_literal_key_name(
+        &self,
+        arena: &NodeArena,
+        mut expr_idx: NodeIndex,
+    ) -> Option<String> {
+        while let Some(node) = arena.get(expr_idx)
+            && node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+        {
+            expr_idx = arena.get_parenthesized(node)?.expression;
+        }
+        let ident_name = arena.get_identifier_text(expr_idx)?.to_string();
+        let aug_binder = self.ctx.get_binder_for_arena(arena)?;
+        let local_sym_id = aug_binder
+            .resolve_identifier(arena, expr_idx)
+            .or_else(|| aug_binder.file_locals.get(&ident_name))?;
+        // Follow an import alias (including a type-only `import type { K }`) to
+        // the `const` in its declaring file. `resolve_import_alias_and_register`
+        // follows the module specifier cross-file; the in-binder
+        // `follow_import_aliases` covers same-binder re-export hops.
+        let sym_id = self
+            .ctx
+            .resolve_import_alias_and_register(local_sym_id)
+            .map(|target| {
+                crate::types_domain::computed_names::follow_import_aliases(&self.ctx, target)
+            })
+            .unwrap_or_else(|| {
+                crate::types_domain::computed_names::follow_import_aliases(&self.ctx, local_sym_id)
+            });
+        let symbol =
+            crate::types_domain::computed_names::symbol_from_any_context(&self.ctx, sym_id)?;
+        let decl = symbol.value_declaration;
+        if decl.is_none() {
+            return None;
+        }
+        let owner_arena = if symbol.decl_file_idx == u32::MAX {
+            arena
+        } else {
+            self.ctx.get_arena_for_file(symbol.decl_file_idx)
+        };
+        if !owner_arena.is_const_variable_declaration(decl) {
+            return None;
+        }
+        let var_decl = owner_arena
+            .get(decl)
+            .and_then(|node| owner_arena.get_variable_declaration(node))?;
+
+        // Initializer literal: `const K = '$_TSR'` / `const K = 1`.
+        if let Some(name) = owner_arena
+            .get(var_decl.initializer)
+            .and_then(|init| owner_arena.get_literal(init))
+            .map(|lit| lit.text.clone())
+        {
+            return Some(name);
+        }
+
+        // Declared literal-type annotation: `declare const K: '$R'`.
+        let mut ann_idx = var_decl.type_annotation;
+        if let Some(ann) = owner_arena.get(ann_idx)
+            && ann.kind == syntax_kind_ext::LITERAL_TYPE
+            && let Some(lit_type) = owner_arena.get_literal_type(ann)
+        {
+            ann_idx = lit_type.literal;
+        }
+        owner_arena
+            .get(ann_idx)
+            .filter(|n| {
+                n.kind == SyntaxKind::StringLiteral as u16
+                    || n.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+                    || n.kind == SyntaxKind::NumericLiteral as u16
+            })
+            .and_then(|_| get_literal_property_name(owner_arena, ann_idx))
     }
 
     fn resolve_computed_property_symbol_in_arena(

--- a/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
@@ -525,3 +525,135 @@ fn compile_exact_name_ambient_precedence_keeps_missing_member_diagnostics() {
         result.diagnostics
     );
 }
+
+/// A `declare global { interface Window { [K]?: T } }` augmentation whose member
+/// is keyed by a computed property name `[K]` (K a string `const`, including an
+/// `import type`-aliased one) must resolve when the augmented member is accessed
+/// (`self.$_TSR`) from a DIFFERENT file than the one declaring the augmentation.
+///
+/// #14137 fixed the same-file form; this is the cross-file residual. The driver
+/// aggregates per-file `global_augmentations`, so this whole-program harness (not
+/// the single-binder checker harness) is what exercises the cross-arena
+/// computed-key member-name evaluation. Witness: tanstack-router
+/// `ssr/tsrScript.ts` accesses `self.$_TSR`/`self.$R` while `ssr/ssr-client.ts`
+/// declares the augmentation with keys imported from `ssr/constants.ts`.
+#[test]
+fn compile_cross_file_declare_global_computed_const_key_resolves() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "es2017",
+            "module": "esnext",
+            "moduleResolution": "bundler",
+            "lib": ["es2017", "dom"],
+            "strict": true,
+            "noEmit": true
+          },
+          "include": ["*.ts"]
+        }"#,
+    );
+    // Both an inferred `const` and a declared-literal-type `declare const`, imported
+    // via `import type` into the augmenting file.
+    write_file(
+        &base.join("constants.ts"),
+        r#"export const GLOBAL_TSR = '$_TSR'
+export declare const GLOBAL_SEROVAL: '$R'
+"#,
+    );
+    write_file(
+        &base.join("aug.ts"),
+        r#"import type { GLOBAL_TSR, GLOBAL_SEROVAL } from './constants'
+interface TsrSsrGlobal { hydrated: boolean }
+declare global {
+  interface Window {
+    [GLOBAL_TSR]?: TsrSsrGlobal
+    [GLOBAL_SEROVAL]?: number
+  }
+}
+export {}
+"#,
+    );
+    // Access the augmented members from a different file. Before the fix tsz
+    // dropped the computed-`const`-keyed members here and reported false TS2339.
+    write_file(
+        &base.join("usage.ts"),
+        r#"self.$_TSR = { hydrated: false }
+const ok: boolean = self.$_TSR!.hydrated
+self.$R = 1
+export {}
+"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    let no_member_drop = !result
+        .diagnostics
+        .iter()
+        .any(|d| d.code == 2339 && (d.message_text.contains("$_TSR") || d.message_text.contains("$R")));
+    assert!(
+        no_member_drop,
+        "cross-file computed-const Window augmentation members ($_TSR/$R) must resolve \
+         (no false TS2339). Diagnostics: {:?}",
+        result.diagnostics
+    );
+}
+
+/// Negative bound for the cross-file computed-`const`-key fix: it must key a
+/// SPECIFIC member, not synthesize an index signature. An ABSENT member on
+/// `Window` still errors TS2339, matching tsc.
+#[test]
+fn compile_cross_file_declare_global_computed_const_key_does_not_overbroaden() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "es2017",
+            "module": "esnext",
+            "moduleResolution": "bundler",
+            "lib": ["es2017", "dom"],
+            "strict": true,
+            "noEmit": true
+          },
+          "include": ["*.ts"]
+        }"#,
+    );
+    write_file(
+        &base.join("aug.ts"),
+        r#"const GLOBAL_TSR = '$_TSR'
+interface TsrSsrGlobal { hydrated: boolean }
+declare global {
+  interface Window {
+    [GLOBAL_TSR]?: TsrSsrGlobal
+  }
+}
+export {}
+"#,
+    );
+    write_file(
+        &base.join("usage.ts"),
+        r#"const bad = self.totallyAbsentMember
+export {}
+"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.code == 2339 && d.message_text.contains("totallyAbsentMember")),
+        "an absent Window member must still error TS2339 (the fix keys a specific \
+         member, not an index signature). Diagnostics: {:?}",
+        result.diagnostics
+    );
+}


### PR DESCRIPTION
Goal: green

A `declare global { interface Window { [K]?: T } }` augmentation whose member is
keyed by a computed property name `[K]` — where `K` is a string/number `const`
(`const K = '$_TSR'`, or a type-only-imported / `declare const K: '$R'`) — dropped
that member when the augmented member was accessed (`self.$_TSR` / `window.$_TSR`)
from a DIFFERENT file than the one declaring the augmentation. Result: false TS2339
("Property '$_TSR' does not exist on type 'Window & typeof globalThis'").

#14137 fixed the SAME-file form (augmentation and access in one file). This closes
the residual CROSS-file form: the witness is tanstack-router `ssr/tsrScript.ts`,
which accesses `self.$_TSR` / `self.$R` while the augmentation lives in
`ssr/ssr-client.ts` (`[GLOBAL_TSR]?` / `[GLOBAL_SEROVAL]?`, imported via
`import type` from `ssr/constants.ts`).

## Structural rule
When a `declare global { interface X { [K]?: T } }` augmentation declares a member
keyed by a computed property name whose `K` is a compile-time string/number `const`,
the binder/checker must evaluate `K` to its literal name and key the member under
that name — the same result tsc produces — regardless of whether the augmented
member is accessed in the augmenting file or a different file.

tsz already does this for the SAME-file access path through
`resolve_local_computed_property_name`, which runs value-position type evaluation
(`get_type_of_node`) on the key expression. The CROSS-file augmentation-merge path
(`resolve_computed_property_name_in_arena`'s cross-arena branch in
`crates/tsz-checker/src/state/type_resolution/computed_property_names.rs`) cannot
run `get_type_of_node` against the foreign augmenting arena, so it only handled
direct literal keys (`['$_TSR']`) and unique-symbol keys, and dropped an
identifier-`const` key. The fix adds a syntactic literal recovery for that branch:
resolve the identifier in the AUGMENTING arena's own binder, follow an import-type
alias to the declaring file (`resolve_import_alias_and_register` +
`follow_import_aliases`), and read the `const`'s string/number literal from THAT
file's arena — both the initializer form (`const K = '$_TSR'`) and the declared
literal-type form (`declare const K: '$R'`). A non-`const` binding or a key that is
not a string/number literal falls through unchanged to the symbol-identity
(`__unique_<id>`) path, so unique-symbol and non-literal keys keep tsc-parity.

Owner layer: checker — cross-file global-augmentation computed-key member-name
evaluation. Wrong operation it was getting: symbol resolution / key-name
evaluation dropped the member because the cross-arena branch had no value-position
type evaluation and no syntactic literal-`const` recovery, so the augmentation type
lowered to `{}` (member dropped) for the other file's `Window & typeof globalThis`
access. No identifier/file/text/printer-output checks; the literal is read from the
binding's own declaration syntax, name-independent.

## Adjacent matrix
Verified against bundled `tsc --strict --noEmit --target es2022 --lib es2022,dom`
(exact parity):
- Cross-file augmentation, inferred `const K = '$_TSR'`, in-augmenting-file const,
  accessed from another file: CLEAN (was TS2339).
- Cross-file augmentation, `import type { K, S }` of `const K = '$_TSR'` AND
  `declare const S: '$R'` from a third file, accessed from a fourth: CLEAN (was
  TS2339 x2).
- Cross-file augmentation, direct string-literal key `['$_TSR']`: CLEAN (unchanged).
- Cross-file augmentation, plain identifier member `plainMember`: CLEAN (unchanged).
- SAME-file augmentation + access (the #14137 form): CLEAN (unchanged — the local
  value-position path is untouched).
- Negative (over-broadening): an ABSENT member on `Window` still errors TS2339 — the
  fix keys a SPECIFIC member, not an index signature. Matches tsc.
- Negative (`let K = '$_TSR'` key, non-literal/widened-`string`): tsz still TS2339,
  matching its SAME-file behavior. tsc instead synthesizes a string index signature
  here; that index-signature-from-widened-key gap is a SEPARATE, pre-existing
  divergence (present same-file too) and is intentionally out of scope.
- Negative (cross-file `unique symbol` key): keyed `__unique_<id>` as before (the
  literal recovery returns `None` for non-literal keys).
- Renamed binders (`TAG`, `GLOBAL_SEROVAL`, not a hard-coded `$_TSR`): parity.

## Verification
- Minimal cross-file repros (augmentation in one file, `self.$_TSR`/`self.$R` in
  another): tsz before TS2339, after CLEAN — matching `tsc` exit 0. Inferred-const,
  `import type`-aliased const, and `declare const X: '$R'` annotation forms all clear.
- Corpus tanstack-router (`packages/router-core`, full `tsconfig.json`,
  tsz-only delta vs `node TypeScript/bin/tsc`): `ssr/tsrScript.ts` 3 false TS2339
  (`$_TSR` x2, `$R`) -> 0, plus 6 cascade diagnostics that were downstream of the
  dropped augmentation (`hydrated`/`streamEnded`/`initialized` TS2339, `script`
  TS7006) cleared once `self.$_TSR` types as `TsrSsrGlobal`. Total project
  diagnostics 428 -> 419. **NEW diagnostics anywhere in the project: 0** (full
  before/after diff vs a clean-`origin/main` binary).
- Conformance (local, pinned tsc cache), zero regressions on the augmentation /
  computed-key / index-signature families, all 100% / 0 known failures:
  computedProperty 146/146, moduleAugmentation 46/46, indexSignature 24/24,
  augmentation 4/4, interfaceMerge 2/2, globalAugmentation 1/1.
- 2 new driver-level regression tests in `tsz-cli` `driver_tests_parts/part_13.rs`
  (the whole-program harness aggregates per-file `global_augmentations` like the
  real driver, which the single-binder checker harness does not): a cross-file
  positive covering inferred-`const` + `import type`-aliased `declare const X:'$R'`
  + init-`const`, and a cross-file over-broadening negative (absent member still
  TS2339). Existing 5 `global_augmentation_computed_key_tests` from #14137 still
  PASS. Binder names varied (`GLOBAL_TSR`/`GLOBAL_SEROVAL`); no name-based logic.
- Delta-gate `-p tsz-checker` (augment/computed/global/merge families, 909 tests):
  identical 11 failing tests on this branch and a clean-`origin/main` binary
  (the known local env-only failures) -> net-new failures = 0. clippy clean
  (`-p tsz-checker`, `-p tsz-cli --tests`). Changed source file
  `computed_property_names.rs` 517 LOC (< 2000).

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
