### PR TITLE
fix(bench-site): size chart bars correctly + drop "Not measured" rows

### DIFF
--- a/crates/tsz-website/scripts/benchmark-data-smoke.mjs
+++ b/crates/tsz-website/scripts/benchmark-data-smoke.mjs
@@ -521,6 +521,9 @@ try {
   assert.match(compatibilityDashboard, /type-challenges solutions[\s\S]*compat-state green/);
   assert.match(compatibilityDashboard, /umami[\s\S]*compat-state green[\s\S]*204 files[\s\S]*200 MiB peak/);
   assert.doesNotMatch(compatibilityDashboard, /type-challenges assertions/);
+  // Unmeasured (gray) rows are excluded entirely; the dashboard never renders "Not measured".
+  assert.doesNotMatch(compatibilityDashboard, /Not measured/);
+  assert.doesNotMatch(compatibilityDashboard, /compat-state gray/);
 
   process.env.TSZ_WEBSITE_BENCHMARK_ARTIFACT = failedOnlyArtifact;
   const failedOnlyCharts = getBenchmarkCharts();
@@ -541,7 +544,10 @@ try {
   assert.match(failedOnlyCompatibility, /data-compat-sort="files"/);
   assert.match(failedOnlyCompatibility, /data-compat-sort="peak"/);
   assert.match(failedOnlyCompatibility, /RxJS[\s\S]*compat-state yellow[\s\S]*diagnostic mismatch[\s\S]*12 files[\s\S]*100 MiB peak/);
-  assert.match(failedOnlyCompatibility, /large-ts-repo[\s\S]*compat-state gray[\s\S]*oracle unavailable[\s\S]*6,061 files/);
+  // Gray "oracle unavailable" / unmeasured rows (e.g. large-ts-repo) are excluded.
+  assert.doesNotMatch(failedOnlyCompatibility, /large-ts-repo/);
+  assert.doesNotMatch(failedOnlyCompatibility, /Not measured/);
+  assert.doesNotMatch(failedOnlyCompatibility, /compat-state gray/);
   assert.match(failedOnlyCompatibility, /utility-types[\s\S]*compat-state red[\s\S]*exit success[\s\S]*10 files[\s\S]*—/);
 
   const slugs = new Map();

--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -152,8 +152,13 @@ function durationLabelFitsBar(label, widthPx) {
   return width >= approximateTextWidth + horizontalPadding;
 }
 
+// A real bar never renders below this width, so a large row in the same chart
+// cannot crush a smaller (but genuine) row to an invisible sub-pixel sliver.
+// A zero value (no timing) stays zero -- no bar is drawn.
+const MIN_VISIBLE_BAR_PX = 3;
 function renderBenchmarkBar(kind, widthPx, label) {
-  const width = Number.isFinite(Number(widthPx)) ? Math.max(0, Number(widthPx)) : 0;
+  const raw = Number.isFinite(Number(widthPx)) ? Math.max(0, Number(widthPx)) : 0;
+  const width = raw > 0 ? Math.max(MIN_VISIBLE_BAR_PX, raw) : 0;
   const placementClass = durationLabelFitsBar(label, width) ? "" : " value-outside";
   return `<div class="bench-bar ${kind}${placementClass}" style="width: ${width.toFixed(2)}px">
           <span class="bench-bar-value">${label}</span>
@@ -1626,12 +1631,15 @@ function generateCharts(data, mode = "projects") {
       return categoryTitle(a).localeCompare(categoryTitle(b));
     });
   const visibleFailedResults = failedResults.filter((row) => failedBelongsToMode(row, mode));
+  // Scale bars only against rows that actually render bars. Failed/excluded rows
+  // (too slow, incomplete) are listed as text below, so their timings must NOT
+  // inflate the bar scale -- otherwise one off-chart slow row (e.g. a 7s outlier)
+  // shrinks every on-chart bar to an unreadable sliver.
   const chartMaxMs = Math.max(
     1,
     ...visibleCategories
       .flatMap((category) => entriesForCategory(category))
       .flatMap((row) => [Number(row.tsz_ms) || 0, Number(row.tsgo_ms) || 0]),
-    ...visibleFailedResults.flatMap((row) => [Number(row.tsz_ms) || 0, Number(row.tsgo_ms) || 0]),
   );
 
   let html = "";
@@ -1752,7 +1760,19 @@ export function getBenchmarkEnvironmentSummary() {
 export function getProjectCompatibilityDashboard() {
   const data = loadBenchmarks();
   const allResults = withExpectedProjectRows(data?.results);
-  const rows = COMPATIBILITY_CORPUS_ROWS.map((definition) => compatibilityRowFor(definition, allResults, data));
+  // Only show rows we actually measured. A "gray" / "Not measured" row (no
+  // compatibility artifact, oracle unavailable, or fixture not recorded) carries
+  // no signal, so it is excluded rather than rendered as "Not measured".
+  const rows = COMPATIBILITY_CORPUS_ROWS
+    .map((definition) => compatibilityRowFor(definition, allResults, data))
+    .filter((row) => row.className !== "gray");
+
+  if (!rows.length) {
+    return `<section class="compat-dashboard">
+  <h2>Project compatibility</h2>
+  <p class="compat-dashboard-intro">No measured project compatibility rows are available in this build yet.</p>
+</section>`;
+  }
 
   const numericSortValue = (value) => {
     const number = finiteNumber(value);


### PR DESCRIPTION
## Summary

Two visible defects in the benchmark dashboard, both follow-ups to the 1.5x
render model (#14574):

### 1. Charts were tiny
After #14574 routed slow rows into the "Not charted" list, those rows still
contributed their timings to `chartMaxMs` (the bar-scale max) even though they
no longer draw bars. A single off-chart outlier — `hotscript-project` at
**7252ms** — made every real bar scale against ~7s, collapsing e.g. RxJS's
163ms bar to a ~9px sliver.

- Scale bars only against rows that actually draw bars (drop the failed/excluded
  contribution to `chartMaxMs`).
- Floor every real bar to a **3px visible minimum** in `renderBenchmarkBar`
  (matching the guard `benchmark_mean_chart.js` already has) so a large row can
  never crush a smaller *real* row to an invisible sub-pixel sliver.

### 2. Dashboard showed ~35 "Not measured" rows
The project-compatibility dashboard rendered one row per corpus project, so
projects with no compatibility artifact / oracle unavailable / fixture not
recorded showed up as gray **"Not measured"** rows.

- Exclude gray/unmeasured rows; render only measured rows (green/yellow/red).
- Added an empty-state note for the all-unmeasured case instead of dangling
  table headers over an empty `<tbody>`.

Presentation-layer only; no compiler logic touched. The render predicates are
numeric (bar-width px, measured compat state) — no user-name/file-name literals,
no rendered-string matching.

## Goal
Goal: fast

The public dashboard that presents the `fast` goal (tsz vs tsgo). The charts
were unreadable slivers and the compatibility table was mostly "Not measured"
noise; this makes both legible.

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

Rendered + full-site-built against current published GCS data
(`bench-runs/latest.json`, generated 2026-06-23):
- **Project chart bars span 43–420px** (RxJS tsgo now 150px, was ~9px); no
  sub-10px slivers. Built `dist/benchmarks/index.html` confirms.
- **Compatibility dashboard: 25 measured rows** (13 green / 9 yellow / 3 red),
  **zero "Not measured"**. Built `dist/compatibility/index.html` confirms.
- Whole-site grep across 169 built files: zero "not measured" / "compat-state
  gray" / "oracle unavailable" on any benchmark/compat row. (The one remaining
  "Not measured" site-wide is unrelated prose in an architecture research doc.)
- Hardening verified on synthetic edge cases: a >42x within-chart ratio now
  floors tiny bars to 3px (was 0.07px); an all-unmeasured dashboard renders the
  empty-state note (no dangling table).
- Adversarial 3-agent verification pass (chart-scaling, dashboard-filter,
  completeness) returned no blockers.

Commands:
- `cd crates/tsz-website && npm run test:benchmarks` — smoke test green.
- `node scripts/sync-docs.mjs && npx @11ty/eleventy` then
  `grep -roi "not measured" dist` on benchmark/compat pages — clean.
