### PR TITLE
fix(checker): generalize literal source to base in TS2769 overload elaboration

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -1034,10 +1034,35 @@ impl<'a> CheckerState<'a> {
         tracing::debug!("File name: {}", self.ctx.file_name);
 
         for failure in failures {
-            let pending: PendingDiagnostic = PendingDiagnostic {
+            let mut pending: PendingDiagnostic = PendingDiagnostic {
                 span: Some(span.clone()),
                 ..failure.clone()
             };
+            // Mirror tsc's `reportRelationError` source generalization for each
+            // overload's argument failure, matching the single-signature TS2345
+            // path: a fresh literal source (`true`, `1`) is widened to its base
+            // (`boolean`, `number`) unless the parameter target could hold a
+            // top-level singleton type. The pre-built solver diagnostic carries
+            // the raw literal source, so without this the overload elaboration
+            // diverges from tsc (and from the single-overload TS2345 display).
+            if pending.code
+                == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+                && let (
+                    Some(tsz_solver::DiagnosticArg::Type(source)),
+                    Some(tsz_solver::DiagnosticArg::Type(target)),
+                ) = (pending.args.first(), pending.args.get(1))
+            {
+                let (source, target) = (*source, *target);
+                let display_source =
+                    crate::query_boundaries::diagnostics::generalized_literal_source_for_display(
+                        self.ctx.types,
+                        source,
+                        target,
+                    );
+                if display_source != source {
+                    pending.args[0] = tsz_solver::DiagnosticArg::Type(display_source);
+                }
+            }
             let diag = formatter.render(&pending);
             if let Some(diag_span) = diag.span.as_ref() {
                 related.push(DiagnosticRelatedInformation {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1267,6 +1267,9 @@ mod overload_anchor_at_argument_tests;
 #[path = "tests/overload_generic_wrapper_compat_tests.rs"]
 mod overload_generic_wrapper_compat_tests;
 #[cfg(test)]
+#[path = "tests/overload_literal_source_generalization_tests.rs"]
+mod overload_literal_source_generalization_tests;
+#[cfg(test)]
 #[path = "tests/overload_param_relation_routing_arch_tests.rs"]
 mod overload_param_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -626,6 +626,25 @@ pub(crate) fn widen_argument_type_for_display(db: &dyn TypeDatabase, type_id: Ty
     tsz_solver::operations::widening::widen_argument_type_for_display(db, type_id)
 }
 
+/// Generalize a fresh literal assignment/argument `source` to its base type for
+/// diagnostic display, mirroring tsc's `reportRelationError`: a literal source
+/// is widened to its base (`true` -> `boolean`, `1` -> `number`) when the
+/// `target` could not hold a top-level singleton type, and preserved otherwise
+/// (`true` vs `1`, `"a"` vs `"b"`). Non-literal sources are returned unchanged.
+pub(crate) fn generalized_literal_source_for_display(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    target: TypeId,
+) -> TypeId {
+    if tsz_solver::type_queries::is_literal_type(db, source)
+        && !tsz_solver::type_queries::type_could_have_top_level_singleton_types(db, target)
+    {
+        tsz_solver::operations::widening::widen_type(db, source)
+    } else {
+        source
+    }
+}
+
 /// Apparent type of an element-access receiver for the implicit-any index
 /// diagnostic (`TS7053`). `tsc` renders `typeToString(getApparentType(objectType))`,
 /// so the `object` intrinsic prints as its apparent type `{}` and a bare

--- a/crates/tsz-checker/src/tests/overload_literal_source_generalization_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_literal_source_generalization_tests.rs
@@ -1,0 +1,173 @@
+//! Regression tests for the source-type display of each overload's argument
+//! failure in a TS2769 ("No overload matches this call") elaboration.
+//!
+//! tsc's `reportRelationError` generalizes a fresh literal source to its base
+//! type unless the target could hold a top-level singleton type. This rule is
+//! already applied on the single-overload TS2345 path; before the fix the
+//! multi-overload TS2769 path rendered the raw literal source, so a boolean
+//! literal argument against a `number`/`string` parameter showed `'true'`
+//! instead of `'boolean'` (and `1` against `string` showed `'1'` instead of
+//! `'number'`), diverging from tsc and from the single-overload display.
+//!
+//! See `crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs`
+//! (`error_no_overload_matches_at`) and
+//! `tsz_solver::type_queries::type_could_have_top_level_singleton_types`.
+
+use crate::test_utils::check_source_diagnostics;
+
+/// Collect the related-information messages of the single TS2769 diagnostic.
+fn overload_failure_messages(source: &str) -> Vec<String> {
+    let diags = check_source_diagnostics(source);
+    let ts2769: Vec<_> = diags.iter().filter(|d| d.code == 2769).collect();
+    assert_eq!(
+        ts2769.len(),
+        1,
+        "Expected exactly one TS2769. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    ts2769[0]
+        .related_information
+        .iter()
+        .map(|r| r.message_text.clone())
+        .collect()
+}
+
+/// A boolean-literal argument against `number`/`string` overload parameters: the
+/// per-overload source is generalized to `boolean` (target is not a singleton),
+/// matching the single-overload TS2345 display and tsc.
+#[test]
+fn boolean_literal_argument_widens_to_boolean_against_primitive_overloads() {
+    let messages = overload_failure_messages(
+        r#"
+declare function f(x: number): void;
+declare function f(x: string): void;
+f(true);
+"#,
+    );
+
+    assert!(
+        messages
+            .iter()
+            .any(|m| m
+                == "Argument of type 'boolean' is not assignable to parameter of type 'number'."),
+        "expected widened 'boolean' source against the number overload, got: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m
+                == "Argument of type 'boolean' is not assignable to parameter of type 'string'."),
+        "expected widened 'boolean' source against the string overload, got: {messages:?}"
+    );
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.contains("Argument of type 'true'")),
+        "the raw boolean literal must not leak into the overload elaboration, got: {messages:?}"
+    );
+}
+
+/// A numeric-literal argument against `string`/`boolean` overload parameters:
+/// generalized to `number` (neither target is a singleton).
+#[test]
+fn numeric_literal_argument_widens_to_number_against_primitive_overloads() {
+    let messages = overload_failure_messages(
+        r#"
+declare function f(x: string): void;
+declare function f(x: boolean): void;
+f(1);
+"#,
+    );
+
+    assert!(
+        messages
+            .iter()
+            .any(|m| m
+                == "Argument of type 'number' is not assignable to parameter of type 'string'."),
+        "expected widened 'number' source against the string overload, got: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m
+                == "Argument of type 'number' is not assignable to parameter of type 'boolean'."),
+        "expected widened 'number' source against the boolean overload, got: {messages:?}"
+    );
+}
+
+/// Control: when every overload parameter is itself a literal/singleton type,
+/// the source literal is preserved (tsc keeps the literal-vs-literal mismatch
+/// legible). The fix must not over-widen these.
+#[test]
+fn literal_argument_preserved_against_literal_overload_targets() {
+    let messages = overload_failure_messages(
+        r#"
+declare function f(x: 1): void;
+declare function f(x: 2): void;
+f(true);
+"#,
+    );
+
+    assert!(
+        messages
+            .iter()
+            .any(|m| m == "Argument of type 'true' is not assignable to parameter of type '1'."),
+        "literal source must be preserved against a literal target, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("'boolean'")),
+        "must not widen the source against a singleton target, got: {messages:?}"
+    );
+}
+
+/// Control: a union target with at least one singleton member preserves the
+/// source literal (tsc's `typeCouldHaveTopLevelSingletonTypes` is any-member),
+/// even though the union also contains a non-singleton (`string`).
+#[test]
+fn literal_argument_preserved_against_union_with_singleton_member() {
+    let messages = overload_failure_messages(
+        r#"
+declare function f(x: 1 | string): void;
+declare function f(x: 2 | string): void;
+f(true);
+"#,
+    );
+
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Argument of type 'true'")),
+        "literal source must be preserved when the union target has a singleton member, got: {messages:?}"
+    );
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.contains("Argument of type 'boolean'")),
+        "must not widen against a union target that could hold a singleton, got: {messages:?}"
+    );
+}
+
+/// Anti-hardcoding: the rule is structural, not keyed to specific binder names
+/// or parameter spellings. A renamed callee/parameter produces the same
+/// generalized display.
+#[test]
+fn generalization_is_independent_of_binder_names() {
+    let messages = overload_failure_messages(
+        r#"
+declare function pick(value: number): void;
+declare function pick(value: string): void;
+pick(false);
+"#,
+    );
+
+    assert!(
+        messages
+            .iter()
+            .any(|m| m
+                == "Argument of type 'boolean' is not assignable to parameter of type 'number'."),
+        "expected widened 'boolean' regardless of binder names, got: {messages:?}"
+    );
+}

