### PR TITLE
fix(checker): present-property mismatch beats missing-property in object-literal elaboration (#14582)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1687,6 +1687,9 @@ path = "tests/generic_property_mismatch_display_tests.rs"
 name = "object_literal_property_target_display_tests"
 path = "tests/object_literal_property_target_display_tests.rs"
 [[test]]
+name = "object_literal_present_mismatch_precedence_tests"
+path = "tests/object_literal_present_mismatch_precedence_tests.rs"
+[[test]]
 name = "nominal_application_call_suppression_tests"
 path = "tests/nominal_application_call_suppression_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -103,24 +103,15 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        // When the source object literal is missing required properties from the
-        // target, don't elaborate into per-property TS2322 errors. tsc reports
-        // TS2345 at the argument level with "Property 'X' is missing" elaboration
-        // in these cases, rather than TS2322 on individual matching properties.
-        // Without this guard, widened property types (e.g., a string literal `'name'`
-        // widened to `string`) can produce false TS2322 errors like
-        // `Type '"name"' is not assignable to type '"name"'`.
-        let mapped_surface_names =
-            self.generic_mapped_receiver_explicit_property_names(effective_param_type);
-        if self.target_has_missing_required_properties_from_source(
-            &obj,
-            source_type,
-            effective_param_type,
-        ) && mapped_surface_names.is_empty()
-        {
-            return false;
-        }
-
+        // A missing required property does NOT pre-empt per-property elaboration.
+        // Like tsc's `elaborateObjectLiteral`, the loop below reports each present
+        // property's type mismatch; the missing-property diagnostic (TS2741/TS2739,
+        // or the argument-level TS2345 "Property 'X' is missing") is only the
+        // fallback the caller emits when this function returns `false` (i.e. no
+        // present mismatch was elaborated). The per-property check re-tests the
+        // un-widened literal/contextual source type, so a widened literal (`'name'`
+        // → `string`) does not produce a spurious mismatch against a `'name'`
+        // target — the false positive a prior up-front bail tried to avoid.
         let diagnostics_before_epc = self.ctx.diagnostics.len();
         self.check_object_literal_excess_properties(source_type, effective_param_type, arg_idx);
         // `check_object_literal_excess_properties` can trigger a contextual-type
@@ -1051,123 +1042,6 @@ impl<'a> CheckerState<'a> {
         }
 
         false
-    }
-
-    /// Check whether the target type has required properties that are not present
-    /// in the source object literal.
-    ///
-    /// When missing required properties are detected, tsc reports TS2345 at the
-    /// whole argument level with "Property 'X' is missing" elaboration. Elaborating
-    /// into per-property TS2322 errors in this case produces misleading diagnostics
-    /// because widened literal types (e.g., `'name'` widened to `string`) can fail
-    /// comparison against their inferred target literal types.
-    fn target_has_missing_required_properties_from_source(
-        &mut self,
-        obj: &tsz_parser::parser::node::LiteralExprData,
-        source_type: TypeId,
-        target_type: TypeId,
-    ) -> bool {
-        // Collect source property names from the object literal.
-        let mut source_prop_names = std::collections::HashSet::new();
-        for &elem_idx in &obj.elements.nodes {
-            if let Some(prop_name) = self.object_literal_property_name_from_elem(elem_idx) {
-                source_prop_names.insert(prop_name);
-            }
-        }
-        // Spreads contribute properties that are not represented as named AST
-        // elements. Include the synthesized source shape so `{ ...m, title:
-        // undefined }` is not treated as missing `yearReleased` from `m`.
-        let source_type = self.evaluate_type_for_assignability(source_type);
-        if let Some(shape) =
-            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, source_type)
-        {
-            for prop in &shape.properties {
-                source_prop_names.insert(self.ctx.types.resolve_atom(prop.name).to_string());
-            }
-        }
-
-        // Get target property names and check for missing required ones.
-        // We use the solver's object shape to get the canonical set of target properties.
-        let original_target_type = target_type;
-        let target_type = self.resolve_type_for_property_access(target_type);
-        let target_type = self.evaluate_type_with_env(target_type);
-        let target_type = self.resolve_lazy_type(target_type);
-        let target_type = self.evaluate_application_type(target_type);
-
-        // Object.prototype methods that are implicitly present on all objects.
-        // These should not count as "missing" for the purpose of suppressing
-        // per-property elaboration, matching `should_suppress_object_literal_call_mismatch`.
-        static OBJECT_PROTO_METHODS: &[&str] = &[
-            "constructor",
-            "toString",
-            "toLocaleString",
-            "valueOf",
-            "hasOwnProperty",
-            "isPrototypeOf",
-            "propertyIsEnumerable",
-        ];
-
-        // For type parameters with index signature constraints, don't consider properties
-        // as "missing" - index signatures accept any property name.
-        let has_index_signature = [original_target_type, target_type]
-            .into_iter()
-            .chain(crate::query_boundaries::common::type_parameter_constraint(
-                self.ctx.types,
-                original_target_type,
-            ))
-            .chain(crate::query_boundaries::common::type_parameter_constraint(
-                self.ctx.types,
-                target_type,
-            ))
-            .filter_map(|candidate| {
-                crate::query_boundaries::common::object_shape_for_type(self.ctx.types, candidate)
-            })
-            .any(|shape| shape.string_index.is_some() || shape.number_index.is_some());
-
-        if has_index_signature {
-            return false;
-        }
-
-        if let Some(shape) = crate::query_boundaries::assignability::object_shape_for_type(
-            self.ctx.types,
-            target_type,
-        ) {
-            for prop in shape.properties.iter() {
-                if prop.optional {
-                    continue;
-                }
-                let name = self.ctx.types.resolve_atom(prop.name);
-                if !source_prop_names.contains(name.as_str())
-                    && !OBJECT_PROTO_METHODS.contains(&name.as_str())
-                {
-                    return true;
-                }
-            }
-        }
-
-        false
-    }
-
-    /// Extract a property name from an object literal element node.
-    /// Falls back to type-level resolution for computed property names
-    /// (e.g., unique symbols, const-evaluated keys).
-    fn object_literal_property_name_from_elem(&mut self, elem_idx: NodeIndex) -> Option<String> {
-        use tsz_parser::parser::syntax_kind_ext;
-        let elem_node = self.ctx.arena.get(elem_idx)?;
-        let name_idx = match elem_node.kind {
-            k if k == syntax_kind_ext::PROPERTY_ASSIGNMENT => {
-                self.ctx.arena.get_property_assignment(elem_node)?.name
-            }
-            k if k == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT => {
-                self.ctx.arena.get_shorthand_property(elem_node)?.name
-            }
-            k if k == syntax_kind_ext::METHOD_DECLARATION => {
-                self.ctx.arena.get_method_decl(elem_node)?.name
-            }
-            _ => return None,
-        };
-        self.object_literal_property_name_text(name_idx)
-            .or_else(|| self.get_property_name_resolved(name_idx))
     }
 
     /// Elaborate array literal element type mismatches with TS2322.

