### PR TITLE
fix(checker): key renamed re-export generic interface to its declaration def (#13212)

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -5,7 +5,6 @@ use crate::query_boundaries::state::type_resolution as query;
 use crate::state::CheckerState;
 use crate::symbol_resolver::TypeSymbolResolution;
 use tsz_binder::symbol_flags;
-use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::{NodeIndex, NodeList, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
@@ -78,80 +77,6 @@ impl CheckerState<'_> {
                 .and_then(|sig| self.ctx.arena.get(sig.name))
                 .is_some_and(|name| name.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
         })
-    }
-
-    fn same_file_type_alias_parts_for_name(
-        &self,
-        name: &str,
-    ) -> Option<(Option<NodeList>, NodeIndex, Option<tsz_binder::SymbolId>)> {
-        self.ctx
-            .arena
-            .nodes
-            .iter()
-            .enumerate()
-            .find_map(|(idx, node)| {
-                let type_alias = self.ctx.arena.get_type_alias(node)?;
-                let alias_name = self.ctx.arena.get_identifier_text(type_alias.name)?;
-                (alias_name == name).then(|| {
-                    (
-                        type_alias.type_parameters.clone(),
-                        type_alias.type_node,
-                        self.ctx.binder.node_symbols.get(&(idx as u32)).copied(),
-                    )
-                })
-            })
-    }
-
-    fn type_node_is_outside_symbol_declarations(
-        &self,
-        node_idx: NodeIndex,
-        sym_id: tsz_binder::SymbolId,
-    ) -> bool {
-        let Some(node) = self.ctx.arena.get(node_idx) else {
-            return true;
-        };
-        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
-            return true;
-        };
-
-        !symbol.declarations.iter().any(|&decl_idx| {
-            self.ctx
-                .arena
-                .get(decl_idx)
-                .is_some_and(|decl| node.pos >= decl.pos && node.end <= decl.end)
-        })
-    }
-
-    fn def_body_involves_depth_poisoned_def(&self, def_id: tsz_solver::DefId) -> bool {
-        if !self.ctx.definition_store.has_any_depth_poisoned() {
-            return false;
-        }
-
-        self.ctx
-            .type_env
-            .try_borrow()
-            .ok()
-            .and_then(|env| env.get_def(def_id))
-            .is_some_and(|body| self.ctx.type_involves_depth_poisoned_def(body))
-    }
-
-    fn def_body_can_own_ambient_depth(&self, def_id: tsz_solver::DefId) -> bool {
-        let Some(body) = self
-            .ctx
-            .type_env
-            .try_borrow()
-            .ok()
-            .and_then(|env| env.get_def(def_id))
-            .or_else(|| self.ctx.definition_store.get_body(def_id))
-        else {
-            return false;
-        };
-
-        let db = self.ctx.types.as_type_database();
-        crate::query_boundaries::common::contains_conditional_type(db, body)
-            || crate::query_boundaries::common::contains_keyof_type(db, body)
-            || crate::query_boundaries::common::contains_index_access_type(db, body)
-            || crate::query_boundaries::common::is_mapped_type(db, body)
     }
 
     /// Get type from a type reference node (e.g., "number", "string", "`MyType`").

--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -1029,9 +1029,30 @@ impl CheckerState<'_> {
                     {
                         return TypeId::ERROR;
                     }
+                    // Key the application base to the *declaration* def when the
+                    // alias reaches a generic interface/class through a re-export
+                    // chain. A renamed re-export
+                    // (`export { Original as Renamed } from './origin'`) resolves
+                    // `target_sym_id` to the renaming hop, whose own name
+                    // ("Renamed") and alias (`TypeAlias`) kind carry no type
+                    // parameters, so `Renamed<number>` would stay an opaque
+                    // `Application` with its argument never substituted — a free
+                    // type parameter leaks to member reads (false TS2322). The
+                    // canonical declaration def (whose parameters resolve on
+                    // demand) substitutes correctly, matching the non-renamed
+                    // re-export forms. Mirrors the entity-name / heritage paths.
                     let def_id = self
                         .ctx
