### PR TITLE
fix(emitter): emit __setModuleDefault at priority 1 to match tsc helper order

### DIFF
--- a/crates/tsz-emitter/src/transforms/helpers.rs
+++ b/crates/tsz-emitter/src/transforms/helpers.rs
@@ -681,7 +681,7 @@ impl HelpersNeeded {
 ///
 /// Priority mapping (from TypeScript's factory/emitHelpers.ts):
 ///   0: extends, makeTemplateObject
-///   1: assign, createBinding
+///   1: assign, createBinding, setModuleDefault
 ///   2: decorate, esDecorate/runInitializers, importStar, exportStar
 ///   3: metadata
 ///   4: param
@@ -702,7 +702,7 @@ pub fn emit_helpers(helpers: &HelpersNeeded) -> String {
         output.push_str(MAKE_TEMPLATE_OBJECT_HELPER);
         output.push('\n');
     }
-    // Priority 1: assign, createBinding
+    // Priority 1: assign, createBinding, setModuleDefault
     if helpers.assign {
         output.push_str(ASSIGN_HELPER);
         output.push('\n');
@@ -711,7 +711,14 @@ pub fn emit_helpers(helpers: &HelpersNeeded) -> String {
         output.push_str(CREATE_BINDING_HELPER);
         output.push('\n');
     }
-    // Priority 2: decorate, esDecorate/runInitializers, importStar (with setModuleDefault), exportStar
+    // `__setModuleDefault` (`typescript:commonjscreatevalue`) is priority 1 in
+    // tsc, not priority 2 with `__importStar` (which references it). It is
+    // needed exactly when `import_star` is. See the priority tiers above.
+    if helpers.import_star {
+        output.push_str(SET_MODULE_DEFAULT_HELPER);
+        output.push('\n');
+    }
+    // Priority 2: decorate, esDecorate/runInitializers, importStar, exportStar
     if helpers.decorate {
         output.push_str(DECORATE_HELPER);
         output.push('\n');
@@ -733,8 +740,6 @@ pub fn emit_helpers(helpers: &HelpersNeeded) -> String {
         output.push('\n');
     }
     if helpers.import_star {
-        output.push_str(SET_MODULE_DEFAULT_HELPER);
-        output.push('\n');
         output.push_str(IMPORT_STAR_HELPER);
         output.push('\n');
     }
@@ -1258,10 +1263,10 @@ mod tests {
     fn emit_helpers_order_decorators_and_async_helpers() {
         // emit_helpers source orders priority-2 helpers as:
         //   decorate, esDecorate, runInitializers,
-        //   propKey, importStar (with setModuleDefault),
-        //   rewriteRelativeImportExtension, exportStar
-        // and places setFunctionName after awaiter/generator but before
-        // async-generator helpers.
+        //   propKey, importStar, rewriteRelativeImportExtension, exportStar
+        // (`__setModuleDefault` is priority 1 and emitted earlier, before any
+        // priority-2 helper) and places setFunctionName after awaiter/generator
+        // but before async-generator helpers.
         let helpers = HelpersNeeded {
             decorate: true,
             run_initializers: true,
@@ -1544,6 +1549,49 @@ mod tests {
         assert!(
             i_set_default < i_import_star,
             "__setModuleDefault must precede __importStar (referenced by it)",
+        );
+    }
+
+    #[test]
+    fn emit_helpers_set_module_default_is_priority_one_before_decorators() {
+        // tsc's `compareEmitHelpers` puts `__setModuleDefault`
+        // (`typescript:commonjscreatevalue`) at priority 1, tied with
+        // `__createBinding`, so it is emitted before every priority-2 helper
+        // (decorators, `__importStar`). Witness: `import * as ns` combined with
+        // a decorated class — tsc 6.x emits
+        //   __createBinding, __setModuleDefault, __runInitializers,
+        //   __esDecorate, __importStar
+        // Regression: tsz previously bundled `__setModuleDefault` with
+        // `__importStar` at priority 2, emitting it AFTER the decorator helpers.
+        let helpers = HelpersNeeded {
+            create_binding: true,
+            import_star: true,
+            es_decorate: true,
+            run_initializers: true,
+            ..HelpersNeeded::default()
+        };
+
+        let output = emit_helpers(&helpers);
+        let i_create = find_helper(&output, "__createBinding");
+        let i_set_default = find_helper(&output, "__setModuleDefault");
+        let i_run = find_helper(&output, "__runInitializers");
+        let i_es_decorate = find_helper(&output, "__esDecorate");
+        let i_import_star = find_helper(&output, "__importStar");
+        assert!(
+            i_create < i_set_default,
+            "__createBinding then __setModuleDefault within priority 1",
+        );
+        assert!(
+            i_set_default < i_run,
+            "priority-1 __setModuleDefault before priority-2 __runInitializers",
+        );
+        assert!(
+            i_set_default < i_es_decorate,
+            "priority-1 __setModuleDefault before priority-2 __esDecorate",
+        );
+        assert!(
+            i_set_default < i_import_star,
+            "__setModuleDefault still precedes __importStar",
         );
     }
 

--- a/docs/how-tsz-works/internals/emitter-helpers-and-decorator-metadata.md
+++ b/docs/how-tsz-works/internals/emitter-helpers-and-decorator-metadata.md
@@ -200,9 +200,9 @@ implement the documented priority tiers (the doc-comment in `emit_helpers`):
 
 ```text
 priority 0 : __extends, __makeTemplateObject
-priority 1 : __assign, __createBinding
+priority 1 : __assign, __createBinding, __setModuleDefault
 priority 2 : __decorate, __esDecorate/__runInitializers, __propKey,
-             __importStar (+__setModuleDefault), __exportStar
+             __importStar, __exportStar
 priority 3 : __metadata
 priority 4 : __param
 priority 5 : __awaiter
@@ -234,8 +234,11 @@ Two intra-tier tiebreaks are encoded as separate flags rather than position:
   `fallback_class_private_order` both consult it.
 
 `__setModuleDefault` is not a `HelpersNeeded` flag — `emit_helpers` emits it
-unconditionally *just before* `__importStar` whenever `import_star` is set,
-because the star helper's body calls it. `__setFunctionName` floats: it is emitted
+whenever `import_star` is set, because the star helper's body calls it. It is a
+priority-1 helper in `tsc`'s `compareEmitHelpers` table
+(`typescript:commonjscreatevalue`), so it is emitted in the priority-1 tier
+(right after `__createBinding`), before any priority-2 helper — not bundled with
+`__importStar`. `__setFunctionName` floats: it is emitted
 right after the priority-6 block when paired with `es_decorate` (TC39), but with
 the unprioritized helpers otherwise — `needed_names` mirrors this with the two
 `set_function_name` pushes around `push_unprioritized_names`.


### PR DESCRIPTION
Goal: hold

Fixes #14551.

## Summary

When a module needs both a namespace import (`import * as ns`) and any **priority-2** emit helper (modern decorators, `__importStar`, `__exportStar`), tsz emitted `__setModuleDefault` **after** the decorator helpers. tsc emits it **before** them.

`__setModuleDefault` (`typescript:commonjscreatevalue`) is **priority 1** in tsc's `compareEmitHelpers` table — tied with `__assign`/`__createBinding` — so it precedes every priority-2 helper. `emit_helpers` bundled it with `__importStar` in the priority-2 tier.

### Before / after (`import * as ns` + decorated class, ES2022/CommonJS/esModuleInterop)

```
tsc:           __createBinding, __setModuleDefault, __runInitializers, __esDecorate, __importStar
tsz (before):  __createBinding, __runInitializers, __esDecorate, __setModuleDefault, __importStar
tsz (after):   __createBinding, __setModuleDefault, __runInitializers, __esDecorate, __importStar  ✓ byte-identical
```

## Root cause / fix

`crates/tsz-emitter/src/transforms/helpers.rs::emit_helpers` walks tsc's priority tiers but emitted `__setModuleDefault` from inside the priority-2 `import_star` block. Authoritative priority extracted from the installed `_tsc.js`: `typescript:commonjscreatevalue` → `priority: 1`.

Move its emission to the priority-1 tier, right after `__createBinding`, gated on `import_star` (it is the star helper's dependency, needed exactly when `import_star` is). `__importStar` stays at priority 2.

**Structural rule:** when a program needs `__setModuleDefault`, tsc emits it in priority tier 1 before any priority-2 helper; tsz now does the same through `emit_helpers`.

`needed_names` (the tslib import-name list) is intentionally unchanged: tslib's `__importStar` references `__setModuleDefault` internally, so it is never imported by name — matching tsc.

## Owner layer

Emitter — helper ordering. No semantic validation, no output surgery; the order is computed before any helper byte is written.

## Adjacent matrix (verified byte-identical to tsc 6.0.2)

- `import * as ns` + decorated class → identical.
- `import * as ns` + `export * from` (`__importStar` + `__exportStar`) → identical.
- Helper order is structural / name-independent (no binder-name dependence).

## Out of scope

`emit_helpers` also places `__propKey` at priority 2 while tsc treats it as no-priority (last) — a separate, lower-frequency divergence (decorator computed-member names), noted in #14551.

## Verification

- `cargo test -p tsz-emitter --lib transforms::helpers` → 32 passed, 0 failed (incl. new regression test `emit_helpers_set_module_default_is_priority_one_before_decorators` and the preserved `emit_helpers_import_star_emits_set_module_default_before_import_star`).
- `cargo test -p tsz-emitter` (full emitter crate) → green.
- Manual `tsc` 6.0.2 vs freshly-built tsz on the two witnesses → byte-identical output.
- Full conformance / emit suites: CI gates this PR.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_016RzEwecscnKMoxRqxBe46R)_