### PR TITLE
fix(ci): bake bench bootstrap toolchain into an optional prebuilt image (#13751)

### DIFF
--- a/.github/workflows/bench-image.yml
+++ b/.github/workflows/bench-image.yml
@@ -1,0 +1,86 @@
+# Build and push the prebuilt benchmark base image for the bench prepare/shard
+# Cloud Builds.
+#
+# This workflow is intentionally SEPARATE from ci.yml / bench.yml and is NOT a
+# required check. It cannot affect PR CI status. Building and pushing an image is
+# safe (it only produces SHA-tagged + :latest image tags in a registry); nothing
+# is switched over to the image until a maintainer points the bench configs at
+# it via the vars.BENCH_IMAGE_REF repo variable (see
+# scripts/infra/bench-base/README.md). Until then the bench configs default to
+# the stock `rust:1.95` image and the inline bootstrap, so this workflow is a
+# no-op on bench behavior.
+#
+# Configuration: this workflow no-ops with a clear message unless the repo
+# variables below are configured by a maintainer:
+#   vars.BENCH_IMAGE_GCP_PROJECT   (required to build)
+#   vars.BENCH_IMAGE_REPO          (required to build; image repo path)
+#   vars.BENCH_IMAGE_GCP_REGION    (optional; defaults to us-central1)
+name: bench-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Provenance note: why are you rebuilding the bench base image?"
+        type: string
+        default: "manual rebuild"
+  push:
+    paths:
+      - 'scripts/infra/bench-base/Dockerfile'
+      - 'scripts/cloudbuild/cloudbuild-bench-image.yaml'
+      - '.github/workflows/bench-image.yml'
+  schedule:
+    # Weekly rebuild to pick up base-image / OS security updates.
+    - cron: '0 7 * * 2'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bench-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build-bench-image
+    runs-on: [self-hosted, tsz-cloud-run]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+
+      - id: config
+        name: Resolve GCP configuration
+        env:
+          GCP_PROJECT: ${{ vars.BENCH_IMAGE_GCP_PROJECT }}
+          IMAGE_REPO: ${{ vars.BENCH_IMAGE_REPO }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GCP_PROJECT}" || -z "${IMAGE_REPO}" ]]; then
+            echo "::notice title=bench-image not configured::Set repo variables BENCH_IMAGE_GCP_PROJECT and BENCH_IMAGE_REPO (and optionally BENCH_IMAGE_GCP_REGION) to enable bench base image builds, then set BENCH_IMAGE_REF to switch the bench configs over. See scripts/infra/bench-base/README.md. No-op for now."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "bench-image build is configured (project=${GCP_PROJECT})."
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - id: build
+        if: steps.config.outputs.configured == 'true'
+        name: Build and push bench base image (SHA-tagged for provenance)
+        env:
+          GCP_PROJECT: ${{ vars.BENCH_IMAGE_GCP_PROJECT }}
+          GCP_REGION: ${{ vars.BENCH_IMAGE_GCP_REGION || 'us-central1' }}
+          IMAGE_REPO: ${{ vars.BENCH_IMAGE_REPO }}
+        run: |
+          set -euo pipefail
+          sha="${GITHUB_SHA}"
+          image_sha_tag="${IMAGE_REPO}:${sha}"
+          echo "Building bench base image ${image_sha_tag} (region=${GCP_REGION})"
+          gcloud builds submit \
+            --project="${GCP_PROJECT}" \
+            --region="${GCP_REGION}" \
+            --config=scripts/cloudbuild/cloudbuild-bench-image.yaml \
+            --substitutions=_IMAGE="${IMAGE_REPO}",_SHA="${sha}" \
+            .
+          echo "Built and pushed ${image_sha_tag} (and :latest). Set vars.BENCH_IMAGE_REF to ${IMAGE_REPO}:latest (or a pinned SHA tag) to switch the bench configs over."

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -45,6 +45,11 @@ env:
   # guard replace the old age/stale/catch-up knobs (all removed).
   GITHUB_SHA: ${{ github.sha }}
   BENCH_TARGET_SHA: ${{ github.sha }}
+  # Build image for the prepare/shard Cloud Builds. Empty (default) falls back to
+  # rust:1.95 + the inline bootstrap; set the BENCH_IMAGE_REF repo variable to a
+  # prebuilt bench base image to remove the per-build bootstrap SPOF (#13751; see
+  # scripts/infra/bench-base/README.md).
+  BENCH_IMAGE_REF: ${{ vars.BENCH_IMAGE_REF }}
   CARGO_HOME: ${{ github.workspace }}/.ci-cache/cargo-home
   npm_config_cache: ${{ github.workspace }}/.ci-cache/npm
   PNPM_STORE_DIR: ${{ github.workspace }}/.ci-cache/pnpm-store
@@ -136,7 +141,7 @@ jobs:
             --region=us-central1 \
             --config=scripts/cloudbuild/cloudbuild-bench-prepare.yaml \
             --gcs-source-staging-dir=gs://tsz-ci_cloudbuild/cb-source-staging \
-            --substitutions=_BENCH_TARGET_SHA="${target_sha}" \
+            --substitutions=_BENCH_TARGET_SHA="${target_sha}",_BENCH_IMAGE="${BENCH_IMAGE_REF:-rust:1.95}" \
             --format='value(id)' \
             .)"
           build_id="$(grep -Eo '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' <<<"$submit_output" | tail -n 1 || true)"
