### PR TITLE
fast(bench): refresh published feed on the 0 3 daily cron, not just perf ticks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -522,7 +522,6 @@ jobs:
       always() &&
       (needs.bench-prepare.outputs.should_run == 'true' ||
        (!(github.event_name == 'workflow_dispatch' && inputs.publish_latest_pgo) &&
-        !(github.event_name == 'schedule' && github.event.schedule == '0 3 * * *') &&
         !(github.event_name == 'schedule' && github.event.schedule == '0 5 * * *') &&
         needs.bench-prepare-cloudbuild.outputs.should_run == 'true')) &&
       !contains(needs.*.result, 'failure') &&


### PR DESCRIPTION
## Summary

The tsz.dev `/benchmarks/` and `/compatibility/` feed (`bench-runs/latest.json`) was frozen at `2026-06-22T09:16` for hours despite cron ticks running. Root cause (full trace in the investigation): GitHub fires the daily `0 3`/`0 5` crons **many hours late and coalesced** into the perf-tick window. A late `0 3` tick ran `bench-prepare-cloudbuild` (prep) but `bench-prep-artifact`'s gate **excluded `0 3`**, so it skipped shards+publish and never refreshed the feed (e.g. the 08:45 tick on 2026-06-22 prepped but did not publish).

## Change

Drop the `0 3` exclusion from `bench-prep-artifact`'s `if:` so the daily-prep tick **also runs the full perf pipeline and publishes** — an extra reliable daily feed refresh on top of the every-3h perf cron, so a coalesced daily cron landing in the perf window refreshes the feed instead of no-oping.

`0 5` (daily PGO release) is deliberately left release-only: making it also prep would force `publish-latest-pgo` to wait behind a ~1h Cloud Build and delay the daily binary release.

Goal: fast

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- `bench.yml` is valid YAML; `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs` and `test-bench-workflow-micro-coverage.mjs` pass (release/prep contract intact).
- A `workflow_dispatch` run (27951445182) was triggered to refresh the feed immediately; subsequent `0 3` ticks will now also refresh.
