### PR TITLE
fix(parser): match tsc TS1434 recovery for object-method `=>` body

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
@@ -912,12 +912,27 @@ impl ParserState {
         } else if self.is_token(SyntaxKind::OpenBraceToken) {
             self.parse_block()
         } else if self.is_token(SyntaxKind::EqualsGreaterThanToken) {
-            // tsc prefers "'{' expected." on `=>` in object methods written like:
-            // `m(n) => T {}` (should be `m(n): T {}`), then TS1434 on the stray type token.
+            // An object-literal method written with `=>` where its body block `{`
+            // is expected. tsc reports `'{' expected.` at the `=>`, then recovers.
+            // It *additionally* reports TS1434 ("Unexpected keyword or
+            // identifier.") on the token after the `=>` only for the
+            // mistyped-return-annotation shape `m(a) => T {` (the user meant
+            // `m(a): T {}`): that is, when the token after `=>` is a lone
+            // identifier/keyword *immediately followed by a `{` block*. When `=>`
+            // instead introduces a concise arrow body — `m(a) => x`, `=> a + 1`,
+            // `=> f()`, `=> x.y` — tsc emits no TS1434 and lets the trailing
+            // tokens recover as a statement (TS1128). tsz previously reported
+            // TS1434 on *every* identifier body, over-diagnosing the concise-body
+            // case; gate it on the following `{` to match tsc's recovery exactly.
             use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
             self.parse_error_at_current_token("'{' expected.", diagnostic_codes::EXPECTED);
             self.next_token(); // consume =>
-            if self.is_identifier_or_keyword() {
+            if self.is_identifier_or_keyword()
+                && self.speculate(|parser| {
+                    parser.next_token();
+                    parser.is_token(SyntaxKind::OpenBraceToken)
+                })
+            {
                 self.parse_error_at_current_token(
                     diagnostic_messages::UNEXPECTED_KEYWORD_OR_IDENTIFIER,
                     diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER,

--- a/crates/tsz-parser/tests/parser_improvement_object_array_literal_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_object_array_literal_recovery_tests.rs
@@ -693,3 +693,46 @@ fn object_method_with_body_reports_no_missing_brace() {
         "a well-formed object method must not produce TS1005, got {diagnostics:?}"
     );
 }
+
+/// An object-literal method whose body block `{` is written with `=>` is
+/// recovered by tsc as `'{' expected.` (TS1005) at the `=>`. tsc *additionally*
+/// reports `Unexpected keyword or identifier.` (TS1434) on the token after the
+/// `=>` only for the mistyped-return-annotation shape `m(a) => T {` (the user
+/// meant `m(a): T {}`) — an identifier/keyword immediately followed by a `{`
+/// block. For a concise arrow body (`=> x`, `=> a + 1`, `=> f()`, `=> x.y`) tsc
+/// emits no TS1434 and lets the tail re-parse as a statement. tsz previously
+/// reported TS1434 on *every* identifier body; the recovery now gates it on the
+/// following `{` to match tsc. Identifier names are varied across cases so the
+/// rule cannot be keyed on any particular name (anti-hardcoding).
+#[test]
+fn object_method_arrow_body_reports_ts1434_only_for_mistyped_return_annotation() {
+    // (source, expects_ts1434)
+    let cases = [
+        ("const o = { m(a) => x };", false),
+        ("const o = { handler() => result };", false),
+        ("const p = { run(n) => n + 1 };", false),
+        ("const q = { build(x) => x.y };", false),
+        ("const r = { make(arg) => factory() };", false),
+        ("const o = { m(a) => T {} };", true),
+        ("const o = { build(x) => Result {} };", true),
+    ];
+    for (source, expects_ts1434) in cases {
+        let (parser, _root) = parse_source(source);
+        let diagnostics = parser.get_diagnostics();
+        let has_ts1434 = diagnostics
+            .iter()
+            .any(|diag| diag.code == diagnostic_codes::UNEXPECTED_KEYWORD_OR_IDENTIFIER);
+        assert_eq!(
+            has_ts1434, expects_ts1434,
+            "TS1434 presence mismatch for {source:?}, got {diagnostics:?}"
+        );
+        // The missing method body always still reports TS1005 `'{' expected.`.
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diag| diag.code == diagnostic_codes::EXPECTED
+                    && diag.message == "'{' expected."),
+            "the missing method body must still report TS1005 `'{{' expected.` for {source:?}, got {diagnostics:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

A malformed object-literal method whose body block `{` is written with `=>`
(`const o = { m(a) => x }`) was recovered by tsz with a **spurious TS1434**
("Unexpected keyword or identifier.") on the arrow-body token. `tsc` reports
only `'{' expected.` (TS1005) at the `=>` and lets the trailing tokens
re-parse as a statement (TS1128).

```ts
const o = { m(a) => x };
```

| diagnostics | `tsc` | tsz (before) | tsz (after) |
| --- | --- | --- | --- |
| at `=>` | `TS1005 '{' expected.` | `TS1005` | `TS1005` |
| at `x` | — | `TS1434` ❌ | — ✅ |
| at `}` | `TS1128` | `TS1128` | `TS1128` |

The TS1005 and TS1128 positions were already correct, so the divergence was
*exactly* the surplus TS1434.

## Structural rule

When an object-literal method is written with `=>` where its body block `{`
is expected, `tsc` reports `'{' expected.` at the `=>` and then emits
`Unexpected keyword or identifier.` (TS1434) on the following token **only**
for the mistyped-return-annotation shape `m(a) => T {` — an identifier/keyword
immediately followed by a `{` block, where the user meant `m(a): T {}`. For a
concise arrow body (`=> x`, `=> a + 1`, `=> f()`, `=> x.y`) `tsc` emits no
TS1434 and recovers the tail as a statement. tsz emitted TS1434 on *every*
identifier body; it now gates the emission on a one-token lookahead for a
following `{`, matching `tsc`'s recovery grammar exactly.

## Owner layer

Parser error-recovery only — `parse_object_method_after_name_with_optional`
(`crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs`),
the `EqualsGreaterThanToken` branch. No scanner/binder/checker change. The
lookahead reuses the same `self.speculate(|parser| { parser.next_token(); … })`
pattern the adjacent `separating_semicolon` recovery in the same function
already uses (consistent altitude, no new abstraction).

Anti-hardcoding: the gate is the structural follow-token (`{`); no
identifier/name predicates. The regression test varies the method and body
identifier names across cases.

## Adjacent matrix (all verified against `tsc` 6.0.3)

| body after `=>` | `tsc` TS1434 | tsz after |
| --- | --- | --- |
| `=> x` (ident, then `}`) | no | no ✅ |
| `=> a + 1` | no | no ✅ |
| `=> f()` / `=> new C()` | no | no ✅ |
| `=> x.y` | no | no ✅ |
| `=> 1` / `=> {}` (control) | no | no ✅ (unchanged) |
| `=> T {}` (mistyped return type) | **yes** | **yes** ✅ (preserved) |
| `=> x {}` (ident then `{`) | **yes** | **yes** ✅ (preserved) |

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Differential testing of tsz `dist`-debug vs `tsc 6.0.3` across the full
  adjacent matrix above: all cases now match (diagnostic codes **and**
  positions).
- New table-driven regression test
  `object_method_arrow_body_reports_ts1434_only_for_mistyped_return_annotation`
  (7 cases, identifier names varied). The pre-existing
  `object_method_arrow_return_token_prefers_brace_expected_then_ts1434` (the
  `=> T {` shape) still passes.
- Full parser suite green locally: `cargo test -p tsz-parser` — 1426 passed,
  0 failed.
- No conformance regression: ran the `tsz-conformance` runner over 1183
  historical compiler tests against the pinned `tsc-cache-full.json` before and
  after — identical results (0 failures; same 8 debug-only timeouts).
- `cargo fmt -p tsz-parser --check`, `cargo clippy -p tsz-parser --lib --tests`,
  and `python3 scripts/arch/arch_guard.py`: clean.
- Reviewed via `/simplify` (reuse / simplification / efficiency / altitude):
  production code confirmed at the right altitude and consistent with the
  neighboring `speculate` lookahead; applied the test-dedup (merged two
  near-identical tests into one table-driven test); declined the
  `look_ahead_is` micro-swap as it would break local consistency for a
  negligible error-path gain.
- Broad conformance / emit / fourslash floors owned by ready-review CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3np77pYBEzjBY2XhEpB7i)_