### PR TITLE
fix(checker): emit TS2428 for class+interface merges with mismatched type-parameter arity

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/declarations_utils.rs
+++ b/crates/tsz-checker/src/types/type_checking/declarations_utils.rs
@@ -123,49 +123,6 @@ impl<'a> CheckerState<'a> {
         true
     }
 
-    /// Check if class+interface merged declarations have compatible type
-    /// parameters. Unlike the interface-only check, this allows different
-    /// arity when the declaration with more params has defaults for the
-    /// extras (e.g., React Component pattern: class<P,S> + interface<P,S,SS=any>).
-    /// Only the overlapping parameters are checked for name+constraint identity.
-    pub(crate) fn class_interface_type_parameters_are_merge_compatible(
-        &mut self,
-        first: NodeIndex,
-        second: NodeIndex,
-    ) -> bool {
-        let Some(first_profile) = self.interface_type_parameter_profile(first) else {
-            return false;
-        };
-        let Some(second_profile) = self.interface_type_parameter_profile(second) else {
-            return false;
-        };
-
-        // Check the overlapping portion only
-        let min_len = first_profile.len().min(second_profile.len());
-
-        // Names must match in overlapping positions before canonicalization.
-        for i in 0..min_len {
-            if first_profile[i].name != second_profile[i].name {
-                return false;
-            }
-        }
-
-        // Build the canonicalization scope from the longer profile so positions
-        // present only on one side (e.g. defaulted extras on the interface side
-        // of a class+interface merge) still have an anchor for the shorter
-        // side's constraints to reference symmetrically.
-        let longest = if first_profile.len() >= second_profile.len() {
-            &first_profile
-        } else {
-            &second_profile
-        };
-        let scope = Self::profile_param_scope(longest);
-
-        let overlap_first = &first_profile[..min_len];
-        let overlap_second = &second_profile[..min_len];
-        self.constraints_and_defaults_match_in_scope(overlap_first, overlap_second, &scope)
-    }
-
     /// Collect type parameter names and constraint type ids from an interface
     /// or class declaration.
     fn interface_type_parameter_profile(

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -851,15 +851,19 @@ impl<'a> CheckerState<'a> {
                             .is_some_and(|n| self.ctx.arena.get_interface(n).is_some())
                     });
                     if has_class && has_interface {
-                        let mismatch = decls_in_scope.as_slice().split_first().is_some_and(
-                            |(baseline, rest)| {
-                                rest.iter().any(|&decl_idx| {
-                                    !self.class_interface_type_parameters_are_merge_compatible(
-                                        *baseline, decl_idx,
-                                    )
-                                })
-                            },
-                        );
+                        // Reuse the group-merge rule (it builds profiles from
+                        // both class and interface nodes): every type-parameter
+                        // position present on only some declarations must carry
+                        // a default, and overlapping positions must agree on
+                        // name/constraint/default. This rejects an arity
+                        // mismatch with a non-defaulted extra (`class A<T>` +
+                        // `interface A`) — tsc's `areTypeParametersIdentical`
+                        // count-in-[min,max] rule — while still allowing
+                        // defaulted extras (React's `class C<P, S>` +
+                        // `interface C<P, S, SS = any>`). The earlier
+                        // overlap-only check silently accepted the former.
+                        let mismatch = !self
+                            .interface_type_parameters_are_group_merge_compatible(&decls_in_scope);
                         if mismatch {
                             let message = format_message(
                                 diagnostic_messages::ALL_DECLARATIONS_OF_MUST_HAVE_IDENTICAL_TYPE_PARAMETERS,

--- a/crates/tsz-checker/tests/ts2428_tests.rs
+++ b/crates/tsz-checker/tests/ts2428_tests.rs
@@ -593,3 +593,119 @@ type A = {}"#;
         "Should NOT emit TS2300 when TS2395 is emitted: got {codes:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Class + interface merges. tsc applies the same `areTypeParametersIdentical`
+// rule across a class/interface merge group: a type-parameter position present
+// on only some declarations must carry a default, otherwise the merge is a
+// TS2428 mismatch. tsz previously compared only the overlapping positions for
+// class+interface merges, silently accepting an arity mismatch whose extra
+// parameter had no default.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn class_generic_and_non_generic_interface_emits_ts2428() {
+    // `class A<T>` + `interface A` — the class's `T` has no default and the
+    // interface omits it, so the declarations are not identical.
+    let source = r#"
+class A<T> {
+    value!: T;
+}
+interface A {
+    extra: number;
+}
+"#;
+    assert!(
+        has_error_with_code(source, 2428),
+        "class<T> merged with a non-generic interface (no default) must emit TS2428"
+    );
+}
+
+#[test]
+fn non_generic_interface_and_class_generic_reversed_order_emits_ts2428() {
+    // Declaration order must not matter.
+    let source = r#"
+interface B {
+    extra: number;
+}
+class B<T> {
+    value!: T;
+}
+"#;
+    assert!(
+        has_error_with_code(source, 2428),
+        "non-generic interface merged with class<T> (no default) must emit TS2428 regardless of order"
+    );
+}
+
+#[test]
+fn class_and_interface_extra_param_without_default_emits_ts2428() {
+    // `class C<T, U>` + `interface C<T>` — the class's extra `U` has no default.
+    let source = r#"
+class C<T, U> {
+    a!: T;
+    b!: U;
+}
+interface C<T> {
+    c: T;
+}
+"#;
+    assert!(
+        has_error_with_code(source, 2428),
+        "class<T, U> merged with interface<T> (extra U lacks a default) must emit TS2428"
+    );
+}
+
+#[test]
+fn class_and_interface_extra_param_with_default_no_ts2428() {
+    // React `Component` pattern: the longer side's extra parameter is defaulted,
+    // so the merge is legal.
+    let source = r#"
+class D<P, S> {
+    p!: P;
+    s!: S;
+}
+interface D<P, S, SS = any> {
+    ss?: SS;
+}
+"#;
+    assert!(
+        !has_error_with_code(source, 2428),
+        "class<P, S> merged with interface<P, S, SS = any> (defaulted extra) must NOT emit TS2428"
+    );
+}
+
+#[test]
+fn non_generic_class_and_interface_with_defaulted_param_no_ts2428() {
+    // The missing position is supplied with a default by the interface, so the
+    // non-generic class declaration is compatible.
+    let source = r#"
+interface E<T = string> {
+    b: T;
+}
+class E {
+    a = 1;
+}
+"#;
+    assert!(
+        !has_error_with_code(source, 2428),
+        "non-generic class merged with interface<T = string> (defaulted extra) must NOT emit TS2428"
+    );
+}
+
+#[test]
+fn class_and_interface_identical_params_no_ts2428() {
+    // Control: identical type parameters are a valid merge.
+    let source = r#"
+class F<T> {
+    value!: T;
+}
+interface F<T> {
+    extra: T;
+}
+"#;
+    assert!(
+        !has_error_with_code(source, 2428),
+        "class<T> merged with interface<T> (identical params) must NOT emit TS2428"
+    );
+}


### PR DESCRIPTION
Fixes #14601.

Goal: hold

## Summary

A `class` and `interface` that merge under one name are subject to `tsc`'s
`areTypeParametersIdentical` rule: a type-parameter position present on only
some declarations must carry a default, otherwise the merge is a **TS2428**
mismatch (`All declarations of 'X' must have identical type parameters`). tsz
enforced this for interface↔interface merges via the group check, but the
dedicated class↔interface check compared only the **overlapping** (min-arity)
positions and silently accepted an arity mismatch whose extra parameter had no
default — surfacing a spurious **TS2322** instead of the expected TS2428.

```ts
class A<T> { value!: T; }
interface A { extra: number; }
// tsc: TS2428 on both declarations
// tsz (before): no TS2428 (spurious TS2322)
```

## Wrong operation

Diagnostic emission for merged declarations — owner: `checker`,
`crates/tsz-checker/src/types/type_checking/`
(`class_interface_type_parameters_are_merge_compatible`, called from
`duplicate_identifiers.rs`).

## Structural rule

When declarations of one symbol merge, each declaration's type-parameter count
must lie within `[minTypeArgumentCount, maxTypeArgumentCount]` of the group (min
excludes trailing defaulted parameters), and overlapping positions must agree on
name/constraint/default; otherwise `tsc` emits TS2428.

## Fix

Route the class+interface branch through the existing
`interface_type_parameters_are_group_merge_compatible` group check — its profile
helper (`interface_type_parameter_profile`) already builds profiles from class
nodes, so the same "extra positions must be defaulted" rule now governs
class+interface merges. Removed the now-unused overlap-only helper.

The group check is the same logic already used (and conformance-tested) for
interface↔interface merges, so same-arity class+interface merges are unchanged;
the only behavioral delta is now correctly emitting TS2428 for arity mismatches
without defaults (and no longer emitting the spurious TS2322).

## Adjacent-case matrix (all verified against `tsc` 6.0.2)

| declarations | `tsc` | tsz (after) |
|---|---|---|
| `class A<T>` + `interface A` (no default) | TS2428 ×2 | TS2428 ×2 |
| `interface B` + `class B<T>` (reversed order) | TS2428 ×2 | TS2428 ×2 |
| `class C<T, U>` + `interface C<T>` (extra `U`, no default) | TS2428 ×2 | TS2428 ×2 |
| `class D<P, S>` + `interface D<P, S, SS = any>` (React pattern) | clean | clean |
| `interface E<T = string>` + `class E` (defaulted extra) | clean | clean |
| `class F<T>` + `interface F<T>` (identical) | clean | clean |
| `class<T> + interface<U>` (same arity, diff name) | TS2428 ×2 | TS2428 ×2 |
| `class<T> + interface<T> + interface` (3-decl, 3rd missing) | TS2428 ×3 | TS2428 ×3 |
| interface-only mismatch / namespace+class | unchanged | unchanged |

## Anti-hardcoding

No identifier/file-name/printer-string predicates introduced. The rule follows
type-parameter profiles (name/constraint/default by position); regression tests
vary the binder names (`A`/`B`/`C`/`D`/`E`/`F`, `T`/`U`/`P`/`S`/`SS`).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-checker --lib ts2428` → **37 passed, 0 failed** (6 new
  class+interface cases + 31 existing interface cases).
- Built `dist`/release `tsz` and diffed against `tsc` 6.0.2 on the matrix above
  — every row matches (including the previously-spurious TS2322 now gone).
- Broad conformance/emit/fourslash suites: ready-review CI owns them.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dk7GkA9Svfy7gct352bpWE)_