### PR TITLE
fix(bench): require charts for green perf-timed projects

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1684,6 +1684,7 @@ jobs:
           node scripts/bench/check-artifact-readiness.mjs \
             --json \
             --require-application-compat \
+            --require-green-project-timing-pairs \
             --require-project-timing-pairs=1 \
             "$GITHUB_WORKSPACE/bench-results.json" \
             > "$GITHUB_WORKSPACE/bench-results-readiness.json"

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -103,6 +103,7 @@ jobs:
               .application_compatibility.missing == 0 and
               .application_compatibility.incomplete == 0 and
               .application_compatibility.duplicates == 0 and
+              .green_project_timing_pair_gaps == 0 and
               .successful_project_timing_pairs >= .required_project_timing_pairs
             ' "${tmpdir}/artifact/bench-results-readiness.json" >/dev/null; then
               rm -rf "${tmpdir}"
@@ -258,6 +259,7 @@ jobs:
               .application_compatibility.missing == 0 and
               .application_compatibility.incomplete == 0 and
               .application_compatibility.duplicates == 0 and
+              .green_project_timing_pair_gaps == 0 and
               .successful_project_timing_pairs >= .required_project_timing_pairs
             ' "${tmpdir}/artifact/bench-results-readiness.json" >/dev/null; then
               rm -rf "${tmpdir}"

--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -902,7 +902,11 @@ function loadBenchmarks() {
   const selectedArtifact = selectLatestBenchmarkArtifact([
     ...benchmarkArtifactFiles(),
     snapshotPath,
-  ], { minimumProjectTimingPairs: 1, requireApplicationCompat: true });
+  ], {
+    minimumProjectTimingPairs: 1,
+    requireApplicationCompat: true,
+    requireGreenProjectTimingPairs: true,
+  });
   if (selectedArtifact) {
     return sanitizeLegacyBenchmarkData(selectedArtifact.data);
   }

--- a/scripts/bench/benchmark-artifact-selection.mjs
+++ b/scripts/bench/benchmark-artifact-selection.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 
 import {
+  PERF_TIMED_PROJECT_ROWS,
   PROJECT_ROW_DEFINITIONS,
   PROJECT_ROWS_BY_NAME,
 } from "./project-rows.mjs";
