### PR TITLE
perf(solver): persist definitive conditional-branch verdicts across evaluators (#8356)

### DIFF
--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -947,6 +947,8 @@ impl PerfCounters {
             && counters.lost_memo_recomputes_other == 0
             && counters.dropped_memo_entries == 0
             && counters.dropped_aux_entries == 0
+            && counters.conditional_verdict_persist_hits == 0
+            && counters.conditional_verdict_persist_inserts == 0
             && termination_total == 0
         {
             return String::new();
@@ -964,7 +966,9 @@ impl PerfCounters {
              authoritative recomputes  {:>12}\n  \
              other recomputes          {:>12}\n  \
              dropped memo entries      {:>12}\n  \
-             dropped aux entries       {:>12}\n",
+             dropped aux entries       {:>12}\n  \
+             cond verdict persist hits {:>12}\n  \
+             cond verdict persist ins  {:>12}\n",
             counters.constructions,
             counters.local_memo_hits,
             counters.compute_nodes,
@@ -977,6 +981,8 @@ impl PerfCounters {
             counters.lost_memo_recomputes_other,
             counters.dropped_memo_entries,
             counters.dropped_aux_entries,
+            counters.conditional_verdict_persist_hits,
+            counters.conditional_verdict_persist_inserts,
         );
         // #14346: which guard cut a walk short, and how often. The
         // firing-order signal — a nonzero bucket fingerprints which bound a

--- a/crates/tsz-common/src/perf_counters/recorders/solver.rs
+++ b/crates/tsz-common/src/perf_counters/recorders/solver.rs
@@ -327,6 +327,31 @@ pub fn record_eval_dropped_aux_entries(count: u64) {
         .fetch_add(count, Ordering::Relaxed);
 }
 
+/// Record a cross-evaluator conditional-branch verdict cache hit (issues
+/// #8356 / #13097): a `check <: extends` branch probe served from the
+/// project-wide cache instead of a fresh structural walk.
+#[inline]
+pub fn record_eval_conditional_verdict_persist_hit() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .eval_conditional_verdict_persist_hits
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record a definitive conditional-branch verdict published to the
+/// project-wide cache (it passed every limit/registration-window gate).
+#[inline]
+pub fn record_eval_conditional_verdict_persist_insert() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .eval_conditional_verdict_persist_inserts
+        .fetch_add(1, Ordering::Relaxed);
+}
+
 /// Record which guard cut a `TypeEvaluator::evaluate` walk short (#14346).
 ///
 /// The firing-order signal the issue flags: which bound a runaway recursive

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -253,6 +253,14 @@ pub struct PerfCounters {
     /// Auxiliary memo entries (conditional-subtype + contains-infer) dropped
     /// with their evaluator; these tables are never drained anywhere.
     pub eval_dropped_aux_entries: AtomicU64,
+    /// Cross-evaluator conditional-branch verdict cache hits (issues #8356 /
+    /// #13097): a definitive `check <: extends` branch probe served from the
+    /// project-wide cache instead of re-running the structural walk in a fresh
+    /// evaluator.
+    pub eval_conditional_verdict_persist_hits: AtomicU64,
+    /// Definitive conditional-branch verdicts published to the project-wide
+    /// cache (passed every limit/registration-window gate).
+    pub eval_conditional_verdict_persist_inserts: AtomicU64,
     /// Which guard cut a `TypeEvaluator::evaluate` walk short, bucketed by
     /// [`EvaluationTerminationGuard`] (#14346). The firing-order signal the
     /// issue flags: which bound a runaway recursive walk hits first. Always
@@ -500,6 +508,8 @@ impl PerfCounters {
             eval_lost_memo_recomputes_other: AtomicU64::new(0),
             eval_dropped_memo_entries: AtomicU64::new(0),
             eval_dropped_aux_entries: AtomicU64::new(0),
+            eval_conditional_verdict_persist_hits: AtomicU64::new(0),
+            eval_conditional_verdict_persist_inserts: AtomicU64::new(0),
             eval_termination_guard_fires: [const { AtomicU64::new(0) };
                 EVALUATION_TERMINATION_GUARD_COUNT],
             interner_intern_calls: AtomicU64::new(0),

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -584,6 +584,11 @@ pub struct EvaluatorMemoCounters {
     /// Auxiliary memo entries (conditional-subtype / contains-infer)
     /// discarded at evaluator drop; never drained anywhere.
     pub dropped_aux_entries: u64,
+    /// Cross-evaluator conditional-branch verdict cache hits (issues #8356 /
+    /// #13097): a branch probe served from the project-wide cache.
+    pub conditional_verdict_persist_hits: u64,
+    /// Definitive conditional-branch verdicts published to that cache.
+    pub conditional_verdict_persist_inserts: u64,
     /// Which guard cut an `evaluate` walk short, bucketed by
     /// [`EvaluationTerminationGuard`] (#14346). The firing-order signal: which
     /// bound a runaway recursive walk hits first. Always
@@ -859,6 +864,12 @@ impl PerfCounters {
                 lost_memo_recomputes_other: load(&c.eval_lost_memo_recomputes_other),
                 dropped_memo_entries: load(&c.eval_dropped_memo_entries),
                 dropped_aux_entries: load(&c.eval_dropped_aux_entries),
+                conditional_verdict_persist_hits: load(
+                    &c.eval_conditional_verdict_persist_hits,
+                ),
+                conditional_verdict_persist_inserts: load(
+                    &c.eval_conditional_verdict_persist_inserts,
+                ),
                 termination_guard_fires: (0..EVALUATION_TERMINATION_GUARD_COUNT)
                     .map(|i| NamedCount {
                         name: EVALUATION_TERMINATION_GUARD_NAMES[i],

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -522,6 +522,42 @@ pub trait TypeApplicationEvalCache {
         _result: TypeId,
     ) {
     }
+
+    /// Look up a cached *conditional-branch* subtype verdict — whether
+    /// `check <: extends` for the purpose of selecting a conditional type's
+    /// branch (issues #8356 / #13097).
+    ///
+    /// This is a distinct relation from plain subtyping: the conditional
+    /// branch probe applies tsc's conditional-only fast paths (the global
+    /// `Function` intrinsic satisfying a callable target; primitives never
+    /// extending `Function`), so its verdict must never be served from — or
+    /// stored into — the ordinary subtype relation cache. Only *definitive*
+    /// verdicts (`Holds`/`Fails`) that consumed no unregistered `Lazy` body,
+    /// took no depth bail, and tripped no recursion/iteration limit are
+    /// persisted, so a stored verdict is a stable function of
+    /// `(check, extends, no_unchecked_indexed_access)` reusable across the many
+    /// fresh `TypeEvaluator` instances instantiation spins up. Default returns
+    /// `None` so non-cache backends opt out.
+    fn lookup_conditional_branch_verdict(
+        &self,
+        _check: TypeId,
+        _extends: TypeId,
+        _no_unchecked_indexed_access: bool,
+    ) -> Option<bool> {
+        None
+    }
+
+    /// Store a definitive conditional-branch subtype verdict. Default is a
+    /// no-op. See [`Self::lookup_conditional_branch_verdict`] for the stability
+    /// gates the caller must enforce before publishing.
+    fn insert_conditional_branch_verdict(
+        &self,
+        _check: TypeId,
+        _extends: TypeId,
+        _no_unchecked_indexed_access: bool,
+        _verdict: bool,
+    ) {
+    }
 }
 
 /// Cache for the canonical `widen_type` result keyed by `TypeId`.

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -224,6 +224,12 @@ pub struct QueryCache<'a> {
     /// Substitution-independent evaluation cache (see the `closed_eval` module
     /// in `evaluate`). Keyed by `(TypeId, no_unchecked_indexed_access)`.
     closed_eval_cache: RefCell<FxHashMap<EvaluationCacheKey, TypeId>>,
+    /// Persistent conditional-branch subtype verdicts (issues #8356 / #13097).
+    /// Keyed by `(check, extends, no_unchecked_indexed_access)`; stores only
+    /// definitive, limit-free verdicts so it survives the per-evaluator
+    /// `conditional_subtype_cache` that is dropped on every evaluator
+    /// construction. Shares this cache's `clear()`/file lifecycle envelope.
+    conditional_branch_verdict_cache: RefCell<FxHashMap<(TypeId, TypeId, bool), bool>>,
     application_eval_cache: RefCell<FxHashMap<ApplicationEvalCacheKey, TypeId>>,
     application_eval_dependency_index: ApplicationEvalDependencyIndex,
     element_access_cache: RefCell<FxHashMap<ElementAccessTypeCacheKey, TypeId>>,
@@ -304,6 +310,7 @@ impl<'a> QueryCache<'a> {
             interner,
             eval_cache: RefCell::new(FxHashMap::default()),
             closed_eval_cache: RefCell::new(FxHashMap::default()),
+            conditional_branch_verdict_cache: RefCell::new(FxHashMap::default()),
             application_eval_cache: RefCell::new(FxHashMap::default()),
             application_eval_dependency_index: RefCell::new(FxHashMap::default()),
             element_access_cache: RefCell::new(FxHashMap::default()),
@@ -335,6 +342,7 @@ impl<'a> QueryCache<'a> {
     pub fn clear(&self) {
         self.eval_cache.borrow_mut().clear();
         self.closed_eval_cache.borrow_mut().clear();
+        self.conditional_branch_verdict_cache.borrow_mut().clear();
         self.element_access_cache.borrow_mut().clear();
         self.application_eval_cache.borrow_mut().clear();
         self.application_eval_dependency_index.borrow_mut().clear();
@@ -371,6 +379,10 @@ impl<'a> QueryCache<'a> {
         QueryCacheStatistics {
             eval_cache_entries: self.eval_cache.borrow().len(),
             closed_eval_cache_entries: self.closed_eval_cache.borrow().len(),
+            conditional_branch_verdict_cache_entries: self
+                .conditional_branch_verdict_cache
+                .borrow()
+                .len(),
             application_eval_cache_entries: self.application_eval_cache.borrow().len(),
             application_eval_cache_hits: self.application_eval_cache_stats.hits(),
             application_eval_cache_misses: self.application_eval_cache_stats.misses(),
@@ -978,6 +990,30 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
             ),
             result,
         );
+    }
+
+    fn lookup_conditional_branch_verdict(
+        &self,
+        check: TypeId,
+        extends: TypeId,
+        no_unchecked_indexed_access: bool,
+    ) -> Option<bool> {
+        self.conditional_branch_verdict_cache
+            .borrow()
+            .get(&(check, extends, no_unchecked_indexed_access))
+            .copied()
+    }
+
+    fn insert_conditional_branch_verdict(
+        &self,
+        check: TypeId,
+        extends: TypeId,
+        no_unchecked_indexed_access: bool,
+        verdict: bool,
+    ) {
+        self.conditional_branch_verdict_cache
+            .borrow_mut()
+            .insert((check, extends, no_unchecked_indexed_access), verdict);
     }
 }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -6,9 +6,9 @@
 
 use crate::caches::application_eval_index::{self, ApplicationEvalDependencyIndex};
 use crate::caches::db::{
-    QueryDatabase, TypeApplicationEvalCache, TypeCompilerOptions, TypeContainsByIdCache,
-    TypeDatabase, TypeDisplayProvenance, TypeExtractParamsCache, TypePredicateCache,
-    TypePruneUnionCache, TypeSubstitutionConstruction, TypeTupleLimitSignal, TypeWidenCache,
+    QueryDatabase, TypeCompilerOptions, TypeContainsByIdCache, TypeDatabase, TypeDisplayProvenance,
+    TypeExtractParamsCache, TypePredicateCache, TypePruneUnionCache, TypeSubstitutionConstruction,
+    TypeTupleLimitSignal, TypeWidenCache,
 };
 use crate::caches::instantiation_cache::{InstantiationCache, InstantiationCacheKey};
 use crate::caches::query_cache_statistics::{QueryCacheStatistics, RelationCacheStats};
@@ -866,154 +866,6 @@ impl TypeCompilerOptions for QueryCache<'_> {
 
     fn exact_optional_property_types(&self) -> bool {
         self.exact_optional_property_types.get()
-    }
-}
-
-impl TypeApplicationEvalCache for QueryCache<'_> {
-    // #14345: delegate the project-wide instantiation cache to the interner
-    // so query_db=Some passes share the same table the query_db=None callers read.
-    fn lookup_proto_instantiation_cache(
-        &self,
-        key: &crate::caches::instantiation_cache::InstantiationCacheKey,
-    ) -> Option<TypeId> {
-        self.interner.proto_instantiation_memo(key)
-    }
-
-    fn insert_proto_instantiation_cache(
-        &self,
-        key: crate::caches::instantiation_cache::InstantiationCacheKey,
-        result: TypeId,
-    ) {
-        self.interner.set_proto_instantiation_memo(key, result);
-    }
-
-    fn lookup_application_eval_cache(
-        &self,
-        def_id: DefId,
-        args: &[TypeId],
-        no_unchecked_indexed_access: bool,
-    ) -> Option<TypeId> {
-        self.check_application_eval_cache((
-            def_id,
-            smallvec::SmallVec::from_slice(args),
-            no_unchecked_indexed_access,
-            self.exact_optional_property_types(),
-        ))
-    }
-
-    fn insert_application_eval_cache(
-        &self,
-        def_id: DefId,
-        args: &[TypeId],
-        no_unchecked_indexed_access: bool,
-        result: TypeId,
-    ) {
-        QueryCache::insert_application_eval_cache(
-            self,
-            (
-                def_id,
-                smallvec::SmallVec::from_slice(args),
-                no_unchecked_indexed_access,
-                self.exact_optional_property_types(),
-            ),
-            result,
-        );
-    }
-
-    fn invalidate_application_eval_cache_for_def(&self, def_id: DefId) {
-        application_eval_index::invalidate_for_def(
-            &self.application_eval_dependency_index,
-            &self.application_eval_cache,
-            def_id,
-        );
-        if let Some(shared) = self.shared
-            && shared.shares_instantiation_family()
-        {
-            shared.invalidate_application_eval_cache_for_def(def_id);
-        }
-    }
-
-    /// Nested eval-memo read for plain evaluators (issue #13097).
-    /// Same layered lookup the top-level boundary uses.
-    fn lookup_eval_memo(
-        &self,
-        type_id: TypeId,
-        no_unchecked_indexed_access: bool,
-    ) -> Option<TypeId> {
-        self.lookup_eval_cache_layers(EvaluationCacheKey::new(
-            type_id,
-            no_unchecked_indexed_access,
-            self.exact_optional_property_types(),
-        ))
-    }
-
-    /// Write-through eval-memo store for plain evaluators (issue #13097).
-    /// First write wins, matching the top-level boundary drain.
-    fn insert_eval_memo(&self, type_id: TypeId, no_unchecked_indexed_access: bool, result: TypeId) {
-        let key = EvaluationCacheKey::new(
-            type_id,
-            no_unchecked_indexed_access,
-            self.exact_optional_property_types(),
-        );
-        self.eval_cache.borrow_mut().entry(key).or_insert(result);
-        if let Some(shared) = self.shared {
-            shared.eval_cache.entry(key).or_insert(result);
-        }
-    }
-
-    fn lookup_closed_eval_cache(
-        &self,
-        type_id: TypeId,
-        no_unchecked_indexed_access: bool,
-    ) -> Option<TypeId> {
-        self.closed_eval_cache
-            .borrow()
-            .get(&EvaluationCacheKey::new(
-                type_id,
-                no_unchecked_indexed_access,
-                self.exact_optional_property_types(),
-            ))
-            .copied()
-    }
-
-    fn insert_closed_eval_cache(
-        &self,
-        type_id: TypeId,
-        no_unchecked_indexed_access: bool,
-        result: TypeId,
-    ) {
-        self.closed_eval_cache.borrow_mut().insert(
-            EvaluationCacheKey::new(
-                type_id,
-                no_unchecked_indexed_access,
-                self.exact_optional_property_types(),
-            ),
-            result,
-        );
-    }
-
-    fn lookup_conditional_branch_verdict(
-        &self,
-        check: TypeId,
-        extends: TypeId,
-        no_unchecked_indexed_access: bool,
-    ) -> Option<bool> {
-        self.conditional_branch_verdict_cache
-            .borrow()
-            .get(&(check, extends, no_unchecked_indexed_access))
-            .copied()
-    }
-
-    fn insert_conditional_branch_verdict(
-        &self,
-        check: TypeId,
-        extends: TypeId,
-        no_unchecked_indexed_access: bool,
-        verdict: bool,
-    ) {
-        self.conditional_branch_verdict_cache
-            .borrow_mut()
-            .insert((check, extends, no_unchecked_indexed_access), verdict);
     }
 }
 
@@ -2013,6 +1865,9 @@ mod tests;
 
 #[path = "query_cache_collect_properties_memo.rs"]
 mod collect_properties_memo;
+
+#[path = "query_cache_application_eval.rs"]
+mod application_eval;
 
 #[path = "query_cache_size.rs"]
 mod size;

--- a/crates/tsz-solver/src/caches/query_cache_application_eval.rs
+++ b/crates/tsz-solver/src/caches/query_cache_application_eval.rs
@@ -1,0 +1,156 @@
+//! Application-evaluation cache trait implementation for [`QueryCache`].
+//!
+//! Split out of `query_cache.rs` to keep that shard under the file-size cap.
+//! This is a child module of `query_cache`, so it keeps access to the cache's
+//! private fields.
+
+use super::*;
+use crate::caches::db::TypeApplicationEvalCache;
+
+impl TypeApplicationEvalCache for QueryCache<'_> {
+    // #14345: delegate the project-wide instantiation cache to the interner
+    // so query_db=Some passes share the same table the query_db=None callers read.
+    fn lookup_proto_instantiation_cache(
+        &self,
+        key: &crate::caches::instantiation_cache::InstantiationCacheKey,
+    ) -> Option<TypeId> {
+        self.interner.proto_instantiation_memo(key)
+    }
+
+    fn insert_proto_instantiation_cache(
+        &self,
+        key: crate::caches::instantiation_cache::InstantiationCacheKey,
+        result: TypeId,
+    ) {
+        self.interner.set_proto_instantiation_memo(key, result);
+    }
+
+    fn lookup_application_eval_cache(
+        &self,
+        def_id: DefId,
+        args: &[TypeId],
+        no_unchecked_indexed_access: bool,
+    ) -> Option<TypeId> {
+        self.check_application_eval_cache((
+            def_id,
+            smallvec::SmallVec::from_slice(args),
+            no_unchecked_indexed_access,
+            self.exact_optional_property_types(),
+        ))
+    }
+
+    fn insert_application_eval_cache(
+        &self,
+        def_id: DefId,
+        args: &[TypeId],
+        no_unchecked_indexed_access: bool,
+        result: TypeId,
+    ) {
+        QueryCache::insert_application_eval_cache(
+            self,
+            (
+                def_id,
+                smallvec::SmallVec::from_slice(args),
+                no_unchecked_indexed_access,
+                self.exact_optional_property_types(),
+            ),
+            result,
+        );
+    }
+
+    fn invalidate_application_eval_cache_for_def(&self, def_id: DefId) {
+        application_eval_index::invalidate_for_def(
+            &self.application_eval_dependency_index,
+            &self.application_eval_cache,
+            def_id,
+        );
+        if let Some(shared) = self.shared
+            && shared.shares_instantiation_family()
+        {
+            shared.invalidate_application_eval_cache_for_def(def_id);
+        }
+    }
+
+    /// Nested eval-memo read for plain evaluators (issue #13097).
+    /// Same layered lookup the top-level boundary uses.
+    fn lookup_eval_memo(
+        &self,
+        type_id: TypeId,
+        no_unchecked_indexed_access: bool,
+    ) -> Option<TypeId> {
+        self.lookup_eval_cache_layers(EvaluationCacheKey::new(
+            type_id,
+            no_unchecked_indexed_access,
+            self.exact_optional_property_types(),
+        ))
+    }
+
+    /// Write-through eval-memo store for plain evaluators (issue #13097).
+    /// First write wins, matching the top-level boundary drain.
+    fn insert_eval_memo(&self, type_id: TypeId, no_unchecked_indexed_access: bool, result: TypeId) {
+        let key = EvaluationCacheKey::new(
+            type_id,
+            no_unchecked_indexed_access,
+            self.exact_optional_property_types(),
+        );
+        self.eval_cache.borrow_mut().entry(key).or_insert(result);
+        if let Some(shared) = self.shared {
+            shared.eval_cache.entry(key).or_insert(result);
+        }
+    }
+
+    fn lookup_closed_eval_cache(
+        &self,
+        type_id: TypeId,
+        no_unchecked_indexed_access: bool,
+    ) -> Option<TypeId> {
+        self.closed_eval_cache
+            .borrow()
+            .get(&EvaluationCacheKey::new(
+                type_id,
+                no_unchecked_indexed_access,
+                self.exact_optional_property_types(),
+            ))
+            .copied()
+    }
+
+    fn insert_closed_eval_cache(
+        &self,
+        type_id: TypeId,
+        no_unchecked_indexed_access: bool,
+        result: TypeId,
+    ) {
+        self.closed_eval_cache.borrow_mut().insert(
+            EvaluationCacheKey::new(
+                type_id,
+                no_unchecked_indexed_access,
+                self.exact_optional_property_types(),
+            ),
+            result,
+        );
+    }
+
+    fn lookup_conditional_branch_verdict(
+        &self,
+        check: TypeId,
+        extends: TypeId,
+        no_unchecked_indexed_access: bool,
+    ) -> Option<bool> {
+        self.conditional_branch_verdict_cache
+            .borrow()
+            .get(&(check, extends, no_unchecked_indexed_access))
+            .copied()
+    }
+
+    fn insert_conditional_branch_verdict(
+        &self,
+        check: TypeId,
+        extends: TypeId,
+        no_unchecked_indexed_access: bool,
+        verdict: bool,
+    ) {
+        self.conditional_branch_verdict_cache
+            .borrow_mut()
+            .insert((check, extends, no_unchecked_indexed_access), verdict);
+    }
+}

--- a/crates/tsz-solver/src/caches/query_cache_application_eval.rs
+++ b/crates/tsz-solver/src/caches/query_cache_application_eval.rs
@@ -4,8 +4,8 @@
 //! This is a child module of `query_cache`, so it keeps access to the cache's
 //! private fields.
 
-use super::*;
-use crate::caches::db::TypeApplicationEvalCache;
+use super::{DefId, EvaluationCacheKey, QueryCache, TypeId, application_eval_index};
+use crate::caches::db::{TypeApplicationEvalCache, TypeCompilerOptions};
 
 impl TypeApplicationEvalCache for QueryCache<'_> {
     // #14345: delegate the project-wide instantiation cache to the interner

--- a/crates/tsz-solver/src/caches/query_cache_size.rs
+++ b/crates/tsz-solver/src/caches/query_cache_size.rs
@@ -40,6 +40,15 @@ impl QueryCache<'_> {
                     + std::mem::size_of::<TypeId>());
         }
 
+        // conditional_branch_verdict_cache: (TypeId, TypeId, bool) -> bool
+        {
+            let map = self.conditional_branch_verdict_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<(TypeId, TypeId, bool)>()
+                    + std::mem::size_of::<bool>());
+        }
+
         // application_eval_cache: (DefId, SmallVec<[TypeId; 4]>, bool) -> TypeId
         {
             let map = self.application_eval_cache.borrow();

--- a/crates/tsz-solver/src/caches/query_cache_statistics.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics.rs
@@ -20,6 +20,8 @@ pub struct QueryCacheStatistics {
     pub eval_cache_entries: usize,
     /// Number of memoized substitution-independent evaluation results.
     pub closed_eval_cache_entries: usize,
+    /// Number of memoized conditional-branch subtype verdicts (#8356 / #13097).
+    pub conditional_branch_verdict_cache_entries: usize,
     /// Number of memoized application evaluation results.
     pub application_eval_cache_entries: usize,
     /// Number of times the application eval cache returned a hit.
@@ -75,6 +77,8 @@ impl QueryCacheStatistics {
     pub const fn merge(&mut self, other: &QueryCacheStatistics) {
         self.eval_cache_entries += other.eval_cache_entries;
         self.closed_eval_cache_entries += other.closed_eval_cache_entries;
+        self.conditional_branch_verdict_cache_entries +=
+            other.conditional_branch_verdict_cache_entries;
         self.application_eval_cache_entries += other.application_eval_cache_entries;
         self.application_eval_cache_hits += other.application_eval_cache_hits;
         self.application_eval_cache_misses += other.application_eval_cache_misses;
@@ -116,6 +120,9 @@ impl QueryCacheStatistics {
 
         let eval = self.eval_cache_entries * (BUCKET_OVERHEAD + 13);
         let closed_eval = self.closed_eval_cache_entries * (BUCKET_OVERHEAD + 13);
+        // (TypeId, TypeId, bool) key + bool value ≈ 10 bytes.
+        let conditional_verdict =
+            self.conditional_branch_verdict_cache_entries * (BUCKET_OVERHEAD + 10);
         let app_eval = self.application_eval_cache_entries * (BUCKET_OVERHEAD + 37);
         let elem = self.element_access_cache_entries * (BUCKET_OVERHEAD + 21);
         let spread = self.object_spread_cache_entries * (BUCKET_OVERHEAD + 4 + 24 + 256);
@@ -129,6 +136,7 @@ impl QueryCacheStatistics {
         let subtype_reduction = self.subtype_reduction_cache_entries * (BUCKET_OVERHEAD + 73);
 
         eval + closed_eval
+            + conditional_verdict
             + app_eval
             + elem
             + spread
@@ -151,6 +159,11 @@ impl std::fmt::Display for QueryCacheStatistics {
             f,
             "  closed_eval_cache:      {}",
             self.closed_eval_cache_entries
+        )?;
+        writeln!(
+            f,
+            "  cond_branch_verdict:    {}",
+            self.conditional_branch_verdict_cache_entries
         )?;
         writeln!(
             f,

--- a/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
@@ -69,6 +69,82 @@ fn closed_eval_cache_is_visible_in_statistics_and_size_estimate() {
 }
 
 #[test]
+fn conditional_branch_verdict_cache_round_trips_and_is_key_partitioned() {
+    // Structural rule (issues #8356 / #13097): the conditional-branch verdict
+    // cache is a per-`QueryCache` map keyed by
+    // `(check, extends, no_unchecked_indexed_access)`. It stores `bool`
+    // verdicts (a distinct relation from plain subtyping), is partitioned by
+    // the `no_unchecked_indexed_access` flag, and is cleared with the rest of
+    // the query cache. Raw-interner backends opt out (default `None`/no-op).
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let before = db.statistics();
+    assert_eq!(before.conditional_branch_verdict_cache_entries, 0);
+
+    // Miss on an empty cache.
+    assert_eq!(
+        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false),
+        None
+    );
+
+    // Round-trip a `true` verdict.
+    db.insert_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, true);
+    assert_eq!(
+        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false),
+        Some(true)
+    );
+
+    // The entry is visible in statistics / size accounting (residency tooling).
+    let after = db.statistics();
+    assert_eq!(after.conditional_branch_verdict_cache_entries, 1);
+    assert!(after.estimated_size_bytes() > before.estimated_size_bytes());
+    assert!(after.to_string().contains("cond_branch_verdict"));
+
+    // The `no_unchecked_indexed_access` flag partitions the key: the same
+    // type pair under the other flag value is a distinct, still-empty slot.
+    assert_eq!(
+        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, true),
+        None
+    );
+    // Operand order matters — `check`/`extends` are not symmetric.
+    assert_eq!(
+        db.lookup_conditional_branch_verdict(TypeId::NUMBER, TypeId::STRING, false),
+        None
+    );
+
+    // A `false` verdict round-trips distinctly from an absent entry.
+    db.insert_conditional_branch_verdict(TypeId::NUMBER, TypeId::STRING, false, false);
+    assert_eq!(
+        db.lookup_conditional_branch_verdict(TypeId::NUMBER, TypeId::STRING, false),
+        Some(false)
+    );
+
+    // Cleared with the rest of the query cache.
+    db.clear();
+    assert_eq!(db.statistics().conditional_branch_verdict_cache_entries, 0);
+    assert_eq!(
+        db.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false),
+        None
+    );
+    assert_eq!(
+        db.lookup_conditional_branch_verdict(TypeId::NUMBER, TypeId::STRING, false),
+        None
+    );
+}
+
+#[test]
+fn conditional_branch_verdict_cache_defaults_off_for_raw_interner() {
+    // The trait default is a no-op so raw `TypeInterner` backends and tests
+    // opt out: a lookup always misses and an insert is dropped.
+    let interner = TypeInterner::new();
+    interner.insert_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false, true);
+    assert_eq!(
+        interner.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::NUMBER, false),
+        None
+    );
+}
+
+#[test]
 fn application_eval_cache_is_per_file_isolated() {
     // Structural rule: `application_eval_cache` is intentionally NOT shared
     // cross-file. Parallel file checking can observe incomplete lib-merge state

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -528,7 +528,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     }
 
     /// Whether `type_id`'s memoized value is a limit-truncated artifact.
-    #[cfg(test)]
     pub(crate) fn is_tainted(&self, type_id: TypeId) -> bool {
         self.tainted.contains(&type_id)
     }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -47,6 +47,16 @@ pub(super) fn classify_branch_relation(relate: impl FnOnce() -> bool) -> BranchR
     }
 }
 
+/// Debug kill-switch for the cross-evaluator conditional-branch verdict cache
+/// (issues #8356 / #13097). Set `TSZ_DISABLE_CONDITIONAL_BRANCH_CACHE=1` to
+/// bypass both reads and writes; used only to bisect regressions, defaults to
+/// enabled. Mirrors `closed_eval`'s `TSZ_DISABLE_CLOSED_EVAL_CACHE` switch.
+pub(super) fn conditional_branch_verdict_cache_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("TSZ_DISABLE_CONDITIONAL_BRANCH_CACHE").is_err())
+}
+
 /// Resolved and pre-computed operands for one conditional evaluation step.
 pub(super) struct ConditionalOperands {
     pub(super) check_type: TypeId,
@@ -537,6 +547,32 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             };
         }
 
