### PR TITLE
perf(solver): memoize collect_contravariant_infer_names per pattern TypeId

### DIFF
--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -539,6 +539,16 @@ pub trait TypeExtractParamsCache {
     /// Record the `extract_type_params_from_type` result for `type_id`.
     /// Default no-op.
     fn set_extract_type_params_memo(&self, _type_id: TypeId, _params: Arc<[TypeParamInfo]>) {}
+
+    /// Look up the memoized `collect_contravariant_infer_names` name list for a
+    /// pattern `type_id`. Default `None` (no caching).
+    fn contravariant_infer_names_memo(&self, _type_id: TypeId) -> Option<Arc<[Atom]>> {
+        None
+    }
+
+    /// Record the `collect_contravariant_infer_names` name list for a pattern
+    /// `type_id`. Default no-op.
+    fn set_contravariant_infer_names_memo(&self, _type_id: TypeId, _names: Arc<[Atom]>) {}
 }
 
 /// Query interface for the solver.
@@ -1066,6 +1076,14 @@ impl TypeExtractParamsCache for TypeInterner {
 
     fn set_extract_type_params_memo(&self, type_id: TypeId, params: Arc<[TypeParamInfo]>) {
         Self::set_extract_type_params_memo(self, type_id, params);
+    }
+
+    fn contravariant_infer_names_memo(&self, type_id: TypeId) -> Option<Arc<[Atom]>> {
+        Self::contravariant_infer_names_memo(self, type_id)
+    }
+
+    fn set_contravariant_infer_names_memo(&self, type_id: TypeId, names: Arc<[Atom]>) {
+        Self::set_contravariant_infer_names_memo(self, type_id, names);
     }
 }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -980,6 +980,15 @@ impl TypeExtractParamsCache for QueryCache<'_> {
     fn set_extract_type_params_memo(&self, type_id: TypeId, params: Arc<[TypeParamInfo]>) {
         self.interner.set_extract_type_params_memo(type_id, params);
     }
