### PR TITLE
perf(solver): memoize prune_impossible_object_union_members on the interner

### DIFF
--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -571,6 +571,30 @@ pub trait TypeContainsByIdCache {
     fn set_contains_type_by_id_memo(&self, _root: TypeId, _target: TypeId, _result: bool) {}
 }
 
+/// Cache for the pure structural `prune_impossible_object_union_members(type_id)`
+/// result, keyed by the union `TypeId`.
+///
+/// Pruning a union's impossible object members consults only structural
+/// predicates over the immutable interned type `DAG` (literal-discriminant
+/// conflicts, never-typed or impossible-unit required properties) plus
+/// resolver-free `evaluate_type` / `is_subtype_of` walks; it threads no resolver,
+/// substitution environment, or compiler option, so the pruned result is a pure
+/// function of the input union `TypeId` and stable within one interner. Kept
+/// separate from [`TypeDatabase`] so the broad query trait stays under its method
+/// cap (#8205); `TypeDatabase` re-exposes these via the supertrait bound, so
+/// `&dyn TypeDatabase` callers are unaffected.
+pub trait TypePruneUnionCache {
+    /// Look up the memoized `prune_impossible_object_union_members(type_id)`
+    /// result. Default `None` (no caching).
+    fn prune_union_members_memo(&self, _type_id: TypeId) -> Option<TypeId> {
+        None
+    }
+
+    /// Record the `prune_impossible_object_union_members(type_id)` result.
+    /// Default no-op.
+    fn set_prune_union_members_memo(&self, _type_id: TypeId, _result: TypeId) {}
+}
+
 /// Query interface for the solver.
 ///
 /// This keeps solver components generic and prevents them from reaching
@@ -585,6 +609,7 @@ pub trait TypeDatabase:
     + TypeSubstitutionConstruction
     + TypeExtractParamsCache
     + TypeContainsByIdCache