+        // Persistent cross-evaluator verdict (issues #8356 / #13097): the
+        // per-evaluator `conditional_subtype_cache` above is dropped on every
+        // one of the many `TypeEvaluator` instances instantiation spins up, so
+        // the same `(check, extends)` branch probe re-runs the full structural
+        // walk per evaluator. A definitive verdict published earlier (subject to
+        // the limit/registration-window gates at the write site below) is a
+        // stable answer, so serve it here and prime the local cache. Reading a
+        // stored definitive verdict is always at least as correct as a fresh
+        // probe — it can only replace this call's conservative depth-bail with
+        // the true answer, never the reverse.
+        if conditional_branch_verdict_cache_enabled()
+            && let Some(verdict) = self.interner().lookup_conditional_branch_verdict(
+                check_type,
+                extends_type,
+                self.no_unchecked_indexed_access(),
+            )
+        {
+            tsz_common::perf_counters::record_eval_conditional_verdict_persist_hit();
+            self.cache_conditional_subtype(check_type, extends_type, verdict);
+            return if verdict {
+                BranchRelation::Holds
+            } else {
+                BranchRelation::Fails
+            };
+        }
+
         // Depth guard: evaluating conditional types can trigger subtype checks
         // that evaluate MORE conditional types, creating an
         // Evaluator -> SubtypeChecker -> Evaluator -> ... chain where each