-                        .get_or_create_def_id_for_symbol_name(target_sym_id, &target_name);
+                        .binder
+                        .file_locals
+                        .get(name)
+                        .and_then(|local_sym| {
+                            self.reexported_declaration_def_id_for_lowering(local_sym, name)
+                        })
+                        .unwrap_or_else(|| {
+                            self.ctx
+                                .get_or_create_def_id_for_symbol_name(target_sym_id, &target_name)
+                        });
                     let base = self.ctx.types.factory().lazy(def_id);
                     return self.ctx.types.factory().application(base, type_args);
                 }

--- a/crates/tsz-checker/src/state/type_resolution/reference_type_params.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_type_params.rs
@@ -386,18 +386,24 @@ impl CheckerState<'_> {
         // *type aliases* need their body eagerly registered under the canonical
         // `DefId` as well (a distinct path); leave them on the existing
         // resolution so this change does not alter the alias path.
-        let decl_is_interface_or_class = self
+        //
+        // Key the `DefId` to the declaration's *own* declared name, not the
+        // local `leaf_name`: a renamed re-export
+        // (`export type { Original as Renamed } from`) resolves the chain to a
+        // declaration whose name differs from the name used at the import site.
+        // `def_id_for_declaration_in_file` requires the declaration's
+        // `escaped_name` to match, so passing `leaf_name` ("Renamed") returns
+        // `None` for the renamed case and the application is left opaque with
+        // its type argument unsubstituted (false TS2322). The declaration name
+        // also keys the body that resolves on demand, so the two agree.
+        let decl_name = self
             .ctx
             .get_binder_for_file(decl_file_idx)
             .and_then(|binder| binder.get_symbol(decl_sym))
-            .is_some_and(|symbol| {
-                symbol.has_any_flags(symbol_flags::INTERFACE | symbol_flags::CLASS)
-            });
-        if !decl_is_interface_or_class {
-            return None;
-        }
+            .filter(|symbol| symbol.has_any_flags(symbol_flags::INTERFACE | symbol_flags::CLASS))
+            .map(|symbol| symbol.escaped_name.clone())?;
         self.ctx
