### PR TITLE
fix(solver): bound mapped/index-access distribution unions with tsc's TS2590 limit

### DIFF
--- a/crates/tsz-checker/tests/generic_type_alias_deferred_eval_tests.rs
+++ b/crates/tsz-checker/tests/generic_type_alias_deferred_eval_tests.rs
@@ -59,3 +59,79 @@ type Boxed<X extends Letter> = { [Key in X]: `${Key}${Key}${Key}${Key}${Key}` };
         "renamed generic alias declaration should not eagerly expand; got {codes:?}"
     );
 }
+
+// A mapped type whose per-key property value is itself a moderate union under
+// the limit, distributed across enough keys that the cumulative member count
+// exceeds tsc's union-complexity budget (`getUnionType`, ~100k), must report
+// TS2590 — instead of materializing the oversized union (CPU-bound
+// non-termination, #13508). `Cell` alone (22^3 = 10648) is under the limit, so
+// the diagnostic is owed to the mapped *distribution* (22 * 10648 = 234_256),
+// not the template expansion.
+#[test]
+fn mapped_distribution_exceeding_union_budget_reports_too_complex() {
+    let codes = diagnostic_codes_for(
+        r#"
+type K = "a"|"b"|"c"|"d"|"e"|"f"|"g"|"h"|"i"|"j"|"k"|"l"|"m"|"n"|"o"|"p"|"q"|"r"|"s"|"t"|"u"|"v";
+type Cell = `${K}-${K}-${K}`;
+type Grid = { [P in K]: Cell };
+"#,
+    );
+
+    assert!(
+        codes.contains(
+            &diagnostic_codes::EXPRESSION_PRODUCES_A_UNION_TYPE_THAT_IS_TOO_COMPLEX_TO_REPRESENT
+        ),
+        "mapped distribution past the union budget should report TS2590; got {codes:?}"
+    );
+}
+
+// Same structural rule via index-access distribution: indexing a wide interface
+// by `keyof` unions all property values. Each value (`Cell`, 8000 members) is
+// under the limit, but the assembled `O[keyof O]` union (20 * 8000 = 160_000)
+// exceeds it, so tsc — and now tsz — reports TS2590 rather than materializing
+// it. Binders differ from the mapped case so the guard tracks the structural
+// shape, not a spelling.
+#[test]
+fn index_access_distribution_exceeding_union_budget_reports_too_complex() {
+    let codes = diagnostic_codes_for(
+        r#"
+type Tag = "a"|"b"|"c"|"d"|"e"|"f"|"g"|"h"|"i"|"j"|"k"|"l"|"m"|"n"|"o"|"p"|"q"|"r"|"s"|"t";
+type Cell = `${Tag}_${Tag}_${Tag}`;
+interface Bag {
+  p0: Cell; p1: Cell; p2: Cell; p3: Cell; p4: Cell;
+  p5: Cell; p6: Cell; p7: Cell; p8: Cell; p9: Cell;
+  q0: Cell; q1: Cell; q2: Cell; q3: Cell; q4: Cell;
+  q5: Cell; q6: Cell; q7: Cell; q8: Cell; q9: Cell;
+}
+type All = Bag[keyof Bag];
+"#,
+    );
+
+    assert!(
+        codes.contains(
+            &diagnostic_codes::EXPRESSION_PRODUCES_A_UNION_TYPE_THAT_IS_TOO_COMPLEX_TO_REPRESENT
+        ),
+        "index-access distribution past the union budget should report TS2590; got {codes:?}"
+    );
+}
+
+// Negative control: a mapped distribution that stays well under the budget must
+// NOT trip TS2590 — the cap must only fire on genuinely oversized unions, not
+// shrink the threshold for ordinary mapped types.
+#[test]
+fn mapped_distribution_within_union_budget_is_not_too_complex() {
+    let codes = diagnostic_codes_for(
+        r#"
+type K = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j";
+type Cell = `${K}-${K}`;
+type Grid = { [P in K]: Cell };
+"#,
+    );
+
+    assert!(
+        !codes.contains(
+            &diagnostic_codes::EXPRESSION_PRODUCES_A_UNION_TYPE_THAT_IS_TOO_COMPLEX_TO_REPRESENT
+        ),
+        "mapped distribution under the union budget must not report TS2590; got {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -1849,6 +1849,16 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
+    /// Constituent count of `type_id`: a union contributes its member count,
+    /// any other type contributes one. Used by the union-complexity (TS2590)
+    /// caps that bound mapped-type and index-access distribution.
+    pub(crate) fn count_union_members(&self, type_id: TypeId) -> usize {
+        match self.interner().lookup(type_id) {
+            Some(TypeData::Union(list_id)) => self.interner().type_list(list_id).len(),
+            _ => 1,
+        }
+    }
+
     /// Check if a type is a meta-type that would benefit from evaluation
     /// inside a tuple element. Excludes type parameters and concrete types
     /// to avoid recursive blowup.

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -20,6 +20,7 @@ use crate::visitor::{
 };
 
 use super::super::evaluate::TypeEvaluator;
+use crate::intern::TEMPLATE_LITERAL_EXPANSION_LIMIT;
 use crate::objects::apparent::literal_value_intrinsic_kind;
 
 const MAX_UNION_INDEX_SIZE: usize = 500;
@@ -1867,21 +1868,56 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 self.mark_depth_exceeded();
                 return TypeId::ERROR;
             }
+            // TS2590 union-complexity bail (parity with tsc's `getUnionType`,
+            // which returns `errorType` once a union reaches ~100k constituents).
+            // Distributing an index union over an object whose members are
+            // themselves large unions — e.g. a recursive mapped/template
+            // distribution `{ [K in T]: `${K}${Rec<Exclude<T, K>>}` }[T]` — grows
+            // the assembled union factorially. Stop accumulating once the running
+            // member total crosses the limit instead of materializing the whole
+            // union (CPU-bound non-termination, #13508); the sticky
+            // `union_too_complex` flag then drives TS2590 in the checker. A
+            // nested distribution that already overflowed (cascade) is detected
+            // via the pre-loop flag snapshot so deeper keys are not re-expanded.
+            let union_complex_before_index = self.interner().is_union_too_complex();
+            let mut cumulative_members: usize = 0;
             let mut results = Vec::new();
             for &member in members.iter() {
                 if self.is_depth_exceeded() {
                     return TypeId::ERROR;
+                }
+                if !union_complex_before_index && self.interner().is_union_too_complex() {
+                    break;
                 }
                 let result = self.recurse_index_access(object_type, member);
                 if result == TypeId::ERROR && self.is_depth_exceeded() {
                     return TypeId::ERROR;
                 }
                 if result != TypeId::UNDEFINED || self.no_unchecked_indexed_access() {
+                    cumulative_members =
+                        cumulative_members.saturating_add(self.count_union_members(result));
                     results.push(result);
+                    if cumulative_members >= TEMPLATE_LITERAL_EXPANSION_LIMIT {
+                        self.interner().mark_union_too_complex();
+                        break;
+                    }
                 }
             }
             if results.is_empty() {
                 return TypeId::UNDEFINED;
+            }
+            // When the distribution overflowed the union-complexity budget and
+            // every collected result is string-typed — the recursive
+            // template-literal family (e.g. route-path parsing) — widen to
+            // `string` instead of interning the oversized literal union. This
+            // mirrors the template-literal expansion cap's widening, keeps the
+            // already-marked TS2590 flag visible to the checker, and collapses
+            // the result so an enclosing recursion does not re-expand it
+            // (terminating the otherwise factorial growth, #13508).
+            if cumulative_members >= TEMPLATE_LITERAL_EXPANSION_LIMIT
+                && results.iter().all(|&r| self.index_result_is_string_like(r))
+            {
+                return TypeId::STRING;
             }
             return self.interner().union(results);
         }
