### PR TITLE
fix(solver): reduce generic wrapper-alias infer pattern to structural form (TS2322 FP)

### DIFF
--- a/crates/tsz-checker/tests/conditional_infer_tests.rs
+++ b/crates/tsz-checker/tests/conditional_infer_tests.rs
@@ -32,3 +32,5 @@ fn check_source_strict_with_default_libs(source: &str) -> Vec<Diagnostic> {
 mod part_00;
 #[path = "conditional_infer_tests/part_01.rs"]
 mod part_01;
+#[path = "conditional_infer_tests/part_02.rs"]
+mod part_02;

--- a/crates/tsz-checker/tests/conditional_infer_tests/part_02.rs
+++ b/crates/tsz-checker/tests/conditional_infer_tests/part_02.rs
@@ -1,0 +1,152 @@
+//! Contiguous test shard split out of the parent module to satisfy the
+//! source-file line cap.
+//!
+//! Regression coverage for #14489: a conditional whose `extends`-type is a
+//! generic *wrapper alias* carrying an `infer` (`type AB<T> = Promise<T[]>`,
+//! pattern `AB<infer U>`) must bind `U` when the check-type is the alias's
+//! *expanded* structural form (`Promise<number[]>`). The alias base (`AB`) does
+//! not positionally correspond to the structural base (`Promise`) — the alias's
+//! type parameter threads through a nested position of the body — so matching
+//! through the positional source-peeling / base-subtype shortcut bound the
+//! `infer` one structural level too shallow (`U = Promise<number[]>` instead of
+//! `number`), or collapsed the conditional to its false branch (`never`),
+//! producing a false TS2322 at the use site. The fix reduces a generic
+//! wrapper-alias pattern to its structural application form (infer-preserving
+//! head-only substitution) before positional matching.
+
+use super::*;
+
+/// Assert that the source produces at least one TS2322 (used by the
+/// negative-control cases where the false branch must stay selected and its
+/// literal type must be enforced).
+fn assert_has_ts2322(source: &str, label: &str) {
+    let diags = tsz_checker::test_utils::check_source_strict(source);
+    let has = diags.iter().any(|d| d.code == 2322);
+    assert!(
+        has,
+        "[{label}] expected a TS2322 (false branch must stay selected), got:\n{:#?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.start, d.message_text.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+fn assert_no_ts2322_with_libs(source: &str, label: &str) {
+    let diags = check_source_strict_with_default_libs(source);
+    let errors: Vec<&Diagnostic> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        errors.is_empty(),
+        "[{label}] expected no TS2322, got:\n{:#?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.start, d.message_text.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+// =============================================================================
+// #14489 — generic wrapper-alias `infer` over an expanded structural source.
+// =============================================================================
+
+#[test]
+fn promise_wrapper_alias_infer_binds_through_expanded_source() {
+    // The exact issue repro: `AB<T> = Promise<T[]>`, pattern `AB<infer U>`,
+    // check-type the *expanded* `Promise<number[]>`. tsc infers `U = number`.
+    assert_no_ts2322_with_libs(
+        r#"
+type AB<T> = Promise<T[]>;
+type Ex<X> = X extends AB<infer U> ? U : never;
+type R = Ex<Promise<number[]>>;
+const a: R = 7;
+export {};
+"#,
+        "AB<T> = Promise<T[]> ; Ex<Promise<number[]>> = number",
+    );
+}
+
+#[test]
+fn promise_wrapper_alias_infer_object_payload_shape() {
+    // Wrapper body carries the param inside a nested object position.
+    assert_no_ts2322_with_libs(
+        r#"
+type Envelope<T> = Promise<{ payload: T[] }>;
+type Unwrap<X> = X extends Envelope<infer U> ? U : never;
+type R = Unwrap<Promise<{ payload: number[] }>>;
+const a: R = 7;
+export {};
+"#,
+        "Envelope<T> = Promise<{payload:T[]}> ; Unwrap = number",
+    );
+}
+
+#[test]
+fn promise_wrapper_alias_infer_returntype_over_async_fn() {
+    // `ReturnType<typeof asyncFn>` yields the expanded `Promise<number[]>`.
+    assert_no_ts2322_with_libs(
+        r#"
+type AB<T> = Promise<T[]>;
+async function asyncFn(): Promise<number[]> { return [1]; }
+type Ex<X> = X extends AB<infer U> ? U : never;
+type R = Ex<ReturnType<typeof asyncFn>>;
+const a: R = 7;
+export {};
+"#,
+        "Ex<ReturnType<typeof asyncFn>> = number",
+    );
+}
+
+#[test]
+fn user_interface_wrapper_alias_infer_binds_at_correct_depth() {
+    // Lib-free, with binders renamed away from the issue text: a generic
+    // *user interface* `Box<T>` as the wrapper base. Single nesting level.
+    assert_no_ts2322(
+        r#"
+interface Box<T> { value: T; }
+type Wrap<P> = Box<P[]>;
+type Pull<X> = X extends Wrap<infer Out> ? Out : never;
+type R = Pull<Box<number[]>>;
+const ok: R = 7;
+export {};
+"#,
+        "Wrap<P> = Box<P[]> ; Pull<Box<number[]>> = number",
+    );
+}
+
+#[test]
+fn nested_user_interface_wrapper_alias_infer_binds_at_correct_depth() {
+    // Two-level nesting through a user interface: the previous "stops one level
+    // early" divergence (`Z` bound to `Cell<string[]>` instead of `string`).
+    // Binders renamed again so the fix cannot key off any identifier.
+    assert_no_ts2322(
+        r#"
+interface Cell<V> { cell: V; }
+type DeepWrap<Q> = Cell<Cell<Q[]>>;
+type DeepPull<Y> = Y extends DeepWrap<infer Z> ? Z : never;
+type R = DeepPull<Cell<Cell<string[]>>>;
+const ok: R = "s";
+export {};
+"#,
+        "DeepWrap<Q> = Cell<Cell<Q[]>> ; DeepPull = string",
+    );
+}
+
+#[test]
+fn wrapper_alias_infer_false_branch_preserved_when_source_shape_differs() {
+    // Negative control: the source genuinely does not match the wrapper shape
+    // (`Box<number>` is not `Box<number[]>`), so the conditional must take its
+    // false branch and the literal type `"MISS"` must be enforced — assigning a
+    // number is a real TS2322, not suppressed by the reduction path.
+    assert_has_ts2322(
+        r#"
+interface Box<T> { value: T; }
+type Wrap<P> = Box<P[]>;
+type PullOr<X> = X extends Wrap<infer Out> ? Out : "MISS";
+type R = PullOr<Box<number>>;
+const ok: R = "MISS";
+const bad: R = 7;
+export {};
+"#,
+        "PullOr<Box<number>> = \"MISS\" (false branch); number is not assignable",
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -11,6 +11,7 @@
 //! - `substitute_infer`: Replace infer types with their bindings
 //! - `bind_infer`: Bind a type to an infer parameter
 
+use crate::def::DefId;
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
 use crate::types::{
     LiteralValue, ParamInfo, TemplateSpan, TupleElement, TypeApplication, TypeData, TypeId,
@@ -1539,11 +1540,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return None;
         };
         let app = self.interner().type_application(app_id);
-        let def_id = match self.interner().lookup(app.base)? {
-            TypeData::Lazy(def_id) => def_id,
-            TypeData::TypeQuery(sym_ref) => self.resolver().symbol_to_def_id(sym_ref)?,
-            _ => return None,
-        };
+        let def_id = self.application_base_def_id(app.base)?;
         let type_params = self.resolver().get_lazy_type_params(def_id)?;
         if type_params.len() != app.args.len() {
             return None;
@@ -1557,6 +1554,33 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             &app.args,
         );
         (substituted != ty).then_some(substituted)
+    }
+
+    /// Decode the `base` of an `Application` to the `DefId` it names: a direct
+    /// `Lazy(DefId)` or a `TypeQuery` resolved through the resolver. `None` when
+    /// the base names no def.
+    fn application_base_def_id(&self, base: TypeId) -> Option<DefId> {
+        match self.interner().lookup(base)? {
+            TypeData::Lazy(def_id) => Some(def_id),
+            TypeData::TypeQuery(sym_ref) => self.resolver().symbol_to_def_id(sym_ref),
+            _ => None,
+        }
+    }
+
+    /// Cheap structural gate for the wrapper-alias head-only pattern reduction:
+    /// whether `base` is a generic type *alias* whose resolved body is itself an
+    /// `Application` (`type AB<T> = Promise<T[]>`), rather than an interface /
+    /// class constructor (`Promise`) whose body is an object shape. Resolving
+    /// the lazy body and inspecting its head is O(1) (cached); it lets the caller
+    /// skip the `instantiate`-bearing `alias_application_substituted_body` on the
+    /// `Promise<infer U>` hot path, where the source-peeling loop matches the
+    /// base positionally and no pattern reduction is needed (#14330).
+    fn application_base_is_application_alias(&self, base: TypeId) -> bool {
+        self.application_base_def_id(base)
+            .and_then(|def_id| self.resolver().resolve_lazy(def_id, self.interner()))
+            .is_some_and(|body| {
+                matches!(self.interner().lookup(body), Some(TypeData::Application(_)))
+            })
     }
 
     /// Peel one alias layer off an `Application` whose body is itself an
@@ -1941,6 +1965,42 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         checker,
                     );
                 }
+
+                // Normalize a *generic wrapper-alias* pattern to its structural
+                // application form before the positional matching below. When the
+                // pattern base is a generic type alias whose parameter threads
+                // through a *nested* body position (`type AB<T> = Promise<T[]>`,
+                // pattern `AB<infer U>`), the alias base does NOT positionally
+                // correspond to the source's structural base (`Promise`), so the
+                // positional source-peeling / base-subtype paths would bind the
+                // `infer` one structural level too shallow (`U = Promise<number[]>`
+                // instead of `number`) — the "stops one Promise level early"
+                // divergence (#14489). Peeling the pattern head-only (infer-
+                // preserving: `AB<infer U>` -> `Promise<(infer U)[]>`) gives the
+                // real structural base, so re-matching binds at the correct depth
+                // and recurses through each nested wrapper level. The gate keeps
+                // `peel_alias_application`'s `instantiate` off the `Promise<infer>`
+                // hot path; the `(source, pattern)` visited guard bounds alias
+                // cycles. `tsc` likewise reduces an alias-pattern to its
+                // application form before infer matching.
+                if self.application_base_is_application_alias(pattern_app.base)
+                    && let Some(reduced_pattern) = self.peel_alias_application(pattern)
+                {
+                    let mut reduced_bindings = bindings.clone();
+                    let reduced_checkpoint = visited.checkpoint();
+                    if self.match_infer_pattern(
+                        source,
+                        reduced_pattern,
+                        &mut reduced_bindings,
+                        visited,
+                        checker,
+                    ) {
+                        *bindings = reduced_bindings;
+                        return true;
+                    }
+                    visited.rollback_to(reduced_checkpoint);
+                }
+
                 let mut current_source = source;
                 for _ in 0..Self::MAX_ALIAS_REDUCTION_STEPS {
                     if let Some(TypeData::Application(source_app_id)) =


### PR DESCRIPTION
## Summary

Closes #14489.

A conditional whose `extends`-type is a generic **wrapper alias** carrying an `infer` (`type AB<T> = Promise<T[]>`, pattern `AB<infer U>`) failed to bind `U` at the correct structural depth when the check-type was the alias's **expanded** structural form (`Promise<number[]>`). The alias base (`AB`) does not positionally correspond to the source's structural base (`Promise`) — the alias's type parameter threads through a *nested* position of the body — so the positional source-peeling / base-subtype paths in the `Application` infer arm bound `U` **one structural level too shallow** (`U = Promise<number[]>` instead of `number`), or collapsed the conditional to its false branch (`never`), producing a **false TS2322** at the use site. `tsc` infers `U = number`.

### Structural rule
When the conditional `extends`-type is `Application(aliasBase, [.. infer ..])` whose base is a generic type alias whose resolved body is itself an `Application`, tsc reduces the alias-pattern to its application form before infer matching; tsz now does the same through the solver. The fix normalizes the pattern **head-only** (infer-preserving `peel_alias_application`: `AB<infer U>` → `Promise<(infer U)[]>`) *before* the positional matching, so the structural base aligns with the source and the `infer` binds at the correct depth, recursing through each nested wrapper level. A cheap O(1) gate (`application_base_is_application_alias`) keeps the `instantiate`-bearing reduction off the `Promise<infer U>` hot path; the existing `(source, pattern)` visited guard bounds alias cycles.

### Owner layer
Solver `match_infer_pattern_inner` `TypeData::Application` arm (`crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs`). No checker/emitter changes; this is a pure relation/evaluation correctness fix.

### Adjacent-case matrix (all confirmed matching `tsc`)
- single-level `Promise<T[]>`, `Set<T[]>`, object-payload `Promise<{ payload: T[] }>`
- nested two-/three-level wrappers (`Promise<Promise<T[]>>`, triple) — the "stops one Promise level early" divergence
- user-interface wrapper bases (`Box`/`Cell`) with binders renamed away from the issue text (anti-hardcoding)
- `ReturnType<typeof asyncFn>` expanded source
- alias-form source (`Ex<AB<number>>`)
- structural-body alias (`Reducer<infer S>` function) — full-expansion fallback unchanged
- negative control: source does not match the wrapper shape → false branch preserved and its literal enforced (real TS2322)

### Anti-hardcoding
No identifier/file-name/printer-string predicate. The gate is a structural test (alias base whose resolved body is an `Application`) using solver primitives; tests vary binder names (`AB`/`U`, `Box`/`Out`, `Cell`/`Z`).

Goal: green

## Verification
- New regression shard `crates/tsz-checker/tests/conditional_infer_tests/part_02.rs` (6 tests) — all pass:
  `cargo nextest run -p tsz-checker --test conditional_infer_tests -E 'test(part_02)'`
- No regression across solver infer/conditional suites (1328/1329; the single failure, `test_conditional_infer_optional_property_present_distributive`, is pre-existing on clean `main` — the #14486 red-floor — and unrelated):
  `cargo nextest run -p tsz-solver -E 'test(infer) or test(conditional)'`
- Differential parity vs `tsc 6.0.2` on the issue repro + 14 adjacent fixtures (`--strict --target es2020 --lib es2020`): all exit codes match.
- `cargo clippy -p tsz-solver --lib`: clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01JBDMhpnkw1ov8MgRGKh75F

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBDMhpnkw1ov8MgRGKh75F)_