### PR TITLE
feat(solver): identity-collision observability counters for the #14344 migration

### DIFF
--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -105,7 +105,10 @@ impl PerfCounters {
              read_package_json calls    {:>12}\n  \
              candidate paths total      {:>12}\n\
              Stable identity:\n  \
-             raw SymbolRef lazy fallback{:>12}\n",
+             raw SymbolRef lazy fallback{:>12}\n  \
+             wrong-decl collisions      {:>12}\n  \
+             symbol_def_index hits      {:>12}\n  \
+             symbol_def_index misses    {:>12}\n",
             snap.delegate.calls,
             snap.delegate.cache_hits_lib,
             snap.delegate.cache_hits_cross_file,
@@ -190,6 +193,9 @@ impl PerfCounters {
             snap.resolver.package_json_reads,
             snap.resolver.candidate_paths_total,
             snap.identity.type_environment_raw_symbol_lazy_fallbacks,
+            snap.identity.identity_collision_wrong_decl_suppressed,
+            snap.identity.symbol_def_index_lookup_hits,
+            snap.identity.symbol_def_index_lookup_misses,
         ) + &Self::dump_compute_type_of_symbol_outcomes()
             + &Self::dump_shared_instantiation_cache(&snap)
             + &Self::dump_relation_limit_cache(&snap)

--- a/crates/tsz-common/src/perf_counters/recorders/solver.rs
+++ b/crates/tsz-common/src/perf_counters/recorders/solver.rs
@@ -1,3 +1,39 @@
+/// #14344 identity-collision observability. Record that the
+/// `raw_symbol_fallback_def` `#13862` guard suppressed a *genuine* content
+/// collision: a store-registered `DefId(N)` whose raw value `N`, reread as a
+/// `SymbolId`, would resolve to a DIFFERENT def whose canonical decl name
+/// differs from `DefId(N)`'s own (the `HTMLDivElement` -> `FileSystemEntry`
+/// class). Callers MUST establish content-difference before calling — mere
+/// raw-`u32` overlap is ~100% by construction and must never be counted here.
+/// Measurement only: never feeds back into resolution (the guard already
+/// returns `None`).
+#[inline]
+pub fn record_identity_collision_wrong_decl_suppressed() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .identity_collision_wrong_decl_suppressed
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// #14344 denominator context. Record a `symbol_def_index` composite-key
+/// `(symbol, file)` resolution attempt, partitioned by whether it hit.
+#[inline]
+pub fn record_symbol_def_index_lookup(hit: bool) {
+    if !enabled_fast() {
+        return;
+    }
+    let c = counters();
+    if hit {
+        c.symbol_def_index_lookup_hits
+            .fetch_add(1, Ordering::Relaxed);
+    } else {
+        c.symbol_def_index_lookup_misses
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
 /// Record a budget-conditional `LimitTrue` relation cache hit (a limit-hit
 /// relation verdict was reused instead of re-burning the relation chain).
 #[inline]

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -64,6 +64,23 @@ pub struct PerfCounters {
     /// `TypeEnvironment::resolve_lazy` had to treat a `DefId` value as a raw
     /// `SymbolId` and redirect it to the real `DefId`.
     pub type_environment_raw_symbol_lazy_fallbacks: AtomicU64,
+    /// #14344 identity-collision observability: times the
+    /// `raw_symbol_fallback_def` `#13862` guard suppressed a *genuine* content
+    /// collision — a store-registered `DefId(N)` whose raw value `N`, reread as
+    /// a `SymbolId`, resolves to a DIFFERENT def whose canonical decl (name)
+    /// differs from `DefId(N)`'s own. This is the `HTMLDivElement(218)` ->
+    /// `FileSystemEntry(symbol 218)` class of collision (#13862), NOT mere
+    /// raw-`u32` overlap (which is ~100% by construction and uninformative). A
+    /// nonzero value is the measurable witness of the non-canonical-identity
+    /// root; the migration's md5-stability gate watches it trend to zero.
+    pub identity_collision_wrong_decl_suppressed: AtomicU64,
+    /// #14344 denominator context: total `symbol_def_index` (`(symbol, file)`
+    /// composite-key) resolution attempts, partitioned into hits/misses, so the
+    /// wrong-decl collision count above has a population to normalize against
+    /// (a raw count is uninterpretable without "out of how many lookups").
+    pub symbol_def_index_lookup_hits: AtomicU64,
+    /// Companion miss counter for [`Self::symbol_def_index_lookup_hits`].
+    pub symbol_def_index_lookup_misses: AtomicU64,
     /// Why each `cached_cross_file_*` reader returned `None`. See
     /// [`CrossFileCacheMissCause`] for the bucket semantics. Sum of
     /// all buckets equals the flat miss count for the four reader
@@ -395,6 +412,9 @@ impl PerfCounters {
             direct_actual_lib_intl_interface_outcome: [const { AtomicU64::new(0) };
                 DIRECT_ACTUAL_LIB_INTL_INTERFACE_OUTCOME_COUNT],
             type_environment_raw_symbol_lazy_fallbacks: AtomicU64::new(0),
+            identity_collision_wrong_decl_suppressed: AtomicU64::new(0),
+            symbol_def_index_lookup_hits: AtomicU64::new(0),
+            symbol_def_index_lookup_misses: AtomicU64::new(0),
             cross_file_cache_miss_cause: [const { AtomicU64::new(0) };
                 CROSS_FILE_CACHE_MISS_CAUSE_COUNT],
             source_file_symbol_arena_cache_eligibility_outcome: [const { AtomicU64::new(0) };

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -364,6 +364,15 @@ pub struct IdentityCounters {
     /// Raw `SymbolId`-shaped `DefId` redirects inside
     /// `TypeEnvironment::resolve_lazy`.
     pub type_environment_raw_symbol_lazy_fallbacks: u64,
+    /// #14344: genuine content collisions suppressed by the
+    /// `raw_symbol_fallback_def` `#13862` guard (store-registered `DefId(N)`
+    /// whose raw value collides with a different-named decl). The migration's
+    /// md5-stability regression signal; trends to zero as identity canonicalizes.
+    pub identity_collision_wrong_decl_suppressed: u64,
+    /// #14344 denominator: `symbol_def_index` composite-key lookups that hit.
+    pub symbol_def_index_lookup_hits: u64,
+    /// #14344 denominator: `symbol_def_index` composite-key lookups that missed.
+    pub symbol_def_index_lookup_misses: u64,
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
@@ -709,6 +718,11 @@ impl PerfCounters {
                 type_environment_raw_symbol_lazy_fallbacks: load(
                     &c.type_environment_raw_symbol_lazy_fallbacks,
                 ),
+                identity_collision_wrong_decl_suppressed: load(
+                    &c.identity_collision_wrong_decl_suppressed,
+                ),
+                symbol_def_index_lookup_hits: load(&c.symbol_def_index_lookup_hits),
+                symbol_def_index_lookup_misses: load(&c.symbol_def_index_lookup_misses),
             },
             lib_bootstrap: LibBootstrapCounters {
                 snapshot_set_load_attempts: load(&c.lib_snapshot_set_load_attempts),

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -473,7 +473,12 @@ mod json_tests {
         assert_section_keys(
             &json,
             "identity",
-            &["type_environment_raw_symbol_lazy_fallbacks"],
+            &[
+                "type_environment_raw_symbol_lazy_fallbacks",
+                "identity_collision_wrong_decl_suppressed",
+                "symbol_def_index_lookup_hits",
+                "symbol_def_index_lookup_misses",
+            ],
         );
         assert_eq!(json["wired"]["stable_identity"], true);
     }

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -648,9 +648,16 @@ impl DefinitionStore {
     /// `register_symbol_mapping`. This is an O(1) lookup that replaces the
     /// expensive multi-binder validation in `get_or_create_def_id`.
     pub fn lookup_by_symbol(&self, symbol_id: u32, file_idx: u32) -> Option<DefId> {
-        self.symbol_def_index
+        let result = self
+            .symbol_def_index
             .get(&(symbol_id, file_idx))
-            .map(|r| *r)
+            .map(|r| *r);
+        // #14344 denominator context (measurement only — `result` is returned
+        // unchanged): partitions composite-key `(symbol, file)` resolution
+        // attempts into hits/misses so the wrong-decl collision count has a
+        // population to normalize against.
+        tsz_common::perf_counters::record_symbol_def_index_lookup(result.is_some());
+        result
     }
 
     /// Get definition info by `DefId`.

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -1009,11 +1009,27 @@ impl TypeEnvironment {
     /// registered `DefId` makes callers defer (the checker materializes the real
     /// body on demand) instead of resolving a collision.
     fn raw_symbol_fallback_def(&self, def_id: DefId) -> Option<DefId> {
-        if self
-            .definition_store
-            .as_ref()
-            .is_some_and(|store| store.contains(def_id))
+        if let Some(store) = self.definition_store.as_ref()
+            && store.contains(def_id)
         {
+            // #14344 observability (measurement only — the early `return None`
+            // below is the unchanged `#13862` behavior). A store-registered
+            // `DefId(N)` here is one whose raw value `N`, reread as a `SymbolId`,
+            // is *prevented* from redirecting to a colliding def. Count it only
+            // when that reinterpretation would genuinely land on a DIFFERENT,
+            // DIFFERENT-NAMED def (the `HTMLDivElement(218)` ->
+            // `FileSystemEntry(symbol 218)` class), not on mere raw-`u32` overlap
+            // (which is ~100% by construction and uninformative). Name identity
+            // is interned `Atom` equality, so this is the content-difference test.
+            if tsz_common::perf_counters::enabled_fast()
+                && let Some(collision_def) = store.find_def_by_symbol(def_id.0)
+                && collision_def != def_id
+                && let (Some(canonical_name), Some(collision_name)) =
+                    (store.get_name(def_id), store.get_name(collision_def))
+                && canonical_name != collision_name
+            {
+                tsz_common::perf_counters::record_identity_collision_wrong_decl_suppressed();
+            }
             return None;
         }
         self.symbol_to_def.get(&def_id.0).copied().or_else(|| {
@@ -1806,6 +1822,82 @@ mod tests {
         // `real`'s body is unmaterialized. The pre-fix code returned the
         // collider's body via symbol conflation; the fix defers instead.
         assert_eq!(env.resolve_lazy(real, &interner), None);
+    }
+
+    /// #14344 identity-collision observability: the wrong-decl counter fires on
+    /// a GENUINE content collision (the `#13862`-suppressed
+    /// `HTMLDivElement(218)` -> `FileSystemEntry(symbol 218)` class) and stays
+    /// silent for a store-registered def with no different-named collider. This
+    /// is measurement only — `resolve_lazy` returns `None` either way (behavior
+    /// unchanged). The counter is the migration's md5-stability regression
+    /// signal.
+    #[test]
+    fn identity_collision_counter_fires_on_genuine_content_collision_only() {
+        use tsz_common::perf_counters::{counters, force_enable_perf_counters_for_tests};
+
+        // Force the gate on so we can observe `fetch_add` deltas regardless of
+        // env / `OnceLock` state (the recorder short-circuits when disabled).
+        force_enable_perf_counters_for_tests();
+
+        let read = || {
+            counters()
+                .identity_collision_wrong_decl_suppressed
+                .load(std::sync::atomic::Ordering::Relaxed)
+        };
+
+        let interner = crate::construction::TypeInterner::new();
+
+        // --- Case 1: genuine content collision (different-named decls). ---
+        let store = Arc::new(DefinitionStore::new());
+        let real = store.register(DefinitionInfo::interface(
+            interner.intern_string("ElementLike"),
+            vec![],
+            vec![],
+        ));
+        let mut collider_info =
+            DefinitionInfo::type_alias(interner.intern_string("Collider"), vec![], TypeId::STRING);
+        collider_info.symbol_id = Some(real.0);
+        let collider = store.register(collider_info);
+        store.set_body(collider, TypeId::STRING);
+        // Precondition: the raw-`u32` reinterpretation lands on the differently
+        // named collider, i.e. the content actually differs.
+        assert_eq!(store.find_def_by_symbol(real.0), Some(collider));
+
+        let mut env = TypeEnvironment::new();
+        env.set_definition_store(Arc::clone(&store));
+
+        let before = read();
+        // Behavior is unchanged: the `#13862` guard still defers.
+        assert_eq!(env.resolve_lazy(real, &interner), None);
+        assert_eq!(
+            read() - before,
+            1,
+            "a genuine different-named raw-u32 collision must be counted exactly once"
+        );
+
+        // --- Case 2: store-registered def with NO collider at its raw id. ---
+        // A fresh store whose only registered def has no symbol sharing its
+        // `DefId` numeric value: the fallback still defers, but there is no
+        // content collision, so the counter must not move.
+        let store2 = Arc::new(DefinitionStore::new());
+        let lonely = store2.register(DefinitionInfo::interface(
+            interner.intern_string("Lonely"),
+            vec![],
+            vec![],
+        ));
+        // No def carries `symbol_id == lonely.0`, so the raw reinterpretation
+        // finds nothing to collide with.
+        assert_eq!(store2.find_def_by_symbol(lonely.0), None);
+        let mut env2 = TypeEnvironment::new();
+        env2.set_definition_store(Arc::clone(&store2));
+
+        let before2 = read();
+        assert_eq!(env2.resolve_lazy(lonely, &interner), None);
+        assert_eq!(
+            read() - before2,
+            0,
+            "raw-u32 overlap with nothing (no different-named decl) must not be counted"
+        );
     }
 
     /// The symbol-conflation fallback stays valid for *zombie* `DefId`s — those


### PR DESCRIPTION
Goal: hold

The adversarially-verified GO first-slice of the #14344 (non-canonical identity) migration: an **identity-collision determinism observability harness**. Additive and parity-safe — it makes the root defect MEASURABLE and is the regression-signal layer the migration's later (canonical-id-flip) stages are gated on (the issue's md5-stability gate). It is independent of the canonical-id flip and changes no resolution behavior.

Reuses the existing `perf_counters` infra (gated by `TSZ_PERF_COUNTERS` via `enabled_fast()`, accumulated as process-wide atomics, surfaced once at end-of-run through the existing `dump_report` / JSON snapshot path) — mirroring the established `record_*` recorder precedent. Measurement only: never fed back into evaluation.

## What it adds

Three net-new counters in the existing `identity` snapshot section:

1. **`identity_collision_wrong_decl_suppressed`** (the high-value signal) — at the `raw_symbol_fallback_def` `#13862` guard (`def/resolver.rs`), counts when the guard suppresses a *genuine* content collision: a store-registered `DefId(N)` whose raw value `N`, reread as a `SymbolId`, would resolve to a DIFFERENT def whose canonical decl **name** differs from `DefId(N)`'s own — the `HTMLDivElement(218)` -> `FileSystemEntry(symbol 218)` class (#13862). It deliberately does NOT count mere raw-`u32` overlap (which is ~100% by construction and uninformative): name identity is interned `Atom` equality, so the count is the content-difference witness. A nonzero value is the measurable fingerprint of the non-canonical-identity root; the migration watches it trend to zero.
2. **`symbol_def_index_lookup_hits` / `symbol_def_index_lookup_misses`** (denominator context) — at the `symbol_def_index` composite-key `(symbol, file)` accessor `lookup_by_symbol` (`def/core.rs`), partitions resolution attempts so the wrong-decl count has a population to normalize against.

## Existing-counter dedup

The fallback-**rate** counter the brief flagged already exists as `type_environment_raw_symbol_lazy_fallbacks` (recorder `cross_arena.rs`, dumped, ratchet-tested). I did NOT duplicate it — this PR references/reuses it and adds only the net-new wrong-decl + denominator signals alongside it in the same `identity` section.

## Structural rule

When the `raw_symbol_fallback_def` `#13862` guard returns `None` for a store-registered `DefId`, tsz now records whether that suppression averted a genuine different-named decl collision (vs. a benign raw-`u32` overlap). The recording is strictly downstream of the unchanged early `return None`, behind `enabled_fast()`, so it is a single predictable branch when counters are off and zero atomic traffic — never on any diagnostic path.

## Parity

Byte-identical diagnostics with counters off, by construction: every new site is additive behind `enabled_fast()`, and the instrumented functions (`raw_symbol_fallback_def`, `lookup_by_symbol`) return exactly their prior values. No DefId allocation, SCC, or termination semantics touched.

## Anti-hardcoding

The collision predicate is structural (`DefinitionStore` decl-name `Atom` identity + `find_def_by_symbol`), never a name/file-string literal or printer-output read.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo check -p tsz-solver` (and `tsz-common`) clean; `cargo clippy -p tsz-common -p tsz-solver` clean
- New `identity_collision_counter_fires_on_genuine_content_collision_only` (def/resolver.rs): force-enables counters, asserts the wrong-decl counter fires exactly once on the genuine different-named raw-`u32` collision (the `#13862` `ElementLike`/`Collider` fixture) and zero on a store-registered def with no colliding symbol. Passes.
- Zero-cost-when-disabled is by the established `enabled_fast()` gating model (single branch, no atomic traffic) — the new detection block's first `&&` term is `enabled_fast()`, short-circuiting all extra lookups when off.
- `identity_section_field_shape` lock updated for the 3 new fields; passes. 103/103 def/resolver tests pass (no behavior drift); the existing `#13862` collision + zombie-fallback tests still pass.
- Pre-existing-failure note: `json_tests::{schema_version_is_ten, snapshot_serializes_with_expected_top_level_keys, wired_keys_match_snapshot_struct_fields}` fail identically on clean `origin/main` (the `wired` section is missing `solver_materialization`, unrelated to this PR's `identity`-section additions) — verified by reverting these files in place. Net-new failures from this change: 0.
- CI conformance/emit/fourslash authoritative for broad parity.
