### PR TITLE
hold(solver): remaining eval guard bails produce Termination::Incomplete (#14346 stage 3)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -140,17 +140,16 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// could short-circuit the expansion that re-derives `TS2589`. See the
     /// `closed_eval` module.
     deep_recursion_seen: bool,
-    /// Set when the per-evaluator *iteration* limit
-    /// (`RecursionResult::IterationExceeded`) cut a walk short during the
-    /// current top-level request. Distinct from the shared `deep_recursion_seen`
-    /// bool (which a cycle / depth / iteration bail all set, so it cannot name
-    /// the kind), this records the specific iteration-limit bail so
-    /// `evaluate_request_result` can surface `Termination::Incomplete{
-    /// IterationExceeded }` (#14346 stage 2). Cleared at every
-    /// `evaluate_request_result` entry so the verdict is scoped to one request
-    /// and never leaks across reused-evaluator requests; the recursive
-    /// `self.evaluate` calls do not re-enter `evaluate_request_result`.
-    iteration_exceeded_this_request: bool,
+    /// Which guard (if any) first cut a walk short during the current
+    /// top-level request, or `None` if it ran to completion. Unlike the shared
+    /// `deep_recursion_seen` bool (which a cycle / depth / iteration bail all
+    /// set, so it cannot name the kind), this records the specific bail class
+    /// so `evaluate_request_result` can surface `Termination::Incomplete{ kind }`
+    /// (#14346 stages 2–3). Written via [`Self::note_request_termination`]
+    /// (which owns the first-wins semantics and the guard set); cleared at
+    /// every `evaluate_request_result` entry so the verdict is scoped to one
+    /// request and never leaks across reused-evaluator requests.
+    request_termination_kind: Option<TerminationKind>,
     /// Monotonic counter of *limit events* (cycle / depth / iteration / divergence
     /// bails) seen so far in this run. Unlike the sticky `deep_recursion_seen` /
     /// `silent_depth_bailed` booleans — which, once set by the first bail anywhere,
@@ -305,7 +304,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             silent_depth_bailed: false,
             detection_growth_runs: FxHashMap::default(),
             deep_recursion_seen: false,
-            iteration_exceeded_this_request: false,
+            request_termination_kind: None,
             limit_epoch: 0,
             app_body_limit_epoch: 0,
             unresolved_def_seen: false,
@@ -578,27 +577,21 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
     /// Evaluate a normalized request and return the typed result stage.
     ///
-    /// The sole producer of [`EvaluationResult`]. As of #14346 stage 2 it
-    /// reports `Termination::Incomplete{ IterationExceeded }` when the
-    /// per-evaluator iteration-limit bail (`RecursionResult::IterationExceeded`)
-    /// fired anywhere within this request — the first real producer of the
-    /// `Incomplete` arm. `self.evaluate` still collapses that bail to the
-    /// opaque, relation-preserving `TypeId` internally and the scaffold's
+    /// The sole producer of [`EvaluationResult`]. As of #14346 stage 3 it
+    /// reports `Termination::Incomplete{ kind }` for any of the bail classes
+    /// [`Self::note_request_termination`] records (cleared here on entry so the
+    /// verdict is scoped to this single top-level request and cannot leak from
+    /// a reused evaluator). `self.evaluate` still collapses each bail to the
+    /// opaque, relation-preserving `TypeId` internally and
     /// `EvaluationResult::incomplete` carries that same `TypeId` as its
     /// `partial`, so every consumer's `into_type_id` collapse — and therefore
     /// the emitted type and diagnostics — is byte-identical to the pre-channel
-    /// evaluator. The remaining bail classes still report
-    /// `Termination::Complete` until later stages wire them in.
-    ///
-    /// The `iteration_exceeded_this_request` signal is cleared on entry so the
-    /// verdict is scoped to this single top-level request and cannot leak from
-    /// a prior request on a reused evaluator; the recursive `self.evaluate`
-    /// calls never re-enter this boundary.
+    /// evaluator.
     pub fn evaluate_request_result(&mut self, request: EvaluationRequest) -> EvaluationResult {
         self.set_no_unchecked_indexed_access(request.no_unchecked_indexed_access());
-        self.iteration_exceeded_this_request = false;
+        self.request_termination_kind = None;
         let type_id = self.evaluate(request.type_id());
-        request_result_verdict(type_id, self.iteration_exceeded_this_request)
+        request_result_verdict(type_id, self.request_termination_kind)
     }
 
     // =========================================================================
@@ -792,6 +785,40 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.note_limit_event();
     }
 
