### PR TITLE
green(bench): infisical — point at real frontend config; demote false required-green

### DIFF
--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -35,7 +35,6 @@ TSZ_COMPILE_GUARD_REQUIRED_ROWS=(
   "vite-vanilla-ts-app"
   "nextjs-fresh-app"
   "comlink-project"
-  "infisical-project"
 )
 
 TSZ_COMPILE_GUARD_CANARY_ROWS=(
@@ -88,6 +87,7 @@ TSZ_COMPILE_GUARD_CANARY_ROWS=(
   "affine-project"
   "immich-server-project"
   "rocketchat-project"
+  "infisical-project"
 )
 
 # Row metadata pre-loaded by tsz_load_fixture_pins_from_rows (pipe-delimited).

--- a/scripts/bench/project-rows.mjs
+++ b/scripts/bench/project-rows.mjs
@@ -813,15 +813,22 @@ export const PROJECT_ROW_DEFINITIONS = [
     family: "real-world application: secrets management dashboard (Next.js)",
     fixture_dir: "infisical",
     source_dir: "frontend",
-    app_tsconfig: "frontend/tsconfig.json",
+    // The upstream frontend/tsconfig.json is a solution-style aggregator
+    // ({"files":[],"references":[...]}) that resolves ZERO files under `-p`
+    // (references are only followed under `-b`), so it produced a phantom
+    // "0 lines, tsz 24.6x faster" benchmark. Point at the real leaf config
+    // whose `include` covers frontend/src. Demoted required -> canary: this
+    // is a strict React app and tsz's real behavior on it is unverified, so
+    // it is advisory (like the other application rows) until proven green.
+    app_tsconfig: "frontend/tsconfig.app.json",
     install_cmd: "npm ci --ignore-scripts",
     install_root: ".",
     repo_env: "INFISICAL_REPO",
     ref_env: "INFISICAL_REF",
     repo: "https://github.com/Infisical/infisical.git",
     ref: "704c8cf7e76f1ce49301a5f943e51303c0db0058",
-    guard_set: "required",
-    benchmark_set: "required",
+    guard_set: "canary",
+    benchmark_set: "canary",
     perf_timed: true,
     category: "application",
   },

--- a/scripts/bench/project-rows.mjs
+++ b/scripts/bench/project-rows.mjs
@@ -814,7 +814,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     fixture_dir: "infisical",
     source_dir: "frontend",
     // The upstream frontend/tsconfig.json is a solution-style aggregator
-    // ({"files":[],"references":[...]}) that resolves ZERO files under `-p`
+    // with empty files plus project references; it resolves ZERO files under `-p`
     // (references are only followed under `-b`), so it produced a phantom
     // "0 lines, tsz 24.6x faster" benchmark. Point at the real leaf config
     // whose `include` covers frontend/src. Demoted required -> canary: this

--- a/scripts/ci/project-compat-baseline.json
+++ b/scripts/ci/project-compat-baseline.json
@@ -9,7 +9,6 @@
   },
   "rows": {
     "comlink-project": "green",
-    "infisical-project": "green",
     "nextjs-fresh-app": "green",
     "rxjs-project": "green",
     "ts-essentials-project": "green",


### PR DESCRIPTION
## Summary

Follow-up to #14477. infisical was a **false baseline-green `required` row**: its `app_tsconfig` pointed at `frontend/tsconfig.json`, a solution-style config:
```json
{ "files": [], "references": [ {"path":"./tsconfig.app.json"}, {"path":"./tsconfig.node.json"} ] }
```
which resolves **zero files** under `--noEmit -p` (references are only followed under `-b`). The compile guard keys on tsz's exit code; with no files tsz exits 0, **tsc is never even consulted**, and the row was scored green without checking anything — the same phantom that published "0 lines, tsz 24.6x faster" on the perf chart.

## Change

Repoint to the real leaf config and demote `required → canary` consistently across **all three surfaces** (the drift check enforces presence; set membership must be moved by hand):

| Surface | Change |
|---|---|
| `project-rows.mjs` | `app_tsconfig` → `frontend/tsconfig.app.json` (its `include` covers `frontend/src`); `guard_set`/`benchmark_set` `required` → `canary` |
| `project-fixtures.sh` | move `"infisical-project"` from `TSZ_COMPILE_GUARD_REQUIRED_ROWS` to `TSZ_COMPILE_GUARD_CANARY_ROWS` (the *operative* compile-gate membership), grouped with the other application rows (payload, medusa, supabase-studio…) which are already canaries because apps are hard for tsz |
| `project-compat-baseline.json` | drop `"infisical-project"` (never legitimately green; the staged ratchet must not expect a phantom-green to stay green) |

## Why this is safe (no wedge regardless of tsz's real behavior)

- The **only** PR-time merge gate is the compile guard (`guard_set === "required"`, `ALLOW_FAILURES=0`). Moving infisical to the canary array makes it **allow-failures** — so whatever tsz does on the real strict React app (compile / diverge / crash / timeout) is advisory, never blocking.
- The perf bench is **cron-only** (Phase 7), so it can't gate PRs either.
- infisical was the *only* application row in `REQUIRED`; every other app is already a canary. This puts it where it belongs.

If tsz later compiles infisical's real config cleanly, it can be re-promoted to `required` and re-added to the baseline.

Goal: green

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- `node scripts/bench/project-row-summary.mjs` (project-row-drift gate) passes — cross-surface membership stays in sync.
- `node scripts/bench/test-project-compat-ratchet.mjs` and `node scripts/bench/test-bench-workflow-micro-coverage.mjs` pass.
- `project-compat-baseline.json` parses; 9 rows, infisical removed.
- `bash -n scripts/bench/project-fixtures.sh` passes.
