### PR TITLE
fix(solver): preserve tuple identity through recursive-utility composition (#14518)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "recursive_utility_tuple_index_14518_tests"
+path = "tests/recursive_utility_tuple_index_14518_tests.rs"
+[[test]]
 name = "readonly_to_mutable_alias_display_tests"
 path = "tests/readonly_to_mutable_alias_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/recursive_utility_tuple_index_14518_tests.rs
+++ b/crates/tsz-checker/tests/recursive_utility_tuple_index_14518_tests.rs
@@ -1,0 +1,146 @@
+//! Regression tests for #14518: a composition of recursive utility aliases
+//! (a homomorphic mapped over a variadic-rebuilt tuple) must preserve
+//! per-index tuple identity — the transformed type stays a fixed tuple, so a
+//! later literal index resolves to the concrete element rather than collapsing
+//! to the element-type union.
+//!
+//! Structural rule: `tsc` keeps a homomorphic mapped type
+//! `{ [K in keyof T]: F<T[K]> }` (and a variadic rebuild
+//! `readonly [G<A>, ...G<B>]`) a *tuple* when its source `T` is a tuple whose
+//! rest element is still a deferred recursive-alias application
+//! (`...DeepRO<B>`) — the `NoopResolver` cannot expand it here, so mapping per
+//! slot now would collapse the hidden slots into the rest's element union and
+//! permanently drop tuple-ness. The instantiator defers the mapped to the
+//! resolver-backed outer evaluator, which expands the rest to a concrete tuple
+//! first. A bare type-parameter rest (`...Elements`) is genuinely opaque and
+//! stays on the eager per-slot path (so `Foo<[...Elements, "abc"]>`-style
+//! variadic-growth recursion still terminates with TS2589, unchanged).
+
+use tsz_checker::diagnostics::Diagnostic;
+
+fn check_source(source: &str) -> Vec<Diagnostic> {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        tsz_checker::context::CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+        &libs,
+    )
+}
+
+fn assert_clean(source: &str, label: &str) {
+    let diagnostics = check_source(source);
+    assert!(
+        diagnostics.is_empty(),
+        "[{label}] expected no diagnostics, got:\n{diagnostics:#?}"
+    );
+}
+
+const PRELUDE: &str = r#"
+type AliasCompute<TValue> = TValue extends (...args: infer P) => infer R ? (...args: P) => R
+  : TValue extends readonly [infer H, ...infer T] ? readonly [AliasCompute<H>, ...AliasCompute<T>]
+  : TValue extends object ? { [K in keyof TValue]: AliasCompute<TValue[K]> } : TValue;
+type NormalizeBox<I> = I extends object ? { [F in keyof I]: NormalizeBox<I[F]> } : I;
+type DeepRO<S> = S extends (...a: any[]) => any ? S
+  : S extends readonly [infer A, ...infer B] ? readonly [DeepRO<A>, ...DeepRO<B>]
+  : S extends object ? { readonly [N in keyof S]: DeepRO<S[N]> } : S;
+type Map1<I> = { [F in keyof I]: I[F] };
+type Tup = readonly [{ a: 1 }, { b: 2 }, { wrapped: 3 }];
+type IsT3<T> = T extends readonly [any, any, any] ? "t3" : T extends readonly any[] ? "array" : "other";
+"#;
+
+/// A homomorphic map over a variadic-rebuilt tuple (`DeepRO<Tup>`) stays a
+/// fixed 3-tuple — `tsc` reports `"t3"`; tsz-main regressed to `"array"`.
+#[test]
+fn issue_14518_homomorphic_map_over_variadic_rebuild_keeps_tuple() {
+    assert_clean(
+        &format!("{PRELUDE}\nexport const a: IsT3<NormalizeBox<DeepRO<Tup>>> = \"t3\";"),
+        "NormalizeBox<DeepRO<Tup>>",
+    );
+    assert_clean(
+        &format!("{PRELUDE}\nexport const a: IsT3<Map1<DeepRO<Tup>>> = \"t3\";"),
+        "identity Map1<DeepRO<Tup>>",
+    );
+}
+
+/// Re-applying a variadic-rebuild utility to an already-rebuilt tuple keeps
+/// tuple-ness (`DeepRO<DeepRO<Tup>>` is a 3-tuple, not an array).
+#[test]
+fn issue_14518_nested_variadic_rebuild_keeps_tuple() {
+    assert_clean(
+        &format!("{PRELUDE}\nexport const a: IsT3<DeepRO<DeepRO<Tup>>> = \"t3\";"),
+        "DeepRO<DeepRO<Tup>>",
+    );
+}
+
+/// The full multi-utility composition is still a fixed 3-tuple.
+#[test]
+fn issue_14518_full_composition_keeps_tuple() {
+    assert_clean(
+        &format!(
+            "{PRELUDE}\nexport const a: IsT3<AliasCompute<NormalizeBox<DeepRO<Tup>>>> = \"t3\";"
+        ),
+        "AliasCompute<NormalizeBox<DeepRO<Tup>>>",
+    );
+    assert_clean(
+        &format!("{PRELUDE}\nexport const a: IsT3<AliasCompute<DeepRO<Tup>>> = \"t3\";"),
+        "AliasCompute<DeepRO<Tup>>",
+    );
+}
+
+/// Control: a variadic-growth tuple whose rest is a bare *type parameter*
+/// (`...Elements`) must stay on the eager per-slot path so the recursive
+/// `Foo<[...Elements, "abc"]>` growth still terminates (TS2589), exactly like
+/// `tsc` — the deferral gate must not fire here.
+#[test]
+fn issue_14518_type_parameter_rest_growth_still_terminates() {
+    let source = r#"
+class Foo<Elements extends readonly unknown[]> {
+  public readonly elements: { [P in keyof Elements]: { bar: Elements[P] } };
+  public constructor(...elements: { [P in keyof Elements]: { bar: Elements[P] } }) {
+    this.elements = elements;
+  }
+  public add(): Foo<[...Elements, "abc"]> {
+    return new Foo<[...Elements, "abc"]>(...this.elements, { bar: "abc" });
+  }
+}
+"#;
+    let diagnostics = check_source(source);
+    // tsc reports TS2589 here ("excessively deep"); the important property is
+    // that tsz terminates with the same diagnostic and does not hang or crash.
+    assert!(
+        diagnostics.iter().any(|d| d.code == 2589),
+        "expected TS2589 (excessively deep), got:\n{diagnostics:#?}"
+    );
+}
+
+/// The original bench witness: a numeric-literal index into the transformed
+/// tuple followed by a property access. The per-index *type* identity is
+/// restored by this change, but the final value-index hop still reads an
+/// order-dependent (cache-poisoned) form under the checker's limited resolver
+/// — the resolver-context-independence root tracked by #13980 / #14330. This
+/// case is the campaign's terminal step and is ignored until that lands.
+#[ignore = "needs the #13980/#14330 resolver-context-independence campaign for the final value-index hop"]
+#[test]
+fn issue_14518_value_index_witness() {
+    let source = r#"
+type AliasCompute<TValue> = TValue extends (...args: infer P) => infer R ? (...args: P) => R
+  : TValue extends readonly [infer H, ...infer T] ? readonly [AliasCompute<H>, ...AliasCompute<T>]
+  : TValue extends object ? { [K in keyof TValue]: AliasCompute<TValue[K]> } : TValue;
+type NormalizeBox<I> = I extends object ? { [F in keyof I]: NormalizeBox<I[F]> } : I;
+type DeepRO<S> = S extends (...a: any[]) => any ? S
+  : S extends readonly [infer A, ...infer B] ? readonly [DeepRO<A>, ...DeepRO<B>]
+  : S extends object ? { readonly [N in keyof S]: DeepRO<S[N]> } : S;
+type Tup = readonly [{ a: 1 }, { b: 2 }, { wrapped: 3 }];
+declare const b: AliasCompute<NormalizeBox<DeepRO<Tup>>>;
+export const q: 3 = b[2].wrapped;
+"#;
+    let diagnostics = check_source(source);
+    assert!(
+        !diagnostics.iter().any(|d| d.code == 2339),
+        "expected no TS2339, got:\n{diagnostics:#?}"
+    );
+}

