### PR TITLE
fix(emit): correct enum-member access in const/property .d.ts initializers

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_enum_access.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_enum_access.rs
@@ -73,21 +73,65 @@ impl<'a> DeclarationEmitter<'a> {
 
     pub(crate) fn simple_enum_access_member_text(&self, expr_idx: NodeIndex) -> Option<String> {
         let expr_idx = self.semantic_simple_enum_access(expr_idx)?;
+        self.enum_member_access_canonical_text(expr_idx)
+    }
+
+    /// Canonical `Base.Member` declaration text for an enum access that resolves
+    /// to a specific enum-member *literal*, or `None` when the access is a
+    /// reverse mapping (numeric / computed / non-member index → `string`) or is
+    /// otherwise not a member literal.
+    ///
+    /// Mirrors `tsc`'s declaration emit (`createLiteralConstValue`): only an
+    /// enum-member literal type is preserved as a member reference, and it is
+    /// always rendered in property-access spelling — so `E["B"]` normalizes to
+    /// `E.B` and a reverse mapping like `E[0]` / `E[E.B]` (type `string`) yields
+    /// `None` so the caller falls back to a `: string` type annotation. The base
+    /// and member are reconstructed from structured entity-name nodes, never a
+    /// raw source slice, so parentheses/non-null punctuation cannot leak into the
+    /// output (e.g. `(E.B)` renders as `E.B`, not `E.B)`).
+    pub(in crate::declaration_emitter) fn enum_member_access_canonical_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        let expr_idx = self.skip_parenthesized_non_null_and_comma(expr_idx);
         let expr_node = self.arena.get(expr_idx)?;
         let access = self.arena.get_access_expr(expr_node)?;
-        let base_name = self.get_identifier_text(access.expression)?;
+
         if expr_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-            let member_name = self.get_identifier_text(access.name_or_argument)?;
-            return Some(format!("{base_name}.{member_name}"));
+            // `E.B` / `ns.E.B` — a dotted entity name already names the member.
+            return self.entity_name_text(expr_idx);
         }
 
         if expr_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
-            let member_node = self.arena.get(access.name_or_argument)?;
-            let member_text = self.get_source_slice(member_node.pos, member_node.end)?;
-            return Some(format!("{base_name}[{member_text}]"));
+            let base = self.entity_name_text(access.expression)?;
+            // Only a string-literal member name names an enum-member literal type.
+            // Numeric / computed indices are reverse mappings whose type is
+            // `string`, so they must not be preserved as a member reference.
+            let member_name = self.string_literal_member_name(access.name_or_argument)?;
+            // tsc normalizes `E["valid"]` to property spelling `E.valid`, but a
+            // member name that is not a valid identifier (e.g. `"hyphen-member"`)
+            // must stay in bracket form `E["hyphen-member"]`.
+            if crate::transforms::emit_utils::is_valid_identifier_name(&member_name) {
+                return Some(format!("{base}.{member_name}"));
+            }
+            let escaped = super::escape_string_for_double_quote(&member_name);
+            return Some(format!("{base}[\"{escaped}\"]"));
         }
 
         None
+    }
+
+    /// The (unquoted) member name when `expr_idx` is a string-literal element
+    /// access argument, e.g. the `B` in `E["B"]`. Returns `None` for any other
+    /// argument (numeric / computed / asserted), which is a reverse mapping.
+    fn string_literal_member_name(&self, expr_idx: NodeIndex) -> Option<String> {
+        let expr_node = self.arena.get(expr_idx)?;
+        if expr_node.kind != SyntaxKind::StringLiteral as u16 {
+            return None;
+        }
+        self.arena
+            .get_literal(expr_node)
+            .map(|lit| lit.text.clone())
     }
 
     pub(crate) fn enum_member_access_initializer_text(
@@ -111,7 +155,10 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
 
-        self.get_source_slice_no_semi(expr_node.pos, expr_node.end)
+        // Render in canonical `Base.Member` spelling rather than a raw source
+        // slice: this normalizes `E["B"]` to `E.B` and prevents parenthesis /
+        // non-null punctuation from leaking into the declaration output.
+        self.enum_member_access_canonical_text(expr_idx)
     }
 
     fn entity_access_chain_symbol(&self, expr_idx: NodeIndex) -> Option<SymbolId> {
@@ -244,18 +291,7 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
 
-        if expr_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-            let member_name = self.get_identifier_text(access.name_or_argument)?;
-            return Some(format!("{base_name}.{member_name}"));
-        }
-
-        if expr_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
-            let member_node = self.arena.get(access.name_or_argument)?;
-            let member_text = self.get_source_slice(member_node.pos, member_node.end)?;
-            return Some(format!("{base_name}[{member_text}]"));
-        }
-
-        None
+        self.enum_member_access_canonical_text(expr_idx)
     }
 
     fn enum_declaration_is_const_named(&self, stmt_idx: NodeIndex, base_name: &str) -> bool {

--- a/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
@@ -1496,3 +1496,100 @@ export type Return = nested.NestedProps;
 
     let _ = std::fs::remove_dir_all(root);
 }
