### PR TITLE
fix(bench-site): render successful rows by 1.5x speed, drop app-compat gate

### DIFF
--- a/crates/tsz-website/.eleventy.js
+++ b/crates/tsz-website/.eleventy.js
@@ -37,8 +37,11 @@ export default function (eleventyConfig) {
     "../../artifacts/bench-vs-tsgo-latest.json",
     "bench-snapshot.json",
   ];
+  // Publish the latest available data; do not gate on app-compat cleanliness or
+  // a green-project minimum. Benchmarks may fail individually; the renderer
+  // decides which rows to chart (tsz within 1.5x of tsgo).
   const latestBenchmarkArtifact = selectLatestBenchmarkArtifact(benchmarkArtifacts, {
-    requireApplicationCompat: true,
+    minimumProjectTimingPairs: 0,
   })?.file;
   if (latestBenchmarkArtifact) {
     eleventyConfig.addPassthroughCopy({

--- a/crates/tsz-website/scripts/benchmark-data-smoke.mjs
+++ b/crates/tsz-website/scripts/benchmark-data-smoke.mjs
@@ -501,9 +501,12 @@ try {
   const charts = getBenchmarkCharts();
   assert.match(charts, /External libraries/);
   assert.match(charts, /Utility types project/);
+  // rxjs is a tsgo 3.0x win (tsz 3x slower), so it is NOT a timed chart bar; it
+  // is surfaced in the "not charted" list with a slow label instead.
   assert.match(charts, /RxJS project/);
-  assert.match(charts, /tsgo 3\.0x faster/);
-  assert.match(charts, /Compile canaries and incomplete project timings/);
+  assert.match(charts, /tsz 3\.0x slower than tsgo/);
+  assert.doesNotMatch(charts, /tsgo 3\.0x faster/);
+  assert.match(charts, /Not charted: canaries, incomplete, or tsz slower than tsgo/);
   assert.match(charts, /type-challenges solutions project/);
 
   const compatibilityDashboard = getProjectCompatibilityDashboard();
@@ -523,10 +526,12 @@ try {
   const failedOnlyCharts = getBenchmarkCharts();
   assert.doesNotMatch(failedOnlyCharts, /No benchmark data/i);
   assert.doesNotMatch(failedOnlyCharts, /No successful project benchmark timing pairs/);
-  assert.match(failedOnlyCharts, /Large repositories/);
+  // large-ts-repo is a tsgo 100x win (tsz 100x slower): not a chart bar, listed
+  // in the "not charted" section with a slow label.
   assert.match(failedOnlyCharts, /Large ts repo project/);
-  assert.match(failedOnlyCharts, /tsgo 100\.0x faster/);
-  assert.match(failedOnlyCharts, /Compile canaries and incomplete project timings/);
+  assert.match(failedOnlyCharts, /tsz 100\.0x slower than tsgo/);
+  assert.doesNotMatch(failedOnlyCharts, /tsgo 100\.0x faster/);
+  assert.match(failedOnlyCharts, /Not charted: canaries, incomplete, or tsz slower than tsgo/);
   assert.match(failedOnlyCharts, /RxJS project/);
   const failedOnlyCompatibility = getProjectCompatibilityDashboard();
   assert.match(failedOnlyCompatibility, /data-compat-sort="project"/);

--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -5,7 +5,6 @@ import { marked } from "marked";
 import {
   COMPILE_CANARY_PROJECT_ROWS,
   COMPATIBILITY_CORPUS_ROWS,
-  PERF_TIMED_PROJECT_ROWS,
   PROJECT_ROWS_BY_NAME,
   REQUIRED_PROJECT_ROWS,
 } from "../../../../scripts/bench/project-rows.mjs";
@@ -231,35 +230,27 @@ function hasSuccessfulTimingPair(row) {
     && hasTiming(row?.tsgo_ms);
 }
 
-function hasSuccessfulTiming(row) {
-  return hasSuccessfulTimingPair(row);
-}
-
-const PERF_TIMED_PROJECT_SET = new Set(PERF_TIMED_PROJECT_ROWS);
-
-// A perf-timed optional row may produce a tsz/tsgo timing pair while still
-// diverging from `tsc` (yellow) or failing tsz (red). Such rows must NOT join
-// the perf comparison chart: only promote a perf-timed optional row once it
-// checks green.
-// Required rows keep their existing behavior (timing pair is sufficient) so this
-// only gates the opt-in timing set, never the required corpus.
+// We run every benchmark and let individual ones fail; the chart renders only
+// the ones that "succeeded", where success means SPEED, not tsc-compatibility:
+// both compilers produced a timing AND tsgo is not >= 1.5x faster than tsz.
+// A row that keeps up with tsgo renders even if it diverges from tsc (yellow);
+// a row where tsz is >= 1.5x slower, errored, or timed out simply does not
+// render — it never blocks the rest of the chart.
+const CHART_MAX_TSZ_TO_TSGO_RATIO = 1.5;
 function isChartEligible(row) {
-  if (!hasSuccessfulTiming(row)) return false;
-  if (PERF_TIMED_PROJECT_SET.has(row?.name)) {
-    return hasGreenProjectCompatibility(row);
-  }
-  return true;
+  const tsz = Number(row?.tsz_ms);
+  const tsgo = Number(row?.tsgo_ms);
+  if (!(tsz > 0) || !(tsgo > 0) || row?.winner === "error") return false;
+  return tsz < tsgo * CHART_MAX_TSZ_TO_TSGO_RATIO;
 }
 
-// A perf-timed optional row that produced a timing pair but is not green is
-// excluded from the chart by isChartEligible. It still has a timing pair, so the
+// A row that produced a real timing pair but is too slow to chart (tsgo is
+// >= 1.5x faster, so isChartEligible() drops it) still has a timing pair, so the
 // normal isFailedBenchmark() check would treat it as "successful" and drop it
-// from the failures list too. Surface it explicitly in the canaries/incomplete
-// section so a timed-but-diverging row stays visible instead of vanishing.
-function isExcludedNonGreenCanary(row) {
-  return PERF_TIMED_PROJECT_SET.has(row?.name)
-    && hasSuccessfulTiming(row)
-    && !hasGreenProjectCompatibility(row);
+// from the failures list too. Surface it explicitly in the excluded/incomplete
+// section so a timed-but-too-slow row stays visible instead of vanishing.
+function isExcludedSlowTimedRow(row) {
+  return hasSuccessfulTimingPair(row) && !isChartEligible(row);
 }
 
 function isFailedBenchmark(row) {
@@ -268,7 +259,13 @@ function isFailedBenchmark(row) {
 }
 
 function statusLabel(row) {
-  return String(row?.status || "timing unavailable");
+  if (row?.status) return String(row.status);
+  const tsz = Number(row?.tsz_ms);
+  const tsgo = Number(row?.tsgo_ms);
+  if (tsz > 0 && tsgo > 0 && tsz >= tsgo * CHART_MAX_TSZ_TO_TSGO_RATIO) {
+    return `tsz ${(tsz / tsgo).toFixed(1)}x slower than tsgo`;
+  }
+  return "timing unavailable";
 }
 
 function firstPresent(...values) {
@@ -899,13 +896,16 @@ function loadBenchmarks() {
   }
 
   const snapshotPath = path.join(ROOT, "crates/tsz-website/bench-snapshot.json");
+  // Always use the latest available data. We do NOT gate selection on every app
+  // being clean, on green-only project timing pairs, or on a minimum count —
+  // benchmarks are allowed to fail individually; isChartEligible() decides which
+  // rows render (tsz within 1.5x of tsgo). Gating selection here is what left the
+  // whole dashboard empty whenever a canary/app legitimately crashed or timed out.
   const selectedArtifact = selectLatestBenchmarkArtifact([
     ...benchmarkArtifactFiles(),
     snapshotPath,
   ], {
-    minimumProjectTimingPairs: 1,
-    requireApplicationCompat: true,
-    requireGreenProjectTimingPairs: true,
+    minimumProjectTimingPairs: 0,
   });
   if (selectedArtifact) {
     return sanitizeLegacyBenchmarkData(selectedArtifact.data);
@@ -1517,7 +1517,7 @@ function buildGroupedBenchmarks(data) {
     ...[...grouped.values()].flat().map((row) => row.name),
   ]);
   const failedResults = allResults.filter((row) => (
-    (isFailedBenchmark(row) || isExcludedNonGreenCanary(row)) && !successfulNames.has(row.name)
+    (isFailedBenchmark(row) || isExcludedSlowTimedRow(row)) && !successfulNames.has(row.name)
   ));
 
   const order = [
@@ -1635,7 +1635,7 @@ function generateCharts(data, mode = "projects") {
   );
 
   let html = "";
-  if (mode === "projects" && visibleCategories.length === 0) {
+  if (mode === "projects" && visibleCategories.length === 0 && visibleFailedResults.length === 0) {
     html += `<div class="bench-placeholder">No successful project benchmark timing pairs are available in this artifact yet. Project rows below are still tracked for compile readiness.</div>\n`;
   }
 
@@ -1705,10 +1705,12 @@ function generateCharts(data, mode = "projects") {
   }
 
   if (visibleFailedResults.length > 0) {
-    const failedTitle = mode === "projects" ? "Compile canaries and incomplete project timings" : "Incomplete timings";
+    const failedTitle = mode === "projects"
+      ? "Not charted: canaries, incomplete, or tsz slower than tsgo"
+      : "Not charted: incomplete or tsz slower than tsgo";
     const failedDescription = mode === "projects"
-      ? "Rows that are tracked for compile readiness but are not part of the timed vs-tsgo chart yet."
-      : "Rows recorded by CI without a full tsz and tsgo timing pair.";
+      ? "Rows that ran but are not in the timed chart: compile canaries, rows without a full tsz and tsgo timing pair, or rows where tsz is at least 1.5x slower than tsgo."
+      : "Rows without a full tsz and tsgo timing pair, or where tsz is at least 1.5x slower than tsgo.";
     html += `<section class="bench-category bench-failures">
   <h3 class="bench-category-title" id="failures">${escapeHtml(failedTitle)}</h3>
   <p class="bench-category-desc">${escapeHtml(failedDescription)}</p>

--- a/crates/tsz-website/src/_data/benchmark_mean_chart.js
+++ b/crates/tsz-website/src/_data/benchmark_mean_chart.js
@@ -63,10 +63,13 @@ function loadBenchmarks() {
     }
   })();
 
+  // Always use the latest available data; do not gate on app-compat cleanliness
+  // or a green-project minimum (benchmarks may fail individually). The renderer
+  // selects which rows to show by the 1.5x speed rule.
   const selectedArtifact = selectLatestBenchmarkArtifact([
     ...artifactFiles,
     path.join(ROOT, "crates/tsz-website/bench-snapshot.json"),
-  ], { minimumProjectTimingPairs: 1, requireApplicationCompat: true });
+  ], { minimumProjectTimingPairs: 0 });
   if (selectedArtifact) {
     return sanitizeLegacyBenchmarkResults(selectedArtifact.data);
   }


### PR DESCRIPTION
## Summary

The benchmark dashboard used an all-or-nothing gating model: artifact selection
required app-compatibility to be clean (`requireApplicationCompat: true`) and a
green-project minimum, and the chart filter promoted a perf-timed project only
once it checked green. Because canaries/apps legitimately crash or time out,
selection returned `null` and the whole dashboard fell back to the
**"No benchmark data is available"** placeholder — even though dozens of rows had
perfectly good timing pairs.

This replaces that with the requested model: **run every benchmark, let
individual ones fail, and render only the rows that succeeded — where success is
SPEED, not tsc-compatibility: tsz keeps up with tsgo (tsgo is not >= 1.5x faster).**

### What changed
- **Artifact selection** (`loadBenchmarks`, `benchmark_mean_chart.js`,
  `.eleventy.js` passthrough that publishes `dist/benchmark-data/latest.json`)
  no longer requires app-compat cleanliness or a green-project minimum. It always
  takes the latest available data (`minimumProjectTimingPairs: 0`). Per-row
  rendering decides what shows.
- **`isChartEligible`** is now a pure speed predicate
  (`tsz_ms < tsgo_ms * 1.5`), replacing the `hasGreenProjectCompatibility` gate
  on perf-timed projects. A row charts iff both compilers produced a timing and
  tsgo is not >= 1.5x faster than tsz.
- **Too-slow timed rows stay visible.** Generalized the existing
  "don't silently vanish" safety (`isExcludedNonGreenCanary` →
  `isExcludedSlowTimedRow`): a row with a real timing pair that is >= 1.5x slower
  surfaces in the "Not charted" list with an honest
  `tsz N.Nx slower than tsgo` label instead of disappearing.
- Suppress the secondary "No successful project timing pairs" sub-placeholder
  when there are excluded rows to display.

No semantic/compiler logic touched — this is presentation-layer only. No
user-name/file-name literals; the predicate is a numeric ratio over measured
timings (no rendered-string matching).

## Goal
Goal: fast

This is the public dashboard that presents the `fast` goal (green rows vs tsgo).
It was showing an empty placeholder; this restores the perf comparison and makes
the 1.5x success bar explicit.

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

Rendered against the **current published GCS data** (`bench-runs/latest.json`),
both the deploy selection path and the passthrough path:
- **No placeholder.** 7 project bars render (RxJS, type-fest, utility-types,
  ts-essentials, Next.js full, Fresh Vite app, Fresh Next.js app) + 78 micro
  rows = 85 = exactly the within-1.5x count.
- **4 slow rows surface as "Not charted"** with honest labels: hotscript 34.8x,
  ts-pattern 2.8x, ts-toolbelt 2.4x, comlink 2.2x slower than tsgo.

Commands:
- `cd crates/tsz-website && npm run test:benchmarks` — updated smoke test green
  (asserts a tsgo 3.0x win is excluded from bars + listed as
  `tsz 3.0x slower than tsgo`, and a tsgo 100x win likewise).
- `node --check` on all four touched files.

Follow-up (not required for recovery): the `gh-pages.yml` deploy still forces the
GCS-latest fallback whenever app-compat readiness fails, so it never uses the
freshest GitHub merged artifact. The GCS fallback already renders correctly with
this change, so the site recovers without it; relaxing that readiness gate for
fresher data is a separate, lower-priority change.
