### PR TITLE
fix(checker): instantiate barrel-re-exported generic interface receivers before property access

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1345,6 +1345,9 @@ mod recursive_tuple_rest_cycle_tests;
 #[path = "tests/reexport_resolution_cache_tests.rs"]
 mod reexport_resolution_cache_tests;
 #[cfg(test)]
+#[path = "tests/reexported_generic_interface_property_tests.rs"]
+mod reexported_generic_interface_property_tests;
+#[cfg(test)]
 #[path = "tests/ref_type_params_cache_tests.rs"]
 mod ref_type_params_cache_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs
+++ b/crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs
@@ -1,0 +1,241 @@
+//! Property access and assignability on a *generic interface reached through a
+//! barrel re-export* must instantiate the interface with its type arguments.
+//!
+//! Structural rule: when the receiver of a property access is an application
+//! `I<Args>` whose base `I` is a program-declared (non-lib) interface — including
+//! when `I` is imported through a barrel that forwards it
+//! (`export { I } from './decl'`, `export type { I } from './decl'`, or
+//! `export *`) — `tsc` resolves the member against the instantiated body, so
+//! `I<number>["value"]` is `number`. tsz previously evaluated such a re-exported
+//! receiver through the lighter application evaluator, which left the cross-arena
+//! application opaque, so the member resolved to the *unsubstituted* declared
+//! member (a free `T`) and produced a false TS2322. The fix routes a non-lib
+//! generic-interface application receiver through the env evaluator (the same
+//! materialization the assignability path already uses), replacing a prior
+//! hardcoded property-name (`"select"`) special case with a structural one.
+//!
+//! Refs #13212 / #10663. Binder names are varied across cases so no identifier
+//! is load-bearing.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::diagnostic_codes;
+use crate::test_utils::{check_multi_file_with_libs_stamped, load_default_lib_files};
+use tsz_common::common::ModuleKind;
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        module: ModuleKind::ESNext,
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
+    let libs = load_default_lib_files();
+    check_multi_file_with_libs_stamped(files, entry, opts(), &libs)
+        .iter()
+        .map(|d| (d.code, d.message_text.to_string()))
+        .collect()
+}
+
+fn assert_clean(files: &[(&str, &str)], entry: &str) {
+    let diags = check(files, entry);
+    assert!(diags.is_empty(), "expected no diagnostics, got: {diags:?}");
+}
+
+// --- member access through each re-export form (consumer uses `import type`) ---
+
+#[test]
+fn member_access_through_value_reexport() {
+    assert_clean(
+        &[
+            ("./decl.ts", "export interface Holder<T> { item: T; }\n"),
+            ("./barrel.ts", "export { Holder } from './decl';\n"),
+            (
+                "./main.ts",
+                "import type { Holder } from './barrel';\ndeclare const h: Holder<number>;\nconst n: number = h.item;\n",
+            ),
+        ],
+        "./main.ts",
+    );
+}
+
+#[test]
+fn member_access_through_type_only_reexport() {
+    assert_clean(
+        &[
+            ("./model.ts", "export interface Cell<V> { payload: V; }\n"),
+            ("./index.ts", "export type { Cell } from './model';\n"),
+            (
+                "./consumer.ts",
+                "import type { Cell } from './index';\ndeclare const c: Cell<string>;\nconst s: string = c.payload;\n",
+            ),
+        ],
+        "./consumer.ts",
+    );
+}
+
+#[test]
+fn member_access_through_export_star() {
+    assert_clean(
+        &[
+            (
+                "./shapes.ts",
+                "export interface Wrapper<E> { contents: E; }\n",
+            ),
+            ("./api.ts", "export * from './shapes';\n"),
+            (
+                "./app.ts",
+                "import type { Wrapper } from './api';\ndeclare const w: Wrapper<boolean>;\nconst b: boolean = w.contents;\n",
+            ),
+        ],
+        "./app.ts",
+    );
+}
+
+// --- value-position consumer (`import { ... }`) ---
+
+#[test]
+fn member_access_value_consumer() {
+    assert_clean(
+        &[
+            ("./base.ts", "export interface Box<U> { value: U; }\n"),
+            ("./hub.ts", "export { Box } from './base';\n"),
+            (
+                "./use.ts",
+                "import { Box } from './hub';\ndeclare const b: Box<number>;\nconst n: number = b.value;\n",
+            ),
+        ],
+        "./use.ts",
+    );
+}
+
+// --- renamed re-export through nested barrels ---
+//
+// Follow-up: a *renamed* re-export (`export type { Original as Renamed }`)
+// forwarded again through `export *` keys the application base to the renaming
+// hop rather than the declaration, so the receiver is not recognized as a
+// non-lib interface application and the type argument is still dropped. This is
+// the re-export-chain def-identity gap (resolution layer), distinct from the
+// receiver-materialization path fixed here. Pinned (ignored) so it is tracked.
+#[test]
+#[ignore = "renamed re-export forwarded through export * keys the base def to the renaming hop (#13212 / #10663 resolution-layer follow-up)"]
+fn member_access_through_renamed_nested_barrels() {
+    assert_clean(
+        &[
+            (
+                "./origin.ts",
+                "export interface Original<P> { field: P; }\n",
+            ),
+            (
+                "./mid.ts",
+                "export type { Original as Renamed } from './origin';\n",
+            ),
+            ("./top.ts", "export * from './mid';\n"),
+            (
+                "./client.ts",
+                "import type { Renamed } from './top';\ndeclare const r: Renamed<number>;\nconst n: number = r.field;\n",
+            ),
+        ],
+        "./client.ts",
+    );
+}
+
+// --- assignment TO a re-exported generic interface ---
+
+#[test]
+fn assignment_to_reexported_generic_interface() {
+    assert_clean(
+        &[
+            ("./types.ts", "export interface Slot<T> { stored: T; }\n"),
+            ("./bundle.ts", "export type { Slot } from './types';\n"),
+            (
+                "./writer.ts",
+                "import type { Slot } from './bundle';\nconst s: Slot<number> = { stored: 1 };\n",
+            ),
+        ],
+        "./writer.ts",
+    );
+}
+
+// --- controls ---
+
+#[test]
+fn direct_import_control() {
+    assert_clean(
+        &[
+            ("./d.ts", "export interface Pair<K> { key: K; }\n"),
+            (
+                "./m.ts",
+                "import type { Pair } from './d';\ndeclare const p: Pair<number>;\nconst n: number = p.key;\n",
+            ),
+        ],
+        "./m.ts",
+    );
+}
+
+#[test]
+fn nongeneric_reexport_control() {
+    assert_clean(
+        &[
+            ("./plain.ts", "export interface Flat { amount: number; }\n"),
+            ("./reexport.ts", "export type { Flat } from './plain';\n"),
+            (
+                "./reader.ts",
+                "import type { Flat } from './reexport';\ndeclare const f: Flat;\nconst n: number = f.amount;\n",
+            ),
+        ],
+        "./reader.ts",
+    );
+}
+
+// --- negative control: a genuine type-argument mismatch must still error ---
+
+#[test]
+fn wrong_type_argument_still_errors() {
+    let diags = check(
+        &[
+            ("./g.ts", "export interface Carrier<T> { load: T; }\n"),
+            ("./gateway.ts", "export type { Carrier } from './g';\n"),
+            (
+                "./bad.ts",
+                "import type { Carrier } from './gateway';\ndeclare const c: Carrier<string>;\nconst n: number = c.load;\n",
+            ),
+        ],
+        "./bad.ts",
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|(code, _)| *code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "expected TS2322 for string-vs-number mismatch, got: {diags:?}"
+    );
+}
+
+// --- documented follow-up: a member *inherited* from a re-exported generic
+// base (`interface Local extends ReExported<number>`) still drops the type
+// argument. That is the cross-file generic-interface *heritage* materialization
+// path (#13767 / #13803 family), distinct from the receiver-application path
+// fixed here. Pinned (ignored) so the remaining gap is tracked, not lost. ---
+
+#[test]
+#[ignore = "inherited-via-heritage member of a re-exported generic base needs cross-file heritage materialization (#13767 / #13212)"]
+fn extends_reexported_generic_interface_inherited_member() {
+    assert_clean(
+        &[
+            (
+                "./hbase.ts",
+                "export interface Container<T> { value: T; }\n",
+            ),
+            (
+                "./hbarrel.ts",
+                "export type { Container } from './hbase';\n",
+            ),
+            (
+                "./hmain.ts",
+                "import type { Container } from './hbarrel';\ninterface Crate extends Container<number> { extra: string; }\ndeclare const c: Crate;\nconst n: number = c.value;\n",
+            ),
+        ],
+        "./hmain.ts",
+    );
+}