--- a/crates/tsz-solver/src/type_queries/flow.rs
+++ b/crates/tsz-solver/src/type_queries/flow.rs
@@ -725,7 +725,7 @@ pub fn type_could_have_top_level_singleton_types(db: &dyn TypeDatabase, type_id:
         return false;
     }
     match db.lookup(type_id) {
-        Some(TypeData::Union(list_id)) | Some(TypeData::Intersection(list_id)) => db
+        Some(TypeData::Union(list_id) | TypeData::Intersection(list_id)) => db
             .type_list(list_id)
             .iter()
             .any(|&member| type_could_have_top_level_singleton_types(db, member)),

--- a/crates/tsz-solver/src/type_queries/flow.rs
+++ b/crates/tsz-solver/src/type_queries/flow.rs
@@ -706,6 +706,34 @@ pub fn is_unit_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     }
 }
 
+/// Mirror of tsc's `typeCouldHaveTopLevelSingletonTypes`: whether `type_id`
+/// could contain a unit (singleton) type at the top level — a literal, enum
+/// member, unique symbol, `null`/`undefined`, a template-literal type, or a
+/// union/intersection with any such member.
+///
+/// The `boolean` base intrinsic is explicitly excluded: although it is the
+/// upper bound of the two boolean literals, tsc treats it as a non-singleton
+/// primitive here (`if (type.flags & TypeFlags.Boolean) return false`).
+///
+/// Used by assignability-diagnostic source display to decide whether to
+/// generalize a fresh literal source to its base type (tsc's
+/// `reportRelationError`): the source literal is preserved when the target could
+/// hold a singleton (a literal/union-of-literals target makes the literal vs
+/// literal mismatch meaningful) and widened to its base otherwise.
+pub fn type_could_have_top_level_singleton_types(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if type_id == TypeId::BOOLEAN {
+        return false;
+    }
+    match db.lookup(type_id) {
+        Some(TypeData::Union(list_id)) | Some(TypeData::Intersection(list_id)) => db
+            .type_list(list_id)
+            .iter()
+            .any(|&member| type_could_have_top_level_singleton_types(db, member)),
+        Some(TypeData::TemplateLiteral(_)) => true,
+        _ => is_unit_type(db, type_id),
+    }
+}
+
 /// Check if a union type contains a specific member type.
 pub fn union_contains(db: &dyn TypeDatabase, type_id: TypeId, target: TypeId) -> bool {
     if let Some(members) = get_union_members(db, type_id) {
@@ -998,6 +1026,66 @@ mod tests {
     use super::*;
     use crate::construction::TypeInterner;
     use crate::types::TupleElement;
+
+    #[test]
+    fn singleton_predicate_excludes_base_primitives() {
+        let interner = TypeInterner::new();
+        // Base primitives cannot hold a top-level singleton: source literals
+        // widen against them.
+        assert!(!type_could_have_top_level_singleton_types(
+            &interner,
+            TypeId::NUMBER
+        ));
+        assert!(!type_could_have_top_level_singleton_types(
+            &interner,
+            TypeId::STRING
+        ));
+        // `boolean` is two literals but is treated as a non-singleton primitive,
+        // mirroring tsc's explicit `TypeFlags.Boolean` carve-out.
+        assert!(!type_could_have_top_level_singleton_types(
+            &interner,
+            TypeId::BOOLEAN
+        ));
+    }
+
+    #[test]
+    fn singleton_predicate_includes_unit_types() {
+        let interner = TypeInterner::new();
+        assert!(type_could_have_top_level_singleton_types(
+            &interner,
+            TypeId::BOOLEAN_TRUE
+        ));
+        assert!(type_could_have_top_level_singleton_types(
+            &interner,
+            TypeId::NULL
+        ));
+        assert!(type_could_have_top_level_singleton_types(
+            &interner,
+            TypeId::UNDEFINED
+        ));
+        assert!(type_could_have_top_level_singleton_types(
+            &interner,
+            interner.literal_number(1.0)
+        ));
+    }
+
+    #[test]
+    fn singleton_predicate_unions_use_any_member() {
+        let interner = TypeInterner::new();
+        // No singleton member -> false (source widens).
+        let primitive_union = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+        assert!(!type_could_have_top_level_singleton_types(
+            &interner,
+            primitive_union
+        ));
+        // Any singleton member -> true (source preserved), even alongside a
+        // non-singleton member.
+        let mixed_union = interner.union(vec![interner.literal_number(1.0), TypeId::STRING]);
+        assert!(type_could_have_top_level_singleton_types(
+            &interner,
+            mixed_union
+        ));
+    }
 
     #[test]
     fn tuple_to_tuple_comparable_same_elements() {


### PR DESCRIPTION
Fixes #14629.

Goal: hold

## Problem

Each overload's argument failure in a **"No overload matches this call" (TS2769)** elaboration rendered the **raw literal source**, so a boolean/number-literal argument against a non-literal parameter showed the literal where `tsc` shows the widened base. The single-overload **TS2345** path (and the TS2322 assignment path) already generalize correctly; only the multi-overload elaboration diverged.

```ts
declare function f(x: number): void;
declare function f(x: string): void;
f(true);
```

| inner argument line | `tsc` | tsz before | tsz after |
| --- | --- | --- | --- |
| vs `number` param | `Argument of type 'boolean' …` | `… 'true' …` ❌ | `… 'boolean' …` ✅ |
| vs `string` param | `Argument of type 'boolean' …` | `… 'true' …` ❌ | `… 'boolean' …` ✅ |

The single-overload form already matched `tsc` (`g(true)` vs `g(x: number)` → `boolean`), so this only closes the elaboration asymmetry.

## Structural rule

When a fresh literal **source** is not assignable to a target that **could not** hold a top-level singleton type, `tsc` (`reportRelationError`) displays the source widened to its base (`true` → `boolean`, `1` → `number`); the literal is **preserved** against a literal / union-of-literals / `null`/`undefined` / template-literal target (`typeCouldHaveTopLevelSingletonTypes`). `tsc` does X; tsz now does X through the checker error-reporter overload-elaboration path. The relation outcome and the diagnostic code/count are unchanged — this is a source-type **display** fix.

## Owner layer

Checker diagnostic source-type display only — no relation/semantic change:

- **`tsz_solver::type_queries::type_could_have_top_level_singleton_types`** — new structural predicate mirroring `tsc`'s `typeCouldHaveTopLevelSingletonTypes`, including the explicit `boolean`-base carve-out and the any-member union/intersection rule (type semantics stay in the solver).
- **`query_boundaries::diagnostics::generalized_literal_source_for_display`** — composes the predicate with `widen_type` (display policy stays in the checker, consistent with where the TS2345 path applies it).
- **`error_no_overload_matches_at`** (`error_reporter/call_errors/error_emission.rs`) — applies the generalization per overload-argument failure before rendering each related-info line.

No hardcoded identifier/file-name predicates; the gate is structural (literal source + non-singleton target) and binder names are varied in the tests.

## Adjacent matrix (verified against the built binary + unit tests)

- boolean-literal arg vs `number`/`string` overloads → widened to `boolean`.
- numeric-literal arg vs `string`/`boolean` overloads → widened to `number`.
- Control: literal arg vs literal overload targets (`1`/`2`, `"b"`/`"c"`) → preserved.
- Control: literal arg vs a union target with a singleton member (`1 | string`) → preserved (any-member rule).
- Control: renamed binders → identical generalized display (anti-hardcoding).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- New regression suite `crates/tsz-checker/src/tests/overload_literal_source_generalization_tests.rs` (5 tests: boolean→`boolean`, numeric→`number`, literal-target control, union-with-singleton control, renamed-binder invariance) — all pass.
- New solver unit tests for `type_could_have_top_level_singleton_types` (base primitives incl. `boolean`, unit types, union any-member) — 3 pass.
- Existing overload suites green locally: `cargo test -p tsz-checker --lib overload` (226 passed), `jsx_multi_construct_overload_tests` (6), `constructor_overload_excess_property_tests`.
- `cargo fmt -p tsz-solver -p tsz-checker --check`, `cargo clippy -p tsz-solver -p tsz-checker --lib`, `python3 scripts/arch/arch_guard.py`: clean.
- Reviewed via `/simplify` (reuse / simplification / efficiency / altitude): no changes needed; the suggested "build-time" relocation was declined as it would push display policy into the solver and invert the solver→checker dependency.
- Display-only and code-neutral: the conformance gate compares diagnostic codes/counts, not chained message text, so the full conformance/emit/fourslash floors (owned by ready-review CI) are unaffected.
https://claude.ai/code/session_01GanxU1jbmVQwDeMpkoSSnx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GanxU1jbmVQwDeMpkoSSnx)_