### PR TITLE
fix(solver): preserve per-slot tuple identity for opaque-rest mapped instantiation

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1165,6 +1165,9 @@ mod mapped_optional_target_excess_property_tests;
 #[path = "tests/mapped_true_base_constraint_relation_routing_arch_tests.rs"]
 mod mapped_true_base_constraint_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/mapped_tuple_opaque_rest_identity_tests.rs"]
+mod mapped_tuple_opaque_rest_identity_tests;
+#[cfg(test)]
 #[path = "../tests/member_access_architecture_boundary_tests.rs"]
 mod member_access_architecture_boundary_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/mapped_tuple_opaque_rest_identity_tests.rs
+++ b/crates/tsz-checker/src/tests/mapped_tuple_opaque_rest_identity_tests.rs
@@ -1,0 +1,94 @@
+//! Regression tests for homomorphic mapped types over a tuple whose rest is an
+//! *opaque* element (a deferred application / type parameter, not a concrete
+//! array or tuple).
+//!
+//! Structural rule: when a homomorphic mapped type `{ [K in keyof T]: F<T[K]> }`
+//! instantiates over a tuple `[E0, ...R]` whose rest `R` cannot yet resolve to a
+//! concrete tuple/array, the mapped rest slot must index the rest element's own
+//! type (`F<R[number]>`), not the whole source tuple (`F<T[number]>`). Indexing
+//! the whole tuple folds the already-fixed prefix slots into the rest, so a
+//! later per-slot reification (`[infer H, ...infer T]` variadic rebuild) re-emits
+//! the prefix element and duplicates it — e.g. `[E0, E0, ...]` instead of
+//! `[E0, E1, ...]` (issue #14518). `tsc` preserves per-index element identity
+//! through these transforms; tsz must too.
+//!
+//! The owner is the solver's mapped-type instantiation
+//! (`instantiate/mapped.rs`, the `OpaqueRest` element binding).
+
+use crate::test_utils::check_source_codes;
+
+fn assert_no_diagnostics(src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        codes.is_empty(),
+        "expected no diagnostics, got: {codes:?}\nsrc:\n{src}"
+    );
+}
+
+/// The minimal witness: a homomorphic mapped (`NormalizeBox`) composed over a
+/// recursive variadic rebuild (`DeepRO`), forced through a conditional
+/// `[infer H, ...infer T]` match (`Probe`). Before the fix the inner mapped
+/// produced `[E0, ...F<WholeTuple[number]>]`; the `Probe` residual reified the
+/// rest over the whole tuple and re-emitted `E0` into slot 1, so `p[1]` came
+/// back as element 0's type and the explicit annotations below failed.
+#[test]
+fn probe_over_normalize_deepro_preserves_per_slot_identity() {
+    assert_no_diagnostics(
+        r#"
+type NormalizeBox<I> = I extends object ? { [F in keyof I]: NormalizeBox<I[F]> } : I;
+type DeepRO<S> =
+  S extends readonly [infer A, ...infer B] ? readonly [DeepRO<A>, ...DeepRO<B>]
+  : S extends object ? { readonly [N in keyof S]: DeepRO<S[N]> } : S;
+type Tup = readonly [{ a: 1 }, { b: 2 }, { wrapped: 3 }];
+type Probe<X> = X extends readonly [infer H, ...infer T] ? readonly [H, ...T] : never;
+
+declare const p: Probe<NormalizeBox<DeepRO<Tup>>>;
+const e0: { readonly a: 1 } = p[0];
+const e1: { readonly b: 2 } = p[1];
+const e2: { readonly wrapped: 3 } = p[2];
+"#,
+    );
+}
+
+/// Same structural scenario with every binder renamed (utilities, type
+/// parameters, infer variables, tuple member keys). The fix is structural, so
+/// the result must not depend on any chosen identifier (anti-hardcoding gate).
+#[test]
+fn probe_over_renamed_utilities_preserves_per_slot_identity() {
+    assert_no_diagnostics(
+        r#"
+type Wrap<Q> = Q extends object ? { [Key in keyof Q]: Wrap<Q[Key]> } : Q;
+type FreezeDeep<Src> =
+  Src extends readonly [infer Head2, ...infer Tail2] ? readonly [FreezeDeep<Head2>, ...FreezeDeep<Tail2>]
+  : Src extends object ? { readonly [Nm in keyof Src]: FreezeDeep<Src[Nm]> } : Src;
+type Triple = readonly [{ first: 10 }, { second: 20 }, { marker: 30 }];
+type Split<In> = In extends readonly [infer First, ...infer Rest] ? readonly [First, ...Rest] : never;
+
+declare const probe: Split<Wrap<FreezeDeep<Triple>>>;
+const s0: { readonly first: 10 } = probe[0];
+const s1: { readonly second: 20 } = probe[1];
+const s2: { readonly marker: 30 } = probe[2];
+"#,
+    );
+}
+
+/// A directly-authored homomorphic mapped over a tuple with a *concrete* prefix
+/// and a deferred (opaque) rest, indexed per slot. This exercises the same
+/// `OpaqueRest` instantiation path without the conditional-rebuild wrapper, and
+/// is the positive control that the prefix slot's identity is preserved.
+#[test]
+fn homomorphic_mapped_over_prefix_plus_opaque_rest_keeps_prefix_slot() {
+    assert_no_diagnostics(
+        r#"
+type Box<T> = { boxed: T };
+type Boxify<Tpl extends readonly unknown[]> = { [K in keyof Tpl]: Box<Tpl[K]> };
+type DeferRest<S> = S extends readonly [infer A, ...infer B] ? readonly [A, ...B] : S;
+
+type Input = readonly ["lead", 1, 2];
+declare const r: Boxify<DeferRest<Input>>;
+const r0: Box<"lead"> = r[0];
+const r1: Box<1> = r[1];
+const r2: Box<2> = r[2];
+"#,
+    );
+}

