### PR TITLE
fix(emit): order no-priority tslib helpers by transform-pass tier (ES2018 before ES2015)

### DIFF
--- a/crates/tsz-emitter/src/transforms/helpers.rs
+++ b/crates/tsz-emitter/src/transforms/helpers.rs
@@ -436,24 +436,61 @@ impl HelpersNeeded {
         }
     }
 
+    /// Record a no-priority helper (deduped), positioned before the earliest
+    /// already-recorded helper for which `precedes` holds. When none match,
+    /// append — preserving request order among helpers of the same tier.
+    fn remember_unprioritized_before(
+        &mut self,
+        helper: HelperEmitOrder,
+        precedes: impl Fn(HelperEmitOrder) -> bool,
+    ) {
+        if self.unprioritized_order.contains(&helper) {
+            return;
+        }
+        match self
+            .unprioritized_order
+            .iter()
+            .position(|&recorded| precedes(recorded))
+        {
+            Some(pos) => self.unprioritized_order.insert(pos, helper),
+            None => self.unprioritized_order.push(helper),
+        }
+    }
+
+    /// Record a no-priority helper that `tsc` lowers in the ES2018 transform
+    /// pass (object-rest + async-iteration: `__rest`, `__await`,
+    /// `__asyncGenerator`, `__asyncValues`, `__asyncDelegator`).
+    ///
+    /// `tsc` sorts no-priority helpers by transform-pass tier first and request
+    /// order only within a tier. The ES2018 pass runs before the ES2015
+    /// iteration/spread pass, so its helpers are always emitted ahead of
+    /// `__values`/`__read`/`__spreadArray` regardless of source position — e.g.
+    /// a `yield*`/`for..of` that requests `__values` earlier in the file than an
+    /// object-rest destructuring requests `__rest`. Insert this helper before
+    /// the earliest already-recorded ES2015 iteration helper; otherwise append,
+    /// which preserves request order within the ES2018 tier.
+    fn remember_es2018_tier_unprioritized(&mut self, helper: HelperEmitOrder) {
+        self.remember_unprioritized_before(helper, is_es2015_iteration_helper);
+    }
+
     pub fn mark_rest(&mut self) {
         self.rest = true;
-        self.remember_unprioritized(HelperEmitOrder::Rest);
+        self.remember_es2018_tier_unprioritized(HelperEmitOrder::Rest);
     }
 
     pub fn mark_await_helper(&mut self) {
         self.await_helper = true;
-        self.remember_unprioritized(HelperEmitOrder::Await);
+        self.remember_es2018_tier_unprioritized(HelperEmitOrder::Await);
     }
 
     pub fn mark_async_generator(&mut self) {
         self.async_generator = true;
-        self.remember_unprioritized(HelperEmitOrder::AsyncGenerator);
+        self.remember_es2018_tier_unprioritized(HelperEmitOrder::AsyncGenerator);
     }
 
     pub fn mark_async_delegator(&mut self) {
         self.async_delegator = true;
-        self.remember_unprioritized(HelperEmitOrder::AsyncDelegator);
+        self.remember_es2018_tier_unprioritized(HelperEmitOrder::AsyncDelegator);
     }
 
     pub fn mark_values(&mut self) {
@@ -463,19 +500,11 @@ impl HelpersNeeded {
 
     pub fn mark_read(&mut self) {
         self.read = true;
-        if self.unprioritized_order.contains(&HelperEmitOrder::Read) {
-            return;
-        }
-        if let Some(spread_pos) = self
-            .unprioritized_order
-            .iter()
-            .position(|helper| *helper == HelperEmitOrder::SpreadArray)
-        {
-            self.unprioritized_order
-                .insert(spread_pos, HelperEmitOrder::Read);
-        } else {
-            self.unprioritized_order.push(HelperEmitOrder::Read);
-        }
+        // `__read` is consumed by `__spreadArray`, so it stays ahead of it even
+        // when array-spread requested `__spreadArray` first.
+        self.remember_unprioritized_before(HelperEmitOrder::Read, |helper| {
+            helper == HelperEmitOrder::SpreadArray
+        });
     }
 
     pub fn mark_spread_array(&mut self) {
@@ -490,22 +519,10 @@ impl HelpersNeeded {
 
     pub fn mark_async_values(&mut self) {
         self.async_values = true;
-        if self
-            .unprioritized_order
-            .contains(&HelperEmitOrder::AsyncValues)
-        {
-            return;
-        }
-        if let Some(spread_pos) = self
-            .unprioritized_order
-            .iter()
-            .position(|helper| *helper == HelperEmitOrder::SpreadArray)
-        {
-            self.unprioritized_order
-                .insert(spread_pos, HelperEmitOrder::AsyncValues);
-        } else {
-            self.unprioritized_order.push(HelperEmitOrder::AsyncValues);
-        }
+        // `__asyncValues` (for-await-of) is an ES2018 async-iteration helper, so
+        // it precedes the whole ES2015 iteration tier (`__values`/`__read`/
+        // `__spreadArray`), not just `__spreadArray`.
+        self.remember_es2018_tier_unprioritized(HelperEmitOrder::AsyncValues);
     }
 
     pub fn mark_class_private_field_get(&mut self) {
@@ -858,6 +875,15 @@ fn emit_class_private_helpers(
         output,
         emitted,
     );
+}
+
+/// The ES2015 iteration/spread no-priority helpers, which `tsc` emits after the
+/// ES2018-pass helpers (object-rest + async-iteration).
+const fn is_es2015_iteration_helper(helper: HelperEmitOrder) -> bool {
+    matches!(
+        helper,
+        HelperEmitOrder::Values | HelperEmitOrder::Read | HelperEmitOrder::SpreadArray
+    )
 }
 
 const fn is_class_private_helper(helper: HelperEmitOrder) -> bool {
@@ -1515,6 +1541,52 @@ mod tests {
         assert_eq!(
             helpers.needed_names(),
             vec!["__asyncValues", "__spreadArray"]
+        );
+    }
+
+    #[test]
+    fn emit_helpers_rest_precedes_values_when_values_requested_first() {
+        // `__values` (ES2015 iteration) requested first — e.g. `yield*`/`for..of`
+        // earlier in the source than an object-rest destructuring. `__rest`
+        // (ES2018 object-rest pass) must still emit ahead of `__values`, matching
+        // tsc's transform-pass ordering.
+        let mut helpers = HelpersNeeded::default();
+        helpers.mark_values();
+        helpers.mark_rest();
+
+        let output = emit_helpers(&helpers);
+        let i_rest = find_helper(&output, "__rest");
+        let i_values = find_helper(&output, "__values");
+        assert!(
+            i_rest < i_values,
+            "rest must precede values, got rest={i_rest} values={i_values}",
+        );
+        assert_eq!(helpers.needed_names(), vec!["__rest", "__values"]);
+    }
+
+    #[test]
+    fn emit_helpers_es2018_tier_precedes_whole_es2015_tier_when_requested_last() {
+        // for-await-of (`__asyncValues`, ES2018) requested after the ES2015
+        // iteration/spread constructs must still emit ahead of the entire ES2015
+        // tier (`__values`/`__read`/`__spreadArray`), not merely before
+        // `__spreadArray`.
+        let mut helpers = HelpersNeeded::default();
+        helpers.mark_values();
+        helpers.mark_read();
+        helpers.mark_spread_array();
+        helpers.mark_async_values();
+
+        let output = emit_helpers(&helpers);
+        let i_async_values = find_helper(&output, "__asyncValues");
+        let i_values = find_helper(&output, "__values");
+        let i_read = find_helper(&output, "__read");
+        let i_spread = find_helper(&output, "__spreadArray");
+        assert!(i_async_values < i_values, "asyncValues must precede values");
+        assert!(i_values < i_read, "values must precede read");
+        assert!(i_read < i_spread, "read must precede spreadArray");
+        assert_eq!(
+            helpers.needed_names(),
+            vec!["__asyncValues", "__values", "__read", "__spreadArray"],
         );
     }
 


### PR DESCRIPTION
Fixes #14617.

## Problem

When more than one no-priority `tslib` helper is emitted inline, tsz orders them by the order they were first requested during the single lowering walk. `tsc` instead orders no-priority helpers by **transform-pass tier first, then request order within a tier**. The ES2018 pass (object-rest + async-iteration) requests its helpers before the ES2015 iteration/spread pass, so `__rest`, `__await`, `__asyncGenerator`, `__asyncValues`, `__asyncDelegator` always precede `__values`, `__read`, `__spreadArray` regardless of source position.

tsz inverted the inline-helper prologue whenever an ES2015 iteration helper was requested earlier in source than an ES2018 helper — e.g. a `yield*`/`for..of` (needs `__values`) appearing before an object-rest destructuring (needs `__rest`):

```ts
function* g(src: number[]) { yield* src; }
declare const o: { a: number; b: number };
const { a, ...r } = o;
```
```
tsc: __generator  __rest   __values
tsz: __generator  __values __rest    <- before
```

A second witness: for-await-of's `__asyncValues` only landed before `__spreadArray` (the previous `mark_async_values` special case) instead of ahead of the whole ES2015 tier:
```
tsc: __awaiter __generator __asyncValues __values __read __spreadArray
tsz: __awaiter __generator __values __read __asyncValues __spreadArray   <- before
```

## Structural rule

When emitting inline no-priority `tslib` helpers, the ES2018-pass helpers (`__rest`, `__await`, `__asyncGenerator`, `__asyncValues`, `__asyncDelegator`) are ordered ahead of the ES2015-pass iteration/spread helpers (`__values`, `__read`, `__spreadArray`), independent of source position; within a tier, request order is preserved (and `__read` stays before `__spreadArray` because `__spreadArray` consumes it). `tsc` does X; tsz now does X through the emitter helper-scheduling layer.

## Owner layer

Emitter helper scheduling only — `crates/tsz-emitter/src/transforms/helpers.rs` (`HelpersNeeded` `unprioritized_order` request-tracking + the `mark_*` insertion logic). No semantic/relation change; pure emit-output ordering. The ES2018-tier markers route through a shared predicate-based insertion (`remember_unprioritized_before`) that places a helper before the earliest recorded ES2015 iteration helper; `mark_read`'s existing insert-before-`__spreadArray` special case is folded into the same primitive (adjacent case, kept correct).

## Adjacent matrix

- `__values` requested first, then `__rest` → `__rest` first (primary witness).
- `__rest`/`yield*` requested first, then iteration → unchanged (already `__rest` first).
- for-await-of `__asyncValues` after the full ES2015 trio → precedes all of `__values`/`__read`/`__spreadArray`.
- `__read` requested after `__spreadArray` → `__read` still precedes `__spreadArray`.
- class-private helpers are emitted in their own block before the general block, so private-vs-rest ordering is unaffected.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- New unit tests `emit_helpers_rest_precedes_values_when_values_requested_first` and `emit_helpers_es2018_tier_precedes_whole_es2015_tier_when_requested_last`; full `tsz-emitter` helper/es5/spread/rest/async suites green locally (`cargo test -p tsz-emitter --lib helper|es5|spread|rest|async`: 353 + 788 + 30 + 91 + 246 passed, 0 failed).
- End-to-end byte-diff vs `tsc` 6.0.2 on 7 reduced repros (es5 ± downlevelIteration, `yield*`/`for-of`/object-rest/array-spread/array-destructure/for-await permutations in both source orders): inline-helper prologue now byte-identical to `tsc`.
- `cargo fmt -p tsz-emitter` clean; `cargo clippy -p tsz-emitter --lib` clean.
- Ready-review CI owns the full conformance / JS-emit / DTS / fourslash parity floors (byte-identical emit baselines).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VL737N5mnMAajXhMdvmDoi)_