@@ -224,7 +229,7 @@ jobs:
             --region=us-central1 \
             --config=scripts/cloudbuild/cloudbuild-bench-prepare.yaml \
             --gcs-source-staging-dir=gs://tsz-ci_cloudbuild/cb-source-staging \
-            --substitutions=_BENCH_TARGET_SHA="${target_sha}" \
+            --substitutions=_BENCH_TARGET_SHA="${target_sha}",_BENCH_IMAGE="${BENCH_IMAGE_REF:-rust:1.95}" \
             --format='value(id)' \
             .)"
           build_id="$(grep -Eo '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' <<<"$submit_output" | tail -n 1 || true)"
@@ -1082,7 +1087,7 @@ jobs:
             --region=us-central1 \
             --config=scripts/cloudbuild/cloudbuild-bench-shard.yaml \
             --gcs-source-staging-dir=gs://tsz-ci_cloudbuild/cb-source-staging \
-            --substitutions=_BENCH_TARGET_SHA="${BENCH_TARGET_SHA}",_BENCH_SHARD_LABEL="${{ matrix.label }}",_BENCH_SHARD_FILTER="${{ matrix.filter }}" \
+            --substitutions=_BENCH_TARGET_SHA="${BENCH_TARGET_SHA}",_BENCH_SHARD_LABEL="${{ matrix.label }}",_BENCH_SHARD_FILTER="${{ matrix.filter }}",_BENCH_IMAGE="${BENCH_IMAGE_REF:-rust:1.95}" \
             --format='value(id)' \
             .)" || submit_rc=$?
           if [[ "$submit_rc" -eq 124 ]]; then

