### PR TITLE
fix(solver): homomorphic mapped alias over readonly-numeric-index source must not reshape to array

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -207,6 +207,9 @@ path = "tests/homomorphic_mapped_keyof_modifier_tests.rs"
 name = "homomorphic_mapped_index_display_tests"
 path = "tests/homomorphic_mapped_index_display_tests.rs"
 [[test]]
+name = "homomorphic_mapped_alias_readonly_index_source_tests"
+path = "tests/homomorphic_mapped_alias_readonly_index_source_tests.rs"
+[[test]]
 name = "intersection_modifier_merge_tests"
 path = "tests/intersection_modifier_merge_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/homomorphic_mapped_alias_readonly_index_source_tests.rs
+++ b/crates/tsz-checker/tests/homomorphic_mapped_alias_readonly_index_source_tests.rs
@@ -175,7 +175,7 @@ const value: Result = { A: 1, B: 2, C: 3 };
 "#,
     );
     assert!(
-        relation_codes(&diags).iter().any(|&c| c == 2353),
+        relation_codes(&diags).contains(&2353),
         "an excess string-named property must still error (TS2353), got: {diags:#?}"
     );
 }

--- a/crates/tsz-checker/tests/homomorphic_mapped_alias_readonly_index_source_tests.rs
+++ b/crates/tsz-checker/tests/homomorphic_mapped_alias_readonly_index_source_tests.rs
@@ -1,0 +1,181 @@
+//! Regression coverage for #14509: a homomorphic mapped-type **alias**
+//! `type M<T> = { [K in keyof T]: T[K] }` applied to a source carrying a
+//! **readonly numeric (or string) index signature** must evaluate like the
+//! inline mapped form, not collapse into a `readonly V[]` array shape.
+//!
+//! Root cause: the mapped-type instantiator's `extract_array_element` (and the
+//! sibling array-shortcut paths) treated *any* object with a readonly numeric
+//! index signature as a `ReadonlyArray`. A plain `{ readonly [k: number]: V }`
+//! object — including a `typeof enum`, which is exactly a numeric index
+//! signature plus named members — has such an index but is **not** an array, so
+//! reshaping it into an array left the aliased application unevaluated and drew
+//! a spurious TS2322 (and TS2339 on member access). The fix gates the
+//! readonly-numeric-index → array shortcut on the array marker methods
+//! (`slice`/`concat`), the same structural signal the evaluator and the
+//! conditional `infer` array path already use.
+
+use tsz_checker::context::CheckerOptions;
+
+fn strict_with_libs(source: &str) -> Vec<(u32, String)> {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn relation_codes(diags: &[(u32, String)]) -> Vec<u32> {
+    diags
+        .iter()
+        .filter(|(code, _)| matches!(*code, 2322 | 2339 | 2353))
+        .map(|(code, _)| *code)
+        .collect()
+}
+
+#[test]
+fn aliased_homomorphic_mapped_over_readonly_numeric_index_plus_named_evaluates() {
+    let diags = strict_with_libs(
+        r#"
+type Source = { readonly [x: number]: string; readonly A: 1; readonly B: 2 };
+type Identity<T> = { [K in keyof T]: T[K] };
+type Result = Identity<Source>;
+const value: Result = { A: 1, B: 2 };
+"#,
+    );
+    assert!(
+        relation_codes(&diags).is_empty(),
+        "aliased homomorphic mapped over readonly-numeric-index+named source should evaluate cleanly, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn aliased_homomorphic_mapped_member_access_is_not_ts2339() {
+    let diags = strict_with_libs(
+        r#"
+type Source = { readonly [x: number]: string; readonly A: 1; readonly B: 2 };
+type Identity<T> = { [K in keyof T]: T[K] };
+type Result = Identity<Source>;
+declare const r: Result;
+const a: 1 = r.A;
+const b: 2 = r.B;
+const n: string = r[5];
+"#,
+    );
+    assert!(
+        relation_codes(&diags).is_empty(),
+        "members of the evaluated alias must be accessible, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn aliased_homomorphic_mapped_over_typeof_enum_evaluates() {
+    // The original witness: `typeof E` is a numeric index signature plus named
+    // members, so it exercises the exact readonly-numeric-index shape.
+    let diags = strict_with_libs(
+        r#"
+enum E { A, B }
+type Identity<W> = { [Q in keyof W]: W[Q] };
+type Result = Identity<typeof E>;
+const value: Result = { A: E.A, B: E.B };
+"#,
+    );
+    assert!(
+        relation_codes(&diags).is_empty(),
+        "aliased homomorphic mapped over `typeof enum` should evaluate cleanly, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn aliased_homomorphic_mapped_over_readonly_string_index_plus_named_evaluates() {
+    let diags = strict_with_libs(
+        r#"
+type Source = { readonly [k: string]: number; readonly x: 1 };
+type Clone<Elem> = { [Key in keyof Elem]: Elem[Key] };
+type Result = Clone<Source>;
+const value: Result = { x: 1, y: 2 };
+"#,
+    );
+    assert!(
+        relation_codes(&diags).is_empty(),
+        "aliased homomorphic mapped over readonly-string-index+named source should evaluate cleanly, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn aliased_homomorphic_mapped_over_readonly_numeric_index_only_evaluates() {
+    // The index-signature-only shape (no named members) must also evaluate.
+    let diags = strict_with_libs(
+        r#"
+type Source = { readonly [x: number]: string };
+type Mirror<Box> = { [Slot in keyof Box]: Box[Slot] };
+type Result = Mirror<Source>;
+const value: Result = { 0: "x" };
+"#,
+    );
+    assert!(
+        relation_codes(&diags).is_empty(),
+        "aliased homomorphic mapped over readonly-numeric-index-only source should evaluate cleanly, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn aliased_homomorphic_mapped_over_readonly_array_still_maps_to_array() {
+    // A genuine `ReadonlyArray<V>` (which carries `slice`/`concat`) must still
+    // map to an array shape — the fix must not over-broaden and break this.
+    let diags = strict_with_libs(
+        r#"
+type Mirror<Box> = { [Slot in keyof Box]: Box[Slot] };
+type Result = Mirror<ReadonlyArray<number>>;
+const value: Result = [1, 2, 3];
+const len: number = value.length;
+const sliced: readonly number[] = value.slice();
+"#,
+    );
+    assert!(
+        relation_codes(&diags).is_empty(),
+        "genuine ReadonlyArray must still map to an array with its methods, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn aliased_homomorphic_mapped_over_mutable_array_still_maps_to_array() {
+    let diags = strict_with_libs(
+        r#"
+type Mirror<Box> = { [Slot in keyof Box]: Box[Slot] };
+type Result = Mirror<number[]>;
+const value: Result = [1, 2];
+value.push(3);
+"#,
+    );
+    assert!(
+        relation_codes(&diags).is_empty(),
+        "mutable Array must still map to a mutable array, got: {diags:#?}"
+    );
+}
+
+#[test]
+fn aliased_homomorphic_mapped_still_rejects_excess_property() {
+    // Negative control: the result is a real object with a readonly numeric
+    // index signature, so a string-named excess property is still rejected —
+    // proving the type was evaluated rather than blanket-accepted.
+    let diags = strict_with_libs(
+        r#"
+type Source = { readonly [x: number]: string; readonly A: 1; readonly B: 2 };
+type Identity<T> = { [K in keyof T]: T[K] };
+type Result = Identity<Source>;
+const value: Result = { A: 1, B: 2, C: 3 };
+"#,
+    );
+    assert!(
+        relation_codes(&diags).iter().any(|&c| c == 2353),
+        "an excess string-named property must still error (TS2353), got: {diags:#?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/array_infer.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/array_infer.rs
@@ -342,8 +342,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     }
 
     pub(crate) fn object_shape_has_readonly_array_markers(&self, shape_id: ObjectShapeId) -> bool {
-        self.object_shape_has_property(shape_id, "slice")
-            && self.object_shape_has_property(shape_id, "concat")
+        let shape = self.interner().object_shape(shape_id);
+        crate::type_queries::object_shape_has_array_marker_methods_db(self.interner(), &shape)
     }
 
     fn object_shape_has_property(&self, shape_id: ObjectShapeId, expected: &str) -> bool {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -1471,11 +1471,21 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             },
             // ObjectWithIndex with readonly numeric index: ReadonlyArray shape from lib
             Some(TypeData::ObjectWithIndex(shape_id)) => {
+                // A readonly numeric index signature alone is not enough — a
+                // plain `{ readonly [k: number]: V }` object has one but tsc
+                // maps it to an object, not `readonly V[]`. Require the array
+                // marker methods so only a genuine `ReadonlyArray<V>` takes the
+                // array shortcut (mirrors the guard in the object-source path
+                // and in `extract_array_element`).
                 let shape = self.interner().object_shape(shape_id);
                 let has_readonly_index = shape
                     .number_index
                     .as_ref()
-                    .is_some_and(|idx| idx.readonly && idx.key_type == TypeId::NUMBER);
+                    .is_some_and(|idx| idx.readonly && idx.key_type == TypeId::NUMBER)
+                    && crate::type_queries::object_shape_has_array_marker_methods_db(
+                        self.interner(),
+                        &shape,
+                    );
                 if has_readonly_index && let Some(index) = &shape.number_index {
                     tracing::trace!(
                         "evaluate_mapped: readonly-array-constrained type parameter → producing readonly array"

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -256,11 +256,26 @@ impl<'a> TypeInstantiator<'a> {
                 }
             }
             Some(TypeData::ObjectWithIndex(shape_id)) => {
+                // A readonly numeric index signature alone does NOT make this a
+                // `ReadonlyArray`: a plain `{ readonly [k: number]: V }` object
+                // (optionally with named members) has one too, and tsc maps it
+                // to an object with a readonly numeric index signature, not to
+                // `readonly V[]`. Require the array marker methods
+                // (`slice`/`concat`) — the same structural signal the mapped
+                // evaluator and conditional `infer` array paths use — before
+                // taking the array shortcut. Without this guard a homomorphic
+                // mapped alias over such a source was reshaped into an array and
+                // then failed to evaluate, surfacing as a spurious TS2322.
                 let shape = interner.object_shape(shape_id);
                 shape
                     .number_index
                     .as_ref()
-                    .filter(|idx| idx.readonly)
+                    .filter(|idx| {
+                        idx.readonly
+                            && crate::type_queries::object_shape_has_array_marker_methods_db(
+                                interner, &shape,
+                            )
+                    })
                     .map(|idx| (idx.value_type, true))
             }
             _ => None,

--- a/crates/tsz-solver/src/tests/file_size_baselines.txt
+++ b/crates/tsz-solver/src/tests/file_size_baselines.txt
@@ -27,7 +27,7 @@ solver_file_narrowing_core 2718
 solver_file_relations_compat 2950
 solver_file_constraints_walker 2348
 solver_file_diag_format_mod 2318
-solver_file_eval_mapped 1497
+solver_file_eval_mapped 1504
 solver_file_subtype_generics 2217
 solver_file_call_args 2097
 solver_file_eval_index_access 2226

--- a/crates/tsz-solver/src/type_queries/shape_queries.rs
+++ b/crates/tsz-solver/src/type_queries/shape_queries.rs
@@ -229,6 +229,34 @@ pub fn application_base_is_mapped_type_db<R: TypeResolver>(
     crate::visitors::visitor_predicates::is_mapped_type(type_db, body)
 }
 
+/// True when an object shape carries the `slice`/`concat` marker methods that
+/// distinguish a genuine (`Readonly`)`Array` lib shape from a plain object that
+/// merely happens to have a numeric index signature.
+///
+/// A bare `{ readonly [k: number]: V }` has a readonly numeric index signature
+/// but no array methods; `tsc` maps `{ [K in keyof T]: T[K] }` over it to an
+/// object with a readonly numeric index signature, **not** to `readonly V[]`.
+/// Only a real `ReadonlyArray<V>` (which carries `slice`/`concat`) maps to an
+/// array. Both the mapped-type instantiator and the mapped-type evaluator gate
+/// the readonly-numeric-index → array shortcut on this predicate so they agree.
+pub fn object_shape_has_array_marker_methods_db(
+    db: &dyn TypeDatabase,
+    shape: &crate::types::ObjectShape,
+) -> bool {
+    let slice = db.intern_string("slice");
+    let concat = db.intern_string("concat");
+    let mut has_slice = false;
+    let mut has_concat = false;
+    for prop in &shape.properties {
+        has_slice |= prop.name == slice;
+        has_concat |= prop.name == concat;
+        if has_slice && has_concat {
+            return true;
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Goal: green

Fixes #14509.

## Summary

A homomorphic mapped-type **alias** `type M<T> = { [K in keyof T]: T[K] }`
applied to a source carrying a **readonly numeric index signature** — e.g.
`{ readonly [x: number]: string; readonly A: 1; readonly B: 2 }`, or a
`typeof enum` (which is exactly a numeric index signature plus named members) —
did not evaluate. The aliased application stayed an unevaluated `M<…>`, so a
fresh object literal assigned to it drew a spurious **TS2322** and property
access on the result drew **TS2339**. `tsc` evaluates it and accepts. The
**inline** mapped form over the same source already evaluated correctly.

```ts
type O = { readonly [x: number]: string; readonly A: 1; readonly B: 2 };
type M<T> = { [K in keyof T]: T[K] };
type R = M<O>;
const x: R = { A: 1, B: 2 };   // tsc: clean ;  tsz (before): TS2322
```

## Root cause

When instantiating `M<O>`, the mapped-type instantiator resolves the source to
an `ObjectWithIndex` and decides whether it is array-like. Both
`extract_array_element`
(`crates/tsz-solver/src/instantiation/instantiate.rs`) and the sibling
`try_evaluate_mapped_over_array_like` array shortcut
(`crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs`) treated **any**
`ObjectWithIndex` with a *readonly numeric* index signature as a
`ReadonlyArray` and reshaped it into `readonly V[]`. A plain
`{ readonly [k: number]: V }` object (with or without named members) has such
an index but is **not** an array, so the reshape produced a mapped result the
relation could not reconcile and the application was left unevaluated.

The conditional `infer` array path
(`array_infer.rs::expanded_array_object_matches`) already guards this exact
distinction by requiring the array **marker methods** (`slice`/`concat`) before
treating a readonly-numeric-index object as an array. The two mapped paths were
missing that guard.

## Structural rule

> When a homomorphic mapped type's source resolves to an `ObjectWithIndex`
> whose readonly numeric index signature is **not** backed by the array marker
> methods (`slice`/`concat`), `tsc` maps it to an object with a readonly numeric
> index signature, not to `readonly V[]`. tsz now gates the
> readonly-numeric-index → array shortcut on that structural signal at both
> mapped sites.

## Owner layer

Solver. A shared free predicate
`object_shape_has_array_marker_methods_db` is added in
`type_queries/shape_queries.rs`; the two mapped sites
(`extract_array_element`, `try_evaluate_mapped_over_array_like`) now require it
alongside the readonly-numeric-index check, and the pre-existing
`TypeEvaluator::object_shape_has_readonly_array_markers` (the
conditional-infer guard) is refactored to reuse the same helper so all three
paths agree. No checker/emitter change.

## Anti-hardcoding

The decision is purely structural — presence of the `slice`/`concat` interned
member atoms on the resolved object shape, the same signal the conditional
`infer` array path already uses. No identifier / file-name / printer-string
checks. Tests vary the alias and type-parameter binder names
(`Identity`/`Clone`/`Mirror`, `T`/`Elem`/`Box`/`W`).

## Adjacent matrix (differential vs bundled `tsc`, `--strict --target es2020 --lib es2020`)

| source | tsc | tsz before | tsz after |
|---|---|---|---|
| `M<{ readonly [x:number]: string; A; B }>` | clean | TS2322 | ✓ clean |
| `M<typeof enum>` (numeric idx + named) | clean | TS2322 | ✓ clean |
| `M<{ readonly [k:string]: number; x }>` (string idx + named) | clean | TS2322 | ✓ clean |
| `M<{ readonly [x:number]: string }>` (idx only) | clean | TS2322 | ✓ clean |
| member access `r.A` / `r[5]` on aliased result | clean | TS2339 | ✓ clean |
| `M<ReadonlyArray<number>>` → still `readonly number[]` (`.length`/`.slice`) | clean | clean | ✓ clean |
| `M<number[]>` → still mutable array (`.push`) | clean | clean | ✓ clean |
| **neg:** excess string-named property on aliased result | TS2353 | (unevaluated) | ✓ TS2353 |

## Verification

- New `crates/tsz-checker/tests/homomorphic_mapped_alias_readonly_index_source_tests.rs`
  (8 cases covering the matrix above) — **8/8 pass**.
- `cargo test -p tsz-solver --lib` — the 3 residual failures
  (`test_conditional_infer_optional_property_present_distributive`,
  `literal_mask_preserves_object_vs_literal_reduction`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`)
  reproduce identically on clean `main` (stash-verified) — net-new failures = 0.
  File-size ratchet baseline updated for `eval_mapped` (1497→1504, well under
  the 2000-line ceiling).
- `cargo test -p tsz-checker --lib mapped` / `readonly`: the 6+3 failures are
  identical on clean `main` (pre-existing) — net-new = 0.
- `cargo fmt -p tsz-solver -p tsz-checker --check` clean;
  `cargo clippy -p tsz-solver --lib` clean.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzLXz5hoUcShBgeCuTatUe)_