+    /// Record that `kind` cut the current top-level request's walk short so the
+    /// `evaluate_request_result` boundary can surface
+    /// `Termination::Incomplete{ kind }` (#14346 stage 3).
+    ///
+    /// First-wins: the verdict names the guard that *first* truncated the walk
+    /// (the firing-order signal #14346 flags); a later bail in the same request
+    /// does not overwrite it. Also bumps the measurement-only
+    /// `record_eval_termination_guard` counter so the typed channel and the
+    /// counter dump name the same set of guards — except `IterationExceeded`,
+    /// which predates the counter and has no bucket (it returns before the
+    /// counter call, preserving the pre-stage-3 counter behavior exactly).
+    ///
+    /// Byte-identical: this only records metadata; the opaque,
+    /// relation-preserving `TypeId` each bail site returns is unchanged, so the
+    /// universal `into_type_id` collapse — and the emitted type and diagnostics
+    /// — are exactly as before.
+    #[inline]
+    fn note_request_termination(&mut self, kind: TerminationKind) {
+        // First-wins: keep the kind that first truncated the walk.
+        self.request_termination_kind.get_or_insert(kind);
+        use tsz_common::perf_counters::EvaluationTerminationGuard as Guard;
+        let guard = match kind {
+            TerminationKind::DepthExceeded => Guard::DepthExceeded,
+            TerminationKind::FuelExhausted => Guard::FuelExhausted,
+            TerminationKind::SolverStackFrames => Guard::SolverStackFrames,
+            TerminationKind::CrossEvalCycle => Guard::CrossEvalCycle,
+            TerminationKind::QueryOpBudget => Guard::QueryOpBudget,
+            // No observability counter exists for the iteration bail; it was
+            // never recorded pre-stage-3 and must not start now.
+            TerminationKind::IterationExceeded => return,
+        };
+        tsz_common::perf_counters::record_eval_termination_guard(guard);
+    }
+
     /// Record that an application's base `DefId` had no resolvable body in
     /// this run (registration-window artifact; see `unresolved_def_seen`).
     ///
@@ -906,18 +933,15 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         // Check if depth was already exceeded in a previous call
         if self.guard.is_exceeded() {
-            // #14346 observability (no-op when counters off): record which
-            // guard cut this walk short. The bail outcome is unchanged.
-            tsz_common::perf_counters::record_eval_termination_guard(
-                tsz_common::perf_counters::EvaluationTerminationGuard::DepthExceeded,
-            );
+            // #14346 stage 3: surface the typed verdict for this request and
+            // bump the observability counter (no-op when counters off). The
+            // bail outcome (the opaque `ERROR` partial) is unchanged.
+            self.note_request_termination(TerminationKind::DepthExceeded);
             return TypeId::ERROR;
         }
         // Cross-instance per-query operation budget (see `query_budget`).
         let Some(_query_frame) = self.enter_eval_query_budget() else {
-            tsz_common::perf_counters::record_eval_termination_guard(
-                tsz_common::perf_counters::EvaluationTerminationGuard::QueryOpBudget,
-            );
+            self.note_request_termination(TerminationKind::QueryOpBudget);
             return type_id;
         };
 
@@ -935,9 +959,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // proceed at a shallower depth without inheriting a sticky
                 // exceeded flag. See the analogous DepthExceeded arm below.
                 self.mark_silent_depth_bailed();
-                tsz_common::perf_counters::record_eval_termination_guard(
-                    tsz_common::perf_counters::EvaluationTerminationGuard::CrossEvalCycle,
-                );
+                self.note_request_termination(TerminationKind::CrossEvalCycle);
                 return type_id;
             }
             let result = self.evaluate_guarded(type_id);
@@ -971,9 +993,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         crate::recursion::with_solver_frame(|| self.evaluate_guarded_inner(type_id)).unwrap_or_else(
             || {
                 self.mark_silent_depth_bailed();
-                tsz_common::perf_counters::record_eval_termination_guard(
-                    tsz_common::perf_counters::EvaluationTerminationGuard::SolverStackFrames,
-                );
+                self.note_request_termination(TerminationKind::SolverStackFrames);
                 type_id
             },
         )
@@ -1143,7 +1163,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // relation-preserving partial) and the `deep_recursion_seen`
                 // cache taint are unchanged, so the collapse via `into_type_id`
                 // is byte-identical.