@@ -547,6 +583,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // every exit including a caught panic-unwind, keeping the relation
         // schedule-independent across batch-worker reuse (#13368).
         let (prev_depth, depth_guard) = ConditionalSubtypeDepthGuard::enter();
+        // A verdict produced by the depth bail or by a structural walk that
+        // itself tripped a recursion/iteration limit is a *budget-bounded*
+        // conservative answer, not a stable function of the type pair: it must
+        // never be published to the cross-evaluator cache (it would permanently
+        // shadow the full answer a deeper-budget run derives). Tracked here and
+        // consulted at the write site.
+        let mut verdict_is_budget_bounded = false;
         // Classify against the unresolved-`Lazy` sentinel: a `false` produced
         // only because the structural walk descended into an unregistered
         // `Lazy` body is reported as `Undetermined` rather than a definitive
@@ -558,6 +601,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // (takes the false/else branch of the conditional).
                 // This matches tsc's behavior of returning the deferred
                 // conditional when instantiation depth is exceeded.
+                verdict_is_budget_bounded = true;
                 false
             } else if Self::is_primitive_vs_function(self.interner(), check_type, extends_type) {
                 // Fast-path: primitive types (string, number, boolean, bigint,
@@ -588,7 +632,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 false
             } else {
                 let mut strict_checker = self.conditional_subtype_checker();
-                strict_checker.is_subtype_of(check_type, extends_type)
+                let verdict = strict_checker.is_subtype_of(check_type, extends_type);
+                // A walk that exhausted its own depth/iteration budget returned
+                // a conservative verdict; mark it un-publishable.
+                if strict_checker.depth_exceeded() || strict_checker.iteration_exceeded() {
+                    verdict_is_budget_bounded = true;
+                }
+                verdict
             }
         });
         // Restore the depth before the cache write to preserve the original
