### PR TITLE
fix(checker): keep lib-interface body publication monotone in members (immer SetIterator next-missing FP, #13942)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/lib_augmentations.rs
+++ b/crates/tsz-checker/src/query_boundaries/lib_augmentations.rs
@@ -1,0 +1,126 @@
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::{DefId, TypeId};
+
+/// True when `candidate`'s named-property set is a strict subset of
+/// `current`'s named-property set.
+///
+/// This is the semantic boundary for lib-interface finalized-body publication:
+/// checker orchestration decides when a lib body may be published, while this
+/// helper owns the object-shape/member-set question used to reject
+/// heritage-thin re-publications.
+pub(crate) fn lib_body_strictly_loses_members(
+    db: &dyn TypeDatabase,
+    current: TypeId,
+    candidate: TypeId,
+) -> bool {
+    if current == candidate {
+        return false;
+    }
+    let Some(current_shape) = super::common::object_shape_for_type(db, current) else {
+        return false;
+    };
+    let Some(candidate_shape) = super::common::object_shape_for_type(db, candidate) else {
+        return false;
+    };
+    if candidate_shape.properties.len() >= current_shape.properties.len() {
+        return false;
+    }
+    // Every candidate member must already be present in `current` (no
+    // additions) and `candidate` is strictly smaller (checked above), so it is
+    // missing at least one member `current` has. Lib interface bodies carry few
+    // members, so a linear scan beats allocating a name set.
+    candidate_shape.properties.iter().all(|cand| {
+        current_shape
+            .properties
+            .iter()
+            .any(|cur| cur.name == cand.name)
+    })
+}
+
+pub(crate) fn is_lazy_def_identity(db: &dyn TypeDatabase, ty: TypeId, def_id: DefId) -> bool {
+    super::definition_identity::is_lazy_def_identity(db, ty, def_id)
+}
+
+pub(crate) fn type_id_is_known_to_db(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    super::common::type_id_is_known_to_db(db, type_id)
+}
+
+pub(crate) fn has_construct_signatures(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    super::checkers::constructor::has_construct_signatures(db, type_id)
+}
+
+#[cfg(test)]
+mod monotone_publication_tests {
+    //! Unit guard for the membership-monotone lib-interface body publication
+    //! that fixes the immer `SetIterator`/`MapIterator` `next`-missing false
+    //! positives (#13942): a heritage-thin re-derivation of a lib interface body
+    //! must never clobber a more-complete one in the shared store / per-file
+    //! `type_env`.
+    use super::lib_body_strictly_loses_members;
+    use tsz_solver::construction::{QueryDatabase, TypeInterner};
+    use tsz_solver::{PropertyInfo, TypeId};
+
+    fn obj(types: &TypeInterner, names: &[&str]) -> TypeId {
+        let props = names
+            .iter()
+            .map(|n| PropertyInfo::new(types.intern_string(n), TypeId::NUMBER))
+            .collect();
+        types.factory().object(props)
+    }
+
+    #[test]
+    fn thin_body_dropping_inherited_member_is_rejected() {
+        let types = TypeInterner::new();
+        // `SetIterator` heritage-complete: own `[Symbol.iterator]` + inherited
+        // `next` (from `IteratorObject` -> `Iterator`).
+        let complete = obj(&types, &["__@iterator", "next"]);
+        // Heritage-thin re-derivation: dropped the inherited `next`.
+        let thin = obj(&types, &["__@iterator"]);
+        assert!(
+            lib_body_strictly_loses_members(&types, complete, thin),
+            "a thin body that drops an inherited member must be rejected",
+        );
+        // Completion in the other order (thin published first, complete arriving)
+        // is a superset and must still win.
+        assert!(
+            !lib_body_strictly_loses_members(&types, thin, complete),
+            "heritage completion (growing the member set) must be allowed",
+        );
+    }
+
+    #[test]
+    fn growth_via_augmentation_is_allowed() {
+        let types = TypeInterner::new();
+        let base = obj(&types, &["a", "b"]);
+        let augmented = obj(&types, &["a", "b", "c"]);
+        assert!(!lib_body_strictly_loses_members(&types, base, augmented));
+    }
+
+    #[test]
+    fn equal_member_set_is_not_a_loss() {
+        let types = TypeInterner::new();
+        let a = obj(&types, &["a", "b"]);
+        let b = obj(&types, &["a", "b"]);
+        // Structurally identical objects intern to the same `TypeId`, so this
+        // also exercises the `current == candidate` short-circuit.
+        assert!(!lib_body_strictly_loses_members(&types, a, b));
+    }
+
+    #[test]
+    fn added_and_dropped_member_same_size_is_not_a_loss() {
+        let types = TypeInterner::new();
+        let current = obj(&types, &["a", "b"]);
+        // Same size, but adds `c` and drops `b`: not a strict subset, so it is
+        // not a pure membership loss and replacement proceeds.
+        let candidate = obj(&types, &["a", "c"]);
+        assert!(!lib_body_strictly_loses_members(&types, current, candidate));
+    }
+
+    #[test]
+    fn non_object_bodies_allow_replacement() {
+        let types = TypeInterner::new();
+        let o = obj(&types, &["a"]);
+        assert!(!lib_body_strictly_loses_members(&types, TypeId::NUMBER, o));
+        assert!(!lib_body_strictly_loses_members(&types, o, TypeId::STRING));
+    }
+}

--- a/crates/tsz-checker/src/query_boundaries/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/mod.rs
@@ -41,6 +41,7 @@ pub(crate) mod inference;
 pub(crate) mod intersection_display;
 pub(crate) mod js_exports;
 pub(crate) mod key_constraints;
+pub(crate) mod lib_augmentations;
 pub(crate) mod name_resolution;
 pub(crate) mod operator_wrappers;
 pub(crate) mod optional_chain;

--- a/crates/tsz-checker/src/types/queries/lib_augmentations.rs
+++ b/crates/tsz-checker/src/types/queries/lib_augmentations.rs
@@ -20,6 +20,50 @@ pub(crate) fn lib_def_finalize_freeze_enabled() -> bool {
     *ENABLED.get_or_init(|| !std::env::var("TSZ_DISABLE_LIB_DEF_FREEZE").is_ok_and(|v| v == "1"))
 }
 
+/// True when `candidate`'s named-property set is a STRICT SUBSET of `current`'s
+/// — i.e. `candidate` carries every member it shares with `current` but is
+/// missing at least one that `current` has, and adds none of its own. Used to
+/// reject a heritage-thinning re-publication of a lib interface body (see
+/// [`CheckerState::register_finalized_lib_body`]).
+///
+/// Both sides must resolve to a plain object shape; if either does not (type
+/// alias, intrinsic, application, union, …) the relation is not a member-set
+/// comparison and this returns `false` so normal replacement proceeds. Disjoint
+/// or overlapping-with-additions sets also return `false`: only a pure
+/// membership loss is blocked, which keeps publication monotone in members
+/// (heritage completion and augmentation, which only grow the set, still win).
+pub(crate) fn lib_body_strictly_loses_members(
+    db: &dyn tsz_solver::construction::TypeDatabase,
+    current: TypeId,
+    candidate: TypeId,
+) -> bool {
+    if current == candidate {
+        return false;
+    }
+    let Some(current_shape) = crate::query_boundaries::common::object_shape_for_type(db, current)
+    else {
+        return false;
+    };
+    let Some(candidate_shape) =
+        crate::query_boundaries::common::object_shape_for_type(db, candidate)
+    else {
+        return false;
+    };
+    if candidate_shape.properties.len() >= current_shape.properties.len() {
+        return false;
+    }
+    // Every candidate member must already be present in `current` (no
+    // additions) and `candidate` is strictly smaller (checked above), so it is
+    // missing at least one member `current` has. Lib interface bodies carry few
+    // members, so a linear scan beats allocating a name set.
+    candidate_shape.properties.iter().all(|cand| {
+        current_shape
+            .properties
+            .iter()
+            .any(|cur| cur.name == cand.name)
+    })
+}
+
 impl<'a> CheckerState<'a> {
     /// Lower augmentation declarations from a given arena and return the resulting `TypeId`.
     ///
@@ -186,21 +230,57 @@ impl<'a> CheckerState<'a> {
         if crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty) == Some(def_id) {
             return;
         }
-        if self.ctx.definition_store.get_body(def_id) == Some(ty) {
+        let existing_body = self.ctx.definition_store.get_body(def_id);
+        if existing_body == Some(ty) {
             return;
         }
+        // Monotone-membership publication for lib interface bodies.
+        //
+        // Lib interface bodies publish to the program-shared `DefinitionStore`
+        // and the per-file `type_env` last-writer-wins (the publish-once freeze
+        // at `resolve_lib_type_by_name`'s tail is opt-in/default-off because it
+        // regresses `declare global` augmentation cases). A later checker can
+        // re-derive a HERITAGE-THIN body for the same def: an iterator interface
+        // momentarily resolved with a heritage-thin base drops the inherited
+        // members (e.g. `SetIterator`/`MapIterator` lose `Iterator.next` reached
+        // through `IteratorObject`). Once that thin form clobbers the complete
+        // one, a consumer materializes against it — `set.values()` becomes a
+        // `next`-less `SetIterator`, drawing false TS2741/TS2322 against
+        // `IterableIterator` (#13942), and the DOM `Node`/`Element` diamond
+        // oscillates the same way (#13862/#12299).
+        //
+        // The published body must only ever GAIN members for a given def, never
+        // lose them: a body whose property set is a STRICT SUBSET of the body
+        // already published is a heritage-thinning re-derivation and is rejected
+        // (we keep and re-mirror the existing, more-complete body). Heritage
+        // completion (thin already published, complete arriving) is a superset
+        // and still wins; augmentation only adds members and still wins; same
+        // member set with refined member types still replaces. The check is
+        // order-independent — the membership-maximal body wins regardless of
+        // which checker finalizes first.
+        //
+        // This guards the FINALIZE entry point, which intentionally bypasses the
+        // store's deferred-publish drop (`set_body_with_params_impl`); the two
+        // guards are complementary — the solver's deferred flag drops thin
+        // NON-finalize re-publications, this drops thin finalize re-publications.
         let type_params = self.ctx.get_def_type_params(def_id).unwrap_or_default();
-        // Publish through the store's finalize entry point first: it bypasses
-        // the deferred-publication drop (the finalized form must replace any
-        // earlier intermediate form), and the env registration below then
-        // write-throughs the identical body (a no-op same-body publication).
-        self.ctx.definition_store.set_body_finalized(
-            def_id,
-            ty,
-            (!type_params.is_empty()).then(|| type_params.clone()),
-        );
+        let keep_existing = existing_body
+            .is_some_and(|prev| lib_body_strictly_loses_members(self.ctx.types, prev, ty));
+        let published = if keep_existing {
+            existing_body.unwrap_or(ty)
+        } else {
+            self.ctx.definition_store.set_body_finalized(
+                def_id,
+                ty,
+                (!type_params.is_empty()).then(|| type_params.clone()),
+            );
+            // The store may still suppress the write (e.g. the opt-in freeze, or
+            // the monotone-deferral guard): mirror the AUTHORITATIVE store body,
+            // not the `ty` we attempted, so the env never diverges below it.
+            self.ctx.definition_store.get_body(def_id).unwrap_or(ty)
+        };
         self.ctx
-            .register_def_auto_params_in_envs(def_id, ty, type_params);
+            .register_def_auto_params_in_envs(def_id, published, type_params);
     }
 
     /// Mutation-isolation campaign: freeze `name`'s lib def body in the
@@ -271,5 +351,81 @@ impl<'a> CheckerState<'a> {
         }
 
         crate::query_boundaries::common::has_construct_signatures(self.ctx.types, type_id)
+    }
+}
+
+#[cfg(test)]
+mod monotone_publication_tests {
+    //! Unit guard for the membership-monotone lib-interface body publication
+    //! that fixes the immer `SetIterator`/`MapIterator` `next`-missing false
+    //! positives (#13942): a heritage-thin re-derivation of a lib interface body
+    //! must never clobber a more-complete one in the shared store / per-file
+    //! `type_env`.
+    use super::lib_body_strictly_loses_members;
+    use crate::query_boundaries::common::{QueryDatabase, TypeInterner};
+    use tsz_solver::{PropertyInfo, TypeId};
+
+    fn obj(types: &TypeInterner, names: &[&str]) -> TypeId {
+        let props = names
+            .iter()
+            .map(|n| PropertyInfo::new(types.intern_string(n), TypeId::NUMBER))
+            .collect();
+        types.factory().object(props)
+    }
+
+    #[test]
+    fn thin_body_dropping_inherited_member_is_rejected() {
+        let types = TypeInterner::new();
+        // `SetIterator` heritage-complete: own `[Symbol.iterator]` + inherited
+        // `next` (from `IteratorObject` -> `Iterator`).
+        let complete = obj(&types, &["__@iterator", "next"]);
+        // Heritage-thin re-derivation: dropped the inherited `next`.
+        let thin = obj(&types, &["__@iterator"]);
+        assert!(
+            lib_body_strictly_loses_members(&types, complete, thin),
+            "a thin body that drops an inherited member must be rejected",
+        );
+        // Completion in the other order (thin published first, complete arriving)
+        // is a superset and must still win.
+        assert!(
+            !lib_body_strictly_loses_members(&types, thin, complete),
+            "heritage completion (growing the member set) must be allowed",
+        );
+    }
+
+    #[test]
+    fn growth_via_augmentation_is_allowed() {
+        let types = TypeInterner::new();
+        let base = obj(&types, &["a", "b"]);
+        let augmented = obj(&types, &["a", "b", "c"]);
+        assert!(!lib_body_strictly_loses_members(&types, base, augmented));
+    }
+
+    #[test]
+    fn equal_member_set_is_not_a_loss() {
+        let types = TypeInterner::new();
+        let a = obj(&types, &["a", "b"]);
+        let b = obj(&types, &["a", "b"]);
+        // Structurally identical objects intern to the same TypeId, so this also
+        // exercises the `current == candidate` short-circuit.
+        assert!(!lib_body_strictly_loses_members(&types, a, b));
+    }
+
+    #[test]
+    fn added_and_dropped_member_same_size_is_not_a_loss() {
+        let types = TypeInterner::new();
+        let current = obj(&types, &["a", "b"]);
+        // Same size, but adds `c` and drops `b`: not a strict subset, so it is
+        // not a pure membership loss and replacement proceeds.
+        let candidate = obj(&types, &["a", "c"]);
+        assert!(!lib_body_strictly_loses_members(&types, current, candidate));
+    }
+
+    #[test]
+    fn non_object_bodies_allow_replacement() {
+        let types = TypeInterner::new();
+        let o = obj(&types, &["a"]);
+        assert!(!lib_body_strictly_loses_members(&types, TypeId::NUMBER, o));
+        assert!(!lib_body_strictly_loses_members(&types, o, TypeId::STRING));
     }
 }

