### PR TITLE
fix(checker): gate object-literal/argument arrow body-return elaboration on annotated parameters

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -836,6 +836,44 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Mirror `tsc`'s `elaborateArrowFunction` gate: the elaborator only drills
+    /// into a function-expression body's return when **no** parameter carries an
+    /// explicit type annotation (`some(node.parameters, hasType)` makes
+    /// `elaborateArrowFunction` return `false`). When any parameter is annotated
+    /// — even with a type that matches the contextual parameter — the mismatch is
+    /// reported at the function-type level (the parameter-contravariance frame,
+    /// e.g. `Type '(x: string) => number' is not assignable to type
+    /// '(x: number) => string'`) instead of being anchored at the body return
+    /// expression. This keeps object-literal property and argument arrows in
+    /// parity with `tsc`'s diagnostic anchor and message.
+    ///
+    /// `func_value_idx` is the function-expression / arrow / method node.
+    ///
+    /// This is deliberately narrower than
+    /// `function_like_has_explicit_signature_annotations` (which also reports a
+    /// standalone explicit *return* type annotation): `tsc`'s
+    /// `elaborateArrowFunction` gate keys on parameters only, so an arrow with a
+    /// return annotation but no parameter annotation (`(x): string => …`) is
+    /// still elaborated into its body.
+    pub(crate) fn function_value_has_explicit_param_annotation(
+        &self,
+        func_value_idx: NodeIndex,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(func_value_idx) else {
+            return false;
+        };
+        let Some(func) = self.ctx.arena.get_function(node) else {
+            return false;
+        };
+        func.parameters.nodes.iter().any(|param_idx| {
+            self.ctx
+                .arena
+                .get(*param_idx)
+                .and_then(|n| self.ctx.arena.get_parameter(n))
+                .is_some_and(|p| p.type_annotation.is_some())
+        })
+    }
+
     fn try_elaborate_function_arg_return_error(
         &mut self,
         arg_idx: NodeIndex,
@@ -997,15 +1035,7 @@ impl<'a> CheckerState<'a> {
                 // typed callbacks (no explicit param annotations). When a developer
                 // explicitly annotates parameter types, the error is reported at the
                 // argument level (TS2345) rather than drilling into the return expression.
-                let has_explicit_param_annotations =
-                    func.parameters.nodes.iter().any(|param_idx| {
-                        self.ctx
-                            .arena
-                            .get(*param_idx)
-                            .and_then(|n| self.ctx.arena.get_parameter(n))
-                            .is_some_and(|p| p.type_annotation.is_some())
-                    });
-                if has_explicit_param_annotations {
+                if self.function_value_has_explicit_param_annotation(arg_idx) {
                     return false;
                 }
                 let body_type = self.get_type_of_node(func.body);

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -538,6 +538,16 @@ impl<'a> CheckerState<'a> {
                     let elaborated_body = (|| {
                         let func_node = self.ctx.arena.get(prop_value_idx)?;
                         let func = self.ctx.arena.get_function(func_node)?;
+                        // `tsc`'s `elaborateArrowFunction` bails (no body-return
+                        // drill) when any parameter carries an explicit type
+                        // annotation, reporting the function-type frame instead.
+                        // Without this gate, an annotated-parameter property arrow
+                        // whose body return also mismatches anchors the TS2322 at
+                        // the body expression and drops the parameter-contravariance
+                        // frame that `tsc` emits at the property.
+                        if self.function_value_has_explicit_param_annotation(prop_value_idx) {
+                            return None;
+                        }
                         let expected_ret = self.first_callable_return_type(target_prop_type)?;
                         if expected_ret == TypeId::VOID || expected_ret == TypeId::ANY {
                             return None;

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1246,6 +1246,9 @@ mod object_literal_relation_architecture_tests;
 #[path = "tests/object_literal_this_member_order_tests.rs"]
 mod object_literal_this_member_order_tests;
 #[cfg(test)]
+#[path = "tests/object_property_arrow_param_annotation_elaboration_tests.rs"]
+mod object_property_arrow_param_annotation_elaboration_tests;
+#[cfg(test)]
 #[path = "tests/object_shorthand_literal_preservation_tests.rs"]
 mod object_shorthand_literal_preservation_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/object_property_arrow_param_annotation_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/object_property_arrow_param_annotation_elaboration_tests.rs
@@ -1,0 +1,174 @@
+//! `tsc`'s `elaborateArrowFunction` only drills into an arrow/function-expression
+//! body's return expression when **no** parameter carries an explicit type
+//! annotation (`some(node.parameters, hasType)` makes the elaborator bail). When
+//! a parameter is annotated — even with a type that matches the contextual
+//! parameter — the assignability failure is reported at the function-type level
+//! (the parameter-contravariance frame, anchored at the property / argument),
+//! not on the body return expression.
+//!
+//! Structural rule: when an object-literal property value (or call argument
+//! reached through an object literal) is an expression-bodied arrow/function
+//! whose body return also mismatches, tsz used to anchor the TS2322 at the body
+//! expression and drop the function-type frame whenever the body mismatched,
+//! regardless of parameter annotations. The direct-callback-argument path
+//! already gated this on annotated parameters; the object-literal-property path
+//! did not. Both now share `function_value_has_explicit_param_annotation`.
+//!
+//! Refs the diagnostic-parity (`hold`) goal. Binder names are varied across the
+//! cases so no identifier is load-bearing.
+
+use crate::test_utils::check_source;
+use tsz_common::options::checker::CheckerOptions;
+
+fn ts2322(source: &str) -> Vec<(u32, String)> {
+    let opts = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.ts", opts)
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| (d.code, d.message_text))
+        .collect()
+}
+
+fn assert_function_type_frame(messages: &[(u32, String)], src_fn: &str, tgt_fn: &str) {
+    assert!(
+        messages
+            .iter()
+            .any(|(_, m)| m.contains(src_fn) && m.contains(tgt_fn)),
+        "expected the function-type frame `{src_fn}` ≰ `{tgt_fn}`, got: {messages:?}"
+    );
+    // The body-anchored bare-return form would be the *only* message and would
+    // not mention the function types at all.
+    assert!(
+        messages.iter().any(|(_, m)| m.contains("=>")),
+        "expected a function-type display in the frame, got: {messages:?}"
+    );
+}
+
+// --- object-literal property, conflicting annotated param + wrong body ---
+
+#[test]
+fn property_arrow_annotated_param_conflict_reports_function_frame() {
+    // `(x: string) => 42` against `(x: number) => string`: both the parameter and
+    // the return mismatch. tsc reports the function-type frame (parameter
+    // contravariance), not the body return `42`.
+    let messages = ts2322(
+        r#"
+interface Sink { cb: (x: number) => string; }
+const sink: Sink = { cb: (x: string) => 42 };
+"#,
+    );
+    assert_function_type_frame(&messages, "(x: string) => number", "(x: number) => string");
+}
+
+// --- object-literal property, annotated param that MATCHES + wrong body ---
+
+#[test]
+fn property_arrow_annotated_matching_param_still_reports_function_frame() {
+    // `(value: number) => 42` against `(value: number) => string`: the parameter
+    // matches, but because it is *annotated* tsc still reports the function-type
+    // frame (with a nested return mismatch), not the body return.
+    let messages = ts2322(
+        r#"
+interface Box { run: (value: number) => string; }
+const box: Box = { run: (value: number) => 42 };
+"#,
+    );
+    assert_function_type_frame(
+        &messages,
+        "(value: number) => number",
+        "(value: number) => string",
+    );
+}
+
+// --- two params, only one annotated (some(parameters, hasType)) ---
+
+#[test]
+fn property_arrow_one_annotated_param_reports_function_frame() {
+    // Only the first parameter is annotated; `some(parameters, hasType)` is true,
+    // so tsc bails the body drill and reports the function-type frame.
+    let messages = ts2322(
+        r#"
+interface Pair { combine: (first: number, second: number) => string; }
+const pair: Pair = { combine: (first: string, second) => 7 };
+"#,
+    );
+    assert_function_type_frame(
+        &messages,
+        "(first: string, second: number) => number",
+        "(first: number, second: number) => string",
+    );
+}
+
+// --- call argument reached through an object literal ---
+
+#[test]
+fn object_literal_argument_arrow_annotated_param_reports_function_frame() {
+    // The object literal is a call argument; the same gate applies on the
+    // argument path.
+    let messages = ts2322(
+        r#"
+declare function consume(opts: { handler: (n: number) => string }): void;
+consume({ handler: (n: string) => 99 });
+"#,
+    );
+    assert_function_type_frame(&messages, "(n: string) => number", "(n: number) => string");
+}
+
+// --- control: NO parameter annotation -> body drill is preserved ---
+
+#[test]
+fn property_arrow_unannotated_param_still_drills_into_body() {
+    // No parameter annotation: the arrow is fully contextually typed, so tsc
+    // (and tsz) anchor the TS2322 at the body return `1` with the bare
+    // `number ≰ string` message — the function-type frame must NOT appear.
+    let messages = ts2322(
+        r#"
+interface Sink { cb: (x: number) => string; }
+const sink: Sink = { cb: (x) => 1 };
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|(_, m)| m == "Type 'number' is not assignable to type 'string'."),
+        "expected body-anchored bare return mismatch, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|(_, m)| m.contains("=>")),
+        "unannotated-param arrow must drill into the body, not show a function-type frame: {messages:?}"
+    );
+}
+
+// --- control: block body already bails (isBlock) regardless of annotation ---
+
+#[test]
+fn property_arrow_block_body_reports_function_frame() {
+    let messages = ts2322(
+        r#"
+interface Sink { cb: (x: number) => string; }
+const sink: Sink = { cb: (x: string) => { return 5; } };
+"#,
+    );
+    assert_function_type_frame(&messages, "(x: string) => number", "(x: number) => string");
+}
+
+// --- control: correct callbacks produce no error ---
+
+#[test]
+fn property_arrow_compatible_callbacks_are_clean() {
+    let messages = ts2322(
+        r#"
+interface Sink { cb: (x: number) => string; }
+const a: Sink = { cb: (x) => String(x) };
+const b: Sink = { cb: (x: number) => "ok" };
+"#,
+    );
+    assert!(
+        messages.is_empty(),
+        "compatible callbacks must not error, got: {messages:?}"
+    );
+}


### PR DESCRIPTION
Fixes #14651.

Goal: hold

## Problem

When an **object-literal property value** (or a call argument reached through an object literal) is an **expression-bodied arrow** that has **at least one explicitly-annotated parameter** *and* a return-body that also mismatches, tsz anchored the `TS2322` at the body return expression with the bare return-type message, dropping the function-type / parameter-contravariance frame that `tsc` reports at the property/argument.

```ts
interface I { cb: (x: number) => string; }
const i: I = { cb: (x: string) => 42 };
```

| | diagnostic |
| --- | --- |
| `tsc` | `(2,16) TS2322: Type '(x: string) => number' is not assignable to type '(x: number) => string'.`<br>&nbsp;&nbsp;`Types of parameters 'x' and 'x' are incompatible.`<br>&nbsp;&nbsp;&nbsp;&nbsp;`Type 'number' is not assignable to type 'string'.` |
| tsz before | `(2,39) TS2322: Type 'number' is not assignable to type 'string'.` ❌ |
| tsz after | matches `tsc` ✅ |

Also reproduces on the call-argument-through-object-literal path (`consume({ handler: (n: string) => 99 })`).

## Structural rule

`tsc`'s `elaborateArrowFunction` only drills into a function-expression body's return expression when **no** parameter carries an explicit type annotation (`some(node.parameters, hasType)` makes the elaborator return `false`). When any parameter is annotated — even with a type that matches the contextual parameter — the failure is reported at the function-type level (the parameter-contravariance frame), not on the body return expression. Block-bodied arrows already bail the same way (`isBlock`).

When an object-literal/argument arrow has any explicitly-annotated parameter, `tsc` reports the function-type frame; tsz drilled into the body return regardless. This PR adds the same gate the direct callback-argument path already had.

The relation outcome and the diagnostic **code/count** are unchanged — this is a diagnostic **anchor + message-text** fix, so the conformance code/count gate is unaffected.

## Owner layer

Checker diagnostic elaboration only — no relation/semantic change:

- `try_elaborate_function_arg_return_error_with_options` (`error_reporter/call_errors/elaboration.rs`) already gated the body-drill on annotated parameters (direct callback argument).
- `try_elaborate_object_literal_properties_with_source` (`error_reporter/call_errors/elaboration_object_properties.rs`) — which also handles object-literal call arguments — did **not**; it now applies the same gate before drilling into an arrow property body.
- The previously-inline check is extracted into a shared `function_value_has_explicit_param_annotation` helper (parameters only, mirroring `tsc`). It is deliberately **distinct** from `function_like_has_explicit_signature_annotations`, which also keys on an explicit *return* annotation and would over-bail return-annotated/param-unannotated arrows (`(x): string => 42`) — verified against `tsc`.

No hardcoded identifier/file-name predicates; the gate is structural and binder names are varied across the regression tests.

## Adjacent matrix (verified against the built binary + `tsc` 6.0.2)

- annotated param **conflict** + wrong body → function-type frame.
- annotated param **matches** + wrong body → function-type frame.
- two params, **one** annotated + wrong body → function-type frame.
- call arg via object literal, annotated param + wrong body → function-type frame.
- Control: **no** param annotation + wrong body → body drill (unchanged).
- Control: block body + annotated param → function-type frame (unchanged).
- Control: return-annotated, param **un**annotated (`(x): string => 42`) → body drill (unchanged).
- Control: compatible callbacks → no diagnostic.
- Renamed binders → identical structural behavior (anti-hardcoding).

Pre-existing, out-of-scope adjacent divergences (unchanged by this PR, documented in the issue): the explicit-return-annotation double-error case, and the literal-source-generalization line (#14629 family).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

## Verification

- New regression suite `crates/tsz-checker/src/tests/object_property_arrow_param_annotation_elaboration_tests.rs` (7 tests: annotated-conflict frame, annotated-matching frame, one-of-two-annotated frame, object-literal-argument frame, unannotated-param body-drill control, block-body frame control, compatible-callbacks clean) — all pass.
- 21-case `tsz` vs `tsc` 6.0.2 matrix (the cases above) — all match.
- No regressions: `cargo test -p tsz-checker --lib` for `elaborat` / `callback` / `arrow` / `object_literal` / `contextual_return` / `function_arg` — every failing test is **pre-existing on `main`** (confirmed by `git stash` diff; the set of failures is byte-identical with and without this change).
- `cargo fmt -p tsz-checker --check`, `cargo clippy -p tsz-checker --lib`, `python3 scripts/arch/arch_guard.py`: clean.
- Reviewed via `/simplify` (reuse / simplification / efficiency / altitude): the reuse suggestion to fold into `function_like_has_explicit_signature_annotations` was declined and documented (different semantics — would regress `(x): string => 42`); altitude/simplification clean; the minor error-path arena re-lookup was kept for the self-contained `NodeIndex` API, consistent with the existing sibling helper's idiom.
- Display-only and code-neutral: the conformance gate compares diagnostic codes/counts, not chained message text, so the conformance / emit / fourslash floors (owned by ready-review CI) are unaffected.

https://claude.ai/code/session_01E9bTM66K7qKoYE7BXn79s8

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9bTM66K7qKoYE7BXn79s8)_