--- a/crates/tsz-solver/src/instantiation/instantiate/mapped.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/mapped.rs
@@ -290,8 +290,15 @@ impl<'a> TypeInstantiator<'a> {
                     /// `type_id` stays array-shaped.
                     RestArray(TypeId),
                     /// Rest of an opaque type (type parameter, lazy ref,
-                    /// etc.) — bind K = number on the existing template
-                    /// so the deferred `T[K]` shape is preserved.
+                    /// application, etc.) — rebind the mapped source to the
+                    /// rest's own inner type and bind K = number, so the
+                    /// deferred index access reads `Rest[number]` rather than
+                    /// `Source[number]`. Indexing the whole source tuple would
+                    /// fold the already-fixed prefix slots into the rest, so a
+                    /// later per-slot reification re-emits a prefix element and
+                    /// duplicates it (issue #14518). The inner type still
+                    /// carries any free type parameter, so reverse-mapped
+                    /// inference over `...T` keeps its `T[K]` relationship.
                     OpaqueRest,
                     /// Fixed element after at least one rest — the
                     /// numeric index on the full source is ambiguous, so
@@ -338,7 +345,7 @@ impl<'a> TypeInstantiator<'a> {
                         ElemBinding::RestArray(rest_arr) => {
                             (rebind_source(rest_arr), TypeId::NUMBER)
                         }
-                        ElemBinding::OpaqueRest => (new_template, TypeId::NUMBER),
+                        ElemBinding::OpaqueRest => (rebind_source(elem.type_id), TypeId::NUMBER),
                         ElemBinding::SuffixFixed => {
                             let proxy = self
                                 .interner


### PR DESCRIPTION
Goal: green

Part of #14518.

## Summary

When instantiating a homomorphic mapped type `{ [K in keyof T]: F<T[K]> }` over a
tuple `[E0, ...R]` whose rest `R` is **opaque** (a deferred application or type
parameter that has not yet resolved to a concrete array/tuple), the `OpaqueRest`
element binding in `instantiate/mapped.rs` indexed the **whole source tuple**
(`F<WholeTuple[number]>`) instead of the rest element's own type (`F<R[number]>`).

Indexing the whole tuple folds the already-fixed prefix slots into the rest. A
later per-slot reification of a `[infer H, ...infer T]` variadic rebuild then
re-expands `F<WholeTuple[number]>` over the entire tuple and re-emits the prefix
element into the rest, **duplicating the head** — producing `[E0, E0, ...]`
instead of `[E0, E1, ...]`. That degraded tuple is what surfaces as the #14518
recursive-utility `TS2339`/over-rejection family once a later literal index reads
the wrong slot.

## Structural rule

When a homomorphic mapped type instantiates over a tuple `[E0, ...R]` with an
opaque rest `R`, the mapped rest slot must index the rest element's own type
(`F<R[number]>`), exactly as the sibling `RestArray` arm rebinds the source to
the array element type. Indexing the whole source tuple is wrong because it
includes the already-fixed prefix slots; `tsc` preserves per-index element
identity through the same transforms.

## Root cause / owner

Solver — homomorphic mapped-type instantiation over a tuple
(`crates/tsz-solver/src/instantiation/instantiate/mapped.rs`, the `OpaqueRest`
element binding). The one-line behavior change rebinds the mapped source to the
rest's inner type (`rebind_source(elem.type_id)`) before binding `K = number`.
The inner type still carries any free type parameter, so reverse-mapped
inference over a bare `...T` keeps its `T[K]` relationship unchanged.

## Scope note (honest)

This fixes the homomorphic-mapped opaque-rest head-duplication mechanism and the
3-utility witness from the issue thread (`NormalizeBox`+`DeepRO`+`Probe`). The
full 4-utility headline repro is **not** fully closed by this change: its
residual false positive is driven by the limited-(first-pass)-resolver producing
a structurally-degraded composed result that is interned and matched before the
full resolver runs — the resolver-context-independence problem tracked by #13980
/ #14330. This PR is a correct, self-contained step in that family, not the whole
campaign, so it does not auto-close #14518.

## Adjacent matrix covered

- Conditional `[infer H, ...infer T]` rebuild over a homomorphic-mapped recursive
  tuple (the head-dup witness).
- The same scenario with every binder (utility names, type parameters, infer
  variables, tuple member keys) renamed — anti-hardcoding gate.
- A directly-authored homomorphic mapped over a tuple with a concrete prefix plus
  an opaque rest, indexed per slot (positive control that the prefix slot is
  preserved).

## Verification

- `cargo test -p tsz-checker --lib mapped_tuple_opaque_rest_identity` — 3/3 pass
  with the fix; the two `Probe` witnesses fail on the clean tree without it
  (verified by stashing the solver change), proving they are genuine regression
  tests.
- `cargo test -p tsz-solver --lib -- mapped tuple instantiat` — 1106/0.
- Full `cargo test -p tsz-solver --lib` and the checker
  `mapped/tuple/variadic/infer/conditional` subset: the fix introduces **zero**
  new failures (the pre-existing failures on this branch are identical with and
  without the change, confirmed by diffing the failing sets).
- Broad conformance / emit / fourslash / project-corpus suites: delegated to
  ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_018Pe52kuCTGB287pHYNDJJT)_