### PR TITLE
perf(solver): #14351 variance-fallthrough relation hot-path counter

### DIFF
--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -110,7 +110,11 @@ impl PerfCounters {
              raw SymbolRef lazy fallback{:>12}\n  \
              wrong-decl collisions      {:>12}\n  \
              symbol_def_index hits      {:>12}\n  \
-             symbol_def_index misses    {:>12}\n",
+             symbol_def_index misses    {:>12}\n\
+             Relation hot path (#14351):\n  \
+             app<->app pairs total      {:>12}\n  \
+             variance fallthrough       {:>12}\n  \
+             ... cross-base (HKT)       {:>12}\n",
             snap.delegate.calls,
             snap.delegate.cache_hits_lib,
             snap.delegate.cache_hits_cross_file,
@@ -198,6 +202,9 @@ impl PerfCounters {
             snap.identity.identity_collision_wrong_decl_suppressed,
             snap.identity.symbol_def_index_lookup_hits,
             snap.identity.symbol_def_index_lookup_misses,
+            snap.identity.relation_app_pair_total,
+            snap.identity.relation_app_pair_variance_fallthrough,
+            snap.identity.relation_app_pair_variance_fallthrough_cross_base,
         ) + &Self::dump_compute_type_of_symbol_outcomes()
             + &Self::dump_shared_instantiation_cache(&snap)
             + &Self::dump_relation_limit_cache(&snap)

--- a/crates/tsz-common/src/perf_counters/recorders/solver.rs
+++ b/crates/tsz-common/src/perf_counters/recorders/solver.rs
@@ -34,6 +34,31 @@ pub fn record_symbol_def_index_lookup(hit: bool) {
     }
 }
 
+/// #14351 relation-hot-path gating measurement. Record one `check_subtype`
+/// `Application`<->`Application` pair that reached the pre-evaluation variance
+/// fast path, partitioned by whether the variance fast path could NOT decide
+/// (`fell_through` => the relation eagerly `evaluate_type`-expands both members,
+/// `cache.rs` ~1161) and, among those, whether the two `Application` BASES
+/// differ (`cross_base` => the cross-base HKT pattern `Kind<F,A>` vs
+/// `HKT<F,B>`). Measurement only: the relation verdict is unchanged whether or
+/// not this fires. `cross_base` is only meaningful when `fell_through`.
+#[inline]
+pub fn record_relation_app_pair(fell_through: bool, cross_base: bool) {
+    if !enabled_fast() {
+        return;
+    }
+    let c = counters();
+    c.relation_app_pair_total.fetch_add(1, Ordering::Relaxed);
+    if fell_through {
+        c.relation_app_pair_variance_fallthrough
+            .fetch_add(1, Ordering::Relaxed);
+        if cross_base {
+            c.relation_app_pair_variance_fallthrough_cross_base
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
 /// Record a budget-conditional `LimitTrue` relation cache hit (a limit-hit
 /// relation verdict was reused instead of re-burning the relation chain).
 #[inline]

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -81,6 +81,22 @@ pub struct PerfCounters {
     pub symbol_def_index_lookup_hits: AtomicU64,
     /// Companion miss counter for [`Self::symbol_def_index_lookup_hits`].
     pub symbol_def_index_lookup_misses: AtomicU64,
+    /// #14351 relation-hot-path gating measurement. Denominator: total
+    /// `check_subtype` `Application`<->`Application` pairs that reached the
+    /// pre-evaluation variance fast path (`cache.rs` ~931).
+    pub relation_app_pair_total: AtomicU64,
+    /// #14351 numerator: of [`Self::relation_app_pair_total`], the pairs whose
+    /// `variance_result` was `None` (the variance fast path could not decide) so
+    /// the relation FELL THROUGH to the eager `evaluate_type` member expansion
+    /// (`cache.rs` ~1161). High share => eager-eval is the variance-undecidable
+    /// cost the lazy-reference-relation lever targets.
+    pub relation_app_pair_variance_fallthrough: AtomicU64,
+    /// #14351 sub-numerator of [`Self::relation_app_pair_variance_fallthrough`]:
+    /// the fall-through pairs whose two `Application` BASES differ (the cross-base
+    /// HKT pattern, e.g. `Kind<F,A>` vs `HKT<F,B>`). A high cross-base share is
+    /// the empirical signal that relating lazy references by per-arg variance
+    /// across heritage (without member expansion) is the fix.
+    pub relation_app_pair_variance_fallthrough_cross_base: AtomicU64,
     /// Why each `cached_cross_file_*` reader returned `None`. See
     /// [`CrossFileCacheMissCause`] for the bucket semantics. Sum of
     /// all buckets equals the flat miss count for the four reader
@@ -429,6 +445,9 @@ impl PerfCounters {
             identity_collision_wrong_decl_suppressed: AtomicU64::new(0),
             symbol_def_index_lookup_hits: AtomicU64::new(0),
             symbol_def_index_lookup_misses: AtomicU64::new(0),
+            relation_app_pair_total: AtomicU64::new(0),
+            relation_app_pair_variance_fallthrough: AtomicU64::new(0),
+            relation_app_pair_variance_fallthrough_cross_base: AtomicU64::new(0),
             cross_file_cache_miss_cause: [const { AtomicU64::new(0) };
                 CROSS_FILE_CACHE_MISS_CAUSE_COUNT],
             source_file_symbol_arena_cache_eligibility_outcome: [const { AtomicU64::new(0) };

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -373,6 +373,15 @@ pub struct IdentityCounters {
     pub symbol_def_index_lookup_hits: u64,
     /// #14344 denominator: `symbol_def_index` composite-key lookups that missed.
     pub symbol_def_index_lookup_misses: u64,
+    /// #14351 relation-hot-path denominator: `Application`<->`Application` pairs
+    /// reaching the pre-evaluation variance fast path.
+    pub relation_app_pair_total: u64,
+    /// #14351 numerator: variance-undecidable pairs that fell through to eager
+    /// `evaluate_type` member expansion.
+    pub relation_app_pair_variance_fallthrough: u64,
+    /// #14351 sub-numerator: fall-through pairs whose two `Application` bases
+    /// differ (cross-base HKT).
+    pub relation_app_pair_variance_fallthrough_cross_base: u64,
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
@@ -735,6 +744,13 @@ impl PerfCounters {
                 ),
                 symbol_def_index_lookup_hits: load(&c.symbol_def_index_lookup_hits),
                 symbol_def_index_lookup_misses: load(&c.symbol_def_index_lookup_misses),
+                relation_app_pair_total: load(&c.relation_app_pair_total),
+                relation_app_pair_variance_fallthrough: load(
+                    &c.relation_app_pair_variance_fallthrough,
+                ),
+                relation_app_pair_variance_fallthrough_cross_base: load(
+                    &c.relation_app_pair_variance_fallthrough_cross_base,
+                ),
             },
             lib_bootstrap: LibBootstrapCounters {
                 snapshot_set_load_attempts: load(&c.lib_snapshot_set_load_attempts),

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -478,6 +478,9 @@ mod json_tests {
                 "identity_collision_wrong_decl_suppressed",
                 "symbol_def_index_lookup_hits",
                 "symbol_def_index_lookup_misses",
+                "relation_app_pair_total",
+                "relation_app_pair_variance_fallthrough",
+                "relation_app_pair_variance_fallthrough_cross_base",
             ],
         );
         assert_eq!(json["wired"]["stable_identity"], true);

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -1005,6 +1005,22 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 None
             };
 
+            // #14351 gating measurement (zero behavior change, TSZ_PERF_COUNTERS
+            // only). For genuine `Application`<->`Application` pairs, record
+            // whether the variance fast path could NOT decide (`fell_through` =>
+            // the relation eagerly `evaluate_type`-expands both members at
+            // ~1161) and, among those, whether the bases differ (cross-base HKT,
+            // reusing the resolver-aware `both_same_base_app`). The cross-base
+            // fall-through share tells us if the lazy-reference-relation lever
+            // (relate refs by per-arg variance across heritage, defer eager
+            // evaluation) is the fix before any hot-path change.
+            if s_app_id.is_some() && t_app_id.is_some() {
+                tsz_common::perf_counters::record_relation_app_pair(
+                    variance_result.is_none(),
+                    !both_same_base_app,
+                );
+            }
+
             if let Some(result) = variance_result {
                 if let Some(dp) = def_entered {
                     self.def_guard.leave(dp);


### PR DESCRIPTION
## Summary

A flag-gated (`TSZ_PERF_COUNTERS`) diagnostic counter at the pre-evaluation
variance fast path in `relations/subtype/cache.rs`. For genuine
`Application`<->`Application` pairs it records whether the variance fast path
could NOT decide — i.e. fell through to the eager `evaluate_type` member
expansion (`cache.rs` ~1161) — and, among those, whether the two `Application`
bases differ (cross-base HKT, `Kind<F,A>` vs `HKT<F,B>`).

Measurement only: an atomic increment behind `enabled_fast()`. Zero behavior
change. Plumbed through `perf_counters` runtime/snapshot/dump/recorders/tests,
mirroring the `#14520` identity-collision counter pattern.

## Why (the gating number for #14351)

The dominant fp-ts relation cost is `check_subtype` eagerly evaluating both
operands to structural objects and walking members, for `Application` pairs
that fall through the same-base-only variance fast path. This counter resolves
the primary risk before any hot-path change: is the eager `evaluate_type`
load-bearing for HKT verdicts, or is the variance signal available but unused?

The number (fp-ts, deterministic across runs):
- `Application`<->`Application` pairs total: 32,324
- variance fallthrough: 30,202 = 93.4% (fast path could not decide -> eager eval)
- ... cross-base (HKT): 14,401 = 44.6% of total / 47.7% of fallthroughs
- same-base fallthrough: 15,801 = 48.9% of total

The fast path succeeds on only 6.6% of fp-ts `Application` relations; eager-eval
is not load-bearing for the bulk. This is the empirical GO for the
lazy-reference-relation lever (relate references by per-argument variance across
heritage without member expansion) — verdict-preserving, distinct from every
refuted downstream-dedup lever.

## Verification

- `cargo nextest run -p tsz-common identity_section_field_shape` (the perf-counter
  snapshot field-shape lock, updated for the three new `identity`-section keys): PASS.
- `cargo clippy -p tsz-common -p tsz-solver --release`: clean.
- Counter values deterministic across 3 fp-ts runs.
- Zero-behavior isolation: the counter is an atomic increment behind
  `enabled_fast()` and cannot alter control flow or diagnostics. NOTE: separately,
  `TSZ_PERF_COUNTERS=1` is already not diagnostic-neutral on `main` — `enabled_fast()`
  gates pre-existing BEHAVIORAL branches (`normalize.rs:1195` `shallow_checks`,
  `evaluate.rs:1262`), so counters-on vs counters-off fp-ts diagnostics differ via
  `#14344`-family FP flapping (corroborating evidence noted on `#14344`, not introduced
  here). This PR's own diff is isolated by comparing instrumented-binary-counters-ON
  vs clean-main-counters-ON.

Goal: fast

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Project Corpus Impact
- Row: n/a (diagnostic-only counter; no row status change)
- Bug family: #14351 relation hot-path variance-fallthrough measurement
- Evidence: fp-ts 93.4% fallthrough / 44.6% cross-base, deterministic; perf-counter test-lock PASS
