### PR TITLE
fix(checker): resolve qualified `typeof a.b` lazily as `(typeof a)["b"]`

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "qualified_typeof_member_deferred_tests"
+path = "tests/qualified_typeof_member_deferred_tests.rs"
+[[test]]
 name = "as_const_object_property_inference_tests"
 path = "tests/as_const_object_property_inference_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
@@ -32,6 +32,36 @@ impl<'a> CheckerState<'a> {
         })
     }
 
+    /// Build the deferred `typeof` representation of a value entity name as a
+    /// chain of indexed accesses over a base `TypeQuery`.
+    ///
+    /// `config` (an identifier) lowers to the deferred `TypeQuery(config)`;
+    /// `config.routes` lowers to `(typeof config)["routes"]`;
+    /// `config.a.b` to `((typeof config)["a"])["b"]`. The result resolves the
+    /// member lazily through the indexed-access machinery, which — unlike an
+    /// eager property access on the already-resolved value object — does not
+    /// depend on the object's members being materialized at the point the query
+    /// is first forced (a `keyof`/mapped operand can force it early). Returns
+    /// `None` when the root does not resolve to a usable value symbol.
+    fn deferred_typeof_value_chain(&self, expr_name: NodeIndex) -> Option<TypeId> {
+        use tsz_solver::SymbolRef;
+        let node = self.ctx.arena.get(expr_name)?;
+        let factory = self.ctx.types.factory();
+        if node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
+            let sym_id = self.resolve_value_symbol_for_lowering(expr_name)?;
+            return Some(factory.type_query(SymbolRef(sym_id)));
+        }
+        if node.kind == tsz_parser::parser::syntax_kind_ext::QUALIFIED_NAME {
+            let qn = self.ctx.arena.get_qualified_name(node)?;
+            let base = self.deferred_typeof_value_chain(qn.left)?;
+            let right_node = self.ctx.arena.get(qn.right)?;
+            let right_ident = self.ctx.arena.get_identifier(right_node)?;
+            let index_type = factory.literal_string(right_ident.escaped_text.as_str());
+            return Some(factory.index_access(base, index_type));
+        }
+        None
+    }
+
     pub(crate) fn get_type_from_type_query_flow_sensitive_with_request(
         &mut self,
         idx: NodeIndex,
@@ -200,6 +230,18 @@ impl<'a> CheckerState<'a> {
                     let left_idx = qn.left;
                     let right_idx = qn.right;
 
+                    // When the left side resolves to a concrete value object but the
+                    // member cannot be resolved *eagerly* (the surrounding type, e.g.
+                    // a `keyof`/mapped operand, is evaluated before the value object's
+                    // members are materialized), fall back to a deferred indexed access
+                    // `(<value object>)["member"]` instead of collapsing to `error`.
+                    // A qualified value query `typeof a.b` is exactly `(typeof a)["b"]`,
+                    // which the indexed-access machinery resolves lazily (and correctly
+                    // reports TS2339 for a genuinely missing member). This keeps inline
+                    // `typeof a.b` in step with the explicit `(typeof a)["b"]` form,
+                    // whose deferral does not depend on member-materialization order.
+                    let mut deferred_value_member_access: Option<TypeId> = None;
+
                     // For merged namespace+interface symbols (e.g., `typeof M2.Point`
                     // where Point is both a namespace and an interface), resolve via
                     // the binder's export tables FIRST. Property access on the parent
@@ -327,8 +369,25 @@ impl<'a> CheckerState<'a> {
                                     };
                                 }
                                 _ => {
-                                    // Property access returned any/error or failed entirely.
-                                    // Fall through to binder-based resolution below.
+                                    // Property access returned any/error or failed
+                                    // entirely. Record a deferred indexed access over the
+                                    // base value's *deferred* `typeof` (a `TypeQuery`), so
+                                    // the member resolves lazily — correct even when the
+                                    // value object's members are not materialized yet
+                                    // (e.g. a `keyof`/mapped operand forces this query
+                                    // before the object literal's property types exist).
+                                    // Indexing the already-resolved object eagerly would
+                                    // reproduce the same premature-resolution failure;
+                                    // `(typeof base)["member"]` does not. Namespace
+                                    // resolution still takes priority below.
+                                    if let Some(deferred_base) =
+                                        self.deferred_typeof_value_chain(left_idx)
+                                    {
+                                        let factory = self.ctx.types.factory();
+                                        let index_type = factory.literal_string(&prop_name);
+                                        deferred_value_member_access =
+                                            Some(factory.index_access(deferred_base, index_type));
+                                    }
                                 }
                             }
                         }
