### PR TITLE
fix(checker): preserve type-alias name in TS2345 readonly array/tuple argument

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2106,3 +2106,7 @@ path = "tests/object_keyword_any_index_tests.rs"
 [[test]]
 name = "conditional_initializer_preserves_narrowing_tests"
 path = "tests/conditional_initializer_preserves_narrowing_tests.rs"
+
+[[test]]
+name = "readonly_array_alias_argument_display_tests"
+path = "tests/readonly_array_alias_argument_display_tests.rs"

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -1861,11 +1861,8 @@ impl<'a> CheckerState<'a> {
         {
             return "IArguments".to_string();
         }
-        // A `readonly` array / `readonly` tuple argument referenced through a
-        // non-generic type alias (`need(ra)` where `ra: RA`) loses its alias on
-        // structural interning; `tsc` renders the alias name it was referenced
-        // through. Recover it from the argument's declared annotation before the
-        // structural fallbacks below collapse it to `readonly number[]`.
+        // Preserve the declared alias display for readonly array/tuple
+        // arguments before structural fallbacks collapse it.
         if let Some(alias) = self.readonly_array_alias_source_display(expr_idx, arg_type) {
             return alias;
         }

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -1861,6 +1861,15 @@ impl<'a> CheckerState<'a> {
         {
             return "IArguments".to_string();
         }
+        // A `readonly` array / `readonly` tuple argument referenced through a
+        // non-generic type alias (`need(ra)` where `ra: RA`) loses its alias on
+        // structural interning; `tsc` renders the alias name it was referenced
+        // through. Recover it from the argument's declared annotation before the
+        // structural fallbacks below collapse it to `readonly number[]`.
+        if let Some(alias) = self.readonly_array_alias_source_display(expr_idx, arg_type) {
+            return alias;
+        }
+
         if query_common::tuple_elements(self.ctx.types, arg_type).is_some()
             && self
                 .ctx

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/type_query_alias.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/type_query_alias.rs
@@ -1,8 +1,94 @@
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// Recover a non-generic `readonly` array / `readonly` tuple type-alias name
+    /// from an argument expression's declared annotation, for the `TS2345`
+    /// argument-mismatch diagnostic.
+    ///
+    /// tsz interns array and `readonly` array/tuple types purely structurally, so
+    /// a shared `readonly number[]` `TypeId` carries no per-reference
+    /// `aliasSymbol`; the diagnostic formatter's reverse `find_def_for_type`
+    /// lookup deliberately excludes `Array`/`ReadonlyType` because that lookup is
+    /// unsound for structurally-interned ids (many aliases share one id). `tsc`
+    /// renders such a source by the alias name it was *referenced through*, which
+    /// is recoverable only from the source expression's declared annotation —
+    /// exactly as the `TS2322` `AssignmentSource` role already does. A *generic*
+    /// alias (`Immutable<number>`) survives as an `Application` and keeps its name
+    /// already, so only the non-generic collapse is repaired here.
+    ///
+    /// `source_expr_idx` is the source/argument expression node; the annotation is
+    /// resolved through its declaring identifier, so a non-identifier source (an
+    /// array literal, a call, an assertion) yields `None` and keeps the existing
+    /// structural display.
+    pub(in crate::error_reporter) fn readonly_array_alias_source_display(
+        &mut self,
+        source_expr_idx: NodeIndex,
+        source_type: TypeId,
+    ) -> Option<String> {
+        // Scope strictly to the `readonly` array / `readonly` tuple forms that
+        // lose their alias on interning; every other source keeps its display.
+        crate::query_boundaries::common::readonly_inner_type(self.ctx.types, source_type)?;
+
+        // Resolve the annotation as a reference to a registered type alias; this
+        // validates the `TYPE_REFERENCE` kind and the alias binding in one step.
+        let annotation_idx = self.declared_source_type_annotation_node(source_expr_idx)?;
+        let def_id = self.annotation_type_reference_alias_def_id(self.ctx.arena, annotation_idx)?;
+
+        // Only a bare, non-generic alias collapses to the shared structural id and
+        // loses its name; a generic alias (`Immutable<number>`) keeps its name via
+        // the `Application` path, so reject a reference with type arguments or an
+        // alias with type parameters.
+        let reference_has_type_arguments = self
+            .ctx
+            .arena
+            .get(annotation_idx)
+            .and_then(|node| self.ctx.arena.get_type_ref(node))
+            .is_some_and(|type_ref| type_ref.type_arguments.is_some());
+        if reference_has_type_arguments
+            || self
+                .ctx
+                .definition_store
+                .get(def_id)
+                .is_none_or(|def| !def.type_params.is_empty())
+        {
+            return None;
+        }
+
+        // Defer to the structural fallback in the same cases the `TS2322` source
+        // path does, reusing the already-resolved `annotation_idx`/`def_id`:
+        //  - a source identifier declared `unknown`/`any` but flow-narrowed to a
+        //    concrete type renders its narrowed type, not its declared annotation;
+        //  - a `typeof`-bodied alias keeps its own display policy;
+        //  - a computed-body alias (a conditional / indexed-access / `keyof` /
+        //    intrinsic body that tsc renders by its underlying type) drops its
+        //    `aliasSymbol` and must not be repainted with the alias name.
+        let ident_idx = self
+            .ctx
+            .arena
+            .skip_parenthesized_and_assertions(source_expr_idx);
+        if self.source_identifier_narrowed_from_unknown_or_any(ident_idx, source_type) {
+            return None;
+        }
+        if self.annotation_names_type_query_alias(self.ctx.arena, annotation_idx) {
+            return None;
+        }
+        if crate::query_boundaries::assignability_alias_display::type_alias_displayed_as_underlying(
+            self.ctx.types.as_type_database(),
+            &self.ctx.definition_store,
+            def_id,
+        )
+        .is_some()
+        {
+            return None;
+        }
+
+        let annotation_text = self.declared_type_annotation_text_for_expression(source_expr_idx)?;
+        Some(self.format_declared_annotation_for_diagnostic(&annotation_text))
+    }
+
     pub(in crate::error_reporter) fn declared_source_annotation_names_type_query_alias(
         &self,
         expr_idx: NodeIndex,

--- a/crates/tsz-checker/tests/readonly_array_alias_argument_display_tests.rs
+++ b/crates/tsz-checker/tests/readonly_array_alias_argument_display_tests.rs
@@ -1,0 +1,114 @@
+//! `TS2345` must render a `readonly` array / `readonly` tuple ARGUMENT by the
+//! non-generic type-alias name it was referenced through (its `aliasSymbol`),
+//! matching `tsc`, instead of the structurally-interned form
+//! (`readonly number[]`).
+//!
+//! This is the argument-mismatch follow-up of #14483 (the `TS4104`
+//! readonly-to-mutable slice is handled separately). tsz interns array and
+//! `readonly` array/tuple types purely structurally, so a shared
+//! `readonly number[]` `TypeId` carries no per-reference alias; `tsc` recovers
+//! the name from the argument expression's declared annotation, and tsz must do
+//! the same. The rule is structural — it holds regardless of the alias name,
+//! element types, and tuple arity — and must NOT fire for an inline
+//! `readonly number[]` annotation (no alias) or repaint a generic alias
+//! application (which already keeps its name via the `Application` path).
+
+use tsz_checker::test_utils::check_source_code_messages;
+
+fn messages(source: &str) -> Vec<(u32, String)> {
+    check_source_code_messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code != 2318)
+        .collect()
+}
+
+fn message_for(source: &str, code: u32) -> String {
+    messages(source)
+        .into_iter()
+        .find(|(c, _)| *c == code)
+        .map(|(_, m)| m)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected TS{code} for source:\n{source}\ngot: {:?}",
+                messages(source)
+            )
+        })
+}
+
+#[test]
+fn ts2345_readonly_array_alias_argument_renders_alias_name() {
+    let msg = message_for(
+        "type Bag = readonly number[]; const b: Bag = []; function need(x: number[]) {} need(b);",
+        2345,
+    );
+    assert_eq!(
+        msg,
+        "Argument of type 'Bag' is not assignable to parameter of type 'number[]'."
+    );
+}
+
+#[test]
+fn ts2345_readonly_array_alias_argument_is_structural_not_name_keyed() {
+    // Renamed binder + different element type: proves the recovery is structural,
+    // not keyed on the alias spelling `Bag` or the element type `number`.
+    let msg = message_for(
+        "type Grid = readonly string[]; const g: Grid = []; function need(x: string[]) {} need(g);",
+        2345,
+    );
+    assert_eq!(
+        msg,
+        "Argument of type 'Grid' is not assignable to parameter of type 'string[]'."
+    );
+}
+
+#[test]
+fn ts2345_readonly_tuple_alias_argument_renders_alias_name() {
+    let msg = message_for(
+        "type Pair = readonly [number, string]; const p: Pair = [1, 'a']; function need(x: [number, string]) {} need(p);",
+        2345,
+    );
+    assert_eq!(
+        msg,
+        "Argument of type 'Pair' is not assignable to parameter of type '[number, string]'."
+    );
+}
+
+#[test]
+fn ts2345_readonly_tuple_alias_argument_arity_three_renders_alias_name() {
+    let msg = message_for(
+        "type Triple = readonly [number, string, boolean]; const t: Triple = [1, 'a', true]; function need(x: [number, string, boolean]) {} need(t);",
+        2345,
+    );
+    assert_eq!(
+        msg,
+        "Argument of type 'Triple' is not assignable to parameter of type '[number, string, boolean]'."
+    );
+}
+
+#[test]
+fn ts2345_inline_readonly_array_argument_keeps_structural_display() {
+    // No alias: the inline `readonly number[]` annotation must stay structural,
+    // exactly as `tsc` renders it.
+    let msg = message_for(
+        "const ra: readonly number[] = []; function need(x: number[]) {} need(ra);",
+        2345,
+    );
+    assert_eq!(
+        msg,
+        "Argument of type 'readonly number[]' is not assignable to parameter of type 'number[]'."
+    );
+}
+
+#[test]
+fn ts2345_generic_readonly_array_alias_application_keeps_name() {
+    // A generic alias survives as an `Application` and already renders by name;
+    // the recovery must not interfere with it.
+    let msg = message_for(
+        "type Frozen<T> = readonly T[]; const f: Frozen<number> = []; function need(x: number[]) {} need(f);",
+        2345,
+    );
+    assert_eq!(
+        msg,
+        "Argument of type 'Frozen<number>' is not assignable to parameter of type 'number[]'."
+    );
+}


