### PR TITLE
fix(solver): infer from the last member of a callable intersection (LastOfUnion idiom, false TS2322)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -803,6 +803,9 @@ path = "tests/enum_discriminant_excess_property_tests.rs"
 name = "inherited_constructor_defaulted_type_arg_tests"
 path = "tests/inherited_constructor_defaulted_type_arg_tests.rs"
 [[test]]
+name = "intersection_infer_last_member_tests"
+path = "tests/intersection_infer_last_member_tests.rs"
+[[test]]
 name = "excess_property_check_recursive_intersection_tests"
 path = "tests/excess_property_check_recursive_intersection_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/intersection_infer_last_member_tests.rs
+++ b/crates/tsz-checker/tests/intersection_infer_last_member_tests.rs
@@ -1,0 +1,139 @@
+//! Regression tests for `infer` extraction from an intersection of function /
+//! callable types: tsc settles on the **last** member (last-wins), the basis of
+//! the `UnionToIntersection` / `LastOfUnion` idiom.
+//!
+//! Structural rule (owner: `evaluation/evaluate_rules/infer_pattern.rs`, the
+//! intersection-source arm of `match_infer_pattern_inner`): for a
+//! function/callable pattern, the matching member of an all-/mixed-callable
+//! intersection that binds the `infer` variable is the LAST one — for both
+//! covariant-return (`(()=>"x")&(()=>"y")&(()=>"z")` extends `() => infer R` →
+//! `"z"`) and contravariant-parameter (`((k:"a")=>void)&((k:"b")=>void)` extends
+//! `(k: infer K) => void` → `"b"`) positions. The arm previously accepted the
+//! FIRST matching member, mis-binding to `"x"`/`"a"` and drawing a spurious
+//! TS2322. Non-signature patterns keep declaration order (first
+//! structurally-matching constituent), e.g. picking the callable out of a
+//! `callable & brand` intersection.
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut c = check_source_codes(source);
+    c.sort_unstable();
+    c.dedup();
+    c
+}
+
+#[test]
+fn covariant_return_infer_picks_last_member() {
+    assert!(
+        codes(
+            r#"
+type I = (() => "x") & (() => "y") & (() => "z");
+type L = I extends () => infer R ? R : never;
+const a: "z" = (null as any as L);
+"#,
+        )
+        .is_empty(),
+        "infer R from an intersection of return-typed functions should be the last (\"z\")",
+    );
+}
+
+#[test]
+fn contravariant_param_infer_picks_last_member() {
+    assert!(
+        codes(
+            r#"
+type I = ((k: "a") => void) & ((k: "b") => void);
+type P = I extends (k: infer K) => void ? K : never;
+const p: "b" = (null as any as P);
+"#,
+        )
+        .is_empty(),
+        "infer K from an intersection of param-typed functions should be the last (\"b\")",
+    );
+}
+
+#[test]
+fn last_of_union_idiom_resolves() {
+    // The full type-fest LastOfUnion / UnionToTuple idiom.
+    assert!(
+        codes(
+            r#"
+type UnionToIntersection<U> =
+  (U extends any ? (k: U) => void : never) extends (k: infer I) => void ? I : never;
+type LastOf<U> =
+  UnionToIntersection<U extends any ? () => U : never> extends () => infer R ? R : never;
+type X = LastOf<"a" | "b" | "c">;
+const x: "c" = (null as any as X);
+"#,
+        )
+        .is_empty(),
+        "LastOf<\"a\"|\"b\"|\"c\"> should resolve to \"c\"",
+    );
+}
+
+#[test]
+fn two_member_intersection_picks_last() {
+    assert!(
+        codes(
+            r#"
+type I = (() => "x") & (() => "y");
+type L = I extends () => infer R ? R : never;
+const a: "y" = (null as any as L);
+"#,
+        )
+        .is_empty(),
+        "two-member function intersection infer should be the last (\"y\")",
+    );
+}
+
+#[test]
+fn last_wins_negative_control_not_first() {
+    // The result must NOT be the first member: assigning the first literal is an
+    // error, proving last-wins rather than accept-anything.
+    assert_eq!(
+        codes(
+            r#"
+type I = (() => "x") & (() => "y") & (() => "z");
+type L = I extends () => infer R ? R : never;
+const bad: "x" = (null as any as L);
+"#,
+        ),
+        vec![2322],
+        "L is \"z\", so assigning to \"x\" must error",
+    );
+}
+
+#[test]
+fn object_intersection_still_gathers_all_members() {
+    // Control: a non-signature (object) pattern must still collect properties
+    // from every intersection member.
+    assert!(
+        codes(
+            r#"
+type I = { a: 1 } & { b: 2 };
+type R = I extends { a: infer A; b: infer B } ? [A, B] : never;
+const r: [1, 2] = (null as any as R);
+"#,
+        )
+        .is_empty(),
+        "object-pattern intersection infer must gather all members",
+    );
+}
+
+#[test]
+fn callable_and_brand_intersection_still_picks_callable() {
+    // Control: a `callable & brand` intersection still binds from the callable
+    // constituent (declaration order is irrelevant when only one matches).
+    assert!(
+        codes(
+            r#"
+type Fn = ((x: number) => void) & { brand: "z" };
+type P = Fn extends (x: infer A) => void ? A : never;
+const p: number = (null as any as P);
+"#,
+        )
+        .is_empty(),
+        "callable & brand intersection should bind from the callable member",
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -1836,7 +1836,26 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // the constituent the pattern targets.
         if let Some(TypeData::Intersection(members)) = self.interner().lookup(source) {
             let members = self.interner().type_list(members);
-            for &member in members.iter() {
+            // For a function/callable pattern, tsc's `infer` settles on the
+            // LAST matching member of an intersection (last-wins), for both
+            // covariant-return (`(()=>"x")&(()=>"y")&(()=>"z")` vs
+            // `() => infer R` → "z") and contravariant-parameter
+            // (`((k:"a")=>void)&((k:"b")=>void)` vs `(k: infer K) => void` → "b")
+            // positions — the UnionToIntersection/LastOfUnion idiom. Iterate in
+            // reverse so the last matching callable member binds. For every
+            // other pattern keep declaration order (first structurally-matching
+            // constituent wins), the long-standing behavior used to pick the
+            // callable constituent out of a `callable & brand` intersection.
+            let pattern_is_signature = matches!(
+                self.interner().lookup(pattern),
+                Some(TypeData::Function(_) | TypeData::Callable(_))
+            );
+            let ordered: Vec<TypeId> = if pattern_is_signature {
+                members.iter().rev().copied().collect()
+            } else {
+                members.iter().copied().collect()
+            };
+            for member in ordered {
                 if member == source {
                     continue;
                 }


### PR DESCRIPTION
Goal: green

## Summary
When a conditional infers through a **function/callable pattern** from an **intersection of callable types**, tsz bound the `infer` variable from the **first** member; tsc uses the **last** (last-wins). This is the basis of the `UnionToIntersection` / `LastOfUnion` idiom, so `LastOf<"a" | "b" | "c">` wrongly yielded `"a"` and drew a spurious **TS2322**.

```ts
type I = (() => "x") & (() => "y") & (() => "z");
type L = I extends () => infer R ? R : never;
const a: "z" = (null as any as L);   // tsc: clean (L = "z") ;  tsz (before): TS2322 (L = "x")
```

tsc settles on the last member for **both** infer positions (verified empirically):
- covariant return: `(()=>"x")&(()=>"y")&(()=>"z")` extends `() => infer R` → `"z"`.
- contravariant parameter: `((k:"a")=>void)&((k:"b")=>void)` extends `(k: infer K) => void` → `"b"`.

## Root cause / fix
`match_infer_pattern_inner`'s intersection-source arm (`evaluation/evaluate_rules/infer_pattern.rs`) iterated members in declaration order and accepted the first that matched the pattern. For a `Function`/`Callable` pattern, iterate the members in **reverse** so the last matching member binds. Every other pattern keeps declaration order — preserving the long-standing behavior of picking the callable constituent out of a `callable & brand` intersection, and letting object patterns gather properties from all members.

Owner: solver evaluation (infer-pattern matching). Contained: only changes member iteration order, and only for signature patterns.

## Verification
- **Flips 5 tests** (fail on main, pass with fix; confirmed by stash-build-diff): covariant return, contravariant param, the `LastOf` idiom, 2-member intersection, and the last-wins negative control (`const bad: "x"` must error).
- **2 controls hold** on base and fix: object-pattern intersection still gathers all members (`{a:1}&{b:2}` → `[1,2]`); `callable & brand` still binds the callable member.
- Matches tsc 6.0.3 across the matrix.
- Neutral: `cargo nextest -p tsz-solver` over infer/conditional/intersection/callable/function = 2162 passed, 1 failed; the 1 (`test_conditional_infer_optional_property_present_distributive`) fails on the base too.
- Full suites: CI gates this PR.

Discovered via a broad tsz-vs-tsc additive-false-positive sweep (conditional-types area); the `UnionToIntersection`/`UnionToTuple` idiom is pervasive (type-fest, etc.).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
