### PR TITLE
fix(checker): substitute heritage type args of cross-file generic interface bases

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/type_params.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_params.rs
@@ -202,7 +202,7 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn extract_simple_type_params_from_decl_in_arena(
+    pub(crate) fn extract_simple_type_params_from_decl_in_arena(
         &self,
         arena: &tsz_parser::parser::node::NodeArena,
         flags: u32,
@@ -399,6 +399,17 @@ impl<'a> CheckerState<'a> {
                     || self.should_delegate_dynamic_type_alias_owner(sym_id, file_idx)
             }
         };
+        // NOTE: a *local* import alias (`import { Generic } from './m'`) is not
+        // followed to its target's params here — only a cross-file overlay alias
+        // is. This is asymmetric with `get_type_of_symbol`, which does follow the
+        // alias to the target body. Threading re-export-chain resolution into this
+        // hot getter is not a safe refactor in isolation: the symbol-path fallback
+        // below (the `!checked_local` block) deliberately keeps the
+        // dynamic-overlay-first owner, because preferring the declaring index for a
+        // re-exported alias reads params from the wrong arena (regression in
+        // `cross_file_recursive_alias_intersection_tests`). The interface-heritage
+        // site compensates for this asymmetry directly via the re-export-chain
+        // recovery in `merge_interface_heritage_types_inner` (#13212).
         if use_dynamic_symbol_owner
             && let Some(symbol) = self.get_cross_file_symbol(sym_id)
             && symbol.has_any_flags(symbol_flags::ALIAS)

--- a/crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs
+++ b/crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs
@@ -212,15 +212,21 @@ fn wrong_type_argument_still_errors() {
     );
 }
 
-// --- documented follow-up: a member *inherited* from a re-exported generic
-// base (`interface Local extends ReExported<number>`) still drops the type
-// argument. That is the cross-file generic-interface *heritage* materialization
-// path (#13767 / #13803 family), distinct from the receiver-application path
-// fixed here. Pinned (ignored) so the remaining gap is tracked, not lost. ---
+// --- a member *inherited* via `extends` from a cross-file generic interface
+// must substitute the heritage type argument. The heritage base is named through
+// a cross-file import / re-export alias, whose own declaration (the import
+// specifier) carries no type-parameter list; the base body still embeds the
+// base's free type parameter, so with no params to bind the supplied arguments
+// the heritage `instantiate_type` was a silent no-op and the inherited member
+// stayed bound to the base's free `T` (false TS2322 on `c.value`). The merge now
+// recovers the base's expanded body and matching params atomically so the
+// substitution applies (#13767 / #13212 cross-file heritage residual).
+//
+// Binder names are varied across cases so no identifier is load-bearing.
 
 #[test]
