### PR TITLE
fix(checker): exclude reverse-mapping numeric index from keyof of enum objects (#14631)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1133,6 +1133,9 @@ path = "tests/concrete_indexed_access_display_tests.rs"
 name = "enum_indexed_access_tests"
 path = "tests/enum_indexed_access_tests.rs"
 [[test]]
+name = "enum_keyof_excludes_number_tests"
+path = "tests/enum_keyof_excludes_number_tests.rs"
+[[test]]
 name = "enum_member_cache_tests"
 path = "tests/enum_member_cache_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -125,11 +125,17 @@ impl CheckerState<'_> {
 
         let properties = props;
         let is_const_enum = symbol.has_any_flags(symbol_flags::CONST_ENUM);
-        let flags = if is_const_enum {
-            tsz_solver::ObjectFlags::CONST_ENUM
-        } else {
-            tsz_solver::ObjectFlags::empty()
-        };
+        // Mark the shape as an enum namespace object (mirroring the merged
+        // enum/namespace path in `namespace_checker`). The flag is what lets
+        // `keyof` drop the implicit reverse-mapping `[index: number]: string`
+        // signature on a numeric/mixed enum: tsc's `keyof typeof E` is the union
+        // of the member names only (`"A" | "B" | ...`), never `number`, even
+        // though `E[someNumber]` reverse-mapping element access still resolves to
+        // `string`. Without the flag the numeric index leaked into `keyof`.
+        let mut flags = tsz_solver::ObjectFlags::ENUM_NAMESPACE;
+        if is_const_enum {
+            flags |= tsz_solver::ObjectFlags::CONST_ENUM;
+        }
         if matches!(
             self.enum_kind(sym_id),
             Some(EnumKind::Numeric) | Some(EnumKind::Mixed)

--- a/crates/tsz-checker/tests/enum_keyof_excludes_number_tests.rs
+++ b/crates/tsz-checker/tests/enum_keyof_excludes_number_tests.rs
@@ -1,0 +1,172 @@
+//! `keyof typeof E` for an enum with numeric members must not include `number`.
+//!
+//! Structural rule: a numeric (or mixed) enum object type carries an implicit
+//! reverse-mapping index signature `[index: number]: string` so that
+//! `E[someNumber]` element access resolves to `string`. tsc excludes that
+//! implicit numeric index from `keyof typeof E`, so the key space is the union
+//! of the member-name string literals only (`"A" | "B" | ...`), never `number`.
+//! A numeric key (`0`) is therefore not assignable to `keyof typeof E`.
+//!
+//! The enum object shape is marked `ObjectFlags::ENUM_NAMESPACE`, which the
+//! solver's `keyof` evaluation uses to drop the implicit numeric index — the
+//! same mechanism the merged enum/namespace path already relied on.
+//!
+//! Binder names (enum name, member names, key-alias variable) are varied across
+//! the cases so the rule is structural, not keyed on any identifier.
+
+use tsz_checker::test_utils::{check_source_code_messages, check_source_codes};
+
+fn ts2322_messages(source: &str) -> Vec<String> {
+    check_source_code_messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, msg)| msg)
+        .collect()
+}
+
+fn ts2322_count(source: &str) -> usize {
+    check_source_codes(source)
+        .into_iter()
+        .filter(|&c| c == 2322)
+        .count()
+}
+
+/// Assert that assigning a numeric key to `keyof typeof E` produces exactly one
+/// TS2322 whose target key union does not mention `number`, and return that
+/// message for any case-specific follow-up assertions.
+fn assert_numeric_key_rejected_without_number(source: &str) -> String {
+    let messages = ts2322_messages(source);
+    assert_eq!(
+        messages.len(),
+        1,
+        "expected exactly one TS2322 for the numeric key, got {messages:?}"
+    );
+    assert!(
+        !messages[0].contains("number"),
+        "keyof of an enum must not include `number`: {}",
+        messages[0]
+    );
+    messages.into_iter().next().unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Numeric enum: `number` is not a member key.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn numeric_enum_keyof_rejects_numeric_key() {
+    // Assigning a numeric literal to `keyof typeof E` must error: tsc excludes
+    // the implicit reverse-mapping numeric index from the key space.
+    let source = r#"
+        enum Color { Red = 1, Green, Blue }
+        const k: keyof typeof Color = 0;
+    "#;
+    let msg = assert_numeric_key_rejected_without_number(source);
+    for member in ["Red", "Green", "Blue"] {
+        assert!(
+            msg.contains(member),
+            "key union should list member `{member}`: {msg}"
+        );
+    }
+}
+
+#[test]
+fn numeric_enum_keyof_accepts_member_name() {
+    let source = r#"
+        enum Color { Red = 1, Green, Blue }
+        const k: keyof typeof Color = "Green";
+    "#;
+    assert_eq!(
+        ts2322_count(source),
+        0,
+        "a real member name is a valid key of `keyof typeof E`"
+    );
+}
+
+#[test]
+fn numeric_enum_keyof_rejects_unknown_name() {
+    let source = r#"
+        enum Color { Red = 1, Green, Blue }
+        const k: keyof typeof Color = "Purple";
+    "#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "a non-member name is not a key of `keyof typeof E`"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mixed enum (has at least one numeric member) — same exclusion applies.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mixed_enum_keyof_rejects_numeric_key() {
+    let source = r#"
+        enum Mix { First = 1, Second = "second", Third = 3 }
+        const k: keyof typeof Mix = 0;
+    "#;
+    assert_numeric_key_rejected_without_number(source);
+}
+
+// ---------------------------------------------------------------------------
+// `const enum` with numeric members — same exclusion applies.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn const_numeric_enum_keyof_rejects_numeric_key() {
+    let source = r#"
+        const enum Flag { On = 1, Off }
+        const k: keyof typeof Flag = 0;
+    "#;
+    assert_numeric_key_rejected_without_number(source);
+}
+
+// ---------------------------------------------------------------------------
+// String enum: control — never had a numeric index, still correct.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn string_enum_keyof_rejects_unknown_name_and_excludes_number() {
+    let source = r#"
+        enum Status { Active = "active", Done = "done" }
+        const k: keyof typeof Status = 0;
+    "#;
+    assert_numeric_key_rejected_without_number(source);
+}
+
+// ---------------------------------------------------------------------------
+// Reverse-mapping element access regression: excluding the numeric index from
+// `keyof` must NOT remove numeric element access. `E[number]` still yields
+// `string`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn numeric_enum_reverse_mapping_still_resolves_to_string() {
+    // `E[1]` and `E[numberVar]` must remain valid and produce `string`.
+    let source = r#"
+        enum Color { Red = 1, Green, Blue }
+        declare const i: number;
+        const a: string = Color[1];
+        const b: string = Color[i];
+    "#;
+    assert_eq!(
+        ts2322_count(source),
+        0,
+        "reverse-mapping element access must still resolve to `string`"
+    );
+}
+
+#[test]
+fn numeric_enum_reverse_mapping_is_not_number() {
+    // The reverse-mapping value is `string`, not `number`.
+    let source = r#"
+        enum Color { Red = 1, Green, Blue }
+        const bad: number = Color[1];
+    "#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "reverse-mapping result is `string` and is not assignable to `number`"
+    );
+}