### PR DESCRIPTION
Goal: hold

Refs #14483 (the argument-mismatch follow-up the issue tracks; the `TS4104`
readonly-to-mutable slice is owned by #14485). Disjoint from #14485 — this PR
touches only the `TS2345` call-argument path, not `render_failure.rs`.

## Summary

A `readonly` array / `readonly` tuple ARGUMENT referenced through a non-generic
type alias (`need(ra)` where `ra: RA`) was rendered by its structural form
(`readonly number[]`) in `TS2345`, where `tsc` preserves the alias name (`RA`)
via its `aliasSymbol`.

| source | tsc | tsz before | tsz after |
|---|---|---|---|
| `type Bag = readonly number[]; const b: Bag = []; function need(x: number[]){} need(b);` | `'Bag'` | `'readonly number[]'` | `'Bag'` ✓ |
| `type Pair = readonly [number, string]; … need(p);` | `'Pair'` | `'readonly [number, string]'` | `'Pair'` ✓ |
| inline `const ra: readonly number[] = []; … need(ra);` | `'readonly number[]'` | `'readonly number[]'` | `'readonly number[]'` ✓ |
| `type Frozen<T> = readonly T[]; const f: Frozen<number> = []; … need(f);` | `'Frozen<number>'` | `'Frozen<number>'` | `'Frozen<number>'` ✓ |

