### PR TITLE
fix(ci): automate runner cleanup + version-floor alert in ci-health

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -175,6 +175,7 @@ jobs:
           fetch-depth: 1
 
       - name: Check runner pool health
+        id: pool
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -207,6 +208,7 @@ jobs:
               fi
             } >> "${GITHUB_STEP_SUMMARY}"
 
+            echo "runner_read=error" >> "${GITHUB_OUTPUT}"
             echo "::warning::runner pool probe unavailable; skipping runner-health failure"
             exit 0
           fi
@@ -233,6 +235,17 @@ jobs:
           ")
           idle=$(( online - busy ))
 
+          # Surface pool metrics as step outputs so the follow-on purge step can
+          # act on the offline count and the version-floor step always runs
+          # (issue #13750). Written before the critical exit below so they are
+          # set on every non-error path.
+          {
+            echo "runner_read=ok"
+            echo "online=${online}"
+            echo "offline=${offline}"
+            echo "idle=${idle}"
+          } >> "${GITHUB_OUTPUT}"
+
           in_progress=$(gh api "repos/${repo}/actions/runs?status=in_progress&per_page=50" \
             --jq '.total_count' 2>/dev/null || echo 0)
           queued=$(gh api "repos/${repo}/actions/runs?status=queued&per_page=50" \
@@ -255,23 +268,126 @@ jobs:
               echo ""
               echo "> ⚠️ **Runner pool saturated** — all runners busy, ${queued} run(s) queued"
             fi
-            if [[ "${offline}" -gt 15 ]]; then
+            if [[ "${offline}" -gt 0 ]]; then
               echo ""
-              echo "> ⚠️ **${offline} stale offline runners** — run \`scripts/ci/cleanup-stale-runners.sh\` to purge"
+              echo "> ⚠️ **${offline} stale offline runner(s)** — the purge step below removes them automatically (\`scripts/ci/cleanup-stale-runners.sh\`)"
             fi
             if [[ "${online}" -lt 20 ]]; then
               echo ""
-              echo "> 🔴 **Low runner count (${online})** — CREMA may not be scaling; check GCP console"
+              echo "> 🔴 **Low runner count (${online})** — CREMA may not be scaling; investigate the Cloud Run runner service"
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
 
           echo "runners: online=${online}/${total} busy=${busy} idle=${idle} offline=${offline}"
           echo "runs: in_progress=${in_progress} queued=${queued}"
 
+          # Make the saturation / low-count signals actionable rather than
+          # buried in the step summary (#13750): emit annotations that surface in
+          # the Actions UI and notifications.
+          if [[ "${idle}" -eq 0 && "${in_progress}" -gt 0 ]]; then
+            echo "::warning::Runner pool saturated — all ${online} runner(s) busy with ${queued} run(s) queued"
+          fi
+          if [[ "${online}" -lt 20 && "${online}" -ge 5 ]]; then
+            echo "::warning::Low runner count (${online} online) — CREMA may not be scaling; investigate the Cloud Run runner service"
+          fi
+
           # Fail loudly when runner pool is critically low (blocks future jobs)
           if [[ "${online}" -lt 5 ]]; then
             echo "::error::CRITICAL: only ${online} runners online — CI is effectively down"
             exit 1
+          fi
+
+      # Runner-version-floor check (#13750). Auto-update is disabled on the
+      # fleet (start.sh sets DISABLE_RUNNER_UPDATE=1 / --disableupdate), so the
+      # deployed runner version equals the Dockerfile pin. If that pin trails the
+      # latest actions/runner release far enough, GitHub can eventually reject
+      # registration once it raises its required minimum and wedge the whole
+      # fleet — warn before that happens so a maintainer can bump the FROM tag
+      # and redeploy. Read-only; runs even when the pool probe failed above.
+      - name: Check runner version floor
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Minor-version gap at which the trailing pin escalates from an
+          # informational summary line to a loud annotation. GitHub supports a
+          # range of recent releases, so a small lag is normal; a large gap means
+          # the required-version floor is approaching.
+          RUNNER_VERSION_FLOOR_GAP: '10'
+        run: |
+          set -uo pipefail
+          dockerfile="scripts/infra/cloud-run-gh-runner/Dockerfile"
+          pinned="$(sed -n 's|^FROM .*/actions-runner:\([0-9][0-9.]*\).*|\1|p' "${dockerfile}" | head -n1)"
+          if [[ -z "${pinned}" ]]; then
+            echo "::warning::Could not parse the runner version pin from ${dockerfile}"
+            exit 0
+          fi
+
+          latest_tag="$(gh api repos/actions/runner/releases/latest --jq '.tag_name' 2>/dev/null || true)"
+          latest="${latest_tag#v}"
+
+          {
+            echo "## Runner version floor — $(date -u '+%Y-%m-%d %H:%M UTC')"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Pinned runner (Dockerfile) | ${pinned} |"
+            echo "| Latest actions/runner release | ${latest:-unknown} |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [[ -z "${latest}" ]]; then
+            echo "Could not determine the latest actions/runner release; skipping the floor comparison."
+            exit 0
+          fi
+
+          echo "runner version: pinned=${pinned} latest=${latest}"
+
+          # Signed minor-version gap (latest - pinned), within or across majors.
+          # >0 behind, 0 current (equal minor / patch-level lag), <0 ahead.
+          # Indented to the block-scalar base so YAML strips it to column-0
+          # Python at runtime (same pattern as the runner-count python above).
+          gap="$(python3 -c "
+          import sys
+          def mm(v):
+              parts = (v.split('.') + ['0', '0'])[:2]
+              return int(parts[0]) * 1000 + int(parts[1])
+          try:
+              print(mm(sys.argv[1]) - mm(sys.argv[2]))
+          except Exception:
+              print(0)
+          " "${latest}" "${pinned}" 2>/dev/null || echo 0)"
+
+          if [[ "${gap}" -le 0 ]]; then
+            echo "> ✅ Runner pin is current (at or ahead of the latest actions/runner release)." >> "${GITHUB_STEP_SUMMARY}"
+          elif [[ "${gap}" -ge "${RUNNER_VERSION_FLOOR_GAP}" ]]; then
+            echo "> 🔴 Pinned runner \`${pinned}\` trails latest \`${latest}\` by ${gap} minor release(s). Auto-update is disabled, so bump \`${dockerfile}\` and redeploy before GitHub raises its required runner-version floor and registration starts failing." >> "${GITHUB_STEP_SUMMARY}"
+            echo "::warning::Runner pin ${pinned} trails latest actions/runner ${latest} by ${gap} minor release(s) (auto-update disabled) — bump the Dockerfile FROM tag and redeploy before the required-version floor rises"
+          else
+            echo "> ⚠️ Pinned runner \`${pinned}\` trails latest \`${latest}\` (gap ${gap} minor release(s)); within the supported range for now. Bump the Dockerfile FROM tag at the next maintenance window." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      # Purge stale offline runner registrations (#13750). The fleet is
+      # ephemeral; a runner that fails to deregister lingers as an `offline`
+      # record until removed. Previously detection-only — the summary merely
+      # suggested running the script by hand, so offline registrations
+      # accumulated. Now the cron purges them automatically. The script deletes
+      # ONLY offline runners, never online/busy ones, so it cannot disrupt
+      # in-flight jobs. Deleting registrations needs repo administration, which
+      # the default GITHUB_TOKEN cannot grant — prefer the PAT when configured
+      # and degrade to a warning otherwise (continue-on-error keeps a token /
+      # permission gap from reddening this job).
+      - name: Purge stale offline runners
+        if: ${{ always() && steps.pool.outputs.runner_read == 'ok' && steps.pool.outputs.offline != '' && steps.pool.outputs.offline != '0' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.TSZ_PR_AUTOMATION_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          echo "Purging ${{ steps.pool.outputs.offline }} stale offline runner registration(s)…"
+          if scripts/ci/cleanup-stale-runners.sh; then
+            echo "Offline runner purge completed." >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "::warning::cleanup-stale-runners.sh could not purge offline runners (the token may lack repo administration scope); re-run scripts/ci/cleanup-stale-runners.sh with an admin token"
           fi
 
   dns:

--- a/scripts/infra/cloud-run-gh-runner/README.md
+++ b/scripts/infra/cloud-run-gh-runner/README.md
@@ -26,12 +26,12 @@ issue #13750.
   auto-update-disabled fleet can hard-fail registration en masse with no in-repo
   remediation. Bumping the `FROM` tag here and rebuilding/redeploying is the
   remediation.
-- **TODO (version-floor alert):** extend the existing `runner-health` job in
-  `.github/workflows/ci-health.yml` to compare the deployed runner version
-  against GitHub's current required minimum and warn *before* the fleet
-  hard-fails. Not implemented here to keep this change scoped to the
-  build/deploy pipeline and avoid editing the health workflow. Tracked under
-  issue #13750.
+- **Version-floor alert (implemented):** the `runner-health` job in
+  `.github/workflows/ci-health.yml` reads this pin (auto-update is disabled, so
+  the pin equals the deployed version), compares it against the latest
+  `actions/runner` release, and warns *before* the fleet hard-fails — a loud
+  annotation once the pin trails by `RUNNER_VERSION_FLOOR_GAP` minor releases
+  (default `10`), an informational summary line for a smaller lag.
 
 ## Build / deploy pipeline
 
@@ -93,12 +93,25 @@ the source of truth, reconcile it with the live service
 cost decision (per-job queue-wait data, #13715), since `minScale>0` defeats
 scale-to-zero.
 
-## Related follow-ups (issue #13750)
+## Health automation (issue #13750)
 
-- **Wire `scripts/ci/cleanup-stale-runners.sh` into the ci-health cron.** It
-  safely removes only `offline` runner registrations but is currently
-  detection-only (`ci-health.yml` merely prints a suggestion to run it), so
-  stale ephemeral registrations accumulate until a human runs it by hand.
-- **Add the runner-version-floor check** described above to `runner-health`.
-- **Make the low-runner-count health response actionable** rather than
-  observe-only.
+The `runner-health` job in `.github/workflows/ci-health.yml` (cron every 15
+minutes) now closes the in-repo follow-ups that previously lived here:
+
+- **Stale-offline purge.** It runs `scripts/ci/cleanup-stale-runners.sh`
+  automatically when offline registrations are present, instead of only
+  printing a suggestion to run it by hand. The script deletes **only** `offline`
+  runners, so it cannot disrupt in-flight jobs. Deleting registrations needs
+  repo administration, which the default `GITHUB_TOKEN` cannot grant, so the
+  step prefers `TSZ_PR_AUTOMATION_TOKEN` and degrades to a warning if no token
+  has the scope.
+- **Runner-version-floor check.** See the section above.
+- **Actionable low-runner-count signal.** Saturation and low-count conditions
+  now emit `::warning::` annotations (surfaced in the Actions UI / notifications)
+  in addition to the step-summary lines.
+
+## Remaining infra follow-ups (issue #13750, need GCP access)
+
+- A dedicated build pool so a bench burst cannot throttle the required
+  merge-queue submit (see #13751), and baking the runner image's apt/Node/pnpm
+  bootstrap into a prebuilt image to remove the per-shard network SPOF.


### PR DESCRIPTION
Goal: hold

Closes the three remaining **in-repo** follow-ups of #13750. The build/deploy
pipeline + IaC skeleton + README already landed; that PR explicitly deferred
these and listed them in `scripts/infra/cloud-run-gh-runner/README.md`
("avoid editing the health workflow"). They are pure `runner-health`/cron
robustness fixes — no GCP access required.

## What was broken

The `runner-health` job in `.github/workflows/ci-health.yml` (cron every 15
min) was observe-only for three real gaps:

1. **Stale offline runners accumulated forever.** `scripts/ci/cleanup-stale-runners.sh`
   exists and is delete-only on `offline` registrations, but nothing invoked
   it — the summary merely printed "run it by hand", so dead ephemeral
   registrations piled up (2 offline / 52 total at audit time).
2. **No runner-version-floor warning.** Auto-update is disabled on the fleet
   (`start.sh`: `DISABLE_RUNNER_UPDATE=1` / `--disableupdate`), so the pinned
   `2.334.0` is frozen. When GitHub raises its required minimum runner version,
   a pinned + auto-update-disabled fleet can hard-fail registration en masse
   with no advance signal.
3. **Low-runner-count / saturation were buried** in the step summary, so the
   signals did not surface in the Actions UI or notifications.

## The fix (owner: `.github/workflows/ci-health.yml`)

- **Auto-purge.** The job now surfaces the offline count as a step output and,
  when offline registrations exist, runs `cleanup-stale-runners.sh`
  automatically. Deleting registrations needs repo `administration` (which the
  default `GITHUB_TOKEN` cannot grant), so the step prefers
  `TSZ_PR_AUTOMATION_TOKEN` and degrades to a `::warning::` under
  `continue-on-error` when no token has the scope — it can never red the job,
  and it only ever deletes `offline` runners (never online/busy).
- **Version-floor check.** A new read-only step parses the Dockerfile pin
  (= the deployed version, since auto-update is off), compares it against the
  latest `actions/runner` release via a single signed minor-version-gap
  computation, and escalates: ✅ current when at/ahead, a soft summary line for
  a small lag, and a loud `::warning::` once the gap reaches
  `RUNNER_VERSION_FLOOR_GAP` minor releases (default `10`) — i.e. before the
  required floor wedges registration.
- **Actionable signals.** Saturation and low-runner-count (excluding the
  already-`::error::`'d critical band) now emit `::warning::` annotations in
  addition to the summary lines. The existing `online < 5` critical
  `::error::`/`exit 1` is preserved.

The README is updated to record these as done and to keep the GCP-side items
(dedicated merge-queue build pool, baked runner image) tracked as the remaining
infra follow-ups.

## Anti-hardcoding

No identifier/file-name/printer-string predicate drives any decision; the
version floor keys purely on the parsed semver pin vs the upstream release, and
the gap threshold is a documented env var.

## Verification

- `bash -n` clean on all three `runner-health` `run` blocks; `ci-health.yml`
  parses as valid YAML.
- Version-floor logic exercised across every branch against a mocked `gh`:
  equal → current, ahead → current, patch-only lag → current, gap 3 → soft
  summary line, gap 16 → loud `::warning::` + 🔴 summary, release lookup
  failure → graceful skip. All correct.
- Confirmed `ci-health.yml` is a standalone scheduled workflow — it is **not**
  a PR-required check, so this change cannot affect `CI Summary` / the merge
  queue; broad floors run via ready-review CI.
- Rebased onto current `main`; no conflicts (touches only `ci-health.yml` +
  the runner README).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: medium

https://claude.ai/code/session_01KBRWRbzf1VefKdmk1fGxYa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBRWRbzf1VefKdmk1fGxYa)_