@@ -344,6 +403,19 @@ impl<'a> CheckerState<'a> {
                                 &type_argument_nodes,
                             );
                         }
+                    }
+                    // Namespace resolution did not apply: resolve the value member
+                    // lazily through the deferred indexed access recorded above.
+                    if let Some(deferred) = deferred_value_member_access {
+                        let resolved = self.apply_type_query_instantiation_arguments(
+                            deferred,
+                            &type_argument_nodes,
+                        );
+                        return if use_flow_sensitive_query && !has_type_args {
+                            self.apply_flow_narrowing(type_query.expr_name, resolved)
+                        } else {
+                            resolved
+                        };
                     }
                 }
             } else if expr_node.kind == tsz_scanner::SyntaxKind::Identifier as u16

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -761,6 +761,27 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             }
         }
 
+        // A qualified value query `typeof a.b` is exactly `(typeof a)["b"]`. The
+        // earlier eager paths (value-property resolution, namespace/enum symbol
+        // resolution) have not resolved it, and the `None` type-resolver lowering
+        // below cannot resolve a qualified value name — it would collapse the query
+        // to `error`, which then leaks into an enclosing `keyof`/mapped/indexed
+        // operand (e.g. `keyof typeof a.b` rendering as `keyof error`). Defer to the
+        // indexed-access form, which resolves the member lazily — correct even when
+        // the value object's members are not materialized at the point the query is
+        // first forced — and reports TS2339 for a genuinely missing member.
+        if name_opt.is_none()
+            && let Some(expr_node) = self.ctx.arena.get(type_query.expr_name)
+            && expr_node.kind == syntax_kind_ext::QUALIFIED_NAME
+            && let Some(deferred) = self.deferred_typeof_value_chain(type_query.expr_name)
+        {
+            if let Some(type_arguments) = &type_arguments {
+                return self
+                    .apply_instantiation_expression_type_arguments(deferred, type_arguments);
+            }
+            return deferred;
+        }
+
         // Fall back to TypeLowering with proper value resolvers
         let value_resolver = |node_idx: NodeIndex| -> Option<u32> {
             let ident = self.ctx.arena.get_identifier_at(node_idx)?;
@@ -1123,6 +1144,37 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 diagnostic_codes::ONLY_REFERS_TO_A_TYPE_BUT_IS_BEING_USED_AS_A_VALUE_HERE,
             );
         }
+    }
+
+    /// Build the deferred `typeof` representation of a value entity name as a
+    /// chain of indexed accesses over a base `TypeQuery`.
+    ///
+    /// `a` (identifier) lowers to `TypeQuery(a)`; `a.b` to `(typeof a)["b"]`;
+    /// `a.b.c` to `((typeof a)["b"])["c"]`. The member resolves lazily through
+    /// the indexed-access machinery, which — unlike an eager property access on
+    /// the already-resolved value object — does not depend on the object's
+    /// members being materialized at the point the query is first forced.
+    /// Returns `None` when the root does not resolve to a value symbol.
+    fn deferred_typeof_value_chain(&self, expr_name: NodeIndex) -> Option<TypeId> {
+        let node = self.ctx.arena.get(expr_name)?;
+        let factory = self.ctx.types.factory();
+        if node.kind == tsz_scanner::SyntaxKind::Identifier as u16 {
+            let sym_id = self.resolve_value_symbol_in_scope(expr_name)?;
+            let symbol = self.ctx.binder.get_symbol(sym_id)?;
+            if symbol.flags & tsz_binder::symbol_flags::VALUE == 0 {
+                return None;
+            }
+            return Some(factory.type_query(tsz_solver::SymbolRef(sym_id.0)));
+        }
+        if node.kind == syntax_kind_ext::QUALIFIED_NAME {
+            let qn = self.ctx.arena.get_qualified_name(node)?;
+            let base = self.deferred_typeof_value_chain(qn.left)?;
+            let right_node = self.ctx.arena.get(qn.right)?;
+            let right_ident = self.ctx.arena.get_identifier(right_node)?;
+            let index_type = factory.literal_string(right_ident.escaped_text.as_str());
+            return Some(factory.index_access(base, index_type));
+        }
+        None
     }
 
     /// Resolve the symbol for a type query expression name.

