### PR TITLE
fix(checker): union unwidened return literals, widen only a single-literal result

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -219,6 +219,9 @@ path = "tests/ts2371_binding_pattern_default_tests.rs"
 name = "block_body_callback_literal_widening_tests"
 path = "tests/block_body_callback_literal_widening_tests.rs"
 [[test]]
+name = "return_literal_union_widening_tests"
+path = "tests/return_literal_union_widening_tests.rs"
+[[test]]
 name = "conditional_branch_array_literal_widening_tests"
 path = "tests/conditional_branch_array_literal_widening_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -12,6 +12,19 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
+/// One block-body return contribution, collected *unwidened* so that a union of
+/// distinct fresh literals (`return "a"; return "b"` → `"a" | "b"`) is preserved
+/// rather than widened per branch. `widen_expr` is `Some(expr)` when this
+/// contribution is a fresh-literal return that would be widened on its own (no
+/// contextual / `satisfies` / `preserve_literal` / `const`-assertion /
+/// conditional carve-out); it is the expression node so the AST-aware widener
+/// (`widen_return_contribution_preserving_const`) can run if the union collapses
+/// to a single literal. See `infer_return_type_from_body_inner` (#14530).
+struct ReturnContribution {
+    type_id: TypeId,
+    widen_expr: Option<NodeIndex>,
+}
+
 impl<'a> CheckerState<'a> {
     fn inference_context_for_block_return_expression(
         &mut self,
@@ -426,27 +439,48 @@ impl<'a> CheckerState<'a> {
         type_id: TypeId,
         return_context: Option<TypeId>,
     ) -> TypeId {
+        if self.return_contribution_is_widenable(expr_idx, type_id, return_context) {
+            return self.widen_return_contribution_preserving_const(expr_idx, type_id);
+        }
+        type_id
+    }
+
+    /// Whether a single return-expression contribution would be widened by
+    /// `maybe_widen_return_contribution` — i.e. it is a fresh literal expression
+    /// with none of the per-expression carve-outs (contextual return type,
+    /// `satisfies`, `preserve_literal_types`, a `const` assertion, or a
+    /// conditional expression).
+    ///
+    /// Block-body inference collects the *unwidened* contributions, unions them,
+    /// and widens the union only when it collapses to a single literal (tsc's
+    /// `getWidenedType(getUnionType(unwidenedReturnTypes))`). Two distinct fresh
+    /// literals (`return "a"; return "b"`) must stay a literal union, so the
+    /// per-branch widen is deferred to that single-literal check. This predicate
+    /// records, per branch, whether that survivor would have been widenable.
+    fn return_contribution_is_widenable(
+        &mut self,
+        expr_idx: NodeIndex,
+        type_id: TypeId,
+        return_context: Option<TypeId>,
+    ) -> bool {
         if let Some(ctx_type) = return_context
             && (!self.ctx.in_satisfies_operand
                 || self.contextual_type_allows_literal(ctx_type, type_id))
         {
-            return type_id;
+            return false;
         }
         if self.ctx.preserve_literal_types {
-            return type_id;
+            return false;
         }
         if self.return_expression_is_const_assertion(expr_idx) {
-            return type_id;
+            return false;
         }
         if self.ctx.arena.get(expr_idx).is_some_and(|node| {
             node.kind == tsz_parser::parser::syntax_kind_ext::CONDITIONAL_EXPRESSION
         }) {
-            return type_id;
+            return false;
         }
-        if self.is_fresh_literal_expression(expr_idx) {
-            return self.widen_return_contribution_preserving_const(expr_idx, type_id);
-        }
-        type_id
+        self.is_fresh_literal_expression(expr_idx)
     }
 
     /// Widen a fresh return-expression contribution while preserving literal
@@ -1057,8 +1091,14 @@ impl<'a> CheckerState<'a> {
             // When a function has value-returning paths AND also falls through
             // (or has empty `return;`), the non-returning paths contribute
             // `undefined` to the union, not `void`. tsc behaves the same way:
-            // `function f(x) { if (x) return 1; }` → `number | undefined`
-            return_types.push(TypeId::UNDEFINED);
+            // `function f(x) { if (x) return 1; }` → `number | undefined`.
+            // `undefined` is never a widenable literal contribution, so it keeps
+            // a literal+undefined union (`"a" | undefined`) from collapsing to a
+            // single-literal widen.
+            return_types.push(ReturnContribution {
+                type_id: TypeId::UNDEFINED,
+                widen_expr: None,
+            });
         }
 
         // Filter out ERROR types from return type inference when there are
@@ -1068,12 +1108,27 @@ impl<'a> CheckerState<'a> {
         // reference), but the base case `return 0` provides a concrete `number` type.
         // tsc filters out circular contributions and infers the return type from
         // non-circular branches only, so `fn1` gets return type `number`.
-        let has_non_error = return_types.iter().any(|&t| t != TypeId::ERROR);
+        let has_non_error = return_types.iter().any(|c| c.type_id != TypeId::ERROR);
         if has_non_error {
-            return_types.retain(|&t| t != TypeId::ERROR);
+            return_types.retain(|c| c.type_id != TypeId::ERROR);
         }
 
-        factory.union(return_types)
+        // Union the UNWIDENED contributions, then widen ONLY when the union
+        // collapses to a single literal (tsc's `getWidenedType(getUnionType(...))`).
+        // `factory.union` dedups and flattens a single surviving member to a
+        // scalar, so a multi-member literal union (`"a" | "b"`, `1 | 2`,
+        // `"a" | undefined`) is NOT a literal type and is returned unwidened,
+        // while a single fresh literal (`return "x"`, or `return "a"; return "a"`
+        // deduped to one) is widened via its originating expression's AST-aware
+        // widener — preserving per-property `const` subtrees (#14530).
+        let widen_expr = return_types.iter().find_map(|c| c.widen_expr);
+        let union = factory.union(return_types.iter().map(|c| c.type_id).collect());
+        if let Some(expr_idx) = widen_expr
+            && crate::query_boundaries::common::is_literal_type(self.ctx.types, union)
+        {
+            return self.widen_return_contribution_preserving_const(expr_idx, union);
+        }
+        union
     }
 
     /// Resolve a Lazy class type to a `TypeQuery` (constructor/value-position type).
@@ -1254,7 +1309,7 @@ impl<'a> CheckerState<'a> {
     fn collect_return_types_in_statement(
         &mut self,
         stmt_idx: NodeIndex,
-        return_types: &mut Vec<TypeId>,
+        return_types: &mut Vec<ReturnContribution>,
         saw_empty: &mut bool,
         return_context: Option<TypeId>,
     ) {
@@ -1282,12 +1337,20 @@ impl<'a> CheckerState<'a> {
                             return_type,
                             return_context,
                         );
-                        let widened = self.maybe_widen_return_contribution(
+                        // Collect the contribution UNWIDENED, recording whether it
+                        // would have been widened. The union of two distinct fresh
+                        // literals must stay a literal union (`"a" | "b"`); only a
+                        // union that collapses to a single literal is widened, in
+                        // `infer_return_type_from_body_inner` (tsc parity, #14530).
+                        let widenable = self.return_contribution_is_widenable(
                             return_data.expression,
                             return_type,
                             return_context,
                         );
-                        return_types.push(widened);
+                        return_types.push(ReturnContribution {
+                            type_id: return_type,
+                            widen_expr: widenable.then_some(return_data.expression),
+                        });
                     }
                 }
             }

--- a/crates/tsz-checker/tests/return_literal_union_widening_tests.rs
+++ b/crates/tsz-checker/tests/return_literal_union_widening_tests.rs
@@ -1,0 +1,221 @@
+//! Regression tests for issue #14530.
+//!
+//! Block-body return-type inference must union the UNWIDENED return-expression
+//! types and widen the result only when it collapses to a single (fresh)
+//! literal — tsc's `getWidenedType(getUnionType(unwidenedReturnTypes))`.
+//! Previously tsz widened each branch's literal independently, so a function
+//! returning two distinct literals inferred `string`/`number` and a
+//! literal-typed assignment of its result drew a spurious TS2322.
+//!
+//! Rule (matches tsc):
+//! - two+ distinct literals  → preserved union (`"a" | "b"`, `1 | 2`)
+//! - literal + fall-through  → `"a" | undefined`
+//! - single literal          → widened (`return "x"` → `string`)
+//! - two identical literals  → dedup to one → widened (`string`)
+//! - literal + non-literal   → widened (`string`)
+//! - `as const` / contextual → preserved (existing carve-outs unchanged)
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn ts2322(source: &str) -> usize {
+    check_source_codes(source)
+        .into_iter()
+        .filter(|&c| c == 2322)
+        .count()
+}
+
+/// The reported repro: two distinct string literals infer `"positive" | "zero"`.
+#[test]
+fn two_distinct_string_literals_infer_literal_union() {
+    let source = r#"
+function classify(n: number) {
+  if (n > 0) return "positive";
+  return "zero";
+}
+const c: "positive" | "zero" = classify(0);
+"#;
+    assert_eq!(
+        ts2322(source),
+        0,
+        "two distinct literal returns must infer the literal union, not `string`: {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// Distinct numeric literals are preserved as `1 | 2`. Renamed binders to keep
+/// the rule structural, not identifier-driven.
+#[test]
+fn two_distinct_number_literals_infer_literal_union() {
+    let source = r#"
+function pick(flag: number) {
+  if (flag > 0) return 1;
+  return 2;
+}
+const chosen: 1 | 2 = pick(0);
+"#;
+    assert_eq!(
+        ts2322(source),
+        0,
+        "distinct numeric literal returns must infer `1 | 2`: {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// A literal return plus an implicit `undefined` fall-through is `"a" | undefined`,
+/// not `string | undefined`.
+#[test]
+fn literal_plus_fallthrough_undefined_preserves_literal() {
+    let source = r#"
+function maybeTag(n: number) {
+  if (n > 0) return "tagged";
+}
+const t: "tagged" | undefined = maybeTag(0);
+"#;
+    assert_eq!(
+        ts2322(source),
+        0,
+        "literal + fall-through must infer `\"tagged\" | undefined`: {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// A single literal return STILL widens to its base (tsc widens a lone fresh
+/// literal). Assigning it to that literal must still error.
+#[test]
+fn single_literal_return_still_widens() {
+    let source = r#"
+function only() { return "x"; }
+const v: "x" = only();
+"#;
+    assert!(
+        ts2322(source) >= 1,
+        "a single fresh-literal return widens to `string`, so `const v: \"x\"` must error: {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// Two IDENTICAL literals dedup to a single literal and therefore widen to the
+/// base — not preserved.
+#[test]
+fn two_identical_literals_dedup_and_widen() {
+    let source = r#"
+function same(n: number) {
+  if (n > 0) return "dup";
+  return "dup";
+}
+const s: "dup" = same(0);
+"#;
+    assert!(
+        ts2322(source) >= 1,
+        "two identical literals dedup to one and widen to `string`, so `const s: \"dup\"` must error: {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// A literal mixed with a non-literal contribution widens (the union collapses
+/// to `string`, which is not a literal).
+#[test]
+fn literal_plus_non_literal_widens() {
+    let source = r#"
+function mix(n: number, s: string) {
+  if (n > 0) return "lit";
+  return s;
+}
+const out: string = mix(0, "z");
+const bad: "lit" = mix(0, "z");
+"#;
+    // `out: string` is clean; `bad: "lit"` must error (inferred `string`).
+    assert!(
+        ts2322(source) >= 1,
+        "literal + non-literal infers `string`, so `const bad: \"lit\"` must error: {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// Negative control: a distinct-literal union is still rejected when assigned to
+/// a NARROWER single literal — the fix preserves the union, it does not widen
+/// away genuine errors.
+#[test]
+fn distinct_literal_union_still_errors_against_narrower_target() {
+    let source = r#"
+function two(n: number) {
+  if (n > 0) return "a";
+  return "b";
+}
+const narrow: "a" = two(0);
+"#;
+    assert!(
+        ts2322(source) >= 1,
+        "`\"a\" | \"b\"` must still be rejected against target `\"a\"`: {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// Carve-out preserved: a single `return x as const` stays its literal type and
+/// is NOT widened.
+#[test]
+fn single_const_assertion_return_stays_literal() {
+    let source = r#"
+function asConst() { return "kept" as const; }
+const k: "kept" = asConst();
+"#;
+    assert_eq!(
+        ts2322(source),
+        0,
+        "`return x as const` must keep the literal type (no widen): {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// Carve-out preserved: a contextually-typed single literal return stays literal.
+#[test]
+fn contextual_single_literal_return_stays_literal() {
+    let source = r#"
+const f: () => "ctx" = () => { return "ctx"; };
+void f;
+"#;
+    assert_eq!(
+        ts2322(source),
+        0,
+        "a contextually-typed literal return must stay literal: {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// `true | false` normalizes to `boolean` (not a literal), so it is not widened
+/// further and assigning to `boolean` is clean.
+#[test]
+fn distinct_boolean_literals_normalize_to_boolean() {
+    let source = r#"
+function flag(n: number) {
+  if (n > 0) return true;
+  return false;
+}
+const b: boolean = flag(0);
+"#;
+    assert_eq!(
+        ts2322(source),
+        0,
+        "`true | false` normalizes to `boolean`, assignable to `boolean`: {:?}",
+        check_source_codes(source)
+    );
+}
+
+/// Adjacent shape: multi-return object literals keep per-property `as const`
+/// discriminants across the union while widening non-asserted siblings.
+#[test]
+fn multi_return_object_literal_preserves_per_property_const() {
+    let source = r#"
+function node(n: number) {
+  if (n > 0) return { kind: "a" as const, v: 1 };
+  return { kind: "b" as const, v: 2 };
+}
+const r: { kind: "a" | "b"; v: number } = node(0);
+"#;
+    assert_eq!(
+        ts2322(source),
+        0,
+        "per-property `as const` discriminants must survive the return union: {:?}",
+        check_source_codes(source)
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes #14530.

## Summary

Block-body return-type inference widened each branch's literal contribution independently, so a function returning two *distinct* literals inferred `string`/`number` and a literal-typed assignment of its result drew a spurious **TS2322**.

```ts
function classify(n: number) {
  if (n > 0) return "positive";
  return "zero";
}
const c: "positive" | "zero" = classify(0);   // tsc: clean ; tsz (before): TS2322 (string)
```

## Structural rule

When `tsc` infers a block-body return type it collects the **unwidened** return-expression types, unions them, and widens the result only when the union collapses to a **single fresh literal** (`getWidenedType(getUnionType(unwidenedReturnTypes))`). tsz instead applied `maybe_widen_return_contribution` **per branch** before the union, so distinct-literal unions and literal+`undefined` collapsed to `string` / `string | undefined`.

| returns | tsc / tsz-after |
| --- | --- |
| single `return "x"` | `string` (widened) |
| `return "a"; return "a"` (dedup → one) | `string` (widened) |
| `return "positive"; return "zero"` | `"positive" \| "zero"` (preserved) |
| `return 1; return 2` | `1 \| 2` (preserved) |
| `return "a"` + fall-through | `"a" \| undefined` (preserved) |
| `return "a"; return s` (non-literal) | `string` (widened) |
| `return true; return false` | `boolean` (normalized) |

## Owner layer

Checker — `crates/tsz-checker/src/types/utilities/return_type.rs`. `collect_return_types_in_statement` now pushes each contribution **unwidened** along with a per-branch widenable flag (recorded by the extracted `return_contribution_is_widenable`, which keeps the existing carve-outs: contextual return type, `satisfies`, `preserve_literal_types`, `const` assertion, conditional expression). `infer_return_type_from_body_inner` unions the unwidened contributions and widens via the originating expression's AST-aware widener (`widen_return_contribution_preserving_const`, preserving per-property `const` subtrees) **only when** the union is a single literal type. `factory.union` already dedups/flattens a single surviving member to a scalar, so a multi-member literal union is not a literal type and is returned unwidened. The concise-body (`() => "x"`) path is unchanged (`maybe_widen_return_contribution` reimplemented in terms of the same predicate, behavior-identical).

## Adjacent cases (regression tests added — `return_literal_union_widening_tests.rs`, 11 cases, varied binders)

- distinct string / number literal unions preserved; literal + fall-through `undefined` preserved;
- single literal still widens; two identical literals dedup-and-widen; literal + non-literal widens;
- `true | false` normalizes to `boolean`;
- carve-outs preserved: single `as const` return, contextually-typed literal return;
- multi-return object literal with per-property `as const` discriminants preserved across the union;
- negative control: a distinct-literal union is still rejected against a narrower single-literal target.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo nextest run -p tsz-checker --test return_literal_union_widening_tests` — 11/11 pass.
- Adjacent widening suites `block_body_callback_literal_widening_tests` + `async_return_widening_tests` show no new failures (the single `async_arrow_returning_promise_expression_preserves_inner` failure is pre-existing — verified identical with this change stashed on clean source).
- `cargo clippy -p tsz-checker --lib` clean.
- High blast radius (changes every block-body literal-returning function); per the issue, the broad surface is gated by ready-CI conformance + project-corpus shards (no local conformance per repo policy). Expected to move baselines toward parity (literal-union returners: classifiers, reducers, state machines).
