### PR TITLE
perf(solver): memoize contains_type_by_id project-wide on the interner

### DIFF
--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -541,6 +541,26 @@ pub trait TypeExtractParamsCache {
     fn set_extract_type_params_memo(&self, _type_id: TypeId, _params: Arc<[TypeParamInfo]>) {}
 }
 
+/// Cache for the pure structural `contains_type_by_id(root, target)` transitive
+/// containment walk, keyed by the `(root, target)` pair.
+///
+/// Transitive `TypeId` containment is a pure function of the immutable interned
+/// type `DAG`, so it can be memoized project-wide and reused across the many fresh
+/// evaluators created during instantiation. Kept separate from [`TypeDatabase`]
+/// so the broad query trait stays under its method cap (#8205); `TypeDatabase`
+/// re-exposes these via the supertrait bound, so `&dyn TypeDatabase` callers are
+/// unaffected.
+pub trait TypeContainsByIdCache {
+    /// Look up the memoized `contains_type_by_id(root, target)` result.
+    /// Default `None` (no caching).
+    fn contains_type_by_id_memo(&self, _root: TypeId, _target: TypeId) -> Option<bool> {
+        None
+    }
+
+    /// Record the `contains_type_by_id(root, target)` result. Default no-op.
+    fn set_contains_type_by_id_memo(&self, _root: TypeId, _target: TypeId, _result: bool) {}
+}
+
 /// Query interface for the solver.
 ///
 /// This keeps solver components generic and prevents them from reaching
@@ -554,6 +574,7 @@ pub trait TypeDatabase:
     + TypeWidenCache
     + TypeSubstitutionConstruction
     + TypeExtractParamsCache
+    + TypeContainsByIdCache
 {
     fn intern(&self, key: TypeData) -> TypeId;
     fn lookup(&self, id: TypeId) -> Option<TypeData>;
@@ -1066,6 +1087,16 @@ impl TypeExtractParamsCache for TypeInterner {
 
     fn set_extract_type_params_memo(&self, type_id: TypeId, params: Arc<[TypeParamInfo]>) {
         Self::set_extract_type_params_memo(self, type_id, params);
+    }
+}
+
+impl TypeContainsByIdCache for TypeInterner {
+    fn contains_type_by_id_memo(&self, root: TypeId, target: TypeId) -> Option<bool> {
+        Self::contains_type_by_id_memo(self, root, target)
+    }
+
+    fn set_contains_type_by_id_memo(&self, root: TypeId, target: TypeId, result: bool) {
+        Self::set_contains_type_by_id_memo(self, root, target, result);
     }
 }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -6,8 +6,8 @@
 
 use crate::caches::application_eval_index::{self, ApplicationEvalDependencyIndex};
 use crate::caches::db::{
-    QueryDatabase, TypeApplicationEvalCache, TypeCompilerOptions, TypeDatabase,
-    TypeDisplayProvenance, TypeExtractParamsCache, TypePredicateCache,
+    QueryDatabase, TypeApplicationEvalCache, TypeCompilerOptions, TypeContainsByIdCache,
+    TypeDatabase, TypeDisplayProvenance, TypeExtractParamsCache, TypePredicateCache,
     TypeSubstitutionConstruction, TypeTupleLimitSignal, TypeWidenCache,
 };
 use crate::caches::instantiation_cache::{InstantiationCache, InstantiationCacheKey};
@@ -979,6 +979,17 @@ impl TypeExtractParamsCache for QueryCache<'_> {
 
     fn set_extract_type_params_memo(&self, type_id: TypeId, params: Arc<[TypeParamInfo]>) {
         self.interner.set_extract_type_params_memo(type_id, params);
+    }
+}
+
+impl TypeContainsByIdCache for QueryCache<'_> {
+    fn contains_type_by_id_memo(&self, root: TypeId, target: TypeId) -> Option<bool> {
+        self.interner.contains_type_by_id_memo(root, target)
+    }
+
+    fn set_contains_type_by_id_memo(&self, root: TypeId, target: TypeId, result: bool) {
+        self.interner
+            .set_contains_type_by_id_memo(root, target, result);
     }
 }
 

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -103,14 +103,6 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// pattern thousands of times while checking whether the application-level
     /// infer fast path applies.
     contains_infer_cache: FxHashMap<TypeId, bool>,
