### PR TITLE
fix(solver): taint unresolved-def index-access deferrals so the registration window is not cached (#14347)

### DIFF
--- a/crates/tsz-checker/src/tests/unresolved_def_eval_cache_backstop_tests.rs
+++ b/crates/tsz-checker/src/tests/unresolved_def_eval_cache_backstop_tests.rs
@@ -93,3 +93,54 @@ fn fully_resolvable_type_is_still_persisted_to_env_eval_cache() {
         );
     });
 }
+
+/// An `IndexAccess` whose object is a `Lazy(DefId)` with nothing registered is
+/// the same registration-window artifact as the unresolved-base `Application`:
+/// the indexed-access evaluator (`visit_lazy`) cannot resolve a body, so it falls
+/// back to the deferred `IndexAccess(Lazy, K)` that re-interns to the input
+/// `TypeId` (no progress). Before the indexed-access taint (issue #14347) this
+/// opaque result was persisted in the `TypeId`-keyed `env_eval_cache` and would
+/// permanently shadow the real member type once the declaring file published the
+/// body. The evaluator now marks `unresolved_def_seen`, so the backstop must
+/// refuse the write — mirroring the `Application`/`keyof`/conditional deferrals.
+#[test]
+fn unresolved_lazy_index_access_is_not_persisted_to_env_eval_cache() {
+    let types = TypeInterner::new();
+    let unregistered = types.lazy(DefId(987_655));
+    let index_access = types.index_access(unregistered, TypeId::STRING);
+
+    with_trivial_checker(&types, |checker| {
+        let _ = checker.evaluate_type_with_env(index_access);
+        assert!(
+            checker.ctx.lookup_env_eval_cache(index_access).is_none(),
+            "an index access whose object def was unresolved is a registration-window \
+             artifact and must not be persisted in the TypeId-keyed env_eval_cache \
+             (issue #14347)",
+        );
+    });
+}
+
+/// Precision floor for the indexed-access taint: a fully-resolvable index access
+/// (`string[][number]` → `string`) observes no unresolved def and makes real
+/// progress on the root, so the backstop must leave its `env_eval_cache` write
+/// intact. This proves the indexed-access taint is keyed on an actually-missing
+/// body, not a blanket disablement of the index-access result memo.
+#[test]
+fn resolvable_index_access_is_still_persisted_to_env_eval_cache() {
+    let types = TypeInterner::new();
+    let index_access = types.index_access(types.array(TypeId::STRING), TypeId::NUMBER);
+
+    with_trivial_checker(&types, |checker| {
+        let result = checker.evaluate_type_with_env(index_access);
+        assert_eq!(
+            result,
+            TypeId::STRING,
+            "string[][number] must evaluate to string",
+        );
+        assert!(
+            checker.ctx.lookup_env_eval_cache(index_access).is_some(),
+            "a fully-resolvable index access observed no unresolved def, so the backstop \
+             must not suppress its env_eval_cache write (issue #14347)",
+        );
+    });
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -10,8 +10,8 @@ use crate::objects::PropertyCollectionResult;
 use crate::relations::subtype::TypeResolver;
 use crate::types::{
     CallableShapeId, IntrinsicKind, LiteralValue, MappedModifier, MappedType, MappedTypeId,
-    ObjectShape, ObjectShapeId, PropertyInfo, SymbolRef, TupleElement, TupleListId, TypeData,
-    TypeId, TypeListId, TypeParamInfo,
+    ObjectShape, ObjectShapeId, PropertyInfo, SymbolRef, TupleListId, TypeData, TypeId, TypeListId,
+    TypeParamInfo,
 };
 use crate::visitor::{
     TypeVisitor, intersection_list_id, keyof_inner_type, literal_number, type_param_info,
@@ -1762,52 +1762,5 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
 
         TypeId::UNDEFINED
-    }
-
-    /// Evaluate property access on an object type with index signatures.
-    pub(crate) fn evaluate_object_with_index(
-        &self,
-        shape: &ObjectShape,
-        index_type: TypeId,
-    ) -> TypeId {
-        super::index_access_object_with_index::evaluate_object_with_index(self, shape, index_type)
-    }
-
-    pub(crate) fn optional_property_type(&self, prop: &PropertyInfo) -> TypeId {
-        crate::utils::optional_property_type(self.interner(), prop)
-    }
-
-    pub(crate) fn add_undefined_if_unchecked(&self, type_id: TypeId) -> TypeId {
-        if !self.no_unchecked_indexed_access() || type_id == TypeId::UNDEFINED {
-            return type_id;
-        }
-        self.interner().union2(type_id, TypeId::UNDEFINED)
-    }
-
-    pub(crate) fn rest_element_type(&self, type_id: TypeId) -> TypeId {
-        super::index_access_keys::rest_element_type(self.interner(), type_id)
-    }
-
-    /// Evaluate index access on a tuple type
-    pub(crate) fn evaluate_tuple_index(
-        &self,
-        elements: &[TupleElement],
-        index_type: TypeId,
-    ) -> TypeId {
-        super::index_access_keys::evaluate_tuple_index(
-            self.interner(),
-            elements,
-            index_type,
-            self.no_unchecked_indexed_access(),
-        )
-    }
-
-    pub(crate) fn evaluate_array_index(&self, elem: TypeId, index_type: TypeId) -> TypeId {
-        super::index_access_keys::evaluate_array_index(
-            self.interner(),
-            elem,
-            index_type,
-            self.no_unchecked_indexed_access(),
-        )
     }
 }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -1073,6 +1073,17 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
                     .recurse_index_access(resolved, self.index_type),
             );
         }
