### PR TITLE
fix(checker): infer class get-accessor return type from body at property access (TS2322 false negative)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -704,6 +704,9 @@ path = "tests/ts2322_tests.rs"
 name = "accessor_assignment_read_surface_tests"
 path = "tests/accessor_assignment_read_surface_tests.rs"
 [[test]]
+name = "inferred_getter_return_property_access_tests"
+path = "tests/inferred_getter_return_property_access_tests.rs"
+[[test]]
 name = "accessor_pair_override_ts2416_tests"
 path = "tests/accessor_pair_override_ts2416_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -1289,10 +1289,14 @@ impl<'a> CheckerState<'a> {
                         let return_type = self.get_type_from_type_node(accessor.type_annotation);
                         return (return_type, Vec::new());
                     }
-                    // No type annotation - try to infer from body return type
-                    // Fall through to use get_type_of_node if body exists
+                    // No type annotation - infer the return type from the body
+                    // (clearing literal preservation and threading the accessor
+                    // node as the enclosing function for parity with the method
+                    // path in `call_signature_from_method`) instead of typing the
+                    // bare block node.
                     if accessor.body.is_some() {
-                        let body_type = self.get_type_of_node(accessor.body);
+                        let body_type =
+                            self.infer_getter_return_type_for_node(decl_idx, accessor.body);
                         if body_type != TypeId::ERROR && body_type != TypeId::UNKNOWN {
                             return (body_type, Vec::new());
                         }

--- a/crates/tsz-checker/src/types/class_type/core.rs
+++ b/crates/tsz-checker/src/types/class_type/core.rs
@@ -133,7 +133,7 @@ impl<'a> CheckerState<'a> {
         self.class_instance_phase2_deferred_methods(class, class_idx, &mut builder);
 
         // Process deferred accessors, then restore `enclosing_class`.
-        self.class_instance_process_deferred_accessors(&mut builder);
+        self.class_instance_process_deferred_accessors(class_idx, &mut builder);
 
         // Convert accessors/methods to properties and add the private brand.
         self.class_instance_finalize_members(class_idx, &mut builder);

--- a/crates/tsz-checker/src/types/class_type/instance.rs
+++ b/crates/tsz-checker/src/types/class_type/instance.rs
@@ -1261,14 +1261,19 @@ impl<'a> CheckerState<'a> {
     /// class's properties and methods, aggregating getter/setter types.
     pub(super) fn class_instance_process_deferred_accessors(
         &mut self,
+        class_idx: NodeIndex,
         b: &mut ClassInstanceBuilder<'_>,
     ) {
-        let factory = self.ctx.types.factory();
         let current_sym = b.current_sym;
         if !b.deferred_accessors.is_empty() {
-            let mut partial_props: Vec<PropertyInfo> =
+            // Base members (own fields + own methods) shared by every accessor's
+            // partial `this`. Built once; accessor placeholders are layered on
+            // per iteration so a getter body that reads an *earlier* accessor
+            // observes its already-resolved type rather than an `any`
+            // placeholder.
+            let mut base_props: Vec<PropertyInfo> =
                 Vec::with_capacity(b.properties.len() + b.methods.len());
-            partial_props.extend(b.properties.values().cloned());
+            base_props.extend(b.properties.values().cloned());
             for (&name, method) in &b.methods {
                 let (signatures, optional) = if !method.overload_signatures.is_empty() {
                     (&method.overload_signatures, method.overload_optional)
@@ -1278,7 +1283,7 @@ impl<'a> CheckerState<'a> {
                 if signatures.is_empty() {
                     continue;
                 }
-                let type_id = factory.callable(CallableShape {
+                let type_id = self.ctx.types.factory().callable(CallableShape {
                     call_signatures: signatures.clone(),
                     construct_signatures: Vec::new(),
                     properties: Vec::new(),
@@ -1287,7 +1292,7 @@ impl<'a> CheckerState<'a> {
                     symbol: None,
                     is_abstract: false,
                 });
-                partial_props.push(PropertyInfo {
+                base_props.push(PropertyInfo {
                     name,
                     type_id,
                     write_type: type_id,
@@ -1304,27 +1309,84 @@ impl<'a> CheckerState<'a> {
                     non_widening: false,
                 });
             }
-            let partial_type = factory.object_with_index(ObjectShape {
-                properties: partial_props,
-                string_index: b.string_index,
-                number_index: b.number_index,
-                symbol: current_sym,
-                ..ObjectShape::default()
-            });
-            self.ctx.this_type_stack.push(partial_type);
+            let deferred_accessors = std::mem::take(&mut b.deferred_accessors);
 
-            // Update enclosing_class.cached_instance_this_type to the current
-            // partial type so that `this` evaluation inside getter/setter bodies
-            // (via class_member_this_type → cached_instance_this) sees the
-            // up-to-date type including properties and methods — not the stale
-            // prescan type from Phase 0.  Without this, `get y() { return this; }`
-            // infers a return type that doesn't match partial_type, preventing the
-            // ThisType rewrite and causing false TS2339 on the accessor property.
-            if let Some(ref mut info) = self.ctx.enclosing_class {
-                info.cached_instance_this_type = Some(partial_type);
+            // Distinct accessor names to layer onto each partial `this`, deduped
+            // once (against the base members and each other) rather than per
+            // iteration. Every accessor member stays present in every partial so
+            // a forward reference (`get a() { return this.b; }` before `b`) never
+            // draws a false TS2339; its type is read fresh from `b.accessors`
+            // each iteration so an already-processed accessor contributes its
+            // resolved type while the rest stay `any`.
+            let mut placeholder_accessors: Vec<&DeferredAccessor> = Vec::new();
+            let mut placeholder_seen: FxHashSet<Atom> =
+                base_props.iter().map(|prop| prop.name).collect();
+            for ad in &deferred_accessors {
+                if placeholder_seen.insert(ad.name_atom) {
+                    placeholder_accessors.push(ad);
+                }
             }
 
-            for deferred in std::mem::take(&mut b.deferred_accessors) {
+            let mut pushed_this = false;
+            for deferred in &deferred_accessors {
+                // (Re)build the partial `this` reflecting accessor types resolved
+                // so far. The accurate field types keep `class_member_this_type`
+                // from falling back to a prescan partial that degrades an
+                // unannotated field to `any`, and an accessor already processed in
+                // this loop contributes its resolved type, so a getter reading an
+                // earlier getter (`get b() { return this.a; }`) sees `a`'s real
+                // type (#14511).
+                let mut props = base_props.clone();
+                for ad in &placeholder_accessors {
+                    let resolved = b
+                        .accessors
+                        .get(&ad.name_atom)
+                        .and_then(|a| a.getter.or(a.setter))
+                        .unwrap_or(TypeId::ANY);
+                    props.push(PropertyInfo {
+                        name: ad.name_atom,
+                        type_id: resolved,
+                        write_type: resolved,
+                        optional: false,
+                        readonly: false,
+                        is_method: false,
+                        is_class_prototype: true,
+                        visibility: ad.visibility,
+                        parent_id: current_sym,
+                        declaration_order: ad.declaration_order,
+                        is_string_named: false,
+                        is_symbol_named: ad.is_symbol_named,
+                        single_quoted_name: false,
+                        non_widening: false,
+                    });
+                }
+                let partial_type = self.ctx.types.factory().object_with_index(ObjectShape {
+                    properties: props,
+                    string_index: b.string_index,
+                    number_index: b.number_index,
+                    symbol: current_sym,
+                    ..ObjectShape::default()
+                });
+                if pushed_this {
+                    self.ctx.this_type_stack.pop();
+                }
+                self.ctx.this_type_stack.push(partial_type);
+                pushed_this = true;
+
+                // Publish the partial as the in-progress instance type so a
+                // re-entrant `this` resolution during body inference observes the
+                // up-to-date field types (mirrors the phase-2 deferred-method
+                // caching), and keep `cached_instance_this_type` in sync so
+                // `class_member_this_type` returns the current construction state
+                // rather than the stale Phase-0 prescan type.
+                self.ctx
+                    .class_instance_type_cache
+                    .borrow_mut()
+                    .insert(class_idx, partial_type);
+                if let Some(ref mut info) = self.ctx.enclosing_class {
+                    info.cached_instance_this_type = Some(partial_type);
+                }
+
                 if deferred.is_getter {
                     let getter_type = if deferred.accessor.type_annotation.is_some() {
                         self.get_type_from_type_node(deferred.accessor.type_annotation)
@@ -1333,7 +1395,10 @@ impl<'a> CheckerState<'a> {
                     {
                         jsdoc_type
                     } else {
-                        let t = self.infer_getter_return_type(deferred.accessor.body);
+                        let t = self.infer_getter_return_type_for_node(
+                            deferred.member_idx,
+                            deferred.accessor.body,
+                        );
                         self.ctx.node_types.insert(deferred.member_idx.0, t);
                         // When a getter without an explicit return type annotation
                         // infers its return type from the body and the result is the
@@ -1411,7 +1476,9 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            self.ctx.this_type_stack.pop();
+            if pushed_this {
+                self.ctx.this_type_stack.pop();
+            }
         }
 
         if let RestoreEnclosingClass::To(prev_enclosing_class) =

--- a/crates/tsz-checker/src/types/queries/class.rs
+++ b/crates/tsz-checker/src/types/queries/class.rs
@@ -954,10 +954,27 @@ impl<'a> CheckerState<'a> {
     /// function-expression branch in `return_expression_type`, where nested
     /// function-like inference does the same).
     pub(crate) fn infer_getter_return_type(&mut self, body_idx: NodeIndex) -> TypeId {
+        self.infer_getter_return_type_for_node(tsz_parser::parser::NodeIndex::NONE, body_idx)
+    }
+
+    /// Infer a get-accessor's return type from its body, threading the accessor
+    /// declaration node as the enclosing function.
+    ///
+    /// Passing the accessor node (rather than `NodeIndex::NONE`) gives the body
+    /// walk the same enclosing-function context a method body receives in
+    /// `call_signature_from_method` (circular-return tracking, self-reference
+    /// detection), keeping getter and method return inference consistent.
+    /// Callers that have no accessor node (e.g. object-literal getters, which
+    /// establish their own context via `get_type_of_function`) pass
+    /// `NodeIndex::NONE`.
+    pub(crate) fn infer_getter_return_type_for_node(
+        &mut self,
+        accessor_idx: NodeIndex,
+        body_idx: NodeIndex,
+    ) -> TypeId {
         let prev = self.ctx.preserve_literal_types;
         self.ctx.preserve_literal_types = false;
-        let r =
-            self.infer_return_type_from_body(tsz_parser::parser::NodeIndex::NONE, body_idx, None);
+        let r = self.infer_return_type_from_body(accessor_idx, body_idx, None);
         self.ctx.preserve_literal_types = prev;
         r
     }

--- a/crates/tsz-checker/tests/inferred_getter_return_property_access_tests.rs
+++ b/crates/tsz-checker/tests/inferred_getter_return_property_access_tests.rs
@@ -1,0 +1,137 @@
+//! Regression coverage for #14511: a class get-accessor with an *inferred*
+//! return type (no explicit annotation) must contribute that inferred type as
+//! its property type at the access site, so assignability checks (TS2322) fire
+//! exactly as they do for an explicitly-annotated getter. tsz previously typed
+//! the inferred-getter property as `any` at the access site (false negative).
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+fn ts2322_count(source: &str) -> usize {
+    check_source_strict_codes(source)
+        .into_iter()
+        .filter(|code| *code == 2322)
+        .count()
+}
+
+#[test]
+fn inferred_getter_number_flows_to_property_access() {
+    // `count` infers `number`; assigning it to `string` must error (tsc: TS2322).
+    let source = r#"
+class C {
+  _v = 0;
+  get count() { return this._v; }
+}
+const wrong: string = new C().count;
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "inferred-getter `count: number` assigned to `string` must report TS2322"
+    );
+}
+
+#[test]
+fn inferred_getter_number_rejects_narrower_literal() {
+    // `count` infers `number` (widened), not the literal `123`.
+    let source = r#"
+class C {
+  _v = 0;
+  get count() { return this._v; }
+}
+const probe: 123 = new C().count;
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "inferred-getter `count: number` assigned to literal `123` must report TS2322"
+    );
+}
+
+#[test]
+fn inferred_getter_valid_assignment_stays_clean() {
+    // Negative control: a valid assignment must not error.
+    let source = r#"
+class C {
+  _v = 0;
+  get count() { return this._v; }
+}
+const ok: number = new C().count;
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        0,
+        "assigning the inferred `number` getter to `number` must stay clean"
+    );
+}
+
+#[test]
+fn inferred_getter_literal_return_flows_to_access() {
+    // A getter that returns a literal infers the widened base in a value
+    // position; assigning to an incompatible type must error.
+    let source = r#"
+class Flag {
+  get ready() { return true; }
+}
+const wrong: string = new Flag().ready;
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "inferred-getter `ready: boolean` assigned to `string` must report TS2322"
+    );
+}
+
+#[test]
+fn inferred_getter_setter_pair_uses_getter_read_type() {
+    // With a getter+setter pair, the read (property) type is the getter return
+    // type. The inferred getter returns `number`, so reading into `string` errors.
+    let source = r#"
+class Box {
+  private _v = 0;
+  get value() { return this._v; }
+  set value(n: number) { this._v = n; }
+}
+const wrong: string = new Box().value;
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "the read type of an inferred getter+setter pair is the getter return type"
+    );
+}
+
+#[test]
+fn inferred_getter_renamed_binders_stay_structural() {
+    // The fix must be name-agnostic: a renamed class/field/accessor reproduces.
+    let source = r#"
+class Widget {
+  private depth = 0;
+  get extent() { return this.depth; }
+}
+const wrong: string = new Widget().extent;
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "inferred getter resolution must be structural, not tied to identifier names"
+    );
+}
+
+#[test]
+fn inferred_getter_chained_getter_flows() {
+    // A getter whose body reads another inferred getter still resolves to a
+    // concrete type at the access site.
+    let source = r#"
+class Chain {
+  _v = 0;
+  get inner() { return this._v; }
+  get outer() { return this.inner; }
+}
+const wrong: string = new Chain().outer;
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "an inferred getter reading another inferred getter must still type-check at access"
+    );
+}


### PR DESCRIPTION
Fixes #14511.

## Summary

A class get-accessor with an **inferred** return type (no annotation) was typed
`any` at the property-access site, so tsz missed assignability errors tsc
reports:

```ts
class C {
  _v = 0;
  get count() { return this._v; }   // inferred number
}
const wrong: string = new C().count;   // tsc: TS2322 ; tsz (before): MISSED
```

With an explicit return annotation tsz was already correct, so the gap was
specifically **inferred getter return type flowing to property access**.

## Root cause

During class-instance construction the get-accessor body is type-inferred under
a partial `this`. But `class_member_this_type` chose the in-progress `this` by
raw **property count**, preferring a stale Phase-0 prescan partial whose
unannotated fields had been degraded to `any`. So `this._v` resolved to `any`,
the inferred getter return type collapsed to `any`, and the access site
re-derived that same `any`. A read wrapped in anything else (`this._v + 1`, a
local copy, a method call) went through the accurate type, which is why only a
bare `this.<unannotated-field>` return reproduced.

## Structural rule

> When a get-accessor has no return annotation, its property type is the
> inferred return type of its body evaluated against the class instance `this`
> (tsc `getTypeOfAccessors` → `getReturnTypeFromBody`). tsz now owns this in the
> class-instance builder rather than inferring it over a degraded prescan
> `this`.

## Owner layer

Checker class-instance construction (`crates/tsz-checker/src/types/class_type/instance.rs`,
`class_instance_process_deferred_accessors`). It now builds an **accurate**
partial `this` — own fields with their real inferred types plus a placeholder
for every accessor — and publishes it to `class_instance_type_cache` and
`cached_instance_this_type`, mirroring the established phase-2 deferred-method
path. The partial is rebuilt per accessor so a getter reading an **earlier**
getter sees its already-resolved type, while every accessor member stays present
so a **forward** reference never draws a false TS2339. Getter return inference
is threaded through the accessor node (`infer_getter_return_type_for_node`) for
parity with the method path. No new user-name/file-name predicates; decisions
are structural (member kind, the solver `b.accessors` aggregate, object-shape
construction).

## Adjacent matrix (differential vs bundled `tsc`, `--strict`)

| source | tsc | tsz before | tsz after |
|---|---|---|---|
| inferred `number` getter → `const s: string = c.count` | TS2322 | missed | ✓ TS2322 |
| inferred getter → narrower literal target `123` | TS2322 | missed | ✓ TS2322 |
| inferred `boolean` (`return true`) getter → string | TS2322 | TS2322 | ✓ TS2322 |
| getter+setter pair (read type = getter return) | TS2322 | missed | ✓ TS2322 |
| getter chain (`get outer(){return this.inner}`) | TS2322 | missed | ✓ TS2322 |
| base-inherited field read in subclass getter | TS2322 | missed | ✓ TS2322 |
| renamed binders (class/field/accessor) | TS2322 | missed | ✓ TS2322 |
| **id** valid assignment `const n: number = c.count` | clean | clean | ✓ clean |
| **id** `get self(){return this}` (ThisType) | clean | clean | ✓ clean |

## Goal
Goal: hold

## Verification
- New `crates/tsz-checker/tests/inferred_getter_return_property_access_tests.rs`
  (7 cases: number/literal getters → TS2322, narrower-literal target,
  getter+setter pair, getter chain, renamed binders, clean control) — 7/7 pass.
- Differential vs freshly-built `tsz` on the matrix above (CLI, `--strict
  --target es2020 --lib es2020`): all rows match tsc, including the
  base-inherited and chained-getter cases.
- No regressions across the class/`this`/accessor suites
  (`accessor_assignment_read_surface_tests`, `accessor_pair_override_ts2416_tests`,
  `object_literal_getter_widening_tests`, `object_literal_set_only_accessor_type_tests`,
  and the `this_type*` / `class_instance*` / `class_member*` / `class_field*` /
  `polymorphic_this*` filters) — all green.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --tests`
  clean (0 warnings).
- Broad conformance / emit / fourslash owned by ready-review CI (this is a
  false-negative fix → expected to move conformance toward parity).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9i8gppt2JFSGiHyMUfzsT)_