### PR TITLE
perf(solver): build unions from borrowed slices in hot paths (#8356 slice)

### DIFF
--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -787,7 +787,7 @@ impl<'a> TypeFormatter<'a> {
                 }
             })
             .collect();
-        let union = self.interner.union(distributed.clone());
+        let union = self.interner.union_from_slice(&distributed);
         self.interner.store_union_origin(union, distributed);
         Some(union)
     }

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -725,7 +725,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // Deep structural simplification using SubtypeChecker
         self.simplify_union_members(&mut evaluated_members);
 
-        let result = self.interner.union(evaluated_members.clone());
+        let result = self.interner.union_from_slice(&evaluated_members);
         display_provenance::record_union_origin(
             self.interner,
             UnionOriginProvenance {

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -864,7 +864,7 @@ impl<'a> InferenceContext<'a> {
         let names_union = if name_literals.len() == 1 {
             name_literals[0]
         } else {
-            self.interner.union(name_literals.clone())
+            self.interner.union_from_slice(&name_literals)
         };
         self.infer_from_types(names_union, mapped.constraint, priority)?;
 

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -788,7 +788,7 @@ impl<'a> TypeInstantiator<'a> {
                     .as_deref()
                     .map_or(canonical_members.as_ref(), Vec::as_slice);
                 if let Some(instantiated) = self.instantiate_type_list_if_changed(members) {
-                    let result = self.interner.union(instantiated.clone());
+                    let result = self.interner.union_from_slice(&instantiated);
                     self.interner.store_union_origin(result, instantiated);
                     result
                 } else {

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -1991,4 +1991,36 @@ mod union_preserve_members_tests {
             "ordinary members are unaffected"
         );
     }
+
+    /// `union(Vec)` and `union_from_slice(&[..])` both delegate to the same
+    /// `union_from_iter` normalizer, so they must return a byte-identical
+    /// `TypeId` for the same member sequence. The hot evaluation/instantiation/
+    /// inference/widening/narrowing paths rely on this equivalence to construct
+    /// unions from a borrowed slice (`union_from_slice`) instead of cloning the
+    /// member vector into `union` — a pure allocation cut with no result change.
+    /// This pins the contract so a future divergence in either constructor is
+    /// caught here rather than as a silent diagnostic drift downstream.
+    #[test]
+    fn union_from_slice_matches_owned_union() {
+        let interner = TypeInterner::new();
+        let cases: &[Vec<TypeId>] = &[
+            vec![TypeId::STRING, TypeId::NUMBER],
+            // Order that requires sorting/normalization.
+            vec![TypeId::NUMBER, TypeId::STRING, TypeId::BOOLEAN],
+            // Duplicates that must dedup identically.
+            vec![TypeId::STRING, TypeId::STRING, TypeId::NUMBER],
+            // Sentinel absorption (`any | T` == `any`).
+            vec![TypeId::ANY, TypeId::STRING],
+            // Single-member and empty edge cases.
+            vec![TypeId::STRING],
+            vec![],
+        ];
+        for members in cases {
+            assert_eq!(
+                interner.union(members.clone()),
+                interner.union_from_slice(members),
+                "union(Vec) and union_from_slice(&[..]) must agree for {members:?}",
+            );
+        }
+    }
 }

--- a/crates/tsz-solver/src/narrowing/discriminants.rs
+++ b/crates/tsz-solver/src/narrowing/discriminants.rs
@@ -642,7 +642,7 @@ impl<'a> NarrowingContext<'a> {
         match index.get(&literal_value) {
             Some(matching) if matching.is_empty() => Some(TypeId::NEVER),
             Some(matching) if matching.len() == 1 => Some(matching[0]),
-            Some(matching) => Some(self.db.union(matching.clone())),
+            Some(matching) => Some(self.db.union_from_slice(matching)),
             None => {
                 // No exact match — try subtype matching for non-literal discriminants
                 // This handles cases like `type: string` matching `type: "specific"`.

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -948,7 +948,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     if all_same_base {
                         let t_app_args = t_app.args.clone();
                         for (i, t_arg) in t_app_args.iter().enumerate() {
-                            let combined = self.interner.union(combined_args[i].clone());
+                            let combined = self.interner.union_from_slice(&combined_args[i]);
                             self.constrain_types(ctx, var_map, combined, *t_arg, priority);
                         }
                     } else {

--- a/crates/tsz-solver/src/operations/expression_ops.rs
+++ b/crates/tsz-solver/src/operations/expression_ops.rs
@@ -989,7 +989,7 @@ pub fn compute_best_common_type_cached<R: TypeResolver>(
     if bct_candidates_proven_pairwise_incomparable_by_unique_required_fields(interner, &widened) {
         if resolver.is_some() {
             let reduced = remove_subtypes_for_bct(interner, query_db, &widened, resolver);
-            return interner.union(reduced.to_vec());
+            return interner.union_from_slice(&reduced);
         }
         return interner.union(widened);
     }
@@ -1070,7 +1070,7 @@ pub fn compute_best_common_type_cached<R: TypeResolver>(
     let reduced = remove_subtypes_for_bct(interner, query_db, &widened, resolver);
 
     // Step 4: Default to union of all types
-    interner.union(reduced.to_vec())
+    interner.union_from_slice(&reduced)
 }
 
 fn common_base_class_for_bct<R: TypeResolver>(

--- a/crates/tsz-solver/src/operations/widening.rs
+++ b/crates/tsz-solver/src/operations/widening.rs
@@ -1169,7 +1169,7 @@ fn widen_union_literal_members(
         return type_id;
     };
 
-    let result = db.union(mapped.clone());
+    let result = db.union_from_slice(&mapped);
     display_provenance::record_union_origin(
         db,
         UnionOriginProvenance {
@@ -1547,7 +1547,7 @@ fn widen_annotation_union_first_display_member(
             }
         })
         .collect();
-    let rebuilt = db.union(mapped.clone());
+    let rebuilt = db.union_from_slice(&mapped);
     match db.lookup(rebuilt) {
         Some(TypeData::Union(new_list)) => {
             let new_members = db.type_list(new_list);
@@ -1793,7 +1793,7 @@ fn widen_annotation_walk(
             if mapped == display_members {
                 type_id
             } else {
-                let widened = db.union(mapped.clone());
+                let widened = db.union_from_slice(&mapped);
                 display_provenance::record_union_origin(
                     db,
                     UnionOriginProvenance {


### PR DESCRIPTION
Goal: fast

Part of #8356 (ts-toolbelt-project runtime row tracker).

## Summary

`TypeInterner::union(Vec<TypeId>)` and `union_from_slice(&[TypeId])` both
delegate to the identical `union_from_iter` normalizer, so `union(x.clone())`
/ `union(x.to_vec())` allocate a **throwaway** `Vec<TypeId>` for a
byte-identical result. This replaces **11** such call sites with the
borrowed-slice constructor across the union-construction hot paths:

| owner | site | before |
|---|---|---|
| solver/evaluation | `evaluate_union` (deferred union reduction) | `union(evaluated_members.clone())` |
| solver/instantiation | union re-interning of an instantiated member list | `union(instantiated.clone())` |
| solver/inference | mapped-name literal union (`infer_matching`) | `union(name_literals.clone())` |
| solver/narrowing | discriminant-index union | `union(matching.clone())` |
| solver/operations | best-common-type subtype reduction (×2) | `union(reduced.to_vec())` over an `Arc<[TypeId]>` |
| solver/operations | literal/annotation widening (×3) | `union(mapped.clone())` |
| solver/operations | generic-argument constraint walking | `union(combined_args[i].clone())` |
| solver/diagnostics | union-distribution display | `union(distributed.clone())` |

Each site that still needs the member vector afterward (origin-order
recording via `record_union_origin`/`store_union_origin`, or a post-build
set-equality check) keeps the owned vector and only borrows for the
construction; the rest borrow a slice they already hold (`Arc<[TypeId]>`,
`&Vec<TypeId>` from an index, a freshly `collect`ed `Vec`).

## Structural rule

When a union is interned from members the caller already owns or holds by
reference, construct it from the borrowed slice (`union_from_slice`) instead
of cloning the member sequence into `union`. Owner: solver type construction.
Behavior-preserving **by construction** — `union_from_slice ≡ union` (same
`union_from_iter` normalizer) — so the resulting `TypeId` is byte-identical
and conformance/emit/fourslash baselines do not move. This is a pure
allocation cut on the recursive union-heavy evaluation paths that dominate
the ts-toolbelt row (`Flatten`/`Compute`/`Without` families).

## Anti-hardcoding

No user-name/file-name/printer-string predicate is involved; the rewrite is a
structural allocation change keyed only on Rust ownership of the member list.

## Verification

- `cargo test -p tsz-solver --lib` → 6937 passed; the only 3 failures
  (`test_conditional_infer_optional_property_present_distributive`,
  `literal_mask_preserves_object_vs_literal_reduction`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`)
  are **pre-existing on `main`**, proven by a `git stash` baseline run on the
  clean tree (same 3 fail, 0 of this PR's changes applied). Net **+1** passing
  test (the new pin), **0** new failures.
- New regression test `union_from_slice_matches_owned_union` pins the
  `union(Vec) == union_from_slice(&[..])` equivalence across ordering,
  dedup, sentinel-absorption, single-member, and empty cases, so a future
  divergence in either constructor is caught here rather than as silent
  diagnostic drift.
- `cargo fmt -p tsz-solver --check`, `cargo clippy -p tsz-solver --lib`, and
  `python3 scripts/arch/arch_guard.py` all clean.
- Broad conformance/emit/fourslash/project suites: owned by ready-review CI
  (behavior is byte-identical, so no baseline movement is expected).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_019hs6jWSBzGX6n9CfcpkCSA

---
_Generated by [Claude Code](https://claude.ai/code/session_019hs6jWSBzGX6n9CfcpkCSA)_