### PR TITLE
docs(emit): triage DTS-emitter type_text predicates as the correct text boundary (#14142)

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_class_properties.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_class_properties.rs
@@ -295,6 +295,12 @@ impl<'a> DeclarationEmitter<'a> {
                         self.arena.get(prop.initializer).is_some_and(|node| {
                             node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
                         });
+                    // DTS text boundary (#14142): the decision is over the rewritten
+                    // declaration text of an object-literal initializer, not over
+                    // `effective_type`. Both a top-level `any` rendering and a nested
+                    // `: any;` member (`.contains`) must prefer the syntactic type
+                    // text; the nested-`any` case has no single in-scope `TypeId`, so
+                    // the rendered-string checks are the correct boundary here.
                     let type_text = if has_object_literal_initializer
                         && (type_text == "any"
                             || type_text.contains(": any;")

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit_binding_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit_binding_types.rs
@@ -878,6 +878,9 @@ impl<'a> DeclarationEmitter<'a> {
             .and_then(|expr_idx| {
                 self.js_constructor_assignment_expression_type_text(expr_idx, params, 0)
             })
+            // DTS text boundary (#14142): this JS-to-DTS return inference works on
+            // rendered declaration text (no in-scope `TypeId`); an empty or `any`
+            // rendering means "no usable annotation", so the caller falls back.
             .filter(|type_text| !type_text.is_empty() && type_text != "any")
     }
 

--- a/crates/tsz-emitter/src/declaration_emitter/core/js_emit_namespace_exports.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/js_emit_namespace_exports.rs
@@ -386,6 +386,13 @@ impl<'a> DeclarationEmitter<'a> {
                 .or_else(|| {
                     resolved_type
                         .as_ref()
+                        // DTS text boundary (#14142): `type_id != ANY` is the
+                        // structural gate; the `emitted_type_text != "any"` guard
+                        // additionally rejects a type that is not the `any`
+                        // singleton yet still *renders* as `any` (e.g. an alias
+                        // `type X = any`, whose own `TypeId != ANY`). The TypeId
+                        // check alone cannot see that, so this rendered-string
+                        // check is the correct boundary and is not redundant.
                         .filter(|resolved| {
                             resolved.type_id != tsz_solver::types::TypeId::ANY
                                 && resolved.emitted_type_text != "any"

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/correlated_union.rs
@@ -452,6 +452,9 @@ impl<'a> DeclarationEmitter<'a> {
     ) -> Option<String> {
         let binder = self.binder?;
         for sym_id in binder.symbols.find_all_by_name(interface_name) {
+            // DTS text boundary (#14142): the member's declared annotation is read
+            // as rendered declaration text (no in-scope `TypeId`); an `any`
+            // rendering is treated as no usable annotation, so the search continues.
             if let Some(type_text) =
                 self.type_member_declared_type_annotation_text(*sym_id, member_name)
                 && type_text != "any"

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/function_analysis.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/function_analysis.rs
@@ -364,6 +364,10 @@ impl<'a> DeclarationEmitter<'a> {
 
         let name = self.js_define_property_name(args.nodes[1])?;
         let (mut type_text, readonly, value) = self.js_define_property_descriptor(args.nodes[2])?;
+        // DTS text boundary (#14142): the descriptor type is recovered as rendered
+        // declaration text (no in-scope `TypeId`); `Object.defineProperty(x, "name",
+        // …)` with an uninferable value renders `any`, which is narrowed to the
+        // `Function.name: string` shape, matching tsc's JS declaration emit.
         if name == "name" && type_text == "any" {
             type_text = "string".to_string();
         }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/js_exports.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/js_exports.rs
@@ -1304,6 +1304,10 @@ impl<'a> DeclarationEmitter<'a> {
             else {
                 continue;
             };
+            // DTS text boundary (#14142): CommonJS export value types are gathered
+            // as rendered declaration text (no in-scope `TypeId`); an `undefined`
+            // rendering is tracked separately so it is appended once to the emitted
+            // union rather than duplicated among the value types.
             if type_text == "undefined" {
                 has_undefined = true;
                 continue;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_enum_access.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_enum_access.rs
@@ -290,6 +290,9 @@ impl<'a> DeclarationEmitter<'a> {
         let expr_node = self.arena.get(expr_idx)?;
         let assertion = self.arena.get_type_assertion(expr_node)?;
         let type_node = self.arena.get(assertion.type_node)?;
+        // Source-syntax check, not a rendered-type predicate (#14142): `type_text`
+        // is the verbatim source slice of the assertion's type node, so this
+        // recognizes the `as const` assertion spelling itself, not a computed type.
         let type_text = self.get_source_slice(type_node.pos, type_node.end)?;
         if type_text != "const" {
             return None;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -1062,6 +1062,10 @@ impl<'a> DeclarationEmitter<'a> {
                         Self::expand_parameters_utility_tuple_type_text(&type_text)
                             .unwrap_or(type_text)
                     })
+                    // DTS text boundary (#14142): `reused_type_text` is already a
+                    // rendered declaration string with no in-scope `TypeId`; an
+                    // empty or `any` rendering means "no usable reuse", so the
+                    // fallbacks below are tried instead.
                     .filter(|type_text| !type_text.is_empty() && type_text != "any");
                 reused_type_text
                     .or_else(|| {
@@ -1104,6 +1108,12 @@ impl<'a> DeclarationEmitter<'a> {
                 } else {
                     self.get_node_type_or_names(&[expr_idx])
                         .map(|type_id| self.print_type_id(type_id))
+                        // DTS text boundary (#14142): filtering on the *rendered*
+                        // text (not `type_id != ANY`) is intentional — a node type
+                        // that is not the `any` singleton can still print as `any`
+                        // (alias-to-`any`, recovered/opaque types), and those must
+                        // fall through to the AST-derived text rather than emit a
+                        // bare `any`. Branching on the `TypeId` would miss them.
                         .filter(|type_text| type_text != "any")
                         .or(ast_type_text)
                 }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_instantiation.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_instantiation.rs
@@ -467,6 +467,11 @@ impl<'a> DeclarationEmitter<'a> {
         (include_right_parts, widen_right_parts)
     }
 
+    // DTS text boundary (#14142): the `short_circuit_*` helpers below classify the
+    // already-rendered constituent type-text of a `&&`/`||` short-circuit union.
+    // They operate on declaration text split into parts (`ShortCircuitTypePart`)
+    // with no in-scope `TypeId`, so the intrinsic-spelling comparisons (`"true"`,
+    // `"string"`, `"number"`, `"bigint"`) are the correct boundary here.
     fn short_circuit_or_literal_needs_right(
         type_text: &str,
         right_parts: &[ShortCircuitTypePart],

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -875,6 +875,10 @@ impl DeclarationEmitter<'_> {
             let Some(type_text) = self.function_parameter_type_text(func, prop.initializer) else {
                 continue;
             };
+            // DTS text boundary (#14142): this is a textual rewrite of already-
+            // emitted `: unknown` member lines; `type_text` is rendered declaration
+            // text with no in-scope `TypeId`, and an `unknown` rendering means there
+            // is nothing to rewrite.
             if type_text == "unknown" {
                 continue;
             }
@@ -932,6 +936,10 @@ impl DeclarationEmitter<'_> {
             let Some(type_text) = self.function_parameter_type_text(func, initializer) else {
                 continue;
             };
+            // DTS text boundary (#14142): textual rewrite of `: unknown;` object
+            // members; `type_text` is rendered declaration text (no in-scope
+            // `TypeId`), and an `unknown` rendering means there is nothing to
+            // rewrite.
             if type_text == "unknown" {
                 continue;
             }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -625,10 +625,9 @@ impl<'a> DeclarationEmitter<'a> {
                 {
                     type_text = widened_type_text;
                 }
-                // DTS text boundary (#14142): `type_text` here has already been
-                // through several declaration-text rewrites above (widening, etc.)
-                // with no single in-scope `TypeId`; a `string` rendering is the
-                // trigger for the template-index-signature refinement.
+                // DTS text boundary (#14142): `type_text` has already passed
+                // declaration-text rewrites; `string` triggers template-index
+                // refinement with no single in-scope `TypeId`.
                 if keyword == "const"
                     && type_text == "string"
                     && let Some(template_index_type) =
@@ -734,8 +733,8 @@ impl<'a> DeclarationEmitter<'a> {
                     .get(initializer)
                     .is_some_and(|node| node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
                 // DTS text boundary (#14142): `preferred_expression_type_text`
-                // returns rendered declaration text (no in-scope `TypeId`); an
-                // `any` rendering means there is no preferred annotation to emit.
+                // returns rendered declaration text; `any` means no preferred
+                // annotation to emit.
                 && let Some(type_text) = self.preferred_expression_type_text(initializer)
                 && type_text != "any"
             {
@@ -1908,11 +1907,9 @@ impl<'a> DeclarationEmitter<'a> {
                 self.js_extends_entity_reference_declared_type_text(expr_idx)
                     .map(|type_text| self.jsdoc_type_text_for_declaration_emit(&type_text))
             });
-        // DTS text boundary (#14142): although `type_id` exists above, a `never`
-        // rendering is not equivalent to `type_id == NEVER` — an alias to `never`
-        // or a collapsed union also prints `never`, and the choice here is between
-        // two already-rendered declaration strings (`type_text` vs the source
-        // heritage text), so the comparison stays on the rendered text.
+        // DTS text boundary (#14142): a `never` rendering is not equivalent to
+        // `type_id == NEVER`; aliases or collapsed unions also print `never`.
+        // The choice is between rendered declaration strings, so compare text.
         let prefer_source_text = type_text == "never"
             || source_type_text.as_ref().is_some_and(|source_type_text| {
                 Self::should_prefer_synthetic_extends_source_type_text(source_type_text, &type_text)

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -625,6 +625,10 @@ impl<'a> DeclarationEmitter<'a> {
                 {
                     type_text = widened_type_text;
                 }
+                // DTS text boundary (#14142): `type_text` here has already been
+                // through several declaration-text rewrites above (widening, etc.)
+                // with no single in-scope `TypeId`; a `string` rendering is the
+                // trigger for the template-index-signature refinement.
                 if keyword == "const"
                     && type_text == "string"
                     && let Some(template_index_type) =
@@ -729,6 +733,9 @@ impl<'a> DeclarationEmitter<'a> {
                     .arena
                     .get(initializer)
                     .is_some_and(|node| node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
+                // DTS text boundary (#14142): `preferred_expression_type_text`
+                // returns rendered declaration text (no in-scope `TypeId`); an
+                // `any` rendering means there is no preferred annotation to emit.
                 && let Some(type_text) = self.preferred_expression_type_text(initializer)
                 && type_text != "any"
             {
@@ -1901,6 +1908,11 @@ impl<'a> DeclarationEmitter<'a> {
                 self.js_extends_entity_reference_declared_type_text(expr_idx)
                     .map(|type_text| self.jsdoc_type_text_for_declaration_emit(&type_text))
             });
+        // DTS text boundary (#14142): although `type_id` exists above, a `never`
+        // rendering is not equivalent to `type_id == NEVER` — an alias to `never`
+        // or a collapsed union also prints `never`, and the choice here is between
+        // two already-rendered declaration strings (`type_text` vs the source
+        // heritage text), so the comparison stays on the rendered text.
         let prefer_source_text = type_text == "never"
             || source_type_text.as_ref().is_some_and(|source_type_text| {
                 Self::should_prefer_synthetic_extends_source_type_text(source_type_text, &type_text)


### PR DESCRIPTION
Goal: hold

Completes the emitter half of #14142 (type-display strings used as semantic predicates). Closes #14142.

## Background

The checker half of #14142 — the rendered-string semantic predicates that had an in-scope structural fact to branch on — was converted in #14160 (`implicit_type == "any[]"` → `ImplicitAnyKind`; `== "error"` → `is_genuine_error_type`). #14160 left the declaration-emitter `type_text == "…"` sites as the open remainder, noting they are the DTS text boundary. This PR finishes the triage the issue's acceptance criteria asks for: *"Emitter sites triaged: each either converted to a type-based check, or annotated with why the text check is the correct boundary for the DTS path."*

## Triage outcome

All 18 `type_text (==|!=) "…"` sites in `crates/tsz-emitter/src/declaration_emitter` are the correct boundary and are now annotated in place. Three categories:

1. **No in-scope `TypeId`** (most sites) — the JS-to-DTS inference and declaration-printing helpers (`function_parameter_type_text`, `js_define_property_descriptor`, `preferred_expression_type_text`, the `short_circuit_*` union-text classifiers, …) operate on rendered declaration text; there is no `TypeId` at the comparison point to branch on.
2. **`TypeId` in scope but the text guard is load-bearing, not redundant** — `js_emit_namespace_exports.rs` and `type_inference_fallback_types.rs` already branch on `type_id != ANY`, but keep an additional rendered-`"any"` guard because a type that is **not** the `any` singleton can still *render* as `any` (an alias `type X = any`, recovered/opaque types). A `TypeId`-only check cannot see those, so removing the text check would not be behavior-preserving (consistent with #14160's call).
3. **Source-syntax check, not a rendered-type predicate** — `type_inference_enum_access.rs` reads the verbatim source slice to recognize the `as const` assertion spelling itself.

## Why this is the right boundary

The Anti-Hardcoding Gate forbids *semantic* code from reading printer output. The DTS declaration pipeline is text-oriented by design: it lowers types to declaration text and then composes/refines that text, with no `TypeId` to consult at these points. The gate's rule ("the printer may read types; types must not read printer output") is satisfied — these are presentation-layer text decisions, not semantic predicates over a type that was already computed.

## Anti-hardcoding

Pure documentation: no name/file-string predicates introduced, no printer-output reads added, no behavior gated on identifiers.

## Verification

- Diff is comments-only (65 additive lines, 11 files) — no behavior change.
- `cargo fmt -p tsz-emitter` clean; `cargo check -p tsz-emitter` clean; `cargo clippy -p tsz-emitter` clean.
- `grep -rE 'type_text *(==|!=) *"' crates/tsz-emitter/src` — all 18 sites now carry an adjacent triage annotation.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ee2UExBFEvC3W5xwaAPp6v)_