--- a/crates/tsz-checker/src/types/queries/lib_augmentations.rs
+++ b/crates/tsz-checker/src/types/queries/lib_augmentations.rs
@@ -20,50 +20,6 @@ pub(crate) fn lib_def_finalize_freeze_enabled() -> bool {
     *ENABLED.get_or_init(|| !std::env::var("TSZ_DISABLE_LIB_DEF_FREEZE").is_ok_and(|v| v == "1"))
 }
 
-/// True when `candidate`'s named-property set is a STRICT SUBSET of `current`'s
-/// — i.e. `candidate` carries every member it shares with `current` but is
-/// missing at least one that `current` has, and adds none of its own. Used to
-/// reject a heritage-thinning re-publication of a lib interface body (see
-/// [`CheckerState::register_finalized_lib_body`]).
-///
-/// Both sides must resolve to a plain object shape; if either does not (type
-/// alias, intrinsic, application, union, …) the relation is not a member-set
-/// comparison and this returns `false` so normal replacement proceeds. Disjoint
-/// or overlapping-with-additions sets also return `false`: only a pure
-/// membership loss is blocked, which keeps publication monotone in members
-/// (heritage completion and augmentation, which only grow the set, still win).
-pub(crate) fn lib_body_strictly_loses_members(
-    db: &dyn tsz_solver::construction::TypeDatabase,
-    current: TypeId,
-    candidate: TypeId,
-) -> bool {
-    if current == candidate {
-        return false;
-    }
-    let Some(current_shape) = crate::query_boundaries::common::object_shape_for_type(db, current)
-    else {
-        return false;
-    };
-    let Some(candidate_shape) =
-        crate::query_boundaries::common::object_shape_for_type(db, candidate)
-    else {
-        return false;
-    };
-    if candidate_shape.properties.len() >= current_shape.properties.len() {
-        return false;
-    }
-    // Every candidate member must already be present in `current` (no
-    // additions) and `candidate` is strictly smaller (checked above), so it is
-    // missing at least one member `current` has. Lib interface bodies carry few
-    // members, so a linear scan beats allocating a name set.
-    candidate_shape.properties.iter().all(|cand| {
-        current_shape
-            .properties
-            .iter()
-            .any(|cur| cur.name == cand.name)
-    })
-}
-
 impl<'a> CheckerState<'a> {
     /// Lower augmentation declarations from a given arena and return the resulting `TypeId`.
     ///
@@ -227,7 +183,11 @@ impl<'a> CheckerState<'a> {
             return;
         };
         self.ctx.definition_store.register_type_to_def(ty, def_id);
-        if crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty) == Some(def_id) {
+        if crate::query_boundaries::lib_augmentations::is_lazy_def_identity(
+            self.ctx.types,
+            ty,
+            def_id,
+        ) {
             return;
         }
         let existing_body = self.ctx.definition_store.get_body(def_id);
@@ -264,8 +224,13 @@ impl<'a> CheckerState<'a> {
         // guards are complementary — the solver's deferred flag drops thin
         // NON-finalize re-publications, this drops thin finalize re-publications.
         let type_params = self.ctx.get_def_type_params(def_id).unwrap_or_default();
-        let keep_existing = existing_body
-            .is_some_and(|prev| lib_body_strictly_loses_members(self.ctx.types, prev, ty));
+        let keep_existing = existing_body.is_some_and(|prev| {
+            crate::query_boundaries::lib_augmentations::lib_body_strictly_loses_members(
+                self.ctx.types,
+                prev,
+                ty,
+            )
+        });
         let published = if keep_existing {
             existing_body.unwrap_or(ty)
         } else {
@@ -328,7 +293,10 @@ impl<'a> CheckerState<'a> {
         let Some(type_id) = cached else {
             return true;
         };
-        if !crate::query_boundaries::common::type_id_is_known_to_db(self.ctx.types, type_id) {
+        if !crate::query_boundaries::lib_augmentations::type_id_is_known_to_db(
+            self.ctx.types,
+            type_id,
+        ) {
             return false;
         }
         for &def_id in self.ctx.collect_lazy_def_ids_cached(type_id).iter() {
@@ -350,82 +318,9 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        crate::query_boundaries::common::has_construct_signatures(self.ctx.types, type_id)
-    }
-}
-
-#[cfg(test)]
-mod monotone_publication_tests {
-    //! Unit guard for the membership-monotone lib-interface body publication
-    //! that fixes the immer `SetIterator`/`MapIterator` `next`-missing false
-    //! positives (#13942): a heritage-thin re-derivation of a lib interface body
-    //! must never clobber a more-complete one in the shared store / per-file
-    //! `type_env`.
-    use super::lib_body_strictly_loses_members;
-    use crate::query_boundaries::common::{QueryDatabase, TypeInterner};
-    use tsz_solver::{PropertyInfo, TypeId};
-
-    fn obj(types: &TypeInterner, names: &[&str]) -> TypeId {
-        let props = names
-            .iter()
-            .map(|n| PropertyInfo::new(types.intern_string(n), TypeId::NUMBER))
-            .collect();
-        types.factory().object(props)
-    }
-
-    #[test]
-    fn thin_body_dropping_inherited_member_is_rejected() {
-        let types = TypeInterner::new();
-        // `SetIterator` heritage-complete: own `[Symbol.iterator]` + inherited
-        // `next` (from `IteratorObject` -> `Iterator`).
-        let complete = obj(&types, &["__@iterator", "next"]);
-        // Heritage-thin re-derivation: dropped the inherited `next`.
-        let thin = obj(&types, &["__@iterator"]);
-        assert!(
-            lib_body_strictly_loses_members(&types, complete, thin),
-            "a thin body that drops an inherited member must be rejected",
-        );
-        // Completion in the other order (thin published first, complete arriving)
-        // is a superset and must still win.
-        assert!(
-            !lib_body_strictly_loses_members(&types, thin, complete),
-            "heritage completion (growing the member set) must be allowed",
-        );
-    }
-
-    #[test]
-    fn growth_via_augmentation_is_allowed() {
-        let types = TypeInterner::new();
-        let base = obj(&types, &["a", "b"]);
-        let augmented = obj(&types, &["a", "b", "c"]);
-        assert!(!lib_body_strictly_loses_members(&types, base, augmented));
-    }
-
-    #[test]
-    fn equal_member_set_is_not_a_loss() {
-        let types = TypeInterner::new();
-        let a = obj(&types, &["a", "b"]);
-        let b = obj(&types, &["a", "b"]);
-        // Structurally identical objects intern to the same TypeId, so this also
-        // exercises the `current == candidate` short-circuit.
-        assert!(!lib_body_strictly_loses_members(&types, a, b));
-    }
-
-    #[test]
-    fn added_and_dropped_member_same_size_is_not_a_loss() {
-        let types = TypeInterner::new();
-        let current = obj(&types, &["a", "b"]);
-        // Same size, but adds `c` and drops `b`: not a strict subset, so it is
-        // not a pure membership loss and replacement proceeds.
-        let candidate = obj(&types, &["a", "c"]);
-        assert!(!lib_body_strictly_loses_members(&types, current, candidate));
-    }
-
-    #[test]
-    fn non_object_bodies_allow_replacement() {
-        let types = TypeInterner::new();
-        let o = obj(&types, &["a"]);
-        assert!(!lib_body_strictly_loses_members(&types, TypeId::NUMBER, o));
-        assert!(!lib_body_strictly_loses_members(&types, o, TypeId::STRING));
+        crate::query_boundaries::lib_augmentations::has_construct_signatures(
+            self.ctx.types,
+            type_id,
+        )
     }
 }


### PR DESCRIPTION
## Summary

Fixes the `SetIterator`/`MapIterator` "Property `next` is missing" false
positives in the **immer** canary (#13942 FP#3/#4 + the `mapset.ts:194`
`[Symbol.iterator]` variant), and the same iterator-heritage flattening
reported in **superstruct** and **zustand**.

## Structural rule

> When a lib interface's heritage-merged (complete) body has already been
> published for a `DefId`, a later heritage-**thin** re-derivation of the same
> `DefId` (one whose property set is a strict subset — it dropped inherited
> members) must NOT replace it. Lib-interface body publication is monotone in
> membership: a body may only gain members for a given def, never lose them.

`tsz` owns this in the checker's lib-interface body publication
(`register_finalized_lib_body`), which write-throughs to the program-shared
`DefinitionStore` and the per-file `type_env`.

## Root cause

Lib-interface bodies publish last-writer-wins (the publish-once freeze at
`resolve_lib_type_by_name`'s tail is opt-in/default-off — it regresses
`declare global` augmentation cases). `SetIterator`/`MapIterator` resolve
heritage-complete on their first resolution (inheriting `Iterator.next`
through `IteratorObject`), but a later per-file checker can re-derive a
`next`-less body. That thin form clobbered the complete one in both the store
and the `type_env`; the solver then materialized `set.values()` /
`set[Symbol.iterator]()` against the thin body, producing a `next`-less
`SetIterator` that failed assignment to `IterableIterator`/`SetIterator<any>`
(false TS2741/TS2322). This is the env-vs-store divergence family (#13944) and
the DOM `Node`/`Element` oscillation (#13862/#12299), specialized to the
iterator graph.

Diagnosis was done in-fixture with a debug build + the immer
project-compile-guard: `register_finalized_lib_body` was observed publishing
the `SetIterator` body `has_next=true` first, then `has_next=false` 5×.

## Fix

`register_finalized_lib_body` rejects a candidate body whose named-property set
is a strict subset of the already-published body (`lib_body_strictly_loses_members`),
keeping and re-mirroring the more-complete body into the envs. Heritage
completion (thin→complete is a superset) and augmentation (adds members) still
win; same-set bodies with refined member types still replace. The decision is
order-independent — the membership-maximal body always wins. This guards the
finalize entry point and complements the solver's deferred-publish guard, which
drops thin non-finalize re-publications.

This is not iterator-specific: any lib interface subject to a heritage-thin
re-derivation (the DOM heritage diamond included) is protected.

Remaining immer FPs (computed-key object literal, curried conditional
inference, patches map-callback param) are independent roots tracked separately
in #13942; this PR closes the iterator-heritage family.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `scripts/ci/project-compile-guard.sh` (immer, debug bin): the three
  iterator-heritage diagnostics at `mapset.ts:194,263,270` are gone (immer
  8→5 diagnostics); the remaining 5 are the unrelated independent immer FPs.
- New unit guard `monotone_publication_tests` in
  `crates/tsz-checker/src/types/queries/lib_augmentations.rs`.
- Targeted checker suites green: `lazy_lib_heritage_guard`, `lib_resolution`,
  `iterator`, `ts2322` builtin-iterator tests, plus the new monotone tests
  (155 passed). Broad suites left to ready-review CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQKd9WGwCaTSFnnBGEirwx)_