### PR TITLE
fix(resolver): one shared exports/imports pattern-key comparator; fix CLI-driver order-dependent subpath selection (#13826)

### DIFF
--- a/crates/tsz-cli/src/driver/resolution/exports_imports.rs
+++ b/crates/tsz-cli/src/driver/resolution/exports_imports.rs
@@ -266,34 +266,33 @@ fn resolve_target_candidates_with_flavor(
     }
 }
 
-/// `(prefix_len, suffix_len)` specificity for a package.json `exports` /
-/// `imports` subpath pattern, per Node.js `PACKAGE_IMPORTS_EXPORTS_RESOLVE`.
-/// Longer prefix beats shorter prefix; longer suffix only breaks
-/// equal-prefix ties. Mirrors `tsz-core`'s `export_pattern_specificity`.
-fn exports_subpath_specificity(pattern: &str) -> (usize, usize) {
-    if let Some(star_pos) = pattern.find('*') {
-        (star_pos, pattern.len() - star_pos - 1)
-    } else {
-        (pattern.len(), 0)
-    }
-}
-
 /// Pick the most-specific pattern entry from `map`. `match_fn` accepts the
 /// captured wildcard portion for a matching key (or returns `None`). Updates
 /// only on strict improvement, so true ties resolve to the first matching
 /// pattern in JSON insertion order (`serde_json` is built with
 /// `preserve_order`).
