### PR TITLE
fix(checker): enum-member discriminant yields precise TS2353 on excess property (was generic TS2322)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -791,6 +791,9 @@ path = "tests/binding_pattern_inference_tests.rs"
 name = "ts2353_tests"
 path = "tests/ts2353_tests.rs"
 [[test]]
+name = "enum_discriminant_excess_property_tests"
+path = "tests/enum_discriminant_excess_property_tests.rs"
+[[test]]
 name = "excess_property_check_recursive_intersection_tests"
 path = "tests/excess_property_check_recursive_intersection_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
@@ -977,12 +977,25 @@ impl<'a> CheckerState<'a> {
             if explicit_property_names.is_some_and(|names| !names.contains(&prop_atom)) {
                 continue;
             }
-            let Some(lit_type) = self.literal_type_from_initializer(prop.initializer) else {
+            // Prefer the purely-syntactic literal value (string/number/bigint/
+            // boolean/`undefined`/const-assertion). When that misses — most
+            // commonly an enum member reference like `Kind.A`, a
+            // PropertyAccessExpression the syntactic query does not resolve —
+            // fall back to the node's computed type, which yields the *nominal*
+            // enum-literal unit type (`Kind.A`) that matches the target union
+            // member's discriminant. Both paths are gated on `is_unit_type`, so
+            // non-discriminant initializers (e.g. `obj.x: number`) are ignored
+            // and the precise-excess path is not entered for them.
+            let lit_type = self
+                .literal_type_from_initializer(prop.initializer)
+                .filter(|&t| query::is_unit_type(self.ctx.types, t))
+                .or_else(|| {
+                    let computed = self.get_type_of_node(prop.initializer);
+                    query::is_unit_type(self.ctx.types, computed).then_some(computed)
+                });
+            let Some(lit_type) = lit_type else {
                 continue;
             };
-            if !query::is_unit_type(self.ctx.types, lit_type) {
-                continue;
-            }
             discriminants.push((prop_atom, lit_type));
         }
 

--- a/crates/tsz-checker/tests/enum_discriminant_excess_property_tests.rs
+++ b/crates/tsz-checker/tests/enum_discriminant_excess_property_tests.rs
@@ -1,0 +1,124 @@
+//! Regression tests for precise excess-property reporting on discriminated
+//! unions whose discriminant is an **enum member** (`Kind.A`).
+//!
+//! Structural rule (owner: `object_literal_direct_unit_discriminants` in
+//! `state_checking/property/excess_property_tail.rs`): to report the precise
+//! TS2353 ("Object literal may only specify known properties") at the offending
+//! property of a discriminated-union assignment, the checker collects the
+//! source object literal's discriminant property values. The purely-syntactic
+//! `literal_type_from_initializer` resolves string/number/boolean/`undefined`
+//! literals but not an enum-member reference (`Kind.A` is a
+//! `PropertyAccessExpression`). When it misses, the collector now falls back to
+//! the initializer's computed type, which yields the *nominal* enum-literal
+//! unit type matching the target member's discriminant. Without it the
+//! discriminant match failed and the check fell back to a generic TS2322.
+//!
+//! Both paths are gated on `is_unit_type`, so a non-discriminant initializer
+//! (e.g. `obj.x: number`) is never mistaken for a discriminant.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut c: Vec<u32> = check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect();
+    c.sort_unstable();
+    c.dedup();
+    c
+}
+
+#[test]
+fn enum_member_discriminant_excess_property_is_ts2353() {
+    // tsz previously emitted a generic TS2322 at the binding; tsc emits the
+    // precise excess-property TS2353 at `b`.
+    assert_eq!(
+        codes(
+            r#"
+enum Kind { A, B }
+type T = { k: Kind.A; a: number } | { k: Kind.B; b: string };
+const bad: T = { k: Kind.A, b: "x" };
+"#,
+        ),
+        vec![2353],
+        "enum-member discriminant excess property should be TS2353",
+    );
+}
+
+#[test]
+fn enum_member_discriminant_excess_property_renamed_binders() {
+    // Not keyed on `Kind`/`A`/`k` — proves the structural rule.
+    assert_eq!(
+        codes(
+            r#"
+enum Tag { First, Second }
+type Shape = { kind: Tag.First; x: number } | { kind: Tag.Second; y: string };
+const bad: Shape = { kind: Tag.First, y: "oops" };
+"#,
+        ),
+        vec![2353],
+        "renamed enum discriminant excess property should be TS2353",
+    );
+}
+
+#[test]
+fn const_enum_member_discriminant_excess_property_is_ts2353() {
+    assert_eq!(
+        codes(
+            r#"
+const enum CE { A, B }
+type T = { k: CE.A; a: number } | { k: CE.B; b: string };
+const bad: T = { k: CE.A, b: "x" };
+"#,
+        ),
+        vec![2353],
+        "const-enum discriminant excess property should be TS2353",
+    );
+}
+
+#[test]
+fn string_enum_member_discriminant_excess_property_is_ts2353() {
+    assert_eq!(
+        codes(
+            r#"
+enum SK { A = "a", B = "b" }
+type T = { k: SK.A; a: number } | { k: SK.B; b: string };
+const bad: T = { k: SK.A, b: "x" };
+"#,
+        ),
+        vec![2353],
+        "string-enum discriminant excess property should be TS2353",
+    );
+}
+
+#[test]
+fn enum_member_correct_member_is_clean() {
+    // Selecting the right member with only its own properties is valid.
+    assert!(
+        codes(
+            r#"
+enum Kind { A, B }
+type T = { k: Kind.A; a: number } | { k: Kind.B; b: string };
+const ok: T = { k: Kind.A, a: 1 };
+"#,
+        )
+        .is_empty(),
+        "correct enum-member object should be clean",
+    );
+}
+
+#[test]
+fn enum_member_correct_discriminant_wrong_value_is_ts2322() {
+    // Right member selected, wrong property value: a genuine TS2322, not TS2353.
+    assert_eq!(
+        codes(
+            r#"
+enum Kind { A, B }
+type T = { k: Kind.A; a: number } | { k: Kind.B; b: string };
+const bad: T = { k: Kind.A, a: "str" };
+"#,
+        ),
+        vec![2322],
+        "wrong property value should be TS2322",
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
For a discriminated-union assignment whose discriminant is an **enum member** (`type T = { k: Kind.A; a: number } | { k: Kind.B; b: string }`), tsz reported a generic **TS2322** at the binding where tsc reports the precise **TS2353** ("Object literal may only specify known properties…") at the offending property:

```ts
enum Kind { A, B }
type T = { k: Kind.A; a: number } | { k: Kind.B; b: string };
const bad: T = { k: Kind.A, b: "x" };   // tsc: TS2353 at `b`; tsz (before): TS2322 at binding
```

## Root cause / fix
`object_literal_direct_unit_discriminants` (`state_checking/property/excess_property_tail.rs`) collects the source object literal's discriminant values via the purely-syntactic `literal_type_from_initializer`, which resolves string/number/bigint/boolean/`undefined`/const literals but **not** an enum-member reference (`Kind.A` is a `PropertyAccessExpression`). The source discriminant `k` was never collected → the discriminant match returned `None` → the precise-excess path was skipped → fallback to generic TS2322.

Fall back to the initializer's **computed type** (`get_type_of_node`) when the syntactic query misses, keeping it only when it `is_unit_type`. For `Kind.A` this is the *nominal* enum-literal unit type, which matches the target member's discriminant. Both paths are gated on `is_unit_type`, so a non-discriminant initializer (e.g. `obj.x: number`) is never treated as a discriminant. The rest of the pipeline already supports enum unit types (`is_unit_type` treats `TypeData::Enum` as a unit); only the source-side discriminant-value extraction was missing.

Owner: checker (`object_literal_direct_unit_discriminants`). No solver change.

## Verification
- **Flips 4 tests** (fail on main → TS2322, pass with fix → TS2353; confirmed by stash-build-diff): enum, renamed binders, const enum, string enum.
- **2 controls hold** on base and fix: correct member is clean; correct discriminant + wrong value → TS2322 (not TS2353).
- Matches tsc 6.0.3 across the matrix (numeric enum, const enum, string enum, string-literal-discriminant control, and a non-discriminant property-access initializer negative control — all `OK`).
- Neutral: 45/45 pass across `excess_property_check_recursive_intersection_tests`, `object_literal_normalization_tests`, `nested_discriminant_narrowing_tests`, `unique_symbol_discriminant_narrowing_tests`, plus the new file.
- Full conformance/checker suites: CI gates this PR.

Discovered via a broad tsz-vs-tsc differential sweep. Enum-keyed discriminated unions (Redux `action.type`, state machines, AST node kinds) are a pervasive real-world pattern, so this is a meaningful conformance-parity fix.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
