### PR TITLE
fix(checker): structural single-missing-required-property diagnostic; drop Callable/Applicable name hardcodes (#14350)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -1642,73 +1642,6 @@ impl<'a> CheckerState<'a> {
 
         let source_is_function_like = self.is_function_like_type(source);
 
-        let target_name = self.format_type_for_assignability_message(target);
-        if target_name == "Callable" || target_name == "Applicable" {
-            let required_name = if target_name == "Callable" {
-                "call"
-            } else {
-                "apply"
-            };
-            let required_atom = self.ctx.types.intern_string(required_name);
-            let source_has_prop = if source_is_function_like {
-                true
-            } else {
-                source_candidates.iter().any(|candidate| {
-                    if let Some(source_callable) =
-                        crate::query_boundaries::common::callable_shape_for_type(
-                            self.ctx.types,
-                            *candidate,
-                        )
-                    {
-                        source_callable
-                            .properties
-                            .iter()
-                            .any(|p| p.name == required_atom)
-                    } else if let Some(source_shape) =
-                        crate::query_boundaries::common::object_shape_for_type(
-                            self.ctx.types,
-                            *candidate,
-                        )
-                    {
-                        source_shape
-                            .properties
-                            .iter()
-                            .any(|p| p.name == required_atom)
-                    } else {
-                        false
-                    }
-                })
-            };
-            if !source_has_prop {
-                return Some(required_atom);
-            }
-        }
-
-        if !source_is_function_like {
-            for target_candidate in target_candidates {
-                let Some(target_callable) =
-                    crate::query_boundaries::common::callable_shape_for_type(
-                        self.ctx.types,
-                        target_candidate,
-                    )
-                else {
-                    continue;
-                };
-                let Some(sym_id) = target_callable.symbol else {
-                    continue;
-                };
-                let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
-                    continue;
-                };
-                if symbol.escaped_name == "Callable" {
-                    return Some(self.ctx.types.intern_string("call"));
-                }
-                if symbol.escaped_name == "Applicable" {
-                    return Some(self.ctx.types.intern_string("apply"));
-                }
-            }
-        }
-
         for target_candidate in target_candidates {
             if let Some(target_callable) = crate::query_boundaries::common::callable_shape_for_type(
                 self.ctx.types,
@@ -1721,37 +1654,34 @@ impl<'a> CheckerState<'a> {
                     .collect();
                 if required_props.len() == 1 {
                     let prop = required_props[0];
-                    let prop_name = self.ctx.types.resolve_atom_ref(prop.name);
-                    if prop_name.as_ref() == "call" || prop_name.as_ref() == "apply" {
-                        let source_has_prop = if source_is_function_like {
-                            true
-                        } else {
-                            source_candidates.iter().any(|candidate| {
-                                if let Some(source_callable) =
-                                    crate::query_boundaries::common::callable_shape_for_type(
-                                        self.ctx.types,
-                                        *candidate,
-                                    )
-                                {
-                                    source_callable
-                                        .properties
-                                        .iter()
-                                        .any(|p| p.name == prop.name)
-                                } else if let Some(source_shape) =
-                                    crate::query_boundaries::common::object_shape_for_type(
-                                        self.ctx.types,
-                                        *candidate,
-                                    )
-                                {
-                                    source_shape.properties.iter().any(|p| p.name == prop.name)
-                                } else {
-                                    false
-                                }
-                            })
-                        };
-                        if !source_has_prop {
-                            return Some(prop.name);
-                        }
+                    let source_has_prop = if source_is_function_like {
+                        true
+                    } else {
+                        source_candidates.iter().any(|candidate| {
+                            if let Some(source_callable) =
+                                crate::query_boundaries::common::callable_shape_for_type(
+                                    self.ctx.types,
+                                    *candidate,
+                                )
+                            {
+                                source_callable
+                                    .properties
+                                    .iter()
+                                    .any(|p| p.name == prop.name)
+                            } else if let Some(source_shape) =
+                                crate::query_boundaries::common::object_shape_for_type(
+                                    self.ctx.types,
+                                    *candidate,
+                                )
+                            {
+                                source_shape.properties.iter().any(|p| p.name == prop.name)
+                            } else {
+                                false
+                            }
+                        })
+                    };
+                    if !source_has_prop {
+                        return Some(prop.name);
                     }
                 }
             }

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -1664,17 +1664,22 @@ impl<'a> CheckerState<'a> {
                                     *candidate,
                                 )
                             {
-                                source_callable
-                                    .properties
-                                    .iter()
-                                    .any(|p| p.name == prop.name)
+                                crate::query_boundaries::common::find_matching_property(
+                                    &source_callable.properties,
+                                    prop.name,
+                                )
+                                .is_some()
                             } else if let Some(source_shape) =
                                 crate::query_boundaries::common::object_shape_for_type(
                                     self.ctx.types,
                                     *candidate,
                                 )
                             {
-                                source_shape.properties.iter().any(|p| p.name == prop.name)
+                                crate::query_boundaries::common::find_matching_property(
+                                    &source_shape.properties,
+                                    prop.name,
+                                )
+                                .is_some()
                             } else {
                                 false
                             }
@@ -1687,34 +1692,16 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let source_with_shape = {
-            let direct = source;
-            let resolved = self.resolve_type_for_property_access(direct);
-            let evaluated = self.judge_evaluate(resolved);
-            [direct, resolved, evaluated]
-                .into_iter()
-                .find(|candidate| {
-                    crate::query_boundaries::common::object_shape_for_type(
-                        self.ctx.types,
-                        *candidate,
-                    )
-                    .is_some()
-                })?
-        };
-        let target_with_shape = {
-            let direct = target;
-            let resolved = self.resolve_type_for_property_access(direct);
-            let evaluated = self.judge_evaluate(resolved);
-            [direct, resolved, evaluated]
-                .into_iter()
-                .find(|candidate| {
-                    crate::query_boundaries::common::object_shape_for_type(
-                        self.ctx.types,
-                        *candidate,
-                    )
-                    .is_some()
-                })?
-        };
+        // Reuse the already-resolved candidate arrays (`[direct, resolved,
+        // evaluated]`) rather than recomputing the resolve/evaluate pipeline.
+        let source_with_shape = source_candidates.into_iter().find(|candidate| {
+            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, *candidate)
+                .is_some()
+        })?;
+        let target_with_shape = target_candidates.into_iter().find(|candidate| {
+            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, *candidate)
+                .is_some()
+        })?;
 
         let source_shape = crate::query_boundaries::common::object_shape_for_type(
             self.ctx.types,

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -174,28 +174,6 @@ impl<'a> CheckerState<'a> {
             );
         }
         if depth == 0
-            && (target_str == "Callable" || target_str == "Applicable")
-            && !crate::query_boundaries::common::is_primitive_type(self.ctx.types, source)
-        {
-            let prop_name = if target_str == "Callable" {
-                "call"
-            } else {
-                "apply"
-            };
-            let message = format_message(
-                diagnostic_messages::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
-                &[prop_name, &source_str, &target_str],
-            );
-            return Diagnostic::error(
-                file_name,
-                start,
-                length,
-                message,
-                diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
-            );
-        }
-
-        if depth == 0
             && let Some((prop_name, owner_name, visibility)) =
                 self.private_or_protected_member_missing_display(source, target, None)
         {

--- a/crates/tsz-checker/src/tests/callable_interface_assignment_tests.rs
+++ b/crates/tsz-checker/src/tests/callable_interface_assignment_tests.rs
@@ -80,6 +80,93 @@ export {};
 }
 
 #[test]
+fn nonfunction_source_to_callsignature_interface_reports_signature_mismatch_not_missing_call() {
+    // A call-signature interface that happens to be *named* `Callable` must be
+    // compared structurally: a non-function object source provides no match for
+    // the call signature (TS2322), and must NOT fall back to a manufactured
+    // "Property 'call' is missing" (TS2741) keyed on the type's display name.
+    let source = r#"
+interface Callable {
+  (x: number): string;
+}
+
+declare const obj: { other: number };
+const c: Callable = obj;
+
+export {};
+"#;
+
+    let codes = codes_for(source);
+    assert!(
+        codes.contains(&2322),
+        "Expected TS2322 signature mismatch for non-function source, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2741),
+        "Display-name `Callable` must not manufacture a missing-`call` TS2741, got: {codes:?}"
+    );
+}
+
+#[test]
+fn renamed_nonfunction_source_to_callsignature_interface_reports_signature_mismatch() {
+    // Same shape with every binder renamed: the structural result is identical,
+    // proving the diagnostic does not depend on the `Callable`/`Applicable`
+    // identifier strings.
+    let source = r#"
+interface Dispatcher {
+  (payload: boolean): number;
+}
+
+declare const obj: { tag: string };
+const d: Dispatcher = obj;
+
+export {};
+"#;
+
+    let codes = codes_for(source);
+    assert!(
+        codes.contains(&2322),
+        "Expected TS2322 signature mismatch for renamed call-signature interface, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2741),
+        "Renamed call-signature interface must not manufacture TS2741, got: {codes:?}"
+    );
+}
+
+#[test]
+fn missing_single_required_property_reports_real_property_name_structurally() {
+    // When the target genuinely has exactly one missing required *property*, tsc
+    // reports that property by its real name. The reported name is derived
+    // structurally from the missing member, not from the target's display name,
+    // so a target named `Callable` whose missing property is `summon` reports
+    // `summon` (never the hardcoded `call`).
+    let source = r#"
+interface Callable {
+  summon: () => void;
+}
+
+declare const obj: { other: number };
+const c: Callable = obj;
+
+export {};
+"#;
+
+    let diagnostics = check_source_diagnostics(source);
+    let has_summon_missing = diagnostics.iter().any(|d| {
+        d.code == 2741 && d.message_text.contains("summon") && !d.message_text.contains("'call'")
+    });
+    assert!(
+        has_summon_missing,
+        "Expected TS2741 naming the real missing property `summon`, got: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn function_to_inline_callable_object_reports_signature_mismatch() {
     let source = r#"
 type Target = {


### PR DESCRIPTION
Goal: hold

Addresses a slice of #14350 (name-keyed whack-a-mole hardcodes); relates to #14142 (type-display strings used as semantic predicates).

## Failure family / structural rule

The `TS2741` "Property '<x>' is missing in type ... but required in type ..." elaboration decided its result by reading **rendered type-display output** and **symbol identifier strings** for library types named `Callable`/`Applicable`, instead of structurally:

- `error_reporter/core_formatting.rs` `missing_single_required_property`: `format_type_for_assignability_message(target) == "Callable"|"Applicable"` (rendered-output predicate), `symbol.escaped_name == "Callable"|"Applicable"` (identifier predicate), and a `call`/`apply` property-name gate.
- `error_reporter/render_failure/type_mismatch.rs`: `target_str == "Callable"|"Applicable"` (rendered-output predicate) emitting the same `TS2741` directly.

> When a relation fails and the target's apparent type has exactly one required member (callable- or object-shape) absent from the source, report that member by its real name.

Owner layer: checker error reporter. No solver/emitter change. The decision now reads only type shapes and member names — no identifier, file-name, or printer output.

## Latent parity bug fixed

Besides violating the Anti-Hardcoding Gate, the hardcode manufactured a wrong diagnostic: for a **call-signature** interface that happens to be named `Callable`, a non-function source produced a spurious `TS2741` ("Property 'call' is missing") where `tsc` reports a call-signature mismatch (`TS2322`).

| source | tsc | tsz before | tsz after |
|---|---|---|---|
| non-function obj → call-sig interface named `Callable` | TS2322 | TS2741 (spurious) | TS2322 |
| same, renamed `Dispatcher` | TS2322 | TS2322 | TS2322 |
| obj missing single required prop `summon` on `Callable` | TS2741 'summon' | TS2741 'summon' | TS2741 'summon' |
| function → call-sig `Callable`/`Invokable` (sig mismatch) | TS2322 | TS2322 | TS2322 |

## Why it is a net deletion

The existing single-missing-required-property machinery already owns this structurally (the object-shape path, and the `render_failure` call site that emits the identical `TS2741`). The deleted predicates were redundant with it for the property-shaped case and wrong for the call-signature case. The callable-shape branch now mirrors the object-shape branch (no property-name gate), so the two are symmetric applications of one structural rule. `call`/`apply` shapes still resolve identically, so the ts-pattern project-compat row is unaffected.

A follow-up commit applies quality-only cleanups (reuse the shared `find_matching_property` helper; reuse the already-resolved candidate arrays instead of recomputing the resolve/evaluate pipeline) — no behavior change.

## Anti-hardcoding

Removes name/display/string-literal semantic predicates; introduces none. Tests vary the binder names (`Callable`→`Dispatcher`/`Invokable`; missing prop `summon`).

## Verification

- `cargo test -p tsz-checker --lib callable_interface_assignment` — 7/7 pass (4 pre-existing + 3 new: parity fix, renamed-binder equivalence, structural property-name reporting).
- `cargo clippy -p tsz-checker --lib` clean; `cargo fmt` clean.
- `cargo test -p tsz-checker --lib` (full lib unit suite) running as the regression gate.
- Broad conformance / emit / fourslash / project-compat (ts-pattern) owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dm3UUpDdZTtu4WEBR7HCmc)_