### PR TITLE
fix(checker): keep alias name for union-result indexed-access type aliases

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
@@ -91,9 +91,18 @@ pub(crate) fn record_source_alias_rejection_kinds(
 /// - An **intersection** drops the alias name only when it collapses to a
 ///   union of purely primitive/literal members (`T1 & ("a"|"b")` ->
 ///   `"a"|"b"`); a distribution into object-typed members keeps the name.
-/// - A **conditional** or **indexed access** resolves away into its branch /
-///   element type and never carries the alias's `aliasSymbol`, so tsc renders
-///   the evaluated underlying type, including bare object and mapped shapes.
+/// - A **conditional** resolves away into its branch type, which is a
+///   pre-existing type that never carries the alias's `aliasSymbol`, so tsc
+///   renders the evaluated underlying type — including a bare object, mapped
+///   shape, or a primitive/literal union branch (`A extends B ? number |
+///   boolean : never` elaborates as `number | boolean`, never the alias name).
+/// - An **indexed access** is the carve-out: when its result is a *union* (an
+///   index over a union / `keyof` that builds a fresh union via tsc's
+///   `getUnionType(propTypes, …, aliasSymbol)`), that union carries the alias
+///   symbol, so it is **not** computed and tsc keeps the alias name
+///   (`type W = T[keyof T]` -> `W`). Only a single-key access that resolves to
+///   one existing member type (no fresh construction, no alias symbol) is
+///   computed and rendered structurally.
 ///   Unions/intersections that mix in objects stay deferred to the separate
 ///   elaboration path; directly-written aliases sharing a bare object shape are
 ///   protected by the def store's "direct wins" provenance.
@@ -114,12 +123,22 @@ pub(crate) fn alias_declaration_body_is_computed(
     };
     match body_node.kind {
         syntax_kind_ext::INTERSECTION_TYPE => result_is_primitive_literal_union(db, result),
-        syntax_kind_ext::CONDITIONAL_TYPE | syntax_kind_ext::INDEXED_ACCESS_TYPE => {
+        syntax_kind_ext::CONDITIONAL_TYPE => {
             !crate::query_boundaries::common::is_conditional_type(db, result)
                 && !crate::query_boundaries::common::is_index_access_type(db, result)
                 && !crate::query_boundaries::diagnostics::union_or_intersection_with_object(
                     db, result,
                 )
+        }
+        syntax_kind_ext::INDEXED_ACCESS_TYPE => {
+            !crate::query_boundaries::common::is_conditional_type(db, result)
+                && !crate::query_boundaries::common::is_index_access_type(db, result)
+                // A union result is freshly constructed by `getUnionType(…,
+                // aliasSymbol)` and therefore carries the alias symbol — tsc
+                // keeps the alias name, so it is *not* a computed body. A
+                // single-key access yields one existing member type (no alias
+                // symbol) and is rendered structurally.
+                && !crate::query_boundaries::common::is_union_type(db, result)
         }
         // `keyof { ... }` over an inline object *type literal* is a reducing
         // operator like indexed access: it resolves away into the operand's key

--- a/crates/tsz-checker/src/tests/type_alias_computed_display_tests.rs
+++ b/crates/tsz-checker/src/tests/type_alias_computed_display_tests.rs
@@ -4,10 +4,20 @@
 //! tsc attaches an `aliasSymbol` (and so renders the alias name) only to
 //! freshly-constructed structural types. A non-generic alias whose declared
 //! body is a *reducing operator* — a conditional or an indexed access — loses
-//! its name once the operator resolves: tsc renders the underlying structural
-//! result instead. Verified against tsc 6.0.2, e.g.
+//! its name once the operator resolves *to a pre-existing type*: tsc renders
+//! the underlying structural result instead. Verified against tsc 6.0.2, e.g.
 //! `type P = true extends true ? [string, number] : never` elaborates as
 //! `[string, number]`, never `P`.
+//!
+//! The one carve-out is an **indexed access over a union / `keyof` index**
+//! (`type W = T[keyof T]`, `type W = T["a" | "b"]`): tsc builds a *fresh* union
+//! via `getUnionType(propTypes, …, aliasSymbol)`, so that union carries the
+//! alias symbol and tsc keeps the name (`W`, never `string | number`). A
+//! single-key access (`T["a"]`) resolves to one pre-existing member type with
+//! no alias symbol and still renders structurally. A non-generic *conditional*
+//! never builds such a union — it returns a pre-existing branch type — so even
+//! a union-typed branch (`A extends B ? number | boolean : never`) renders
+//! structurally as `number | boolean`.
 //!
 //! These tests pin the tuple / array / function / scalar / primitive-union
 //! family, the bare-object family (a conditional / indexed access reducing to an
@@ -193,6 +203,88 @@ const h: Holder = { v: 0 };
     assert!(
         msg.contains("DirectPair"),
         "expected a directly-written tuple alias to keep its name, got: {msg}"
+    );
+}
+
+// ── indexed-access-over-union-index family (fresh union keeps the name) ───
+//
+// `type W = T[keyof T]` / `type W = T["a" | "b"]` indexes by a union, so tsc
+// builds a *fresh* union (`getUnionType(propTypes, …, aliasSymbol)`) that
+// carries the alias symbol — the alias name survives (`W`, never the expanded
+// `string | number`). This is the inverse of the single-key access in test 4,
+// which resolves to one pre-existing member type with no alias symbol. Binder
+// names vary so a hardcoded fix cannot satisfy these.
+
+// 6a. Indexed access by `keyof` over a multi-typed object → fresh union → keeps
+//     the alias name.
+#[test]
+fn indexed_access_by_keyof_to_union_keeps_alias_name() {
+    let msg = ts2322_target(
+        r#"
+type Record1 = { a: number; b: string };
+type AnyValue = Record1[keyof Record1];
+const v: AnyValue = true;
+"#,
+    );
+    assert!(
+        msg.contains("'AnyValue'") && !msg.contains("string | number"),
+        "expected `T[keyof T]` union alias to keep its name, got: {msg}"
+    );
+}
+
+// 6b. Renamed binder, explicit union index key → fresh union → keeps the name.
+//     Proves the rule is structural (a union *result*), not keyed on `keyof` or
+//     any identifier.
+#[test]
+fn indexed_access_by_explicit_union_key_keeps_alias_name() {
+    let msg = ts2322_target(
+        r#"
+type Palette = { primary: number; secondary: string };
+type Swatch = Palette["primary" | "secondary"];
+const s: Swatch = true;
+"#,
+    );
+    assert!(
+        msg.contains("'Swatch'") && !msg.contains("string | number"),
+        "expected `T[\"a\" | \"b\"]` union alias to keep its name, got: {msg}"
+    );
+}
+
+// 6c. Control: a `keyof` index that collapses to a *single* value type resolves
+//     to one member (no fresh union, no alias symbol) and still renders
+//     structurally — the carve-out is gated on a union *result*, not on the
+//     `keyof` spelling.
+#[test]
+fn indexed_access_collapsing_to_single_member_renders_underlying() {
+    let msg = ts2322_target(
+        r#"
+type Uniform = { a: number; b: number };
+type OnlyValue = Uniform[keyof Uniform];
+const v: OnlyValue = "x";
+"#,
+    );
+    assert!(
+        msg.contains("type 'number'") && !msg.contains("OnlyValue"),
+        "expected a single-member indexed access to render structurally, got: {msg}"
+    );
+}
+
+// 6d. Control: a non-generic *conditional* whose branch is a primitive union is
+//     NOT a fresh-union construction — it returns the pre-existing branch type,
+//     so it still renders structurally. Locks the conditional/indexed-access
+//     distinction that this carve-out introduced.
+#[test]
+fn conditional_to_primitive_union_branch_renders_underlying() {
+    let msg = ts2322_target(
+        r#"
+type Branch = string extends string ? number | boolean : never;
+type Holder = { v: Branch };
+const h: Holder = { v: "x" };
+"#,
+    );
+    assert!(
+        msg.contains("number | boolean") && !msg.contains("Branch"),
+        "expected a conditional union branch to render structurally, got: {msg}"
     );
 }
 


### PR DESCRIPTION
Fixes #14635.

## Problem

A **non-generic** type alias whose body is an **indexed access over a union or
`keyof` index** (`type W = T[keyof T]`, `type W = T["a" | "b"]`) was rendered by
its **expanded union** in assignability diagnostics; `tsc` keeps the alias name.

```ts
type T = { a: number; b: string };
type W = T[keyof T];
const v: W = true;
// tsc:        ... is not assignable to type 'W'.
// tsz before: ... is not assignable to type 'string | number'.
```

The single-key form (`T["a"]`) already matched `tsc` (it expands), so this only
closes the union-index asymmetry.

## Structural rule

When the index of an indexed-access alias body is a **union** (or a `keyof`
yielding a multi-member union), `tsc` builds a **fresh union** via
`getUnionType(propTypes, …, aliasSymbol)`. That union carries the alias symbol,
so `tsc` renders the alias name. A single-key access resolves to one
*pre-existing* member type (no alias symbol) and renders structurally. A
non-generic **conditional** returns a pre-existing branch type — no fresh union
— so even a union-typed branch renders structurally (`number | boolean`). tsz
now keeps the alias name through the checker's computed-body attribution. The
relation outcome and diagnostic code/count are unchanged — this is a
source/target-type **display** fix.

## Owner layer

Checker diagnostic **alias-name display** only — no relation/semantic change.
`alias_declaration_body_is_computed`
(`state/type_analysis/source_alias_attribution.rs`) grouped `INDEXED_ACCESS_TYPE`
with `CONDITIONAL_TYPE` and marked any non-object union result a "computed body",
which makes the def store's `find_type_alias_by_body` reverse lookup skip the
alias name and expand. The indexed-access arm is split out: a union result is
**not** a computed body (it carries the fresh-union alias symbol). Both display
pipelines (the solver `TypeFormatter` reverse lookup and the checker
assignability formatter) agree without further change, because the evaluated
union body is no longer in the computed set.

No hardcoded identifier/file-name predicates; the gate is the structural result
shape (a union from an indexed-access body). Binder names vary across the tests.

## Adjacent matrix (verified against the built binary + tsc 6.0.2)

| alias body | tsc display | result |
| --- | --- | --- |
| `T[keyof T]` (distinct value types) | `W` | keep ✓ |
| `T["a" \| "b"]` | `W` | keep ✓ |
| `T[keyof T]` (object value types) | `W` | keep (already correct) ✓ |
| `T["a"]` (single key) | `number` | expand ✓ |
| `T[keyof T]` (uniform value type) | `number` | expand ✓ |
| `A extends B ? number \| boolean : never` | `number \| boolean` | expand (control) ✓ |
| `string \| number` (directly written) | `W` | keep (control) ✓ |

Display contexts verified to keep the name: `TS2322` assignment, `TS2345`
parameter, array element, property, and source-position elaboration.

## Out of scope

A union-result indexed-access alias and a directly-written union alias of the
**identical** shape coexisting in one program share a `TypeId`;
`find_type_alias_by_body` then returns an arbitrary def, so the colliding alias
may render with the other's name. That is the cross-shape identity ambiguity
tracked under #14344, not this display rule.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New unit cases in `crates/tsz-checker/src/tests/type_alias_computed_display_tests.rs`
  (`indexed_access_by_keyof_to_union_keeps_alias_name`,
  `indexed_access_by_explicit_union_key_keeps_alias_name`,
  `indexed_access_collapsing_to_single_member_renders_underlying`,
  `conditional_to_primitive_union_branch_renders_underlying`) — binder names
  varied.
- Existing `type_alias_computed`/`type_alias_primitive`/`computed_alias` suites
  green locally (57 passed), plus the broader `alias`/`display`/`keyof`/
  `indexed_access`/`source_alias` filter; the 9 unrelated direct-unit failures
  in that filter are pre-existing (identical on a clean `main` checkout — the
  known-red direct unit set).
- `cargo fmt -p tsz-checker -- --check`, `cargo clippy -p tsz-checker --lib`,
  `python3 scripts/arch/arch_guard.py`: clean.
- Differential harness (tsz dist-debug vs `tsc 6.0.2`) over the adjacent matrix
  and a 44-case probe corpus: no code-multiset regressions; the witnessed text
  divergence is resolved.
- Reviewed via `/simplify` (reuse / simplification / efficiency / altitude):
  applied the reuse finding (use `is_union_type` instead of
  `union_members(…).is_none()`); other angles already clean.
- Display-only and code-neutral: the conformance gate compares diagnostic
  codes/counts, not chained message text, so the broad conformance / emit /
  fourslash floors (owned by ready-review CI) are unaffected.

https://claude.ai/code/session_01TSvmwe5R3GFuYwB18VKUWN

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSvmwe5R3GFuYwB18VKUWN)_