### PR TITLE
fix(solver): variadic-tuple under-arg call reports TS2555 (arity) unless rest leads with a rest element

### DIFF
--- a/crates/tsz-checker/tests/variadic_tuple_arity_inference_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_arity_inference_tests.rs
@@ -532,3 +532,73 @@ type _ = Assert<Eq<Parts<[1]>, [1, unknown, unknown[]]>>;
         "required head consumed, optional middle absent, rest unknown[]",
     );
 }
+
+// =============================================================================
+// Arity-diagnostic selection for a variadic-tuple rest parameter (#14488-adjacent)
+//
+// When a call supplies fewer args than the rest tuple's minimum arity, tsc
+// chooses the diagnostic by the position of the FIRST top-level rest element:
+//   * leading fixed element(s) then a rest (`[cmd, ...flags]`, even
+//     `[a, ...b[], c]`) -> determinate minimum arity -> TS2555 (arity).
+//   * a *leading* rest (`[...flags, last]`) -> indeterminate length ->
+//     TS2345 (args-as-tuple assignability).
+// tsz previously took the TS2345 path whenever ANY element was a rest.
+// =============================================================================
+
+fn codes_of(source: &str) -> Vec<u32> {
+    let mut codes = check_source_codes(source);
+    codes.sort_unstable();
+    codes.dedup();
+    codes
+}
+
+#[test]
+fn leading_fixed_then_rest_underarg_is_ts2555() {
+    assert_eq!(
+        codes_of("function run(...args: [cmd: string, ...flags: string[]]): void {}\nrun();\n"),
+        vec![2555],
+        "leading fixed element before the rest => determinate arity => TS2555",
+    );
+}
+
+#[test]
+fn leading_fixed_then_rest_underarg_is_ts2555_renamed_binders() {
+    // Same structural rule, different identifiers — not keyed on `cmd`/`flags`.
+    assert_eq!(
+        codes_of("function exec(...parts: [head: number, ...tail: boolean[]]): void {}\nexec();\n"),
+        vec![2555],
+        "renamed leading-fixed+rest => TS2555",
+    );
+}
+
+#[test]
+fn fixed_rest_then_required_tail_underarg_is_ts2555() {
+    // A required element AFTER the rest does not change the discriminator: the
+    // first element is still fixed, so the minimum arity is determinate.
+    assert_eq!(
+        codes_of("function f(...args: [a: string, ...b: number[], c: boolean]): void {}\nf();\n"),
+        vec![2555],
+        "fixed, rest, required-tail => TS2555",
+    );
+}
+
+#[test]
+fn leading_rest_then_required_underarg_is_ts2345() {
+    // A *leading* rest makes the length indeterminate: tsc reports the
+    // args-as-tuple assignability error, not an arity error.
+    assert_eq!(
+        codes_of("function f(...args: [...flags: string[], last: number]): void {}\nf();\n"),
+        vec![2345],
+        "leading rest then required => TS2345 (preserved)",
+    );
+}
+
+#[test]
+fn optional_leading_then_rest_underarg_is_clean() {
+    // Minimum arity 0: a zero-arg call is valid, no diagnostic.
+    assert!(
+        codes_of("function f(...args: [first?: string, ...rest: number[]]): void {}\nf();\n")
+            .is_empty(),
+        "optional-leading rest tuple has min arity 0 => no diagnostic",
+    );
+}

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -1474,15 +1474,9 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 let should_type_check = if rest_type == TypeId::NEVER {
                     true
                 } else if let Some(TypeData::Tuple(elements)) = self.interner.lookup(rest_type) {
-                    // Only a *leading* rest element makes the call-arg length
-                    // indeterminate (e.g. `[...T[], R]`), which tsc reports as an
-                    // assignability TS2345. When at least one fixed element
-                    // precedes the first rest (`[cmd: string, ...flags: string[]]`,
-                    // even `[a, ...b[], c]`), the minimum arity is determinate and
-                    // tsc reports the arity error TS2555 instead. The discriminator
-                    // is the position of the first top-level rest, not whether any
-                    // rest exists. A leading nested-tuple rest (`[...[...]]`) still
-                    // has `elems[0].rest == true`, so the head check suffices.
+                    // A leading rest element makes arity indeterminate (TS2345);
+                    // a fixed element before the first rest keeps min arity
+                    // determinate (TS2555), even for `[a, ...b[], c]`.
                     let elems = self.interner.tuple_list(elements);
                     elems.first().is_some_and(|e| e.rest)
                 } else {

--- a/crates/tsz-solver/src/operations/core/call_resolution.rs
+++ b/crates/tsz-solver/src/operations/core/call_resolution.rs
@@ -1474,8 +1474,17 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 let should_type_check = if rest_type == TypeId::NEVER {
                     true
                 } else if let Some(TypeData::Tuple(elements)) = self.interner.lookup(rest_type) {
+                    // Only a *leading* rest element makes the call-arg length
+                    // indeterminate (e.g. `[...T[], R]`), which tsc reports as an
+                    // assignability TS2345. When at least one fixed element
+                    // precedes the first rest (`[cmd: string, ...flags: string[]]`,
+                    // even `[a, ...b[], c]`), the minimum arity is determinate and
+                    // tsc reports the arity error TS2555 instead. The discriminator
+                    // is the position of the first top-level rest, not whether any
+                    // rest exists. A leading nested-tuple rest (`[...[...]]`) still
+                    // has `elems[0].rest == true`, so the head check suffices.
                     let elems = self.interner.tuple_list(elements);
-                    elems.iter().any(|e| e.rest)
+                    elems.first().is_some_and(|e| e.rest)
                 } else {
                     false
                 };


### PR DESCRIPTION
Goal: green

## Summary
When a call supplies fewer arguments than a variadic-tuple rest parameter's minimum arity, tsz reported **TS2345** (args-as-tuple assignability) where tsc reports **TS2555** ("Expected at least N arguments, but got M") for the common leading-fixed-element pattern (`function run(...args: [cmd: string, ...flags: string[]])`).

Structural rule (verified against tsc 6.0.3): the diagnostic is selected by the position of the **first top-level rest element** of the rest tuple:
- a leading **fixed** element then a rest (`[cmd, ...flags]`, even `[a, ...b[], c]`) → determinate minimum arity → **TS2555**.
- a **leading** rest (`[...flags, last]`) → indeterminate length → **TS2345**.

`resolve_function_call`'s `should_type_check` predicate used `elems.iter().any(|e| e.rest)`, taking the TS2345 path whenever *any* element was a rest. Changed to `elems.first().is_some_and(|e| e.rest)` (a leading nested-tuple rest still has `elems[0].rest == true`, so the head check suffices). The `...args: never` branch is unchanged.

Owner: `crates/tsz-solver/src/operations/core/call_resolution.rs` (one-condition change). `min_args`/arity math in `call_args.rs` was already correct; only the diagnostic-selection predicate was wrong.

## Verification
- **Flips 3 tests** (fail on main, pass with fix; confirmed by stash-build-diff): `leading_fixed_then_rest_underarg_is_ts2555`, `leading_fixed_then_rest_underarg_is_ts2555_renamed_binders`, `fixed_rest_then_required_tail_underarg_is_ts2555`.
- **2 controls hold** on base and fix: `leading_rest_then_required_underarg_is_ts2345` (leading rest stays TS2345), `optional_leading_then_rest_underarg_is_clean` (min arity 0, no diagnostic).
- Matches tsc 6.0.3 on an 8-case matrix (leading-fixed+rest, 2-fixed+rest, fixed+rest+required-tail, leading-rest+required, leading-rest+2-required, optional-leading, all-rest, `never` rest).
- Neutral: `cargo nextest -p tsz-solver` over call/variadic/tuple/arity/operations/spread/rest = 1471 passed, 1 failed; the 1 (`higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`) fails on the pristine base too (verified by rebuild-and-diff).
- Full suites: CI gates this PR.

Discovered via a broad tsz-vs-tsc differential sweep.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
