### PR TITLE
fix(checker): append "Type 'X' has no call/construct signatures." note to TS2349/TS2351

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -1171,16 +1171,29 @@ impl<'a> CheckerState<'a> {
         };
 
         if let Some(loc) = self.get_source_location(report_idx) {
-            let mut builder = tsz_solver::SpannedDiagnosticBuilder::with_symbols(
-                self.ctx.types,
-                &self.ctx.binder.symbols,
-                self.ctx.file_name.as_str(),
-            )
-            .with_def_store(&self.ctx.definition_store);
-            let diag = builder.not_callable(type_id, loc.start, loc.length());
-            self.ctx
-                .diagnostics
-                .push(diag.to_checker_diagnostic(&self.ctx.file_name));
+            let (start, length) = (loc.start, loc.length());
+            let mut checker_diag = {
+                let mut builder = tsz_solver::SpannedDiagnosticBuilder::with_symbols(
+                    self.ctx.types,
+                    &self.ctx.binder.symbols,
+                    self.ctx.file_name.as_str(),
+                )
+                .with_def_store(&self.ctx.definition_store);
+                builder
+                    .not_callable(type_id, start, length)
+                    .to_checker_diagnostic(&self.ctx.file_name)
+            };
+            // tsc appends `Type 'X' has no call signatures.` beneath the
+            // `This expression is not callable.` headline (`invocationErrorDetails`).
+            if let Some(detail) = self.invocation_signature_detail(
+                type_id,
+                crate::error_reporter::operator_errors::InvocationSignatureKind::Call,
+                start,
+                length,
+            ) {
+                checker_diag.related_information.push(detail);
+            }
+            self.ctx.diagnostics.push(checker_diag);
         }
     }
 

--- a/crates/tsz-checker/src/error_reporter/operator_errors.rs
+++ b/crates/tsz-checker/src/error_reporter/operator_errors.rs
@@ -1,12 +1,26 @@
 //! Binary operator error reporting (TS2362, TS2363, TS2365, TS2469).
 
