### PR TITLE
fix(cli): treat removed-option notice (TS5102) as fatal for semantic diagnostics

### DIFF
--- a/crates/tsz-cli/src/driver/config_deprecation.rs
+++ b/crates/tsz-cli/src/driver/config_deprecation.rs
@@ -2,9 +2,8 @@
 
 use super::{
     CliArgs, CompilationResult, Diagnostic, FileInfo, FxHashSet, PhaseTimings,
-    ResolvedCompilerOptions, SourceEntry, collect_parse_only_no_check_diagnostics,
-    collect_source_reference_lib_diagnostics, is_grammar_error_for_deprecation_priority,
-    remove_deprecation_diagnostics,
+    ResolvedCompilerOptions, SourceEntry, apply_fatal_config_notice_priority,
+    collect_parse_only_no_check_diagnostics, collect_source_reference_lib_diagnostics,
 };
 use std::path::PathBuf;
 #[cfg(test)]
@@ -125,16 +124,7 @@ pub(super) fn maybe_compile_no_emit_deprecation(
         diagnostics.retain(|d| !input.binary_file_names_to_suppress.contains(&d.file));
     }
 
-    let has_grammar_errors = diagnostics
-        .iter()
-        .any(|d| is_grammar_error_for_deprecation_priority(d.code));
-
-    if has_grammar_errors {
-        remove_deprecation_diagnostics(&mut config_diagnostics);
-    } else {
-        diagnostics
-            .retain(|d| (d.code == 2318 && d.file.is_empty() && d.start == 0) || d.code == 2792);
-    }
+    apply_fatal_config_notice_priority(&mut diagnostics, &mut config_diagnostics);
 
     diagnostics.extend(config_diagnostics);
     diagnostics.extend(input.binary_file_diagnostics.iter().cloned());

--- a/crates/tsz-cli/src/driver/core_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/core_diagnostics.rs
@@ -54,8 +54,49 @@ pub(super) const fn is_grammar_error_for_deprecation_priority(code: u32) -> bool
         || matches!(code, 2458 | 2754)
 }
 
