### PR TITLE
green(canary): promote io-ts to required compile-guard row

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1002,7 +1002,7 @@ jobs:
             filter: 'Mapped complex template keys'
           - label: projects
             timeout: 135
-            filter: 'utility-types/|ts-toolbelt/|ts-essentials/|utility-types-project|ts-toolbelt-project|ts-essentials-project|rxjs-project|type-fest-project|zod-project|kysely-project|comlink-project|vite-vanilla-ts-app|nextjs-fresh-app|nextjs'
+            filter: 'utility-types/|ts-toolbelt/|ts-essentials/|utility-types-project|ts-toolbelt-project|ts-essentials-project|rxjs-project|type-fest-project|zod-project|kysely-project|comlink-project|io-ts-project|vite-vanilla-ts-app|nextjs-fresh-app|nextjs'
           # Passing-canary perf rows. Isolated from the required `projects` shard
           # so timing the opt-in canary corpus (PERF_TIMED_CANARY_PROJECT_ROWS in
           # scripts/bench/project-rows.mjs) never spends the required shard's
@@ -1011,7 +1011,7 @@ jobs:
           # check green.
           - label: bench-canaries
             timeout: 135
-            filter: 'valibot-project|msw-project|effect-project|drizzle-orm-project|ts-rest-project|ofetch-project|ts-pattern-project|trpc-project|tanstack-query-project|tanstack-router-project|zustand-project|jotai-project|fp-ts-project|io-ts-project|immer-project|remeda-project|ts-morph-project|arktype-project|superstruct-project|runtypes-project|hotscript-project|typebox-project|class-transformer-project|type-graphql-project|neverthrow-project|xstate-project|mobx-project'
+            filter: 'valibot-project|msw-project|effect-project|drizzle-orm-project|ts-rest-project|ofetch-project|ts-pattern-project|trpc-project|tanstack-query-project|tanstack-router-project|zustand-project|jotai-project|fp-ts-project|immer-project|remeda-project|ts-morph-project|arktype-project|superstruct-project|runtypes-project|hotscript-project|typebox-project|class-transformer-project|type-graphql-project|neverthrow-project|xstate-project|mobx-project'
           # Application rows need their real dependency graph to produce a
           # meaningful tsz-vs-tsgo timing pair. Keep them in an optional shard:
           # clean rows get chart data when timing completes, but app install

