### PR TITLE
fix(solver): preserve tuple identity in homomorphic maps over recursive-utility tuples (#14518)

### DIFF
--- a/crates/tsz-checker/src/tests/tuple_spread_flattening_tests.rs
+++ b/crates/tsz-checker/src/tests/tuple_spread_flattening_tests.rs
@@ -171,3 +171,107 @@ const c: number = t[7];
 "#
     ));
 }
+
+// ── Homomorphic mapped over a tuple, through recursive utility composition ───
+//
+// `{ [K in keyof T]: F<T[K]> }` is homomorphic over `T` even when the per-key
+// value passes through another utility `F`, so the tuple structure (and each
+// element's per-index identity) must be preserved. Before the fix the mapped
+// collapsed the tuple to an array (`F<T[number]>[]`) because the homomorphic
+// source could not be recovered through the `F<…>` application wrapper, and the
+// variadic rebuild folded every spread index onto a single `source[index]`.
+
+/// The four-utility composition from the bug report: a homomorphic mapped
+/// (`NormalizeBox`/`AliasCompute`) sits over a variadic-rebuilt tuple
+/// (`DeepRO`) reached through a key-remap mapped (`PickStr`). `tuple[2]` must be
+/// the third element, so `.wrapped` resolves.
+#[test]
+fn recursive_utility_composition_preserves_tuple_index_identity() {
+    assert!(no_access_errors(
+        r#"
+type AliasCompute<TValue> = TValue extends (...args: infer P) => infer R
+  ? (...args: P) => R
+  : TValue extends readonly [infer H, ...infer T]
+    ? readonly [AliasCompute<H>, ...AliasCompute<T>]
+    : TValue extends object ? { [K in keyof TValue]: AliasCompute<TValue[K]> } : TValue;
+type NormalizeBox<I> = I extends object ? { [F in keyof I]: NormalizeBox<I[F]> } : I;
+type DeepRO<S> = S extends (...a: any[]) => any ? S
+  : S extends readonly [infer A, ...infer B] ? readonly [DeepRO<A>, ...DeepRO<B>]
+  : S extends object ? { readonly [N in keyof S]: DeepRO<S[N]> } : S;
+type PickStr<R> = { [M in keyof R as M extends string ? M : never]: R[M] };
+type UtilityPipeline<X> = AliasCompute<NormalizeBox<DeepRO<PickStr<X>>>>;
+type Seed = { readonly tuple: readonly [{ a: 1 }, { b: 2 }, { wrapped: 3 }] };
+declare const m: UtilityPipeline<Seed>;
+const probe: 3 = m.tuple[2].wrapped;
+"#
+    ));
+}
+
+/// Reduced witness with renamed binders: a homomorphic map (`Wrap`) over an
+/// object whose property is a variadic-rebuilt tuple (`Freeze`), read per index
+/// in value position. Every literal index resolves to its own element.
+#[test]
+fn homomorphic_map_over_rebuilt_tuple_each_index_resolves() {
+    assert!(no_access_errors(
+        r#"
+type Wrap<Box> = Box extends object ? { [Slot in keyof Box]: Wrap<Box[Slot]> } : Box;
+type Freeze<Src> = Src extends readonly [infer Lead, ...infer Trail]
+  ? readonly [Freeze<Lead>, ...Freeze<Trail>]
+  : Src extends object ? { readonly [Pos in keyof Src]: Freeze<Src[Pos]> } : Src;
+type Holder = { readonly cells: readonly [{ p: 1 }, { q: 2 }, { r: 3 }] };
+declare const h: Wrap<Freeze<Holder>>;
+const c0: 1 = h.cells[0].p;
+const c1: 2 = h.cells[1].q;
+const c2: 3 = h.cells[2].r;
+"#
+    ));
+}
+
+/// Negative control: a `number` index into the same composed tuple must still
+/// yield the element *union*, not a single element — so reading a property that
+/// only exists on one element is rejected.
+#[test]
+fn composed_tuple_number_index_stays_element_union() {
+    let found = codes(
+        r#"
+type Wrap<Box> = Box extends object ? { [Slot in keyof Box]: Wrap<Box[Slot]> } : Box;
+type Freeze<Src> = Src extends readonly [infer Lead, ...infer Trail]
+  ? readonly [Freeze<Lead>, ...Freeze<Trail>]
+  : Src extends object ? { readonly [Pos in keyof Src]: Freeze<Src[Pos]> } : Src;
+type Holder = { readonly cells: readonly [{ p: 1 }, { q: 2 }, { r: 3 }] };
+declare const h: Wrap<Freeze<Holder>>;
+declare const n: number;
+const u = h.cells[n];
+const onlyP: { readonly p: 1 } = u;
+"#,
+    );
+    assert!(
+        found.contains(&2322),
+        "number index must stay the element union (TS2322 expected): {found:?}"
+    );
+}
+
+/// Length preservation: the composed receiver's tuple property keeps exactly
+/// three elements (it is not widened to an array), so reading the whole tuple
+/// observes a fixed-length tuple rather than `(elt)[]`.
+#[test]
+fn composed_tuple_keeps_fixed_length_three() {
+    // A genuine array would assign to `readonly unknown[]` but never expose a
+    // length-3 tuple shape. Assigning the tuple to a 2-tuple target must fail
+    // (lengths differ), proving the third element is present and distinct.
+    let found = codes(
+        r#"
+type Wrap<Box> = Box extends object ? { [Slot in keyof Box]: Wrap<Box[Slot]> } : Box;
+type Freeze<Src> = Src extends readonly [infer Lead, ...infer Trail]
+  ? readonly [Freeze<Lead>, ...Freeze<Trail>]
+  : Src extends object ? { readonly [Pos in keyof Src]: Freeze<Src[Pos]> } : Src;
+type Holder = { readonly cells: readonly [{ p: 1 }, { q: 2 }, { r: 3 }] };
+declare const h: Wrap<Freeze<Holder>>;
+const twoOnly: readonly [{ p: 1 }, { q: 2 }] = h.cells;
+"#,
+    );
+    assert!(
+        found.contains(&2322),
+        "length-3 tuple must not assign to a 2-tuple target (TS2322 expected): {found:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -330,7 +330,20 @@ impl<'a> CheckerState<'a> {
                 // solver's own element-access evaluator is resolver-less and
                 // would leave the spread opaque.
                 let resolved = self.resolve_lazy_type(elem.type_id);
-                let resolved = self.evaluate_application_type(resolved);
+                let mut resolved = self.evaluate_application_type(resolved);
+                // A homomorphic-map-over-rest spread
+                // (`...{ [K in keyof R]: F<R[K]> }`, produced by the solver when
+                // a recursive utility's rest could not be flattened eagerly in
+                // the resolver-less / depth-limited evaluation frame) is neither
+                // a `Lazy` nor an `Application`, so the resolution above leaves it
+                // opaque. Evaluate it through the full env-backed evaluator so the
+                // spread inlines its now-concrete tuple instead of surfacing as a
+                // single nested-tuple element.
+                if crate::query_boundaries::common::mapped_type_id(self.ctx.types, resolved)
+                    .is_some()
+                {
+                    resolved = self.evaluate_type_with_env(resolved);
+                }
                 if resolved != elem.type_id {
                     changed = true;
                 }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/key_extraction.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/key_extraction.rs
@@ -642,21 +642,62 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
         template: TypeId,
         iter_name: Atom,
     ) -> Option<TypeId> {
+        self.extract_template_index_source_bounded(template, iter_name, 0)
+    }
+
+    /// Recursively search `template` for a `source[K]` indexed access whose key is
+    /// the mapped iteration variable `iter_name`, returning the indexed `source`.
+    ///
+    /// The template of a homomorphic mapped type need not be the bare `T[K]`: a
+    /// utility wrapper such as `{ [K in keyof T]: F<T[K]> }` keeps the source `T`
+    /// homomorphic (every key still reads `T[K]`, the result merely passes through
+    /// `F`). When the constraint `keyof T` has already been eagerly evaluated to a
+    /// literal-key union (the post-instantiation form), the source can no longer be
+    /// recovered from the constraint, so it is recovered here from the template.
+    /// We therefore look through `Application` arguments (the `F<…>` wrapper) and
+    /// `ReadonlyType` wrappers in addition to the union/intersection/conditional
+    /// shapes, so tuple/array structure preservation is not lost just because the
+    /// per-element value is computed through another utility.
+    fn extract_template_index_source_bounded(
+        &mut self,
+        template: TypeId,
+        iter_name: Atom,
+        depth: usize,
+    ) -> Option<TypeId> {
+        const MAX_TEMPLATE_SOURCE_DEPTH: usize = 16;
+        if depth > MAX_TEMPLATE_SOURCE_DEPTH {
+            return None;
+        }
         match self.interner().lookup(template) {
             Some(TypeData::IndexAccess(obj, idx)) => match self.interner().lookup(idx) {
                 Some(TypeData::TypeParameter(param)) if param.name == iter_name => Some(obj),
-                _ => None,
+                _ => self.extract_template_index_source_bounded(obj, iter_name, depth + 1),
             },
             Some(TypeData::Union(list_id) | TypeData::Intersection(list_id)) => {
                 let members = self.interner().type_list(list_id);
-                members
-                    .iter()
-                    .find_map(|&member| self.extract_template_index_source(member, iter_name))
+                members.iter().find_map(|&member| {
+                    self.extract_template_index_source_bounded(member, iter_name, depth + 1)
+                })
             }
             Some(TypeData::Conditional(cond_id)) => {
                 let cond = self.interner().get_conditional(cond_id);
-                self.extract_template_index_source(cond.true_type, iter_name)
-                    .or_else(|| self.extract_template_index_source(cond.false_type, iter_name))
+                self.extract_template_index_source_bounded(cond.true_type, iter_name, depth + 1)
+                    .or_else(|| {
+                        self.extract_template_index_source_bounded(
+                            cond.false_type,
+                            iter_name,
+                            depth + 1,
+                        )
+                    })
+            }
+            Some(TypeData::Application(app_id)) => {
+                let args = self.interner().type_application(app_id).args.clone();
+                args.iter().find_map(|&arg| {
+                    self.extract_template_index_source_bounded(arg, iter_name, depth + 1)
+                })
+            }
+            Some(TypeData::ReadonlyType(inner)) => {
+                self.extract_template_index_source_bounded(inner, iter_name, depth + 1)
             }
             _ => None,
         }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_array.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_array.rs
@@ -334,6 +334,39 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             };
         }
 
