### PR TITLE
fix(solver): relate shadowed same-named type parameters by identity, not name

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1375,6 +1375,9 @@ mod satisfies_callback_return_widening_tests;
 #[path = "tests/satisfies_relation_routing_arch_tests.rs"]
 mod satisfies_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/shadowed_type_param_identity_tests.rs"]
+mod shadowed_type_param_identity_tests;
+#[cfg(test)]
 #[path = "tests/split_accessor_variance_tests.rs"]
 mod split_accessor_variance_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/shadowed_type_param_identity_tests.rs
+++ b/crates/tsz-checker/src/tests/shadowed_type_param_identity_tests.rs
@@ -1,0 +1,128 @@
+//! Regression tests: two distinct type parameters that share a *name* must not
+//! be treated as the same parameter when their constraints prove they are
+//! distinct declarations.
+//!
+//! `TypeParamInfo` carries no declaration handle, so the subtype relation used a
+//! shared name as a proxy for parameter identity. For an inner generic that
+//! shadows an outer one with an *incompatible* constraint, that proxy is wrong:
+//! the parameters are unrelated and `tsc` reports the assignment failure
+//! (TS2719, "two different types with this name exist, but they are unrelated").
+//! The fix suppresses the name-based reflexive shortcut when both constraints
+//! are present and mutually non-assignable, so a real mismatch is reported.
+//!
+//! The names are varied across cases so the routing is exercised structurally,
+//! not keyed on a particular identifier spelling.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::check_source;
+
+fn strict() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn codes(src: &str) -> Vec<u32> {
+    check_source(src, "test.ts", strict())
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn shadowed_param_incompatible_constraints_report_ts2719() {
+    // Inner `T extends number` shadows outer `T extends string`; assigning the
+    // inner-parameter value to the outer-parameter binding is unrelated.
+    let c = codes(
+        r#"
+function outer<T extends string>(x: T) {
+    function inner<T extends number>(y: T) {
+        x = y;
+    }
+}
+"#,
+    );
+    assert!(
+        c.contains(&2719),
+        "distinct same-named params with incompatible constraints must report TS2719, got {c:?}"
+    );
+}
+
+#[test]
+fn shadowed_param_incompatible_constraints_report_ts2719_renamed() {
+    // Same structural scenario, different identifier spelling for the shared
+    // name — proves the routing is structural, not a literal `T` check.
+    let c = codes(
+        r#"
+function wrap<Elem extends boolean>(a: Elem) {
+    function nested<Elem extends string>(b: Elem) {
+        a = b;
+    }
+}
+"#,
+    );
+    assert!(
+        c.contains(&2719),
+        "renamed distinct same-named params must still report TS2719, got {c:?}"
+    );
+}
+
+#[test]
+fn distinct_differently_named_params_still_report_ts2322() {
+    // Guard: parameters that do not share a name keep routing through the
+    // ordinary TS2322 path (display strings differ, so no TS2719).
+    let c = codes(
+        r#"
+function host<A>(x: A) {
+    function child<B>(y: B) {
+        x = y;
+    }
+}
+"#,
+    );
+    assert!(
+        c.contains(&2322),
+        "differently-named params must report TS2322, got {c:?}"
+    );
+    assert!(
+        !c.contains(&2719),
+        "differently-named params must not report TS2719, got {c:?}"
+    );
+}
+
+#[test]
+fn alpha_equivalent_generic_signatures_do_not_regress() {
+    // Two generic function signatures that differ only in type-parameter name
+    // are mutually assignable (alpha-equivalence). The reflexive shortcut must
+    // remain for the unconstrained case so this keeps type-checking cleanly.
+    let c = codes(
+        r#"
+declare let f: <T>(x: T) => T;
+declare let g: <U>(x: U) => U;
+f = g;
+g = f;
+"#,
+    );
+    assert!(
+        !c.contains(&2322) && !c.contains(&2719),
+        "alpha-equivalent generic signatures must not error, got {c:?}"
+    );
+}
+
+#[test]
+fn alpha_equivalent_constrained_signatures_do_not_regress() {
+    // Same as above but with an identical constraint written on both sides.
+    let c = codes(
+        r#"
+declare let f: <T extends object>(x: T) => T;
+declare let g: <U extends object>(x: U) => U;
+f = g;
+g = f;
+"#,
+    );
+    assert!(
+        !c.contains(&2322) && !c.contains(&2719),
+        "alpha-equivalent constrained signatures must not error, got {c:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/unions.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/unions.rs
@@ -32,7 +32,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Implements TypeScript's soundness rules for type parameter compatibility.
     ///
     /// ## TypeScript Soundness Rules:
-    /// - Same type parameter by name → reflexive (always compatible)
+    /// - Same type parameter (shared name, not proven distinct by an
+    ///   incompatible constraint) → reflexive (always compatible)
     /// - Different type parameters → check constraint transitivity
     /// - Type parameter vs concrete → constraint must be subtype of concrete
     /// - Unconstrained type parameter → acts like `unknown` (top type)
@@ -43,7 +44,20 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ) -> SubtypeResult {
         // Type parameter vs type parameter
         if let Some(t_info) = type_param_info(self.interner, target) {
-            if s_info.name == t_info.name {
+            // A shared *name* is only a proxy for parameter identity: a
+            // `TypeParamInfo` carries no declaration handle, so two distinct
+            // type parameters that happen to share a name (e.g. an inner generic
+            // shadowing an outer one) are not necessarily the same parameter.
+            // When both carry constraints that are provably incompatible
+            // (neither assignable to the other), the parameters are definitely
+            // distinct — `tsc` treats them as unrelated and reports the failure
+            // (TS2719, "two different types with this name exist"). Only the
+            // reflexive same-parameter case may short-circuit to `True`; the
+            // distinct case must fall through to constraint transitivity so a
+            // genuine mismatch is reported instead of silently accepted.
+            if s_info.name == t_info.name
+                && !self.same_named_type_params_are_distinct(s_info, &t_info)
+            {
                 return SubtypeResult::True;
             }
             if let Some(s_constraint) = s_info.constraint {
@@ -122,6 +136,43 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
 
         SubtypeResult::False
+    }
+
+    /// Decide whether two same-named type parameters are *provably distinct*
+    /// declarations rather than the same parameter seen twice.
+    ///
+    /// `TypeParamInfo` has no declaration handle, so a shared name cannot prove
+    /// identity. The conservative signal that two same-named parameters are
+    /// genuinely different is that both carry constraints which are mutually
+    /// non-assignable: the same parameter always presents the same constraint
+    /// (interning to the same `TypeId`, or — when the constraint is reached
+    /// through different-but-equal representations — a mutually-assignable one),
+    /// so an incompatible constraint pair can only come from two different
+    /// declarations. Returning `true` here suppresses the name-based reflexive
+    /// shortcut so the relation falls through to constraint transitivity and a
+    /// real mismatch is reported, mirroring `tsc`'s handling of distinct
+    /// identically-named type parameters.
+    ///
+    /// Unconstrained (or one-sided-unconstrained) same-named pairs return
+    /// `false`: they intern to one `TypeId` and never reach this path, or cannot
+    /// be told apart without a parameter identity, so the historical reflexive
+    /// behaviour is preserved to avoid regressing alpha-renamed generic-signature
+    /// comparisons.
+    fn same_named_type_params_are_distinct(
+        &mut self,
+        s_info: &TypeParamInfo,
+        t_info: &TypeParamInfo,
+    ) -> bool {
+        let (Some(s_constraint), Some(t_constraint)) = (s_info.constraint, t_info.constraint)
+        else {
+            return false;
+        };
+        if s_constraint == t_constraint {
+            return false;
+        }
+        let constraints_equivalent = self.check_subtype(s_constraint, t_constraint).is_true()
+            && self.check_subtype(t_constraint, s_constraint).is_true();
+        !constraints_equivalent
     }
 
     fn type_param_constraint_allows_spread_identity(

--- a/crates/tsz-solver/src/relations/subtype/rules/unions.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/unions.rs
@@ -32,8 +32,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Implements TypeScript's soundness rules for type parameter compatibility.
     ///
     /// ## TypeScript Soundness Rules:
-    /// - Same type parameter (shared name, not proven distinct by an
-    ///   incompatible constraint) → reflexive (always compatible)
+    /// - Same type parameter (shared name, not proven distinct by mutually
+    ///   incompatible constraints) → reflexive (always compatible)
     /// - Different type parameters → check constraint transitivity
     /// - Type parameter vs concrete → constraint must be subtype of concrete
     /// - Unconstrained type parameter → acts like `unknown` (top type)
@@ -51,10 +51,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // When both carry constraints that are provably incompatible
             // (neither assignable to the other), the parameters are definitely
             // distinct — `tsc` treats them as unrelated and reports the failure
-            // (TS2719, "two different types with this name exist"). Only the
-            // reflexive same-parameter case may short-circuit to `True`; the
-            // distinct case must fall through to constraint transitivity so a
-            // genuine mismatch is reported instead of silently accepted.
+            // (TS2719, "two different types with this name exist"). Related
+            // but non-identical constraints are not enough evidence: without a
+            // declaration handle they may still be the same parameter viewed
+            // through a primitive/object or alias relation. Only the reflexive
+            // same-parameter case may short-circuit to `True`; the distinct
+            // case must fall through to constraint transitivity so a genuine
+            // mismatch is reported instead of silently accepted.
             if s_info.name == t_info.name
                 && !self.same_named_type_params_are_distinct(s_info, &t_info)
             {
@@ -146,12 +149,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// genuinely different is that both carry constraints which are mutually
     /// non-assignable: the same parameter always presents the same constraint
     /// (interning to the same `TypeId`, or — when the constraint is reached
-    /// through different-but-equal representations — a mutually-assignable one),
-    /// so an incompatible constraint pair can only come from two different
-    /// declarations. Returning `true` here suppresses the name-based reflexive
-    /// shortcut so the relation falls through to constraint transitivity and a
-    /// real mismatch is reported, mirroring `tsc`'s handling of distinct
-    /// identically-named type parameters.
+    /// through different-but-related representations — at least a one-way
+    /// assignable one), so a constraint pair with no assignable direction can
+    /// only come from two different declarations. Returning `true` here
+    /// suppresses the name-based reflexive shortcut so the relation falls
+    /// through to constraint transitivity and a real mismatch is reported,
+    /// mirroring `tsc`'s handling of distinct identically-named type parameters.
     ///
     /// Unconstrained (or one-sided-unconstrained) same-named pairs return
     /// `false`: they intern to one `TypeId` and never reach this path, or cannot
@@ -170,9 +173,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if s_constraint == t_constraint {
             return false;
         }
-        let constraints_equivalent = self.check_subtype(s_constraint, t_constraint).is_true()
-            && self.check_subtype(t_constraint, s_constraint).is_true();
-        !constraints_equivalent
+        let source_extends_target = self.check_subtype(s_constraint, t_constraint).is_true();
+        let target_extends_source = self.check_subtype(t_constraint, s_constraint).is_true();
+        !source_extends_target && !target_extends_source
     }
 
     fn type_param_constraint_allows_spread_identity(

--- a/crates/tsz-solver/tests/type_parameter_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/type_parameter_comprehensive_tests.rs
@@ -896,3 +896,59 @@ fn unrelated_bare_type_parameters_are_not_subtypes() {
     assert!(!is_subtype_of(&interner, t, u), "T is not assignable to U");
     assert!(is_subtype_of(&interner, t, t), "T is reflexively a subtype");
 }
+
+#[test]
+fn same_named_type_parameters_only_split_on_mutually_disjoint_constraints() {
+    use crate::relations::subtype::SubtypeChecker;
+
+    let interner = TypeInterner::new();
+    let shared_name = interner.intern_string("Item");
+
+    let related_narrow = interner.type_param(TypeParamInfo {
+        name: shared_name,
+        constraint: Some(TypeId::NUMBER),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    let related_wide = interner.type_param(TypeParamInfo {
+        name: shared_name,
+        constraint: Some(TypeId::UNKNOWN),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        checker.is_subtype_of(related_narrow, related_wide),
+        "one-way-related same-named constraints are not enough proof of distinct declarations"
+    );
+
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        checker.is_subtype_of(related_wide, related_narrow),
+        "same-named type parameters keep the reflexive shortcut unless constraints are mutually disjoint"
+    );
+
+    let disjoint_string = interner.type_param(TypeParamInfo {
+        name: shared_name,
+        constraint: Some(TypeId::STRING),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+    let disjoint_number = interner.type_param(TypeParamInfo {
+        name: shared_name,
+        constraint: Some(TypeId::NUMBER),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        !checker.is_subtype_of(disjoint_string, disjoint_number),
+        "mutually disjoint same-named constraints must still be treated as distinct"
+    );
+}


### PR DESCRIPTION
Goal: hold

Refs #14101 (type-identity correctness family — the "self-equal TS2322 / TS2719" identity axis).

## Summary

Two distinct type parameters that share a *name* (e.g. an inner generic
shadowing an outer one) were treated as the same parameter by the
type-parameter subtype rule, which short-circuited to `True` on a bare
name match (`check_type_parameter_subtype`,
`crates/tsz-solver/src/relations/subtype/rules/unions.rs`). `TypeParamInfo`
carries no declaration handle, so a shared name is only a proxy for
identity — relating by it is the anti-hardcoding gate's classic
"user-chosen identifier driving compiler logic".

When both parameters carry constraints that are **mutually non-assignable**
they are provably distinct declarations, and `tsc` reports the assignment
as unrelated: **TS2719** ("Type 'T' is not assignable to type 'T'. Two
different types with this name exist, but they are unrelated."). tsz
previously accepted it silently (a soundness false-negative). The fix
suppresses the name-based reflexive shortcut in exactly that case so the
relation falls through to constraint transitivity and the genuine mismatch
is reported.

## Structural rule

When source and target are both type parameters that share a name but
carry mutually non-assignable constraints, they are distinct declarations;
`tsc` relates them only by constraint transitivity (yielding TS2719), and
tsz now does the same through the subtype relation (owner:
`SubtypeChecker::check_type_parameter_subtype`).

## Why this altitude

The full repair is a declaration identity on `TypeParamInfo` (a
SymbolId/DefId threaded through ~300 construction sites plus canonical
alpha-renaming in generic-signature comparison — a multi-crate, ~1000+ LOC
follow-up that risks the alpha-equivalence cliff). This PR is the surgical,
sound slice: it adds one gated predicate, changes one call site, regresses
nothing, and leaves the unconstrained-shadowing case (which interns to a
single `TypeId` and is indistinguishable without identity) for that
follow-up.

## Adjacent-case matrix (new tests, binder names varied)

`crates/tsz-checker/src/tests/shadowed_type_param_identity_tests.rs`:
- shadowed `T extends string` / `T extends number` → **TS2719** (positive).
- renamed binders `Elem extends boolean` / `Elem extends string` → **TS2719**
  (proves structural, not a literal `T` check).
- differently-named `A` / `B` → **TS2322**, no TS2719 (fallback preserved).
- alpha-equivalent `<T>(x:T)=>T` vs `<U>(x:U)=>U` → clean (no regression).
- alpha-equivalent `<T extends object>` vs `<U extends object>` → clean.

## Verification

- `cargo test -p tsz-checker --lib -- shadowed_type_param_identity` — 5/5 pass.
- Targeted regression sweep of the type-parameter / generic / variance /
  TS2416 families: 233 passed; the only failures present were confirmed
  **pre-existing on the unmodified base** (e.g. `return_context_type_param_shadowing_tests`,
  `index_access_type_parameter_mismatch_elaboration`) — zero new failures
  attributable to this change.
- `cargo clippy -p tsz-solver --lib` — clean.
- Hot-path cost: the two added `check_subtype` calls run only when names
  match AND both constraints are `Some` AND the constraint `TypeId`s differ;
  the common cases (unconstrained, or equal-`TypeId` constraints) short-circuit
  before any relation call.
- CI conformance / emit / fourslash floors own the broad parity validation.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk9yWozxFs9PSbqZWw3qpD)_