+        // The object is a `Lazy(DefId)` with no resolvable body on this query (the
+        // declaring file has not published one yet — the cross-file registration
+        // window). `evaluate_index_access` then falls back to the deferred
+        // `IndexAccess(Lazy, K)`, a function of *which* refs were resolved when the
+        // pass ran rather than of the input `TypeId`; caching it would let the
+        // under-resolved answer shadow the real member type once the body registers.
+        // Mark the taint so the TypeId-keyed eval-cache backstops refuse the write
+        // and the authoritative pass recomputes — the registration-window-artifact
+        // discipline shared with the `Application`/`keyof`/conditional deferrals
+        // (#14347).
+        self.evaluator.mark_unresolved_def_seen();
         None
     }
 
@@ -1104,11 +1115,19 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
         {
             self.evaluator
                 .resolver()
-                .resolve_lazy(def_id, self.evaluator.interner())?
+                .resolve_lazy(def_id, self.evaluator.interner())
         } else {
             self.evaluator
                 .resolver()
-                .resolve_symbol_ref(symbol_ref, self.evaluator.interner())?
+                .resolve_symbol_ref(symbol_ref, self.evaluator.interner())
+        };
+        let Some(resolved) = resolved else {
+            // The referenced symbol/def has no resolvable body yet, so this access
+            // falls back to a deferred `IndexAccess(Ref, K)` — the same
+            // registration-window artifact as the `Lazy` arm above. Keep it out of
+            // the `TypeId`-keyed eval caches (#14347).
+            self.evaluator.mark_unresolved_def_seen();
+            return None;
         };
         if resolved == self.object_type {
             Some(

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_evaluator_helpers.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_evaluator_helpers.rs
@@ -5,7 +5,7 @@ use crate::types::{ObjectShape, PropertyInfo, TupleElement, TypeId};
 
 use super::super::evaluate::TypeEvaluator;
 
-impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+impl<R: TypeResolver> TypeEvaluator<'_, R> {
     /// Evaluate property access on an object type with index signatures.
     pub(crate) fn evaluate_object_with_index(
         &self,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_evaluator_helpers.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_evaluator_helpers.rs
@@ -1,0 +1,55 @@
+//! `TypeEvaluator` helper methods shared by indexed-access rules.
+
+use crate::relations::subtype::TypeResolver;
+use crate::types::{ObjectShape, PropertyInfo, TupleElement, TypeId};
+
+use super::super::evaluate::TypeEvaluator;
+
+impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+    /// Evaluate property access on an object type with index signatures.
+    pub(crate) fn evaluate_object_with_index(
+        &self,
+        shape: &ObjectShape,
+        index_type: TypeId,
+    ) -> TypeId {
+        super::index_access_object_with_index::evaluate_object_with_index(self, shape, index_type)
+    }
+
+    pub(crate) fn optional_property_type(&self, prop: &PropertyInfo) -> TypeId {
+        crate::utils::optional_property_type(self.interner(), prop)
+    }
+
+    pub(crate) fn add_undefined_if_unchecked(&self, type_id: TypeId) -> TypeId {
+        if !self.no_unchecked_indexed_access() || type_id == TypeId::UNDEFINED {
+            return type_id;
+        }
+        self.interner().union2(type_id, TypeId::UNDEFINED)
+    }
+
+    pub(crate) fn rest_element_type(&self, type_id: TypeId) -> TypeId {
+        super::index_access_keys::rest_element_type(self.interner(), type_id)
+    }
+
+    /// Evaluate index access on a tuple type.
+    pub(crate) fn evaluate_tuple_index(
+        &self,
+        elements: &[TupleElement],
+        index_type: TypeId,
+    ) -> TypeId {
+        super::index_access_keys::evaluate_tuple_index(
+            self.interner(),
+            elements,
+            index_type,
+            self.no_unchecked_indexed_access(),
+        )
+    }
+
+    pub(crate) fn evaluate_array_index(&self, elem: TypeId, index_type: TypeId) -> TypeId {
+        super::index_access_keys::evaluate_array_index(
+            self.interner(),
+            elem,
+            index_type,
+            self.no_unchecked_indexed_access(),
+        )
+    }
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
@@ -18,6 +18,7 @@ pub mod conditional;
 pub mod index_access;
 mod index_access_callable;
 mod index_access_empty_key;
+mod index_access_evaluator_helpers;
 mod index_access_keys;
 mod index_access_object_with_index;
 mod index_access_optional_read;


### PR DESCRIPTION
Goal: hold

Self-contained slice of #14347 ("caches memoize values that are not pure functions of their keys"). Extends the existing unresolved-def taint discipline to the **indexed-access** evaluator — the operation behind the cross-arena `error[]`/member-degradation family in #13484/#10663. Sibling to the in-flight `keyof` slice (#14569); no file overlap.

## The bug class

`mark_unresolved_def_seen()` is the established mechanism for a result that depended on a `Lazy(DefId)` whose body is not yet registered (the cross-file/cross-arena registration window): the closed-eval / application-eval / `env_eval_cache` backstops gate cache writes on it, because such a result is a function of *which* refs happened to be resolved when the pass ran, not of the input `TypeId`. Persisting it lets the under-resolved answer permanently shadow the real type once the body registers.

`Application` (`evaluate/application.rs`) and the conditional deferrals (`evaluate_rules/conditional/phases.rs`) already mark the taint. The **indexed-access** evaluator did not: when `T[K]`'s object is a `Lazy`/`Ref` with no resolvable body, `visit_lazy` / `visit_ref` fell back to the deferred `IndexAccess` via the dispatcher's "keep as IndexAccess (deferred)" tail **without** marking the taint, so the registration-window artifact was persisted and shadowed the real member type.

## Structural rule

When an indexed access `T[K]` is evaluated and its object is a `Lazy(DefId)`/`Ref` with no resolvable body on this query, `tsc` re-derives the member once the body resolves; tsz must not memoize the pending deferred `IndexAccess` as authoritative. Owner: solver evaluation (`IndexAccessVisitor::visit_lazy` / `visit_ref`), via the existing `unresolved_def_seen` taint the cache backstops already honor.

## Fix (owner layer: solver)

`visit_lazy` and `visit_ref` now call `mark_unresolved_def_seen()` on the no-body fallback. Marking is at the **per-site** level, not the dispatcher tail, on purpose: legitimate generic/type-parameter deferrals (`visit_type_parameter`, `visit_object`, `visit_tuple`, `visit_enum`) also reach the dispatcher's `None` path and must stay cacheable — they never flow through `visit_lazy`/`visit_ref`. So the taint is keyed on an actually-missing body, never a blanket disablement of the index-access memo.

## Why this is parity-safe

`mark_unresolved_def_seen()` only suppresses *cache writes* of a result that already depended on an unresolved def; it never changes a computed result within a run. In the conformance corpus (single-file, every def resolvable) the flag is not set during these ops, so behavior is unchanged. When it *is* set (cross-arena window), suppressing the write can only prevent a wrong cached value from shadowing the correct one — strictly more correct. The env-eval backstop additionally requires no-progress (`result == type_id`) before suppressing, so partial progress still caches.

## Anti-hardcoding

Pure structural decision over the operand's `TypeData` (`Lazy`/`Ref` with no resolvable body); no identifier/file-name/printer-output predicates; reuses the existing `mark_unresolved_def_seen` helper and `with_trivial_checker` test harness rather than introducing new machinery.

## Adjacent-case matrix (tests)

`crates/tsz-checker/src/tests/unresolved_def_eval_cache_backstop_tests.rs`:
- index access over an unregistered `Lazy(DefId)` is **not** persisted in the `TypeId`-keyed `env_eval_cache` (poison guard).
- fully-resolvable `string[][number]` → `string` **is** still persisted (precision floor; proves no over-suppression).

## Known follow-ups (not in scope)

The same taint audit applies to `evaluate_mapped` (deferral sites intermix legitimate generic deferrals with unresolved-def ones — needs careful per-site classification) and the template/string-intrinsic operands. `keyof` is handled separately by #14569. Tracked under #14347.

## Verification

- `cargo test -p tsz-checker --lib unresolved_def_eval_cache_backstop` → 4 passed (2 new).
- `cargo test -p tsz-solver --lib index_access` → 144 passed.
- `cargo test -p tsz-solver --lib evaluat` → 1255 passed; 1 pre-existing failure (`test_conditional_infer_optional_property_present_distributive`, a TypeId-allocation-order-dependent assertion) fails **identically with and without this change** — verified by stashing the diff, so not introduced here.
- `cargo clippy -p tsz-solver --lib` clean; `cargo fmt` clean.
- Broad conformance / emit / fourslash floors: ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pon2vmZ1qvnHCNxQckbS8R)_