+        // Deferred resolvable rest (`...Util<R>`): the spread operand is an
+        // alias/conditional/indexed-access that *resolves to* a tuple or array
+        // but could not be evaluated to a concrete shape in this frame — e.g. a
+        // recursive utility reached at a deep `def_depth`, or a cross-file alias
+        // mid-registration. Collapsing it through the opaque `F<source[index]>`
+        // path below loses per-element identity (every spread index folds onto
+        // the same `source[index]`). Instead keep the rest as a homomorphic map
+        // over the *rest itself* (`...{ [K in keyof R]: F<R[K]> }`): a later
+        // evaluation pass — most importantly the top-level element access, where
+        // the `def_depth` budget is fresh and the resolver is fully populated —
+        // resolves `R` to its concrete tuple and the deferred map flattens to the
+        // correct per-element values. Genuine opaque rests (a bare `...T` type
+        // parameter, which is not a "needs-evaluation" deferral) fall through to
+        // the indexed-access path below, preserving the reverse-inference link.
+        if elem.rest
+            && !matches!(rest_inner_kind, Some(Some(TypeData::Array(_))))
+            && self.mapped_tuple_rest_needs_evaluation(rest_inner)
+        {
+            let mut inner_mapped = self.rebind_mapped_source(mapped, source, evaluated_rest_type);
+            // The mapped constraint may have been eagerly evaluated to a literal
+            // key union of the *outer* tuple; re-anchor it on `keyof R` so the
+            // deferred map is recognized as homomorphic over the rest when it is
+            // finally evaluated.
+            inner_mapped.constraint = self.interner().keyof(evaluated_rest_type);
+            let deferred = self.interner().mapped(inner_mapped);
+            return TupleElement {
+                type_id: deferred,
+                name: elem.name,
+                optional: elem.optional,
+                rest: true,
+            };
+        }
+
         // Opaque variadic rests (`...T`) must keep the source tuple in the
         // indexed access. Rewriting to `T[number]` loses the relationship that
         // reverse inference uses to infer `T` from mapped tuple rest elements.


