### PR TITLE
fix(emit): wrap async arrow/function-expression return types in Promise in DTS

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -584,22 +584,39 @@ impl<'a> DeclarationEmitter<'a> {
         scratch.write(") => ");
         if func.type_annotation.is_some() {
             scratch.emit_type(func.type_annotation);
-        } else if func.body.is_some() && scratch.body_returns_void(func.body) {
-            scratch.write("void");
-        } else if let Some(return_type) = scratch.expression_body_parameter_return_type_text(func) {
-            scratch.write(&return_type);
-        } else if func.body.is_some()
-            && let Some(return_type) = scratch
-                .function_expression_return_type_text(func, depth + 1)
-                .filter(|text| !text.is_empty() && text != "any")
-        {
-            scratch.write(&return_type);
-        } else if let Some(return_type) =
-            scratch.function_body_preferred_return_type_text(func.body)
-        {
-            scratch.write(&return_type);
         } else {
-            scratch.write("any");
+            let inferred_return = if func.body.is_some() && scratch.body_returns_void(func.body) {
+                "void".to_string()
+            } else if let Some(return_type) =
+                scratch.expression_body_parameter_return_type_text(func)
+            {
+                return_type
+            } else if func.body.is_some()
+                && let Some(return_type) = scratch
+                    .function_expression_return_type_text(func, depth + 1)
+                    .filter(|text| !text.is_empty() && text != "any")
+            {
+                return_type
+            } else if let Some(return_type) =
+                scratch.function_body_preferred_return_type_text(func.body)
+            {
+                return_type
+            } else {
+                "any".to_string()
+            };
+            // Wrap the body-derived text in `Promise<...>` for async
+            // non-generators (see `wrap_async_function_return_type_text`). The
+            // body return type drives the double-wrap guard, so it is only
+            // resolved on the async non-generator path.
+            let body_return_type_id = (func.is_async && !func.asterisk_token)
+                .then(|| self.function_body_return_value_type_id(func))
+                .flatten();
+            let inferred_return = scratch.wrap_async_function_return_type_text(
+                func,
+                inferred_return,
+                body_return_type_id,
+            );
+            scratch.write(&inferred_return);
         }
         Some(scratch.writer.take_output())
     }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_async.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_async.rs
@@ -1,7 +1,8 @@
 //! Async method return-type helpers for declaration inference.
 
 use super::super::DeclarationEmitter;
