### PR TITLE
fix(checker): elaborate contravariant parameter mismatches for union/array/tuple/index leaves (#14655)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -387,15 +387,18 @@ impl<'a> CheckerState<'a> {
         // Parameters are contravariant, so the leaf compares the (innermost)
         // target parameter against the source parameter.
         if Self::contravariant_param_leaf_needs_header(leaf_reason) {
-            // A structural object property-type mismatch leads with an explicit
-            // `Type 'S' is not assignable to type 'T'.` object header before the
-            // `Types of property 'p' …` drill — exactly like a top-level object
-            // relation — so emit that header here and render the structured
-            // reason one level deeper.
+            // A header-led structural mismatch (object property-type, tuple
+            // element/arity, or index-signature) leads with its specialized
+            // line at depth >= 1, so emit the explicit `Type 'S' is not
+            // assignable to type 'T'.` header over the parameter pair first and
+            // render the structured reason one level deeper — exactly like the
+            // union-source renderer drills its member. The drill takes the
+            // parameter (parent) types so a tuple/index reason renders against
+            // the whole parameter, not its element/value type.
             self.push_callback_signature_relation_line(diag, leaf_src, leaf_tgt, next_depth);
             if let Some(leaf) = leaf_reason {
-                let (s, t) = Self::nested_failure_display_types(leaf, leaf_src, leaf_tgt);
-                let leaf_diag = self.render_failure_reason(leaf, s, t, idx, next_depth + 1);
+                let leaf_diag =
+                    self.render_failure_reason(leaf, leaf_src, leaf_tgt, idx, next_depth + 1);
                 Self::push_nested_chain(diag, leaf_diag, next_depth + 1);
             }
         } else {
@@ -420,6 +423,21 @@ impl<'a> CheckerState<'a> {
         use crate::query_boundaries::common::SubtypeFailureReason;
         match leaf_reason {
             None => true,
+            // The leaf relation `target_param <: source_param` is an ordinary
+            // assignability failure, so its reason can take any of the shapes a
+            // union member's failure can — the contravariant frame plays the
+            // same role as the `Type 'M' is not assignable to type 'T'.` union
+            // line. Accept the same member-failure set the union-source renderer
+            // composes exactly (plus the union reasons themselves, which arise
+            // when a parameter is a union): self-heading leaves
+            // (scalar/literal/error, missing-property summaries, array-element,
+            // readonly-to-mutable, and nested union failures) render their own
+            // member line, and the header-led structural reasons
+            // (tuple/property/index) get an explicit `Type 'S' is not assignable
+            // to type 'T'.` header from `contravariant_param_leaf_needs_header`.
+            // `ReturnTypeMismatch`/`ParameterTypeMismatch` never bottom out here
+            // (the descent loop above keeps walking while both params are
+            // callable), so they are intentionally absent.
             Some(reason) => matches!(
                 reason,
                 SubtypeFailureReason::TypeMismatch { .. }
@@ -429,21 +447,35 @@ impl<'a> CheckerState<'a> {
                     | SubtypeFailureReason::MissingProperty { .. }
                     | SubtypeFailureReason::MissingProperties { .. }
                     | SubtypeFailureReason::PropertyTypeMismatch { .. }
+                    | SubtypeFailureReason::ArrayElementMismatch { .. }
+                    | SubtypeFailureReason::ReadonlyToMutableAssignment { .. }
+                    | SubtypeFailureReason::UnionSourceMismatch { .. }
+                    | SubtypeFailureReason::NoUnionMemberMatches { .. }
+                    | SubtypeFailureReason::TupleElementTypeMismatch { .. }
+                    | SubtypeFailureReason::TupleVariadicPositionMismatch { .. }
+                    | SubtypeFailureReason::TupleElementMismatch { .. }
+                    | SubtypeFailureReason::TupleArityMismatch(_)
+                    | SubtypeFailureReason::IndexSignatureMismatch { .. }
             ),
         }
     }
 
-    /// Whether the terminating leaf reason needs an explicit object
+    /// Whether the terminating leaf reason needs an explicit
     /// `Type 'S' is not assignable to type 'T'.` header emitted before its drill.
-    /// Only the object `PropertyTypeMismatch` leaf does; scalar and
-    /// missing-property leaves self-head.
+    /// The header-led structural reasons (object property-type, tuple
+    /// element/arity, and index-signature mismatches) lead with a specialized
+    /// line (`Types of property 'p' …`, `Type at position N …`, `'string' index
+    /// signatures are incompatible.`) at depth >= 1, so the header is supplied
+    /// here; scalar, missing-property, array-element, and union leaves self-head.
+    /// This is the same split the union-source member renderer applies, so the
+    /// contravariant parameter chain reproduces the identical nested layout.
     const fn contravariant_param_leaf_needs_header(
         leaf_reason: Option<&tsz_solver::SubtypeFailureReason>,
     ) -> bool {
-        matches!(
-            leaf_reason,
-            Some(tsz_solver::SubtypeFailureReason::PropertyTypeMismatch { .. })
-        )
+        match leaf_reason {
+            Some(reason) => Self::union_member_nested_needs_header(reason),
+            None => false,
+        }
     }
 
     fn no_union_member_matches_switch_source_display(

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -920,7 +920,9 @@ impl<'a> CheckerState<'a> {
     /// `MissingProperty`/`MissingProperties` summaries, `ParameterTypeMismatch`
     /// — whose own first line is the signature relation — and plain leaf
     /// relations) already carry the member line themselves.
-    const fn union_member_nested_needs_header(reason: &tsz_solver::SubtypeFailureReason) -> bool {
+    pub(super) const fn union_member_nested_needs_header(
+        reason: &tsz_solver::SubtypeFailureReason,
+    ) -> bool {
         matches!(
             reason,
             tsz_solver::SubtypeFailureReason::TupleElementTypeMismatch { .. }

--- a/crates/tsz-checker/src/tests/function_parameter_mismatch_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/function_parameter_mismatch_elaboration_tests.rs
@@ -535,6 +535,190 @@ target = source;
     );
 }
 
+/// A contravariant parameter whose leaf relation fails through a **union
+/// source** (the target parameter is a wider union than the source parameter)
+/// must drill the failing union member beneath the `Types of parameters` frame,
+/// not stop at the bare signature line. This is the witnessed regression: the
+/// contravariant-leaf renderer previously accepted only scalar/missing-property
+/// /object-property leaves and dropped the whole chain for a union leaf.
+#[test]
+fn union_source_parameter_leaf_elaborates_member_chain() {
+    let text = elaboration(
+        r#"
+let target: (x: string | number) => void;
+let source: (x: string) => void;
+target = source;
+"#,
+        2322,
+    );
+    assert_eq!(
+        text,
+        "Type '(x: string) => void' is not assignable to type '(x: string | number) => void'.\n\
+         Types of parameters 'x' and 'x' are incompatible.\n\
+         Type 'string | number' is not assignable to type 'string'.\n\
+         Type 'number' is not assignable to type 'string'.",
+        "Expected the union-source member chain under the parameter frame. Got: {text:?}"
+    );
+}
+
+/// The mirror case: the contravariant leaf relation fails because the source
+/// parameter is a **union target** that the (narrower) target parameter cannot
+/// satisfy. tsc self-heads the union line with no further member drill, exactly
+/// as it does for the same relation at the top level.
+#[test]
+fn union_target_parameter_leaf_elaborates_union_line() {
+    let text = elaboration(
+        r#"
+let target: (x: string) => void;
+let source: (x: "a" | "b") => void;
+target = source;
+"#,
+        2322,
+    );
+    assert_eq!(
+        text,
+        "Type '(x: \"a\" | \"b\") => void' is not assignable to type '(x: string) => void'.\n\
+         Types of parameters 'x' and 'x' are incompatible.\n\
+         Type 'string' is not assignable to type '\"a\" | \"b\"'.",
+        "Expected the union-target parameter line. Got: {text:?}"
+    );
+}
+
+/// A contravariant parameter whose leaf is an **array element** mismatch
+/// self-heads with the `se[] … te[]` line and drills the element relation.
+#[test]
+fn array_element_parameter_leaf_elaborates_element_chain() {
+    let text = elaboration(
+        r#"
+let target: (x: number[]) => void;
+let source: (x: string[]) => void;
+target = source;
+"#,
+        2322,
+    );
+    assert_eq!(
+        text,
+        "Type '(x: string[]) => void' is not assignable to type '(x: number[]) => void'.\n\
+         Types of parameters 'x' and 'x' are incompatible.\n\
+         Type 'number[]' is not assignable to type 'string[]'.\n\
+         Type 'number' is not assignable to type 'string'.",
+        "Expected the array-element chain under the parameter frame. Got: {text:?}"
+    );
+}
+
+/// A contravariant parameter whose leaf is a **tuple element** mismatch is
+/// header-led: the parameter-pair header precedes the `Type at position N …`
+/// positional line and the element relation.
+#[test]
+fn tuple_element_parameter_leaf_elaborates_positional_chain() {
+    let text = elaboration(
+        r#"
+let target: (x: [number, number]) => void;
+let source: (x: [string, string]) => void;
+target = source;
+"#,
+        2322,
+    );
+    assert_eq!(
+        text,
+        "Type '(x: [string, string]) => void' is not assignable to type '(x: [number, number]) => void'.\n\
+         Types of parameters 'x' and 'x' are incompatible.\n\
+         Type '[number, number]' is not assignable to type '[string, string]'.\n\
+         Type at position 0 in source is not compatible with type at position 0 in target.\n\
+         Type 'number' is not assignable to type 'string'.",
+        "Expected the tuple positional chain under the parameter frame. Got: {text:?}"
+    );
+}
+
+/// A contravariant parameter whose leaf is an **index-signature** mismatch is
+/// header-led: the parameter-pair header precedes the `'string' index
+/// signatures are incompatible.` line and the value relation.
+#[test]
+fn index_signature_parameter_leaf_elaborates_index_chain() {
+    let text = elaboration(
+        r#"
+let target: (x: { [k: string]: number }) => void;
+let source: (x: { [k: string]: string }) => void;
+target = source;
+"#,
+        2322,
+    );
+    assert_eq!(
+        text,
+        "Type '(x: { [k: string]: string; }) => void' is not assignable to type '(x: { [k: string]: number; }) => void'.\n\
+         Types of parameters 'x' and 'x' are incompatible.\n\
+         Type '{ [k: string]: number; }' is not assignable to type '{ [k: string]: string; }'.\n\
+         'string' index signatures are incompatible.\n\
+         Type 'number' is not assignable to type 'string'.",
+        "Expected the index-signature chain under the parameter frame. Got: {text:?}"
+    );
+}
+
+/// The union-leaf rule is structural (renamed binders) and surface-independent:
+/// the same descending chain appears under the call-argument (TS2345) surface,
+/// and renamed parameters prove it is not keyed on the `x` spelling.
+#[test]
+fn union_source_parameter_leaf_is_structural_renamed_and_call_argument() {
+    let renamed = elaboration(
+        r#"
+let dst: (payload: string | number) => void;
+let src: (payload: string) => void;
+dst = src;
+"#,
+        2322,
+    );
+    assert!(
+        renamed.contains("Types of parameters 'payload' and 'payload' are incompatible.")
+            && renamed.contains("Type 'string | number' is not assignable to type 'string'.")
+            && renamed.contains("Type 'number' is not assignable to type 'string'."),
+        "Expected the renamed union-source chain. Got: {renamed:?}"
+    );
+
+    let call_argument = elaboration(
+        r#"
+declare function take(cb: (value: string | number) => void): void;
+take((value: string) => {});
+"#,
+        2345,
+    );
+    assert!(
+        call_argument.contains("Types of parameters 'value' and 'value' are incompatible.")
+            && call_argument.contains("Type 'string | number' is not assignable to type 'string'.")
+            && call_argument.contains("Type 'number' is not assignable to type 'string'."),
+        "Expected the union-source chain under TS2345. Got: {call_argument:?}"
+    );
+}
+
+/// The architectural invariant for the union leaf too: the call-argument
+/// (TS2345) and direct-assignment (TS2322) surfaces render the identical
+/// related-information chain (both route through the shared
+/// `render_failure_reason`); only the headline code differs.
+#[test]
+fn union_source_call_argument_and_assignment_render_identical_chain() {
+    let argument_chain = elaboration(
+        r#"
+declare function take(cb: (value: string | number) => void): void;
+take((value: string) => {});
+"#,
+        2345,
+    );
+    let assignment_chain = elaboration(
+        r#"
+let target: (value: string | number) => void;
+let source: (value: string) => void;
+target = source;
+"#,
+        2322,
+    );
+    let related = |text: &str| text.split('\n').skip(1).collect::<Vec<_>>().join("\n");
+    assert_eq!(
+        related(&argument_chain),
+        related(&assignment_chain),
+        "TS2345 and TS2322 must elaborate the same union-source parameter chain. \
+         argument={argument_chain:?} assignment={assignment_chain:?}"
+    );
+}
+
 #[test]
 fn class_method_with_fewer_params_implements_interface_with_more_params() {
     // TypeScript allows a class method to implement an interface method with


### PR DESCRIPTION
Fixes #14655.

Goal: hold

## Problem

When a function/callback type is not assignable to another because a **parameter** is contravariantly incompatible, `tsc` reports the signature line, a `Types of parameters 'a' and 'b' are incompatible.` frame, and the contravariant leaf relation. tsz dropped the **entire** elaboration chain — stopping at the bare signature line — whenever the failing parameter leaf was anything other than a scalar / missing-property / object-property mismatch.

Witness:

```ts
const f: (x: string | number) => void = (x: string) => {};
```

Before (tsz):
```
error TS2322: Type '(x: string) => void' is not assignable to type '(x: string | number) => void'.
```

After (matches tsc):
```
error TS2322: Type '(x: string) => void' is not assignable to type '(x: string | number) => void'.
  Types of parameters 'x' and 'x' are incompatible.
    Type 'string | number' is not assignable to type 'string'.
      Type 'number' is not assignable to type 'string'.
```

The same drop affected **array** (`number[]`/`string[]`), **tuple** (`[number, number]`/`[string, string]`), **index-signature** (`{ [k: string]: number }`/`{ [k: string]: string }`), and the **union-target** mirror (`string`/`"a" | "b"`) leaves — across the direct-assignment (TS2322), call-argument (TS2345), and nested-callback surfaces.

## Structural rule

When a contravariant parameter relation `target_param <: source_param` fails, `tsc` elaborates that sub-relation recursively exactly as it would at the top level. tsz now reproduces the **same** nested chain regardless of the leaf reason's shape (union member, array element, tuple position, index signature, object property, scalar) — tsz through the checker's `render_failure` parameter-mismatch path.

## Owner layer

Checker diagnostic rendering only — `error_reporter/render_failure.rs`. No relation/inference/solver change: the relation verdict was already correct; only the explanation was truncated.

- `contravariant_param_leaf_supported`: the leaf allowlist was a too-narrow private duplicate of the union-source member renderer. Widened to the same member-failure set the union-source path composes exactly (`ArrayElementMismatch`, `ReadonlyToMutableAssignment`, `TupleElement*`/`TupleArity`/`TupleVariadicPosition`, `IndexSignatureMismatch`) plus the union reasons themselves (`UnionSourceMismatch`, `NoUnionMemberMatches`), which arise when a parameter is a union. `ReturnTypeMismatch`/`ParameterTypeMismatch` never bottom out here (the descent loop keeps walking while both params are callable), so they stay absent.
- `contravariant_param_leaf_needs_header`: now reuses the proven `union_member_nested_needs_header` (made `pub(super)`) instead of duplicating a `PropertyTypeMismatch`-only rule, so the header-vs-self-head split is identical to the union-source member layout.
- Header-led leaves are drilled with the parameter (parent) types so a tuple/index reason renders against the whole parameter, not its element/value type.

This is the same nested-relation rendering the union-source member path already uses; the contravariant frame plays the role of the union line. No new user-name/file-name predicate, no formatted-string predicate; the gate is purely the structural reason kind. Tests vary the binder name (`payload`) to prove the rule is not keyed on the `x` spelling.

## Invariant

The nested chain under `Types of parameters` now reproduces exactly what tsz already renders for the same leaf relation at the top level (confirmed for every shape above). The union→union / union-target cases that `tsz` does not yet member-drill at the top level are a separate, pre-existing union-elaboration gap and are intentionally out of scope; this change keeps the parameter-nested case consistent with the top-level rendering at every depth.

## Verification

- New regression tests in `function_parameter_mismatch_elaboration_tests` (8): union-source, union-target, array-element, tuple-position, index-signature leaves, plus renamed-binder and call-argument (TS2345) structural variants and a cross-surface identity check. `cargo test -p tsz-checker --lib function_parameter_mismatch_elaboration_tests` → 28 passed.
- No regressions: `ts2322_tests` (318 passed), callback/override/strict-callback/function-parameter (210 passed), `union_source_structural_elaboration_tests` (19), `function_bivariance` (17), `promise_callback_variance_tests` (8), `override_incompatibility_elaboration` (7). Every failing test in these suites was confirmed pre-existing on clean `main` via `git stash`.
- `cargo fmt -p tsz-checker --check`, `cargo clippy -p tsz-checker --lib` (clean), `python3 scripts/arch/arch_guard.py` (passed).
- Ready-review CI owns the full conformance / JS-emit / DTS / fourslash parity floors; this change touches only diagnostic rendering.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01FyJ9jfCuZnhWaQZTJXEmuL

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyJ9jfCuZnhWaQZTJXEmuL)_