-use super::fingerprint_policy::DiagnosticRenderRequest;
-use crate::diagnostics::diagnostic_codes;
+use super::fingerprint_policy::{
+    DiagnosticAnchorKind, DiagnosticRenderRequest, RelatedInformationPolicy,
+};
+use crate::diagnostics::{
+    DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes, diagnostic_messages,
+    format_message,
+};
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
+
+/// Which invocation-error detail (`tsc`'s `invocationErrorDetails`) a non-union
+/// callee/constructor source lacks: a call signature (`TS2349`) or a construct
+/// signature (`TS2351`).
+#[derive(Clone, Copy)]
+pub(crate) enum InvocationSignatureKind {
+    Call,
+    Construct,
+}
 
 impl<'a> CheckerState<'a> {
     /// Report TS2351: "This expression is not constructable. Type 'X' has no construct signatures."
@@ -19,16 +33,81 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        let mut formatter = self.ctx.create_type_formatter();
-        let type_str = formatter.format(type_id);
+        let Some(anchor) = self.resolve_diagnostic_anchor(idx, DiagnosticAnchorKind::Exact) else {
+            return;
+        };
 
-        self.emit_render_request(
-            idx,
-            DiagnosticRenderRequest::simple_msg(
+        let related = self
+            .invocation_signature_detail(
+                type_id,
+                InvocationSignatureKind::Construct,
+                anchor.start,
+                anchor.length,
+            )
+            .map(|detail| vec![detail])
+            .unwrap_or_default();
+
+        let message = diagnostic_messages::THIS_EXPRESSION_IS_NOT_CONSTRUCTABLE.to_string();
+
+        self.emit_render_request_at_anchor(
+            anchor,
+            DiagnosticRenderRequest::with_related(
+                DiagnosticAnchorKind::Exact,
                 diagnostic_codes::THIS_EXPRESSION_IS_NOT_CONSTRUCTABLE,
-                &[&type_str],
+                message,
+                related,
+                RelatedInformationPolicy::ELABORATION,
             ),
         );
+    }
+
+    /// Build `tsc`'s `invocationErrorDetails` chain link for a non-union
+    /// callee/constructor source: the `Type 'X' has no call signatures.`
+    /// (`TS2757`) / `Type 'X' has no construct signatures.` (`TS2761`) note
+    /// rendered one indent level beneath the `This expression is not
+    /// callable/constructable.` headline. The source is displayed as its
+    /// apparent type (`number` -> `Number`, `object` -> `{}`), matching
+    /// `typeToString(getApparentType(type))`.
+    ///
+    /// Returns `None` for `any`/error sources and for unions: `tsc` renders a
+    /// union callee through the distinct `Not all constituents of type 'U' are
+    /// ...` / `No constituent of type 'U' is ...` shapes, so callers keep the
+    /// existing union rendering untouched rather than mislabeling it here.
+    pub(crate) fn invocation_signature_detail(
+        &mut self,
+        type_id: TypeId,
+        kind: InvocationSignatureKind,
+        start: u32,
+        length: u32,
+    ) -> Option<DiagnosticRelatedInformation> {
+        let apparent =
+            crate::query_boundaries::diagnostics::invocation_signature_detail_apparent_type(
+                self.ctx.types,
+                type_id,
+            )?;
+        let mut formatter = self.ctx.create_type_formatter();
+        let type_str = formatter.format(apparent);
+
+        let (code, template) = match kind {
+            InvocationSignatureKind::Call => (
+                diagnostic_codes::TYPE_HAS_NO_CALL_SIGNATURES,
+                diagnostic_messages::TYPE_HAS_NO_CALL_SIGNATURES,
+            ),
+            InvocationSignatureKind::Construct => (
+                diagnostic_codes::TYPE_HAS_NO_CONSTRUCT_SIGNATURES,
+                diagnostic_messages::TYPE_HAS_NO_CONSTRUCT_SIGNATURES,
+            ),
+        };
+
+        Some(DiagnosticRelatedInformation {
+            category: DiagnosticCategory::Message,
+            code,
+            file: self.ctx.file_name.clone(),
+            start,
+            length,
+            message_text: format_message(template, &[&type_str]),
+            depth: 0,
+        })
     }
 
     // =========================================================================

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1018,6 +1018,9 @@ mod intersection_source_literal_member_display_tests;
 #[path = "tests/intersection_target_elaboration_tests.rs"]
 mod intersection_target_elaboration_tests;
 #[cfg(test)]
+#[path = "tests/invocation_signature_detail_tests.rs"]
+mod invocation_signature_detail_tests;
+#[cfg(test)]
 #[path = "tests/issue_9762_literal_init_callback_inference.rs"]
 mod issue_9762_literal_init_callback_inference;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -49,6 +49,30 @@ pub(crate) fn assignment_numeric_display_children(
     tsz_solver::type_queries::assignment_numeric_display_children(db, type_id)
 }
 
+/// Apparent type of a non-union callee/constructor source for `tsc`'s
+/// `invocationErrorDetails` note (`Type 'X' has no call/construct signatures.`),
+/// mirroring `typeToString(getApparentType(type))`: a number-/string-/boolean-/
+/// bigint-/symbol-like source (including a literal such as `1` or `"a"`) maps to
+/// its boxed wrapper interface (`Number`, `String`, ...), the `object`
+/// intrinsic maps to the empty object type `{}`, and every other type is
+/// returned unchanged. The literal is widened to its base first so a literal
+/// source resolves to the same wrapper `tsc` shows (`1` -> `Number`).
+///
+/// Returns `None` for `any`/error sources and for unions: `tsc` renders a union
+/// callee through the distinct `Not all constituents of type 'U' are ...` /
+/// `No constituent of type 'U' is ...` shapes, so the caller keeps the existing
+/// union rendering untouched rather than mislabeling it.
+pub(crate) fn invocation_signature_detail_apparent_type(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    if type_id == TypeId::ERROR || type_id == TypeId::ANY || is_union_type(db, type_id) {
+        return None;
+    }
+    let widened = super::common::widen_literal_type(db, type_id);
+    Some(index_receiver_apparent_type(db, widened))
+}
+
 /// Return the body of a non-generic alias shaped as `Foo[keyof Foo]`.
 pub(crate) fn indexed_access_alias_body(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/tests/invocation_signature_detail_tests.rs
+++ b/crates/tsz-checker/src/tests/invocation_signature_detail_tests.rs
@@ -1,0 +1,166 @@
+//! Regression tests for the `tsc` `invocationErrorDetails` chain link beneath
+//! a non-callable / non-constructable expression error.
+//!
+//! Structural rule (verified against `tsc` 6.0.2): when a `new` or call target
+//! has no construct / call signatures, `tsc`'s `resolveNewExpression` /
+//! `resolveCallExpression` append a chained note beneath the headline —
+//! `Type 'X' has no construct signatures.` (TS2761) under
+//! `This expression is not constructable.` (TS2351), and
+//! `Type 'X' has no call signatures.` (TS2757) under
+//! `This expression is not callable.` (TS2349). The source is shown as its
+//! apparent type (`number` -> `Number`, `1` -> `Number`, `object` -> `{}`),
+//! matching `typeToString(getApparentType(type))`.
+//!
+//! tsz emitted only the headline and dropped the note at every single-type
+//! site. The fix builds the note through the shared
+//! `invocation_signature_detail` reporter helper for both surfaces, guarding
+//! out union sources (whose distinct `Not all constituents …` / `No
+//! constituent …` shapes are a separate, ordering-coupled concern). Display
+//! only — the diagnostic code and count are unchanged.
+
+use crate::CheckerOptions;
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+/// Run the strict pipeline with the default libs loaded, so a bare primitive
+/// source resolves to its boxed wrapper interface (`Number`, `String`, ...) for
+/// display — the behavior a real compilation observes.
+fn check(source: &str) -> Vec<Diagnostic> {
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions::default(),
+        &load_default_lib_files(),
+    )
+}
+
+/// Collect a single diagnostic's full text (headline plus every related note,
+/// newline-joined) for `code`, asserting exactly one such diagnostic exists.
+fn detail(source: &str, code: u32) -> String {
+    let diags = check(source);
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "Expected exactly one TS{code}. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    let mut lines = vec![matching[0].message_text.clone()];
+    lines.extend(
+        matching[0]
+            .related_information
+            .iter()
+            .map(|info| info.message_text.clone()),
+    );
+    lines.join("\n")
+}
+
+// ── TS2351: not constructable ───────────────────────────────────────────────
+
+#[test]
+fn new_number_value_notes_boxed_wrapper() {
+    let text = detail("const widget = 1;\nnew widget();\n", 2351);
+    assert!(
+        text.contains("This expression is not constructable."),
+        "headline missing: {text:?}"
+    );
+    assert!(
+        text.contains("Type 'Number' has no construct signatures."),
+        "apparent-typed note missing (number -> Number): {text:?}"
+    );
+}
+
+#[test]
+fn new_string_literal_value_notes_boxed_wrapper() {
+    // A fresh string-literal source is widened to its boxed wrapper for display.
+    let text = detail("const banner = \"hello\";\nnew banner();\n", 2351);
+    assert!(
+        text.contains("Type 'String' has no construct signatures."),
+        "string literal should display as String: {text:?}"
+    );
+}
+
+#[test]
+fn new_object_value_notes_structural_shape() {
+    let text = detail("const bag = {};\nnew bag();\n", 2351);
+    assert!(
+        text.contains("Type '{}' has no construct signatures."),
+        "object should display structurally: {text:?}"
+    );
+}
+
+#[test]
+fn new_interface_value_notes_interface_name() {
+    // Binder names vary across cases so the note follows the apparent type, not
+    // any fixed identifier (anti-hardcoding).
+    let text = detail(
+        "interface Gadget {}\ndeclare const thing: Gadget;\nnew thing();\n",
+        2351,
+    );
+    assert!(
+        text.contains("Type 'Gadget' has no construct signatures."),
+        "interface name should display: {text:?}"
+    );
+}
+
+// ── TS2349: not callable ────────────────────────────────────────────────────
+
+#[test]
+fn call_number_value_notes_boxed_wrapper() {
+    let text = detail("const tally = 42;\ntally();\n", 2349);
+    assert!(
+        text.contains("This expression is not callable."),
+        "headline missing: {text:?}"
+    );
+    assert!(
+        text.contains("Type 'Number' has no call signatures."),
+        "apparent-typed note missing (number -> Number): {text:?}"
+    );
+}
+
+#[test]
+fn call_object_value_notes_structural_shape() {
+    let text = detail("const crate = {};\ncrate();\n", 2349);
+    assert!(
+        text.contains("Type '{}' has no call signatures."),
+        "object should display structurally: {text:?}"
+    );
+}
+
+#[test]
+fn call_interface_value_notes_interface_name() {
+    let text = detail(
+        "interface Sprocket {}\ndeclare const part: Sprocket;\npart();\n",
+        2349,
+    );
+    assert!(
+        text.contains("Type 'Sprocket' has no call signatures."),
+        "interface name should display: {text:?}"
+    );
+}
+
+// ── Controls ────────────────────────────────────────────────────────────────
+
+#[test]
+fn valid_construct_emits_no_diagnostic() {
+    // A real construct signature must not produce a spurious note.
+    let diags = check("class Engine {}\nnew Engine();\n");
+    assert!(
+        !diags.iter().any(|d| d.code == 2351),
+        "valid `new` must not emit TS2351: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn valid_call_emits_no_diagnostic() {
+    let diags = check("function ping() {}\nping();\n");
+    assert!(
+        !diags.iter().any(|d| d.code == 2349),
+        "valid call must not emit TS2349: {:?}",
+        diags.iter().map(|d| d.code).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Fixes #14647.

Goal: hold

## Problem

When a `new` or call target has **no construct / call signatures**, `tsc`'s
`resolveNewExpression` / `resolveCallExpression` (`invocationErrorDetails`)
append a chained note beneath the headline. tsz emitted **only the headline**
and dropped the note at every single-type site.

```ts
const x = 1;
new x();   // tsc: TS2351 + "  Type 'Number' has no construct signatures."
x();       // tsc: TS2349 + "  Type 'Number' has no call signatures."
```

| inner note | `tsc` 6.0.2 | tsz before | tsz after |
| --- | --- | --- | --- |
| `new (number)` | `Type 'Number' has no construct signatures.` | *(dropped)* ❌ | `Type 'Number' has no construct signatures.` ✅ |
| `call (object)` | `Type '{}' has no call signatures.` | *(dropped)* ❌ | `Type '{}' has no call signatures.` ✅ |

The drop affected **every** single-type callee/constructor shape across both
surfaces (number/string/boolean/bigint/symbol literals and bases, `{}`,
interfaces, class instances, `never`, arrays, function values, tagged-template
tags).

## Structural rule

When a `new`/call target has no construct/call signatures, `tsc` appends the
note `Type 'X' has no construct signatures.` (TS2761) / `Type 'X' has no call
signatures.` (TS2757) one indent level beneath the `This expression is not
constructable./callable.` headline (TS2351/TS2349). The source is rendered as
its **apparent** type — `typeToString(getApparentType(type))` — so `number` and
the literal `1` both display as `Number`, `object` as `{}`, etc. `tsc` does X;
tsz now does X through the checker error-reporter. The relation outcome and the
diagnostic code/count are unchanged — the note is attached as related
information.

## Owner layer

Checker diagnostic **display** only — no relation/semantic change:

- **`query_boundaries::diagnostics::invocation_signature_detail_apparent_type`** —
  new display query computing `getApparentType` for the source (widen literal →
  boxed wrapper, reusing the sibling `index_receiver_apparent_type` boundary +
  `common::widen_literal_type`), returning `None` for `any`/error and union
  sources so type-shape policy stays on the solver-backed display boundary
  (#12947), not in the reporter.
- **`error_reporter::operator_errors::invocation_signature_detail`** — shared
  reporter helper that builds the TS2757/TS2761 note (apparent-type-formatted,
  depth-0 related info). Consumed by the TS2351 site (`error_not_constructable_at`,
  via `emit_render_request_at_anchor` + `with_related`) and the TS2349 site
  (`error_not_callable_at`, appended after the solver builder's headline).

No hardcoded identifier/file-name predicates; the gate is structural
(`is_union_type` + apparent-type classification) and binder names are varied in
the tests.

## Adjacent matrix (verified against the built binary + unit tests, vs tsc 6.0.2)

- `new`/call on number/string/boolean/bigint literal → boxed wrapper (`Number`/`String`/...).
- base primitive, `symbol`, `never` → wrapper / `never`.
- object literal value → `{}`; interface value → interface name; class instance → instance name.
- array value, function value, tagged-template tag → matching apparent type.
- renamed binders → identical note (anti-hardcoding).
- control: valid `new`/call → no diagnostic, no spurious note.

## Out of scope (documented residuals)

- **Union callees** — `tsc` renders these through the distinct `Not all
  constituents of type 'U' are callable/constructable.` / `No constituent of
  type 'U' is callable/constructable.` shapes; tsz still has no emission site for
  those, and that family is coupled to the separate primitive-union member
  ordering display gap. The guard returns `None` for unions, so they keep their
  current (headline-only) rendering — no regression.
- **Numeric/string enum-typed callee** — `getApparentType` folds an enum to
  `Number`/`String`; tsz shows the enum name. Pathological code; left as a
  getApparentType enum-folding residual.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- New regression suite `crates/tsz-checker/src/tests/invocation_signature_detail_tests.rs`
  (9 tests: number/string-literal → boxed wrapper, object → `{}`, interface name
  on both surfaces, plus two valid-callee negative controls) — all pass.
- Differential testing of the built `tsz` debug binary vs `tsc 6.0.2` across the
  adjacent matrix: all match.
- `python3 scripts/arch/arch_guard.py`, `cargo fmt -p tsz-checker -p tsz-solver
  -- --check`, `cargo clippy -p tsz-checker --lib`: clean. (The
  `query_boundaries::common` quarantine is **not** grown — the helper lives on
  the `diagnostics` boundary and reuses `common` internally only.)
- Reviewed via `/simplify` (reuse / simplification / efficiency / altitude):
  applied two findings — delegated the apparent-type helper to the sibling
  `index_receiver_apparent_type` boundary wrapper, and replaced
  `format_message(.., &[])` with `.to_string()` for the placeholder-free
  headline. Remaining angles already clean.
- Display-only and code-neutral: the conformance gate compares diagnostic
  codes/counts, not chained message text, so the full conformance / emit /
  fourslash floors (owned by ready-review CI) are unaffected.

https://claude.ai/code/session_014PbRi53UvbB3Jd4pSKKVDy

---
_Generated by [Claude Code](https://claude.ai/code/session_014PbRi53UvbB3Jd4pSKKVDy)_