### PR DESCRIPTION
Fixes #14631.

## Summary

For an enum with at least one **numeric** member, tsz computed `keyof typeof E` as `number | "<members>"` and even accepted a numeric literal as a key. `tsc` excludes `number`: the key space of an enum object type is the union of the member-name string literals only.

```ts
enum Color { Red = 1, Green, Blue }
const k: keyof typeof Color = 0;
// tsc:  error TS2322: Type '0' is not assignable to type '"Red" | "Green" | "Blue"'.
// tsz before: accepted (number leaked into the key set) ❌
```

This is a **semantic** divergence (a numeric key was wrongly accepted), not just display. Affects numeric, mixed (any numeric member), and const numeric enums; string-only enums were already correct.

## Structural rule

When an enum object type carries an implicit reverse-mapping index signature `[index: number]: string` (so `E[someNumber]` element access resolves to `string`), `tsc` excludes that implicit numeric index from `keyof typeof E` — the key space is the member-name literals only, even though `E[number]` element access still resolves to `string`. tsz now does the same.

## Owner layer

Checker enum object-type construction. `CheckerState::enum_object_type` (`crates/tsz-checker/src/state/type_environment/core.rs`) built the numeric/mixed enum object shape **without** the `ObjectFlags::ENUM_NAMESPACE` marker (it set only `CONST_ENUM` or `empty()`).

