### PR TITLE
refactor(checker): hoist SymbolTypeCache version-bump into one owner (#14347)

### DIFF
--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -538,6 +538,19 @@ impl SymbolTypeCache {
         self.version.get()
     }
 
+    /// Advance the monotonic mutation counter by one.
+    ///
+    /// The single owner of the "a lookup-affecting mutation happened" signal:
+    /// every mutator that actually changes a stored entry calls this exactly
+    /// once, after its no-op guard, so a version change always means "some
+    /// previously observed symbol type may have changed". No-op writes (storing
+    /// the same value, or removing an absent key) must not call this, or version
+    /// consumers would needlessly drop memoized state.
+    #[inline]
+    fn bump_version(&self) {
+        self.version.set(self.version.get() + 1);
+    }
+
     #[inline]
     pub fn get(&self, key: &SymbolId) -> Option<TypeId> {
         self.data.borrow().get(key).copied()
@@ -553,13 +566,13 @@ impl SymbolTypeCache {
             if existing.is_none() {
                 return;
             }
-            self.version.set(self.version.get() + 1);
+            self.bump_version();
             Arc::make_mut(&mut self.data.borrow_mut()).remove(&key);
         } else {
             if existing == Some(value) {
                 return;
             }
-            self.version.set(self.version.get() + 1);
+            self.bump_version();
             Arc::make_mut(&mut self.data.borrow_mut()).insert(key, value);
         }
     }
@@ -574,7 +587,7 @@ impl SymbolTypeCache {
         if !self.data.borrow().contains_key(key) {
             return None;
         }
-        self.version.set(self.version.get() + 1);
+        self.bump_version();
         Arc::make_mut(&mut self.data.borrow_mut()).remove(key)
     }
 
@@ -593,7 +606,7 @@ impl SymbolTypeCache {
                 .unwrap_or(TypeId::NONE);
         }
         if !self.data.borrow().contains_key(&key) {
-            self.version.set(self.version.get() + 1);
+            self.bump_version();
         }
         *Arc::make_mut(&mut self.data.borrow_mut())
             .entry(key)
@@ -641,7 +654,7 @@ impl SymbolTypeCache {
         if !changes {
             return;
         }
-        self.version.set(self.version.get() + 1);
+        self.bump_version();
         let mut data_guard = self.data.borrow_mut();
         let data = Arc::make_mut(&mut data_guard);
         for (&symbol_id, &type_id) in other_data.iter() {


### PR DESCRIPTION
Goal: hold

A narrow, behavior-preserving consolidation in the cache out-of-band-guard family that #14347 names (the version-bump is exactly the kind of out-of-band cache-validity signal that issue is about). `SymbolTypeCache` open-coded its monotonic mutation-counter bump (`self.version.set(self.version.get() + 1)`) at 5 call sites across 4 mutators (`insert` x2 branches, `remove`, `entry_or_insert`, `extend`). This hoists that one rule into a single `bump_version()` owner; every mutator now calls it once after its no-op guard.

This is a pure dedup — no semantic change. The no-op guards (skip the bump when storing the same value or removing an absent key) stay at each call site exactly as before; only the increment itself moves into the helper. It is NOT the risky core canonical-identity / per-dependency-invalidation refactor (#14347's XL end-state), which stays gated on Sin 1 (#14344).

## Structural rule

The `SymbolTypeCache` version counter has exactly one writer. A version change always means "a lookup-affecting mutation happened" (consumed by `CheckerContext::assignability_eval_memo` stamps); reads never bump it, and no-op writes never bump it. Centralizing the increment makes that invariant a single-owner property instead of a 5-site copy, so the version contract cannot drift between mutators.

## Anti-hardcoding

Pure consolidation: no name/file-string predicates, no printer-output reads, no behavior gated on identifiers.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- cargo check -p tsz-checker clean
- cargo clippy -p tsz-checker --lib clean
- witnesses pass: 17/17 in `context::caches` + `assignability_eval_memo` tests, including `symbol_type_cache_version_tracks_mutations_not_reads` (the exact version-bump witness) and the stamp-consumer memo tests (`memo_drops_entries_when_any_stamp_component_moves`, `memo_serves_entries_under_unchanged_stamp`)
- narrow `tsz-checker` nextest (`context::`): no NEW failures vs clean-origin/main baseline (the lone `file_session_reset::reset_clears_file_local_lookup_caches_and_flags` failure reproduces identically on clean main, verified by reverting this file in place — a known env-only local failure, untouched by this change)
- CI conformance/emit/fourslash authoritative for broad impact