### PR TITLE
fix(checker): emit bare-type-parameter-target note at every TS2322 chain depth (#14642)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1949,6 +1949,7 @@ impl<'a> CheckerState<'a> {
                 &tgt_str,
                 anchor.start,
                 anchor.length,
+                0,
             ) {
                 self.emit_render_request_at_anchor(
                     anchor,

--- a/crates/tsz-checker/src/error_reporter/assignability_type_parameter_target.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_type_parameter_target.rs
@@ -36,11 +36,19 @@ impl<'a> CheckerState<'a> {
         target_display: &str,
         start: u32,
         length: u32,
+        note_depth: u32,
     ) -> Option<DiagnosticRelatedInformation> {
         if !self.target_is_bare_type_parameter(target) {
             return None;
         }
         let file = self.ctx.file_name.clone();
+        // `note_depth` is the related-info chain depth the caller wants this note
+        // rendered at — directly beneath the failing `Type '{src}' is not
+        // assignable to type '{T}'.` line. `tsc` appends the note at *every*
+        // nesting level a bare-type-parameter target fails at, not only the
+        // top-level mismatch, so the caller threads the failing line's child
+        // depth through here.
+        let note_depth = u8::try_from(note_depth).unwrap_or(u8::MAX);
         let elaboration = |code, message_text| DiagnosticRelatedInformation {
             category: DiagnosticCategory::Message,
             code,
@@ -48,7 +56,7 @@ impl<'a> CheckerState<'a> {
             start,
             length,
             message_text,
-            depth: 0,
+            depth: note_depth,
         };
         let constraint =
             crate::query_boundaries::diagnostics::type_parameter_constraint(self.ctx.types, target)

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -566,16 +566,21 @@ impl<'a> CheckerState<'a> {
             base,
             diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
         );
-        if depth == 0
-            && let Some(related) = self.unrelated_type_parameter_target_related_info(
-                source,
-                target,
-                &source_str,
-                &target_str,
-                start,
-                length,
-            )
-        {
+        // The note is a child of the failing mismatch line this function renders
+        // at chain depth `depth`; place it one level deeper, matching the
+        // child-depth idiom used by the other nested-elaboration renderers. The
+        // top-level mismatch is the diagnostic header, so its first child stays
+        // at depth 0.
+        let note_depth = if depth == 0 { 0 } else { depth + 1 };
+        if let Some(related) = self.unrelated_type_parameter_target_related_info(
+            source,
+            target,
+            &source_str,
+            &target_str,
+            start,
+            length,
+            note_depth,
+        ) {
             diagnostic.related_information.push(related);
         }
         diagnostic

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1186,6 +1186,9 @@ mod namespace_property_mismatch_boundary_arch_tests;
 #[path = "tests/nested_tuple_literal_source_display_tests.rs"]
 mod nested_tuple_literal_source_display_tests;
 #[cfg(test)]
+#[path = "tests/nested_type_parameter_target_elaboration_tests.rs"]
+mod nested_type_parameter_target_elaboration_tests;
+#[cfg(test)]
 #[path = "../tests/never_absorption_call_spread_tests.rs"]
 mod never_absorption_call_spread_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/nested_type_parameter_target_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/nested_type_parameter_target_elaboration_tests.rs
@@ -1,0 +1,198 @@
+//! Tests that `tsc`'s bare-type-parameter-target elaboration
+//! (`TS5082`/`TS5075`, "`'T'` could be instantiated with an arbitrary type
+//! …" / "… could be instantiated with a different subtype of constraint …") is
+//! attached at *every* nesting level the type-parameter target fails at, not
+//! only the top-level mismatch.
+//!
+//! Structural rule: when a concrete source fails to relate to a bare
+//! type-parameter target, `tsc`'s `reportRelationError` appends the
+//! type-parameter note beneath the failing `Type '{src}' is not assignable to
+//! type '{T}'.` line — whether that line is the top-level diagnostic or a
+//! nested `Types of property 'x' are incompatible.` elaboration child. Before
+//! the fix tsz gated the note on `depth == 0`, dropping it for the nested
+//! object-literal / tuple / array-element forms that real generic code (e.g.
+//! the valibot row, #13212) hits.
+//!
+//! The note's related-info `depth` tracks the failing line's chain depth so it
+//! renders one indentation level deeper, mirroring tsc's progressive indent.
+
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_source_diagnostics;
+
+/// `TS5082` — "`'{T}'` could be instantiated with an arbitrary type …".
+const COULD_BE_INSTANTIATED_ARBITRARY: u32 = 5082;
+/// `TS5075` — "… could be instantiated with a different subtype of constraint …".
+const COULD_BE_INSTANTIATED_DIFFERENT_SUBTYPE: u32 = 5075;
+
+fn ts2322(source: &str) -> Diagnostic {
+    check_source_diagnostics(source)
+        .into_iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| panic!("expected a TS2322 for source:\n{source}"))
+}
+
+/// Find the type-parameter elaboration note (either constraint variant) and
+/// return its rendering `depth`.
+fn type_param_note_depth(diag: &Diagnostic, code: u32) -> u8 {
+    diag.related_information
+        .iter()
+        .find(|r| r.code == code)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected related note TS{code}; got: {:?}",
+                diag.related_information
+            )
+        })
+        .depth
+}
+
+#[test]
+fn direct_type_parameter_return_note_at_depth_zero() {
+    // A direct mismatch against a bare type-parameter target: the failing
+    // `Type 'number' is not assignable to type 'T'.` line is the diagnostic
+    // header itself, so the note is its first child at related-depth 0.
+    let diag = ts2322(
+        r#"
+function make<T>(value: number): T {
+    return value;
+}
+"#,
+    );
+    assert_eq!(
+        type_param_note_depth(&diag, COULD_BE_INSTANTIATED_ARBITRARY),
+        0,
+        "direct type-param note must sit at depth 0, got: {:?}",
+        diag.related_information
+    );
+}
+
+#[test]
+fn nested_object_property_note_indents_below_chain() {
+    // `{ field: T }` reached through a non-fresh source builds the structural
+    // chain `Type '{…}' …` → `Types of property 'field' are incompatible.` →
+    // `Type 'string' is not assignable to type 'T'.`, so the note sits two
+    // levels deeper than the header (related-depth 2). Before the fix this note
+    // was dropped entirely for the nested form.
+    let diag = ts2322(
+        r#"
+function make<T>(): { field: T } {
+    const built = { field: "value" };
+    return built;
+}
+"#,
+    );
+    assert_eq!(
+        type_param_note_depth(&diag, COULD_BE_INSTANTIATED_ARBITRARY),
+        2,
+        "nested object-property type-param note must indent below the chain, got: {:?}",
+        diag.related_information
+    );
+}
+
+#[test]
+fn array_element_type_parameter_note_indents_deepest() {
+    // An array-element relation adds one more chain frame
+    // (`Type '{…}[]' …` → `Type '{…}' …` → `Types of property 'x' …` →
+    // `Type 'string' … 'T'.`), so the note lands at related-depth 3.
+    let diag = ts2322(
+        r#"
+function make<T>(): { x: T }[] {
+    const built = [{ x: "value" }];
+    return built;
+}
+"#,
+    );
+    assert_eq!(
+        type_param_note_depth(&diag, COULD_BE_INSTANTIATED_ARBITRARY),
+        3,
+        "array-element type-param note must indent past every chain frame, got: {:?}",
+        diag.related_information
+    );
+}
+
+#[test]
+fn renamed_binders_still_emit_nested_note() {
+    // Anti-hardcoding: a different type-parameter spelling and property name
+    // must produce the identical note (structural, not name-keyed).
+    let diag = ts2322(
+        r#"
+function build<Elem>(): { entry: Elem } {
+    const made = { entry: "value" };
+    return made;
+}
+"#,
+    );
+    let note = diag
+        .related_information
+        .iter()
+        .find(|r| r.code == COULD_BE_INSTANTIATED_ARBITRARY)
+        .unwrap_or_else(|| panic!("expected TS5082; got: {:?}", diag.related_information));
+    assert!(
+        note.message_text.contains("Elem"),
+        "note must name the actual type parameter, got: {}",
+        note.message_text
+    );
+}
+
+#[test]
+fn deeper_nested_object_property_note_indents_further() {
+    // `{ outer: { inner: T } }` collapses to a single `The types of
+    // 'outer.inner' are incompatible …` line at related-depth 0, so the failing
+    // `… type 'T'.` line is at depth 1 and the note sits one deeper, at depth 2.
+    let diag = ts2322(
+        r#"
+function make<Held>(): { outer: { inner: Held } } {
+    const built = { outer: { inner: "value" } };
+    return built;
+}
+"#,
+    );
+    assert_eq!(
+        type_param_note_depth(&diag, COULD_BE_INSTANTIATED_ARBITRARY),
+        2,
+        "deeply nested type-param note must indent past the collapse line, got: {:?}",
+        diag.related_information
+    );
+}
+
+#[test]
+fn satisfiable_constraint_emits_subtype_variant_nested() {
+    // The source satisfies the constraint, so tsc reports the TS5075 "different
+    // subtype of constraint" variant — still emitted at the nested leaf.
+    let diag = ts2322(
+        r#"
+function make<T extends string | number>(): { field: T } {
+    const built = { field: "value" };
+    return built;
+}
+"#,
+    );
+    assert_eq!(
+        type_param_note_depth(&diag, COULD_BE_INSTANTIATED_DIFFERENT_SUBTYPE),
+        2,
+        "constraint-satisfied source must use the TS5075 subtype variant nested, got: {:?}",
+        diag.related_information
+    );
+}
+
+#[test]
+fn non_type_parameter_nested_mismatch_has_no_note() {
+    // Control: a nested mismatch whose target is a concrete primitive (not a
+    // bare type parameter) must NOT gain the type-parameter elaboration.
+    let diag = ts2322(
+        r#"
+function make(): { field: { value: number } } {
+    const built = { field: { value: "text" } };
+    return built;
+}
+"#,
+    );
+    assert!(
+        diag.related_information
+            .iter()
+            .all(|r| r.code != COULD_BE_INSTANTIATED_ARBITRARY
+                && r.code != COULD_BE_INSTANTIATED_DIFFERENT_SUBTYPE),
+        "concrete-target nested mismatch must not emit a type-param note, got: {:?}",
+        diag.related_information
+    );
+}


### PR DESCRIPTION
Fixes #14642.

Goal: hold

## Problem

`tsc`'s `reportRelationError` appends the bare-type-parameter-target note beneath **every** failing `Type '{src}' is not assignable to type '{T}'.` line — TS5082 (`'T' could be instantiated with an arbitrary type which could be unrelated to '{src}'.`) or TS5075 (`'{src}' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint '{C}'.`). tsz gated the note on `depth == 0`, so it was **dropped** whenever the type-parameter mismatch was nested inside a chained elaboration.

```ts
function f<T>(): { x: T } {
  const o = { x: "hello" };
  return o;
}
```

| | output |
| --- | --- |
| `tsc` 6.0.2 | `Type '{ x: string; }' …` → `Types of property 'x' are incompatible.` → `Type 'string' is not assignable to type 'T'.` → `'T' could be instantiated with an arbitrary type which could be unrelated to 'string'.` |
| tsz before | same chain, **missing** the final `'T' could be instantiated …` line |
| tsz after | matches `tsc` (note at the correct deeper indent) |

A direct mismatch (`function f<T>(v: number): T { return v; }`) already matched; only the nested form diverged. This is the structural residual behind the valibot row (#13212) messaging.

## Structural rule

When a concrete source fails to relate to a bare type-parameter target, `tsc` appends the TS5082/TS5075 note beneath the failing `… is not assignable to type 'T'` line at *every* chain depth, not only the top-level mismatch; tsz now does X through the checker error-reporter, with the note's related-info depth tracking the failing line's child depth.

## Owner layer

Checker diagnostic **display** only — no relation/semantic change, code- and count-neutral:

- **`error_reporter::assignability_type_parameter_target::unrelated_type_parameter_target_related_info`** — gains a `note_depth` parameter and renders the note at that chain depth instead of a hardcoded `0`.
- **`error_reporter::render_failure::type_mismatch`** — drops the `depth == 0` gate and threads the failing line's child depth via the shared nested-elaboration idiom `if depth == 0 { 0 } else { depth + 1 }` (the same spelling used by the union/intersection/array/tuple renderers). The top-level direct-mismatch caller (`assignability.rs`) passes `0` (its note is the header's first child).

No hardcoded identifier/file-name predicates; the gate is structural (`target_is_bare_type_parameter`) and binder names are varied in the tests.

## Adjacent matrix (verified against the built binary + new unit tests, vs tsc 6.0.2)

- direct type-parameter return → note at depth 0 (control, already correct)
- object-property type parameter via non-fresh source → note at depth 2
- array-element `{ x: T }[]` → note at depth 3
- two-level `{ outer: { inner: T } }` collapse → note past the collapse line
- constraint-satisfiable source → **TS5075** subtype variant nested
- renamed binders → identical note (anti-hardcoding)
- control: nested mismatch with a concrete (non-type-parameter) target → **no** note

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- New regression suite `crates/tsz-checker/src/tests/nested_type_parameter_target_elaboration_tests.rs` (7 tests: direct depth-0, nested object-property depth-2, array-element depth-3, two-level collapse, TS5075 constraint variant, renamed-binder invariance, non-type-parameter control) — all pass.
- Differential testing of the built `tsz` debug binary vs `tsc 6.0.2` across the adjacent matrix: all match.
- **No new test failures**: `cargo test -p tsz-checker --lib` failing-test set is byte-identical with and without this change (the residual `index_access_type_parameter_mismatch_elaboration` / `mapped_type_generic_indexed_access_class_member` / `async_return` / `static_schema_*` failures are pre-existing on the clean tree — confirmed via `git stash` diff).
- `cargo fmt -p tsz-checker --check`, `cargo clippy -p tsz-checker --lib`, `python3 scripts/arch/arch_guard.py`: clean.
- Reviewed via `/simplify` (reuse / simplification / efficiency / altitude): applied the altitude finding — moved the child-depth idiom out of the note builder to the caller so the function takes the final note depth, matching the other nested-elaboration renderers. The reuse suggestion to call `Diagnostic::push_elaboration_at` was declined: the builder returns an `Option<DiagnosticRelatedInformation>` consumed by two callers (one feeds it into `DiagnosticRenderRequest::with_related(vec[…])`), so there is no owning `Diagnostic` to push onto.
- Display-only and code-neutral: the conformance gate compares diagnostic codes/counts, not chained message text, so the full conformance / emit / fourslash floors (owned by ready-review CI) are unaffected.

https://claude.ai/code/session_017HSoPXUq1PPRVN8x1RYrPu

---
_Generated by [Claude Code](https://claude.ai/code/session_017HSoPXUq1PPRVN8x1RYrPu)_