### PR TITLE
test(checker): regression guard for fleet-fixed #14499 (NoInfer transparency in intersection)

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -14,6 +14,7 @@ mod indexed_callable_member_param_tests;
 mod interface_merge_alias_application_2322;
 mod membership_semantics;
 mod narrowing;
+mod noinfer_intersection_transparency_14499;
 mod optional_chain;
 mod predicate_alias_typeof_2677_2304;
 mod spread_param_constraint_2345;

--- a/crates/tsz-checker/tests/conformance_issues/types/noinfer_intersection_transparency_14499.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/noinfer_intersection_transparency_14499.rs
@@ -1,0 +1,65 @@
+//! `NoInfer<T>` is an inference-only intrinsic: when its inner type `T` is
+//! concrete (no free type parameter), it must be TRANSPARENT to every
+//! intersection reduction and relation — disjoint members collapse to `never`,
+//! `any` absorbs, and object members merge — exactly as if the wrapper were
+//! absent. tsz left the wrapper opaque inside intersections, producing tsz-only
+//! false TS2322s (and corrupting the `0 extends 1 & NoInfer<T>` `IsAny` idiom).
+//! Fixed in solver `intern/intersection.rs` (`normalize_intersection` unwraps a
+//! concrete-inner `NoInfer` member for reduction); this guards it. (#14499)
+
+use super::super::core::*;
+
+/// Disjoint unit literals must collapse to `never` through `NoInfer`:
+/// `"a" & NoInfer<"b">` is `never`, so it is assignable to a `never` annotation.
+#[test]
+fn noinfer_disjoint_literals_collapse_to_never_no_ts2322() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type R1 = "a" & NoInfer<"b">;
+const x1: never = null as any as R1;
+export {};
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2322),
+        "no TS2322 expected — `\"a\" & NoInfer<\"b\">` collapses to `never` (disjoint \
+         units, NoInfer transparent). Actual: {diagnostics:#?}"
+    );
+}
+
+/// The `IsAny` idiom: `0 extends 1 & NoInfer<T>` with `T = any` must take the
+/// `true` branch (`any` absorbs through `NoInfer`), so `IsAny<any>` is `true`.
+#[test]
+fn noinfer_any_absorption_isany_idiom_no_ts2322() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type IsAny<T> = 0 extends 1 & NoInfer<T> ? true : false;
+const a: IsAny<any> = true;
+export {};
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2322),
+        "no TS2322 expected — `any` absorbs through `NoInfer`, so `IsAny<any>` is \
+         `true`. Actual: {diagnostics:#?}"
+    );
+}
+
+/// Negative control: the transparency must not over-collapse. The disjoint
+/// collapse to `never` is real, so assigning a non-`never` value to the result
+/// is rejected (proving the reduction fired, not a blanket suppression).
+#[test]
+fn noinfer_disjoint_collapse_rejects_non_never_value_ts2322() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type R1 = "a" & NoInfer<"b">;
+const bad: R1 = "a";
+export {};
+"#,
+    );
+    assert!(
+        has_error(&diagnostics, 2322),
+        "TS2322 expected — `\"a\" & NoInfer<\"b\">` is `never`, so the string `\"a\"` \
+         is not assignable to it. Actual: {diagnostics:#?}"
+    );
+}


### PR DESCRIPTION
Regression guard for a fleet-fixed canary false positive. No compiler source
changes — parity-floor protection (`Goal: hold`).

Goal: hold

## What it guards
#14499 (TS2322): `NoInfer<T>` with a concrete inner `T` must be transparent to
intersection reduction — disjoint members collapse to `never` and an `any` inner
absorbs, exactly as if the wrapper were absent. tsz left the wrapper opaque,
producing tsz-only false TS2322s and corrupting the `0 extends 1 & NoInfer<T>`
`IsAny` idiom that utility-type libraries rely on. Fixed on main in solver
`intern/intersection.rs` (`normalize_intersection` probes a concrete-inner
`NoInfer` member for the total `never`/`any` collapses).

## Tests
- `"a" & NoInfer<"b">` collapses to `never` (assignable to a `never` annotation).
- `IsAny<any>` (`0 extends 1 & NoInfer<any>`) is `true` (`any` absorbs through
  `NoInfer`).
- Negative control: the disjoint collapse is real — assigning `"a"` to the
  `never` result still errors (TS2322), proving the reduction fired rather than a
  blanket suppression.

## Verification
- `cargo nextest run -p tsz-checker -j 2 noinfer_intersection_transparency` — 3 pass.
- CI gates: lint, unit-checker-integration, conformance-aggregate, emit-aggregate,
  fourslash-*, project-compile-guard, CI Summary.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max