### PR TITLE
fix(emit): match tsc __spreadArray pack flag and trailing elision in ES5 array spreads

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers.rs
@@ -141,7 +141,7 @@ impl<'a> Printer<'a> {
     fn emit_array_spread_segment(&mut self, elems: &[NodeIndex]) {
         self.write("[");
         self.emit_comma_separated(elems);
-        if elems.last().is_some_and(|idx| idx.is_none()) {
+        if elems.last().is_some_and(NodeIndex::is_none) {
             self.write(",");
         }
         self.write("]");

--- a/crates/tsz-emitter/src/emitter/es5/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers.rs
@@ -17,10 +17,15 @@ pub(in crate::emitter) enum ArraySegment<'a> {
 impl<'a> Printer<'a> {
     /// Emit an array literal with ES5 spread transformation.
     /// Uses TypeScript's __spreadArray helper for exact tsc matching.
+    /// The third (`pack`) argument of each segment follows tsc: it is `false`
+    /// when the spread source is already dense — a packed array literal or a
+    /// `__read(...)`-wrapped spread — and `true` otherwise (see
+    /// `spread_segment_pack`).
     /// Pattern: [...a] -> __spreadArray([], a, true)
     /// Pattern: [...a, 1] -> __spreadArray(__spreadArray([], a, true), [1], false)
     /// Pattern: [1, ...a] -> __spreadArray([1], a, true)
     /// Pattern: [1, ...a, 2] -> __spreadArray(__spreadArray([1], a, true), [2], false)
+    /// Pattern: [1, ...[2, 3], 4] -> __spreadArray(__spreadArray([1], [2, 3], false), [4], false)
     pub(in crate::emitter) fn emit_array_literal_es5(&mut self, elements: &[NodeIndex]) {
         if let Some(flattened) = self.flatten_single_spread_array_literal(elements) {
             self.write("[");
@@ -66,24 +71,18 @@ impl<'a> Printer<'a> {
             match &segments[0] {
                 ArraySegment::Elements(elems) => {
                     // No spreads, emit normally
-                    self.write("[");
-                    self.emit_comma_separated(elems);
-                    self.write("]");
+                    self.emit_array_spread_segment(elems);
                 }
                 ArraySegment::Spread(spread_idx) => {
-                    // Only a spread element: [...a] -> __spreadArray([], a, true)
-                    // When __read wraps the spread, the pack arg is false because
-                    // __read already produces an array.
+                    // Only a spread element: [...a] -> __spreadArray([], a, true).
+                    // The pack arg is false when the source is already dense (a
+                    // packed array literal, or a `__read(...)`-wrapped spread).
                     self.write_helper("__spreadArray");
                     self.write("([], ");
                     if let Some(spread_node) = self.arena.get(*spread_idx) {
                         self.emit_spread_expression_with_read(spread_node, wrap_spread_with_read);
                     }
-                    if wrap_spread_with_read {
-                        self.write(", false)");
-                    } else {
-                        self.write(", true)");
-                    }
+                    self.write_spread_pack_arg(*spread_idx, wrap_spread_with_read);
                 }
             }
         } else {
@@ -97,23 +96,18 @@ impl<'a> Printer<'a> {
             // Emit the first segment as the innermost base.
             match &segments[0] {
                 ArraySegment::Elements(elems) => {
-                    self.write("[");
-                    self.emit_comma_separated(elems);
-                    self.write("]");
+                    self.emit_array_spread_segment(elems);
                 }
                 ArraySegment::Spread(spread_idx) => {
                     // First segment is spread: base is __spreadArray([], spread, true)
-                    // unless __read already packed the spread source.
+                    // unless the source is already dense (packed array literal or
+                    // a `__read(...)`-wrapped spread).
                     self.write_helper("__spreadArray");
                     self.write("([], ");
                     if let Some(spread_node) = self.arena.get(*spread_idx) {
                         self.emit_spread_expression_with_read(spread_node, wrap_spread_with_read);
                     }
-                    if wrap_spread_with_read {
-                        self.write(", false)");
-                    } else {
-                        self.write(", true)");
-                    }
+                    self.write_spread_pack_arg(*spread_idx, wrap_spread_with_read);
                 }
             }
 
@@ -121,9 +115,9 @@ impl<'a> Printer<'a> {
             for segment in &segments[1..] {
                 match segment {
                     ArraySegment::Elements(elems) => {
-                        self.write(", [");
-                        self.emit_comma_separated(elems);
-                        self.write("], false)");
+                        self.write(", ");
+                        self.emit_array_spread_segment(elems);
+                        self.write(", false)");
                     }
                     ArraySegment::Spread(spread_idx) => {
                         self.write(", ");
@@ -133,14 +127,69 @@ impl<'a> Printer<'a> {
                                 wrap_spread_with_read,
                             );
                         }
-                        if wrap_spread_with_read {
-                            self.write(", false)");
-                        } else {
-                            self.write(", true)");
-                        }
+                        self.write_spread_pack_arg(*spread_idx, wrap_spread_with_read);
                     }
                 }
             }
+        }
+    }
+
+    /// Emit one non-spread `[ ... ]` segment of an ES5 spread transform.
+    /// Mirrors the standalone array-literal printer's elision handling: a
+    /// trailing hole (stored as `NodeIndex::NONE`) keeps its comma so that
+    /// `[1, ,]` / `[,]` round-trip exactly, matching tsc.
+    fn emit_array_spread_segment(&mut self, elems: &[NodeIndex]) {
+        self.write("[");
+        self.emit_comma_separated(elems);
+        if elems.last().is_some_and(|idx| idx.is_none()) {
+            self.write(",");
+        }
+        self.write("]");
+    }
+
+    /// Mirror tsc's `isPackedArrayLiteral`: an array literal expression whose
+    /// every element is present (no elision holes) and is not itself a spread.
+    /// tsc spreads such a value with `pack = false` because it is already a
+    /// dense array; any other source spreads with `pack = true`.
+    fn is_packed_array_literal(&self, expr_idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::ARRAY_LITERAL_EXPRESSION {
+            return false;
+        }
+        let Some(literal) = self.arena.get_literal_expr(node) else {
+            return false;
+        };
+        literal.elements.nodes.iter().all(|&elem_idx| {
+            // Elision holes are stored as `NodeIndex::NONE`; a spread element
+            // makes the result's length non-static, so neither is "packed".
+            elem_idx != NodeIndex::NONE && !emit_utils::is_spread_element(self.arena, elem_idx)
+        })
+    }
+
+    /// Compute the `pack` argument for one `__spreadArray(to, from, pack)`
+    /// segment, mirroring tsc. A spread of a packed array literal — or of a
+    /// `__read(...)`-wrapped source under `downlevelIteration` — already yields
+    /// a dense array, so `pack` is `false`; every other source needs `true`.
+    fn spread_segment_pack(&self, spread_idx: NodeIndex, wrap_spread_with_read: bool) -> bool {
+        if wrap_spread_with_read {
+            return false;
+        }
+        self.arena
+            .get(spread_idx)
+            .and_then(|node| self.arena.get_spread(node))
+            .map(|spread| spread.expression)
+            .is_none_or(|expr_idx| !self.is_packed_array_literal(expr_idx))
+    }
+
+    /// Write the trailing `, true)` / `, false)` pack argument of a
+    /// `__spreadArray(to, from, pack)` spread segment.
+    fn write_spread_pack_arg(&mut self, spread_idx: NodeIndex, wrap_spread_with_read: bool) {
+        if self.spread_segment_pack(spread_idx, wrap_spread_with_read) {
+            self.write(", true)");
+        } else {
+            self.write(", false)");
         }
     }
 

--- a/crates/tsz-emitter/tests/es5_transforms_e2e_parts/part_01.rs
+++ b/crates/tsz-emitter/tests/es5_transforms_e2e_parts/part_01.rs
@@ -206,6 +206,72 @@ fn test_spread_in_call() {
     );
 }
 
+#[test]
+fn test_array_spread_pack_flag_matches_tsc_per_segment() {
+    // tsc sets the third `__spreadArray(to, from, pack)` argument to `false`
+    // when `from` is a packed array literal (dense, no holes/spreads) and to
+    // `true` for any other source. tsz previously hardcoded `true` for every
+    // array-literal spread segment.
+
+    // Packed array literal in the middle: that segment packs `false`.
+    let output = emit_es5("const a = [1, ...[2, 3], 4];\n");
+    assert!(
+        output.contains("__spreadArray(__spreadArray([1], [2, 3], false), [4], false)"),
+        "packed array-literal spread must use pack=false.\nOutput:\n{output}"
+    );
+
+    // Leading packed array literal as the base, plus trailing elements.
+    let output = emit_es5("const a = [...[2, 3], 4];\n");
+    assert!(
+        output.contains("__spreadArray(__spreadArray([], [2, 3], false), [4], false)"),
+        "leading packed array-literal base must use pack=false.\nOutput:\n{output}"
+    );
+
+    // Two packed array literals: both pack `false`.
+    let output = emit_es5("const a = [...[1, 2], ...[3, 4]];\n");
+    assert!(
+        output.contains("__spreadArray(__spreadArray([], [1, 2], false), [3, 4], false)"),
+        "consecutive packed array literals must each use pack=false.\nOutput:\n{output}"
+    );
+
+    // A non-array-literal source (a binding) is not packed: pack stays `true`.
+    let output = emit_es5("declare const x: number[];\nconst a = [1, ...x, 2];\n");
+    assert!(
+        output.contains("__spreadArray(__spreadArray([1], x, true), [2], false)"),
+        "non-array-literal spread source must keep pack=true.\nOutput:\n{output}"
+    );
+
+    // An array literal that contains a hole is not packed: pack stays `true`.
+    let output = emit_es5("const a = [0, ...[, 3], 4];\n");
+    assert!(
+        output.contains("__spreadArray(__spreadArray([0], [, 3], true), [4], false)"),
+        "array literal with an elision hole is not packed (pack=true).\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn test_array_spread_preserves_trailing_elision_in_segments() {
+    // A non-spread `[ ... ]` segment that ends in an elision hole must keep its
+    // comma, exactly like the standalone array-literal printer (and tsc).
+    let output = emit_es5("declare const x: number[];\nconst a = [, ...x];\n");
+    assert!(
+        output.contains("__spreadArray([,], x, true)"),
+        "leading hole must be preserved in the base segment.\nOutput:\n{output}"
+    );
+
+    let output = emit_es5("declare const x: number[];\nconst a = [1, , ...x];\n");
+    assert!(
+        output.contains("__spreadArray([1, ,], x, true)"),
+        "trailing hole in a populated base segment must be preserved.\nOutput:\n{output}"
+    );
+
+    let output = emit_es5("declare const x: number[];\nconst a = [...x, ,];\n");
+    assert!(
+        output.contains("__spreadArray(__spreadArray([], x, true), [,], false)"),
+        "trailing-elision segment after a spread must keep its comma.\nOutput:\n{output}"
+    );
+}
+
 // =============================================================================
 // Exponentiation Transform (ES2016)
 // =============================================================================


### PR DESCRIPTION
Goal: hold

Fixes #14567.

## Summary

Downleveling an **array literal** that contains a spread to ES5/ES3 emitted the
wrong third (`pack`) argument to the `__spreadArray(to, from, pack)` helper, and
dropped a trailing elision hole in non-spread `[ ... ]` segments — both diverge
from `tsc` byte-for-byte (verified against bundled `tsc` 6.0.2). The
call-argument spread path was already correct; only `emit_array_literal_es5` was
affected.

Before → after (tsc), `--target ES5`:

| source | before | tsc / after |
|---|---|---|
| `[1, ...[2, 3], 4]` | `…([1], [2, 3], `**`true`**`), [4], false)` | `…([1], [2, 3], `**`false`**`), [4], false)` |
| `[...[1, 2], ...[3, 4]]` | `…[1, 2], `**`true`**`), [3, 4], `**`true`**`)` | `…[1, 2], `**`false`**`), [3, 4], `**`false`**`)` |
| `[1, ...x, 2]` (binding) | `…([1], x, true), [2], false)` | unchanged — `true` is correct |
| `[, ...x]` | `__spreadArray(`**`[]`**`, x, true)` | `__spreadArray(`**`[,]`**`, x, true)` |
| `[...x, ,]` | `…, `**`[]`**`, false)` | `…, `**`[,]`**`, false)` |

## Structural rule

When tsz lowers an array literal with a spread to ES5, `tsc` sets each spread
segment's `pack` argument from `isPackedArrayLiteral(from)`: `false` when `from`
is a **packed array literal** (no elision holes, no nested spread element) or a
`__read(...)`-wrapped source under `downlevelIteration`, and `true` otherwise
(a binding, a call result, or an array literal that contains a hole). A
non-spread `[ ... ]` segment must additionally preserve a trailing elision
hole's comma, exactly like the standalone array-literal printer. tsz's
`emit_array_literal_es5` hardcoded `pack = true` for every array-literal spread
segment and emitted segment elements without the trailing-hole comma.

Owner layer: emitter (`crates/tsz-emitter/src/emitter/es5/helpers.rs`,
`emit_array_literal_es5`). No semantic/type change; ES5/ES3 downlevel JS output
only.

## Adjacent-case matrix (all asserted in new tests, byte-checked vs tsc)

- Packed array literal mid-array, as base, and consecutive → `pack=false`.
- Non-array-literal source (a binding) → `pack=true` (unchanged).
- Array literal **with a hole** as the source (`[0, ...[, 3], 4]`) → not packed → `pack=true`.
- Trailing elision preserved in base and trailing segments (`[, ...x]`, `[1, , ...x]`, `[...x, ,]`).
- Binder names varied across the witnesses; the rule is structural (no identifier/printer-string predicates).

## Anti-hardcoding

Mirrors tsc's `isPackedArrayLiteral` structurally over the AST (array-literal
kind + no `NodeIndex::NONE` holes + no spread elements) and reuses the existing
`emit_utils::is_spread_element` / arena spread accessors. No type-name,
file-name, or rendered-output string checks.

## Verification

- `cargo test -p tsz-emitter --lib` → 3799 passed, 0 failed (incl. 2 new
  regression tests: `test_array_spread_pack_flag_matches_tsc_per_segment`,
  `test_array_spread_preserves_trailing_elision_in_segments`).
- Differential vs bundled `tsc` 6.0.2 on the full witness matrix (array-literal
  and call-argument contexts, normal ES5) → byte-identical.
- Confirmed the `downlevelIteration` `__read`-wrapping divergence for packed
  literals is **pre-existing** (reproduced on `main`) and left out of scope.
- `cargo fmt -p tsz-emitter --check` and `cargo clippy -p tsz-emitter
  --all-targets` clean. Broad conformance/emit suites: ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKfdKhs81QmbgVyU7QtNHa)_