@@ -1898,6 +1934,23 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         // For other types, keep as IndexAccess (deferred)
         self.interner().index_access(object_type, index_type)
+    }
+
+    /// Whether an index-distribution result is a string-domain type (possibly a
+    /// union all of whose members are string-domain). Used by the TS2590
+    /// union-complexity bail to decide it is sound to widen an oversized result
+    /// union to `string` rather than materialize it. The leaf check reuses the
+    /// shared `is_string_like_type` (string / string-literal / template /
+    /// string-mapping); only the union-recursion is local.
+    fn index_result_is_string_like(&self, ty: TypeId) -> bool {
+        if let Some(TypeData::Union(list_id)) = self.interner().lookup(ty) {
+            return self
+                .interner()
+                .type_list(list_id)
+                .iter()
+                .all(|&m| self.index_result_is_string_like(m));
+        }
+        crate::type_queries::is_string_like_type(self.interner(), ty)
     }
 
     fn evaluate_index_access_result(&mut self, result: TypeId) -> TypeId {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -20,7 +20,6 @@ use crate::visitor::{
 };
 
 use super::super::evaluate::TypeEvaluator;
-use crate::intern::TEMPLATE_LITERAL_EXPANSION_LIMIT;
 use crate::objects::apparent::literal_value_intrinsic_kind;
 
 const MAX_UNION_INDEX_SIZE: usize = 500;
@@ -1863,63 +1862,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // when both object and index are unions: (X | Y)[A | B] -> X[A] | X[B] | Y[A] | Y[B]
         if let Some(members_id) = union_list_id(self.interner(), index_type) {
             let members = self.interner().type_list(members_id);
-            // Limit to prevent OOM with large unions
-            if members.len() > MAX_UNION_INDEX_SIZE {
-                self.mark_depth_exceeded();
-                return TypeId::ERROR;
-            }
-            // TS2590 union-complexity bail (parity with tsc's `getUnionType`,
-            // which returns `errorType` once a union reaches ~100k constituents).
-            // Distributing an index union over an object whose members are
-            // themselves large unions — e.g. a recursive mapped/template
-            // distribution `{ [K in T]: `${K}${Rec<Exclude<T, K>>}` }[T]` — grows
-            // the assembled union factorially. Stop accumulating once the running
-            // member total crosses the limit instead of materializing the whole
-            // union (CPU-bound non-termination, #13508); the sticky
-            // `union_too_complex` flag then drives TS2590 in the checker. A
-            // nested distribution that already overflowed (cascade) is detected
-            // via the pre-loop flag snapshot so deeper keys are not re-expanded.
-            let union_complex_before_index = self.interner().is_union_too_complex();
-            let mut cumulative_members: usize = 0;
-            let mut results = Vec::new();
-            for &member in members.iter() {
-                if self.is_depth_exceeded() {
-                    return TypeId::ERROR;
-                }
-                if !union_complex_before_index && self.interner().is_union_too_complex() {
-                    break;
-                }
-                let result = self.recurse_index_access(object_type, member);
-                if result == TypeId::ERROR && self.is_depth_exceeded() {
-                    return TypeId::ERROR;
-                }
-                if result != TypeId::UNDEFINED || self.no_unchecked_indexed_access() {
-                    cumulative_members =
-                        cumulative_members.saturating_add(self.count_union_members(result));
-                    results.push(result);
-                    if cumulative_members >= TEMPLATE_LITERAL_EXPANSION_LIMIT {
-                        self.interner().mark_union_too_complex();
-                        break;
-                    }
-                }
-            }
-            if results.is_empty() {
-                return TypeId::UNDEFINED;
-            }
-            // When the distribution overflowed the union-complexity budget and
-            // every collected result is string-typed — the recursive
-            // template-literal family (e.g. route-path parsing) — widen to
-            // `string` instead of interning the oversized literal union. This
-            // mirrors the template-literal expansion cap's widening, keeps the
-            // already-marked TS2590 flag visible to the checker, and collapses
-            // the result so an enclosing recursion does not re-expand it
-            // (terminating the otherwise factorial growth, #13508).
-            if cumulative_members >= TEMPLATE_LITERAL_EXPANSION_LIMIT
-                && results.iter().all(|&r| self.index_result_is_string_like(r))
-            {
-                return TypeId::STRING;
-            }
-            return self.interner().union(results);
+            return super::index_access_union_distribution::evaluate_index_union_distribution(
+                self,
+                object_type,
+                &members,
+            );
         }
 
         let interner = self.interner();
@@ -1934,23 +1881,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         // For other types, keep as IndexAccess (deferred)
         self.interner().index_access(object_type, index_type)
-    }
-
-    /// Whether an index-distribution result is a string-domain type (possibly a
-    /// union all of whose members are string-domain). Used by the TS2590
-    /// union-complexity bail to decide it is sound to widen an oversized result
-    /// union to `string` rather than materialize it. The leaf check reuses the
-    /// shared `is_string_like_type` (string / string-literal / template /
-    /// string-mapping); only the union-recursion is local.
-    fn index_result_is_string_like(&self, ty: TypeId) -> bool {
-        if let Some(TypeData::Union(list_id)) = self.interner().lookup(ty) {
-            return self
-                .interner()
-                .type_list(list_id)
-                .iter()
-                .all(|&m| self.index_result_is_string_like(m));
-        }
-        crate::type_queries::is_string_like_type(self.interner(), ty)
     }
 
     fn evaluate_index_access_result(&mut self, result: TypeId) -> TypeId {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_union_distribution.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_union_distribution.rs
@@ -1,0 +1,89 @@
+//! Index-union distribution for indexed access types.
+
+use crate::intern::TEMPLATE_LITERAL_EXPANSION_LIMIT;
+use crate::relations::subtype::TypeResolver;
+use crate::types::{TypeData, TypeId};
+
+use super::super::evaluate::TypeEvaluator;
+
+const MAX_UNION_INDEX_SIZE: usize = 500;
+
+pub(super) fn evaluate_index_union_distribution<R: TypeResolver>(
+    evaluator: &mut TypeEvaluator<'_, R>,
+    object_type: TypeId,
+    members: &[TypeId],
+) -> TypeId {
+    // Limit to prevent OOM with large unions.
+    if members.len() > MAX_UNION_INDEX_SIZE {
+        evaluator.mark_depth_exceeded();
+        return TypeId::ERROR;
+    }
+
+    // TS2590 union-complexity bail (parity with tsc's `getUnionType`, which
+    // returns `errorType` once a union reaches ~100k constituents).
+    //
+    // Distributing an index union over an object whose members are themselves
+    // large unions grows the assembled union factorially. Stop accumulating
+    // once the running member total crosses the limit instead of materializing
+    // the whole union; the sticky `union_too_complex` flag then drives TS2590
+    // in the checker. A nested distribution that already overflowed is detected
+    // via the pre-loop flag snapshot so deeper keys are not re-expanded.
+    let union_complex_before_index = evaluator.interner().is_union_too_complex();
+    let mut cumulative_members: usize = 0;
+    let mut results = Vec::new();
+    for &member in members {
+        if evaluator.is_depth_exceeded() {
+            return TypeId::ERROR;
+        }
+        if !union_complex_before_index && evaluator.interner().is_union_too_complex() {
+            break;
+        }
+        let result = evaluator.recurse_index_access(object_type, member);
+        if result == TypeId::ERROR && evaluator.is_depth_exceeded() {
+            return TypeId::ERROR;
+        }
+        if result != TypeId::UNDEFINED || evaluator.no_unchecked_indexed_access() {
+            cumulative_members =
+                cumulative_members.saturating_add(evaluator.count_union_members(result));
+            results.push(result);
+            if cumulative_members >= TEMPLATE_LITERAL_EXPANSION_LIMIT {
+                evaluator.interner().mark_union_too_complex();
+                break;
+            }
+        }
+    }
+
+    if results.is_empty() {
+        return TypeId::UNDEFINED;
+    }
+
+    // When the distribution overflowed the union-complexity budget and every
+    // collected result is string-typed, widen to `string` instead of interning
+    // the oversized literal union. This mirrors the template-literal expansion
+    // cap's widening, keeps the already-marked TS2590 flag visible to the
+    // checker, and collapses the result so an enclosing recursion does not
+    // re-expand it.
+    if cumulative_members >= TEMPLATE_LITERAL_EXPANSION_LIMIT
+        && results
+            .iter()
+            .all(|&result| index_result_is_string_like(evaluator, result))
+    {
+        return TypeId::STRING;
+    }
+
+    evaluator.interner().union(results)
+}
+
+fn index_result_is_string_like<R: TypeResolver>(
+    evaluator: &TypeEvaluator<'_, R>,
+    ty: TypeId,
+) -> bool {
+    if let Some(TypeData::Union(list_id)) = evaluator.interner().lookup(ty) {
+        return evaluator
+            .interner()
+            .type_list(list_id)
+            .iter()
+            .all(|&member| index_result_is_string_like(evaluator, member));
+    }
+    crate::type_queries::is_string_like_type(evaluator.interner(), ty)
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -12,6 +12,7 @@ use crate::construction::TypeDatabase;
 use crate::instantiation::instantiate::{
     TypeSubstitution, instantiate_type_cached, instantiate_type_preserving_cached,
 };
+use crate::intern::TEMPLATE_LITERAL_EXPANSION_LIMIT;
 use crate::objects::PropertyCollectionResult;
 use crate::relations::subtype::TypeResolver;
 use crate::types::Visibility;
@@ -594,10 +595,35 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             && matches!(mapped.optional_modifier, Some(MappedModifier::Remove))
             && source_object.is_some();
 
+        // TS2590 union-complexity bail (parity with tsc's `getUnionType`, which
+        // returns `errorType` once a union reaches ~100k constituents). A
+        // recursive mapped distribution such as
+        // `{ [K in T]: `${K}${Rec<Exclude<T, K>>}` }[T]` produces one
+        // property-value union per key; indexing the result (`[T]`) unions them,
+        // so the cumulative member count grows factorially and tsz would
+        // materialize an oversized union (CPU-bound non-termination, #13508)
+        // where tsc bails. Track the running member total and stop once it
+        // crosses the limit, mirroring the existing template-literal /
+        // cross-product expansion caps. The sticky `union_too_complex` flag then
+        // drives TS2590 in the checker.
+        let mut cumulative_value_members: usize = 0;
+        // Snapshot the flag so the cascade short-circuit reacts only to
+        // complexity that arose *inside* this evaluation (a nested key's
+        // sub-evaluation), never to a flag a sibling type left set before this
+        // mapped type was reached.
+        let union_complex_before_mapped = self.interner().is_union_too_complex();
+
         for mapped_key in key_set.keys {
             // Check if depth was exceeded during previous iterations
             if self.is_depth_exceeded() {
                 return TypeId::ERROR;
+            }
+            // Cascade short-circuit: a previous key's nested distribution already
+            // overflowed the union-complexity budget, so the whole mapped result
+            // is too complex (TS2590). Stop before instantiating/evaluating the
+            // remaining keys instead of re-paying the per-key cost for each.
+            if !union_complex_before_mapped && self.interner().is_union_too_complex() {
+                break;
             }
             let key_name = mapped_key.name;
             let key_literal = mapped_key.key_literal;
@@ -692,6 +718,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // Naming flags an identity key inherits from its homomorphic source.
             let (src_string_named, src_symbol_named, src_single_quoted) =
                 source_info.map_or((false, false, false), |&(_, _, _, s, y, q)| (s, y, q));
+            // Accumulate the constituent count this key contributes (each remapped
+            // key emits one property whose value is `property_type`).
+            cumulative_value_members = cumulative_value_members.saturating_add(
+                self.count_union_members(property_type)
+                    .saturating_mul(remapped_keys.len()),
+            );
             for mk in remapped_keys {
                 let identity = mk.name == key_name;
                 // Numeric-named string-literal key (`"0"`) stays string-named so `keyof` yields `"0"`, not `0`.
@@ -718,6 +750,15 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     single_quoted_name,
                     non_widening: false,
                 });
+            }
+
+            // Stop materializing further keys once the produced property-value
+            // unions cross tsc's union-complexity budget; the sticky flag drives
+            // TS2590. The already-built properties are kept so the (now
+            // too-complex) result still has shape for downstream display.
+            if cumulative_value_members >= TEMPLATE_LITERAL_EXPANSION_LIMIT {
+                self.interner().mark_union_too_complex();
+                break;
             }
         }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