-    /// PERF: Cache exact `TypeId` containment checks within this evaluator.
-    ///
-    /// Distributive conditional evaluation asks whether each branch references
-    /// the original distribution source before deciding whether substitution is
-    /// necessary. Recursive utility aliases can revisit the same branch/source
-    /// pair across tail-recursive conditional iterations; this memo keeps that
-    /// pure solver predicate O(1) after the first walk.
-    contains_type_by_id_cache: FxHashMap<(TypeId, TypeId), bool>,
     /// Ceiling for eager mapped-key expansion before bailing out.
     max_mapped_keys: usize,
     /// When true, flag `depth_exceeded` on Application cycle detection.
@@ -244,8 +236,6 @@ pub struct TypeEvaluatorCacheStatistics {
     pub conditional_subtype_entries: usize,
     /// Entries in the `contains infer` predicate memo keyed by `TypeId`.
     pub contains_infer_entries: usize,
-    /// Entries in the exact `contains_type_by_id(root, target)` memo.
-    pub contains_type_by_id_entries: usize,
     estimated_size_bytes: usize,
 }
 
@@ -296,7 +286,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             suppress_this_binding: false,
             conditional_subtype_cache: FxHashMap::default(),
             contains_infer_cache: FxHashMap::default(),
-            contains_type_by_id_cache: FxHashMap::default(),
             max_mapped_keys: DEFAULT_MAX_MAPPED_KEYS,
             flag_depth_on_app_cycle: false,
             expand_application_display_alias_args: false,
@@ -321,21 +310,15 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     pub fn cache_statistics(&self) -> TypeEvaluatorCacheStatistics {
         let conditional_subtype_entries = self.conditional_subtype_cache.len();
         let contains_infer_entries = self.contains_infer_cache.len();
-        let contains_type_by_id_entries = self.contains_type_by_id_cache.len();
         let type_evaluator_cache_estimated_size_bytes = conditional_subtype_entries
             .saturating_mul(std::mem::size_of::<((TypeId, TypeId), bool)>())
             .saturating_add(
                 contains_infer_entries.saturating_mul(std::mem::size_of::<(TypeId, bool)>()),
-            )
-            .saturating_add(
-                contains_type_by_id_entries
-                    .saturating_mul(std::mem::size_of::<((TypeId, TypeId), bool)>()),
             );
 
         TypeEvaluatorCacheStatistics {
             conditional_subtype_entries,
             contains_infer_entries,
-            contains_type_by_id_entries,
             estimated_size_bytes: type_evaluator_cache_estimated_size_bytes,
         }
     }
@@ -568,7 +551,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     pub fn reset(&mut self) {
         self.cache.clear();
         self.tainted.clear();
-        self.contains_type_by_id_cache.clear();
         self.guard.reset();
         self.def_depth.clear();
         self.def_eval_stack.clear();
@@ -650,18 +632,25 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.contains_infer_cache.insert(type_id, result);
     }
 
-    /// PERF: Exact `TypeId` containment with an evaluator-local memo.
+    /// PERF: Exact `TypeId` containment, memoized project-wide on the interner.
+    ///
+    /// `contains_type_by_id` is a pure function of the immutable interned type
+    /// `DAG` (no resolver, substitution env, or compiler option), so its result is
+    /// permanently stable per `(root, target)` within one interner. Memoizing on
+    /// the interner — rather than per `TypeEvaluator` — lets the many fresh
+    /// evaluators created during recursive-alias instantiation reuse the walk
+    /// instead of re-running it after each evaluator is dropped (#13097 / #8356).
     #[inline]
