### PR TITLE
test(checker): production-faithful multi-file lib harness; activate fleet-fixed FP guards (#14263/#14231/#14230)

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/core/helpers.rs
+++ b/crates/tsz-checker/tests/conformance_issues/core/helpers.rs
@@ -259,7 +259,30 @@ pub(crate) fn compile_named_files_get_diagnostics_with_lib_and_options(
 ) -> Vec<(u32, String)> {
     let lib_files = load_lib_files_for_test();
     compile_named_files_get_diagnostics_with_lib_files_and_options(
-        files, entry_file, options, lib_files,
+        files, entry_file, options, lib_files, false,
+    )
+}
+
+/// Production-faithful variant of
+/// [`compile_named_files_get_diagnostics_with_lib_and_options`]: each binder is
+/// given its file index *before* binding (so `stamp_file_idx` records every
+/// module-local symbol's `decl_file_idx`) and the `global_symbol_file_index` is
+/// wired, exactly like the CLI driver's bind-result reducer.
+///
+/// The plain (unstamped) variant leaves `decl_file_idx == u32::MAX`, which makes
+/// a module-local symbol that shadows a lib global (e.g. an imported value named
+/// `Promise`) look like the lib symbol. Witnesses that turn on that distinction —
+/// notably lib-global shadowing in call position (#14263) — must use this helper
+/// so the harness matches production symbol provenance rather than reporting a
+/// harness-only false positive.
+pub(crate) fn compile_named_files_get_diagnostics_with_lib_and_options_stamped(
+    files: &[(&str, &str)],
+    entry_file: &str,
+    options: CheckerOptions,
+) -> Vec<(u32, String)> {
+    let lib_files = load_lib_files_for_test();
+    compile_named_files_get_diagnostics_with_lib_files_and_options(
+        files, entry_file, options, lib_files, true,
     )
 }
 
@@ -271,7 +294,7 @@ pub(crate) fn compile_named_files_get_diagnostics_with_compiled_libs_and_options
 ) -> Vec<(u32, String)> {
     let lib_files = tsz_checker::test_utils::load_compiled_lib_files(lib_names);
     compile_named_files_get_diagnostics_with_lib_files_and_options(
-        files, entry_file, options, lib_files,
+        files, entry_file, options, lib_files, false,
     )
 }
 
@@ -280,6 +303,7 @@ fn compile_named_files_get_diagnostics_with_lib_files_and_options(
     entry_file: &str,
     options: CheckerOptions,
     lib_files: Vec<Arc<LibFile>>,
+    stamp: bool,
 ) -> Vec<(u32, String)> {
     let mut arenas = Vec::with_capacity(files.len());
     let mut binders = Vec::with_capacity(files.len());
@@ -301,10 +325,20 @@ fn compile_named_files_get_diagnostics_with_lib_files_and_options(
         })
         .collect();
 
