### PR TITLE
fix(solver): reduce generic type alias with `unknown` body to canonical unknown

### DIFF
--- a/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
@@ -657,3 +657,91 @@ export {}
         result.diagnostics
     );
 }
+
+// ---------------------------------------------------------------------------
+// A generic type alias whose body is `unknown` (`type Foo<T> = unknown`) must
+// reduce its applications to canonical `unknown`, matching tsc's eager alias
+// substitution. Previously the evaluator kept `Foo<Args>` opaque whenever its
+// body resolved to `unknown` (a guard meant for unregistered cross-file
+// placeholders), so a later reflexive relation `unknown <: Foo<Args>` on an
+// interface/object member typed by exactly this alias produced a false TS2322
+// (`'unknown' is not assignable to 'Foo<Args>'`). Binder names vary across the
+// cases (alias/interface/param identifiers) so no name string drives the fix.
+// ---------------------------------------------------------------------------
+#[test]
+fn compile_generic_alias_with_unknown_body_reduces_in_member_and_return_positions() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "target": "es2020"
+  },
+  "files": ["main.ts"]
+}"#,
+    );
+    write_file(
+        &base.join("main.ts"),
+        r#"
+declare const top: unknown;
+
+// Generic alias whose body ignores its parameter and is exactly `unknown`.
+type Boxed<TElement> = unknown;
+
+// Member position (object literal -> interface).
+interface Holder { slot: Boxed<number>; }
+const viaLiteral: Holder = { slot: top };
+
+// Member position (non-fresh variable source).
+declare const holderSrc: { slot: unknown };
+const viaVariable: Holder = holderSrc;
+
+// Function-return position, concrete argument.
+const viaReturn: () => Boxed<string> = () => top;
+
+// Function-argument position.
+declare function consume(holder: Holder): void;
+function callConsume(): void {
+    consume({ slot: top });
+}
+
+// Standalone generic function-return position (alias arg is a type parameter).
+function generic<TParam>(): void {
+    const localReturn: () => Boxed<TParam> = () => top;
+    void localReturn;
+}
+
+// A different alias name, used as a plain (non-function) member.
+type AnyShape<TKey> = unknown;
+interface Wrapper<TKey> { payload: AnyShape<TKey>; }
+function makeWrapper<TKey>(): Wrapper<TKey> {
+    return { payload: top };
+}
+
+void viaLiteral;
+void viaVariable;
+void viaReturn;
+void callConsume;
+void generic;
+void makeWrapper;
+export {};
+"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|d| d.code != 2322 && d.code != 2345),
+        "a generic alias with an `unknown` body must reduce to `unknown` in member \
+         and return positions (no false TS2322/TS2345). Diagnostics: {:?}",
+        result.diagnostics
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate/application.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/application.rs
@@ -14,6 +14,22 @@
 
 use super::*;
 
+/// Kill-switch (`TSZ_DISABLE_GENERIC_ALIAS_UNKNOWN_BODY_REDUCTION=1`) for the
+/// genuine-`unknown`-body alias reduction in [`TypeEvaluator::evaluate_application_body`].
+///
+/// Default is enabled: a generic type alias whose *registered* body is
+/// `unknown` reduces its application to canonical `unknown` (tsc parity).
+/// Setting the variable restores the prior always-opaque behavior, where such
+/// an application stayed un-reduced and a later `unknown <: Foo<Args>` relation
+/// failed reflexivity.
+fn generic_alias_unknown_body_reduction_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| {
+        !std::env::var("TSZ_DISABLE_GENERIC_ALIAS_UNKNOWN_BODY_REDUCTION").is_ok_and(|v| v == "1")
+    })
+}
+
 struct ApplicationFinalizeContext<'a> {
     original_args: &'a [TypeId],
     expanded_args: &'a [TypeId],