-    pub(crate) fn cached_contains_type_by_id(&mut self, root: TypeId, target: TypeId) -> bool {
+    pub(crate) fn cached_contains_type_by_id(&self, root: TypeId, target: TypeId) -> bool {
         if root == target {
             return true;
         }
-        if let Some(cached) = self.contains_type_by_id_cache.get(&(root, target)) {
-            return *cached;
+        if let Some(cached) = self.interner.contains_type_by_id_memo(root, target) {
+            return cached;
         }
         let result = crate::visitor::contains_type_by_id(self.interner, root, target);
-        self.contains_type_by_id_cache
-            .insert((root, target), result);
+        self.interner
+            .set_contains_type_by_id_memo(root, target, result);
         result
     }
 

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -263,6 +263,24 @@ pub struct TypeInterner {
     /// collapses the repeats to O(1) and is shared across the many fresh
     /// `TypeEvaluator` instances created during instantiation (#14330).
     pub(super) extract_type_params_cache: DashMap<TypeId, Arc<[TypeParamInfo]>, FxBuildHasher>,
+    /// Result memo for the pure structural `contains_type_by_id(root, target)`
+    /// transitive-containment walk, keyed by the `(root, target)` pair.
+    ///
+    /// Transitive `TypeId` containment is a pure function of the immutable
+    /// interned type `DAG` — it consults neither the resolver nor the substitution
+    /// environment nor any compiler option, so the answer is permanently stable
+    /// per `(root, target)` within one interner and reusable across every
+    /// `TypeEvaluator` instance in a project run. Distributive conditional
+    /// evaluation asks it for each branch against the distribution source on
+    /// every tail-recursive iteration, and recursive utility aliases (`Exclude`,
+    /// `Diff`, `Flatten`, …) mint a fresh `TypeEvaluator` per instantiation step;
+    /// the per-evaluator memo that previously held this result is dropped on
+    /// `reset()`, so without a project-wide memo the same pair is re-walked once
+    /// per evaluator (the per-evaluator cache-discard residue, #13097 / #8356).
+    /// Memoizing on the interner collapses the repeats to O(1), exactly like the
+    /// sibling `extract_type_params_cache` / `widen_type_cache` pure-function
+    /// memos.
+    pub(super) contains_type_by_id_cache: DashMap<(TypeId, TypeId), bool, FxBuildHasher>,
     /// Packed per-`TypeId` caches for immutable structural content predicates.
     ///
     /// Each bit records one predicate's known/truthy state. This preserves the
@@ -447,6 +465,8 @@ pub struct TypePredicateCacheStatistics {
     pub eval_contains_infer_cache_entries: usize,
     /// Number of memoized file-relative containment predicate results.
     pub contains_file_relative_cache_entries: usize,
+    /// Number of memoized structural `contains_type_by_id(root, target)` results.
+    pub contains_type_by_id_cache_entries: usize,
 }
 
 impl std::fmt::Debug for TypeInterner {
@@ -488,6 +508,7 @@ impl TypeInterner {
                 .predicate_cache_entries_for(PredicateCacheKind::EvalContainsInfer),
             contains_file_relative_cache_entries: self
                 .predicate_cache_entries_for(PredicateCacheKind::ContainsFileRelative),
+            contains_type_by_id_cache_entries: self.contains_type_by_id_cache.len(),
         }
     }
 
@@ -551,6 +572,7 @@ impl TypeInterner {
             predicate_cache: DashMap::with_hasher(FxBuildHasher),
             widen_type_cache: DashMap::with_hasher(FxBuildHasher),
             extract_type_params_cache: DashMap::with_hasher(FxBuildHasher),
+            contains_type_by_id_cache: DashMap::with_hasher(FxBuildHasher),
             union_normalize_cache: DashMap::with_hasher(FxBuildHasher),
             array_base_type: AtomicU32::new(u32::MAX),
             array_display_base_type: AtomicU32::new(u32::MAX),
@@ -821,6 +843,21 @@ impl TypeInterner {
     #[inline]
     pub fn set_extract_type_params_memo(&self, type_id: TypeId, params: Arc<[TypeParamInfo]>) {
         self.extract_type_params_cache.insert(type_id, params);
+    }
+
+    /// Look up the memoized structural `contains_type_by_id(root, target)` result.
+    #[inline]
+    pub fn contains_type_by_id_memo(&self, root: TypeId, target: TypeId) -> Option<bool> {
+        self.contains_type_by_id_cache
+            .get(&(root, target))
+            .map(|v| *v)
+    }
+
+    /// Record the structural `contains_type_by_id(root, target)` result.
+    #[inline]
+    pub fn set_contains_type_by_id_memo(&self, root: TypeId, target: TypeId, result: bool) {
+        self.contains_type_by_id_cache
+            .insert((root, target), result);
     }
 
     /// Intern a string into an Atom.

--- a/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_core.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_core.rs
@@ -21,6 +21,67 @@ fn evaluator_cache_statistics_report_entries_and_size() {
     );
 }
 
+/// `contains_type_by_id` is a pure function of the immutable interned `DAG`, so its
+/// memo is published project-wide on the interner and reused across `TypeEvaluator`
+/// instances — the fresh-evaluator-per-instantiation-step shape that previously
+/// re-walked the same `(root, target)` pair after each evaluator was dropped
+/// (#13097 / #8356). This pins both the byte-identical value and the sharing.
+#[test]
+fn contains_type_by_id_memo_is_project_wide_across_evaluators() {
+    let interner = TypeInterner::new();
+    // `root` structurally contains NUMBER (a union member) but not BOOLEAN.
+    let root = interner.union2(TypeId::STRING, TypeId::NUMBER);
+
+    // Cold: nothing memoized yet for either pair.
+    assert_eq!(interner.contains_type_by_id_memo(root, TypeId::NUMBER), None);
+    assert_eq!(interner.contains_type_by_id_memo(root, TypeId::BOOLEAN), None);
+
+    // First evaluator computes both answers and publishes them to the interner.
+    let first = {
+        let eval_a = TypeEvaluator::new(&interner);
+        (
+            eval_a.cached_contains_type_by_id(root, TypeId::NUMBER),
+            eval_a.cached_contains_type_by_id(root, TypeId::BOOLEAN),
+        )
+    };
+    assert_eq!(first, (true, false));
+
+    // The memoized values equal the uncached structural walk (byte-identical).
+    assert!(crate::visitor::contains_type_by_id(
+        &interner,
+        root,
+        TypeId::NUMBER
+    ));
+    assert!(!crate::visitor::contains_type_by_id(
+        &interner,
+        root,
+        TypeId::BOOLEAN
+    ));
+
+    // Published to the interner, so a *fresh* evaluator (the dropped-and-recreated
+    // case) reuses them rather than re-walking.
+    assert_eq!(
+        interner.contains_type_by_id_memo(root, TypeId::NUMBER),
+        Some(true)
+    );
+    assert_eq!(
+        interner.contains_type_by_id_memo(root, TypeId::BOOLEAN),
+        Some(false)
+    );
+
+    let eval_b = TypeEvaluator::new(&interner);
+    assert!(eval_b.cached_contains_type_by_id(root, TypeId::NUMBER));
+    assert!(!eval_b.cached_contains_type_by_id(root, TypeId::BOOLEAN));
+
+    // Identity short-circuit is never memoized (root == target is structural).
+    assert!(eval_b.cached_contains_type_by_id(root, root));
+    assert_eq!(interner.contains_type_by_id_memo(root, root), None);
+
+    // Observability counter reflects exactly the two memoized pairs.
+    let stats = interner.type_predicate_cache_statistics();
+    assert_eq!(stats.contains_type_by_id_cache_entries, 2);
+}
+
 #[test]
 fn test_conditional_true_branch() {
     let interner = TypeInterner::new();


### PR DESCRIPTION
Goal: fast

Refs #8356 (ts-toolbelt recursive type-evaluation pressure; the per-evaluator cache-discard residue named in the post-#13239 profile).

## Structural rule

When the evaluator asks `contains_type_by_id(root, target)` — the transitive `TypeId` containment that distributive conditional evaluation runs for each branch against the distribution source — the answer is a **pure function of the immutable interned type `DAG`**: it walks `for_each_child_by_id` over already-interned children and consults neither the resolver, the substitution environment, nor any compiler option. So the result is permanently stable per `(root, target)` within one interner, and `tsz` now serves repeats from a **project-wide** interner memo, exactly mirroring the established `extract_type_params` (#14330) / `widen_type` (#13598) / `normalize_union` (#13239) pure-function memos.

Owner layer: **solver** — `TypeInterner` cache + new `TypeContainsByIdCache` trait (a supertrait of `TypeDatabase`, kept separate per the #8205 method cap), consumed by `TypeEvaluator::cached_contains_type_by_id`.

## What changed

- New `contains_type_by_id_cache: DashMap<(TypeId, TypeId), bool>` on `TypeInterner`, with `contains_type_by_id_memo` / `set_contains_type_by_id_memo` inherent methods.
- New `TypeContainsByIdCache` trait (default no-op), forwarded by `TypeInterner` and `QueryCache` so both `&dyn TypeDatabase` shapes hit the shared interner cache.
- `cached_contains_type_by_id` now reads/writes the project-wide memo instead of a per-`TypeEvaluator` `FxHashMap` that was dropped on `reset()`. The per-evaluator field, its `reset()` clear, and its `TypeEvaluatorCacheStatistics` entry are removed; a project-wide `contains_type_by_id_cache_entries` observability counter is added.
- The identity short-circuit (`root == target`) is unchanged and still never memoized.

## Why this is correct (byte-identical)

The memo returns exactly what `crate::visitor::contains_type_by_id` computes; the value is a pure function of the `(root, target)` pair over immutable interned types, so no diagnostic, inference, or narrowing decision changes. Only the memo's **lifetime** widens from one evaluator to the project — the fresh-evaluator-per-instantiation-step shape (recursive utility aliases `Exclude` / `Diff` / `Flatten`, …) stops re-walking the same pair after each evaluator is dropped. This is a speed-only change.

## Anti-hardcoding

No identifier / file-name / printer-string predicates — the cache key is the structural `(root, target)` pair and the value is the structural containment answer. Mirrors the established pure-function-memo convention.

## Verification

- New regression test `contains_type_by_id_memo_is_project_wide_across_evaluators` (binder-name-agnostic, structural shapes): pins the cold state, the byte-identical equivalence to the uncached `visitor::contains_type_by_id` walk, the cross-evaluator sharing (a fresh evaluator reuses a dropped one's result), the never-memoized identity short-circuit, and the observability counter. **Passes.**
- `cargo test -p tsz-solver --lib` on the rebased tree: **6920 passed**, 4 failed; the 4 failures (`test_conditional_infer_optional_property_present_distributive`, `literal_mask_preserves_object_vs_literal_reduction`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`, `test_solver_oversized_file_size_ceilings`) reproduce identically on clean `origin/main` (confirmed via `git stash`) — **net-new failures = 0**.
- `cargo fmt -p tsz-solver --check` clean; `cargo clippy -p tsz-solver --lib` clean (incl. `doc_markdown`). `cargo build -p tsz-checker --lib` clean (the new supertrait does not affect downstream `&dyn TypeDatabase` callers). All touched files < 2000 LOC.
- Reviewed with three `/simplify` passes (reuse / simplification / efficiency / altitude): consistent with sibling caches, no dead code, correct altitude.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Lev4SV4woaHggyAx1h1L2Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lev4SV4woaHggyAx1h1L2Q)_