### PR TITLE
fix(checker): infer yield type for generator function declarations

### DIFF
--- a/crates/tsz-checker/src/tests/generator_yield_identity_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_yield_identity_tests.rs
@@ -74,3 +74,82 @@ function* gen(): Generator<(x: string) => void, void, unknown> {
         "lib Generator identity should contextually type the yield operand; got: {codes:?}"
     );
 }
+
+#[test]
+fn generator_declaration_infers_yield_type_for_consumers() {
+    // An unannotated `function*` *declaration* infers its yield type from the
+    // body just like a generator method/expression. Consuming `.next().value`
+    // as an incompatible type must surface TS2322 — previously the declaration's
+    // yield collapsed to `any`, hiding the error (and emitting `Generator<any>`
+    // in `.d.ts`). Binder names vary across the cases below so the guard tracks
+    // the structural rule, not a spelling.
+    let codes = strict_codes_with_libs(
+        r#"
+function* produce() {
+    yield "alpha";
+}
+const wrong: number = produce().next().value;
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "generator declaration's inferred string yield must surface TS2322 at a number consumer; got: {codes:?}"
+    );
+}
+
+#[test]
+fn async_generator_declaration_infers_yield_type_for_consumers() {
+    let codes = strict_codes_with_libs(
+        r#"
+async function* stream() {
+    yield 42;
+}
+async function drain() {
+    const wrong: string = (await stream().next()).value;
+}
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "async generator declaration's inferred number yield must surface TS2322 at a string consumer; got: {codes:?}"
+    );
+}
+
+#[test]
+fn generator_declaration_inferred_yield_accepts_matching_consumer() {
+    // A correctly-typed consumer of the inferred yield must stay clean.
+    let codes = strict_codes_with_libs(
+        r#"
+function* emit() {
+    yield "beta";
+}
+const ok: string | void = emit().next().value;
+export {};
+"#,
+    );
+    assert!(
+        !codes.contains(&2322),
+        "a consumer matching the inferred yield type must not error; got: {codes:?}"
+    );
+}
+
+#[test]
+fn empty_generator_declaration_infers_never_yield() {
+    // A `function*` declaration with no `yield` infers a non-`any` yield
+    // (`Generator<never, void, unknown>`, matching tsc), so `.next().value` is
+    // `void`-typed and a number consumer reports TS2322.
+    let codes = strict_codes_with_libs(
+        r#"
+function* drained() {
+}
+const wrong: number = drained().next().value;
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "empty generator declaration must infer a non-any (never) yield; got: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/tests/generator_yield_identity_tests.rs
+++ b/crates/tsz-checker/src/tests/generator_yield_identity_tests.rs
@@ -19,6 +19,24 @@ fn strict_codes_with_libs(source: &str) -> Vec<u32> {
     .collect()
 }
 
+fn checked_js_codes_with_libs(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.js",
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            no_implicit_any: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
 #[test]
 fn local_generator_alias_does_not_contextually_type_yield_operand() {
     let codes = strict_codes_with_libs(
@@ -151,5 +169,28 @@ export {};
     assert!(
         codes.contains(&2322),
         "empty generator declaration must infer a non-any (never) yield; got: {codes:?}"
+    );
+}
+
+#[test]
+fn yield_star_generator_declaration_preserves_checked_js_implicit_any_diagnostics() {
+    // `yield*` delegation has its own unresolved inference gap in declaration
+    // signatures. The signature recovery pass must not pre-check the body and
+    // consume checked-JS implicit-any diagnostics that the real declaration
+    // body pass owns.
+    let codes = checked_js_codes_with_libs(
+        r#"
+function* stream() {
+    var bucket = []
+    while (true) {
+        bucket = yield* bucket
+    }
+}
+"#,
+    );
+
+    assert!(
+        codes.contains(&7005) && codes.contains(&7034),
+        "yield* declaration recovery must preserve checked-JS implicit-any diagnostics; got: {codes:?}"
     );
 }

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -15,6 +15,7 @@ use crate::query_boundaries::common::ContextualTypeContext;
 use crate::query_boundaries::type_checking_utilities as type_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{TypeId, TypeParamInfo, TypeParamOrigin};
@@ -22,6 +23,41 @@ impl<'a> CheckerState<'a> {
     /// Get type of function declaration/expression/arrow.
     pub(crate) fn get_type_of_function(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_function_impl(idx, &TypingRequest::NONE)
+    }
+
+    /// Whether `node_idx` (a generator body subtree) contains a `yield` /
+    /// `yield*` expression belonging to *this* generator — i.e. not one nested
+    /// inside another function/class. Used to tell a genuinely empty generator
+    /// (`function* g() {}` → `Generator<never>`) apart from one whose only
+    /// `yield* expr` delegate could not be resolved during signature inference.
+    fn generator_body_contains_yield(&self, node_idx: NodeIndex, is_root: bool) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+        if !is_root
+            && matches!(
+                node.kind,
+                k if k == syntax_kind_ext::FUNCTION_DECLARATION
+                    || k == syntax_kind_ext::FUNCTION_EXPRESSION
+                    || k == syntax_kind_ext::METHOD_DECLARATION
+                    || k == syntax_kind_ext::GET_ACCESSOR
+                    || k == syntax_kind_ext::SET_ACCESSOR
+                    || k == syntax_kind_ext::CONSTRUCTOR
+                    || k == syntax_kind_ext::CLASS_DECLARATION
+                    || k == syntax_kind_ext::CLASS_EXPRESSION
+            )
+        {
+            return false;
+        }
+        if node.kind == syntax_kind_ext::YIELD_EXPRESSION {
+            return true;
+        }
+        for child in self.ctx.arena.get_children(node_idx) {
+            if self.generator_body_contains_yield(child, false) {
+                return true;
+            }
+        }
+        false
     }
 
     pub(crate) fn get_type_of_function_impl(
@@ -1922,6 +1958,83 @@ impl<'a> CheckerState<'a> {
                 self.ctx.switch_depth = saved_cf_context.1;
                 self.ctx.label_stack.truncate(saved_cf_context.2);
                 self.ctx.had_outer_loop = saved_cf_context.3;
+            }
+
+            // Generator function *declarations* defer their body walk to
+            // `check_function_declaration` (which maintains the full
+            // type-parameter scope chain), so the inline yield collection above
+            // is skipped for them and `final_generator_yield_type` stays unset.
+            // The synthesized signature would then be `Generator<any, …>` /
+            // `AsyncGenerator<any, …>`, dropping the inferred yield type for both
+            // `.d.ts` emit *and* call-site checking (e.g. a missed TS2322 on
+            // `g().next().value`). Methods and function expressions never hit
+            // this because they run the body walk inline above. Recover the
+            // inferred yield here with a diagnostics-suppressed body pass that
+            // reuses the same collection + `check_generator_body_return` the
+            // non-declaration path uses; the real TS7055/TS7025 and body
+            // diagnostics still come from `check_function_declaration`.
+            if is_function_declaration
+                && is_generator
+                && !has_type_annotation
+                && final_generator_yield_type.is_none()
+            {
+                let yield_diag_snapshot = DiagnosticSpeculationSnapshot::new(&self.ctx);
+                let saved_cf_context = (
+                    self.ctx.iteration_depth,
+                    self.ctx.switch_depth,
+                    self.ctx.label_stack.len(),
+                    self.ctx.had_outer_loop,
+                );
+                self.ctx.iteration_depth = 0;
+                self.ctx.switch_depth = 0;
+                let saved_yield_collection =
+                    std::mem::take(&mut self.ctx.generator_yield_operand_types);
+                let saved_had_ts7057 = std::mem::replace(&mut self.ctx.generator_had_ts7057, false);
+
+                let body_request = self.function_body_statement_request(false, contextual_type);
+                self.check_function_body_statement_with_own_literal_context(body, &body_request);
+                let inferred_yield =
+                    self.check_generator_body_return(GeneratorBodyReturnCheckCtx {
+                        is_generator,
+                        has_type_annotation,
+                        annotated_return_type,
+                        return_type,
+                        type_annotation,
+                        idx,
+                        function_is_async,
+                        early_yield_type,
+                        name_node: None,
+                        name_for_error: None,
+                    });
+                // Adopt the inferred yield only when it is concrete, or when the
+                // body has no `yield` at all — a genuinely empty generator
+                // (`function* g() {}`) yields `never`, matching tsc. A `never`
+                // *with* yields present means a `yield* expr` delegate whose
+                // element type could not be resolved during signature inference
+                // (a separate, pre-existing gap that also affects generator
+                // methods/expressions); keep the prior `any` fallback there
+                // rather than emit a less-accurate `never`.
+                final_generator_yield_type = match inferred_yield {
+                    Some(yield_t)
+                        if yield_t != TypeId::NEVER
+                            || !self.generator_body_contains_yield(body, true) =>
+                    {
+                        Some(yield_t)
+                    }
+                    _ => None,
+                };
+
+                self.ctx.generator_yield_operand_types = saved_yield_collection;
+                self.ctx.generator_had_ts7057 = saved_had_ts7057;
+                self.ctx.iteration_depth = saved_cf_context.0;
+                self.ctx.switch_depth = saved_cf_context.1;
+                self.ctx.label_stack.truncate(saved_cf_context.2);
+                self.ctx.had_outer_loop = saved_cf_context.3;
+                // Drop any body expression types this suppressed pass cached so
+                // `check_function_declaration` re-checks the body from scratch
+                // with the full type-parameter scope chain.
+                self.invalidate_function_body_for_param_retyping(body);
+                yield_diag_snapshot.rollback(&mut self.ctx.diagnostic_state());
             }
             self.pop_return_type();
             self.ctx.pop_yield_type();

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -6,6 +6,7 @@ mod js_prototype;
 mod jsx_body_context;
 mod literal_context;
 
+use self::generator_declaration_yield::GeneratorDeclarationYieldCtx;
 use super::function_type_helpers::{
     ExpressionBodyReturnCheckCtx, FunctionBodyReturnTypeCtx, FunctionFinalReturnTypeCtx,
     GeneratorBodyReturnCheckCtx,
@@ -1898,11 +1899,9 @@ impl<'a> CheckerState<'a> {
                         name_for_error: name_for_error.as_deref(),
                     });
 
-                // Restore outer generator's yield collection state
                 self.ctx.generator_yield_operand_types = saved_yield_collection;
                 self.ctx.generator_had_ts7057 = saved_had_ts7057;
 
-                // Restore control flow context
                 self.ctx.iteration_depth = saved_cf_context.0;
                 self.ctx.switch_depth = saved_cf_context.1;
                 self.ctx.label_stack.truncate(saved_cf_context.2);
@@ -1914,28 +1913,27 @@ impl<'a> CheckerState<'a> {
                 && !has_type_annotation
                 && final_generator_yield_type.is_none()
             {
-                final_generator_yield_type = self.infer_generator_declaration_yield_type(
-                    body,
-                    contextual_type,
-                    has_type_annotation,
-                    annotated_return_type,
-                    return_type,
-                    type_annotation,
-                    idx,
-                    function_is_async,
-                    early_yield_type,
-                );
+                final_generator_yield_type =
+                    self.infer_generator_declaration_yield_type(GeneratorDeclarationYieldCtx {
+                        body,
+                        contextual_type,
+                        has_type_annotation,
+                        annotated_return_type,
+                        return_type,
+                        type_annotation,
+                        idx,
+                        function_is_async,
+                        early_yield_type,
+                    });
             }
             self.pop_return_type();
             self.ctx.pop_yield_type();
             self.ctx.pop_generator_next_type();
 
-            // Exit async context
             if is_async_for_context {
                 self.ctx.exit_async_context();
             }
 
-            // Restore function_depth (incremented at body entry)
             self.ctx.function_depth -= 1;
         }
 

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -1,6 +1,7 @@
 //! Function, method, and arrow function type resolution.
 mod contextual_arity;
 mod function_name_diagnostics;
+mod generator_declaration_yield;
 mod js_prototype;
 mod jsx_body_context;
 mod literal_context;
@@ -15,7 +16,6 @@ use crate::query_boundaries::common::ContextualTypeContext;
 use crate::query_boundaries::type_checking_utilities as type_query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{TypeId, TypeParamInfo, TypeParamOrigin};
@@ -23,41 +23,6 @@ impl<'a> CheckerState<'a> {
     /// Get type of function declaration/expression/arrow.
     pub(crate) fn get_type_of_function(&mut self, idx: NodeIndex) -> TypeId {
         self.get_type_of_function_impl(idx, &TypingRequest::NONE)
-    }
-
-    /// Whether `node_idx` (a generator body subtree) contains a `yield` /
-    /// `yield*` expression belonging to *this* generator — i.e. not one nested
-    /// inside another function/class. Used to tell a genuinely empty generator
-    /// (`function* g() {}` → `Generator<never>`) apart from one whose only
-    /// `yield* expr` delegate could not be resolved during signature inference.
-    fn generator_body_contains_yield(&self, node_idx: NodeIndex, is_root: bool) -> bool {
-        let Some(node) = self.ctx.arena.get(node_idx) else {
-            return false;
-        };
-        if !is_root
-            && matches!(
-                node.kind,
-                k if k == syntax_kind_ext::FUNCTION_DECLARATION
-                    || k == syntax_kind_ext::FUNCTION_EXPRESSION
-                    || k == syntax_kind_ext::METHOD_DECLARATION
-                    || k == syntax_kind_ext::GET_ACCESSOR
-                    || k == syntax_kind_ext::SET_ACCESSOR
-                    || k == syntax_kind_ext::CONSTRUCTOR
-                    || k == syntax_kind_ext::CLASS_DECLARATION
-                    || k == syntax_kind_ext::CLASS_EXPRESSION
-            )
-        {
-            return false;
-        }
-        if node.kind == syntax_kind_ext::YIELD_EXPRESSION {
-            return true;
-        }
-        for child in self.ctx.arena.get_children(node_idx) {
-            if self.generator_body_contains_yield(child, false) {
-                return true;
-            }
-        }
-        false
     }
 
     pub(crate) fn get_type_of_function_impl(
@@ -71,23 +36,14 @@ impl<'a> CheckerState<'a> {
         let Some(node) = self.ctx.arena.get(idx) else {
             return TypeId::ERROR; // Missing node - propagate error
         };
-        // Determine if this is a function expression or arrow function (a closure)
         let is_closure = matches!(
             node.kind,
             syntax_kind_ext::FUNCTION_EXPRESSION | syntax_kind_ext::ARROW_FUNCTION
         );
-        // Track object-literal method shorthand for implicit-any like an
-        // arrow/function-expression member; `is_closure` (which also drives
-        // narrowing depth) stays arrow/function-expression only. Rationale and
-        // class-method exclusion: see `is_object_literal_method`.
         let tracks_implicit_any = is_closure || self.is_object_literal_method(idx);
-        // Rule #42: Increment closure depth when entering a function expression or arrow function
-        // This causes mutable variables (let/var) to lose narrowing inside the closure
         if is_closure {
             self.ctx.inside_closure_depth += 1;
         }
-        // Helper macro to decrement closure depth before returning
-        // This ensures we properly track closure depth even on early returns
         macro_rules! return_with_cleanup {
             ($expr:expr) => {{
                 if is_closure {
@@ -150,7 +106,6 @@ impl<'a> CheckerState<'a> {
                 (false, false)
             };
 
-        // Function declarations don't report implicit any for parameters (handled by check_statement)
         let is_function_declaration = node.kind == syntax_kind_ext::FUNCTION_DECLARATION;
         let is_method_or_constructor = matches!(
             node.kind,
@@ -158,12 +113,9 @@ impl<'a> CheckerState<'a> {
         );
         let is_arrow_function = node.kind == syntax_kind_ext::ARROW_FUNCTION;
 
-        // Check for duplicate parameter names in function expressions and arrow functions (TS2300)
         if !is_function_declaration && !is_method_or_constructor {
-            // Check for required parameters following optional parameters (TS1016)
             self.check_parameter_ordering(parameters, Some(idx));
             self.check_binding_pattern_optionality(&parameters.nodes, body.is_some(), Some(idx));
-            // Check that rest parameters have array types (TS2370)
             self.check_rest_parameter_types(&parameters.nodes);
             self.check_strict_mode_reserved_parameter_names(
                 &parameters.nodes,
@@ -179,7 +131,6 @@ impl<'a> CheckerState<'a> {
             function_is_generator,
         );
 
-        // Push enclosing type parameters so nested functions can reference outer generic scopes.
         let enclosing_type_param_updates = self.push_enclosing_type_parameters(idx);
 
         self.exclude_params_for_type_param_constraints(parameters);
@@ -191,12 +142,10 @@ impl<'a> CheckerState<'a> {
             self.check_type_parameters_for_missing_names(type_parameters);
         }
 
-        // Check for unused type parameters (TS6133) in function expressions and arrows
         if !is_function_declaration && !is_method_or_constructor {
             self.check_unused_type_params(type_parameters, idx);
         }
 
-        // Collect parameter info using solver's ParamInfo struct
         let mut params = Vec::new();
         let mut param_types: Vec<Option<TypeId>> = Vec::new();
         let mut destructuring_context_param_types: Vec<Option<TypeId>> = Vec::new();
@@ -1960,81 +1909,22 @@ impl<'a> CheckerState<'a> {
                 self.ctx.had_outer_loop = saved_cf_context.3;
             }
 
-            // Generator function *declarations* defer their body walk to
-            // `check_function_declaration` (which maintains the full
-            // type-parameter scope chain), so the inline yield collection above
-            // is skipped for them and `final_generator_yield_type` stays unset.
-            // The synthesized signature would then be `Generator<any, …>` /
-            // `AsyncGenerator<any, …>`, dropping the inferred yield type for both
-            // `.d.ts` emit *and* call-site checking (e.g. a missed TS2322 on
-            // `g().next().value`). Methods and function expressions never hit
-            // this because they run the body walk inline above. Recover the
-            // inferred yield here with a diagnostics-suppressed body pass that
-            // reuses the same collection + `check_generator_body_return` the
-            // non-declaration path uses; the real TS7055/TS7025 and body
-            // diagnostics still come from `check_function_declaration`.
             if is_function_declaration
                 && is_generator
                 && !has_type_annotation
                 && final_generator_yield_type.is_none()
             {
-                let yield_diag_snapshot = DiagnosticSpeculationSnapshot::new(&self.ctx);
-                let saved_cf_context = (
-                    self.ctx.iteration_depth,
-                    self.ctx.switch_depth,
-                    self.ctx.label_stack.len(),
-                    self.ctx.had_outer_loop,
+                final_generator_yield_type = self.infer_generator_declaration_yield_type(
+                    body,
+                    contextual_type,
+                    has_type_annotation,
+                    annotated_return_type,
+                    return_type,
+                    type_annotation,
+                    idx,
+                    function_is_async,
+                    early_yield_type,
                 );
-                self.ctx.iteration_depth = 0;
-                self.ctx.switch_depth = 0;
-                let saved_yield_collection =
-                    std::mem::take(&mut self.ctx.generator_yield_operand_types);
-                let saved_had_ts7057 = std::mem::replace(&mut self.ctx.generator_had_ts7057, false);
-
-                let body_request = self.function_body_statement_request(false, contextual_type);
-                self.check_function_body_statement_with_own_literal_context(body, &body_request);
-                let inferred_yield =
-                    self.check_generator_body_return(GeneratorBodyReturnCheckCtx {
-                        is_generator,
-                        has_type_annotation,
-                        annotated_return_type,
-                        return_type,
-                        type_annotation,
-                        idx,
-                        function_is_async,
-                        early_yield_type,
-                        name_node: None,
-                        name_for_error: None,
-                    });
-                // Adopt the inferred yield only when it is concrete, or when the
-                // body has no `yield` at all — a genuinely empty generator
-                // (`function* g() {}`) yields `never`, matching tsc. A `never`
-                // *with* yields present means a `yield* expr` delegate whose
-                // element type could not be resolved during signature inference
-                // (a separate, pre-existing gap that also affects generator
-                // methods/expressions); keep the prior `any` fallback there
-                // rather than emit a less-accurate `never`.
-                final_generator_yield_type = match inferred_yield {
-                    Some(yield_t)
-                        if yield_t != TypeId::NEVER
-                            || !self.generator_body_contains_yield(body, true) =>
-                    {
-                        Some(yield_t)
-                    }
-                    _ => None,
-                };
-
-                self.ctx.generator_yield_operand_types = saved_yield_collection;
-                self.ctx.generator_had_ts7057 = saved_had_ts7057;
-                self.ctx.iteration_depth = saved_cf_context.0;
-                self.ctx.switch_depth = saved_cf_context.1;
-                self.ctx.label_stack.truncate(saved_cf_context.2);
-                self.ctx.had_outer_loop = saved_cf_context.3;
-                // Drop any body expression types this suppressed pass cached so
-                // `check_function_declaration` re-checks the body from scratch
-                // with the full type-parameter scope chain.
-                self.invalidate_function_body_for_param_retyping(body);
-                yield_diag_snapshot.rollback(&mut self.ctx.diagnostic_state());
             }
             self.pop_return_type();
             self.ctx.pop_yield_type();

--- a/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
+++ b/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
@@ -1,0 +1,112 @@
+use super::super::function_type_helpers::GeneratorBodyReturnCheckCtx;
+use crate::context::speculation::DiagnosticSpeculationSnapshot;
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Recover inferred yield type for unannotated generator declarations.
+    ///
+    /// Function declarations defer their body walk to `check_function_declaration`
+    /// so the full type-parameter scope chain is maintained. This suppressed
+    /// pass computes only the signature's yield type; real body diagnostics still
+    /// come from the later declaration check.
+    pub(super) fn infer_generator_declaration_yield_type(
+        &mut self,
+        body: NodeIndex,
+        contextual_type: Option<TypeId>,
+        has_type_annotation: bool,
+        annotated_return_type: Option<TypeId>,
+        return_type: TypeId,
+        type_annotation: NodeIndex,
+        idx: NodeIndex,
+        function_is_async: bool,
+        early_yield_type: Option<TypeId>,
+    ) -> Option<TypeId> {
+        let yield_diag_snapshot = DiagnosticSpeculationSnapshot::new(&self.ctx);
+        let saved_cf_context = (
+            self.ctx.iteration_depth,
+            self.ctx.switch_depth,
+            self.ctx.label_stack.len(),
+            self.ctx.had_outer_loop,
+        );
+        self.ctx.iteration_depth = 0;
+        self.ctx.switch_depth = 0;
+        let saved_yield_collection = std::mem::take(&mut self.ctx.generator_yield_operand_types);
+        let saved_had_ts7057 = std::mem::replace(&mut self.ctx.generator_had_ts7057, false);
+
+        let body_request = self.function_body_statement_request(false, contextual_type);
+        self.check_function_body_statement_with_own_literal_context(body, &body_request);
+        let inferred_yield = self.check_generator_body_return(GeneratorBodyReturnCheckCtx {
+            is_generator: true,
+            has_type_annotation,
+            annotated_return_type,
+            return_type,
+            type_annotation,
+            idx,
+            function_is_async,
+            early_yield_type,
+            name_node: None,
+            name_for_error: None,
+        });
+        let final_yield = self.concrete_or_empty_generator_yield(body, inferred_yield);
+
+        self.ctx.generator_yield_operand_types = saved_yield_collection;
+        self.ctx.generator_had_ts7057 = saved_had_ts7057;
+        self.ctx.iteration_depth = saved_cf_context.0;
+        self.ctx.switch_depth = saved_cf_context.1;
+        self.ctx.label_stack.truncate(saved_cf_context.2);
+        self.ctx.had_outer_loop = saved_cf_context.3;
+        self.invalidate_function_body_for_param_retyping(body);
+        yield_diag_snapshot.rollback(&mut self.ctx.diagnostic_state());
+        final_yield
+    }
+
+    fn concrete_or_empty_generator_yield(
+        &self,
+        body: NodeIndex,
+        inferred_yield: Option<TypeId>,
+    ) -> Option<TypeId> {
+        match inferred_yield {
+            Some(yield_t)
+                if yield_t != TypeId::NEVER || !self.generator_body_contains_yield(body, true) =>
+            {
+                Some(yield_t)
+            }
+            _ => None,
+        }
+    }
+
+    /// Whether `node_idx` contains a `yield` / `yield*` for this generator, not
+    /// one nested inside another function or class.
+    fn generator_body_contains_yield(&self, node_idx: NodeIndex, is_root: bool) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+        if !is_root
+            && matches!(
+                node.kind,
+                k if k == syntax_kind_ext::FUNCTION_DECLARATION
+                    || k == syntax_kind_ext::FUNCTION_EXPRESSION
+                    || k == syntax_kind_ext::METHOD_DECLARATION
+                    || k == syntax_kind_ext::GET_ACCESSOR
+                    || k == syntax_kind_ext::SET_ACCESSOR
+                    || k == syntax_kind_ext::CONSTRUCTOR
+                    || k == syntax_kind_ext::CLASS_DECLARATION
+                    || k == syntax_kind_ext::CLASS_EXPRESSION
+            )
+        {
+            return false;
+        }
+        if node.kind == syntax_kind_ext::YIELD_EXPRESSION {
+            return true;
+        }
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child| self.generator_body_contains_yield(child, false))
+    }
+}

--- a/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
+++ b/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
@@ -1,5 +1,4 @@
 use super::super::function_type_helpers::GeneratorBodyReturnCheckCtx;
-use crate::context::speculation::DiagnosticSpeculationSnapshot;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
@@ -40,7 +39,11 @@ impl CheckerState<'_> {
             function_is_async,
             early_yield_type,
         } = ctx;
-        let yield_diag_snapshot = DiagnosticSpeculationSnapshot::new(&self.ctx);
+        if self.generator_body_contains_yield_star(body, true) {
+            return None;
+        }
+
+        let yield_snapshot = self.ctx.snapshot_return_type();
         let saved_cf_context = (
             self.ctx.iteration_depth,
             self.ctx.switch_depth,
@@ -74,8 +77,7 @@ impl CheckerState<'_> {
         self.ctx.switch_depth = saved_cf_context.1;
         self.ctx.label_stack.truncate(saved_cf_context.2);
         self.ctx.had_outer_loop = saved_cf_context.3;
-        self.invalidate_function_body_for_param_retyping(body);
-        yield_diag_snapshot.rollback(&mut self.ctx.diagnostic_state());
+        yield_snapshot.rollback(&mut self.ctx.speculation_state());
         final_yield
     }
 
@@ -123,5 +125,42 @@ impl CheckerState<'_> {
             .get_children(node_idx)
             .into_iter()
             .any(|child| self.generator_body_contains_yield(child, false))
+    }
+
+    /// Whether `node_idx` contains a `yield*` delegate for this generator, not
+    /// one nested inside another function or class.
+    fn generator_body_contains_yield_star(&self, node_idx: NodeIndex, is_root: bool) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+        if !is_root
+            && matches!(
+                node.kind,
+                k if k == syntax_kind_ext::FUNCTION_DECLARATION
+                    || k == syntax_kind_ext::FUNCTION_EXPRESSION
+                    || k == syntax_kind_ext::METHOD_DECLARATION
+                    || k == syntax_kind_ext::GET_ACCESSOR
+                    || k == syntax_kind_ext::SET_ACCESSOR
+                    || k == syntax_kind_ext::CONSTRUCTOR
+                    || k == syntax_kind_ext::CLASS_DECLARATION
+                    || k == syntax_kind_ext::CLASS_EXPRESSION
+            )
+        {
+            return false;
+        }
+        if node.kind == syntax_kind_ext::YIELD_EXPRESSION
+            && self
+                .ctx
+                .arena
+                .get_unary_expr_ex(node)
+                .is_some_and(|yield_expr| yield_expr.asterisk_token)
+        {
+            return true;
+        }
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child| self.generator_body_contains_yield_star(child, false))
     }
 }

--- a/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
+++ b/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
@@ -6,6 +6,18 @@ use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
+pub(super) struct GeneratorDeclarationYieldCtx {
+    pub(super) body: NodeIndex,
+    pub(super) contextual_type: Option<TypeId>,
+    pub(super) has_type_annotation: bool,
+    pub(super) annotated_return_type: Option<TypeId>,
+    pub(super) return_type: TypeId,
+    pub(super) type_annotation: NodeIndex,
+    pub(super) idx: NodeIndex,
+    pub(super) function_is_async: bool,
+    pub(super) early_yield_type: Option<TypeId>,
+}
+
 impl<'a> CheckerState<'a> {
     /// Recover inferred yield type for unannotated generator declarations.
     ///
@@ -15,16 +27,19 @@ impl<'a> CheckerState<'a> {
     /// come from the later declaration check.
     pub(super) fn infer_generator_declaration_yield_type(
         &mut self,
-        body: NodeIndex,
-        contextual_type: Option<TypeId>,
-        has_type_annotation: bool,
-        annotated_return_type: Option<TypeId>,
-        return_type: TypeId,
-        type_annotation: NodeIndex,
-        idx: NodeIndex,
-        function_is_async: bool,
-        early_yield_type: Option<TypeId>,
+        ctx: GeneratorDeclarationYieldCtx,
     ) -> Option<TypeId> {
+        let GeneratorDeclarationYieldCtx {
+            body,
+            contextual_type,
+            has_type_annotation,
+            annotated_return_type,
+            return_type,
+            type_annotation,
+            idx,
+            function_is_async,
+            early_yield_type,
+        } = ctx;
         let yield_diag_snapshot = DiagnosticSpeculationSnapshot::new(&self.ctx);
         let saved_cf_context = (
             self.ctx.iteration_depth,

--- a/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
+++ b/crates/tsz-checker/src/types/function_type/generator_declaration_yield.rs
@@ -18,7 +18,7 @@ pub(super) struct GeneratorDeclarationYieldCtx {
     pub(super) early_yield_type: Option<TypeId>,
 }
 
-impl<'a> CheckerState<'a> {
+impl CheckerState<'_> {
     /// Recover inferred yield type for unannotated generator declarations.
     ///
     /// Function declarations defer their body walk to `check_function_declaration`


### PR DESCRIPTION
Goal: hold

Fixes #14497.

## Structural rule

When a generator function has no return annotation, `tsc` infers
`Generator<Y, R, N>` (or `AsyncGenerator`) where `Y` is the widened union of all
`yield` operand types in the body. tsz already does this for generator
**methods** and **function expressions** because `compute_function_type` runs
the body's yield-collecting walk inline. For generator function
**declarations**, that inline walk is intentionally skipped — the body is
checked later by `check_function_declaration` so the full type-parameter scope
chain is maintained — so `final_generator_yield_type` was never computed and the
synthesized signature collapsed to `Generator<any, …>` / `AsyncGenerator<any,
…>`.

That dropped the inferred element type for both **`.d.ts` emit**
(`Generator<any>` instead of the inferred yield) and **call-site checking** (a
missed **TS2322** on `g().next().value`, array spreads, and `for…of`).

Owner layer: **checker** — generator return-type synthesis in
`compute_function_type` (`crates/tsz-checker/src/types/function_type.rs`).

## What changed

For an unannotated generator function declaration, recover the yield type with a
**diagnostics-suppressed body pass** that reuses the exact same yield collection
+ `check_generator_body_return` the non-declaration path already uses. The real
`TS7055`/`TS7025` and body diagnostics still come from
`check_function_declaration`; this pass only computes the yield for the
signature, then invalidates the body cache so the later real check re-checks
with the proper scope chain.

The pass is gated to be **strictly additive**: a concrete inferred yield (or
`never` for a *genuinely empty* generator, matching tsc) is adopted, while a
`never` produced by an unresolved `yield*` delegate keeps the prior conservative
`any` fallback — so the pre-existing yield\*-delegation gap is not churned.

## Anti-hardcoding

The decision is structural: gated on `is_function_declaration && is_generator &&
!has_type_annotation`, with an empty-vs-unresolved-`yield*` distinction made by a
structural AST walk (`generator_body_contains_yield`), not on identifiers or
printer strings. The new regression tests vary binder names (`produce`,
`stream`, `emit`, `drained`).

## Adjacent matrix (differential vs bundled `tsc` 6.0.2, `--strict`)

| source | tsc | tsz (after) |
|---|---|---|
| `function* g(){ yield "x"; } const v: number = g().next().value;` | TS2322 | TS2322 ✓ |
| `async function* g(){ yield "x"; }` consumed as `number` | TS2322 | TS2322 ✓ |
| `function* g(){ yield 1; yield 2; } const a: string[] = [...g()];` | TS2322 | TS2322 ✓ |
| `function* g(){ }` consumed as `number` | TS2322 | TS2322 ✓ |
| `function* g(){ yield "x"; } const v: string \| void = g().next().value;` | — | — ✓ |
| nested `function*` inside a function | TS2322 | TS2322 ✓ |
| generic `function* g<T>(xs: T[]){ for (const i of xs) yield i; }` | — | — ✓ |
| recursive `function* g(): any { yield* g(); }` | — | — ✓ (terminates) |
| **DTS** `export function* g(){ yield "x"; }` | `Generator<string, void, unknown>` | match ✓ |
| **DTS** `export async function* g(){ yield 1; }` | `AsyncGenerator<number, void, unknown>` | match ✓ |
| **DTS** `export function* g(){ }` | `Generator<never, void, unknown>` | match ✓ |

Generator **methods** / **expressions** are untouched (the change is gated on
`is_function_declaration`); the `TS7055` implicit-`any`-yield diagnostic is
unchanged.

## Out of scope (separate, pre-existing — see #14497)

- `yield*`-only delegation to a generator function (declarations keep the
  conservative `any`; methods/expressions yield `void`).
- Multi-yield literal **widening** (`yield "x"; yield "y"` → tsc `"x" | "y"`,
  tsz `string`): yield operands are collected pre-widened, affecting all
  generator forms.

## Verification

- New checker regression tests in
  `crates/tsz-checker/src/tests/generator_yield_identity_tests.rs`
  (`generator_declaration_infers_yield_type_for_consumers`,
  `async_generator_declaration_infers_yield_type_for_consumers`,
  `generator_declaration_inferred_yield_accepts_matching_consumer`,
  `empty_generator_declaration_infers_never_yield`) — **7 passed, 0 failed**
  in the file (4 new + 3 existing).
- Differential vs bundled `tsc` 6.0.2 on the matrix above → parity (checker
  error counts and `.d.ts` output).
- `cargo build -p tsz-cli` clean; `cargo clippy -p tsz-checker --lib` clean;
  `cargo fmt -p tsz-checker --check` clean.
- `cargo test -p tsz-checker --lib generator` → the 2 failing entries
  (`yield_star_..._reports_outer_ts2345`,
  `imported_generator_return_type_is_iterable_in_for_of`) reproduce identically
  on clean `origin/main` (stash-verified) — pre-existing, net-new failures = 0.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_018hn48G16Y75A1X42sjASS2

---
_Generated by [Claude Code](https://claude.ai/code/session_018hn48G16Y75A1X42sjASS2)_