### PR TITLE
fix(checker): scope template-literal pattern index signatures to matching properties in TS2411

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1768,6 +1768,9 @@ path = "tests/template_literal_record_key_tests.rs"
 name = "keyof_template_index_signature_tests"
 path = "tests/keyof_template_index_signature_tests.rs"
 [[test]]
+name = "ts2411_pattern_index_signature_tests"
+path = "tests/ts2411_pattern_index_signature_tests.rs"
+[[test]]
 name = "template_literal_generic_call_indexed_keyof_constraint_tests"
 path = "tests/template_literal_generic_call_indexed_keyof_constraint_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -275,7 +275,11 @@ impl<'a> CheckerState<'a> {
         let derived_overload_callables = self
             .collect_overloaded_derived_method_callables(&derived_members, &derived_method_counts);
 
-        let mut derived_string_index_type: Option<(TypeId, NodeIndex)> = None;
+        // `(value_type, key_type, member_idx)` — the key type is carried so a
+        // template-literal *pattern* index (`[k: `id_${number}`]`, stored in the
+        // string slot) only constrains base properties that match the pattern,
+        // and is labeled by the pattern rather than `string`.
+        let mut derived_string_index_type: Option<(TypeId, TypeId, NodeIndex)> = None;
         let mut derived_number_index_type: Option<(TypeId, NodeIndex)> = None;
         for &decl_idx in &all_iface_decls {
             let Some(sym_id) = iface_sym_id else {
@@ -318,7 +322,7 @@ impl<'a> CheckerState<'a> {
                         if key_type == TypeId::NUMBER {
                             derived_number_index_type = Some((value_type, member_idx));
                         } else {
-                            derived_string_index_type = Some((value_type, member_idx));
+                            derived_string_index_type = Some((value_type, key_type, member_idx));
                         }
                     }
                 }
@@ -1482,12 +1486,13 @@ impl<'a> CheckerState<'a> {
                             }
                         }
 
-                        if let Some((string_index_value, string_index_node)) =
+                        if let Some((string_index_value, string_index_key, string_index_node)) =
                             derived_string_index_type
                         {
                             self.check_type_alias_base_properties_against_derived_string_index(
                                 base_type,
                                 string_index_value,
+                                string_index_key,
                                 string_index_node,
                             );
                         }
@@ -1860,7 +1865,7 @@ impl<'a> CheckerState<'a> {
                     }
                 }
 
