### PR TITLE
fix(checker): TS18016 for private-id access on any-typed receiver outside a class

### DIFF
--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -528,43 +528,6 @@ impl BinderState {
         (symbols, saw_class_scope)
     }
 
-    /// Check whether any class scope (not just those enclosing `node_idx`)
-    /// declares a private identifier with the given escaped text. Used to
-    /// downgrade TS18016 "private identifiers are not allowed outside class
-    /// bodies" to TS18013-style diagnostics when the name is declared
-    /// elsewhere in the file — matching tsc, which emits TS18016 only when
-    /// the name is truly absent from every class.
-    #[must_use]
-    pub fn private_identifier_declared_in_any_class(&self, name: &str) -> bool {
-        self.scopes
-            .iter()
-            .any(|scope| scope.kind == ContainerKind::Class && scope.table.get(name).is_some())
-    }
-
-    /// Find the name of a class that declares the given private identifier.
-    /// Returns the first match in scope order — used to format TS18013 diagnostics.
-    #[must_use]
-    pub fn find_class_declaring_private_identifier(
-        &self,
-        arena: &NodeArena,
-        name: &str,
-    ) -> Option<String> {
-        for scope in self.scopes.iter() {
-            if scope.kind != ContainerKind::Class || scope.table.get(name).is_none() {
-                continue;
-            }
-            let node = arena.get(scope.container_node)?;
-            if let Some(cls) = arena.get_class(node)
-                && let Some(name_node) = arena.get(cls.name)
-                && let Some(ident) = arena.get_identifier(name_node)
-            {
-                return Some(ident.escaped_text.to_string());
-            }
-            return Some(String::new());
-        }
-        None
-    }
-
     // =========================================================================
     // Import Resolution
     // =========================================================================

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs
@@ -454,52 +454,18 @@ impl<'a> CheckerState<'a> {
                     }
                     return TypeId::ERROR;
                 }
