### PR TITLE
fix(checker): preserve declared signature return/param literals in TS2322 display (#14645)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1330,11 +1330,15 @@ impl<'a> CheckerState<'a> {
                 || self.source_carries_canonical_literal_member_inner(child, visiting, depth + 1)
         };
 
-        if let Some(shape) = crate::query_boundaries::diagnostics::object_shape_for_type(db, ty) {
-            return shape
+        // A hybrid object that also carries call/construct signatures
+        // (`{ x: number; (): 1 }`) falls through to the signature descent below.
+        if let Some(shape) = crate::query_boundaries::diagnostics::object_shape_for_type(db, ty)
+            && shape
                 .properties
                 .iter()
-                .any(|p| recurse(p.type_id, visiting));
+                .any(|p| recurse(p.type_id, visiting))
+        {
+            return true;
         }
         if let Some(elem) = crate::query_boundaries::diagnostics::array_element_type(db, ty) {
             return recurse(elem, visiting);
@@ -1353,7 +1357,9 @@ impl<'a> CheckerState<'a> {
         if let Some(members) = crate::query_boundaries::diagnostics::intersection_members(db, ty) {
             return members.iter().any(|&m| recurse(m, visiting));
         }
-        false
+        super::assignability_type_helpers::signature_carries_canonical_literal_member(
+            db, ty, visiting, recurse,
+        )
     }
 
     pub(super) fn rewrite_target_display_for_non_literal_assignability(

--- a/crates/tsz-checker/src/error_reporter/assignability_type_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_type_helpers.rs
@@ -11,6 +11,47 @@ pub(super) fn is_function_like_for_literal_member_widening(
         || crate::query_boundaries::common::callable_shape_for_type(db, type_id).is_some()
 }
 
+/// Whether any function/method/constructor **signature** reachable from `ty`
+/// carries a canonical literal member in a return or parameter position
+/// (`{ m(): 1 }`, `{ f: () => 1 }`, `(x: 2) => void`). `tsc`'s `getWidenedType`
+/// widens only *fresh* literals, so a declared signature literal is rendered
+/// verbatim; the source-literal-member traversal must descend into signatures
+/// to recognise it. `recurse` performs the literal-or-deeper check on a child
+/// type, threading the cycle-guard `visiting` set.
+pub(super) fn signature_carries_canonical_literal_member<F>(
+    db: &dyn tsz_solver::construction::TypeDatabase,
+    ty: TypeId,
+    visiting: &mut rustc_hash::FxHashSet<TypeId>,
+    mut recurse: F,
+) -> bool
+where
+    F: FnMut(TypeId, &mut rustc_hash::FxHashSet<TypeId>) -> bool,
+{
+    if let Some(func) = crate::query_boundaries::diagnostics::function_shape_for_type(db, ty)
+        && (recurse(func.return_type, visiting)
+            || func.params.iter().any(|p| recurse(p.type_id, visiting)))
+    {
+        return true;
+    }
+    if let Some(callable) = crate::query_boundaries::diagnostics::callable_shape_for_type(db, ty) {
+        // A hybrid object that also carries call/construct signatures
+        // (`{ x: number; (): 1 }`) keeps its signature literals too.
+        return callable
+            .call_signatures
+            .iter()
+            .chain(callable.construct_signatures.iter())
+            .any(|sig| {
+                recurse(sig.return_type, visiting)
+                    || sig.params.iter().any(|p| recurse(p.type_id, visiting))
+            })
+            || callable
+                .properties
+                .iter()
+                .any(|p| recurse(p.type_id, visiting));
+    }
+    false
+}
+
 /// Returns true if the formatted type name matches a built-in wrapper type
 /// (Boolean, Number, String, Object). These types inherit properties from Object
 /// and missing-property diagnostics should be suppressed in favor of TS2322.

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1522,6 +1522,13 @@ impl<'a> CheckerState<'a> {
         if node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
             return None;
         }
+        // The source is a *declared* identifier reference, not a fresh function
+        // expression, so its signature return literals (`{ m(): 1 }`, `() => 1`)
+        // are rendered verbatim — `tsc` widens only fresh literals. Fresh
+        // function-expression sources never reach this path and keep widening.
+        let _preserve_signature_returns =
+            crate::error_reporter::core::type_display::PreserveSignatureReturnLiteralsScope::enter(
+            );
         let sym_id = self.resolve_identifier_symbol(expr_idx)?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
         if !symbol.has_any_flags(tsz_binder::symbol_flags::VARIABLE) {

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -11,7 +11,72 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
 
+thread_local! {
+    /// When set, `normalize_assignability_display_type` preserves the *literal*
+    /// return type of a function/method/constructor signature instead of
+    /// widening it for display (`{ m(): 1 }` stays `{ m(): 1 }`, not
+    /// `{ m(): number }`).
+    ///
+    /// `tsc`'s `getWidenedType` widens only *fresh* literals, so a literal in a
+    /// **declared** signature position is rendered verbatim, while a **fresh**
+    /// function expression's inferred return literal is widened (`(x) => 1`
+    /// displays as `(x) => number`). tsz loses per-literal freshness for inferred
+    /// arrow returns, so the discriminator is the *source provenance*: only the
+    /// declared-identifier source path activates this scope. Off by default, so
+    /// fresh function-expression sources keep widening.
+    static PRESERVE_SIGNATURE_RETURN_LITERALS: std::cell::Cell<bool> =
+        const { std::cell::Cell::new(false) };
+}
+
+fn preserve_signature_return_literals_active() -> bool {
+    PRESERVE_SIGNATURE_RETURN_LITERALS.with(std::cell::Cell::get)
+}
+
+/// RAII guard that makes assignability display normalization preserve declared
+/// signature return literals for the duration of its lifetime, restoring the
+/// previous state on drop (including on unwind), mirroring the depth/budget
+/// guards in `normalize_assignability_display_type`.
+pub(in crate::error_reporter) struct PreserveSignatureReturnLiteralsScope(bool);
+
+impl PreserveSignatureReturnLiteralsScope {
+    pub(in crate::error_reporter) fn enter() -> Self {
+        Self(PRESERVE_SIGNATURE_RETURN_LITERALS.with(|cell| cell.replace(true)))
+    }
+}
+
+impl Drop for PreserveSignatureReturnLiteralsScope {
+    fn drop(&mut self) {
+        PRESERVE_SIGNATURE_RETURN_LITERALS.with(|cell| cell.set(self.0));
+    }
+}
+
 impl<'a> CheckerState<'a> {
+    /// Apply display widening to an already-normalized signature return type.
+    ///
+    /// A deferred conditional return is left as-is; a fresh function
+    /// expression's inferred return literal widens to its base (`(x) => 1` →
+    /// `(x) => number`); a declared (non-fresh) signature return literal is kept
+    /// verbatim (`{ m(): 1 }`) when [`PreserveSignatureReturnLiteralsScope`] is
+    /// active. A fresh object-literal return widens in both cases.
+    fn display_widen_signature_return(
+        &self,
+        original_return: TypeId,
+        normalized_return: TypeId,
+    ) -> TypeId {
+        if crate::query_boundaries::common::is_conditional_type(self.ctx.types, original_return) {
+            return normalized_return;
+        }
+        // A declared (non-fresh) signature return literal is kept verbatim; a
+        // fresh function expression's inferred return literal widens to its base.
+        // A fresh object-literal return widens in both cases.
+        let return_type = if preserve_signature_return_literals_active() {
+            normalized_return
+        } else {
+            crate::query_boundaries::common::widen_type(self.ctx.types, normalized_return)
+        };
+        self.widen_fresh_object_literal_properties_for_display(return_type)
+    }
+
     pub(in crate::error_reporter) fn sanitize_type_annotation_text_for_diagnostic(
         &self,
         text: String,
@@ -844,18 +909,8 @@ impl<'a> CheckerState<'a> {
                         visiting.remove(&ty);
                         return evaluated;
                     }
-                    let return_type = if crate::query_boundaries::common::is_conditional_type(
-                        self.ctx.types,
-                        shape.return_type,
-                    ) {
-                        return_type
-                    } else {
-                        let widened = crate::query_boundaries::common::widen_type(
-                            self.ctx.types,
-                            return_type,
-                        );
-                        self.widen_fresh_object_literal_properties_for_display(widened)
-                    };
+                    let return_type =
+                        self.display_widen_signature_return(shape.return_type, return_type);
                     if params.iter().zip(shape.params.iter()).all(|(a, b)| a == b)
                         && return_type == shape.return_type
                     {
@@ -1140,16 +1195,8 @@ impl<'a> CheckerState<'a> {
                     visiting.remove(&ty);
                     return evaluated;
                 }
-                let return_type = if crate::query_boundaries::common::is_conditional_type(
-                    self.ctx.types,
-                    shape.return_type,
-                ) {
-                    return_type
-                } else {
-                    let widened =
-                        crate::query_boundaries::common::widen_type(self.ctx.types, return_type);
-                    self.widen_fresh_object_literal_properties_for_display(widened)
-                };
+                let return_type =
+                    self.display_widen_signature_return(shape.return_type, return_type);
                 if params.iter().zip(shape.params.iter()).all(|(a, b)| a == b)
                     && return_type == shape.return_type
                 {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -193,6 +193,9 @@ mod control_flow_type_guard_tests;
 #[path = "tests/cross_module_class_self_member_tests.rs"]
 mod cross_module_class_self_member_tests;
 #[cfg(test)]
+#[path = "tests/declared_signature_return_literal_display_tests.rs"]
+mod declared_signature_return_literal_display_tests;
+#[cfg(test)]
 #[path = "tests/decorator_return_relation_routing_arch_tests.rs"]
 mod decorator_return_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/declared_signature_return_literal_display_tests.rs
+++ b/crates/tsz-checker/src/tests/declared_signature_return_literal_display_tests.rs
@@ -1,0 +1,209 @@
+//! Tests that a **declared** (non-fresh) signature source preserves its literal
+//! return and parameter types verbatim in TS2322 assignability diagnostics,
+//! while a **fresh** function expression's inferred return literal still widens.
+//!
+//! Structural rule: `tsc`'s `getWidenedType` widens only *fresh* literals, so a
+//! literal written in a declared signature position — `{ m(): 1 }`,
+//! `(x: 2) => void`, `() => 1` — is rendered verbatim, whereas a fresh function
+//! expression's inferred return (`(x) => 1`) is widened to its base
+//! (`(x) => number`). tsz lost per-literal freshness for inferred arrow returns,
+//! so the discriminator is the *source provenance*: only the declared-identifier
+//! source path preserves the signature literal; fresh function-expression
+//! sources keep widening.
+//!
+//! Before the fix, the assignability display normalizer widened *every*
+//! function/method/constructor return literal, so a declared `{ m(): 1 }` source
+//! rendered as `{ m(): number; }`. The traversal that recognizes a non-fresh
+//! source's canonical literal members also did not descend into signature
+//! parameter/return positions, so a declared `{ m(x: 1): void }` param widened
+//! too.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322_messages(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+fn assert_source_displays(source: &str, expected_source_type: &str) {
+    let messages = ts2322_messages(source);
+    assert!(
+        messages.iter().any(|m| m.contains(expected_source_type)),
+        "expected source display `{expected_source_type}`, got: {messages:?}"
+    );
+}
+
+#[test]
+fn declared_method_return_literal_is_preserved() {
+    assert_source_displays(
+        r#"
+declare const v: { m(): 1 };
+const s: string = v;
+"#,
+        "{ m(): 1; }",
+    );
+}
+
+#[test]
+fn declared_method_string_return_literal_is_preserved() {
+    assert_source_displays(
+        r#"
+declare const v: { m(): "x" };
+const s: string = v;
+"#,
+        "{ m(): \"x\"; }",
+    );
+}
+
+#[test]
+fn declared_method_parameter_literal_is_preserved() {
+    // The non-fresh-literal-member traversal must descend into signature
+    // parameter positions, not just return positions.
+    assert_source_displays(
+        r#"
+declare const v: { m(x: 1): void };
+const s: string = v;
+"#,
+        "{ m(x: 1): void; }",
+    );
+}
+
+#[test]
+fn declared_method_param_and_return_literals_are_preserved() {
+    assert_source_displays(
+        r#"
+declare const v: { m(x: 1): 2 };
+const s: string = v;
+"#,
+        "{ m(x: 1): 2; }",
+    );
+}
+
+#[test]
+fn nested_declared_method_return_literal_is_preserved() {
+    assert_source_displays(
+        r#"
+declare const v: { o: { m(): 2 } };
+const s: string = v;
+"#,
+        "{ o: { m(): 2; }; }",
+    );
+}
+
+#[test]
+fn declared_top_level_function_return_literal_is_preserved() {
+    assert_source_displays(
+        r#"
+declare const v: () => 1;
+const s: string = v;
+"#,
+        "() => 1",
+    );
+}
+
+#[test]
+fn declared_method_literal_preserved_when_source_is_in_target_role_position() {
+    // The mismatching source here is `x` (`{ m(): 2 }`); it must keep `2`.
+    assert_source_displays(
+        r#"
+declare const x: { m(): 2 };
+const v: { m(): 1 } = x;
+"#,
+        "{ m(): 2; }",
+    );
+}
+
+#[test]
+fn renamed_binders_preserve_declared_method_return_literal() {
+    // Anti-hardcoding: the rule is structural, not keyed on identifier names.
+    assert_source_displays(
+        r#"
+declare const widget: { compute(): 7 };
+const out: string = widget;
+"#,
+        "{ compute(): 7; }",
+    );
+}
+
+#[test]
+fn fresh_arrow_expression_return_literal_still_widens() {
+    // A fresh function expression's inferred return literal is widened to its
+    // base, matching tsc (`(x) => 1` → `(x: number) => number`).
+    let messages = ts2322_messages(
+        r#"
+interface T { (x: number): string }
+declare let t: T;
+t = (x: number) => 1;
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("(x: number) => number")),
+        "fresh arrow return should widen to `number`, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("(x: number) => 1")),
+        "fresh arrow return must not be preserved as a literal, got: {messages:?}"
+    );
+}
+
+#[test]
+fn fresh_function_expression_return_literal_still_widens() {
+    let messages = ts2322_messages(
+        r#"
+interface T { (x: number): string }
+declare let t: T;
+t = function (x: number) { return 1; };
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("(x: number) => number")),
+        "fresh function-expression return should widen, got: {messages:?}"
+    );
+}
+
+#[test]
+fn fresh_object_literal_method_return_still_widens() {
+    // A fresh object literal's inferred method return is widened at inference,
+    // so it must keep displaying the widened base.
+    let messages = ts2322_messages(
+        r#"
+const v = { m() { return 1; } };
+const s: string = v;
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("{ m(): number; }")),
+        "fresh object-literal method return should widen, got: {messages:?}"
+    );
+}
+
+#[test]
+fn declared_plain_literal_property_still_preserved_control() {
+    // Pre-existing behavior: a declared non-method literal property is kept.
+    assert_source_displays(
+        r#"
+declare const v: { a: 1 };
+const s: string = v;
+"#,
+        "{ a: 1; }",
+    );
+}
+
+#[test]
+fn declared_unit_literal_source_still_widens_control() {
+    // A declared *scalar* unit-literal source widens to its base against a
+    // non-literal target (unchanged by this fix; literals have no signature).
+    let messages = ts2322_messages(
+        r#"
+declare const v: 1;
+const s: string = v;
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("Type 'number'")),
+        "declared unit literal should widen to base, got: {messages:?}"
+    );
+}


### PR DESCRIPTION
Fixes #14645.

Goal: hold

## Problem

When the assignability **source** of a `TS2322`-family diagnostic is a
**declared** (non-fresh) type whose method/function/constructor **signature**
carries a literal in a return or parameter position, tsz widened that literal to
its base, while `tsc` renders it verbatim.

```ts
declare const value: { m(): 1 };
const text: string = value;
// tsc:        Type '{ m(): 1; }' is not assignable to type 'string'.
// tsz before: Type '{ m(): number; }' is not assignable to type 'string'.
```

The relation outcome and the diagnostic code/position are unchanged — only the
**displayed** source type diverged (`{ m(): 1 } ≰ { m(): 2 }` still rejects with
both literals intact), so this is a display-only, code-neutral fix.

## Structural rule

`tsc`'s `getWidenedType` widens only **fresh** literals, so a literal written in
a **declared** signature position — `{ m(): 1 }`, `(x: 2) => void`, `() => 1` —
is rendered verbatim, while a **fresh** function expression's inferred return
literal is widened (`t = (x) => 1` displays `(x: number) => number`). tsz loses
per-literal freshness for inferred arrow returns, so the type-level normalizer
cannot distinguish declared from fresh; the discriminator is the **source
provenance**. `tsc` does X; tsz now does X.

## Owner layer

Checker diagnostic **source-type display** only — no relation/semantic change.
Two roots:

1. **`error_reporter/core/type_display.rs`** —
   `normalize_assignability_display_type_inner` widened **every**
   function/method/constructor return literal via `widen_type`. The two
   signature-return branches are unified into `display_widen_signature_return`,
   gated on a new thread-local RAII scope (`PreserveSignatureReturnLiteralsScope`,
   mirroring the existing `DEPTH`/`DisplayBudgetScope` guards in the same
   function). The scope is **off by default** (so fresh function-expression
   sources keep widening) and turned **on** only by the declared-identifier
   source path.
2. **`error_reporter/assignability.rs`** —
   `source_carries_canonical_literal_member_inner` (the non-fresh-source
   preservation traversal used by the source- and target-side rewrites) now
   descends into function/callable **signature** return and parameter positions,
   so a declared `{ m(x: 1): void }` param is preserved through the rewrite path.
   The descent is factored into
   `assignability_type_helpers::signature_carries_canonical_literal_member`.
3. **`error_reporter/core/diagnostic_source.rs`** —
   `declared_identifier_source_display` activates the scope at entry; fresh
   function-expression sources never reach this path.

No hardcoded identifier/file-name predicates; the gates are structural (source
provenance + signature traversal). Binder names are varied across the tests.

## Adjacent matrix (verified against the built binary vs `tsc` 6.0.2)

| source | tsc display | result |
| --- | --- | --- |
| `{ m(): 1 }` / `{ m(): "x" }` | `{ m(): 1; }` / `{ m(): "x"; }` | keep ✓ |
| `{ m(x: 1): void }` (param) | `{ m(x: 1): void; }` | keep ✓ |
| `{ m(x: 1): 2 }` | `{ m(x: 1): 2; }` | keep ✓ |
| `{ o: { m(): 2 } }` (nested) | `{ o: { m(): 2; }; }` | keep ✓ |
| `() => 1` (declared top-level) | `() => 1` | keep ✓ |
| target-role source `{ m(): 2 }` | `{ m(): 2; }` | keep ✓ |
| `{ x: number; (): 7 }` (hybrid) | `{ (): 7; x: number; }` | keep ✓ |
| `t = (x: number) => 1` (fresh expr) | `(x: number) => number` | widen (control) ✓ |
| `const v = { m() { return 1 } }` (fresh) | `{ m(): number; }` | widen (control) ✓ |
| `{ a: 1 }` (declared prop) | `{ a: 1; }` | keep (control) ✓ |
| `declare const v: 1` (unit literal) | `number` | widen (control) ✓ |

## Out of scope / known limitations

- The deeper fix — widening inferred **arrow** return types at construction (as
  object-literal methods already are) so the type itself carries the widened
  return — is a broad semantic change deferred to a separate effort; this PR is
  display-only.
- Declared signatures rendered through non-identifier source-display
  fall-throughs (declared-annotation-text path, enum-mismatch fallback) are not
  scope-covered; no current witness reaches them.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- New regression suite
  `crates/tsz-checker/src/tests/declared_signature_return_literal_display_tests.rs`
  (13 tests: method/string/param/param+return/nested/top-level-function/
  target-role/renamed-binder preservation, plus fresh-arrow / fresh-fn-expr /
  fresh-object-method / declared-plain-prop / declared-unit-literal controls) —
  all pass.
- Differential matrix above run through the built `tsz` release binary vs
  `tsc` 6.0.2 — all match.
- No regressions: the `display` / `literal` / `assignab` / `object_` / `ts2322` /
  `overload` / `function_` / `return_` / `widen` checker lib suites show **zero
  new failures** vs a clean-tree baseline (`git stash` diff); the residual
  failures are pre-existing known-red direct-unit tests.
- `cargo fmt -p tsz-checker -- --check`, `cargo clippy -p tsz-checker --lib`,
  `python3 scripts/arch/arch_guard.py`: clean (`assignability.rs` kept under the
  2000-LOC ceiling by extracting the signature descent into a helper).
- Reviewed via `/simplify` (reuse / simplification / efficiency / altitude):
  inlined a single-use closure, hoisted a shared widening tail, and confirmed the
  thread-local scope mirrors the existing display guards.
- Display-only and code-neutral: the conformance gate compares diagnostic
  codes/counts, not chained message text, so the broad conformance / emit /
  fourslash floors (owned by ready-review CI) are unaffected.

https://claude.ai/code/session_01MSevKhYiC3PJsZ3XPorUcM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSevKhYiC3PJsZ3XPorUcM)_