### PR TITLE
fix(checker): apply default type arguments when recovering a failed generic call/new (#14565)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "failed_generic_call_default_type_args_tests"
+path = "tests/failed_generic_call_default_type_args_tests.rs"
+[[test]]
 name = "recursive_utility_tuple_index_14518_tests"
 path = "tests/recursive_utility_tuple_index_14518_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/classes/constructor_checker.rs
+++ b/crates/tsz-checker/src/classes/constructor_checker.rs
@@ -772,7 +772,7 @@ impl<'a> CheckerState<'a> {
             .iter()
             .flat_map(|sig| sig.type_params.iter().map(|tp| tp.name))
             .collect();
-        crate::query_boundaries::common::resolve_named_type_params_to_defaults(
+        crate::query_boundaries::type_defaults::resolve_named_type_params_to_defaults(
             self.ctx.types,
             instance_type,
             &names,

--- a/crates/tsz-checker/src/classes/constructor_checker.rs
+++ b/crates/tsz-checker/src/classes/constructor_checker.rs
@@ -747,6 +747,38 @@ impl<'a> CheckerState<'a> {
         self.instance_type_from_constructor_type_inner(ctor_type, &mut visited)
     }
 
+    /// Resolve `instance_type`'s references to the construct signature's own type
+    /// parameters to their `default → constraint → unknown` fallback, used to
+    /// recover the instance type of a `new` expression that failed the
+    /// argument-count check (so a bare `T` does not leak into the instance type).
+    pub(crate) fn resolve_constructor_default_type_args(
+        &mut self,
+        ctor_type: TypeId,
+        instance_type: TypeId,
+    ) -> TypeId {
+        let Some(signatures) = crate::query_boundaries::common::construct_signatures_for_type(
+            self.ctx.types,
+            ctor_type,
+        ) else {
+            return instance_type;
+        };
+        // Non-generic constructors (the common case) need no resolution; skip
+        // the name-set allocation. Overloaded constructors fold every
+        // signature's parameters into one name set.
+        if signatures.iter().all(|sig| sig.type_params.is_empty()) {
+            return instance_type;
+        }
+        let names: rustc_hash::FxHashSet<tsz_common::interner::Atom> = signatures
+            .iter()
+            .flat_map(|sig| sig.type_params.iter().map(|tp| tp.name))
+            .collect();
+        crate::query_boundaries::common::resolve_named_type_params_to_defaults(
+            self.ctx.types,
+            instance_type,
+            &names,
+        )
+    }
+
     pub(crate) fn instance_type_from_named_import_type_reference(
         &mut self,
         alias_type: TypeId,

--- a/crates/tsz-checker/src/query_boundaries/checkers/call.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/call.rs
@@ -206,7 +206,7 @@ pub(crate) fn stable_call_recovery_return_type_with_default_type_args(
     stable_call_recovery_return_type_impl(
         db,
         type_id,
-        &super::super::common::resolve_signature_default_type_args,
+        &super::super::type_defaults::resolve_signature_default_type_args,
     )
 }
 

--- a/crates/tsz-checker/src/query_boundaries/checkers/call.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/call.rs
@@ -179,23 +179,67 @@ pub(crate) fn stable_call_recovery_return_type(
     db: &dyn TypeDatabase,
     type_id: TypeId,
 ) -> Option<TypeId> {
+    // Identity leaf: return the signature's raw return type, type parameters
+    // left intact (callers that want default type arguments use the variant
+    // below).
+    stable_call_recovery_return_type_impl(db, type_id, &|_db, return_type, _type_params| {
+        return_type
+    })
+}
+
+/// Like [`stable_call_recovery_return_type`], but instantiates the recovered
+/// signature's *own* type parameters with their `default → constraint →
+/// unknown` fallback.
+///
+/// When a generic call fails the argument-count check, tsc reports TS2554/TS2555
+/// yet still produces a best-effort result type by substituting each signature
+/// type parameter with its default type argument (`getInferredTypes` →
+/// `getDefaultTypeArgumentType`). The plain recovery above returns the raw
+/// return type, leaking the bare type parameter (e.g. `T`) into the result and
+/// drawing a spurious `TS2322`/`TS2339` at the use site. Only the signature's
+/// own parameters are resolved; an enclosing-scope parameter the return type
+/// legitimately mentions stays abstract.
+pub(crate) fn stable_call_recovery_return_type_with_default_type_args(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    stable_call_recovery_return_type_impl(
+        db,
+        type_id,
+        &super::super::common::resolve_signature_default_type_args,
+    )
+}
+
+/// Shared walk for [`stable_call_recovery_return_type`] and its
+/// default-type-argument variant: peel a function / callable / intersection
+/// type down to a single, agreed-upon recovery return type, applying `leaf` to
+/// each signature's `(return_type, type_params)`. An intersection recovers only
+/// when every callable member agrees on the (leaf-transformed) return type.
+fn stable_call_recovery_return_type_impl(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    leaf: &impl Fn(&dyn TypeDatabase, TypeId, &[tsz_solver::TypeParamInfo]) -> TypeId,
+) -> Option<TypeId> {
     if let Some(shape) = tsz_solver::type_queries::get_function_shape(db, type_id) {
-        return Some(shape.return_type);
+        return Some(leaf(db, shape.return_type, &shape.type_params));
     }
 
     if let Some(shape) = tsz_solver::type_queries::get_callable_shape(db, type_id) {
-        let first = shape.call_signatures.first()?.return_type;
-        return shape
+        let first = shape.call_signatures.first()?;
+        if shape
             .call_signatures
             .iter()
-            .all(|sig| sig.return_type == first)
-            .then_some(first);
+            .any(|sig| sig.return_type != first.return_type)
+        {
+            return None;
+        }
+        return Some(leaf(db, first.return_type, &first.type_params));
     }
 
     let members = tsz_solver::type_queries::get_intersection_members(db, type_id)?;
     let mut candidate = None;
     for member in members {
-        let Some(return_type) = stable_call_recovery_return_type(db, member) else {
+        let Some(return_type) = stable_call_recovery_return_type_impl(db, member, leaf) else {
             continue;
         };
         if let Some(existing) = candidate {

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -186,6 +186,37 @@ pub(crate) fn resolve_unbound_type_params_to_defaults<S: std::hash::BuildHasher>
     tsz_solver::computation::resolve_unbound_type_params_to_defaults(db, member_type, in_scope)
 }
 
+/// Resolve the named (signature-own) type parameters that appear free in a
+/// *failed* generic call's recovered result type to their declared
+/// `default → constraint → unknown`, matching tsc's instantiation of a call
+/// with default type arguments when the argument-count check fails before
+/// inference runs. Type parameters not in `names` (enclosing-scope parameters)
+/// are preserved.
+/// See [`tsz_solver::computation::resolve_named_type_params_to_defaults`].
+pub(crate) fn resolve_named_type_params_to_defaults(
+    db: &dyn TypeDatabase,
+    ty: TypeId,
+    names: &rustc_hash::FxHashSet<tsz_common::interner::Atom>,
+) -> TypeId {
+    tsz_solver::computation::resolve_named_type_params_to_defaults(db, ty, names)
+}
+
+/// Resolve `ty`'s references to a signature's own `type_params` to their
+/// `default → constraint → unknown` fallback (a no-op when the signature is
+/// non-generic). Shared by the call and constructor failed-arity recovery paths.
+pub(crate) fn resolve_signature_default_type_args(
+    db: &dyn TypeDatabase,
+    ty: TypeId,
+    type_params: &[tsz_solver::TypeParamInfo],
+) -> TypeId {
+    if type_params.is_empty() {
+        return ty;
+    }
+    let names: rustc_hash::FxHashSet<tsz_common::interner::Atom> =
+        type_params.iter().map(|tp| tp.name).collect();
+    resolve_named_type_params_to_defaults(db, ty, &names)
+}
+
 /// Check if a type parameter has a constraint that contains a conditional type.
 /// This is used to suppress false-positive TS2339 errors when accessing properties
 /// on generic conditional types like `Parameters<T>["length"]` where the property

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -186,37 +186,6 @@ pub(crate) fn resolve_unbound_type_params_to_defaults<S: std::hash::BuildHasher>
     tsz_solver::computation::resolve_unbound_type_params_to_defaults(db, member_type, in_scope)
 }
 
-/// Resolve the named (signature-own) type parameters that appear free in a
-/// *failed* generic call's recovered result type to their declared
-/// `default → constraint → unknown`, matching tsc's instantiation of a call
-/// with default type arguments when the argument-count check fails before
-/// inference runs. Type parameters not in `names` (enclosing-scope parameters)
-/// are preserved.
-/// See [`tsz_solver::computation::resolve_named_type_params_to_defaults`].
-pub(crate) fn resolve_named_type_params_to_defaults(
-    db: &dyn TypeDatabase,
-    ty: TypeId,
-    names: &rustc_hash::FxHashSet<tsz_common::interner::Atom>,
-) -> TypeId {
-    tsz_solver::computation::resolve_named_type_params_to_defaults(db, ty, names)
-}
-
-/// Resolve `ty`'s references to a signature's own `type_params` to their
-/// `default → constraint → unknown` fallback (a no-op when the signature is
-/// non-generic). Shared by the call and constructor failed-arity recovery paths.
-pub(crate) fn resolve_signature_default_type_args(
-    db: &dyn TypeDatabase,
-    ty: TypeId,
-    type_params: &[tsz_solver::TypeParamInfo],
-) -> TypeId {
-    if type_params.is_empty() {
-        return ty;
-    }
-    let names: rustc_hash::FxHashSet<tsz_common::interner::Atom> =
-        type_params.iter().map(|tp| tp.name).collect();
-    resolve_named_type_params_to_defaults(db, ty, &names)
-}
-
 /// Check if a type parameter has a constraint that contains a conditional type.
 /// This is used to suppress false-positive TS2339 errors when accessing properties
 /// on generic conditional types like `Parameters<T>["length"]` where the property

--- a/crates/tsz-checker/src/query_boundaries/type_defaults.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_defaults.rs
@@ -21,10 +21,10 @@ pub(crate) fn fill_application_defaults(
 /// inference runs. Type parameters not in `names` (enclosing-scope parameters)
 /// are preserved.
 /// See [`tsz_solver::computation::resolve_named_type_params_to_defaults`].
-pub(crate) fn resolve_named_type_params_to_defaults(
+pub(crate) fn resolve_named_type_params_to_defaults<S: std::hash::BuildHasher>(
     db: &dyn TypeDatabase,
     ty: TypeId,
-    names: &FxHashSet<Atom>,
+    names: &std::collections::HashSet<Atom, S>,
 ) -> TypeId {
     tsz_solver::computation::resolve_named_type_params_to_defaults(db, ty, names)
 }

--- a/crates/tsz-checker/src/query_boundaries/type_defaults.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_defaults.rs
@@ -1,5 +1,7 @@
 //! Query-boundary wrappers for generic type-argument defaulting.
 
+use rustc_hash::FxHashSet;
+use tsz_common::interner::Atom;
 use tsz_solver::TypeId;
 use tsz_solver::construction::TypeDatabase;
 
@@ -10,4 +12,34 @@ pub(crate) fn fill_application_defaults(
     params: &[tsz_solver::TypeParamInfo],
 ) -> Option<Vec<TypeId>> {
     tsz_solver::computation::fill_application_defaults(db, args, params)
+}
+
+/// Resolve the named (signature-own) type parameters that appear free in a
+/// *failed* generic call's recovered result type to their declared
+/// `default → constraint → unknown`, matching tsc's instantiation of a call
+/// with default type arguments when the argument-count check fails before
+/// inference runs. Type parameters not in `names` (enclosing-scope parameters)
+/// are preserved.
+/// See [`tsz_solver::computation::resolve_named_type_params_to_defaults`].
+pub(crate) fn resolve_named_type_params_to_defaults(
+    db: &dyn TypeDatabase,
+    ty: TypeId,
+    names: &FxHashSet<Atom>,
+) -> TypeId {
+    tsz_solver::computation::resolve_named_type_params_to_defaults(db, ty, names)
+}
+
+/// Resolve `ty`'s references to a signature's own `type_params` to their
+/// `default → constraint → unknown` fallback (a no-op when the signature is
+/// non-generic). Shared by the call and constructor failed-arity recovery paths.
+pub(crate) fn resolve_signature_default_type_args(
+    db: &dyn TypeDatabase,
+    ty: TypeId,
+    type_params: &[tsz_solver::TypeParamInfo],
+) -> TypeId {
+    if type_params.is_empty() {
+        return ty;
+    }
+    let names: FxHashSet<Atom> = type_params.iter().map(|tp| tp.name).collect();
+    resolve_named_type_params_to_defaults(db, ty, &names)
 }

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -363,6 +363,20 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    /// Recovery return type for a generic call that failed the argument-count
+    /// check, with the signature's own type parameters resolved to their
+    /// `default → constraint → unknown` fallback (matching tsc). Falls back to
+    /// the plain recovery if the default-resolving walk finds no signature.
+    fn stable_call_recovery_return_type_with_default_type_args(
+        &self,
+        callee_type: TypeId,
+    ) -> Option<TypeId> {
+        crate::query_boundaries::checkers::call::stable_call_recovery_return_type_with_default_type_args(
+            self.ctx.types,
+            callee_type,
+        )
+    }
+
     fn is_spread_argument_marker_type(&self, type_id: TypeId) -> bool {
         common::is_spread_marker_tuple(self.ctx.types.as_type_database(), type_id)
     }
@@ -1017,7 +1031,8 @@ impl<'a> CheckerState<'a> {
                 }
                 if is_super_call {
                     TypeId::VOID
-                } else if let Some(return_type) = self.stable_call_recovery_return_type(callee_type)
+                } else if let Some(return_type) =
+                    self.stable_call_recovery_return_type_with_default_type_args(callee_type)
                 {
                     self.finalize_call_return_like_success(
                         callee_expr,

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -1805,7 +1805,14 @@ impl<'a> CheckerState<'a> {
                 }
                 // Recover with the constructor instance type so downstream checks
                 // (e.g. property access TS2339) still run after arity diagnostics.
+                // Resolve the construct signature's own type parameters to their
+                // default → constraint → unknown fallback so a bare `T` does not
+                // leak into the instance type (spurious TS2322/TS2339), matching
+                // tsc's instantiation of a failed `new` with default type arguments.
                 self.instance_type_from_constructor_type(constructor_type)
+                    .map(|instance_type| {
+                        self.resolve_constructor_default_type_args(constructor_type, instance_type)
+                    })
                     .unwrap_or(TypeId::ERROR)
             }
             CallResult::OverloadArgumentCountMismatch {

--- a/crates/tsz-checker/tests/failed_generic_call_default_type_args_tests.rs
+++ b/crates/tsz-checker/tests/failed_generic_call_default_type_args_tests.rs
@@ -1,0 +1,180 @@
+//! When a generic call (function or constructor) fails the argument-count
+//! check (TS2554/TS2555), tsc still produces a best-effort result type by
+//! substituting each of the signature's own type parameters with its
+//! `default → constraint → unknown` fallback (`getInferredTypes` →
+//! `getDefaultTypeArgumentType`). tsz previously left the bare type parameter
+//! (`T`) in the recovered result, leaking it into the use-site value type and
+//! drawing a spurious `TS2322`/`TS2339` that tsc never reports.
+//!
+//! These tests pin the parity. Binder names vary across cases so the result is
+//! structural, not keyed to a particular identifier.
+
+use tsz_checker::test_utils::{check_source_code_messages, check_source_codes};
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_codes(source)
+}
+
+/// `new Box()` where `Box<T = string>` requires a constructor argument: TS2554
+/// fires, but `b.value` is `string` (the default), so the `string` assignment
+/// is clean — no spurious TS2322.
+#[test]
+fn constructor_single_default_no_spurious_ts2322() {
+    let c = codes(
+        r#"
+class Box<T = string> { constructor(public value: T) {} }
+const b = new Box();
+const v: string = b.value;
+"#,
+    );
+    assert!(c.contains(&2554), "expected TS2554, got {c:?}");
+    assert!(!c.contains(&2322), "no spurious TS2322 expected, got {c:?}");
+}
+
+/// Multiple type parameters, each with a default, all resolve.
+#[test]
+fn constructor_multiple_defaults_no_spurious_ts2322() {
+    let c = codes(
+        r#"
+class Pair<A = string, B = number> { constructor(public a: A, public b: B) {} }
+const p = new Pair();
+const a: string = p.a;
+const b: number = p.b;
+"#,
+    );
+    assert!(c.contains(&2554), "expected TS2554, got {c:?}");
+    assert!(!c.contains(&2322), "no spurious TS2322 expected, got {c:?}");
+}
+
+/// A default that references an earlier type parameter (`Two = One[]`) must
+/// resolve through it (`One = string` ⇒ `Two = string[]`).
+#[test]
+fn constructor_default_referencing_earlier_param_resolves() {
+    let c = codes(
+        r#"
+class Holder<One = string, Two = One[]> { constructor(public head: One, public tail: Two) {} }
+const h = new Holder();
+const head: string = h.head;
+const tail: string[] = h.tail;
+"#,
+    );
+    assert!(c.contains(&2554), "expected TS2554, got {c:?}");
+    assert!(!c.contains(&2322), "no spurious TS2322 expected, got {c:?}");
+}
+
+/// A constrained default (`Elem extends object = { x: number }`) resolves to the
+/// default object type, so `.x` exists — no spurious TS2339.
+#[test]
+fn constructor_constrained_default_no_spurious_ts2339() {
+    let c = codes(
+        r#"
+class Wrap<Elem extends object = { x: number }> { constructor(public value: Elem) {} }
+const w = new Wrap();
+const n: number = w.value.x;
+"#,
+    );
+    assert!(c.contains(&2554), "expected TS2554, got {c:?}");
+    assert!(!c.contains(&2339), "no spurious TS2339 expected, got {c:?}");
+}
+
+/// The same bug surfaces for a generic *function* call, not only `new`.
+#[test]
+fn generic_function_call_default_no_spurious_ts2322() {
+    let c = codes(
+        r#"
+declare function build<Out = string>(seed: Out): { value: Out };
+const made = build();
+const v: string = made.value;
+"#,
+    );
+    assert!(c.contains(&2554), "expected TS2554, got {c:?}");
+    assert!(!c.contains(&2322), "no spurious TS2322 expected, got {c:?}");
+}
+
+/// No default and no constraint: tsc renders the un-inferred parameter as
+/// `unknown` in the residual TS2322 (not the bare parameter name).
+#[test]
+fn no_default_renders_unknown_not_bare_param() {
+    let msgs = check_source_code_messages(
+        r#"
+class Cell<Item> { constructor(public value: Item) {} }
+const c = new Cell();
+const v: string = c.value;
+"#,
+    );
+    let ts2322: Vec<&String> = msgs
+        .iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, m)| m)
+        .collect();
+    assert!(
+        ts2322.iter().any(|m| m.contains("unknown")),
+        "expected a TS2322 mentioning 'unknown', got {ts2322:?}"
+    );
+    assert!(
+        !ts2322.iter().any(|m| m.contains("'Item'")),
+        "TS2322 must not leak the bare type parameter name, got {ts2322:?}"
+    );
+}
+
+/// A constraint but no default: the un-inferred parameter renders as its
+/// constraint (`number`), not the bare parameter name.
+#[test]
+fn constrained_no_default_renders_constraint_not_bare_param() {
+    let msgs = check_source_code_messages(
+        r#"
+class Cell<Item extends number> { constructor(public value: Item) {} }
+const c = new Cell();
+const v: string = c.value;
+"#,
+    );
+    let ts2322: Vec<&String> = msgs
+        .iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, m)| m)
+        .collect();
+    assert!(
+        ts2322.iter().any(|m| m.contains("number")),
+        "expected a TS2322 mentioning the constraint 'number', got {ts2322:?}"
+    );
+    assert!(
+        !ts2322.iter().any(|m| m.contains("'Item'")),
+        "TS2322 must not leak the bare type parameter name, got {ts2322:?}"
+    );
+}
+
+/// Negative control: a *successful* `new` with a default still types the
+/// instance through the default — no arity error, no spurious assignment error.
+#[test]
+fn successful_new_with_default_is_clean() {
+    let c = codes(
+        r#"
+class Box<T = string> { value!: T; }
+const b = new Box();
+const v: string = b.value;
+"#,
+    );
+    assert!(
+        !c.contains(&2554),
+        "no TS2554 expected for a valid new, got {c:?}"
+    );
+    assert!(!c.contains(&2322), "no TS2322 expected, got {c:?}");
+}
+
+/// Negative control: a genuinely wrong assignment off the defaulted instance
+/// still errors (the fix must not blanket-suppress real mismatches).
+#[test]
+fn defaulted_instance_still_reports_real_mismatch() {
+    let c = codes(
+        r#"
+class Box<T = string> { constructor(public value: T) {} }
+const b = new Box();
+const v: number = b.value;
+"#,
+    );
+    assert!(c.contains(&2554), "expected TS2554, got {c:?}");
+    assert!(
+        c.contains(&2322),
+        "string default is not assignable to number — TS2322 expected, got {c:?}"
+    );
+}

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -1075,10 +1075,10 @@ pub fn resolve_unbound_type_params_to_defaults<S: std::hash::BuildHasher>(
 /// stay abstract. This is the value-position sibling of
 /// [`resolve_unbound_type_params_to_defaults`]: both stop a bare, unbound generic
 /// parameter from leaking into a value type (a false `TS2322`/`TS2339`).
-pub fn resolve_named_type_params_to_defaults(
+pub fn resolve_named_type_params_to_defaults<S: std::hash::BuildHasher>(
     db: &dyn TypeDatabase,
     ty: TypeId,
-    names: &FxHashSet<tsz_common::Atom>,
+    names: &std::collections::HashSet<tsz_common::Atom, S>,
 ) -> TypeId {
     if names.is_empty() {
         return ty;

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -1056,18 +1056,58 @@ pub fn resolve_unbound_type_params_to_defaults<S: std::hash::BuildHasher>(
     member_type: TypeId,
     in_scope: &std::collections::HashSet<TypeId, S>,
 ) -> TypeId {
+    resolve_type_params_to_defaults_core(db, member_type, |param_id, _info| {
+        !in_scope.contains(&param_id)
+    })
+}
+
+/// Resolve the type parameters whose declared name is in `names` and appear
+/// free in `ty` to their `default → constraint → unknown`, matching tsc's
+/// instantiation of a *failed* generic call's result with default type
+/// arguments (`getInferredTypes` falling back to `getDefaultTypeArgumentType`).
+///
+/// When a generic call (function or constructor) fails the argument-count check
+/// before inference runs, tsc still produces a best-effort result type by
+/// substituting each of the *signature's own* type parameters with its default,
+/// then its constraint, then `unknown`. Resolving only the named (signature-own)
+/// parameters preserves any enclosing-scope type parameter the result legitimately
+/// mentions (e.g. a nested generic referencing an outer parameter), which must
+/// stay abstract. This is the value-position sibling of
+/// [`resolve_unbound_type_params_to_defaults`]: both stop a bare, unbound generic
+/// parameter from leaking into a value type (a false `TS2322`/`TS2339`).
+pub fn resolve_named_type_params_to_defaults(
+    db: &dyn TypeDatabase,
+    ty: TypeId,
+    names: &FxHashSet<tsz_common::Atom>,
+) -> TypeId {
+    if names.is_empty() {
+        return ty;
+    }
+    resolve_type_params_to_defaults_core(db, ty, |_param_id, info| names.contains(&info.name))
+}
+
+/// Shared driver for the default-type-argument fallback. `should_resolve`
+/// decides, per free type parameter, whether it is replaced by its
+/// `default → constraint → unknown` fill (true) or preserved (false). The
+/// multi-pass loop lets a parameter default that references an earlier
+/// (already-resolved) parameter settle, bounded by [`MAX_UNBOUND_DEFAULT_DEPTH`].
+fn resolve_type_params_to_defaults_core(
+    db: &dyn TypeDatabase,
+    ty: TypeId,
+    should_resolve: impl Fn(TypeId, &crate::types::TypeParamInfo) -> bool,
+) -> TypeId {
     use crate::visitors::visitor_predicates::free_type_parameter_ids_in;
 
-    let mut current = member_type;
+    let mut current = ty;
     for _ in 0..MAX_UNBOUND_DEFAULT_DEPTH {
         let mut substitution = TypeSubstitution::new();
         for param_id in free_type_parameter_ids_in(db, [current]) {
-            if in_scope.contains(&param_id) {
-                continue;
-            }
             let Some(TypeData::TypeParameter(info)) = db.lookup(param_id) else {
                 continue;
             };
+            if !should_resolve(param_id, &info) {
+                continue;
+            }
             let usable = |t: Option<TypeId>| t.filter(|&t| t != TypeId::ERROR);
             let fill = usable(info.default)
                 .or_else(|| usable(info.constraint))

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -173,8 +173,8 @@ pub mod computation {
         instantiate_type_preserving_meta, instantiate_type_preserving_meta_cached,
         instantiate_type_with_depth_status, instantiate_type_with_infer,
         instantiate_type_with_infer_cached, instantiate_type_with_request,
-        resolve_unbound_type_params_to_defaults, substitute_this_type,
-        substitute_this_type_at_return_position, substitute_this_type_cached,
+        resolve_named_type_params_to_defaults, resolve_unbound_type_params_to_defaults,
+        substitute_this_type, substitute_this_type_at_return_position, substitute_this_type_cached,
     };
     pub use crate::instantiation::request::{InstantiationOptions, InstantiationRequest};
     pub use crate::instantiation::result::InstantiationResult;


### PR DESCRIPTION
Goal: hold

Fixes #14565.

## Summary

When a generic call — a function call **or** a `new` expression — fails the
**argument-count** check (TS2554/TS2555), `tsc` still produces a best-effort
result type by substituting each of the *signature's own* type parameters with
its **default → constraint → unknown** fallback (`getInferredTypes` →
`getDefaultTypeArgumentType`). tsz instead left the **bare type parameter**
(`T`) in the recovered result, which leaked into the use-site value type and
drew a spurious **TS2322**/**TS2339** `tsc` never reports (and rendered the
wrong type in the cases where an error is genuinely expected).

```ts
class Box<T = string> { constructor(public value: T) {} }
const b = new Box();          // tsc: TS2554 (missing arg) — correct
const v: string = b.value;    // tsc: clean ; tsz (before): spurious TS2322 ("Type 'T' …")
```

## Structural rule

> When a generic call (function or constructor) fails the argument-count check,
> tsc reports TS2554/TS2555 yet instantiates the call with **default type
> arguments**: each of the signature's own type parameters resolves to its
> `default → constraint → unknown` fallback, while any enclosing-scope type
> parameter the result legitimately mentions stays abstract.

Owner layer: **checker recovery policy** (the TS2554 arms of call-result and
new-expression handling), delegating the type computation to the **solver**.
This is the value-position sibling of the `error`/`never`-in-a-type-argument-slot
leak family (#13484): both stop a bare, unbound generic parameter from leaking
into a value type.

## Root cause

`resolve_generic_call_inner`
(`crates/tsz-solver/src/operations/generic_call/resolve.rs`) early-returns
`CallResult::ArgumentCountMismatch` **before** inference finalization runs — and
finalization (`…/resolve/finalize.rs`) is exactly where the
`default → constraint → unknown` fallback lives. The checker then recovered the
return/instance type with the type parameters left bare.

## Fix

- **solver** (`instantiation/instantiate/api.rs`): add
  `resolve_named_type_params_to_defaults`, the value-position sibling of the
  existing `resolve_unbound_type_params_to_defaults`. Both now share one
  multi-pass core (`resolve_type_params_to_defaults_core`) that resolves a
  chosen set of free type parameters to `default → constraint → unknown` (the
  multi-pass loop lets a default referencing an earlier parameter settle).
- **checker**: the TS2554 recovery arms for function calls
  (`types/computation/call_result.rs`) and `new` expressions
  (`types/computation/complex.rs`) now resolve the recovered signature's **own**
  type parameters through that helper. The function-call and `new` recoveries
  share one peeling walk (`stable_call_recovery_return_type_impl`) parameterized
  by a per-signature leaf transform, so the plain and default-resolving variants
  do not duplicate the function/callable/intersection traversal.

## Anti-hardcoding

The decision is purely structural — it reads each signature's declared type
parameters (`name` / `default` / `constraint`) and resolves only those, never an
identifier, file name, or printer output. The new tests vary the binder names.

## Adjacent-case matrix (regression tests, differential vs tsc 6.0.2)

`crates/tsz-checker/tests/failed_generic_call_default_type_args_tests.rs` (9/9):

- constructor single default → no spurious TS2322
- multiple defaults (`Pair<A = string, B = number>`) → no spurious TS2322
- default referencing an earlier parameter (`Holder<One = string, Two = One[]>`) → resolves through it
- constrained default (`Wrap<Elem extends object = { x: number }>`) → `.x` exists, no TS2339
- generic **function** call (`build<Out = string>()`) → no spurious TS2322
- **no** default/constraint → renders `unknown` (not the bare param name)
- constraint, no default → renders the constraint (`number`), not the bare param name
- **negative:** a successful `new` with a default stays clean
- **negative:** a genuinely wrong assignment off the defaulted instance still reports TS2322 (no blanket suppression)

## Verification

- `cargo test -p tsz-checker --test failed_generic_call_default_type_args_tests` → **9 passed, 0 failed**.
- Existing related suites green: `type_arg_count_mismatch_tests` (the lone
  failure, `namespace_import_required_class_type_reference_still_requires_type_arg`,
  reproduces identically on clean `main` — stash-verified, net-new = 0),
  `abstract_constructor_argument_tests`, `abstract_constructor_elaboration_tests`,
  `generic_default_branch_independence_tests`, `variance_skip_type_param_default_tests`.
- Differential end-to-end vs bundled `tsc` 6.0.2 (`--strict --noEmit`): full
  parity on the matrix above plus ~46 unrelated probe programs (no regressions).
- `cargo fmt` clean; `cargo clippy -p tsz-solver -p tsz-checker --lib` clean.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01QgrP9gcsWuaN4APLSchSjJ)_