### PR TITLE
fix(checker): render flow-narrowed union source by its narrowed type, not the declared alias

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
@@ -157,6 +157,21 @@ impl<'a> CheckerState<'a> {
         if self.assignment_source_narrowed_from_declared_top_type(anchor_idx, source) {
             return None;
         }
+        // A source identifier flow-narrowed to a strict subset of its declared
+        // type (the canonical case being a declared union alias narrowed to a
+        // sub-union) keeps its narrowed structural display: `tsc` drops the
+        // `aliasSymbol` on `filterType` for a proper subset, so the declared
+        // union-alias repaint below would restore a stale broader type. Mirrors
+        // the top-type guard above and the source-display narrowing guard in
+        // `format_assignment_source_type_for_diagnostic`.
+        if let Some(expr_idx) = self
+            .direct_diagnostic_source_expression(anchor_idx)
+            .or_else(|| self.assignment_source_expression(anchor_idx))
+            && let Some(declared_type) = self.declared_type_of_variable_identifier_source(expr_idx)
+            && self.source_flow_type_strictly_narrows_declared(source, declared_type)
+        {
+            return None;
+        }
         if let Some(expr_idx) = self
             .direct_diagnostic_source_expression(anchor_idx)
             .or_else(|| self.assignment_source_expression(anchor_idx))

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -447,6 +447,82 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// The declared (pre-narrowing) type of a source *variable* identifier
+    /// expression, or `None` when `expr_idx` is not a usable variable
+    /// identifier. Merged `INTERFACE`+`VALUE` symbols resolve to the interface
+    /// side via `get_type_of_symbol`, so they are excluded; `Error`/`unknown`
+    /// declared types carry no useful alias to compare against. Shared by the
+    /// source-display paths that compare the flow-narrowed checked type against
+    /// the declared type.
+    pub(in crate::error_reporter) fn declared_type_of_variable_identifier_source(
+        &mut self,
+        expr_idx: NodeIndex,
+    ) -> Option<TypeId> {
+        let node = self.ctx.arena.get(expr_idx)?;
+        if node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
+            return None;
+        }
+        let sym_id = self.resolve_identifier_symbol(expr_idx)?;
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        if !symbol.has_any_flags(tsz_binder::symbol_flags::VARIABLE) {
+            return None;
+        }
+        if symbol.has_any_flags(tsz_binder::symbol_flags::INTERFACE)
+            && !symbol.has_any_flags(tsz_binder::symbol_flags::CLASS)
+        {
+            return None;
+        }
+        let declared_type = self.get_type_of_symbol(sym_id);
+        if matches!(declared_type, TypeId::ERROR | TypeId::UNKNOWN) {
+            return None;
+        }
+        Some(declared_type)
+    }
+
+    /// True when a source identifier's flow-narrowed checked type
+    /// `expr_display_type` is a strict narrowing of its `declared_type` —
+    /// either a strict subtype (assignable one way only) or a strict union
+    /// member subset (flow eliminated some declared union members). `tsc` drops
+    /// the declared `aliasSymbol` on `filterType`/`getNarrowedType` whenever the
+    /// result is a proper subset, so the narrowed structural type is displayed
+    /// rather than the declared alias/annotation name. Shared by the source
+    /// display path (`format_assignment_source_type_for_diagnostic`) and the
+    /// TS2322/TS2741 alias repaint (`declared_generic_alias_assignment_pair_display`)
+    /// so both agree on the narrowing-drops-the-alias rule. It mirrors the
+    /// narrowing detection inlined in `declared_identifier_source_display`.
+    ///
+    /// `declared_type == TypeId::ANY` is intentionally not detected here: `any`
+    /// is bidirectionally related to every type, so the subtype check never
+    /// fires; the `any`/`unknown` top-type narrowing is handled separately by
+    /// the `source_identifier_narrowed_from_unknown_or_any` and
+    /// `assignment_source_narrowed_from_declared_top_type` guards.
+    pub(in crate::error_reporter) fn source_flow_type_strictly_narrows_declared(
+        &mut self,
+        expr_display_type: TypeId,
+        declared_type: TypeId,
+    ) -> bool {
+        if expr_display_type == declared_type {
+            return false;
+        }
+        // Restricted to a *declared union*: `tsc` drops the `aliasSymbol` on
+        // `filterType`, which narrows unions by eliminating members. A non-union
+        // declared alias (e.g. a static-schema array alias `Input[]` whose
+        // structural expansion is asymmetrically related under the decision-only
+        // relation) must keep its established display path and is not a member
+        // of this flow-narrowing-drops-the-alias family.
+        if crate::query_boundaries::common::union_members(self.ctx.types, declared_type).is_none() {
+            return false;
+        }
+        let is_assignability_narrower = self
+            .diagnostic_source_narrowing_relation_outcome(expr_display_type, declared_type)
+            .related
+            && !self
+                .diagnostic_source_narrowing_relation_outcome(declared_type, expr_display_type)
+                .related;
+        is_assignability_narrower
+            || self.is_strict_union_member_subset(expr_display_type, declared_type)
+    }
+
     pub(in crate::error_reporter) fn should_prefer_declared_source_annotation_display(
         &mut self,
         expr_idx: NodeIndex,

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -476,8 +476,7 @@ impl<'a> CheckerState<'a> {
             declaration_binder
                 .symbol_arenas
                 .get(&sym_id)
-                .map(std::convert::AsRef::as_ref)
-                .unwrap_or(self.ctx.arena)
+                .map_or(self.ctx.arena, std::convert::AsRef::as_ref)
         };
 
         let annotation_arena = declaration_binder

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -25,6 +25,7 @@ use crate::query_boundaries::diagnostics as diagnostic_query;
 use crate::state::CheckerState;
 use crate::types_domain::type_node_helpers::type_node_includes_explicit_undefined;
 use span_diagnostic_queries::strip_module_specifier_extension;
+use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
@@ -447,6 +448,77 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    fn declared_type_annotation_node_for_symbol(
+        &self,
+        sym_id: SymbolId,
+    ) -> Option<(&tsz_parser::NodeArena, NodeIndex)> {
+        let symbol = self.get_cross_file_symbol(sym_id)?;
+        let decl_idx = symbol.value_declaration;
+        if decl_idx.is_none() {
+            return None;
+        }
+
+        let owner_binder = self
+            .ctx
+            .resolve_symbol_file_index(sym_id)
+            .and_then(|file_idx| self.ctx.get_binder_for_file(file_idx))
+            .or_else(|| {
+                self.ctx
+                    .binder
+                    .symbol_arenas
+                    .get(&sym_id)
+                    .and_then(|arena| self.ctx.get_binder_for_arena(arena))
+            })
+            .unwrap_or(self.ctx.binder);
+        let fallback_arena = if symbol.decl_file_idx != u32::MAX {
+            self.ctx.get_arena_for_file(symbol.decl_file_idx)
+        } else {
+            owner_binder
+                .symbol_arenas
+                .get(&sym_id)
+                .map(std::convert::AsRef::as_ref)
+                .unwrap_or(self.ctx.arena)
+        };
+
+        let decl_arena = owner_binder
+            .declaration_arenas
+            .get(&(sym_id, decl_idx))
+            .and_then(|arenas| arenas.first().map(|arena| arena.as_ref()))
+            .filter(|arena| arena.get(decl_idx).is_some())
+            .unwrap_or(fallback_arena);
+        let decl = decl_arena.get(decl_idx)?;
+
+        if let Some(param) = decl_arena.get_parameter(decl)
+            && param.type_annotation.is_some()
+        {
+            return Some((decl_arena, param.type_annotation));
+        }
+
+        if let Some(var_decl) = decl_arena.get_variable_declaration(decl)
+            && var_decl.type_annotation.is_some()
+        {
+            return Some((decl_arena, var_decl.type_annotation));
+        }
+
+        None
+    }
+
+    fn declared_annotation_can_name_union_source(&self, sym_id: SymbolId) -> bool {
+        let Some((decl_arena, annotation_idx)) =
+            self.declared_type_annotation_node_for_symbol(sym_id)
+        else {
+            return false;
+        };
+        decl_arena.get(annotation_idx).is_some_and(|node| {
+            matches!(
+                node.kind,
+                syntax_kind_ext::TYPE_REFERENCE
+                    | syntax_kind_ext::UNION_TYPE
+                    | syntax_kind_ext::PARENTHESIZED_TYPE
+            )
+        })
+    }
+
     /// The declared (pre-narrowing) type of a source *variable* identifier
     /// expression, or `None` when `expr_idx` is not a usable variable
     /// identifier. Merged `INTERFACE`+`VALUE` symbols resolve to the interface
@@ -470,6 +542,9 @@ impl<'a> CheckerState<'a> {
         if symbol.has_any_flags(tsz_binder::symbol_flags::INTERFACE)
             && !symbol.has_any_flags(tsz_binder::symbol_flags::CLASS)
         {
+            return None;
+        }
+        if !self.declared_annotation_can_name_union_source(sym_id) {
             return None;
         }
         let declared_type = self.get_type_of_symbol(sym_id);

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -452,13 +452,13 @@ impl<'a> CheckerState<'a> {
         &self,
         sym_id: SymbolId,
     ) -> Option<(&tsz_parser::NodeArena, NodeIndex)> {
-        let symbol = self.get_cross_file_symbol(sym_id)?;
-        let decl_idx = symbol.value_declaration;
-        if decl_idx.is_none() {
+        let symbol_record = self.get_cross_file_symbol(sym_id)?;
+        let declaration_idx = symbol_record.value_declaration;
+        if declaration_idx.is_none() {
             return None;
         }
 
-        let owner_binder = self
+        let declaration_binder = self
             .ctx
             .resolve_symbol_file_index(sym_id)
             .and_then(|file_idx| self.ctx.get_binder_for_file(file_idx))
@@ -470,46 +470,46 @@ impl<'a> CheckerState<'a> {
                     .and_then(|arena| self.ctx.get_binder_for_arena(arena))
             })
             .unwrap_or(self.ctx.binder);
-        let fallback_arena = if symbol.decl_file_idx != u32::MAX {
-            self.ctx.get_arena_for_file(symbol.decl_file_idx)
+        let symbol_arena = if symbol_record.decl_file_idx != u32::MAX {
+            self.ctx.get_arena_for_file(symbol_record.decl_file_idx)
         } else {
-            owner_binder
+            declaration_binder
                 .symbol_arenas
                 .get(&sym_id)
                 .map(std::convert::AsRef::as_ref)
                 .unwrap_or(self.ctx.arena)
         };
 
-        let decl_arena = owner_binder
+        let annotation_arena = declaration_binder
             .declaration_arenas
-            .get(&(sym_id, decl_idx))
+            .get(&(sym_id, declaration_idx))
             .and_then(|arenas| arenas.first().map(|arena| arena.as_ref()))
-            .filter(|arena| arena.get(decl_idx).is_some())
-            .unwrap_or(fallback_arena);
-        let decl = decl_arena.get(decl_idx)?;
+            .filter(|arena| arena.get(declaration_idx).is_some())
+            .unwrap_or(symbol_arena);
+        let declaration = annotation_arena.get(declaration_idx)?;
 
-        if let Some(param) = decl_arena.get_parameter(decl)
+        if let Some(param) = annotation_arena.get_parameter(declaration)
             && param.type_annotation.is_some()
         {
-            return Some((decl_arena, param.type_annotation));
+            return Some((annotation_arena, param.type_annotation));
         }
 
-        if let Some(var_decl) = decl_arena.get_variable_declaration(decl)
+        if let Some(var_decl) = annotation_arena.get_variable_declaration(declaration)
             && var_decl.type_annotation.is_some()
         {
-            return Some((decl_arena, var_decl.type_annotation));
+            return Some((annotation_arena, var_decl.type_annotation));
         }
 
         None
     }
 
     fn declared_annotation_can_name_union_source(&self, sym_id: SymbolId) -> bool {
-        let Some((decl_arena, annotation_idx)) =
+        let Some((annotation_arena, annotation_idx)) =
             self.declared_type_annotation_node_for_symbol(sym_id)
         else {
             return false;
         };
-        decl_arena.get(annotation_idx).is_some_and(|node| {
+        annotation_arena.get(annotation_idx).is_some_and(|node| {
             matches!(
                 node.kind,
                 syntax_kind_ext::TYPE_REFERENCE
@@ -585,7 +585,7 @@ impl<'a> CheckerState<'a> {
         // structural expansion is asymmetrically related under the decision-only
         // relation) must keep its established display path and is not a member
         // of this flow-narrowing-drops-the-alias family.
-        if crate::query_boundaries::common::union_members(self.ctx.types, declared_type).is_none() {
+        if diagnostic_query::union_members(self.ctx.types, declared_type).is_none() {
             return false;
         }
         let is_assignability_narrower = self

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -201,6 +201,24 @@ impl<'a> CheckerState<'a> {
         {
             return self.format_type_for_assignability_message(source);
         }
+        // A source identifier flow-narrowed to a strict subset of its declared
+        // type — a discriminated-union parameter narrowed to one member, or a
+        // union narrowed to a sub-union — renders its narrowed *checked* type,
+        // not the declared alias/annotation name: `tsc` drops the `aliasSymbol`
+        // on `filterType`/`getNarrowedType` whenever the result is a proper
+        // subset, so it prints the narrowed structural type. Resolve it here,
+        // before the declared-annotation recovery and the literal-widening
+        // fallbacks below repaint the narrowed member with the declared union
+        // alias (`Shape`, `U`) or widen its literal discriminant. Mirrors the
+        // `unknown`/`any` top-type guard above.
+        if let Some(expr_idx) = self
+            .direct_diagnostic_source_expression(anchor_idx)
+            .or_else(|| self.assignment_source_expression(anchor_idx))
+            && let Some(declared_type) = self.declared_type_of_variable_identifier_source(expr_idx)
+            && self.source_flow_type_strictly_narrows_declared(source, declared_type)
+        {
+            return self.format_assignability_type_for_message(source, target);
+        }
         // A deferred meta-type source — a bare conditional (`T extends U ? X : Y`)
         // or indexed-access (`T["x"]`), or an `Application` of a conditional/
         // indexed-bodied alias (`T95<U>`) — that still carries free type

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -188,12 +188,8 @@ impl<'a> CheckerState<'a> {
         anchor_idx: NodeIndex,
     ) -> String {
         // A source identifier declared `unknown`/`any` but flow-narrowed to a
-        // concrete type (e.g. by a `x is T` guard) must render its narrowed
-        // type, not its stale `unknown`/`any` annotation. The annotation-recovery
-        // heuristics below exist to recover lost alias/parameter *names*; for a
-        // narrowed `unknown`/`any` operand they would widen the display back to
-        // the declared supertype, diverging from `tsc` (which prints the narrowed
-        // type). Render the narrowed `source` structurally instead.
+        // concrete type must render the narrowed source, not the stale top-type
+        // annotation.
         if let Some(expr_idx) = self
             .direct_diagnostic_source_expression(anchor_idx)
             .or_else(|| self.assignment_source_expression(anchor_idx))
@@ -202,15 +198,9 @@ impl<'a> CheckerState<'a> {
             return self.format_type_for_assignability_message(source);
         }
         // A source identifier flow-narrowed to a strict subset of its declared
-        // type — a discriminated-union parameter narrowed to one member, or a
-        // union narrowed to a sub-union — renders its narrowed *checked* type,
-        // not the declared alias/annotation name: `tsc` drops the `aliasSymbol`
-        // on `filterType`/`getNarrowedType` whenever the result is a proper
-        // subset, so it prints the narrowed structural type. Resolve it here,
-        // before the declared-annotation recovery and the literal-widening
-        // fallbacks below repaint the narrowed member with the declared union
-        // alias (`Shape`, `U`) or widen its literal discriminant. Mirrors the
-        // `unknown`/`any` top-type guard above.
+        // union renders the narrowed checked type. `tsc` drops the `aliasSymbol`
+        // for proper-subset flow results, so avoid repainting with the stale
+        // declared alias/annotation below.
         if let Some(expr_idx) = self
             .direct_diagnostic_source_expression(anchor_idx)
             .or_else(|| self.assignment_source_expression(anchor_idx))

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1183,6 +1183,9 @@ mod mutable_binding_widening_from_const_literal_tests;
 #[path = "tests/namespace_property_mismatch_boundary_arch_tests.rs"]
 mod namespace_property_mismatch_boundary_arch_tests;
 #[cfg(test)]
+#[path = "tests/narrowed_union_source_display_tests.rs"]
+mod narrowed_union_source_display_tests;
+#[cfg(test)]
 #[path = "tests/nested_tuple_literal_source_display_tests.rs"]
 mod nested_tuple_literal_source_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/narrowed_union_source_display_tests.rs
+++ b/crates/tsz-checker/src/tests/narrowed_union_source_display_tests.rs
@@ -21,16 +21,18 @@ fn source_not_assignable_message(diags: &[crate::diagnostics::Diagnostic]) -> St
     diags
         .iter()
         .find(|d| d.code == 2322 || d.code == 2741)
-        .map(|d| d.message_text.clone())
-        .unwrap_or_else(|| {
-            panic!(
-                "expected a TS2322/TS2741 assignability diagnostic; got: {:?}",
-                diags
-                    .iter()
-                    .map(|d| (d.code, &d.message_text))
-                    .collect::<Vec<_>>()
-            )
-        })
+        .map_or_else(
+            || {
+                panic!(
+                    "expected a TS2322/TS2741 assignability diagnostic; got: {:?}",
+                    diags
+                        .iter()
+                        .map(|d| (d.code, &d.message_text))
+                        .collect::<Vec<_>>()
+                )
+            },
+            |d| d.message_text.clone(),
+        )
 }
 
 #[test]

--- a/crates/tsz-checker/src/tests/narrowed_union_source_display_tests.rs
+++ b/crates/tsz-checker/src/tests/narrowed_union_source_display_tests.rs
@@ -1,0 +1,200 @@
+//! Regression coverage for the *source-type display* of a flow-narrowed
+//! identifier in assignability diagnostics.
+//!
+//! When a source identifier whose declared type is a named union/alias is
+//! flow-narrowed to a strict subset (a discriminated-union parameter narrowed
+//! to one member, or a union narrowed to a sub-union), `tsc` drops the
+//! `aliasSymbol` on `filterType`/`getNarrowedType` and renders the narrowed
+//! *structural* type. tsz previously repainted the narrowed source with its
+//! declared alias name (`Shape`, `U`) — and, on the structural fallback, even
+//! widened the narrowed literal discriminant (`"square"` -> `string`). These
+//! tests pin the structural narrowed display and the not-narrowed control
+//! (where the alias name is correctly preserved).
+//!
+//! The rule is structural, never name-keyed: the renamed-binder variants below
+//! vary the alias name, the discriminant property name, and the member spelling
+//! to prove the fix reads the narrowed type's shape, not any identifier string.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn source_not_assignable_message(diags: &[crate::diagnostics::Diagnostic]) -> String {
+    diags
+        .iter()
+        .find(|d| d.code == 2322 || d.code == 2741)
+        .map(|d| d.message_text.clone())
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a TS2322/TS2741 assignability diagnostic; got: {:?}",
+                diags
+                    .iter()
+                    .map(|d| (d.code, &d.message_text))
+                    .collect::<Vec<_>>()
+            )
+        })
+}
+
+#[test]
+fn discriminated_union_narrowed_to_member_renders_structural_member_not_alias() {
+    // `sh` narrows to the `"square"` member in the `default` arm; tsc renders
+    // `{ kind: "square"; s: number; }`, not the alias `Shape`.
+    let diags = check_source_diagnostics(
+        r#"
+type Shape = { kind: "circle"; r: number } | { kind: "square"; s: number };
+function f(sh: Shape) {
+  if (sh.kind === "circle") return;
+  const bad: number = sh;
+}
+"#,
+    );
+    let msg = source_not_assignable_message(&diags);
+    assert!(
+        msg.contains(r#"{ kind: "square"; s: number; }"#),
+        "narrowed source must render the structural member with its literal \
+         discriminant preserved; got: {msg}"
+    );
+    assert!(
+        !msg.contains("'Shape'"),
+        "narrowed source must not repaint to the declared alias name; got: {msg}"
+    );
+}
+
+#[test]
+fn discriminated_union_narrowed_to_sub_union_renders_structural_union_not_alias() {
+    // `u` narrows to the two-member residual `{ k: "b" } | { k: "c" }`; tsc
+    // renders that sub-union structurally, not the three-member alias `U`.
+    let diags = check_source_diagnostics(
+        r#"
+type U = { k: "a"; x: number } | { k: "b"; y: number } | { k: "c"; z: number };
+function f(u: U) {
+  if (u.k === "a") return;
+  const bad: number = u;
+}
+"#,
+    );
+    let msg = source_not_assignable_message(&diags);
+    assert!(
+        msg.contains(r#"{ k: "b"; y: number; } | { k: "c"; z: number; }"#),
+        "narrowed source must render the residual sub-union structurally; got: {msg}"
+    );
+    assert!(
+        !msg.contains("'U'"),
+        "narrowed sub-union source must not repaint to the declared alias name; got: {msg}"
+    );
+}
+
+#[test]
+fn object_union_narrowed_via_in_operator_renders_structural_member() {
+    // `in`-operator narrowing of a named object union to a single member.
+    let diags = check_source_diagnostics(
+        r#"
+type Payload = { a: number } | { b: string };
+function f(p: Payload) {
+  if ("a" in p) return;
+  const bad: { a: number } = p;
+}
+"#,
+    );
+    let msg = source_not_assignable_message(&diags);
+    assert!(
+        msg.contains("{ b: string; }"),
+        "narrowed-via-`in` source must render the surviving member structurally; got: {msg}"
+    );
+    assert!(
+        !msg.contains("'Payload'"),
+        "narrowed source must not repaint to the declared alias name; got: {msg}"
+    );
+}
+
+#[test]
+fn exhaustiveness_never_assignment_renders_narrowed_member_not_alias() {
+    // The classic exhaustiveness pattern: the unhandled member is assigned to
+    // `never`. tsc shows the unhandled member, not the full alias.
+    let diags = check_source_diagnostics(
+        r#"
+type Shape = { kind: "circle"; r: number } | { kind: "square"; s: number };
+function area(sh: Shape): number {
+  switch (sh.kind) {
+    case "circle": return sh.r;
+    default: {
+      const _exhaustive: never = sh;
+      return _exhaustive;
+    }
+  }
+}
+"#,
+    );
+    let msg = source_not_assignable_message(&diags);
+    assert!(
+        msg.contains(r#"{ kind: "square"; s: number; }"#),
+        "unhandled member assigned to never must render structurally; got: {msg}"
+    );
+    assert!(
+        !msg.contains("'Shape'"),
+        "unhandled member must not repaint to the declared alias name; got: {msg}"
+    );
+}
+
+#[test]
+fn not_narrowed_union_alias_keeps_its_name() {
+    // Control: with no narrowing, the full union is still the alias `U`, and
+    // tsc keeps the alias name. The fix must not strip the alias here.
+    let diags = check_source_diagnostics(
+        r#"
+type U = { a: number } | { b: string };
+function f(u: U) {
+  const bad: { a: number } = u;
+}
+"#,
+    );
+    let msg = source_not_assignable_message(&diags);
+    assert!(
+        msg.contains("'U'"),
+        "an un-narrowed union alias source must keep its declared name; got: {msg}"
+    );
+}
+
+#[test]
+fn narrowing_display_rule_is_structural_not_name_keyed() {
+    // Renamed-binder variant: a different alias name (`Figure`), a different
+    // discriminant property (`tag`), and different member spellings. The fix
+    // reads the narrowed shape, so the structural member is rendered exactly as
+    // for `Shape` above — proving the rule is not keyed on any identifier text.
+    let diags = check_source_diagnostics(
+        r#"
+type Figure = { tag: "dot"; px: number } | { tag: "line"; len: number };
+function g(fig: Figure) {
+  if (fig.tag === "dot") return;
+  const bad: number = fig;
+}
+"#,
+    );
+    let msg = source_not_assignable_message(&diags);
+    assert!(
+        msg.contains(r#"{ tag: "line"; len: number; }"#),
+        "renamed-binder narrowed source must render structurally; got: {msg}"
+    );
+    assert!(
+        !msg.contains("'Figure'"),
+        "renamed-binder narrowed source must not repaint to the alias name; got: {msg}"
+    );
+}
+
+#[test]
+fn typeof_narrowed_primitive_union_source_unchanged() {
+    // Control: typeof narrowing of a primitive union already rendered the
+    // narrowed member structurally; the new guard must not perturb it.
+    let diags = check_source_diagnostics(
+        r#"
+function f(x: string | number) {
+  if (typeof x === "string") {
+    const bad: number = x;
+  }
+}
+"#,
+    );
+    let msg = source_not_assignable_message(&diags);
+    assert!(
+        msg.contains("Type 'string' is not assignable to type 'number'"),
+        "typeof-narrowed primitive source display must be unchanged; got: {msg}"
+    );
+}


### PR DESCRIPTION
Fixes #14622.

## Problem

When a source identifier whose declared type is a **named union alias** is flow-narrowed to a strict subset — a discriminated-union parameter narrowed to one member, or a union narrowed to a sub-union — `tsc` drops the `aliasSymbol` on `filterType`/`getNarrowedType` and renders the narrowed **structural** type. tsz instead repainted the narrowed source with the declared alias name (`Shape`, `U`) in `TS2322`/`TS2741` assignability diagnostics, and on the structural fallback even widened the narrowed literal discriminant (`"square"` → `string`). The pass/fail relation already used the narrowed type; only the **displayed** source type diverged.

Repro (`tsz --noEmit --strict`):

```ts
type Shape = { kind: "circle"; r: number } | { kind: "square"; s: number };
function f(sh: Shape) {
  if (sh.kind === "circle") return;   // sh narrows to the "square" member
  const bad: number = sh;
}
```

| source type in TS2322 | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| narrow to one member | `{ kind: "square"; s: number; }` | `Shape` ❌ | `{ kind: "square"; s: number; }` ✅ |
| narrow to sub-union | `{ k: "b"; … } \| { k: "c"; … }` | `U` ❌ | `{ k: "b"; … } \| { k: "c"; … }` ✅ |

## Structural rule

When a source identifier's flow-narrowed checked type is a **proper subset of its declared *union* type**, the assignability diagnostic displays the narrowed structural type, never the declared union alias name. `tsc` does X; tsz now does X. A non-narrowed union alias keeps its name (control), and non-union alias sources (e.g. a static-schema `Input[]`) keep their established display path.

## Owner layer

Checker diagnostic **source-type display** only — no relation/semantic change. Two sibling display paths gain the same narrowing guard, mirroring the pre-existing `unknown`/`any` top-type guards:

- `format_assignment_source_type_for_diagnostic` (`error_reporter/core/diagnostic_source/assignment_formatting.rs`) — the source display; an early guard renders the narrowed type un-widened, before the declared-annotation recovery and literal-widening fallbacks.
- `declared_generic_alias_assignment_pair_display` (`error_reporter/assignability_alias_display.rs`) — the `TS2322`/`TS2741` alias repaint used by `render_type_mismatch` and the union-source-mismatch outer line.

Both share two new helpers in `error_reporter/core/diagnostic_source.rs`: `declared_type_of_variable_identifier_source` and `source_flow_type_strictly_narrows_declared` (restricted to a declared **union**, since `filterType` is what drops the `aliasSymbol`, so non-union alias sources are untouched).

## Adjacent matrix (verified against the built binary)

- Discriminated union narrowed to one member; to a residual sub-union; via `in`, discriminant `===`, and the exhaustiveness `never` assignment → narrowed structural display.
- Renamed-binder variant (different alias name, discriminant property, member spelling) → identical structural display, proving the rule is not name-keyed (anti-hardcoding gate).
- Control: a **non-narrowed** union alias keeps its declared name (`U`).
- Control: `typeof`/truthiness/literal-union narrowing source display unchanged.
- Control: static-schema array alias (`Input[]`, a non-union alias) keeps its established structural-expansion path.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New regression suite `crates/tsz-checker/src/tests/narrowed_union_source_display_tests.rs` (7 tests): single-member, sub-union, `in`-narrowing, `never` exhaustiveness, not-narrowed control, renamed-binder invariance, and `typeof` control — all pass.
- The 135-test adjacent display/alias/narrowing suite (`source_display`/`assignability_alias`/`declared_identifier`) shows zero new failures vs. the clean base (the 2 pre-existing `static_schema_*` failures fail identically with and without this change and are unrelated/environment-dependent).
- `cargo clippy -p tsz-checker --lib` clean on the touched files.
- Ready-review CI owns the full conformance / JS-emit / DTS / fourslash parity floors; this change is diagnostic-display only and touches no emit printer or relation logic.