### PR TITLE
fix(solver): taint unresolved bare-Lazy eval so the registration window is not cached (#14347)

### DIFF
--- a/crates/tsz-checker/src/tests/unresolved_def_eval_cache_backstop_tests.rs
+++ b/crates/tsz-checker/src/tests/unresolved_def_eval_cache_backstop_tests.rs
@@ -75,6 +75,33 @@ fn unresolved_base_application_is_not_persisted_to_env_eval_cache() {
     });
 }
 
+/// A *bare* `Lazy(DefId)` (no `Application` wrapper) whose base has nothing
+/// registered is the same registration-window artifact, reached through the
+/// evaluator's canonical bare-`Lazy` path (`visit_lazy`) rather than the
+/// application path. The evaluator must mark `unresolved_def_seen` there too, so
+/// `evaluate_type_with_env` refuses to persist the opaque `input -> input`
+/// result in the `TypeId`-keyed `env_eval_cache`. Without the mark the
+/// under-resolved `Lazy` would be cached and shadow the real expansion once the
+/// def registers (the cross-arena member-degradation class, #14347 / #13484 /
+/// #10663). This guards every consumer that bottoms out at an unresolved bare
+/// `Lazy` through `evaluate` (template-literal spans, string-intrinsic
+/// arguments, mapped-type constraints, …).
+#[test]
+fn unresolved_bare_lazy_is_not_persisted_to_env_eval_cache() {
+    let types = TypeInterner::new();
+    let unregistered = types.lazy(DefId(987_655));
+
+    with_trivial_checker(&types, |checker| {
+        let _ = checker.evaluate_type_with_env(unregistered);
+        assert!(
+            checker.ctx.lookup_env_eval_cache(unregistered).is_none(),
+            "a bare Lazy(DefId) evaluated while its base def was unresolved is a \
+             registration-window artifact and must not be persisted in the TypeId-keyed \
+             env_eval_cache (issue #14347)",
+        );
+    });
+}
+
 /// Precision floor: a fully-resolvable type with no unresolved reference never
 /// trips `unresolved_def_seen`, so the backstop must leave its `env_eval_cache`
 /// write intact. This proves the suppression is keyed on the taint flag, not a

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -1548,6 +1548,29 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // Re-evaluate the resolved type in case it needs further evaluation
             self.evaluate(resolved)
         } else {
+            // The `Lazy(DefId)` has no resolvable body on this query: the def is
+            // mid-registration, or owned by a file whose checker has not yet
+            // published it (the cross-file / cross-arena registration window).
+            // The bare `Lazy` returned here is a *registration-window artifact*,
+            // not a stable function of `original_type_id`: once the declaring
+            // file registers the body, `evaluate` reduces the same `Lazy` to the
+            // concrete type. Mark the taint so this opaque result is kept out of
+            // the `TypeId`-keyed eval caches — the same discipline the other
+            // unresolved-def deferral sites already apply (`evaluate_application`,
+            // conditional reduction, `evaluate_keyof`, the indexed-access
+            // visitor). Without it the under-resolved `Lazy` is memoized as
+            // authoritative and permanently shadows the real type, the
+            // cross-arena member-degradation class tracked under #14347
+            // (witnessed by #13484 / #10663). This is the *canonical* bare-`Lazy`
+            // evaluation path: every consumer that bottoms out at an unresolved
+            // `Lazy` through `evaluate` (template-literal spans, string-intrinsic
+            // arguments, mapped-type constraints, …) inherits the taint here, so
+            // no per-consumer classification is required.
+            //
+            // `resolve_lazy` succeeding (including the self-recursive promise
+            // cycle break above) never reaches this arm, so a genuinely resolved
+            // — merely recursive — alias is not tainted.
+            self.mark_unresolved_def_seen();
             original_type_id
         }
     }


### PR DESCRIPTION
Goal: hold

Self-contained slice of #14347 ("caches memoize values that are not pure functions of their keys"). Extends the established unresolved-def taint discipline to the evaluator's **canonical bare-`Lazy(DefId)` path** — the one site `evaluate_application`, conditional reduction, `evaluate_keyof` (#14569), and the just-merged indexed-access fix (#14573) all *bypass*. No file overlap with those PRs.

## The bug class