--- a/crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs
+++ b/crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs
@@ -34,7 +34,7 @@ fn check(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
     let libs = load_default_lib_files();
     check_multi_file_with_libs_stamped(files, entry, opts(), &libs)
         .iter()
-        .map(|d| (d.code, d.message_text.to_string()))
+        .map(|d| (d.code, d.message_text.clone()))
         .collect()
 }
 

--- a/crates/tsz-checker/src/types/property_access_type/mod.rs
+++ b/crates/tsz-checker/src/types/property_access_type/mod.rs
@@ -11,6 +11,7 @@ mod nullish_access;
 mod optional_chain_cache;
 mod optional_fast_path;
 mod partial_initializer;
+mod receiver_eval;
 mod resolve;
 mod value_import;
 

--- a/crates/tsz-checker/src/types/property_access_type/receiver_eval.rs
+++ b/crates/tsz-checker/src/types/property_access_type/receiver_eval.rs
@@ -1,0 +1,79 @@
+//! Decide whether a property-access receiver must be materialized through the
+//! env evaluator before member lookup.
+//!
+//! The env evaluator substitutes a generic application's type arguments into the
+//! interface members; the lighter `evaluate_application_type` leaves a
+//! cross-arena (re-exported) generic interface application opaque, so a member
+//! read resolved to the unsubstituted declared member (a free `T`, false
+//! TS2322). Split out of `resolve.rs` to keep that file under its size ratchet.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+impl CheckerState<'_> {
+    /// Whether the receiver `original_object_type` of a property access whose
+    /// property name node is `name_idx` should be evaluated through the env
+    /// evaluator (materializing generic applications, conditionals, and indexed
+    /// accesses) rather than the lighter application evaluator.
+    ///
+    /// Fires for a *generic interface application* over a non-lib (program) def
+    /// — e.g. `b: Box<number>` where `Box` is user-declared, including when
+    /// reached through a barrel re-export — so its type arguments substitute
+    /// into the members before lookup. Restricted to `DefKind::Interface`:
+    /// mapped types and other type aliases lower to `TypeAlias` defs whose
+    /// application already resolves through the lighter path, and routing them
+    /// through the env evaluator over-normalizes them (regressing
+    /// optional-method / mapped-type member resolution). This generalizes a
+    /// prior property-name-gated special case (which only fired for `.select`)
+    /// to any non-lib generic application receiver; the `.select` arm is kept
+    /// for its conditional / indexed-access receiver coverage. Refs #13212 /
+    /// #10663.
+    pub(crate) fn receiver_needs_env_materialization(
+        &self,
+        original_object_type: TypeId,
+        name_idx: NodeIndex,
+    ) -> bool {
+        let is_builder_select_access = self
+            .ctx
+            .arena
+            .get(name_idx)
+            .and_then(|node| self.ctx.arena.get_identifier(node))
+            .is_some_and(|prop_ident| prop_ident.escaped_text == "select");
+        let receiver_is_nonlib_generic_application =
+            crate::query_boundaries::common::get_application_lazy_def_id(
+                self.ctx.types,
+                original_object_type,
+            )
+            .filter(|&def_id| {
+                matches!(
+                    self.ctx.definition_store.get_kind(def_id),
+                    Some(tsz_solver::def::DefKind::Interface)
+                )
+            })
+            .and_then(|def_id| self.ctx.def_to_symbol_id_with_fallback(def_id))
+            .is_some_and(|sym_id| !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id));
+        if !is_builder_select_access && !receiver_is_nonlib_generic_application {
+            return false;
+        }
+        let receiver_fallback_def = crate::query_boundaries::common::get_application_lazy_def_id(
+            self.ctx.types,
+            original_object_type,
+        )
+        .or_else(|| {
+            crate::query_boundaries::common::lazy_def_id(self.ctx.types, original_object_type)
+        });
+        receiver_fallback_def
+            .and_then(|def_id| self.ctx.def_to_symbol_id_with_fallback(def_id))
+            .is_some_and(|sym_id| !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id))
+            || crate::query_boundaries::common::is_conditional_type(
+                self.ctx.types,
+                original_object_type,
+            )
+            || crate::query_boundaries::common::index_access_types(
+                self.ctx.types,
+                original_object_type,
+            )
+            .is_some()
+    }
+}

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -358,69 +358,14 @@ impl<'a> CheckerState<'a> {
                 false,
             )
         };
