### PR TITLE
fix(checker): keep literal members of a non-fresh intersection source in TS2322 display (#14639)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1345,6 +1345,14 @@ impl<'a> CheckerState<'a> {
         if let Some(members) = crate::query_boundaries::diagnostics::union_members(db, ty) {
             return members.iter().any(|&m| recurse(m, visiting));
         }
+        // Intersections carry their members' canonical literal properties just
+        // like unions do — a declared `number & { tag: "x" }` source keeps its
+        // `"x"` member in tsc diagnostics. Without this arm the object member is
+        // not reached, so the source falls through to the non-literal-target
+        // widening below and renders `number & { tag: string }`.
+        if let Some(members) = crate::query_boundaries::diagnostics::intersection_members(db, ty) {
+            return members.iter().any(|&m| recurse(m, visiting));
+        }
         false
     }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1012,6 +1012,9 @@ mod intersection_callable_constraint_ts2344_tests;
 #[path = "../tests/intersection_signatures.rs"]
 mod intersection_signatures;
 #[cfg(test)]
+#[path = "tests/intersection_source_literal_member_display_tests.rs"]
+mod intersection_source_literal_member_display_tests;
+#[cfg(test)]
 #[path = "tests/intersection_target_elaboration_tests.rs"]
 mod intersection_target_elaboration_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/intersection_source_literal_member_display_tests.rs