+///
+/// Specificity is ranked by the shared
+/// [`pattern_key_specificity`](tsz_common::module_resolution::package_exports::pattern_key_specificity)
+/// comparator (Node.js `comparePatternKeys`), so this driver cannot drift from
+/// the tsz-core resolver or from `tsc`. The earlier `(prefix_len, suffix_len)`
+/// 2-tuple dropped the `+1` on a wildcard's base length and the wildcard-beats-
+/// directory tiebreak, so a directory key (`"./"`, `"./lib/"`) tied its
+/// corresponding wildcard (`"./*"`, `"./lib/*"`) and the chosen file flipped
+/// with JSON key order.
 fn find_best_subpath_pattern<'a>(
     map: &'a serde_json::Map<String, serde_json::Value>,
     match_fn: impl Fn(&str) -> Option<String>,
 ) -> Option<(String, &'a serde_json::Value)> {
+    use tsz_common::module_resolution::package_exports::pattern_key_specificity;
+
     let mut best: Option<(String, &'a serde_json::Value)> = None;
-    let mut best_score: Option<(usize, usize)> = None;
+    let mut best_score: Option<(usize, usize, usize)> = None;
     for (key, value) in map {
         let Some(wildcard) = match_fn(key) else {
             continue;
         };
-        let specificity = exports_subpath_specificity(key);
+        let specificity = pattern_key_specificity(key);
         if best_score.is_none_or(|s| specificity > s) {
             best_score = Some(specificity);
             best = Some((wildcard, value));
@@ -555,25 +554,41 @@ mod tests {
         );
     }
 
+    // The `pattern_key_specificity` comparator itself is unit-tested in
+    // `tsz_common::module_resolution::package_exports`; the driver tests below
+    // pin that the resolver actually routes its key selection through it
+    // (end-to-end, in either JSON authoring order).
+
     #[test]
-    fn exports_subpath_specificity_uses_prefix_then_suffix_tuple() {
-        // Covers each branch of the algorithm plus the regression cases:
-        //   * exact/non-wildcard keys score `(pattern.len(), 0)`,
-        //   * patterns with `*` score `(prefix_len, suffix_len)` and so the
-        //     equal-total-length / unequal-prefix pair `./abc/*` vs `./*/abc`
-        //     resolves strictly (the previous `key.len()` heuristic tied them),
-        //   * identical-prefix patterns are broken by suffix length.
-        assert_eq!(exports_subpath_specificity("./exact.js"), (10, 0));
-        assert_eq!(exports_subpath_specificity("./"), (2, 0));
-        assert_eq!(exports_subpath_specificity("./*"), (2, 0));
-        assert_eq!(exports_subpath_specificity("./prefix*"), (8, 0));
-        assert_eq!(exports_subpath_specificity("./*.ts"), (2, 3));
-        assert_eq!(exports_subpath_specificity("./abc/*"), (6, 0));
-        assert_eq!(exports_subpath_specificity("./*/abc"), (2, 4));
-        assert!(exports_subpath_specificity("./abc/*") > exports_subpath_specificity("./*/abc"));
-        assert!(
-            exports_subpath_specificity("./lib/*.d.ts") > exports_subpath_specificity("./lib/*")
-        );
+    fn resolve_exports_subpath_wildcard_beats_directory_key_in_either_order() {
+        // Regression: a `*` key is strictly more specific than the trailing-slash
+        // directory key it shares a base with, so `tsc` always picks the wildcard
+        // target regardless of JSON authoring order. The prior 2-tuple comparator
+        // tied them and let JSON order pick the (wrong) directory target.
+        for exports in [
+            serde_json::json!({ "./lib/": "./d/", "./lib/*": "./s/*" }),
+            serde_json::json!({ "./lib/*": "./s/*", "./lib/": "./d/" }),
+        ] {
+            assert_eq!(
+                resolve_exports_subpath(&exports, "./lib/foo.js", &["default"], TEST_VERSION)
+                    .into_option()
+                    .as_deref(),
+                Some("./s/foo.js"),
+            );
+        }
+
+        // The bare-`"./"` directory sugar vs `"./*"` shows the same fix.
+        for exports in [
+            serde_json::json!({ "./": "./pub/", "./*": "./src/*" }),
+            serde_json::json!({ "./*": "./src/*", "./": "./pub/" }),
+        ] {
+            assert_eq!(
+                resolve_exports_subpath(&exports, "./foo.js", &["default"], TEST_VERSION)
+                    .into_option()
+                    .as_deref(),
+                Some("./src/foo.js"),
+            );
+        }
     }
 
     #[test]

--- a/crates/tsz-common/src/module_resolution/package_exports.rs
+++ b/crates/tsz-common/src/module_resolution/package_exports.rs
@@ -1,13 +1,51 @@
-//! Shared reverse lookup helpers for `package.json#exports`.
+//! Shared `package.json#exports`/`imports` primitives.
 //!
-//! Declaration emit and checker nameability both need to answer the same
-//! question: given a package-local runtime target such as `./dist/index.js`,
-//! which public export specifier, if any, exposes it? Keeping this logic here
-//! prevents checker diagnostics and DTS output from drifting on condition,
-//! wildcard, array, and folder-entry handling.
+//! Two directions live here so the forward resolver, reverse lookup, checker
+//! diagnostics, and DTS output cannot drift on condition, wildcard, array, and
+//! folder-entry handling:
+//!
+//! - **Forward** ([`pattern_key_specificity`]): rank subpath pattern keys by
+//!   Node.js `comparePatternKeys` so both the tsz-core resolver and the CLI
+//!   driver pick the same most-specific key.
+//! - **Reverse**: given a package-local runtime target such as
+//!   `./dist/index.js`, which public export specifier, if any, exposes it?
+//!   (Declaration emit and checker nameability need this.)
 
 use serde_json::Value;
 use std::path::Path;
+
+/// Specificity ranking key for a `package.json` `exports`/`imports` subpath
+/// pattern key, mirroring Node.js `comparePatternKeys` (which `tsc`
+/// reimplements in `moduleNameResolver`). The returned tuple is compared
+/// lexicographically with **larger wins**, reproducing the comparator's sort
+/// order so the single most-specific matching key is chosen independently of
+/// JSON declaration order:
+///
+/// 1. **`base_length`** — the anchored prefix length. For a single-`*` key this
+///    is `indexOf('*') + 1`; for a non-wildcard key (exact or `/`-suffixed
+///    directory) it is the full key length. A longer base is more specific. This
+///    is what lets a long directory key (`"./lib/"`, base 6) outrank a short
+///    wildcard (`"./*"`, base 3), and a wildcard (`"./lib/*"`, base 7) outrank
+///    that directory key.
+/// 2. **`is_pattern`** — `1` for keys containing `*`, else `0`. At equal base
+///    length a wildcard key beats a directory/exact key, matching
+///    `comparePatternKeys` (`aPatternIndex === -1 ? 1`). Without this term a
+///    directory key (`"./"`, base 2) ties its wildcard (`"./*"`, base 2 with a
+///    2-tuple comparator) and the winner flips with JSON key order.
+/// 3. **`total_length`** — longer keys win last, reached only when both keys are
+///    wildcards with equal base. For two wildcards with equal base this orders
+///    by suffix length, e.g. `"./*.js"` beats `"./*"`.
+///
+/// True ties (identical ranking) resolve to the first key in iteration order, so
+/// callers must iterate an insertion-order map and update only on strict
+/// improvement (`>`).
+pub fn pattern_key_specificity(key: &str) -> (usize, usize, usize) {
+    let len = key.len();
+    match key.find('*') {
+        Some(star_index) => (star_index + 1, 1, len),
+        None => (len, 0, len),
+    }
+}
 
 /// Read `package.json` under `package_root` and reverse-match its `exports`
 /// map for `runtime_relative_path`.
@@ -169,5 +207,26 @@ mod tests {
             match_export_target("./feature/", "./dist/feature/", "./dist/feature/a.js"),
             Some("feature/a.js".to_string())
         );
+    }
+
+    #[test]
+    fn pattern_key_specificity_mirrors_compare_pattern_keys() {
+        // Non-wildcard (exact / `/`-directory) keys: base == total == full length.
+        assert_eq!(pattern_key_specificity("./exact.js"), (10, 0, 10));
+        assert_eq!(pattern_key_specificity("./"), (2, 0, 2));
+        assert_eq!(pattern_key_specificity("./lib/"), (6, 0, 6));
+        // Wildcard keys: base == indexOf('*') + 1, is_pattern == 1.
+        assert_eq!(pattern_key_specificity("./*"), (3, 1, 3));
+        assert_eq!(pattern_key_specificity("./lib/*"), (7, 1, 7));
+        assert_eq!(pattern_key_specificity("./*.ts"), (3, 1, 6));
+
+        // A wildcard strictly outranks the directory key it shares a base with —
+        // the order-independence the 2-tuple comparator lost.
+        assert!(pattern_key_specificity("./*") > pattern_key_specificity("./"));
+        assert!(pattern_key_specificity("./lib/*") > pattern_key_specificity("./lib/"));
+        // Longer base still wins first (directory beats shorter wildcard).
+        assert!(pattern_key_specificity("./lib/") > pattern_key_specificity("./*"));
+        // Equal base, both wildcards: longer total (suffix) wins.
+        assert!(pattern_key_specificity("./*.js") > pattern_key_specificity("./*"));
     }
 }

--- a/crates/tsz-core/src/resolution/helpers.rs
+++ b/crates/tsz-core/src/resolution/helpers.rs
@@ -223,13 +223,13 @@ pub(crate) fn match_export_pattern(pattern: &str, subpath: &str) -> Option<Strin
 /// True ties (identical ranking) resolve to the first key in iteration order, so
 /// callers must iterate an insertion-order map (`IndexMap`) and update only on
 /// strict improvement (`>`).
+///
+/// The ranking itself is owned by
+/// [`tsz_common::module_resolution::package_exports::pattern_key_specificity`]
+/// so the tsz-core resolver and the CLI driver cannot drift from each other or
+/// from `comparePatternKeys`.
 pub(crate) fn export_pattern_specificity(pattern: &str) -> (usize, usize, usize) {
-    let len = pattern.len();
-    if let Some(star_pos) = pattern.find('*') {
-        (star_pos + 1, 1, len)
-    } else {
-        (len, 0, len)
-    }
+    tsz_common::module_resolution::package_exports::pattern_key_specificity(pattern)
 }
 
 /// Find the most-specific pattern entry that matches `target`.


### PR DESCRIPTION
Goal: hold

Resolver slice of #13826 (`exports`/subpath sub-root). Removes a divergent second copy of the pattern-key specificity comparator — the recurring bug class on this umbrella.

## Structural rule

When more than one `package.json` `exports`/`imports` subpath key matches a specifier, `tsc` (`comparePatternKeys`, reimplementing Node `PACKAGE_IMPORTS_EXPORTS_RESOLVE`) selects the single most-specific key by: (1) **base length** — `indexOf('*') + 1` for a wildcard key, full length for a non-`*` (exact / `/`-directory) key; (2) at equal base, a **wildcard key beats a non-wildcard** key; (3) then longer total length. tsz must rank identically — owner: the module resolver's pattern selection.

## The bug

The tsz-core resolver already encoded this as a 3-tuple `(base_length, is_pattern, total_length)`. The **CLI driver** (`crates/tsz-cli/src/driver/resolution/exports_imports.rs::exports_subpath_specificity`) used a divergent 2-tuple `(prefix_len, suffix_len)` that dropped both the `+1` on a wildcard's base length **and** the wildcard-beats-directory tiebreak. So a directory key tied its corresponding wildcard and the chosen file flipped with JSON declaration order:

```jsonc
{ "./lib/": "./d/", "./lib/*": "./s/*" }   // import "pkg/lib/foo.js"
// tsc: "./lib/*" is strictly more specific -> ./s/foo.js
// tsz CLI (before): tie -> first-in-JSON-order wins (./d/foo.js when "./lib/" is first)
```

Same for `"./"` vs `"./*"`. The CLI driver is the layer that runs real project/canary resolution, so this is squarely the `exports`/subpath sub-root of #13826.

## Fix (owner layer: module resolver)

Add one shared `pattern_key_specificity` in `tsz_common::module_resolution::package_exports` (the anti-drift home), mirroring `comparePatternKeys`, and route **both** the tsz-core resolver (`export_pattern_specificity`) and the CLI driver (`find_best_subpath_pattern`) through it. This removes the divergent copy rather than adding one; behavior of the already-correct tsz-core path is unchanged.

## Anti-hardcoding

Pure structural ranking over key shape (`indexOf('*')`, length). No identifier/file-name/printer-output predicates; no new copy introduced (one removed).

## Adjacent-case matrix (tests)

- Shared comparator unit test (tsz-common): exact/`/`-directory keys score `(len, 0, len)`; wildcard keys `(idx+1, 1, len)`; `./*` > `./`; `./lib/*` > `./lib/`; longer base wins first (`./lib/` > `./*`); equal-base wildcards broken by total length (`./*.js` > `./*`).
- CLI driver end-to-end (both JSON authoring orders): a `*` key strictly beats the trailing-slash directory key it shares a base with — `"./lib/"`/`"./lib/*"` and `"./"`/`"./*"` both resolve to the wildcard target regardless of order.
- Existing prefix-specificity, true-tie (first-in-JSON-order), and replace-all-`*` driver tests still pass.

## Verification

- `cargo test -p tsz-common --lib package_exports` -> 5 passed.
- `cargo test -p tsz-cli --lib driver::resolution::exports_imports` -> 14 passed.
- `cargo test -p tsz-core --lib resolution::helpers` -> 18 passed; `--lib module_resolver` -> 283 passed.
- `cargo test -p tsz-core --test module_resolution_tests` -> 62 passed.
- `cargo fmt` + `cargo clippy -p tsz-common -p tsz-core -p tsz-cli --lib` clean.
- Pre-existing (unrelated) failure on `main`: `tsz-cli --bin tsz-server collect_import_candidates_respects_node_next_package_exports_root_only` fails identically with and without this change (verified by stash) — not introduced here.
- Broad conformance / emit / project suites: ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmNPqjDtz6suf4fvQYP2Pv)_