### PR TITLE
test(cli): driver witness for genuine `unknown`-bodied generic alias reduction

### DIFF
--- a/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
@@ -657,3 +657,93 @@ export {}
         result.diagnostics
     );
 }
+
+// ---------------------------------------------------------------------------
+// End-to-end driver witness for the genuine-`unknown`-bodied generic alias
+// reduction landed in #14595 (#13212 slice). A generic type alias whose body is
+// exactly `unknown` (`type Foo<T> = unknown`) must reduce its applications to
+// canonical `unknown`, matching tsc's eager alias substitution; otherwise a
+// later reflexive relation `unknown <: Foo<Args>` on an interface/object member
+// typed by exactly this alias produces a false TS2322. #14595 carries the solver
+// reduction plus checker/solver unit guards; this pins the same behavior through
+// the full project driver (tsconfig + multi-position usage), the path on which
+// the regression originally surfaced. Binder names vary across cases
+// (alias/interface/param identifiers) so no name string drives the result.
+// ---------------------------------------------------------------------------
+#[test]
+fn compile_generic_alias_with_unknown_body_reduces_in_member_and_return_positions() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true,
+    "target": "es2020"
+  },
+  "files": ["main.ts"]
+}"#,
+    );
+    write_file(
+        &base.join("main.ts"),
+        r#"
+declare const top: unknown;
+
+// Generic alias whose body ignores its parameter and is exactly `unknown`.
+type Boxed<TElement> = unknown;
+
+// Member position (object literal -> interface).
+interface Holder { slot: Boxed<number>; }
+const viaLiteral: Holder = { slot: top };
+
+// Member position (non-fresh variable source).
+declare const holderSrc: { slot: unknown };
+const viaVariable: Holder = holderSrc;
+
+// Function-return position, concrete argument.
+const viaReturn: () => Boxed<string> = () => top;
+
+// Function-argument position.
+declare function consume(holder: Holder): void;
+function callConsume(): void {
+    consume({ slot: top });
+}
+
+// Standalone generic function-return position (alias arg is a type parameter).
+function generic<TParam>(): void {
+    const localReturn: () => Boxed<TParam> = () => top;
+    void localReturn;
+}
+
+// A different alias name, used as a plain (non-function) member.
+type AnyShape<TKey> = unknown;
+interface Wrapper<TKey> { payload: AnyShape<TKey>; }
+function makeWrapper<TKey>(): Wrapper<TKey> {
+    return { payload: top };
+}
+
+void viaLiteral;
+void viaVariable;
+void viaReturn;
+void callConsume;
+void generic;
+void makeWrapper;
+export {};
+"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|d| d.code != 2322 && d.code != 2345),
+        "a generic alias with an `unknown` body must reduce to `unknown` in member \
+         and return positions (no false TS2322/TS2345). Diagnostics: {:?}",
+        result.diagnostics
+    );
+}


### PR DESCRIPTION
Goal: hold

## Summary

Test-only follow-up to **#14595** (genuine-`unknown`-bodied generic alias reduction, #13212 slice). It adds an **end-to-end project-driver** regression witness for that behavior. #14595 carries the solver fix plus checker (`contextual_typing`) and solver (`evaluate_application_orchestrator`) unit guards; this pins the same behavior through the full CLI driver — `tsconfig` + multi-file project mode — which is the integration path on which the regression originally surfaced.

This is the distinct artifact the #14599 closing comment invited porting as a follow-up test-only PR on top of `main` (the #14599 implementation was superseded by #14595; only its driver coverage was novel).

## Structural rule (pinned)

A generic type alias whose body is exactly `unknown` (`type Foo<T> = unknown`) reduces its applications to canonical `unknown`, matching tsc's eager alias substitution. Otherwise a later reflexive relation `unknown <: Foo<Args>` on an interface/object member typed by exactly this alias emits a **false TS2322**.

## Coverage (one driver compile, all must be diagnostic-free)

- Member position via object literal → interface.
- Member position via non-fresh variable source.
- Function-return position, concrete arg (`() => Boxed<string>`).
- Call-argument position.
- Standalone generic function-return (`() => Boxed<TParam>`, alias arg is a type parameter).
- A second alias name used as a plain (non-function) member — binder names varied across cases (anti-hardcoding).

No production code changes.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-cli --lib compile_generic_alias_with_unknown_body` → 1 passed, against current `main` (#14595 implementation).
- `cargo fmt -p tsz-cli --check` clean.
- Test-only; broad suites gated by ready-review CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UdnxK1RNoZoGK6tkmb2cq6)_