### PR TITLE
refactor(checker): one shared body-registration variant constructor for dual-env writes (#14348)

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping_flow_mirror.rs
+++ b/crates/tsz-checker/src/context/def_mapping_flow_mirror.rs
@@ -19,18 +19,10 @@ impl CheckerContext<'_> {
         body: TypeId,
         params: &[tsz_solver::TypeParamInfo],
     ) {
-        let op = if params.is_empty() {
-            DeferredFlowEnvWrite::InsertDef { def_id, body }
-        } else {
-            // Variances are left unset here, matching the prior direct
-            // `insert_def_with_params` mirror at this site.
-            DeferredFlowEnvWrite::InsertDefWithParams {
-                def_id,
-                body,
-                params: params.to_vec(),
-                variances: None,
-            }
-        };
+        // Variances are left unset here (`None`), matching the prior direct
+        // `insert_def_with_params` mirror at this site.
+        let op =
+            DeferredFlowEnvWrite::insert_def_choosing_params(def_id, body, params.to_vec(), None);
         self.mirror_to_flow_env(op);
     }
 

--- a/crates/tsz-checker/src/context/def_mapping_resolved_env.rs
+++ b/crates/tsz-checker/src/context/def_mapping_resolved_env.rs
@@ -10,15 +10,8 @@ impl CheckerContext<'_> {
     /// through the race-safe deferred-write path.
     pub(crate) fn register_resolved_def_in_envs(&self, def_id: DefId, body: TypeId) {
         let params = self.get_def_type_params(def_id).unwrap_or_default();
-        if params.is_empty() {
-            self.register_in_envs(DeferredFlowEnvWrite::InsertDef { def_id, body });
-        } else {
-            self.register_in_envs(DeferredFlowEnvWrite::InsertDefWithParams {
-                def_id,
-                body,
-                params,
-                variances: None,
-            });
-        }
+        self.register_in_envs(DeferredFlowEnvWrite::insert_def_choosing_params(
+            def_id, body, params, None,
+        ));
     }
 }

--- a/crates/tsz-checker/src/context/def_mapping_tests.rs
+++ b/crates/tsz-checker/src/context/def_mapping_tests.rs
@@ -434,6 +434,52 @@ fn both_envs_defer_then_replay_under_simultaneous_borrow() {
     );
 }
 
+/// Pins the body-registration construction rule shared by
+/// `register_resolved_def_in_envs` and `mirror_def_in_type_environment`:
+/// empty params build the non-generic `InsertDef` variant, non-empty params
+/// build `InsertDefWithParams` with the threaded-through variances. This is the
+/// single rule both pure-construction sites now route through
+/// (`DeferredFlowEnvWrite::insert_def_choosing_params`), so a drift in one of
+/// them is caught here. Uses synthetic `DefId`s, so it is binder-name
+/// independent.
+#[test]
+fn insert_def_choosing_params_selects_variant_by_params_emptiness() {
+    use super::super::deferred_flow_env_write::DeferredFlowEnvWrite;
+    use tsz_common::interner::Atom;
+    use tsz_solver::TypeId;
+    use tsz_solver::def::DefId;
+
+    let def_id = DefId(7);
+    let body = TypeId::STRING;
+
+    // Empty params -> non-generic InsertDef, variances ignored.
+    let empty = DeferredFlowEnvWrite::insert_def_choosing_params(def_id, body, vec![], None);
+    assert!(
+        matches!(
+            empty,
+            DeferredFlowEnvWrite::InsertDef { def_id: d, body: b } if d == def_id && b == body
+        ),
+        "empty params must build the non-generic InsertDef variant"
+    );
+
+    // Non-empty params -> generic InsertDefWithParams; `None` variances flow through.
+    let params = vec![tsz_solver::TypeParamInfo::simple(Atom::default())];
+    let generic =
+        DeferredFlowEnvWrite::insert_def_choosing_params(def_id, body, params.clone(), None);
+    assert!(
+        matches!(
+            generic,
+            DeferredFlowEnvWrite::InsertDefWithParams {
+                def_id: d,
+                body: b,
+                params: ref p,
+                variances: None,
+            } if d == def_id && b == body && p.len() == params.len()
+        ),
+        "non-empty params must build the generic InsertDefWithParams variant with the given variances"
+    );
+}
+
 /// Regression for #13944 / #13086: a `DefId -> TypeId` body re-published by the
 /// lazy-resolution path (`register_resolved_def_in_envs`, the gateway
 /// `try_insert_def_in_type_env` now uses) must travel the race-safe deferred

