### PR TITLE
fix(solver): reduce generic-wrapper-alias infer pattern in conditional extends-type (false TS2322, #14489)

### DIFF
--- a/crates/tsz-checker/tests/conditional_alias_lib_application_tests.rs
+++ b/crates/tsz-checker/tests/conditional_alias_lib_application_tests.rs
@@ -109,3 +109,75 @@ const value: Result = 1;
 
     assert_clean(source, "user alias inner application");
 }
+
+// ── #14489: generic wrapper-alias `infer` in the conditional EXTENDS-type ──────
+//
+// When the conditional's extends-type is a generic wrapper alias carrying the
+// `infer` (`X extends AB<infer U>` with `type AB<T> = Promise<T[]>`) and the
+// check-source is the EXPANDED structural form (`Promise<number[]>`, not written
+// via the alias), the pattern alias must be reduced head-only to its body
+// application form (`Promise<(infer U)[]>`) so the infer binds. Previously tsz
+// failed to reduce the alias pattern, collapsed the conditional to its false
+// branch (`never`), and emitted a false TS2322 at the use site.
+
+#[test]
+fn wrapper_alias_infer_pattern_binds_on_expanded_source() {
+    // R must resolve to `number`; assigning a number is clean.
+    let source = r#"
+type AB<T> = Promise<T[]>;
+type Ex<X> = X extends AB<infer U> ? U : never;
+type R = Ex<Promise<number[]>>;
+const a: R = 7;
+"#;
+    assert_clean(source, "wrapper-alias infer pattern binds U=number");
+}
+
+#[test]
+fn wrapper_alias_infer_pattern_payload_shape_binds() {
+    let source = r#"
+type W<T> = Promise<{ payload: T[] }>;
+type Ex<X> = X extends W<infer U> ? U : never;
+type R = Ex<Promise<{ payload: string[] }>>;
+const a: R = "ok";
+"#;
+    assert_clean(source, "payload-shaped wrapper alias binds U=string");
+}
+
+#[test]
+fn wrapper_alias_infer_pattern_set_promise_binds() {
+    // The infer parameter sits one level deeper (`Set<Promise<T>>`).
+    let source = r#"
+type SW<T> = Set<Promise<T>>;
+type Ex<X> = X extends SW<infer U> ? U : never;
+type R = Ex<Set<Promise<boolean>>>;
+const a: R = true;
+"#;
+    assert_clean(source, "Set<Promise<T>> wrapper alias binds U=boolean");
+}
+
+#[test]
+fn wrapper_alias_infer_pattern_still_rejects_wrong_assignment() {
+    // With U bound to `number`, assigning a string is a real TS2322 — the fix
+    // must not over-accept.
+    let source = r#"
+type AB<T> = Promise<T[]>;
+type Ex<X> = X extends AB<infer U> ? U : never;
+type R = Ex<Promise<number[]>>;
+const b: R = "no";
+"#;
+    assert_ts2322(source, "wrong assignment to inferred U=number");
+}
+
+#[test]
+fn wrapper_alias_infer_pattern_false_branch_when_source_mismatches() {
+    // A source that genuinely does not match the wrapper must take the false
+    // branch (`never`), so assigning any value is rejected — proving the
+    // reduction did not loosen the match.
+    let source = r#"
+type AB<T> = Promise<T[]>;
+type Ex<X> = X extends AB<infer U> ? U : never;
+type R = Ex<string>;
+const a: R = "anything";
+"#;
+    assert_ts2322(source, "non-matching source stays never");
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -2002,6 +2002,43 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     }
                 }
 
