### PR TITLE
data(ci): add hotscript + infisical to the green project-compat ratchet baseline

### DIFF
--- a/scripts/ci/project-compat-baseline.json
+++ b/scripts/ci/project-compat-baseline.json
@@ -2,13 +2,15 @@
   "schema": "tsz-project-compat-baseline/v1",
   "description": "No-regression ratchet baseline for the project-compile canary. Each listed row currently compiles like tsc ('green'); once the canary is flipped to blocking, a merge that regresses any of these rows from green to non-green is blocked. Rows NOT listed (currently red/yellow/gray, or brand-new) are advisory and never block. Application rows that fail to clone/install are recorded as 'fixture invalid' (gray) and treated as inconclusive, not a regression. DATA ONLY at this stage: no gate reads this file yet; it is wired up when the canary becomes blocking. Regenerate by intersecting the green rows across recent successful main-CI project-compile-compatibility + project-compile-canary-logs artifacts (exclude any row that is green in only some runs).",
   "source": {
-    "ci_run_ids": ["27887229928", "27886360536"],
-    "source_commit": "01bebe97d9bdf2a49c4e18419e94bcf3d6084392",
-    "artifact_generated_at": "2026-06-20T23:45:40.444Z",
+    "ci_run_ids": ["28080595776", "28077434524"],
+    "source_commit": "26b038f94303ff6ea12a369a897bdb7484b41cbe",
+    "artifact_generated_at": "2026-06-24T06:47:58Z",
     "method": "intersection of green rows across the two most recent successful main CI runs (zero divergence between them)"
   },
   "rows": {
     "comlink-project": "green",
+    "hotscript-project": "green",
+    "infisical-project": "green",
     "nextjs-fresh-app": "green",
     "rxjs-project": "green",
     "ts-essentials-project": "green",


### PR DESCRIPTION
Adds two newly-green canary projects to the project-compile green ratchet baseline
so the maintained green-canary allowlist reflects current compile readiness.

Goal: green

## What & why
`scripts/ci/project-compat-baseline.json` is the no-regression ratchet baseline:
each listed row currently compiles like tsc ('green'). Its own description mandates
regenerating it by intersecting the green rows across the two most recent
successful main-CI `project-compile-compatibility` + `project-compile-canary-logs`
artifacts.

The baseline was 4 days stale (generated 2026-06-20, 10 rows). Two canary-tier
projects have since reached green and were missing:

- **hotscript-project** — green
- **infisical-project** — green

Verified by the intersection of the two most recent successful main CI runs
(`28080595776`, `28077434524`, commit `26b038f9`): both runs' `project-compile-
canary-logs` artifacts mark `hotscript-project`, `infisical-project`, and the
already-listed `ts-pattern-project` as `state: green`, `exit_class: exit success`,
with zero divergence between runs.

Source metadata (`ci_run_ids`, `source_commit`, `artifact_generated_at`) refreshed
to the verifying runs. All 12 baseline rows exist in `PROJECT_ROW_DEFINITIONS`.

## Context on website compatibility charts
Investigated whether any green canary was hidden from the website compatibility
charts and needed a display whitelist. Finding: there is **no hidden-canary
whitelist** — `crates/tsz-website` shows every row in
`REQUIRED_PROJECT_ROWS ∪ COMPILE_CANARY_PROJECT_ROWS` (all 60 canaries), and the
green/red state is data-driven from the CI compatibility artifact
(`hasGreenProjectCompatibility` / `compatibilityState` in
`src/_data/benchmark_data.js`). Green canaries therefore surface automatically once
fresh CI data lands; no per-canary website edit is required. The one genuinely
stale, human-maintained green list was this ratchet baseline, fixed here.

## Verification
- `python3 -c "import json; json.load(open('scripts/ci/project-compat-baseline.json'))"` — valid JSON, 12 rows.
- All 12 rows confirmed present in `scripts/bench/project-rows.mjs` `PROJECT_ROW_DEFINITIONS`.
- Both source CI runs independently confirm the two added rows green (intersection method).

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max