-            .def_id_for_declaration_in_file(decl_sym, decl_file_idx, leaf_name)
+            .def_id_for_declaration_in_file(decl_sym, decl_file_idx, &decl_name)
     }
 
     pub(crate) fn reference_import_alias_export_target(

--- a/crates/tsz-checker/src/state/type_resolution/reference_type_params.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_type_params.rs
@@ -2,10 +2,84 @@
 
 use crate::state::CheckerState;
 use tsz_binder::{SymbolId, symbol_flags};
-use tsz_parser::parser::node::NodeArena;
-use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
+use tsz_parser::parser::node::{NodeAccess, NodeArena};
+use tsz_parser::parser::{NodeIndex, NodeList, syntax_kind_ext};
 
 impl CheckerState<'_> {
+    pub(super) fn same_file_type_alias_parts_for_name(
+        &self,
+        name: &str,
+    ) -> Option<(Option<NodeList>, NodeIndex, Option<SymbolId>)> {
+        self.ctx
+            .arena
+            .nodes
+            .iter()
+            .enumerate()
+            .find_map(|(idx, node)| {
+                let type_alias = self.ctx.arena.get_type_alias(node)?;
+                let alias_name = self.ctx.arena.get_identifier_text(type_alias.name)?;
+                (alias_name == name).then(|| {
+                    (
+                        type_alias.type_parameters.clone(),
+                        type_alias.type_node,
+                        self.ctx.binder.node_symbols.get(&(idx as u32)).copied(),
+                    )
+                })
+            })
+    }
+
+    pub(super) fn type_node_is_outside_symbol_declarations(
+        &self,
+        node_idx: NodeIndex,
+        sym_id: SymbolId,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return true;
+        };
+        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+            return true;
+        };
+
+        !symbol.declarations.iter().any(|&decl_idx| {
+            self.ctx
+                .arena
+                .get(decl_idx)
+                .is_some_and(|decl| node.pos >= decl.pos && node.end <= decl.end)
+        })
+    }
+
+    pub(super) fn def_body_involves_depth_poisoned_def(&self, def_id: tsz_solver::DefId) -> bool {
+        if !self.ctx.definition_store.has_any_depth_poisoned() {
+            return false;
+        }
+
+        self.ctx
+            .type_env
+            .try_borrow()
+            .ok()
+            .and_then(|env| env.get_def(def_id))
+            .is_some_and(|body| self.ctx.type_involves_depth_poisoned_def(body))
+    }
+
+    pub(super) fn def_body_can_own_ambient_depth(&self, def_id: tsz_solver::DefId) -> bool {
+        let Some(body) = self
+            .ctx
+            .type_env
+            .try_borrow()
+            .ok()
+            .and_then(|env| env.get_def(def_id))
+            .or_else(|| self.ctx.definition_store.get_body(def_id))
+        else {
+            return false;
+        };
+
+        let db = self.ctx.types.as_type_database();
+        crate::query_boundaries::common::contains_conditional_type(db, body)
+            || crate::query_boundaries::common::contains_keyof_type(db, body)
+            || crate::query_boundaries::common::contains_index_access_type(db, body)
+            || crate::query_boundaries::common::is_mapped_type(db, body)
+    }
+
     pub(crate) fn declaration_file_type_shadow_for_lib_name(
         &self,
         name: &str,

--- a/crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs
+++ b/crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs
@@ -110,16 +110,19 @@ fn member_access_value_consumer() {
     );
 }
 
-// --- renamed re-export through nested barrels ---
+// --- renamed re-export (`export { Original as Renamed } from`) ---
 //
-// Follow-up: a *renamed* re-export (`export type { Original as Renamed }`)
-// forwarded again through `export *` keys the application base to the renaming
-// hop rather than the declaration, so the receiver is not recognized as a
-// non-lib interface application and the type argument is still dropped. This is
-// the re-export-chain def-identity gap (resolution layer), distinct from the
-// receiver-materialization path fixed here. Pinned (ignored) so it is tracked.
+// A renamed re-export resolves the chain to a declaration whose own name
+// differs from the name used at the import site, so the type-reference lowering
+// keyed the application base to the renaming *hop* (an alias symbol minted as a
+// `TypeAlias` named "Renamed", carrying no type parameters) rather than to the
+// `Original` interface declaration. `Renamed<number>` then stayed an opaque
+// `Application` and its argument was never substituted, leaking a free type
+// parameter to member reads (false TS2322). The lowering now canonicalizes a
+// re-export alias that reaches a generic interface/class declaration to the
+// declaration def (the same chase the entity-name and heritage paths use),
+// keying `def_id_for_declaration_in_file` to the declaration's own name.
 #[test]
