### PR TITLE
fix(checker): render TypeBox Static&lt;…&gt; schema arrays structurally in TS2322

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/static_schema.rs
@@ -19,6 +19,37 @@ impl<'a> CheckerState<'a> {
         {
             return Some(query_display);
         }
+        // Fast, deterministic path: reduce the already-resolved schema element
+        // object in place, recursively rewriting its nested `Static<…>`
+        // projection members, then render it with the object `display_alias`
+        // suppressed. This operates on the resolved element shape, so it does not
+        // re-type-check the schema's `const` value declaration the way the
+        // re-resolution paths below do. Those paths re-evaluate enough of the
+        // schema to exhaust the shared display work budget on the first of a
+        // message's two renders and then truncate back to the bare alias
+        // (`Input[]`) on the second, making the structural display
+        // non-deterministic.
+        //
+        // The rewrite is itself recursion-depth bounded, so it runs with the
+        // display budget suspended: the attempt must not spend the fuel the
+        // re-resolution fallback below relies on when the shape-only rewrite
+        // cannot fully reduce a member (it leaves a residual `Static<…>`), which
+        // happens when the element type was resolved without the lib types the
+        // full schema needs. Only the fully-reduced result is used here; a
+        // residual one falls through to the re-resolution paths with the budget
+        // intact.
+        let fully_reduced = {
+            let _suspend =
+                crate::error_reporter::display_budget::SuspendDisplayBudgetScope::enter();
+            self.rewrite_nested_static_projection_members(element_type, 0)
+                .filter(|&reduced| !self.type_has_residual_static_schema(reduced, 0))
+        };
+        if let Some(reduced) = fully_reduced {
+            let rebuilt = self.static_schema_array_display_type(reduced);
+            return Some(
+                self.format_type_for_assignability_message_skip_object_display_alias(rebuilt),
+            );
+        }
         if let Some(static_type) = self.static_schema_alias_element_structural_type(element_type) {
             return Some(self.format_static_schema_array_structural_type(static_type, format_peer));
         }
@@ -86,6 +117,26 @@ impl<'a> CheckerState<'a> {
     fn is_static_schema_application(&self, type_id: TypeId) -> bool {
         self.static_schema_application_schema_type(type_id)
             .is_some()
+    }
+
+    /// Whether `type_id` (or any nested object member, bounded by `depth`) is
+    /// still an unreduced `Static<…>` projection application. Used to detect
+    /// when the in-place shape rewrite under-reduced (so the caller falls back
+    /// to the full re-resolution path) versus produced the fully structural
+    /// form.
+    fn type_has_residual_static_schema(&self, type_id: TypeId, depth: u8) -> bool {
+        if depth > 12 {
+            return false;
+        }
+        if self.is_static_schema_application(type_id) {
+            return true;
+        }
+        diagnostic_query::object_shape_for_type(self.ctx.types, type_id).is_some_and(|shape| {
+            shape
+                .properties
+                .iter()
+                .any(|prop| self.type_has_residual_static_schema(prop.type_id, depth + 1))
+        })
     }
 
     pub(crate) fn type_alias_projects_static_member(&self, base: TypeId) -> bool {
@@ -308,11 +359,18 @@ impl<'a> CheckerState<'a> {
         let schema_type = self.type_of_value_declaration_for_symbol(sym_id, value_decl);
         let schema_type = self.evaluate_type_for_assignability(schema_type);
         let static_type = self.typebox_schema_static_type(schema_type, 0)?;
-        let static_type = self.evaluate_type_for_assignability(static_type);
-        let static_type = self.widen_type_for_display(static_type);
-        let static_type = self.normalize_assignability_display_type(static_type);
-        let rebuilt = self.ctx.types.array(static_type);
+        let rebuilt = self.static_schema_array_display_type(static_type);
         Some(self.format_type_diagnostic(rebuilt))
+    }
+
+    /// Evaluate, widen, and normalize a schema's reduced element type, then wrap
+    /// it back into the array type to display. Shared by the structural-display
+    /// entry points so they prepare the element identically.
+    fn static_schema_array_display_type(&mut self, element_type: TypeId) -> TypeId {
+        let element_type = self.evaluate_type_for_assignability(element_type);
+        let element_type = self.widen_type_for_display(element_type);
+        let element_type = self.normalize_assignability_display_type(element_type);
+        self.ctx.types.array(element_type)
     }
 
     fn format_static_schema_array_structural_type(
@@ -320,10 +378,7 @@ impl<'a> CheckerState<'a> {
         static_type: TypeId,
         other: TypeId,
     ) -> String {
-        let static_type = self.evaluate_type_for_assignability(static_type);
-        let static_type = self.widen_type_for_display(static_type);
-        let static_type = self.normalize_assignability_display_type(static_type);
-        let rebuilt = self.ctx.types.array(static_type);
+        let rebuilt = self.static_schema_array_display_type(static_type);
         self.format_assignability_type_for_message(rebuilt, other)
     }
 }

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -951,6 +951,28 @@ impl<'a> CheckerState<'a> {
         formatter.format(ty).into_owned()
     }
 
+    /// Format an assignability-message type while suppressing the `display_alias`
+    /// repaint on `Object` / `ObjectWithIndex` nodes.
+    ///
+    /// An evaluated structural object can carry an evaluation-origin
+    /// `display_alias` back to the `Application` it reduced from. For a
+    /// self-referential `Static<typeof X>` schema alias, the reduced object *is*
+    /// the alias body, so the alias `X` repaints it (`X[]` instead of the
+    /// structural shape). Callers that have already reduced a type to a concrete
+    /// structural shape use this entry so the shape is rendered rather than
+    /// collapsing back to the alias spelling.
+    pub(crate) fn format_type_for_assignability_message_skip_object_display_alias(
+        &mut self,
+        ty: TypeId,
+    ) -> String {
+        self.ensure_relation_input_ready(ty);
+        let mut formatter = self
+            .ctx
+            .create_assignability_type_formatter()
+            .with_skip_object_display_alias();
+        formatter.format(ty).into_owned()
+    }
+
     pub(crate) fn format_assignability_type_for_message_preserving_nullish(
         &mut self,
         ty: TypeId,

--- a/crates/tsz-checker/src/error_reporter/display_budget.rs
+++ b/crates/tsz-checker/src/error_reporter/display_budget.rs
@@ -62,6 +62,35 @@ fn scope_is_active() -> bool {
     SCOPE_DEPTH.with(|depth| depth.get() > 0)
 }
 
+/// RAII guard that temporarily suspends the active display budget so the work
+/// done while it is in scope neither consumes the budget nor observes its
+/// truncation.
+///
+/// Used for a *separately bounded* sub-computation that must not deplete the
+/// budget the enclosing render relies on — e.g. the in-place `TypeBox`
+/// `Static<…>` schema reduction, which is bounded by its own recursion-depth
+/// cap. Without this, attempting that reduction (even when it is ultimately
+/// discarded) would spend the shared eval fuel and degrade a later fallback
+/// render of the same message back to the bare alias.
+pub(crate) struct SuspendDisplayBudgetScope(u32);
+
+impl SuspendDisplayBudgetScope {
+    pub(crate) fn enter() -> Self {
+        let saved = SCOPE_DEPTH.with(|depth| {
+            let saved = depth.get();
+            depth.set(0);
+            saved
+        });
+        Self(saved)
+    }
+}
+
+impl Drop for SuspendDisplayBudgetScope {
+    fn drop(&mut self) {
+        SCOPE_DEPTH.with(|depth| depth.set(self.0));
+    }
+}
+
 /// RAII scope delimiting the rendering of one displayed type.
 ///
 /// The outermost scope installs a fresh budget; nested scopes (rendering

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -79,28 +79,23 @@
 # always instantiates the template with the read type and strips `undefined`
 # after. Covered by mapped_strip_optional_template_undefined_tests and the
 # corrected homomorphic_remove_optional_conditional_tests.
-TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
-# deeplyNestedMappedTypes.ts: PARTIAL. tsc 6.0.3 emits 5 TS2322 (`foo2`, `foo4`,
-# and the three `problematicFunction` returns; no error on `bar2`). The earlier
-# `const Readonly`-shadows-lib-`Readonly<T>` defect and `problematicFunction1`
-# already passed. `problematicFunction3` — whose parameter `(typeof Input.static)[]`
-# is a parenthesized `typeof`-property-access used as a postfix-array element —
-# was the residual miss: `CheckerState::get_type_from_type_node`'s ARRAY_TYPE
-# branch resolved the element directly, but a parenthesized element delegated to
-# the leaner `TypeNodeChecker::check` lowering, leaving the `typeof` operand in an
-# under-evaluated deferred form, so the relation mis-accepted it against a
-# structurally-equal target via the `isDeeplyNestedType` one-sided expansion
-# bailout. The ARRAY_TYPE branch now unwraps a parenthesized `typeof` element and
-# resolves the operand through the rich, binder-aware path (so `(typeof X.y)[]`
-# relates like `Array<typeof X.y>` and a `type E = typeof X.y; E[]` alias; covered
-# by `parenthesized_typeof_array_element_relates_like_alias_and_array_generic`).
-# That fixes the simplified/embedded-lib reducer, but with the full pinned
-# `lib.es5`/`lib.es2015` `Readonly`/`Pick`/`Omit`/`Required` the `Static`/
-# `PropertiesReduce` reducer is deeper and STILL trips `isDeeplyNestedType`, so
-# `problematicFunction3` remains a real-lib miss. Retiring this row needs the
-# deeper relation/evaluation work (the `isDeeplyNestedType` family), so the entry
-# stays accepted; the parenthesized-`typeof`-array-element lowering fix lands as
-# independent progress.
+# deeplyNestedMappedTypes.ts: RESOLVED. tsc 6.0.3 emits exactly 5 TS2322 (`foo2`,
+# `foo4`, and the three `problematicFunction` returns; no error on `bar2`). tsz
+# already produced that exact error-CODE set; the residual was a diagnostic
+# *display* divergence, not the `isDeeplyNestedType` relation miss the earlier
+# PARTIAL note hypothesized. The three `problematicFunction` TS2322 messages
+# rendered the source/target array element through its unreduced TypeBox
+# `Static<typeof X>` evaluation-origin `display_alias` (`Input[]`,
+# `PropertiesReduce<…>[]`) instead of tsc's fully-reduced structural object
+# (`{ level1: { level2: { foo: string; }; }; }[]`), so the fingerprint compare
+# failed even though the codes matched. `static_schema_array_structural_display`
+# now reduces the already-resolved schema element object in place — recursively
+# rewriting its nested `Static<…>` projection members — and renders it with the
+# object `display_alias` suppressed. The in-place reduction runs with the
+# diagnostic display work budget suspended, so attempting it never starves the
+# message's second render (which previously truncated back to the bare alias,
+# making the structural display non-deterministic). Verified byte-identical to
+# the tsc 6.0.3 cache by the conformance runner against the pinned lib (1/1).
 # intersectionsOfLargeUnions.ts: RESOLVED. Two-part fix: (1) IndexAccess structural
 # comparison (PR #13146) distinguishes `ElementTagNameMap[T]` from
 # `HTMLElementTagNameMap[T]` when both sides are IndexAccess types; (2)


### PR DESCRIPTION
Goal: hold

## Summary

When the source/target of a `TS2322` is a TypeBox-style `Static<typeof X>` schema array, `tsc` renders the fully-reduced structural object (`{ level1: { level2: { foo: string; }; }; }[]`); `tsz` rendered the unreduced evaluation-origin alias (`Input[]`, `PropertiesReduce<…>[]`). The error **codes already matched** (5× `TS2322` on `deeplyNestedMappedTypes.ts`); only the message fingerprint diverged, so the row was an accepted conformance regression — the **last active entry** in the ledger, now retired.

## Structural rule

When an assignability error displays an array whose element is a TypeBox `Static<…>` schema object (`type S = (T & { params: P })["static"]`), `tsc` shows the element's fully-reduced structural shape, not the alias it was evaluated from. `tsz` now does too, through the checker error-reporter's `static_schema_array_structural_display`. Display-only: the relation outcome (the `TS2322` itself, and its code) is unchanged.

## Root cause (twofold)

1. The evaluated structural object carries an evaluation-origin `display_alias` back to its self-referential `Static<typeof X>` application, so the formatter repaints it as the alias (`Input[]`).
2. The existing re-resolution display paths re-type-check the schema's `const` value declaration, exhausting the shared per-render display work budget on the **first** of a message's two renders (source + target); the **second** render then truncated back to the bare alias — making the structural display non-deterministic.

## Fix

- Reduce the already-resolved schema element object **in place** (`rewrite_nested_static_projection_members`), gated to only fire when it fully reduces (`type_has_residual_static_schema`), and render it with the object `display_alias` suppressed (`with_skip_object_display_alias`).
- Run the bounded in-place reduction under a new `SuspendDisplayBudgetScope` so the attempt never starves the message's second render; a residual (under-reduced) result falls through to the existing re-resolution paths with the budget intact.
- Retire the `deeplyNestedMappedTypes.ts` accepted-regression entry.

Name-agnostic / structural: no new identifier/file-name/printer-string predicate drives the logic; the gate is the existing `Static<…>`-projection structural query, and the printer reads types, not its own rendered output.

## Adjacent matrix

- `Static<typeof X>[]` element vs an object target, vs a bare type-parameter target (`Result`), and vs another `Static<…>[]` target — all render the structural shape.
- Negative / fallback: when the element type was resolved without the lib types the schema needs, the in-place rewrite leaves a residual `Static<…>` and the existing re-resolution fallback is used unchanged.
- `Id<…>` / `Id2<…>` deep mapped-type applications in the same fixture still render their alias-application form (`Id<{…}>`), matching tsc.

## Verification

- `deeplyNestedMappedTypes.ts` via the conformance runner against the pinned TS 6.0.3 lib: **1/1 passed, fingerprint-only: 0** — all 5 expected `TS2322` byte-identical to the checked-in tsc cache (was the accepted regression).
- `cargo clippy -p tsz-checker` clean; `cargo fmt --check` clean; `cargo build -p tsz-cli` green.
- The change executes only on the TypeBox `Static<…>` array display path. The pre-existing static-schema display unit guards (`assignment_checker_typebox_tests`, `assignment_checker_template_display_tests`) are already red on `main` (rendering `Input[]`) because they run in a non-pinned-lib unit env where the schema cannot fully reduce; they are unchanged by this display-only fix (verified identical `Input[]` output on `main` and this branch).
- Ready-review CI owns the full conformance / emit / fourslash suites.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrBdC6HX2ipfPoBpzsX7az)_