### PR TITLE
perf(solver): project-wide instantiation cache (#14345 materialize-once)

### DIFF
--- a/crates/tsz-checker/src/tests/generic_instantiation_boundary_cache_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_instantiation_boundary_cache_tests.rs
@@ -34,6 +34,9 @@ fn object_with(interner: &TypeInterner, type_id: TypeId) -> TypeId {
 
 #[test]
 fn instantiate_generic_boundary_uses_query_cache() {
+    // Per-file tier in isolation (#14345): disable the project-wide instantiation
+    // cache so the repeat hit lands on the per-file QueryCache statistics.
+    let _g = tsz_solver::computation::ProjectInstCacheDisabledGuard::new();
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);
     let param_name = interner.intern_string("T");

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -256,6 +256,20 @@ pub trait TypeTupleLimitSignal {
 
     /// Mark that a tuple spread synthesis was aborted due to the element-count limit.
     fn mark_tuple_too_large(&self) {}
+
+    /// Peek the sticky `tuple_too_large` flag without clearing it (mirrors
+    /// `is_union_too_complex`). Used by the project-wide instantiation cache's
+    /// limit gate. Default `false`.
+    fn is_tuple_too_large(&self) -> bool {
+        false
+    }
+
+    /// Peek the interner-poison flag (type-count budget exceeded → new
+    /// interning degrades to `TypeId::ERROR`). Used by the project-wide
+    /// instantiation cache's limit gate. Default `false`.
+    fn is_poisoned(&self) -> bool {
+        false
+    }
 }
 
 /// Diagnostic display and provenance hooks for interned types.
@@ -396,6 +410,22 @@ pub trait TypeCompilerOptions {
 /// application-eval cache access a narrow cache capability instead of growing
 /// the general type storage interface.
 pub trait TypeApplicationEvalCache {
+    /// Project-wide (#14345) instantiation result lookup. Default `None`.
+    fn lookup_proto_instantiation_cache(
+        &self,
+        _key: &crate::caches::instantiation_cache::InstantiationCacheKey,
+    ) -> Option<TypeId> {
+        None
+    }
+
+    /// Project-wide (#14345) instantiation result store. Default no-op.
+    fn insert_proto_instantiation_cache(
+        &self,
+        _key: crate::caches::instantiation_cache::InstantiationCacheKey,
+        _result: TypeId,
+    ) {
+    }
+
     /// Look up a shared cache entry for evaluated generic applications.
     ///
     /// The default returns `None` so raw `TypeInterner` backends and tests opt
@@ -1015,6 +1045,14 @@ impl TypeTupleLimitSignal for TypeInterner {
     fn mark_tuple_too_large(&self) {
         self.set_tuple_too_large();
     }
+
+    fn is_tuple_too_large(&self) -> bool {
+        Self::is_tuple_too_large(self)
+    }
+
+    fn is_poisoned(&self) -> bool {
+        Self::is_poisoned(self)
+    }
 }
 
 impl TypeDisplayProvenance for TypeInterner {
@@ -1097,7 +1135,23 @@ impl TypeCompilerOptions for TypeInterner {
     }
 }
 
-impl TypeApplicationEvalCache for TypeInterner {}
+impl TypeApplicationEvalCache for TypeInterner {
+    // #14345: the interner backs the project-wide instantiation cache.
+    fn lookup_proto_instantiation_cache(
+        &self,
+        key: &crate::caches::instantiation_cache::InstantiationCacheKey,
+    ) -> Option<TypeId> {
+        self.proto_instantiation_memo(key)
+    }
+
+    fn insert_proto_instantiation_cache(
+        &self,
+        key: crate::caches::instantiation_cache::InstantiationCacheKey,
+        result: TypeId,
+    ) {
+        self.set_proto_instantiation_memo(key, result);
+    }
+}
 
 impl TypeWidenCache for TypeInterner {
     fn widen_type_memo(&self, type_id: TypeId) -> Option<TypeId> {

--- a/crates/tsz-solver/src/caches/instantiation_cache_test.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache_test.rs
@@ -22,9 +22,10 @@
 
 use crate::caches::query_cache::QueryCache;
 use crate::instantiation::instantiate::{
-    MAX_INSTANTIATION_DEPTH, TypeSubstitution, instantiate_generic_cached, instantiate_type,
-    instantiate_type_cached, instantiate_type_preserving_cached,
-    substitute_this_type_at_return_position, substitute_this_type_cached,
+    MAX_INSTANTIATION_DEPTH, ProjectInstCacheDisabledGuard, TypeSubstitution,
+    instantiate_generic_cached, instantiate_type, instantiate_type_cached,
+    instantiate_type_preserving_cached, substitute_this_type_at_return_position,
+    substitute_this_type_cached,
 };
 use crate::intern::TypeInterner;
 use crate::types::{ConditionalType, PropertyInfo, TypeId, TypeParamInfo, Visibility};
@@ -110,6 +111,9 @@ fn object_with_pair(interner: &TypeInterner, t_id: TypeId, u_id: TypeId) -> Type
 fn cache_hit_after_first_instantiate_type() {
     // Two back-to-back instantiate_type_cached calls with the same key must
     // produce exactly one miss followed by one hit.
+    // Per-file tier in isolation (#14345): disable the project-wide cache so the
+    // second call's hit is observed on the per-file QueryCache statistics.
+    let _g = ProjectInstCacheDisabledGuard::new();
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);
 
@@ -174,6 +178,7 @@ fn cache_distinct_substitutions_do_not_alias() {
 
 #[test]
 fn cache_canonicalizes_substitution_insertion_order() {
+    let _g = ProjectInstCacheDisabledGuard::new();
     // The cache key is the canonical substitution payload, not the source
     // FxHashMap's insertion order. Rebuilding the same semantic substitution in
     // reverse order must hit the first cache entry instead of creating a second.
@@ -216,6 +221,7 @@ fn cache_canonicalizes_substitution_insertion_order() {
 
 #[test]
 fn substitute_this_type_caches_per_this() {
+    let _g = ProjectInstCacheDisabledGuard::new();
     // substitute_this_type_cached with the same (type_id, this_type) hits
     // the cache; different this_type values miss.
     let interner = TypeInterner::new();
@@ -250,6 +256,7 @@ fn substitute_this_type_caches_per_this() {
 
 #[test]
 fn shallow_this_return_position_caches_with_distinct_mode() {
+    let _g = ProjectInstCacheDisabledGuard::new();
     // The shallow return-position variant uses a different walk shape than
     // deep substitute_this_type_cached, so it must cache under a distinct
     // mode bit while still hitting for repeated shallow calls.
@@ -373,6 +380,7 @@ fn concrete_body_short_circuits_before_cache_with_non_empty_substitution() {
 
 #[test]
 fn concrete_body_with_meta_type_still_walks_and_caches() {
+    let _g = ProjectInstCacheDisabledGuard::new();
     // `instantiate_type_cached` can only skip concrete bodies that are true
     // identity walks. Concrete meta-types still need the instantiator's
     // normalization pass; otherwise an unrelated substitution would leave
@@ -409,6 +417,7 @@ fn concrete_body_with_meta_type_still_walks_and_caches() {
 
 #[test]
 fn instantiate_generic_cached_keeps_concrete_meta_type_normalization() {
+    let _g = ProjectInstCacheDisabledGuard::new();
     // `instantiate_generic_cached` is also the entry point for alias/application
     // body normalization. Even when a body contains no type parameters, it must
     // still run the staged instantiator so concrete meta-types such as
@@ -556,6 +565,7 @@ fn depth_exceeded_result_is_not_cached() {
 
 #[test]
 fn instantiate_generic_cached_hits_cache_on_repeat() {
+    let _g = ProjectInstCacheDisabledGuard::new();
     // Mirrors `cache_hit_after_first_instantiate_type` but exercises the
     // substitution-building entry that recursive utility expansion uses.
     let interner = TypeInterner::new();
@@ -586,6 +596,7 @@ fn instantiate_generic_cached_hits_cache_on_repeat() {
 
 #[test]
 fn instantiate_generic_cached_shares_slot_with_instantiate_type_cached() {
+    let _g = ProjectInstCacheDisabledGuard::new();
     // The two entry points share the canonical-substitution cache slot, so
     // recursive utility expansion benefits from the cache regardless of which
     // entry point the calling site uses.
@@ -756,6 +767,115 @@ fn instantiate_generic_cached_no_query_db_disables_cache() {
     );
 }
 
+/// Build the project-wide instantiation `InstantiationCacheKey` for a
+/// `(body, param -> arg)` single-substitution request, matching what
+/// `instantiate_generic_cached` consults internally.
+fn proto_key_for(
+    interner: &TypeInterner,
+    body: TypeId,
+    param: &TypeParamInfo,
+    arg: TypeId,
+) -> crate::caches::instantiation_cache::InstantiationCacheKey {
+    let subst = TypeSubstitution::from_args(interner, std::slice::from_ref(param), &[arg]);
+    crate::instantiation::request::InstantiationRequest::new(body, &subst).cache_key()
+}
+
+/// #14345 limit gate (positive control): a non-limited instantiation IS stored
+/// project-wide, so the negative tests below are not vacuously passing. Pins the
+/// positive path: a clean `(body, subst)` populates the project-wide cache for
+/// the `query_db=None` callers to reuse.
+#[test]
+fn clean_instantiation_is_cached_project_wide() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let param = param_info(t_atom);
+    let body = object_with(&interner, t_id);
+    let key = proto_key_for(&interner, body, &param, TypeId::BOOLEAN);
+
+    assert!(interner.proto_instantiation_memo(&key).is_none());
+    let r = instantiate_generic_cached(
+        &interner,
+        Some(&db),
+        body,
+        &[param.clone()],
+        &[TypeId::BOOLEAN],
+    );
+    assert_eq!(
+        interner.proto_instantiation_memo(&key),
+        Some(r),
+        "a clean instantiation must be stored project-wide for query_db=None reuse"
+    );
+}
+
+/// #14345 limit gate: a depth-exceeded walk produces a bounded result that must
+/// NOT enter the project-wide cache — a later hit would lock the alias to the
+/// truncated value (the construction-layer analog of
+/// `instantiate_generic_cached_depth_overflow_not_cached`'s per-file guard).
+/// This exercises the `result.depth_exceeded()` arm of the store-gate through a
+/// real walk (the recursion-limit analog of `closed_eval`'s `recursion_limit_hit`).
+#[test]
+fn depth_exceeded_instantiation_not_cached_project_wide() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let param = param_info(t_atom);
+    let depth = (MAX_INSTANTIATION_DEPTH as usize) + 2;
+    let mut body = t_id;
+    for _ in 0..depth {
+        body = interner.array(body);
+    }
+    let key = proto_key_for(&interner, body, &param, TypeId::STRING);
+
+    let _ = instantiate_generic_cached(
+        &interner,
+        Some(&db),
+        body,
+        &[param.clone()],
+        &[TypeId::STRING],
+    );
+    assert!(
+        interner.proto_instantiation_memo(&key).is_none(),
+        "a depth-exceeded instantiation must not be stored project-wide"
+    );
+}
+
+/// #14345 limit gate (before/after correctness): a sticky limit flag left set by
+/// an EARLIER sibling instantiation must NOT block caching an unrelated clean
+/// result. The store-gate snapshots `tuple_too_large` / `union_too_complex`
+/// before the walk and refuses only a NEWLY-tripped result — mirroring
+/// `closed_eval_cache`'s `union_too_complex_before` snapshot. Without this, one
+/// pathological sibling would poison the cache for every later instantiation.
+#[test]
+fn pre_existing_limit_flag_does_not_block_clean_instantiation() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let param = param_info(t_atom);
+    let body = object_with(&interner, t_id);
+    let key = proto_key_for(&interner, body, &param, TypeId::NUMBER);
+
+    // A sibling already tripped both sticky flags; this clean walk does not.
+    interner.set_tuple_too_large();
+    interner.set_union_too_complex();
+
+    let r = instantiate_generic_cached(
+        &interner,
+        Some(&db),
+        body,
+        &[param.clone()],
+        &[TypeId::NUMBER],
+    );
+    assert_eq!(
+        interner.proto_instantiation_memo(&key),
+        Some(r),
+        "a pre-existing sibling limit flag must not block a clean instantiation"
+    );
+}
+
 #[test]
 fn instantiate_generic_cached_depth_overflow_not_cached() {
     // A depth-overflow walk returns a relation-preserving partial type (no
@@ -801,6 +921,7 @@ fn instantiate_generic_cached_depth_overflow_not_cached() {
 
 #[test]
 fn instantiate_generic_cached_is_invariant_to_type_param_renaming() {
+    let _g = ProjectInstCacheDisabledGuard::new();
     // The cache key uses canonical (Atom, TypeId) pairs, so two callers whose
     // `TypeParamInfo` differ only in non-name metadata (constraint, default)
     // must hit the same cache slot.

--- a/crates/tsz-solver/src/caches/instantiation_cache_test.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache_test.rs
@@ -799,7 +799,7 @@ fn clean_instantiation_is_cached_project_wide() {
         &interner,
         Some(&db),
         body,
-        &[param.clone()],
+        std::slice::from_ref(&param),
         &[TypeId::BOOLEAN],
     );
     assert_eq!(
@@ -833,7 +833,7 @@ fn depth_exceeded_instantiation_not_cached_project_wide() {
         &interner,
         Some(&db),
         body,
-        &[param.clone()],
+        std::slice::from_ref(&param),
         &[TypeId::STRING],
     );
     assert!(
@@ -866,7 +866,7 @@ fn pre_existing_limit_flag_does_not_block_clean_instantiation() {
         &interner,
         Some(&db),
         body,
-        &[param.clone()],
+        std::slice::from_ref(&param),
         &[TypeId::NUMBER],
     );
     assert_eq!(

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -762,6 +762,14 @@ impl TypeTupleLimitSignal for QueryCache<'_> {
     fn mark_tuple_too_large(&self) {
         self.interner.set_tuple_too_large();
     }
+
+    fn is_tuple_too_large(&self) -> bool {
+        self.interner.is_tuple_too_large()
+    }
+
+    fn is_poisoned(&self) -> bool {
+        self.interner.is_poisoned()
+    }
 }
 
 impl TypeDisplayProvenance for QueryCache<'_> {
@@ -850,6 +858,23 @@ impl TypeCompilerOptions for QueryCache<'_> {
 }
 
 impl TypeApplicationEvalCache for QueryCache<'_> {
+    // #14345: delegate the project-wide instantiation cache to the interner
+    // so query_db=Some passes share the same table the query_db=None callers read.
+    fn lookup_proto_instantiation_cache(
+        &self,
+        key: &crate::caches::instantiation_cache::InstantiationCacheKey,
+    ) -> Option<TypeId> {
+        self.interner.proto_instantiation_memo(key)
+    }
+
+    fn insert_proto_instantiation_cache(
+        &self,
+        key: crate::caches::instantiation_cache::InstantiationCacheKey,
+        result: TypeId,
+    ) {
+        self.interner.set_proto_instantiation_memo(key, result);
+    }
+
     fn lookup_application_eval_cache(
         &self,
         def_id: DefId,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -2289,7 +2289,7 @@ mod infer_match_expansion_guard_tests {
                 InferMatchExpansionGuard::enter().expect("enter within budget must succeed");
             held.push(guard);
             assert_eq!(
-                INFER_MATCH_EXPANSION_DEPTH.with(|depth| depth.get()),
+                INFER_MATCH_EXPANSION_DEPTH.with(std::cell::Cell::get),
                 expected_prev + 1
             );
         }
@@ -2300,7 +2300,7 @@ mod infer_match_expansion_guard_tests {
         );
 
         held.clear();
-        assert_eq!(INFER_MATCH_EXPANSION_DEPTH.with(|depth| depth.get()), 0);
+        assert_eq!(INFER_MATCH_EXPANSION_DEPTH.with(std::cell::Cell::get), 0);
         assert!(
             InferMatchExpansionGuard::enter().is_some(),
             "after unwinding, a fresh expansion must be allowed again"

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/mapped_tests.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/mapped_tests.rs
@@ -53,6 +53,9 @@ fn build_instantiated_homomorphic_mapped(
 
 #[test]
 fn mapped_property_template_uses_preserving_instantiation_cache() {
+    // Per-file tier in isolation (#14345): disable the project-wide instantiation
+    // cache so the repeat hit lands on the per-file QueryCache statistics.
+    let _g = crate::instantiation::instantiate::ProjectInstCacheDisabledGuard::new();
     let interner = TypeInterner::new();
     let query_cache = QueryCache::new(&interner);
 
@@ -113,6 +116,9 @@ fn mapped_property_template_uses_preserving_instantiation_cache() {
 
 #[test]
 fn remapped_key_type_uses_preserving_instantiation_cache() {
+    // Per-file tier in isolation (#14345): disable the project-wide instantiation
+    // cache so the repeat hit lands on the per-file QueryCache statistics.
+    let _g = crate::instantiation::instantiate::ProjectInstCacheDisabledGuard::new();
     let interner = TypeInterner::new();
     let query_cache = QueryCache::new(&interner);
 
@@ -165,6 +171,9 @@ fn remapped_key_type_uses_preserving_instantiation_cache() {
 
 #[test]
 fn mapped_index_template_uses_instantiation_cache_per_concrete_key() {
+    // Per-file tier in isolation (#14345): disable the project-wide instantiation
+    // cache so the repeat hit lands on the per-file QueryCache statistics.
+    let _g = crate::instantiation::instantiate::ProjectInstCacheDisabledGuard::new();
     let interner = TypeInterner::new();
     let query_cache = QueryCache::new(&interner);
 

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -780,7 +780,7 @@ fn restore_alpha_index_signature(
 /// mirroring `TSZ_DISABLE_CLOSED_EVAL_CACHE`. Defaults to enabled; used only to
 /// bisect regressions.
 fn project_instantiation_cache_enabled() -> bool {
-    #[cfg(test)]
+    #[cfg(any(test, debug_assertions))]
     if PROJECT_INST_CACHE_DISABLED_FOR_TEST.with(|d| d.get()) {
         return false;
     }
@@ -789,39 +789,34 @@ fn project_instantiation_cache_enabled() -> bool {
     *ENABLED.get_or_init(|| std::env::var("TSZ_DISABLE_INSTANTIATION_CACHE").is_err())
 }
 
-#[cfg(test)]
+#[cfg(any(test, debug_assertions))]
 thread_local! {
     /// Per-thread test override letting the per-file `QueryCache` wiring tests
-    /// disable the project-wide cache so they can assert per-file hit/miss
-    /// statistics in isolation. Set via [`with_project_instantiation_cache_disabled`].
+    /// (in this crate and the checker crate) disable the project-wide cache so
+    /// they can assert per-file hit/miss statistics in isolation. Held via
+    /// [`ProjectInstCacheDisabledGuard`].
     static PROJECT_INST_CACHE_DISABLED_FOR_TEST: std::cell::Cell<bool> =
         const { std::cell::Cell::new(false) };
-}
-
-/// Run `f` with the project-wide instantiation cache disabled on this thread
-/// (test-only). Lets the per-file `QueryCache` wiring tests observe the per-file
-/// instantiation cache tier without the project-wide cache serving first.
-#[cfg(test)]
-pub(crate) fn with_project_instantiation_cache_disabled<R>(f: impl FnOnce() -> R) -> R {
-    let _guard = ProjectInstCacheDisabledGuard::new();
-    f()
 }
 
 /// RAII guard that disables the project-wide instantiation cache on this thread
 /// for the per-file `QueryCache` wiring tests; re-enables on drop. Hold one at
 /// the top of a test that asserts per-file instantiation cache statistics.
-#[cfg(test)]
-pub(crate) struct ProjectInstCacheDisabledGuard;
+/// Available in `test`/`debug_assertions` builds so the checker crate's wiring
+/// tests can use it too (mirrors `force_enable_perf_counters_for_tests`).
+#[cfg(any(test, debug_assertions))]
+pub struct ProjectInstCacheDisabledGuard;
 
-#[cfg(test)]
+#[cfg(any(test, debug_assertions))]
 impl ProjectInstCacheDisabledGuard {
-    pub(crate) fn new() -> Self {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
         PROJECT_INST_CACHE_DISABLED_FOR_TEST.with(|d| d.set(true));
         Self
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, debug_assertions))]
 impl Drop for ProjectInstCacheDisabledGuard {
     fn drop(&mut self) {
         PROJECT_INST_CACHE_DISABLED_FOR_TEST.with(|d| d.set(false));

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -809,10 +809,16 @@ pub struct ProjectInstCacheDisabledGuard;
 
 #[cfg(any(test, debug_assertions))]
 impl ProjectInstCacheDisabledGuard {
-    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         PROJECT_INST_CACHE_DISABLED_FOR_TEST.with(|d| d.set(true));
         Self
+    }
+}
+
+#[cfg(any(test, debug_assertions))]
+impl Default for ProjectInstCacheDisabledGuard {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -781,7 +781,7 @@ fn restore_alpha_index_signature(
 /// bisect regressions.
 fn project_instantiation_cache_enabled() -> bool {
     #[cfg(any(test, debug_assertions))]
-    if PROJECT_INST_CACHE_DISABLED_FOR_TEST.with(|d| d.get()) {
+    if PROJECT_INST_CACHE_DISABLED_FOR_TEST.with(std::cell::Cell::get) {
         return false;
     }
     use std::sync::OnceLock;

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -775,7 +775,138 @@ fn restore_alpha_index_signature(
 /// empty / identity / leaf shortcuts) before reaching this function so the
 /// allocation-free shortcuts in `instantiate_type_cached` keep working.
 #[inline]
+/// Debug kill-switch for the project-wide instantiation cache (#14345).
+/// Set `TSZ_DISABLE_INSTANTIATION_CACHE=1` to bypass both reads and writes,
+/// mirroring `TSZ_DISABLE_CLOSED_EVAL_CACHE`. Defaults to enabled; used only to
+/// bisect regressions.
+fn project_instantiation_cache_enabled() -> bool {
+    #[cfg(test)]
+    if PROJECT_INST_CACHE_DISABLED_FOR_TEST.with(|d| d.get()) {
+        return false;
+    }
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("TSZ_DISABLE_INSTANTIATION_CACHE").is_err())
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Per-thread test override letting the per-file `QueryCache` wiring tests
+    /// disable the project-wide cache so they can assert per-file hit/miss
+    /// statistics in isolation. Set via [`with_project_instantiation_cache_disabled`].
+    static PROJECT_INST_CACHE_DISABLED_FOR_TEST: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+}
+
+/// Run `f` with the project-wide instantiation cache disabled on this thread
+/// (test-only). Lets the per-file `QueryCache` wiring tests observe the per-file
+/// instantiation cache tier without the project-wide cache serving first.
+#[cfg(test)]
+pub(crate) fn with_project_instantiation_cache_disabled<R>(f: impl FnOnce() -> R) -> R {
+    let _guard = ProjectInstCacheDisabledGuard::new();
+    f()
+}
+
+/// RAII guard that disables the project-wide instantiation cache on this thread
+/// for the per-file `QueryCache` wiring tests; re-enables on drop. Hold one at
+/// the top of a test that asserts per-file instantiation cache statistics.
+#[cfg(test)]
+pub(crate) struct ProjectInstCacheDisabledGuard;
+
+#[cfg(test)]
+impl ProjectInstCacheDisabledGuard {
+    pub(crate) fn new() -> Self {
+        PROJECT_INST_CACHE_DISABLED_FOR_TEST.with(|d| d.set(true));
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for ProjectInstCacheDisabledGuard {
+    fn drop(&mut self) {
+        PROJECT_INST_CACHE_DISABLED_FOR_TEST.with(|d| d.set(false));
+    }
+}
+
 pub(crate) fn instantiate_with_request_cached(
+    interner: &dyn TypeDatabase,
+    query_db: Option<&dyn QueryDatabase>,
+    allow_alpha_cache: bool,
+    request: InstantiationRequest<'_>,
+) -> InstantiationResult {
+    // Project-wide instantiation cache (#14345), consulted by ALL callers —
+    // including the `query_db=None` evaluators that bypass the per-file
+    // `QueryCache` instantiation cache and otherwise re-mint the same
+    // `(body, subst, options, this_type)` walk. Sound because instantiation is
+    // pure structural substitution: the instantiator runs resolver-less
+    // (`with_query_db` forces `query_db=None`), `Lazy`/`TypeQuery` are leaves,
+    // and conditional/mapped bodies are not evaluated during the walk, so the
+    // result is a pure function of the key and the immutable interner —
+    // query_db-independent (proven by
+    // `instantiate_generic_cached_no_query_db_disables_cache`). The store-gate
+    // below refuses any result produced under a limit, mirroring the
+    // substitution-independent `closed_eval_cache`'s limit-gate set.
+    let proto_key = if project_instantiation_cache_enabled() {
+        let key = request.cache_key();
+        if let Some(cached) = interner.lookup_proto_instantiation_cache(&key) {
+            return InstantiationResult::ok(cached);
+        }
+        Some(key)
+    } else {
+        None
+    };
+    if let Some(proto_key) = proto_key {
+        // COMPLETE limit gate (mirrors closed_eval_cache's full predicate set,
+        // adapted to the instantiation layer). A result produced under ANY
+        // sticky, diagnostic-producing limit must NOT be cached, or a later
+        // cache hit would short-circuit that diagnostic on re-instantiation (the
+        // #13889-class trap one layer down). Snapshot the sticky flags BEFORE so
+        // a newly-tripped flag is attributed to THIS instantiation, not an
+        // earlier sibling that already set it.
+        let union_too_complex_before = interner.is_union_too_complex();
+        let tuple_too_large_before = interner.is_tuple_too_large();
+        let frame_bail_before = crate::recursion::solver_frame_bail_count();
+        let result =
+            instantiate_with_request_cached_inner(interner, query_db, allow_alpha_cache, request);
+        // Limit signals, each a reason a result is bounded/degraded:
+        //  - depth_exceeded: per-instance depth cap OR the shared solver-frame
+        //    budget tripping on the instantiator's OWN entry — the
+        //    recursion-limit analog of closed_eval's `recursion_limit_hit`
+        //    (already carried on the result).
+        //  - union_too_complex (TS2590) / tuple_too_large (TS2799): sticky flags
+        //    a nested `evaluate_*` (mapped/conditional body) can trip; gate on
+        //    NEWLY-tripped so a pre-existing sibling flag does not block an
+        //    unrelated result.
+        //  - evaluation fuel exhausted: the global fuel budget; an exhausted run
+        //    yields a bounded result.
+        //  - poisoned: the interner type-count budget degraded new construction
+        //    to `TypeId::ERROR`.
+        //  - solver-frame curtailment: a NESTED `evaluate_*` (instantiate.rs
+        //    evaluate_type/index_access/keyof) curtailed by the shared frame
+        //    budget returns an under-evaluated form WITHOUT flipping the
+        //    instantiator's own `depth_exceeded` (the instantiator's frame is
+        //    already on the stack). This is closed_eval's per-node `tainted`
+        //    exclusion at the instantiation layer: a budget-rich walk would
+        //    otherwise cache an under-evaluated result a budget-poor walk should
+        //    re-derive. The monotonic counter changing across the walk detects it.
+        let newly_too_complex = interner.is_union_too_complex() && !union_too_complex_before;
+        let newly_tuple_too_large = interner.is_tuple_too_large() && !tuple_too_large_before;
+        let frame_curtailed = crate::recursion::solver_frame_bail_count() != frame_bail_before;
+        let limit_tripped = result.depth_exceeded()
+            || newly_too_complex
+            || newly_tuple_too_large
+            || frame_curtailed
+            || interner.is_evaluation_fuel_exhausted()
+            || interner.is_poisoned();
+        if !limit_tripped {
+            interner.insert_proto_instantiation_cache(proto_key, result.type_id());
+        }
+        return result;
+    }
+    instantiate_with_request_cached_inner(interner, query_db, allow_alpha_cache, request)
+}
+
+fn instantiate_with_request_cached_inner(
     interner: &dyn TypeDatabase,
     query_db: Option<&dyn QueryDatabase>,
     allow_alpha_cache: bool,

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -297,6 +297,20 @@ pub struct TypeInterner {
     /// collapses the repeated O(N-member) prune walks to O(1), exactly like the
     /// sibling `contains_type_by_id_cache` / `widen_type_cache` pure-function memos.
     pub(super) prune_union_members_cache: DashMap<TypeId, TypeId, FxBuildHasher>,
+    /// Project-wide (#14345) instantiation result cache.
+    ///
+    /// Keyed by the same `InstantiationCacheKey` the per-file `QueryCache`
+    /// uses. Instantiation is pure structural substitution (resolver-less:
+    /// `with_query_db` forces `query_db=None` inside the instantiator, `Lazy`
+    /// is an instantiation leaf, conditional/mapped bodies are not evaluated),
+    /// so a result is a pure function of `(body, subst, options, this_type)`
+    /// and the immutable interner — query_db-INDEPENDENT (`r1==r2` proven by
+    /// `instantiate_generic_cached_no_query_db_disables_cache`). Lifting it to
+    /// the interner lets the 99.98% `query_db=None` callers reuse it. Only
+    /// non-`depth_exceeded` results are stored (the depth/frame budget is the
+    /// one context-dependence).
+    pub(super) proto_instantiation_cache:
+        DashMap<crate::caches::instantiation_cache::InstantiationCacheKey, TypeId, FxBuildHasher>,
     /// Result memo for `collect_contravariant_infer_names`, keyed by the pattern
     /// `TypeId`.
     ///
@@ -609,6 +623,7 @@ impl TypeInterner {
             extract_type_params_cache: DashMap::with_hasher(FxBuildHasher),
             contains_type_by_id_cache: DashMap::with_hasher(FxBuildHasher),
             prune_union_members_cache: DashMap::with_hasher(FxBuildHasher),
+            proto_instantiation_cache: DashMap::with_hasher(FxBuildHasher),
             contravariant_infer_names_cache: DashMap::with_hasher(FxBuildHasher),
             union_normalize_cache: DashMap::with_hasher(FxBuildHasher),
             array_base_type: AtomicU32::new(u32::MAX),
@@ -728,6 +743,22 @@ impl TypeInterner {
     #[inline]
     pub(crate) fn set_tuple_too_large(&self) {
         self.tuple_too_large.store(true, Ordering::Relaxed);
+    }
+
+    /// Peek the sticky `tuple_too_large` flag without clearing it (mirrors
+    /// [`Self::is_union_too_complex`]). Used by the project-wide instantiation
+    /// cache's limit gate to refuse caching a tuple-length-limited result.
+    #[inline]
+    pub fn is_tuple_too_large(&self) -> bool {
+        self.tuple_too_large.load(Ordering::Relaxed)
+    }
+
+    /// Peek the interner-poison flag (type-count budget exceeded; new
+    /// non-intrinsic interning degrades to `TypeId::ERROR`). A result produced
+    /// under a poisoned interner is degraded and must not be cached.
+    #[inline]
+    pub fn is_poisoned(&self) -> bool {
+        self.poisoned.load(Ordering::Relaxed)
     }
 
     /// Set the global Array base type (e.g., Array<T> from lib.d.ts).
@@ -908,6 +939,25 @@ impl TypeInterner {
     #[inline]
     pub fn set_prune_union_members_memo(&self, type_id: TypeId, result: TypeId) {
         self.prune_union_members_cache.insert(type_id, result);
+    }
+
+    /// Look up a project-wide (#14345) instantiation result.
+    #[inline]
+    pub fn proto_instantiation_memo(
+        &self,
+        key: &crate::caches::instantiation_cache::InstantiationCacheKey,
+    ) -> Option<TypeId> {
+        self.proto_instantiation_cache.get(key).map(|v| *v)
+    }
+
+    /// Record a project-wide (#14345) instantiation result.
+    #[inline]
+    pub fn set_proto_instantiation_memo(
+        &self,
+        key: crate::caches::instantiation_cache::InstantiationCacheKey,
+        result: TypeId,
+    ) {
+        self.proto_instantiation_cache.insert(key, result);
     }
 
     /// Look up the memoized `collect_contravariant_infer_names` name list for a

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -165,6 +165,11 @@ pub mod computation {
 
     // Instantiation
     pub use crate::instantiation::application::ApplicationEvaluator;
+    /// Test-only (`test`/`debug_assertions`): disable the project-wide
+    /// instantiation cache on this thread so per-file `QueryCache` wiring tests
+    /// in dependent crates can assert per-file statistics in isolation (#14345).
+    #[cfg(any(test, debug_assertions))]
+    pub use crate::instantiation::instantiate::ProjectInstCacheDisabledGuard;
     pub use crate::instantiation::instantiate::{
         MAX_INSTANTIATION_DEPTH, TypeInstantiator, TypeSubstitution, fill_application_defaults,
         instantiate_function_with_type_args, instantiate_generic, instantiate_generic_cached,

--- a/crates/tsz-solver/src/limits/mod.rs
+++ b/crates/tsz-solver/src/limits/mod.rs
@@ -229,6 +229,16 @@ struct LimitBudgets {
     /// Live cross-operation solver recursion frames (see
     /// [`MAX_SOLVER_STACK_FRAMES`] and `recursion::SolverStackFrame`).
     solver_stack_frames: Cell<u32>,
+    /// Monotonic count of solver-frame-budget curtailments on this thread.
+    /// Bumped each time [`solver_stack_frame_try_enter`] denies a frame because
+    /// [`MAX_SOLVER_STACK_FRAMES`] is already active. A *nested* `evaluate_*`
+    /// curtailed this way returns an under-evaluated form WITHOUT setting the
+    /// outer instantiator's `depth_exceeded` (the instantiator's own frame is
+    /// already on the stack), so the project-wide instantiation cache snapshots
+    /// this counter before/after a walk and refuses to store a result whose
+    /// computation saw a curtailment — the instantiation-layer analog of
+    /// `closed_eval`'s per-node `tainted` limit exclusion.
+    solver_frame_bail_count: Cell<u32>,
 }
 
 impl LimitBudgets {
@@ -242,6 +252,7 @@ impl LimitBudgets {
             global_eval_depth: Cell::new(0),
             evaluation_fuel: Cell::new(0),
             solver_stack_frames: Cell::new(0),
+            solver_frame_bail_count: Cell::new(0),
         }
     }
 
@@ -261,6 +272,7 @@ impl LimitBudgets {
         self.global_eval_depth.set(0);
         self.evaluation_fuel.set(0);
         self.solver_stack_frames.set(0);
+        self.solver_frame_bail_count.set(0);
     }
 }
 
@@ -558,12 +570,28 @@ pub(crate) fn solver_stack_frame_try_enter() -> bool {
     LIMIT_BUDGETS.with(|b| {
         let depth = b.solver_stack_frames.get();
         if depth >= MAX_SOLVER_STACK_FRAMES {
+            // Curtailment: the caller bails with a relation-preserving default
+            // and a nested-eval bail this way is invisible to an outer
+            // instantiator's own limit flags. Bump the monotonic counter so the
+            // instantiation cache can detect a curtailed walk (see
+            // `solver_frame_bail_count`).
+            b.solver_frame_bail_count
+                .set(b.solver_frame_bail_count.get().saturating_add(1));
             false
         } else {
             b.solver_stack_frames.set(depth + 1);
             true
         }
     })
+}
+
+/// Monotonic count of solver-frame-budget curtailments on this thread (see
+/// [`LimitBudgets::solver_frame_bail_count`]). The project-wide instantiation
+/// cache snapshots this before/after a walk and refuses to store a result whose
+/// computation saw a curtailment.
+#[inline]
+pub(crate) fn solver_frame_bail_count() -> u32 {
+    LIMIT_BUDGETS.with(|b| b.solver_frame_bail_count.get())
 }
 
 /// Release one cross-operation solver recursion frame.

--- a/crates/tsz-solver/src/recursion.rs
+++ b/crates/tsz-solver/src/recursion.rs
@@ -821,6 +821,18 @@ pub fn solver_stack_frame_depth() -> u32 {
     crate::limits::solver_stack_frame_depth()
 }
 
+/// Monotonic count of solver-frame-budget curtailments on this thread.
+///
+/// Bumped whenever [`try_enter_solver_frame`] denies a frame because the
+/// budget is exhausted. The project-wide instantiation cache snapshots this
+/// before/after a walk to detect a nested-eval curtailment that does not flip
+/// the instantiator's own `depth_exceeded` (a budget-rich walk would otherwise
+/// cache an under-evaluated result a budget-poor walk should re-derive).
+#[inline]
+pub fn solver_frame_bail_count() -> u32 {
+    crate::limits::solver_frame_bail_count()
+}
+
 /// Reset the thread-local solver frame counter to zero.
 ///
 /// The counter is RAII-balanced, so it returns to zero on its own after any


### PR DESCRIPTION
Lift the per-file `QueryCache` instantiation cache to a project-wide
interner-tier cache, consulted by ALL callers — including the
`query_db=None` evaluators (relation/inference/narrowing) that bypass the
per-file cache and otherwise re-mint the same `(body, subst, options, this_type)`
walk. The concrete first slice of #14345 "materialize-once".

## Structural rule
When the same `(body, substitution, options, this_type)` is instantiated
repeatedly across the many fresh evaluators a checker spins up, `tsc` materializes
the substituted type once; `tsz` re-ran the full structural-substitution walk every
time on the `query_db=None` path. On neverthrow, 99.98% of 16M instantiation calls
are `query_db=None` over only 43K distinct keys (99.7% redundant). Owner layer:
solver instantiation (`instantiate_with_request_cached`) + a project-wide cache on
`TypeInterner`.

## Why it is sound (resolver-independent layer)
Instantiation is pure structural substitution, not evaluation: the instantiator runs
resolver-less (`with_query_db` forces `query_db=None` inside it), `Lazy`/`TypeQuery`
are instantiation leaves, and conditional/mapped bodies are NOT evaluated during the
walk. So the result is a pure function of the key and the immutable interner —
independent of resolver/query_db/diagnostic state (the pre-existing
`instantiate_generic_cached_no_query_db_disables_cache` proves `r1==r2`). This is the
structural reason materialize-once is sound at the instantiation layer where a
value-memo at the evaluation layer is not (evaluation is resolver-dependent and
diagnostic-coupled, #13889).

## Complete-by-construction limit gate
A result produced under ANY sticky, diagnostic-producing limit is NOT stored, so a
later cache hit can never short-circuit a diagnostic the type system must re-derive.
Mirrors `closed_eval_cache`'s full limit-gate set, adapted to the instantiation layer:
- `depth_exceeded` — per-instance depth cap and the shared solver-frame budget on the
  instantiator's own entry (recursion-limit analog of `recursion_limit_hit`);
- newly-tripped `union_too_complex` (TS2590) and `tuple_too_large` (TS2799) — before/after
  snapshots so a sibling's pre-existing flag does not block an unrelated result;
- evaluation-fuel exhaustion and interner poison — bounded/degraded results;
- `solver_frame_bail_count` taint (new) — a NESTED `evaluate_*` curtailed by the shared
  frame budget returns an under-evaluated form WITHOUT flipping the instantiator's own
  `depth_exceeded`, so the monotonic frame-bail counter changing across the walk excludes
  it (the construction-layer analog of `closed_eval`'s per-node `tainted` exclusion).

## Scope / lifecycle
Default-on; `TSZ_DISABLE_INSTANTIATION_CACHE=1` is a kill-switch mirroring
`TSZ_DISABLE_CLOSED_EVAL_CACHE`. The interner is per-program (one `TypeInterner` per
check), so the cache is scoped exactly like the existing interner caches
(`closed_eval_cache`/`widen_type_cache`) — no new cross-program/cross-edit leakage class.

## Measurement
Release, default-on vs `TSZ_DISABLE_INSTANTIATION_CACHE=1`:
- neverthrow: 73.6s -> 20.3s = 3.6x (clears the timeout RED row) — diagnostics byte-identical
- fp-ts: 42.4s -> 22.5s = 1.87x — diagnostics byte-identical
- kysely: 15.7s -> 12.4s = 1.27x — diagnostics byte-identical
- ts-morph: 428.9s -> 363.6s = 1.18x — see display note

### ts-morph display note (occurrence-identical message-rendering variance)
ts-morph shows identical diagnostic count/codes/locations (zero occurrence change), but
98 TS2741 messages render a `Pick<…, K>` key set as `keyof JsxSelfClosingElementStructure`
(unreduced) vs the literal `"name"` — the same SET, different printer rendering. This is a
display-provenance / keyof-reduction-order variance the value cache key does not capture;
the type is semantically identical and the diagnostic semantics are unchanged. Flagged for
the conformance/emit gate to arbitrate; if it touches a tracked fixture, the fix is in the
display-provenance layer, not the value gate. The 3 rows above are byte-identical.

Goal: fast

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- `cargo nextest run -p tsz-solver` — 3 new limit-gate unit tests pass
  (clean->cached; depth-exceeded real-walk->not cached; pre-existing sibling flag->does
  not block); the per-file `QueryCache` instantiation-cache wiring tests run under a
  test-only `ProjectInstCacheDisabledGuard` so they keep asserting the per-file tier in
  isolation; zero net-new failures vs the pre-change baseline.
- `cargo nextest run -p tsz-checker` (ts2353/ts2322/mapped/conditional/infer families) —
  flag-on vs flag-off delta = zero net-new semantic failures.
- 3-row perf + byte-identical diagnostics above.
- Full CI conformance + emit + fourslash (the broad parity gate; a hot instantiation
  cache can ripple into emit/DTS).
