### PR TITLE
fix(solver): infer through intrinsic string mapping (Uppercase/Lowercase/…) in template-literal pattern (false TS2322)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -791,6 +791,9 @@ path = "tests/binding_pattern_inference_tests.rs"
 name = "ts2353_tests"
 path = "tests/ts2353_tests.rs"
 [[test]]
+name = "template_intrinsic_infer_tests"
+path = "tests/template_intrinsic_infer_tests.rs"
+[[test]]
 name = "excess_property_check_recursive_intersection_tests"
 path = "tests/excess_property_check_recursive_intersection_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/template_intrinsic_infer_tests.rs
+++ b/crates/tsz-checker/tests/template_intrinsic_infer_tests.rs
@@ -1,0 +1,145 @@
+//! Regression tests for inferring through an **intrinsic string mapping** in a
+//! template-literal pattern: `S extends \`${Uppercase<infer P>}\` ? P : never`.
+//!
+//! Structural rule (owner: `match_intrinsic_span_from` in
+//! `evaluation/evaluate_rules/infer_pattern_template_match.rs`): a template span
+//! that is a string-intrinsic (`Uppercase`/`Lowercase`/`Capitalize`/
+//! `Uncapitalize`) wrapping an `infer` matches only when the captured segment
+//! is a **fixpoint** of the mapping (e.g. an already-uppercase run for
+//! `Uppercase`), and infers the variable as `string` — the intrinsic's domain —
+//! not the literal segment. So `"ABC" extends \`${Uppercase<infer P>}\` ? P :
+//! never` is `string` (any string assignable), while a non-uppercase source
+//! takes the false branch (`never`). Previously the span was unhandled and the
+//! conditional wrongly collapsed to `never`, drawing a spurious TS2322.
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut c = check_source_codes(source);
+    c.sort_unstable();
+    c.dedup();
+    c
+}
+
+#[test]
+fn uppercase_infer_matches_uppercase_source() {
+    // Result is `string` (the intrinsic domain): assigning any string is clean.
+    assert!(
+        codes(
+            r#"
+type X = "ABC" extends `${Uppercase<infer P>}` ? P : never;
+const a: X = "ABC";
+"#,
+        )
+        .is_empty(),
+        "Uppercase<infer P> over an uppercase source should match",
+    );
+}
+
+#[test]
+fn uppercase_infer_binds_string_not_literal() {
+    // Because P infers as `string` (not "ABC"), assigning a different string is
+    // also clean — this distinguishes the intrinsic case from plain `infer P`.
+    assert!(
+        codes(
+            r#"
+type X = "ABC" extends `${Uppercase<infer P>}` ? P : never;
+const a: X = "xyz";
+"#,
+        )
+        .is_empty(),
+        "intrinsic infer binds `string`, so any string is assignable",
+    );
+}
+
+#[test]
+fn uppercase_infer_nonmatching_source_takes_false_branch() {
+    // A lowercase source is not a fixpoint of Uppercase, so X = never and the
+    // assignment is rejected (TS2322).
+    assert_eq!(
+        codes(
+            r#"
+type X = "abc" extends `${Uppercase<infer P>}` ? P : never;
+const a: X = "abc";
+"#,
+        ),
+        vec![2322],
+        "non-uppercase source should take the false branch (never)",
+    );
+}
+
+#[test]
+fn lowercase_infer_matches_lowercase_source() {
+    assert!(
+        codes(
+            r#"
+type X = "abc" extends `${Lowercase<infer P>}` ? P : never;
+const a: X = "abc";
+"#,
+        )
+        .is_empty(),
+        "Lowercase<infer P> over a lowercase source should match",
+    );
+}
+
+#[test]
+fn capitalize_infer_matches_capitalized_source() {
+    assert!(
+        codes(
+            r#"
+type X = "Abc" extends `${Capitalize<infer P>}` ? P : never;
+const a: X = "Abc";
+"#,
+        )
+        .is_empty(),
+        "Capitalize<infer P> over a capitalized source should match",
+    );
+}
+
+#[test]
+fn uppercase_infer_with_prefix_text_matches() {
+    // The intrinsic span follows literal head text.
+    assert!(
+        codes(
+            r#"
+type X = "prefix-ABC" extends `prefix-${Uppercase<infer P>}` ? P : never;
+const a: X = "ABC";
+"#,
+        )
+        .is_empty(),
+        "intrinsic infer after a text prefix should match",
+    );
+}
+
+#[test]
+fn uppercase_infer_generic_alias_form_matches() {
+    // Not keyed on a particular alias/param name; works through a generic alias.
+    assert!(
+        codes(
+            r#"
+type Up<S extends string> = S extends `${Uppercase<infer P>}` ? P : never;
+const a: Up<"ABC"> = "ABC";
+"#,
+        )
+        .is_empty(),
+        "generic-alias intrinsic infer should match",
+    );
+}
+
+#[test]
+fn plain_infer_still_binds_literal() {
+    // Control: a *plain* `infer P` (no intrinsic) still binds the precise
+    // literal, so assigning a different string errors — proving the new arm did
+    // not loosen non-intrinsic template inference.
+    assert_eq!(
+        codes(
+            r#"
+type X = "ABC" extends `${infer P}` ? P : never;
+const a: X = "ABC";
+const b: X = "xyz";
+"#,
+        ),
+        vec![2322],
+        "plain infer P should still bind the literal (b: X = \"xyz\" errors)",
+    );
+}

--- a/crates/tsz-checker/tests/template_intrinsic_infer_tests.rs
+++ b/crates/tsz-checker/tests/template_intrinsic_infer_tests.rs
@@ -1,5 +1,5 @@
 //! Regression tests for inferring through an **intrinsic string mapping** in a