@@ -30,6 +31,7 @@ function hasTiming(value) {
 const APPLICATION_PROJECT_ROW_NAMES = PROJECT_ROW_DEFINITIONS
   .filter((row) => row.category === "application")
   .map((row) => row.name);
+const PERF_TIMED_PROJECT_ROW_NAMES = new Set(PERF_TIMED_PROJECT_ROWS);
 
 export function successfulProjectTimingPairCount(data) {
   return (Array.isArray(data?.results) ? data.results : []).filter((row) => (
@@ -43,6 +45,33 @@ export function successfulProjectTimingPairCount(data) {
 
 export function hasSuccessfulProjectTimingPairs(data, minimum = 1) {
   return successfulProjectTimingPairCount(data) >= minimum;
+}
+
+function hasGreenCompatibilityEvidence(row) {
+  const compatibility = row?.compatibility;
+  if (!compatibility || typeof compatibility !== "object") return false;
+  const state = String(compatibility.state || "").toLowerCase();
+  const exitClass = String(compatibility.exit_class || "").toLowerCase();
+  const diagnosticStatus = String(compatibility.diagnostic_status || "").toLowerCase();
+  return state === "green"
+    && exitClass === "exit success"
+    && (!diagnosticStatus || diagnosticStatus === "none");
+}
+
+function hasTimingPair(row) {
+  return hasTiming(row?.tsz_ms) && hasTiming(row?.tsgo_ms) && row?.winner !== "error" && !row?.status;
+}
+
+export function greenProjectTimingPairGapCount(data) {
+  return (Array.isArray(data?.results) ? data.results : []).filter((row) => (
+    PERF_TIMED_PROJECT_ROW_NAMES.has(String(row?.name || "")) &&
+    hasGreenCompatibilityEvidence(row) &&
+    !hasTimingPair(row)
+  )).length;
+}
+
+export function hasGreenProjectTimingPairs(data) {
+  return greenProjectTimingPairGapCount(data) === 0;
 }
 
 export function applicationCompatibilityRowCount(data) {
@@ -64,6 +93,7 @@ export function hasApplicationCompatibilityRows(data) {
 export function selectLatestBenchmarkArtifact(files, options = {}) {
   const minimumProjectTimingPairs = Math.max(0, Number(options.minimumProjectTimingPairs ?? 0));
   const requireApplicationCompat = options.requireApplicationCompat === true;
+  const requireGreenProjectTimingPairs = options.requireGreenProjectTimingPairs === true;
   const candidates = [];
   for (const [index, file] of files.entries()) {
     const data = readBenchmarkArtifact(file);
@@ -72,12 +102,15 @@ export function selectLatestBenchmarkArtifact(files, options = {}) {
     if (projectTimingPairs < minimumProjectTimingPairs) continue;
     const applicationCompatibilityRows = applicationCompatibilityRowCount(data);
     if (requireApplicationCompat && applicationCompatibilityRows < APPLICATION_PROJECT_ROW_NAMES.length) continue;
+    const greenProjectTimingPairGaps = greenProjectTimingPairGapCount(data);
+    if (requireGreenProjectTimingPairs && greenProjectTimingPairGaps > 0) continue;
     candidates.push({
       file,
       data,
       generatedAtMs: benchmarkGeneratedAtMs(data),
       projectTimingPairs,
       applicationCompatibilityRows,
+      greenProjectTimingPairGaps,
       index,
     });
   }

--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -8,6 +8,8 @@
  *       --require-green release gate found non-green required rows, the
  *       --require-clean-metadata gate found artifact metadata warnings,
  *       --require-application-compat found missing/incomplete application rows,
+ *       --require-green-project-timing-pairs found green perf-timed rows
+ *       missing tsz/tsgo timing pairs,
  *       or the --require-source-current gate found a stale artifact source commit
  *   2 — artifact file absent or unparseable
  *
@@ -19,7 +21,7 @@
  * is absent (exit 2) so callers reliably get machine-readable status in all cases.
  *
  * Usage:
- *   node scripts/bench/check-artifact-readiness.mjs [--json] [--require-green] [--require-clean-metadata] [--require-application-compat] [--require-project-timing-pairs[=<n>]] [--expect-source-commit=<sha>] [--require-source-current] <artifact.json>
+ *   node scripts/bench/check-artifact-readiness.mjs [--json] [--require-green] [--require-clean-metadata] [--require-application-compat] [--require-green-project-timing-pairs] [--require-project-timing-pairs[=<n>]] [--expect-source-commit=<sha>] [--require-source-current] <artifact.json>
  */
 
 import fs from "node:fs";
@@ -29,6 +31,7 @@ import {
   REQUIRED_PROJECT_ROWS,
   PROJECT_ROW_DEFINITIONS,
   PROJECT_ROWS_BY_NAME,
+  PERF_TIMED_PROJECT_ROWS,
 } from "./project-rows.mjs";
 import { BENCH_RUNNER_EXCLUDED_ROWS } from "./project-row-summary.mjs";
 import {
@@ -65,6 +68,7 @@ function parseArgs(rawArgs) {
     requireGreen: false,
     requireCleanMetadata: false,
     requireApplicationCompat: false,
+    requireGreenProjectTimingPairs: false,
     requireSourceCurrent: false,
     requiredProjectTimingPairs: 0,
     expectedSourceCommit: process.env.TSZ_BENCH_EXPECT_SOURCE_COMMIT ?? null,
@@ -81,6 +85,8 @@ function parseArgs(rawArgs) {
       options.requireCleanMetadata = true;
     } else if (arg === "--require-application-compat") {
       options.requireApplicationCompat = true;
+    } else if (arg === "--require-green-project-timing-pairs") {
+      options.requireGreenProjectTimingPairs = true;
     } else if (arg === "--require-source-current") {
       options.requireSourceCurrent = true;
     } else if (arg === "--require-project-timing-pairs") {
@@ -111,6 +117,7 @@ const {
   requireGreen,
   requireCleanMetadata,
   requireApplicationCompat,
+  requireGreenProjectTimingPairs,
   requireSourceCurrent,
   requiredProjectTimingPairs: rawRequiredProjectTimingPairs,
   expectedSourceCommit: rawExpectedSourceCommit,
@@ -179,6 +186,29 @@ function applicationCompatibilityState(row, duplicate = false) {
 }
 
 const STATE_ICON = { green: "✅", yellow: "⚠️", red: "❌", gray: "⬜", missing: "🚫" };
+
+function hasSuccessfulTimingPair(row) {
+  return (
+    Number.isFinite(Number(row?.tsz_ms)) &&
+    Number(row.tsz_ms) > 0 &&
+    Number.isFinite(Number(row?.tsgo_ms)) &&
+    Number(row.tsgo_ms) > 0 &&
+    row?.winner !== "error" &&
+    !row?.status
+  );
+}
+
+function hasGreenCompatibilityEvidence(row) {
+  const compatibility = row?.compatibility;
+  if (!compatibility || typeof compatibility !== "object") return false;
+  const state = String(compatibility.state || "").toLowerCase();
+  const exitClass = String(compatibility.exit_class || "").toLowerCase();
+  const diagnosticStatus = String(compatibility.diagnostic_status || "").toLowerCase();
+  return state === "green"
+    && exitClass === "exit success"
+    && (!diagnosticStatus || diagnosticStatus === "none")
+    && hasCompletePhaseMetadata(compatibility);
+}
 
 function cleanValidationWarnings(warnings) {
   if (!Array.isArray(warnings)) return [];
@@ -321,6 +351,14 @@ function analyzeArtifact(artifact, expectedCommit) {
   const applicationRows = APPLICATION_PROJECT_ROWS.map((name) =>
     compatibilityRow(name, applicationCompatibilityState),
   );
+  const greenTimedRowsMissingTimingPairs = PERF_TIMED_PROJECT_ROWS
+    .map((name) => compatibilityRow(name, applicationCompatibilityState))
+    .filter((row) => {
+      const sourceRow = byName.get(row.name);
+      return row.duplicate_count <= 1 &&
+        hasGreenCompatibilityEvidence(sourceRow) &&
+        !hasSuccessfulTimingPair(sourceRow);
+    });
 
   return {
     measurementProfile: measurementProfileStatus(artifact),
@@ -335,13 +373,10 @@ function analyzeArtifact(artifact, expectedCommit) {
       r.metadata_complete !== true
     )),
     applicationDuplicates: applicationRows.filter((r) => r.duplicate_count > 1),
+    greenTimedRowsMissingTimingPairs,
     successfulProjectTimingPairs: rows.filter((row) => (
       row.state === "green" &&
-      Number.isFinite(Number(row.tsz_ms)) &&
-      Number(row.tsz_ms) > 0 &&
-      Number.isFinite(Number(row.tsgo_ms)) &&
-      Number(row.tsgo_ms) > 0 &&
-      row.winner !== "error"
+      hasSuccessfulTimingPair(row)
     )),
     missing: rows.filter((r) => r.state === "missing"),
     red: rows.filter((r) => r.state === "red"),
@@ -373,6 +408,7 @@ function buildJson({
   applicationMissing,
   applicationIncomplete,
   applicationDuplicates,
+  greenTimedRowsMissingTimingPairs,
   successfulProjectTimingPairs,
   missing,
   red,
@@ -415,6 +451,15 @@ function buildJson({
     required_row_count: rows?.length ?? REQUIRED_MEASURED_ROWS.length,
     successful_project_timing_pairs: successfulProjectTimingPairs?.length ?? 0,
     required_project_timing_pairs: requiredProjectTimingPairs,
+    require_green_project_timing_pairs: requireGreenProjectTimingPairs,
+    green_project_timing_pair_gaps: greenTimedRowsMissingTimingPairs?.length ?? 0,
+    green_project_timing_pair_gap_rows: greenTimedRowsMissingTimingPairs?.map((r) => ({
+      name: r.name,
+      label: r.label,
+      state: r.state,
+      tsz_ms: r.tsz_ms,
+      tsgo_ms: r.tsgo_ms,
+    })) ?? [],
     application_compatibility: applicationRows
       ? {
           required: requireApplicationCompat,
@@ -547,6 +592,7 @@ function buildReport({
   applicationMissing,
   applicationIncomplete,
   applicationDuplicates,
+  greenTimedRowsMissingTimingPairs,
   successfulProjectTimingPairs,
   missing,
   red,
@@ -584,6 +630,7 @@ function buildReport({
     `| Binary target CPU | ${profile.rust_target_cpu ? `\`${profile.rust_target_cpu}\`` : "—"} |`,
     `| Required rows | ${rows.length} |`,
     `| Successful project timing pairs | ${successfulProjectTimingPairs.length} |`,
+    `| Green perf-timed rows missing timing | ${greenTimedRowsMissingTimingPairs.length} |`,
     `| Application compatibility rows | ${applicationRows.length - applicationMissing.length}/${applicationRows.length} present, ${applicationIncomplete.length} incomplete |`,
     `| ✅ green | ${green.length} |`,
     `| ⚠️ yellow | ${yellow.length} |`,
@@ -616,6 +663,14 @@ function buildReport({
     for (const r of applicationMissing) lines.push(`- \`${r.name}\`: missing compatibility row`);
     for (const r of applicationIncomplete) lines.push(`- \`${r.name}\`: incomplete compatibility metadata`);
     for (const r of applicationDuplicates) lines.push(`- \`${r.name}\`: duplicate compatibility row (${r.duplicate_count})`);
+    lines.push("");
+  }
+
+  if (greenTimedRowsMissingTimingPairs.length > 0) {
+    lines.push(`### Green perf-timed rows missing timing (${greenTimedRowsMissingTimingPairs.length})`, "");
+    for (const r of greenTimedRowsMissingTimingPairs) {
+      lines.push(`- \`${r.name}\`: compatibility is green but no tsz/tsgo timing pair was recorded`);
+    }
     lines.push("");
   }
 
@@ -696,6 +751,7 @@ if (artifactAbsent || parseError) {
         applicationMissing: null,
         applicationIncomplete: null,
         applicationDuplicates: null,
+        greenTimedRowsMissingTimingPairs: null,
         missing: null,
         red: null,
         yellow: null,
@@ -719,6 +775,7 @@ const {
   applicationMissing,
   applicationIncomplete,
   applicationDuplicates,
+  greenTimedRowsMissingTimingPairs,
   successfulProjectTimingPairs,
   missing,
   red,
@@ -744,6 +801,7 @@ if (jsonOutput) {
       applicationMissing,
       applicationIncomplete,
       applicationDuplicates,
+      greenTimedRowsMissingTimingPairs,
       successfulProjectTimingPairs,
       missing,
       red,
@@ -819,6 +877,14 @@ if (successfulProjectTimingPairs.length < requiredProjectTimingPairs) {
   process.stderr.write(
     `bench-artifact-readiness: ${successfulProjectTimingPairs.length} successful project timing pair(s); ` +
       `required ${requiredProjectTimingPairs} before publishing latest benchmark data\n`,
+  );
+  process.exit(1);
+}
+
+if (requireGreenProjectTimingPairs && greenTimedRowsMissingTimingPairs.length > 0) {
+  process.stderr.write(
+    `bench-artifact-readiness: ${greenTimedRowsMissingTimingPairs.length} green perf-timed project row(s) ` +
+      `missing tsz/tsgo timing pairs: ${greenTimedRowsMissingTimingPairs.map((r) => r.name).join(", ")}\n`,
   );
   process.exit(1);
 }

--- a/scripts/bench/test-benchmark-artifact-selection.mjs
+++ b/scripts/bench/test-benchmark-artifact-selection.mjs
@@ -52,6 +52,12 @@ function applicationCompatibilityRows() {
     }));
 }
 
+function applicationTimedRows() {
+  return PROJECT_ROW_DEFINITIONS
+    .filter((row) => row.category === "application")
+    .map((row) => projectRow(row.name, "green"));
+}
+
 try {
   const snapshot = writeArtifact("bench-snapshot.json", "2026-05-17T01:23:02.991Z");
   const github = writeArtifact("bench-vs-tsgo-github-latest.json", "2026-05-28T02:14:24.444Z");
@@ -100,6 +106,30 @@ try {
     )?.file,
     olderWithApplications,
     "a newer artifact without application compatibility should not mask older app-compatible benchmark data",
+  );
+  const olderWithApplicationTimings = writeArtifact("older-with-application-timings.json", "2026-06-04T00:00:00.000Z", [
+    projectRow("utility-types-project"),
+    ...applicationTimedRows(),
+  ]);
+  const newerWithGreenCompileOnlyApplications = writeArtifact(
+    "newer-with-green-compile-only-applications.json",
+    "2026-06-05T00:00:00.000Z",
+    [
+      projectRow("utility-types-project"),
+      ...applicationCompatibilityRows(),
+    ],
+  );
+  assert.equal(
+    selectLatestBenchmarkArtifact(
+      [olderWithApplicationTimings, newerWithGreenCompileOnlyApplications],
+      {
+        minimumProjectTimingPairs: 1,
+        requireApplicationCompat: true,
+        requireGreenProjectTimingPairs: true,
+      },
+    )?.file,
+    olderWithApplicationTimings,
+    "a newer artifact with green compile-only app rows should not mask older app chart data",
   );
   assert.equal(
     selectLatestBenchmarkArtifact([path.join(tempDir, "missing.json")]),

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -501,6 +501,57 @@ withTempDir((dir) => {
 console.log("✅ --require-application-compat accepts complete compile-only app rows");
 
 // ---------------------------------------------------------------------------
+// Test: --require-green-project-timing-pairs rejects green perf-timed rows that
+// only have compile compatibility. They would otherwise appear green in the
+// compatibility table while being absent from the vs-tsgo chart.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const requiredRows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  const applicationRows = APPLICATION_PROJECT_ROWS.map((name) =>
+    makeRow(name, "green", {
+      errorStatus: "compile canary tracked in CI; not timed by vs-tsgo benchmarks",
+      tsz_ms: null,
+      tsgo_ms: null,
+      winner: "error",
+    }),
+  );
+  writeJson(file, makeArtifact([...requiredRows, ...applicationRows]));
+  const result = run(file, [
+    "--json",
+    "--require-application-compat",
+    "--require-green-project-timing-pairs",
+  ]);
+  assert.equal(result.status, 1, "green compile-only perf-timed rows should fail the chart timing gate");
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.require_green_project_timing_pairs, true);
+  assert.equal(parsed.green_project_timing_pair_gaps, APPLICATION_PROJECT_ROWS.length);
+  assert.match(result.stderr, /green perf-timed project row\(s\) missing tsz\/tsgo timing pairs/);
+  assert.match(result.stderr, new RegExp(APPLICATION_PROJECT_ROWS[0]));
+});
+console.log("✅ --require-green-project-timing-pairs rejects green app rows without charts");
+
+// ---------------------------------------------------------------------------
+// Test: --require-green-project-timing-pairs accepts green perf-timed rows once
+// the benchmark artifact includes real tsz/tsgo timings for them.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const requiredRows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  const applicationRows = APPLICATION_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  writeJson(file, makeArtifact([...requiredRows, ...applicationRows]));
+  const result = run(file, [
+    "--json",
+    "--require-application-compat",
+    "--require-green-project-timing-pairs",
+  ]);
+  assert.equal(result.status, 0, `green timed application rows should pass:\n${result.stderr}`);
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.green_project_timing_pair_gaps, 0);
+});
+console.log("✅ --require-green-project-timing-pairs accepts green timed app rows");
+
+// ---------------------------------------------------------------------------
 // Test: complete gray application compatibility is still authoritative data.
 // Fixture-invalid/reference-failed app rows should not block publishing green
 // timed app rows; only missing or partial compatibility metadata should.

--- a/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
+++ b/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
@@ -43,8 +43,8 @@ assert.match(
 
 assert.match(
   workflow,
-  /artifact_ready_for_pages\(\)[\s\S]+application_compatibility\.required == true[\s\S]+application_compatibility\.missing == 0[\s\S]+application_compatibility\.incomplete == 0[\s\S]+application_compatibility\.duplicates == 0[\s\S]+successful_project_timing_pairs >= \.required_project_timing_pairs/,
-  "Pages deploy should require benchmark readiness JSON with complete application compatibility before using merged artifacts",
+  /artifact_ready_for_pages\(\)[\s\S]+application_compatibility\.required == true[\s\S]+application_compatibility\.missing == 0[\s\S]+application_compatibility\.incomplete == 0[\s\S]+application_compatibility\.duplicates == 0[\s\S]+green_project_timing_pair_gaps == 0[\s\S]+successful_project_timing_pairs >= \.required_project_timing_pairs/,
+  "Pages deploy should require benchmark readiness JSON with complete application compatibility and green project timing pairs before using merged artifacts",
 );
 
 assert.match(

--- a/scripts/bench/test-project-winner-regression-report.mjs
+++ b/scripts/bench/test-project-winner-regression-report.mjs
@@ -254,8 +254,8 @@ assert.match(
 );
 assert.match(
   benchWorkflow,
-  /check-artifact-readiness\.mjs\s+\\\s*\n\s+--json\s+\\\s*\n\s+--require-application-compat\s+\\\s*\n\s+--require-project-timing-pairs=1\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results\.json"/,
-  "bench publish should reject artifacts with missing app compatibility or no successful project timing pairs before publishing latest.json",
+  /check-artifact-readiness\.mjs\s+\\\s*\n\s+--json\s+\\\s*\n\s+--require-application-compat\s+\\\s*\n\s+--require-green-project-timing-pairs\s+\\\s*\n\s+--require-project-timing-pairs=1\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results\.json"/,
+  "bench publish should reject artifacts with missing app compatibility, green rows missing chart timing, or no successful project timing pairs before publishing latest.json",
 );
 assert.match(
   benchWorkflow,


### PR DESCRIPTION
Goal: fast

When a project row is marked `perf_timed` and its compatibility metadata says it compiles green, the benchmark website should publish and select only artifacts that include a real `tsz`/`tsgo` timing pair for that row. Clean projects should not appear green in the compatibility table while silently missing from the vs-tsgo benchmark chart.

## What Changed

- Added a `--require-green-project-timing-pairs` readiness gate that reports green perf-timed rows missing timing pairs and fails publishing when requested.
- Taught benchmark artifact selection to skip newer artifacts with green compile-only perf-timed rows when chart completeness is required.
- Wired Bench publish and Pages artifact readiness to enforce the new field before latest benchmark data or redeploys are accepted.
- Added focused regression coverage for compile-only application rows, timed application rows, artifact selection, Bench workflow wiring, and Pages readiness checks.

## Verification

- `node scripts/bench/test-check-artifact-readiness.mjs`
- `node scripts/bench/test-benchmark-artifact-selection.mjs`
- `node scripts/bench/test-project-winner-regression-report.mjs`
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `git diff --check`
- `npm --prefix crates/tsz-website install --no-save --no-package-lock marked@^15` then `node crates/tsz-website/scripts/benchmark-data-smoke.mjs` because the checkout lacked website node deps.

## Provenance

Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