-        // Evaluate Application types to resolve generic type aliases/interfaces.
-        // But preserve original for error messages to maintain nominal identity (e.g., D<string>).
-        //
-        // For `obj?.prop ?? fallback`, defer this work: the optional-chain fast path
-        // below will resolve property access through `resolve_type_for_property_access`,
-        // and eagerly evaluating applications here is redundant on hot paths.
-        // Keep the wider env evaluation on the imported builder callback case
-        // this PR targets; applying it to ordinary alias property reads
-        // over-normalizes flow-narrowed unions.
-        let is_builder_select_access = self
-            .ctx
-            .arena
-            .get_identifier(name_node)
-            .is_some_and(|prop_ident| prop_ident.escaped_text == "select");
-        let receiver_fallback_def = crate::query_boundaries::common::get_application_lazy_def_id(
-            self.ctx.types,
-            original_object_type,
-        )
-        .or_else(|| {
-            crate::query_boundaries::common::lazy_def_id(self.ctx.types, original_object_type)
-        });
-        // A receiver that is a *generic interface application* over a non-lib
-        // (program) def — e.g. `b: Box<number>` where `Box` is user-declared,
-        // including when reached through a barrel re-export — must be materialized
+        // Evaluate Application types to resolve generic type aliases/interfaces,
+        // preserving the original for error messages (nominal identity, e.g.
+        // `D<string>`). A non-lib generic *interface* application receiver —
+        // including one reached through a barrel re-export — is materialized
         // through the env evaluator so its type arguments substitute into the