@@ -21,6 +21,7 @@ mod index_access_empty_key;
 mod index_access_keys;
 mod index_access_object_with_index;
 mod index_access_tuple_literal;
+mod index_access_union_distribution;
 pub mod infer_pattern;
 mod infer_pattern_helpers;
 mod infer_pattern_object_match;

--- a/crates/tsz-solver/src/tests/file_size_baselines.txt
+++ b/crates/tsz-solver/src/tests/file_size_baselines.txt
@@ -27,13 +27,13 @@ solver_file_narrowing_core 2718
 solver_file_relations_compat 2950
 solver_file_constraints_walker 2348
 solver_file_diag_format_mod 2318
-solver_file_eval_mapped 1453
+solver_file_eval_mapped 1497
 solver_file_subtype_generics 2217
 solver_file_call_args 2097
 solver_file_eval_index_access 2226
 solver_file_def_core 2244
 solver_file_visitor_predicates 742
-solver_file_types   2131
+solver_file_types   2146
 
 binder_max_loc        2890
 binder_oversized      1


### PR DESCRIPTION
Goal: green

Refs #13508.

## Structural rule

When a type's evaluation assembles a union by distributing over keys/members —
the mapped-type property-value assembly (`{ [K in T]: V }`) or the
index-access-over-union distribution (`O[K1 | K2 | …]`) — `tsc`'s `getUnionType`
returns `errorType` and reports **TS2590** once the assembled union reaches its
~100k-constituent budget. A recursive distribution such as