@@ -600,11 +650,35 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // resolved pass decides the conditional (issue #14238). Definitive
         // verdicts are cached as before.
         if relation != BranchRelation::Undetermined {
-            self.cache_conditional_subtype(
-                check_type,
-                extends_type,
-                relation == BranchRelation::Holds,
-            );
+            let verdict = relation == BranchRelation::Holds;
+            self.cache_conditional_subtype(check_type, extends_type, verdict);
+
+            // Publish to the cross-evaluator verdict cache only when the answer
+            // is a stable function of `(check, extends, no_unchecked)`:
+            //  - definitive (not `Undetermined`, already guaranteed here) — a
+            //    `false` that consumed an unregistered `Lazy` body never reaches
+            //    this arm, so no registration-window artifact is published;
+            //  - not budget-bounded — neither the depth bail nor a limit-tripped
+            //    structural walk produced it;
+            //  - the enclosing evaluation window saw no recursion limit and no
+            //    unresolved application body (`recursion_limit_hit` /
+            //    `unresolved_def_seen`), and neither operand is tainted — the
+            //    same whole-run gates `closed_eval` uses before persisting.
+            if conditional_branch_verdict_cache_enabled()
+                && !verdict_is_budget_bounded
+                && !self.recursion_limit_hit()
+                && !self.unresolved_def_seen()
+                && !self.is_tainted(check_type)
+                && !self.is_tainted(extends_type)
+            {
+                self.interner().insert_conditional_branch_verdict(
+                    check_type,
+                    extends_type,
+                    self.no_unchecked_indexed_access(),
+                    verdict,
+                );
+                tsz_common::perf_counters::record_eval_conditional_verdict_persist_insert();
+            }
         }
         relation
     }