--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -1055,7 +1055,6 @@ run_fp_ts_project_benchmarks() {
 }
 
 run_io_ts_project_benchmarks() {
-    should_run_compile_canary_project || return 0
     if ! is_benchmark_selected "io-ts-project"; then
         return
     fi

--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -35,6 +35,7 @@ TSZ_COMPILE_GUARD_REQUIRED_ROWS=(
   "vite-vanilla-ts-app"
   "nextjs-fresh-app"
   "comlink-project"
+  "io-ts-project"
   "infisical-project"
 )
 
@@ -55,7 +56,6 @@ TSZ_COMPILE_GUARD_CANARY_ROWS=(
   "zustand-project"
   "jotai-project"
   "fp-ts-project"
-  "io-ts-project"
   "immer-project"
   "remeda-project"
   "ts-morph-project"

--- a/scripts/bench/project-rows.mjs
+++ b/scripts/bench/project-rows.mjs
@@ -436,9 +436,8 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref_env: "IO_TS_REF",
     repo: "https://github.com/gcanti/io-ts.git",
     ref: "864a3a2f03c5d7b974afeb1da0faf46c21758779",
-    guard_set: "canary",
-    benchmark_set: "canary",
-    perf_timed: true,
+    guard_set: "required",
+    benchmark_set: "required",
     category: "external",
   },
   {


### PR DESCRIPTION
Goal: green

Promotes the **io-ts** project row from compile-guard canary to a required, must-pass compile-guard row. This is a reviewable GATE change — once merged, io-ts runs in the blocking `project-compile-guard` job on every PR. **Team: please confirm before queueing.**

## Structural rule

When a project's tsz diagnostics match `tsc` exactly (empty tsz-only delta vs the bundled tsc oracle), the row is eligible to graduate from the non-blocking canary set into the required compile gate. io-ts now satisfies this: on the required compile-guard path, tsz and the vendored tsc 6.0.3 oracle emit **byte-identical** diagnostics — only the shared `TS5101` `baseUrl`-deprecation that tsc also emits. The oracle subtracts it, leaving **0 tsz-only diagnostics**, so the row records green.

The oracle is guaranteed available in the required `project-compile-guard` job: the `type-challenges-solutions-project` row (required, earlier in the iteration order) installs `scripts/node_modules` (`typescript@^6.0.3`), so `scripts/node_modules/.bin/tsc` resolves before io-ts (index 9) is checked.

## Adjacent matrix (co-dependent files updated)

The required-row invariants are tightly coupled; a guard-required row must also be `benchmark_set: required` (the `test-project-rows.mjs` `allTrackedRows` / `COMPATIBILITY_CORPUS_ROWS` invariants reject a `guard=required, benchmark=canary` row). Promotion mirrors the infisical promotion (#13775):

- `scripts/bench/project-rows.mjs`: io-ts `guard_set`/`benchmark_set` `canary` -> `required`; drop `perf_timed` (required external rows time in the required `projects` shard, not the opt-in `bench-canaries` shard — matching zod/kysely/comlink, none of which set `perf_timed`).
- `scripts/bench/project-fixtures.sh`: move `io-ts-project` from the canary to the required static fallback array.
- `scripts/bench/bench-vs-tsgo.sh`: drop the `should_run_compile_canary_project` gate in `run_io_ts_project_benchmarks` so io-ts times in the default (required) benchmark flow (matches zod/kysely).
- `.github/workflows/bench.yml`: move `io-ts-project` from the `bench-canaries` shard filter to the required `projects` shard filter (keeps the `bench-canaries` filter == `PERF_TIMED_CANARY_PROJECT_ROWS` invariant after dropping `perf_timed`).

No ROADMAP change: the "Required project rows" table is a curated subset (comlink/infisical are also required and not listed); the metadata test only requires roadmap labels to be a subset of required rows.

## Verification

Stability / determinism (vendored tsc 6.0.3 oracle, `--noEmit`, io-ts `tsconfig.tsz-guard.json`):
- 3x direct `tsz` and 3x direct `tsc`: byte-identical output, **sha256 `2f0dad7c478c897afa15a2fd431468f3b86a4f337505f0187e490d8a002ea241`** both sides; tsz-only delta empty.
- 5x required compile-guard (forced oracle) + 3x CI-faithful guard (auto-resolved `scripts/node_modules/.bin/tsc`): all `exit=0`, `state=green`, `failures=0`, "io-ts-project matches tsc (0 tsz-only diagnostics)".
- io-ts compile is bounded (16 source files; ~8s on the debug binary, sub-second on the release/dist-fast binary CI uses) — no perf-shard risk.

Local guard/metadata/shard fingerprint tests (all green on this branch):
`test-project-rows.mjs`, `validate-project-metadata.mjs`, `test-validate-project-metadata.mjs`, `test-bench-workflow-cloudbuild-shards.mjs`, `test-bench-workflow-cloudbuild-prep.mjs`, `test-bench-workflow-micro-coverage.mjs`, `test-check-artifact-readiness.mjs`, `test-merge-results.mjs`, `test-benchmark-artifact-selection.mjs`, `test-gh-pages-benchmark-artifact-gate.mjs`, `test-project-row-summary.mjs`, `test-project-file-stats.mjs`, `project-row-summary.mjs`, `test-bench-readiness-banner.mjs`, `test-tsgo-winner-report.mjs`, `test-project-winner-regression-report.mjs`, `test-ci-health-benchmark-readiness.mjs`, `test-project-compile-guard-{readiness-artifacts,fingerprint,rss-sentinel}.mjs`, `test-project-compatibility.mjs`, and `arch/{arch_guard_project,arch_guard_projects,test_arch_guard_project,test_arch_guard_projects}.py` — 23+ validators, 0 failures.

No Rust touched (clippy/format N/A).

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