-#[ignore = "inherited-via-heritage member of a re-exported generic base needs cross-file heritage materialization (#13767 / #13212)"]
 fn extends_reexported_generic_interface_inherited_member() {
+    // Type-only barrel re-export of the generic base.
     assert_clean(
         &[
             (
@@ -237,5 +243,137 @@ fn extends_reexported_generic_interface_inherited_member() {
             ),
         ],
         "./hmain.ts",
+    );
+}
+
+#[test]
+fn extends_direct_cross_file_generic_interface_inherited_member() {
+    // Direct cross-file import (no barrel hop), differently-named binders.
+    assert_clean(
+        &[
+            ("./holder.ts", "export interface Holder<P> { slot: P; }\n"),
+            (
+                "./consumer.ts",
+                "import type { Holder } from './holder';\ninterface Bag extends Holder<number> { label: string; }\ndeclare const b: Bag;\nconst n: number = b.slot;\n",
+            ),
+        ],
+        "./consumer.ts",
+    );
+}
+
+#[test]
+fn extends_value_reexport_generic_interface_inherited_member() {
+    // Value (`export { X } from`) barrel rather than type-only.
+    assert_clean(
+        &[
+            ("./store.ts", "export interface Store<E> { entry: E; }\n"),
+            ("./gateway.ts", "export { Store } from './store';\n"),
+            (
+                "./app.ts",
+                "import { Store } from './gateway';\ninterface Shelf extends Store<string> { id: number; }\ndeclare const s: Shelf;\nconst v: string = s.entry;\n",
+            ),
+        ],
+        "./app.ts",
+    );
+}
+
+#[test]
+fn extends_renamed_reexport_generic_interface_inherited_member() {
+    // Renamed re-export: the import-site name differs from the declaration name.
+    assert_clean(
+        &[
+            (
+                "./origin.ts",
+                "export interface Original<Q> { field: Q; }\n",
+            ),
+            (
+                "./mid.ts",
+                "export type { Original as Renamed } from './origin';\n",
+            ),
+            (
+                "./client.ts",
+                "import type { Renamed } from './mid';\ninterface Crate extends Renamed<number> { extra: string; }\ndeclare const c: Crate;\nconst n: number = c.field;\n",
+            ),
+        ],
+        "./client.ts",
+    );
+}
+
+#[test]
+fn extends_cross_file_generic_interface_two_type_args() {
+    // Two type parameters, both substituted through the heritage clause.
+    assert_clean(
+        &[
+            (
+                "./pair.ts",
+                "export interface Pair<A, B> { left: A; right: B; }\n",
+            ),
+            ("./barrel.ts", "export type { Pair } from './pair';\n"),
+            (
+                "./use.ts",
+                "import type { Pair } from './barrel';\ninterface Combo extends Pair<number, string> { tag: boolean; }\ndeclare const c: Combo;\nconst l: number = c.left;\nconst r: string = c.right;\n",
+            ),
+        ],
+        "./use.ts",
+    );
+}
+
+#[test]
+#[ignore = "deeper residual: the inherited member reaches through TWO chained \
+            cross-file generic interfaces (Crate extends Wrap<number>, \
+            Wrap<V> extends Box<V>); the second hop's type argument is not yet \
+            threaded through the chained heritage materialization (#13212)"]
+fn extends_cross_file_generic_interface_two_level_chain() {
+    // The inherited member reaches through *two* cross-file generic interfaces:
+    // `Crate extends Wrap<number>` (cross-file) and `Wrap<V> extends Box<V>`
+    // (also cross-file). The deepest member `item` must still resolve to number.
+    assert_clean(
+        &[
+            ("./box.ts", "export interface Box<U> { item: U; }\n"),
+            (
+                "./wrap.ts",
+                "import type { Box } from './box';\nexport interface Wrap<V> extends Box<V> { tag: string; }\n",
+            ),
+            (
+                "./top.ts",
+                "import type { Wrap } from './wrap';\ninterface Crate extends Wrap<number> { extra: boolean; }\ndeclare const c: Crate;\nconst n: number = c.item;\n",
+            ),
+        ],
+        "./top.ts",
+    );
+}
+
+#[test]
+fn extends_same_file_generic_interface_inherited_member_control() {
+    // Control: an all-local generic base was already correct; it must stay clean.
+    assert_clean(
+        &[(
+            "./local.ts",
+            "interface Container<T> { value: T; }\ninterface Crate extends Container<number> { extra: string; }\ndeclare const c: Crate;\nconst n: number = c.value;\n",
+        )],
+        "./local.ts",
+    );
+}
+
+#[test]
+fn extends_cross_file_generic_interface_wrong_arg_still_errors() {
+    // Negative control: a genuine type-argument mismatch on the inherited member
+    // must still report TS2322 (the substitution is applied, not skipped).
+    let diags = check(
+        &[
+            ("./carrier.ts", "export interface Carrier<T> { load: T; }\n"),
+            ("./hub.ts", "export type { Carrier } from './carrier';\n"),
+            (
+                "./bad.ts",
+                "import type { Carrier } from './hub';\ninterface Crate extends Carrier<string> { extra: number; }\ndeclare const c: Crate;\nconst n: number = c.load;\n",
+            ),
+        ],
+        "./bad.ts",
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|(code, _)| *code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "expected TS2322 for string-vs-number mismatch on inherited member, got: {diags:?}"
     );
 }

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -1024,8 +1024,80 @@ impl<'a> CheckerState<'a> {
                     // which returns the base class's own type parameters matching the
                     // `TypeId`s embedded in the (uninstantiated) instance type; use those
                     // so the substitution below applies the heritage arguments correctly.
-                    let base_type_params = base_class_params
+                    let base_is_class_base = base_class_params.is_some();
+                    let mut base_type_params = base_class_params
                         .unwrap_or_else(|| self.get_type_params_for_symbol(base_sym_id));
+
+                    // A generic base reached through a cross-file import / re-export
+                    // alias keeps `base_sym_id` on the *alias* symbol, whose own
+                    // declaration is the import specifier and so carries no
+                    // type-parameter list. `get_type_of_symbol` above still follows the
+                    // alias to the base's expanded body (whose members embed the base's
+                    // free type parameter), but `get_type_params_for_symbol` on the
+                    // alias returns nothing — so with heritage arguments supplied there
+                    // is no parameter to bind them to, the `instantiate_type`
+                    // substitution below is a silent no-op, and every inherited member
+                    // stays bound to the base's free `T` (false TS2322 on `c.value` for
+                    // `interface Crate extends Container<number>` imported from another
+                    // module — #13767 / #13212 cross-file heritage residual).
+                    //
+                    // Recover the base declaration's type-parameter list by reading it
+                    // directly from the declaring module's arena, resolved through the
+                    // full re-export chain (`reference_import_alias_export_target` ->
+                    // `resolve_reexport_chain_to_declaration`, which handles multi-hop
+                    // barrels and renames). Re-exported `SymbolId`s collide numerically
+                    // across binders (#14344), so identity-based re-resolution and arity
+                    // comparisons are unreliable here; the by-name substitution only
+                    // needs the parameter *names*, and those are interned to the same
+                    // `Atom`s already embedded as free type parameters in `base_type`.
+                    // Gated on the broken signature only — heritage arguments supplied,
+                    // no params resolved, and not the class path — so same-file and lib
+                    // generic bases (already param-matched) and genuinely non-generic
+                    // bases (recovered params stay empty) are left unchanged.
+                    if !base_is_class_base && base_type_params.is_empty() && !type_args.is_empty() {
+                        let chain_target = self
+                            .ctx
+                            .binder
+                            .get_symbol(base_sym_id)
+                            .filter(|alias_symbol| {
+                                self.reference_symbol_is_import_alias(alias_symbol)
+                            })
+                            .and_then(|alias_symbol| {
+                                self.reference_import_alias_export_target(
+                                    alias_symbol,
+                                    &base_symbol_name,
+                                )
+                            });
+                        if let Some((decl_sym, Some(owner_file_idx))) = chain_target
+                            && let Some((decl_flags, decl_decls, decl_name)) = self
+                                .ctx
+                                .get_binder_for_file(owner_file_idx)
+                                .and_then(|binder| binder.get_symbol(decl_sym))
+                                .map(|decl_symbol| {
+                                    (
+                                        decl_symbol.flags,
+                                        decl_symbol.declarations.clone(),
+                                        decl_symbol.escaped_name.clone(),
+                                    )
+                                })
+                        {
+                            let owner_arena = self.ctx.get_arena_for_file(owner_file_idx as u32);
+                            for decl_idx in decl_decls {
+                                if let Some(params) = self
+                                    .extract_simple_type_params_from_decl_in_arena(
+                                        owner_arena,
+                                        decl_flags,
+                                        decl_idx,
+                                        &decl_name,
+                                    )
+                                    && !params.is_empty()
+                                {
+                                    base_type_params = params;
+                                    break;
+                                }
+                            }
+                        }
+                    }
 
                     if type_args.len() < base_type_params.len() {
                         for (param_index, param) in


### PR DESCRIPTION
## Summary

A member **inherited via `extends`** from a generic interface that is imported
from another module (directly, or through a barrel `export { X } from` /
`export type { X } from` / renamed re-export) dropped its heritage type argument:
the inherited member stayed bound to the base's free type parameter, producing a
false **TS2322** (e.g. `const n: number = c.value` where `value: T`). `tsc` is
clean. This is the cross-file generic-interface **heritage** residual that the
`#[ignore]`d follow-up of #13767 / #13212 tracked (distinct from the
receiver-application path those PRs already fixed).

### Witness (tsc clean; tsz emitted TS2322 before this change)

```ts
// hbase.ts
export interface Container<T> { value: T; }
// hbarrel.ts
export type { Container } from './hbase';
// hmain.ts
import type { Container } from './hbarrel';
interface Crate extends Container<number> { extra: string; }
declare const c: Crate;
const n: number = c.value;   // tsz before: TS2322 'T' is not assignable to 'number'
```

## Root cause

In the heritage merge (`merge_interface_heritage_types_inner`), the base body and
its type parameters are fetched separately: `get_type_of_symbol(base_sym_id)`
**follows the import/re-export alias** to the base's expanded body (whose members
embed the base's free type parameter), but `get_type_params_for_symbol(base_sym_id)`
reads the params off the *alias* symbol — whose own declaration is the import
specifier and carries **no** type-parameter list. So `base_type_params` was empty,
the `TypeSubstitution::from_args` map was empty, and `instantiate_type` was a
silent no-op that left every inherited member bound to the base's free `T`.

The same-file and lib cases were already correct (their params resolve directly,
matching the body), which is why this only reproduced for a cross-file generic
base. Re-exported `SymbolId`s also collide numerically across binders (#14344), so
identity-based re-resolution / arity comparison bails on the chained-alias case.

## Structural rule

> When a generic interface base is reached through a cross-file import or
> re-export chain, `tsc` substitutes the heritage type arguments into the
> inherited members. tsz now recovers the base declaration's type-parameter list
> by reading it directly from the **declaring module's arena** — resolved through
> the full re-export chain — so the by-name substitution applies. The
> substitution keys on parameter **names**, which are interned to the same
> `Atom`s already embedded as free type parameters in the resolved base body.

## Owner layer / fix

Checker interface heritage materialization (solver-backed type construction):

- **`crates/tsz-checker/src/types/interface_type.rs`** —
  `merge_interface_heritage_types_inner`: when the base resolved to an expanded
  body but its param list came back empty while heritage arguments were supplied
  (and it is not the class-instance path), recover the base declaration's
  type-parameter names from its owner arena. The declaration is located through
  the full re-export chain via `reference_import_alias_export_target`
  (`-> resolve_reexport_chain_to_declaration`, which already handles multi-hop
  barrels and renames), and the names are read with the existing arena-direct,
  name-guarded `extract_simple_type_params_from_decl_in_arena` (so a colliding
  foreign node index cannot leak unrelated params — #13599 guard).
- **`crates/tsz-checker/src/state/type_environment/type_params.rs`** —
  `extract_simple_type_params_from_decl_in_arena` is now `pub(crate)` so the
  heritage path can reuse it (it stays name-guarded; the #13599 arch test that
  asserts the guard still matches the `fn` substring). A `NOTE` documents the
  `get_type_of_symbol` / `get_type_params_for_symbol` alias-following asymmetry
  and why a deeper consolidation is not a safe in-isolation refactor.

No hardcoded identifier/file-name predicates; the recovery is structural
(import-alias detection + re-export chain + arena type-parameter read) and binder
names are varied across the tests.

## Adjacent matrix (all clean; binder names varied)

- type-only barrel re-export of the generic base (primary witness)
- direct cross-file import (no barrel hop)
- value (`export { X } from`) barrel
- renamed re-export (`export type { Original as Renamed }`)
- two type parameters, both substituted
- same-file generic base — control (already correct, must stay clean)
- negative control: a genuine wrong type argument on the inherited member still
  errors (TS2322)

## Out of scope (deeper residual, pinned)

A member inherited through **two chained cross-file generic interfaces**
(`Crate extends Wrap<number>`, `Wrap<V> extends Box<V>`, both cross-file) still
drops the second hop's argument — the chained-heritage materialization threads one
hop, not two. Tracked as an `#[ignore]`d test with a note (#13212); strictly a
superset of the case fixed here, a further reduction in false positives once
closed.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- `cargo test -p tsz-checker --lib reexported_generic_interface_property_tests`:
  **15 passed, 2 ignored** (the previously-`#[ignore]`d
  `extends_reexported_generic_interface_inherited_member` now passes; added the
  adjacent + control cases above; the two-level chain and the pre-existing
  `member_access_through_renamed_nested_barrels` stay pinned).
- Adjacent lib suites green locally:
  `interface_extends_generic_override_variance_tests`,
  `cross_file_type_param_decl_identity_tests` (32 passed, 2 ignored together).
- `cargo fmt -p tsz-checker -- --check` clean; `cargo clippy -p tsz-checker --lib`
  clean.
- Broad conformance / emit / fourslash floors owned by ready-review CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QVnj7ZAvS9KyTGHnKBhZNv)_