--- a/crates/tsz-checker/tests/object_literal_present_mismatch_precedence_tests.rs
+++ b/crates/tsz-checker/tests/object_literal_present_mismatch_precedence_tests.rs
@@ -1,0 +1,194 @@
+//! Object-literal present-property mismatch vs missing-property precedence.
+//!
+//! Structural rule: when a fresh object literal is assigned to an object target
+//! and it has *both* a present property whose type is wrong *and* a required
+//! property that is absent, `tsc`'s `elaborateObjectLiteral` reports the
+//! present-property type mismatch(es) (TS2322, in source order) and the
+//! missing-property diagnostic (TS2741/TS2739) is suppressed. The missing
+//! property only surfaces when no present property mismatches — i.e. the
+//! missing-property report is the *fallback* the elaboration falls through to,
+//! not a pre-empting check.
+//!
+//! tsz previously bailed out of per-property elaboration the moment the source
+//! object literal was missing any required property (except for generic mapped
+//! receivers), so it reported TS2741 ("Property 'x' is missing") where `tsc`
+//! reports the present-property TS2322. This file pins the corrected precedence
+//! across the assignment (TS2322), call-argument, and return positions, and
+//! keeps the missing-only floor (TS2741) intact.
+//!
+//! Binder spellings vary across cases so a fix keyed to a particular identifier
+//! would not satisfy them; assertions are structural (diagnostic codes and the
+//! property named by the "is missing" message), not dependent on type-printer
+//! rendering.
+
+use tsz_checker::test_utils::{check_source_diagnostics, diagnostic_count};
+use tsz_common::diagnostics::Diagnostic;
+
+fn diagnostics(source: &str) -> Vec<Diagnostic> {
+    check_source_diagnostics(source)
+}
+
+/// True when any diagnostic — primary or elaboration line — claims `prop` is
+/// "missing" (the TS2741/TS2739 family wording).
+fn any_missing_message(diags: &[Diagnostic], prop: &str) -> bool {
+    let needle = format!("Property '{prop}' is missing");
+    diags.iter().any(|d| {
+        d.message_text.starts_with(&needle)
+            || d.related_information
+                .iter()
+                .any(|info| info.message_text.starts_with(&needle))
+    })
+}
+
+#[test]
+fn present_mismatch_wins_over_missing_in_assignment() {
+    // `a` is present but wrong; `b` is absent. tsc reports the present mismatch
+    // (TS2322 on `a`), not "Property 'b' is missing".
+    let diags = diagnostics(
+        r#"
+interface Box { a: string; b: number; }
+const x: Box = { a: 1 };
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "expected a present-property TS2322; got {diags:?}"
+    );
+    assert!(
+        !any_missing_message(&diags, "b"),
+        "missing-property report must be suppressed when a present property mismatches; got {diags:?}"
+    );
+}
+
+#[test]
+fn precedence_is_identifier_independent() {
+    // Same shape, different binder spellings — proves the rule is structural.
+    let diags = diagnostics(
+        r#"
+interface Settings { label: string; count: number; }
+const cfg: Settings = { label: 42 };
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "expected a present-property TS2322 for renamed binders; got {diags:?}"
+    );
+    assert!(
+        !any_missing_message(&diags, "count"),
+        "renamed missing property must also be suppressed; got {diags:?}"
+    );
+}
+
+#[test]
+fn all_present_mismatches_reported_and_missing_suppressed() {
+    // Two present-wrong properties plus one absent: tsc reports both present
+    // mismatches (TS2322 x2) and omits the missing-property report entirely.
+    let diags = diagnostics(
+        r#"
+interface Rec { a: string; b: number; c: boolean; }
+const x: Rec = { a: 1, b: "z" };
+"#,
+    );
+    assert!(
+        diagnostic_count(&diags, 2322) >= 2,
+        "expected both present-property mismatches; got {diags:?}"
+    );
+    assert!(
+        !any_missing_message(&diags, "c"),
+        "missing 'c' must be suppressed while present properties mismatch; got {diags:?}"
+    );
+}
+
+#[test]
+fn present_mismatch_wins_in_call_argument() {
+    let diags = diagnostics(
+        r#"
+interface Param { a: string; b: number; }
+declare function need(p: Param): void;
+need({ a: 1 });
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "expected a present-property TS2322 in the call-argument position; got {diags:?}"
+    );
+    assert!(
+        !any_missing_message(&diags, "b"),
+        "missing 'b' must be suppressed in the call-argument position; got {diags:?}"
+    );
+}
+
+#[test]
+fn present_mismatch_wins_in_return_position() {
+    let diags = diagnostics(
+        r#"
+interface Out { a: string; b: number; }
+function make(): Out { return { a: 1 }; }
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "expected a present-property TS2322 in the return position; got {diags:?}"
+    );
+    assert!(
+        !any_missing_message(&diags, "b"),
+        "missing 'b' must be suppressed in the return position; got {diags:?}"
+    );
+}
+
+#[test]
+fn nested_present_mismatch_wins_over_outer_missing() {
+    // The mismatch is one level deep (`a.x`) while `b` is absent at the top.
+    let diags = diagnostics(
+        r#"
+interface Nested { a: { x: string }; b: number; }
+const x: Nested = { a: { x: 1 } };
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "expected a nested present-property TS2322; got {diags:?}"
+    );
+    assert!(
+        !any_missing_message(&diags, "b"),
+        "outer missing 'b' must be suppressed when a nested property mismatches; got {diags:?}"
+    );
+}
+
+#[test]
+fn missing_only_still_reports_missing_floor() {
+    // Negative/floor case: all present properties are correct, one is absent.
+    // The missing-property diagnostic (TS2741) must still surface, and no
+    // spurious present-property TS2322 may appear.
+    let diags = diagnostics(
+        r#"
+interface Box { a: string; b: number; }
+const x: Box = { a: "ok" };
+"#,
+    );
+    assert!(
+        any_missing_message(&diags, "b"),
+        "an absent property with all-correct present properties must still report 'missing'; got {diags:?}"
+    );
+    assert!(
+        diagnostic_count(&diags, 2322) == 0,
+        "no spurious present-property mismatch may appear in the missing-only case; got {diags:?}"
+    );
+}
+
+#[test]
+fn fully_assignable_literal_reports_nothing() {
+    // Floor: a correct object literal produces no diagnostic.
+    let diags = diagnostics(
+        r#"
+interface Box { a: string; b: number; }
+const x: Box = { a: "ok", b: 2 };
+"#,
+    );
+    assert!(
+        diags
+            .iter()
+            .all(|d| d.code != 2322 && d.code != 2741 && d.code != 2739),
+        "a fully-assignable object literal must not error; got {diags:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Fixes #14582.

## Summary

When a **fresh object literal** is assigned to an object target and it has *both* a present property whose type is wrong *and* a required property that is absent, `tsc` reports the present-property type mismatch (`TS2322`, in source order) and suppresses the missing-property diagnostic. tsz reported the missing-property (`TS2741`/`TS2739`) — the wrong diagnostic code at the wrong location. This is a broad parity divergence across the assignment, call-argument, return, class-target, type-alias, and nested-object positions.

```ts
interface R { a: string; b: number; }
const x: R = { a: 1 };
// tsc: TS2322 Type 'number' is not assignable to type 'string'.   (on `a`)
// tsz before: TS2741 Property 'b' is missing …                    ← wrong
```

## Structural rule

When a fresh object literal is assigned to an object target, `tsc`'s `elaborateObjectLiteral` reports the type mismatch of each present property first; the missing-property report (`TS2741`/`TS2739`, or the argument-level `TS2345` "Property 'X' is missing") is only the **fallback** that surfaces when present-property elaboration reports nothing. For a non-fresh source (a variable, not a literal) there is no elaboration, so the relation's missing-property report stands — tsz already matched there.

Owner layer: checker error-reporter object-literal elaboration (`crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs`, `try_elaborate_object_literal_properties_with_source`).

## The fix

`try_elaborate_object_literal_properties_with_source` bailed out of per-property elaboration the moment the source literal was missing any required property — **except** for generic mapped receivers. That carve-out is exactly why a mapped-type target already matched `tsc` (reported the present mismatch) while plain interface/class/type-alias targets emitted `TS2741`. The fix **removes the special-case bail** so the precedence is unified for all object targets: the function's existing `elaborated` return already encodes "emit the generic missing-property only when no present mismatch was elaborated", so the caller now falls back to the missing-property diagnostic only when the loop reports nothing. The per-property loop's un-widened literal/contextual re-check already prevents the widening false positive the bail was originally meant to avoid (verified by the generic-inference cases below), so the now-dead guard helpers (`target_has_missing_required_properties_from_source`, `object_literal_property_name_from_elem`) are removed.

This generalizes the underlying mechanism rather than adding another special case — net −121 lines of source.

## Adjacent-case matrix (all verified vs tsc 6.0.2)

- present-wrong + missing → `TS2322` (was `TS2741`); present-wrong + two missing → `TS2322` (was `TS2739`).
- positions: variable initializer, call argument, return, class target, type alias, nested object — all flip to the present-property `TS2322`.
- two present-wrong + missing → both `TS2322` in source order, missing suppressed.
- renamed binders (anti-hardcoding) behave identically.
- **floors preserved**: missing-only still `TS2741`; non-literal source still `TS2741`; fully-assignable literal still clean; generic-inference widening (`f<T>(x:{a:T;b:T})` with `f({a:"name"})`) does **not** regress into a spurious present-property error.

## Out of scope

`tsc` also suppresses the excess-property report (`TS2353`) when a present property mismatches. That is a distinct, pre-existing precedence facet (the excess check runs before elaboration in the var-init driver) and is intentionally not folded in here.

## Verification

- New regression guard: `cargo test -p tsz-checker --test object_literal_present_mismatch_precedence_tests` → 8/8 (assignment/call/return/class/type-alias/nested present-mismatch precedence + missing-only and fully-assignable floors, with varied binder names).
- No regressions in the elaboration/missing-property suites: `union_source_missing_property_elaboration_tests` (19), `union_target_missing_property_elaboration_tests` (5), `intersection_target_missing_property_elaboration_tests` (13), `nullable_union_missing_property_tests` (5), `generic_multi_prop_object_literal_tests` (5), `jsx_spread_assignability_suppresses_ts2741` (4), `property_chain_elaboration_collapse_tests` (7), `satisfies_elaboration_chain_tests` (3), `ts2322_destructuring_obj_literal_tests` (6), `elaboration_wrapper_init_tests` (4), `satisfies_object_property_position_tests` (7), `object_literal_property_target_display_tests` (6), `ts2353_mapped_template_literal_key_tests` (9) — all green.
- `cargo test -p tsz-checker --lib` filtered to `object_literal/elaboration/missing_property/remapped/intersection_target`: 309 passed; the 10 failures are present **identically** on clean `main` (arena-order-sensitive local-harness artifacts) — confirmed by a stashed re-run, i.e. zero delta from this change.
- 24-case `tsc` vs `tsz` parity matrix (assignment/call/return/class/alias/nested/mapped, present-wrong/missing-only/non-literal) all match after the fix.
- `cargo fmt -p tsz-checker`, `cargo clippy -p tsz-checker --tests`, and `scripts/arch/check-checker-boundaries.sh` clean.
- Broad conformance / emit / fourslash floors: ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01VBgbF8nVYZdruJCV5nZAFM

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBgbF8nVYZdruJCV5nZAFM)_