### PR TITLE
fix(solver): bind `infer` in type-predicate position (`x is infer R`) (#14561)

### DIFF
--- a/crates/tsz-checker/tests/conditional_infer_tests/part_02.rs
+++ b/crates/tsz-checker/tests/conditional_infer_tests/part_02.rs
@@ -150,3 +150,146 @@ export {};
         "PullOr<Box<number>> = \"MISS\" (false branch); number is not assignable",
     );
 }
+
+// =============================================================================
+// Type-predicate `infer`: `T extends (v: any) => v is infer R ? R : never`.
+//
+// A type guard's `infer` variable lives in the predicate target (`x is infer R`),
+// not the boolean return type. Two solver gaps suppressed the binding: the
+// contains-infer walk did not descend into `FunctionShape.type_predicate` (so a
+// conditional never ran infer matching at all), and `match_infer_function_pattern`
+// had no branch for predicate-only infer. tsc infers `R` from the source guard's
+// asserted type (`inferFromSignature`); tsz collapsed it to the `never` false
+// branch, producing spurious TS2322 (witnessed in the ts-pattern `P.string` /
+// `when(isString)` chainable family). Binder names are varied so the fix cannot
+// key off any identifier.
+// =============================================================================
+
+#[test]
+fn type_predicate_infer_binds_narrowed_type() {
+    // `R` must bind to the guard's asserted type (`string`), not `never`.
+    assert_no_ts2322(
+        r#"
+type Narrowed<P> = P extends (value: any) => value is infer R ? R : never;
+declare const isText: (probe: unknown) => probe is string;
+type Out = Narrowed<typeof isText>;
+const ok: Out = "hello";
+export {};
+"#,
+        "Narrowed<(probe) => probe is string> = string",
+    );
+}
+
+#[test]
+fn type_predicate_infer_is_not_never_or_any() {
+    // The dual control: a non-`string` assignment must still error, proving the
+    // bound type is exactly `string` (not `never`, which would also reject the
+    // positive case, nor `any`/`unknown`, which would accept this one).
+    assert_has_ts2322(
+        r#"
+type Narrowed<P> = P extends (value: any) => value is infer R ? R : never;
+declare const isText: (probe: unknown) => probe is string;
+type Out = Narrowed<typeof isText>;
+const bad: Out = 123;
+export {};
+"#,
+        "Narrowed<...> = string; number is not assignable",
+    );
+}
+
+#[test]
+fn generic_type_guard_when_pattern_infers_narrowed() {
+    // The ts-pattern `when(isString)` shape: a generic helper whose return type
+    // is a conditional extracting the predicate's narrowed type from a generic
+    // type guard `<U>(x: U | string) => x is string`.
+    assert_no_ts2322(
+        r#"
+function pick<input, predicate extends (value: input) => unknown>(
+  predicate: predicate
+): predicate extends (value: any) => value is infer narrowed ? narrowed : never {
+  return null as any;
+}
+function looksTextual<U>(candidate: U | string): candidate is string {
+  return typeof candidate === "string";
+}
+const picked = pick(looksTextual);
+const ok: string = picked;
+export {};
+"#,
+        "pick(looksTextual) narrowed = string",
+    );
+}
+
+#[test]
+fn generic_type_guard_when_pattern_is_not_any() {
+    // Control for the generic-guard case: the bound narrowed type is `string`,
+    // so a `number` annotation on the result is a real TS2322.
+    assert_has_ts2322(
+        r#"
+function pick<input, predicate extends (value: input) => unknown>(
+  predicate: predicate
+): predicate extends (value: any) => value is infer narrowed ? narrowed : never {
+  return null as any;
+}
+function looksTextual<U>(candidate: U | string): candidate is string {
+  return typeof candidate === "string";
+}
+const picked = pick(looksTextual);
+const bad: number = picked;
+export {};
+"#,
+        "pick(looksTextual) narrowed = string; number is not assignable",
+    );
+}
+
+#[test]
+fn asserts_predicate_infer_binds_narrowed_type() {
+    // The `asserts value is infer R` variant binds `R` the same way.
+    assert_has_ts2322(
+        r#"
+type AssertNarrowed<P> = P extends (value: any) => asserts value is infer R ? R : never;
+declare const ensureText: (subject: unknown) => asserts subject is string;
+type Out = AssertNarrowed<typeof ensureText>;
+const ok: Out = "x";
+const bad: Out = 7;
+export {};
+"#,
+        "AssertNarrowed<asserts subject is string> = string; number is not assignable",
+    );
+}
+
+#[test]
+fn non_guard_source_takes_false_branch() {
+    // Negative control: a source that returns `boolean` (no type predicate) is
+    // not a guard, so the conditional must keep its false branch — the suppress
+    // must not over-fire on every function type.
+    assert_has_ts2322(
+        r#"
+type GuardOut<P> = P extends (value: any) => value is infer R ? R : "NOT_A_GUARD";
+declare const plainCheck: (subject: unknown) => boolean;
+type Out = GuardOut<typeof plainCheck>;
+const ok: Out = "NOT_A_GUARD";
+const bad: Out = "other";
+export {};
+"#,
+        "GuardOut<(subject) => boolean> = \"NOT_A_GUARD\" (false branch)",
+    );
+}
+
+#[test]
+fn asserts_source_does_not_bind_non_asserts_infer_pattern() {
+    // Predicate kinds must match: an `asserts x is string` source does NOT bind a
+    // non-asserts `value is infer R` pattern, so the conditional takes its false
+    // branch (mirrors tsc's `typePredicateKindsMatch`).
+    assert_has_ts2322(
+        r#"
+type GuardOut<P> = P extends (value: any) => value is infer R ? R : "NO_MATCH";
+declare const ensureText: (subject: unknown) => asserts subject is string;
+type Out = GuardOut<typeof ensureText>;
+const ok: Out = "NO_MATCH";
+const bad: Out = "other";
+export {};
+"#,
+        "asserts source vs non-asserts pattern = \"NO_MATCH\" (false branch)",
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -352,6 +352,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         .this_type
                         .is_some_and(|this_type| self.type_contains_infer_inner(this_type, visited))
                     || self.type_contains_infer_inner(shape.return_type, visited)
+                    // A type-guard return (`x is infer R`) carries its infer in the
+                    // predicate target, not the boolean return type.
+                    || shape
+                        .type_predicate
+                        .and_then(|predicate| predicate.type_id)
+                        .is_some_and(|type_id| self.type_contains_infer_inner(type_id, visited))
             }
             TypeData::Callable(shape_id) => {
                 let shape = self.interner().callable_shape(shape_id);
@@ -363,6 +369,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             self.type_contains_infer_inner(this_type, visited)
                         })
                         || self.type_contains_infer_inner(sig.return_type, visited)
