### PR TITLE
fix(checker): drill into member mismatches against generic-interface targets (TS2322 parity)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "generic_interface_target_property_elaboration_tests"
+path = "tests/generic_interface_target_property_elaboration_tests.rs"
+[[test]]
 name = "failed_generic_call_default_type_args_tests"
 path = "tests/failed_generic_call_default_type_args_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -50,7 +50,21 @@ impl<'a> CheckerState<'a> {
         )
     }
 
-    const fn should_preserve_missing_property_diagnostic(
+    /// Whether the relation failed at a concrete *member* of the source/target
+    /// shape — a missing required property, or a present property whose value
+    /// type is incompatible.
+    ///
+    /// `tsc` always drills into such failures (`Types of property 'x' are
+    /// incompatible.` and the nested root reason), even when the target is a
+    /// generic application like `A<T>`. The coarse "outer assignment" path
+    /// (`target_prefers_outer_assignment_diagnostic`) is meant only for the
+    /// type-argument / indexed-access / conditional / mapped surfaces where
+    /// drilling into the evaluated shape would be misleading (e.g. same-generic
+    /// `C<A>` vs `C<B>`); a genuine member mismatch must keep its elaboration.
+    /// The rich `analyze_assignability_failure` path already produces the
+    /// correct reason — the structural property chain for a plain-object source
+    /// and the direct type-argument reason for a same-generic application.
+    const fn should_preserve_structural_property_diagnostic(
         &self,
         outcome: &crate::query_boundaries::assignability::RelationOutcome,
     ) -> bool {
@@ -58,6 +72,7 @@ impl<'a> CheckerState<'a> {
             outcome.failure,
             Some(RelationFailure::MissingProperty { .. })
                 | Some(RelationFailure::MissingProperties { .. })
+                | Some(RelationFailure::IncompatiblePropertyValue { .. })
         )
     }
 
@@ -750,7 +765,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
         if self.target_prefers_outer_assignment_diagnostic(target)
-            && !self.should_preserve_missing_property_diagnostic(&outcome)
+            && !self.should_preserve_structural_property_diagnostic(&outcome)
             && self
                 .missing_required_properties_from_index_signature_source(source, target)
                 .is_none()
@@ -999,7 +1014,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
         if self.target_prefers_outer_assignment_diagnostic(target)
-            && !self.should_preserve_missing_property_diagnostic(&outcome)
+            && !self.should_preserve_structural_property_diagnostic(&outcome)
             && self
                 .missing_required_properties_from_index_signature_source(source, target)
                 .is_none()

--- a/crates/tsz-checker/tests/generic_interface_target_property_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/generic_interface_target_property_elaboration_tests.rs
@@ -1,0 +1,104 @@
+//! TS2322 elaboration must drill into the failing member when the target is a
+//! generic-interface application (`Iface<T>`), mirroring `tsc`.
+//!
+//! Regression: a structural property mismatch against an instantiated generic
+//! interface used to collapse to the bare outer
+//! `Type 'S' is not assignable to type 'Iface<T>'.` line because the target was
+//! routed to the "outer assignment" coarse diagnostic reserved for the
+//! type-argument / indexed-access / mapped surfaces. `tsc` always elaborates a
+//! genuine member mismatch (`Types of property 'p' are incompatible.` + the
+//! nested root reason), so the structural property failure must keep its chain.
+
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn ts2322(source: &str) -> Diagnostic {
+    let diagnostics: Vec<Diagnostic> = check_source_diagnostics(source)
+        .into_iter()
+        .filter(|diagnostic| diagnostic.code == 2322)
+        .collect();
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one TS2322 diagnostic, got {diagnostics:#?}"
+    );
+    diagnostics.into_iter().next().unwrap()
+}
+
+fn has_related(diagnostic: &Diagnostic, expected: &str) -> bool {
+    diagnostic
+        .related_information
+        .iter()
+        .any(|related| related.message_text.contains(expected))
+}
+
+/// A concrete property mismatch against a generic-interface target drills into
+/// the `Types of property 'p' are incompatible.` chain and the nested root
+/// reason — not the bare outer line.
+#[test]
+fn concrete_member_mismatch_against_generic_interface_target_drills_in() {
+    let diagnostic = ts2322(
+        "interface Box<T> { value: string; tag: T; }\n\
+         function make<T>(input: { value: number; tag: T }): Box<T> { return input; }\n",
+    );
+    assert!(
+        has_related(&diagnostic, "Types of property 'value' are incompatible."),
+        "expected the property-path wrapper, got {diagnostic:#?}"
+    );
+    assert!(
+        has_related(
+            &diagnostic,
+            "Type 'number' is not assignable to type 'string'."
+        ),
+        "expected the nested root reason, got {diagnostic:#?}"
+    );
+}
+
+/// The drill-in is keyed on the structural relation, not on any identifier:
+/// vary the interface name, the type-parameter spelling, and the failing
+/// property name. Every variant must still elaborate the member mismatch.
+#[test]
+fn generic_interface_member_mismatch_drill_in_is_name_independent() {
+    for (iface, type_param, prop) in [
+        ("Container", "Element", "head"),
+        ("Wrapper", "K", "slot"),
+        ("Holder", "Payload", "data"),
+    ] {
+        let source = format!(
+            "interface {iface}<{type_param}> {{ {prop}: string; rest: {type_param}; }}\n\
+             function build<{type_param}>(\
+                input: {{ {prop}: number; rest: {type_param} }}\
+             ): {iface}<{type_param}> {{ return input; }}\n",
+        );
+        let diagnostic = ts2322(&source);
+        let wrapper = format!("Types of property '{prop}' are incompatible.");
+        assert!(
+            has_related(&diagnostic, &wrapper),
+            "[{iface}/{type_param}/{prop}] expected property-path wrapper, got {diagnostic:#?}"
+        );
+        assert!(
+            has_related(
+                &diagnostic,
+                "Type 'number' is not assignable to type 'string'."
+            ),
+            "[{iface}/{type_param}/{prop}] expected nested root reason, got {diagnostic:#?}"
+        );
+    }
+}
+
+/// A missing required member against a generic-interface target keeps its
+/// dedicated TS2741 elaboration rather than collapsing to the outer line.
+#[test]
+fn missing_member_against_generic_interface_target_is_preserved() {
+    let diagnostic = check_source_diagnostics(
+        "interface Pair<T> { left: T; right: string; }\n\
+         function take<T>(input: { left: T }): Pair<T> { return input; }\n",
+    )
+    .into_iter()
+    .find(|diagnostic| diagnostic.code == 2741 || diagnostic.code == 2739)
+    .expect("expected a missing-property diagnostic (TS2741/TS2739)");
+    assert!(
+        diagnostic.message_text.contains("right"),
+        "expected the missing 'right' member to be named, got {diagnostic:#?}"
+    );
+}


### PR DESCRIPTION
## Summary

When a structural source (object literal or named object type) is assigned to a
**generic-interface application** target such as `Iface<T>` and a member fails,
`tsc` elaborates the failure (`Types of property 'p' are incompatible.` + the
nested root reason). tsz instead collapsed to the bare outer
`Type 'S' is not assignable to type 'Iface<T>'.` line.

Root cause: `check_assignable_or_report[_at_exact_anchor]` routes any
`target_prefers_outer_assignment_diagnostic` target (a generic application whose
args contain type parameters, or an indexed-access / conditional / mapped
surface) to the coarse "outer assignment" diagnostic **regardless of the failure
kind**. The coarse path only preserved the member chain for
`MissingProperty`/`MissingProperties`, so a present-but-incompatible property
(`IncompatiblePropertyValue`) lost its elaboration.

### Reproduction (vs `tsc` 6.0.2)

```ts
interface Box<T> { value: string; tag: T; }
function make<T>(input: { value: number; tag: T }): Box<T> { return input; }
```

Before — tsz:
```
Type '{ value: number; tag: T; }' is not assignable to type 'Box<T>'.
```
`tsc` (and tsz after this change):
```
Type '{ value: number; tag: T; }' is not assignable to type 'Box<T>'.
  Types of property 'value' are incompatible.
    Type 'number' is not assignable to type 'string'.
```

## Structural rule

When the relation fails at a concrete member — a missing required property, or a
present property whose value type is incompatible — `tsc` always drills into that
member, even against a generic-application target. The coarse outer form is
reserved for the type-argument / indexed-access / conditional / mapped surfaces
where drilling into the *evaluated* shape would be misleading (e.g. same-generic
`C<A>` vs `C<B>`). tsz now preserves the member-level chain for
`IncompatiblePropertyValue` in addition to the missing-property variants (new
`should_preserve_structural_property_diagnostic`); the rich
`analyze_assignability_failure` path already produces the correct reason for both
a plain-object source and a same-generic application source.

**Owner layer:** checker assignability diagnostic routing
(`crates/tsz-checker/src/assignability/assignability_diagnostics.rs`) — the
`relation -> reason -> diagnostic` gateway. This is **post-verdict elaboration
only**: it runs after the relation has already decided not-assignable, so it
cannot change any assignable/not-assignable outcome — only the rendered message.

## Adjacent matrix (verified against `tsc` 6.0.2)

- object-literal source / named-object source → `Iface<T>` target, concrete leaf
  mismatch: now byte-identical to `tsc` (drills in). 
- non-generic interface target (`B`): unchanged, already matched `tsc`.
- concrete generic instance target (`A<string>`): unchanged (still coarse leaf,
  matches `tsc`).
- missing-property against `Iface<T>`: keeps the dedicated TS2741/TS2739 form.
- properly-assignable program: still clean (no spurious diagnostic).

This is a residual diagnostic-elaboration gap in the generic-target family
tracked by #13212 / #13806 (the headline "T not assignable to T" false positive
there is already fixed on `main`; this addresses the remaining elaboration
parity for genuine member mismatches). A separate, pre-existing gap remains: the
innermost `'T' could be instantiated with an arbitrary type ...` note is not
emitted for a **nested** bare-type-parameter leaf (the note is depth-0 gated and
`push_nested_chain` does not offset nested related-info depth) — left for a
focused follow-up to avoid shifting existing nested elaboration chains.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- New regression suite `generic_interface_target_property_elaboration_tests`
  (3 tests, binder-name-varied per the anti-hardcoding gate): **pass**.
- Neutral / no new failures vs `main` baseline across the elaboration suites
  (run under `cargo nextest`/isolated `cargo test`):
  `ts2322_tests` (290 pass / 6 pre-existing fail, identical both sides),
  `same_generic_application_assign_outcome_tests` (2 pre-existing fail both
  sides), `generic_property_mismatch_display_tests` (9 pre-existing fail both
  sides), `property_chain_elaboration_collapse_tests` (7),
  `type_parameter_source_constraint_chain_tests` (9),
  `tuple_argument_mismatch_elaboration_tests` (7),
  `union_source_structural_elaboration_tests` (19),
  `satisfies_elaboration_chain_tests` (3),
  `assertion_freshness_elaboration_tests` (4), `ts2430_tests` (53),
  `ts2353_tests` (79), `signature_assignability_regression_tests` (6) — all
  green and unchanged.
- Repro matrix diffed against `tsc` 6.0.2 (`--noEmit --strict`).
- Broad conformance / emit / fourslash floors owned by ready-review CI.

https://claude.ai/code/session_01BHT33WXEMp2JirWvJeLAgs

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHT33WXEMp2JirWvJeLAgs)_