### PR TITLE
hold(solver): IterationExceeded eval bail produces Termination::Incomplete (#14346 stage 2)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -26,6 +26,7 @@ use crate::diagnostics::display_provenance::{
 };
 use crate::evaluation::request::EvaluationRequest;
 use crate::evaluation::result::EvaluationResult;
+use crate::evaluation::result::TerminationKind;
 #[cfg(test)]
 #[allow(unused_imports)]
 use crate::instantiation::instantiate::instantiate_generic;
@@ -139,6 +140,17 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// could short-circuit the expansion that re-derives `TS2589`. See the
     /// `closed_eval` module.
     deep_recursion_seen: bool,
+    /// Set when the per-evaluator *iteration* limit
+    /// (`RecursionResult::IterationExceeded`) cut a walk short during the
+    /// current top-level request. Distinct from the shared `deep_recursion_seen`
+    /// bool (which a cycle / depth / iteration bail all set, so it cannot name
+    /// the kind), this records the specific iteration-limit bail so
+    /// `evaluate_request_result` can surface `Termination::Incomplete{
+    /// IterationExceeded }` (#14346 stage 2). Cleared at every
+    /// `evaluate_request_result` entry so the verdict is scoped to one request
+    /// and never leaks across reused-evaluator requests; the recursive
+    /// `self.evaluate` calls do not re-enter `evaluate_request_result`.
+    iteration_exceeded_this_request: bool,
     /// Monotonic counter of *limit events* (cycle / depth / iteration / divergence
     /// bails) seen so far in this run. Unlike the sticky `deep_recursion_seen` /
     /// `silent_depth_bailed` booleans — which, once set by the first bail anywhere,
@@ -293,6 +305,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             silent_depth_bailed: false,
             detection_growth_runs: FxHashMap::default(),
             deep_recursion_seen: false,
+            iteration_exceeded_this_request: false,
             limit_epoch: 0,
             app_body_limit_epoch: 0,
             unresolved_def_seen: false,
@@ -565,16 +578,27 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
     /// Evaluate a normalized request and return the typed result stage.
     ///
-    /// The sole producer of [`EvaluationResult`]. In this #14346 scaffold
-    /// slice it always reports `Termination::Complete`: `self.evaluate`
-    /// already collapses every guard bail to a (relation-preserving) `TypeId`
-    /// internally, so the typed channel cannot observe an incomplete walk yet.
-    /// A future stage threads the bail verdict out so a budget-truncated walk
-    /// stops fabricating a finished type; until then the result is
-    /// byte-identical to the pre-channel evaluator.
+    /// The sole producer of [`EvaluationResult`]. As of #14346 stage 2 it
+    /// reports `Termination::Incomplete{ IterationExceeded }` when the
+    /// per-evaluator iteration-limit bail (`RecursionResult::IterationExceeded`)
+    /// fired anywhere within this request — the first real producer of the
+    /// `Incomplete` arm. `self.evaluate` still collapses that bail to the
+    /// opaque, relation-preserving `TypeId` internally and the scaffold's
+    /// `EvaluationResult::incomplete` carries that same `TypeId` as its
+    /// `partial`, so every consumer's `into_type_id` collapse — and therefore
+    /// the emitted type and diagnostics — is byte-identical to the pre-channel
+    /// evaluator. The remaining bail classes still report
+    /// `Termination::Complete` until later stages wire them in.
+    ///
+    /// The `iteration_exceeded_this_request` signal is cleared on entry so the
+    /// verdict is scoped to this single top-level request and cannot leak from
+    /// a prior request on a reused evaluator; the recursive `self.evaluate`
+    /// calls never re-enter this boundary.
     pub fn evaluate_request_result(&mut self, request: EvaluationRequest) -> EvaluationResult {
         self.set_no_unchecked_indexed_access(request.no_unchecked_indexed_access());
-        EvaluationResult::complete(self.evaluate(request.type_id()))
+        self.iteration_exceeded_this_request = false;
+        let type_id = self.evaluate(request.type_id());
+        request_result_verdict(type_id, self.iteration_exceeded_this_request)
     }
 
     // =========================================================================
