### PR TITLE
fix(checker): preserve type-alias name in TS4104 readonly-to-mutable source

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "readonly_to_mutable_alias_display_tests"
+path = "tests/readonly_to_mutable_alias_display_tests.rs"
+[[test]]
 name = "qualified_typeof_member_deferred_tests"
 path = "tests/qualified_typeof_member_deferred_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/type_query_alias.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/type_query_alias.rs
@@ -116,6 +116,60 @@ impl<'a> CheckerState<'a> {
             .is_some()
     }
 
+    /// When the source expression is an identifier whose declared annotation is
+    /// a **non-generic** `TYPE_REFERENCE` to a type alias whose name `tsc`
+    /// preserves in diagnostics (its `aliasSymbol` survives — the body is not a
+    /// computed type rendered by its underlying form), return that alias name.
+    ///
+    /// `tsc` stamps an `aliasSymbol` onto a referenced structural type so the
+    /// alias spelling survives into diagnostics. `tsz` interns array,
+    /// readonly-array, and readonly-tuple types purely structurally, so a shared
+    /// `readonly number[]` `TypeId` carries no per-reference alias and the name
+    /// is recoverable only from the source expression's annotation. A diagnostic
+    /// whose source is such a structurally-interned type (notably `TS4104`
+    /// readonly-to-mutable) consults this to render the alias `tsc` shows (`RA`
+    /// rather than `readonly number[]`). A generic alias application
+    /// (`Immutable<string>`) keeps its `Name<Args>` surface through the
+    /// structural formatter and is intentionally excluded.
+    pub(in crate::error_reporter) fn declared_source_type_reference_alias_name(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let annotation_idx = self.declared_source_type_annotation_node(expr_idx)?;
+        let annotation_node = self.ctx.arena.get(annotation_idx)?;
+        // `get_type_ref` yields `Some` only for a `TYPE_REFERENCE` node, so it
+        // also serves as the annotation-kind gate.
+        let type_ref = self.ctx.arena.get_type_ref(annotation_node)?;
+        // Only a bare (no-type-argument) reference loses its name; a generic
+        // application keeps its `Name<Args>` surface through the formatter.
+        if type_ref.type_arguments.is_some() {
+            return None;
+        }
+        let def_id = self.annotation_type_reference_alias_def_id(self.ctx.arena, annotation_idx)?;
+        let alias_name = {
+            let def = self.ctx.definition_store.get(def_id)?;
+            if !def.type_params.is_empty() {
+                return None;
+            }
+            def.name
+        };
+        // A non-generic alias whose body `tsc` renders by its underlying type
+        // (computed conditional / indexed-access / `keyof` / reducing
+        // application / intrinsic-or-literal singleton) carries no
+        // `aliasSymbol`; keep that underlying display rather than repainting it
+        // with the alias name.
+        if crate::query_boundaries::assignability_alias_display::type_alias_displayed_as_underlying(
+            self.ctx.types.as_type_database(),
+            &self.ctx.definition_store,
+            def_id,
+        )
+        .is_some()
+        {
+            return None;
+        }
+        Some(self.ctx.types.resolve_atom(alias_name))
+    }
+
     fn declared_source_type_annotation_node(&self, expr_idx: NodeIndex) -> Option<NodeIndex> {
         let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(expr_idx);
         let node = self.ctx.arena.get(expr_idx)?;

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -1351,7 +1351,22 @@ impl<'a> CheckerState<'a> {
                 source_type,
                 target_type,
             } => {
-                let source_str =
+                // `tsc` preserves the source's type-alias name in the TS4104
+                // message (`The type 'RA' is 'readonly' …`). `tsz` interns the
+                // readonly array/tuple structurally, so the alias is recovered
+                // from the source expression's declared annotation; falls back
+                // to the structural display for inline (non-aliased) readonly
+                // types and generic alias applications.
+                let alias_source_display = if depth == 0 {
+                    self.direct_diagnostic_source_expression(idx)
+                        .or_else(|| self.assignment_source_expression(idx))
+                        .and_then(|expr_idx| {
+                            self.declared_source_type_reference_alias_name(expr_idx)
+                        })
+                } else {
+                    None
+                };
+                let source_str = alias_source_display.unwrap_or_else(|| {
                     if let Some(inner) = crate::query_boundaries::common::readonly_inner_type(
                         self.ctx.types,
                         *source_type,
@@ -1361,7 +1376,8 @@ impl<'a> CheckerState<'a> {
                         format!("readonly {tuple_display}")
                     } else {
                         self.format_type_diagnostic(*source_type)
-                    };
+                    }
+                });
                 let target_str = self
                     .format_tuple_shape_for_readonly_to_mutable(*target_type)
                     .unwrap_or_else(|| self.format_type_diagnostic(*target_type));

--- a/crates/tsz-checker/tests/readonly_to_mutable_alias_display_tests.rs
+++ b/crates/tsz-checker/tests/readonly_to_mutable_alias_display_tests.rs
@@ -1,0 +1,159 @@
+//! Parity tests for the `TS4104` ("The type 'X' is 'readonly' and cannot be
+//! assigned to the mutable type 'Y'") source display.
+//!
+//! Structural rule: when a readonly array / readonly tuple is assigned to a
+//! mutable array / tuple, `tsc` renders the source by the **type-alias name** it
+//! was referenced through (its `aliasSymbol`), e.g. `The type 'RA' is
+//! 'readonly' …`, not the expanded `readonly number[]`. `tsz` interns array and
+//! readonly array/tuple types purely structurally, so the per-reference alias is
+//! recovered from the source expression's declared annotation rather than from
+//! the type. Inline (non-aliased) readonly sources keep their structural display,
+//! and generic alias applications keep their `Name<Args>` surface.
+//!
+//! Owner layer: checker error reporter
+//! (`render_failure::ReadonlyToMutableAssignment`), via
+//! `declared_source_type_reference_alias_name`.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::{Diagnostic, DiagnosticCategory};
+use tsz_common::common::{ModuleKind, ScriptTarget};
+
+fn check(source: &str) -> Vec<Diagnostic> {
+    tsz_checker::test_utils::check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ESNext,
+            module: ModuleKind::CommonJS,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn ts4104_message(diagnostics: &[Diagnostic]) -> String {
+    let mut msgs: Vec<&str> = diagnostics
+        .iter()
+        .filter(|d| d.category == DiagnosticCategory::Error && d.code == 4104)
+        .map(|d| d.message_text.as_str())
+        .collect();
+    assert_eq!(
+        msgs.len(),
+        1,
+        "expected exactly one TS4104 diagnostic, got: {diagnostics:#?}"
+    );
+    msgs.remove(0).to_string()
+}
+
+#[test]
+fn readonly_array_alias_source_renders_alias_name() {
+    // `readonly number[]` aliased as `RA`: tsc shows `The type 'RA' is …`.
+    let source = r#"
+        type RA = readonly number[];
+        const value: RA = [1, 2, 3];
+        const mutable: number[] = value;
+    "#;
+    let msg = ts4104_message(&check(source));
+    assert_eq!(
+        msg, "The type 'RA' is 'readonly' and cannot be assigned to the mutable type 'number[]'.",
+        "array-alias source must render the alias name, got: {msg}"
+    );
+}
+
+#[test]
+fn application_bodied_alias_source_renders_alias_name() {
+    // A non-generic alias whose body is a generic application that resolves to a
+    // readonly array (`Frozen = RArr<number>`) still renders by the alias name —
+    // tsc keeps the `aliasSymbol` on the freshly-constructed readonly array.
+    let source = r#"
+        type RArr<T> = readonly T[];
+        type Frozen = RArr<number>;
+        const xs: Frozen = [1];
+        const mutable: number[] = xs;
+    "#;
+    let msg = ts4104_message(&check(source));
+    assert_eq!(
+        msg,
+        "The type 'Frozen' is 'readonly' and cannot be assigned to the mutable type 'number[]'.",
+        "application-bodied alias source must render the alias name, got: {msg}"
+    );
+}
+
+#[test]
+fn readonly_tuple_alias_source_renders_alias_name() {
+    // `readonly [number, string]` aliased as `Pair`.
+    let source = r#"
+        type Pair = readonly [number, string];
+        const pair: Pair = [1, "x"];
+        const mutable: [number, string] = pair;
+    "#;
+    let msg = ts4104_message(&check(source));
+    assert_eq!(
+        msg,
+        "The type 'Pair' is 'readonly' and cannot be assigned to the mutable type '[number, string]'.",
+        "readonly-tuple-alias source must render the alias name, got: {msg}"
+    );
+}
+
+#[test]
+fn alias_display_is_binder_name_agnostic() {
+    // The decision is structural, not keyed to a spelling: renaming the alias
+    // changes only the rendered name.
+    let source = r#"
+        type Immutables = readonly number[];
+        const seq: Immutables = [9];
+        const mutable: number[] = seq;
+    "#;
+    let msg = ts4104_message(&check(source));
+    assert_eq!(
+        msg,
+        "The type 'Immutables' is 'readonly' and cannot be assigned to the mutable type 'number[]'.",
+        "renamed alias must render under its own name, got: {msg}"
+    );
+}
+
+#[test]
+fn inline_readonly_array_source_keeps_structural_display() {
+    // No alias reference: tsc (and tsz) render the structural form.
+    let source = r#"
+        const value: readonly number[] = [1, 2, 3];
+        const mutable: number[] = value;
+    "#;
+    let msg = ts4104_message(&check(source));
+    assert_eq!(
+        msg,
+        "The type 'readonly number[]' is 'readonly' and cannot be assigned to the mutable type 'number[]'.",
+        "inline readonly array must keep structural display, got: {msg}"
+    );
+}
+
+#[test]
+fn inline_readonly_tuple_source_keeps_structural_display() {
+    let source = r#"
+        const pair: readonly [number, string] = [1, "x"];
+        const mutable: [number, string] = pair;
+    "#;
+    let msg = ts4104_message(&check(source));
+    assert_eq!(
+        msg,
+        "The type 'readonly [number, string]' is 'readonly' and cannot be assigned to the mutable type '[number, string]'.",
+        "inline readonly tuple must keep structural display, got: {msg}"
+    );
+}
+
+#[test]
+fn generic_alias_application_source_keeps_application_surface() {
+    // A generic alias application keeps its `Name<Args>` form (it is not a bare
+    // alias reference); the structural formatter already renders it correctly.
+    let source = r#"
+        type Immutable<T> = readonly T[];
+        const xs: Immutable<string> = ["a"];
+        const mutable: string[] = xs;
+    "#;
+    let msg = ts4104_message(&check(source));
+    assert_eq!(
+        msg,
+        "The type 'Immutable<string>' is 'readonly' and cannot be assigned to the mutable type 'string[]'.",
+        "generic alias application must keep its application surface, got: {msg}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Fixes #14483.

## Summary

`TS4104` ("The type 'X' is 'readonly' and cannot be assigned to the mutable type 'Y'") rendered an **array / readonly-array / readonly-tuple type alias** source by its structural form (`readonly number[]`) where `tsc` preserves the alias name (`RA`). Found by differential testing against bundled `tsc` 6.0.2.

| source | tsc | tsz before | tsz after |
|---|---|---|---|
| `type RA = readonly number[]; const ra: RA = []; const m: number[] = ra;` | `'RA'` | `'readonly number[]'` | `'RA'` ✓ |
| `type RT = readonly [number, string]; …` | `'RT'` | `'readonly [number, string]'` | `'RT'` ✓ |
| `type RA2 = ReadonlyArray<number>; …` | `'RA2'` | `'readonly number[]'` | `'RA2'` ✓ |
| inline `const ra: readonly number[] = []; …` | `'readonly number[]'` | `'readonly number[]'` | `'readonly number[]'` ✓ |
| `type Immutable<T> = readonly T[]; const xs: Immutable<string> = []; …` | `'Immutable<string>'` | `'Immutable<string>'` | `'Immutable<string>'` ✓ |

## Structural rule

When a readonly array/tuple referenced through a non-generic type alias is assigned to a mutable array/tuple, `tsc` renders the source by the alias name it was referenced through (its `aliasSymbol`). `tsz` interns array and readonly array/tuple types **purely structurally**, so a shared `readonly number[]` `TypeId` carries no per-reference alias; the diagnostic type formatter's reverse `find_def_for_type` lookup (`crates/tsz-solver/src/diagnostics/format/mod.rs`) deliberately excludes `Array`/`ReadonlyType` because that lookup is unsound for structurally-interned types (multiple aliases share one `TypeId`). The alias is therefore recoverable only from the source expression's declared annotation — which the `TS2322` `AssignmentSource` display role already does and `TS4104` did not.

`tsz` now does X through `render_failure::ReadonlyToMutableAssignment`: at depth 0 it recovers the source alias name via the new `declared_source_type_reference_alias_name`, falling back to the existing structural display.

## Owner layer

Checker error reporter (`crates/tsz-checker/src/error_reporter`). Display/code only — same diagnostic count, code, and span; only the rendered source type string changes toward `tsc` parity. No relation/inference/evaluation behavior changes.

## Anti-hardcoding

Structural and name-agnostic: the decision is "the source expression's declared annotation is a **non-generic** `TYPE_REFERENCE` to a type alias whose body `tsc` renders by name (gated by the shared `type_alias_displayed_as_underlying` policy)". No identifier / file-name / printer-string predicates. Tests vary the alias spelling (`RA`, `RT`, `Pair`, `Immutables`, `Frozen`) so assertions track the structural shape, not a name.

## Scope / follow-up

The same alias-loss affects the `TS2345` argument-mismatch path for array aliases (`need(ra)` shows `readonly number[]`); tracked as a related follow-up on #14483. This PR is the bounded, sound `TS4104` slice (mirrors the established `TS2322` recovery pattern rather than touching the structural interner).

## Verification

- New `crates/tsz-checker/tests/readonly_to_mutable_alias_display_tests.rs` (7 tests: array/readonly-tuple/application-bodied alias → name; inline array/tuple → structural; generic application → `Name<Args>`; binder-name-agnostic). **7 passed.**
- Adjacent regression guard: `readonly_tuple_to_array_constraint_tests` (5), `mapped_readonly_tuple_tests` (9), `conditional_extends_readonly_variance_tests` (14), `fresh_const_array_mutable_assignment` (15) — all pass.
- End-to-end differential vs bundled `tsc` 6.0.2 on a 50+-case battery (satisfies/template/tuple/mapped/keyof/narrowing/const-TP/conditional/awaited/utility-types/variadic/…): **0 mismatches** (the TS4104 alias case was the only prior divergence).
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib` clean.
- Reviewed with `/simplify` (reuse / simplification / efficiency / altitude): removed a redundant annotation-kind check; altitude confirmed appropriately scoped.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_017YYgqYUSVFZinyAVPzfVyk

---
_Generated by [Claude Code](https://claude.ai/code/session_017YYgqYUSVFZinyAVPzfVyk)_