### PR DESCRIPTION
Goal: fast

Targets the `ts-toolbelt-project` row (#8356): green but tsgo-winning, with the
named #13097 per-evaluator cache-discard family in the conditional recompute
headroom.

## Repeated operation

Conditional branch selection (`check <: extends`, deciding a conditional type's
true/false branch) runs through a freshly-constructed `SubtypeChecker` whose
verdict is memoized only in the **per-evaluator** `conditional_subtype_cache`.
That cache is dropped on every one of the many `TypeEvaluator` instances
instantiation / relation / inference spin up (≈2000 constructions on a small
fixture). For a **non-closed** conditional node (a free type parameter in a
branch, so `closed_eval` cannot cache the node) the same definitive
`(check, extends)` probe is therefore re-walked by every fresh evaluator.

## Structural rule

When the solver decides a conditional branch via the structural subtype probe,
`tsc` computes that relation once and reuses it; tsz re-walked it per evaluator
because the only memo was per-evaluator. This PR adds a project-wide
`conditional_branch_verdict_cache` on `QueryCache` (sibling to
`closed_eval_cache`), keyed by `(check, extends, no_unchecked_indexed_access)`,
so a definitive verdict survives evaluator construction.

The conditional-branch verdict is a **distinct relation** from plain subtyping —
it applies tsc's conditional-only fast paths (the global `Function` intrinsic
satisfying a callable target; primitives never extending `Function`) — so it
must never share slots with the ordinary subtype relation cache. Hence its own
map + trait pair rather than reusing `RelationCacheKey`/the subtype cache.