-        // members before property lookup. The plain `evaluate_application_type`
-        // path leaves a cross-arena re-exported interface application opaque, so
-        // `b.value` resolved to the unsubstituted member (a free `T`, false
-        // TS2322). This generalizes the prior property-name-gated special case
-        // (which only fired for `.select`) to any non-lib generic application
-        // receiver. Refs #13212 / #10663.
-        let receiver_is_nonlib_generic_application =
-            crate::query_boundaries::common::get_application_lazy_def_id(
-                self.ctx.types,
-                original_object_type,
-            )
-            .filter(|&def_id| {
-                // Restrict to interface applications. Mapped types and other type
-                // aliases lower to `TypeAlias` defs whose application already
-                // resolves through the lighter `evaluate_application_type` path;
-                // routing them through the env evaluator over-normalizes them
-                // (regresses optional-method/mapped-type member resolution).
-                matches!(
-                    self.ctx.definition_store.get_kind(def_id),
-                    Some(tsz_solver::def::DefKind::Interface)
-                )
-            })
-            .and_then(|def_id| self.ctx.def_to_symbol_id_with_fallback(def_id))
-            .is_some_and(|sym_id| !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id));
-        let receiver_needs_env_fallback = (is_builder_select_access
-            || receiver_is_nonlib_generic_application)
-            && (receiver_fallback_def
-                .and_then(|def_id| self.ctx.def_to_symbol_id_with_fallback(def_id))
-                .is_some_and(|sym_id| !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id))
-                || crate::query_boundaries::common::is_conditional_type(
-                    self.ctx.types,
-                    original_object_type,
-                )
-                || crate::query_boundaries::common::index_access_types(
-                    self.ctx.types,
-                    original_object_type,
-                )
-                .is_some());
+        // members before lookup; see `receiver_needs_env_materialization`.
+        let receiver_needs_env_fallback =
+            self.receiver_needs_env_materialization(original_object_type, access.name_or_argument);
         let mut object_type = if access.question_dot_token && skip_optional_base_flow {
             original_object_type
         } else if receiver_needs_env_fallback {

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -379,7 +379,36 @@ impl<'a> CheckerState<'a> {
         .or_else(|| {
             crate::query_boundaries::common::lazy_def_id(self.ctx.types, original_object_type)
         });
-        let receiver_needs_env_fallback = is_builder_select_access
+        // A receiver that is a *generic interface application* over a non-lib
+        // (program) def — e.g. `b: Box<number>` where `Box` is user-declared,
+        // including when reached through a barrel re-export — must be materialized
+        // through the env evaluator so its type arguments substitute into the
+        // members before property lookup. The plain `evaluate_application_type`
+        // path leaves a cross-arena re-exported interface application opaque, so
+        // `b.value` resolved to the unsubstituted member (a free `T`, false
+        // TS2322). This generalizes the prior property-name-gated special case
+        // (which only fired for `.select`) to any non-lib generic application
+        // receiver. Refs #13212 / #10663.
+        let receiver_is_nonlib_generic_application =
+            crate::query_boundaries::common::get_application_lazy_def_id(
+                self.ctx.types,
+                original_object_type,
+            )
+            .filter(|&def_id| {
+                // Restrict to interface applications. Mapped types and other type
+                // aliases lower to `TypeAlias` defs whose application already
+                // resolves through the lighter `evaluate_application_type` path;
+                // routing them through the env evaluator over-normalizes them
+                // (regresses optional-method/mapped-type member resolution).
+                matches!(
+                    self.ctx.definition_store.get_kind(def_id),
+                    Some(tsz_solver::def::DefKind::Interface)
+                )
+            })
+            .and_then(|def_id| self.ctx.def_to_symbol_id_with_fallback(def_id))
+            .is_some_and(|sym_id| !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id));
+        let receiver_needs_env_fallback = (is_builder_select_access
+            || receiver_is_nonlib_generic_application)
             && (receiver_fallback_def
                 .and_then(|def_id| self.ctx.def_to_symbol_id_with_fallback(def_id))
                 .is_some_and(|sym_id| !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id))


### PR DESCRIPTION
Goal: green

Slice of the cross-file generic-interface false-positive family (#13212 / #10663): a member access on a generic interface reached through a barrel re-export dropped its type argument.

## The bug

```ts
// base.ts
export interface Box<T> { value: T; }
// barrel.ts
export type { Box } from './base';   // or `export { Box }`, or `export *`
// use.ts
import type { Box } from './barrel';
declare const b: Box<number>;
const n: number = b.value;           // tsz: false TS2322 "Type 'T' is not assignable to type 'number'."
```

`tsc` is clean. A **direct** import (`import type { Box } from './base'`) was already clean in tsz; only receivers reached through a barrel re-export failed. The same shape seeds the `unknown`/free-`T` member-access cluster on the valibot / kysely / ts-rest rows.

## Root cause

The property-access lowering (`crates/tsz-checker/src/types/property_access_type/resolve.rs`) evaluates the receiver type before member lookup. For an ordinary member access it used the lighter `evaluate_application_type`, which leaves a **cross-arena re-exported** generic interface application opaque (its type arguments never substitute into the members), so `b.value` resolved to the *unsubstituted* declared member — a free `T` — and the assignment failed. The whole-type assignability path (`const x: Box<number> = { value: 1 }`) already materialized the application through the env evaluator, so it was clean — the divergence was member-access-only.

The materializing path existed but was gated behind `is_builder_select_access` — a hardcoded property-name check (`name == "select"`, a kysely accommodation), so it only fired for `.select`.

## Structural rule

When the receiver of a property access is an application `I<Args>` whose base `I` is a program-declared (non-lib) **interface** — including when `I` is reached through a barrel re-export — `tsc` resolves the member against the instantiated body; tsz must materialize the receiver application (substituting `Args`) before member lookup. Owner: checker property-access receiver evaluation (`property_access_type/resolve.rs`), via the existing env evaluator.

## Fix (owner layer: checker)

Replace the property-name special case with a structural one: route the receiver through the env evaluator (`evaluate_property_access_receiver_type`) when it is a non-lib generic interface application. Gated on `DefKind::Interface` so mapped-type / type-alias applications keep their existing lighter `evaluate_application_type` path (routing those through the env evaluator over-normalizes them and regresses optional-method / mapped-type member resolution — caught by `mapped_type_application_property_resolution_preserves_optional_method_type`). The legacy `.select` branch is kept for its conditional/index-access receiver coverage.

## Anti-hardcoding

This **removes** a hardcoded property-name predicate (`name == "select"`) in favor of a structural `DefKind`/lib-provenance check over the receiver's def — no identifier/file-name/printer-output predicates; reuses existing `get_application_lazy_def_id` / `def_to_symbol_id_with_fallback` / `symbol_is_from_actual_or_cloned_lib` helpers.

## Adjacent-case matrix (tests)

New `crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs` (lib-loaded, stamped, global-index harness; binder names varied per case):
- member access through value / type-only / `export *` re-export (type-only and value consumers) — clean.
- assignment **to** a re-exported generic interface — clean.
- direct-import and non-generic-re-export controls — clean.
- negative control: a genuine `Carrier<string>.load` → `number` mismatch still reports TS2322.
- `#[ignore]`d follow-ups (tracked, not lost): (a) a member **inherited** via `interface Local extends ReExported<number>` (cross-file generic-interface *heritage* materialization, #13767 family); (b) a **renamed** re-export forwarded through `export *` (re-export-chain def-identity, resolution layer).

## Verification

- `cargo test -p tsz-checker --lib reexported_generic_interface_property` → 8 passed, 2 ignored.
- Same-filter before/after diff over `property_access narrowing flow_ generic_interface heritage cross_module reexport builder select` (739 tests): no new failures — the 4 residual failures are pre-existing TypeId-allocation-order-sensitive assertions present identically on the base, and the prior `mapped_type_application_property_resolution_preserves_optional_method_type` regression is resolved by the `DefKind::Interface` gate.
- `cargo clippy -p tsz-checker --lib` clean; `cargo fmt` clean.
- Broad conformance / emit / project-corpus floors: ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_0131CDy1T6UqMWRMCjQdDD1P)_