### PR TITLE
grow(bench): promote ts-pattern to the project-compat no-regression baseline

### DIFF
--- a/scripts/ci/project-compat-baseline.json
+++ b/scripts/ci/project-compat-baseline.json
@@ -12,6 +12,7 @@
     "nextjs-fresh-app": "green",
     "rxjs-project": "green",
     "ts-essentials-project": "green",
+    "ts-pattern-project": "green",
     "ts-toolbelt-project": "green",
     "type-challenges-solutions-project": "green",
     "type-fest-project": "green",


### PR DESCRIPTION
Goal: grow

Promotes `ts-pattern-project` into the project-compile no-regression baseline (`scripts/ci/project-compat-baseline.json`). ts-pattern now compiles **green** — tsz emits exactly tsc's diagnostics (0 tsz-only false positives, tsc-clean) — on current main, per a fresh canary oracle survey (dist-fast binary + TS 6.0.3 oracle). Adding it to the baseline protects the row from green→non-green regressions once the canary becomes blocking, growing the protected set from 9 to 10 rows.

## Verification
- `node scripts/bench/project-row-summary.mjs` → "All 60 rows consistent across surfaces" (the project-row-drift gate)
- Fresh canary oracle survey: ts-pattern = 0 tsz-only diagnostics, tsc-clean
- This PR's `project-compile-canary` run confirms ts-pattern compiles green in the CI environment before merge

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
