### PR TITLE
fix(solver): taint unresolved-def deferrals in type-argument expansion (#14347)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -310,11 +310,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 if let Some(resolved) = self.resolver.resolve_type_query(sym_ref, self.interner) {
                     resolved
                 } else if let Some(def_id) = self.resolver.symbol_to_def_id(sym_ref) {
-                    self.resolver
-                        .resolve_lazy(def_id, self.interner)
-                        .unwrap_or(arg)
+                    match self.resolver.resolve_lazy(def_id, self.interner) {
+                        Some(resolved) => resolved,
+                        // No registered body on this query (#14347 deferral).
+                        None => self.defer_unexpanded_type_arg(arg),
+                    }
                 } else {
-                    arg
+                    // The `typeof` symbol resolves to no def yet (#14347 deferral).
+                    self.defer_unexpanded_type_arg(arg)
                 }
             }
             TypeData::Application(_)
@@ -353,13 +356,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // `ApplyDefaultOptions`/`RequiredKeysOf`, #13609). Resolve the
                 // name to its def and follow the same alias-chain expansion as
                 // the `Lazy` arm; keep the name opaque only when it genuinely
-                // does not resolve (registration-window artifact, preserved by
-                // the `else => arg` fallthrough below).
+                // does not resolve (a registration-window artifact deferred via
+                // `defer_unexpanded_type_arg` in the `else` below).
                 let name = self.interner.resolve_atom(atom);
                 if let Some(def_id) = self.resolver.resolve_unresolved_type_name(&name) {
                     self.expand_lazy_arg_chain(def_id, arg)
                 } else {
-                    arg
+                    // The name resolves to no def yet (#14347 deferral).
+                    self.defer_unexpanded_type_arg(arg)
                 }
             }
             _ => arg,
@@ -377,14 +381,38 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let mut current_def = def_id;
         for _ in 0..MAX_LAZY_CHAIN_DEPTH {
             let Some(body) = self.resolver.resolve_lazy(current_def, self.interner) else {
-                return fallback;
+                // The alias body is not registered on this query (a cross-file
+                // alias whose declaring file has not published it yet): keep the
+                // argument opaque and record the registration-window taint so the
+                // enclosing application's under-expanded result is kept out of the
+                // `TypeId`-keyed evaluation caches (#14347).
+                return self.defer_unexpanded_type_arg(fallback);
             };
             match self.interner.lookup(body) {
                 Some(TypeData::Lazy(next_def)) => current_def = next_def,
                 _ => return body,
             }
         }
-        // Circular or unusually deep alias chain.
+        // Circular or unusually deep alias chain — a depth bail, not an
+        // unresolved-body artifact: keep it opaque without the taint.
+        fallback
+    }
+
+    /// Keep an unexpanded type-argument opaque and record that its alias/name
+    /// could not be expanded because the declaring body is not yet registered.
+    ///
+    /// The un-expanded argument flows into the enclosing
+    /// application/instantiation evaluation, so that result is a function of the
+    /// *registration window* it ran in, not of the input `TypeId` alone: once the
+    /// declaring file publishes the real body, a fresh expansion yields a
+    /// different, fully-reduced argument. Marking `unresolved_def_seen` keeps the
+    /// registration-window result out of the `TypeId`-keyed evaluation caches
+    /// (`closed_eval_cache` / `application_eval_cache` / the checker's env-eval
+    /// backstop), exactly as the type-position `Lazy` visit ([`Self::visit_lazy`])
+    /// and the application-base deferrals (`evaluate/application.rs`) already do.
+    /// This is the type-argument arm of the `#14347` cache-purity invariant.
+    const fn defer_unexpanded_type_arg(&mut self, fallback: TypeId) -> TypeId {
+        self.mark_unresolved_def_seen();
         fallback
     }
 

--- a/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
@@ -121,6 +121,85 @@ fn evaluate_application_unknown_body_keeps_application_opaque() {
     );
 }
 