+/// Drops the fatal config notices a grammar error outranks: deprecation
+/// (TS5101/TS5107) and removed-option (TS5102). tsc reports only the grammar
+/// error in that case, so neither notice survives.
 pub(super) fn remove_deprecation_diagnostics(diagnostics: &mut Vec<Diagnostic>) {
-    diagnostics.retain(|d| !is_deprecation_diagnostic_code(d.code));
+    diagnostics.retain(|d| {
+        !is_deprecation_diagnostic_code(d.code) && !is_removed_option_diagnostic_code(d.code)
+    });
+}
+
+/// Applies tsc's precedence between a fatal config-level notice and the
+/// file-level diagnostics.
+///
+/// tsc surfaces a config deprecation (TS5101/TS5107) or a removed-option notice
+/// (TS5102) only when the program is otherwise free of grammar errors. When a
+/// grammar error is present it takes precedence and the config notice is
+/// dropped; tsc's `getOptionsDiagnostics`/`getGlobalDiagnostics` never reach the
+/// reporter once `getSyntacticDiagnostics` produces an error. Absent a grammar
+/// error the notice is fatal and file-level semantic diagnostics are suppressed,
+/// with only the global TS2318 ("Cannot find global type") and TS2792 ("Did you
+/// mean to set moduleResolution?") diagnostics preserved.
+///
+/// This unifies the deprecation (TS5101/TS5107) and removed-option (TS5102)
+/// handling: a removed-but-parsed option passed on the CLI follows the same
+/// "config notice is fatal for semantic diagnostics" rule that tsc applies, so a
+/// real type error in the source must not leak alongside the removal notice.
+pub(super) fn apply_fatal_config_notice_priority(
+    diagnostics: &mut Vec<Diagnostic>,
+    config_diagnostics: &mut Vec<Diagnostic>,
+) {
+    let has_grammar_errors = diagnostics
+        .iter()
+        .any(|d| is_grammar_error_for_deprecation_priority(d.code));
+
+    if has_grammar_errors {
+        // Grammar errors take precedence — drop both the deprecation and the
+        // removed-option notices (tsc reports only the grammar error).
+        remove_deprecation_diagnostics(config_diagnostics);
+    } else {
+        // The config notice is fatal — suppress file-level diagnostics,
+        // preserving only the global TS2318/TS2792 diagnostics tsc still emits.
+        diagnostics
+            .retain(|d| (d.code == 2318 && d.file.is_empty() && d.start == 0) || d.code == 2792);
+    }
 }
 
 pub(super) fn collect_parse_only_no_check_diagnostics(
@@ -250,6 +291,14 @@ pub(super) fn compile_inner(
     let has_deprecation_diagnostics = config_diagnostics
         .iter()
         .any(|d| is_deprecation_diagnostic_code(d.code));
+    // A removed-option notice (TS5102) sourced from the CLI reaches the full
+    // pipeline (config-sourced removals already returned early above). tsc treats
+    // it as fatal for semantic diagnostics exactly like a deprecation notice, so
+    // it must drive the same file-level suppression below.
+    let has_removed_option_diagnostic = config_diagnostics
+        .iter()
+        .any(|d| is_removed_option_diagnostic_code(d.code));
+    let has_fatal_config_notice = has_deprecation_diagnostics || has_removed_option_diagnostic;
 
     let mut resolved = match resolve_compiler_options(
         config
@@ -735,18 +784,8 @@ pub(super) fn compile_inner(
             diagnostics.retain(|d| !binary_file_names_to_suppress.contains(&d.file));
         }
 
-        if has_deprecation_diagnostics {
-            let has_grammar_errors = diagnostics
-                .iter()
-                .any(|d| is_grammar_error_for_deprecation_priority(d.code));
-
-            if has_grammar_errors {
-                remove_deprecation_diagnostics(&mut config_diagnostics);
-            } else {
-                diagnostics.retain(|d| {
-                    (d.code == 2318 && d.file.is_empty() && d.start == 0) || d.code == 2792
-                });
-            }
+        if has_fatal_config_notice {
+            apply_fatal_config_notice_priority(&mut diagnostics, &mut config_diagnostics);
         }
 
         diagnostics.extend(config_diagnostics);
@@ -830,18 +869,8 @@ pub(super) fn compile_inner(
             diagnostics.retain(|d| !binary_file_names_to_suppress.contains(&d.file));
         }
 
-        if has_deprecation_diagnostics {
-            let has_grammar_errors = diagnostics
-                .iter()
-                .any(|d| is_grammar_error_for_deprecation_priority(d.code));
-
-            if has_grammar_errors {
-                remove_deprecation_diagnostics(&mut config_diagnostics);
-            } else {
-                diagnostics.retain(|d| {
-                    (d.code == 2318 && d.file.is_empty() && d.start == 0) || d.code == 2792
-                });
-            }
+        if has_fatal_config_notice {
+            apply_fatal_config_notice_priority(&mut diagnostics, &mut config_diagnostics);
         }
 
         diagnostics.extend(config_diagnostics);
@@ -1008,26 +1037,11 @@ pub(super) fn compile_inner(
         diagnostics.retain(|d| !binary_file_names_to_suppress.contains(&d.file));
     }
 
-    // Handle TS5107/TS5101 deprecation diagnostics.
-    // tsc can return TS5107/TS5101 together with file diagnostics; in practice,
-    // grammar errors should suppress these deprecation diagnostics.
-    if has_deprecation_diagnostics {
-        let has_grammar_errors = diagnostics
-            .iter()
-            .any(|d| is_grammar_error_for_deprecation_priority(d.code));
-
-        if has_grammar_errors {
-            // Grammar errors take precedence - suppress TS5107/TS5101
-            remove_deprecation_diagnostics(&mut config_diagnostics);
-        } else {
-            // TS5107 takes priority (fatal) - suppress most file-level diagnostics.
-            // Preserve only global-level TS2318 ("Cannot find global type") and
-            // TS2792 ("Did you mean to set moduleResolution?"). tsc suppresses
-            // TS2882 (side-effect import) when TS5107 is present.
-            diagnostics.retain(|d| {
-                (d.code == 2318 && d.file.is_empty() && d.start == 0) || d.code == 2792
-            });
-        }
+    // A fatal config notice (deprecation TS5101/TS5107 or removed-option TS5102)
+    // takes priority over file-level semantic diagnostics, unless a grammar error
+    // outranks it. See `apply_fatal_config_notice_priority`.
+    if has_fatal_config_notice {
+        apply_fatal_config_notice_priority(&mut diagnostics, &mut config_diagnostics);
     }
 
     // JS-only-syntactic short-circuit for semantic diagnostics.

--- a/crates/tsz-cli/tests/driver_tests_parts/part_10.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_10.rs
@@ -1771,3 +1771,74 @@ q["asd"].b;
     );
 }
 
+
+// A removed-but-parsed option passed on the CLI (e.g. `--keyofStringsOnly`)
+// emits the removed-option notice TS5102. tsc treats that notice as fatal for
+// semantic diagnostics — `getOptionsDiagnostics` short-circuits the reporter
+// before `getSemanticDiagnostics` surfaces — so a real type error in the source
+// must NOT leak alongside the removal notice. Mirrors tsc 6.0.3:
+//   tsz --noEmit --keyofStringsOnly main.ts  =>  only TS5102
+#[test]
+fn cli_removed_option_suppresses_semantic_diagnostics() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+    // `main.ts` has a genuine TS2322 that tsc suppresses behind the TS5102 notice.
+    write_file(&base.join("main.ts"), "const n: number = \"s\";\n");
+
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--noEmit",
+        "--pretty",
+        "false",
+        "--keyofStringsOnly",
+        "main.ts",
+    ])
+    .expect("CLI args should parse");
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+
+    assert!(
+        codes.contains(&5102),
+        "expected the removed-option notice TS5102, got: {:#?}",
+        result.diagnostics
+    );
+    assert!(
+        !codes.contains(&2322),
+        "removed-option notice TS5102 must suppress the semantic TS2322, got: {:#?}",
+        result.diagnostics
+    );
+}
+
+// A grammar error outranks the removed-option notice: tsc reports only the
+// syntactic error and drops TS5102 (its `getSyntacticDiagnostics` precede the
+// options diagnostics). Mirrors tsc 6.0.3:
+//   tsz --noEmit --keyofStringsOnly bad.ts  =>  only the grammar error, no TS5102
+#[test]
+fn cli_removed_option_grammar_error_takes_precedence() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+    write_file(&base.join("bad.ts"), "const x = ;\n");
+
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--noEmit",
+        "--pretty",
+        "false",
+        "--keyofStringsOnly",
+        "bad.ts",
+    ])
+    .expect("CLI args should parse");
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+
+    assert!(
+        codes.contains(&1109),
+        "expected the grammar error TS1109, got: {:#?}",
+        result.diagnostics
+    );
+    assert!(
+        !codes.contains(&5102),
+        "grammar error must outrank and drop the removed-option notice TS5102, got: {:#?}",
+        result.diagnostics
+    );
+}