@@ -1113,6 +1137,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             RecursionResult::IterationExceeded => {
                 // Iteration-limit bail: also a bounded run.
                 self.mark_deep_recursion_seen();
+                // Record the kind so the top-level `evaluate_request_result`
+                // boundary can surface `Termination::Incomplete{ IterationExceeded }`
+                // (#14346 stage 2). The returned `type_id` (the opaque,
+                // relation-preserving partial) and the `deep_recursion_seen`
+                // cache taint are unchanged, so the collapse via `into_type_id`
+                // is byte-identical.
+                self.iteration_exceeded_this_request = true;
                 self.memo_insert(limit_epoch_at_entry, type_id, type_id);
                 return type_id;
             }
@@ -1181,6 +1212,26 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     }
 
     // Additional evaluator support methods live in the nested support module.
+}
+
+/// Translate a finished `evaluate` result plus the per-request iteration-bail
+/// flag into the typed [`EvaluationResult`] verdict (#14346 stage 2).
+///
+/// `EvaluationResult::incomplete` carries `type_id` as its `partial`, so
+/// `into_type_id` is identical for both arms — the verdict is additive metadata,
+/// not a value change, keeping every consumer byte-identical. Factored out (and
+/// free of the evaluator's `R`/lifetime) so the `Complete`/`Incomplete`
+/// selection is unit-testable without driving a real >100k-iteration bail.
+#[inline]
+pub(crate) const fn request_result_verdict(
+    type_id: TypeId,
+    iteration_exceeded: bool,
+) -> EvaluationResult {
+    if iteration_exceeded {
+        EvaluationResult::incomplete(type_id, TerminationKind::IterationExceeded)
+    } else {
+        EvaluationResult::complete(type_id)
+    }
 }
 
 impl<R: TypeResolver> Drop for TypeEvaluator<'_, R> {

--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -14,13 +14,17 @@
 //! outer collapse silently treat a budget-truncated partial as a finished
 //! type.
 //!
-//! In this slice the channel is a parity-safe scaffold: the sole producer
-//! ([`crate::evaluation::evaluate::TypeEvaluator::evaluate_request_result`])
-//! always reports [`Termination::Complete`], and every consumer collapses
-//! through [`EvaluationResult::into_type_id`], which ignores the verdict. The
-//! [`EvaluationResult::incomplete`] constructor is intentionally unreached
-//! (dead-code) here — a future stage wires the bail sites to it so a
-//! limit-truncated walk stops fabricating a wrong, fully-formed type.
+//! The channel is parity-safe: every consumer collapses through
+//! [`EvaluationResult::into_type_id`], which returns the relation-preserving
+//! `partial` (= the same opaque `TypeId` the bail produced before the channel),
+//! so the emitted type and diagnostics are byte-identical. As of #14346
+//! stage 2 the [`crate::evaluation::evaluate::TypeEvaluator::evaluate_request_result`]
+//! producer reports [`Termination::Incomplete`] with
+//! [`TerminationKind::IterationExceeded`] when the per-evaluator iteration limit
+//! cut the walk short — the first real producer of the `Incomplete` arm — while
+//! still surfacing the same `partial` and preserving the `deep_recursion_seen`
+//! cache taint. The remaining bail classes still report
+//! [`Termination::Complete`] until later stages wire them in.
 
 use crate::types::TypeId;
 
@@ -30,7 +34,8 @@ use crate::types::TypeId;
 /// `crate::evaluation::evaluate::TypeEvaluator::evaluate`: the
 /// recursion-depth guard, the process-wide evaluation fuel counter, the shared
 /// solver-stack-frame breaker, the cross-evaluator global-depth cycle limit,
-/// and the per-query operation budget. Carried inside
+/// the per-query operation budget, and the per-evaluator iteration limit.
+/// Carried inside
 /// [`Termination::Incomplete`] so a downstream consumer can distinguish a
 /// genuine result from a budget-limited approximation, and (in a later stage)
 /// refuse to memoize it.