-                self.iteration_exceeded_this_request = true;
+                self.note_request_termination(TerminationKind::IterationExceeded);
                 self.memo_insert(limit_epoch_at_entry, type_id, type_id);
                 return type_id;
             }
@@ -1164,9 +1184,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             self.mark_depth_exceeded();
             self.guard.leave(type_id);
             self.memo_insert(limit_epoch_at_entry, type_id, TypeId::ERROR);
-            tsz_common::perf_counters::record_eval_termination_guard(
-                tsz_common::perf_counters::EvaluationTerminationGuard::FuelExhausted,
-            );
+            self.note_request_termination(TerminationKind::FuelExhausted);
             return TypeId::ERROR;
         }
 
@@ -1214,23 +1232,25 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     // Additional evaluator support methods live in the nested support module.
 }
 
-/// Translate a finished `evaluate` result plus the per-request iteration-bail
-/// flag into the typed [`EvaluationResult`] verdict (#14346 stage 2).
+/// Translate a finished `evaluate` result plus the per-request termination
+/// verdict into the typed [`EvaluationResult`] (#14346 stages 2–3).
 ///
-/// `EvaluationResult::incomplete` carries `type_id` as its `partial`, so
-/// `into_type_id` is identical for both arms — the verdict is additive metadata,
-/// not a value change, keeping every consumer byte-identical. Factored out (and
-/// free of the evaluator's `R`/lifetime) so the `Complete`/`Incomplete`
-/// selection is unit-testable without driving a real >100k-iteration bail.
+/// `termination` is the first bail class that fired during the request (see
+/// [`TypeEvaluator::note_request_termination`]), or `None` for a walk that ran
+/// to completion. `EvaluationResult::incomplete` carries `type_id` as its
+/// `partial`, so `into_type_id` is identical for both arms — the verdict is
+/// additive metadata, not a value change, keeping every consumer
+/// byte-identical. Factored out (and free of the evaluator's `R`/lifetime) so
+/// the `Complete`/`Incomplete` selection is unit-testable without driving a
+/// real bail through the full evaluator.
 #[inline]
 pub(crate) const fn request_result_verdict(
     type_id: TypeId,
-    iteration_exceeded: bool,
+    termination: Option<TerminationKind>,
 ) -> EvaluationResult {
-    if iteration_exceeded {
-        EvaluationResult::incomplete(type_id, TerminationKind::IterationExceeded)
-    } else {
-        EvaluationResult::complete(type_id)
+    match termination {
+        Some(kind) => EvaluationResult::incomplete(type_id, kind),
+        None => EvaluationResult::complete(type_id),
     }
 }
 

--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -18,13 +18,19 @@
 //! [`EvaluationResult::into_type_id`], which returns the relation-preserving
 //! `partial` (= the same opaque `TypeId` the bail produced before the channel),
 //! so the emitted type and diagnostics are byte-identical. As of #14346
-//! stage 2 the [`crate::evaluation::evaluate::TypeEvaluator::evaluate_request_result`]
-//! producer reports [`Termination::Incomplete`] with
-//! [`TerminationKind::IterationExceeded`] when the per-evaluator iteration limit
-//! cut the walk short — the first real producer of the `Incomplete` arm — while
-//! still surfacing the same `partial` and preserving the `deep_recursion_seen`
-//! cache taint. The remaining bail classes still report
-//! [`Termination::Complete`] until later stages wire them in.
+//! stage 3 the [`crate::evaluation::evaluate::TypeEvaluator::evaluate_request_result`]
+//! producer reports [`Termination::Incomplete`] for every one of the six bail
+//! classes: stage 2 wired [`TerminationKind::IterationExceeded`] (the
+//! per-evaluator iteration limit), and stage 3 wired the five guards that
+//! already carried a `record_eval_termination_guard` observability counter —
+//! [`TerminationKind::DepthExceeded`], [`TerminationKind::FuelExhausted`],
+//! [`TerminationKind::SolverStackFrames`], [`TerminationKind::CrossEvalCycle`],
+//! and [`TerminationKind::QueryOpBudget`] — through the shared
+//! `note_request_termination` helper (first-wins: the verdict names the guard
+//! that first truncated the walk). Each still surfaces the same `partial` and
+//! preserves the existing cache taint, so the collapse is byte-identical; the
+//! verdict is additive metadata a later stage (cache eligibility as a property
+//! of the result) can act on.
 
 use crate::types::TypeId;
 
@@ -94,12 +100,12 @@ impl EvaluationResult {
     /// relation-preserving `partial` type and the [`TerminationKind`] that
     /// fired.
     ///
-    /// Reached as of #14346 stage 2 for [`TerminationKind::IterationExceeded`]
-    /// (see `evaluate_request_result`). `type_id` is set to `partial`, so the
-    /// universal [`EvaluationResult::into_type_id`] collapse is byte-identical
-    /// to the pre-channel opaque bail; the verdict is additional metadata a
-    /// future verdict-aware consumer can act on. The other bail classes still
-    /// route through [`Self::complete`] until later stages wire them here.
+    /// Reached for every bail class as of #14346 stage 3 (stage 2 wired
+    /// [`TerminationKind::IterationExceeded`]; stage 3 added the five
+    /// guard bails — see `evaluate_request_result`). `type_id` is set to
+    /// `partial`, so the universal [`EvaluationResult::into_type_id`] collapse
+    /// is byte-identical to the pre-channel opaque bail; the verdict is
+    /// additional metadata a future verdict-aware consumer can act on.
     pub const fn incomplete(partial: TypeId, kind: TerminationKind) -> Self {
         Self {
             type_id: partial,
@@ -153,7 +159,9 @@ mod tests {
 
     #[test]
     fn incomplete_result_carries_partial_and_kind() {
-        // Reserved for a future stage; today no producer reaches this arm.
+        // `DepthExceeded` is a real producer as of #14346 stage 3 (the
+        // `guard.is_exceeded()` prologue bail); the partial/verdict contract is
+        // identical for every kind.
         let result = EvaluationResult::incomplete(TypeId::NUMBER, TerminationKind::DepthExceeded);
 
         assert!(result.is_incomplete());

--- a/crates/tsz-solver/tests/evaluate_tests_parts/iteration_exceeded_incomplete.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/iteration_exceeded_incomplete.rs
@@ -1,17 +1,16 @@
-// #14346 stage 2: the iteration-limit bail (`RecursionResult::IterationExceeded`)
-// is the first real producer of `Termination::Incomplete`. These tests pin the
-// boundary contract that keeps the channel parity-safe:
+// #14346 stages 2–3: the `evaluate_request_result` boundary turns the
+// per-request termination verdict into a typed `EvaluationResult`. These tests
+// pin the boundary contract that keeps the channel parity-safe:
 //
-//   * a request that hit the iteration bail reports
-//     `Incomplete { kind: IterationExceeded, partial }` where `partial` is the
-//     opaque, relation-preserving `TypeId` the bail surfaced;
+//   * a request that hit a bail reports `Incomplete { kind, partial }` where
+//     `partial` is the opaque, relation-preserving `TypeId` the bail surfaced;
 //   * `into_type_id()` returns that same `partial`, so every consumer's collapse
 //     — and therefore the emitted type and diagnostics — is byte-identical to a
 //     `Complete` result carrying the same `TypeId`;
-//   * a request that did not hit the bail still reports `Complete`.
+//   * a request that did not hit a bail still reports `Complete`.
 //
-// Driving a genuine >100k-iteration bail through the full evaluator would be slow
-// and fragile, so these exercise the boundary's verdict translation directly
+// Driving genuine bails through the full evaluator would be slow and fragile, so
+// these exercise the boundary's verdict translation directly
 // (`TypeEvaluator::request_result_verdict`), which is the exact function
 // `evaluate_request_result` uses to choose the arm.
 
@@ -21,7 +20,7 @@ use crate::evaluation::result::Termination;
 fn iteration_exceeded_request_reports_incomplete_with_partial() {
     // The opaque, relation-preserving partial the bail returns unchanged.
     let partial = TypeId::STRING;
-    let result = request_result_verdict(partial, true);
+    let result = request_result_verdict(partial, Some(TerminationKind::IterationExceeded));
 
     assert!(result.is_incomplete());
     assert_eq!(
@@ -38,9 +37,34 @@ fn iteration_exceeded_request_reports_incomplete_with_partial() {
 
 #[test]
 fn non_bailed_request_reports_complete() {
-    let result = request_result_verdict(TypeId::NUMBER, false);
+    let result = request_result_verdict(TypeId::NUMBER, None);
 
     assert!(!result.is_incomplete());
     assert_eq!(result.termination(), Termination::Complete);
     assert_eq!(result.into_type_id(), TypeId::NUMBER);
+}
+
+#[test]
+fn every_guard_bail_reports_incomplete_with_its_kind_and_partial() {
+    // Stage 3: each of the five guard bails surfaces its own kind while keeping
+    // the same opaque partial, so `into_type_id` stays byte-identical across the
+    // board. The partial varies per case only to prove it is threaded through
+    // unchanged, never replaced by a sentinel.
+    for (kind, partial) in [
+        (TerminationKind::DepthExceeded, TypeId::ERROR),
+        (TerminationKind::FuelExhausted, TypeId::ERROR),
+        (TerminationKind::SolverStackFrames, TypeId::STRING),
+        (TerminationKind::CrossEvalCycle, TypeId::NUMBER),
+        (TerminationKind::QueryOpBudget, TypeId::BOOLEAN),
+    ] {
+        let result = request_result_verdict(partial, Some(kind));
+
+        assert!(result.is_incomplete());
+        assert_eq!(
+            result.termination(),
+            Termination::Incomplete { kind, partial }
+        );
+        assert_eq!(result.into_type_id(), partial);
+        assert!(result.is_identity_for(partial));
+    }
 }


### PR DESCRIPTION
## Summary

Stage 3 of the `EvaluationResult` typed-termination channel (#14346 migration step 1). Stage 2 (#14554) made `RecursionResult::IterationExceeded` the first real producer of `Termination::Incomplete`. The other five evaluator bail classes already carried `record_eval_termination_guard` observability counters at their bail sites but were **not** wired into the typed `EvaluationResult` channel — so a budget-truncated walk surfaced a verdict for only one of six bail kinds.

This wires the remaining five — `DepthExceeded`, `FuelExhausted`, `SolverStackFrames`, `CrossEvalCycle`, `QueryOpBudget` — through one shared `note_request_termination` helper, so every guard the counter dump already names now also produces a typed verdict via `evaluate_request_result`.

## Structural rule

When any evaluator guard cuts a top-level evaluation request short, `evaluate_request_result` must report `Termination::Incomplete{ kind }` naming the guard that *first* truncated the walk; `tsz` previously named only `IterationExceeded` and silently reported `Complete` for the other five. Owner: solver (`evaluation::evaluate` / `evaluation::result`).

## What changed

- Replaced the single-purpose `iteration_exceeded_this_request: bool` field with `request_termination_kind: Option<TerminationKind>`.
- Added `TypeEvaluator::note_request_termination(kind)`: first-wins per-request recording + the same perf-counter bump the inline calls did (except `IterationExceeded`, which predates the counter and keeps no bucket — behavior preserved exactly).
- Routed all six bail sites through the helper; `request_result_verdict` now takes `Option<TerminationKind>`.
- Cleared the field at every `evaluate_request_result` entry so the verdict is scoped to one request and never leaks across reused evaluators.

## Parity / boundary

**Zero diagnostic delta — byte-identical.** Every bail still returns the same opaque, relation-preserving `TypeId`, and `EvaluationResult::incomplete` carries it as `partial`, so the universal `into_type_id` collapse — and therefore emitted types and diagnostics — is unchanged. The verdict is additive metadata a later stage (cache eligibility as a property of the result, per the migration path) can act on. No name/file-string predicates introduced; the `TerminationKind → EvaluationTerminationGuard` mapping is an explicit match (no fragile discriminant-layout coupling).

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: medium

## Verification
- `cargo check -p tsz-solver` — clean.
- `cargo clippy -p tsz-solver --lib` — clean (no warnings).
- `cargo test -p tsz-solver --lib evaluation::result` — 2 pass.
- New boundary tests (`evaluate_tests_parts/iteration_exceeded_incomplete.rs`): `iteration_exceeded_request_reports_incomplete_with_partial`, `non_bailed_request_reports_complete`, `every_guard_bail_reports_incomplete_with_its_kind_and_partial` — all pass.
- `cargo test -p tsz-common perf_counters::dump_tests` — 3 pass (counter routing unchanged).
- Full `cargo test -p tsz-solver --lib evaluation::` introduces zero new failures (the one failure, `test_conditional_infer_optional_property_present_distributive`, is a pre-existing interner-state/order artifact under single-process `cargo test`; it fails identically on clean `main` and is green under CI's per-test nextest isolation).
- Ready-review CI owns the broad conformance/emit/fourslash suites.

https://claude.ai/code/session_01TipvJMyLarzJLEcwQLZ4vS

---
_Generated by [Claude Code](https://claude.ai/code/session_01TipvJMyLarzJLEcwQLZ4vS)_