--- a/crates/tsz-checker/src/context/deferred_flow_env_write.rs
+++ b/crates/tsz-checker/src/context/deferred_flow_env_write.rs
@@ -59,6 +59,35 @@ pub enum DeferredFlowEnvWrite {
 }
 
 impl DeferredFlowEnvWrite {
+    /// Build the body-registration variant for a definition, selecting
+    /// [`Self::InsertDef`] when `params` is empty and
+    /// [`Self::InsertDefWithParams`] otherwise.
+    ///
+    /// The "empty params -> non-generic insert, else generic insert" choice is
+    /// the single rule every body-registration site shares; expressing it once
+    /// here keeps the resolved-body (`register_resolved_def_in_envs`) and
+    /// flow-mirror (`mirror_def_in_type_environment`) construction paths from
+    /// drifting apart. `variances` is threaded through unchanged so callers that
+    /// already computed declared variances keep them and callers that do not
+    /// pass `None`, exactly as before.
+    pub(crate) fn insert_def_choosing_params(
+        def_id: DefId,
+        body: TypeId,
+        params: Vec<tsz_solver::TypeParamInfo>,
+        variances: Option<Arc<[tsz_solver::type_handles::Variance]>>,
+    ) -> Self {
+        if params.is_empty() {
+            Self::InsertDef { def_id, body }
+        } else {
+            Self::InsertDefWithParams {
+                def_id,
+                body,
+                params,
+                variances,
+            }
+        }
+    }
+
     /// Apply this deferred registration to a flow-analyzer `TypeEnvironment`.
     pub(crate) fn apply(&self, env: &mut TypeEnvironment) {
         match self {


### PR DESCRIPTION
Goal: hold

Migration **step 2** for #14348 (`ROBUSTNESS_AUDIT` item #3, "dual `TypeEnvironment`"), continuing #14367. A behavior-preserving consolidation: the "empty params -> non-generic `InsertDef`, else generic `InsertDefWithParams`" body-registration construction rule was duplicated byte-for-byte in two pure-construction sites (`register_resolved_def_in_envs` and `mirror_def_in_type_environment`). This PR expresses that single rule once as `DeferredFlowEnvWrite::insert_def_choosing_params(def_id, body, params, variances)` and routes both sites through it.

No semantic change: the constructor builds exactly the same enum variant each caller built before, and `variances` is threaded through unchanged (both current callers pass `None`, matching their prior direct construction). This shrinks the surface the eventual single-authoritative-env collapse must touch and removes a drift hazard between the two body-write paths.

## Why not the full collapse?

The audit's end-state (make `type_environment` a read-only snapshot, delete the deferred-write machinery) is **not** parity-safe in one shot, and that has not changed: the flow analyzer holds `type_environment` borrowed across narrowing (`flow/control_flow/core.rs:684`, `FlowAnalyzer::from_ctx`) while a re-entrant evaluator must `try_borrow_mut` `type_env` to publish-and-read freshly resolved `DefId -> TypeId` bodies (e.g. `state/type_environment/lazy.rs:1584` writes directly then reads back). A single `RefCell` would force that re-entrant publish-then-read to defer, and deferred replay cannot make a write visible mid-borrow within the same narrowing op. That step still needs full-conformance validation against the borrow-race witnesses (#13741 / #13944 / #13951 / #13952) and remains a follow-up.

## Structural rule

When a `DefId` body is registered through a pure-construction dual-env path, the choice of non-generic vs generic `TypeEnvironment` write depends only on whether the param list is empty; that one rule now lives in a single constructor on `DeferredFlowEnvWrite`, owned by the checker `context` layer. The race-safe deferral discipline (#14367) and the never-drop invariant for the shared-`DefinitionStore` write-through are unchanged — only the variant-selection is deduplicated.

## Anti-hardcoding

Pure consolidation: no name/file-string predicates, no printer-output reads, no behavior gated on identifiers. The new unit test (`insert_def_choosing_params_selects_variant_by_params_emptiness`) uses synthetic `DefId`s, so it is binder-name independent.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo check -p tsz-checker` clean
- `cargo clippy -p tsz-checker --lib` clean
- borrow-race / dual-env witnesses pass: all 8 pre-existing `context::def_mapping` tests (#8269/#13086/#13944 deferral + simultaneous-both-borrowed replay) plus the new construction-rule test = 9/9
- narrow `tsz-checker` nextest (`context::` + `architecture_contract`): no NEW failures vs clean-`origin/main` baseline (identical 8 known env-only local relative-path/cache-flag failures on both; my change adds exactly one passing test)
- CI conformance/emit/fourslash authoritative for broad impact

