### PR TITLE
fix(solver): drop origin from canonical bound type-parameter identity (#13609)

### DIFF
--- a/crates/tsz-solver/src/canonicalize/mod.rs
+++ b/crates/tsz-solver/src/canonicalize/mod.rs
@@ -733,24 +733,43 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
     /// mapped binding sites).
     ///
     /// On top of [`Self::canonical_type_param`] this also erases the declared
-    /// `name`. Once every reference to the parameter is positional, its name is
-    /// purely cosmetic: `tsc`'s `compareTypeParametersIdentical` maps parameters
-    /// positionally and compares constraints only — never names. Keeping the name
-    /// in the canonical shape let two alpha-equivalent generic callables
-    /// (`<T extends X>() => T` vs `<U extends X>() => U`) hash to distinct
-    /// `TypeId`s and miss the relation's reflexive/identity fast path — the same
-    /// fragmentation family as #13609, here on the parameter *name* axis rather
-    /// than a declaration modifier. The mapped-type binder already erased the name
-    /// for exactly this reason (`{ [K in T]: K }` vs `{ [P in T]: P }`); this
-    /// generalizes it to every binding site. The name is never looked up off the
-    /// canonical form (it is identity/hashing only) and the *interned* parameter
-    /// keeps its name where it is actually rendered.
+    /// `name` and the internal `origin` discriminant. Once every reference to the
+    /// parameter is positional, its name is purely cosmetic: `tsc`'s
+    /// `compareTypeParametersIdentical` maps parameters positionally and compares
+    /// constraints only — never names. Keeping the name in the canonical shape let
+    /// two alpha-equivalent generic callables (`<T extends X>() => T` vs
+    /// `<U extends X>() => U`) hash to distinct `TypeId`s and miss the relation's
+    /// reflexive/identity fast path — the same fragmentation family as #13609, here
+    /// on the parameter *name* axis rather than a declaration modifier. The
+    /// mapped-type binder already erased the name for exactly this reason
+    /// (`{ [K in T]: K }` vs `{ [P in T]: P }`); this generalizes it to every
+    /// binding site.
+    ///
+    /// The [`TypeParamOrigin`](crate::types::TypeParamOrigin) discriminant is
+    /// erased to the [`User`](crate::types::TypeParamOrigin::User) default for the
+    /// same reason. `origin` is a purely internal tsz classification (whether a
+    /// parameter is a source-written generic or an inference placeholder) and is
+    /// never part of TypeScript's notion of type identity. Its inference variants
+    /// carry program-unique `id`s (`InferPlaceholder { id }` / `InferSource { id,
+    /// .. }`), and `TypeParamInfo` derives `Eq`/`Hash` over `origin`, so two
+    /// otherwise-identical *bound* signatures whose parameters are
+    /// higher-order-inference placeholders minted at different ids (the
+    /// re-generalized return-type form) canonicalized to distinct `TypeId`s and
+    /// missed the reflexive short-circuit — the `origin` axis of the #13609
+    /// fragmentation family. Because a bound parameter's references are already
+    /// positional, the id is never load-bearing here. (A *free* reference is
+    /// different: an inference placeholder's `id` is its identity, so
+    /// [`Self::canonical_type_param`] keeps `origin` — exactly as it keeps the
+    /// name.) The discriminant is still read where it matters (inference) off the
+    /// *interned* parameter, which is unchanged; only this comparison/hashing-only
+    /// canonical form drops it.
     fn canonical_bound_type_param(
         &mut self,
         tp: crate::types::TypeParamInfo,
     ) -> crate::types::TypeParamInfo {
         crate::types::TypeParamInfo {
             name: Atom::NONE,
+            origin: crate::types::TypeParamOrigin::User,
             ..self.canonical_type_param(tp)
         }
     }
@@ -909,3 +928,7 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
 #[cfg(test)]
 #[path = "../../tests/canonicalize_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "../../tests/canonicalize_origin_axis_tests.rs"]
+mod origin_axis_tests;

--- a/crates/tsz-solver/tests/canonicalize_origin_axis_tests.rs
+++ b/crates/tsz-solver/tests/canonicalize_origin_axis_tests.rs
@@ -1,0 +1,308 @@
+//! Canonical type-parameter identity must not fragment on the internal
+//! [`TypeParamOrigin`](crate::types::TypeParamOrigin) discriminant — the
+//! `origin` axis of the #13609 identity-fragmentation family.
+//!
+//! `origin` is a purely internal tsz classification (source-written generic vs
+//! inference placeholder) that `tsc` never compares for type identity
+//! (`compareTypeParametersIdentical` compares constraints only). Its inference
+//! variants carry program-unique `id`s, and `TypeParamInfo` derives `Eq`/`Hash`
+//! over `origin`, so two otherwise-identical *bound* signatures whose parameters
+//! are inference placeholders minted at different ids fragmented into distinct
+//! canonical `TypeId`s and missed the relation's reflexive short-circuit.
+//!
+//! These tests pin the fix: at a *bound* binding site (function / call
+//! signature / mapped) the canonical form erases `origin` (alongside the name),
+//! while a *free* reference — where an inference placeholder's `id` is its real
+//! identity — keeps it.
+
+use super::*;
+use crate::intern::TypeInterner;
+use crate::relations::subtype::TypeEnvironment;
+use crate::types::{TypeData, TypeParamInfo, TypeParamOrigin};
+
+/// `<T extends X>(x: T) => T` where the bound type parameter is a *source*
+/// generic vs an *inference-source placeholder* must canonicalize to the SAME
+/// identity: `origin` is identity-irrelevant for a positional (bound) parameter.
+#[test]
+fn bound_type_param_origin_is_alpha_equivalent_function() {
+    use crate::types::{FunctionShape, ParamInfo};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    // `<name>(x: name) => name` with the given origin/constraint.
+    let make = |name: &str, origin: TypeParamOrigin, constraint: Option<TypeId>| {
+        let info = TypeParamInfo {
+            name: interner.intern_string(name),
+            constraint,
+            default: None,
+            is_const: false,
+            origin,
+        };
+        let pref = interner.type_param(info);
+        interner.function(FunctionShape {
+            type_params: vec![info],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("x")),
+                type_id: pref,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: pref,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+
+    // Vary the binder name as well so the assertion checks structure, not a
+    // hard-coded spelling.
+    let user = make("T", TypeParamOrigin::User, Some(TypeId::STRING));
+    let placeholder = make(
+        "Other",
+        TypeParamOrigin::InferSource {
+            id: 7,
+            origin_name: Some(interner.intern_string("T")),
+        },
+        Some(TypeId::STRING),
+    );
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(user),
+        c2.canonicalize(placeholder),
+        "a bound type parameter's origin discriminant is identity-irrelevant; \
+         a source generic and an inference placeholder with the same constraint \
+         are alpha-equivalent"
+    );
+}
+
+/// Two *bound* parameters that are both inference placeholders but minted at
+/// different program-unique ids — the higher-order re-generalized return-type
+/// form — must collapse to one canonical identity (the ids are internal, never
+/// part of type identity).
+#[test]
+fn bound_type_param_distinct_placeholder_ids_collapse() {
+    use crate::types::{FunctionShape, ParamInfo};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let make = |id: u64| {
+        let info = TypeParamInfo {
+            name: interner.intern_string("__infer_src"),
+            constraint: None,
+            default: None,
+            is_const: false,
+            origin: TypeParamOrigin::InferSource {
+                id,
+                origin_name: None,
+            },
+        };
+        let pref = interner.type_param(info);
+        interner.function(FunctionShape {
+            type_params: vec![info],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("a")),
+                type_id: pref,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: pref,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(make(1)),
+        c2.canonicalize(make(99)),
+        "bound inference placeholders differing only in their program-unique id \
+         must share one canonical form"
+    );
+}
+
+/// Negative control: erasing `origin` must NOT erase the constraint. Two bound
+/// parameters with identical origin treatment but different constraints stay
+/// distinct.
+#[test]
+fn bound_type_param_origin_drop_preserves_constraint_distinction() {
+    use crate::types::{FunctionShape, ParamInfo};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let make = |constraint: TypeId| {
+        let info = TypeParamInfo {
+            name: interner.intern_string("T"),
+            constraint: Some(constraint),
+            default: None,
+            is_const: false,
+            origin: TypeParamOrigin::InferSource {
+                id: 3,
+                origin_name: None,
+            },
+        };
+        let pref = interner.type_param(info);
+        interner.function(FunctionShape {
+            type_params: vec![info],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("x")),
+                type_id: pref,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: pref,
+            type_predicate: None,
+            is_constructor: false,
+            is_method: false,
+        })
+    };
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_ne!(
+        c1.canonicalize(make(TypeId::STRING)),
+        c2.canonicalize(make(TypeId::NUMBER)),
+        "dropping origin must not collapse parameters with different constraints"
+    );
+}
+
+/// Call-signature path (`canonicalize_signature`, shared by `Callable`): the
+/// bound `origin` axis collapses there too.
+#[test]
+fn bound_type_param_origin_alpha_equivalent_call_signature() {
+    use crate::types::{CallSignature, CallableShape, ParamInfo};
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let make = |name: &str, origin: TypeParamOrigin| {
+        let info = TypeParamInfo {
+            name: interner.intern_string(name),
+            constraint: None,
+            default: None,
+            is_const: false,
+            origin,
+        };
+        let pref = interner.type_param(info);
+        let sig = CallSignature {
+            type_params: vec![info],
+            params: vec![ParamInfo {
+                name: Some(interner.intern_string("x")),
+                type_id: pref,
+                optional: false,
+                rest: false,
+            }],
+            this_type: None,
+            return_type: pref,
+            type_predicate: None,
+            is_method: false,
+        };
+        interner.callable(CallableShape {
+            call_signatures: vec![sig],
+            construct_signatures: vec![],
+            properties: vec![],
+            string_index: None,
+            number_index: None,
+            symbol: None,
+            is_abstract: false,
+        })
+    };
+
+    let user = make("T", TypeParamOrigin::User);
+    let placeholder = make("Q", TypeParamOrigin::InferPlaceholder { id: 42 });
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(user),
+        c2.canonicalize(placeholder),
+        "generic call signatures differing only in bound type-parameter origin \
+         are alpha-equivalent"
+    );
+}
+
+/// A mapped type's bound iteration variable also lives at a binding site, so its
+/// `origin` is identity-irrelevant: `{ [K in T]: K }` over a source `T` and over
+/// an inference-placeholder `T` (same constraint) canonicalize identically.
+#[test]
+fn bound_type_param_origin_alpha_equivalent_mapped() {
+    use crate::types::MappedType;
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let make = |name: &str, origin: TypeParamOrigin| {
+        let info = TypeParamInfo {
+            name: interner.intern_string(name),
+            constraint: None,
+            default: None,
+            is_const: false,
+            origin,
+        };
+        let kref = interner.type_param(info);
+        interner.mapped(MappedType {
+            type_param: info,
+            constraint: TypeId::STRING,
+            template: kref,
+            name_type: None,
+            readonly_modifier: None,
+            optional_modifier: None,
+        })
+    };
+
+    let user = make("K", TypeParamOrigin::User);
+    let placeholder = make("P", TypeParamOrigin::InferPlaceholder { id: 5 });
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    assert_eq!(
+        c1.canonicalize(user),
+        c2.canonicalize(placeholder),
+        "a mapped type's bound iteration variable origin is identity-irrelevant"
+    );
+}
+
+/// A *free* type-parameter reference is different: an inference placeholder's
+/// program-unique `id` IS its identity, so `canonical_type_param` keeps `origin`.
+/// Two free references sharing a name but carrying distinct placeholder ids must
+/// stay distinct — the fix must not over-widen free references.
+#[test]
+fn free_inference_placeholder_ids_stay_distinct() {
+    let interner = TypeInterner::new();
+    let env = TypeEnvironment::new();
+
+    let name = interner.intern_string("__infer");
+    let make = |id: u64| {
+        interner.type_param(TypeParamInfo {
+            name,
+            constraint: None,
+            default: None,
+            is_const: false,
+            origin: TypeParamOrigin::InferPlaceholder { id },
+        })
+    };
+
+    // No surrounding binding scope: these are free references.
+    let a = make(1);
+    let b = make(2);
+
+    let mut c1 = Canonicalizer::new(&interner, &env);
+    let mut c2 = Canonicalizer::new(&interner, &env);
+    let ca = c1.canonicalize(a);
+    let cb = c2.canonicalize(b);
+
+    // Both remain free `TypeParameter` references (not rewritten to a bound index).
+    assert!(
+        matches!(interner.lookup(ca), Some(TypeData::TypeParameter(_))),
+        "a free reference stays a free TypeParameter"
+    );
+    assert_ne!(
+        ca, cb,
+        "free inference placeholders with distinct ids must keep distinct identity \
+         (origin id is load-bearing for a free reference)"
+    );
+}


### PR DESCRIPTION
Goal: hold

Part of the #13609 canonical type-parameter identity-fragmentation family. Prior
slices peeled the identity-irrelevant facets off `TypeParamInfo` one axis at a
time — `default` (#13888), `is_const` (#14090), the bound-parameter `name`
(#14096/#14098), the `Infer` arm (#14074) — leaving one field still copied
straight into the canonical (comparison/hashing-only) form: the internal
`origin` discriminant.

## Structural rule

When two **bound** generic signatures are alpha-equivalent (`tsc`'s
`compareSignaturesIdentical` / `compareTypeParametersIdentical` maps type
parameters positionally and compares constraints only), they must canonicalize
to one identity so the relation's reflexive/identity fast path
(`are_types_structurally_identical`) fires. `TypeParamOrigin` is a purely
internal tsz classification (source-written generic vs inference placeholder)
that is **never** part of TypeScript's notion of type identity; its inference
variants carry program-unique ids (`InferPlaceholder { id }`,
`InferSource { id, .. }`). Because `TypeParamInfo` derives `Eq`/`Hash` over
`origin`, two otherwise-identical bound signatures whose parameters are
higher-order-inference placeholders minted at different ids — the re-generalized
return-type form — canonicalized to **distinct** `TypeId`s, missed the reflexive
short-circuit, and fell into the resolver-state-dependent structural member walk
this thread pins (→ false `TS2322`/`TS2344`).

`tsz` now erases `origin` to the `User` default in `canonical_bound_type_param`
(the function / call-signature / mapped binding sites), alongside the already-
erased `name`. A bound parameter's references are positional (`BoundParameter`),
so the id is never load-bearing there.

A **free** `TypeParameter`/`Infer` reference is deliberately left alone: an
inference placeholder's `id` *is* its identity when the reference is free, so
`canonical_type_param` keeps `origin` (exactly as it keeps the name for free
references). The fix widens identity only where it is provably safe.

## Owner layer

Solver canonicalizer (`crates/tsz-solver/src/canonicalize/mod.rs`),
`canonical_bound_type_param`. Identity-widening only; interning is unchanged and
the `origin` classification is still read where it matters (inference) off the
*interned* parameter, not the canonical form. Name-agnostic — keys on the
structural `origin`/`name` fields, no identifier/file-name/printer-string
predicate.

## Adjacent matrix (new `canonicalize_origin_axis_tests.rs`)

- bound `<T extends X>` source generic ≡ bound inference-source placeholder with
  the same constraint — **collapse** (function path).
- two bound `InferSource` placeholders differing only in their program-unique id
  — **collapse**.
- bound origin difference with **different constraints** — **stay distinct**
  (negative control: erasing origin does not erase the constraint).
- call-signature path (`Callable`) — **collapse** on the origin axis.
- mapped-type bound iteration variable — **collapse** on the origin axis.
- **free** inference placeholders with distinct ids — **stay distinct** (proves
  the fix does not over-widen free references; the result remains a free
  `TypeParameter`).

Binder names are varied per case so the assertions check structure, not
spellings.

## Verification

- `cargo test -p tsz-solver --lib origin_axis` → 6/6 pass (new file).
- `cargo test -p tsz-solver --lib canonical` → 104/104 pass (existing
  canonicalize suite + the 6 new, no regression on the `default`/`is_const`/
  name/`Infer`/`NoInfer` slices).
- Full `cargo test -p tsz-solver --lib` → **net-new failures = 0**: the same 5
  failures reproduce byte-identically on a clean stash of `origin/main`
  (`literal_mask_preserves_object_vs_literal_reduction`,
  `test_conditional_infer_optional_property_present_distributive`,
  `array_isarray_keeps_mutable_and_readonly_array_members`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`,
  and the `src/types.rs` file-size ratchet drift — none touched by this change).
- `cargo fmt -p tsz-solver --check` clean; `cargo clippy -p tsz-solver --tests`
  clean. Changed source file `canonicalize/mod.rs` 935 LOC; new test file ~290
  LOC (both < 2000).
- Broad conformance / emit / fourslash / corpus owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMSPEvqEuQ93oPFsX7v3UT)_