### PR TITLE
fix(checker): bind omitted base type-argument defaults for this-member reads

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -676,6 +676,9 @@ mod assertion_type_predicate_diagnostics_tests;
 #[path = "tests/assign_to_import_shadowing_local_tests.rs"]
 mod assign_to_import_shadowing_local_tests;
 #[cfg(test)]
+#[path = "tests/base_type_param_default_inheritance_tests.rs"]
+mod base_type_param_default_inheritance_tests;
+#[cfg(test)]
 #[path = "../tests/bigint_target_ts2737_tests.rs"]
 mod bigint_target_ts2737_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -178,10 +178,10 @@ pub(crate) fn type_parameter_default(db: &dyn TypeDatabase, type_id: TypeId) -> 
 /// context's own parameters) — to their declared `default → constraint →
 /// unknown`, matching tsc's `fillMissingTypeArguments`.
 /// See [`tsz_solver::computation::resolve_unbound_type_params_to_defaults`].
-pub(crate) fn resolve_unbound_type_params_to_defaults(
+pub(crate) fn resolve_unbound_type_params_to_defaults<S: std::hash::BuildHasher>(
     db: &dyn TypeDatabase,
     member_type: TypeId,
-    in_scope: &rustc_hash::FxHashSet<TypeId>,
+    in_scope: &std::collections::HashSet<TypeId, S>,
 ) -> TypeId {
     tsz_solver::computation::resolve_unbound_type_params_to_defaults(db, member_type, in_scope)
 }

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -173,6 +173,19 @@ pub(crate) fn type_parameter_default(db: &dyn TypeDatabase, type_id: TypeId) -> 
     tsz_solver::type_queries::get_type_parameter_default(db, type_id)
 }
 
+/// Resolve "dangling" free type parameters in a property-access result — those
+/// free in `member_type` but not present in `in_scope` (the enclosing generic
+/// context's own parameters) — to their declared `default → constraint →
+/// unknown`, matching tsc's `fillMissingTypeArguments`.
+/// See [`tsz_solver::computation::resolve_unbound_type_params_to_defaults`].
+pub(crate) fn resolve_unbound_type_params_to_defaults(
+    db: &dyn TypeDatabase,
+    member_type: TypeId,
+    in_scope: &rustc_hash::FxHashSet<TypeId>,
+) -> TypeId {
+    tsz_solver::computation::resolve_unbound_type_params_to_defaults(db, member_type, in_scope)
+}
+
 /// Check if a type parameter has a constraint that contains a conditional type.
 /// This is used to suppress false-positive TS2339 errors when accessing properties
 /// on generic conditional types like `Parameters<T>["length"]` where the property

