### PR TITLE
fix(checker): keep contextual type for wrapped-type-param generic call initializers

### DIFF
--- a/crates/tsz-checker/src/checkers/call_context.rs
+++ b/crates/tsz-checker/src/checkers/call_context.rs
@@ -552,8 +552,27 @@ impl<'a> CheckerState<'a> {
             common::type_param_info(self.ctx.types, param.type_id)
                 .is_some_and(|info| return_type_params.contains(&info.name))
         });
+        // A parameter that *wraps* a return type parameter (e.g. `v: T[]` for a
+        // `(...) => T[]` signature) also benefits from the contextual return type:
+        // the contextual array/wrapper specializes `T`, which then flows back to
+        // contextually type the argument so its element literals are preserved.
+        // `tsc` performs this downward inference; the `specializes && !stable`
+        // guard below keeps it confined to wrappers the contextual type actually
+        // specializes (arrays, awaited, readonly), so a non-specializing return
+        // such as `{ [P in keyof T]: ... }` still falls through to suppression.
+        let has_wrapped_return_param_argument = !has_bare_return_param_argument && {
+            let mut found = false;
+            for param in &shape.params {
+                let names = self.collect_type_param_names_for_context_overlap(param.type_id);
+                if names.iter().any(|name| return_type_params.contains(name)) {
+                    found = true;
+                    break;
+                }
+            }
+            found
+        };
         if !return_is_bare_type_param
-            && has_bare_return_param_argument
+            && (has_bare_return_param_argument || has_wrapped_return_param_argument)
             && let Some(contextual_type) = contextual_type
         {
             let specializes = self.contextual_return_type_specializes_wrapped_params(

--- a/crates/tsz-checker/src/tests/contextual_return_wrapper_tests.rs
+++ b/crates/tsz-checker/src/tests/contextual_return_wrapper_tests.rs
@@ -443,3 +443,65 @@ const b: Box<number> = new BoxImpl<string>("x");
         "Expected TS2322 — Box<string> is not assignable to Box<number>"
     );
 }
+
+/// A generic call whose return type *wraps* a type parameter (`(v: T[]) => T[]`)
+/// in an initializer position must receive the variable's declared type as a
+/// contextual type, so the array-literal argument's element literals are
+/// preserved by downward inference. Previously the contextual type was
+/// suppressed whenever a parameter overlapped a return type parameter — but that
+/// suppression should only apply when the contextual type does not specialize the
+/// wrapped return (`tsc` performs the downward inference here). Binder names are
+/// varied to prove the rule is structural, not name-keyed.
+#[test]
+fn wrapped_type_param_return_preserves_arg_literals_via_contextual_init() {
+    // `Elem[]` return, array-literal argument, declared union-of-literals element.
+    let diags = check_source_diagnostics(
+        r#"
+declare function collect<Elem>(items: Elem[]): Elem[];
+const picked: ("north" | "south")[] = collect(["north", "south"]);
+"#,
+    );
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        0,
+        "Expected no TS2322 — the declared element union should contextually \
+         type the array literal, got: {:?}",
+        diagnostic_messages(&ts2322)
+    );
+
+    // `readonly Elem[]` wrapper and an object-property literal, different binders.
+    let diags = check_source_diagnostics(
+        r#"
+declare function gather<Member>(rows: Member[]): readonly Member[];
+const out: readonly { kind: "a" | "b" }[] = gather([{ kind: "a" }, { kind: "b" }]);
+"#,
+    );
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        0,
+        "Expected no TS2322 — the declared property literal union should \
+         contextually type the object-literal elements, got: {:?}",
+        diagnostic_messages(&ts2322)
+    );
+}
+
+/// Negative control for the wrapped-return contextual rule: when the declared
+/// contextual type genuinely mismatches the inferred result, the assignment must
+/// still report `TS2322`. The relaxed suppression only changes which contextual
+/// type flows in, never whether a real mismatch is reported.
+#[test]
+fn wrapped_type_param_return_still_reports_genuine_mismatch() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function collect<Elem>(items: Elem[]): Elem[];
+const picked: number[] = collect(["north", "south"]);
+"#,
+    );
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        !ts2322.is_empty(),
+        "Expected TS2322 — string[] is not assignable to number[]"
+    );
+}


### PR DESCRIPTION
## Summary

A generic call whose **parameter wraps a return type parameter** (e.g.
`wrap<T>(v: T[]): T[]`) used as a variable initializer in a contextual position
emitted a false `TS2322`: the array-literal argument's element literals were
widened because the variable's declared type was **not** flowed in as a
contextual type.

```ts
declare function collect<T>(items: T[]): T[];
const picked: ("north" | "south")[] = collect(["north", "south"]);
// tsc 6.0.2: clean
// tsz (before): TS2322 Type 'string[]' is not assignable to type '("north" | "south")[]'.
```