The solver's `keyof` evaluator already drops the implicit numeric index for enum-namespace shapes (`extend_keyof_with_index_signature_keys` / the `is_enum_namespace` gate in `crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs`), and the merged enum/namespace path (`namespace_checker.rs`) already sets the flag — but the direct `enum_object_type` constructor omitted it, so the exclusion never fired. The fix sets `ENUM_NAMESPACE` at that single construction site, **reusing the existing mechanism** rather than adding a new special case.

Anti-hardcoding: the gate is the structural `ENUM_NAMESPACE` flag; no identifier/file-name predicates. The new unit suite varies binder names (`Color`/`Status`/`Mix`/`Flag`, member names) across cases.

## Adjacent matrix (vs tsc 6.0.2)

| enum | `keyof typeof E` excludes `number` | `E[number]` reverse mapping still `string` |
| --- | --- | --- |
| numeric (`A = 1, B, C`) | ✅ | ✅ preserved |
| mixed (`A = 1, B = "b"`) | ✅ | ✅ |
| const numeric | ✅ | ✅ |
| string-only (control) | ✅ already | n/a |

## Out of scope

`{ [K in keyof typeof E]: K }` emits a spurious `"X" is not assignable to "X"` self-identity error — but that reproduces with a **plain object literal** `{ [K in keyof typeof O]: K }` (no enum at all), so it is the canonical-identity family (#14344), independent of this fix.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Differential testing of tsz dist-debug vs `tsc 6.0.2` across the full matrix above: all enum keyof cases now match; reverse-mapping element access (`E[1]`, `E[number]` -> `string`) unchanged.
- New unit suite `enum_keyof_excludes_number_tests` — 8 passing cases (numeric/mixed/const reject numeric key with no `number` in the rendered key union; member name accepted; unknown name rejected; reverse-mapping regression guards), binder names varied.
- Regression suites green locally: `enum_indexed_access_tests` (17), `enum_merge_tests` (10), `enum_nominality_tests` (40), `enum_equality_narrowing_tests` (13), `enum_recursion_tests` (112), `ts2450_const_enum_tests` (7), `const_enum_merge_ts2567_tests` (8), `ts2536_keyof_string_index_signature_tests` (28), `keyof_source_display_tests` (7), `ts2862_keyof_tparam_tests` (3).
- `cargo fmt -p tsz-checker -p tsz-solver -- --check` and `cargo clippy -p tsz-checker --lib` clean.
- Reviewed via `/simplify` (reuse / simplification / efficiency / altitude): altitude confirmed (no other enum-object construction site omits the flag); applied the test-helper dedup; skipped a single-caller flag-builder helper (over-abstraction) and a `namespace_checker` `CONST_ENUM` note (out-of-scope behavior change).
- Broad conformance / emit / fourslash floors owned by ready-review CI.

https://claude.ai/code/session_017a9GcdL1UfABA9GqbMJxZS

---
_Generated by [Claude Code](https://claude.ai/code/session_017a9GcdL1UfABA9GqbMJxZS)_