-//! template-literal pattern: `S extends \`${Uppercase<infer P>}\` ? P : never`.
+//! template-literal pattern whose span is `Uppercase<infer P>`.
 //!
 //! Structural rule (owner: `match_intrinsic_span_from` in
 //! `evaluation/evaluate_rules/infer_pattern_template_match.rs`): a template span
@@ -7,10 +7,10 @@
 //! `Uncapitalize`) wrapping an `infer` matches only when the captured segment
 //! is a **fixpoint** of the mapping (e.g. an already-uppercase run for
 //! `Uppercase`), and infers the variable as `string` — the intrinsic's domain —
-//! not the literal segment. So `"ABC" extends \`${Uppercase<infer P>}\` ? P :
-//! never` is `string` (any string assignable), while a non-uppercase source
-//! takes the false branch (`never`). Previously the span was unhandled and the
-//! conditional wrongly collapsed to `never`, drawing a spurious TS2322.
+//! not the literal segment. So the `"ABC"`-against-`Uppercase<infer P>` case is
+//! `string` (any string assignable), while a non-uppercase source takes the
+//! false branch (`never`). Previously the span was unhandled and the conditional
+//! wrongly collapsed to `never`, drawing a spurious TS2322.
 
 use tsz_checker::test_utils::check_source_codes;
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_template_match.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_template_match.rs
@@ -470,6 +470,51 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // Wildcards and other intrinsics fall through to generic handling.
                 _ => None,
             },
+            // A template span that is an intrinsic string mapping wrapping an
+            // `infer` (e.g. `${Uppercase<infer P>}`). tsc matches such a span
+            // only when the captured segment is a fixpoint of the mapping (an
+            // already-uppercase run for `Uppercase`, etc.) and infers the
+            // variable as `string` — the intrinsic's domain — not the literal
+            // segment (`"ABC" extends \`${Uppercase<infer P>}\` ? P : never` is
+            // `string`, and a non-uppercase source takes the false branch).
+            // Without this the span is unhandled and the conditional wrongly
+            // collapses to its false branch.
+            TypeData::StringIntrinsic { kind, type_arg } => {
+                let Some(TypeData::Infer(info)) = self.interner().lookup(type_arg) else {
+                    return None;
+                };
+                for end in self.cached_candidate_template_capture_ends(
+                    source,
+                    cursor.pos,
+                    pattern,
+                    cursor.index,
+                    scratch,
+                ) {
+                    let segment = &source[cursor.pos..end];
+                    // The segment must be unchanged by the mapping; otherwise
+                    // no `string` argument could have produced it.
+                    if self.apply_string_transform(kind, segment) != segment {
+                        continue;
+                    }
+                    let mut next_bindings = bindings.clone();
+                    if !self.bind_infer(&info, TypeId::STRING, &mut next_bindings, checker) {
+                        continue;
+                    }
+                    if self.match_template_literal_string_from(
+                        source,
+                        pattern,
+                        end,
+                        cursor.index + 1,
+                        &mut next_bindings,
+                        checker,
+                        scratch,
+                    ) {
+                        *bindings = next_bindings;
+                        return Some(true);
+                    }
+                }
+                Some(false)
+            }
             _ => None,
         }
     }


### PR DESCRIPTION
Goal: green

## Summary
Inferring through an **intrinsic string mapping** in a template-literal pattern — `S extends \`${Uppercase<infer P>}\` ? P : never` — produced a spurious **TS2322** in tsz: the span was unhandled, so the conditional wrongly collapsed to its false branch (`never`). tsc matches and infers.

```ts
type X = "ABC" extends `${Uppercase<infer P>}` ? P : never;
const a: X = "ABC";   // tsc: clean ;  tsz (before): TS2322
```

## Root cause / fix
`match_intrinsic_span_from` (`evaluation/evaluate_rules/infer_pattern_template_match.rs`) handled only `number`/`bigint`/`boolean`/`undefined` intrinsic spans; a `TypeData::StringIntrinsic { kind, type_arg }` span wrapping an `infer` fell through to `None` → no match.

Add a `StringIntrinsic` arm with tsc-faithful semantics (verified empirically):
- The span matches only when the captured segment is a **fixpoint** of the mapping (an already-uppercase run for `Uppercase`, lowercase for `Lowercase`, etc.) — reusing the existing `apply_string_transform`. A non-uppercase source therefore takes the false branch (`never`).
- On a match, the `infer` variable is bound to **`string`** — the intrinsic's domain — **not** the literal segment. So `"ABC" extends \`${Uppercase<infer P>}\` ? P : never` is `string` (any string assignable), matching tsc.

The arm is **purely additive**: such spans previously always failed to match, so no non-intrinsic template inference reaches it (zero blast radius outside the broken construct).

## Verification
- **Flips 6 tests** (fail on main, pass with fix; confirmed by stash-build-diff): Uppercase/Lowercase/Capitalize matches, the `P = string` binding (`const a: X = "xyz"` clean), prefix-text span, generic-alias form.
- **2 controls hold** on base and fix: non-matching (lowercase) source → `never`/TS2322; plain `infer P` (no intrinsic) still binds the precise literal (`const b: X = "xyz"` errors).
- Matches tsc 6.0.3 across the 8-case matrix (all four intrinsics, P=string semantics, fixpoint gating, prefix text, generic alias, plain-infer control).
- Neutral: `cargo nextest -p tsz-solver` over template/infer/string_intrinsic/conditional = 1685 passed, 1 failed; the 1 (`test_conditional_infer_optional_property_present_distributive`) fails on the base too.
- Full suites: CI gates this PR.

Discovered via a broad tsz-vs-tsc differential sweep (template-literals area).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