### PR DESCRIPTION
Fixes #14518.

Goal: green

## Structural rule

When a homomorphic mapped type `{ [K in keyof T]: F<T[K]> }` is evaluated over a tuple `T`, `tsc` keeps the result a tuple with per-index element identity (the per-key value merely passes through the wrapper `F`), so a literal index `Tuple[K]` is exactly the (transformed) element `K`. tsz instead collapsed the tuple to the element-type union (`F<T[number]>[]`) whenever the map was reached through a recursive-utility composition, so `Tuple[K]` over-included other elements and a property present only on element `K` was reported missing — exactly one false `TS2339` per generated case in the **"Recursive utility aliases N=120/240"** microbenchmark, which blocked the row from recording a tsz/tsgo timing pair.

Owner layer: solver homomorphic mapped-type evaluation (`crates/tsz-solver/src/evaluation/evaluate_rules/mapped/…`), plus the checker's value-position spread flattening boundary.

## What was wrong (two solver defects + one checker gap)

1. **Homomorphic-source recovery missed the `F<…>` wrapper.** After instantiation the constraint `keyof T` is eagerly evaluated to a literal-key union, so the homomorphic source must be recovered from the template's `T[K]`. `extract_template_index_source` only matched a bare `T[K]` template and returned `None` for `F<T[K]>` (an `Application` wrapping the index access). With no source, the array/tuple-preservation dispatch was skipped and the generic object-property build reshaped the tuple into a numeric-index object (rendered as `(elt)[]`). It now looks through `Application` arguments and `ReadonlyType` wrappers (depth-bounded); the existing `keyof source == constraint` validation still gates the recovered candidate.