--- a/crates/tsz-checker/tests/qualified_typeof_member_deferred_tests.rs
+++ b/crates/tsz-checker/tests/qualified_typeof_member_deferred_tests.rs
@@ -1,0 +1,182 @@
+//! Tests for qualified `typeof a.b` member resolution under type operators.
+//!
+//! ## Structural rule
+//!
+//! A qualified value type query `typeof a.b` is exactly `(typeof a)["b"]`: the
+//! member is resolved by indexing the value-space type of `a`. `tsc` resolves
+//! it lazily, so the result is identical whether the query stands alone or is
+//! the operand of a `keyof` / mapped / conditional / indexed-access type — and
+//! whether or not the value object's members have been materialized at the
+//! point the enclosing type is first forced.
+//!
+//! tsz previously resolved a qualified `typeof a.b` *eagerly* off the resolved
+//! value object and, when that eager read had not yet materialized (e.g. a
+//! `keyof`/mapped operand forced the query during type-alias evaluation, before
+//! the object literal's property types existed), collapsed the query to the
+//! internal `error` type. That `error` then leaked into the enclosing operator,
+//! surfacing as a false `TS2322` (`keyof error` not assignable to the real key
+//! union) or an empty mapped-type key set. The fix lowers a qualified value
+//! `typeof a.b` to the deferred indexed access `(typeof a)["b"]`, which resolves
+//! the member through the indexed-access machinery regardless of evaluation
+//! order — matching the explicit `(typeof a)["b"]` spelling, which was always
+//! correct.
+//!
+//! The rule is keyed on structure, not on identifier spelling: renaming the
+//! value binding, its members, or the type aliases must not change the result
+//! (anti-hardcoding directive). Each scenario is therefore covered with at least
+//! two unrelated naming sets.
+
+use tsz_checker::test_utils::check_source_codes;
+
+/// `keyof typeof obj.member` — the canonical witness. The deferred resolution
+/// must produce the member's key union, not `keyof error` (false TS2322).
+#[test]
+fn keyof_qualified_typeof_member_no_false_ts2322() {
+    let codes = check_source_codes(
+        r#"
+const config = { routes: { home: "/", about: "/about" } };
+type RouteKey = keyof typeof config.routes;
+const rk: "home" | "about" = "home" as RouteKey;
+"#,
+    );
+    assert!(
+        !codes.contains(&2322),
+        "no false TS2322 for `keyof typeof config.routes`, got: {codes:?}"
+    );
+}
+
+/// Same structural shape, unrelated names — the decision must not key on the
+/// `config`/`routes`/`RouteKey` spelling.
+#[test]
+fn keyof_qualified_typeof_member_name_agnostic() {
+    let codes = check_source_codes(
+        r#"
+const registry = { handlers: { open: 1, close: 2 } };
+type Slot = keyof typeof registry.handlers;
+const s: "open" | "close" = "open" as Slot;
+"#,
+    );
+    assert!(
+        !codes.contains(&2322),
+        "no false TS2322 for renamed `keyof typeof registry.handlers`, got: {codes:?}"
+    );
+}
+
+/// Two levels of member access: `keyof typeof a.b.c`.
+#[test]
+fn keyof_qualified_typeof_two_level_member() {
+    let codes = check_source_codes(
+        r#"
+const store = { outer: { inner: { leaf: true } } };
+type K = keyof typeof store.outer.inner;
+const k: "leaf" = "leaf" as K;
+"#,
+    );
+    assert!(
+        !codes.contains(&2322),
+        "no false TS2322 for `keyof typeof store.outer.inner`, got: {codes:?}"
+    );
+}
+
+/// A `declare const` (no inference) must resolve identically — the eager path's
+/// premature-materialization failure was independent of how the value's type
+/// was obtained.
+#[test]
+fn keyof_qualified_typeof_member_on_declared_const() {
+    let codes = check_source_codes(
+        r#"
+declare const settings: { theme: { dark: boolean; light: boolean } };
+type ThemeKey = keyof typeof settings.theme;
+const tk: "dark" | "light" = "dark" as ThemeKey;
+"#,
+    );
+    assert!(
+        !codes.contains(&2322),
+        "no false TS2322 for `keyof typeof settings.theme` on a declared const, got: {codes:?}"
+    );
+}
+
+/// The query under a mapped type's key constraint is lowered through the
+/// generic type-lowering pass; it must resolve the member set, not produce an
+/// empty key space (which previously surfaced as TS2322/TS2353).
+#[test]
+fn mapped_key_over_qualified_typeof_member() {
+    let codes = check_source_codes(
+        r#"
+const config = { routes: { home: "/", about: "/about" } };
+type Flags = { [K in keyof typeof config.routes]: boolean };
+const f: Flags = { home: true, about: false };
+"#,
+    );
+    assert!(
+        !codes.contains(&2322) && !codes.contains(&2353),
+        "no false TS2322/TS2353 for a mapped type over `keyof typeof config.routes`, got: {codes:?}"
+    );
+}
+
+/// Mapped-key variant with unrelated names.
+#[test]
+fn mapped_key_over_qualified_typeof_member_name_agnostic() {
+    let codes = check_source_codes(
+        r#"
+const palette = { colors: { primary: 0, secondary: 1 } };
+type Shades = { [Tone in keyof typeof palette.colors]: string };
+const sh: Shades = { primary: "a", secondary: "b" };
+"#,
+    );
+    assert!(
+        !codes.contains(&2322) && !codes.contains(&2353),
+        "no false TS2322/TS2353 for renamed mapped type over typeof member, got: {codes:?}"
+    );
+}
+
+/// The query as a conditional check type must resolve to the member object so
+/// the conditional selects the correct branch.
+#[test]
+fn conditional_over_qualified_typeof_member() {
+    let codes = check_source_codes(
+        r#"
+const config = { routes: { home: "/" } };
+type Picked = typeof config.routes extends { home: infer H } ? H : never;
+const p: string = "x" as Picked;
+"#,
+    );
+    assert!(
+        !codes.contains(&2322),
+        "no false TS2322 for a conditional over `typeof config.routes`, got: {codes:?}"
+    );
+}
+
+/// A bare qualified `typeof a.b` standing alone was already correct; guard that
+/// it stays correct (the fix must not change the working eager path).
+#[test]
+fn bare_qualified_typeof_member_still_resolves() {
+    let codes = check_source_codes(
+        r#"
+const config = { routes: { home: "/" } };
+type R = typeof config.routes;
+const r: { home: string } = null as unknown as R;
+"#,
+    );
+    assert!(
+        !codes.contains(&2322) && !codes.contains(&2339),
+        "bare `typeof config.routes` still resolves to its object type, got: {codes:?}"
+    );
+}
+
+/// Indexing the deferred member access by a literal resolves to the property
+/// type (the value path the deferred chain is built on).
+#[test]
+fn indexed_access_of_qualified_typeof_member() {
+    let codes = check_source_codes(
+        r#"
+const config = { routes: { home: "/" } };
+type Home = (typeof config.routes)["home"];
+const h: string = "x" as Home;
+"#,
+    );
+    assert!(
+        !codes.contains(&2322) && !codes.contains(&2339),
+        "indexing `(typeof config.routes)[\"home\"]` resolves to the property type, got: {codes:?}"
+    );
+}

