### PR TITLE
test(checker): activate regression guards for fleet-fixed #14213/#14216/#14229/#14255

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026.rs
@@ -192,7 +192,7 @@ fn issue_13484_generic_base_class_member_substituted_no_ts2322() {
 /// (curried) form `(a) => (): T => ({ m: (x, y) => ... })` must not report
 /// TS7006 ("Parameter implicitly has an 'any' type") on `x`/`y`.
 #[test]
-#[ignore = "reproduces #14213; FP still present (TS7006 on inner-arrow object-literal method params under a curried annotated return)"]
+// Now fixed on `main`; kept as a live regression guard (was #[ignore] for #14213).
 fn issue_14213_curried_arrow_object_literal_method_params_no_ts7006() {
     let diagnostics = compile_and_get_diagnostics(
         r#"
@@ -285,7 +285,7 @@ export {};
 /// every type position of the signature. `type Guard = (a: { z: string }) => a is
 /// typeof a & { y: boolean }` must not report TS2304 ("Cannot find name 'a'").
 #[test]
-#[ignore = "reproduces #14229; FP still present (TS2304 'Cannot find name a' for `typeof a` in a function-type-alias predicate asserted type)"]
+// Now fixed on `main`; kept as a live regression guard (was #[ignore] for #14229).
 fn issue_14229_typeof_param_in_predicate_asserted_type_no_ts2304() {
     let diagnostics = compile_and_get_diagnostics(
         r#"
@@ -317,7 +317,7 @@ export {};
 /// in-module binding for `Exp`; in-module `Capitalize<S>` must keep its intrinsic
 /// meaning. The witness must not report TS2315 ("'Capitalize' is not generic").
 #[test]
-#[ignore = "reproduces #14255; FP still present (TS2315 'Type Local is not generic' — `export { Local as Capitalize }` shadows the string-mapping intrinsic in-module)"]
+// Now fixed on `main`; kept as a live regression guard (was #[ignore] for #14255).
 fn issue_14255_export_rename_shadowing_intrinsic_no_ts2315() {
     let diagnostics = compile_and_get_diagnostics(
         r#"
@@ -399,7 +399,7 @@ fn issue_14258_export_star_reexport_type_alias_named_import_no_ts2749() {
 /// class meaning (value and type). No TS2749 at type sites, no TS2552 at value
 /// sites.
 #[test]
-#[ignore = "reproduces #14216; FP still present (export-alias `export { box as Box }` clobbers the local `class Box` in value and type space)"]
+// Now fixed on `main`; kept as a live regression guard (was #[ignore] for #14216).
 fn issue_14216_export_alias_collides_local_class_no_ts2552_ts2749() {
     if !lib_files_available() {
         return;


### PR DESCRIPTION
Goal: hold

Regression-guard audit (round 6). No compiler source changes — parity-floor
protection.

## What changed
Four `fp_repro_audit_2026` witnesses were left `#[ignore]`d as "FP still
present", but the underlying false positives are **fixed on `main`**. The stale
`#[ignore]` markers are actively misleading (they cause re-investigation of
already-fixed bugs) and leave the fixes unguarded. Each was re-verified clean and
activated as a live regression guard:

- **#14213** (TS7006): curried arrow whose inner `(): Algebra =>` annotation
  contextually types the returned object literal's method params (`(x, y)`).
- **#14216** (TS2552/TS2749): a module-local `class Box` re-exported as
  `export { box as Box }` keeps the local class meaning for in-module value/type
  references.
- **#14229** (TS2304): `typeof <param>` inside a function-type-alias type
  predicate's asserted type resolves the signature's value parameter.
- **#14255** (TS2315): `export { Local as Capitalize }` records the rename only on
  the export surface; in-module `Capitalize<S>` keeps the intrinsic meaning.

These follow the round-5 audit (#14447, which activated #14231/#14261 in
`fp_repro_audit_2026_c.rs`) and the `fp_repro_audit_2026_b.rs` "Now fixed on
`main`; kept as a live regression guard" convention. Disjoint file from #14447,
so no conflict.

#14230 stays `#[ignore]`d (genuinely open; mapped symbol/string index
representation, tracked under #14381). #14220's witness also stays ignored — its
true root (an `interface`/class source not expanding the mapped `Record<any,any>`
`any`-waiver) overlaps #14381; root cause recorded on the issue.

## Verification
- `cargo test -p tsz-checker --test conformance_issues_types fp_repro_audit_2026`
  → 26 passed, 0 failed, 9 ignored (the 4 activated tests now run and pass; the
  remaining ignored set is the genuinely-open #14167/#14220/#14230/#14231/#14261/#14263).
- Each fix independently re-confirmed clean on its exact repro via a debug `tsz`
  CLI (`tsz -p`, strict): #14213/#14229/#14255 exit 0; #14216 exit 0 incl. the
  cross-file / rename / type-only adjacent variants.
- `cargo fmt -p tsz-checker -- --check` clean.
- Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01NKNj2F2mXUf1HbKSZGBzww

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKNj2F2mXUf1HbKSZGBzww)_