### PR TITLE
fix(cli): expand include: ["."] / ["./"] to root-relative **/* (TS18003 parity)

### DIFF
--- a/crates/tsz-cli/src/project/fs.rs
+++ b/crates/tsz-cli/src/project/fs.rs
@@ -288,10 +288,29 @@ fn expand_include_patterns(patterns: &[String]) -> Vec<String> {
         }
 
         // Directory pattern (no extension or glob at end) - expand to match all files
-        let base = pattern.trim_end_matches('/');
-        expanded.push(format!("{base}/**/*"));
+        expanded.push(directory_recursive_glob(pattern));
     }
     expanded
+}
+
+/// Expand a bare directory include entry to its recursive glob.
+///
+/// A directory spec matches every supported file beneath it, mirroring tsc's
+/// `getFileMatcherPatterns`, which appends `/**/*` to a directory. The
+/// current-directory specs `"."` and `"./"` (the latter normalized to an empty
+/// string by [`normalize_patterns`]) denote the project root: they must expand
+/// to a root-relative `**/*`, never `./**/*` or `/**/*`. The discovery walk
+/// matches files by their path relative to `base_dir` (see
+/// [`matches_discovery_patterns`]), and `globset` does not strip a leading `./`
+/// or treat a leading `/` as the walk root, so those spellings would match
+/// nothing and surface a spurious TS18003 "No inputs were found".
+fn directory_recursive_glob(pattern: &str) -> String {
+    let base = pattern.trim_end_matches('/');
+    if base.is_empty() || base == "." {
+        "**/*".to_string()
+    } else {
+        format!("{base}/**/*")
+    }
 }
 
 fn is_terminal_wildcard_pattern(pattern: &str) -> bool {
@@ -601,6 +620,61 @@ mod tests {
                 "subdir/*.tsx".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn test_expand_include_current_directory_is_root_recursive() {
+        // tsc expands a directory spec to `<dir>/**/*`; the current-directory
+        // spellings `"."` and `"./"` (the latter normalized to "") must become a
+        // root-relative `**/*`, not `./**/*` or `/**/*` (which globset cannot
+        // match against discovery-relative paths). See `directory_recursive_glob`.
+        assert_eq!(
+            expand_include_patterns(&normalize_patterns(&[".".to_string()])),
+            vec!["**/*".to_string()]
+        );
+        assert_eq!(
+            expand_include_patterns(&normalize_patterns(&["./".to_string()])),
+            vec!["**/*".to_string()]
+        );
+        assert_eq!(
+            expand_include_patterns(&normalize_patterns(&["./src".to_string()])),
+            vec!["src/**/*".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_discover_current_directory_include_recurses() {
+        // Regression: `include: ["."]` must discover every nested source file
+        // (matching tsc), not resolve to zero inputs / TS18003.
+        let dir = unique_temp_dir("current_dir_include");
+        fs::create_dir_all(dir.join("src/nested")).unwrap();
+        fs::write(dir.join("top.ts"), "export const top = 1;").unwrap();
+        fs::write(dir.join("src/a.ts"), "export const a = 1;").unwrap();
+        fs::write(dir.join("src/nested/b.ts"), "export const b = 1;").unwrap();
+
+        for spec in ["./", "."] {
+            let options = FileDiscoveryOptions {
+                base_dir: dir.clone(),
+                files: Vec::new(),
+                files_explicitly_set: false,
+                include: Some(vec![spec.to_string()]),
+                exclude: None,
+                out_dir: None,
+                follow_links: false,
+                allow_js: false,
+                resolve_json_module: false,
+            };
+
+            let result = discover_ts_files(&options).unwrap();
+            for expected in ["top.ts", "src/a.ts", "src/nested/b.ts"] {
+                assert!(
+                    result.iter().any(|path| path.ends_with(expected)),
+                    "include [{spec:?}] should discover {expected}, got: {result:?}"
+                );
+            }
+        }
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
Goal: hold

Fixes #14481.

## Summary

`tsz -p tsconfig.json` with `"include": ["."]` (or `["./"]`) resolved to **zero
inputs** and emitted a spurious `TS18003: No inputs were found ...`, leaving the
entire project unchecked, while `tsc` recursively includes every supported file
under the project root. A named subdir (`"src"`) already worked, so only the
current-directory spelling was broken.

## Structural rule

When an `include` entry is a bare directory, `tsc`'s `getFileMatcherPatterns`
matches every supported file beneath it. The current-directory specs `.` / `./`
denote the project root and must expand to a **root-relative** `**/*`, never
`./**/*` or `/**/*`. tsz does this through `expand_include_patterns` /
`directory_recursive_glob` in `crates/tsz-cli/src/project/fs.rs`.

Owner layer: **tsz-cli** project file discovery (no checker/solver behavior change).

## Root cause

`expand_include_patterns` turned a directory spec `<dir>` into `<dir>/**/*`. For
the current-directory spellings that produced `./**/*` (`"."`) or `/**/*`
(`"./"`, which `normalize_patterns` rewrites to `""`). Discovery matches files by
their path **relative to `base_dir`** (e.g. `src/a.ts`), and `globset` neither
strips a leading `./` nor treats a leading `/` as the walk root, so both globs
matched nothing and the config fell through to the spurious `TS18003`.

## Fix

Add `directory_recursive_glob`: a directory base of `.` or empty (the project
root) expands to a root-relative `**/*`; every other directory keeps
`<dir>/**/*` unchanged. No identifier/file-name/printer-string predicates — the
decision is purely on the structural directory base.

## Adjacent matrix (differential vs bundled `tsc` 6.0.2, `--strict --noEmit`)

Project with `top.ts`, `src/a.ts`, `src/sub/b.ts` (each one error):

| include | tsc | tsz before | tsz after |
|---|---|---|---|
| `["."]`   | 3 (recursive) | TS18003 (0 inputs) | 3 ✓ |
| `["./"]`  | 3 | TS18003 (0 inputs) | 3 ✓ |
| `["src"]` | 2 | 2 | 2 ✓ |
| `["./src"]` | 2 | 2 | 2 ✓ |

## Verification

- New unit test `test_expand_include_current_directory_is_root_recursive`
  (`.`/`./` -> `**/*`, `./src` -> `src/**/*`) and end-to-end discovery test
  `test_discover_current_directory_include_recurses` (`["."]` and `["./"]`
  discover every nested source file). `cargo test -p tsz-cli --lib project::fs`
  -> **27 passed, 0 failed**.
- End-to-end differential vs `tsc` 6.0.2 on the matrix above -> parity.
- `cargo fmt -p tsz-cli --check` clean; `cargo clippy -p tsz-cli --lib` clean.
- Reviewed for reuse/simplification/efficiency/altitude; the helper is the
  minimal correct form and is reused by the single directory-expansion site.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01TmQj87FBTmdT39kHLq1HcL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmQj87FBTmdT39kHLq1HcL)_