### PR DESCRIPTION
Goal: hold

## Summary

A removed-but-parsed compiler option passed on the CLI (e.g. `--keyofStringsOnly`) emits the removed-option notice **TS5102**. tsc treats that notice exactly like a deprecation notice (TS5101/TS5107): its `getOptionsDiagnostics`/`getGlobalDiagnostics` are gated behind `getSyntacticDiagnostics`, so file-level **semantic diagnostics are suppressed** (only the global TS2318/TS2792 survive) and a grammar error outranks the notice entirely. tsz already handled deprecation notices this way, but left the **CLI-sourced removed-option** path running full semantic checking — so a real type error leaked alongside TS5102.

### Witness (tsc 6.0.3)

```
const n: number = "s";   // main.ts
```

| invocation | tsc 6.0.3 | tsz before | tsz after |
| --- | --- | --- | --- |
| `--noEmit --keyofStringsOnly main.ts` | `[TS5102]` | `[TS5102, TS2322]` ❌ | `[TS5102]` ✅ |
| `--keyofStringsOnly main.ts` (emit) | `[TS5102]` + emits JS | `[TS5102, TS2322]` + JS ❌ | `[TS5102]` + JS ✅ |
| `--noEmit --keyofStringsOnly bad.ts` (grammar error) | `[TS1109]` | `[TS5102, TS1109]` ❌ | `[TS1109]` ✅ |
| `--noEmit --target es5 main.ts` (deprecated) | `[TS5107]` | `[TS5107]` | `[TS5107]` (unchanged) |
| config-sourced removed option | `[TS5102]` | `[TS5102]` | `[TS5102]` (unchanged, early fatal) |

