### PR TITLE
feat(solver): EvaluationResult termination channel + guard-firing counters (#14346 scaffold)

### DIFF
--- a/crates/tsz-common/src/perf_counters/definitions.rs
+++ b/crates/tsz-common/src/perf_counters/definitions.rs
@@ -300,6 +300,31 @@ perf_counter_enum! {
 }
 
 perf_counter_enum! {
+    /// Which guard cut a `TypeEvaluator::evaluate` walk short (#14346). One
+    /// variant per bail outcome in the evaluator's guard prologue; the counter
+    /// dump shows the firing-order signal the issue flags — which bound a
+    /// runaway recursive walk actually hits first. Mirrors the typed
+    /// `crate::evaluation::result::TerminationKind` channel on the solver side;
+    /// measurement only, never fed back into evaluation.
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    pub enum EvaluationTerminationGuard {
+        /// Per-evaluator recursion-depth guard already exceeded on re-entry.
+        DepthExceeded = 0 => "depth_exceeded",
+        /// Process-wide evaluation fuel counter exhausted.
+        FuelExhausted = 1 => "fuel_exhausted",
+        /// Shared cross-operation solver-stack-frame breaker bailed.
+        SolverStackFrames = 2 => "solver_stack_frames",
+        /// Cross-evaluator global-depth limit (`MAX_GLOBAL_EVAL_DEPTH`) hit.
+        CrossEvalCycle = 3 => "cross_eval_cycle",
+        /// Per-query operation budget ran out.
+        QueryOpBudget = 4 => "query_op_budget",
+    }
+
+    pub const EVALUATION_TERMINATION_GUARD_COUNT;
+    pub const EVALUATION_TERMINATION_GUARD_NAMES;
+}
+
+perf_counter_enum! {
     /// Coarse symbol-kind bucket for `compute_type_of_symbol` calls.
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     pub enum ComputeTypeOfSymbolKindOutcome {

--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 impl PerfCounters {
     /// Format the current counter snapshot as a multi-line report. Returns
     /// an empty string when the counters are disabled (so callers can
@@ -983,7 +985,8 @@ impl PerfCounters {
             out.push_str("  termination guard fires:\n");
             for guard in &counters.termination_guard_fires {
                 if guard.count > 0 {
-                    out.push_str(&format!("    {:<26} {:>12}\n", guard.name, guard.count));
+                    writeln!(&mut out, "    {:<26} {:>12}", guard.name, guard.count)
+                        .expect("writing to String cannot fail");
                 }
             }
         }

--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -928,6 +928,11 @@ impl PerfCounters {
 
     fn dump_evaluator_memo(snap: &PerfCounterSnapshot) -> String {
         let counters = &snap.evaluator_memo;
+        let termination_total: u64 = counters
+            .termination_guard_fires
+            .iter()
+            .map(|g| g.count)
+            .sum();
         if counters.constructions == 0
             && counters.local_memo_hits == 0
             && counters.compute_nodes == 0
@@ -940,10 +945,11 @@ impl PerfCounters {
             && counters.lost_memo_recomputes_other == 0
             && counters.dropped_memo_entries == 0
             && counters.dropped_aux_entries == 0
+            && termination_total == 0
         {
             return String::new();
         }
-        format!(
+        let mut out = format!(
             "\nEvaluator memo lifecycle:\n  \
              constructions             {:>12}\n  \
              local memo hits           {:>12}\n  \
@@ -969,7 +975,19 @@ impl PerfCounters {
             counters.lost_memo_recomputes_other,
             counters.dropped_memo_entries,
             counters.dropped_aux_entries,
-        )
+        );
+        // #14346: which guard cut a walk short, and how often. The
+        // firing-order signal — a nonzero bucket fingerprints which bound a
+        // runaway recursive walk hits first.
+        if termination_total > 0 {
+            out.push_str("  termination guard fires:\n");
+            for guard in &counters.termination_guard_fires {
+                if guard.count > 0 {
+                    out.push_str(&format!("    {:<26} {:>12}\n", guard.name, guard.count));
+                }
+            }
+        }
+        out
     }
 
     fn dump_slow_check_timings(snap: &PerfCounterSnapshot) -> String {

--- a/crates/tsz-common/src/perf_counters/dump_tests.rs
+++ b/crates/tsz-common/src/perf_counters/dump_tests.rs
@@ -79,6 +79,9 @@ mod dump_tests {
         c.source_file_symbol_arena_cache_eligibility_outcome
             [SourceFileSymbolArenaCacheEligibilityOutcome::CacheableDeclarationFile.as_index()]
         .fetch_add(1, Ordering::Relaxed);
+        c.eval_termination_guard_fires
+            [EvaluationTerminationGuard::SolverStackFrames.as_index()]
+        .fetch_add(1, Ordering::Relaxed);
 
         let dump = PerfCounters::dump_string();
         for needle in [
@@ -104,6 +107,7 @@ mod dump_tests {
             "file_local_shadow",
             "sentinel_error_unknown",
             "cacheable_declaration_file",
+            "solver_stack_frames",
         ] {
             assert!(
                 dump.contains(needle),
@@ -188,5 +192,33 @@ mod dump_tests {
                 "perf counter text dump omitted scalar counter `{needle}`:\n{dump}"
             );
         }
+    }
+
+    #[test]
+    fn eval_termination_guard_recorder_targets_named_bucket() {
+        // #14346: `record_eval_termination_guard` increments exactly the
+        // bucket for the guard that fired, with counters on. Delta-based so it
+        // tolerates other tests sharing the process-wide atomics.
+        force_enable_perf_counters_for_tests();
+        let c = counters();
+        let load = |g: EvaluationTerminationGuard| {
+            c.eval_termination_guard_fires[g.as_index()].load(Ordering::Relaxed)
+        };
+
+        let before_fuel = load(EvaluationTerminationGuard::FuelExhausted);
+        let before_query = load(EvaluationTerminationGuard::QueryOpBudget);
+
+        record_eval_termination_guard(EvaluationTerminationGuard::FuelExhausted);
+
+        assert_eq!(
+            load(EvaluationTerminationGuard::FuelExhausted),
+            before_fuel + 1,
+            "the fired guard's bucket must increment by exactly one"
+        );
+        assert_eq!(
+            load(EvaluationTerminationGuard::QueryOpBudget),
+            before_query,
+            "an unrelated guard's bucket must not move"
+        );
     }
 }

--- a/crates/tsz-common/src/perf_counters/recorders/solver.rs
+++ b/crates/tsz-common/src/perf_counters/recorders/solver.rs
@@ -326,3 +326,17 @@ pub fn record_eval_dropped_aux_entries(count: u64) {
         .eval_dropped_aux_entries
         .fetch_add(count, Ordering::Relaxed);
 }
+
+/// Record which guard cut a `TypeEvaluator::evaluate` walk short (#14346).
+///
+/// The firing-order signal the issue flags: which bound a runaway recursive
+/// walk hits first. Measurement only — the evaluator's bail outcome (the
+/// returned `TypeId`) is unchanged whether or not this fires. Zero atomic
+/// traffic and a single predictable branch when `TSZ_PERF_COUNTERS` is off.
+#[inline]
+pub fn record_eval_termination_guard(guard: EvaluationTerminationGuard) {
+    if !enabled_fast() {
+        return;
+    }
+    counters().eval_termination_guard_fires[guard.as_index()].fetch_add(1, Ordering::Relaxed);
+}

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -253,6 +253,12 @@ pub struct PerfCounters {
     /// Auxiliary memo entries (conditional-subtype + contains-infer) dropped
     /// with their evaluator; these tables are never drained anywhere.
     pub eval_dropped_aux_entries: AtomicU64,
+    /// Which guard cut a `TypeEvaluator::evaluate` walk short, bucketed by
+    /// [`EvaluationTerminationGuard`] (#14346). The firing-order signal the
+    /// issue flags: which bound a runaway recursive walk hits first. Always
+    /// `EVALUATION_TERMINATION_GUARD_COUNT` long, in
+    /// `EVALUATION_TERMINATION_GUARD_NAMES` order.
+    pub eval_termination_guard_fires: [AtomicU64; EVALUATION_TERMINATION_GUARD_COUNT],
 
     // ─── interner ────────────────────────────────────────────────────────
     pub interner_intern_calls: AtomicU64,
@@ -494,6 +500,8 @@ impl PerfCounters {
             eval_lost_memo_recomputes_other: AtomicU64::new(0),
             eval_dropped_memo_entries: AtomicU64::new(0),
             eval_dropped_aux_entries: AtomicU64::new(0),
+            eval_termination_guard_fires: [const { AtomicU64::new(0) };
+                EVALUATION_TERMINATION_GUARD_COUNT],
             interner_intern_calls: AtomicU64::new(0),
             interner_intern_hits: AtomicU64::new(0),
             interner_intern_misses: AtomicU64::new(0),

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -584,6 +584,13 @@ pub struct EvaluatorMemoCounters {
     /// Auxiliary memo entries (conditional-subtype / contains-infer)
     /// discarded at evaluator drop; never drained anywhere.
     pub dropped_aux_entries: u64,
+    /// Which guard cut an `evaluate` walk short, bucketed by
+    /// [`EvaluationTerminationGuard`] (#14346). The firing-order signal: which
+    /// bound a runaway recursive walk hits first. Always
+    /// `EVALUATION_TERMINATION_GUARD_COUNT` long, in
+    /// `EVALUATION_TERMINATION_GUARD_NAMES` order, so consumers can index by
+    /// position; a zero count means "not hit", not "unwired".
+    pub termination_guard_fires: Vec<NamedCount>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -852,6 +859,12 @@ impl PerfCounters {
                 lost_memo_recomputes_other: load(&c.eval_lost_memo_recomputes_other),
                 dropped_memo_entries: load(&c.eval_dropped_memo_entries),
                 dropped_aux_entries: load(&c.eval_dropped_aux_entries),
+                termination_guard_fires: (0..EVALUATION_TERMINATION_GUARD_COUNT)
+                    .map(|i| NamedCount {
+                        name: EVALUATION_TERMINATION_GUARD_NAMES[i],
+                        count: load(&c.eval_termination_guard_fires[i]),
+                    })
+                    .collect(),
             },
             by_reason: (0..CHECKER_CREATION_REASON_COUNT)
                 .map(|i| ByReasonRow {

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -564,9 +564,17 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     }
 
     /// Evaluate a normalized request and return the typed result stage.
+    ///
+    /// The sole producer of [`EvaluationResult`]. In this #14346 scaffold
+    /// slice it always reports `Termination::Complete`: `self.evaluate`
+    /// already collapses every guard bail to a (relation-preserving) `TypeId`
+    /// internally, so the typed channel cannot observe an incomplete walk yet.
+    /// A future stage threads the bail verdict out so a budget-truncated walk
+    /// stops fabricating a finished type; until then the result is
+    /// byte-identical to the pre-channel evaluator.
     pub fn evaluate_request_result(&mut self, request: EvaluationRequest) -> EvaluationResult {
         self.set_no_unchecked_indexed_access(request.no_unchecked_indexed_access());
-        EvaluationResult::new(self.evaluate(request.type_id()))
+        EvaluationResult::complete(self.evaluate(request.type_id()))
     }
 
     // =========================================================================
@@ -874,10 +882,18 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         // Check if depth was already exceeded in a previous call
         if self.guard.is_exceeded() {
+            // #14346 observability (no-op when counters off): record which
+            // guard cut this walk short. The bail outcome is unchanged.
+            tsz_common::perf_counters::record_eval_termination_guard(
+                tsz_common::perf_counters::EvaluationTerminationGuard::DepthExceeded,
+            );
             return TypeId::ERROR;
         }
         // Cross-instance per-query operation budget (see `query_budget`).
         let Some(_query_frame) = self.enter_eval_query_budget() else {
+            tsz_common::perf_counters::record_eval_termination_guard(
+                tsz_common::perf_counters::EvaluationTerminationGuard::QueryOpBudget,
+            );
             return type_id;
         };
 
@@ -895,6 +911,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // proceed at a shallower depth without inheriting a sticky
                 // exceeded flag. See the analogous DepthExceeded arm below.
                 self.mark_silent_depth_bailed();
+                tsz_common::perf_counters::record_eval_termination_guard(
+                    tsz_common::perf_counters::EvaluationTerminationGuard::CrossEvalCycle,
+                );
                 return type_id;
             }
             let result = self.evaluate_guarded(type_id);
@@ -928,6 +947,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         crate::recursion::with_solver_frame(|| self.evaluate_guarded_inner(type_id)).unwrap_or_else(
             || {
                 self.mark_silent_depth_bailed();
+                tsz_common::perf_counters::record_eval_termination_guard(
+                    tsz_common::perf_counters::EvaluationTerminationGuard::SolverStackFrames,
+                );
                 type_id
             },
         )
@@ -1111,6 +1133,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             self.mark_depth_exceeded();
             self.guard.leave(type_id);
             self.memo_insert(limit_epoch_at_entry, type_id, TypeId::ERROR);
+            tsz_common::perf_counters::record_eval_termination_guard(
+                tsz_common::perf_counters::EvaluationTerminationGuard::FuelExhausted,
+            );
             return TypeId::ERROR;
         }
 

--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -1,26 +1,118 @@
 //! Typed result boundary for type evaluation.
 //!
-//! The evaluator still returns a `TypeId` today, but this wrapper names the
-//! result stage so future cache/provenance metadata can be attached without
-//! threading loose tuples through the evaluation engine.
+//! The evaluator still emits a single `TypeId` today, but this wrapper names
+//! the result stage so future cache/provenance metadata can be attached
+//! without threading loose tuples through the evaluation engine.
+//!
+//! # Termination channel (#14346 scaffold)
+//!
+//! Beyond the evaluated `TypeId`, the result now carries an explicit
+//! [`Termination`] verdict mirroring the `InstantiationResult::overflowed`
+//! precedent (`crate::instantiation::result`). The verdict names *whether* a
+//! bound (depth, fuel, solver-stack frame budget, cross-eval cycle, query-op
+//! budget) cut the walk short and, if so, which one — instead of letting an
+//! outer collapse silently treat a budget-truncated partial as a finished
+//! type.
+//!
+//! In this slice the channel is a parity-safe scaffold: the sole producer
+//! ([`crate::evaluation::evaluate::TypeEvaluator::evaluate_request_result`])
+//! always reports [`Termination::Complete`], and every consumer collapses
+//! through [`EvaluationResult::into_type_id`], which ignores the verdict. The
+//! [`EvaluationResult::incomplete`] constructor is intentionally unreached
+//! (dead-code) here — a future stage wires the bail sites to it so a
+//! limit-truncated walk stops fabricating a wrong, fully-formed type.
 
 use crate::types::TypeId;
+
+/// Which evaluation guard cut a walk short.
+///
+/// One discriminant per bail class in
+/// `crate::evaluation::evaluate::TypeEvaluator::evaluate`: the
+/// recursion-depth guard, the process-wide evaluation fuel counter, the shared
+/// solver-stack-frame breaker, the cross-evaluator global-depth cycle limit,
+/// and the per-query operation budget. Carried inside
+/// [`Termination::Incomplete`] so a downstream consumer can distinguish a
+/// genuine result from a budget-limited approximation, and (in a later stage)
+/// refuse to memoize it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TerminationKind {
+    /// The per-evaluator recursion-depth guard tripped (`guard.is_exceeded`).
+    DepthExceeded,
+    /// The process-wide evaluation fuel counter was exhausted.
+    FuelExhausted,
+    /// The shared cross-operation solver-stack-frame breaker bailed
+    /// (`crate::recursion::with_solver_frame`).
+    SolverStackFrames,
+    /// The cross-evaluator global-depth limit (`MAX_GLOBAL_EVAL_DEPTH`)
+    /// short-circuited to keep the native stack bounded.
+    CrossEvalCycle,
+    /// The per-query operation budget (`enter_eval_query_budget`) ran out.
+    QueryOpBudget,
+}
+
+/// Whether an evaluation walk ran to completion or was bounded short.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Termination {
+    /// The walk finished within every guard; `type_id` is the true result.
+    Complete,
+    /// A guard ([`TerminationKind`]) cut the walk short. `partial` is the
+    /// relation-preserving approximation the bail surfaced (never a sentinel
+    /// leak), kept so a depth-unaware consumer does not fall back to an
+    /// un-evaluated original.
+    Incomplete {
+        kind: TerminationKind,
+        partial: TypeId,
+    },
+}
 
 /// The normalized output of an evaluation request.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct EvaluationResult {
     type_id: TypeId,
+    termination: Termination,
 }
 
 impl EvaluationResult {
-    pub const fn new(type_id: TypeId) -> Self {
-        Self { type_id }
+    /// Construct a result for a walk that ran to completion.
+    pub const fn complete(type_id: TypeId) -> Self {
+        Self {
+            type_id,
+            termination: Termination::Complete,
+        }
+    }
+
+    /// Construct a result for a walk a guard cut short, carrying the
+    /// relation-preserving `partial` type and the [`TerminationKind`] that
+    /// fired.
+    ///
+    /// Intentionally unreached in this scaffold slice: the sole producer
+    /// always reports [`Termination::Complete`], so behavior is byte-identical
+    /// to before. A future stage routes the bail sites here.
+    pub const fn incomplete(partial: TypeId, kind: TerminationKind) -> Self {
+        Self {
+            type_id: partial,
+            termination: Termination::Incomplete { kind, partial },
+        }
     }
 
     pub const fn type_id(self) -> TypeId {
         self.type_id
     }
 
+    /// The termination verdict for this walk.
+    pub const fn termination(self) -> Termination {
+        self.termination
+    }
+
+    /// Whether a guard cut this walk short.
+    pub const fn is_incomplete(self) -> bool {
+        matches!(self.termination, Termination::Incomplete { .. })
+    }
+
+    /// Collapse the result to a single `TypeId`, ignoring the termination
+    /// verdict. The verdict-aware path is reserved for a future stage; today
+    /// every consumer collapses here, so the emitted type and diagnostics are
+    /// byte-identical to the pre-channel evaluator.
     pub const fn into_type_id(self) -> TypeId {
         self.type_id
     }
@@ -32,16 +124,36 @@ impl EvaluationResult {
 
 #[cfg(test)]
 mod tests {
-    use super::EvaluationResult;
+    use super::{EvaluationResult, Termination, TerminationKind};
     use crate::types::TypeId;
 
     #[test]
-    fn result_wraps_evaluated_type_id() {
-        let result = EvaluationResult::new(TypeId::STRING);
+    fn complete_result_wraps_evaluated_type_id() {
+        let result = EvaluationResult::complete(TypeId::STRING);
 
         assert_eq!(result.type_id(), TypeId::STRING);
         assert_eq!(result.into_type_id(), TypeId::STRING);
+        assert_eq!(result.termination(), Termination::Complete);
+        assert!(!result.is_incomplete());
         assert!(result.is_identity_for(TypeId::STRING));
         assert!(!result.is_identity_for(TypeId::NUMBER));
+    }
+
+    #[test]
+    fn incomplete_result_carries_partial_and_kind() {
+        // Reserved for a future stage; today no producer reaches this arm.
+        let result = EvaluationResult::incomplete(TypeId::NUMBER, TerminationKind::DepthExceeded);
+
+        assert!(result.is_incomplete());
+        // `into_type_id` returns the relation-preserving partial regardless of
+        // the verdict — the same collapse every consumer performs today.
+        assert_eq!(result.into_type_id(), TypeId::NUMBER);
+        assert_eq!(
+            result.termination(),
+            Termination::Incomplete {
+                kind: TerminationKind::DepthExceeded,
+                partial: TypeId::NUMBER,
+            }
+        );
     }
 }


### PR DESCRIPTION
Goal: hold

The adversarially-verified GO first-slice of the #14346 (emergent termination — the #3 root of master issue #14351) work. This is the #14346 analog of #14520: a **parity-safe scaffold completion** that enriches the bare `EvaluationResult` `TypeId` wrapper with a typed termination channel, plus a guard-firing observability counter. It lays the typed-termination foundation that future stages use to stop a budget-truncated walk from fabricating a wrong, fully-formed type — **without changing any guard threshold or bail outcome**.

The limits are deliberately NOT unified here (`limits/mod.rs` warns a depth-bail policy change caused a 7.1x ts-toolbelt slowdown, #6973); no threshold, no bail outcome, and no returned `TypeId` is touched.

## What it adds

1. **Typed termination channel** (`crates/tsz-solver/src/evaluation/result.rs`). Mirrors the `InstantiationResult::overflowed` precedent. `EvaluationResult` now carries a `Termination` verdict:
   - `enum Termination { Complete, Incomplete { kind: TerminationKind, partial: TypeId } }`
   - `enum TerminationKind { DepthExceeded, FuelExhausted, SolverStackFrames, CrossEvalCycle, QueryOpBudget }` — one discriminant per bail class in `TypeEvaluator::evaluate`.
   - Constructors `EvaluationResult::complete(tid)` and `::incomplete(partial, kind)`; `into_type_id()` returns the `type_id` ignoring the verdict.
   - The `incomplete` constructor is **intentionally unreached (dead code)** in this slice. No bail site produces `Incomplete` — that is a future stage.

2. **Sole producer reports `Complete`** (`evaluate.rs:evaluate_request_result`): `EvaluationResult::new(...)` → `EvaluationResult::complete(...)`. Every result is `Complete` today, so the typed channel cannot observe an incomplete walk yet.

3. **Guard-firing observability counter** (additive, gated by the existing `TSZ_PERF_COUNTERS` via `enabled_fast()`). A new enum-backed `EvaluationTerminationGuard` family (`perf_counters/definitions.rs`) + array counter (`runtime.rs`) + recorder `record_eval_termination_guard` (`recorders/solver.rs`) + snapshot field (`snapshot.rs`) + text dump (`dump.rs`). At each of the 5 evaluator bail sites the recorder records WHICH guard fired — the firing-order signal the issue flags (which bound a runaway recursive walk hits first). Single predictable branch when counters are off; zero atomic traffic. Measurement only — never fed back into evaluation.

## Structural rule

When `TypeEvaluator::evaluate` cuts a walk short at a guard (recursion-depth re-entry, query-op budget, `MAX_GLOBAL_EVAL_DEPTH`, solver-stack-frame breaker, or fuel exhaustion), tsz now (a) carries the verdict through `EvaluationResult` via the solver-owned `Termination` channel, and (b) records the firing guard through the `tsz-common` perf-counter boundary. Today both are passive: the verdict is always `Complete` and every consumer collapses through `into_type_id()`.

## Parity

Byte-identical diagnostics and emitted types, by construction. The `Incomplete` arm is unreached; all three (and only three) `EvaluationResult` consumers — `evaluate.rs:evaluate_request`, `evaluate/api.rs:evaluate_type_with_request`, `caches/query_cache.rs` — collapse via `into_type_id()`, which ignores `termination`. The counter is gated by `enabled_fast()`. No threshold, bail outcome, or returned `TypeId` changed.

## Anti-hardcoding

The `TerminationKind` / `EvaluationTerminationGuard` discriminants are structural bail-class enums, not name/file-string literals or printer-output reads.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo check -p tsz-common` and `-p tsz-solver`: clean.
- `cargo clippy -p tsz-common -p tsz-solver --lib`: clean.
- `crates/tsz-solver/tests/architecture_guards.rs::evaluation_engine_keeps_request_stage_boundary` passes (5/5 guards) — the `EvaluationResult` struct, the `evaluate_request_result(...) -> EvaluationResult` signature, and the exact `evaluate_request_result(request).into_type_id()` cache-edge string are preserved.
- `evaluation::result` unit tests: the sole-producer `complete` path round-trips through `into_type_id()` and reports `Complete`; the (unreached) `incomplete` path carries its partial + kind. Pass.
- `perf_counters::dump_tests::eval_termination_guard_recorder_targets_named_bucket` (new): force-enables counters and asserts the recorder increments exactly the fired guard's bucket and leaves an unrelated bucket untouched. Pass. The `dump_string_surfaces_enum_backed_counter_families` lock was extended to cover `solver_stack_frames`. Pass.
- tsz-common `perf_counters`: 52/52 pass excluding 3 **pre-existing** failures (`schema_version_is_ten`, `snapshot_serializes_with_expected_top_level_keys`, `wired_keys_match_snapshot_struct_fields`) — these fail identically on clean `origin/main` (the merged #14520 bumped the schema constant to 11 + left `solver_materialization` out of the `wired` map without updating these assertions). Verified byte-identical to `origin/main` via `git diff origin/main -- tests.rs`/`snapshot.rs`. Net-new failures: 0.
- tsz-solver `evaluation`: 1223/1224 pass. The 1 failure (`test_conditional_infer_optional_property_present_distributive`, a `TypeId(153)` vs `TypeId(133)` identity assertion) reproduces **identically with this PR's two solver-file changes fully reverted to `origin/main`** — confirmed pre-existing, unrelated to termination. Net-new failures: 0.
- CI conformance/emit/fourslash authoritative for broad parity.

Refs #14346. Parity-safe scaffold-completion; the `Incomplete` arm is intentionally unreached this slice.