`mark_unresolved_def_seen()` is the established mechanism for a result that depended on a `Lazy(DefId)` whose body is not yet registered (the cross-file / cross-arena registration window). Such a result is a function of *which* refs happened to be resolved when the pass ran, not of the input `TypeId`, so the eval-cache backstops gate cache writes on the flag. Persisting it lets the under-resolved answer permanently shadow the real type once the body registers — the member-degradation cascade in #13484 / #10663.

`evaluate_application` / conditional / `evaluate_keyof` / the indexed-access visitor each mark the taint at their *own* resolve sites, which never reach the evaluator's `visit_lazy`. But `visit_lazy` itself — the canonical path every bare `Lazy` evaluation funnels through, and the one that **template-literal spans, string-intrinsic arguments, and mapped-type constraints** all reach via `evaluate()` — returned the unresolved `original_type_id` on a `resolve_lazy` miss **without** marking the taint. A bare `Lazy` evaluated mid-registration was therefore memoized as `input -> input` and shadowed the real expansion.

## Structural rule

When `evaluate` reaches a `Lazy(DefId)` with no resolvable body on this query, `tsc` re-derives the type once the body resolves; tsz must not memoize the pending bare `Lazy` as authoritative. Owner: solver evaluation (`TypeEvaluator::visit_lazy`, `crates/tsz-solver/src/evaluation/evaluate/support.rs`), via the existing `unresolved_def_seen` taint the `env_eval_cache` backstops already honor.

## Why this is the broad fix (altitude)

Fixing the single chokepoint subsumes the per-consumer follow-ups #14573 named ("`evaluate_mapped` deferrals … template/string-intrinsic operands"): every consumer that bottoms out at an unresolved bare `Lazy` through `evaluate()` inherits the taint here, with **no per-site classification required**, because the mark fires only when an actual `Lazy(DefId)` body failed to resolve — never on a legitimate generic/type-parameter deferral (those don't flow through `visit_lazy`'s miss arm). `resolve_lazy` succeeding (including the self-recursive promise cycle break immediately above the arm) never reaches it, so a genuinely resolved — merely recursive — alias is not tainted.

## Why this is parity-safe

`mark_unresolved_def_seen()` only suppresses cache *writes* of a result that already depended on an unresolved def; it never changes a computed result within a run. In the conformance corpus (single-file, every def resolvable) the flag is not set during this op, so behavior is unchanged. When it *is* set (cross-arena window), suppressing the write can only prevent a wrong cached value from shadowing the correct one — strictly more correct. The env-eval backstop additionally requires no progress (`result == type_id`) before suppressing, so a partially-resolved root still caches.

## Anti-hardcoding

Pure structural decision over `resolve_lazy(def_id)` returning `None`; no identifier/file-name/printer-output predicates; reuses the existing `mark_unresolved_def_seen` helper and the `with_trivial_checker` harness.

## Adjacent-case matrix (tests)

`crates/tsz-checker/src/tests/unresolved_def_eval_cache_backstop_tests.rs`:
- a bare `Lazy(DefId)` over an unregistered def is **not** persisted in the `TypeId`-keyed `env_eval_cache` (poison guard);
- the pre-existing `Application`-over-unresolved and fully-resolvable cases, and #14573's indexed-access cases, still pass (precision floor — proves no over-suppression).

## Verification

- `cargo test -p tsz-checker --lib unresolved_def_eval_cache_backstop` → 5 passed (1 new).
- `cargo test -p tsz-solver --lib` targeted: `keyof` 264, `mapped` 407, `index_access` 144, `lazy` 80, `closed_eval` 8, `template` 411, `string_intrinsic` 54 — all green.
- `cargo test -p tsz-checker --lib lazy_lib_heritage_guard` → 15 passed; `cross_file_unresolved_alias` → 4 passed.
- `cargo test -p tsz-checker --lib cross_file` → identical failure set with and without this change (9 pre-existing failures, verified by stashing the diff and re-running on clean `main`); `tsz-solver --lib` shares the same pre-existing `test_conditional_infer_optional_property_present_distributive` TypeId-allocation-order flake noted in #14573.
- `cargo fmt` / `cargo clippy -p tsz-solver --lib` clean.
- Broad conformance / emit / fourslash floors: ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_013YPZLDox23bqzXjtihbvak

---
_Generated by [Claude Code](https://claude.ai/code/session_013YPZLDox23bqzXjtihbvak)_