--- a/crates/tsz-lowering/src/lower/advanced.rs
+++ b/crates/tsz-lowering/src/lower/advanced.rs
@@ -870,8 +870,46 @@ impl TypeLowering<'_> {
                     _ => {}
                 }
             }
+            // A qualified value query `typeof a.b` is exactly `(typeof a)["b"]`.
+            // Lower it to a deferred indexed-access chain so the member resolves
+            // lazily through the indexed-access machinery (matching the checker's
+            // typeof resolution). Without this a qualified `typeof` collapses to
+            // `error` here — e.g. inside a mapped type's key constraint
+            // `{ [K in keyof typeof a.b]: V }`, which is lowered through this pass.
+            if let Some(deferred) = self.lower_deferred_typeof_value_chain(data.expr_name) {
+                if let Some(args) = &data.type_arguments
+                    && !args.nodes.is_empty()
+                {
+                    let type_args: Vec<TypeId> =
+                        args.nodes.iter().map(|&idx| self.lower_type(idx)).collect();
+                    return self.interner.application(deferred, type_args);
+                }
+                return deferred;
+            }
             TypeId::ERROR
         }
+    }
+
+    /// Build the deferred `typeof` representation of a value entity name as a
+    /// chain of indexed accesses over a base `TypeQuery`: `a` → `TypeQuery(a)`,
+    /// `a.b` → `(typeof a)["b"]`, `a.b.c` → `((typeof a)["b"])["c"]`. The member
+    /// resolves lazily through the indexed-access machinery rather than being
+    /// eagerly read off the (possibly not-yet-materialized) value object.
+    /// Returns `None` when the root does not resolve to a value symbol.
+    fn lower_deferred_typeof_value_chain(&self, expr_name: NodeIndex) -> Option<TypeId> {
+        let node = self.arena.get(expr_name)?;
+        if node.kind == syntax_kind_ext::QUALIFIED_NAME {
+            let qn = self.arena.get_qualified_name(node)?;
+            let base = self.lower_deferred_typeof_value_chain(qn.left)?;
+            let right_node = self.arena.get(qn.right)?;
+            let right_ident = self.arena.get_identifier(right_node)?;
+            let index_type = self
+                .interner
+                .literal_string(right_ident.escaped_text.as_str());
+            return Some(self.interner.index_access(base, index_type));
+        }
+        let symbol_id = self.resolve_value_symbol(expr_name)?;
+        Some(self.interner.type_query(SymbolRef(symbol_id)))
     }
 
     /// Lower a type operator (keyof, readonly, unique)