+                // Wrapper-alias pattern reduction: when the pattern is a
+                // generic *wrapper* alias carrying the `infer`
+                // (`AB<infer U>` with `AB<T> = Promise<T[]>`) and the source is
+                // the expanded structural form (`Promise<number[]>`, not
+                // written via the alias), reduce the pattern head-only to its
+                // body application form (`Promise<(infer U)[]>`), preserving the
+                // `infer`, and match the source against that. The structural
+                // `evaluate_for_infer_match` fallback below does not reduce an
+                // infer-bearing application, so without this the alias pattern
+                // never aligns with the expanded source and the conditional
+                // wrongly collapses to its false branch (#14489). Gated to
+                // aliases whose substituted body is itself an `Application`
+                // (true wrappers) so conditional-/structural-body aliases stay
+                // on the structural-expansion path.
+                if let Some(reduced_pattern) = self.alias_application_substituted_body(pattern)
+                    && reduced_pattern != pattern
+                    && matches!(
+                        self.interner().lookup(reduced_pattern),
+                        Some(TypeData::Application(_))
+                    )
+                {
+                    let mut reduced_bindings = bindings.clone();
+                    let reduced_checkpoint = visited.checkpoint();
+                    if self.match_infer_pattern(
+                        source,
+                        reduced_pattern,
+                        &mut reduced_bindings,
+                        visited,
+                        checker,
+                    ) && reduced_bindings.len() >= bindings.len()
+                    {
+                        *bindings = reduced_bindings;
+                        return true;
+                    }
+                    visited.rollback_to(reduced_checkpoint);
+                }
+
                 // Fallback: Structural expansion
                 // Expand the pattern Application to its structural form and recurse
                 // This handles cases like: Reducer<infer S> matching a structural function type


### PR DESCRIPTION
Goal: green

## Summary
A conditional whose **extends-type is a generic *wrapper* alias carrying the `infer`** (`X extends AB<infer U> ? U : never`, with `type AB<T> = Promise<T[]>`) failed to bind `U` when the **check-source was the expanded structural form** (`Promise<number[]>`, not written via the alias). tsz collapsed the conditional to its false branch (`never`) and emitted a **false TS2322** at the use site; `tsc` infers `U = number`.

This is the **extends-type counterpart** of the check-type reduction in #14488 (which fixed the source side for #14330). Discovered via the differential fuzz run that verified #14488 (11 of 20 divergences traced to this single root across the returntype / recursive-unwrap / nested-generic-wrapper families).

## Structural rule
When the conditional pattern is `Application(aliasBase, [.. infer ..])` and `aliasBase` is a **wrapper** alias (its resolved body is itself an `Application`, e.g. `AB<T> = Promise<T[]>`), reduce the pattern **head-only** to its body application form (`Promise<(infer U)[]>`) — preserving the `infer` — and match the source against that. The structural `evaluate_for_infer_match` fallback could not do this because evaluating an infer-bearing application is blocked, so the alias pattern stayed opaque and the conditional silently took its false branch.

Owner: `crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs`, `match_infer_pattern_inner` `TypeData::Application` arm. Reuses the existing `alias_application_substituted_body` (infer-preserving via `instantiate_generic_cached`); gated to wrapper aliases (substituted body is an `Application`) so conditional-/structural-body aliases stay on the structural-expansion path.

## Verification
- **Flips 3 tests** (fail on main, pass with fix; confirmed by stash-build-diff): `wrapper_alias_infer_pattern_binds_on_expanded_source`, `wrapper_alias_infer_pattern_payload_shape_binds`, `wrapper_alias_infer_pattern_set_promise_binds`.
- **2 negative controls** guard against over-broadening (pass on base and fix): `wrapper_alias_infer_pattern_still_rejects_wrong_assignment` (wrong assignment to inferred `U=number` stays TS2322); `wrapper_alias_infer_pattern_false_branch_when_source_mismatches` (a source that genuinely doesn't match the wrapper stays `never`).
- vs `tsc` 6.0.3 on the repro matrix (`Promise<T[]>`, `Promise<{payload:T[]}>`, `Set<Promise<T>>`, alias-source control, non-matching-source control): all match exactly.
- **Neutral on pre-existing failures**: `cargo nextest -p tsz-solver` conditional/infer/awaited/recursive/mapped/keyof/reduce/application/return_type/parameters = 2211 passed, 1 failed (the 1, `test_conditional_infer_optional_property_present_distributive`, fails on base too). The checker `conditional_application_display_tests` / `conditional_alias_lib_application_tests` pre-existing failures (`deferred_generic_conditional_keeps_branch_union`, `conditional_alias_reduces_return_type_inner_application`) fail identically on the pristine base (verified by rebuild-and-diff) — this change neither fixes nor breaks them.
- Scope: single-level wrappers are fully covered; **nested alias-in-alias** (`Wrap<Wrap<T>>`) and **conditional-body alias check-types** (`ReturnType<F> extends Promise<infer T>`) remain separate pre-existing residuals (the latter is #14330/#14488 territory).
- Full conformance / checker / emit suites: CI gates this PR.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
