### PR TITLE
fix(solver): widen array-literal element unions of any size to their primitive base (string[])

### DIFF
--- a/crates/tsz-solver/src/operations/widening.rs
+++ b/crates/tsz-solver/src/operations/widening.rs
@@ -674,16 +674,31 @@ fn widen_type_cached(
 
         // Arrays: recursively widen element type
         Some(TypeData::Array(element_type)) => {
-            let widened = widen_type_cached(
-                db,
-                element_type,
-                cache,
-                widen_boolean_intrinsics,
-                widen_functions,
-                widen_object_union_members,
-                preserve_booleans_in_rest_tuples,
-                respect_object_freshness,
-            );
+            // An array literal's element type is always a fresh expression type
+            // (tsc's RequiresWidening), so a literal element union widens to its
+            // primitive base regardless of member count — `['A','B','C','D']`
+            // (4 fresh members) widens to `string[]` exactly like the 3-member
+            // case. The general `Union` arm below only widens "small" (≤3) literal
+            // unions as a RequiresWidening proxy, which wrongly preserves larger
+            // fresh element unions. Widen array-element literal unions directly
+            // here via `widen_literal_type`, which has no count threshold and is
+            // gated on `array_element_union_widens_literals` (a literal-bearing
+            // union of only literals/already-widened primitives — never an alias
+            // union that mixes in objects/null/undefined).
+            let widened = if crate::visitor::array_element_union_widens_literals(db, element_type) {
+                widen_literal_type(db, element_type)
+            } else {
+                widen_type_cached(
+                    db,
+                    element_type,
+                    cache,
+                    widen_boolean_intrinsics,
+                    widen_functions,
+                    widen_object_union_members,
+                    preserve_booleans_in_rest_tuples,
+                    respect_object_freshness,
+                )
+            };
             if widened != element_type {
                 let widened_arr = db.array(widened);
                 propagate_display_alias(db, type_id, widened_arr);

--- a/crates/tsz-solver/tests/widening_tests.rs
+++ b/crates/tsz-solver/tests/widening_tests.rs
@@ -1264,6 +1264,52 @@ fn annotation_widen_array_string_element_but_not_number_element() {
 }
 
 #[test]
+fn widen_array_of_four_member_literal_union_to_string_array() {
+    // tsc widens an array-literal element union to its primitive base
+    // regardless of member count: `['A','B','C','D']` is `string[]`, not
+    // `('A'|'B'|'C'|'D')[]`. The generic union arm only widens "small" (<=3)
+    // literal unions as a RequiresWidening proxy, so the array arm must widen
+    // literal element unions of any size via `widen_literal_type`.
+    let interner = TypeInterner::new();
+    let union = interner.union(vec![
+        interner.literal_string("A"),
+        interner.literal_string("B"),
+        interner.literal_string("C"),
+        interner.literal_string("D"),
+    ]);
+    let arr = interner.array(union);
+    let widened = widen_type(&interner as &dyn crate::construction::TypeDatabase, arr);
+    assert_eq!(
+        widened,
+        interner.array(TypeId::STRING),
+        "4-member literal element union widens to string[] like the 3-member case"
+    );
+}
+
+#[test]
+fn widen_array_of_literal_union_with_null_not_force_widened() {
+    // A mixed literal+null element union is NOT a pure literal-bearing union;
+    // `array_element_union_widens_literals` returns false, so the array arm
+    // does not force-widen it to `string[]` (conservative baseline that keeps
+    // the literal members available for downstream narrowing).
+    let interner = TypeInterner::new();
+    let union = interner.union(vec![
+        interner.literal_string("A"),
+        interner.literal_string("B"),
+        interner.literal_string("C"),
+        interner.literal_string("D"),
+        TypeId::NULL,
+    ]);
+    let arr = interner.array(union);
+    let widened = widen_type(&interner as &dyn crate::construction::TypeDatabase, arr);
+    assert_ne!(
+        widened,
+        interner.array(TypeId::STRING),
+        "literal+null element union must not collapse to string[]"
+    );
+}
+
+#[test]
 fn annotation_widen_union_first_display_member() {
     let interner = TypeInterner::new();
     let prop_type = interner.union(vec![


### PR DESCRIPTION
Goal: green

Fixes a `green` false-positive family: a non-contextually-typed array literal of
fresh string/number/boolean/bigint literals failed to widen its element union to
the primitive base when the union had **more than three** members.

## Structural rule
When an array-literal element type is a union of only fresh literals (or literals
mixed with an already-widened primitive), `tsc` widens it to the primitive base
regardless of member count — `['A','B','C','D']` is `string[]`, exactly like the
3-member `['A','B','C']`. tsz did this through the `Array` arm of
`widen_type_cached`, which recursed into the generic `Union` arm; that arm only
widens "small" (<=3) literal unions as a `RequiresWidening` proxy, so 4+-member
fresh element unions were wrongly preserved as `('A'|'B'|'C'|'D')[]`. Downstream
this surfaced as false `TS2345`/`TS2322` (e.g. `arr.push('E')` rejected, or
assignment to a `string[]` target failing).

## Fix
Owner: `crates/tsz-solver/src/operations/widening.rs` (solver). The `Array` arm now
widens a literal element union directly via `widen_literal_type` (no count
threshold), gated on the existing `array_element_union_widens_literals` predicate
(`visitors/visitor_predicates.rs`) so only pure literal-bearing unions are
affected — alias unions mixing in objects/`null`/`undefined` are left alone for
downstream narrowing. <=3-member unions reach the same primitive base as before
(no behavior change), so the only delta is the >3-member case converging to `tsc`.

## Adjacent cases
- positive: 4-member `'A'|'B'|'C'|'D'` element union widens to `string[]`
- control: 3-member union still widens (pre-existing `test_widen_array_of_literals_widens_element`)
- negative: literal+`null` element union is **not** force-widened to `string[]`

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo nextest run -p tsz-solver widen_array_of` — 4 passed (2 new regression tests + 2 controls)
- `cargo check -p tsz-solver` — clean
- CI conformance-0..3 + project-row-drift gates (broad-impact authoritative check)
