### PR TITLE
fix(checker): instantiate inherited-constructor defaulted type arg through the substitution (false TS2322)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -794,6 +794,9 @@ path = "tests/ts2353_tests.rs"
 name = "enum_discriminant_excess_property_tests"
 path = "tests/enum_discriminant_excess_property_tests.rs"
 [[test]]
+name = "inherited_constructor_defaulted_type_arg_tests"
+path = "tests/inherited_constructor_defaulted_type_arg_tests.rs"
+[[test]]
 name = "excess_property_check_recursive_intersection_tests"
 path = "tests/excess_property_check_recursive_intersection_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -1440,14 +1440,34 @@ impl<'a> CheckerState<'a> {
                                 for &arg_idx in &args.nodes {
                                     type_args.push(self.get_type_from_type_node(arg_idx));
                                 }
-                                // Fill missing args with defaults/constraints
+                                // Fill missing args with defaults/constraints,
+                                // instantiated against the substitution built so
+                                // far so a default that references an earlier
+                                // (supplied) param — `Items = T[]` with the
+                                // subclass writing `extends Base<number>` —
+                                // resolves `T` to `number` instead of leaving it
+                                // free in the inherited constructor. Mirrors the
+                                // instance-side path in `instance_merge.rs`.
                                 if type_args.len() < base_type_params.len() {
-                                    for param in base_type_params.iter().skip(type_args.len()) {
+                                    for (param_index, param) in
+                                        base_type_params.iter().enumerate().skip(type_args.len())
+                                    {
                                         let fallback = param
                                             .default
                                             .or(param.constraint)
                                             .unwrap_or(TypeId::UNKNOWN);
-                                        type_args.push(fallback);
+                                        let substitution = TypeSubstitution::from_args(
+                                            self.ctx.types,
+                                            &base_type_params[..param_index],
+                                            &type_args,
+                                        );
+                                        type_args.push(
+                                            crate::query_boundaries::common::instantiate_type_preserving_meta(
+                                                self.ctx.types,
+                                                fallback,
+                                                &substitution,
+                                            ),
+                                        );
                                     }
                                 }
                                 if type_args.len() > base_type_params.len() {
@@ -1554,12 +1574,28 @@ impl<'a> CheckerState<'a> {
                                 type_args_vec.push(self.get_type_from_type_node(arg_idx));
                             }
                             if type_args_vec.len() < base_type_params.len() {
-                                for param in base_type_params.iter().skip(type_args_vec.len()) {
+                                // Instantiate each unsupplied default through the
+                                // substitution so far (see the sibling loop above)
+                                // so inter-param default references resolve.
+                                for (param_index, param) in
+                                    base_type_params.iter().enumerate().skip(type_args_vec.len())
+                                {
                                     let fallback = param
                                         .default
                                         .or(param.constraint)
                                         .unwrap_or(TypeId::UNKNOWN);
-                                    type_args_vec.push(fallback);
+                                    let substitution = TypeSubstitution::from_args(
+                                        self.ctx.types,
+                                        &base_type_params[..param_index],
+                                        &type_args_vec,
+                                    );
+                                    type_args_vec.push(
+                                        crate::query_boundaries::common::instantiate_type_preserving_meta(
+                                            self.ctx.types,
+                                            fallback,
+                                            &substitution,
+                                        ),
+                                    );
                                 }
                             }
                             if type_args_vec.len() > base_type_params.len() {
@@ -1659,12 +1695,28 @@ impl<'a> CheckerState<'a> {
                             self.push_type_parameters(&base_class.type_parameters);
 
                         if type_args.len() < base_type_params.len() {
-                            for param in base_type_params.iter().skip(type_args.len()) {
+                            // Instantiate each unsupplied default through the
+                            // substitution so far (see the sibling loops above)
+                            // so inter-param default references resolve.
+                            for (param_index, param) in
+                                base_type_params.iter().enumerate().skip(type_args.len())
+                            {
                                 let fallback = param
                                     .default
                                     .or(param.constraint)
                                     .unwrap_or(TypeId::UNKNOWN);
-                                type_args.push(fallback);
+                                let substitution = TypeSubstitution::from_args(
+                                    self.ctx.types,
+                                    &base_type_params[..param_index],
+                                    &type_args,
+                                );
+                                type_args.push(
+                                    crate::query_boundaries::common::instantiate_type_preserving_meta(
+                                        self.ctx.types,
+                                        fallback,
+                                        &substitution,
+                                    ),
+                                );
                             }
                         }
                         if type_args.len() > base_type_params.len() {

--- a/crates/tsz-checker/tests/inherited_constructor_defaulted_type_arg_tests.rs
+++ b/crates/tsz-checker/tests/inherited_constructor_defaulted_type_arg_tests.rs
@@ -1,0 +1,110 @@
+//! Regression tests for inherited-constructor instantiation of a base class
+//! whose defaulted type parameter references an earlier parameter.
+//!
+//! Structural rule (owner: `class_type/constructor.rs`): when a base class has a
+//! defaulted type parameter whose default references an earlier parameter
+//! (`class Base<T, Items = T[]>`) and a subclass supplies only the earlier
+//! argument (`class Sub extends Base<number>`), the inherited-constructor path
+//! must instantiate the default through the substitution being built so the
+//! earlier argument (`T = number`) propagates into the default (`Items =
+//! number[]`). The three missing-type-arg fill loops previously pushed the raw
+//! default (`T[]`) with `T` left free, so `new Sub([1, 2, 3])` checked
+//! `number[]` against an abstract `T[]` and drew a spurious TS2322. This mirrors
+//! the already-correct instance-side path in `class_type/instance_merge.rs`.
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut c = check_source_codes(source);
+    c.sort_unstable();
+    c.dedup();
+    c
+}
+
+#[test]
+fn inherited_ctor_array_default_resolves_earlier_param() {
+    assert!(
+        codes(
+            r#"
+class Base<T, Items = T[]> {
+  constructor(public items: Items) {}
+}
+class IntList extends Base<number> {}
+const il = new IntList([1, 2, 3]);
+"#,
+        )
+        .is_empty(),
+        "Items = T[] should resolve to number[] in the inherited constructor",
+    );
+}
+
+#[test]
+fn inherited_ctor_object_shape_default_resolves_earlier_param() {
+    assert!(
+        codes(
+            r#"
+class Base<T, S = { value: T; list: T[] }> {
+  constructor(public s: S) {}
+}
+class C extends Base<number> {}
+const c = new C({ value: 1, list: [2, 3] });
+"#,
+        )
+        .is_empty(),
+        "object-shape default referencing T should resolve to number",
+    );
+}
+
+#[test]
+fn inherited_ctor_default_resolves_earlier_param_renamed_binders() {
+    // Not keyed on `T`/`Items` names.
+    assert!(
+        codes(
+            r#"
+class Base<A, B = A[]> {
+  constructor(public b: B) {}
+}
+class Sub extends Base<string> {}
+const s = new Sub(["a", "b"]);
+"#,
+        )
+        .is_empty(),
+        "renamed defaulted-param reference should resolve",
+    );
+}
+
+#[test]
+fn direct_instantiation_with_defaulted_param_still_clean() {
+    // Control: direct instantiation (not via a subclass) already worked.
+    assert!(
+        codes(
+            r#"
+class Base<T, Items = T[]> {
+  constructor(public items: Items) {}
+}
+const b = new Base<number>([1, 2, 3]);
+"#,
+        )
+        .is_empty(),
+        "direct instantiation should remain clean",
+    );
+}
+
+#[test]
+fn inherited_ctor_incompatible_argument_still_errors() {
+    // Negative control: a genuinely wrong element type must still error — the
+    // fix resolves the default, it does not suppress real mismatches.
+    assert!(
+        codes(
+            r#"
+class Base<T, Items = T[]> {
+  constructor(public items: Items) {}
+}
+class IntList extends Base<number> {}
+const il = new IntList(["a", "b"]);
+"#,
+        )
+        .contains(&2322),
+        "a string[] argument to a number[] parameter must still draw TS2322",
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
When a base class has a defaulted type parameter whose default references an **earlier** parameter (`class Base<T, Items = T[]>`) and a subclass supplies only the earlier argument (`class IntList extends Base<number>`), tsz left `T` free in the inherited constructor, so `new IntList([1, 2, 3])` checked `number[]` against an abstract `T[]` and drew a spurious **TS2322** (one per element). tsc resolves `Items = number[]` and accepts.

```ts
class Base<T, Items = T[]> { constructor(public items: Items) {} }
class IntList extends Base<number> {}
const il = new IntList([1, 2, 3]);   // tsc: clean ;  tsz (before): 3× TS2322
```

## Root cause / fix
The three missing-type-arg fill loops in `class_type/constructor.rs` pushed the **raw** default (`param.default.or(constraint).unwrap_or(UNKNOWN)`) into the type-argument list *before* building the `TypeSubstitution`. Because the slot was pre-filled, the solver's Phase-3 default resolution (which correctly instantiates a default against the substitution-so-far) was skipped, so `Items` bound to `T[]` with `T` still abstract.

Fix: instantiate each unsupplied default through `TypeSubstitution::from_args` over the params filled so far (via `instantiate_type_preserving_meta`), so `T → number` propagates into `Items = T[]` yielding `number[]`. This mirrors the already-correct **instance-side** path in `class_type/instance_merge.rs` (which is why instance-method use already worked).

Additive/contained: only changes the value pushed for an unsupplied trailing base type-param whose default references an earlier param. Owner: checker (the constructor builder mis-fed the solver `TypeSubstitution` helper; the solver's `from_args` was already correct).

## Verification
- **Flips 3 tests** (fail on main, pass with fix; confirmed by stash-build-diff): array default, object-shape default, renamed-binder default.
- **2 controls hold** on base and fix: direct instantiation (`new Base<number>([…])`); incompatible argument (`new IntList(["a"])`) still draws TS2322.
- Matches tsc 6.0.3 across array / object-shape / `Map` defaults + renamed binders + the negative control.
- **Neutral**: the full `tsz-checker` test set is **7136 passed / 77 failed identically** on the pristine base and with this change (verified by rebuild-and-diff; the 77 are pre-existing, unrelated). Focused class/heritage/constructor/generic-default binaries: 368/368 pass.
- Full suites: CI gates this PR.

Discovered via a broad tsz-vs-tsc additive-false-positive sweep (generic-instantiation area); the generic-container-subclass pattern is common in real code.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