### PR DESCRIPTION
Goal: green

## Summary

A qualified value type query `typeof a.b` was resolved by eagerly reading member `b` off the resolved value object. When the enclosing type forced the query *before* that object's members were materialized — e.g. a `keyof`/mapped operand evaluated during type-alias construction, before an object literal's property types existed — the eager read failed and the query collapsed to the internal `error` type. That `error` then leaked into the enclosing operator:

```ts
const config = { routes: { home: "/" } };
type RouteKey = keyof typeof config.routes;   // tsz: `keyof error`  → false TS2322 ; tsc: "home"
type Flags    = { [K in keyof typeof config.routes]: boolean }; // tsz: empty key set → false TS2322/TS2353
```

`tsc` compiles both cleanly. The query resolved correctly on its own (`type T = typeof config.routes`) and via the explicit indexed-access spelling `(typeof config)["routes"]`, but `keyof`/mapped over the dotted entity-name form degraded to `error`.

## Structural rule

When the LHS of a qualified value type query resolves to a value whose member is read as `typeof a.b`, `tsc` resolves it as `(typeof a)["b"]` — by indexing the value-space type of `a`, **lazily**. The result is therefore identical whether the query stands alone or is the operand of a `keyof` / mapped / conditional / indexed-access type, and regardless of member-materialization order. tsz now lowers a qualified `typeof a.b` (and `a.b.c`) to the deferred indexed-access chain `(typeof a)["b"]`, which the indexed-access machinery resolves lazily — the same representation as the explicit `(typeof a)["b"]` spelling (which was always correct, and which reports TS2339 for a genuinely missing member).

