### PR TITLE
fix(checker): report TS2769 on no-overload-match even when callee class has a structural error

### DIFF
--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1524,14 +1524,16 @@ impl<'a> CheckerState<'a> {
                     return TypeId::ERROR;
                 }
 
-                // Check if we should suppress TS2769 due to structural errors on the callee
-                let suppress_due_to_structural_errors =
-                    self.should_suppress_no_overload_due_to_structural_errors(callee_expr);
+                // A genuine no-overload-match always reports TS2769, matching tsc,
+                // even when the callee's class/interface/namespace carries its own
+                // structural error (TS2420/TS2430/TS2694). tsc treats the structural
+                // error and the call-site overload failure as independent and emits
+                // both; error-typed callees/arguments are already short-circuited
+                // above via `has_error_surface`.
                 let suppress_due_to_callback_body_errors =
                     self.should_suppress_no_overload_due_to_callback_body_errors(args);
 
-                let should_emit_no_overload_error = !suppress_due_to_structural_errors
-                    && !suppress_due_to_callback_body_errors
+                let should_emit_no_overload_error = !suppress_due_to_callback_body_errors
                     && !self.should_suppress_weak_key_no_overload(callee_expr, args);
 
                 if should_emit_no_overload_error {
@@ -1901,35 +1903,9 @@ impl<'a> CheckerState<'a> {
         expanded
     }
 
-    /// Check if TS2769 (no overload matches) should be suppressed due to structural
-    /// errors on the callee type. When a class/interface has structural errors
-    /// (TS2420, TS2430, TS2694), we suppress "no overload matches" errors because
-    /// the type is known to be broken and the primary errors should be shown instead.
-    fn should_suppress_no_overload_due_to_structural_errors(
-        &mut self,
-        callee_expr: NodeIndex,
-    ) -> bool {
-        // Only check for property access expressions (e.g., Promise.try)
-        let Some(callee_node) = self.ctx.arena.get(callee_expr) else {
-            return false;
-        };
-
-        let Some(access) = self.ctx.arena.get_access_expr(callee_node) else {
-            return false;
-        };
-
-        // Get the base expression (e.g., Promise in Promise.try)
-        let base_expr = access.expression;
-
-        // Resolve the base identifier to its symbol
-        let Some(symbol_id) = self.resolve_identifier_symbol(base_expr) else {
-            return false;
-        };
-
-        // Check if this symbol has structural error diagnostics
-        self.symbol_has_structural_errors(symbol_id)
-    }
-
+    /// Suppress TS2769 (no overload matches) when the failure originates inside a
+    /// callback argument's body. The callback's own diagnostics already explain the
+    /// mismatch, so the outer overload error would be a redundant cascade.
     fn should_suppress_no_overload_due_to_callback_body_errors(&self, args: &[NodeIndex]) -> bool {
         const CALLBACK_BODY_DIAGNOSTIC_CODES: &[u32] = &[2322, 2339, 2345, 2347, 7006, 7019, 7031];
 
@@ -1946,38 +1922,5 @@ impl<'a> CheckerState<'a> {
                         })
                     })
         })
-    }
-
-    /// Check if a symbol has structural error diagnostics (TS2420, TS2430, TS2694).
-    fn symbol_has_structural_errors(&self, symbol_id: tsz_binder::SymbolId) -> bool {
-        let Some(symbol) = self.ctx.binder.get_symbol(symbol_id) else {
-            return false;
-        };
-
-        let structural_error_codes = [
-            diagnostic_codes::CLASS_INCORRECTLY_IMPLEMENTS_INTERFACE,
-            diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE,
-            diagnostic_codes::NAMESPACE_HAS_NO_EXPORTED_MEMBER,
-        ];
-
-        // Check if any structural error diagnostics are within this symbol's declaration spans
-        for &decl_idx in &symbol.declarations {
-            let Some(node) = self.ctx.arena.get(decl_idx) else {
-                continue;
-            };
-            let decl_start = node.pos;
-            let decl_end = node.end;
-
-            for diag in &self.ctx.diagnostics {
-                if structural_error_codes.contains(&diag.code)
-                    && diag.start >= decl_start
-                    && diag.start < decl_end
-                {
-                    return true;
-                }
-            }
-        }
-
-        false
     }
 }