## Structural rule

When a **fatal config notice** (deprecation TS5101/TS5107 **or** removed-option TS5102) is present and no grammar error outranks it, tsc reports only the config-level notice and suppresses file-level semantic diagnostics; a grammar error drops the notice and is reported alone. Emit still proceeds for removed-but-parsed flags, matching tsc. tsz now does the same — previously it applied this rule to deprecation notices only.

## Owner layer

CLI compile driver diagnostic-priority logic (`crates/tsz-cli/src/driver`). The change generalizes the existing deprecation handling rather than special-casing TS5102:

- `core_diagnostics.rs`: new shared `apply_fatal_config_notice_priority` helper replaces **three duplicated** suppression blocks in `compile_inner`, keyed on `has_fatal_config_notice` (`has_deprecation_diagnostics || has_removed_option_diagnostic`). `remove_deprecation_diagnostics` now drops both notice families on the grammar-wins branch.
- `config_deprecation.rs`: the `--noEmit` worker fast-path re-inlined the same precedence block (a 4th copy) — it now calls the shared helper too.

Config-sourced removed options are unchanged: they still hit the existing early fatal-config return (no emit), which is correct per tsc's hard-stop on config-level errors.

No hardcoded identifier/file-name predicates; the gate is purely structural (diagnostic codes via the existing `is_deprecation_diagnostic_code` / `is_removed_option_diagnostic_code` / `is_grammar_error_for_deprecation_priority` predicates). Net dedup: 4 copies of the precedence logic → 1 helper.

## Adjacent matrix

- removed option + semantic error (noEmit / emit) → only TS5102; emit still produced.
- removed option + grammar error → only the grammar error (TS5102 dropped).
- deprecated option (TS5107) + semantic error → unchanged (regression-guarded).
- config-sourced removed option → unchanged early fatal.
- normal compile (no notice) → all semantic diagnostics preserved.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- New regression tests in `crates/tsz-cli/tests/driver_tests_parts/part_10.rs`: `cli_removed_option_suppresses_semantic_diagnostics`, `cli_removed_option_grammar_error_takes_precedence` — both pass.
- `cargo test -p tsz-cli --lib` for `deprecation`/`ts5107`/`ts5102`/`grammar`/`config_deprecation`/`tests_diagnostics`/`removed_option`: **50 passed, 0 failed** (single-threaded; one unrelated timing-only assertion in `normal_no_emit_config_deprecation_stays_on_full_program_path` is a pre-existing flake under parallel load and passes in isolation).
- Worker fast-path tests (`config_deprecation_tests`) green after the consolidation.
- Binary matrix above verified against tsc 6.0.3.
- `cargo fmt -p tsz-cli --check` and `cargo clippy -p tsz-cli --lib` clean.
- Reviewed via `/simplify` (reuse / simplification / efficiency / altitude): applied the consolidation of the worker fast-path's duplicated block onto the shared helper; other angles already clean.
- Ready-review CI owns the broad conformance / emit / fourslash floors. This change touches only CLI-sourced option diagnostics (the conformance harness uses config-sourced options, which already hit the unchanged early-fatal path), so zero conformance delta is expected.

https://claude.ai/code/session_01UCDjMftvQfT2yDPrLi1NDV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCDjMftvQfT2yDPrLi1NDV)_