## Owner layer

Checker typeof-resolution + the lowering pass. The deferral is added at the three independent typeof-resolution sites, each of which previously had **no** deferral for a qualified value name and collapsed it to `error`:

- `CheckerState::get_type_from_type_query_flow_sensitive_with_request` (`crates/tsz-checker/src/state/type_analysis/core_type_query.rs`) — after eager property access fails, before the value collapses to `error`; namespace binder-export resolution still takes priority.
- `TypeNodeChecker::get_type_from_type_query` (`crates/tsz-checker/src/types/type_node_advanced.rs`) — before the `None`-resolver `TypeLowering` fallback that cannot resolve a qualified value name.
- `TypeLowering::lower_type_query` (`crates/tsz-lowering/src/lower/advanced.rs`) — the generic lowering pass that handles a mapped type's key constraint, which had **no** qualified-name handling at all.

The three sites are genuinely independent code paths (two checker structs + the cross-arena lowering pass with no binder access); a `/simplify` altitude review confirmed they cannot be collapsed to one chokepoint across the crate/struct boundary. Each builds the chain with the canonical `type_query` / `index_access` / `literal_string` constructors.

## Anti-hardcoding

The decision is keyed on node structure (`QUALIFIED_NAME` over a value symbol), not on any identifier/file-name/printer string. New tests vary the value binding, member, and alias names across two unrelated naming sets per scenario.

## Adjacent matrix (verified against bundled `tsc` 6.0.2, `--strict --noEmit`)

- `keyof typeof a.b` → member key union (was `keyof error`).
- `keyof typeof a.b.c` (two-level) → leaf key union.
- `{ [K in keyof typeof a.b]: V }` mapped key → member set (was empty → TS2322/TS2353).
- `typeof a.b extends { … } ? … : …` conditional → correct branch.
- `declare const` (no inference) and `let`/`const`/`as const` bindings — all resolve.
- Renamed bindings/members/aliases — parity (structural, not name-based).
- Negative/guard: bare `typeof a.b` standalone still resolves to its object; `(typeof a)["b"]` explicit form unchanged; `typeof a.b` resolves to the **widened** member type (`string`, not the literal).
- `typeof NS.member` (namespace), `typeof Enum.Member`, `typeof obj.method` — unchanged.

A separate, pre-existing reflexivity bug (`'X' not assignable to 'X'`, the #13609 canonical-identity family) is *exposed* — not introduced — when a mapped type's **value** re-derives a literal via `typeof a.b[K]`; it reproduces identically for the non-qualified `typeof o[K]` form that this change never touches, and is left to that campaign.

## Verification

- `cargo test -p tsz-checker --test qualified_typeof_member_deferred_tests` → 9/9 (keyof/mapped/conditional/indexed/declared-const, two naming sets each).
- Targeted lib suites `cargo test -p tsz-checker --lib -- typeof type_query keyof indexed_access mapped` → **net-new failures = 0** vs clean `origin/main` (same 12 pre-existing local-env failures with and without the change; sampled non-filter failures e.g. `array_isarray_*`, `typebox_*`, `higher_order_regeneralization_*` reproduce identically on baseline).
- 56-snippet `tsz` vs bundled `tsc` 6.0.2 differential (varied TS features) → 0 regressions on debug and `dist-fast`.
- `cargo fmt -p tsz-checker -p tsz-lowering --check` clean; `cargo clippy -p tsz-checker -p tsz-lowering --lib` clean. All touched files < 2000 LOC.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCMLR3Dy7EWZ9Fy9C5EkGi)_