-                if let (Some((derived_val, _)), Some(base_val)) =
+                if let (Some((derived_val, _, _)), Some(base_val)) =
                     (derived_string_index_type, base_string_index_value)
                     && !self.index_value_assignable_for_interface_extends(derived_val, base_val)
                 {

--- a/crates/tsz-checker/src/classes/interface_heritage_index.rs
+++ b/crates/tsz-checker/src/classes/interface_heritage_index.rs
@@ -8,6 +8,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         base_type: TypeId,
         string_index_value: TypeId,
+        string_index_key: TypeId,
         string_index_node: NodeIndex,
     ) {
         let resolved_base = self.resolve_type_query_type(base_type);
@@ -43,6 +44,12 @@ impl<'a> CheckerState<'a> {
             if tsz_solver::utils::is_synthetic_private_brand_name(&prop_name) {
                 continue;
             }
+            // A template-literal pattern index constrains only base property
+            // names that match the pattern (e.g. `[k: `id_${number}`]` does not
+            // constrain `foo`), mirroring tsc's index-applicability rule.
+            if !self.property_name_matches_index_key(&prop_name, string_index_key) {
+                continue;
+            }
             let prop_result = self.resolve_property_access_with_env(base_for_props, &prop_name);
             let crate::query_boundaries::common::PropertyAccessResult::Success {
                 type_id: prop_type,
@@ -63,10 +70,11 @@ impl<'a> CheckerState<'a> {
             }
             let prop_type_str = self.format_type(prop_type);
             let index_type_str = self.format_type(string_index_value);
+            let index_kind_str = self.index_signature_key_display(string_index_key);
             self.error_at_node_msg(
                 string_index_node,
                 diagnostic_codes::PROPERTY_OF_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,
-                &[&prop_name, &prop_type_str, "string", &index_type_str],
+                &[&prop_name, &prop_type_str, &index_kind_str, &index_type_str],
             );
         }
     }

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -856,11 +856,23 @@ impl<'a> CheckerState<'a> {
                 synthesized_instance_number_value_type
                     .or_else(|| index_info.number_index.as_ref().map(|idx| idx.value_type))
             };
-            let applicable_string_value = if is_static_member {
-                static_string_value_type
+            // The applicable string index as `(value_type, key_type)`. The
+            // `string_index` slot may carry a template-literal *pattern* key
+            // (`[k: `id_${number}`]`) — the solver stores such a pattern here
+            // rather than collapsing it to `string`. Static and
+            // computed-member-synthesized string indexes are always plain
+            // `string`; only an inherited/own `index_info.string_index` can be a
+            // pattern. Carry the key type so the property check gates on a match
+            // and labels the diagnostic with the pattern instead of `string`.
+            let applicable_string_index = if is_static_member {
+                static_string_value_type.map(|value| (value, TypeId::STRING))
+            } else if let Some(value) = synthesized_instance_string_value_type {
+                Some((value, TypeId::STRING))
             } else {
-                synthesized_instance_string_value_type
-                    .or_else(|| index_info.string_index.as_ref().map(|idx| idx.value_type))
+                index_info
+                    .string_index
+                    .as_ref()
+                    .map(|idx| (idx.value_type, idx.key_type))
             };
 
             // Check against number index signature first (for numeric properties)
@@ -886,8 +898,10 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            // Check against string index signature
-            if let Some(string_value_type) = applicable_string_value
+            // Check against string index signature. A template-literal pattern
+            // key constrains only property names that match the pattern.
+            if let Some((string_value_type, string_key_type)) = applicable_string_index
+                && self.property_name_matches_index_key(&prop_name, string_key_type)
                 && !self.property_type_assignable_to_index_type(prop_type, string_value_type)
             {
                 // Deduplicate TS2411 across merged interface bodies (same as above).
@@ -897,11 +911,17 @@ impl<'a> CheckerState<'a> {
 
                     let prop_type_str = self.format_ts2411_type(prop_type);
                     let index_type_str = self.format_ts2411_type(string_value_type);
+                    let index_kind_str = self.index_signature_key_display(string_key_type);
 
                     self.error_at_node_msg(
                         name_idx,
                         diagnostic_codes::PROPERTY_OF_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,
-                        &[&diag_prop_name, &prop_type_str, "string", &index_type_str],
+                        &[
+                            &diag_prop_name,
+                            &prop_type_str,
+                            &index_kind_str,
+                            &index_type_str,
+                        ],
                     );
                 }
             }
@@ -1271,18 +1291,24 @@ impl<'a> CheckerState<'a> {
             }
 
             // Skip properties already covered by a base that owns the string index sig.
-            if let Some(ref string_idx) = index_info.string_index
+            // A template-literal pattern key constrains only matching names.
+            if let Some((string_key_type, string_value_type)) = index_info
+                .string_index
+                .as_ref()
+                .map(|s| (s.key_type, s.value_type))
                 && !string_index_covered.contains(&prop_name)
-                && !self.property_type_assignable_to_index_type(prop_type, string_idx.value_type)
+                && self.property_name_matches_index_key(&prop_name, string_key_type)
+                && !self.property_type_assignable_to_index_type(prop_type, string_value_type)
             {
                 let prop_type_str = self.format_ts2411_type(prop_type);
-                let index_type_str = self.format_ts2411_type(string_idx.value_type);
+                let index_type_str = self.format_ts2411_type(string_value_type);
+                let index_kind_str = self.index_signature_key_display(string_key_type);
                 let error_node = string_index_sig_node.unwrap_or(name_fallback_node);
 
                 self.error_at_node_msg(
                     error_node,
                     diagnostic_codes::PROPERTY_OF_TYPE_IS_NOT_ASSIGNABLE_TO_INDEX_TYPE,
-                    &[&prop_name, &prop_type_str, "string", &index_type_str],
+                    &[&prop_name, &prop_type_str, &index_kind_str, &index_type_str],
                 );
             }
         }

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_key_helpers.rs
@@ -171,6 +171,42 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Does a property named `prop_name` fall under a `string`-slot index
+    /// signature whose key type is `key_type`?
+    ///
+    /// A plain `string` (or `any`) key matches every string-named property. A
+    /// template-literal *pattern* key (`[k: `id_${number}`]`) is stored in the
+    /// same `string_index` slot, but only constrains property names assignable
+    /// to the pattern — mirroring tsc, where a property participates in an index
+    /// signature's `TS2411` check only when its name type is assignable to the
+    /// index's key type. Without this gate a pattern index wrongly constrains
+    /// every string-named property (a `TS2411` false positive on `size` for
+    /// `interface D { [k: `id_${number}`]: string; size: number }`).
+    pub(crate) fn property_name_matches_index_key(
+        &mut self,
+        prop_name: &str,
+        key_type: TypeId,
+    ) -> bool {
+        if key_type == TypeId::STRING || key_type == TypeId::ANY {
+            return true;
+        }
+        let name_literal = self.ctx.types.literal_string(prop_name);
+        self.index_signature_relation_outcome(name_literal, key_type)
+            .related
+    }
+
+    /// Display text for the *kind* of a `string`-slot index signature key in a
+    /// `TS2411` message: `string` for a plain string key, otherwise the key
+    /// type's own rendering (e.g. the template-literal pattern `` `id_${number}` ``,
+    /// which tsc shows in place of `string`).
+    pub(crate) fn index_signature_key_display(&mut self, key_type: TypeId) -> String {
+        if key_type == TypeId::STRING {
+            "string".to_string()
+        } else {
+            self.format_type(key_type)
+        }
+    }
+
     pub(crate) fn template_pattern_key_is_subset(&self, source: TypeId, target: TypeId) -> bool {
         let Some((source_prefix, source_suffix)) = self.template_pattern_bounds(source) else {
             return false;

--- a/crates/tsz-checker/tests/ts2411_pattern_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/ts2411_pattern_index_signature_tests.rs
@@ -1,0 +1,211 @@
+//! TS2411 with template-literal (pattern) index signatures.
+//!
+//! A template-literal pattern index signature (`[k: `id_${number}`]: V`) is
+//! stored in the same `string_index` slot as a plain `[k: string]` signature,
+//! but it constrains only property names that *match the pattern*. tsc checks a
+//! property against an index signature only when the property's name type is
+//! assignable to the index's key type, and renders the pattern (not `string`)
+//! as the index kind in the diagnostic.
+//!
+//! Before this was gated, every string-named property was checked against the
+//! pattern's value type (a TS2411 false positive on non-matching properties such
+//! as `size`), and matching properties were mislabeled `'string' index type`.
+
+use tsz_checker::test_utils::{check_source_strict_codes, check_source_strict_messages};
+
+fn ts2411_count(source: &str) -> usize {
+    check_source_strict_codes(source)
+        .into_iter()
+        .filter(|code| *code == 2411)
+        .count()
+}
+
+#[test]
+fn pattern_index_does_not_constrain_non_matching_property() {
+    // `size` does not match `id_${number}`, so tsc reports nothing.
+    let source = r#"
+interface Registry {
+    [key: `id_${number}`]: string;
+    size: number;
+}
+"#;
+    assert_eq!(
+        ts2411_count(source),
+        0,
+        "a pattern index signature must not constrain a non-matching property"
+    );
+}
+
+#[test]
+fn pattern_index_constrains_matching_property_with_pattern_label() {
+    // `id_1` matches `id_${number}`; its `number` value is incompatible with the
+    // `string` index value, so tsc reports TS2411 — labeled with the pattern.
+    let source = r#"
+interface Registry {
+    [key: `id_${number}`]: string;
+    id_1: number;
+}
+"#;
+    let messages = check_source_strict_messages(source);
+    let hit = messages.iter().find(|(code, _)| *code == 2411);
+    assert!(
+        hit.is_some_and(|(_, m)| m.contains("'id_1'")
+            && m.contains("`id_${number}`")
+            && m.contains("index type 'string'")
+            && !m.contains("'string' index type")),
+        "matching property must report TS2411 labeled with the pattern key, got: {messages:?}"
+    );
+}
+
+#[test]
+fn pattern_index_accepts_matching_property_with_compatible_value() {
+    let source = r#"
+interface Registry {
+    [key: `id_${number}`]: string;
+    id_1: string;
+}
+"#;
+    assert_eq!(
+        ts2411_count(source),
+        0,
+        "a matching property with a compatible value type is fine"
+    );
+}
+
+#[test]
+fn union_of_patterns_only_constrains_matching_names() {
+    // Neither member of `cother` matches an `a${string}` / `b${string}` pattern.
+    let source = r#"
+interface Bus {
+    [evt: `a${string}` | `b${string}`]: string;
+    cother: number;
+}
+"#;
+    assert_eq!(
+        ts2411_count(source),
+        0,
+        "a union-of-patterns key must not constrain a name matching no member"
+    );
+}
+
+#[test]
+fn prefix_pattern_reports_only_matching_property() {
+    // `p_x` matches `p_${string}`; `other` does not.
+    let source = r#"
+interface Slots {
+    [slot: `p_${string}`]: string;
+    p_x: number;
+    other: boolean;
+}
+"#;
+    assert_eq!(
+        ts2411_count(source),
+        1,
+        "only the pattern-matching property is constrained, not the unrelated one"
+    );
+}
+
+#[test]
+fn plain_string_index_still_constrains_every_property() {
+    // Control: a plain `string` index is unchanged — it constrains all
+    // string-named properties and is labeled `'string' index type`.
+    let source = r#"
+interface Plain {
+    [key: string]: string;
+    size: number;
+}
+"#;
+    let messages = check_source_strict_messages(source);
+    let hit = messages.iter().find(|(code, _)| *code == 2411);
+    assert!(
+        hit.is_some_and(|(_, m)| m.contains("'size'") && m.contains("'string' index type 'string'")),
+        "a plain string index keeps its `string` label and constrains every property, got: {messages:?}"
+    );
+}
+
+#[test]
+fn pattern_index_inherited_does_not_constrain_non_matching_derived_property() {
+    // The pattern index is inherited; the derived non-matching `label`
+    // must not be constrained by it.
+    let source = r#"
+interface Base {
+    [key: `id_${number}`]: string;
+}
+interface Derived extends Base {
+    label: number;
+}
+"#;
+    assert_eq!(
+        ts2411_count(source),
+        0,
+        "an inherited pattern index must not constrain a non-matching derived property"
+    );
+}
+
+#[test]
+fn pattern_index_rule_is_not_binder_name_dependent() {
+    // Anti-hardcoding: rename the interface, the pattern prefix, the index
+    // parameter, and the properties — behavior is identical to the canonical
+    // cases (one matching error, zero non-matching errors).
+    let source = r#"
+interface Catalogue {
+    [slot: `sku_${number}`]: string;
+    sku_7: number;
+    weight: number;
+}
+"#;
+    let messages = check_source_strict_messages(source);
+    let count = messages.iter().filter(|(code, _)| *code == 2411).count();
+    assert_eq!(
+        count, 1,
+        "renamed binders must behave identically (only `sku_7` matches), got: {messages:?}"
+    );
+    assert!(
+        messages.iter().any(|(code, m)| *code == 2411
+            && m.contains("'sku_7'")
+            && m.contains("`sku_${number}`")),
+        "the matching property is labeled with its own pattern, got: {messages:?}"
+    );
+}
+
+#[test]
+fn derived_pattern_index_does_not_constrain_non_matching_type_alias_base_property() {
+    // A derived interface that adds a pattern index over a *type-alias* base
+    // must not constrain the base's non-matching properties — exercises the
+    // `check_type_alias_base_properties_against_derived_string_index` path.
+    let source = r#"
+type Base = { foo: number; bar: string };
+interface Derived extends Base {
+    [k: `id_${number}`]: string;
+}
+"#;
+    assert_eq!(
+        ts2411_count(source),
+        0,
+        "a derived pattern index must not constrain non-matching type-alias base properties"
+    );
+}
+
+#[test]
+fn derived_pattern_index_reports_matching_type_alias_base_property_once() {
+    // The matching base property is reported exactly once (the inherited-property
+    // and type-alias-base heritage paths must agree on the pattern label so they
+    // dedupe to a single diagnostic, not two).
+    let source = r#"
+type Base = { id_5: number };
+interface Derived extends Base {
+    [k: `id_${number}`]: string;
+}
+"#;
+    let messages = check_source_strict_messages(source);
+    let hits: Vec<_> = messages.iter().filter(|(code, _)| *code == 2411).collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "the matching base property is reported exactly once, got: {messages:?}"
+    );
+    assert!(
+        hits[0].1.contains("'id_5'") && hits[0].1.contains("`id_${number}`"),
+        "the single diagnostic is labeled with the pattern key, got: {messages:?}"
+    );
+}


### PR DESCRIPTION
## Problem

A **template-literal pattern** index signature such as `[k: T]: V` where the key `T` is
`` `id_${number}` `` constrains only property names that *match the pattern*. tsc checks a
property against an index signature only when the property's name type is assignable to the
index's key type, and renders the pattern (not `string`) as the index kind in the `TS2411`
message.

tsz stored such a pattern in the same `string_index` slot as a plain `[k: string]` and
then treated the slot as a plain `string` index, so a pattern index wrongly constrained
**every** string-named property and mislabeled the kind:

```ts
interface Registry {
  [key: `id_${number}`]: string;
  size: number;   // tsc: ok    tsz before: TS2411 'number' not assignable to 'string' index 'string'  ❌
  id_1: number;   // tsc: TS2411 ... '`id_${number}`' index   tsz before: ... 'string' index  ❌ (wrong label)
}
```

## Structural rule

When a property is checked against a `string`-slot index signature whose key type is a
template-literal pattern (or a union of patterns), tsc constrains the property **only if
its name type is assignable to the key type**, and labels the diagnostic with the key
pattern. A plain `string`/`any` key still matches every string-named property and is
labeled `string`. tsz now does the same through the checker's `TS2411` paths.

## Owner layer

Checker member-compatibility (`TS2411`) — three emission sites shared the same wrong
assumption that a `string_index` slot is always a plain `string` index:

- `state_checking_members/index_signature_checks.rs` — own-property and inherited-property
  checks. Carry the index `key_type` alongside the value type; gate the property check on a
  new structural predicate and label via the key.
- `classes/interface_heritage_index.rs` (`check_type_alias_base_properties_against_derived_string_index`)
  plus its caller `classes/class_checker_compat.rs` — the derived-index-vs-type-alias-base
  path. Thread the `key_type` through and apply the same gate/label. Aligning this path's
  label also lets the two heritage checks **dedupe** a matching base property to a single
  diagnostic (previously two, once the inherited path's label was corrected).

New shared helpers in `index_signature_key_helpers.rs`:
- `property_name_matches_index_key` — `string`/`any` ⇒ all names; otherwise the property
  name (interned as a string-literal type) must be assignable to the key type, via the
  existing index-signature relation. No printer/string-display predicate; no name/file-name
  literals — purely structural.
- `index_signature_key_display` — `string` for a plain key, else the key type's rendering.

## Adjacent matrix (built binary vs `tsc` 6.0.2, `--strict --lib es2022`)

| case | tsc | tsz after |
| --- | --- | --- |
| pattern index + non-matching `size` | (no error) | (no error) ✓ |
| pattern index + matching `id_1: number` | TS2411 with pattern index label | same ✓ |
| pattern index + matching `id_1: string` | (no error) | (no error) ✓ |
| union-of-patterns + non-matching name | (no error) | (no error) ✓ |
| prefix pattern + matching + unrelated | one TS2411 on the match | same ✓ |
| plain `string` index + `size` (control) | TS2411 with `string` label | same ✓ |
| inherited pattern index + non-matching derived | (no error) | (no error) ✓ |
| pattern index over **type-alias base**, non-matching | (no error) | (no error) ✓ |
| pattern index over type-alias base, matching | **one** TS2411 (pattern label) | same ✓ |

Renamed binders (interface / pattern prefix / index parameter / property) behave
identically — covered by an anti-hardcoding test.

## Anti-hardcoding

The gate is the structural relation between the property-name type and the index key type;
no rendered-display predicate, no identifier/file-name literals. The new test suite varies
binder names.

## Out of scope

The structural-display of an interface whose **only** member is a template-literal index
signature still renders as `{}` in a `TS7053` message (e.g. `index type '{}'` instead of
`'Dict'`); that is a separate solver-formatter facet, not the `TS2411` applicability rule
fixed here.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- New suite `crates/tsz-checker/tests/ts2411_pattern_index_signature_tests.rs` (10 tests):
  non-matching/matching/compatible, union-of-patterns, prefix pattern, plain-string control,
  inherited pattern, type-alias-base non-matching/matching-dedup, renamed-binder invariance —
  all pass.
- Differential harness (built `tsz` dist-fast vs `tsc` 6.0.2) over the full adjacent matrix:
  every case matches; a 54-case probe corpus shows **no new diagnostic-code or message
  divergences** (the pre-existing divergences are unrelated alias/elaboration display).
- No regressions: `cargo test -p tsz-checker --lib` for `index_sig`/`interface_heritage`/
  `class_extends_index`/`class_implements_index`/`incorrectly_extends` (260 pass; the single
  `index_signature_symbol_keyspace` failure is pre-existing on a clean `main`, verified by
  stash).
- `cargo fmt -p tsz-checker -- --check`, `cargo clippy -p tsz-checker --lib`,
  `python3 scripts/arch/arch_guard.py`: clean.
- Reviewed via `/simplify` (reuse / simplification / efficiency / altitude): merged the
  parallel `applicable_string_value`/`applicable_string_key` into one `Option<(value, key)>`;
  the common plain-`string`/`any` case short-circuits before any interning (efficiency); the
  matching predicate is novel (no existing checker/query-boundary equivalent).
- Broad conformance / emit / fourslash floors owned by ready-review CI; this change only
  affects `TS2411` diagnostics.

https://claude.ai/code/session_0129SVxhiBZ2wccZGDz8xt2n