--- a/crates/tsz-checker/tests/conformance_issues/errors/callable_objects.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/callable_objects.rs
@@ -820,19 +820,14 @@ v({ s: "", n: 0 }).toLowerCase();
     );
 }
 
-// Known tsz divergence from tsc 6.0.2 (pinned, not papered over): this asserts a
-// tsz-specific design where the overload TS2769 is *suppressed* when a structural
-// class error (TS2420) already explains the broken callee, and where that
-// suppression must also avoid an orphaned `never` follow-on TS2339. tsc 6.0.2
-// does NOT suppress: it emits TS2420 + TS2769 + the `never` TS2339 together.
-// tsz currently suppresses TS2769 but still surfaces the `never` TS2339, so it
-// matches neither tsc nor its own design goal. The parity-correct fix is to
-// emit TS2769 like tsc (a solver overload-resolution change out of scope here);
-// ignored so the witness is preserved without asserting non-tsc behavior as a
-// gate.
+// tsz must match tsc 6.0.2: a genuine no-overload-match reports TS2769 even when
+// the callee's class carries its own structural error (TS2420). tsc treats the
+// two as independent and emits TS2420 + TS2769 + the `never` follow-on TS2339
+// together (verified against tsc 6.0.2). tsz previously suppressed TS2769 when a
+// structural class/interface/namespace error sat on the callee's base symbol,
+// matching neither tsc nor its own design goal; that suppression is removed.
 #[test]
-#[ignore = "tsz diverges from tsc 6.0.2 here (tsc emits TS2769 + never TS2339; tsz suppresses TS2769 but keeps the never TS2339); parity fix tracked separately"]
-fn test_suppressed_overload_error_does_not_return_never_for_follow_on_access() {
+fn test_no_overload_match_reports_ts2769_even_with_structural_callee_error() {
     let diagnostics = compile_and_get_diagnostics_with_options(
         r#"
 interface Required {
@@ -860,14 +855,100 @@ Broken.make({ s: "", n: 0 }).toLowerCase();
         "Expected TS2420 for the structurally invalid class.\nActual: {diagnostics:#?}"
     );
     assert!(
+        has_error(&diagnostics, 2769),
+        "Expected TS2769 for the failed overload call; the callee's structural error must not suppress it (tsc emits both).\nActual: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|(code, message)| *code == 2339 && message.contains("type 'never'")),
+        "Expected the failed overload result to behave like `never` and surface TS2339 on `.toLowerCase()`, matching tsc.\nActual: {diagnostics:#?}"
+    );
+}
+
+// Same rule with renamed binders, proving it is structural and not keyed on the
+// `Broken`/`make` identifiers. tsc emits TS2420 + TS2769 + the `never` TS2339.
+#[test]
+fn test_no_overload_match_reports_ts2769_structural_callee_error_renamed() {
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        r#"
+interface Spec {
+    value: string;
+}
+
+class Service implements Spec {
+    static pick(x: { id: number }): number;
+    static pick(x: { name: string }): string;
+    static pick(_x: unknown): string | number {
+        return "";
+    }
+}
+
+Service.pick({ id: 0, name: "x" }).toUpperCase();
+"#,
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        has_error(&diagnostics, 2420),
+        "Expected TS2420 for the structurally invalid class.\nActual: {diagnostics:#?}"
+    );
+    assert!(
+        has_error(&diagnostics, 2769),
+        "Expected TS2769 for the failed overload call regardless of binder names.\nActual: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|(code, message)| *code == 2339 && message.contains("type 'never'")),
+        "Expected the failed overload result to surface a `never` TS2339, matching tsc.\nActual: {diagnostics:#?}"
+    );
+}
+
+// Control: a structurally-broken callee class must not turn a *matching* overload
+// call into a spurious no-overload-match. When one overload matches, tsc reports
+// only the class's TS2420 and resolves the call to the matched return type, so the
+// follow-on member access is valid (no TS2769, no `never` TS2339).
+#[test]
+fn test_matching_overload_on_structurally_broken_class_still_resolves() {
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        r#"
+interface Spec {
+    value: string;
+}
+
+class Service implements Spec {
+    static pick(x: { id: number }): number;
+    static pick(x: { name: string }): string;
+    static pick(_x: unknown): string | number {
+        return "";
+    }
+}
+
+Service.pick({ name: "x" }).toLowerCase();
+"#,
+        CheckerOptions {
+            target: ScriptTarget::ES2015,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        has_error(&diagnostics, 2420),
+        "Expected TS2420 for the structurally invalid class.\nActual: {diagnostics:#?}"
+    );
+    assert!(
         !has_error(&diagnostics, 2769),
-        "Expected TS2769 to remain suppressed when structural errors already explain the broken callee.\nActual: {diagnostics:#?}"
+        "A matching overload must not be reported as a no-overload-match.\nActual: {diagnostics:#?}"
     );
     assert!(
         !diagnostics
             .iter()
             .any(|(code, message)| *code == 2339 && message.contains("type 'never'")),
-        "Suppressed TS2769 must not turn the call result into never and orphan a follow-on TS2339.\nActual: {diagnostics:#?}"
+        "A matching overload resolves to its real return type, so the follow-on access must be valid.\nActual: {diagnostics:#?}"
     );
 }
 


### PR DESCRIPTION
Fixes #14612.

Goal: hold

## What

A genuine no-overload-match must report **TS2769** like `tsc`, even when the
callee's class/interface/namespace carries its own structural error
(TS2420/TS2430/TS2694). `tsc` treats the structural error and the call-site
overload failure as independent and emits both, plus the `never` follow-on
TS2339. tsz suppressed TS2769 in that case while still resolving the call to
`never` — matching neither `tsc` nor tsz's own design (it dropped TS2769 but
kept the orphaned `never` TS2339).