@@ -274,6 +290,23 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
+    /// Canonical `unknown` reduction for a generic alias whose **genuinely
+    /// registered** body (shared `DefinitionStore` raw body) is `unknown`.
+    ///
+    /// An `unknown` alias body contains no type parameters, so `Foo<Args>`
+    /// reduces to canonical `unknown` for *any* arguments — independent of
+    /// whether this query's resolver has cached the def's params/body. That
+    /// makes the reduction correct even on the relation `type_env`, where a
+    /// transitively-reached local alias may be absent. Returns `None` when the
+    /// raw body is not a published `unknown` (a non-`unknown` body, or an
+    /// unregistered registration-window placeholder whose raw body is absent),
+    /// leaving the caller's existing opaque-bail in force.
+    fn genuine_unknown_alias_reduction(&self, def_id: DefId) -> Option<TypeId> {
+        (generic_alias_unknown_body_reduction_enabled()
+            && self.resolver.get_def_raw_body(def_id, self.interner) == Some(TypeId::UNKNOWN))
+        .then_some(TypeId::UNKNOWN)
+    }
+
     /// Phase-5 dispatch between the canonical known-params path and the
     /// lite-resolver fallback that extracts parameters from the resolved
     /// type's shape.
@@ -318,6 +351,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         if let Some(type_params) = ctx.type_params.as_ref() {
             let Some(resolved) = ctx.resolved else {
+                // A genuine `type Foo<T> = unknown` whose registered body the
+                // shared store still exposes reduces to canonical `unknown` even
+                // when this query's resolver lacks the body (the relation
+                // `type_env` for a transitively-reached local alias). See
+                // `genuine_unknown_alias_reduction`.
+                if let Some(reduced) = self.genuine_unknown_alias_reduction(def_id) {
+                    return ApplicationEvalOutcome::Computed(reduced);
+                }
                 // Generic def with registered params but no body: the def is
                 // mid-registration (or owned by a file whose checker has not
                 // published it yet). The opaque result is a registration-window
@@ -337,11 +378,28 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // opaque so later evaluator passes (with a populated body) can
             // expand it correctly.
             if resolved == TypeId::UNKNOWN {
-                self.mark_unresolved_def_seen();
-                crate::evaluation::eval_materialization_probe::record_application_body_path(
-                    crate::evaluation::eval_materialization_probe::ApplicationBodyPath::OpaqueResolvedUnknown,
-                );
-                return ApplicationEvalOutcome::Computed(original_type_id);
+                // The opaque-bail guards `Foo<Args>` against collapsing to bare
+                // `unknown` when the body is an UNREGISTERED placeholder — a
+                // cross-file alias whose declaring file has not yet published its
+                // body under parallel checking, where the resolver answers
+                // `unknown` as a stand-in. But a genuine `type Foo<T> = unknown`
+                // has `unknown` as its real, *registered* body and MUST reduce:
+                // tsc eagerly substitutes a type-alias application
+                // (`getTypeAliasInstantiation`), so the result is canonical
+                // `unknown`. Keeping it opaque leaves `Foo<Args>` un-reduced, and
+                // a later relation `unknown <: Foo<Args>` (an interface/object
+                // member typed by exactly this alias) then wrongly fails
+                // reflexivity (false TS2322 "`unknown` not assignable to
+                // `Foo<Args>`"). Distinguish the two via the `DefinitionStore`'s
+                // raw body: a *published* body of `unknown` is the genuine alias;
+                // an absent raw body is the registration-window placeholder.
+                if self.genuine_unknown_alias_reduction(def_id).is_none() {
+                    self.mark_unresolved_def_seen();
+                    crate::evaluation::eval_materialization_probe::record_application_body_path(
+                        crate::evaluation::eval_materialization_probe::ApplicationBodyPath::OpaqueResolvedUnknown,
+                    );
+                    return ApplicationEvalOutcome::Computed(original_type_id);
+                }
             }
 
             // The same situation arises when the body resolves to the alias's
@@ -428,6 +486,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 );
                 ApplicationEvalOutcome::Computed(original_type_id)
             }