@@ -48,6 +53,10 @@ pub enum TerminationKind {
     CrossEvalCycle,
     /// The per-query operation budget (`enter_eval_query_budget`) ran out.
     QueryOpBudget,
+    /// The per-evaluator recursion guard's *iteration* limit tripped
+    /// (`RecursionResult::IterationExceeded`) — a bounded run that leaves the
+    /// node opaque and marks the `deep_recursion_seen` cache taint.
+    IterationExceeded,
 }
 
 /// Whether an evaluation walk ran to completion or was bounded short.
@@ -85,9 +94,12 @@ impl EvaluationResult {
     /// relation-preserving `partial` type and the [`TerminationKind`] that
     /// fired.
     ///
-    /// Intentionally unreached in this scaffold slice: the sole producer
-    /// always reports [`Termination::Complete`], so behavior is byte-identical
-    /// to before. A future stage routes the bail sites here.
+    /// Reached as of #14346 stage 2 for [`TerminationKind::IterationExceeded`]
+    /// (see `evaluate_request_result`). `type_id` is set to `partial`, so the
+    /// universal [`EvaluationResult::into_type_id`] collapse is byte-identical
+    /// to the pre-channel opaque bail; the verdict is additional metadata a
+    /// future verdict-aware consumer can act on. The other bail classes still
+    /// route through [`Self::complete`] until later stages wire them here.
     pub const fn incomplete(partial: TypeId, kind: TerminationKind) -> Self {
         Self {
             type_id: partial,

--- a/crates/tsz-solver/tests/evaluate_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_tests.rs
@@ -72,3 +72,4 @@ include!("evaluate_tests_parts/tuple_keyof_indexed_access.rs");
 include!("evaluate_tests_parts/distributive_tuple_union_regression.rs");
 include!("evaluate_tests_parts/deferred_index_key_regression.rs");
 include!("evaluate_tests_parts/cross_arena_unresolved_name_regression.rs");
+include!("evaluate_tests_parts/iteration_exceeded_incomplete.rs");

--- a/crates/tsz-solver/tests/evaluate_tests_parts/iteration_exceeded_incomplete.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/iteration_exceeded_incomplete.rs
@@ -1,0 +1,46 @@
+// #14346 stage 2: the iteration-limit bail (`RecursionResult::IterationExceeded`)
+// is the first real producer of `Termination::Incomplete`. These tests pin the
+// boundary contract that keeps the channel parity-safe:
+//
+//   * a request that hit the iteration bail reports
+//     `Incomplete { kind: IterationExceeded, partial }` where `partial` is the
+//     opaque, relation-preserving `TypeId` the bail surfaced;
+//   * `into_type_id()` returns that same `partial`, so every consumer's collapse
+//     — and therefore the emitted type and diagnostics — is byte-identical to a
+//     `Complete` result carrying the same `TypeId`;
+//   * a request that did not hit the bail still reports `Complete`.
+//
+// Driving a genuine >100k-iteration bail through the full evaluator would be slow
+// and fragile, so these exercise the boundary's verdict translation directly
+// (`TypeEvaluator::request_result_verdict`), which is the exact function
+// `evaluate_request_result` uses to choose the arm.
+
+use crate::evaluation::result::Termination;
+
+#[test]
+fn iteration_exceeded_request_reports_incomplete_with_partial() {
+    // The opaque, relation-preserving partial the bail returns unchanged.
+    let partial = TypeId::STRING;
+    let result = request_result_verdict(partial, true);
+
+    assert!(result.is_incomplete());
+    assert_eq!(
+        result.termination(),
+        Termination::Incomplete {
+            kind: TerminationKind::IterationExceeded,
+            partial,
+        }
+    );
+    // Byte-identical collapse: consumers see exactly the opaque partial.
+    assert_eq!(result.into_type_id(), partial);
+    assert!(result.is_identity_for(partial));
+}
+
+#[test]
+fn non_bailed_request_reports_complete() {
+    let result = request_result_verdict(TypeId::NUMBER, false);
+
+    assert!(!result.is_incomplete());
+    assert_eq!(result.termination(), Termination::Complete);
+    assert_eq!(result.into_type_id(), TypeId::NUMBER);
+}


### PR DESCRIPTION
Goal: hold

#14346 stage 2. Makes the iteration-limit evaluation bail the FIRST real producer
of the `Termination::Incomplete` arm introduced by the #14542 scaffold, threading
genuine termination data through the typed `EvaluationResult` channel without
changing any diagnostic.

## Failure family / structural rule
The `EvaluationResult` termination channel (#14542) added a `Termination::Incomplete
{ kind, partial }` arm that was dead — no bail site produced it, every consumer
collapsed through `into_type_id()`. Stage 2 wires ONE bail site to produce it:

When the per-evaluator recursion guard's *iteration* limit trips
(`RecursionResult::IterationExceeded`, `evaluate.rs`), the evaluator leaves the
node opaque (returns the un-expanded `type_id`) and marks the `deep_recursion_seen`
cache taint. tsz does this through the checker→solver evaluation boundary
`TypeEvaluator::evaluate_request_result`, which now reports
`Termination::Incomplete { kind: IterationExceeded, partial: type_id }` for such a
request instead of an unconditional `Complete`.

## Owner layer / why parity-safe (no diagnostic change)
Solver evaluation boundary only:
- `result.rs`: add `TerminationKind::IterationExceeded` (the scaffold's 5-variant
  enum did not enumerate the iteration bail, which is a genuine distinct bail
  class — this completes the taxonomy; the enum is construction-only/dead today,
  so `cargo check` confirms NO exhaustive match is forced to change behavior).
- `evaluate.rs`: a per-request `iteration_exceeded_this_request` flag set at the
  `IterationExceeded` arm (alongside the existing `mark_deep_recursion_seen`),
  cleared at every `evaluate_request_result` entry so the verdict is scoped to one
  top-level request and never leaks across reused-evaluator requests (the recursive
  `self.evaluate` calls do not re-enter the boundary). The boundary builds the
  verdict via `request_result_verdict`.
- Byte-identical: `EvaluationResult::incomplete(type_id, ..)` sets its `type_id`
  field to the `partial`, so the universal `into_type_id()` collapse every consumer
  performs (`evaluate.rs:563`, `evaluate/api.rs:59`, `caches/query_cache.rs:1500` —
  the last pinned by an architecture guard) returns the same opaque `TypeId` as
  before. The `deep_recursion_seen` cache taint (which gates depth-agnostic cache
  persistence, #11586) is preserved unchanged, so cache behavior is identical too.
  No solver/checker/emitter relation or diagnostic path reads the new verdict yet.

## Adjacent / verification
- New unit tests (`evaluate_tests_parts/iteration_exceeded_incomplete.rs`): an
  iteration-bailed request reports `Incomplete{ IterationExceeded, partial }` with
  `into_type_id() == partial`; a non-bailed request reports `Complete`. The scaffold's
  own `incomplete`/`complete` round-trip tests still pass.
- `cargo check -p tsz-solver` clean — no exhaustive-match site forced to change.
- `cargo nextest run -p tsz-solver`: no NEW failures vs clean `origin/main`. The 3
  residual local failures (`test_conditional_infer_optional_property_present_distributive`,
  `literal_mask_preserves_object_vs_literal_reduction`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`) are
  pre-existing environment-only failures that reproduce on clean main. The
  `evaluation_engine_keeps_request_stage_boundary` architecture guard passes (the
  `EvaluationResult` import is kept on its own line per the guard's exact-string check).
- `cargo clippy -p tsz-solver --lib` clean.
- Full-CI conformance/emit byte-identical is the hard gate (hot eval path).

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- cargo nextest run -p tsz-solver (new tests + architecture guard + no new failures vs main)
- cargo check -p tsz-solver (no forced exhaustive-match behavior change)
- cargo clippy -p tsz-solver --lib (clean)
- CI conformance + emit byte-identical (channel is metadata-only; every consumer collapses via into_type_id)