+                        || sig
+                            .type_predicate
+                            .and_then(|predicate| predicate.type_id)
+                            .is_some_and(|type_id| self.type_contains_infer_inner(type_id, visited))
                 }) || shape.construct_signatures.iter().any(|sig| {
                     sig.params
                         .iter()
@@ -371,6 +381,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             self.type_contains_infer_inner(this_type, visited)
                         })
                         || self.type_contains_infer_inner(sig.return_type, visited)
+                        || sig
+                            .type_predicate
+                            .and_then(|predicate| predicate.type_id)
+                            .is_some_and(|type_id| self.type_contains_infer_inner(type_id, visited))
                 }) || shape
                     .properties
                     .iter()

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs
@@ -15,7 +15,7 @@ use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
 use crate::types::{
     CallableShapeId, FunctionShape, FunctionShapeId, IntrinsicKind, LiteralValue, ParamInfo,
-    TupleElement, TypeData, TypeId, TypeParamInfo,
+    TupleElement, TypeData, TypeId, TypeParamInfo, TypePredicate, TypePredicateTarget,
 };
 use crate::visitor::array_element_type;
 use rustc_hash::FxHashMap;
@@ -84,6 +84,97 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return return_type;
         };
         instantiate_type(self.interner(), return_type, &subst)
+    }
+
+    /// Mirror of tsc `inferFromSignature`'s type-predicate handling: when both
+    /// the source signature and the inference pattern carry a type predicate
+    /// that names a type (`x is T` / `asserts x is T`), the inference for the
+    /// return position is taken from the predicate target types rather than the
+    /// boolean return type. Returns the source predicate's target type
+    /// (instantiated with the source signature's generic constraints) when the
+    /// predicate kinds are compatible, else `None` (which makes the pattern fail
+    /// so the conditional takes its false branch — a non-guard source does not
+    /// match a `value is infer R` pattern).
+    fn source_predicate_target_for_infer(
+        &self,
+        source_predicate: Option<TypePredicate>,
+        pattern_predicate: TypePredicate,
+        source_type_params: &[TypeParamInfo],
+    ) -> Option<TypeId> {
+        let source_predicate = source_predicate?;
+        // Predicate "kinds" must match (tsc compares predicate kind): the
+        // `asserts` modifier and the target shape (`this` vs an identifier).
+        if source_predicate.asserts != pattern_predicate.asserts {
+            return None;
+        }
+        let same_target_kind = matches!(
+            (source_predicate.target, pattern_predicate.target),
+            (TypePredicateTarget::This, TypePredicateTarget::This)
+                | (
+                    TypePredicateTarget::Identifier(_),
+                    TypePredicateTarget::Identifier(_)
+                )
+        );
+        if !same_target_kind {
+            return None;
+        }
+        let target_type = source_predicate.type_id?;
+        Some(self.erase_return_type_for_infer(target_type, source_type_params))
+    }
+
+    /// Extract a source `Function`/`Callable` signature's predicate target type
+    /// (when present and kind-compatible with `pattern_predicate`) for
+    /// predicate-`infer` matching, plus its instantiated params — but only when
+    /// `needs_params` (the pattern's params carry an infer). The dominant
+    /// predicate pattern `(value: any) => value is infer R` has no param infer,
+    /// so skipping the param instantiation avoids a wasted `Vec` clone on this
+    /// hot inference path. `None` when `source` is not a callable signature.
+    fn source_sig_for_predicate_infer(
+        &self,
+        source: TypeId,
+        pattern_predicate: TypePredicate,
+        needs_params: bool,
+    ) -> Option<(Vec<ParamInfo>, Option<TypeId>)> {
+        let instantiate_params = |params: &[ParamInfo], return_type, type_params: &[_]| {
+            if needs_params {
+                self.instantiate_signature_for_infer(params, return_type, type_params)
+                    .0
+            } else {
+                Vec::new()
+            }
+        };
+        match self.interner().lookup(source)? {
+            TypeData::Function(source_fn_id) => {
+                let source_fn = self.interner().function_shape(source_fn_id);
+                let params = instantiate_params(
+                    &source_fn.params,
+                    source_fn.return_type,
+                    &source_fn.type_params,
+                );
+                let predicate_type = self.source_predicate_target_for_infer(
+                    source_fn.type_predicate,
+                    pattern_predicate,
+                    &source_fn.type_params,
+                );
+                Some((params, predicate_type))
+            }
+            TypeData::Callable(source_shape_id) => {
+                let source_shape = self.interner().callable_shape(source_shape_id);
+                let source_sig = source_shape.call_signatures.last()?;
+                let params = instantiate_params(
+                    &source_sig.params,
+                    source_sig.return_type,
+                    &source_sig.type_params,
+                );
+                let predicate_type = self.source_predicate_target_for_infer(
+                    source_sig.type_predicate,
+                    pattern_predicate,
+                    &source_sig.type_params,
+                );
+                Some((params, predicate_type))
+            }
+            _ => None,
+        }
     }
 
     fn instantiate_signature_for_infer(
@@ -319,6 +410,95 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let has_single_rest_infer = pattern_fn.params.len() == 1
             && pattern_fn.params[0].rest
             && self.type_contains_infer(pattern_fn.params[0].type_id);
+        // A type-guard pattern `(v) => v is infer R` carries its infer variable
+        // in the predicate target type, not the (boolean) return type. The
+        // param/return-infer branches below never see it, so handle it here.
+        let has_predicate_infer = pattern_fn
+            .type_predicate
+            .and_then(|predicate| predicate.type_id)
+            .is_some_and(|type_id| self.type_contains_infer(type_id));
+
+        if pattern_fn.this_type.is_none() && has_predicate_infer && !has_return_infer {
+            // The boolean return holds no infer var; the inference target is the
+            // predicate's asserted type, and (per tsc) it binds only when the
+            // SOURCE is itself a type guard of the same predicate kind.
+            let Some(pattern_predicate) = pattern_fn.type_predicate else {
+                return false;
+            };
+            let Some(pattern_predicate_type) = pattern_predicate.type_id else {
+                return false;
+            };
+
+            let mut match_predicate_sig = |source_params: &[ParamInfo],
+                                           source_predicate_type: Option<TypeId>,
+                                           bindings: &mut FxHashMap<Atom, TypeId>|
+             -> bool {
+                if has_param_infer {
+                    if has_single_rest_infer {
+                        if !self.match_rest_infer_tuple(
+                            source_params,
+                            pattern_fn.params[0].type_id,
+                            bindings,
+                            checker,
+                        ) {
+                            return false;
+                        }
+                    } else if !self.match_signature_params_for_infer(
+                        source_params,
+                        &pattern_fn.params,
+                        bindings,
+                        checker,
+                    ) {
+                        return false;
+                    }
+                }
+                let Some(source_predicate_type) = source_predicate_type else {
+                    return false;
+                };
+                self.match_infer_pattern(
+                    source_predicate_type,
+                    pattern_predicate_type,
+                    bindings,
+                    visited,
+                    checker,
+                )
+            };
+
+            // A union source (`Guard1 | Guard2`) binds the infer to the union of
+            // each member's narrowed type; a single callable binds directly.
+            if let Some(TypeData::Union(members)) = self.interner().lookup(source) {
+                let members = self.interner().type_list(members);
+                let mut combined = FxHashMap::default();
+                for &member in members.iter() {
+                    let Some((params, source_predicate_type)) = self
+                        .source_sig_for_predicate_infer(member, pattern_predicate, has_param_infer)
+                    else {
+                        return false;
+                    };
+                    let mut member_bindings = FxHashMap::default();
+                    if !match_predicate_sig(&params, source_predicate_type, &mut member_bindings) {
+                        return false;
+                    }
+                    for (name, ty) in member_bindings {
+                        combined
+                            .entry(name)
+                            .and_modify(|existing| {
+                                *existing = self.interner().union2(*existing, ty);
+                            })
+                            .or_insert(ty);
+                    }
+                }
+                bindings.extend(combined);
+                return true;
+            }
+
+            let Some((params, source_predicate_type)) =
+                self.source_sig_for_predicate_infer(source, pattern_predicate, has_param_infer)
+            else {
+                return false;
+            };
+            return match_predicate_sig(&params, source_predicate_type, bindings);
+        }
 
         if pattern_fn.this_type.is_none() && has_param_infer && has_return_infer {
             let mut match_params_and_return = |_source_type: TypeId,


### PR DESCRIPTION
Goal: grow

Fixes #14561.

## Summary
A conditional whose `extends`-type is a **type-guard signature with `infer` in the predicate position** never bound the infer variable, so the conditional always took its false branch:

```ts
type Narrowed<P> = P extends (value: any) => value is infer R ? R : never;
declare const isText: (probe: unknown) => probe is string;
type Out = Narrowed<typeof isText>;   // tsc: string ; tsz (before): never
const ok: Out = "hello";              // tsz (before): spurious TS2322 (never)
```

Witnessed in the **ts-pattern** canary (`gvergnaud/ts-pattern@c92ca43`, tsc-6.0.2-clean): `src/patterns.ts:928/1075/1201`, the `P.string`/`P.number`/`P.bigint` chainables built from `when(isString)` etc. (`when` returns `predicate extends (value: any) => value is infer narrowed ? narrowed : never`). tsz inferred `narrowed = never`, drawing spurious **TS2322**.

## Root cause (two solver gaps)
A type guard's `infer` lives in `FunctionShape.type_predicate`, separate from the boolean `return_type`. Two sites ignored it:

1. **`match_contains_infer`** (`evaluation/evaluate_rules/infer_pattern.rs`) did not descend into a signature's `type_predicate`, so `type_contains_infer((v) => v is infer R)` returned `false`, the conditional's `extends_has_infer` gate stayed `false`, and infer matching never ran → false branch.
2. **`match_infer_function_pattern`** (`evaluation/evaluate_rules/infer_pattern_helpers.rs`) had branches for param/return/this infer but **none for predicate-infer**, so even when reached it bound nothing.

## Structural rule
When the inference pattern is a type-guard signature `(v) => [asserts] v is infer R`, the infer target is the predicate's asserted type. Mirroring tsc `inferFromSignature`: when source and pattern signatures share a type predicate of the **same kind** (`asserts` flag + `this`/identifier target) with a named type, infer `R` from the predicate target types; a non-guard source does not match (false branch). Owner layer: solver conditional-type infer matching. No checker/emitter change.

## Owner layer & altitude
Both fixes live in the solver's infer machinery. The new predicate-infer branch is a peer of the existing param/return/this-infer branches (the function already gates per infer-position combination), and reuses the existing `instantiate_signature_for_infer` / `erase_return_type_for_infer` / `match_infer_pattern` helpers. Param instantiation is skipped when the pattern has no param infer (the dominant `(value: any) => value is infer R` shape).

## Anti-hardcoding
The decision is purely structural (predicate kind: `asserts` flag + `This`/`Identifier` target discriminant, and the predicate's named type). No identifier, file-name, or printer-output predicate. Every test varies the binder names.

## Adjacent-case matrix (regression tests in `conditional_infer_tests/part_02.rs`, all matched against tsc 6.0.2)
- `value is infer R` binds the narrowed type (`string`), not `never`; the dual control proves it is not `any`/`unknown` (a `number` assignment still errors).
- Generic guard `<U>(x: U | string) => x is string` through a `when`-shaped helper (the ts-pattern witness).
- `asserts value is infer R` binds the same way.
- **Negative:** a non-guard `(x) => boolean` source keeps the false branch (no over-suppression on every function type).
- **Negative:** an `asserts x is string` source does **not** bind a non-asserts `value is infer R` pattern (predicate-kind discrimination, mirroring tsc `typePredicateKindsMatch`).

## Out of scope
- ts-pattern `src/patterns.ts:928` retains a residual self-mismatch on `StringChainable.startsWith` (template-literal / `const`-param method variance) and `:475` a `Record<PropertyKey, object>` TS2345 — both independent roots; this PR clears the `number`/`bigint` predicate rows and corrects the `string` row's inferred type (ts-pattern tsz-only diagnostics 4 → 2).
- A non-asserts guard with an unconstrained predicate type (`<T>(x: T) => x is string`) still misses TS2677 — a separate pre-existing false-negative, unchanged here.

## Verification
- New `cargo test -p tsz-checker --test conditional_infer_tests` predicate cases — 9/9 pass; full file: 117 pass (the 3 pre-existing env failures reproduce identically on clean main, stash-verified).
- `cargo test -p tsz-solver --lib` infer/conditional/predicate/callable/signature/function/narrowing families — no new failures (the 2 perf-counter flakes under parallel runs reproduce identically on clean main, stash-verified).
- Differential vs tsc 6.0.2 on the matrix above and the ts-pattern project (down from 4 to 2 tsz-only diagnostics).
- `cargo fmt` + `cargo clippy -p tsz-solver -p tsz-checker --lib` clean.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

---
_Generated by [Claude Code](https://claude.ai/code/session_0138dPqcNZJFAqwuot8mtec1)_