### PR TITLE
fix(checker): use inferred get-accessor return type at property access (missed TS2322)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -994,6 +994,9 @@ mod indexed_access_constraint_relation_routing_arch_tests;
 #[path = "tests/infer_conditional_relation_routing_arch_tests.rs"]
 mod infer_conditional_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/inferred_getter_return_property_access_tests.rs"]
+mod inferred_getter_return_property_access_tests;
+#[cfg(test)]
 #[path = "tests/initializer_relation_routing_arch_tests.rs"]
 mod initializer_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/inferred_getter_return_property_access_tests.rs
+++ b/crates/tsz-checker/src/tests/inferred_getter_return_property_access_tests.rs
@@ -1,0 +1,121 @@
+//! Regression tests for inferred get-accessor return types flowing to property
+//! access (issue #14511).
+//!
+//! A class getter with no explicit return annotation must contribute its
+//! *inferred* return type as the property type at access sites. The defect was
+//! that `this.<field>` inside the getter body resolved against a Phase 0 prescan
+//! instance type whose members are all `any` (initializers/getter bodies not yet
+//! evaluated), so the inferred return collapsed to `any` and tsz missed the
+//! `TS2322` that `tsc` reports. The fix ranks the instance-`this` candidate by
+//! how *resolved* its members are, so the freshly-built partial type (concrete
+//! members) wins over the all-`any` prescan during getter-body inference.
+//!
+//! Binder names are varied across cases so the behavior cannot be keyed on any
+//! identifier.
+
+use crate::test_utils::check_source_strict_codes;
+
+fn assert_has_2322(src: &str) {
+    let codes = check_source_strict_codes(src);
+    assert!(
+        codes.contains(&2322),
+        "expected TS2322, got none. Got: {codes:?}"
+    );
+}
+
+fn assert_no_2322(src: &str) {
+    let codes = check_source_strict_codes(src);
+    assert!(!codes.contains(&2322), "unexpected TS2322. Got: {codes:?}");
+}
+
+#[test]
+fn inferred_getter_reading_field_is_number_at_access() {
+    // `get count()` infers `number` from `this._v`; assigning it to `string`
+    // must report TS2322 at the access site.
+    assert_has_2322(
+        "class C { _v = 0; get count() { return this._v; } }
+         const wrong: string = new C().count;",
+    );
+}
+
+#[test]
+fn inferred_getter_is_widened_not_literal() {
+    // The inferred getter return widens `0` to `number`, so a `123` target still
+    // mismatches (parity with tsc's getter inference).
+    assert_has_2322(
+        "class C { _v = 0; get count() { return this._v; } }
+         const probe: 123 = new C().count;",
+    );
+}
+
+#[test]
+fn inferred_getter_valid_assignment_stays_clean() {
+    assert_no_2322(
+        "class C { _v = 0; get count() { return this._v; } }
+         const ok: number = new C().count;",
+    );
+}
+
+#[test]
+fn inferred_getter_renamed_binders() {
+    // Same shape with different identifiers — the fix is structural, not name-keyed.
+    assert_has_2322(
+        "class Node { internalValue = 42; get exposed() { return this.internalValue; } }
+         const bad: string = new Node().exposed;",
+    );
+}
+
+#[test]
+fn inferred_getter_setter_pair_uses_getter_return() {
+    // A getter+setter pair's property type is the getter's (inferred) return type.
+    assert_has_2322(
+        "class P {
+            _v = 0;
+            get count() { return this._v; }
+            set count(x: number) { this._v = x; }
+         }
+         const bad: string = new P().count;",
+    );
+}
+
+#[test]
+fn inferred_getter_returning_union() {
+    // `this.flag ? 1 : \"a\"` infers `number | string`; assigning to `boolean`
+    // mismatches.
+    assert_has_2322(
+        "class U { flag = true; get k() { return this.flag ? 1 : \"a\"; } }
+         const bad: boolean = new U().k;",
+    );
+}
+
+#[test]
+fn inferred_getter_reading_another_inferred_getter() {
+    // A getter reading another inferred getter still resolves to the concrete type.
+    assert_has_2322(
+        "class Chain {
+            _v = 0;
+            get a() { return this._v; }
+            get b() { return this.a; }
+         }
+         const bad: string = new Chain().b;",
+    );
+}
+
+#[test]
+fn explicit_getter_annotation_unchanged() {
+    // Control: an explicitly-annotated getter is unaffected by the fix.
+    assert_has_2322(
+        "class E { _v = 0; get count(): number { return this._v; } }
+         const bad: string = new E().count;",
+    );
+}
+
+#[test]
+fn inferred_getter_returning_this_preserves_polymorphic_this() {
+    // Control: a getter whose body is `return this` stays the class instance type
+    // (polymorphic `this`), not collapsed to `any`.
+    assert_has_2322(
+        "class S { x = 1; get me() { return this; } }
+         const bad: number = new S().me;",
+    );
+}