```ts
type Perm<T extends string> =
  [T] extends [never] ? "" : { [K in T]: `${K}${Perm<Exclude<T, K>>}` }[T];
```

grows that union factorially. tsz already enforced the budget for
template-literal expansion and intersection cross-products
(`TEMPLATE_LITERAL_EXPANSION_LIMIT`, the same ~100k figure), but **not** for the
mapped property-value assembly or the index-access union distribution, so those
unions were materialized in full — CPU-bound non-termination (the tanstack
template-literal route-path family in #13508) where `tsc` bails.

`tsz does X through` the solver `TypeEvaluator`: the cap lives at the two
distribution sites (not the central union constructor), because the members are
materialized *before* they reach `union_from_iter` — a constructor-level cap
cannot prevent the upstream blow-up, exactly the established per-site pattern
(`template_literal.rs`, `intern/template.rs`, `operations/property.rs`).

## Owner layer

solver — `evaluation/evaluate_rules/mapped.rs` (`evaluate_mapped`) and
`evaluation/evaluate_rules/index_access.rs` (`evaluate_index_access`'s
index-union distribution). Both track the cumulative constituent count and
`mark_union_too_complex()` + stop once it crosses the limit; the sticky
`union_too_complex` flag then drives TS2590 in the checker (the existing
mechanism). A snapshot-guarded cascade short-circuit (`!before && is_complex`)
stops an enclosing distribution from re-expanding a nested overflow. A
string-typed index distribution widens to `string` on overflow — mirroring the
template-literal cap — so a recursive cascade collapses instead of re-growing.

## Anti-hardcoding

Purely structural: the decision is the constituent count vs the shared
`TEMPLATE_LITERAL_EXPANSION_LIMIT`; no identifier / file-name / printer-string
predicate. The string-domain check reuses the shared `is_string_like_type`;
member counting is shared via `count_union_members`. Tests vary binder names
(`K`/`Grid`/`Cell` vs `Tag`/`Bag`) so the guards track the structural shape.

## Adjacent matrix

| source | tsc | tsz (after) |
|---|---|---|
| mapped distribution, cumulative > 100k (`{ [P in K]: Cell }`, 22×10648) | TS2590 | TS2590 ✓ |
| index distribution, cumulative > 100k (`Bag[keyof Bag]`, 20×8000) | TS2590 | TS2590 ✓ |
| mapped distribution under budget (`{ [P in K]: \`${K}-${K}\` }`, 10×100) | — | — ✓ (no false TS2590) |
| recursive `Perm<U>` (N=9, N=10) | TS2590 / errorType | **terminates** (no hang) |

Before this change `Perm<U>` for N≥9 was CPU-bound (N=10 did not finish in
70s); after it terminates. Full TS2590 *surfacing* through deep recursive
`Application` instantiation, and instantiation memoization for the recursive
case, remain the deeper #13508 levers and are out of scope here.

## Verification

- `cargo test -p tsz-checker --test generic_type_alias_deferred_eval_tests` —
  6/6 pass (3 new guards: mapped over-budget → TS2590, index over-budget →
  TS2590, under-budget negative control → no TS2590; + the 3 pre-existing).
- `cargo test -p tsz-solver --lib` — 6920 passed; the 3 failures
  (`test_conditional_infer_optional_property_present_distributive`,
  `literal_mask_preserves_object_vs_literal_reduction`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`)
  reproduce identically on clean `origin/main` (stash-verified) — net-new
  failures = 0.
- End-to-end CLI: `Perm<U>` N=9 terminates (was non-terminating); the direct
  mapped/index over-budget cases emit TS2590; a corpus of advanced-but-valid
  generic/mapped/conditional/template programs stays clean (no spurious TS2590).
- `cargo fmt -p tsz-solver --check` clean; `cargo clippy -p tsz-solver --lib`
  clean. File-size ratchet baseline updated for `mapped.rs`.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3YX1vXpSHDkUwDw1RcyLo)_