## Owner layer

- **Cache + key/invalidation**: `crates/tsz-solver/src/caches/query_cache.rs`
  (field, ctor, `clear()`), exposed via default-`None`/no-op `TypeApplicationEvalCache`
  trait methods in `caches/db.rs` (raw-interner backends opt out). Registered in
  the `QueryCache` size (`query_cache_size.rs`) and statistics
  (`query_cache_statistics.rs`) surfaces like its sibling.
- **Publish/serve gates**: `evaluation/evaluate_rules/conditional/phases.rs`
  (`conditional_subtype_relation`). The evaluator owns the publish-eligibility
  state, so the gate lives at the probe site, mirroring `closed_eval`.

## Cache key, invalidation, residency

- **Key**: `(check, extends, no_unchecked_indexed_access)`. The conditional
  checker fixes the other relation flags, and `exact_optional` is not consulted,
  so this is the full discriminant.
- **Publish gates** (a stored verdict is a stable function of the key):
  - definitive (`Holds`/`Fails`) — `classify_branch_relation` already routes a
    `false` that consumed an unregistered `Lazy` body to `Undetermined`, so no
    registration-window artifact reaches the write site;
  - not budget-bounded — neither the conditional depth bail nor a structural walk
    that tripped its own `depth_exceeded`/`iteration_exceeded` is published;
  - the same whole-run gates `closed_eval` uses: `!recursion_limit_hit()`,
    `!unresolved_def_seen()`, and neither operand `is_tainted`.
