### PR TITLE
fix(solver): reject overload candidate when a const type param fell back to its constraint

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1019,6 +1019,9 @@ path = "tests/kysely_callback_context_tests.rs"
 name = "inline_mapped_array_return_tests"
 path = "tests/inline_mapped_array_return_tests.rs"
 [[test]]
+name = "overload_constraint_fallback_applicability_tests"
+path = "tests/overload_constraint_fallback_applicability_tests.rs"
+[[test]]
 name = "overload_inference_literal_preservation_tests"
 path = "tests/overload_inference_literal_preservation_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/overload_constraint_fallback_applicability_tests.rs
+++ b/crates/tsz-checker/tests/overload_constraint_fallback_applicability_tests.rs
@@ -1,0 +1,158 @@
+//! Regression tests for overload candidate applicability when a (const or
+//! plain) type parameter falls back to its constraint.
+//!
+//! Structural rule: when an overload's generic type parameter supplies no valid
+//! lower bound from the argument and therefore falls back to its *constraint*,
+//! the candidate must be re-validated — if the original argument is not
+//! assignable to the constraint-instantiated parameter, the signature is
+//! non-applicable and a later overload may win. Previously a bare `const` type
+//! parameter unconditionally suppressed the final argument-type mismatch
+//! (assuming "const params are inferred directly from the argument, so always
+//! assignable"), which is false on the constraint-fallback path: the argument
+//! was never inferred from, it was discarded in favor of the constraint.
+//!
+//! See issue #14510.
+
+use tsz_checker::test_utils::{check_source_strict, check_source_strict_codes};
+
+fn ts_codes(source: &str) -> Vec<u32> {
+    let mut codes = check_source_strict_codes(source);
+    codes.sort_unstable();
+    codes
+}
+
+fn clean(source: &str) -> bool {
+    check_source_strict(source).is_empty()
+}
+
+/// Two `const` overloads distinguished only by their type-parameter constraint;
+/// the argument matches the *second*. The first overload's `T extends string`
+/// gets no lower bound from `5`, falls back to `string`, and must be rejected so
+/// overload 2 (`T extends number`, `T = 5`) wins → `r = { n: 5 }`.
+#[test]
+fn const_overload_constraint_fallback_picks_matching_signature() {
+    let src = "\
+        declare function f<const T extends string>(x: T): [T];\n\
+        declare function f<const T extends number>(x: T): { n: T };\n\
+        const r = f(5);\n\
+        const ok: { n: 5 } = r;\n";
+    assert!(
+        clean(src),
+        "argument 5 must select the `number`-constrained overload (r = {{ n: 5 }}), not the \
+         `string`-constrained one falling back to its constraint; got {:?}",
+        check_source_strict(src)
+    );
+}
+
+/// Same shape, renamed function and type-parameter binders — the fix is
+/// structural, not keyed on the spelling `f`/`T`.
+#[test]
+fn const_overload_constraint_fallback_renamed_binders() {
+    let src = "\
+        declare function widget<const Elem extends string>(input: Elem): [Elem];\n\
+        declare function widget<const Elem extends number>(input: Elem): { n: Elem };\n\
+        const z = widget(7);\n\
+        const ok: { n: 7 } = z;\n";
+    assert!(
+        clean(src),
+        "renamed binders must resolve identically; got {:?}",
+        check_source_strict(src)
+    );
+}
+
+/// The argument matches overload **1**; it must still be selected (the
+/// constraint-fallback rejection only fires for the genuinely non-matching
+/// candidate, never for the matching one).
+#[test]
+fn const_overload_matching_first_signature_still_selected() {
+    let src = "\
+        declare function f<const T extends string>(x: T): [T];\n\
+        declare function f<const T extends number>(x: T): { n: T };\n\
+        const r = f(\"a\");\n\
+        const ok: [\"a\"] = r;\n";
+    assert!(
+        clean(src),
+        "argument \"a\" must select the `string`-constrained overload (r = [\"a\"]); got {:?}",
+        check_source_strict(src)
+    );
+}
+
+/// Three-way `const` overload set; the argument matches the *third*.
+#[test]
+fn const_three_way_overload_set_picks_third() {
+    let src = "\
+        declare function f<const T extends string>(x: T): [T];\n\
+        declare function f<const T extends number>(x: T): { n: T };\n\
+        declare function f<const T extends boolean>(x: T): { b: T };\n\
+        const r = f(true);\n\
+        const ok: { b: true } = r;\n";
+    assert!(
+        clean(src),
+        "argument true must select the `boolean`-constrained overload (r = {{ b: true }}); got {:?}",
+        check_source_strict(src)
+    );
+}
+
+/// The argument matches *no* overload's constraint — the genuine no-overload
+/// error (TS2769) must still surface; the constraint-fallback rejection must not
+/// silently swallow it.
+#[test]
+fn const_overload_no_matching_constraint_reports_ts2769() {
+    let src = "\
+        declare function f<const T extends string>(x: T): [T];\n\
+        declare function f<const T extends number>(x: T): { n: T };\n\
+        const r = f(true);\n";
+    assert_eq!(
+        ts_codes(src),
+        vec![2769],
+        "an argument assignable to no overload constraint must report TS2769"
+    );
+}
+
+/// Plain (non-`const`) constrained overloads exhibit the same selection and were
+/// already correct — guard against regressions from the shared finalize path.
+#[test]
+fn plain_overload_constraint_fallback_picks_matching_signature() {
+    let src = "\
+        declare function f<T extends string>(x: T): [T];\n\
+        declare function f<T extends number>(x: T): { n: T };\n\
+        const r = f(5);\n\
+        const ok: { n: 5 } = r;\n";
+    assert!(
+        clean(src),
+        "plain constrained overloads must select the `number` overload; got {:?}",
+        check_source_strict(src)
+    );
+}
+
+/// A single-signature `const` generic called with a non-matching argument must
+/// STILL report TS2345 — the constraint fallback is legitimate outside overload
+/// resolution and must keep erroring on the argument.
+#[test]
+fn single_signature_const_constraint_fallback_still_errors() {
+    let src = "\
+        declare function g<const T extends string>(x: T): [T];\n\
+        const s = g(5);\n";
+    assert_eq!(
+        ts_codes(src),
+        vec![2345],
+        "a single-signature const generic must still report TS2345 on a non-assignable argument"
+    );
+}
+
+/// The legitimate bare-`const` skip this fix narrows must be preserved: a const
+/// type parameter genuinely inferred from the argument (no constraint fallback)
+/// must not draw a spurious mismatch from the `in_const_assertion` TypeId
+/// divergence.
+#[test]
+fn bare_const_genuine_inference_remains_clean() {
+    let src = "\
+        declare function h<const T extends readonly unknown[]>(x: T): T;\n\
+        const r = h([1, 2, 3]);\n\
+        const ok: readonly [1, 2, 3] = r;\n";
+    assert!(
+        clean(src),
+        "a const param genuinely inferred from the argument must stay clean; got {:?}",
+        check_source_strict(src)
+    );
+}

