### PR TITLE
fix(solver): relate genuine unknown-bodied generic alias in function-return position

### DIFF
--- a/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
@@ -747,3 +747,127 @@ export {};
         result.diagnostics
     );
 }
+
+/// A generic type alias whose body is a genuinely-registered `unknown`
+/// (`type U<T> = unknown`, or a conditional whose selected branch is `unknown`)
+/// reduces its applications to canonical `unknown`. When such an application
+/// appears as the RETURN TYPE of a function-typed interface member
+/// (`run: () => U<T>`) and the interface is instantiated, the relation layer's
+/// return-type comparison previously misclassified the genuine `unknown` body
+/// as a missing-body placeholder and fell back to comparing the raw deferred
+/// `Application` against the source — a false TS2322
+/// `unknown` =< `U<...>`. tsc 6.0.2 is clean. This is the function-return-position
+/// slice of the #13212 identity family (the #14595 fix covered property/direct
+/// positions via the evaluator; the relation-layer return-type gate needs the
+/// same genuine-vs-placeholder distinction).
+///
+/// Binder names are varied across the cases (anti-hardcoding): the rule keys on
+/// the structural `unknown`-body classification, never on identifier text.
+#[test]
+fn compile_generic_unknown_bodied_alias_in_function_return_position_no_ts2322() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "esnext",
+            "strict": true,
+            "noEmit": true
+          },
+          "include": ["*.ts"]
+        }"#,
+    );
+    write_file(
+        &base.join("main.ts"),
+        r#"
+// Genuine `unknown` body, function-return position, generic interface.
+type Boxed<T> = unknown;
+interface Carrier<T> {
+  run: () => Boxed<T>;
+}
+function makeCarrier<T>(): Carrier<T> {
+  return { run: () => 1 as unknown };
+}
+
+// Conditional alias whose both branches are `unknown` (selected branch is the
+// canonical intrinsic), distinct binder names.
+type Reduced<Elem> = Elem extends 1 ? unknown : unknown;
+interface Holder<Elem> {
+  emit: () => Reduced<Elem>;
+}
+function makeHolder<Elem>(): Holder<Elem> {
+  return { emit: () => "anything" };
+}
+
+// Nested function-return position: `() => () => U<T>`.
+interface DeepCarrier<Shape> {
+  thunk: () => () => Boxed<Shape>;
+}
+function makeDeep<Shape>(): DeepCarrier<Shape> {
+  return { thunk: () => () => true as unknown };
+}
+
+export { makeCarrier, makeHolder, makeDeep };
+"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "a genuine `unknown`-bodied generic alias in function-return position must \
+         relate as canonical `unknown` (everything is assignable), matching tsc — \
+         no false TS2322. Diagnostics: {:?}",
+        result.diagnostics
+    );
+}
+
+/// Soundness bound for the function-return-position fix: it must NOT make every
+/// alias-returning member relate vacuously. A generic alias with a NON-`unknown`
+/// body still compares structurally, so a mismatched return value is rejected
+/// exactly like tsc.
+#[test]
+fn compile_generic_alias_function_return_still_rejects_mismatched_non_unknown_body() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "esnext",
+            "strict": true,
+            "noEmit": true
+          },
+          "include": ["*.ts"]
+        }"#,
+    );
+    write_file(
+        &base.join("main.ts"),
+        r#"
+// Both branches are `string`, never `unknown`: the member return must still be
+// compared structurally, so returning a `number` is a genuine error.
+type AlwaysStr<Param> = Param extends 1 ? string : string;
+interface Sink<Param> {
+  run: () => AlwaysStr<Param>;
+}
+function makeSink<Param>(): Sink<Param> {
+  return { run: () => 123 };
+}
+export { makeSink };
+"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert!(
+        result.diagnostics.iter().any(|d| d.code == 2322),
+        "a non-`unknown` alias body in function-return position must still reject a \
+         mismatched return value (TS2322), matching tsc. Diagnostics: {:?}",
+        result.diagnostics
+    );
+}

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -378,6 +378,23 @@ pub trait TypeResolver {
     fn get_def_raw_body(&self, _def_id: DefId, _interner: &dyn TypeDatabase) -> Option<TypeId> {
         None
     }
+
+    /// Whether `def_id` names a generic type alias whose body is a *genuinely
+    /// registered* `unknown` (`type C<T> = unknown`, or a utility alias that
+    /// reduces to `unknown`), as opposed to a cross-file registration-window
+    /// placeholder whose `unknown` is a not-yet-published-body sentinel.
+    ///
+    /// The two are indistinguishable from a resolved `unknown` alone: a genuine
+    /// body is recorded in the definition store at alias-registration time
+    /// (surfaced by [`Self::get_def_raw_body`]), whereas a placeholder `unknown`
+    /// comes from an unresolved symbol-type fallback with no registered body.
+    /// This is the single source of truth for that distinction, consumed by both
+    /// the evaluator (whether to reduce `C<Args>` to canonical `unknown`) and the
+    /// relation layer (whether a deferred `unknown`-returning member relates as
+    /// `unknown`). See issues #14595 / #13212.
+    fn is_genuine_unknown_alias_body(&self, def_id: DefId, interner: &dyn TypeDatabase) -> bool {
+        self.get_def_raw_body(def_id, interner) == Some(TypeId::UNKNOWN)
+    }
 }
 
 /// A no-op resolver that doesn't resolve any references.