+
+    fn contravariant_infer_names_memo(&self, type_id: TypeId) -> Option<Arc<[Atom]>> {
+        self.interner.contravariant_infer_names_memo(type_id)
+    }
+
+    fn set_contravariant_infer_names_memo(&self, type_id: TypeId, names: Arc<[Atom]>) {
+        self.interner
+            .set_contravariant_infer_names_memo(type_id, names);
+    }
 }
 
 impl TypeDatabase for QueryCache<'_> {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -556,9 +556,30 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// This mirrors tsc's `inferTypes`, where a type variable with any
     /// contravariant occurrence produces an intersection of its candidates.
     pub(crate) fn collect_contravariant_infer_names(&self, pattern: TypeId) -> FxHashSet<Atom> {
+        // An intrinsic pattern carries no `infer` names; skip the memo round-trip.
+        if pattern.is_intrinsic() {
+            return FxHashSet::default();
+        }
+        // Project-wide memo: the contravariant-`infer`-name set is a pure function
+        // of the immutable interned pattern structure (the variance walk consults
+        // neither the resolver nor the substitution environment), so the answer is
+        // stable per `TypeId`. Recursive conditional/`infer` matching re-asks it
+        // for the same pattern across many fresh evaluators (#14330).
+        if let Some(cached) = self.interner().contravariant_infer_names_memo(pattern) {
+            // The empty set is the dominant case (most patterns have no
+            // contravariant `infer`); return it without iterating the slice.
+            if cached.is_empty() {
+                return FxHashSet::default();
+            }
+            return cached.iter().copied().collect();
+        }
         let mut result = FxHashSet::default();
         let mut visited = FxHashSet::default();
         self.collect_variance_infer_names(pattern, false, &mut result, &mut visited);
+        self.interner().set_contravariant_infer_names_memo(
+            pattern,
+            result.iter().copied().collect::<Vec<_>>().into(),
+        );
         result
     }
 

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -263,6 +263,22 @@ pub struct TypeInterner {
     /// collapses the repeats to O(1) and is shared across the many fresh
     /// `TypeEvaluator` instances created during instantiation (#14330).
     pub(super) extract_type_params_cache: DashMap<TypeId, Arc<[TypeParamInfo]>, FxBuildHasher>,
+    /// Result memo for `collect_contravariant_infer_names`, keyed by the pattern
+    /// `TypeId`.
+    ///
+    /// The set of `infer` names that occur in a contravariant (function/callable
+    /// parameter) position of a pattern is a pure function of the immutable
+    /// interned pattern structure — the variance walk never consults the resolver
+    /// or substitution environment. Infer-pattern matching nonetheless recomputes
+    /// it on every union-member distribution and every object-property match
+    /// (`match_infer_pattern_union_members` / `match_infer_object_properties`),
+    /// each time re-walking the whole pattern subtree. A recursive conditional
+    /// that re-applies itself over an alias `Application` re-asks it for the same
+    /// (often shared) pattern across the many fresh `TypeEvaluator` instances
+    /// instantiation spins up. Memoizing the result per `TypeId` collapses the
+    /// repeats to O(1); the stored `Arc<[Atom]>` is the deduplicated name list the
+    /// caller reconstructs into a set (#14330).
+    pub(super) contravariant_infer_names_cache: DashMap<TypeId, Arc<[Atom]>, FxBuildHasher>,
     /// Packed per-`TypeId` caches for immutable structural content predicates.
     ///
     /// Each bit records one predicate's known/truthy state. This preserves the
@@ -551,6 +567,7 @@ impl TypeInterner {
             predicate_cache: DashMap::with_hasher(FxBuildHasher),
             widen_type_cache: DashMap::with_hasher(FxBuildHasher),
             extract_type_params_cache: DashMap::with_hasher(FxBuildHasher),
+            contravariant_infer_names_cache: DashMap::with_hasher(FxBuildHasher),
             union_normalize_cache: DashMap::with_hasher(FxBuildHasher),
             array_base_type: AtomicU32::new(u32::MAX),
             array_display_base_type: AtomicU32::new(u32::MAX),
@@ -821,6 +838,22 @@ impl TypeInterner {
     #[inline]
     pub fn set_extract_type_params_memo(&self, type_id: TypeId, params: Arc<[TypeParamInfo]>) {
         self.extract_type_params_cache.insert(type_id, params);
+    }
+
+    /// Look up the memoized `collect_contravariant_infer_names` name list for a
+    /// pattern `TypeId`.
+    #[inline]
+    pub fn contravariant_infer_names_memo(&self, type_id: TypeId) -> Option<Arc<[Atom]>> {
+        self.contravariant_infer_names_cache
+            .get(&type_id)
+            .map(|v| Arc::clone(&v))
+    }
+
+    /// Record the `collect_contravariant_infer_names` name list for a pattern
+    /// `TypeId`.
+    #[inline]
+    pub fn set_contravariant_infer_names_memo(&self, type_id: TypeId, names: Arc<[Atom]>) {
+        self.contravariant_infer_names_cache.insert(type_id, names);
     }
 
     /// Intern a string into an Atom.


### PR DESCRIPTION
Goal: fast

Refs #14330 (recursive-conditional / `infer` evaluation hot path).

## Summary

`collect_contravariant_infer_names(pattern)` computes the set of `infer` names that occur in a **contravariant** (function/callable parameter) position of a pattern. It is a **pure function of the immutable interned pattern structure** — the variance walk consults neither the resolver nor the substitution environment, so the answer is stable per `TypeId`.

It was nonetheless recomputed (a full O(pattern-size) subtree walk) on **every** union-member distribution (`match_infer_pattern_union_members`) and **every** object-property match (`match_infer_object_properties`). A recursive conditional that re-applies itself over an alias `Application` (e.g. `DeepUnwrap<AsyncBox<…>>`, the #14330 fixture) re-asks it for the same pattern across the many fresh `TypeEvaluator` instances instantiation spins up.

## Structural rule

When the contravariant-`infer`-name set of a pattern is needed, it is a pure function of the pattern's interned structure; `tsz` now serves repeats from a project-wide per-`TypeId` memo through the solver interner, exactly mirroring the `extract_type_params_cache` memo landed for this same family.

Owner layer: **solver** — `TypeInterner` cache + `TypeExtractParamsCache` trait (forwarded by `QueryCache`), consumed by `collect_contravariant_infer_names`.

- New `contravariant_infer_names_cache: DashMap<TypeId, Arc<[Atom]>>` on the interner.
- Exposed via two `TypeExtractParamsCache` trait methods (default no-op), forwarded by `TypeInterner` and `QueryCache` so `&dyn TypeDatabase` callers and the per-file query cache both hit the shared interner cache.
- The dominant empty result (most patterns have no contravariant `infer`) and intrinsic patterns short-circuit before any slice work.

## Why this is correct (byte-identical)

The memo returns exactly what the walk computes; the value is a pure function of the pattern `TypeId`, so no diagnostic, inference, or narrowing decision changes. This is a speed-only change.

## Anti-hardcoding

No identifier / file-name / printer-string predicates — the cache key is the structural pattern `TypeId` and the value is the structural name set. Mirrors the established pure-function-memo convention (`extract_type_params_cache`, `widen_type_cache`, `predicate_cache`).

## Verification

- **Zero-diff differential**: built the changed binary and a clean `origin/main` baseline binary; ran both over a corpus heavy in contravariant-`infer` patterns (`UnionToIntersection`, bivariant `{ v: infer U; f: (x: infer U) => void }`, parameter/return `infer`, variadic `infer A`, the `DeepUnwrap` recursive-conditional fixture, plus negative/error cases) → **byte-identical output** on every file.
- `cargo test -p tsz-solver --lib infer` → 1066 passed; `--lib conditional` → 486 passed. The single failure in each (`test_conditional_infer_optional_property_present_distributive`) reproduces identically on a clean stash of the parent commit — **net-new failures = 0**.
- `cargo fmt -p tsz-solver --check` clean; `cargo clippy -p tsz-solver --lib` clean on the touched code. All changed files < 2000 LOC.
- Broad conformance / emit / fourslash owned by ready-review CI.

Note: this is a focused, correctness-neutral hot-path slice (one pure-function memo), not a closure of the #14330 per-case gap — the deeper lever there is lazy conditional-body instantiation (a checker inference-architecture change), tracked on the issue.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKxZSYk3j6pLGEbwE6D3Za)_