### PR TITLE
fix(bench): chart clean slow project timings

### DIFF
--- a/crates/tsz-website/scripts/benchmark-data-smoke.mjs
+++ b/crates/tsz-website/scripts/benchmark-data-smoke.mjs
@@ -93,6 +93,50 @@ await fs.writeFile(artifact, `${JSON.stringify({
       },
     },
     {
+      name: "rxjs-project",
+      lines: 12000,
+      kb: 900,
+      tsz_ms: 300,
+      tsgo_ms: 100,
+      winner: "tsgo",
+      factor: 3,
+      compatibility: {
+        generated_at: "2026-05-16T00:00:00.000Z",
+        source_commit: "local",
+        workflow_name: "Bench",
+        workflow_run_id: "1001",
+        workflow_run_url: "https://github.com/tsz-org/tsz/actions/runs/1001",
+        workflow_run_attempt: "1",
+        run_status: "completed",
+        state: "green",
+        exit_class: "exit success",
+        first_failure_class: null,
+        owner_track: null,
+        phase: "check",
+        last_successful_phase: "check",
+        diagnostic_status: "none",
+        diagnostic_deltas: [],
+        diagnostic_subsystems: [],
+        known_blockers: [],
+        reduced_repro_path: null,
+        repro: {},
+        exit_codes: { tsc: [0], tsz: [0], tsgo: [0] },
+        files_reached: 12,
+        files_reached_reason: null,
+        peak_memory_bytes: 104857600,
+        peak_memory_bytes_reason: null,
+        fixture_sources: [
+          {
+            name: "rxjs",
+            repository: "https://github.com/ReactiveX/rxjs.git",
+            ref: "rxjs-ref",
+          },
+        ],
+        emit_status: "not in scope (noEmit project check)",
+        dts_status: "not in scope (noEmit project check)",
+      },
+    },
+    {
       name: "type-challenges-solutions-project",
       lines: 78,
       kb: 0,
@@ -457,6 +501,8 @@ try {
   const charts = getBenchmarkCharts();
   assert.match(charts, /External libraries/);
   assert.match(charts, /Utility types project/);
+  assert.match(charts, /RxJS project/);
+  assert.match(charts, /tsgo 3\.0x faster/);
   assert.match(charts, /Compile canaries and incomplete project timings/);
   assert.match(charts, /type-challenges solutions project/);
 

--- a/scripts/bench/lib/bench-vs-tsgo-results.sh
+++ b/scripts/bench/lib/bench-vs-tsgo-results.sh
@@ -731,28 +731,6 @@ run_project_benchmark() {
                 ratio=$(printf "%.2f" "$(echo "$tsz_mean / $tsgo_mean" | bc -l 2>/dev/null)" 2>/dev/null || echo "N/A")
             fi
 
-            # Hard-gate EVERY perf_timed row, canaries included: when tsz is at
-            # or past the slowdown threshold (default 1.5x) slower than tsgo, null
-            # the timing (ERR,ERR) so the row surfaces as a perf failure and drops
-            # out of the chart instead of charting a quiet "tsgo Nx faster" loss.
-            # Canaries were previously exempted (via TSZ_BENCH_SHARD_LABEL) to keep
-            # the gap charted; per owner decision the 1.5x rule now applies to them
-            # too — a >=1.5x loss is a failure regardless of guard/benchmark set.
-            if [ "$winner" = "tsgo" ] \
-                && tsz_project_slowdown_failure_reached "$tsz_mean" "$tsgo_mean"; then
-                local threshold
-                threshold="$(tsz_project_slowdown_failure_factor)"
-                local status
-                status="tsz slowdown (${ratio}x slower than tsgo; threshold ${threshold}x)"
-                local diagnostic_delta
-                diagnostic_delta="timing failure: tsz ${tsz_ms} ms, tsgo ${tsgo_ms} ms, ratio ${ratio}x, threshold ${threshold}x"
-                echo -e "${YELLOW}$name${NC} - ${RED}ERROR${NC} (${status})" >&2
-                record_project_compatibility "$name" "slowdown" "timing" "$(project_failure_status slowdown)" "$diagnostic_delta" "$file_count" "$peak_memory_bytes" "$tsc_exit_codes" "0" "0" "$tsconfig" "$src_dir"
-                RESULTS_CSV="${RESULTS_CSV}${name},${lines},${kb},ERR,ERR,N/A,N/A,error,0,${status}\n"
-                rm -f "$json_file"
-                return
-            fi
-
             local success_exit_class="exit success"
             local success_phase="check"
             local success_diagnostic_status="none"

--- a/scripts/bench/test-readme-perf-svg.mjs
+++ b/scripts/bench/test-readme-perf-svg.mjs
@@ -44,7 +44,7 @@ const artifact = {
     {
       // tsz is 3x slower than tsgo here — past the 1.5x slowdown-failure
       // threshold, so this row must NOT count toward the README headline
-      // (matches the site chart + the perf gate dropping >=1.5x-slower rows).
+      // even though the website benchmark page still charts its timing pair.
       name: "utility-types-project",
       lines: 2000,
       tsz_ms: 9000,
@@ -72,8 +72,8 @@ const artifact = {
 };
 
 const summary = createReadmePerfSummary(artifact);
-// utility-types-project (tsz 3x slower) is excluded by the 1.5x slowdown
-// threshold; only the within-threshold rxjs-project counts toward the headline.
+// utility-types-project (tsz 3x slower) is excluded from the README headline by
+// the 1.5x slowdown threshold; only the within-threshold rxjs-project counts.
 assert.equal(summary.rows, 1);
 assert.equal(summary.projectRows, 1);
 assert.equal(summary.microRows, 3);


### PR DESCRIPTION
Goal: fast

When a project row compiles cleanly and both `tsz` and `tsgo` produce valid timing measurements, the benchmark website should keep the vs-tsgo timing pair even if `tsz` is slower. Slow green rows are still Fast-goal work through the tsgo-winner/two-x-target reports; they should not be converted into `ERR,ERR` rows that disappear from the benchmark chart.

## What Changed

- Removed the bench merge hard gate that converted clean `tsgo` wins past the slowdown threshold into `ERR,ERR` timing rows.
- Added a website smoke regression for a green RxJS project row where `tsgo` is `3.0x` faster and the chart still renders it.
- Updated README perf-test comments to clarify that the README headline can still exclude very slow rows while the website chart preserves their timing pair.

## Verification

- `bash -n scripts/bench/lib/bench-vs-tsgo-results.sh`
- `node scripts/bench/test-readme-perf-svg.mjs`
- `node scripts/bench/test-tsgo-winner-report.mjs`
- `node scripts/bench/test-merge-results.mjs`
- `node crates/tsz-website/scripts/benchmark-data-smoke.mjs` after `npm --prefix crates/tsz-website install --no-save marked@^15` in the worktree, because the fresh checkout lacked website node deps.

## Provenance

Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