2. **A deferred resolvable rest collapsed onto one element.** When the source tuple's spread operand `...Util<R>` could not be evaluated to a concrete tuple in the current (deep `def_depth` / registration-window) frame, `evaluate_mapped_tuple_element` rewrote it to the opaque `F<source[index]>`, folding every spread index onto the same slot. It now keeps the rest as a homomorphic map over the rest itself (`...{ [K in keyof R]: F<R[K]> }`, re-anchored on `keyof R`) so a later pass — most importantly the top-level element access, where the def-depth budget is fresh and the resolver is fully populated — resolves `R` and flattens to the correct per-element values. Genuine `...T` type-parameter rests still take the indexed-access path, preserving the reverse-inference relationship.

3. **Value-position flattening didn't resolve a `Mapped` rest.** The checker's `flatten_tuple_spread_rests` resolved only `Lazy`/`Application` rests; it now also evaluates a `Mapped` rest through the env-backed evaluator, so the new deferred map inlines its concrete tuple in value position (`m.tuple[2]`) too.

## Adjacent-case matrix (all match `tsc`)

- Per-index reads `[0]`/`[1]`/`[2]` each resolve to their own element.
- `readonly` and mutable tuple sources.
- Single access vs. multiple accesses in one file (a caching interaction).
- Renamed binders (anti-hardcoding: the structural rule, not a spelling).
- Negative control: a `number` index still yields the **element union** (reading a one-element-only property is rejected).
- Length preserved: the composed tuple stays a fixed-length 3-tuple, not an array.
- The full 4-utility composition from the report (`AliasCompute<NormalizeBox<DeepRO<PickStr<X>>>>`) and a reduced 2-utility witness.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New regression tests in `crates/tsz-checker/src/tests/tuple_spread_flattening_tests.rs` (positive per-index, number-index union, fixed-length, full + reduced compositions) — 13 passed.
- `cargo test -p tsz-solver --lib mapped` — 407 passed; `-- tuple index_access keyof` — 960 passed; `-- conditional infer instantiat variadic` — 1539 passed (1 pre-existing failure identical on baseline).
- `cargo test -p tsz-checker --lib -- access tuple mapped` — 944 passed; the 15 failures are pre-existing (identical set on `main` before this change, the known environment-specific/#13255 set) — **zero net-new failures**.
- `cargo clippy -p tsz-solver -p tsz-checker --lib` clean; `cargo fmt` clean; `git diff --check` clean; `python3 scripts/arch/arch_guard.py` passed.
- Manual `tsz --noEmit --strict` on the issue's minimal repro: now exits 0 (was `rc=2`, one `TS2339`), matching `tsc`.
- Broad conformance / emit / fourslash / project floors: all green on this PR head.

https://claude.ai/code/session_01Cn3ESukjBo9GLMRBdMtmwx