### PR TITLE
feat(solver): flag-gated generation-validated canonical_def_id memo (#14344 Stage 4)

### DIFF
--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -58,6 +58,24 @@ fn lib_def_monotone_publish_enabled() -> bool {
     *ON.get_or_init(|| !std::env::var("TSZ_DISABLE_LIB_DEF_MONOTONE").is_ok_and(|v| v == "1"))
 }
 
+/// Whether the generation-validated `canonical_def_id` memo (#14344 Stage 4) is
+/// active.
+///
+/// Default-OFF: `TSZ_CANONICAL_DEFID=1` opts in. When off, `canonical_def_id`
+/// delegates straight to `canonical_def_id_uncached`, which is the verbatim
+/// pre-memo alias-forward chase — so flag-off is byte-identical to before this
+/// change. When on, repeated `canonical_def_id` calls for the same `DefId` are
+/// served from a per-`DefId` memo that is invalidated whenever the store's
+/// `generation` bumps (every `alias_forwards` mutation bumps it via
+/// `set_alias_forward`), so the memo can never return a stale canonical after a
+/// chain is extended. Gated behind a `OnceLock` read of the env var, mirroring
+/// [`lib_def_monotone_publish_enabled`].
+fn canonical_defid_memo_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("TSZ_CANONICAL_DEFID").is_ok_and(|v| v == "1"))
+}
+
 type CrossFileQueryCacheKey = (u8, u32, u32, u32, u64);
 type CrossFileQueryCacheValue = (TypeId, Arc<Vec<TypeParamInfo>>);
 type DefDashMap<K, V> = DashMap<K, V, FxBuildHasher>;