--- a/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs
@@ -1398,8 +1398,18 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     // `in_const_assertion = true` (producing one TypeId) while the solver's
                     // inference engine applies `apply_const_assertion` separately (producing
                     // a different TypeId). Both represent the same readonly/literal type.
+                    //
+                    // This holds ONLY when the parameter was actually inferred from the
+                    // argument. If the type parameter instead fell back to its *constraint*
+                    // because the argument supplied no valid lower bound (recorded in
+                    // `constraint_fallback_tp_names`), the argument was NOT inferred from —
+                    // it is genuinely not assignable to the constraint-instantiated
+                    // parameter, so the mismatch is real and must be reported. This lets a
+                    // later overload whose constraint the argument *does* satisfy win
+                    // instead of locking onto this candidate via a spurious `Success`.
                     let is_bare_const_type_param = func.type_params.iter().any(|tp| {
                         tp.is_const
+                            && !constraint_fallback_tp_names.contains(&tp.name)
                             && matches!(
                                 self.interner.lookup(param_type),
                                 Some(TypeData::TypeParameter(info)) if info.name == tp.name


### PR DESCRIPTION
Goal: green

Fixes #14510.

## Summary

With two generic overloads distinguished only by their type-parameter
constraint, tsz selected the **wrong** overload when the argument matched the
*second*, producing a spurious **TS2741**.

```ts
declare function f<const T extends string>(x: T): [T];
declare function f<const T extends number>(x: T): { n: T };
const r = f(5);
const ok: { n: 5 } = r;   // tsc: clean (r = { n: 5 }) ; tsz (before): TS2741 (r = [string])
```

tsz picked overload **1**, defaulting `T` to its constraint `string` and
returning `[string]`.

## Root cause

For overload 1 (`const T extends string`) the argument `5` provides no valid
lower bound, so inference falls back to the constraint — `T` becomes `string`
and the parameter name is recorded in `constraint_fallback_tp_names`
(`crates/tsz-solver/src/operations/generic_call/resolve/finalize.rs`, ~L963).

The final argument check then **correctly** produces an `ArgumentTypeMismatch`
(`5` not assignable to `string`). But the bare-`const`-type-param skip a few
lines later (`finalize.rs` ~L1401) unconditionally swallowed that mismatch and
returned `CallResult::Success([string])`, on the rationale that *"const params
are inferred directly from the argument, so the argument is always assignable by
construction."* That rationale is **false on the constraint-fallback path**: the
argument was never inferred from — it was discarded in favor of the constraint —
so the parameter became `string` and `5` is genuinely incompatible. The spurious
`Success` locked overload 1 in, so overload 2 (`const T extends number`,
`T = 5`, `{ n: 5 }`) could never win.

## Structural rule

> When an overload's generic type parameter supplies no valid lower bound from
> the argument and therefore falls back to its **constraint**, the candidate must
> be re-validated: if the original argument is not assignable to the
> constraint-instantiated parameter, the signature is non-applicable and a later
> overload may win.

## Owner layer

Solver — `finalize.rs` candidate-applicability scoring. The
`is_bare_const_type_param` skip is now gated on
`!constraint_fallback_tp_names.contains(&tp.name)`, so a const parameter that
fell back to its constraint no longer suppresses the genuine mismatch. This
mirrors the adjacent `default_fallback_tp_names` skip (~L1379), which already
exempts the fallback path; plain (non-`const`) constrained overloads were
already correct because they have no unconditional skip. The legitimate const
skip (the `in_const_assertion` TypeId divergence when a const param *is* inferred
from the argument) is untouched.

## Anti-hardcoding

The decision is purely structural — keyed on `tp.is_const`, the
`constraint_fallback_tp_names` set the solver already maintains, and a
`TypeParameter` identity match. No identifier / file-name / printer-string
checks. Every test varies the binder names.

## Adjacent matrix (differential vs bundled `tsc`, `--strict --noEmit`)

| source | tsc | tsz before | tsz after |
|---|---|---|---|
| `f(5)` over const `string`/`number` overloads → `{ n: 5 }` | ok | TS2741 | ✓ ok |
| renamed binders (`widget`/`Elem`) | ok | TS2741 | ✓ ok |
| `f("a")` matches overload 1 → `["a"]` | ok | ok | ✓ ok |
| 3-way const overloads, `f(true)` → `{ b: true }` | ok | TS2741 | ✓ ok |
| arg matches **no** constraint (`f(true)` over `string`/`number`) | TS2769 | TS2769 | ✓ TS2769 |
| plain (non-const) overloads, `f(5)` → `{ n: 5 }` | ok | ok | ✓ ok |
| single-sig const generic `g(5)` (`T extends string`) | TS2345 | TS2345 | ✓ TS2345 |
| bare-const genuine infer `h([1,2,3])` → `readonly [1,2,3]` | ok | ok | ✓ ok |

## Verification

- New `crates/tsz-checker/tests/overload_constraint_fallback_applicability_tests.rs`
  (8 cases covering the matrix above) — 8/8 pass.
- Adjacent suites unchanged: `overload_inference_literal_preservation_tests`
  (7), `overload_modifier_tests` (48),
  `issue_9785_const_type_param_satisfies_repro` (8) — all green.
- `generic_call_inference_tests`: the 5 failing entries
  (`*_generator_*_ts2345`, `generic_rest_parameter_infers_literal_tuple_*`,
  `noinfer_array_alias_widens_to_primitive`,
  `pipe_contextual_return_flows_through_nested_generic_call_chain`) reproduce
  identically on clean `main` (stash-verified) — net-new failures = 0.
- `cargo clippy -p tsz-checker --tests` clean.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMSKnPewr94ZLpoJbALDsT)_