- **Reads** serve any evaluator: a stored definitive verdict can only replace a
  call's conservative depth-bail with the true answer, never the reverse.
- **Invalidation/residency**: per-file `QueryCache` lifetime (cleared in
  `clear()`); never drained cross-file; counted in size + statistics.
- **Kill-switch**: `TSZ_DISABLE_CONDITIONAL_BRANCH_CACHE=1` bypasses reads and
  writes (mirrors `TSZ_DISABLE_CLOSED_EVAL_CACHE`).

No fixture-name fast paths; the gate is purely structural.

## Adjacent matrix

- closed conditional (concrete probe) → `closed_eval` already caches the node, so
  the verdict cache inserts once and the node is never re-probed (no double work).
- non-closed conditional with a definitive concrete probe → verdict published once,
  served across evaluators (the win).
- `Undetermined` (unresolved-`Lazy`) / depth-bail / limit-tripped verdict →
  never published.
- `no_unchecked_indexed_access` true vs false → partitioned keys.
- operand order (`check`/`extends`) → asymmetric keys.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- **Behavior-neutral**: byte-identical diagnostics with the cache on vs the
  `TSZ_DISABLE_CONDITIONAL_BRANCH_CACHE=1` kill-switch across multiple synthetic
  conditional fixtures (incl. a 121-diagnostic case).
