### PR TITLE
fast(bench): exclude >=1.5x-slower rows from the README perf chart

### DIFF
--- a/scripts/bench/readme-perf-svg.mjs
+++ b/scripts/bench/readme-perf-svg.mjs
@@ -238,11 +238,28 @@ function finiteNumber(value) {
   return Number.isFinite(number) ? number : null;
 }
 
+// Mirror the bench harness's slowdown-failure policy (default 1.5x; see
+// scripts/bench/project-fixtures.sh tsz_project_slowdown_failure_factor): a row
+// where tsz is >=1.5x slower than tsgo is a failure and must not count toward the
+// README headline chart, matching the website chart which drops these rows.
+const SLOWDOWN_FAILURE_FACTOR = 1.5;
+
 function hasSuccessfulTimingPair(row) {
   return !row?.status
     && row?.winner !== "error"
     && finiteNumber(row?.tsz_ms) > 0
     && finiteNumber(row?.tsgo_ms) > 0;
+}
+
+// A row counts toward the README headline only if it has a valid timing pair AND
+// tsz is within the slowdown-failure threshold of tsgo (i.e. not a >=1.5x-slower
+// failure). Matches the site chart and the perf gate so the three never diverge.
+function countsTowardReadmeChart(row) {
+  if (!hasSuccessfulTimingPair(row)) return false;
+  const tszMs = finiteNumber(row?.tsz_ms);
+  const tsgoMs = finiteNumber(row?.tsgo_ms);
+  if (tszMs === null || tsgoMs === null || tsgoMs <= 0) return false;
+  return tszMs < SLOWDOWN_FAILURE_FACTOR * tsgoMs;
 }
 
 function isProjectBenchmark(row) {
@@ -254,7 +271,7 @@ function benchmarkRowsForReadme(data) {
   // no longer excluded, so the README total matches the site's micro chart.
   return Array.isArray(data?.results)
     ? data.results.filter((row) => (
-      hasSuccessfulTimingPair(row)
+      countsTowardReadmeChart(row)
         && !isProjectBenchmark(row)
     ))
     : [];
@@ -263,7 +280,7 @@ function benchmarkRowsForReadme(data) {
 function projectRowsForReadme(data) {
   return Array.isArray(data?.results)
     ? data.results.filter((row) => (
-      hasSuccessfulTimingPair(row)
+      countsTowardReadmeChart(row)
         && isProjectBenchmark(row)
     ))
     : [];

--- a/scripts/bench/test-readme-perf-svg.mjs
+++ b/scripts/bench/test-readme-perf-svg.mjs
@@ -42,9 +42,21 @@ const artifact = {
       winner: "tsz",
     },
     {
+      // tsz is 3x slower than tsgo here — past the 1.5x slowdown-failure
+      // threshold, so this row must NOT count toward the README headline
+      // (matches the site chart + the perf gate dropping >=1.5x-slower rows).
       name: "utility-types-project",
       lines: 2000,
       tsz_ms: 9000,
+      tsgo_ms: 3000,
+      winner: "tsgo",
+    },
+    {
+      // tsz is ~1.17x slower — within the 1.5x threshold, so this project row
+      // DOES count toward the headline.
+      name: "rxjs-project",
+      lines: 1500,
+      tsz_ms: 3500,
       tsgo_ms: 3000,
       winner: "tsgo",
     },
@@ -60,14 +72,16 @@ const artifact = {
 };
 
 const summary = createReadmePerfSummary(artifact);
+// utility-types-project (tsz 3x slower) is excluded by the 1.5x slowdown
+// threshold; only the within-threshold rxjs-project counts toward the headline.
 assert.equal(summary.rows, 1);
 assert.equal(summary.projectRows, 1);
 assert.equal(summary.microRows, 3);
 assert.equal(summary.rowKind, "project");
-assert.equal(summary.totalRows, 5);
-assert.equal(summary.tszMs, 9000);
+assert.equal(summary.totalRows, 6);
+assert.equal(summary.tszMs, 3500);
 assert.equal(summary.tsgoMs, 3000);
-assert.equal(summary.speedup, 1 / 3);
+assert.equal(summary.speedup, 3000 / 3500);
 assert.equal(summary.winner, "tsgo");
 assert.equal(summary.generatedAt, "2026-05-28T02:14:24Z");
 assert.equal(summary.sourceCommit, "0123456789ab");
@@ -84,9 +98,9 @@ assert.doesNotMatch(renderReadmePerfSvg(artifact, { theme: "dark" }), /fill="#0d
 assert.doesNotMatch(svg, />Latest benchmark snapshot</);
 assert.doesNotMatch(svg, />2 successful micro rows</);
 assert.doesNotMatch(svg, />tsz 3\.0x faster</);
-assert.match(svg, />tsgo is 3\.0x faster</);
+assert.match(svg, />tsgo is 1\.2x faster</);
 assert.match(svg, />1 project rows</);
-assert.match(svg, /9\.0s/);
+assert.match(svg, /3\.5s/);
 assert.match(svg, /3\.0s/);
 assert.doesNotMatch(svg, /Project-mode and tiny startup fixtures are excluded/);
 


### PR DESCRIPTION
## Summary

The README headline perf chart (`scripts/bench/readme-perf-svg.mjs`) counted **every** row with a valid timing pair, including ones where tsz is well past the 1.5x slowdown-failure threshold. So a row like `utility-types-project` at **3x slower** still counted toward "tsz/tsgo is Nx faster across N rows" — inconsistent with the website chart and the perf gate, which both treat a `>=1.5x`-slower row as a failure and drop it.

## Change

Add `countsTowardReadmeChart()`: a row counts only if it has a valid timing pair **and** tsz is within the 1.5x threshold of tsgo (`tsz_ms < 1.5 * tsgo_ms`). Use it in both `projectRowsForReadme` and `benchmarkRowsForReadme`. The threshold constant mirrors `scripts/bench/project-fixtures.sh` `tsz_project_slowdown_failure_factor` (default 1.5), so the README chart, the site chart, and the perf gate stay in lockstep.

Rows within 1.5x (including tsz slightly slower) still count; only `>=1.5x`-slower rows are excluded.

Goal: fast

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- `node scripts/bench/test-readme-perf-svg.mjs` passes: the fixture's 3x-slower `utility-types-project` is now excluded; a new within-threshold `rxjs-project` (1.17x) is asserted to still count, and the headline drops from "3.0x" to "1.2x".
- `node scripts/bench/test-tsgo-winner-report.mjs` passes.
- `node --check scripts/bench/readme-perf-svg.mjs` passes.
