### PR TITLE
hold(bench): SIGPIPE-proof run-cliff overlay-entries grep

### DIFF
--- a/scripts/bench/scale-cliff/run-cliff.sh
+++ b/scripts/bench/scale-cliff/run-cliff.sh
@@ -153,7 +153,11 @@ run_one() {
     # Format is "copy_symbol_file_targets   N  (M entries copied)"
     overlay_calls=$(awk '/copy_symbol_file_targets/ {for (i=1;i<=NF;i++) if ($i ~ /^[0-9]+$/) {print $i; exit}}' "$out")
     # macOS awk doesn't support match() with array arg; use sed instead.
-    overlay_entries=$(grep "copy_symbol_file_targets" "$out" | sed -E 's/.*\(([0-9]+) entries.*/\1/' | head -1)
+    # `grep -m1` (not `grep ... | head -1`) so grep itself closes the pipe after
+    # the first match: under `set -euo pipefail` a `grep | head` lets head close
+    # the reader while grep keeps scanning a multi-match dump, SIGPIPEing grep
+    # (exit 141) and aborting this assignment (the #14449 freeze family).
+    overlay_entries=$(grep -m1 "copy_symbol_file_targets" "$out" | sed -E 's/.*\(([0-9]+) entries.*/\1/')
     if ! [[ "$overlay_entries" =~ ^[0-9]+$ ]]; then overlay_entries=0; fi
 
     local compute_calls


### PR DESCRIPTION
## Summary

`scripts/bench/scale-cliff/run-cliff.sh` runs under `set -euo pipefail`. The
overlay-entries counter was extracted with:

```bash
overlay_entries=$(grep "copy_symbol_file_targets" "$out" | sed ... | head -1)
```

`head -1` closes the reader after the first line while `grep` keeps scanning a
potentially multi-match counters dump — so `grep` writes to a closed pipe,
SIGPIPEs (exit 141), `pipefail` propagates it, and `set -e` aborts the
assignment. This is the same failure family as the publishing-freeze fix
**#14449** (`avoid SIGPIPE in diagnostic first-line extraction`).

Fix: use `grep -m1` so `grep` itself closes the pipe after the first match and
never writes to a closed reader (structurally SIGPIPE-proof), dropping the
redundant `| head -1`.

## Context — SIGPIPE sweep result

This PR is the only code change from a full `set -o pipefail` + SIGPIPE sweep of
`scripts/bench`, `scripts/ci`, `scripts/cloudbuild`, and `.github/workflows`
(prompted by the publishing freeze). Findings:

- **Freeze cause already fixed:** `bench-vs-tsgo-results.sh` `printf | head -1`
  → fixed by #14449; verified by a post-fix perf-cron running `bench-project-hotspots` green.
- **Publish path is otherwise clean.** Every other `| head` / `| grep` / `read < <()` hit is safe by construction:
  - `gcp-full-ci.sh` / `gcp-full-ci-conformance.sh` `find | head` — no `pipefail`, so the pipeline exits with `head`'s status.
  - `$(tool --version | head -1)` — `echo`-argument position; `set -e` ignores command-sub failures there.
  - `read -r ... < <(producer)` — process-substitution exit is not propagated to `set -e`.
  - `| tail` (reads to EOF, can't SIGPIPE the producer) and `|| true` (swallows 141).
  - `extract_counter` `awk … exit` prints ≤1 line then exits — never writes to the closed pipe.
- **`run-cliff.sh` is a manual diagnostic** (not invoked by CI / bench / publish), so this is hardening, not a freeze fix.

Goal: hold

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- `bash -n scripts/bench/scale-cliff/run-cliff.sh` passes.
- `grep -m1 | sed` yields the identical single value as `grep | sed | head -1` for the normal single-match dump, with no SIGPIPE on a multi-match dump.
- Sweep (above) confirms no other `pipefail` SIGPIPE site remains in the CI/bench publish path post-#14449.