+        } else if let Some(reduced) = self.genuine_unknown_alias_reduction(def_id) {
+            // A genuine `type Foo<...> = unknown` whose body the shared store
+            // still exposes reduces to canonical `unknown` for any args, even
+            // when neither params nor body are registered on this query's
+            // resolver. See `genuine_unknown_alias_reduction`.
+            ApplicationEvalOutcome::Computed(reduced)
         } else {
             // Neither type parameters nor a body are registered for the base
             // def (e.g. an import-alias `DefId` that was never forwarded to

--- a/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
@@ -91,12 +91,14 @@ fn evaluate_application_known_params_instantiates_alias_body() {
     );
 }
 
-/// Phase 5 — UNKNOWN body. When the resolver returns `unknown` (because
-/// the declaring file is still being processed in parallel checking),
-/// the orchestrator must bail and keep the `Application` opaque so a
-/// later pass with a populated body can expand it.
+/// Phase 5 — genuine `unknown` alias body. A type alias whose *registered*
+/// body is `unknown` (`type Foo<T> = unknown`) reduces its application to
+/// canonical `unknown` for any args, matching tsc's eager alias substitution
+/// (`getTypeAliasInstantiation`). The prior behavior kept it opaque, which
+/// broke a later reflexive relation `unknown <: Foo<Args>` on an
+/// interface/object member typed by exactly this alias (false TS2322).
 #[test]