- **Cache exercised**: a hit-heavy repro (`P<T> = "a" extends string ? T : never`,
  param-in-branch so the node stays non-closed) shows **800 cross-evaluator probes
  served from the cache, 2 inserts, 0 diagnostic change** (`TSZ_PERF_COUNTERS`
  `cond verdict persist hits/ins`).
- `cargo nextest run -p tsz-solver` for `infer`/`instantiat`/`subtype`/`distribut`/`extends`/`narrow`/`exclude`/`relation`/`conditional`: 3437/3438 pass; the
  one failure (`test_conditional_infer_optional_property_present_distributive`)
  is pre-existing on `main` (confirmed by `git stash`).
- New unit tests: round-trip / key-partitioning / clear / statistics-visibility /
  raw-interner opt-out for the verdict cache (`query_cache_statistics_test.rs`).
- `cargo fmt --check`, `cargo clippy -p tsz-solver -p tsz-common`,
  `python3 scripts/arch/arch_guard.py`: clean.
- Reviewed via `/simplify` (reuse / simplification / efficiency / altitude):
  applied the altitude finding (registered the cache in the `QueryCache` size +
  statistics surfaces like `closed_eval_cache`); other angles already clean.
- Ready-review CI owns the full conformance / emit / fourslash parity floors.

https://claude.ai/code/session_01HrJ29eXK1kqKjzZ7CxhNv8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrJ29eXK1kqKjzZ7CxhNv8)_