### PR TITLE
fix(checker): keyof of a key-preserving wrapper is a valid index (spurious TS2536)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1490,6 +1490,9 @@ path = "tests/union_index_access_function_application_param_tests.rs"
 name = "union_index_annotation_missing_key_tests"
 path = "tests/union_index_annotation_missing_key_tests.rs"
 [[test]]
+name = "indexed_access_keyof_wrapper_ts2536_tests"
+path = "tests/indexed_access_keyof_wrapper_ts2536_tests.rs"
+[[test]]
 name = "indexed_access_resolved_union_property_tests"
 path = "tests/indexed_access_resolved_union_property_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
@@ -53,8 +53,8 @@ fn indexed_access_key_space_helpers_use_relation_outcome_boundary() {
         function
             .matches("indexed_access_key_space_relation_outcome(")
             .count(),
-        3,
-        "string-index, constrained-keyof, and union-member key-space checks should route through the named RelationRequest"
+        4,
+        "string-index, constrained-keyof, union-member, and transformed-index key-space checks should route through the named RelationRequest"
     );
     assert!(
         !function.contains("assign_relation_outcome("),
@@ -139,7 +139,7 @@ fn indexed_access_type_checking_helpers_use_relation_outcome_boundary() {
         helpers
             .matches("indexed_access_key_space_relation_outcome(")
             .count(),
-        11,
+        13,
         "indexed-access helper key-space probes should route through the named RelationRequest"
     );
     assert!(

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -1558,6 +1558,10 @@ impl<'a> CheckerState<'a> {
                 if self.generic_index_mentions_transformed_current_type_param(
                     index_type,
                     pre_resolution_object_type,
+                ) && !self.transformed_index_key_space_indexes_object(
+                    index_type,
+                    None,
+                    pre_resolution_object_type,
                 ) {
                     use crate::diagnostics::{
                         diagnostic_codes, diagnostic_messages, format_message,

--- a/crates/tsz-checker/src/types/computation/access.rs
+++ b/crates/tsz-checker/src/types/computation/access.rs
@@ -32,34 +32,6 @@ impl<'a> CheckerState<'a> {
         self.get_type_of_element_access_with_request(idx, &TypingRequest::NONE)
     }
 
-    /// Resolve the member-access result type when the (resolved) object type is
-    /// `unknown`, under `strictNullChecks`.
-    ///
-    /// `tsc` forbids accessing a member of a value of type `unknown` — by name
-    /// (`x.p`), by index (`x[k]`), or through an optional chain (`x?.p` / `x?.[k]`)
-    /// — so under `strictNullChecks` we emit the diagnostic and return `Some`:
-    /// `TS18046` (`'x' is of type 'unknown'.`) when the base expression has a
-    /// printable name, otherwise the object form `TS2571` (`Object is of type
-    /// 'unknown'.`), returning `ERROR` to stop cascading diagnostics. When
-    /// `strictNullChecks` is off, `unknown` behaves like `any`; we return `None` so
-    /// each caller can apply its own non-strict fallback (index-signature handling
-    /// for element access, `error_property_not_exist_at` for property access).
-    ///
-    /// This is the single decision gate for the unknown-object access result,
-    /// shared by the element-access `literal_string`/`literal_index` arms and the
-    /// property-access path, so the `TS2571`/`TS18046` choice is not re-derived
-    /// independently in each place.
-    pub(crate) fn unknown_object_access_result(&mut self, base_expr: NodeIndex) -> Option<TypeId> {
-        if !self.ctx.compiler_options.strict_null_checks {
-            return None;
-        }
-        if self.error_is_of_type_unknown(base_expr) {
-            Some(TypeId::ERROR)
-        } else {
-            Some(TypeId::ANY)
-        }
-    }
-
     pub(crate) fn get_type_of_element_access_with_request(
         &mut self,
         idx: NodeIndex,

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -10,6 +10,34 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::{SymbolRef, TypeId};
 
 impl<'a> CheckerState<'a> {
+    /// Resolve the member-access result type when the (resolved) object type is
+    /// `unknown`, under `strictNullChecks`.
+    ///
+    /// `tsc` forbids accessing a member of a value of type `unknown` — by name
+    /// (`x.p`), by index (`x[k]`), or through an optional chain (`x?.p` / `x?.[k]`)
+    /// — so under `strictNullChecks` we emit the diagnostic and return `Some`:
+    /// `TS18046` (`'x' is of type 'unknown'.`) when the base expression has a
+    /// printable name, otherwise the object form `TS2571` (`Object is of type
+    /// 'unknown'.`), returning `ERROR` to stop cascading diagnostics. When
+    /// `strictNullChecks` is off, `unknown` behaves like `any`; we return `None` so
+    /// each caller can apply its own non-strict fallback (index-signature handling
+    /// for element access, `error_property_not_exist_at` for property access).
+    ///
+    /// This is the single decision gate for the unknown-object access result,
+    /// shared by the element-access `literal_string`/`literal_index` arms and the
+    /// property-access path, so the `TS2571`/`TS18046` choice is not re-derived
+    /// independently in each place.
+    pub(crate) fn unknown_object_access_result(&mut self, base_expr: NodeIndex) -> Option<TypeId> {
+        if !self.ctx.compiler_options.strict_null_checks {
+            return None;
+        }
+        if self.error_is_of_type_unknown(base_expr) {
+            Some(TypeId::ERROR)
+        } else {
+            Some(TypeId::ANY)
+        }
+    }
+
     pub(crate) fn expando_element_key_name(&mut self, key_expr_idx: NodeIndex) -> Option<String> {
         let node = self.ctx.arena.get(key_expr_idx)?;
         match node.kind {

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -991,12 +991,24 @@ impl<'a> CheckerState<'a> {
     /// `TS2536` on this relation-backed query. Returns true when the index key
     /// space genuinely indexes `object_param` and the diagnostic must be
     /// suppressed.
+    ///
+    /// Suppression is restricted to a **type-parameter** index `K extends keyof
+    /// F<T>`. tsc allows an unconstrained generic `T` to be indexed by a *key
+    /// parameter* whose constraint reduces to `keyof T`, but a **direct**
+    /// transformed-keyof value such as `k: keyof (T & {})` still draws TS2536
+    /// even though `keyof (T & {})` reduces to `keyof T` (see
+    /// `conformance/types/unknown/unknownControlFlow.ts` `ff3`). Only the
+    /// type-parameter form is suppressed here; a direct keyof expression keeps
+    /// the heuristic's diagnostic.
     pub(crate) fn transformed_index_key_space_indexes_object(
         &mut self,
         index_type: TypeId,
         index_constraint: Option<TypeId>,
         object_param: TypeId,
     ) -> bool {
+        if !crate::query_boundaries::common::is_type_parameter_like(self.ctx.types, index_type) {
+            return false;
+        }
         let constraint = index_constraint
             .or_else(|| {
                 crate::query_boundaries::common::type_parameter_constraint(

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -976,6 +976,41 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    /// `T[K]` where `K`'s constraint is `keyof F<T>` (a transform of the object
+    /// type parameter `T`) is still a valid index when the transformed key space
+    /// is assignable to `keyof T`. Key-preserving transforms keep
+    /// `keyof F<T> = keyof T` — a transparent alias `type Alias<T> = T`,
+    /// `NonNullable<T>` (`T & {}`), `Readonly<T>`, `Partial<T>`. Only a
+    /// key-*changing* transform (a key remap, `Pick`/`Omit`, or a *foreign* type
+    /// parameter's keys such as `keyof U` with `U extends T`) produces keys
+    /// outside `keyof T` and must keep emitting `TS2536`.
+    ///
+    /// The structural `generic_index_mentions_transformed_current_type_param`
+    /// heuristic cannot by itself tell a key-preserving transform from a
+    /// key-changing one (both merely *mention* `T`), so callers gate its
+    /// `TS2536` on this relation-backed query. Returns true when the index key
+    /// space genuinely indexes `object_param` and the diagnostic must be
+    /// suppressed.
+    pub(crate) fn transformed_index_key_space_indexes_object(
+        &mut self,
+        index_type: TypeId,
+        index_constraint: Option<TypeId>,
+        object_param: TypeId,
+    ) -> bool {
+        let constraint = index_constraint
+            .or_else(|| {
+                crate::query_boundaries::common::type_parameter_constraint(
+                    self.ctx.types,
+                    index_type,
+                )
+            })
+            .unwrap_or(index_type);
+        let index_key_space = self.evaluate_type_with_env(constraint);
+        let object_key_space = self.ctx.types.evaluate_keyof(object_param);
+        self.indexed_access_key_space_relation_outcome(index_key_space, object_key_space)
+            .related
+    }
+
     /// Return the type parameter source when `index_type` is `keyof S` or `K extends keyof S`
     /// for a type parameter `S` different from `type_param`.
     ///

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -569,6 +569,11 @@ impl<'a> CheckerState<'a> {
 
         if crate::query_boundaries::common::is_type_parameter_like(self.ctx.types, object_type)
             && self.generic_index_mentions_transformed_current_type_param(index_type, object_type)
+            && !self.transformed_index_key_space_indexes_object(
+                index_type,
+                index_constraint,
+                object_type,
+            )
         {
             let obj_type_str = self.format_type(object_type);
             let index_type_str = self.format_type(index_type);

--- a/crates/tsz-checker/tests/indexed_access_keyof_wrapper_ts2536_tests.rs
+++ b/crates/tsz-checker/tests/indexed_access_keyof_wrapper_ts2536_tests.rs
@@ -118,6 +118,35 @@ fn key_remapping_wrapper_still_reports_ts2536() {
 }
 
 #[test]
+fn direct_keyof_intersection_index_still_reports_ts2536() {
+    // tsc distinguishes a *type-parameter* index `K extends keyof (T & {})`
+    // (allowed) from a *direct* keyof value `k: keyof (T & {})` (still TS2536),
+    // even though both reduce to `keyof T`. Mirrors
+    // `conformance/types/unknown/unknownControlFlow.ts` `ff3`. The suppression
+    // must not extend to the direct-value form.
+    let src = "function ff3<T>(t: T, k: keyof (T & {})) { t[k]; }";
+    assert_eq!(
+        count(src, 2536),
+        1,
+        "a direct transformed-keyof value index must keep erroring: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn direct_keyof_of_own_object_index_no_ts2536() {
+    // Control: indexing by the object's *own* `keyof T` (not a transform) is
+    // valid in tsc (`unknownControlFlow.ts` `ff1`), and unaffected.
+    let src = "function ff1<T>(t: T, k: keyof T) { t[k]; }";
+    assert_eq!(
+        count(src, 2536),
+        0,
+        "indexing by the object's own keyof is valid: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
 fn foreign_type_parameter_keys_body_indexing_still_reports_ts2536() {
     // Expression-path negative control: the gate must not over-suppress. `keyof U`
     // (U extends T) is not assignable to keyof T, so `o[k]` keeps erroring.

--- a/crates/tsz-checker/tests/indexed_access_keyof_wrapper_ts2536_tests.rs
+++ b/crates/tsz-checker/tests/indexed_access_keyof_wrapper_ts2536_tests.rs
@@ -1,0 +1,131 @@
+//! Regression coverage for issue #14528: indexing a type parameter `T` by a key
+//! parameter whose constraint is `keyof Wrapper<T>` must not draw a spurious
+//! `TS2536` when the wrapper is *key-preserving* (`type Alias<T> = T`,
+//! `NonNullable<T>`, `Readonly<T>`, `Partial<T>`).
+//!
+//! Structural rule: `T[K]` where `K extends keyof F<T>` is a valid index when
+//! the transformed key space `keyof F<T>` is assignable to `keyof T`. The
+//! structural "the index mentions a transformed `T`" heuristic cannot tell a
+//! key-preserving transform from a key-changing one, so the `TS2536` it raises
+//! is gated on the relation-backed `transformed_index_key_space_indexes_object`
+//! query. Only a key-*changing* transform (a key remap, or a *foreign* type
+//! parameter's keys such as `keyof U` with `U extends T`) yields keys outside
+//! `keyof T` and must keep erroring.
+//!
+//! Verified against `tsc` 6.x: the positive cases are clean, the negative
+//! controls report `TS2536`.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source, diagnostic_codes};
+
+fn codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    diagnostic_codes(&check_source(source, "test.ts", options))
+}
+
+fn count(source: &str, code: u32) -> usize {
+    codes(source).into_iter().filter(|&c| c == code).count()
+}
+
+#[test]
+fn transparent_alias_wrapper_keyof_constraint_no_ts2536() {
+    let src = "type Alias<T> = T;\n\
+               declare function get<T, K extends keyof Alias<T>>(o: T, k: K): T[K];";
+    assert_eq!(
+        count(src, 2536),
+        0,
+        "keyof of a transparent alias preserves keyof T: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn nonnullable_wrapper_keyof_constraint_no_ts2536() {
+    let src = "declare function get<T, K extends keyof NonNullable<T>>(o: T, k: K): T[K];";
+    assert_eq!(
+        count(src, 2536),
+        0,
+        "keyof NonNullable<T> indexes T like keyof T: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn readonly_and_partial_wrapper_keyof_constraint_no_ts2536() {
+    let src = "declare function r<T, K extends keyof Readonly<T>>(o: T, k: K): T[K];\n\
+               declare function p<T, K extends keyof Partial<T>>(o: T, k: K): T[K];";
+    assert_eq!(
+        count(src, 2536),
+        0,
+        "homomorphic mapped wrappers preserve keyof T: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn renamed_binders_keyof_wrapper_constraint_no_ts2536() {
+    // No dependence on the chosen identifier names.
+    let src = "type Wrap<Q> = Q;\n\
+               declare function getW<Obj, Key extends keyof Wrap<Obj>>(o: Obj, k: Key): Obj[Key];";
+    assert_eq!(
+        count(src, 2536),
+        0,
+        "renamed alias/binders behave identically: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn keyof_wrapper_constraint_indexes_in_function_body_no_ts2536() {
+    // Expression / computation path (`o[k]` in a body) must also accept it.
+    let src = "type Alias<T> = T;\n\
+               function read<T, K extends keyof Alias<T>>(o: T, k: K) { return o[k]; }";
+    assert_eq!(
+        count(src, 2536),
+        0,
+        "expression-path indexing of a key-preserving wrapper is valid: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn foreign_type_parameter_keys_still_report_ts2536() {
+    // `keyof U` with `U extends T`: keyof U may be wider than keyof T, so it is
+    // not assignable to keyof T and must keep erroring.
+    let src = "declare function bad<T, U extends T, K extends keyof U>(o: T, k: K): T[K];";
+    assert_eq!(
+        count(src, 2536),
+        1,
+        "foreign type-parameter keys are not a valid index for T: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn key_remapping_wrapper_still_reports_ts2536() {
+    // A key remap produces keys outside `keyof T`, so the index is invalid.
+    let src = "type Remap<T> = { [P in keyof T as `get_${string & P}`]: T[P] };\n\
+               declare function bad<T, K extends keyof Remap<T>>(o: T, k: K): T[K];";
+    assert_eq!(
+        count(src, 2536),
+        1,
+        "a key-changing transform must keep erroring: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn foreign_type_parameter_keys_body_indexing_still_reports_ts2536() {
+    // Expression-path negative control: the gate must not over-suppress. `keyof U`
+    // (U extends T) is not assignable to keyof T, so `o[k]` keeps erroring.
+    let src = "function bad<T, U extends T, K extends keyof U>(o: T, k: K) { return o[k]; }";
+    assert_eq!(
+        count(src, 2536),
+        1,
+        "expression-path foreign type-parameter keys must keep erroring: {:?}",
+        codes(src)
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes #14528.

## Summary

`T[K]` where `K extends keyof F<T>` drew a spurious **TS2536** ("Type 'K'
cannot be used to index type 'T'") when `F` is a *key-preserving* transform of
`T` — a transparent alias `type Alias<T> = T`, `NonNullable<T>`,
`Readonly<T>`, `Partial<T>`. `tsc` accepts these because `keyof F<T> = keyof T`.

```ts
type Alias<T> = T;
declare function get<T, K extends keyof Alias<T>>(o: T, k: K): T[K];        // tsc: ok ; tsz (before): TS2536
declare function get2<T, K extends keyof NonNullable<T>>(o: T, k: K): T[K]; // tsc: ok ; tsz (before): TS2536
```

## Structural rule

When a key parameter's constraint is `keyof F<T>` (a transform of the object
type parameter `T`), tsc permits `T[K]` iff the transformed key space
`keyof F<T>` is assignable to `keyof T`. Key-preserving transforms keep
`keyof F<T> = keyof T` (transparent alias, `NonNullable`, `Readonly`,
`Partial`); only a key-*changing* transform (a key remap, `Pick`/`Omit`, or a
*foreign* type parameter's keys such as `keyof U` with `U extends T`) yields
keys outside `keyof T` and is rejected with TS2536.

## Root cause

The structural heuristic `generic_index_mentions_transformed_current_type_param`
(`crates/tsz-checker/src/query_boundaries/key_constraints.rs`) returns true for
*any* transform that merely **mentions** `T`, so it cannot tell a
key-preserving transform from a key-changing one. Two emit sites errored
eagerly on it — the type-node path
(`types/type_checking/indexed_access.rs`) and the expression/computation path
(`types/computation/access.rs`) — **before** the later authoritative key-space
relation check. `Readonly<T>`/`Partial<T>` already passed (the heuristic never
fires on their evaluated mapped form); `Alias<T>` (evaluates to `T`) and
`NonNullable<T>` (conditional / `T & {}`) tripped it.

## Owner layer

Checker indexed-access key validity. A new relation-backed query
`transformed_index_key_space_indexes_object` (`types/computation/access_helpers.rs`)
evaluates the index's key space and asks whether it is assignable to
`keyof T` through the shared `indexed_access_key_space_relation_outcome`
gateway (relation → outcome). Both eager emit sites gate their TS2536 on
`&& !transformed_index_key_space_indexes_object(...)`. The structural heuristic
is unchanged (it is a pure structural function that cannot do relation checks);
the precise key-preserving-vs-key-changing decision is owned by the relation
boundary.

## Adjacent-case matrix

- Positive (now clean): `keyof Alias<T>`, `keyof NonNullable<T>`,
  `keyof Readonly<T>`, `keyof Partial<T>`; renamed binders (`type Wrap<Q> = Q`);
  type-node (`declare function`) and expression (`o[k]` in a body) paths.
- Negative control (still TS2536): foreign type-parameter keys
  `keyof U` with `U extends T` (type-node and body paths); a key-remapping
  transform (a mapped type with an `as` clause that rewrites keys); an
  out-of-range literal key `T["notAKey"]`.

## Fallback

The fix can only *suppress* the heuristic's eager TS2536 when the relation
proves the index legitimately indexes `T`; it never adds diagnostics. When the
relation cannot prove validity, the original TS2536 stands and the later
authoritative checks remain in force.

## Verification

- New regression suite `indexed_access_keyof_wrapper_ts2536_tests` (8 cases,
  positive + negative, including renamed binders and both code paths) — all
  pass.
- Targeted existing suites pass:
  `ts2536_keyof_string_index_signature_tests`,
  `keyof_operand_indexed_access_validation_tests`,
  `ts2862_keyof_tparam_tests`,
  `concrete_tuple_generic_index_chain_ts2536_tests`,
  `ts7053_*`, `mapped_indexed_constraint_substitution_tests`,
  `homomorphic_indexed_access_tests`,
  `type_parameter_source_constraint_chain_tests`, and the
  `indexed_access_constraint_relation_routing_arch_tests` (arch-test counts
  updated for the added relation probe; a pre-existing stale count corrected).
- Manual repro: issue #14528 cases compile clean (`rc=0`); negative controls
  still emit TS2536.
- `cargo clippy -p tsz-checker --lib` clean; `cargo fmt` clean.
- Broad conformance/emit/fourslash owned by ready-review CI (not run locally
  per repo policy).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01CUKz6qmTcRsUEethdEstoi