--- a/crates/tsz-checker/src/tests/base_type_param_default_inheritance_tests.rs
+++ b/crates/tsz-checker/src/tests/base_type_param_default_inheritance_tests.rs
@@ -1,0 +1,213 @@
+//! Regression tests for false TS2339/TS7053/TS2322 when a derived class extends
+//! a generic base class WITHOUT type arguments and reads, through `this`, a
+//! member typed by one of the base's type parameters.
+//!
+//! When `class Sub extends Base` and `Base<P = …>` has a default, `tsc` binds
+//! the omitted argument to that default (`fillMissingTypeArguments`), so an
+//! inherited member typed `P` is seen as the default type. tsz previously left
+//! the bare base parameter unbound, so `this.member` resolved to the raw
+//! parameter `P` (rendered `unknown` via its implicit constraint), producing a
+//! false TS7053 on an index/`TS2339` on a property access / TS2322 on a return.
+//! This is the raw-parameter sibling of the `error`/`never`-in-a-type-argument
+//! leak family (issue <https://github.com/tsz-org/tsz/issues/13484>).
+//!
+//! The fix resolves such "dangling" base parameters (free in the member but not
+//! bound by the enclosing generic scope) to their `default → constraint →
+//! unknown` at the property-access boundary. Type parameters of the enclosing
+//! generic class/function (`T` of a generic `Box<T>`) stay in scope and must be
+//! preserved — the negative/identity guards below pin that.
+//!
+//! Test integrity: binder names are varied (`Holder`/`Wrapper`/`Vault`, the
+//! type parameters `V`/`Elem`/`Payload`, the members `slot`/`cell`/`store`) so
+//! the assertions track the structural shape, not any identifier; the cases use
+//! only in-source declarations so they do not depend on a lib surface.
+
+use std::sync::{Arc, OnceLock};
+use tsz_binder::lib_loader::LibFile;
+
+use crate::CheckerOptions;
+use crate::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
+
+fn default_libs() -> &'static [Arc<LibFile>] {
+    static DEFAULT_LIBS: OnceLock<Vec<Arc<LibFile>>> = OnceLock::new();
+    DEFAULT_LIBS.get_or_init(load_default_lib_files)
+}
+
+fn check(src: &str) -> Vec<(u32, String)> {
+    check_source_with_libs_code_messages(src, "test.ts", CheckerOptions::default(), default_libs())
+}
+
+fn assert_clean(src: &str) {
+    let diags = check(src);
+    assert!(diags.is_empty(), "expected no diagnostics, got: {diags:?}");
+}
+
+fn assert_has_code(src: &str, code: u32) {
+    let diags = check(src);
+    assert!(
+        diags.iter().any(|(c, _)| *c == code),
+        "expected diagnostic TS{code}, got: {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases: the omitted base argument binds to the parameter default.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn this_member_typed_by_base_param_with_any_default_is_indexable() {
+    // Default `any` -> `this.slot` is `any`, so indexing with a string is fine.
+    assert_clean(
+        "
+class Holder<V = any> { slot!: V; }
+class Sub extends Holder { read(k: string) { return this.slot[k]; } }
+",
+    );
+}
+
+#[test]
+fn this_member_typed_by_base_param_with_concrete_default() {
+    // Default `string` -> `this.cell` is `string`.
+    assert_clean(
+        "
+class Wrapper<Elem = string> { cell!: Elem; }
+class Child extends Wrapper { take(): string { return this.cell; } }
+",
+    );
+}
+
+#[test]
+fn this_member_typed_by_base_param_with_object_default() {
+    assert_clean(
+        "
+class Vault<Payload = { count: number }> { store!: Payload; }
+class Branch extends Vault { total(): number { return this.store.count; } }
+",
+    );
+}
+
+#[test]
+fn nested_base_param_position_binds_default() {
+    // The base parameter appears inside `Elem[]`; the whole element type must
+    // bind so `this.items[0]` is `any`, not a bare parameter.
+    assert_clean(
+        "
+class Bag<Elem = any> { items!: Elem[]; }
+class Pouch extends Bag { peek() { return this.items[0].anything; } }
+",
+    );
+}
+
+#[test]
+fn chained_base_param_defaults_resolve_transitively() {
+    // `Second = First[]` references an earlier base parameter; both must
+    // resolve (`First` -> `string`, `Second` -> `string[]`).
+    assert_clean(
+        "
+class Pair<First = string, Second = First[]> { head!: First; tail!: Second; }
+class Combo extends Pair {
+  first(): string { return this.head; }
+  rest(): string[] { return this.tail; }
+}
+",
+    );
+}
+
+#[test]
+fn generic_derived_still_binds_omitted_base_default() {
+    // The derived class is generic, but it still omits the base argument, so
+    // the base parameter binds to its default while the derived `T` is unused
+    // by the inherited member.
+    assert_clean(
+        "
+class Source<Out = any> { value!: Out; }
+class Relay<T> extends Source { use(k: string) { return this.value[k]; } }
+function consume(r: Relay<number>) { return r.use('x'); }
+",
+    );
+}
+
+#[test]
+fn abstract_base_param_member_binds_default() {
+    // The zod-shaped abstract base / concrete derived form.
+    assert_clean(
+        "
+abstract class Definition<Shape> { readonly meta!: Shape; }
+interface NumberShape { entries: number[]; }
+class NumberDef extends Definition<NumberShape> {
+  push(n: number) { const all = [...this.meta.entries, n]; const out: number[] = all; return out; }
+}
+",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: the resolved (defaulted) member type is still enforced.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn defaulted_member_type_is_still_checked_against_return() {
+    // `this.cell` resolves to `string`, so returning it as `number` is TS2322.
+    assert_has_code(
+        "
+class Wrapper<Elem = string> { cell!: Elem; }
+class Child extends Wrapper { take(): number { return this.cell; } }
+",
+        2322,
+    );
+}
+
+#[test]
+fn defaulted_object_member_rejects_missing_property() {
+    // `this.store` resolves to `{ count: number }`, so `.missing` is TS2339 on
+    // the resolved object type (not on a bare parameter).
+    assert_has_code(
+        "
+class Vault<Payload = { count: number }> { store!: Payload; }
+class Branch extends Vault { peek() { return this.store.missing; } }
+",
+        2339,
+    );
+}
+
+#[test]
+fn explicit_base_argument_is_unaffected() {
+    // Explicitly supplied base argument keeps its binding (`Elem = string`),
+    // so returning it as `number` is still TS2322.
+    assert_has_code(
+        "
+class Wrapper<Elem> { cell!: Elem; }
+class Child extends Wrapper<string> { take(): number { return this.cell; } }
+",
+        2322,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Identity guards: an in-scope generic parameter must NOT be substituted away.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generic_class_own_parameter_is_preserved_internally() {
+    // `Box<T>` reading `this.payload` must keep `T` (it is bound by the class),
+    // so the round-trip through a method stays well-typed.
+    assert_clean(
+        "
+class Box<T> { payload!: T; get(): T { return this.payload; } set(x: T) { this.payload = x; } }
+function roundtrip(b: Box<number>) { const n: number = b.get(); b.set(3); }
+",
+    );
+}
+
+#[test]
+fn explicit_base_param_threading_is_preserved() {
+    // `Sub<T> extends Carrier<T>` threads the derived parameter into the base,
+    // so the inherited member is `T`, not a default.
+    assert_clean(
+        "
+class Carrier<P> { freight!: P; }
+class Sub<T> extends Carrier<T> { unwrap(): T { return this.freight; } }
+function open(s: Sub<number>) { const n: number = s.unwrap(); }
+",
+    );
+}

--- a/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
+++ b/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
@@ -32,6 +32,59 @@ impl<'a> CheckerState<'a> {
         name_node: &Node,
         request: IdentifierPropertyAccessRequest,
     ) -> TypeId {
+        let is_this_access = request.is_this_access;
+        let member_type =
+            self.resolve_identifier_property_access_inner(idx, access, name_node, request);
+        self.bind_omitted_base_type_args_for_this_member(member_type, is_this_access)
+    }
+
+    /// Bind "dangling" base-class type parameters of a `this`-member read to the
+    /// base parameter's `default → constraint → unknown`.
+    ///
+    /// When a class extends a generic base WITHOUT type arguments
+    /// (`class Der extends Base`, where `Base<P = …>`), the omitted argument is
+    /// never bound on the `this`-member resolution path (an external receiver
+    /// reads the already-defaulted instance shape, so it is unaffected). The bare
+    /// parameter `P` would otherwise leak into the value's type — a false
+    /// `TS2339`/`TS7053`/`TS2322` on `this.member`, the raw-parameter sibling of
+    /// the `error`/`never`-in-a-type-argument-slot leak family (#13484). `tsc`
+    /// binds such an omitted base argument to its default
+    /// (`fillMissingTypeArguments`); this does the same.
+    ///
+    /// Type parameters of the enclosing generic context (a class's / function's
+    /// own parameters, e.g. `T` of a generic `Box<T>`) stay in scope and are
+    /// preserved, so only genuinely unbound base parameters are resolved. Gated on
+    /// the `this`-receiver flag and the cheap memoized free-parameter predicate so
+    /// concrete results and non-`this` deferred-generic reads are untouched.
+    fn bind_omitted_base_type_args_for_this_member(
+        &mut self,
+        member_type: TypeId,
+        is_this_access: bool,
+    ) -> TypeId {
+        if !is_this_access
+            || !crate::query_boundaries::common::contains_free_type_parameters(
+                self.ctx.types,
+                member_type,
+            )
+        {
+            return member_type;
+        }
+        let in_scope: rustc_hash::FxHashSet<TypeId> =
+            self.ctx.type_parameter_scope.values().copied().collect();
+        crate::query_boundaries::common::resolve_unbound_type_params_to_defaults(
+            self.ctx.types,
+            member_type,
+            &in_scope,
+        )
+    }
+
+    fn resolve_identifier_property_access_inner(
+        &mut self,
+        idx: NodeIndex,
+        access: &AccessExprData,
+        name_node: &Node,
+        request: IdentifierPropertyAccessRequest,
+    ) -> TypeId {
         let IdentifierPropertyAccessRequest {
             object_type,
             original_object_type,

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -1000,7 +1000,7 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let member_type = self.resolve_identifier_property_access(
+        self.resolve_identifier_property_access(
             idx,
             access,
             name_node,
@@ -1017,40 +1017,6 @@ impl<'a> CheckerState<'a> {
                 is_this_access,
                 js_expando_before_assignment,
             },
-        );
-
-        // A `this.member` read can resolve to a type that still mentions a base
-        // class's type parameter when the class extended that base WITHOUT type
-        // arguments (`class Der extends Base`, where `Base<P = …>`): the omitted
-        // argument is never bound on the `this`-member path (unlike an external
-        // receiver, which reads the already-defaulted instance shape), so the bare
-        // `P` leaks into the value's type (false TS2339/TS7053/TS2322 on
-        // `this.member`). `tsc` binds such an omitted base argument to its default
-        // (then constraint), per `fillMissingTypeArguments`; do the same here.
-        //
-        // Scoped to `this`-receiver reads: an external/value receiver already
-        // resolves these correctly, and a non-`this` deferred-generic access (a
-        // member typed by a type parameter that is legitimately still free, e.g.
-        // inside a generic function) must keep its parameter. Type parameters of
-        // the enclosing generic context (a class's / function's own parameters,
-        // e.g. `T` of a generic `Box<T>`) stay in scope and are preserved.
-        // Gated first on the cheap memoized free-parameter predicate so concrete
-        // results are untouched.
-        if is_this_access
-            && crate::query_boundaries::common::contains_free_type_parameters(
-                self.ctx.types,
-                member_type,
-            )
-        {
-            let in_scope: rustc_hash::FxHashSet<TypeId> =
-                self.ctx.type_parameter_scope.values().copied().collect();
-            crate::query_boundaries::common::resolve_unbound_type_params_to_defaults(
-                self.ctx.types,
-                member_type,
-                &in_scope,
-            )
-        } else {
-            member_type
-        }
+        )
     }
 }

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -1000,7 +1000,7 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        self.resolve_identifier_property_access(
+        let member_type = self.resolve_identifier_property_access(
             idx,
             access,
             name_node,
@@ -1017,6 +1017,40 @@ impl<'a> CheckerState<'a> {
                 is_this_access,
                 js_expando_before_assignment,
             },
-        )
+        );
+
+        // A `this.member` read can resolve to a type that still mentions a base
+        // class's type parameter when the class extended that base WITHOUT type
+        // arguments (`class Der extends Base`, where `Base<P = …>`): the omitted
+        // argument is never bound on the `this`-member path (unlike an external
+        // receiver, which reads the already-defaulted instance shape), so the bare
+        // `P` leaks into the value's type (false TS2339/TS7053/TS2322 on
+        // `this.member`). `tsc` binds such an omitted base argument to its default
+        // (then constraint), per `fillMissingTypeArguments`; do the same here.
+        //
+        // Scoped to `this`-receiver reads: an external/value receiver already
+        // resolves these correctly, and a non-`this` deferred-generic access (a
+        // member typed by a type parameter that is legitimately still free, e.g.
+        // inside a generic function) must keep its parameter. Type parameters of
+        // the enclosing generic context (a class's / function's own parameters,
+        // e.g. `T` of a generic `Box<T>`) stay in scope and are preserved.
+        // Gated first on the cheap memoized free-parameter predicate so concrete
+        // results are untouched.
+        if is_this_access
+            && crate::query_boundaries::common::contains_free_type_parameters(
+                self.ctx.types,
+                member_type,
+            )
+        {
+            let in_scope: rustc_hash::FxHashSet<TypeId> =
+                self.ctx.type_parameter_scope.values().copied().collect();
+            crate::query_boundaries::common::resolve_unbound_type_params_to_defaults(
+                self.ctx.types,
+                member_type,
+                &in_scope,
+            )
+        } else {
+            member_type
+        }
     }
 }

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -1051,10 +1051,10 @@ const MAX_UNBOUND_DEFAULT_DEPTH: usize = 8;
 /// generic `Box<T>`); those are preserved, so only genuinely unbound base
 /// parameters are resolved. Type parameters bound by an enclosing callable
 /// signature are already excluded by [`free_type_parameter_ids_in`].
-pub fn resolve_unbound_type_params_to_defaults(
+pub fn resolve_unbound_type_params_to_defaults<S: std::hash::BuildHasher>(
     db: &dyn TypeDatabase,
     member_type: TypeId,
-    in_scope: &FxHashSet<TypeId>,
+    in_scope: &std::collections::HashSet<TypeId, S>,
 ) -> TypeId {
     use crate::visitors::visitor_predicates::free_type_parameter_ids_in;
 

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -1027,6 +1027,65 @@ pub fn instantiate_type_params_to_constraints_uncached(
     }
 }
 
+/// Maximum number of substitution passes [`resolve_unbound_type_params_to_defaults`]
+/// makes. A parameter default may reference an earlier base parameter
+/// (`B = A[]`), so one pass can re-introduce a now-resolvable parameter; the
+/// bound plus the per-pass no-progress check terminate self-referential
+/// defaults (`T = T`).
+const MAX_UNBOUND_DEFAULT_DEPTH: usize = 8;
+
+/// Resolve "dangling" free type parameters in `member_type` — those that are
+/// free in the member but NOT present in `in_scope` — to their declared
+/// `default → constraint → unknown`, matching tsc's `fillMissingTypeArguments`.
+///
+/// A value-position member read can resolve to a type that still mentions a
+/// base class's type parameter when the class extended that base WITHOUT type
+/// arguments (`class Der extends Base`, where `Base<P = …>`): the omitted
+/// argument is never bound, so the bare `P` would otherwise leak into the
+/// member's value type (a false `TS2339`/`TS7053`/`TS2322` — the raw-parameter
+/// sibling of the `error`/`never`-in-a-type-argument-slot leak family). `tsc`
+/// binds such an omitted base argument to the parameter's default.
+///
+/// `in_scope` holds the type parameters legitimately bound by the enclosing
+/// generic context (the class's / function's own parameters, e.g. `T` of a
+/// generic `Box<T>`); those are preserved, so only genuinely unbound base
+/// parameters are resolved. Type parameters bound by an enclosing callable
+/// signature are already excluded by [`free_type_parameter_ids_in`].
+pub fn resolve_unbound_type_params_to_defaults(
+    db: &dyn TypeDatabase,
+    member_type: TypeId,
+    in_scope: &FxHashSet<TypeId>,
+) -> TypeId {
+    use crate::visitors::visitor_predicates::free_type_parameter_ids_in;
+
+    let mut current = member_type;
+    for _ in 0..MAX_UNBOUND_DEFAULT_DEPTH {
+        let mut substitution = TypeSubstitution::new();
+        for param_id in free_type_parameter_ids_in(db, [current]) {
+            if in_scope.contains(&param_id) {
+                continue;
+            }
+            let Some(TypeData::TypeParameter(info)) = db.lookup(param_id) else {
+                continue;
+            };
+            let usable = |t: Option<TypeId>| t.filter(|&t| t != TypeId::ERROR);
+            let fill = usable(info.default)
+                .or_else(|| usable(info.constraint))
+                .unwrap_or(TypeId::UNKNOWN);
+            substitution.insert(info.name, fill);
+        }
+        if substitution.is_empty() {
+            return current;
+        }
+        let next = instantiate_type(db, current, &substitution);
+        if next == current {
+            return current;
+        }
+        current = next;
+    }
+    current
+}
+
 fn collect_type_param_constraint_substitutions(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -172,7 +172,8 @@ pub mod computation {
         instantiate_type_preserving, instantiate_type_preserving_cached,
         instantiate_type_preserving_meta, instantiate_type_preserving_meta_cached,
         instantiate_type_with_depth_status, instantiate_type_with_infer,
-        instantiate_type_with_infer_cached, instantiate_type_with_request, substitute_this_type,
+        instantiate_type_with_infer_cached, instantiate_type_with_request,
+        resolve_unbound_type_params_to_defaults, substitute_this_type,
         substitute_this_type_at_return_position, substitute_this_type_cached,
     };
     pub use crate::instantiation::request::{InstantiationOptions, InstantiationRequest};


### PR DESCRIPTION
Goal: green

Closes the single-file, `this`-receiver slice of #13484 (and supplies the
minimally-reproducible witness that issue says it lacked).

## Summary

When a class extends a generic base **without** type arguments
(`class Sub extends Base`, where `Base<P = …>`), `tsc` binds the omitted
argument to the parameter's default (`fillMissingTypeArguments`). tsz already
builds the derived **instance shape** correctly (the omitted base argument is
defaulted), so an external receiver `new Sub().member` is clean — but a
`this.member` read re-resolves an inherited member typed by a base parameter
through the class declaration and left the bare parameter `P` **unbound**.

The leaked parameter surfaced (via its implicit `unknown` constraint) as:
- a false **TS7053** on `this.member[k]`,
- a false **TS2339** on `this.member.prop`, and
- a false **TS2322** returning `this.member`.

This is the raw-parameter sibling of the `error`/`never`-in-a-type-argument-slot
leak family tracked in #13484 — which records that "every minimal single-/two-file
reduction is clean". It is not: the `this`-member form reproduces in a single
file (see the new tests and the differential matrix below).

```ts
class Holder<V = any> { slot!: V; }
class Sub extends Holder { read(k: string) { return this.slot[k]; } } // tsz: false TS7053; tsc: clean
```

## Structural rule

> When a `this`-member read resolves to a type that still mentions a type
> parameter which is **free in the member but not bound by the enclosing generic
> scope** (the class's / function's own parameters), that parameter is an omitted
> base argument and resolves to its `default → constraint → unknown`, exactly
> like an under-applied `Base<…>` reference. tsz left it as the bare parameter.

## Owner layer

Solver owns the semantics: new
`resolve_unbound_type_params_to_defaults(db, member_type, in_scope)`
(`crates/tsz-solver/src/instantiation/instantiate/api.rs`) maps every free
parameter not in `in_scope` to its `default → constraint → unknown`, to a
fixpoint so chained defaults (`B = A[]`) resolve. The checker calls it through
the `query_boundaries::common` gateway at the **`this`-receiver** property-access
boundary (`crates/tsz-checker/src/types/property_access_type/resolve.rs`).

Display/relation only at the consumption point — no instance-type, heritage, or
relation behavior changes. Gated on the cheap memoized free-parameter predicate
**and** the `this`-receiver check so concrete results and non-`this`
deferred-generic reads are untouched.

## Adjacent-case matrix (differential vs `tsc` 6.0.2, `--strict`)

| source | tsc | tsz before | tsz after |
|---|---|---|---|
| `Holder<V=any>`; `Sub extends Holder`; `this.slot[k]` | clean | TS7053 | ✓ |
| `Wrapper<Elem=string>`; `this.cell` returned as `string` | clean | TS2322 (`'Elem'`) | ✓ |
| `Vault<Payload={count:number}>`; `this.store.count` | clean | TS2339 | ✓ |
| `Bag<Elem=any>`; `this.items[0].anything` (nested `Elem[]`) | clean | TS2339 | ✓ |
| `Pair<First=string, Second=First[]>` (chained default) | clean | TS2322 ×2 | ✓ |
| generic `Relay<T> extends Source<Out=any>`; `this.value[k]` | clean | TS7053 | ✓ |
| abstract `Definition<Shape>` / concrete `NumberDef` (zod-shaped) | clean | TS2339 | ✓ |
| **neg** `Wrapper<Elem=string>`; return `this.cell` as `number` | TS2322 | (wrong reason) | TS2322 ✓ |
| **neg** `Vault<{count:number}>`; `this.store.missing` | TS2339 | (wrong reason) | TS2339 ✓ |
| **neg** explicit `Sub extends Wrapper<string>`; as `number` | TS2322 | TS2322 | TS2322 ✓ |
| **id** generic `Box<T>`; `this.payload` keeps `T` | clean | clean | clean ✓ |
| **id** `Sub<T> extends Carrier<T>`; `this.freight` is `T` | clean | clean | clean ✓ |

## Anti-hardcoding

Purely structural: the decision is "the member's free parameter is not in the
enclosing type-parameter scope" using the shared `free_type_parameter_ids_in`
solver visitor + the name-agnostic `contains_free_type_parameters` predicate — no
identifier / file-name / printer-string predicate. The new tests vary binder
names (`Holder`/`Wrapper`/`Vault`/`Bag`/`Pair`, params `V`/`Elem`/`Payload`/
`First`/`Second`, members `slot`/`cell`/`store`/`items`).

## Verification

- New `crates/tsz-checker/src/tests/base_type_param_default_inheritance_tests.rs`
  (12 cases) — `cargo test -p tsz-checker --lib base_type_param_default_inheritance`
  → **12 passed, 0 failed**.
- `cargo test -p tsz-solver --lib instantiate` → 123 passed, 0 failed.
- Regression baseline vs clean `main` (stash A/B) on the `generic`,
  `property_access`, `heritage`, and `class_instance` filters: failure counts
  **identical** (16 / 1 / 1 / 1 — the pre-existing #14486 red floor), i.e.
  **net-new failures = 0**.
- Differential parity vs bundled `tsc` 6.0.2 on the matrix above.
- `cargo fmt -p tsz-checker -p tsz-solver --check` clean; `cargo clippy -p
  tsz-checker --lib` / `-p tsz-solver --lib` clean.
- Reviewed for reuse/simplification/altitude before opening (lazy `in_scope`
  build, single gated call site, fixpoint helper reuses the existing
  free-parameter visitor and substitution primitives).
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

https://claude.ai/code/session_01LXEgm7B2mCErMFhCqhy6QU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXEgm7B2mCErMFhCqhy6QU)_