+
+// =====================================================================
+// Enum-member access in const / readonly-property initializers (.d.ts)
+//
+// tsc's declaration emit (`createLiteralConstValue`) preserves an enum access
+// as a member reference ONLY when it names a specific enum-member literal, and
+// always renders it in property-access spelling:
+//   - `E.B`            -> `= E.B`
+//   - `E["B"]`         -> `= E.B`            (normalized to identifier spelling)
+//   - `E["hyphen-x"]`  -> `= E["hyphen-x"]`  (non-identifier member stays bracketed)
+//   - `(E.B)`          -> `= E.B`            (no leaked parentheses)
+// A reverse mapping (`E[0]`, `E[E.B]`, computed index) has type `string`, so it
+// is NOT preserved as an initializer — the type annotation path takes over.
+// =====================================================================
+
+#[test]
+fn test_enum_element_access_string_member_normalizes_to_property_spelling() {
+    let output = emit_dts_with_binding("enum E { A, B = 2, C }\nexport const x = E[\"B\"];\n");
+    assert!(
+        output.contains("export declare const x = E.B;"),
+        "Expected E[\"B\"] to normalize to E.B: {output}"
+    );
+    assert!(
+        !output.contains(r#"E["B"]"#),
+        "Should not preserve bracket spelling for an identifier member: {output}"
+    );
+}
+
+#[test]
+fn test_enum_element_access_non_identifier_member_stays_bracketed() {
+    let output = emit_dts_with_binding(
+        "enum E { \"hyphen-member\" = 1, regular = 2 }\nexport const x = E[\"hyphen-member\"];\nexport const y = E.regular;\n",
+    );
+    assert!(
+        output.contains(r#"export declare const x = E["hyphen-member"];"#),
+        "Non-identifier member must keep bracket spelling: {output}"
+    );
+    assert!(
+        output.contains("export declare const y = E.regular;"),
+        "Identifier member uses property spelling: {output}"
+    );
+}
+
+#[test]
+fn test_enum_parenthesized_member_access_drops_parentheses() {
+    let output = emit_dts_with_binding("enum E { A, B = 2, C }\nexport const x = (E.B);\n");
+    assert!(
+        output.contains("export declare const x = E.B;"),
+        "Parenthesized enum access must render as E.B: {output}"
+    );
+    assert!(
+        !output.contains("E.B)"),
+        "Parenthesis must not leak into declaration output: {output}"
+    );
+}
+
+#[test]
+fn test_enum_reverse_mapping_index_not_preserved_as_initializer() {
+    // `E[0]` / `E[E.B]` are reverse mappings (type `string`), never a member
+    // literal — so they must not be emitted as a `= E[...]` initializer, and in
+    // particular must not produce the malformed `E[E.B]]` double-bracket form.
+    let output = emit_dts_with_binding(
+        "enum E { A, B = 2, C }\nexport const c = E[0];\nexport const d = E[E.B];\n",
+    );
+    assert!(
+        !output.contains("= E[0]"),
+        "Numeric reverse-mapping index must not be a preserved initializer: {output}"
+    );
+    assert!(
+        !output.contains("E[E.B]"),
+        "Enum-valued reverse-mapping index must not be a preserved initializer (and never the malformed E[E.B]]): {output}"
+    );
+    assert!(
+        !output.contains("]]"),
+        "Must never emit a doubled closing bracket: {output}"
+    );
+}
+
+#[test]
+fn test_enum_readonly_property_element_access_normalizes() {
+    let output = emit_dts_with_binding(
+        "enum E { A, B = 2, C }\nexport class K {\n  readonly p = E[\"B\"];\n}\n",
+    );
+    assert!(
+        output.contains("readonly p = E.B;"),
+        "Readonly class property with E[\"B\"] must normalize to E.B: {output}"
+    );
+}
+
+#[test]
+fn test_const_enum_element_access_string_member_normalizes() {
+    let output = emit_dts_with_binding("const enum CE { X, Y = 5 }\nexport const x = CE[\"Y\"];\n");
+    assert!(
+        output.contains("export declare const x = CE.Y;"),
+        "const enum CE[\"Y\"] must normalize to CE.Y: {output}"
+    );
+}


### PR DESCRIPTION
Goal: hold

## Summary

In declaration emit, an enum access used as a `const` / readonly-property
initializer was unconditionally preserved as a **raw source-slice initializer**,
regardless of what the access actually resolved to. This produced three
divergences from `tsc` (found by probing enum `.d.ts` emit against `tsc 6.0.2`):

| source | `tsc` | tsz (before) |
|---|---|---|
| `const y = E.B` | `= E.B` | `= E.B` ✓ |
| `const y = E["B"]` | `= E.B` | `= E["B"]` ✗ (not normalized) |
| `const y = E[0]` | `: string` | `= E[0]` ✗ |
| `const y = E[E.B]` | `: string` | `= E[E.B]]` ✗ (**malformed, invalid `.d.ts`**) |
| `const y = (E.B)` | `= E.B` | `= E.B)` ✗ (**stray paren**) |
| `const y = CE["Y"]` (const enum) | `= CE.Y` | `= CE["Y"]` ✗ |

The `E[E.B]]` case emits **syntactically invalid** declaration output.

## Structural rule

When an enum access is used as a literal-`const`/readonly-property initializer,
`tsc`'s declaration emit (`createLiteralConstValue`) preserves it as a member
reference **only when it names a specific enum-member literal**, and always
renders it in property-access spelling. A reverse mapping (`E[0]`, `E[E.B]`, any
numeric/computed index) has type `string`, so it is emitted as a `: string`
**type annotation**, never as an initializer.

Owner layer: emitter (declaration emit) —
`crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_enum_access.rs`.
No semantic validation or output surgery; this is purely the declaration text
that the emitter already owns.

## Fix

The three enum-access text helpers (`simple_enum_access_member_text`,
`enum_member_access_initializer_text` — the binder-backed path —, and
`simple_const_enum_access_member_text`) each constructed their own text from raw
source slices. They now route through a single canonical builder,
`enum_member_access_canonical_text`, which:

- reconstructs `Base.Member` from **structured entity-name nodes** (reusing the
  existing `entity_name_text`), so parentheses / non-null punctuation can never
  leak into the output (`(E.B)` → `E.B`, not `E.B)`);
- normalizes a string-literal element access `E["valid"]` to property spelling
  `E.valid`, while keeping a **non-identifier** member name bracketed
  (`E["hyphen-member"]`, `E["with space"]`, `E["123num"]`);
- returns `None` for any non-string-literal element index (numeric/computed →
  reverse mapping → `string`), so the existing type-annotation path takes over
  and emits `: string`.

## Adjacent-case matrix (all verified byte-identical to `tsc 6.0.2`)

- `E.B` / `(E.B)` / `E["B"]` → `= E.B`; reverse maps `E[0]` / `E[E.B]` /
  `E[k]` (`k: 0 | 2`) → `: string`.
- Const enum `CE.Y` / `CE["Y"]` → `= CE.Y`.
- Non-identifier members stay bracketed (`E["hyphen-member"]`,
  `E["with space"]`, `E["123num"]`); identifier members normalize
  (`E["valid_id"]` → `E.valid_id`).
- `as const`: `E.B as const` / `E["B"] as const` → `: E.B`; `E[0] as const` →
  `: string`.
- Imported enum (cross-file) — same rules.
- Class readonly properties — same rules.
- Binder names vary across the regression cases (anti-hardcoding); the rule is
  structural, not a spelling.

## Known out-of-scope residual

`const y = E["nope" as any]` is `: string` in `tsc` but `: any` in tsz. That is a
pre-existing **solver indexed-access** inference gap (the type of indexing an
enum object with an `any`-typed key), a different owner layer. It is *not*
regressed here — that case previously emitted malformed preserved text — and is
left for a solver-side fix.

## Verification

- New regression tests in
  `crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs`
  (normalization, non-identifier bracket preservation, paren-drop, reverse-map
  not-preserved / no `]]`, readonly-property element access, const enum) — 6
  passed.
- `cargo test -p tsz-emitter --lib declaration_emitter` — 1504 passed, 0 failed.
- `cargo test -p tsz-emitter --lib` — 3806 passed, 0 failed.
- Manual `tsz --declaration --emitDeclarationOnly --strict` vs `tsc 6.0.2` on the
  full matrix above — byte-identical (except the documented `any`-index
  residual).
- `cargo clippy -p tsz-emitter --lib` clean; `cargo fmt --check` clean;
  `python3 scripts/arch/arch_guard.py` passed.
- Full conformance / emit / fourslash parity: ready-review CI owns the broad
  gate.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01W3FyAEhp5tthRytm9WKP7N

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3FyAEhp5tthRytm9WKP7N)_