-    for (name, source) in files {
+    for (file_idx, (name, source)) in files.iter().enumerate() {
         let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
         let root = parser.parse_source_file();
         let mut binder = BinderState::new();
+        if stamp {
+            // Stamp the driver-assigned file index before binding so
+            // `stamp_file_idx` (run at bind end) records every module-local
+            // symbol's `decl_file_idx`, exactly as the production driver's
+            // bind-result reducer does. Without this, `decl_file_idx == u32::MAX`
+            // and a module-local symbol that shadows a lib global (e.g. an
+            // imported value named `Promise`) is misclassified as the lib symbol,
+            // producing a harness-only false positive (#14263).
+            binder.set_file_idx(file_idx as u32);
+        }
         if !raw_lib_contexts.is_empty() {
             binder.merge_lib_contexts_into_binder(&raw_lib_contexts);
         }
@@ -335,6 +369,31 @@ fn compile_named_files_get_diagnostics_with_lib_files_and_options(
     checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
     checker.ctx.set_all_binders(Arc::clone(&all_binders));
     checker.ctx.set_current_file_idx(entry_idx);
+    if stamp {
+        // Build the immutable declaring-file index (`SymbolId -> file_idx`) like
+        // the production driver's `build_global_symbol_file_index`, so cross-file
+        // symbol provenance (and lib-global shadowing) matches the real pipeline.
+        //
+        // Only module-local symbols are mapped: `stamp_file_idx` (run at bind
+        // end) leaves lib symbols at `decl_file_idx == u32::MAX`, so they are
+        // excluded here. Mapping a merged lib symbol to a user file would
+        // mis-provenance lib globals (e.g. make `console` / node-builtin lookups
+        // look user-declared).
+        let symbol_capacity: usize = all_binders.iter().map(|b| b.symbols.len()).sum();
+        let mut symbol_file_index =
+            FxHashMap::with_capacity_and_hasher(symbol_capacity, Default::default());
+        for (file_idx, binder) in all_binders.iter().enumerate() {
+            for symbol in binder.symbols.iter() {
+                if symbol.decl_file_idx == u32::MAX {
+                    continue;
+                }
+                symbol_file_index.entry(symbol.id).or_insert(file_idx);
+            }
+        }
+        checker
+            .ctx
+            .set_global_symbol_file_index(Arc::new(symbol_file_index));
+    }
     checker
         .ctx
         .set_resolved_module_paths(Arc::new(resolved_module_paths));

--- a/crates/tsz-checker/tests/conformance_issues/core/helpers.rs
+++ b/crates/tsz-checker/tests/conformance_issues/core/helpers.rs
@@ -8,7 +8,7 @@
 //!
 //! See docs/conformance-*.md for full context.
 
-pub(crate) use rustc_hash::{FxHashMap, FxHashSet};
+pub(crate) use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 pub(crate) use std::sync::Arc;
 pub(crate) use tsz_binder::BinderState;
 pub(crate) use tsz_binder::lib_loader::LibFile;
@@ -381,7 +381,7 @@ fn compile_named_files_get_diagnostics_with_lib_files_and_options(
         // look user-declared).
         let symbol_capacity: usize = all_binders.iter().map(|b| b.symbols.len()).sum();
         let mut symbol_file_index =
-            FxHashMap::with_capacity_and_hasher(symbol_capacity, Default::default());
+            FxHashMap::with_capacity_and_hasher(symbol_capacity, FxBuildHasher);
         for (file_idx, binder) in all_binders.iter().enumerate() {
             for symbol in binder.symbols.iter() {
                 if symbol.decl_file_idx == u32::MAX {

--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026.rs
@@ -12,9 +12,10 @@ use super::super::core::*;
 
 /// #14230 (TS2536, single-file): a homomorphic-keys mapped type whose key set is
 /// `string | number | symbol` is indexable by `symbol`; `M[symbol]` must not
-/// report TS2536 ("Type 'symbol' cannot be used to index type 'M'").
+/// report TS2536 ("Type 'symbol' cannot be used to index type 'M'"). Fixed on
+/// `main` (dedicated `symbol_index` slot on `ObjectShape` + mapped lowering);
+/// kept as a live regression guard.
 #[test]
-#[ignore = "reproduces #14230; FP still present (TS2536 on `M[symbol]` for a `string | number | symbol`-keyed mapped type)"]
 fn issue_14230_mapped_over_keyof_any_indexed_by_symbol_no_ts2536() {
     let diagnostics = compile_and_get_diagnostics(
         r#"
@@ -28,19 +29,22 @@ export {};
         "no TS2536 expected — `M` is keyed by `string | number | symbol`, so `M[symbol]` \
          is a valid indexed access. Actual: {diagnostics:#?}"
     );
-    // Negative control: indexing by a key NOT in the key set must still report
-    // TS2536. `boolean` is not part of `string | number | symbol`.
+    // Negative control: `symbol` is a valid index *kind*, but a mapped type whose
+    // key set is only `string | number` carries no symbol index, so `M2[symbol]`
+    // must still report TS2536 — exactly tsc's behavior. (Indexing by a non-index
+    // type such as `boolean` is the different TS2538 family, so it is not used
+    // here.) This keeps the control on the same `symbol` axis as the positive case.
     let neg = compile_and_get_diagnostics(
         r#"
-type M = { [K in string | number]: number };
-type Bad = M[boolean];
+type M2 = { [K in string | number]: number };
+type Bad = M2[symbol];
 export {};
 "#,
     );
     assert!(
         has_error(&neg, 2536),
-        "TS2536 expected — `boolean` is not in the `string | number` key set of `M`. \
-         Actual: {neg:#?}"
+        "TS2536 expected — `M2` is keyed by `string | number` only, so it has no symbol \
+         index for `M2[symbol]`. Actual: {neg:#?}"
     );
 }
 
@@ -250,7 +254,6 @@ export function make(lazy: (...args: any) => LazyEvaluator, args: readonly unkno
 /// must not report TS2677 ("A type predicate's type must be assignable to its
 /// parameter's type").
 #[test]
-#[ignore = "reproduces #14231; FP still present (TS2677 on alias-typed type-predicate parameter in a function-type node)"]
 fn issue_14231_type_predicate_through_alias_no_ts2677() {
     let diagnostics = compile_and_get_diagnostics(
         r#"

--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026_c.rs
@@ -220,7 +220,6 @@ export { useType, useValue }
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "reproduces #14230"]
 fn issue_14230_mapped_index_by_symbol_no_ts2536() {
     let diags = compile_and_get_diagnostics_with_lib_and_options(
         r#"
@@ -324,8 +323,15 @@ export {};
 // shadowing the global in call position (typebox). Multi-file.
 // ---------------------------------------------------------------------------
 
+// Fixed in production (verified 2026-06-22): the global-value recovery in
+// `resolved_identifier_meaning_guards` excludes import `ALIAS` symbols, and
+// `declare_symbol` shadows lib globals for `ALIAS` declarations in external
+// modules. This guard runs through the **production-faithful** multi-file
+// harness (`..._stamped`), which wires `global_symbol_file_index` and stamps
+// each binder's `decl_file_idx` exactly like the CLI driver — the un-stamped
+// harness left the imported value's provenance ambiguous and produced a
+// harness-only TS2348.
 #[test]
-#[ignore = "reproduces #14263 (issue closed but minimal repro still emits TS2348)"]
 fn issue_14263_imported_value_shadows_global_ctor_no_ts2348() {
     if !lib_files_available() {
         return;
@@ -348,11 +354,53 @@ export { a, b }
 "#,
         ),
     ];
-    let diags =
-        compile_named_files_get_diagnostics_with_lib_and_options(files, "main.ts", strict_opts());
+    let diags = compile_named_files_get_diagnostics_with_lib_and_options_stamped(
+        files,
+        "main.ts",
+        strict_opts(),
+    );
     assert!(
         !has_error(&diags, 2348),
         "no TS2348 — imported `Promise`/`Map` values must shadow the global ctor in call position. Actual: {diags:#?}"
+    );
+}
+
+/// Adjacent to #14263: the shadowing is structural (by symbol provenance), not
+/// keyed on `Promise`/`Map`. Other global-constructor names re-exported through
+/// a barrel hop must shadow the global in call position just the same, so a
+/// `string`-returning imported value is callable without TS2348.
+#[test]
+fn imported_value_shadows_global_ctor_through_reexport_no_ts2348() {
+    if !lib_files_available() {
+        return;
+    }
+    let files = &[
+        (
+            "origin.ts",
+            r#"
+export function Set(x: number): string { return "" }
+export function Date(x: number): string { return "" }
+"#,
+        ),
+        ("barrel.ts", "export { Set, Date } from './origin'"),
+        (
+            "entry.ts",
+            r#"
+import { Set, Date } from './barrel'
+const s: string = Set(1)
+const d: string = Date(2)
+export { s, d }
+"#,
+        ),
+    ];
+    let diags = compile_named_files_get_diagnostics_with_lib_and_options_stamped(
+        files,
+        "entry.ts",
+        strict_opts(),
+    );
+    assert!(
+        !has_error(&diags, 2348),
+        "no TS2348 — re-exported `Set`/`Date` values must shadow the global ctor in call position. Actual: {diags:#?}"
     );
 }
 


### PR DESCRIPTION
Goal: hold

Fixes #14465. Refs #14263.

## Summary

The shared multi-file conformance lib helper
`compile_named_files_get_diagnostics_with_lib_and_options`
(`crates/tsz-checker/tests/conformance_issues/core/helpers.rs`) was **not**
production-faithful: it never stamped each binder's `decl_file_idx` before
binding (so `stamp_file_idx` left every module-local symbol at
`decl_file_idx == u32::MAX`) and never wired `global_symbol_file_index`. The
real driver — and the src-side `check_multi_file_with_libs_stamped` — do both.
Without them, a module-local symbol that shadows a lib global is mis-classified
as the lib symbol by `symbol_is_from_actual_or_cloned_lib`, producing a
**harness-only** false positive.

This is the "witness-faithfulness cleanup" #14263 deferred. With it, the
fleet-fixed witnesses that the production fix already makes pass can finally be
activated as live regression guards.

## Structural rule

When the harness checks a multi-file program, it must replicate the driver's
per-file symbol provenance: stamp each binder's file index before binding and
build `global_symbol_file_index` from the declaring file of every module-local
symbol (lib symbols, left at `decl_file_idx == u32::MAX`, are excluded so a
merged lib global is never mis-provenanced as user-declared). Owner: the
multi-file conformance test harness only — no checker/solver/emitter change.

## Owner layer

Test harness + regression guards. The faithfulness is added as an **opt-in
`stamp` flag** on the shared impl, with a `..._stamped` public wrapper; the
existing unstamped path is byte-for-byte unchanged, so no other test shifts.

## Why opt-in (scope honesty)

Making the shared helper unconditionally faithful is deliberately out of scope:
it unmasks the open cross-arena bug #13484 (its minimal 2-file witness flips red
— the unfaithful harness was masking it) plus ~15 other lenient-tuned
divergences across the `conformance_issues_*` targets. Those need their own
investigation and are not folded in here.

## What is activated

- **#14263** (TS2348 — imported `Promise`/`Map` values must shadow the global
  ctor in call position) now runs through the faithful harness, plus a new
  re-export adjacent guard using `Set`/`Date` through a barrel hop to prove the
  shadowing is structural (symbol provenance), not `Promise`/`Map`-keyed.
- **#14231** (TS2677 — type predicate resolved through a type alias).
- **#14230** (TS2536 — `string|number|symbol`-keyed mapped indexed by bare
  `symbol`) in both audit files. The single-file negative control is corrected
  to `M2[symbol]` — a genuine TS2536 (`symbol` is a valid index *kind* but the
  `string|number`-keyed type has no symbol index) — instead of `M[boolean]`,
  which tsc reports as the different **TS2538** ("cannot be used as an index
  type") family.

(#14220 was activated separately by #14451, now on `main`; this branch is
rebased on top of it.)

## Anti-hardcoding

The new guard varies binder/ctor names (`Promise`/`Map` vs `Set`/`Date`) and
adds a re-export indirection so the assertion tracks symbol provenance, not a
fixed spelling. The index build is keyed on `decl_file_idx`, not on any
identifier/file-name/printer string.

## Verification

- `cargo test -p tsz-checker --test conformance_issues_types -- fp_repro_audit`
  → **39 passed, 0 failed, 0 ignored** (rebased on current `main`).
- `cargo test -p tsz-checker --test conformance_issues_types` → no new failures;
  the 3 remaining failures
  (`test_generic_indexed_access_variance_failure_preserves_ts2322`,
  `test_invariant_recursive_generic_error_elaboration_preserves_ts2322`,
  `test_imported_conditional_application_default_satisfies_tuple_constraint`)
  reproduce identically on clean `origin/main` (confirmed via stash) — they are
  pre-existing and unrelated.
- `conformance_issues_{modules,features,errors}` compile clean (signature
  change); behavior unchanged because the unstamped path is untouched.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --tests` clean.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01U8amvgXxHHDjZLDPb26NhV