-#[ignore = "renamed re-export forwarded through export * keys the base def to the renaming hop (#13212 / #10663 resolution-layer follow-up)"]
 fn member_access_through_renamed_nested_barrels() {
     assert_clean(
         &[
@@ -138,6 +141,83 @@ fn member_access_through_renamed_nested_barrels() {
             ),
         ],
         "./client.ts",
+    );
+}
+
+// Rename applied at the import site (`import { Original as Renamed }`): the
+// alias already carries `import_name = "Original"`, so this worked before — kept
+// as a control that the canonicalization does not perturb it.
+#[test]
+fn member_access_through_renamed_direct_import() {
+    assert_clean(
+        &[
+            (
+                "./origin.ts",
+                "export interface Original<P> { field: P; }\n",
+            ),
+            (
+                "./client.ts",
+                "import type { Original as Renamed } from './origin';\ndeclare const r: Renamed<number>;\nconst n: number = r.field;\n",
+            ),
+        ],
+        "./client.ts",
+    );
+}
+
+// Rename applied at a single named barrel, consumed directly (no `export *`):
+// the minimal renamed-hop reproduction.
+#[test]
+fn member_access_through_renamed_single_barrel() {
+    assert_clean(
+        &[
+            (
+                "./origin.ts",
+                "export interface Original<P> { field: P; }\n",
+            ),
+            (
+                "./mid.ts",
+                "export type { Original as Renamed } from './origin';\n",
+            ),
+            (
+                "./client.ts",
+                "import type { Renamed } from './mid';\ndeclare const r: Renamed<number>;\nconst n: number = r.field;\n",
+            ),
+        ],
+        "./client.ts",
+    );
+}
+
+// Control: the same two-hop `export *` chain *without* a rename was already
+// clean; the rename is the only differing factor above.
+#[test]
+fn member_access_through_nonrenamed_nested_star() {
+    assert_clean(
+        &[
+            (
+                "./origin.ts",
+                "export interface Original<P> { field: P; }\n",
+            ),
+            ("./mid.ts", "export type { Original } from './origin';\n"),
+            ("./top.ts", "export * from './mid';\n"),
+            (
+                "./client.ts",
+                "import type { Original } from './top';\ndeclare const r: Original<number>;\nconst n: number = r.field;\n",
+            ),
+        ],
+        "./client.ts",
+    );
+}
+
+// Control: same-file `interface Crate extends Container<number>` substitutes the
+// inherited member correctly (the cross-file heritage case below does not).
+#[test]
+fn extends_same_file_generic_interface_inherited_member() {
+    assert_clean(
+        &[(
+            "./hmain.ts",
+            "interface Container<T> { value: T; }\ninterface Crate extends Container<number> { extra: string; }\ndeclare const c: Crate;\nconst n: number = c.value;\n",
+        )],
+        "./hmain.ts",
     );
 }
 
@@ -212,14 +292,17 @@ fn wrong_type_argument_still_errors() {
     );
 }
 
-// --- documented follow-up: a member *inherited* from a re-exported generic
-// base (`interface Local extends ReExported<number>`) still drops the type
-// argument. That is the cross-file generic-interface *heritage* materialization
-// path (#13767 / #13803 family), distinct from the receiver-application path
-// fixed here. Pinned (ignored) so the remaining gap is tracked, not lost. ---
+// --- documented follow-up: a member *inherited* from a generic base declared
+// in another file (`interface Local extends Base<number>`) still drops the type
+// argument. This is NOT re-export-specific — it reproduces with a *direct*
+// cross-file import too (see `extends_same_file_generic_interface_inherited_member`
+// for the passing same-file control), so the barrel here is incidental. The
+// owner is the cross-file generic-interface *heritage* materialization path
+// (#13767 / #13803 family), distinct from the type-reference application path
+// fixed in this change. Pinned (ignored) so the remaining gap is tracked. ---
 
 #[test]