+/// Type-argument deferral taint (#14347). When an application's base resolves
+/// but a type *argument* is a `Lazy(DefId)` whose body is not registered on this
+/// query (a cross-file alias whose declaring file has not published it yet), the
+/// argument stays opaque — and the evaluator must record `unresolved_def_seen`
+/// so the enclosing application's under-expanded result is kept out of the
+/// `TypeId`-keyed evaluation caches. This is the argument-side mirror of the
+/// application-base deferrals in `evaluate/application.rs`.
+#[test]
+fn evaluate_application_unresolved_arg_alias_taints_unresolved_def_seen() {
+    let interner = TypeInterner::new();
+    let t_param = unconstrained_param(&interner, "T");
+    let t_type = interner.intern(TypeData::TypeParameter(t_param));
+    let value_name = interner.intern_string("value");
+    let body = interner.object(vec![PropertyInfo::new(value_name, t_type)]);
+
+    // `Box<Unregistered>` where `Unregistered`'s body is absent on this query.
+    let unresolved_arg = interner.lazy(DefId(909));
+    let mut env = TypeEnvironment::new();
+    let app = alias_application(
+        &interner,
+        &mut env,
+        DefId(101),
+        DefKind::TypeAlias,
+        body,
+        vec![t_param],
+        vec![unresolved_arg],
+    );
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    let _ = evaluator.evaluate(app);
+
+    assert!(
+        evaluator.is_unresolved_def_seen(),
+        "an application argument whose alias body is unresolved must taint \
+         `unresolved_def_seen` so the result is not cached as authoritative"
+    );
+}
+
+/// Negative control for #14347: a type argument whose alias body *is* registered
+/// expands cleanly and must NOT taint `unresolved_def_seen`. This pins the taint
+/// to genuine registration-window deferrals, never a steady-state expansion.
+#[test]
+fn evaluate_application_resolved_arg_alias_does_not_taint() {
+    let interner = TypeInterner::new();
+    let t_param = unconstrained_param(&interner, "T");
+    let t_type = interner.intern(TypeData::TypeParameter(t_param));
+    let value_name = interner.intern_string("value");
+    let body = interner.object(vec![PropertyInfo::new(value_name, t_type)]);
+
+    let mut env = TypeEnvironment::new();
+    // `type StringAlias = string` — a fully registered, resolvable alias arg.
+    env.insert_def_with_params(DefId(808), TypeId::STRING, vec![]);
+    env.insert_def_kind(DefId(808), DefKind::TypeAlias);
+    let resolved_arg = interner.lazy(DefId(808));
+
+    let app = alias_application(
+        &interner,
+        &mut env,
+        DefId(101),
+        DefKind::TypeAlias,
+        body,
+        vec![t_param],
+        vec![resolved_arg],
+    );
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    let result = evaluator.evaluate(app);
+
+    assert!(
+        !evaluator.is_unresolved_def_seen(),
+        "a resolvable argument alias must not taint `unresolved_def_seen`"
+    );
+    let expected = interner.object(vec![PropertyInfo::new(value_name, TypeId::STRING)]);
+    assert_eq!(
+        result, expected,
+        "Box<StringAlias> must expand to {{ value: string }}"
+    );
+}
+
 fn tuple_elem(type_id: TypeId) -> TupleElement {
     TupleElement {
         type_id,


### PR DESCRIPTION
Goal: hold

## Summary

A concrete, bounded slice of #14347 ("caches memoize values that are not pure functions of their keys"): complete the **type-argument** arm of the registration-window cache-purity invariant.

Application **base** deferrals already record `unresolved_def_seen` when a base `DefId` has no resolvable body on the current query (`crates/tsz-solver/src/evaluation/evaluate/application.rs:325/340/371/436`), keeping the registration-window result out of the `TypeId`-keyed evaluation caches (`closed_eval_cache` / `application_eval_cache` / the checker's env-eval backstop). The symmetric type-**argument** expansion deferrals in `try_expand_type_arg` / `expand_lazy_arg_chain` did **not** — so an application whose base resolves but whose argument's alias body is still mid-registration cached an under-expanded result as if it were a pure function of the input `TypeId`.

The three argument-deferral sites (the `TypeQuery` `resolve_lazy → None`, the `UnresolvedTypeName` no-def `else`, and the `Lazy`-chain no-body bail in `expand_lazy_arg_chain`) now route through a shared `defer_unexpanded_type_arg` helper that records the taint. The circular/too-deep alias-chain bail keeps the opaque fallback **without** the taint — that is a depth bail, not an unresolved-body artifact.

## Structural rule

When a generic application's type *argument* is an alias/`typeof`/unresolved-name reference whose declaring body is not registered on this query, `tsc` re-derives the argument once the body publishes; tsz must not memoize the enclosing application's under-expanded result as authoritative. Owner layer: solver evaluation (`try_expand_type_arg` / `expand_lazy_arg_chain`), via the existing `unresolved_def_seen` taint the cache write-gates already honor — the argument-side mirror of the application-base deferrals.

## Why it is parity-safe by construction

The taint only makes a cache **skip a write**; it never changes a computed value. A cache miss recomputes the identical result, so no diagnostic can change — the taint can only stop a registration-window result from shadowing the fully-resolved answer a later pass derives. The change adds no overhead on the common (resolved) path; the helper is reached only when `resolve_lazy` / name resolution genuinely returns `None`.

## Adjacent-case matrix

- Positive: application argument is a `Lazy(DefId)` with no registered body → taints `unresolved_def_seen`.
- Negative control: application argument is a fully-registered resolvable alias → does **not** taint, and `Box<StringAlias>` still expands to `{ value: string }`. Binder `DefId`s vary across cases.

## Relationship to other PRs

Distinct, non-overlapping slice of #14347. Draft #14569 adds the analogous taint to the `evaluate_keyof` `Lazy`-unresolved path (the kysely #10663 facet); this PR covers the type-argument-expansion family instead. #14580 is the project-wide instantiation cache (a different lever).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-solver --lib orchestrator_tests::` — 12 passed (2 new: positive taint + negative control; the 10 pre-existing orchestrator phase tests unchanged).
- `cargo test -p tsz-solver --lib closed_eval` (8) / `unresolved` (15) / `instantiat` (191) / `cache_poison` (1) — all green; zero net-new failures vs the pre-change baseline.
- `cargo clippy -p tsz-solver --lib` clean; `cargo fmt -p tsz-solver` clean.
- Broad conformance / emit / fourslash floors: CI gates this PR (a hot evaluation-cache change can ripple into emit/DTS). The taint is write-skip-only, so diagnostics are byte-stable by construction.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MRj37hBAQ6v5jfo272JhJf)_