### PR TITLE
test(checker): activate guard for fleet-fixed #14230 (mapped index by symbol) — regression-guard audit round 6

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
@@ -220,7 +220,6 @@ export { useType, useValue }
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "reproduces #14230"]
 fn issue_14230_mapped_index_by_symbol_no_ts2536() {
     let diags = compile_and_get_diagnostics_with_lib_and_options(
         r#"


### PR DESCRIPTION
Round 6 (final) of the canary FP regression-guard audit. No compiler source
changes — parity-floor protection (`Goal: hold`).

Goal: hold

## What changed
The last remaining `#[ignore]`d witness whose issue closed was re-checked against
current `main` and now PASSES — activated as a regression guard:
- **#14230** (TS2536): a mapped type over `keyof any` (`{ [K in string | number |
  symbol]: number }`) indexed by the bare `symbol` intrinsic (`M[symbol]`) — fixed
  on main (the architectural mapped symbol-index support).

This closes out the canary-FP regression-guard worklist: all fleet-fixed witnesses
are now active guards; the remaining `#[ignore]`d entries are documented
closed-but-still-reproducing FPs (#14167/#14220/#14225/#14263).

## Verification
- `cargo nextest run -p tsz-checker -j 2 issue_14230` — passes.
- CI gates: lint, unit-checker-integration, conformance-aggregate, emit-aggregate,
  fourslash-*, project-compile-guard, CI Summary.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max