@@ -299,6 +317,20 @@ pub struct DefinitionStore {
     /// and an opaque application.
     alias_forwards: DefDashMap<DefId, DefId>,
 
+    /// Generation-validated memo of [`Self::canonical_def_id`] (#14344 Stage 4).
+    ///
+    /// Maps a queried `DefId` to `(canonical_def_id, generation_at_memo_time)`.
+    /// `canonical_def_id` re-chases the `alias_forwards` map on every call, and
+    /// it is consulted while building relation/eval cache keys, so a hot program
+    /// re-walks the same short chains constantly. This memo collapses the repeats
+    /// to O(1) — but the chain is MUTABLE (`set_alias_forward` can extend
+    /// `A -> B` to `A -> B -> C` after a memo entry exists), so an entry is only
+    /// trusted while its stored generation matches the store's current
+    /// `generation`. Every `alias_forwards` mutation bumps the generation (see
+    /// `set_alias_forward`), so a stale entry can never be returned: a changed
+    /// chain forces a re-chase. Only consulted when [`canonical_defid_memo_enabled`].
+    canonical_def_id_memo: DefDashMap<DefId, (DefId, u64)>,
+
     /// Reverse map: `TypeId` -> `DefId` for named types.
     ///
     /// When a class/interface instance type is computed, the checker registers it here
@@ -497,6 +529,7 @@ impl DefinitionStore {
             next_id: AtomicU32::new(DefId::FIRST_VALID),
             generation: AtomicU64::new(1),
             alias_forwards: DefDashMap::default(),
+            canonical_def_id_memo: DefDashMap::default(),
             type_to_def: DefDashMap::default(),
             type_param_for_decl_node: DefDashMap::default(),
             symbol_def_index: DefDashMap::with_capacity_and_hasher(id_capacity, Default::default()),
@@ -995,10 +1028,51 @@ impl DefinitionStore {
     }
 
     /// Resolve a `DefId` through the import-alias forwarding chain to the
-    /// declaring definition. Identity for non-alias defs. The chase is
-    /// depth-bounded so a (refused, but defensively handled) cycle cannot
-    /// loop.
+    /// declaring definition. Identity for non-alias defs.
+    ///
+    /// When [`canonical_defid_memo_enabled`] (`TSZ_CANONICAL_DEFID=1`, #14344
+    /// Stage 4), repeats are served from a generation-validated memo: an entry
+    /// is trusted only while its stored generation matches the store's current
+    /// `generation`. Every `alias_forwards` mutation bumps the generation, so a
+    /// chain extended after an entry was memoized (`A -> B` becomes
+    /// `A -> B -> C`) is re-chased instead of returning the stale `B`. When the
+    /// flag is off (default), this delegates straight to
+    /// [`Self::canonical_def_id_uncached`], so behavior is byte-identical to the
+    /// pre-memo chase.
     pub fn canonical_def_id(&self, def_id: DefId) -> DefId {
+        if canonical_defid_memo_enabled() {
+            self.canonical_def_id_memoized(def_id)
+        } else {
+            self.canonical_def_id_uncached(def_id)
+        }
+    }
+
+    /// Generation-validated memo path for [`Self::canonical_def_id`].
+    ///
+    /// Kept as a flag-independent method so the memo's correctness — in
+    /// particular its generation invalidation when an alias chain is extended
+    /// after an entry is cached — can be unit-tested directly without depending
+    /// on the process-wide `TSZ_CANONICAL_DEFID` `OnceLock`/env state.
+    fn canonical_def_id_memoized(&self, def_id: DefId) -> DefId {
+        let current_gen = self.generation();
+        if let Some(entry) = self.canonical_def_id_memo.get(&def_id)
+            && entry.1 == current_gen
+        {
+            return entry.0;
+        }
+        let canonical = self.canonical_def_id_uncached(def_id);
+        self.canonical_def_id_memo
+            .insert(def_id, (canonical, current_gen));
+        canonical
+    }
+
+    /// The verbatim alias-forward chase: resolve `def_id` through the
+    /// import-alias forwarding chain to the declaring definition. Identity for
+    /// non-alias defs. The chase is depth-bounded so a (refused, but
+    /// defensively handled) cycle cannot loop. This is the pre-memo behavior;
+    /// [`Self::canonical_def_id`] wraps it with the optional generation-validated
+    /// memo.
+    pub fn canonical_def_id_uncached(&self, def_id: DefId) -> DefId {
         let mut current = def_id;
         for _ in 0..8 {
             match self.alias_forwards.get(&current) {

--- a/crates/tsz-solver/tests/def_tests.rs
+++ b/crates/tsz-solver/tests/def_tests.rs
@@ -1886,4 +1886,87 @@ fn test_all_definition_names_qualifies_namespace_exports() {
     );
 }
 
+/// #14344 Stage 4: the generation-validated `canonical_def_id` memo must NOT
+/// return a stale canonical after the alias chain is EXTENDED past a cached
+/// entry. This is the correctness blocker the design hinges on: cache `A -> B`,
+/// then add `B -> C`, and the next resolve of `A` must return `C` (the chain is
+/// mutable; `set_alias_forward` bumps the store generation, invalidating the
+/// stamped memo entry so it re-chases).
+#[test]
+fn canonical_def_id_memo_rechase_after_chain_extension() {
+    let interner = create_test_interner();
+    let store = DefinitionStore::new();
+
+    let a = store.register(DefinitionInfo::type_alias(
+        interner.intern_string("A"),
+        vec![],
+        TypeId::NUMBER,
+    ));
+    let b = store.register(DefinitionInfo::type_alias(
+        interner.intern_string("B"),
+        vec![],
+        TypeId::STRING,
+    ));
+    let c = store.register(DefinitionInfo::type_alias(
+        interner.intern_string("C"),
+        vec![],
+        TypeId::BOOLEAN,
+    ));
+
+    // Chain A -> B, then prime the memo so an entry `A -> (B, gen)` exists.
+    store.set_alias_forward(a, b);
+    assert_eq!(store.canonical_def_id_memoized(a), b);
+
+    // Extend the chain B -> C. `set_alias_forward` bumps the generation, so the
+    // stamped `A -> B` memo entry is no longer trusted.
+    store.set_alias_forward(b, c);
+    assert_eq!(
+        store.canonical_def_id_memoized(a),
+        c,
+        "memo must re-chase after the chain was extended, not return stale B"
+    );
+    // And the uncached chase agrees (the memo result is never invented).
+    assert_eq!(store.canonical_def_id_uncached(a), c);
+}
+
+/// The memo result is byte-identical to the uncached chase for a stable chain
+/// and for a non-alias identity def, across repeated calls (warm hits).
+#[test]
+fn canonical_def_id_memo_matches_uncached_for_stable_chain() {
+    let interner = create_test_interner();
+    let store = DefinitionStore::new();
+
+    let a = store.register(DefinitionInfo::type_alias(
+        interner.intern_string("A"),
+        vec![],
+        TypeId::NUMBER,
+    ));
+    let b = store.register(DefinitionInfo::type_alias(
+        interner.intern_string("B"),
+        vec![],
+        TypeId::STRING,
+    ));
+    let lonely = store.register(DefinitionInfo::type_alias(
+        interner.intern_string("Lonely"),
+        vec![],
+        TypeId::BOOLEAN,
+    ));
+    store.set_alias_forward(a, b);
+
+    // Repeated calls (first a miss-then-fill, then warm hits) all agree with
+    // the uncached chase.
+    for _ in 0..3 {
+        assert_eq!(
+            store.canonical_def_id_memoized(a),
+            store.canonical_def_id_uncached(a)
+        );
+        assert_eq!(
+            store.canonical_def_id_memoized(lonely),
+            store.canonical_def_id_uncached(lonely)
+        );
+    }
+    // A non-alias def is its own canonical.
+    assert_eq!(store.canonical_def_id_memoized(lonely), lonely);
+}
+
 include!("def_tests_parts/type_to_def.rs");


### PR DESCRIPTION
Goal: hold

The prototype of #14344 Stage 4's corrected viable design: a **generation-validated lazy memo of `canonical_def_id`**. Flag-gated infrastructure for the canonical-identity migration — flag-OFF (default) is byte-identical to today; flag-ON serves the alias-forward chase from a memo that can never return a stale canonical.

This lands as `hold` (#14344 infra), NOT a perf `fast` PR: I measured and `canonical_def_id` is NOT hot (see Measurement). The value is the verified, parity-safe Stage-4 scaffold with its correctness blocker proven, not a speed win.

## Corrected design (why the lazy memo, not registration-time materialization)

The Stage-4 design Workflow refuted "materialize canonical id at registration": `alias_forwards` is populated LATE and mutably by the checker (`heritage_publication.rs` `register_alias_def_forwarding`), not at `DefinitionStore::register`, so a registration-time capture stores the stale identity. The viable shape is a lazy memo of the existing `canonical_def_id` 8-hop alias chase.

## What changed

- `canonical_def_id` (def/core.rs) split into `canonical_def_id_uncached` (the verbatim pre-change chase) + a public wrapper.
- New `canonical_def_id_memo: DefDashMap<DefId, (DefId, generation)>` on `DefinitionStore`.
- `canonical_defid_memo_enabled()` — `OnceLock` env gate `TSZ_CANONICAL_DEFID=1`, default OFF, mirroring `lib_def_monotone_publish_enabled`. Flag-OFF delegates straight to `canonical_def_id_uncached`.
- All existing `canonical_def_id` read-sites inherit the memo via delegation — zero edits.

## Structural rule (the correctness blocker)

The alias chain is MUTABLE: `set_alias_forward` can extend `A -> B` to `A -> B -> C` after a memo entry for `A` exists. So a memo entry is trusted ONLY while its stored generation equals the store's current `generation`. Every `alias_forwards` mutation bumps the generation (in `set_alias_forward`), so an extended chain forces a re-chase — the memo can never return a stale canonical. Proven by `canonical_def_id_memo_rechase_after_chain_extension`: cache `A -> B`, add `B -> C`, assert the next resolve returns `C`.

## Honest scope

This is a perf/infra memo of the alias chase. It does NOT move the `type_environment_raw_symbol_lazy_fallbacks` counter from #14520 — that is a different (raw-SymbolId-fallback) path. This PR is not the content-canonical identity flip (Stage 5); it is the flag-gated memo scaffold Stage 4 needs.

## Anti-hardcoding

No name/file-string predicates; the memo key is the structural `DefId` and the value is the structural canonical + a generation stamp.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo check -p tsz-solver` clean; `cargo clippy -p tsz-solver` clean.
- (A) Flag-OFF byte-parity (hard gate): the default path delegates to `canonical_def_id_uncached`, the verbatim pre-change chase — byte-identical by construction. 105/105 `def::` tests pass.
- (B) Flag-independent correctness unit tests pass: `canonical_def_id_memo_rechase_after_chain_extension` (generation-invalidation on chain extension — the blocker), `canonical_def_id_memo_matches_uncached_for_stable_chain` (warm-hit + non-alias identity equal the uncached chase). Tested via a flag-independent `canonical_def_id_memoized` helper so the invalidation logic is verified without the process-wide `OnceLock`.
- (C) Measurement (HONEST): instrumented the public `canonical_def_id` ENTRY (entry-calls / distinct, per the measure-at-the-boundary discipline). On a 137-file, 16-deep barrel-re-export, 10k-line alias-heavy workload, `set_alias_forward` fired 0 times and `canonical_def_id` was called <4 times total — `alias_forwards` stays empty/trivial in the common case (the single populating site, `register_alias_def_forwarding`, is a narrow import-alias-in-annotation case). So `canonical_def_id` is NOT hot and the memo yields no wall-time win. Hence flag-gated `hold` infra, not always-on `fast`.
- CI conformance/emit/fourslash authoritative for broad parity (flag-OFF default).
