### PR TITLE
fix(checker): report TS2540 for readonly element-access write through a type-level index (#14636)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -704,6 +704,9 @@ path = "tests/ts2430_cross_file_generic_heritage_tests.rs"
 name = "ts2540_readonly_tests"
 path = "tests/ts2540_readonly_tests.rs"
 [[test]]
+name = "ts2540_readonly_typed_index_tests"
+path = "tests/ts2540_readonly_typed_index_tests.rs"
+[[test]]
 name = "mapped_readonly_tuple_tests"
 path = "tests/mapped_readonly_tuple_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/readonly.rs
+++ b/crates/tsz-checker/src/state/state_checking/readonly.rs
@@ -1383,6 +1383,67 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Collect every readonly *named-property* key targeted by an element-access
+    /// write `obj[index]`.
+    ///
+    /// The index type is evaluated first so a `keyof T` (or any other deferred
+    /// key set) resolves to its literal-key union; tsc classifies the resolved
+    /// index and reports **one TS2540 per readonly key** it targets (e.g.
+    /// `o[k] = …` with `k: "a" | "b"` and both readonly emits two TS2540s).
+    /// Index-signature matches and readonly tuple/named props reached *through*
+    /// an index signature are excluded here — the caller reports those as
+    /// TS2542. A generic `keyof T` (T a bare type parameter) stays deferred and
+    /// yields no keys, matching tsc which does not flag such writes.
+    fn readonly_named_element_access_keys(
+        &mut self,
+        object_type: TypeId,
+        index_expr: NodeIndex,
+        index_type: TypeId,
+    ) -> Vec<String> {
+        // Candidate property names. A literal index *expression* (`o["a"]`,
+        // `o[0]`) yields its key directly. Only when the expression is not a
+        // literal (a variable/expression such as `o[k]`) do we resolve the
+        // index *type* — evaluating it turns a type-level index like `keyof T`
+        // into the same `"a" | "b"` literal union a written-out index would
+        // have. Gating the evaluation on the non-literal case keeps the common
+        // `o[i] = …` write off the type-evaluation path.
+        let mut candidates: Vec<String> = Vec::new();
+        if let Some(name) = self.get_literal_string_from_node(index_expr) {
+            candidates.push(name);
+        }
+        if let Some(index) = self.get_literal_index_from_node(index_expr) {
+            candidates.push(index.to_string());
+        }
+        if candidates.is_empty() {
+            let resolved_index = self.evaluate_type_for_assignability(index_type);
+            if let Some((string_keys, number_keys)) =
+                self.get_literal_key_union_from_type(resolved_index)
+            {
+                for key in string_keys {
+                    candidates.push(self.ctx.types.resolve_atom(key));
+                }
+                for key in number_keys {
+                    candidates.push(format!("{key}"));
+                }
+            }
+        }
+
+        // Keep only readonly *named* properties (not index-signature matches),
+        // de-duplicated in first-seen order so each key yields a single TS2540.
+        let mut names: Vec<String> = Vec::new();
+        for name in candidates {
+            if names.iter().any(|n| n == &name) {
+                continue;
+            }
+            if self.is_property_readonly(object_type, &name)
+                && !self.readonly_element_access_from_index_signature(object_type, &name)
+            {
+                names.push(name);
+            }
+        }
+        names
+    }
+
     /// Classify a readonly element/index-access write for `object_type`,
     /// emitting TS2542 (readonly index signature) or TS2540 (readonly named
     /// property) and returning the matching diagnostic variant, or `None` when
@@ -1397,6 +1458,20 @@ impl<'a> CheckerState<'a> {
         index_type: TypeId,
         target_idx: NodeIndex,
     ) -> Option<ReadonlyAssignmentDiagnostic> {
+        // Readonly named-property writes (TS2540). A type-level index such as
+        // `keyof T` or a `"a" | "b"` union can target several readonly
+        // properties at once; tsc reports one TS2540 per readonly key and
+        // suppresses the TS2322 type-mismatch. Resolve and report them all
+        // before the single-name index-signature path below.
+        let named_keys =
+            self.readonly_named_element_access_keys(object_type, index_expr, index_type);
+        if !named_keys.is_empty() {
+            for name in &named_keys {
+                self.error_readonly_property_at(name, index_expr);
+            }
+            return Some(ReadonlyAssignmentDiagnostic::NamedProperty);
+        }
+
         if let Some(name) =
             self.get_readonly_element_access_name(object_type, index_expr, index_type)
         {

--- a/crates/tsz-checker/tests/ts2540_readonly_typed_index_tests.rs
+++ b/crates/tsz-checker/tests/ts2540_readonly_typed_index_tests.rs
@@ -1,0 +1,261 @@
+//! Tests for TS2540 readonly element-access writes through a *type-level* index.
+//!
+//! Structural rule: when `obj[key]` is an assignment target and `key`'s type
+//! resolves to one or more concrete property keys (`keyof T`, a `"a" | "b"`
+//! literal-key union, or a single literal-key-typed variable), `tsc` reports
+//! one TS2540 per readonly key it targets and suppresses the TS2322
+//! type-mismatch — exactly as for a directly-written readonly property write.
+//! A bare generic `keyof T` (T a free type parameter) stays deferred and is not
+//! flagged. Differential ground truth: `tsc` 6.0.2.
+//!
+//! These exercise the gap where a literal index expression (`o["a"]`) was
+//! detected but a *type-level* index was not: `keyof T` was classified as
+//! "other" so no key was resolved, and a union index reported only its first
+//! readonly key instead of one per key.
+
+use tsz_checker::test_utils::check_source_code_messages;
+
+/// `(code, message)` pairs with the empty-lib `TS2318` ("Cannot find global
+/// type") noise filtered out, matching the sibling readonly suites.
+fn diags(source: &str) -> Vec<(u32, String)> {
+    check_source_code_messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code != 2318)
+        .collect()
+}
+
+fn count_code(source: &str, code: u32) -> usize {
+    diags(source).iter().filter(|(c, _)| *c == code).count()
+}
+
+fn has_code(source: &str, code: u32) -> bool {
+    count_code(source, code) >= 1
+}
+
+/// True when a TS2540 naming `prop` (rendered as `'prop'` in the message) is
+/// present.
+fn has_readonly_for(source: &str, prop: &str) -> bool {
+    let needle = format!("'{prop}'");
+    diags(source)
+        .iter()
+        .any(|(c, m)| *c == 2540 && m.contains(&needle))
+}
+
+// ---------------------------------------------------------------------------
+// keyof index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn keyof_single_readonly_property_emits_2540() {
+    let source = r"
+type Rec = { readonly field: number };
+declare const obj: Rec;
+declare const key: keyof Rec;
+obj[key] = 99;
+";
+    assert!(
+        has_readonly_for(source, "field"),
+        "keyof index onto a readonly property must emit TS2540, got: {:?}",
+        diags(source)
+    );
+    assert!(
+        !has_code(source, 2322),
+        "a readonly named-property write must suppress TS2322, got: {:?}",
+        diags(source)
+    );
+}
+
+#[test]
+fn keyof_all_readonly_emits_one_2540_per_key() {
+    let source = r"
+type Pair = { readonly left: number; readonly right: number };
+declare const pair: Pair;
+declare const key: keyof Pair;
+pair[key] = 1;
+";
+    assert_eq!(
+        count_code(source, 2540),
+        2,
+        "each readonly key in the keyof union must emit its own TS2540, got: {:?}",
+        diags(source)
+    );
+    assert!(has_readonly_for(source, "left"));
+    assert!(has_readonly_for(source, "right"));
+}
+
+#[test]
+fn keyof_mixed_readonly_and_mutable_emits_only_readonly_keys() {
+    let source = r"
+type Mixed = { readonly locked: number; open: number };
+declare const value: Mixed;
+declare const key: keyof Mixed;
+value[key] = 7;
+";
+    assert_eq!(
+        count_code(source, 2540),
+        1,
+        "only the readonly key must emit TS2540, got: {:?}",
+        diags(source)
+    );
+    assert!(has_readonly_for(source, "locked"));
+    assert!(
+        !has_readonly_for(source, "open"),
+        "the mutable key must not emit TS2540"
+    );
+    assert!(!has_code(source, 2322));
+}
+
+#[test]
+fn keyof_readonly_value_mismatch_suppresses_2322() {
+    // A real value mismatch is still suppressed by the readonly named-property
+    // write (tsc emits only TS2540).
+    let source = r"
+type Rec = { readonly amount: number };
+declare const obj: Rec;
+declare const key: keyof Rec;
+obj[key] = 'not a number';
+";
+    assert!(has_readonly_for(source, "amount"));
+    assert!(
+        !has_code(source, 2322),
+        "readonly named-property write suppresses the value-mismatch TS2322, got: {:?}",
+        diags(source)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// explicit literal-key union / single literal-key variable
+// ---------------------------------------------------------------------------
+
+#[test]
+fn literal_key_union_emits_one_2540_per_readonly_key() {
+    let source = r"
+type Rec = { readonly alpha: number; readonly beta: number };
+declare const rec: Rec;
+declare const key: 'alpha' | 'beta';
+rec[key] = 0;
+";
+    assert_eq!(
+        count_code(source, 2540),
+        2,
+        "a written-out literal-key union must report each readonly key, got: {:?}",
+        diags(source)
+    );
+    assert!(has_readonly_for(source, "alpha"));
+    assert!(has_readonly_for(source, "beta"));
+}
+
+#[test]
+fn single_literal_key_typed_variable_emits_2540() {
+    let source = r"
+type Rec = { readonly only: number };
+declare const rec: Rec;
+declare const key: 'only';
+rec[key] = 5;
+";
+    assert!(has_readonly_for(source, "only"));
+}
+
+// ---------------------------------------------------------------------------
+// `as const` receiver via `keyof typeof`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn const_asserted_object_keyof_typeof_index_emits_2540() {
+    let source = r"
+const frozen = { count: 1 } as const;
+let key: keyof typeof frozen = 'count';
+frozen[key] = 2;
+";
+    assert!(
+        has_readonly_for(source, "count"),
+        "writing a `keyof typeof` index of an `as const` object must emit TS2540, got: {:?}",
+        diags(source)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// compound assignment / increment route through the same check
+// ---------------------------------------------------------------------------
+
+#[test]
+fn keyof_readonly_compound_assignment_emits_2540() {
+    let source = r"
+type Pair = { readonly first: number; readonly second: number };
+declare const pair: Pair;
+declare const key: keyof Pair;
+pair[key] += 1;
+";
+    assert_eq!(
+        count_code(source, 2540),
+        2,
+        "compound assignment to a keyof-indexed readonly target must emit TS2540 per key, got: {:?}",
+        diags(source)
+    );
+}
+
+#[test]
+fn keyof_readonly_increment_emits_2540() {
+    let source = r"
+type Rec = { readonly total: number };
+declare const obj: Rec;
+declare const key: keyof Rec;
+obj[key]++;
+";
+    assert!(has_readonly_for(source, "total"));
+}
+
+// ---------------------------------------------------------------------------
+// controls
+// ---------------------------------------------------------------------------
+
+#[test]
+fn keyof_mutable_object_does_not_emit_2540() {
+    let source = r"
+type Rec = { writable: number };
+declare const obj: Rec;
+declare const key: keyof Rec;
+obj[key] = 3;
+";
+    assert!(
+        !has_code(source, 2540),
+        "a fully-mutable receiver must not emit any readonly error, got: {:?}",
+        diags(source)
+    );
+}
+
+#[test]
+fn generic_keyof_of_bare_type_parameter_is_not_flagged() {
+    // `keyof T` for a free type parameter stays deferred; tsc does not flag the
+    // write (the cast launders the value type), so neither should tsz.
+    let source = r"
+function write<T extends { readonly a: number }>(obj: T, key: keyof T): void {
+    obj[key] = 1 as T[keyof T];
+}
+";
+    assert!(
+        !has_code(source, 2540),
+        "a bare generic keyof index must not be flagged readonly, got: {:?}",
+        diags(source)
+    );
+}
+
+#[test]
+fn renamed_binders_emit_identical_per_key_2540() {
+    // Anti-hardcoding control: a structurally identical program with different
+    // identifiers must behave the same (two TS2540, one per readonly key).
+    let source = r"
+type Bundle = { readonly xÿz: number; readonly qrs: number };
+declare const bundle: Bundle;
+declare const sel: keyof Bundle;
+bundle[sel] = 4;
+";
+    assert_eq!(
+        count_code(source, 2540),
+        2,
+        "renamed binders must still report each readonly key, got: {:?}",
+        diags(source)
+    );
+    assert!(has_readonly_for(source, "xÿz"));
+    assert!(has_readonly_for(source, "qrs"));
+}


### PR DESCRIPTION
Fixes #14636.

Goal: hold

## Problem

Writing to an element access `obj[key]` whose **index is a type** — `keyof T`, a `"a" | "b"` literal-key union, or a single literal-key-typed variable — failed to report readonly writes the way `tsc` does. A direct (`obj.a = …`) or string-literal element access (`obj["a"] = …`) was already correct; only the *type-level* index diverged, in two ways:

1. **`keyof T` was not resolved** → the readonly check was skipped, so tsz emitted a spurious TS2322 — or, when the value also matched, **no diagnostic at all** (a false negative).
2. **A literal-key union reported only its first readonly key**, where `tsc` reports **one TS2540 per readonly key**.

```ts
const o = { a: 1 } as const;
let k: keyof typeof o = "a";
o[k] = 2;        // tsc: TS2540 'a' readonly   tsz before: TS2322 '2' not assignable to '1' ❌

type T = { readonly a: number; readonly b: number };
declare const o2: T; declare const k2: keyof T;
o2[k2] = 99;     // tsc: TS2540 'a' + TS2540 'b'   tsz before: nothing ❌
```

## Structural rule

When `obj[key]` is an assignment target and `key`'s type resolves to one or more concrete property keys, `tsc` checks each resolved property's readonly modifier and reports **one TS2540 per readonly named key**, suppressing the TS2322 type-mismatch (the readonly write is the error regardless of value). A bare generic `keyof T` (`T` a free type parameter) stays deferred and is **not** flagged; a readonly index-signature target stays TS2542. `tsc` does this; tsz now does too.

## Owner layer

Checker readonly-assignment classification — `crates/tsz-checker/src/state/state_checking/readonly.rs`, the element-access path of `emit_readonly_element_access_diag`:

- New `readonly_named_element_access_keys` collects **every** readonly *named* key targeted by the write. The index type is evaluated (turning `keyof T` into its literal-key union) **only when the index expression is not already a literal key**, so the common `obj[i] = …` write stays off the type-evaluation path. Index-signature matches (and named props reached *through* an index signature, e.g. readonly arrays) are excluded — the caller still reports those as TS2542 via the unchanged single-name path.
- `emit_readonly_element_access_diag` emits one TS2540 per collected key and returns `NamedProperty` (which suppresses TS2322), before falling through to the existing index-signature / mapped-readonly logic.

No hardcoded identifier/file-name predicates; the gate is purely structural (literal/`keyof`/union index resolving to readonly named properties), and binder names are varied in the tests.

## Adjacent matrix (verified against the built binary vs `tsc` 6.0.2)

- `keyof T` single / multiple / mixed-readonly-and-mutable keys.
- written-out `"a" | "b"` union; single literal-key-typed variable; `keyof typeof obj` of an `as const` object.
- compound assignment (`obj[k] += 1`) and increment (`obj[k]++`) — same per-key TS2540.
- value-mismatch under a readonly write → TS2540 only, TS2322 suppressed.
- Controls: fully-mutable receiver (no TS2540); bare generic `keyof T` (not flagged); readonly index signature stays TS2542; renamed binders behave identically.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- New regression suite `crates/tsz-checker/tests/ts2540_readonly_typed_index_tests.rs` (12 tests: keyof single/multi/mixed, literal-key union, single literal-key var, `keyof typeof` of `as const`, compound `+=`, increment `++`, value-mismatch suppression, mutable-receiver control, bare-generic-keyof control, renamed-binder invariance) — all pass.
- Differential matrix of 17 cases run through the built `tsz` binary vs `tsc` 6.0.2 (reductions, mixed unions, index-signature controls, compound/increment) — all match.
- No regressions in the readonly suites: `ts2540_readonly_tests` (40 pass) and `ts2542_readonly_index_coemission_tests` (7 pass); the 3 remaining failures across those suites are **pre-existing on a clean tree** (verified by stashing this change — they fail identically), caused by the minimal unit-test lib lacking `ReadonlyArray`/`DeepReadonly`-style globals.
- `cargo fmt -p tsz-checker --check`, `cargo clippy -p tsz-checker --lib`, `python3 scripts/arch/arch_guard.py`: clean.
- Reviewed via `/simplify` (reuse / simplification / efficiency / altitude): applied the efficiency finding (gate the index-type evaluation on the non-literal-index case); declined a `type_has_readonly_members` pre-gate (it returns false for `Ref`/`Lazy`/`Application`/interface receivers and would regress interface receivers) and a `HashSet` dedup micro-opt (candidate count is tiny; the `Vec` dedup matches existing convention).
- Display/code-affecting but conformance-floor-safe: the change only fixes readonly-write diagnostics; broad conformance/emit/fourslash floors are owned by ready-review CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEs7QatvENBuV1o3XeUGJb)_