--- a/crates/tsz-checker/src/types/queries/class.rs
+++ b/crates/tsz-checker/src/types/queries/class.rs
@@ -1412,17 +1412,36 @@ impl<'a> CheckerState<'a> {
         }
 
         if !is_static {
-            let object_property_count = |this: &Self, type_id| {
+            // Rank an instance-`this` candidate by how *resolved* its members are,
+            // not merely how many it has: `(non-`any` property count, total property
+            // count)`. A Phase 0 prescan instance type carries every member but
+            // types them all `any` (initializers/getter bodies not yet evaluated),
+            // while the partial type built during real construction has fewer
+            // members but types them concretely. Comparing on total count alone let
+            // the all-`any` prescan shadow the partial type when resolving `this`
+            // inside a deferred getter body, so `this.field` came back `any` and the
+            // getter's inferred return type collapsed to `any` (missed TS2322).
+            // Ranking resolved members first keeps the genuinely-fuller candidate
+            // winning while never preferring an all-`any` shape over a typed one.
+            let object_property_rank = |this: &Self, type_id| {
                 crate::query_boundaries::common::object_shape_for_type(this.ctx.types, type_id)
-                    .map(|shape| shape.properties.len())
-                    .unwrap_or(0)
+                    .map(|shape| {
+                        let total = shape.properties.len();
+                        let resolved = shape
+                            .properties
+                            .iter()
+                            .filter(|prop| prop.type_id != TypeId::ANY)
+                            .count();
+                        (resolved, total)
+                    })
+                    .unwrap_or((0, 0))
             };
 
             if let Some(cached) = cached_instance_this
                 && cached != TypeId::ANY
                 && cached != TypeId::ERROR
             {
-                let cached_count = object_property_count(self, cached);
+                let cached_rank = object_property_rank(self, cached);
                 let in_progress = self
                     .ctx
                     .class_instance_type_cache
@@ -1432,7 +1451,7 @@ impl<'a> CheckerState<'a> {
                 if let Some(in_progress) = in_progress
                     && in_progress != TypeId::ANY
                     && in_progress != TypeId::ERROR
-                    && object_property_count(self, in_progress) > cached_count
+                    && object_property_rank(self, in_progress) > cached_rank
                 {
                     if let Some(info) = self.ctx.enclosing_class.as_mut()
                         && info.class_idx == class_idx


### PR DESCRIPTION
Goal: hold

Closes #14511.

## Summary

A class get-accessor with an **inferred** return type was typed `any` at the
property-access site, so tsz missed assignability errors that `tsc` reports:

```ts
class C {
  _v = 0;
  get count() { return this._v; }   // inferred number
}
const wrong: string = new C().count;   // tsc: TS2322 ; tsz (before): MISSED
const probe: 123  = new C().count;     // tsc: TS2322 ; tsz (before): MISSED
```

With an explicit return annotation tsz was already correct, so the gap was
specifically **getter return-type inference flowing to property access**.

## Root cause

While building the class instance type, deferred get-accessor bodies are
inferred under a freshly-built *partial* `this` type whose members are
concretely typed (`crates/tsz-checker/src/types/class_type/instance.rs`). But
`this.<field>` inside the getter resolves `this` through
`class_member_this_type` (`crates/tsz-checker/src/types/queries/class.rs`),
which chose between that partial type (`cached_instance_this`) and an
`in_progress` type from `class_instance_type_cache` by preferring whichever had
**more total properties**.

The `in_progress` candidate is the Phase 0 *prescan* instance type — it carries
every member but types them all `any` (initializers/getter bodies not yet
evaluated). Having more properties, it shadowed the partial type, so
`this._v` came back `any` and the getter's inferred return collapsed to `any`.

## Structural rule

> When choosing the instance-`this` candidate for a class member body, prefer
> the **more resolved** type — ranked `(non-`any` property count, total property
> count)` — not merely the one with more properties. An all-`any` prescan shape
> must never shadow a partial shape whose members are concretely typed.

The decision is purely structural (property type identity vs `any`); it reads no
identifier, file-name, or printer output. Tests vary the binder names.

## Owner layer

Checker only — the class-member `this`-type selection heuristic. The fix
generalizes that heuristic rather than special-casing getters; the prescan
shape is still available for Phase 1 initializer resolution (its legitimate
role), it just no longer outranks a more-resolved partial shape.

## Adjacent matrix

| source | tsc | tsz before | tsz after |
|---|---|---|---|
| inferred `get count()` reading `this._v`, assigned to `string` | TS2322 | missed | ✓ TS2322 |
| same, assigned to `123` (widened to `number`) | TS2322 | missed | ✓ TS2322 |
| getter+setter pair (property type = getter return) | TS2322 | missed | ✓ TS2322 |
| getter returning `cond ? 1 : "a"` → `number \| string` | TS2322 | missed | ✓ TS2322 |
| getter reading another inferred getter | TS2322 | missed | ✓ TS2322 |
| renamed binders | TS2322 | missed | ✓ TS2322 |
| explicit `get count(): number` (control) | TS2322 | TS2322 | ✓ TS2322 |
| getter `return this` (polymorphic `this` control) | TS2322 | TS2322 | ✓ TS2322 |
| valid `const ok: number = new C().count` (negative control) | clean | clean | ✓ clean |

## Verification

- New `crates/tsz-checker/src/tests/inferred_getter_return_property_access_tests.rs`
  (9 cases above): `cargo test -p tsz-checker --lib inferred_getter_return_property_access` → 9/9 pass.
- `cargo test -p tsz-checker --lib accessor` / `--lib getter`: green except one
  failure (`split_accessor_variance_tests::type_literal_split_accessor_narrower_setter_rejected`)
  that reproduces identically on clean `main` (stash-verified) — net-new = 0.
- `cargo clippy -p tsz-checker --lib` clean; `cargo fmt` clean.
- This is a false-*negative* fix (tsz starts emitting correct errors) with broad
  reach, so the conformance / project-corpus parity floor is owned by
  ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01DqazEkKtrCeB9Au2XjdDgp)_