-#[ignore = "inherited-via-heritage member of a re-exported generic base needs cross-file heritage materialization (#13767 / #13212)"]
+#[ignore = "inherited-via-heritage member of a cross-file generic base needs cross-file heritage materialization; reproduces with a direct import too (#13767 / #13212)"]
 fn extends_reexported_generic_interface_inherited_member() {
     assert_clean(
         &[


### PR DESCRIPTION
## Summary

A **renamed re-export** (`export { Original as Renamed } from './origin'`) resolves the type-reference chain to a declaration whose own name differs from the name used at the import site. tsz's type-reference lowering keyed the application base to the renaming **hop** — an alias symbol minted as a `TypeAlias` named `Renamed` that carries no type parameters — instead of the `Original` interface declaration. `Renamed<number>` then stayed an opaque `Application` whose type argument was never substituted, so a free type parameter leaked to member reads and assignment, producing a false **TS2322**.

This is the `member_access_through_renamed_nested_barrels` follow-up that PR #14578 pinned (`#[ignore]`d) when it fixed the non-renamed re-export receiver path.

### Witness (tsc clean; tsz emitted TS2322 before this change)

```ts
// origin.ts
export interface Original<P> { field: P; }
// mid.ts
export type { Original as Renamed } from './origin';
// top.ts
export * from './mid';
// client.ts
import type { Renamed } from './top';
declare const r: Renamed<number>;
const n: number = r.field;   // tsz before: TS2322 'P' is not assignable to 'number'
```

The receiver application carried `def kind=TypeAlias name="Renamed"` (the renaming hop), so the #14578 generic-interface receiver-materialization gate never fired and the member resolved to the unsubstituted declared `P`.

## Structural rule

When a type-only import alias used in **type position** reaches a generic interface/class declaration through a re-export chain, `tsc` keys the application to the **declaration** (whose type parameters substitute). tsz now does the same by canonicalizing through `reexported_declaration_def_id_for_lowering` at the type-reference lowering site — the same chase the entity-name and heritage paths already use.

## Owner layer

Checker type-reference lowering / re-export def-identity (resolution layer):

- **`state/type_resolution/core.rs`** — in the type-only-import-alias branch of `get_type_from_type_reference`, prefer the declaration def from `reexported_declaration_def_id_for_lowering` over the renaming-hop def; fall back to the prior `get_or_create_def_id_for_symbol_name` when the alias does not reach a generic interface/class declaration (non-generic / value / type-alias re-exports keep their existing path, so behavior is unchanged there).
- **`state/type_resolution/reference_type_params.rs`** — `reexported_declaration_def_id_for_lowering` now keys `def_id_for_declaration_in_file` to the declaration's **own** `escaped_name` rather than the local `leaf_name`. That helper requires the name to match the declaration, so a renamed chain (decl `Original` vs leaf `Renamed`) previously returned `None` and fell back to the opaque hop.

No hardcoded identifier/file-name predicates; the gate is structural (`DefKind::Interface`/`Class`, non-lib) and binder names are varied across the tests.

## Adjacent matrix (all clean; binder names varied)

- rename at the import site (`import { Original as Renamed }`) — control, already passed
- rename at a single named barrel, consumed directly
- rename forwarded through nested `export *` (primary witness)
- non-renamed two-hop `export *` — control (the rename is the only differing factor)
- same-file generic heritage inherited member — control
- negative control: a genuine wrong type argument still errors (TS2322)

## Out of scope (separate, deeper root)

A member **inherited** via `interface Local extends Base<number>` still drops the type argument. This is **not** re-export-specific — it reproduces with a *direct* cross-file import (same-file works), so it is the cross-file generic-interface **heritage** materialization path (#13767 / #13803), distinct from the type-reference application path fixed here. It stays pinned/ignored with an updated note.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- New/un-ignored unit tests in `crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs`: **13 passed, 1 ignored** (the cross-file-heritage follow-up). The previously-`#[ignore]`d `member_access_through_renamed_nested_barrels` now passes; added adjacent + control cases.
- Related integration suites green locally: `heritage_reexport_generic_type_params_tests` (8), `heritage_reexport_type_params_tests` (11), `export_star_as_named_import_type_anchor_tests` (6), `cross_file_type_params_cache_tests` (6).
- The 2 failures in `import_type_utility_identity_tests` are **pre-existing** (fail identically on a clean `git stash` of this change).
- `cargo fmt -p tsz-checker -- --check` clean; `cargo clippy -p tsz-checker` clean.
- Broad conformance / emit / fourslash floors owned by ready-review CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QpUHgQvnSC6sBHuiNqtXAe)_