## Structural rule

When a `readonly` array/tuple referenced through a non-generic type alias is
passed where a mutable array/tuple is expected, `tsc` renders the argument by
the alias name it was *referenced through* (its `aliasSymbol`). tsz interns
array and `readonly` array/tuple types **purely structurally**, so a shared
`readonly number[]` `TypeId` carries no per-reference alias; the diagnostic
formatter's reverse `find_def_for_type` lookup deliberately excludes
`Array`/`ReadonlyType` because that lookup is unsound for structurally-interned
ids (many aliases share one `TypeId`). The alias is therefore recoverable only
from the argument expression's declared annotation — which the `TS2322`
`AssignmentSource` display role already does, and the `TS2345` argument path did
not. tsz now does this through the checker error reporter
(`format_call_argument_type_for_diagnostic` → the new
`readonly_array_alias_source_display`), mirroring the established `TS2322`
recovery.

## Owner layer

Checker error reporter (`crates/tsz-checker/src/error_reporter`). Display/code
only — same diagnostic count, code, and span; only the rendered argument type
string changes toward `tsc` parity. No relation / inference / evaluation
behavior changes.

## Anti-hardcoding

Structural and name-agnostic: the decision is "the argument expression's
declared annotation is a **non-generic**, type-argument-free `TYPE_REFERENCE` to
a type alias whose body `tsc` renders by name (gated by the shared
`type_alias_displayed_as_underlying` policy), the source is a `readonly`
array/tuple, and the operand is not a narrowed `unknown`/`any` or a `typeof`
alias". No identifier / file-name / printer-string predicates. Tests vary the
alias spelling (`Bag`, `Grid`, `Pair`, `Triple`, `Frozen`) and element types so
the assertions track the structural shape, not a name. The new helper reuses the
already-resolved `annotation_idx` / `def_id` for the `typeof` and
displayed-as-underlying guards rather than re-walking the annotation.

## Verification

- New `crates/tsz-checker/tests/readonly_array_alias_argument_display_tests.rs`
  (6 tests: `readonly` array / `readonly` tuple / arity-3 tuple alias → name;
  renamed-binder structural control; inline `readonly number[]` → structural;
  generic `Frozen<number>` application → `Frozen<number>`). **6 passed.**
- Adjacent regression guards all pass: `tuple_argument_mismatch_elaboration_tests`
  (7), `tuple_call_argument_elaboration_tests` (6), `readonly_tuple_source_display_tests`
  (5), `readonly_tuple_to_array_constraint_tests` (5), `mapped_readonly_tuple_tests`
  (9).
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib --tests` clean.
- Reviewed with `/simplify` ×3 (reuse / simplification / efficiency / altitude):
  consolidated the `typeof` and displayed-as-underlying guards to reuse the
  resolved `annotation_idx`/`def_id`; altitude confirmed consistent with the
  established `TS2322` `AssignmentSource` recovery (not a bandaid).
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01RbM6cpiHKYZJbFiUZHtpVs

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbM6cpiHKYZJbFiUZHtpVs)_