### PR TITLE
hold(bench): #14344 content-addressing flip validation harness + baseline

### DIFF
--- a/scripts/bench/canonical-defid-harness/README.md
+++ b/scripts/bench/canonical-defid-harness/README.md
@@ -1,0 +1,66 @@
+# #14344 content-addressing flip — end-to-end validation harness
+
+Validates the #14344 canonical-`DefId` flip (issue #18 / dualenv brick-3 election
+wiring) against the #13862 cross-arena wrong-decl identity-collision witness.
+
+## What it measures
+
+Per `RAYON_NUM_THREADS` in {1,2,4,8,16}, with `TSZ_CANONICAL_DEFID` both OFF and ON:
+
+1. The **#14520 counter** `identity_collision_wrong_decl_suppressed` (printed by the
+   `--extendedDiagnostics` perf-counter dump as `wrong-decl collisions`). It increments
+   in `tsz-solver/src/def/resolver.rs::raw_symbol_fallback_def` whenever a
+   store-registered `DefId(N)`, reread as a `SymbolId`, would resolve to a
+   **different-named** def — the #13862 `HTMLDivElement(218) → FileSystemEntry(symbol 218)`
+   class of collision (the guard defers instead of resolving wrong).
+2. The **md5 of the sorted diagnostic output** (the observational behavior).
+
+## Witness fixture
+
+`fixtures/dom_multi.tsconfig.json` — a 3-file project (`widgets.ts`/`forms.ts`/`app.ts`)
+that indexes `HTMLElementTagNameMap[...]` (div/span/a/input/button) and threads those
+DOM types across module boundaries. The DOM lib drives the collision: lib symbols keep
+the `u32::MAX` declaration-file sentinel, so the symbol→def index is first-writer-wins
+across lib binders, and `HTMLElementTagNameMap["div"]` resolution hits the colliding
+fallback. (A pure user-type cross-module fixture — `fixtures/{shared,mod_a,mod_b,entry}.ts`
+— is kept as a NEGATIVE control: it fires the counter 0 times, confirming the collision
+is lib-symbol-id-space specific, not generic cross-module.) `fixtures/dom_tagname.ts` is
+the minimal single-file variant (counter 36).
+
+`fixtures/div_fsentry_isolation.tsconfig.json` — smallest single-file witness that
+keeps both colliding names live: `HTMLElementTagNameMap["div"]` (resolves
+`HTMLDivElement`) plus a `FileSystemEntry` reference (the documented
+`HTMLDivElement(218) → FileSystemEntry(symbol 218)` collision in
+`raw_symbol_fallback_def`). Counter 44, md5 `d41d8cd9…` (clean). Use this for
+focused flag-ON two-pass debugging.
+
+## Baseline (flag-OFF, current main `a3ee589afe`, 2026-06-22)
+
+```
+threads | OFF_counter | OFF_md5                          | ON_counter | ON_md5
+1..16   | 44          | d41d8cd98f00b204e9800998ecf8427e | 44         | d41d8cd98f00b204e9800998ecf8427e
+```
+
+- Counter is a **stable 44** on every thread count (single-file variant: 36).
+- md5 `d41d8cd9…` is the empty-string md5 — **0 user diagnostics** (the collision is
+  internally suppressed by the #13862 defer guard; it corrupts identity, not output).
+- flag-ON == flag-OFF today: `TSZ_CANONICAL_DEFID` is not recognized yet (PR1/brick-1
+  hasn't landed), so the flip is a no-op. **Expected.**
+
+## Flip success criteria (what brick-3 must achieve)
+
+- **flag-ON `counter == 0`** on every thread count — canonical content-addressed identity
+  removes the collision entirely (no def resolves to a different-named def).
+- **flag-ON `md5 == flag-OFF md5`** (`d41d8cd9…`) on every thread count — the flip fixes
+  identity only; it must be observationally byte-identical on diagnostics.
+- flag-OFF md5 stays stable across threads (regression guard).
+
+## Run
+
+```
+scripts/bench/canonical-defid-harness/measure.sh [fixture-tsconfig] [tsz-bin]
+# defaults: fixtures/dom_multi.tsconfig.json + .target/release/tsz
+```
+
+Build the release binary first (`cargo build --release -p tsz-cli`). Release only —
+a checker-test build ENOSPCs the shared volume.

--- a/scripts/bench/canonical-defid-harness/fixtures/crossmod.tsconfig.json
+++ b/scripts/bench/canonical-defid-harness/fixtures/crossmod.tsconfig.json
@@ -1,0 +1,1 @@
+{ "compilerOptions": { "strict": true, "noEmit": true, "target": "es2022", "module": "esnext", "moduleResolution": "bundler", "types": [], "skipLibCheck": true }, "include": ["shared.ts","mod_a.ts","mod_b.ts","entry.ts"] }

--- a/scripts/bench/canonical-defid-harness/fixtures/div_fsentry_isolation.ts
+++ b/scripts/bench/canonical-defid-harness/fixtures/div_fsentry_isolation.ts
@@ -1,0 +1,14 @@
+// Minimal #13862 isolation witness: HTMLDivElement (resolved via the
+// HTMLElementTagNameMap["div"] index) and FileSystemEntry both bound from the
+// DOM lib. Per resolver.rs::raw_symbol_fallback_def, HTMLDivElement's registered
+// DefId collides (raw-u32) with FileSystemEntry's symbol id; the read of
+// HTMLElementTagNameMap["div"] drives the colliding raw_symbol_fallback_def path.
+// Keeps both names live so the content-difference (different-named) counter test
+// has its colliding partner present. Smallest fixture that fires #14520.
+declare const map: HTMLElementTagNameMap;
+type Div = HTMLElementTagNameMap["div"];
+declare const fse: FileSystemEntry;
+const d: Div = map.div;
+const tag: string = d.tagName;
+const fsName: string = fse.name;
+export {};

--- a/scripts/bench/canonical-defid-harness/fixtures/div_fsentry_isolation.tsconfig.json
+++ b/scripts/bench/canonical-defid-harness/fixtures/div_fsentry_isolation.tsconfig.json
@@ -1,0 +1,1 @@
+{ "compilerOptions": { "strict": true, "noEmit": true, "target": "es2022", "lib": ["es2022","dom","dom.iterable"], "types": [], "skipLibCheck": false }, "include": ["div_fsentry_isolation.ts"] }

--- a/scripts/bench/canonical-defid-harness/fixtures/dom_multi.tsconfig.json
+++ b/scripts/bench/canonical-defid-harness/fixtures/dom_multi.tsconfig.json
@@ -1,0 +1,1 @@
+{ "compilerOptions": { "strict": true, "noEmit": true, "target": "es2022", "module": "esnext", "moduleResolution": "bundler", "lib": ["es2022","dom","dom.iterable"], "types": [], "skipLibCheck": false }, "include": ["dom_multi/widgets.ts","dom_multi/forms.ts","dom_multi/app.ts"] }

--- a/scripts/bench/canonical-defid-harness/fixtures/dom_multi/app.ts
+++ b/scripts/bench/canonical-defid-harness/fixtures/dom_multi/app.ts
@@ -1,0 +1,8 @@
+import { el, type Div, type Anchor } from "./widgets";
+import { wrap, type Input, type Button } from "./forms";
+const d: Div = el("div");
+const a: Anchor = el("a");
+const i: Input = el("input");
+const b: Button = el("button");
+const tags: string[] = [d.tagName, a.href, i.value, b.type, wrap(d).tagName];
+export { tags };

--- a/scripts/bench/canonical-defid-harness/fixtures/dom_multi/forms.ts
+++ b/scripts/bench/canonical-defid-harness/fixtures/dom_multi/forms.ts
@@ -1,0 +1,5 @@
+import type { Div } from "./widgets";
+export type Input = HTMLElementTagNameMap["input"];
+export type Button = HTMLElementTagNameMap["button"];
+export function wrap(d: Div): Div { return d; }
+export const inp: Input = document.createElement("input");

--- a/scripts/bench/canonical-defid-harness/fixtures/dom_multi/widgets.ts
+++ b/scripts/bench/canonical-defid-harness/fixtures/dom_multi/widgets.ts
@@ -1,0 +1,6 @@
+export type Div = HTMLElementTagNameMap["div"];
+export type Span = HTMLElementTagNameMap["span"];
+export type Anchor = HTMLElementTagNameMap["a"];
+export function el<K extends keyof HTMLElementTagNameMap>(k: K): HTMLElementTagNameMap[K] {
+  return document.createElement(k);
+}

--- a/scripts/bench/canonical-defid-harness/fixtures/dom_tagname.ts
+++ b/scripts/bench/canonical-defid-harness/fixtures/dom_tagname.ts
@@ -1,0 +1,9 @@
+// #13862 witness: indexing HTMLElementTagNameMap by 'div' resolves HTMLDivElement,
+// whose registered DefId collides (raw-u32) with a different-named lib symbol
+// (FileSystemEntry). Forces the raw_symbol_fallback_def collision path.
+declare const map: HTMLElementTagNameMap;
+type Div = HTMLElementTagNameMap["div"];
+const d: Div = map.div;
+const tag: string = d.tagName;
+function make(): HTMLElementTagNameMap["div"] { return map.div; }
+export {};

--- a/scripts/bench/canonical-defid-harness/fixtures/dom_tagname.tsconfig.json
+++ b/scripts/bench/canonical-defid-harness/fixtures/dom_tagname.tsconfig.json
@@ -1,0 +1,1 @@
+{ "compilerOptions": { "strict": true, "noEmit": true, "target": "es2022", "lib": ["es2022","dom","dom.iterable"], "types": [], "skipLibCheck": false }, "include": ["dom_tagname.ts"] }

--- a/scripts/bench/canonical-defid-harness/fixtures/entry.ts
+++ b/scripts/bench/canonical-defid-harness/fixtures/entry.ts
@@ -1,0 +1,8 @@
+import { pickA, a } from "./mod_a";
+import { pickB, b } from "./mod_b";
+// Use the cross-module Shared generically from both arenas to force
+// cross-boundary identity resolution of the same declaration.
+const ra = pickA(a);
+const rb = pickB(b);
+const merged: { id: number; name: string } = ra.id > rb.id ? ra : rb;
+export { merged };

--- a/scripts/bench/canonical-defid-harness/fixtures/mod_a.ts
+++ b/scripts/bench/canonical-defid-harness/fixtures/mod_a.ts
@@ -1,0 +1,3 @@
+import type { Shared } from "./shared";
+export function pickA<T extends Shared>(x: T): T { return x; }
+export const a: Shared = { id: 1, name: "a" };

--- a/scripts/bench/canonical-defid-harness/fixtures/mod_b.ts
+++ b/scripts/bench/canonical-defid-harness/fixtures/mod_b.ts
@@ -1,0 +1,4 @@
+import type { Shared as S, Other } from "./shared";
+export function pickB<T extends S>(x: T): T { return x; }
+export const b: S = { id: 2, name: "b" };
+export const o: Other = { kind: "k", data: null };

--- a/scripts/bench/canonical-defid-harness/fixtures/shared.ts
+++ b/scripts/bench/canonical-defid-harness/fixtures/shared.ts
@@ -1,0 +1,2 @@
+export interface Shared { id: number; name: string; }
+export interface Other { kind: string; data: unknown; }

--- a/scripts/bench/canonical-defid-harness/measure.sh
+++ b/scripts/bench/canonical-defid-harness/measure.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# #14344 content-addressing flip — end-to-end validation harness.
+# ==============================================================
+# Measures the #13862 cross-arena wrong-decl identity collision witness:
+#   (a) the #14520 `identity_collision_wrong_decl_suppressed` perf counter, and
+#   (b) the md5 of the (sorted) diagnostic output,
+# across RAYON_NUM_THREADS in {1,2,4,8,16}, with the `TSZ_CANONICAL_DEFID`
+# flip flag both OFF (baseline) and ON.
+#
+# SUCCESS CRITERIA for the flip (#18 PR3 / dualenv brick-3 election wiring):
+#   - flag-ON counter == 0 on every thread count (canonical identity removes the
+#     collision: no def is resolved through the raw-symbol fallback to a
+#     different-named def).
+#   - flag-ON diagnostic md5 == flag-OFF diagnostic md5 on every thread count
+#     (the flip is observationally byte-identical on output; it only fixes
+#     identity, never changes a diagnostic).
+#   - flag-OFF md5 is stable across thread counts (it is today: the harness
+#     records it so a regression is visible).
+#
+# Until brick-3 lands, the flag is unrecognized and flag-ON == flag-OFF
+# (counter stays at the baseline); that is EXPECTED — this script + the recorded
+# baseline are what brick-3 validates against.
+#
+# Usage:
+#   scripts/bench/canonical-defid-harness/measure.sh [fixture-tsconfig] [tsz-bin]
+# Defaults: the multi-file DOM witness + .target/release/tsz.
+#
+# NOTE: deliberately NOT `set -e`/`pipefail` — tsz exits non-zero when it emits
+# diagnostics and grep exits 1 on no match; both are normal here. Failures are
+# handled explicitly (`${var:-NA}`, verdict column).
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+
+TSCONFIG="${1:-$HERE/fixtures/dom_multi.tsconfig.json}"
+TSZ_BIN="${2:-$ROOT/.target/release/tsz}"
+THREADS=(1 2 4 8 16)
+
+if [[ ! -x "$TSZ_BIN" ]]; then
+  echo "error: tsz binary not found/executable: $TSZ_BIN" >&2
+  echo "  build it first: cargo build --release -p tsz-cli" >&2
+  exit 2
+fi
+
+# One compile run. Echoes "<counter>\t<diag_md5>".
+#   $1 = thread count, $2 = canonical-defid flag value (0/1)
+run_one() {
+  local threads="$1" flag="$2"
+  local counter diag_md5 raw diag_raw
+  # tsz exits non-zero when it emits diagnostics, and grep exits 1 on no match;
+  # neither is a harness error, so run these pipelines tolerant of both
+  # (pipefail/-e off inside the subshell).
+  # Counter side: needs TSZ_PERF_COUNTERS + --extendedDiagnostics to surface the
+  # perf-counter dump; the label printed is "wrong-decl collisions".
+  raw="$(RAYON_NUM_THREADS="$threads" TSZ_CANONICAL_DEFID="$flag" TSZ_PERF_COUNTERS=1 \
+    TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 \
+    "$TSZ_BIN" --noEmit --extendedDiagnostics -p "$TSCONFIG" 2>&1 || true)"
+  counter="$(printf '%s\n' "$raw" | grep -iE "wrong-decl collisions" | grep -oE "[0-9]+" | head -1)"
+  counter="${counter:-NA}"
+  # Diagnostic side: a separate clean run (no extendedDiagnostics noise), sorted
+  # so thread-order does not perturb the md5; only the diagnostic *set* matters.
+  diag_raw="$(RAYON_NUM_THREADS="$threads" TSZ_CANONICAL_DEFID="$flag" \
+    TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 \
+    "$TSZ_BIN" --noEmit -p "$TSCONFIG" 2>&1 || true)"
+  diag_md5="$(printf '%s\n' "$diag_raw" | grep -E "error TS" | sort | { md5 -q 2>/dev/null || md5sum | cut -d' ' -f1; })"
+  printf '%s\t%s\n' "$counter" "$diag_md5"
+}
+
+echo "# #14344 flip validation harness"
+echo "# fixture : $TSCONFIG"
+echo "# tsz     : $TSZ_BIN"
+echo "# columns : threads | OFF_counter | OFF_md5 | ON_counter | ON_md5 | verdict"
+echo
+
+off_md5_ref=""
+fail=0
+for t in "${THREADS[@]}"; do
+  IFS=$'\t' read -r off_counter off_md5 < <(run_one "$t" 0) || true
+  IFS=$'\t' read -r on_counter on_md5 < <(run_one "$t" 1) || true
+  if [[ -z "$off_md5_ref" ]]; then off_md5_ref="$off_md5"; fi
+
+  verdict="ok"
+  # md5 must be stable across threads (flag OFF) and identical OFF==ON.
+  if [[ "$off_md5" != "$off_md5_ref" ]]; then verdict="OFF-MD5-DRIFT"; fail=1; fi
+  if [[ "$on_md5" != "$off_md5" ]]; then verdict="ON!=OFF-MD5"; fail=1; fi
+  # When the flip is active, the counter must reach 0. (Pre-flip it stays at the
+  # baseline and `ON==OFF`, which this harness reports without failing — the
+  # caller compares against the recorded baseline.)
+  printf '%-7s | %-11s | %s | %-10s | %s | %s\n' \
+    "$t" "$off_counter" "$off_md5" "$on_counter" "$on_md5" "$verdict"
+done
+
+echo
+if [[ "$fail" -eq 0 ]]; then
+  echo "HARNESS OK: md5 stable across threads and OFF==ON (pre-flip baseline shape)."
+else
+  echo "HARNESS DRIFT: see verdict column — md5 instability is a regression."
+fi
+echo "FLIP SUCCESS = flag-ON counter==0 on every thread AND ON_md5==OFF_md5."


### PR DESCRIPTION
Standing diagnostic + validation gate for the #14344 content-addressing flip (issue #18 / the election-wiring two-pass effort). Adds `scripts/bench/canonical-defid-harness/` only — `measure.sh` + `README.md` + fixtures. No compiler/checker/solver logic; parity-safe by construction (adds scripts + .ts fixtures, nothing imports them).

What it does: compiles a #13862 cross-arena wrong-decl identity-collision witness under `TSZ_CANONICAL_DEFID` OFF and ON, across `RAYON_NUM_THREADS` {1,2,4,8,16}, capturing (a) the #14520 `identity_collision_wrong_decl_suppressed` perf counter (printed as "wrong-decl collisions") and (b) the sorted-diagnostic md5.

Witness: `fixtures/dom_multi.tsconfig.json` indexes `HTMLElementTagNameMap[...]` across modules — fires the counter because the collision is lib-symbol-id-space specific (lib symbols keep the `u32::MAX` decl-file sentinel → first-writer-wins symbol→def index in `raw_symbol_fallback_def`). A pure user-type cross-module fixture is kept as a NEGATIVE control (counter 0).

Recorded baseline (flag-OFF, deterministic across all thread counts): counter = 44, diag md5 = d41d8cd98f00b204e9800998ecf8427e (= empty md5; 0 user diagnostics — the collision is suppressed by the #13862 defer guard, so it corrupts identity not output). Flip success criteria, documented in the README: flag-ON counter == 0 on every thread count AND md5 unchanged — which fires only once the two-pass re-check wiring calls the election during checking (the mechanism bricks #14544/#14546 are byte-identical OFF/ON against this harness; confirmed).

Goal: hold

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `scripts/bench/canonical-defid-harness/measure.sh` (release binary) on current main: counter=44, md5=d41d8cd9, OFF==ON, stable across RAYON_NUM_THREADS {1,2,4,8,16}; negative-control fixture fires 0.
- Release-build diagnostic only; does NOT run in CI (no test/gate wiring added).
- `python3 scripts/arch/arch_guard.py` PASS; `bash -n measure.sh` clean.