`tsz` suppressed the contextual return type whenever a parameter overlapped a
return type parameter, to keep argument inference authoritative (#14262). That
suppression has an escape hatch — when the contextual type **specializes** the
wrapped return and no concrete argument already pins it, the contextual type is
kept so downward inference preserves literals — but the escape only fired when a
parameter was a **bare** `T`. For a parameter that *wraps* `T` (`T[]`,
`readonly T[]`, …) the escape never ran, so the contextual type was dropped and
the array literal widened.

## Structural rule

> When a generic call's parameter wraps a return type parameter and the
> contextual type **specializes** that wrapped return (array / `readonly` /
> awaited wrapper), `tsc` keeps the contextual type so the argument is typed by
> the downward-inferred element type; `tsz` now does the same through the
> checker's generic-return-context suppression gate. A non-specializing return
> (e.g. `{ [P in keyof T]: … }`) and a concrete argument that already pins the
> parameter still suppress the contextual type.

## Owner layer

Checker contextual-typing decision only — no relation/inference change:

- `CheckerState::suppress_generic_return_context_for_direct_arg_overlap`
  (`crates/tsz-checker/src/checkers/call_context.rs`) — the
  `has_bare_return_param_argument` gate on the existing `specializes && !stable`
  escape is extended with `has_wrapped_return_param_argument` (a parameter whose
  collected type-param names overlap the return type params). The escape's body
  is unchanged; the structural `contextual_return_type_specializes_wrapped_params`
  / `wrapped_return_context_has_stable_overlap_arg` guards keep mapped /
  non-specializing returns and concretely-pinned arguments suppressed. A cheap
  `type_param_info` bare check is kept first so the more expensive
  collect-overlap loop only runs when no bare parameter already matched.

Anti-hardcoding: the gate is purely structural (type-parameter overlap +
specialization), no identifier/file-name predicates. The new tests vary binder
names (`Elem`/`Member`/`collect`/`gather`, element/property names).

## Adjacent matrix (all differentially verified vs `tsc 6.0.2`)

| call | contextual | result |
| --- | --- | --- |
| `wrap<T>(v: T[]): T[]` + `["a","b"]` | `("a"\|"b")[]` | drop suppression → clean ✓ (was FP) |
| `wrap<T>(v: T[]): readonly T[]` | `readonly ("a"\|"b")[]` | clean ✓ |
| `wrap<T>(v: T[]): T[]` + `[{k:"a"},{k:"b"}]` | `{k:"a"\|"b"}[]` | clean ✓ |
| `wrap<T>(v: [T,T]): T[]` | `("a"\|"b")[]` | clean ✓ |
| `wrap<T>(v: T[]): { [P in keyof T]: T[P] }` | `("a"\|"b")[]` | **still errors** (mapped, non-specializing) — matches `tsc` |
| `wrap<T>(v: T[]): T[]` + `["a","b"]` | `number[]` | **still errors** — genuine mismatch preserved |
| `id<T>(x: T): T` / `box<T>(x: T): T[]` | bare-param control | unchanged ✓ |
| `reduce<T>(init: T, fn) as never` / `invoke<T>(f: () => T): T` | pin / callback control | unchanged ✓ |

## Out of scope (same contextual-inference family, separate mechanisms)

- `Promise.all([...])` in a typed initializer/return still false-positives — its
  return is a homomorphic **mapped** type (`{ [P in keyof T]: Awaited<T[P]> }`),
  which `contextual_return_type_specializes_wrapped_params` correctly does not
  treat as specializing, so it remains suppressed. That is the mapped-return /
  return-position slice tracked under #14141 (`inferFromGenericFunctionReturnTypes3`).

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Differential testing of `tsz` dist-debug vs `tsc 6.0.2` across the adjacent
  matrix above (wrapped `T[]` / `readonly T[]` / `[T,T]` returns preserve
  literals; mapped return + genuine mismatch + bare-param + callback + pin
  controls all match `tsc`).
- New regression tests in `contextual_return_wrapper_tests`
  (`wrapped_type_param_return_preserves_arg_literals_via_contextual_init`,
  `wrapped_type_param_return_still_reports_genuine_mismatch`), binder names
  varied.
- Existing suppression suites green locally: `contextual_return_wrapper` (lib,
  14), and the `generic_argument_suppression` / `generic_call_non_fresh_object` /
  `generic_callback_outer_context` / `generic_class_constructor_literal` /
  `object_shorthand_literal_preservation` / `issue_9762` set (56). Full
  `tsz-checker` lib suite shows no new failures vs the clean tree (the
  pre-existing failures are unit-harness-without-lib `Promise`/global-type cases,
  identical with and without this change).
- Broad conformance / emit / fourslash floors owned by ready-review CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_014WgExxvjMNp3nsJDrtXm7p)_