### PR TITLE
refactor(checker): drop redundant DefinitionStore flow-env mirror (#14348)

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -768,23 +768,32 @@ impl CheckerContext<'_> {
         def_id
     }
 
-    /// Ensure **both** `TypeEnvironment` instances have a reference to the shared
-    /// `DefinitionStore`.
+    /// Ensure both `TypeEnvironment` instances end up with a reference to the
+    /// shared `DefinitionStore`, by writing it to the authoritative evaluator
+    /// env and letting reconcile propagate it to the flow-analyzer env.
     ///
-    /// Both `type_env` (primary evaluator) and `type_environment` (flow-analyzer)
-    /// need the `DefinitionStore` fallback so that `get_def_kind` can locate
-    /// entries that were not written directly due to `RefCell` borrow conflicts
-    /// during recursive resolution.
+    /// `type_env` (primary evaluator) needs the `DefinitionStore` fallback so
+    /// that `get_def_kind` can locate entries not written directly due to
+    /// `RefCell` borrow conflicts during recursive resolution; it is written
+    /// here (race-safe, via the same deferral discipline as every other
+    /// evaluator-env registration).
     ///
-    /// Wiring only `type_env` and leaving `type_environment` without the store
-    /// forces callers to clone one environment over the other just to propagate
-    /// the pointer — this helper eliminates that need.
+    /// The flow-analyzer env (`type_environment`) receives the *same* `Arc`
+    /// through `overlay_missing_from` at the file-prep reconcile boundary
+    /// (`reconcile_flow_and_evaluator_envs`), which runs before flow analysis
+    /// reads the env. The `DefinitionStore` is a single content-identical shared
+    /// pointer regardless of which env holds it, so eagerly *mirroring* it into
+    /// the flow env is pure redundancy with the reconcile vacancy-fill. Dropping
+    /// that mirror removes the `SetDefinitionStore` op from the flow-env mirror
+    /// set as the first provably zero-delta step of the dual-`TypeEnvironment`
+    /// collapse (#14348) — the eager mirror added work (and a possible deferred
+    /// replay) for a pointer reconcile already installs.
     ///
     /// `set_definition_store` is idempotent when the same `Arc` pointer is
     /// reinstalled (checked via `Arc::ptr_eq`), so calling this function
     /// multiple times across registration sites is safe.
     pub fn ensure_both_envs_have_definition_store(&self) {
-        self.register_in_envs(DeferredFlowEnvWrite::SetDefinitionStore(Arc::clone(
+        self.apply_to_eval_env(DeferredFlowEnvWrite::SetDefinitionStore(Arc::clone(
             &self.definition_store,
         )));
     }

--- a/crates/tsz-checker/src/context/def_mapping_tests.rs
+++ b/crates/tsz-checker/src/context/def_mapping_tests.rs
@@ -25,10 +25,12 @@ fn minimal_checker_ctx() -> (
     )
 }
 
-/// Pins the dual-env wiring invariant introduced in #8269:
-/// `ensure_both_envs_have_definition_store` must give `type_environment`
-/// (the flow-analyzer snapshot) the `DefinitionStore` fallback, so that
-/// `get_def_kind` works there without relying on the clone-over in
+/// Pins the dual-env store-wiring invariant as updated for #14348: the shared
+/// `DefinitionStore` reaches the authoritative evaluator env (`type_env`)
+/// EAGERLY, and the flow-analyzer env (`type_environment`) receives the same
+/// `Arc` through the reconcile-boundary `overlay_missing_from` (not an eager
+/// mirror). `get_def_kind` must work in both — `type_env` immediately, and
+/// `type_environment` after reconcile — without relying on the clone-over in
 /// `source_file.rs`.
 #[test]
 fn ensure_both_envs_wires_store_into_type_environment() {
@@ -62,14 +64,38 @@ fn ensure_both_envs_wires_store_into_type_environment() {
         "type_environment must not find a store-only DefKind before wiring"
     );
 
-    // Wire both environments.
+    // Wire the store into the authoritative evaluator env.
     ctx.ensure_both_envs_have_definition_store();
 
-    // Now type_environment reaches the kind via the store fallback.
+    // The evaluator env reaches the kind via the store fallback immediately.
+    assert_eq!(
+        ctx.type_env.borrow().get_def_kind(def_id),
+        Some(DefKind::TypeAlias),
+        "type_env (authoritative) must find store-only DefKind eagerly"
+    );
+
+    // The flow-analyzer env is no longer eagerly mirrored (#14348): it still
+    // lacks the store until the reconcile-boundary overlay runs.
+    assert_eq!(
+        ctx.type_environment.borrow().get_def_kind(def_id),
+        None,
+        "type_environment is no longer eagerly mirrored; the store arrives via reconcile overlay"
+    );
+
+    // Drive the reconcile overlay exactly as `reconcile_flow_and_evaluator_envs`
+    // does (overlay the evaluator env into the flow env).
+    {
+        let eval_snapshot = ctx.type_env.borrow();
+        ctx.type_environment
+            .borrow_mut()
+            .overlay_missing_from(&eval_snapshot);
+    }
+
+    // Now type_environment reaches the kind via the same shared-Arc fallback.
     assert_eq!(
         ctx.type_environment.borrow().get_def_kind(def_id),
         Some(DefKind::TypeAlias),
-        "type_environment must find store-only DefKind via fallback after ensure_both_envs_have_definition_store"
+        "type_environment must find store-only DefKind via reconcile overlay after ensure_both_envs_have_definition_store"
     );
 }
 


### PR DESCRIPTION
Goal: hold

Advances #14348 (and the #14351 root-cause umbrella). First **provably zero-delta** step of the dual-`TypeEnvironment` collapse.

## Summary
`CheckerContext` keeps two `RefCell<TypeEnvironment>` — `type_env` (authoritative evaluator env, #13086) and `type_environment` (flow-analyzer env) — kept in sync by `register_*_in_envs` dual-writes + deferred-replay + `overlay_missing_from` reconciliation. `ensure_both_envs_have_definition_store` eagerly mirrored the shared `DefinitionStore` `Arc` into **both** envs.

But the `DefinitionStore` is a single, content-identical shared `Arc` no matter which env holds it, and `overlay_missing_from` already vacancy-fills it into the flow env at the `reconcile_flow_and_evaluator_envs` boundary — which runs **before** flow analysis reads the env. So the eager flow-env mirror was pure redundancy (extra work, plus a possible deferred replay on a borrow race) for a pointer that reconcile installs anyway.

This PR writes the store only into the authoritative evaluator env (race-safe, same deferral discipline as every other evaluator-env registration) and lets reconcile propagate the identical `Arc` to the flow env — removing the `SetDefinitionStore` op from the flow-env mirror set (one of eight dual-write ops).

## Structural rule
A dual-env registration whose payload is a **content-identical shared pointer already vacancy-filled by reconcile** does not need an eager flow-env mirror; write it to the authoritative env and let reconcile propagate. The load-bearing mirrors that carry env-specific or latest-authoritative content (per-DefId bodies, class instances, class-extends, the deferred replay + `overlay_missing_from` + `set_local_def_type` convergence backstop) are deliberately **untouched** — each repairs a distinct gap (verified by a read-only multi-agent study of the write/read/race surface).

## Owner layer
Checker context (`crates/tsz-checker/src/context/def_mapping.rs`). No solver change; reconcile/overlay semantics unchanged. The `SetDefinitionStore` enum variant is retained — it is still constructed for the eval-env write's own borrow-race deferral.

## Scope note (honest)
This is **step 1**, not the full collapse. A deep study established the full collapse is NOT safely zero-delta in one change: making `type_environment` a frozen snapshot misses types materialized by the on-demand `get_type_of_symbol` epilogue during checking, and pointing flow at `type_env` directly shifts the borrow topology into the independent `deferred_eval_env_writes` re-entrancy problem. So #14348 remains a multi-PR campaign; this lands the one piece that is both a net reduction and provably behavior-preserving.

## Verification (zero diagnostic delta)
- Conformance (CI-matching harness): `moduleAugmentation` 46/46, `globalAugment` 1/1, `declarationMerging` 28/28, `interfacesExtendingClasses` 9/9 — all 100%, 0 known failures.
- `cargo nextest run -p tsz-checker --lib def_mapping` → 10/10, incl. the borrow-race deferral/replay + reconcile guards (`flow_env_mirror_is_deferred_under_borrow_then_replayed`, `resolved_def_mirror_is_deferred_under_borrow_then_envs_reconcile`, `both_envs_defer_then_replay_under_simultaneous_borrow`) and the updated `ensure_both_envs_wires_store_into_type_environment` (now asserts eager into `type_env` + arrival in `type_environment` via reconcile overlay).
- `cargo nextest run -p tsz-cli --test parallel_sequential_agreement_tests` → 6/6 (forced-parallel == sequential byte-identity; DOM heritage, disposable delegation, lib-iterator heritage, scope-registry alias republication — the schedule-race missed-write guard).
- `scripts/arch/check-checker-boundaries.sh` passed; `cargo clippy -p tsz-checker --tests` clean; `def_mapping.rs` 1958 lines (< 2000).
- Note: 3 multi-file unit tests in `module_augmentation_declaration_identity_tests` fail in local single-process nextest both BEFORE and AFTER this change (revert-test confirmed pre-existing; the conformance harness shows the same augmentation surface 100% green) — an arena-order-sensitive local-harness artifact, not a delta from this PR.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

— M1FableArchitect
