### PR TITLE
fix(module-resolution): JSON-null exports/imports target blocks resolution (#13826)

### DIFF
--- a/crates/tsz-cli/src/driver/resolution/exports_imports.rs
+++ b/crates/tsz-cli/src/driver/resolution/exports_imports.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use crate::config::ResolvedCompilerOptions;
 use tsz::module_resolver::PackageType;
+use tsz_common::module_resolution::TargetMatch;
 use tsz_common::module_resolution::types_versions;
 
 #[allow(unused_imports)]
@@ -51,45 +52,50 @@ pub(crate) fn resolve_exports_subpath(
     subpath_key: &str,
     conditions: &[&str],
     compiler_version: SemVer,
-) -> Option<String> {
+) -> TargetMatch<String> {
     match exports {
-        serde_json::Value::String(value) => (subpath_key == ".").then(|| value.clone()),
+        serde_json::Value::String(value) => {
+            if subpath_key == "." {
+                TargetMatch::Resolved(value.clone())
+            } else {
+                TargetMatch::NotApplicable
+            }
+        }
+        // A bare `"exports": null` blocks the package entirely.
+        serde_json::Value::Null => TargetMatch::Blocked,
         serde_json::Value::Array(list) => {
             for entry in list {
-                if let Some(resolved) =
-                    resolve_exports_subpath(entry, subpath_key, conditions, compiler_version)
-                {
-                    return Some(resolved);
+                match resolve_exports_subpath(entry, subpath_key, conditions, compiler_version) {
+                    TargetMatch::NotApplicable => {}
+                    stop => return stop,
                 }
             }
-            None
+            TargetMatch::NotApplicable
         }
         serde_json::Value::Object(map) => {
             let has_subpath_keys = map.keys().any(|key| key.starts_with('.'));
             if has_subpath_keys {
-                if let Some(value) = map.get(subpath_key)
-                    && let Some(target) =
-                        resolve_exports_target(value, conditions, compiler_version)
-                {
-                    return Some(target);
+                // An exact subpath key is authoritative — its result (resolved,
+                // blocked, or miss) is returned without pattern fallthrough.
+                if let Some(value) = map.get(subpath_key) {
+                    return resolve_exports_target(value, conditions, compiler_version);
                 }
 
                 if let Some((wildcard, value)) =
                     find_best_subpath_pattern(map, |key| match_exports_subpath(key, subpath_key))
-                    && let Some(target) =
-                        resolve_exports_target(value, conditions, compiler_version)
                 {
-                    return Some(apply_exports_subpath(&target, &wildcard));
+                    return resolve_exports_target(value, conditions, compiler_version)
+                        .map(|target| apply_exports_subpath(&target, &wildcard));
                 }
 
-                None
+                TargetMatch::NotApplicable
             } else if subpath_key == "." {
                 resolve_exports_target(exports, conditions, compiler_version)
             } else {
-                None
+                TargetMatch::NotApplicable
             }
         }
-        _ => None,
+        _ => TargetMatch::NotApplicable,
     }
 }
 
@@ -97,44 +103,48 @@ pub(crate) fn resolve_exports_target(
     target: &serde_json::Value,
     conditions: &[&str],
     compiler_version: SemVer,
-) -> Option<String> {
+) -> TargetMatch<String> {
     match target {
-        serde_json::Value::String(value) => Some(value.clone()),
+        serde_json::Value::String(value) => TargetMatch::Resolved(value.clone()),
+        // An explicit JSON `null` reached through a matching condition or array
+        // element blocks the whole resolution (Node `PACKAGE_TARGET_RESOLVE`):
+        // it must not fall through to a sibling condition or an outer fallback.
+        serde_json::Value::Null => TargetMatch::Blocked,
         serde_json::Value::Array(list) => {
             for entry in list {
-                if let Some(resolved) = resolve_exports_target(entry, conditions, compiler_version)
-                {
-                    return Some(resolved);
+                match resolve_exports_target(entry, conditions, compiler_version) {
+                    TargetMatch::NotApplicable => {}
+                    stop => return stop,
                 }
             }
-            None
+            TargetMatch::NotApplicable
         }
         serde_json::Value::Object(map) => {
             // Process keys in insertion order (Node.js spec). For each key:
             // 1. Check if it's a plain condition match
             // 2. Check if it's a versioned condition like "types@>=1"
             for (key, value) in map {
-                // Check for versioned condition (e.g., "types@>=1")
-                if let Some(at_pos) = key.find('@') {
+                let matched = if let Some(at_pos) = key.find('@') {
                     let base_condition = &key[..at_pos];
                     let version_range = &key[at_pos + 1..];
-                    if conditions.contains(&base_condition)
+                    conditions.contains(&base_condition)
                         && types_versions_range_matches(version_range, compiler_version)
-                        && let Some(resolved) =
-                            resolve_exports_target(value, conditions, compiler_version)
-                    {
-                        return Some(resolved);
+                } else {
+                    conditions.contains(&key.as_str())
+                };
+                if matched {
+                    // A matching condition (including one mapping to `null`)
+                    // stops the search: Resolved and Blocked both short-circuit;
+                    // only NotApplicable continues to the next condition.
+                    match resolve_exports_target(value, conditions, compiler_version) {
+                        TargetMatch::NotApplicable => {}
+                        stop => return stop,
                     }
-                } else if conditions.contains(&key.as_str())
-                    && let Some(resolved) =
-                        resolve_exports_target(value, conditions, compiler_version)
-                {
-                    return Some(resolved);
                 }
             }
-            None
+            TargetMatch::NotApplicable
         }
-        _ => None,
+        _ => TargetMatch::NotApplicable,
     }
 }
 
@@ -158,14 +168,21 @@ pub(crate) fn resolve_imports_subpath_candidates_with_flavor(
         return Vec::new();
     }
 
+    // An exact key is authoritative (no pattern fallthrough). A `null` block and
+    // an empty miss both collapse to "no candidates" here — `#imports`
+    // resolution has no further fallback, so both terminate as NotFound.
     if let Some(value) = map.get(subpath_key) {
-        return resolve_target_candidates_with_flavor(value, conditions, compiler_version, false);
+        return resolve_target_candidates_with_flavor(value, conditions, compiler_version, false)
+            .into_option()
+            .unwrap_or_default();
     }
 
     if let Some((wildcard, value)) =
         find_best_subpath_pattern(map, |key| match_imports_subpath(key, subpath_key))
     {
         return resolve_target_candidates_with_flavor(value, conditions, compiler_version, false)
+            .into_option()
+            .unwrap_or_default()
             .into_iter()
             .map(|(target, is_types)| (apply_exports_subpath(&target, &wildcard), is_types))
             .collect();
@@ -184,57 +201,68 @@ fn resolve_target_candidates_with_flavor(
     conditions: &[&str],
     compiler_version: SemVer,
     is_types_condition: bool,
-) -> Vec<(String, bool)> {
+) -> TargetMatch<Vec<(String, bool)>> {
     match target {
-        serde_json::Value::String(value) => vec![(value.clone(), is_types_condition)],
+        serde_json::Value::String(value) => {
+            TargetMatch::Resolved(vec![(value.clone(), is_types_condition)])
+        }
+        // An explicit JSON `null` reached through a matching condition or array
+        // element blocks the whole `#imports` resolution: it must not fall
+        // through to a sibling condition or an outer fallback. The earlier
+        // `return Vec::new()` only blocked at the exact nesting level, so a
+        // *nested* null still let the enclosing conditional pick a later
+        // sibling — the bug this `Blocked` propagation fixes.
+        serde_json::Value::Null => TargetMatch::Blocked,
         serde_json::Value::Array(list) => {
+            // Disk probing is deferred to the caller, so matching targets are
+            // accumulated in order (the caller probes them in order). A matching
+            // `null` short-circuits the whole collection.
             let mut candidates = Vec::new();
             for entry in list {
-                candidates.extend(resolve_target_candidates_with_flavor(
+                match resolve_target_candidates_with_flavor(
                     entry,
                     conditions,
                     compiler_version,
                     is_types_condition,
-                ));
+                ) {
+                    TargetMatch::Resolved(found) => candidates.extend(found),
+                    TargetMatch::Blocked => return TargetMatch::Blocked,
+                    TargetMatch::NotApplicable => {}
+                }
             }
-            candidates
+            TargetMatch::from_candidates(candidates)
         }
         serde_json::Value::Object(map) => {
             let mut candidates = Vec::new();
             for (key, value) in map {
-                if let Some(at_pos) = key.find('@') {
+                let (matched, nested_is_types) = if let Some(at_pos) = key.find('@') {
                     let base_condition = &key[..at_pos];
                     let version_range = &key[at_pos + 1..];
-                    if conditions.contains(&base_condition)
-                        && types_versions_range_matches(version_range, compiler_version)
-                    {
-                        if value.is_null() {
-                            return Vec::new();
-                        }
-                        let nested_is_types = is_types_condition || base_condition == "types";
-                        candidates.extend(resolve_target_candidates_with_flavor(
-                            value,
-                            conditions,
-                            compiler_version,
-                            nested_is_types,
-                        ));
-                    }
-                } else if conditions.contains(&key.as_str()) {
-                    if value.is_null() {
-                        return Vec::new();
-                    }
-                    let nested_is_types = is_types_condition || key == "types";
-                    candidates.extend(resolve_target_candidates_with_flavor(
+                    let matched = conditions.contains(&base_condition)
+                        && types_versions_range_matches(version_range, compiler_version);
+                    (matched, is_types_condition || base_condition == "types")
+                } else {
+                    (
+                        conditions.contains(&key.as_str()),
+                        is_types_condition || key == "types",
+                    )
+                };
+                if matched {
+                    match resolve_target_candidates_with_flavor(
                         value,
                         conditions,
                         compiler_version,
                         nested_is_types,
-                    ));
+                    ) {
+                        TargetMatch::Resolved(found) => candidates.extend(found),
+                        TargetMatch::Blocked => return TargetMatch::Blocked,
+                        TargetMatch::NotApplicable => {}
+                    }
                 }
             }
-            candidates
+            TargetMatch::from_candidates(candidates)
         }
-        _ => Vec::new(),
+        _ => TargetMatch::NotApplicable,
     }
 }
 
@@ -421,6 +449,112 @@ mod tests {
         patch: 0,
     };
 
+    // --- JSON-`null` target blocking (Node `PACKAGE_TARGET_RESOLVE`) ---------
+    //
+    // A `null` reached through a *matching* condition / array element / exact
+    // subpath key blocks the whole resolution; it must not fall through to a
+    // sibling. A `null` on an UNMATCHED condition is never reached. Verified
+    // against bundled `tsc` 6.0.2. CommonJS conditions used here:
+    // `["require", "types", "node", "default"]`.
+    const CJS_CONDS: &[&str] = &["require", "types", "node", "default"];
+
+    #[test]
+    fn exports_target_nested_matching_null_blocks_outer_default() {
+        // node -> require:null blocks; neither the inner `default` nor the outer
+        // `default` is reached.
+        let exports = serde_json::json!({
+            "node": { "require": null, "default": "./inner.js" },
+            "default": "./outer.js"
+        });
+        assert_eq!(
+            resolve_exports_target(&exports, CJS_CONDS, TEST_VERSION),
+            TargetMatch::Blocked,
+        );
+    }
+
+    #[test]
+    fn exports_target_top_level_matching_null_blocks_sibling() {
+        let exports = serde_json::json!({ "node": null, "default": "./fallback.js" });
+        assert_eq!(
+            resolve_exports_target(&exports, CJS_CONDS, TEST_VERSION),
+            TargetMatch::Blocked,
+        );
+    }
+
+    #[test]
+    fn exports_target_null_on_unmatched_condition_resolves_default() {
+        // `import` is not a CommonJS condition, so its null is never reached.
+        let exports = serde_json::json!({ "import": null, "default": "./present.js" });
+        assert_eq!(
+            resolve_exports_target(&exports, CJS_CONDS, TEST_VERSION),
+            TargetMatch::Resolved("./present.js".to_string()),
+        );
+    }
+
+    #[test]
+    fn exports_target_null_array_element_blocks_remaining() {
+        let exports = serde_json::json!([null, "./real.js"]);
+        assert_eq!(
+            resolve_exports_target(&exports, CJS_CONDS, TEST_VERSION),
+            TargetMatch::Blocked,
+        );
+    }
+
+    #[test]
+    fn exports_subpath_exact_null_key_blocks_without_pattern_fallthrough() {
+        // `"./blocked": null` blocks even though `"./*"` would otherwise match;
+        // a different subpath still resolves through the wildcard.
+        let exports = serde_json::json!({ "./blocked": null, "./*": "./impl/*.js" });
+        assert_eq!(
+            resolve_exports_subpath(&exports, "./blocked", &["default"], TEST_VERSION),
+            TargetMatch::Blocked,
+        );
+        assert_eq!(
+            resolve_exports_subpath(&exports, "./allowed", &["default"], TEST_VERSION)
+                .into_option()
+                .as_deref(),
+            Some("./impl/allowed.js"),
+        );
+    }
+
+    #[test]
+    fn imports_candidates_nested_matching_null_blocks_and_yields_no_candidates() {
+        // The `#imports` twin: a nested matching null blocks the collection, so
+        // the outer `default` is never accumulated and the import is unresolved.
+        let imports = serde_json::json!({
+            "#feature": {
+                "node": { "require": null, "default": "./inner.js" },
+                "default": "./outer.js"
+            }
+        });
+        assert!(
+            resolve_imports_subpath_candidates_with_flavor(
+                &imports,
+                "#feature",
+                CJS_CONDS,
+                TEST_VERSION,
+            )
+            .is_empty(),
+            "nested matching null must yield no #imports candidates"
+        );
+    }
+
+    #[test]
+    fn imports_candidates_null_on_unmatched_condition_resolves_default() {
+        let imports = serde_json::json!({
+            "#feature": { "import": null, "default": "./present.js" }
+        });
+        assert_eq!(
+            resolve_imports_subpath_candidates_with_flavor(
+                &imports,
+                "#feature",
+                CJS_CONDS,
+                TEST_VERSION,
+            ),
+            vec![("./present.js".to_string(), false)],
+        );
+    }
+
     #[test]
     fn exports_subpath_specificity_uses_prefix_then_suffix_tuple() {
         // Covers each branch of the algorithm plus the regression cases:
@@ -460,6 +594,7 @@ mod tests {
         ] {
             assert_eq!(
                 resolve_exports_subpath(&exports, "./abc/abc", &["default"], TEST_VERSION)
+                    .into_option()
                     .as_deref(),
                 Some("./by-abc-star.js"),
             );
@@ -476,7 +611,9 @@ mod tests {
             "./b/*": "./second.js"
         });
         assert_eq!(
-            resolve_exports_subpath(&exports, "./a/x", &["default"], TEST_VERSION).as_deref(),
+            resolve_exports_subpath(&exports, "./a/x", &["default"], TEST_VERSION)
+                .into_option()
+                .as_deref(),
             Some("./first.js"),
         );
 
@@ -486,6 +623,7 @@ mod tests {
         });
         assert_eq!(
             resolve_exports_subpath(&exports_reversed, "./b/x", &["default"], TEST_VERSION)
+                .into_option()
                 .as_deref(),
             Some("./second.js"),
         );
@@ -522,7 +660,9 @@ mod tests {
         // TARGET resolves with no literal `*` left behind.
         let exports = serde_json::json!({ "./*": "./dist/*/*.js" });
         assert_eq!(
-            resolve_exports_subpath(&exports, "./button", &["default"], TEST_VERSION).as_deref(),
+            resolve_exports_subpath(&exports, "./button", &["default"], TEST_VERSION)
+                .into_option()
+                .as_deref(),
             Some("./dist/button/button.js"),
         );
     }

--- a/crates/tsz-cli/src/driver/resolution/package_resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution/package_resolution.rs
@@ -6,6 +6,7 @@ use crate::config::{ModuleResolutionKind, ResolvedCompilerOptions};
 use crate::fs::is_valid_module_file;
 use tsz::emitter::ModuleKind;
 use tsz::module_resolver::PackageType;
+use tsz_common::module_resolution::TargetMatch;
 
 #[allow(unused_imports)]
 use super::*;
@@ -198,18 +199,24 @@ pub(crate) fn resolve_node_module_specifier(
                             Some(value) => format!("./{value}"),
                             None => ".".to_string(),
                         };
+                        // A best-effort output-to-source remap: an explicit-null
+                        // block or a miss both mean "no remap here", so collapse
+                        // with `into_option`.
                         if let Some(target) = resolve_exports_subpath(
                             exports,
                             &subpath_key,
                             &conditions,
                             types_versions_compiler_version(options),
-                        ) && let Some(resolved) = try_remap_output_to_source(
-                            dir,
-                            &target,
-                            from_file,
-                            options,
-                            resolution_cache,
-                        ) {
+                        )
+                        .into_option()
+                            && let Some(resolved) = try_remap_output_to_source(
+                                dir,
+                                &target,
+                                from_file,
+                                options,
+                                resolution_cache,
+                            )
+                        {
                             return Some(resolved);
                         }
                     }
@@ -478,19 +485,30 @@ pub(crate) fn resolve_package_specifier(
                 Some(value) => format!("./{value}"),
                 None => ".".to_string(),
             };
-            if let Some(target) = resolve_exports_subpath(
+            match resolve_exports_subpath(
                 exports,
                 &subpath_key,
                 conditions,
                 types_versions_compiler_version(options),
-            ) && let Some(resolved) = resolve_export_entry(
-                package_root,
-                &target,
-                options,
-                package_type,
-                resolution_cache,
             ) {
-                return Some(resolved);
+                TargetMatch::Resolved(target) => {
+                    if let Some(resolved) = resolve_export_entry(
+                        package_root,
+                        &target,
+                        options,
+                        package_type,
+                        resolution_cache,
+                    ) {
+                        return Some(resolved);
+                    }
+                    // Target present but its file is missing — fall through to
+                    // the `typesVersions` fallback below (existing behavior).
+                }
+                // An explicit JSON `null` block is authoritative: the specifier
+                // is not exported, so `typesVersions`/file fallback must not be
+                // consulted. This matches Node `PACKAGE_TARGET_RESOLVE` / tsc.
+                TargetMatch::Blocked => return None,
+                TargetMatch::NotApplicable => {}
             }
             if let Some(types_versions) = package_json.types_versions.as_ref() {
                 let types_subpath = subpath.unwrap_or("index");

--- a/crates/tsz-cli/src/driver/resolution/type_packages.rs
+++ b/crates/tsz-cli/src/driver/resolution/type_packages.rs
@@ -413,7 +413,8 @@ pub(crate) fn resolve_type_package_entry_with_mode_and_cache(
     // Try the exports map first
     let compiler_version = types_versions_compiler_version(options);
     if let Some(exports) = &package_json.exports
-        && let Some(target) = resolve_exports_subpath(exports, ".", &conditions, compiler_version)
+        && let Some(target) =
+            resolve_exports_subpath(exports, ".", &conditions, compiler_version).into_option()
         && let Some(target_path) = package_relative_target_path(package_root, &target)
     {
         // Try to find a declaration file at the target

--- a/crates/tsz-common/src/module_resolution/mod.rs
+++ b/crates/tsz-common/src/module_resolution/mod.rs
@@ -41,16 +41,18 @@ pub enum TargetMatch<T> {
 impl<T> TargetMatch<T> {
     /// `true` only for [`TargetMatch::Blocked`].
     pub const fn is_blocked(&self) -> bool {
-        matches!(self, TargetMatch::Blocked)
+        matches!(self, Self::Blocked)
     }
 
     /// Map the payload of a [`TargetMatch::Resolved`], leaving the
     /// `Blocked`/`NotApplicable` control states untouched.
     pub fn map<U>(self, f: impl FnOnce(T) -> U) -> TargetMatch<U> {
+        use TargetMatch::{Blocked, NotApplicable, Resolved};
+
         match self {
-            TargetMatch::Resolved(value) => TargetMatch::Resolved(f(value)),
-            TargetMatch::Blocked => TargetMatch::Blocked,
-            TargetMatch::NotApplicable => TargetMatch::NotApplicable,
+            Resolved(value) => Resolved(f(value)),
+            Blocked => Blocked,
+            NotApplicable => NotApplicable,
         }
     }
 
@@ -59,8 +61,8 @@ impl<T> TargetMatch<T> {
     /// (both mean "this layer produced nothing").
     pub fn into_option(self) -> Option<T> {
         match self {
-            TargetMatch::Resolved(value) => Some(value),
-            TargetMatch::Blocked | TargetMatch::NotApplicable => None,
+            Self::Resolved(value) => Some(value),
+            Self::Blocked | Self::NotApplicable => None,
         }
     }
 }
@@ -72,9 +74,9 @@ impl<T> TargetMatch<Vec<T>> {
     /// block is reported separately by the caller and is never collapsed here.
     pub fn from_candidates(candidates: Vec<T>) -> Self {
         if candidates.is_empty() {
-            TargetMatch::NotApplicable
+            Self::NotApplicable
         } else {
-            TargetMatch::Resolved(candidates)
+            Self::Resolved(candidates)
         }
     }
 }

--- a/crates/tsz-common/src/module_resolution/mod.rs
+++ b/crates/tsz-common/src/module_resolution/mod.rs
@@ -7,3 +7,107 @@
 pub mod package_exports;
 pub mod path_identity;
 pub mod types_versions;
+
+/// Three-way outcome of resolving a single `package.json` `exports`/`imports`
+/// target, mirroring Node.js `PACKAGE_TARGET_RESOLVE` (which `tsc`
+/// reimplements in `moduleNameResolver`).
+///
+/// The Node algorithm distinguishes a deliberately *blocked* mapping from a
+/// mere *miss*, and the two have opposite control flow. Representing both as
+/// `Option::None` (a miss) is the defect this type fixes: a JSON `null` reached
+/// through a matching condition must stop the whole search, not fall through to
+/// a sibling.
+///
+/// - [`Resolved`](TargetMatch::Resolved): a usable target was produced.
+/// - [`Blocked`](TargetMatch::Blocked): an explicit JSON `null` was reached
+///   through a *matching* condition, array element, or exact subpath key. Per
+///   the spec this terminates the entire `exports`/`imports` resolution — it
+///   must NOT fall through to a sibling condition, a later array element, the
+///   enclosing conditional, or pattern matching. Both Node and `tsc` then
+///   report the specifier as not exported (`TS2307`).
+/// - [`NotApplicable`](TargetMatch::NotApplicable): no usable target here (the
+///   condition did not match, or the resolved file is missing). The caller
+///   keeps searching siblings/fallbacks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetMatch<T> {
+    /// A usable target was produced.
+    Resolved(T),
+    /// An explicit JSON `null` blocked the whole resolution.
+    Blocked,
+    /// No usable target here; keep searching.
+    NotApplicable,
+}
+
+impl<T> TargetMatch<T> {
+    /// `true` only for [`TargetMatch::Blocked`].
+    pub const fn is_blocked(&self) -> bool {
+        matches!(self, TargetMatch::Blocked)
+    }
+
+    /// Map the payload of a [`TargetMatch::Resolved`], leaving the
+    /// `Blocked`/`NotApplicable` control states untouched.
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> TargetMatch<U> {
+        match self {
+            TargetMatch::Resolved(value) => TargetMatch::Resolved(f(value)),
+            TargetMatch::Blocked => TargetMatch::Blocked,
+            TargetMatch::NotApplicable => TargetMatch::NotApplicable,
+        }
+    }
+
+    /// Collapse to an [`Option`], discarding the block/miss distinction. Only
+    /// safe at a boundary where a block and a miss lead to the same outcome
+    /// (both mean "this layer produced nothing").
+    pub fn into_option(self) -> Option<T> {
+        match self {
+            TargetMatch::Resolved(value) => Some(value),
+            TargetMatch::Blocked | TargetMatch::NotApplicable => None,
+        }
+    }
+}
+
+impl<T> TargetMatch<Vec<T>> {
+    /// Wrap an accumulated candidate list: a non-empty list is
+    /// [`TargetMatch::Resolved`]; an empty list is [`TargetMatch::NotApplicable`]
+    /// ("no matching condition produced a target — keep searching"). A `null`
+    /// block is reported separately by the caller and is never collapsed here.
+    pub fn from_candidates(candidates: Vec<T>) -> Self {
+        if candidates.is_empty() {
+            TargetMatch::NotApplicable
+        } else {
+            TargetMatch::Resolved(candidates)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TargetMatch;
+
+    #[test]
+    fn map_only_transforms_the_resolved_payload() {
+        assert_eq!(
+            TargetMatch::Resolved(2).map(|n| n * 3),
+            TargetMatch::Resolved(6)
+        );
+        assert_eq!(
+            TargetMatch::<i32>::Blocked.map(|n| n * 3),
+            TargetMatch::Blocked
+        );
+        assert_eq!(
+            TargetMatch::<i32>::NotApplicable.map(|n| n * 3),
+            TargetMatch::NotApplicable
+        );
+    }
+
+    #[test]
+    fn is_blocked_and_into_option_distinguish_block_from_miss() {
+        assert!(TargetMatch::<i32>::Blocked.is_blocked());
+        assert!(!TargetMatch::Resolved(1).is_blocked());
+        assert!(!TargetMatch::<i32>::NotApplicable.is_blocked());
+
+        // `into_option` deliberately collapses the block/miss distinction.
+        assert_eq!(TargetMatch::Resolved(7).into_option(), Some(7));
+        assert_eq!(TargetMatch::<i32>::Blocked.into_option(), None);
+        assert_eq!(TargetMatch::<i32>::NotApplicable.into_option(), None);
+    }
+}

--- a/crates/tsz-core/src/module_resolver/exports_imports.rs
+++ b/crates/tsz-core/src/module_resolver/exports_imports.rs
@@ -11,6 +11,7 @@ use crate::config::ModuleResolutionKind;
 use crate::module_resolver_helpers::*;
 use crate::span::Span;
 use std::path::{Component, Path, PathBuf};
+use tsz_common::module_resolution::TargetMatch;
 
 /// Returns true when an exports/imports pattern key literally ends with a
 /// TypeScript source extension. This mirrors tsc's `resolvedUsingTsExtension`
@@ -233,8 +234,14 @@ impl ModuleResolver {
             && !key.contains('*')
         {
             let resolved_using_ts_extension = key_ends_with_ts_extension(key);
+            // An exact key is authoritative — no pattern fallthrough. A `null`
+            // block and an empty miss both collapse to "no candidates" here
+            // (both terminate the `#imports` resolution as NotFound, which has
+            // no further fallback to fall through to), so `into_option` is safe.
             return self
                 .resolve_export_targets_to_strings(value, conditions, false)
+                .into_option()
+                .unwrap_or_default()
                 .into_iter()
                 .map(|(target, is_types)| (target, resolved_using_ts_extension, is_types))
                 .collect();
@@ -250,6 +257,8 @@ impl ModuleResolver {
             let is_directory_match = pattern.ends_with('/') && !pattern.contains('*');
             return self
                 .resolve_export_targets_to_strings(value, conditions, false)
+                .into_option()
+                .unwrap_or_default()
                 .into_iter()
                 .map(|(target, is_types)| {
                     (
@@ -279,49 +288,70 @@ impl ModuleResolver {
         value: &PackageExports,
         conditions: &[String],
         is_types_condition: bool,
-    ) -> Vec<(String, bool)> {
+    ) -> TargetMatch<Vec<(String, bool)>> {
         match value {
-            PackageExports::String(s) => vec![(s.clone(), is_types_condition)],
+            PackageExports::String(s) => {
+                TargetMatch::Resolved(vec![(s.clone(), is_types_condition)])
+            }
+            // An explicit JSON `null` reached through a matching condition or
+            // array element blocks the whole `#imports` resolution: it must not
+            // fall through to a sibling condition or an outer fallback. The
+            // earlier `return Vec::new()` only blocked at the exact nesting
+            // level, so a *nested* null still let the enclosing conditional pick
+            // a later sibling — the bug this `Blocked` propagation fixes.
+            PackageExports::Null => TargetMatch::Blocked,
             PackageExports::Conditional(cond_entries) => {
                 // Iterate condition map entries in JSON key order.
                 //
-                // The imports path now resolves collected targets through the
-                // spec'd runtime probe (`try_export_target`), which refuses to
-                // add an extension to an extensionless target under
+                // Disk probing is deferred to the caller, so — unlike the
+                // exports path — matching conditions are accumulated in order
+                // (the caller probes them in order, which yields the same
+                // first-existing-wins result as Node resolving each in turn and
+                // continuing past a missing file). A matching `null`, however,
+                // short-circuits the whole collection.
+                //
+                // The imports path resolves collected targets through the spec'd
+                // runtime probe (`try_export_target`), which refuses to add an
+                // extension to an extensionless target under
                 // Node16/NodeNext/Bundler. So — exactly like the exports path —
-                // it must thread `is_types_condition` so a versioned-types
-                // branch (`types`/`types@<range>`) keeps declaration-aware
-                // probing for an extensionless target.
+                // it threads `is_types_condition` so a versioned-types branch
+                // (`types`/`types@<range>`) keeps declaration-aware probing for
+                // an extensionless target.
                 let mut results = Vec::new();
                 for (key, nested) in cond_entries {
                     if self.condition_key_matches(key, conditions) {
-                        if matches!(nested, PackageExports::Null) {
-                            return Vec::new();
-                        }
                         let nested_is_types = is_types_condition || is_types_condition_key(key);
-                        results.extend(self.resolve_export_targets_to_strings(
+                        match self.resolve_export_targets_to_strings(
                             nested,
                             conditions,
                             nested_is_types,
-                        ));
+                        ) {
+                            TargetMatch::Resolved(found) => results.extend(found),
+                            TargetMatch::Blocked => return TargetMatch::Blocked,
+                            TargetMatch::NotApplicable => {}
+                        }
                     }
                 }
-                results
+                TargetMatch::from_candidates(results)
             }
             PackageExports::Array(elements) => {
                 // Array of fallback targets — preserve order so the caller can
                 // probe each syntactically applicable target.
                 let mut results = Vec::new();
                 for element in elements {
-                    results.extend(self.resolve_export_targets_to_strings(
+                    match self.resolve_export_targets_to_strings(
                         element,
                         conditions,
                         is_types_condition,
-                    ));
+                    ) {
+                        TargetMatch::Resolved(found) => results.extend(found),
+                        TargetMatch::Blocked => return TargetMatch::Blocked,
+                        TargetMatch::NotApplicable => {}
+                    }
                 }
-                results
+                TargetMatch::from_candidates(results)
             }
-            PackageExports::Map(_) | PackageExports::Null => Vec::new(), // Subpath maps not valid here
+            PackageExports::Map(_) => TargetMatch::NotApplicable, // Subpath maps not valid here
         }
     }
 
@@ -415,24 +445,27 @@ impl ModuleResolver {
         conditions: &[String],
         is_types_condition: bool,
         target_package_type: Option<super::PackageType>,
-    ) -> Option<(PathBuf, bool)> {
+    ) -> TargetMatch<(PathBuf, bool)> {
         match exports {
             PackageExports::String(s) => {
                 if subpath == "." {
-                    let resolved = package_relative_target_path(package_dir, s)?;
-                    if is_types_condition {
-                        if let Some(r) = self
-                            .try_types_entry(&resolved, target_package_type)
+                    let Some(resolved) = package_relative_target_path(package_dir, s) else {
+                        return TargetMatch::NotApplicable;
+                    };
+                    let probed = if is_types_condition {
+                        self.try_types_entry(&resolved, target_package_type)
                             .or_else(|| self.try_export_target(&resolved, target_package_type))
-                        {
-                            return Some((r, false));
-                        }
-                    } else if let Some(r) = self.try_export_target(&resolved, target_package_type) {
-                        return Some((r, false));
+                    } else {
+                        self.try_export_target(&resolved, target_package_type)
+                    };
+                    if let Some(r) = probed {
+                        return TargetMatch::Resolved((r, false));
                     }
                 }
-                None
+                TargetMatch::NotApplicable
             }
+            // A bare `"exports": null` blocks the package entirely.
+            PackageExports::Null => TargetMatch::Blocked,
             PackageExports::Map(map) => {
                 // First try exact match.
                 // Keys containing '*' are pattern keys and must not be treated as exact matches.
@@ -440,6 +473,9 @@ impl ModuleResolver {
                     && !key.contains('*')
                 {
                     let key_uses_ts = key_ends_with_ts_extension(key);
+                    // An exact subpath key is authoritative: its result (resolved,
+                    // blocked, or miss) is returned without pattern fallthrough,
+                    // matching Node `PACKAGE_IMPORTS_EXPORTS_RESOLVE`.
                     return self
                         .resolve_export_value_with_conditions(
                             package_dir,
@@ -466,29 +502,25 @@ impl ModuleResolver {
                     let substituted_value =
                         substitute_wildcard_in_exports(value, &wildcard, is_directory_match);
                     let key_uses_ts = key_ends_with_ts_extension(pattern);
-                    if let Some(resolved) = self.resolve_export_value_with_conditions(
-                        package_dir,
-                        &substituted_value,
-                        conditions,
-                        is_types_condition,
-                        target_package_type,
-                    ) {
-                        return Some((resolved, key_uses_ts));
-                    }
+                    return self
+                        .resolve_export_value_with_conditions(
+                            package_dir,
+                            &substituted_value,
+                            conditions,
+                            is_types_condition,
+                            target_package_type,
+                        )
+                        .map(|p| (p, key_uses_ts));
                 }
 
-                None
+                TargetMatch::NotApplicable
             }
             PackageExports::Conditional(cond_entries) => {
                 // Iterate condition map entries in JSON key order (not our conditions order)
                 for (key, value) in cond_entries {
                     if self.condition_key_matches(key, conditions) {
                         let is_types = is_types_condition || is_types_condition_key(key);
-                        // null means explicitly blocked - stop here
-                        if matches!(value, PackageExports::Null) {
-                            return None;
-                        }
-                        if let Some(resolved) = self.resolve_package_exports_with_conditions(
+                        match self.resolve_package_exports_with_conditions(
                             package_dir,
                             value,
                             subpath,
@@ -496,16 +528,18 @@ impl ModuleResolver {
                             is_types,
                             target_package_type,
                         ) {
-                            return Some(resolved);
+                            // Resolved or Blocked both stop the search.
+                            TargetMatch::NotApplicable => {}
+                            stop => return stop,
                         }
                     }
                 }
-                None
+                TargetMatch::NotApplicable
             }
             PackageExports::Array(elements) => {
                 // Array of fallback targets — try each element in order
                 for element in elements {
-                    if let Some(resolved) = self.resolve_package_exports_with_conditions(
+                    match self.resolve_package_exports_with_conditions(
                         package_dir,
                         element,
                         subpath,
@@ -513,12 +547,12 @@ impl ModuleResolver {
                         is_types_condition,
                         target_package_type,
                     ) {
-                        return Some(resolved);
+                        TargetMatch::NotApplicable => {}
+                        stop => return stop,
                     }
                 }
-                None
+                TargetMatch::NotApplicable
             }
-            PackageExports::Null => None,
         }
     }
 
@@ -526,6 +560,12 @@ impl ModuleResolver {
     ///
     /// This walks the value side of an exports entry only — it does not touch
     /// subpath keys, so it does not contribute to `resolved_using_ts_extension`.
+    ///
+    /// Returns a [`TargetMatch`]: a probed path, an explicit-`null` block, or
+    /// "not applicable" (condition unmatched / file missing). A block produced
+    /// by a JSON `null` reached through a matching condition or array element
+    /// short-circuits every enclosing arm so resolution never falls through to
+    /// a sibling, matching Node `PACKAGE_TARGET_RESOLVE` / tsc.
     pub(super) fn resolve_export_value_with_conditions(
         &self,
         package_dir: &Path,
@@ -533,54 +573,62 @@ impl ModuleResolver {
         conditions: &[String],
         is_types_condition: bool,
         target_package_type: Option<super::PackageType>,
-    ) -> Option<PathBuf> {
+    ) -> TargetMatch<PathBuf> {
         match value {
             PackageExports::String(s) => {
-                let resolved = package_relative_target_path(package_dir, s)?;
-                if is_types_condition {
+                let Some(resolved) = package_relative_target_path(package_dir, s) else {
+                    return TargetMatch::NotApplicable;
+                };
+                let probed = if is_types_condition {
                     self.try_types_entry(&resolved, target_package_type)
                         .or_else(|| self.try_export_target(&resolved, target_package_type))
                 } else {
                     self.try_export_target(&resolved, target_package_type)
+                };
+                match probed {
+                    Some(path) => TargetMatch::Resolved(path),
+                    None => TargetMatch::NotApplicable,
                 }
             }
+            // An explicit JSON `null` reached through a matching condition or
+            // array element blocks the whole resolution.
+            PackageExports::Null => TargetMatch::Blocked,
             PackageExports::Conditional(cond_entries) => {
                 // Iterate condition map entries in JSON key order
                 for (key, nested) in cond_entries {
                     if self.condition_key_matches(key, conditions) {
                         let is_types = is_types_condition || is_types_condition_key(key);
-                        // null means explicitly blocked - stop here
-                        if matches!(nested, PackageExports::Null) {
-                            return None;
-                        }
-                        if let Some(resolved) = self.resolve_export_value_with_conditions(
+                        match self.resolve_export_value_with_conditions(
                             package_dir,
                             nested,
                             conditions,
                             is_types,
                             target_package_type,
                         ) {
-                            return Some(resolved);
+                            // Resolved or Blocked both stop the search.
+                            TargetMatch::NotApplicable => {}
+                            stop => return stop,
                         }
                     }
                 }
-                None
+                TargetMatch::NotApplicable
             }
             PackageExports::Array(elements) => {
                 for element in elements {
-                    if let Some(resolved) = self.resolve_export_value_with_conditions(
+                    match self.resolve_export_value_with_conditions(
                         package_dir,
                         element,
                         conditions,
                         is_types_condition,
                         target_package_type,
                     ) {
-                        return Some(resolved);
+                        TargetMatch::NotApplicable => {}
+                        stop => return stop,
                     }
                 }
-                None
+                TargetMatch::NotApplicable
             }
-            PackageExports::Map(_) | PackageExports::Null => None,
+            PackageExports::Map(_) => TargetMatch::NotApplicable,
         }
     }
 

--- a/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
+++ b/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
@@ -12,6 +12,7 @@ use crate::config::ModuleResolutionKind;
 use crate::module_resolver_helpers::*;
 use crate::span::Span;
 use std::path::{Path, PathBuf};
+use tsz_common::module_resolution::TargetMatch;
 
 const PACKAGE_INDEX_FALLBACK_EXTENSIONS: &[&str] = &["ts", "tsx", "d.ts"];
 const PACKAGE_INDEX_FALLBACK_ALLOW_JS_EXTENSIONS: &[&str] = &["ts", "tsx", "d.ts", "js", "jsx"];
@@ -424,6 +425,9 @@ impl ModuleResolver {
             None => ".".to_string(),
         };
 
+        // Both an explicit-`null` block and a plain miss mean the `exports` map
+        // did not yield a path, so the search must stop in the authoritative
+        // (Node16/NodeNext/Bundler) modes — collapse them with `into_option`.
         self.resolve_package_exports_with_conditions(
             package_dir,
             &exports,
@@ -432,6 +436,7 @@ impl ModuleResolver {
             false,
             target_pt,
         )
+        .into_option()
         .is_none()
     }
 
@@ -593,46 +598,58 @@ impl ModuleResolver {
             if self.resolve_package_json_exports
                 && let Some(exports) = &package_json.exports
             {
-                if let Some((resolved, resolved_using_ts_extension)) = self
-                    .resolve_package_exports_with_conditions(
-                        package_dir,
-                        exports,
-                        &subpath_key,
-                        conditions,
-                        false,
-                        target_pt,
-                    )
-                {
-                    return Ok(ResolvedModule {
-                        resolved_path: resolved.clone(),
-                        resolved_using_ts_extension,
-                        is_external: true,
-                        package_name: Some(package_json.name.clone().unwrap_or_default()),
-                        original_specifier: original_specifier.to_string(),
-                        extension: ModuleExtension::from_path(&resolved),
-                    });
-                }
-                // In Node16/NodeNext/Bundler an `exports` field is authoritative:
-                // a subpath that the `exports` map does not expose is unresolved,
-                // and `typesVersions` must NOT be consulted as a fallback. This
-                // mirrors tsc's `loadModuleFromSpecificNodeModulesDirectory`, where
-                // `loadModuleFromExports` returns unconditionally when `exports` is
-                // present ("package exports are higher priority than
-                // file/directory/typesVersions lookups and ... blocks them"), so the
-                // `versionPaths`/`typesVersions` branch is never reached. The legacy
-                // `typesVersions` field only applies to packages WITHOUT an `exports`
-                // map (handled below).
-                if matches!(
-                    self.resolution_kind,
-                    ModuleResolutionKind::Node16
-                        | ModuleResolutionKind::NodeNext
-                        | ModuleResolutionKind::Bundler
+                match self.resolve_package_exports_with_conditions(
+                    package_dir,
+                    exports,
+                    &subpath_key,
+                    conditions,
+                    false,
+                    target_pt,
                 ) {
-                    return Err(ResolutionFailure::NotFound {
-                        specifier: original_specifier.to_string(),
-                        containing_file: containing_file.to_string(),
-                        span: specifier_span,
-                    });
+                    TargetMatch::Resolved((resolved, resolved_using_ts_extension)) => {
+                        return Ok(ResolvedModule {
+                            resolved_path: resolved.clone(),
+                            resolved_using_ts_extension,
+                            is_external: true,
+                            package_name: Some(package_json.name.clone().unwrap_or_default()),
+                            original_specifier: original_specifier.to_string(),
+                            extension: ModuleExtension::from_path(&resolved),
+                        });
+                    }
+                    // An explicit JSON `null` blocks the subpath in every mode:
+                    // the package author opted it out, so it is not exported and
+                    // `typesVersions`/file fallback must not be consulted.
+                    TargetMatch::Blocked => {
+                        return Err(ResolutionFailure::NotFound {
+                            specifier: original_specifier.to_string(),
+                            containing_file: containing_file.to_string(),
+                            span: specifier_span,
+                        });
+                    }
+                    // In Node16/NodeNext/Bundler an `exports` field is authoritative:
+                    // a subpath that the `exports` map does not expose is unresolved,
+                    // and `typesVersions` must NOT be consulted as a fallback. This
+                    // mirrors tsc's `loadModuleFromSpecificNodeModulesDirectory`, where
+                    // `loadModuleFromExports` returns unconditionally when `exports` is
+                    // present ("package exports are higher priority than
+                    // file/directory/typesVersions lookups and ... blocks them"), so the
+                    // `versionPaths`/`typesVersions` branch is never reached. The legacy
+                    // `typesVersions` field only applies to packages WITHOUT an `exports`
+                    // map (handled below).
+                    TargetMatch::NotApplicable => {
+                        if matches!(
+                            self.resolution_kind,
+                            ModuleResolutionKind::Node16
+                                | ModuleResolutionKind::NodeNext
+                                | ModuleResolutionKind::Bundler
+                        ) {
+                            return Err(ResolutionFailure::NotFound {
+                                specifier: original_specifier.to_string(),
+                                containing_file: containing_file.to_string(),
+                                span: specifier_span,
+                            });
+                        }
+                    }
                 }
             }
 
@@ -705,38 +722,49 @@ impl ModuleResolver {
         if self.resolve_package_json_exports
             && let Some(exports) = &package_json.exports
         {
-            if let Some((resolved, resolved_using_ts_extension)) = self
-                .resolve_package_exports_with_conditions(
-                    package_dir,
-                    exports,
-                    ".",
-                    conditions,
-                    false,
-                    target_pt,
-                )
-            {
-                return Ok(ResolvedModule {
-                    resolved_path: resolved.clone(),
-                    resolved_using_ts_extension,
-                    is_external: true,
-                    package_name: Some(package_json.name.clone().unwrap_or_default()),
-                    original_specifier: original_specifier.to_string(),
-                    extension: ModuleExtension::from_path(&resolved),
-                });
-            }
-            // In Node16/NodeNext/Bundler, exports field is authoritative.
-            // Return NotFound (TS2307) — the driver handles Classic→TS2792 conversion.
-            if matches!(
-                self.resolution_kind,
-                ModuleResolutionKind::Node16
-                    | ModuleResolutionKind::NodeNext
-                    | ModuleResolutionKind::Bundler
+            match self.resolve_package_exports_with_conditions(
+                package_dir,
+                exports,
+                ".",
+                conditions,
+                false,
+                target_pt,
             ) {
-                return Err(ResolutionFailure::NotFound {
-                    specifier: original_specifier.to_string(),
-                    containing_file: containing_file.to_string(),
-                    span: specifier_span,
-                });
+                TargetMatch::Resolved((resolved, resolved_using_ts_extension)) => {
+                    return Ok(ResolvedModule {
+                        resolved_path: resolved.clone(),
+                        resolved_using_ts_extension,
+                        is_external: true,
+                        package_name: Some(package_json.name.clone().unwrap_or_default()),
+                        original_specifier: original_specifier.to_string(),
+                        extension: ModuleExtension::from_path(&resolved),
+                    });
+                }
+                // An explicit `"."` -> `null` block opts the entry point out in
+                // every mode (not exported).
+                TargetMatch::Blocked => {
+                    return Err(ResolutionFailure::NotFound {
+                        specifier: original_specifier.to_string(),
+                        containing_file: containing_file.to_string(),
+                        span: specifier_span,
+                    });
+                }
+                // In Node16/NodeNext/Bundler, exports field is authoritative.
+                // Return NotFound (TS2307) — the driver handles Classic→TS2792 conversion.
+                TargetMatch::NotApplicable => {
+                    if matches!(
+                        self.resolution_kind,
+                        ModuleResolutionKind::Node16
+                            | ModuleResolutionKind::NodeNext
+                            | ModuleResolutionKind::Bundler
+                    ) {
+                        return Err(ResolutionFailure::NotFound {
+                            specifier: original_specifier.to_string(),
+                            containing_file: containing_file.to_string(),
+                            span: specifier_span,
+                        });
+                    }
+                }
             }
         }
 

--- a/crates/tsz-core/src/module_resolver/self_reference.rs
+++ b/crates/tsz-core/src/module_resolver/self_reference.rs
@@ -8,6 +8,7 @@ use crate::config::ModuleResolutionKind;
 use crate::module_resolver_helpers::cached_is_file;
 use crate::span::Span;
 use std::path::Path;
+use tsz_common::module_resolution::TargetMatch;
 
 /// Result of trying to resolve a self-reference
 pub(super) enum SelfReferenceResultV2 {
@@ -70,42 +71,52 @@ impl ModuleResolver {
                         };
 
                         let target_pt = self.target_package_type_from_json(&package_json, None);
-                        if let Some((resolved, resolved_using_ts_extension)) = self
-                            .resolve_package_exports_with_conditions(
-                                &current,
-                                exports,
-                                &subpath_key,
-                                conditions,
-                                false,
-                                target_pt,
-                            )
-                        {
-                            // Self-reference resolved successfully via exports.
-                            // This includes .ts files found via .js -> .ts extension
-                            // substitution, which is the standard Node16/NodeNext
-                            // behavior for source-to-output mapping.
-                            //
-                            // `resolved_using_ts_extension` is propagated from the
-                            // matched export pattern key: when the package author
-                            // wrote `"./*.ts": ...` in exports, the import path's
-                            // `.ts` was consumed by the exports map (rather than
-                            // preserved through to the resolved file), suppressing
-                            // TS2877 in the checker's import-extension gate.
-                            return SelfReferenceResultV2::Resolved(ResolvedModule {
-                                resolved_path: resolved.clone(),
-                                resolved_using_ts_extension,
-                                is_external: false,
-                                package_name: Some(package_name.to_string()),
-                                original_specifier: original_specifier.to_string(),
-                                extension: ModuleExtension::from_path(&resolved),
-                            });
+                        match self.resolve_package_exports_with_conditions(
+                            &current,
+                            exports,
+                            &subpath_key,
+                            conditions,
+                            false,
+                            target_pt,
+                        ) {
+                            TargetMatch::Resolved((resolved, resolved_using_ts_extension)) => {
+                                // Self-reference resolved successfully via exports.
+                                // This includes .ts files found via .js -> .ts extension
+                                // substitution, which is the standard Node16/NodeNext
+                                // behavior for source-to-output mapping.
+                                //
+                                // `resolved_using_ts_extension` is propagated from the
+                                // matched export pattern key: when the package author
+                                // wrote `"./*.ts": ...` in exports, the import path's
+                                // `.ts` was consumed by the exports map (rather than
+                                // preserved through to the resolved file), suppressing
+                                // TS2877 in the checker's import-extension gate.
+                                return SelfReferenceResultV2::Resolved(ResolvedModule {
+                                    resolved_path: resolved.clone(),
+                                    resolved_using_ts_extension,
+                                    is_external: false,
+                                    package_name: Some(package_name.to_string()),
+                                    original_specifier: original_specifier.to_string(),
+                                    extension: ModuleExtension::from_path(&resolved),
+                                });
+                            }
+                            // An explicit JSON `null` block is a definitive
+                            // "not exported" (TS2307), never the ambiguous-root
+                            // diagnostic (TS2209): the author opted the specifier
+                            // out, so the result does not depend on `rootDir`.
+                            TargetMatch::Blocked => {
+                                return SelfReferenceResultV2::ExportsFailed;
+                            }
+                            TargetMatch::NotApplicable => {
+                                // Self-reference detected but exports didn't resolve to
+                                // an existing file. Check if this is due to ambiguous
+                                // project root (TS2209).
+                                if self.root_dir.is_none() && self.out_dir.is_none() {
+                                    return SelfReferenceResultV2::AmbiguousRoot;
+                                }
+                                return SelfReferenceResultV2::ExportsFailed;
+                            }
                         }
-                        // Self-reference detected but exports didn't resolve to an existing file
-                        // Check if this is due to ambiguous project root (TS2209)
-                        if self.root_dir.is_none() && self.out_dir.is_none() {
-                            return SelfReferenceResultV2::AmbiguousRoot;
-                        }
-                        return SelfReferenceResultV2::ExportsFailed;
                     }
                     // Name matches but no exports field - not a self-reference for Node16+
                     // Fall through to NotSelfReference

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -20,6 +20,7 @@ mod mixed_esm_cjs_exports;
 mod module_extension;
 mod node16_modes;
 mod node_protocol_builtins;
+mod null_target_blocking;
 mod package_exports_imports;
 mod package_json_data;
 mod path_existence_reset;

--- a/crates/tsz-core/src/module_resolver/tests/null_target_blocking.rs
+++ b/crates/tsz-core/src/module_resolver/tests/null_target_blocking.rs
@@ -1,0 +1,220 @@
+//! JSON-`null` `exports`/`imports` target blocking.
+//!
+//! Node.js `PACKAGE_TARGET_RESOLVE` (which `tsc` reimplements) treats a `null`
+//! target reached through a *matching* condition, array element, or exact
+//! subpath key as a **block**: the whole `exports`/`imports` resolution stops
+//! and the specifier is reported as not exported (`TS2307`). The block must NOT
+//! fall through to a sibling condition, a later array element, the enclosing
+//! conditional, or pattern matching.
+//!
+//! Each case below is verified byte-for-byte against bundled `tsc` 6.0.2
+//! (`module: node16`). Package and file names are varied across cases so the
+//! behavior is keyed on structure, not on any identifier.
+
+use super::super::*;
+use super::fixtures::TempFixture;
+
+/// Resolve `specifier` against a single `node_modules/<pkg>` package whose
+/// `package.json` is `package_json`, importing from a `.cts` file (CommonJS, so
+/// the active conditions are `types`, `node`, `require`, `default`). `targets`
+/// are written as empty `.d.ts` files inside the package.
+fn resolve_cjs(
+    pkg: &str,
+    package_json: &str,
+    targets: &[&str],
+    specifier: &str,
+) -> Result<ResolvedModule, ResolutionFailure> {
+    let fixture = TempFixture::new();
+    fixture.write(format!("node_modules/{pkg}/package.json"), package_json);
+    for target in targets {
+        fixture.write(
+            format!("node_modules/{pkg}/{target}"),
+            "export declare const value: number;",
+        );
+    }
+    let importer = fixture.write("main.cts", "export {};");
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        resolve_package_json_exports: true,
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+    resolver.resolve(specifier, &importer, Span::new(0, specifier.len() as u32))
+}
+
+#[test]
+fn nested_matching_null_blocks_and_does_not_fall_through_to_sibling() {
+    // `require` (matched) maps to null INSIDE the matched `node` branch. tsc:
+    // node -> require -> null -> blocked; neither the inner `default` nor the
+    // outer `default` is reached. This is the canary reduction that motivated
+    // the fix — a *nested* null whose block previously leaked to the outer
+    // `default`.
+    let result = resolve_cjs(
+        "alpha-lib",
+        r#"{"name":"alpha-lib","exports":{".":{"node":{"require":null,"default":"./inner.js"},"default":"./outer.js"}}}"#,
+        &["inner.d.ts", "outer.d.ts"],
+        "alpha-lib",
+    );
+    assert!(
+        matches!(result, Err(ResolutionFailure::NotFound { .. })),
+        "nested matching null must block the whole resolution, got {result:?}"
+    );
+}
+
+#[test]
+fn top_level_matching_null_blocks_sibling_default() {
+    // `node` (matched) maps directly to null; the sibling `default` must not be
+    // tried. tsc: TS2307.
+    let result = resolve_cjs(
+        "bravo-kit",
+        r#"{"name":"bravo-kit","exports":{".":{"node":null,"default":"./fallback.js"}}}"#,
+        &["fallback.d.ts"],
+        "bravo-kit",
+    );
+    assert!(
+        matches!(result, Err(ResolutionFailure::NotFound { .. })),
+        "top-level matching null must block the sibling default, got {result:?}"
+    );
+}
+
+#[test]
+fn null_on_non_matching_condition_does_not_block() {
+    // `import` does NOT match a CommonJS importer, so its null is never reached
+    // and `default` resolves normally. tsc: resolves `./present.d.ts`.
+    let result = resolve_cjs(
+        "charlie-pkg",
+        r#"{"name":"charlie-pkg","exports":{".":{"import":null,"default":"./present.js"}}}"#,
+        &["present.d.ts"],
+        "charlie-pkg",
+    )
+    .expect("a null on an unmatched condition must not block the matched default");
+    assert!(
+        result.resolved_path.ends_with("present.d.ts"),
+        "expected ./present.d.ts, got {}",
+        result.resolved_path.display()
+    );
+}
+
+#[test]
+fn null_array_element_blocks_remaining_elements() {
+    // A null FIRST element of a fallback array blocks the array — the later
+    // `./real.js` is never tried. tsc: TS2307.
+    let result = resolve_cjs(
+        "delta-mod",
+        r#"{"name":"delta-mod","exports":{".":[null,"./real.js"]}}"#,
+        &["real.d.ts"],
+        "delta-mod",
+    );
+    assert!(
+        matches!(result, Err(ResolutionFailure::NotFound { .. })),
+        "a null array element must block the remaining fallbacks, got {result:?}"
+    );
+}
+
+#[test]
+fn missing_string_target_in_array_falls_through_to_next() {
+    // A *missing file* (not a null) is a miss, not a block: the array falls
+    // through to the next element. tsc: resolves `./real.d.ts`.
+    let result = resolve_cjs(
+        "echo-tools",
+        r#"{"name":"echo-tools","exports":{".":["./absent.js","./real.js"]}}"#,
+        &["real.d.ts"],
+        "echo-tools",
+    )
+    .expect("a missing string target must fall through to the next array element");
+    assert!(
+        result.resolved_path.ends_with("real.d.ts"),
+        "expected ./real.d.ts, got {}",
+        result.resolved_path.display()
+    );
+}
+
+#[test]
+fn exact_subpath_null_blocks_without_pattern_fallthrough() {
+    // `"./blocked": null` blocks the `blocked` subpath even though a `"./*"`
+    // wildcard would otherwise match it; the exact key is authoritative. A
+    // different subpath still resolves through the wildcard, proving the block
+    // is scoped to the exact key, not the whole map.
+    let package_json =
+        r#"{"name":"foxtrot-suite","exports":{"./blocked":null,"./*":"./impl/*.js"}}"#;
+
+    let blocked = resolve_cjs(
+        "foxtrot-suite",
+        package_json,
+        &["impl/blocked.d.ts", "impl/allowed.d.ts"],
+        "foxtrot-suite/blocked",
+    );
+    assert!(
+        matches!(blocked, Err(ResolutionFailure::NotFound { .. })),
+        "an exact null subpath key must block without pattern fallthrough, got {blocked:?}"
+    );
+
+    let allowed = resolve_cjs(
+        "foxtrot-suite",
+        package_json,
+        &["impl/blocked.d.ts", "impl/allowed.d.ts"],
+        "foxtrot-suite/allowed",
+    )
+    .expect("a non-blocked subpath must still resolve through the wildcard");
+    assert!(
+        allowed.resolved_path.ends_with("impl/allowed.d.ts"),
+        "expected impl/allowed.d.ts, got {}",
+        allowed.resolved_path.display()
+    );
+}
+
+/// Resolve a `#`-prefixed import against the importer's own package scope.
+fn resolve_imports_cjs(
+    package_json: &str,
+    targets: &[&str],
+    specifier: &str,
+) -> Result<ResolvedModule, ResolutionFailure> {
+    let fixture = TempFixture::new();
+    fixture.write("package.json", package_json);
+    for target in targets {
+        fixture.write(target, "export declare const value: number;");
+    }
+    let importer = fixture.write("main.cts", "export {};");
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        resolve_package_json_imports: true,
+        resolve_package_json_exports: true,
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+    resolver.resolve(specifier, &importer, Span::new(0, specifier.len() as u32))
+}
+
+#[test]
+fn imports_nested_matching_null_blocks_outer_default() {
+    // The `#imports` twin of `nested_matching_null_...`: a nested matching null
+    // must block the outer `default`, not fall through to it. tsc: TS2307.
+    let result = resolve_imports_cjs(
+        r##"{"name":"golf-app","imports":{"#feature":{"node":{"require":null,"default":"./inner.js"},"default":"./outer.js"}}}"##,
+        &["inner.d.ts", "outer.d.ts"],
+        "#feature",
+    );
+    assert!(
+        matches!(result, Err(ResolutionFailure::NotFound { .. })),
+        "nested matching null must block the #imports resolution, got {result:?}"
+    );
+}
+
+#[test]
+fn imports_null_on_non_matching_condition_resolves_default() {
+    // `import` does not match a CommonJS importer, so its null is unreached and
+    // `default` resolves. tsc: resolves `./present.d.ts`.
+    let result = resolve_imports_cjs(
+        r##"{"name":"hotel-app","imports":{"#feature":{"import":null,"default":"./present.js"}}}"##,
+        &["present.d.ts"],
+        "#feature",
+    )
+    .expect("a null on an unmatched condition must not block the matched default");
+    assert!(
+        result.resolved_path.ends_with("present.d.ts"),
+        "expected ./present.d.ts, got {}",
+        result.resolved_path.display()
+    );
+}


### PR DESCRIPTION
Goal: hold

Fixes a reproducible `exports`/`imports` resolution slice of #13826.

## Structural rule

When a `package.json` `exports`/`imports` target reached **through a matching
condition, array element, or exact subpath key** is JSON `null`, Node
`PACKAGE_TARGET_RESOLVE` (which `tsc` reimplements in `moduleNameResolver`)
treats it as a **block**: the whole resolution stops and the specifier is
reported not exported (`TS2307`). The block must NOT fall through to a sibling
condition, a later array element, the enclosing conditional, or pattern
matching. A `null` on a **non-matching** condition is never reached and does not
block.

tsz encoded "blocked" and "missing" with the same value (`Option::None` /
empty `Vec`), two states with opposite control flow. So a **nested** `null`
leaked to a sibling (`{"node":{"require":null,"default":"./n.js"},"default":"./d.js"}`
wrongly resolved `./n.js`/`./d.js`), and the **CLI driver never blocked on
`null` at all** (`resolve_exports_target` routed `null` through its `_ => None`
arm and continued to the next condition).

## Owner layer

Module resolver, both live layers:

- **tsz-core** `ModuleResolver` (over the typed `PackageExports` enum):
  `crates/tsz-core/src/module_resolver/{exports_imports,node_modules_resolution,self_reference}.rs`.
- **tsz-cli** driver resolver (over `serde_json::Value`):
  `crates/tsz-cli/src/driver/resolution/{exports_imports,package_resolution,type_packages}.rs`.

A shared `TargetMatch<T>` tri-state (`Resolved` / `Blocked` / `NotApplicable`)
lives in `tsz_common::module_resolution` — the lowest crate both resolvers
already depend on (alongside the existing `types_versions` / `path_identity`
primitives). `Blocked` short-circuits the conditional/array/map/pattern arms and
terminates with `NotFound`; `NotApplicable` keeps the existing "try next"
semantics. This removes the scattered per-site `if matches!(value, Null)` /
`if value.is_null() { return Vec::new() }` special-cases in favor of one
`Null => Blocked` arm in the value dispatch whose block propagates structurally.

## Adjacent-case matrix (all verified byte-for-byte against bundled `tsc` 6.0.2, `module: node16`)

| case | tsc | tsz (after) |
|---|---|---|
| nested matching `null` (`node`→`require:null`) + outer `default` | TS2307 | TS2307 |
| top-level matching `null` (`node:null`) + sibling `default` | TS2307 | TS2307 |
| `null` on **non-matching** condition (`import:null`, CJS importer) | resolves `default` | resolves `default` |
| array `[null, "./real.js"]` | TS2307 | TS2307 |
| array `["./absent.js", "./real.js"]` (missing file, not null) | resolves `./real.js` | resolves `./real.js` |
| exact subpath key `"./blocked": null` with `"./*"` sibling | TS2307 (no pattern fallthrough); other subpaths still resolve | same |
| `#imports` twin of the nested-null case | TS2307 | TS2307 |

## Anti-hardcoding

Structural only — no identifier/file-name/printer-string predicates. The
block/miss/resolve distinction is the value shape (`Null` vs `String` vs missing
file), not any name. Tests vary package, condition-target, and file names per
case.

## Verification

- `cargo test -p tsz-core module_resolver::tests::null_target_blocking` → 8/8 (new fixture matrix, names varied per case).
- `cargo test -p tsz-cli --lib driver::resolution::exports_imports::tests` → 14/14 (7 new pure-function null cases + 7 existing).
- `cargo test -p tsz-common module_resolution::tests` → 2/2 (`TargetMatch` API).
- `cargo test -p tsz-core module_resolver::tests::package_exports_imports` → 32/32 (no regression in the broader exports/imports suite).
- Full `cargo test -p tsz-core --lib` → no new failures vs `origin/main` (the 8 pre-existing failures — `source_map_tests_1`, `parallel::residency`/`clone`, `scanner_impl`, `checker_state` abstract-property — reproduce identically on a clean stash of the parent commit; confirmed).
- End-to-end through the real `tsz` CLI driver: the 7-case matrix above matches `tsc` 6.0.2 exit codes.
- `cargo fmt --check` + `cargo clippy --lib` clean on all three crates.
- Broad conformance/emit/fourslash owned by ready-review CI.

> Note: the one local `tsc_compat_tests::tsc_parity_ts6046_module_resolution` failure is a sandbox tsc-version artifact (local tsc 6.0.2 lists fewer valid `--moduleResolution` values in its `TS6046` message than tsz emits) — unrelated to this change, which touches no CLI argument validation.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_012sHi9rtz65RuBVsYRpZubD

---
_Generated by [Claude Code](https://claude.ai/code/session_012sHi9rtz65RuBVsYRpZubD)_