### PR TITLE
fix(solver): relate generic sources to nested homomorphic identity mapped types (Prettify<Prettify<T>>)

### DIFF
--- a/crates/tsz-cli/src/driver/mod.rs
+++ b/crates/tsz-cli/src/driver/mod.rs
@@ -28,3 +28,7 @@ mod declare_global_interface_keyof_merge_tests;
 #[cfg(test)]
 #[path = "cross_file_type_only_namespace_unique_symbol_tests.rs"]
 mod cross_file_type_only_namespace_unique_symbol_tests;
+
+#[cfg(test)]
+#[path = "nested_homomorphic_mapped_identity_tests.rs"]
+mod nested_homomorphic_mapped_identity_tests;

--- a/crates/tsz-cli/src/driver/nested_homomorphic_mapped_identity_tests.rs
+++ b/crates/tsz-cli/src/driver/nested_homomorphic_mapped_identity_tests.rs
@@ -1,0 +1,182 @@
+//! Parity guard for nested homomorphic *identity* mapped types
+//! (`Id<Id<T>>`, the `Prettify<Prettify<T>>` idiom).
+//!
+//! `tsc` reduces `keyof { [P in keyof S]: S[P] }` to `keyof S` and
+//! `{ [P in keyof S]: S[P] }[K]` to `S[K]`, so a homomorphic identity mapped
+//! type is interchangeable with its source. A generic source `T` therefore
+//! relates to `Id<Id<T>>` exactly as it does to the single-level `Id<T>`
+//! (`tsc` is clean). tsz used to emit a false `TS2322` because the relation's
+//! homomorphic-mapped recognition stopped at the inner mapped type instead of
+//! peeling it to its underlying type parameter.
+//!
+//! Owner: solver relation layer (`is_assignable_to_homomorphic_mapped` /
+//! `homomorphic_mapped_constraint_source`). These cases pin the structural
+//! shape — binder/alias spellings are varied across cases so the guard follows
+//! the structure rather than any identifier (anti-hardcoding).
+
+use super::compile;
+use crate::args::CliArgs;
+use clap::Parser;
+use std::fs;
+use tsz_common::diagnostics::Diagnostic;
+
+/// Write `source` plus a strict `noEmit` tsconfig into a fresh temp dir and run
+/// the single-file project compile. Returns every emitted diagnostic.
+fn compile_single(source: &str) -> Vec<Diagnostic> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let tsconfig = r#"{ "compilerOptions": { "strict": true, "target": "es2022", "lib": ["es2022"], "noEmit": true }, "files": ["main.ts"] }"#;
+    fs::write(dir.path().join("tsconfig.json"), tsconfig).expect("write tsconfig");
+    fs::write(dir.path().join("main.ts"), source).expect("write source");
+
+    let project = dir.path().to_string_lossy().to_string();
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--project",
+        project.as_str(),
+        "--noEmit",
+        "--pretty",
+        "false",
+    ])
+    .expect("project args");
+    compile(&args, dir.path())
+        .expect("compile succeeds")
+        .diagnostics
+}
+
+/// TS2322 (type not assignable) — the family the missing homomorphic-identity
+/// peel produced.
+fn assignability_errors(diags: &[Diagnostic]) -> Vec<(u32, String)> {
+    diags
+        .iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+fn no_errors() -> Vec<(u32, String)> {
+    Vec::new()
+}
+
+// ---- Positive cases (tsc-clean; tsz must match) ----
+
+/// `T <: Id<Id<T>>` — the reported residual. Two-level homomorphic identity.
+#[test]
+fn source_param_assignable_to_double_nested_identity() {
+    let diags = compile_single(
+        r#"
+type Id<T> = { [K in keyof T]: T[K] };
+function widen<T>(x: T): Id<Id<T>> { return x; }
+"#,
+    );
+    assert_eq!(
+        assignability_errors(&diags),
+        no_errors(),
+        "T must be assignable to Id<Id<T>> (keyof/index identity collapses the nesting)"
+    );
+}
+
+/// Triple nesting and a differently-spelled alias/parameter still collapse.
+#[test]
+fn source_param_assignable_to_triple_nested_identity_renamed() {
+    let diags = compile_single(
+        r#"
+type Same<U> = { [P in keyof U]: U[P] };
+function pass<Widget>(value: Widget): Same<Same<Same<Widget>>> { return value; }
+"#,
+    );
+    assert_eq!(
+        assignability_errors(&diags),
+        no_errors(),
+        "renamed triple-nested homomorphic identity must still accept the source param"
+    );
+}
+
+/// Reverse direction: `Id<Id<T>> <: T` (the mapped source relates back to T).
+#[test]
+fn double_nested_identity_assignable_to_source_param() {
+    let diags = compile_single(
+        r#"
+type Id<T> = { [K in keyof T]: T[K] };
+function narrow<Shape>(x: Id<Id<Shape>>): Shape { return x; }
+"#,
+    );
+    assert_eq!(
+        assignability_errors(&diags),
+        no_errors(),
+        "Id<Id<Shape>> must be assignable back to Shape"
+    );
+}
+
+/// A `readonly` outer wrapper over an identity inner mapped type still peels the
+/// inner source. `readonly` does not change assignability from the source.
+#[test]
+fn readonly_over_identity_inner_accepts_source_param() {
+    let diags = compile_single(
+        r#"
+type Id<T> = { [K in keyof T]: T[K] };
+type Frozen<T> = { readonly [K in keyof T]: T[K] };
+function freeze<T>(x: T): Frozen<Id<T>> { return x; }
+"#,
+    );
+    assert_eq!(
+        assignability_errors(&diags),
+        no_errors(),
+        "T must be assignable to Readonly<Id<T>> (inner identity peeled, readonly is irrelevant)"
+    );
+}
+
+/// `Pick`-shape (`{ [P in K]: S[P] }`, constraint a key subset rather than
+/// `keyof S`) over an identity inner wrapper still peels to the source, so the
+/// source type parameter supplies every picked property.
+#[test]
+fn pick_shape_over_identity_inner_accepts_source_param() {
+    let diags = compile_single(
+        r#"
+type Id<T> = { [K in keyof T]: T[K] };
+type Subset<T, K extends keyof T> = { [P in K]: T[P] };
+function take<T, K extends keyof T & keyof Id<T>>(x: T): Subset<Id<T>, K> { return x; }
+"#,
+    );
+    assert_eq!(
+        assignability_errors(&diags),
+        no_errors(),
+        "T must be assignable to a Pick-shape over Id<T> (inner identity peeled)"
+    );
+}
+
+// ---- Negative controls (tsc errors; tsz must keep erroring) ----
+
+/// `Required<Id<T>>` removes optionality, so `T` (which may carry optional
+/// members) is NOT assignable. The peel must not over-accept here.
+#[test]
+fn required_over_identity_inner_still_rejects_source_param() {
+    let diags = compile_single(
+        r#"
+type Id<T> = { [K in keyof T]: T[K] };
+type AllRequired<T> = { [K in keyof T]-?: T[K] };
+function demand<T>(x: T): AllRequired<Id<T>> { return x; }
+"#,
+    );
+    assert_eq!(
+        assignability_errors(&diags).len(),
+        1,
+        "T must NOT be assignable to Required<Id<T>> (optionality removal narrows the target)"
+    );
+}
+
+/// Nesting around a *concrete* inner source is not interchangeable with a bare
+/// type parameter. `T <: Id<Id<{ a: number }>>` must still fail.
+#[test]
+fn concrete_inner_nesting_still_rejects_source_param() {
+    let diags = compile_single(
+        r#"
+type Id<T> = { [K in keyof T]: T[K] };
+function bad<T>(x: T): Id<Id<{ a: number }>> { return x; }
+"#,
+    );
+    assert_eq!(
+        assignability_errors(&diags).len(),
+        1,
+        "T must NOT be assignable to a nested identity over a concrete object shape"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/mapped_target.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/mapped_target.rs
@@ -471,7 +471,7 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
 
     fn homomorphic_mapped_constraint_source(&mut self, mapped: &MappedType) -> Option<TypeId> {
         if let Some(source) = keyof_inner_type(self.interner, mapped.constraint) {
-            return Some(source);
+            return Some(self.peel_homomorphic_identity_mapped_source(source));
         }
 
         let (template_obj, template_idx) = index_access_parts(self.interner, mapped.template)?;
@@ -484,10 +484,80 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
         if self.mapped_key_constraint_covers(mapped.constraint, full_key_set)
             && self.mapped_key_constraint_covers(full_key_set, mapped.constraint)
         {
-            Some(template_obj)
+            Some(self.peel_homomorphic_identity_mapped_source(template_obj))
         } else {
             None
         }
+    }
+
+    /// Collapse a homomorphic *identity* mapped type to the source object it
+    /// preserves, recursively.
+    ///
+    /// A homomorphic identity mapped type `{ [P in keyof S]: S[P] }` (no name
+    /// remap, no `readonly`/`?` modifier change) is interchangeable with `S` as
+    /// the picked-from object of an enclosing homomorphic mapped type, because
+    /// `tsc` reduces `keyof { [P in keyof S]: S[P] }` to `keyof S` and
+    /// `{ [P in keyof S]: S[P] }[K]` to `S[K]`. Nested `Prettify<Prettify<T>>` /
+    /// `Id<Id<T>>` wrappers therefore collapse to the single-level case, so a
+    /// source type parameter `T` relates to `Id<Id<T>>` exactly as it does to
+    /// `Id<T>`. The peel is bounded against pathological self-referential
+    /// nesting and only follows pure identity mapped types, so it never widens
+    /// the accepted key/value domain (it preserves `tsc` semantics rather than
+    /// relaxing them).
+    pub(crate) fn peel_homomorphic_identity_mapped_source(&mut self, source: TypeId) -> TypeId {
+        let mut current = source;
+        for _ in 0..8 {
+            // Fast path: a bare type parameter (the common source, and the peel's
+            // own terminal) can never be a mapped type, so skip the evaluation.
+            if matches!(
+                self.interner.lookup(current),
+                Some(TypeData::TypeParameter(_) | TypeData::Infer(_))
+            ) {
+                break;
+            }
+            // Normalize an alias application (`Id<X>`) to its mapped body so the
+            // identity shape is observable regardless of the deferred-vs-evaluated
+            // representation a nested instantiation happened to mint.
+            let normalized = self.evaluate_type(current);
+            let Some(TypeData::Mapped(mapped_id)) = self.interner.lookup(normalized) else {
+                break;
+            };
+            let mapped = self.interner.get_mapped(mapped_id);
+            if mapped.name_type.is_some()
+                || mapped.optional_modifier.is_some()
+                || mapped.readonly_modifier.is_some()
+            {
+                break;
+            }
+            let Some(inner_source) = keyof_inner_type(self.interner, mapped.constraint) else {
+                break;
+            };
+            let Some((template_obj, template_idx)) =
+                index_access_parts(self.interner, mapped.template)
+            else {
+                break;
+            };
+            let Some(idx_param) = type_param_info(self.interner, template_idx) else {
+                break;
+            };
+            if idx_param.name != mapped.type_param.name {
+                break;
+            }
+            // The template's indexed object must be the *same type* as the
+            // constraint's `keyof` source for this to be a genuine identity mapped
+            // `{ [P in keyof S]: S[P] }` (rather than `{ [P in keyof A]: B[P] }`,
+            // which is not identity-preserving). Structural identity — not handle
+            // equality — so a nested instantiation that minted `S` as two
+            // distinct-but-equal representations still matches.
+            if template_obj != inner_source
+                && !(self.check_subtype(template_obj, inner_source).is_true()
+                    && self.check_subtype(inner_source, template_obj).is_true())
+            {
+                break;
+            }
+            current = inner_source;
+        }
+        current
     }
 
     /// Distribute a homomorphic mapped type over an intersection argument.

--- a/crates/tsz-solver/src/relations/subtype/rules/unions.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/unions.rs
@@ -249,14 +249,29 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let (constraint_source, is_identity_template) =
             match keyof_inner_type(self.interner, mapped.constraint) {
                 Some(source) => {
+                    // A homomorphic *identity* mapped source (`keyof Id<S>`,
+                    // where `Id<S> = { [P in keyof S]: S[P] }`) is interchangeable
+                    // with `S` itself, because `keyof Id<S> = keyof S` and
+                    // `Id<S>[K] = S[K]`. Peeling it collapses nested
+                    // `Prettify<Prettify<T>>` / `Id<Id<T>>` wrappers to the
+                    // single-level case so a source type parameter `T` is
+                    // recognised as assignable.
+                    let source = self.peel_homomorphic_identity_mapped_source(source);
                     // Classic case: detect an identity `S[P]` template so the
-                    // general check can be skipped.
-                    let identity = index_access_parts(self.interner, mapped.template)
-                        .and_then(|(template_obj, template_idx)| {
-                            let idx_param = type_param_info(self.interner, template_idx)?;
-                            Some(idx_param.name == mapped.type_param.name && template_obj == source)
-                        })
-                        .unwrap_or(false);
+                    // general check can be skipped. The template's indexed object
+                    // is peeled the same way so a template written over a nested
+                    // identity wrapper (`Id<S>[P]`) still matches the peeled
+                    // source `S`.
+                    let identity = match index_access_parts(self.interner, mapped.template) {
+                        Some((template_obj, template_idx)) => {
+                            let name_matches = type_param_info(self.interner, template_idx)
+                                .is_some_and(|idx_param| idx_param.name == mapped.type_param.name);
+                            name_matches
+                                && self.peel_homomorphic_identity_mapped_source(template_obj)
+                                    == source
+                        }
+                        None => false,
+                    };
                     (source, identity)
                 }
                 None => {
@@ -280,7 +295,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     if !self.mapped_key_constraint_covers(full_key_set, mapped.constraint) {
                         return false;
                     }
-                    (template_obj, true)
+                    // Peel a nested identity wrapper here too, mirroring the
+                    // classic-`keyof S` arm above, so `Pick<Id<S>, K>` recognises
+                    // the underlying source.
+                    (
+                        self.peel_homomorphic_identity_mapped_source(template_obj),
+                        true,
+                    )
                 }
             };
 


### PR DESCRIPTION
Goal: green

Addresses the nested-mapped-identity residual called out in #14604 (a
**distinct root** from the empty-object-removal fix in #14605 — it reproduces
with **no** `& {}` at all).

## Summary

A generic source `T` now relates to a **nested** homomorphic identity mapped
type — `Id<Id<T>>`, the `Prettify<Prettify<T>>` / `Simplify` idiom — exactly as
it does to the single-level `Id<T>`. `tsc` is clean here; tsz raised a false
`TS2322`.

```ts
type Id<T> = { [K in keyof T]: T[K] };
function widen<T>(x: T): Id<Id<T>> { return x; } // tsz (before): false TS2322
```

Nested `Prettify`/`Simplify`/`Merge` wrappers are pervasive in real libraries
(type-fest, ts-essentials, kysely, valibot, zod, …), so this is a broad
real-project false-positive family, not a one-off.

## Wrong operation & owner

Solver relation layer — `is_assignable_to_homomorphic_mapped`
(`relations/subtype/rules/unions.rs`) and the shared
`homomorphic_mapped_constraint_source` (`relations/subtype/rules/mapped_target.rs`).

When deciding `T <: { [K in keyof S]: S[K] }`, the relation read the constraint
source `S` and required it to be the source type parameter. For `Id<Id<T>>` the
inner source `S` is itself the mapped type `Id<T>`, not a type parameter, so the
final identity check failed and the relation returned `false`.

`tsc` reduces `keyof { [P in keyof S]: S[P] }` to `keyof S` and
`{ [P in keyof S]: S[P] }[K]` to `S[K]`, so a homomorphic **identity** mapped
type is interchangeable with its source object. The fix introduces
`peel_homomorphic_identity_mapped_source`, which collapses such a source (and the
template's indexed object) through nested identity wrappers to its root before
the type-parameter identity check. Nested wrappers then reduce to the
single-level case that already worked.

## Structural rule

> When relating against a homomorphic mapped type whose picked-from source `S` is
> itself a homomorphic *identity* mapped type `{ [P in keyof S']: S'[P] }`
> (no name remap, no `readonly`/`?` modifier change), `tsc` treats it as `S'`,
> because `keyof Id<S'> = keyof S'` and `Id<S'>[K] = S'[K]`. tsz must peel the
> nested identity wrapper to recognise the underlying source. Owner: solver
> relation layer.

The peel only follows **pure identity** mapped types and matches the
template's indexed object to the constraint's `keyof` source by **structural
identity** (so non-canonical instantiation representations of the same `S` still
match). It therefore preserves `tsc` semantics rather than relaxing them — it
never widens the accepted key/value domain.

## Adjacent-case matrix (verified against `tsc` 6.0.2 + new driver tests)

| target | `tsc` | tsz (after) |
|---|---|---|
| `T <: Id<Id<T>>` (double, the residual) | clean | clean |
| `T <: Same<Same<Same<Widget>>>` (triple, renamed binders) | clean | clean |
| `Id<Id<Shape>> <: Shape` (reverse direction) | clean | clean |
| `T <: Readonly<Id<T>>` (modifier outer, identity inner) | clean | clean |
| `T <: Pick<Id<T>, K>` (subset/`Pick` shape over identity) | clean | clean |
| `T <: Required<Id<T>>` (removes optionality) | TS2322 | TS2322 |
| `T <: Id<Id<{ a: number }>>` (concrete inner shape) | TS2322 | TS2322 |

## Anti-hardcoding

No identifier/file-name/printer-string predicate is involved — the rule keys
purely on the structural `TypeData::Mapped` shape (constraint `keyof S`, identity
template `S[P]`). Regression tests vary the alias and type-parameter spellings
(`Id`/`Same`, `T`/`U`/`Widget`/`Shape`).

## Scope / residual

This is a scoped relation-layer fix. The deeper, fully-general remedy is canonical
reduction of nested mapped types at construction/evaluation time, which belongs to
the non-canonical-instantiation-identity campaign (#13806 / #14344) and is
deliberately out of scope here. The `& {}` empty-object-removal half of #14604
landed in #14605 (now on `main`); the two are orthogonal and **compose** — with
both in place, `Prettify<T>` *and* nested `Prettify<Prettify<T>>` are clean
(verified on the rebased tree).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- Minimal repro + the full adjacent matrix above diffed against a built `tsz`
  (every positive row clean, every negative row still `TS2322`).
- New driver regression tests:
  `cargo test -p tsz-cli --lib nested_homomorphic_mapped_identity` → 7 passed
  (double/triple-renamed/reverse/readonly/pick positives + required/concrete
  negatives; binder names varied).
- `cargo test -p tsz-solver --lib` → 6938 passed; the only 3 reds
  (`literal_mask_preserves_object_vs_literal_reduction`,
  `test_conditional_infer_optional_property_present_distributive`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`)
  are **pre-existing on `main`** (confirmed by a clean-tree baseline).
- This is a solver-only change; the affected checker behavior is pinned by the
  new `tsz-cli` driver tests above. Sampled `tsz-checker --lib` failures were
  confirmed **pre-existing** by reverting the two solver files to the parent and
  reproducing the identical failures (including two architecture-contract
  source-scanning tests that a solver change cannot affect).
- `cargo fmt --check`, `cargo clippy -p tsz-solver --lib`,
  `python3 scripts/arch/arch_guard.py` — all clean.
- Broad conformance / emit / fourslash floors: ready-review CI.

https://claude.ai/code/session_01Vo4i5S57pE2PZjyr93QMj1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vo4i5S57pE2PZjyr93QMj1)_