--- a/scripts/ci/test-cloudbuild-config-paths.mjs
+++ b/scripts/ci/test-cloudbuild-config-paths.mjs
@@ -12,6 +12,10 @@ const workflowConfigs = new Map([
     ["cloudbuild-bench-prepare.yaml", "cloudbuild-bench-shard.yaml"],
   ],
   [
+    ".github/workflows/bench-image.yml",
+    ["cloudbuild-bench-image.yaml"],
+  ],
+  [
     ".github/workflows/ci.yml",
     ["cloudbuild-checker-integration.yaml", "cloudbuild-unit.yaml"],
   ],

--- a/scripts/cloudbuild/cloudbuild-bench-image.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-image.yaml
@@ -1,0 +1,38 @@
+# Cloud Build config that builds and pushes the prebuilt benchmark base image
+# from scripts/infra/bench-base/Dockerfile.
+#
+# Invoked by .github/workflows/bench-image.yml via `gcloud builds submit`. The
+# workflow passes the destination image path and the commit SHA as
+# substitutions so every build is SHA-tagged for provenance. The `latest` tag is
+# updated alongside the SHA tag so the bench prepare/shard configs can track the
+# most recent build via vars.BENCH_IMAGE_REF (see
+# scripts/infra/bench-base/README.md).
+#
+# Substitutions (all required, supplied by the workflow):
+#   _IMAGE  fully-qualified image repository, e.g.
+#           us-central1-docker.pkg.dev/<project>/<repo>/tsz-bench-base
+#   _SHA    git commit SHA the image is built from (provenance tag)
+
+steps:
+  - id: build-bench-base-image
+    name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --tag
+      - '${_IMAGE}:${_SHA}'
+      - --tag
+      - '${_IMAGE}:latest'
+      - --file
+      - scripts/infra/bench-base/Dockerfile
+      - scripts/infra/bench-base
+
+images:
+  - '${_IMAGE}:${_SHA}'
+  - '${_IMAGE}:latest'
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+
+# The base install (apt packages, Node tarball, pnpm, llvm-tools-preview on top
+# of rust:1.95) is moderately heavy; allow generous headroom.
+timeout: 2400s

--- a/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
@@ -3,7 +3,8 @@
 
 steps:
   - id: bench-prepare
-    name: rust:1.95
+    # Build image; see the _BENCH_IMAGE substitution at the bottom of this file.
+    name: ${_BENCH_IMAGE}
     env:
       - 'BENCH_FULL=1'
       - 'BENCH_COLD=1'
@@ -31,22 +32,30 @@ steps:
       #!/usr/bin/env bash
       set -euo pipefail
 
-      apt-get update
-      apt-get install -y --no-install-recommends \
-        bc \
-        ca-certificates \
-        curl \
-        git \
-        hyperfine \
-        jq \
-        pkg-config \
-        xz-utils
-      rm -rf /var/lib/apt/lists/*
+      # Bootstrap the bench toolchain only when it is not already present. On the
+      # stock rust:1.95 image this installs it inline (as before); on the
+      # prebuilt bench base image (vars.BENCH_IMAGE_REF) the tools are baked in,
+      # so this is skipped and the per-build external-mirror SPOF is removed
+      # (#13751). Keep the baked set in scripts/infra/bench-base/Dockerfile in
+      # sync with the packages/versions below.
+      if ! command -v hyperfine >/dev/null 2>&1 || ! command -v node >/dev/null 2>&1; then
+        apt-get update
+        apt-get install -y --no-install-recommends \
+          bc \
+          ca-certificates \
+          curl \
+          git \
+          hyperfine \
+          jq \
+          pkg-config \
+          xz-utils
+        rm -rf /var/lib/apt/lists/*
 
-      node_version="22.13.1"
-      node_arch="x64"
-      curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz" \
-        | tar -xJ -C /usr/local --strip-components=1
+        node_version="22.13.1"
+        node_arch="x64"
+        curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz" \
+          | tar -xJ -C /usr/local --strip-components=1
+      fi
 
       # Cloud Build source archives do not include `.git`, but the benchmark
       # prep fingerprint uses `git ls-files` for tracked source inputs. Add
@@ -147,6 +156,10 @@ artifacts:
 
 substitutions:
   _BENCH_TARGET_SHA: unknown
+  # Build image; defaults to the stock rust:1.95 + inline bootstrap. Override
+  # via the bench.yml _BENCH_IMAGE passthrough (vars.BENCH_IMAGE_REF) to run on
+  # the prebuilt bench base image (scripts/infra/bench-base/README.md).
+  _BENCH_IMAGE: rust:1.95
 
 options:
   pool:

--- a/scripts/cloudbuild/cloudbuild-bench-shard.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-shard.yaml
@@ -46,7 +46,8 @@ steps:
       exit 0
 
   - id: bench-shard
-    name: rust:1.95
+    # Build image; see the _BENCH_IMAGE substitution at the bottom of this file.
+    name: ${_BENCH_IMAGE}
     env:
       - 'CI=true'
       - 'BENCH_FULL=1'
@@ -100,22 +101,31 @@ steps:
         test -f bench-prep.env
         test -f bench-prep.tar
 
-        apt-get update
-        apt-get install -y --no-install-recommends \
-          bc \
-          ca-certificates \
-          curl \
-          git \
-          hyperfine \
-          jq \
-          pkg-config \
-          xz-utils
-        rm -rf /var/lib/apt/lists/*
+        # Bootstrap the bench toolchain only when it is not already present. On
+        # the stock rust:1.95 image this installs it inline (as before); on the
+        # prebuilt bench base image (vars.BENCH_IMAGE_REF) the tools are baked
+        # in, so this is skipped and the per-shard external-mirror SPOF is
+        # removed (#13751). Keep the baked set in
+        # scripts/infra/bench-base/Dockerfile in sync with the packages/versions
+        # below.
+        if ! command -v hyperfine >/dev/null 2>&1 || ! command -v node >/dev/null 2>&1; then
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            bc \
+            ca-certificates \
+            curl \
+            git \
+            hyperfine \
+            jq \
+            pkg-config \
+            xz-utils
+          rm -rf /var/lib/apt/lists/*
 
-        node_version="22.13.1"
-        node_arch="x64"
-        curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz" \
-          | tar -xJ -C /usr/local --strip-components=1
+          node_version="22.13.1"
+          node_arch="x64"
+          curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz" \
+            | tar -xJ -C /usr/local --strip-components=1
+        fi
 
         if ! command -v pnpm >/dev/null 2>&1; then
           npm install -g pnpm --silent
@@ -206,6 +216,10 @@ substitutions:
   _BENCH_TARGET_SHA: unknown
   _BENCH_SHARD_LABEL: unknown
   _BENCH_SHARD_FILTER: unknown
+  # Build image; defaults to the stock rust:1.95 + inline bootstrap. Override
+  # via the bench.yml _BENCH_IMAGE passthrough (vars.BENCH_IMAGE_REF) to run on
+  # the prebuilt bench base image (scripts/infra/bench-base/README.md).
+  _BENCH_IMAGE: rust:1.95
 
 options:
   pool:
@@ -221,9 +235,11 @@ options:
 # downloads artifacts well inside the 135m GitHub job timeout. Keep this value
 # strictly below the bench.yml wait-loop deadline.
 #
-# Follow-up (infra, out of scope for this file-only PR): a dedicated
+# The per-shard apt/curl/npm bootstrap network SPOF (#13751 fix 3) is addressed
+# by the prebuilt bench base image (scripts/infra/bench-base/): set the
+# _BENCH_IMAGE substitution (vars.BENCH_IMAGE_REF) to that image and the guarded
+# bootstrap above becomes a no-op. Remaining follow-up (GCP infra): a dedicated
 # tsz-ci-merge-pool so a bench burst cannot throttle the required
-# unit-checker-integration merge-queue submit, and a prebuilt image baking
-# hyperfine/jq/xz-utils/Node 22/pnpm to remove the per-shard apt/curl/npm
-# bootstrap network SPOF (see #13751 proposed fixes 1 and 3).
+# unit-checker-integration merge-queue submit (#13751 fix 1; largely mitigated
+# already by bench.yml's schedule-only single-flight design).
 timeout: 6300s

--- a/scripts/infra/bench-base/Dockerfile
+++ b/scripts/infra/bench-base/Dockerfile
@@ -1,0 +1,45 @@
+# Prebuilt base image for the benchmark prepare/shard Cloud Builds.
+#
+# Today cloudbuild-bench-prepare.yaml and cloudbuild-bench-shard.yaml run on the
+# stock `rust:1.95` image and re-install the same bench bootstrap (apt packages,
+# Node, pnpm) at the start of EVERY build — 1 prepare + 9 shards = 10 redundant
+# installs per bench run, each an external-mirror network SPOF (a nodejs.org /
+# Debian-mirror blip reds a shard and drops below the 9-shard publish gate; see
+# issue #13751). Baking those tools here once, at image-build time, removes both
+# the redundancy and the SPOF: the libraries land in the image filesystem, so
+# there is no relocatability problem and no critical-path download.
+#
+# The apt/Node/pnpm bootstrap below is kept identical to the inline bootstrap in
+# the two cloudbuild configs so switching a build over to this image does not
+# change any benchmark measurement — it only removes the bootstrap step. Keep the
+# versions in sync with those files. `llvm-tools-preview` is additionally baked
+# (matching the prepare config's `rustup component add` step) as a harmless
+# superset so prepare needs no rustup download either.
+FROM rust:1.95
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# One layer: install, then sanity-check the toolchain so a broken image fails the
+# build instead of reaching a bench run.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      bc \
+      ca-certificates \
+      curl \
+      git \
+      hyperfine \
+      jq \
+      pkg-config \
+      xz-utils \
+    && rm -rf /var/lib/apt/lists/* \
+    && node_version="22.13.1" \
+    && node_arch="x64" \
+    && curl -fsSL "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_arch}.tar.xz" \
+       | tar -xJ -C /usr/local --strip-components=1 \
+    && npm install -g pnpm --silent \
+    && rustup component add llvm-tools-preview \
+    && cargo --version \
+    && node --version \
+    && pnpm --version \
+    && hyperfine --version \
+    && jq --version

--- a/scripts/infra/bench-base/README.md
+++ b/scripts/infra/bench-base/README.md
@@ -1,0 +1,63 @@
+# Benchmark base image (`tsz-bench-base`)
+
+A prebuilt Cloud Build image that bakes the benchmark bootstrap toolchain
+(apt packages, Node 22, pnpm, `llvm-tools-preview`) on top of `rust:1.95`.
+
+## Why
+
+`scripts/cloudbuild/cloudbuild-bench-prepare.yaml` and
+`scripts/cloudbuild/cloudbuild-bench-shard.yaml` historically ran on the stock
+`rust:1.95` image and re-installed the same bootstrap at the start of **every**
+build: `apt-get install` (hyperfine/jq/xz-utils/…), a Node tarball from
+`nodejs.org`, and `npm install -g pnpm`. With 1 prepare + 9 shards that is 10
+redundant installs per bench run, and each is an external-mirror network single
+point of failure — a `nodejs.org` or Debian-mirror blip reds a shard, which can
+drop a run below the 9-shard publish gate (issue #13751).
+
+Baking the toolchain into an image once removes both the redundancy and the
+SPOF, and (because the libraries land in the image filesystem) avoids the
+relocatability problems of trying to copy apt binaries between containers.
+
+## Behavior-preserving by default
+
+This is a **zero-behavior-change-by-default** rollout:
+
+- The bench configs take a `_BENCH_IMAGE` substitution that **defaults to
+  `rust:1.95`**, so with no configuration the bench builds run exactly as before.
+- The inline bootstrap in both configs is guarded by `command -v` checks, so it
+  runs on the stock image (tools absent) and is skipped on the baked image
+  (tools present). The baked apt/Node/pnpm toolchain matches the inline
+  bootstrap, so switching over does not change any benchmark measurement — it
+  only removes the bootstrap step. (`llvm-tools-preview` is baked too, matching
+  the prepare config's `rustup component add` step.)
+
+## Build
+
+The `bench-image` GitHub workflow (`.github/workflows/bench-image.yml`) builds
+and pushes the image. It is **not** a required check and cannot affect PR CI. It
+no-ops until a maintainer sets these repo variables:
+
+| Repo variable               | Required | Purpose                                                |
+| --------------------------- | -------- | ------------------------------------------------------ |
+| `BENCH_IMAGE_GCP_PROJECT`   | yes      | GCP project that hosts the image registry.             |
+| `BENCH_IMAGE_REPO`          | yes      | Image repo path, e.g. `us-central1-docker.pkg.dev/<project>/<repo>/tsz-bench-base`. |
+| `BENCH_IMAGE_GCP_REGION`    | no       | Cloud Build region (defaults to `us-central1`).        |
+
+Triggers: push to the `Dockerfile` / cloudbuild config / workflow paths, a
+weekly cron, and manual `workflow_dispatch`. Every build is tagged with the
+commit SHA (provenance) and `:latest`.
+
+## Switch the bench builds over
+
+After the image exists in the registry, set one more repo variable:
+
+| Repo variable      | Purpose                                                            |
+| ------------------ | ----------------------------------------------------------------- |
+| `BENCH_IMAGE_REF`  | Image reference the bench configs run on, e.g. `<repo>:latest` or a pinned `<repo>:<sha>`. Defaults to `rust:1.95` when unset. |
+
+`.github/workflows/bench.yml` passes `BENCH_IMAGE_REF` to the prepare and shard
+Cloud Build submits as the `_BENCH_IMAGE` substitution. Pinning a SHA tag is
+recommended for reproducibility; `:latest` tracks the newest build.
+
+To roll back, clear `BENCH_IMAGE_REF`: the next bench run falls back to
+`rust:1.95` and the inline bootstrap with no other change.


### PR DESCRIPTION
Addresses fix 3 of #13751 (the per-shard apt/curl/npm bootstrap network SPOF). Fixes 1 and 2 are already on main: fix 2 (decoupled timeouts) landed (6300s < 6900s < 135m, with `#13751` comments in `cloudbuild-bench-shard.yaml`/`bench.yml`), and fix 1 (bench-burst throttling the required merge-queue job) is largely mitigated by `bench.yml`'s redesign to a schedule-only, single-flight `concurrency` model (the per-CI-completion `workflow_run` trigger that caused bursts was removed). The remaining piece of fix 1 — a dedicated GCP `tsz-ci-merge-pool` — is GCP-side infra out of scope here.

Goal: hold

## Problem

`cloudbuild-bench-prepare.yaml` and `cloudbuild-bench-shard.yaml` run on the stock `rust:1.95` image and re-install the same bootstrap (apt packages, Node 22.13.1, pnpm) at the start of **every** build. With 1 prepare + 9 shards that is 10 redundant installs per bench run, and each `apt-get`/`nodejs.org` fetch is an external-mirror network single point of failure: a mirror blip reds a shard, which can drop a run below the 9-shard publish gate.

## Change

Mirror the established runner-image pattern (`runner-image.yml` + `cloudbuild-runner-image.yaml` + `scripts/infra/cloud-run-gh-runner/`) for a benchmark base image:

- **`scripts/infra/bench-base/Dockerfile`** — bakes the exact apt/Node/pnpm bootstrap (plus `llvm-tools-preview`, matching prepare's `rustup component add`) on top of `rust:1.95`, with a build-time toolchain sanity check.
- **`scripts/cloudbuild/cloudbuild-bench-image.yaml`** + **`.github/workflows/bench-image.yml`** — config-gated build/push pipeline (no-op `::notice` until `vars.BENCH_IMAGE_GCP_PROJECT`/`BENCH_IMAGE_REPO` are set; SHA + `:latest` tagging; not a required check, cannot affect PR CI).
- **`cloudbuild-bench-prepare.yaml` / `cloudbuild-bench-shard.yaml`** — take a `_BENCH_IMAGE` substitution (default `rust:1.95`) used as the step image, and the inline bootstrap is now guarded by `command -v hyperfine`/`command -v node` checks.
- **`bench.yml`** — passes `_BENCH_IMAGE="${BENCH_IMAGE_REF:-rust:1.95}"` to the three prepare/shard submits, sourced from the optional `vars.BENCH_IMAGE_REF` repo variable.
- **`scripts/infra/bench-base/README.md`** — documents the build + two-step rollout + rollback.

## Behavior-preserving by default

This is a zero-behavior-change-by-default, config-gated rollout:

- Default (`BENCH_IMAGE_REF` unset): `_BENCH_IMAGE` resolves to `rust:1.95` and the `command -v`-guarded bootstrap runs exactly as before — **byte-identical** to current bench behavior.
- Configured (`BENCH_IMAGE_REF` -> baked image): tools are present, the bootstrap is skipped, and the per-build external-mirror SPOF is removed. The baked apt/Node/pnpm set is kept in sync with the inline bootstrap so benchmark measurements are unchanged.
- Rollback is clearing one repo variable.

The toolchain version duplication across the Dockerfile and the two cloudbuild configs (kept aligned by "keep in sync" comments) matches the existing runner-image convention; Cloud Build/Dockerfile have no shared-include mechanism.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- No Rust crates touched — this is CI-infra only (Dockerfile, Cloud Build configs, GitHub workflows, README), so the unit/conformance/emit/fourslash floors are unaffected.
- `bench-image.yml` and `bench.yml` are not PR-required checks (bench is schedule-only; bench-image is path/dispatch-triggered), so they cannot affect this PR's CI status.
- All five YAML files parse (`yaml.safe_load`); the embedded `script:` blocks pass `bash -n`.
- Default path proven unchanged: `_BENCH_IMAGE` defaults to `rust:1.95` in both configs and `${BENCH_IMAGE_REF:-rust:1.95}` in `bench.yml`, and the inline bootstrap's `command -v` guard is false on the stock image, so it runs as before.
- Reviewed via `/simplify` (reuse/simplification/efficiency/altitude): structure mirrors the runner-image pipeline; applied fixes (folded the Dockerfile sanity-check into one layer, removed dead workflow outputs, tightened comments).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QThDtX5Br8fR3MKS3id4ji)_