### PR TITLE
fast(bench): honest perf rows — hard-gate canary slowdowns + guard 0-file phantom wins

### DIFF
--- a/scripts/bench/lib/bench-vs-tsgo-results.sh
+++ b/scripts/bench/lib/bench-vs-tsgo-results.sh
@@ -408,6 +408,25 @@ run_project_benchmark() {
     local kb=$((bytes / 1024))
     local info="${lines} lines, ${kb}KB (${file_count} project files)"
 
+    # Integrity guard: a tsconfig that resolves zero input files under `-p`
+    # (e.g. a solution-style {"files":[],"references":[...]} config, whose
+    # references are only followed under `-b`) type-checks NOTHING, so every
+    # compiler "passes" trivially and the row would publish a meaningless ratio
+    # (the infisical "0 lines, tsz 24.6x faster" phantom). project_tsconfig_stats
+    # resolves files the same way the compilers do under -p
+    # (parseJsonConfigFileContent().fileNames), so file_count==0 means -p checks
+    # nothing. Record fixture-invalid (gray, advisory) and never a winner.
+    if ! [[ "${file_count:-0}" =~ ^[0-9]+$ ]] || [ "${file_count:-0}" -eq 0 ]; then
+        local zero_status="0 input files (references-only/empty tsconfig under -p)"
+        echo -e "${YELLOW}$name${NC} - ${YELLOW}SKIP${NC} (${zero_status})"
+        record_project_compatibility "$name" "fixture invalid" "fixture setup" \
+            "zero input files under -p" \
+            "tsconfig resolves 0 project files under -p; references are only followed under -b, so this is not a valid compile" \
+            "$file_count" "$peak_memory_bytes" "" "" "" "$tsconfig" "$src_dir"
+        RESULTS_CSV="${RESULTS_CSV}${name},${lines},${kb},ERR,ERR,N/A,N/A,error,0,${zero_status}\n"
+        return
+    fi
+
     # Set project-level Node options for large-ts-repo so tsc/tsgo/tsz can
     # run with a larger heap during compilation.
     local -a project_node_prefix=()
@@ -712,13 +731,14 @@ run_project_benchmark() {
                 ratio=$(printf "%.2f" "$(echo "$tsz_mean / $tsgo_mean" | bc -l 2>/dev/null)" 2>/dev/null || echo "N/A")
             fi
 
-            # The perf-comparison canary shard intentionally charts tsz-vs-tsgo
-            # even when tsz is much slower than tsgo — that gap IS the comparison
-            # we want to surface. The slowdown-failure gate nulls the timing
-            # (ERR,ERR), which would drop every canary off the chart, so it must
-            # not apply to the bench-canaries shard. Required project rows keep it.
+            # Hard-gate EVERY perf_timed row, canaries included: when tsz is at
+            # or past the slowdown threshold (default 1.5x) slower than tsgo, null
+            # the timing (ERR,ERR) so the row surfaces as a perf failure and drops
+            # out of the chart instead of charting a quiet "tsgo Nx faster" loss.
+            # Canaries were previously exempted (via TSZ_BENCH_SHARD_LABEL) to keep
+            # the gap charted; per owner decision the 1.5x rule now applies to them
+            # too — a >=1.5x loss is a failure regardless of guard/benchmark set.
             if [ "$winner" = "tsgo" ] \
-                && [ "${TSZ_BENCH_SHARD_LABEL:-}" != "bench-canaries" ] \
                 && tsz_project_slowdown_failure_reached "$tsz_mean" "$tsgo_mean"; then
                 local threshold
                 threshold="$(tsz_project_slowdown_failure_factor)"


### PR DESCRIPTION
## Summary

Two integrity defects on the published benchmark page (both reported by the owner):

### 1. Hotscript — real 9.1x loss charted as a neutral row (canary slowdown not gated)
`Hotscript` is a `perf_timed` **canary**. The 1.5x slowdown-failure gate (#14208) was deliberately exempted for the `bench-canaries` shard so canaries could chart the gap, so its `tsz 1.9s / tsgo 213ms` (9.1x slower) published as a quiet "tsgo 9.1x faster" row instead of a failure.

Per owner decision (**hard-gate canaries**), remove the `TSZ_BENCH_SHARD_LABEL != "bench-canaries"` exemption in `run_project_benchmark`. Any `perf_timed` row — canary or required — that is `>=1.5x` slower than tsgo is now nulled (`ERR,ERR`) and surfaces as a perf failure, dropping off the chart exactly like required rows already do.

### 2. infisical — phantom "0 lines, tsz 24.6x faster" win
infisical's `app_tsconfig` points at `frontend/tsconfig.json`, which at the pinned ref is a **solution-style** config:
```json
{ "files": [], "references": [ {"path":"./tsconfig.app.json"}, {"path":"./tsconfig.node.json"} ] }
```
Project references are only followed under `-b`; under `--noEmit -p` (what the bench runs) **all three compilers type-check ZERO files**. The "24.6x faster" is pure startup noise on an empty check, and `project_tsconfig_stats` correctly reports "0 lines".

Add an integrity guard in `run_project_benchmark`: when the tsconfig resolves **0 input files** (`project_tsconfig_stats` uses the same `parseJsonConfigFileContent().fileNames` resolution as `-p`), record the row **fixture-invalid** (gray, advisory) and never a winner.

## Audit scope (why this is the complete set)

A workflow audited **all 60 project rows**. The harness writes its own `<fixture>/tsconfig.tsz-bench.json` (explicit include globs) for external rows, generates configs for generated rows, and uses a flat config for large-ts-repo — none can be phantom. **Only the 20 `application` rows pass an upstream `app_tsconfig` straight to `-p`, and of those only infisical's is solution-style.** The guard is general defense for any future references-only app row.

## Follow-up (separate PR)

infisical is also a **false baseline-green required row** (the compile guard keys on tsz's exit code; with 0 files tsz exits 0 and tsc is never consulted). A follow-up repoints it to `frontend/tsconfig.app.json` (the real `include: ./src/**/*`), demotes it from required to advisory, and removes it from `project-compat-baseline.json` — surfacing tsz's real behavior on the app without wedging the merge queue.

Goal: fast

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- `bash -n scripts/bench/lib/bench-vs-tsgo-results.sh` passes.
- `node scripts/bench/test-merge-results.mjs` and `node scripts/bench/test-tsgo-winner-report.mjs` pass (slowdown + merge invariants intact; the `:1179` canary-merge test covers compile-only canaries, a disjoint layer).
- Guard fires on `file_count==0` (the infisical solution-config case) and is a no-op for every row with real input files.