+    + TypePruneUnionCache
 {
     fn intern(&self, key: TypeData) -> TypeId;
     fn lookup(&self, id: TypeId) -> Option<TypeData>;
@@ -1115,6 +1140,16 @@ impl TypeContainsByIdCache for TypeInterner {
 
     fn set_contains_type_by_id_memo(&self, root: TypeId, target: TypeId, result: bool) {
         Self::set_contains_type_by_id_memo(self, root, target, result);
+    }
+}
+
+impl TypePruneUnionCache for TypeInterner {
+    fn prune_union_members_memo(&self, type_id: TypeId) -> Option<TypeId> {
+        Self::prune_union_members_memo(self, type_id)
+    }
+
+    fn set_prune_union_members_memo(&self, type_id: TypeId, result: TypeId) {
+        Self::set_prune_union_members_memo(self, type_id, result);
     }
 }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -8,7 +8,7 @@ use crate::caches::application_eval_index::{self, ApplicationEvalDependencyIndex
 use crate::caches::db::{
     QueryDatabase, TypeApplicationEvalCache, TypeCompilerOptions, TypeContainsByIdCache,
     TypeDatabase, TypeDisplayProvenance, TypeExtractParamsCache, TypePredicateCache,
-    TypeSubstitutionConstruction, TypeTupleLimitSignal, TypeWidenCache,
+    TypePruneUnionCache, TypeSubstitutionConstruction, TypeTupleLimitSignal, TypeWidenCache,
 };
 use crate::caches::instantiation_cache::{InstantiationCache, InstantiationCacheKey};
 use crate::caches::query_cache_statistics::{QueryCacheStatistics, RelationCacheStats};
@@ -999,6 +999,16 @@ impl TypeContainsByIdCache for QueryCache<'_> {
     fn set_contains_type_by_id_memo(&self, root: TypeId, target: TypeId, result: bool) {
         self.interner
             .set_contains_type_by_id_memo(root, target, result);
+    }
+}
+
+impl TypePruneUnionCache for QueryCache<'_> {
+    fn prune_union_members_memo(&self, type_id: TypeId) -> Option<TypeId> {
+        self.interner.prune_union_members_memo(type_id)
+    }
+
+    fn set_prune_union_members_memo(&self, type_id: TypeId, result: TypeId) {
+        self.interner.set_prune_union_members_memo(type_id, result);
     }
 }
 

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -281,6 +281,22 @@ pub struct TypeInterner {
     /// sibling `extract_type_params_cache` / `widen_type_cache` pure-function
     /// memos.
     pub(super) contains_type_by_id_cache: DashMap<(TypeId, TypeId), bool, FxBuildHasher>,
+    /// Result memo for `prune_impossible_object_union_members(type_id)`, keyed by
+    /// the union `TypeId`.
+    ///
+    /// Pruning impossible object members from a union is a pure function of the
+    /// immutable interned type `DAG`: it inspects only structural predicates
+    /// (literal-discriminant conflicts in intersection members, never-typed or
+    /// impossible-unit required object properties) over resolver-free
+    /// `evaluate_type` / `is_subtype_of` walks, threading no resolver, substitution
+    /// environment, or compiler option. The pruned result is therefore stable per
+    /// input union `TypeId` within one interner. Object-union property access asks
+    /// it for the same union `TypeId` on every property read against a
+    /// discriminated union (`property_visitor.rs`), and the checker re-asks it via
+    /// `prune_impossible_object_union_members_with_env`; memoizing on the interner
+    /// collapses the repeated O(N-member) prune walks to O(1), exactly like the
+    /// sibling `contains_type_by_id_cache` / `widen_type_cache` pure-function memos.
+    pub(super) prune_union_members_cache: DashMap<TypeId, TypeId, FxBuildHasher>,
     /// Result memo for `collect_contravariant_infer_names`, keyed by the pattern
     /// `TypeId`.
     ///
@@ -483,6 +499,8 @@ pub struct TypePredicateCacheStatistics {
     pub contains_file_relative_cache_entries: usize,
     /// Number of memoized structural `contains_type_by_id(root, target)` results.
     pub contains_type_by_id_cache_entries: usize,
+    /// Number of memoized `prune_impossible_object_union_members(type_id)` results.
+    pub prune_union_members_cache_entries: usize,
 }
 
 impl std::fmt::Debug for TypeInterner {
@@ -525,6 +543,7 @@ impl TypeInterner {
             contains_file_relative_cache_entries: self
                 .predicate_cache_entries_for(PredicateCacheKind::ContainsFileRelative),
             contains_type_by_id_cache_entries: self.contains_type_by_id_cache.len(),
+            prune_union_members_cache_entries: self.prune_union_members_cache.len(),
         }
     }
 
@@ -589,6 +608,7 @@ impl TypeInterner {
             widen_type_cache: DashMap::with_hasher(FxBuildHasher),
             extract_type_params_cache: DashMap::with_hasher(FxBuildHasher),
             contains_type_by_id_cache: DashMap::with_hasher(FxBuildHasher),
+            prune_union_members_cache: DashMap::with_hasher(FxBuildHasher),
             contravariant_infer_names_cache: DashMap::with_hasher(FxBuildHasher),
             union_normalize_cache: DashMap::with_hasher(FxBuildHasher),
             array_base_type: AtomicU32::new(u32::MAX),
@@ -875,6 +895,19 @@ impl TypeInterner {
     pub fn set_contains_type_by_id_memo(&self, root: TypeId, target: TypeId, result: bool) {
         self.contains_type_by_id_cache
             .insert((root, target), result);
+    }
+
+    /// Look up the memoized `prune_impossible_object_union_members(type_id)`
+    /// result.
+    #[inline]
+    pub fn prune_union_members_memo(&self, type_id: TypeId) -> Option<TypeId> {
+        self.prune_union_members_cache.get(&type_id).map(|v| *v)
+    }
+
+    /// Record the `prune_impossible_object_union_members(type_id)` result.
+    #[inline]
+    pub fn set_prune_union_members_memo(&self, type_id: TypeId, result: TypeId) {
+        self.prune_union_members_cache.insert(type_id, result);
     }
 
     /// Look up the memoized `collect_contravariant_infer_names` name list for a

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -1765,10 +1765,27 @@ fn unit_intersection_is_impossible(db: &dyn TypeDatabase, type_id: TypeId) -> bo
     false
 }
 
+/// Prune union members whose object/intersection shape is structurally
+/// impossible (conflicting literal discriminants, never-typed or impossible-unit
+/// required properties), returning the narrowed union (or `never` / the single
+/// survivor / the input unchanged).
+///
+/// Pure function of the input union `TypeId`: it consults only structural
+/// predicates over the immutable interned type `DAG` via resolver-free
+/// `evaluate_type` / `is_subtype_of` walks, threading no resolver, substitution
+/// environment, or compiler option. The result is therefore memoized
+/// project-wide on the interner ([`TypePruneUnionCache`]) so the repeated
+/// per-property-read prune walks that object-union property access issues
+/// against the same discriminated-union `TypeId` collapse to O(1), mirroring the
+/// sibling `contains_type_by_id` / `widen_type` pure-function memos.
 pub fn prune_impossible_object_union_members(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
     let Some(TypeData::Union(list_id)) = db.lookup(type_id) else {
         return type_id;
     };
+
+    if let Some(cached) = db.prune_union_members_memo(type_id) {
+        return cached;
+    }
 
     let members = db.type_list(list_id);
     let retained: Vec<_> = members
@@ -1780,12 +1797,15 @@ pub fn prune_impossible_object_union_members(db: &dyn TypeDatabase, type_id: Typ
         })
         .collect();
 
-    match retained.len() {
+    let result = match retained.len() {
         0 => TypeId::NEVER,
         len if len == members.len() => type_id,
         1 => retained[0],
         _ => db.union_preserve_members(retained),
-    }
+    };
+
+    db.set_prune_union_members_memo(type_id, result);
+    result
 }
 
 fn intersection_member_preserves_literal_keys(db: &dyn TypeDatabase, type_id: TypeId) -> bool {

--- a/crates/tsz-solver/tests/db_tests.rs
+++ b/crates/tsz-solver/tests/db_tests.rs
@@ -273,6 +273,77 @@ fn query_cache_caches_object_spread_properties() {
     assert_eq!(db.object_spread_properties_cache_len(), 1);
 }
 
+/// `prune_impossible_object_union_members` is a pure function of the input union
+/// `TypeId` (only structural predicates over the immutable interned `DAG`), so its
+/// result is memoized project-wide on the interner. Object-union property access
+/// re-asks the same discriminated-union `TypeId` once per property read; this pins
+/// both the byte-identical pruned value and the cross-call cache reuse.
+#[test]
+fn prune_impossible_object_union_members_memo_is_byte_identical_and_reused() {
+    let interner = TypeInterner::new();
+
+    let kind_prop = |lit: TypeId, order: u32| PropertyInfo {
+        name: interner.intern_string("kind"),
+        type_id: lit,
+        write_type: lit,
+        optional: false,
+        readonly: false,
+        is_method: false,
+        is_class_prototype: false,
+        visibility: Visibility::Public,
+        parent_id: None,
+        declaration_order: order,
+        is_string_named: false,
+        is_symbol_named: false,
+        single_quoted_name: false,
+        non_widening: false,
+    };
+
+    let lit_a = interner.literal_string("a");
+    let lit_b = interner.literal_string("b");
+    let lit_c = interner.literal_string("c");
+
+    // An intersection with conflicting required `kind` discriminants is a
+    // structurally impossible object member, so pruning drops it. Build it with
+    // the raw (un-normalized) intersection so it survives as an `Intersection`
+    // node and actually reaches the prune predicate, rather than being collapsed
+    // to `never` at construction time.
+    let impossible = interner.intersect_types_raw2(
+        interner.object(vec![kind_prop(lit_a, 0)]),
+        interner.object(vec![kind_prop(lit_b, 0)]),
+    );
+    let valid = interner.object(vec![kind_prop(lit_c, 0)]);
+    let union = interner.union_preserve_members(vec![impossible, valid]);
+
+    // The setup must hold a real two-member `Union` so the prune path is exercised
+    // (otherwise the early non-`Union` guard would short-circuit the memo).
+    let Some(TypeData::Union(members)) = interner.lookup(union) else {
+        panic!("expected a Union for the prune-memo setup, got {union:?}");
+    };
+    assert_eq!(interner.type_list(members).len(), 2);
+
+    let db: &dyn TypeDatabase = &interner;
+
+    // Pruning drops the structurally impossible intersection member, leaving the
+    // single valid object — the byte-identical structural answer.
+    let pruned = crate::type_queries::prune_impossible_object_union_members(db, union);
+    assert_eq!(pruned, valid);
+
+    // The result is memoized on the interner, so a second call returns the same
+    // value from the cache rather than re-walking the union.
+    assert_eq!(db.prune_union_members_memo(union), Some(pruned));
+    let pruned_again = crate::type_queries::prune_impossible_object_union_members(db, union);
+    assert_eq!(pruned_again, pruned);
+
+    // Non-union inputs are returned unchanged (the early `Union` guard) and never
+    // populate the union-keyed memo.
+    assert_eq!(
+        crate::type_queries::prune_impossible_object_union_members(db, TypeId::NUMBER),
+        TypeId::NUMBER
+    );
+    assert_eq!(db.prune_union_members_memo(TypeId::NUMBER), None);
+}
+
 #[test]
 fn type_interner_query_db_tracks_no_unchecked_indexed_access() {
     let interner = TypeInterner::new();


### PR DESCRIPTION
Goal: fast

`prune_impossible_object_union_members(db, type_id)` removes union members whose
object/intersection shape is structurally impossible (conflicting required
literal discriminants in intersection members, never-typed or impossible-unit
required object properties). It consults only structural predicates over the
immutable interned type DAG via resolver-free `evaluate_type` / `is_subtype_of`
walks — it threads no resolver, substitution environment, or compiler option —
so the pruned result is a pure function of the input union `TypeId` and stable
within one interner.

The hot caller is object-union property access (`property_visitor.rs:300`):
every property read against a discriminated union re-asks the prune for the same
union `TypeId`, so the O(N-member) prune walk was recomputed once per read. The
solver-internal `keyof` evaluation and `signatures_and_advanced` keyof-narrowing
callers re-ask the same union too.

Promote the result to a project-wide `DashMap<TypeId, TypeId>` on `TypeInterner`,
exposed via a new `TypePruneUnionCache` supertrait of `TypeDatabase`, mirroring
the established `TypeContainsByIdCache` (#14475) / `TypeWidenCache` pure-function
memos. Byte-identical: the stored value is exactly the function's own result;
only its lifetime widens to the project. The checker's separate resolver-threaded
`prune_impossible_object_union_members_with_env` path is intentionally out of
scope — it is not pure of `type_id` alone and keeps its own behavior.

## Measurement
Measured with a temporary atomic call/hit counter (removed before commit) plus
`--extendedDiagnostics`, on the same workload against clean `origin/main`
(`affd6fb45b`-based) vs this branch. Two synthetic discriminated-union-heavy
workloads (unions <=64 members so they pass the `property_visitor.rs:300` prune
gate, property reads in isolated function scopes) and real zod source
(`93b0b689`, src/).

Multi-file synthetic (12 unions x 60 members x 400 reads, no TS2563), 4 runs each:
- clean main: Check 0.66-0.67s, Total 0.70s
- this branch: Check 0.56-0.57s, Total 0.60s  (~15% Check, ~14% Total)
- PRUNE_CALLS=4824, PRUNE_CACHE_HITS=4800 -> 99.5% hit rate, 24 unique prunes

Single-file synthetic (12 unions x 60 richer-shape members x 800 reads), 3 runs:
- clean main: Check ~1.85s
- this branch: Check ~1.65s  (~11% Check)
- PRUNE_CALLS=9624, PRUNE_CACHE_HITS=9600 -> 99.75% hit rate

Real zod (8-file src ref): PRUNE_CALLS=617, PRUNE_CACHE_HITS=552 (89.5% hit rate);
timing within noise (cheap walks dominated by other work) but the redundant
recompute is clearly eliminated. Confirms the function is genuinely hot and the
memo collapses near-100% of repeats with no behavior change.

Complexity: O(1) amortized cache read keyed by `TypeId`; no invalidation needed —
interned structure is immutable within a session. Memory: one `DashMap` entry per
distinct union `TypeId` that reaches the prune.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo nextest run -p tsz-solver` — new regression test
  `prune_impossible_object_union_members_memo_is_byte_identical_and_reused`
  pins the byte-identical pruned value (impossible intersection member dropped),
  cross-call cache reuse, and non-union no-poison. The 4 local failures
  (`test_solver_oversized_file_size_ceilings` baseline drift on `src/types.rs`,
  plus 3 conditional-infer/normalize/generic-pipe TypeId-value tests) reproduce
  identically on clean `origin/main` in this worktree and are pre-existing
  environment failures (CI clean env is authoritative).
- `cargo clippy -p tsz-solver --lib` — clean.
- premerge-microbench / forced-parallel-determinism CI gates.
