### PR TITLE
fix(solver): keep array-like union members in Array.isArray narrowing

### DIFF
--- a/crates/tsz-solver/src/narrowing/compound.rs
+++ b/crates/tsz-solver/src/narrowing/compound.rs
@@ -703,16 +703,22 @@ impl<'a> NarrowingContext<'a> {
             let mut array_like: Vec<TypeId> = members
                 .iter()
                 .filter_map(|&member| {
-                    // tsc's `mapType(matching, t => isRelated(c, t) ? c : ...)`
-                    // substitutes the predicate type `c = any[]` when
-                    // `any[] <: member` structurally — detected via
-                    // `is_any_array_compat`. Check BEFORE recursing so the
-                    // substitution is detected at the union level (not
-                    // swallowed by `narrow_to_array`) and `has_any_compat` is
-                    // set correctly for the array-like retention pass below.
+                    // tsc narrows each union member `t` against the predicate
+                    // `c = any[]` as `isSubtypeOf(t, c) ? t : isSubtypeOf(c, t)
+                    // ? c : ...`: an already-array-like `t` is kept, and `c` is
+                    // only substituted for a non-array member that merely
+                    // *contains* `any[]` (`Record<string, any>`, `object`,
+                    // `{}`). So skip array-like members here — `number[]` is a
+                    // subtype of `any[]` (its element `any <: number` makes
+                    // `any[] <: number[]` too), and substituting it would drop
+                    // the concrete element type tsc preserves. Check BEFORE
+                    // recursing so the substitution is detected at the union
+                    // level (not swallowed by `narrow_to_array`) and
+                    // `has_any_compat` is set for the retention pass below.
                     let resolved_member = self.resolve_type(member);
-                    if self.is_any_array_compat(resolved_member)
-                        || is_subtype_of(self.db, any_array, resolved_member)
+                    if !self.is_array_like(resolved_member)
+                        && (self.is_any_array_compat(resolved_member)
+                            || is_subtype_of(self.db, any_array, resolved_member))
                     {
                         has_any_compat = true;
                         return Some(any_array);

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_01.rs
@@ -446,6 +446,78 @@ fn array_isarray_keeps_mutable_and_readonly_array_members() {
     );
 }
 
+/// A union of two *distinct* mutable arrays must keep both members with their
+/// concrete element types: each is a subtype of the predicate `any[]`, so tsc
+/// keeps it rather than substituting `any[]`. Guards the regression where a
+/// mutable array `number[]` was collapsed to `any[]` because
+/// `any[] <: number[]` (its element `any <: number`) tripped the
+/// any-array-compat substitution that is meant only for non-array members.
+#[test]
+fn array_isarray_keeps_multiple_distinct_mutable_arrays() {
+    let interner = TypeInterner::new();
+    let mutable_numbers = interner.array(TypeId::NUMBER);
+    let mutable_strings = interner.array(TypeId::STRING);
+    let union = interner.union(vec![mutable_numbers, mutable_strings, TypeId::BOOLEAN]);
+    let ctx = NarrowingContext::new(&interner);
+
+    let narrowed = ctx.narrow_type(union, &TypeGuard::Array, GuardSense::Positive);
+    let expected = interner.union2(mutable_numbers, mutable_strings);
+    let any_array = interner.array(TypeId::ANY);
+
+    assert_eq!(
+        narrowed, expected,
+        "Array.isArray should keep both distinct mutable array members, not \
+         collapse them to any[]"
+    );
+    assert_ne!(
+        narrowed, any_array,
+        "the mutable array members must not be substituted with any[]"
+    );
+}
+
+/// A mutable array alongside a non-array, any-array-compatible member: tsc
+/// keeps the genuine array (`number[] <: any[]`) and substitutes the predicate
+/// `any[]` only for the structurally-array-like-but-not-array member
+/// (`{ [k: string]: any }`). The fix must preserve the concrete `number[]`
+/// element type while still substituting the index-signature member.
+#[test]
+fn array_isarray_substitutes_only_nonarray_any_compat_member() {
+    let interner = TypeInterner::new();
+    let mutable_numbers = interner.array(TypeId::NUMBER);
+    let any_string_index = interner.object_with_index(ObjectShape {
+        flags: ObjectFlags::empty(),
+        properties: vec![],
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::ANY,
+            readonly: false,
+            param_name: None,
+        }),
+        number_index: None,
+        symbol_index: None,
+        symbol: None,
+    });
+    let union = interner.union(vec![mutable_numbers, any_string_index, TypeId::BOOLEAN]);
+    let ctx = NarrowingContext::new(&interner);
+
+    let narrowed = ctx.narrow_type(union, &TypeGuard::Array, GuardSense::Positive);
+    let any_array = interner.array(TypeId::ANY);
+
+    let members = match interner.lookup(narrowed) {
+        Some(TypeData::Union(list)) => interner.type_list(list).to_vec(),
+        _ => vec![narrowed],
+    };
+    assert!(
+        members.contains(&mutable_numbers),
+        "the concrete mutable array `number[]` must be preserved, got {members:?}"
+    );
+    assert!(
+        members.contains(&any_array),
+        "the non-array `{{ [k: string]: any }}` member must be substituted with any[], \
+         got {members:?}"
+    );
+}
+
 // =============================================================================
 // `in`-operator narrowing of the `object` intrinsic chained with `typeof`
 // =============================================================================


### PR DESCRIPTION
Goal: hold

Fixes #14468.

## Summary

`narrow_to_array` — the `Array.isArray(x)` true-branch narrower in
`crates/tsz-solver/src/narrowing/compound.rs` — substituted the predicate type
`any[]` for any union member `t` satisfying
`is_any_array_compat(t) || any[] <: t`. That check fires for **genuine mutable
arrays**: `any[] <: number[]` holds because the element relation `any <: number`
holds, so a `number[]` member of a narrowed union was collapsed to `any[]`,
dropping its concrete element type.

`tsc` narrows each union member against the predicate type `c = any[]` as
`isSubtypeOf(t, c) ? t : isSubtypeOf(c, t) ? c : never` — it keeps a member that
is itself array-like (a genuine array/tuple/readonly-array is a subtype of
`any[]`) and only substitutes `c` for a **non-array** member that merely
*contains* `any[]` (`Record<string, any>`, `object`, `{}`).

## Structural rule

When `Array.isArray(x)` narrows a union, `tsc` keeps every member `t` with
`t <: any[]` (its concrete element type intact) and substitutes `any[]` only for
non-array members structurally compatible with `any[]`. tsz now gates the
`any[]` substitution on `!is_array_like(member)`, so already-array-like members
(arrays, tuples, readonly arrays) are kept rather than collapsed. Owner layer:
solver narrowing (`NarrowingContext::narrow_to_array`).

The proxy `is_array_like(member)` matches exactly the concrete-array cases that
were wrongly substituted; it does not match a bare type parameter, so
`T extends any[]` members still take the existing substitution/intersection
path (no behavior change). Readonly-array members were already preserved (they
are not subtypes of mutable `any[]`).

## Anti-hardcoding

Structural only — the decision is `is_array_like` (array/tuple/readonly-array
shape) plus the existing subtype/index-signature checks, with no
identifier/file-name/printer-string predicates. New tests vary element types
and member shapes.

## Adjacent matrix

- `number[] | ReadonlyArray<string> | boolean` → `number[] | ReadonlyArray<string>`
  (was `any[] | ReadonlyArray<string>`) — the activated regression test.
- `number[] | string[] | boolean` → `number[] | string[]` (two distinct mutable
  arrays both kept, not collapsed to `any[]`).
- `number[] | { [k: string]: any } | boolean` → keeps `number[]`, substitutes
  `any[]` for the index-signature member.
- `ReadonlyArray<string> | string`, bare `ReadonlyArray<number>`,
  `Record<string, any> | Record<string, any>[]` → unchanged (existing tests).

End-to-end (`tsz --strict --noEmit`), matching bundled `tsc`:
```ts
function f(x: number[] | ReadonlyArray<string> | boolean) {
  if (Array.isArray(x)) {
    const first = x[0];        // number | string (was any)
    const bad: object = first; // TS2322 (was silently accepted)
  }
}
```

## Verification

- `cargo test -p tsz-solver --lib -- array_isarray` → 7/7 (5 pre-existing +
  2 new adjacent guards); the previously-red
  `array_isarray_keeps_mutable_and_readonly_array_members` now passes.
- `cargo test -p tsz-solver --lib -- narrowing::` → 202/202.
- `cargo test -p tsz-solver --lib` → only the 4 unrelated pre-existing failures
  remain (`test_conditional_infer_optional_property_present_distributive`,
  `literal_mask_preserves_object_vs_literal_reduction`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`,
  `test_solver_oversized_file_size_ceilings`); this change resolves the fifth
  (`array_isarray_…`). Net-new failures = 0.
- `cargo fmt -p tsz-solver --check` clean; `cargo clippy -p tsz-solver --lib`
  clean.
- End-to-end differential vs bundled `tsc` on the snippet above → parity.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high