-fn evaluate_application_unknown_body_keeps_application_opaque() {
+fn evaluate_application_genuine_unknown_body_reduces_to_unknown() {
     let interner = TypeInterner::new();
     let t_param = unconstrained_param(&interner, "T");
 
@@ -106,7 +108,7 @@ fn evaluate_application_unknown_body_keeps_application_opaque() {
         &mut env,
         DefId(202),
         DefKind::TypeAlias,
-        // Unknown sentinel mirrors the cross-file race condition.
+        // A genuinely registered `unknown` body — `type Foo<T> = unknown`.
         TypeId::UNKNOWN,
         vec![t_param],
         vec![TypeId::STRING],
@@ -116,8 +118,41 @@ fn evaluate_application_unknown_body_keeps_application_opaque() {
     let result = evaluator.evaluate(app);
 
     assert_eq!(
+        result,
+        TypeId::UNKNOWN,
+        "a genuine `type Foo<T> = unknown` application must reduce to canonical unknown"
+    );
+}
+
+/// Phase 5 — UNREGISTERED body (the real cross-file race). When the alias's
+/// body is *not registered* on this query — its declaring file is still being
+/// processed in parallel checking, so the resolver has no body to answer —
+/// the orchestrator keeps the `Application` opaque so a later pass with a
+/// populated body can expand it, and taints `unresolved_def_seen` so the
+/// registration-window result stays out of the persistent caches. This is the
+/// scenario the `unknown`-body bail was originally meant to guard; it is
+/// distinguished from a genuine `= unknown` alias by the *absent* raw body
+/// (`get_def_raw_body` → `None`), not by the resolved value alone.
+#[test]
+fn evaluate_application_unregistered_body_keeps_application_opaque() {
+    let interner = TypeInterner::new();
+
+    // Register only the def's kind — no body, no params — mirroring a
+    // cross-file alias whose declaring file has not yet published anything.
+    let mut env = TypeEnvironment::new();
+    env.insert_def_kind(DefId(303), DefKind::TypeAlias);
+    let app = interner.application(interner.lazy(DefId(303)), vec![TypeId::STRING]);
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    let result = evaluator.evaluate(app);
+
+    assert_eq!(
         result, app,
-        "unknown alias body must not collapse `Foo<Args>` to bare `unknown`"
+        "an unregistered alias body must keep `Foo<Args>` opaque for a later pass"
+    );
+    assert!(
+        evaluator.is_unresolved_def_seen(),
+        "an unregistered-body deferral must taint `unresolved_def_seen`"
     );
 }
 


### PR DESCRIPTION
Goal: green

Fixes #14598

## Summary

A generic type alias whose body is exactly `unknown` (`type Foo<T> = unknown`) did not reduce its applications to canonical `unknown`. tsc eagerly substitutes a type-alias application (`getTypeAliasInstantiation`), so `Foo<Args>` is `unknown`; tsz kept `Foo<Args>` opaque, so a later reflexive relation `unknown <: Foo<Args>` — when the alias types an interface/object member — failed and emitted a **false TS2322** (`'unknown' is not assignable to 'Foo<Args>'`).

Minimal repro (tsc clean; tsz emitted TS2322), `--strict`, single file:

```ts
type Boxed<T> = unknown;
interface Holder { slot: Boxed<number>; }
declare const top: unknown;
const x: Holder = { slot: top };
```

## Wrong operation & owner layer

Solver evaluation — generic type-alias application reduction. `crates/tsz-solver/src/evaluation/evaluate/application.rs` `evaluate_application_body` kept an application opaque whenever the alias body resolved to `TypeId::UNKNOWN`. That guard exists for an **unregistered** cross-file placeholder (a parallel-checking registration window where the declaring file has not published its body and the resolver answers `unknown` as a stand-in), but it fired for a **genuine** `= unknown` body too.

## Structural rule

When a generic type alias's **genuinely registered** body is `unknown`, `Foo<Args>` reduces to canonical `unknown` for any arguments (an `unknown` body contains no type parameters) — matching tsc. Only an **unregistered** placeholder body (raw body absent in the shared `DefinitionStore`) stays opaque (and tainted) for a later pass. The two are distinguished by the shared-store raw body (`get_def_raw_body`): a published `Some(unknown)` is the genuine alias; an absent `None` is the registration-window placeholder. Because the body is parameter-free, the reduction is valid even on the relation `type_env`, where a transitively-reached local alias may be absent.

Tracing confirms an unpublished cross-file alias resolves to `None` (not `unknown`), so the prior `resolved == UNKNOWN` guard only ever fired on genuine bodies. Gated by `TSZ_DISABLE_GENERIC_ALIAS_UNKNOWN_BODY_REDUCTION=1` (kill-switch restores the prior always-opaque behavior).

## Adjacent-case matrix (all now match tsc)

- Member position, object literal → interface (`{ slot } : Holder`).
- Member position, non-fresh variable source.
- Function-return position, concrete arg (`() => Boxed<number>`).
- Call-argument position.
- Standalone generic function-return (`() => Boxed<TParam>`, alias arg is a type parameter).
- Second alias name as a plain (non-function) member — binder names varied (anti-hardcoding).
- Negative/fallback: an **unregistered** body (raw body absent) still stays opaque and taints `unresolved_def_seen` (pinned by a new unit test).

## Scope / residual

The generic interface-member **function-return** form (`interface E<T>{ run: () => Foo<T> }`) still emits the FP because that relation sub-path runs with an empty/no-op resolver that has no view of the def at all — that is the separate dual-/empty-resolver path (#14348), deliberately out of scope. DTS emit is unchanged (the `Foo<Args>` alias display is preserved via the known-params path).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Minimal repros above pass after the fix; DTS emit byte-identical with the kill-switch on/off (alias display preserved).
- `cargo test -p tsz-solver --lib` — no new failures (the 3 reds are pre-existing on `main`, per #14593); new orchestrator unit tests pin both genuine-reduction (`evaluate_application_genuine_unknown_body_reduces_to_unknown`) and unregistered-placeholder-stays-opaque (`evaluate_application_unregistered_body_keeps_application_opaque`).
- `cargo test -p tsz-cli --lib compile_generic_alias_with_unknown_body` — new driver regression test passes.
- `cargo fmt --check`, `cargo clippy -p tsz-solver --lib`, `python3 scripts/arch/arch_guard.py` — all clean.
- Broad conformance / emit / fourslash floors: ready-review CI (path-affecting — removes false TS2322/TS2345 on this family).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UdnxK1RNoZoGK6tkmb2cq6)_