-use tsz_parser::parser::node::MethodDeclData;
+use tsz_parser::parser::node::{FunctionData, MethodDeclData};
+use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
 impl<'a> DeclarationEmitter<'a> {
@@ -43,6 +44,54 @@ impl<'a> DeclarationEmitter<'a> {
     pub(in crate::declaration_emitter) fn method_is_async(&self, method: &MethodDeclData) -> bool {
         self.arena
             .has_modifier(&method.modifiers, SyntaxKind::AsyncKeyword)
+    }
+
+    /// Wrap a source-faithful, *unwrapped* function-body return-type text in
+    /// `Promise<...>` when the function is an `async` non-generator, mirroring the
+    /// method path's [`wrap_async_method_return_type_text`].
+    ///
+    /// The AST-walking declaration paths (`emit_function_initializer_type_annotation`,
+    /// `function_expression_type_text_from_ast_at`) derive the return type from the
+    /// function body, which yields the body's own return type. tsc reports an async
+    /// function's return type as `Promise<Awaited<T>>`; when the body itself already
+    /// produces a global `Promise<...>` value (`Awaited` collapses the nesting) the
+    /// text is left as-is to avoid a spurious `Promise<Promise<...>>`. The
+    /// `body_return_type_id` is the body's *unwrapped* return type (not the function
+    /// signature's already-wrapped return type), so the global-`Promise` check
+    /// distinguishes the two cases. Generators (`async function*`) flow through the
+    /// generator-yield path and are skipped here.
+    pub(in crate::declaration_emitter) fn wrap_async_function_return_type_text(
+        &self,
+        func: &FunctionData,
+        text: String,
+        body_return_type_id: Option<tsz_solver::types::TypeId>,
+    ) -> String {
+        if !func.is_async || func.asterisk_token {
+            return text;
+        }
+        if body_return_type_id
+            .is_some_and(|type_id| self.type_id_is_global_promise_application(type_id))
+        {
+            return text;
+        }
+        format!("Promise<{text}>")
+    }
+
+    /// The body's *unwrapped* return value type for a concise-body arrow or a
+    /// single-`return` block body, used to decide whether an async wrapper would
+    /// double-wrap an already-`Promise` body (see
+    /// [`wrap_async_function_return_type_text`]).
+    pub(in crate::declaration_emitter) fn function_body_return_value_type_id(
+        &self,
+        func: &FunctionData,
+    ) -> Option<tsz_solver::types::TypeId> {
+        let body_node = self.arena.get(func.body)?;
+        if body_node.kind == syntax_kind_ext::BLOCK {
+            let return_expr = self.function_body_single_return_expression(func.body)?;
+            self.get_node_type(return_expr)
+        } else {
+            self.get_node_type(func.body)
+        }
     }
 
     fn type_id_is_global_promise_application(&self, type_id: tsz_solver::types::TypeId) -> bool {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl_function_initializers.rs
@@ -72,17 +72,29 @@ impl<'a> DeclarationEmitter<'a> {
             return true;
         }
 
+        // A returned identifier resolves to its source-faithful type text. For an
+        // `async` function the same text is wrapped in `Promise<...>`; the body's
+        // unwrapped return type (only resolved on that path) drives the
+        // double-wrap guard.
         if func.body.is_some()
             && let Some(returned_identifier) =
                 self.function_body_unique_return_identifier(func.body)
             && let Some(type_text) =
                 self.function_return_identifier_type_text(func, returned_identifier)
         {
+            let body_return_type_id = (func.is_async && !func.asterisk_token)
+                .then(|| {
+                    self.function_return_identifier_declared_type_id(func, returned_identifier)
+                        .or_else(|| self.get_node_type_or_names(&[returned_identifier]))
+                })
+                .flatten();
+            let type_text =
+                self.wrap_async_function_return_type_text(func, type_text, body_return_type_id);
             self.write(&type_text);
             return true;
         }
 
-        let preferred_return_type_text = if func.body.is_some() {
+        let mut preferred_return_type_text = if func.body.is_some() {
             self.arena.get(func.body).and_then(|body_node| {
                 if body_node.kind == syntax_kind_ext::BLOCK {
                     self.function_body_preferred_return_type_text(func.body)
@@ -93,6 +105,31 @@ impl<'a> DeclarationEmitter<'a> {
         } else {
             None
         };
+
+        // An `async` function's return type is `Promise<Awaited<T>>`. Render the
+        // body's own (source-faithful) return type text and wrap it, matching the
+        // method path. Done here, after `preferred_return_type_text` is known, so
+        // async reuses the same body inference as the non-async paths instead of
+        // the alias-expanding signature printer. (A returned identifier is already
+        // handled above.)
+        if func.is_async && !func.asterisk_token && func.body.is_some() {
+            let async_inner = if self.body_returns_void(func.body) {
+                Some(("void".to_string(), None))
+            } else {
+                preferred_return_type_text
+                    .take()
+                    .map(|text| (text, self.function_body_return_value_type_id(func)))
+            };
+            if let Some((inner_text, body_return_type_id)) = async_inner {
+                let wrapped = self.wrap_async_function_return_type_text(
+                    func,
+                    inner_text,
+                    body_return_type_id,
+                );
+                self.write(&wrapped);
+                return true;
+            }
+        }
 
         if func.body.is_some()
             && let Some(predicate_text) = self.function_source_type_predicate_text(func)

--- a/crates/tsz-emitter/src/declaration_emitter/tests/probes_tsc_comparison.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/probes_tsc_comparison.rs
@@ -1482,3 +1482,67 @@ fn explore_generic_class_with_default_type() {
         "Should emit default type param: {output}"
     );
 }
+
+// Regression: an `async` arrow / function-expression initializer's inferred
+// return type must be wrapped in `Promise<...>` in declaration emit, matching
+// tsc (the body-derived inference otherwise yields the unwrapped body type).
+// Covers the variable-declaration path and the object-literal-member path;
+// generators, explicit annotations, and non-async functions are untouched.
+
+#[test]
+fn async_arrow_initializer_return_wrapped_in_promise() {
+    let output = emit_dts("export const f = async (x: number) => x;");
+    assert!(
+        output.contains("const f: (x: number) => Promise<number>;"),
+        "async arrow return must be Promise-wrapped: {output}"
+    );
+}
+
+#[test]
+fn async_arrow_void_body_return_wrapped_in_promise() {
+    let output = emit_dts("export const g = async () => {};");
+    assert!(
+        output.contains("const g: () => Promise<void>;"),
+        "async void arrow must emit Promise<void>: {output}"
+    );
+}
+
+#[test]
+fn async_function_expression_return_wrapped_in_promise() {
+    let output = emit_dts("export const h = async function (x: number) { return x; };");
+    assert!(
+        output.contains("const h: (x: number) => Promise<number>;"),
+        "async function expression return must be Promise-wrapped: {output}"
+    );
+}
+
+#[test]
+fn async_arrow_explicit_annotation_not_double_wrapped() {
+    let output = emit_dts("export const i = async (x: number): Promise<number> => x;");
+    assert!(
+        output.contains("const i: (x: number) => Promise<number>;"),
+        "explicit Promise annotation must not be re-wrapped: {output}"
+    );
+    assert!(
+        !output.contains("Promise<Promise<"),
+        "must not double-wrap an explicit Promise return: {output}"
+    );
+}
+
+#[test]
+fn async_object_member_arrow_return_wrapped_in_promise() {
+    let output = emit_dts("export const o = { m: async (x: number) => x };");
+    assert!(
+        output.contains("m: (x: number) => Promise<number>;"),
+        "async object-member arrow return must be Promise-wrapped: {output}"
+    );
+}
+
+#[test]
+fn non_async_arrow_initializer_return_unchanged() {
+    let output = emit_dts("export const s = (x: number) => x;");
+    assert!(
+        output.contains("const s: (x: number) => number;"),
+        "non-async arrow return must stay unwrapped: {output}"
+    );
+}


### PR DESCRIPTION
## Summary

The `.d.ts` emitter dropped the `Promise<...>` wrapper on the inferred return type of `async` arrow functions and function expressions, emitting `const f: (x: number) => number` where `tsc` emits `(x: number) => Promise<number>`. The type checker was already correct; only the AST-walking declaration-emit paths were wrong.

## Structural rule

When an `async` non-generator function expression / arrow has no explicit return annotation, `tsc` reports its return type as `Promise<Awaited<T>>`. tsz's declaration emitter derives the return type from the function body (the unwrapped `T`). The method path already compensates via `wrap_async_method_return_type_text`, but two sibling AST entry points did not: variable-declaration initializers (`emit_function_initializer_type_annotation`) and object-literal members (`function_expression_type_text_from_ast_at`).

## Fix (owner: emitter / declaration_emitter)

Both paths now wrap the source-faithful body return text in `Promise<...>` for async non-generators, mirroring the method path. A `body_return_type_id` guard (new `function_body_return_value_type_id` + existing `type_id_is_global_promise_application`) suppresses re-wrapping when the body already produces a global `Promise` (preserves `Awaited` collapse, no `Promise<Promise<...>>`). The wrap reuses the same body inference as the non-async paths, preserving source fidelity (e.g. `Promise<Alias>`). Generators (`async function*`), explicit annotations, and non-async functions are untouched. No checker/semantic behavior changes — DTS output only.

## Adjacent-case matrix (all identical to tsc 6.0.2)

concise `async () => 42`; block `async function (x) { return x }`; void body; returned identifier; already-Promise body (no double-wrap); generic `<T>(x: T) => Promise<T>`; nested async; object members; default export; local type-alias fidelity `Promise<Alias>`; negative: non-async + async generators unchanged.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-emitter --lib` — 3818 passed, 0 failed (6 new regression tests in `declaration_emitter/tests/probes_tsc_comparison.rs`).
- `cargo clippy -p tsz-emitter --lib` — clean.
- Differential vs tsc 6.0.2 (`--declaration --emitDeclarationOnly --strict`) across the matrix above — all identical. Remaining survey diffs were pre-existing async-independent widening bugs (literal/union widening, array best-common-type, custom-thenable `Awaited`), confirmed via non-async controls.
- Broad conformance/emit/fourslash floors: ready-review CI.

https://claude.ai/code/session_01PBYAPB79mA8ePoCXCdAT9k