-                // TSC special case: for any-like types, private names can't be looked up
-                // dynamically. If we're outside any class body, emit TS18016 — but only
-                // when the private identifier is NOT declared in any class in the file.
-                // If it IS declared somewhere, tsc instead routes through the
-                // "property exists but not accessible" path (TS18013), so we fall
-                // through to the else-branch that emits TS2339 here.
-                let declared_in_some_class = self
-                    .ctx
-                    .arena
-                    .get(name_idx)
-                    .and_then(|n| self.ctx.arena.get_identifier(n))
-                    .is_some_and(|ident| {
-                        self.ctx
-                            .binder
-                            .private_identifier_declared_in_any_class(&ident.escaped_text)
-                    });
-                if !saw_class_scope && !declared_in_some_class {
+                // For an any-like receiver a private name can't be looked up
+                // dynamically. tsc resolves it only against lexically enclosing
+                // classes; with no enclosing class (`!saw_class_scope`) it emits the
+                // grammar error TS18016 unconditionally. A same-named member in some
+                // other (non-lexical) class is irrelevant and does NOT downgrade this
+                // to the concretely-typed-receiver TS18013 path.
+                if !saw_class_scope {
                     use crate::diagnostics::diagnostic_codes;
                     self.error_at_node(
                         name_idx,
                         "Private identifiers are not allowed outside class bodies.",
                         diagnostic_codes::PRIVATE_IDENTIFIERS_ARE_NOT_ALLOWED_OUTSIDE_CLASS_BODIES,
-                    );
-                } else if !saw_class_scope && declared_in_some_class {
-                    // Private name declared in another class in this file but accessed
-                    // outside any class body. tsc emits TS18013 "Property '#x' is not
-                    // accessible outside class '...' because it has a private identifier."
-                    use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-                    let class_name = self
-                        .ctx
-                        .arena
-                        .get(name_idx)
-                        .and_then(|n| self.ctx.arena.get_identifier(n))
-                        .and_then(|ident| {
-                            self.ctx.binder.find_class_declaring_private_identifier(
-                                self.ctx.arena,
-                                &ident.escaped_text,
-                            )
-                        })
-                        .unwrap_or_default();
-                    self.error_at_node(
-                        name_idx,
-                        &diagnostic_messages::PROPERTY_IS_NOT_ACCESSIBLE_OUTSIDE_CLASS_BECAUSE_IT_HAS_A_PRIVATE_IDENTIFIER
-                            .replace("{0}", &property_name)
-                            .replace("{1}", &class_name),
-                        diagnostic_codes::PROPERTY_IS_NOT_ACCESSIBLE_OUTSIDE_CLASS_BECAUSE_IT_HAS_A_PRIVATE_IDENTIFIER,
                     );
                 } else if self.is_js_file() && !self.ctx.should_resolve_jsdoc() {
                     // In unchecked JS files (allowJs without checkJs/@ts-check), tsc emits

--- a/crates/tsz-checker/tests/private_brands.rs
+++ b/crates/tsz-checker/tests/private_brands.rs
@@ -391,6 +391,33 @@ fn test_ts18016_private_id_on_any_outside_class() {
     );
 }
 
+/// Private identifier on an `any`-typed receiver, accessed outside any class
+/// body, where the private name *is* declared in another class in the same file.
+///
+/// tsc resolves a private name only against the *lexically enclosing* classes
+/// (`lookupSymbolForPrivateIdentifierDeclaration`). A class declared elsewhere in
+/// the file is not in lexical scope at a top-level access site, so the any-like
+/// branch still hits the grammar error TS18016 — NOT the TS18013 "not accessible
+/// outside class" path, which is reserved for a concretely-typed receiver whose
+/// class declares the member. This is the regression guard for a bug where tsz
+/// downgraded TS18016 to TS18013 whenever the name appeared in any class.
+#[test]
+fn test_ts18016_private_id_on_any_outside_class_when_declared_elsewhere() {
+    let source = r"
+        class C { #x = 1; }
+        declare const c: any;
+        c.#x;
+    ";
+    assert!(
+        has_error_code(source, 18016),
+        "Should emit TS18016 for a private name on an any receiver outside any class body, even when the name is declared in another class"
+    );
+    assert!(
+        !has_error_code(source, 18013),
+        "Should NOT emit TS18013 for an any-typed receiver outside a class body"
+    );
+}
+
 /// Private identifier on a function prototype assignment outside class body -> TS18016.
 #[test]
 fn test_ts18016_private_id_on_js_prototype_assignment_outside_class() {


### PR DESCRIPTION
## Summary

Accessing a private identifier as `obj.#name` on an **any-like receiver outside
any class body** must report **TS18016** ("Private identifiers are not allowed
outside class bodies"). tsz was reporting **TS18013** ("Property '#x' is not
accessible outside class 'C' because it has a private identifier") whenever the
private name happened to be declared in *some* class in the file.

### Structural rule

When a private identifier is accessed on an any-like receiver and there is **no
lexically-enclosing class**, `tsc` emits TS18016 — *unconditionally*. `tsc`
resolves a private name only against lexically-enclosing classes
(`lookupSymbolForPrivateIdentifierDeclaration`), so a same-named member declared
in some other, non-lexical class is irrelevant. tsz did this through the checker
(`get_type_of_private_property_access`), but additionally scanned **every** class
scope in the file and downgraded the grammar error to TS18013 — a diagnostic
reserved for a *concretely-typed* receiver whose class declares the member.

### Owner layer

Checker — `crates/tsz-checker/src/state/type_analysis/computed_helpers_private.rs`,
`get_type_of_private_property_access` (the `symbols.is_empty()` + any-like arm).
The fix collapses the branch so `!saw_class_scope` always emits TS18016, and
deletes the two now-dead binder helpers that performed the file-wide scan
(`private_identifier_declared_in_any_class`,
`find_class_declaring_private_identifier` in `tsz-binder`). The legitimate
TS18013 path for concretely-typed receivers (`report_private_identifier_outside_class`,
which derives the class name from the receiver's declaring type) is unchanged.

### Adjacent-case matrix (all verified tsz == tsc 6.0.2)

| Case | tsc | was tsz | now |
| --- | --- | --- | --- |
| `(c as any).#x` outside class (`#x` in C) | TS18016 | TS18013 ❌ | TS18016 ✅ |
| `arr.map(o => o.#x)` at top level | TS18016 | TS18013 ❌ | TS18016 ✅ |
| `(0 as any).#x` / static `o.#s` | TS18016 | TS18013 ❌ | TS18016 ✅ |
| undeclared name on any outside class | TS18016 | TS18016 | TS18016 ✅ |
| `o.#x` on any **inside** a class (not in scope) | TS2339 | TS2339 | TS2339 ✅ |
| `c.#x` on concretely-typed receiver outside class | TS18013 | TS18013 | TS18013 ✅ |
| `o?.#x` (optional chain) | TS18030 | TS18030 | TS18030 ✅ |
| any receiver where `#x` **is** lexically in scope | (ok) | (ok) | (ok) ✅ |

This is a net deletion (-39 lines): it removes a fragile file-wide scan and a
guess-the-class-name helper rather than adding a special case.

Goal: hold

## Verification

- `cargo test -p tsz-checker --test private_brands` — 36 passed (incl. new
  regression `test_ts18016_private_id_on_any_outside_class_when_declared_elsewhere`,
  asserting TS18016 present and TS18013 absent).
- `cargo test -p tsz-checker --test conformance_issues_errors` — 296 passed.
- `cargo test -p tsz-checker --test lazy_class_constructor_type_tests`,
  `conformance_issues_types -- optional_chain`,
  `conformance_issues_modules -- file_formats`,
  `conformance_issues_errors -- runtime` — all pass.
- 13 + 8 private-identifier permutations diffed against `tsc 6.0.2`: exact match.
- `cargo fmt -- --check` and `cargo clippy -p tsz-checker -p tsz-binder` clean.
- tsz-core's 9–10 pre-existing, environment-dependent failures (source-map
  parity, scanner atom, residency watermark, abstract-property) are identical
  with and without this change (confirmed via `git stash`).
- Rebased on `main` (`8a48c7d`); no conflicts. Broad conformance/emit/fourslash
  floors owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_016jEtoRbbsReCHC6zS8a6KE)_