## Structural rule

When an overloaded call resolves to `NoOverloadMatch` and the callee/arguments
are not themselves error-typed, `tsc` reports TS2769 regardless of any
structural error on the callee declaration. tsz owns this in the checker
(`crates/tsz-checker/src/types/computation/call_result.rs`,
`CallResult::NoOverloadMatch`).

## Change

Remove the `should_suppress_no_overload_due_to_structural_errors` /
`symbol_has_structural_errors` heuristic (the only thing diverging from `tsc`
here). Genuinely error-typed callees and arguments are already short-circuited
upstream by the `has_error_surface` check, so the only behavioral change is the
parity-correct one. This is a broad fix: it corrects the diagnostic for **every**
overloaded call on a property-access whose base declaration carries TS2420/2430/2694,
not just the reported witness. The callback-body and weak-key suppressions are
left untouched (separate concerns).

The previously `#[ignore]`d witness in
`conformance_issues/errors/callable_objects.rs` is activated and rewritten to
assert `tsc` parity, with adjacent cases added:
- renamed binders (proves the rule is structural, not keyed on identifiers);
- a matching-overload control (a broken callee class must not turn a valid call
  into a spurious no-overload-match).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: medium

## Verification
- `cargo test -p tsz-checker --test conformance_issues_errors -- errors::callable_objects` — 29 passed, 0 failed, 0 ignored (incl. the 3 activated/added parity tests).
- CI `unit` and `unit-checker-integration` (required) both green on this head.
- `tsc` 6.0.2 ground truth confirmed for the repro and both adjacent cases (TS2420 + TS2769 + `never` TS2339; matching-overload control emits only TS2420).
- Removed helpers are local to `call_result.rs` with no other callers; `resolve_identifier_symbol` remains widely used.
- Broad conformance/emit/fourslash parity owned by ready-review CI.
