### PR TITLE
fix(solver): reduce homomorphic mapped type over `never` source to `never` (#14460)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1133,6 +1133,9 @@ path = "tests/homomorphic_mapped_empty_keyspace_tests.rs"
 name = "homomorphic_mapped_symbol_iterator_tests"
 path = "tests/homomorphic_mapped_symbol_iterator_tests.rs"
 [[test]]
+name = "homomorphic_mapped_never_source_tests"
+path = "tests/homomorphic_mapped_never_source_tests.rs"
+[[test]]
 name = "homomorphic_mapped_union_distribution_tests"
 path = "tests/homomorphic_mapped_union_distribution_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/homomorphic_mapped_never_source_tests.rs
+++ b/crates/tsz-checker/tests/homomorphic_mapped_never_source_tests.rs
@@ -1,0 +1,177 @@
+//! Tests for homomorphic mapped types whose source instantiates to `never`
+//! (issue #14460).
+//!
+//! `tsc`'s `instantiateMappedType` maps the homomorphic source type variable
+//! through `mapType`, and `mapType(never)` is `never`: a homomorphic mapped type
+//! `{ [K in keyof T]: ... }` whose source `T` instantiates to `never` reduces to
+//! `never`, independent of the template shape (`T[K]` or a constant), of key
+//! remapping (`as`), and of added/removed modifiers.
+//!
+//! Before the fix, the instantiation short-circuit gated on `is_primitive_type`,
+//! which deliberately excludes `never`, so a `never` source fell through to the
+//! object-expansion path and materialized a malformed
+//! `{ [K in keyof never]: never[K] }` shape (an index access into `never`, since
+//! `keyof never` is `string | number | symbol`). That shape is not assignable to
+//! `never` and surfaced as a false TS2322.
+//!
+//! Binder names (`T`/`Source`, `K`/`Key`, alias spellings) vary across cases so
+//! the behavior tracks the type shape, not a spelling.
+use tsz_checker::test_utils::check_source_diagnostics;
+
+/// A homomorphic mapped type over a `never` source must reduce to `never`, so
+/// assigning it to a `never` annotation produces no diagnostic.
+fn no_errors(source: &str) {
+    let diagnostics = check_source_diagnostics(source);
+    let relevant: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| !matches!(d.code, 2318 | 2304))
+        .collect();
+    assert!(
+        relevant.is_empty(),
+        "Expected no diagnostics, got: {relevant:#?}"
+    );
+}
+
+/// Assert a TS2322 is present — used by negative controls that must NOT reduce a
+/// non-`never` homomorphic source to `never`.
+fn has_2322(source: &str) {
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2322),
+        "Expected TS2322, got: {diagnostics:#?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive: every homomorphic shape over `never` reduces to `never`.
+// ---------------------------------------------------------------------------
+
+/// Identity template `{ [K in keyof T]: T[K] }` over `never` → `never`.
+#[test]
+fn identity_homomorphic_mapped_over_never_is_never() {
+    no_errors(
+        r#"
+type Identity<T> = { [K in keyof T]: T[K] };
+const a: never = (null as any as Identity<never>);
+"#,
+    );
+}
+
+/// Constant template `{ [K in keyof T]: number }` (does NOT read `T[K]`) over
+/// `never` → `never`. The reduction must not depend on the template shape.
+#[test]
+fn constant_template_homomorphic_mapped_over_never_is_never() {
+    no_errors(
+        r#"
+type Constant<Source> = { [Key in keyof Source]: number };
+const b: never = (null as any as Constant<never>);
+"#,
+    );
+}
+
+/// Non-identity source-index template `{ [K in keyof T]: T[K][] }` over `never`
+/// → `never`.
+#[test]
+fn nonidentity_source_index_homomorphic_mapped_over_never_is_never() {
+    no_errors(
+        r#"
+type Arrayify<T> = { [K in keyof T]: T[K][] };
+const c: never = (null as any as Arrayify<never>);
+"#,
+    );
+}
+
+/// Key-remapping (`as`) homomorphic template over `never` → `never`. The
+/// `name_type`/`as` clause must not block the reduction.
+#[test]
+fn remapped_homomorphic_mapped_over_never_is_never() {
+    no_errors(
+        r#"
+type Prefixed<T> = { [K in keyof T as `p${string & K}`]: T[K] };
+const d: never = (null as any as Prefixed<never>);
+"#,
+    );
+}
+
+/// Added `readonly` modifier homomorphic template over `never` → `never`.
+#[test]
+fn readonly_modifier_homomorphic_mapped_over_never_is_never() {
+    no_errors(
+        r#"
+type Frozen<Source> = { readonly [Key in keyof Source]: Source[Key] };
+const e: never = (null as any as Frozen<never>);
+"#,
+    );
+}
+
+/// Added optional modifier homomorphic template over `never` → `never`.
+#[test]
+fn optional_modifier_homomorphic_mapped_over_never_is_never() {
+    no_errors(
+        r#"
+type Loosen<T> = { [K in keyof T]?: T[K] };
+const f: never = (null as any as Loosen<never>);
+"#,
+    );
+}
+
+/// The reduction holds when the `never` source arrives through a conditional
+/// type (`T extends ... ? ... : never`) — the project-scale shape behind the
+/// never-collapse false positives — rather than the bare `never` literal.
+#[test]
+fn homomorphic_mapped_over_conditional_never_is_never() {
+    no_errors(
+        r#"
+type OnlyObjects<T> = T extends object ? T : never;
+type Identity<T> = { [K in keyof T]: T[K] };
+const g: never = (null as any as Identity<OnlyObjects<string>>);
+"#,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: non-`never` sources must NOT be reduced to `never`.
+// ---------------------------------------------------------------------------
+
+/// A homomorphic mapped type over a real object keeps its shape — it is NOT
+/// `never`, so assigning it to a `never` annotation still errors (TS2322).
+#[test]
+fn homomorphic_mapped_over_object_is_not_never() {
+    has_2322(
+        r#"
+type Identity<T> = { [K in keyof T]: T[K] };
+const a: never = (null as any as Identity<{ x: number }>);
+"#,
+    );
+}
+
+/// A homomorphic mapped type over a real object remains usable: its properties
+/// survive (no false reduction stripped them).
+#[test]
+fn homomorphic_mapped_over_object_preserves_properties() {
+    no_errors(
+        r#"
+type Identity<Source> = { [Key in keyof Source]: Source[Key] };
+const a: Identity<{ x: number; y: string }> = { x: 1, y: "s" };
+"#,
+    );
+}
+
+/// A non-homomorphic mapped type `{ [P in K]: V }` with an empty (`never`) key
+/// union is `{}`, NOT `never`: an empty object literal is assignable, but a
+/// `never` annotation is not (TS2322), so the bottom-collapse must not leak here.
+#[test]
+fn nonhomomorphic_mapped_over_never_key_union_is_empty_object_not_never() {
+    no_errors(
+        r#"
+type FromKeys<K extends PropertyKey> = { [P in K]: number };
+const a: FromKeys<never> = {};
+"#,
+    );
+    has_2322(
+        r#"
+type FromKeys<K extends PropertyKey> = { [P in K]: number };
+const b: never = (null as any as FromKeys<never>);
+"#,
+    );
+}

--- a/crates/tsz-solver/src/instantiation/instantiate/mapped.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/mapped.rs
@@ -48,6 +48,21 @@ impl<'a> TypeInstantiator<'a> {
             && let Some(substituted) = self.substitution.get(tp_info.name)
         {
             let resolved = self.evaluate_type(substituted);
+            // tsc's `instantiateMappedType` maps the homomorphic source type
+            // variable through `mapType`, and `mapType(never)` is `never`: a
+            // homomorphic mapped type `{ [K in keyof T]: ... }` whose source `T`
+            // instantiates to `never` reduces to `never`. This is independent of
+            // the template shape (`T[K]` or a constant), of key remapping (`as`),
+            // and of added/removed modifiers, so it must run before the
+            // template-shape-specific reductions below. Without it, the later
+            // object-expansion path materializes a spurious
+            // `{ [K in keyof never]: never[K] }` shape (an index access into
+            // `never`, since `keyof never` is `string | number | symbol`), which
+            // is not assignable to `never` and surfaces as a false TS2322.
+            if resolved == TypeId::NEVER {
+                self.exit_shadowing_scope(shadowed_len, saved_visiting);
+                return TypeId::NEVER;
+            }
             if let Some(TypeData::Union(list_id)) = self.interner.lookup(resolved)
                 && !Self::is_array_or_tuple_like(self.interner, resolved)
             {


### PR DESCRIPTION
Goal: hold

Fixes #14460.

## Summary
A homomorphic mapped type `{ [K in keyof T]: ... }` whose source type variable
`T` instantiates to `never` must reduce to `never`. `tsc`'s
`instantiateMappedType` maps the homomorphic source variable through `mapType`,
and `mapType(never)` is `never`. `tsz` instead materialized a spurious object
shape and reported a **false TS2322**:

```ts
type Map2<T> = { [K in keyof T]: T[K] };
type H = Map2<never>;
const h: never = (null as any as H);   // tsz: false TS2322; tsc: clean
```

`tsz` rendered the offending type as a malformed `never[string] | never[symbol]`
— an index access into `never`, because `keyof never` is `string | number | symbol`.

## Structural rule
When a homomorphic mapped type `{ [K in keyof T]: ... }` has its source type
variable `T` instantiated to `never`, `tsc` reduces the whole type to `never`.
This is independent of the template shape (`T[K]` or a constant), of key
remapping (`as`), and of added/removed modifiers.

Owner layer: **solver instantiation**. The evaluation path's
`is_mapped_short_circuit_source` (`evaluation/evaluate_rules/mapped.rs`) already
includes `Never`, but the **instantiation** short-circuit
(`instantiation/instantiate.rs::is_primitive_or_primitive_union`) gates on
`is_primitive_type`, which deliberately excludes `NEVER`. So the
homomorphic-source passthrough never fired for a `never` source and the type
fell through to the object-expansion path that builds the malformed shape.

The fix adds the `never` reduction at the homomorphic-source detection block in
`instantiation/instantiate/mapped.rs::instantiate_mapped`, before the
template-shape-specific reductions — the same block that already handles
homomorphic union distribution. Placing it there (rather than extending the
primitive passthrough, which is gated on `template_uses_source_index`) is what
covers the constant-template and `as`-remap cases that `tsc` also reduces.

## Anti-hardcoding
Structural only — keyed on the resolved homomorphic source being `TypeId::NEVER`,
not on any identifier/file-name/printer-string. New tests vary binder/alias names
(`T`/`Source`, `K`/`Key`) per case so the behavior tracks the type shape.

## Adjacent matrix (all verified against bundled `tsc` 6.0.2, `--strict --noEmit`)
| case | tsc | tsz (after) |
|---|---|---|
| identity `{ [K in keyof T]: T[K] }` over `never` | `never` | `never` |
| constant `{ [K in keyof T]: number }` over `never` (no `T[K]` read) | `never` | `never` |
| non-identity `{ [K in keyof T]: T[K][] }` over `never` | `never` | `never` |
| key-remap `{ [K in keyof T as ... ]: T[K] }` over `never` | `never` | `never` |
| `readonly`/optional modifier over `never` | `never` | `never` |
| `never` arriving via `T extends object ? T : never` | `never` | `never` |
| homomorphic over a real object (negative) | object kept | object kept (not reduced) |
| non-homomorphic `{ [P in K]: V }` with `K = never` | `{}` | `{}` (unchanged) |
| `keyof never` | `string \| number \| symbol` | unchanged |
| enum-literal homomorphic source `Map2<E.A>` | `E.A` | `E.A` (unchanged) |

## Verification
- New regression target `cargo test -p tsz-checker --test homomorphic_mapped_never_source_tests` → 10/10 (6 positive homomorphic shapes + conditional-`never` source + 3 negative controls; binder names varied).
- `cargo test -p tsz-solver --lib mapped` → 406/406.
- `cargo test -p tsz-solver --lib` → net-new failures = 0 vs clean `origin/main` (the 5 pre-existing failures — `test_conditional_infer_optional_property_present_distributive`, `literal_mask_preserves_object_vs_literal_reduction`, `array_isarray_keeps_mutable_and_readonly_array_members`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`, `test_solver_oversized_file_size_ceilings` — reproduce identically on a clean stash of the parent commit).
- Related checker targets all green: `homomorphic_mapped_union_distribution_tests` (26), `homomorphic_mapped_symbol_iterator_tests` (4), `keyof_mapped_as_clause_tests` (22), `intersection_mapped_alias_indexed_access_tests` (10), `mapped_remapped_excess_function_property_tests` (8), `homomorphic_remove_optional_conditional_tests` (10).
- End-to-end `tsz -p` vs bundled `tsc` 6.0.2 differential on the matrix above → byte-parity; broader feature batches (template-literal recursion, type-fest utilities, narrowing/satisfies/overloads) → 0 regressions.
- `cargo fmt -p tsz-solver -p tsz-checker --check` clean; `cargo clippy -p tsz-solver --lib` clean. Changed source file `mapped.rs` 558 LOC (< 2000).
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01L1DFHMw3LR5w9UiGffbGxc

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1DFHMw3LR5w9UiGffbGxc)_