--- a/crates/tsz-solver/src/instantiation/instantiate/mapped.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/mapped.rs
@@ -263,137 +263,169 @@ impl<'a> TypeInstantiator<'a> {
             if let Some((tuple_id, source_readonly)) = tuple_source {
                 use crate::types::MappedModifier;
                 let elements = self.interner.tuple_list(tuple_id);
-                // Instantiate template first (substitutes T, keeps K shadowed).
-                // After this `new_template` holds the *resolved* source tuple
-                // wherever T appeared.
-                let new_template = self.instantiate(mapped.template);
-                self.exit_shadowing_scope(shadowed_len, saved_visiting);
+                // A rest element that is still an unresolved lazy *application*
+                // (`...DeepRO<B>`, a recursive alias the `NoopResolver` cannot
+                // expand here) means the source tuple is only *partially*
+                // resolved: its true element count and per-slot identities live
+                // behind that application. Mapping per slot now collapses those
+                // hidden slots into the rest's element union
+                // (`[F<O[0]>, ...F<O[number]>]`), permanently losing per-index
+                // identity (#14518). Skip the eager fast-path and fall through
+                // to the resolver-gated deferral tail, which (via
+                // `mapped_constraint_needs_resolver` on the now `keyof
+                // <application>` constraint) hands the mapped to the
+                // resolver-backed outer evaluator; it expands the rest to a
+                // concrete tuple before mapping. A bare type-parameter rest
+                // (`...Elements`) is genuinely opaque, never resolves further,
+                // and stays on this fast path so variadic-growth recursion
+                // still terminates.
+                let tuple_rest_needs_resolver = elements.iter().any(|elem| {
+                    elem.rest && {
+                        let inner =
+                            crate::type_queries::data::unwrap_readonly(self.interner, elem.type_id);
+                        type_contains_lazy_application(self.interner, inner)
+                    }
+                });
+                if !tuple_rest_needs_resolver {
+                    // Instantiate template first (substitutes T, keeps K shadowed).
+                    // After this `new_template` holds the *resolved* source tuple
+                    // wherever T appeared.
+                    let new_template = self.instantiate(mapped.template);
+                    self.exit_shadowing_scope(shadowed_len, saved_visiting);
 
-                // Per-element rebinding mirrors tsc's
-                // `instantiateMappedTupleType`. The choice of (template, key)
-                // determines whether `T[K]` resolves to this element's own
-                // type or the union of every element type. The naive
-                // pre-fix loop bound K = "i" for every element, which:
-                //   - dropped the Array<> wrapper from a rest element's
-                //     type_id (producing structurally invalid tuples like
-                //     `[string, ...number]`); and
-                //   - silently widened any fixed element after a rest to
-                //     the union of all element types, because `T["i"]` is
-                //     ambiguous when the rest range could be 0 or more
-                //     elements long.
-                //
-                // The four cases below mirror tsc's switch on per-element kind.
-                enum ElemBinding {
-                    /// Rest of `Array<E>` / `readonly E[]` — rewrite the
-                    /// resolved source to `Array<E>` and bind K = number;
-                    /// the result must re-wrap in `Array<>` so the rest's
-                    /// `type_id` stays array-shaped.
-                    RestArray(TypeId),
-                    /// Rest of an opaque type (type parameter, lazy ref,
-                    /// etc.) — bind K = number on the existing template
-                    /// so the deferred `T[K]` shape is preserved.
-                    OpaqueRest,
-                    /// Fixed element after at least one rest — the
-                    /// numeric index on the full source is ambiguous, so
-                    /// rewrite the source to a single-element proxy and
-                    /// bind K = "0".
-                    SuffixFixed,
-                    /// Fixed element before any rest — the literal index
-                    /// resolves unambiguously, no rebinding needed.
-                    PrefixFixed,
-                }
-
-                let rebind_source = |new_source: TypeId| {
-                    let mut memo: FxHashMap<TypeId, TypeId> = FxHashMap::default();
-                    crate::evaluation::evaluate_rules::substitute::substitute_exact_type_db(
-                        self.interner,
-                        new_template,
-                        resolved,
-                        new_source,
-                        &mut memo,
-                    )
-                };
-
-                let mut seen_rest = false;
-                let mut new_elements = Vec::with_capacity(elements.len());
-                for (i, elem) in elements.iter().enumerate() {
-                    let is_suffix = seen_rest && !elem.rest;
-                    if elem.rest {
-                        seen_rest = true;
+                    // Per-element rebinding mirrors tsc's
+                    // `instantiateMappedTupleType`. The choice of (template, key)
+                    // determines whether `T[K]` resolves to this element's own
+                    // type or the union of every element type. The naive
+                    // pre-fix loop bound K = "i" for every element, which:
+                    //   - dropped the Array<> wrapper from a rest element's
+                    //     type_id (producing structurally invalid tuples like
+                    //     `[string, ...number]`); and
+                    //   - silently widened any fixed element after a rest to
+                    //     the union of all element types, because `T["i"]` is
+                    //     ambiguous when the rest range could be 0 or more
+                    //     elements long.
+                    //
+                    // The four cases below mirror tsc's switch on per-element kind.
+                    enum ElemBinding {
+                        /// Rest of `Array<E>` / `readonly E[]` — rewrite the
+                        /// resolved source to `Array<E>` and bind K = number;
+                        /// the result must re-wrap in `Array<>` so the rest's
+                        /// `type_id` stays array-shaped.
+                        RestArray(TypeId),
+                        /// Rest of an opaque type (type parameter, lazy ref,
+                        /// etc.) — bind K = number on the existing template
+                        /// so the deferred `T[K]` shape is preserved.
+                        OpaqueRest,
+                        /// Fixed element after at least one rest — the
+                        /// numeric index on the full source is ambiguous, so
+                        /// rewrite the source to a single-element proxy and
+                        /// bind K = "0".
+                        SuffixFixed,
+                        /// Fixed element before any rest — the literal index
+                        /// resolves unambiguously, no rebinding needed.
+                        PrefixFixed,
                     }
 
-                    let binding = match (elem.rest, self.interner.lookup(elem.type_id)) {
-                        (true, Some(TypeData::Array(_))) => ElemBinding::RestArray(elem.type_id),
-                        (true, Some(TypeData::ReadonlyType(roi)))
-                            if matches!(self.interner.lookup(roi), Some(TypeData::Array(_))) =>
-                        {
-                            ElemBinding::RestArray(roi)
-                        }
-                        (true, _) => ElemBinding::OpaqueRest,
-                        (false, _) if is_suffix => ElemBinding::SuffixFixed,
-                        (false, _) => ElemBinding::PrefixFixed,
+                    let rebind_source = |new_source: TypeId| {
+                        let mut memo: FxHashMap<TypeId, TypeId> = FxHashMap::default();
+                        crate::evaluation::evaluate_rules::substitute::substitute_exact_type_db(
+                            self.interner,
+                            new_template,
+                            resolved,
+                            new_source,
+                            &mut memo,
+                        )
                     };
 
-                    let (rebound_template, key_type) = match binding {
-                        ElemBinding::RestArray(rest_arr) => {
-                            (rebind_source(rest_arr), TypeId::NUMBER)
+                    let mut seen_rest = false;
+                    let mut new_elements = Vec::with_capacity(elements.len());
+                    for (i, elem) in elements.iter().enumerate() {
+                        let is_suffix = seen_rest && !elem.rest;
+                        if elem.rest {
+                            seen_rest = true;
                         }
-                        ElemBinding::OpaqueRest => (new_template, TypeId::NUMBER),
-                        ElemBinding::SuffixFixed => {
-                            let proxy = self
-                                .interner
-                                .tuple(vec![crate::types::TupleElement::fixed(elem.type_id)]);
-                            (rebind_source(proxy), self.interner.literal_string("0"))
-                        }
-                        ElemBinding::PrefixFixed => {
-                            (new_template, self.interner.literal_string(&i.to_string()))
-                        }
+
+                        let binding = match (elem.rest, self.interner.lookup(elem.type_id)) {
+                            (true, Some(TypeData::Array(_))) => {
+                                ElemBinding::RestArray(elem.type_id)
+                            }
+                            (true, Some(TypeData::ReadonlyType(roi)))
+                                if matches!(
+                                    self.interner.lookup(roi),
+                                    Some(TypeData::Array(_))
+                                ) =>
+                            {
+                                ElemBinding::RestArray(roi)
+                            }
+                            (true, _) => ElemBinding::OpaqueRest,
+                            (false, _) if is_suffix => ElemBinding::SuffixFixed,
+                            (false, _) => ElemBinding::PrefixFixed,
+                        };
+
+                        let (rebound_template, key_type) = match binding {
+                            ElemBinding::RestArray(rest_arr) => {
+                                (rebind_source(rest_arr), TypeId::NUMBER)
+                            }
+                            ElemBinding::OpaqueRest => (new_template, TypeId::NUMBER),
+                            ElemBinding::SuffixFixed => {
+                                let proxy = self
+                                    .interner
+                                    .tuple(vec![crate::types::TupleElement::fixed(elem.type_id)]);
+                                (rebind_source(proxy), self.interner.literal_string("0"))
+                            }
+                            ElemBinding::PrefixFixed => {
+                                (new_template, self.interner.literal_string(&i.to_string()))
+                            }
+                        };
+
+                        let subst = TypeSubstitution::single(mapped.type_param.name, key_type);
+                        let mapped_type = self.evaluate_type(instantiate_type_cached(
+                            self.interner,
+                            self.query_db,
+                            rebound_template,
+                            &subst,
+                        ));
+
+                        // Re-wrap a `...E[]` rest in `Array<>`; absorb
+                        // `Add ?` on a rest as `T | undefined` (a rest can
+                        // not syntactically combine with `?`); apply the
+                        // optional modifier to fixed slots only.
+                        let (type_id, optional) = match (binding, mapped.optional_modifier) {
+                            (ElemBinding::RestArray(_), Some(MappedModifier::Add)) => (
+                                self.interner
+                                    .union2(self.interner.array(mapped_type), TypeId::UNDEFINED),
+                                elem.optional,
+                            ),
+                            (ElemBinding::RestArray(_), _) => {
+                                (self.interner.array(mapped_type), elem.optional)
+                            }
+                            (ElemBinding::OpaqueRest, Some(MappedModifier::Add)) => (
+                                self.interner.union2(mapped_type, TypeId::UNDEFINED),
+                                elem.optional,
+                            ),
+                            (ElemBinding::OpaqueRest, _) | (_, None) => {
+                                (mapped_type, elem.optional)
+                            }
+                            (_, Some(MappedModifier::Add)) => (mapped_type, true),
+                            (_, Some(MappedModifier::Remove)) => (mapped_type, false),
+                        };
+
+                        new_elements.push(crate::types::TupleElement {
+                            type_id,
+                            name: elem.name,
+                            optional,
+                            rest: elem.rest,
+                        });
+                    }
+
+                    let tuple_type = self.interner.tuple(new_elements);
+                    return if mapped.resolve_readonly(source_readonly) {
+                        self.interner.readonly_type(tuple_type)
+                    } else {
+                        tuple_type
                     };
-
-                    let subst = TypeSubstitution::single(mapped.type_param.name, key_type);
-                    let mapped_type = self.evaluate_type(instantiate_type_cached(
-                        self.interner,
-                        self.query_db,
-                        rebound_template,
-                        &subst,
-                    ));
-
-                    // Re-wrap a `...E[]` rest in `Array<>`; absorb
-                    // `Add ?` on a rest as `T | undefined` (a rest can
-                    // not syntactically combine with `?`); apply the
-                    // optional modifier to fixed slots only.
-                    let (type_id, optional) = match (binding, mapped.optional_modifier) {
-                        (ElemBinding::RestArray(_), Some(MappedModifier::Add)) => (
-                            self.interner
-                                .union2(self.interner.array(mapped_type), TypeId::UNDEFINED),
-                            elem.optional,
-                        ),
-                        (ElemBinding::RestArray(_), _) => {
-                            (self.interner.array(mapped_type), elem.optional)
-                        }
-                        (ElemBinding::OpaqueRest, Some(MappedModifier::Add)) => (
-                            self.interner.union2(mapped_type, TypeId::UNDEFINED),
-                            elem.optional,
-                        ),
-                        (ElemBinding::OpaqueRest, _) | (_, None) => (mapped_type, elem.optional),
-                        (_, Some(MappedModifier::Add)) => (mapped_type, true),
-                        (_, Some(MappedModifier::Remove)) => (mapped_type, false),
-                    };
-
-                    new_elements.push(crate::types::TupleElement {
-                        type_id,
-                        name: elem.name,
-                        optional,
-                        rest: elem.rest,
-                    });
                 }
-
-                let tuple_type = self.interner.tuple(new_elements);
-                return if mapped.resolve_readonly(source_readonly) {
-                    self.interner.readonly_type(tuple_type)
-                } else {
-                    tuple_type
-                };
             }
 
             // Then check for Array (tsc: instantiateMappedArrayType)


### PR DESCRIPTION
Goal: green

Toward #14518 (does not fully close it — see "Residual" below).

## Summary

A homomorphic mapped type `{ [K in keyof T]: F<T[K]> }` whose source tuple `T`
still carries a rest element that is a **deferred lazy alias application**
(`...DeepRO<B>`, an unresolvable recursive alias under the instantiator's
`NoopResolver`) was being materialized eagerly by the tuple fast-path in
`instantiate_mapped`. That path maps per slot, so the slots hidden behind the
unresolved rest collapse into the rest's element union
(`[F<O[0]>, ...F<O[number]>]`) and **tuple-ness is permanently dropped**.

The result: `tsc` keeps these recursive-utility compositions fixed tuples, but
tsz treated them as arrays — the over-rejection family behind #14518.

Differential vs `tsc` (each was `"array"` on tsz-main, `"t3"`/clean on tsc):

| type | tsc | tsz before | tsz after |
|---|---|---|---|
| `NormalizeBox<DeepRO<Tup>> extends [a,b,c]` | `t3` | `array` | `t3` |
| `{ [F in keyof I]: I[F] }<DeepRO<Tup>>` (identity map) | `t3` | `array` | `t3` |
| `DeepRO<DeepRO<Tup>>` | `t3` | `array` | `t3` |
| `AliasCompute<NormalizeBox<DeepRO<Tup>>>` | `t3` | `array` | `t3` |

## Structural rule

> When a homomorphic mapped (or variadic-rebuild) is instantiated over a tuple
> whose **rest element is still a deferred lazy application** the `NoopResolver`
> cannot expand, the tuple is only *partially* resolved — its true element count
> and per-slot identities live behind that application. Mapping per slot now is
> lossy, so defer the whole mapped to the resolver-backed outer evaluator, which
> expands the rest to a concrete tuple first. A bare type-parameter rest
> (`...Elements`) is genuinely opaque and stays eager.

## Owner layer

Solver — `crates/tsz-solver/src/instantiation/instantiate/mapped.rs`,
`instantiate_mapped`. The fix skips the eager tuple fast-path when a rest
element `type_contains_lazy_application`, letting the **existing**
resolver-gated deferral tail (its `keyof <application>` constraint trips
`mapped_constraint_needs_resolver`) hand the mapped to the outer evaluator. No
new deferral mechanism — it reuses the file's established gates. The structural
predicate reads only type shape (`elem.rest` + lazy-application content), never
identifiers, file names, or printer output.

## Anti-hardcoding

Discriminator is purely structural: lazy-`Application` rest (defer) vs bare
type-parameter rest (eager). No name/file-string predicate. Tests vary the
alias/binder names.

## Adjacent matrix (regression tests, `crates/tsz-checker/tests/recursive_utility_tuple_index_14518_tests.rs`)

- Homomorphic map / identity map / nested rebuild / full composition over a
  variadic-rebuilt tuple all stay fixed tuples (4 active tests).
- **Control (termination):** a variadic-growth tuple whose rest is a bare type
  parameter (`Foo<[...Elements, "abc"]>`, the
  `circularInlineMappedGenericTupleTypeNoCrash` shape) still terminates with
  TS2589 — the deferral gate must not fire for type-parameter rests.

## Residual (why this does not yet close #14518)

The original bench witness `m.tuple[2].wrapped` has its **per-index type
identity** restored by this change, but the final *value*-index hop still reads
an order-dependent (cache-poisoned) form under the checker's limited resolver —
the resolver-context-independence root tracked by **#13980 / #14330** (warming
the type via a conditional changes `b[2]` between three different wrong forms,
proving order/cache dependence, not a tuple-construction bug). That terminal
step belongs to that campaign and is covered here by an `#[ignore]`d regression
test so it activates automatically once the campaign lands. #14518 stays open.

## Verification

- `cargo test -p tsz-checker --test recursive_utility_tuple_index_14518_tests` →
  4 passed, 1 ignored (the campaign-gated value-index witness).
- `cargo test -p tsz-solver --lib mapped|tuple|variadic|instantiat|homomorphic|index_access`
  → all green (407/594/66/191/61/144).
- `cargo clippy -p tsz-solver --lib` clean; `cargo fmt` clean.
- One pre-existing `tsz-solver --lib evaluate` failure
  (`test_conditional_infer_optional_property_present_distributive`) reproduces
  identically on clean `main` (stash-verified) — net-new = 0.
- Broad conformance / emit / fourslash owned by CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mg41kFNE6FyYRWmWtEGpxo)_