--- a/crates/tsz-solver/src/evaluation/evaluate/application.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/application.rs
@@ -377,8 +377,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // this special case.
             if resolved == TypeId::UNKNOWN {
                 let genuine_unknown_body = genuine_unknown_alias_reduction_enabled()
-                    && self.resolver.get_def_raw_body(def_id, self.interner)
-                        == Some(TypeId::UNKNOWN);
+                    && self
+                        .resolver
+                        .is_genuine_unknown_alias_body(def_id, self.interner);
                 if genuine_unknown_body {
                     return ApplicationEvalOutcome::Computed(TypeId::UNKNOWN);
                 }

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
@@ -1003,13 +1003,32 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
         let is_placeholder = match def_id {
             Some(def_id) => match self.resolver.resolve_lazy(def_id, self.interner) {
-                Some(body) => {
-                    body == TypeId::UNKNOWN
-                        || matches!(
-                            self.interner.lookup(body),
-                            Some(TypeData::Lazy(body_def)) if body_def == def_id
-                        )
-                }
+                // A resolved body of `unknown` is ambiguous: it is EITHER a
+                // cross-file registration-window placeholder (the declaring file
+                // has not published its real body yet, so its `unknown` is a
+                // missing-body sentinel) OR a genuine, finalized `unknown` body
+                // (`type C<T> = unknown`, or a utility alias that reduces to
+                // `unknown`). Only the placeholder justifies the raw-form
+                // fallback; for a genuine body the evaluator's `unknown` is
+                // authoritative and the source must relate to it (everything is
+                // assignable to `unknown`). Mirror the genuine-vs-placeholder
+                // distinction made by `evaluate_application` via the shared
+                // `is_genuine_unknown_alias_body` predicate (issue #14595 /
+                // #13212). Without this guard a function-typed member returning
+                // such an alias (`run: () => C<T>`) reaches this check with a
+                // genuine `unknown` body, is misclassified as a placeholder, and
+                // the raw deferred `Application` is compared against the source —
+                // a false `unknown` ≰ `C<...>` (TS2322) in function-return
+                // position.
+                Some(body) if body == TypeId::UNKNOWN => !self
+                    .resolver
+                    .is_genuine_unknown_alias_body(def_id, self.interner),
+                // A self-referential `Lazy` wrapper is a structural body not yet
+                // materialized on this query — also a placeholder.
+                Some(body) => matches!(
+                    self.interner.lookup(body),
+                    Some(TypeData::Lazy(body_def)) if body_def == def_id
+                ),
                 None => true,
             },
             None => true,


### PR DESCRIPTION
Goal: green

Part of #13212 (the function-return-position slice of the F1 "non-canonical
instantiation results / `unknown` ≠ `unknown`" identity family).

## Summary

A generic type alias whose body is a genuinely-registered `unknown`
(`type C<T> = unknown`, or a utility alias that reduces to `unknown`) used as the
**return type of a function-typed interface member** raised a false `TS2322`
once the interface was instantiated. `tsc` 6.0.2 is clean.

```ts
type Boxed<T> = unknown;
interface Carrier<T> { run: () => Boxed<T>; }
function make<T>(): Carrier<T> { return { run: () => 1 as unknown }; }
// tsz (before): error TS2322: Type '{ run: () => unknown; }' is not assignable to type 'Carrier<T>'.
// tsc: clean
```

Property position (`p: Boxed<T>`) and direct return (`function f<T>(): Boxed<T>`)
were already fixed by #14595; only the **function-return-through-instantiation**
position regressed.

## Wrong operation & owner

Solver relation layer — `return_type_needs_raw_fallback`
(`crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs`).

The return-type gate classified *any* return alias whose `resolve_lazy` body is
`unknown` as a missing-body **placeholder** and forced a raw (unevaluated)
comparison of the deferred `Application` against the source — which the relation
layer cannot recognize as `unknown`, hence the false positive. But a genuine
`type C<T> = unknown` body legitimately resolves to `unknown`.

The evaluator (`evaluate_application`, #14595) already distinguishes a genuine
body from a cross-file registration-window placeholder via `get_def_raw_body`
(a genuine body is recorded in the definition store at alias-registration time;
a placeholder `unknown` comes from an unresolved symbol-type fallback with no
registered body). The relation-layer gate did **not** carry that distinction, so
the two layers diverged.

## Structural rule

> When a function-typed member returns an alias application whose body is a
> genuinely-registered `unknown`, the evaluated `unknown` is authoritative and
> the source relates to it (everything is assignable to `unknown`). Only an
> unresolvable/placeholder body justifies the raw-form fallback. Owner: solver
> relation layer (return-type gate), keyed on the genuine-vs-placeholder body
> classification — never on identifier/file-name text.

## Fix

- Add the genuine-vs-placeholder distinction to `return_type_needs_raw_fallback`.
- **Altitude / DRY:** extract the `get_def_raw_body(def_id) == Some(unknown)`
  idiom (previously duplicated in `evaluate_application`) into a single
  `TypeResolver::is_genuine_unknown_alias_body` predicate, and call it from both
  the evaluator and the relation layer so they cannot diverge again.

## Adjacent / negative matrix (all verified against `tsc` 6.0.2)

| case | tsc | tsz (after) |
|---|---|---|
| `() => Boxed<T>` member, `type Boxed<T> = unknown` | clean | clean |
| `() => Reduced<T>`, `type Reduced<T> = T extends 1 ? unknown : unknown` | clean | clean |
| nested `() => () => Boxed<T>` | clean | clean |
| `() => AlwaysStr<T>`, `type AlwaysStr<T> = ... ? string : string`, return `123` | TS2322 | TS2322 |
| `() => "hi"` source vs `() => Boxed<T>` (string ≤ unknown) | clean | clean |

## Anti-hardcoding

No identifier/file-name/printer-string predicate is involved — the rule keys on
the structural `unknown`-body classification. Regression tests vary the alias and
type-parameter spellings (`Boxed`/`Reduced`/`AlwaysStr`, `T`/`Elem`/`Shape`/`Param`).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Minimal repro + the adjacent/negative matrix above diffed against `tsc` 6.0.2 (built `tsz` matches every row).
- New CLI driver regression tests (`cargo test -p tsz-cli --lib compile_generic_unknown_bodied_alias_in_function_return_position_no_ts2322` and `..._still_rejects_mismatched_non_unknown_body`) → both pass; negative control proves soundness is preserved.
- `cargo test -p tsz-solver --lib evaluate_application` → 13 passed; `--lib subtype` → 1314 passed; `--lib relations::` → 1364 passed; `conditional_deferred_return_tests` → 4 passed.
- `cargo fmt --check`, `cargo clippy -p tsz-solver --lib`, `python3 scripts/arch/arch_guard.py` — all clean.
- The ~27 pre-existing `tsz-cli --lib` failures (CLI help text, tsbuildinfo permissions, module resolution, lib version) reproduce identically on a clean-tree baseline (verified by `git stash` + rebuild); this change introduces zero new failures.
- Broad conformance / emit / fourslash floors: ready-review CI.

https://claude.ai/code/session_01WcmcfjMLRfnKYGEEZaQ4uB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcmcfjMLRfnKYGEEZaQ4uB)_