+++ b/crates/tsz-checker/src/tests/intersection_source_literal_member_display_tests.rs
@@ -1,0 +1,201 @@
+//! Tests for preserving the literal property members of a non-fresh
+//! *intersection* source in TS2322-family assignability diagnostics.
+//!
+//! Structural rule: when the assignability source is a declared (non-fresh)
+//! intersection that mixes a primitive with an object member carrying literal
+//! property types — `number & { tag: "x" }` — `tsc` renders the source
+//! structurally with its literal members intact. `getWidenedType` only widens
+//! *fresh* types (already applied at construction), so a declared intersection
+//! keeps `"x"` verbatim.
+//!
+//! Before the fix, `rewrite_source_display_for_non_literal_target_assignability`
+//! reached the non-literal-target widening path because its
+//! `source_carries_canonical_literal_member` traversal recursed into object,
+//! array, tuple, and union members but **not** intersection members — so a
+//! `primitive & { tag: "x" }` source was not recognised as carrying a canonical
+//! literal member and rendered as `number & { tag: string }`. The fix adds the
+//! intersection arm to that traversal, mirroring the union arm.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322_messages(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+#[test]
+fn primitive_object_intersection_keeps_literal_member() {
+    // `number & { tag: "x" }` assigned to `string`: the object member's literal
+    // `"x"` must survive, matching `tsc` (`number & { tag: "x"; }`).
+    let messages = ts2322_messages(
+        r#"
+declare const value: number & { tag: "x" };
+const text: string = value;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains(r#"number & { tag: "x"; }"#)),
+        "intersection object member literal must be preserved, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("tag: string")),
+        "the literal member must not be widened, got: {messages:?}"
+    );
+}
+
+#[test]
+fn renamed_binders_keep_literal_member() {
+    // The rule is structural, not keyed on the identifier/property spelling:
+    // a differently-named binder and member behave identically (anti-hardcoding
+    // control).
+    let messages = ts2322_messages(
+        r#"
+declare const widget: number & { kind: "circle" };
+const label: string = widget;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains(r#"number & { kind: "circle"; }"#)),
+        "renamed intersection member literal must be preserved, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("kind: string")),
+        "the literal member must not be widened, got: {messages:?}"
+    );
+}
+
+#[test]
+fn boolean_base_intersection_keeps_literal_member() {
+    // The primitive base of the intersection is not number-specific.
+    let messages = ts2322_messages(
+        r#"
+declare const flag: boolean & { z: 1 };
+const text: string = flag;
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("boolean & { z: 1; }")),
+        "boolean-base intersection literal must be preserved, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("z: number")),
+        "the literal member must not be widened, got: {messages:?}"
+    );
+}
+
+#[test]
+fn nested_object_in_intersection_keeps_deep_literal() {
+    // A literal nested inside an object member of the intersection is preserved
+    // at every depth (the traversal recurses).
+    let messages = ts2322_messages(
+        r#"
+declare const node: number & { inner: { depth: 5 } };
+const text: string = node;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("number & { inner: { depth: 5; }; }")),
+        "deeply nested intersection literal must be preserved, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("depth: number")),
+        "the nested literal must not be widened, got: {messages:?}"
+    );
+}
+
+#[test]
+fn readonly_literal_member_in_intersection_preserved() {
+    let messages = ts2322_messages(
+        r#"
+declare const cell: number & { readonly slot: 5 };
+const text: string = cell;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("number & { readonly slot: 5; }")),
+        "readonly literal member must be preserved, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("slot: number")),
+        "the readonly literal member must not be widened, got: {messages:?}"
+    );
+}
+
+#[test]
+fn binary_assignment_intersection_keeps_literal_member() {
+    // The binary-assignment (`x = y`) source-display path preserves the literal
+    // member the same way the variable-initializer path does.
+    let messages = ts2322_messages(
+        r#"
+declare const source: number & { tag: "x" };
+let target: string;
+target = source;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains(r#"number & { tag: "x"; }"#)),
+        "binary-assignment intersection literal must be preserved, got: {messages:?}"
+    );
+}
+
+#[test]
+fn fresh_object_literal_source_still_widens() {
+    // Control: a *fresh* object literal source still widens its members to
+    // their primitive base, exactly as `tsc` does — the fix only changes the
+    // non-fresh (declared) path.
+    let messages = ts2322_messages(
+        r#"
+const text: string = { tag: "x" } as number & { tag: "x" };
+"#,
+    );
+    // The intersection alias keeps its literal even via `as`, mirroring tsc;
+    // the important control is that fresh *bare* object literals widen.
+    let widened = ts2322_messages(
+        r#"
+const plain: string = { count: 1, name: "n" };
+"#,
+    );
+    assert!(
+        widened
+            .iter()
+            .any(|m| m.contains("{ count: number; name: string; }")),
+        "fresh bare object literal must widen its members, got: {widened:?}"
+    );
+    // Sanity: the intersection assertion case still produces a TS2322 (shape
+    // assertion to a primitive is an error in both compilers).
+    assert!(
+        !messages.is_empty(),
+        "intersection assertion to a primitive should still error, got: {messages:?}"
+    );
+}
+
+#[test]
+fn object_object_intersection_unaffected() {
+    // Control: an object-and-object intersection (no primitive member) was
+    // already preserved and must remain so.
+    let messages = ts2322_messages(
+        r#"
+declare const pair: { a: 1 } & { b: "y" };
+const text: string = pair;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains(r#"{ a: 1; } & { b: "y"; }"#)),
+        "object-object intersection literals must be preserved, got: {messages:?}"
+    );
+}


### PR DESCRIPTION
Fixes #14639.

Goal: hold

## Problem

When the assignability **source** of a `TS2322`-family diagnostic is a declared
(non-fresh) **intersection** mixing a primitive with an object member carrying
literal property types — `number & { tag: "x" }` — tsz widened the object
member's literal to its primitive base, while `tsc` keeps the literal intact.

```ts
declare const value: number & { tag: "x" };
const text: string = value;
// tsc:        Type 'number & { tag: "x"; }' is not assignable to type 'string'.
// tsz before: Type 'number & { tag: string; }' is not assignable to type 'string'.
```

The relation outcome and the diagnostic code/position are unchanged — only the
**displayed** source type diverged. Assignability is correct
(`number & { tag: "x" }` ≰ `number & { tag: "y" }` still rejects with both
literals intact), so this is a display-only, code-neutral fix.

## Structural rule

When the assignability source is a **non-fresh** type carrying canonical literal
members at any nesting depth, `tsc` renders those members verbatim —
`getWidenedType` only widens *fresh* types (the `FRESH_LITERAL` flag), and that
widening already happened at construction. A genuinely *fresh* object-literal
source still widens. `tsc` does this; tsz now does too for intersection sources.

## Owner layer

Checker diagnostic **source-type display** only — no relation/semantic change.

tsz already preserves the literal members of a non-fresh source via
`rewrite_source_display_for_non_literal_target_assignability`
(`crates/tsz-checker/src/error_reporter/assignability.rs`): it returns the source
un-widened when `source_carries_canonical_literal_member` finds a literal member.
That traversal (`source_carries_canonical_literal_member_inner`) recursed into
**object, array, tuple, and union** members but **omitted intersection
members**, so a `primitive & { tag: "x" }` source was not recognised and fell
through to the non-literal-target widening path. This adds the intersection arm,
mirroring the union arm — an 8-line change.

The same traversal is also consulted on the target side
(`rewrite_target_display_for_non_literal_assignability`), so a non-fresh
intersection *target* benefits identically.

No hardcoded identifier/file-name predicates; the gate is purely structural (a
non-fresh intersection carrying a canonical literal member). Binder names are
varied across the tests.

## Adjacent matrix (verified against the built binary vs `tsc` 6.0.2)

| source | tsc display | result |
| --- | --- | --- |
| `number & { tag: "x" }` | `number & { tag: "x"; }` | keep ✓ |
| `boolean & { z: 1 }` / `bigint & { z: 1 }` / `symbol & { z: 1 }` | `… { z: 1; }` | keep ✓ |
| `number & { o: { z: 1 } }` (nested) | `number & { o: { z: 1; }; }` | keep ✓ |
| `number & { readonly k: 5 }` | `number & { readonly k: 5; }` | keep ✓ |
| binary assignment `x = y` | `number & { tag: "x"; }` | keep ✓ |
| return position | `number & { tag: "x"; }` | keep ✓ |
| `{ a: 1 } & { b: "y" }` (object∧object) | `{ a: 1; } & { b: "y"; }` | keep (control) ✓ |
| fresh bare object literal `{ count: 1, name: "n" }` | `{ count: number; name: string; }` | widen (control) ✓ |

## Out of scope (separate, adjacent gaps; noted in #14639)

- A declared **object** whose method/function return is a literal (`{ m(): 1 }`)
  still widens — the traversal does not descend function signatures.
- A generic alias instantiation `type Tag<T> = T & { ... }` drops its
  `Tag<number>` alias name and renders the primitive as the boxed `Number`
  apparent type — a separate alias-expansion/apparent-type divergence.
- A declared top-level literal-union / boolean source is *under*-widened
  (`1 | 2` shown instead of `number`) via the annotation-preference branch.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- New regression suite
  `crates/tsz-checker/src/tests/intersection_source_literal_member_display_tests.rs`
  (8 tests: primitive∧object literal, renamed-binder invariance, boolean base,
  deeply-nested literal, readonly literal member, binary-assignment path,
  fresh-object-still-widens control, object∧object control) — all pass.
- Differential matrix of the cases above run through the built `tsz` release
  binary vs `tsc` 6.0.2 — all match; a 60+-case probe sweep shows no new
  diagnostic divergences (the residual divergences are unrelated, pre-existing
  alias-display / instantiable-target families).
- No regressions: the filtered `source_display`/`intersection`/`widen`/`display`
  checker lib suites are green; the 8 failures in that filter are **pre-existing
  on a clean tree** (verified by `git stash` — identical 0-passed/8-failed
  baseline, the known-red direct-unit set).
- `cargo fmt -p tsz-checker -- --check`, `cargo clippy -p tsz-checker --lib`,
  `python3 scripts/arch/arch_guard.py`: clean.
- Reviewed via `/simplify` (reuse / simplification / efficiency / altitude): no
  changes needed — the added arm reuses the canonical `intersection_members`
  query and mirrors the existing union arm; the parallel separate-arm style
  matches the surrounding object/array/tuple/union arms (collapsing was
  considered and declined as churn).
- Display-only and code-neutral: the conformance gate compares diagnostic
  codes/counts, not chained message text, so the broad conformance / emit /
  fourslash floors (owned by ready-review CI) are unaffected.

https://claude.ai/code/session_01AT3w8gYVuuiDpFWhimRseP


---
_Generated by [Claude Code](https://claude.ai/code/session_01AT3w8gYVuuiDpFWhimRseP)_