### PR TITLE
fix(checker): narrow let/var union declarations by their object/class initializer

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2193,3 +2193,6 @@ path = "tests/readonly_array_alias_argument_display_tests.rs"
 [[test]]
 name = "try_finally_pre_try_narrowing_tests"
 path = "tests/try_finally_pre_try_narrowing_tests.rs"
+[[test]]
+name = "let_var_initializer_assignment_reduced_type_tests"
+path = "tests/let_var_initializer_assignment_reduced_type_tests.rs"

--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -532,25 +532,21 @@ impl<'a> FlowAnalyzer<'a> {
                     literal_type,
                 );
             }
-            // For a variable declaration with a type annotation, narrow the
-            // declared type by the initializer exactly as tsc's
-            // `getAssignmentReducedType` does. (Primitive-literal initializers
-            // are already handled by the `literal_type_from_node` branch above;
-            // this block covers object/array literals and non-literal
+            // Narrow a variable declaration's declared type by its initializer,
+            // as tsc's `getAssignmentReducedType` does. (Primitive-literal
+            // initializers are handled by the `literal_type_from_node` branch
+            // above; this block covers object/array literals and non-literal
             // initializers such as `new C()` or another reference.)
             //
-            // A `const` is always narrowed. A `let`/`var` is narrowed only when
-            // the variable is *never reassigned* — i.e. it is an effectively
-            // constant reference, mirroring tsc's `isConstantReference`
-            // (`isParameterOrMutableLocalVariable(symbol) &&
-            // !isSymbolAssigned(symbol)`). A reassigned mutable local keeps its
-            // declared type so the flow graph's assignment / loop fixed-point
-            // machinery owns its evolution: narrowing the initializer of a
-            // loop-reassigned variable would evaluate the loop body's first
-            // fixed-point pass against the narrowed entry type and surface
-            // spurious diagnostics (the #8513 `Optional<r>` repro). Narrowing a
-            // never-reassigned local is unconditionally safe because it can
-            // never appear on a loop back-edge.
+            // `const` always narrows; a `let`/`var` narrows only when it is
+            // never reassigned — an effectively constant reference, mirroring
+            // tsc's `isConstantReference`. A reassigned mutable local keeps its
+            // declared type so the loop fixed-point machinery owns its
+            // evolution: narrowing a loop-reassigned initializer would evaluate
+            // the loop body's first fixed-point pass against the narrowed entry
+            // type and surface spurious diagnostics (the #8513 `Optional<r>`
+            // repro). A never-reassigned local can never sit on a loop
+            // back-edge, so narrowing it is always safe.
             if self.is_var_decl_with_type_annotation(assignment_node) {
                 let initializer_narrows_declared_type = self
                     .is_const_variable_declaration(assignment_node)

--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -548,6 +548,9 @@ impl<'a> FlowAnalyzer<'a> {
             // repro). A never-reassigned local can never sit on a loop
             // back-edge, so narrowing it is always safe.
             if self.is_var_decl_with_type_annotation(assignment_node) {
+                if self.var_decl_redeclares_parameter_for_reference(assignment_node, target) {
+                    return None;
+                }
                 let initializer_narrows_declared_type = self
                     .is_const_variable_declaration(assignment_node)
                     || self

--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -532,26 +532,49 @@ impl<'a> FlowAnalyzer<'a> {
                     literal_type,
                 );
             }
-            // For variable declarations with type annotations, preserve the declared
-            // type (return None) in two cases:
+            // For a variable declaration with a type annotation, narrow the
+            // declared type by the initializer exactly as tsc's
+            // `getAssignmentReducedType` does. (Primitive-literal initializers
+            // are already handled by the `literal_type_from_node` branch above;
+            // this block covers object/array literals and non-literal
+            // initializers such as `new C()` or another reference.)
             //
-            // 1. Non-const (let/var) declarations: the declared type is the authoritative
-            //    flow type. E.g., `let x: string | number = "hello"` has flow type
-            //    `string | number`, not `"hello"`. Critical for loop fixed-point analysis.
-            //
-            // 2. Object/array literal initializers (even const): the structural type
-            //    loses optional properties and interface/readonly modifiers.
-            //    E.g., `const xs: readonly number[] = [1, 2]` must keep `readonly number[]`.
+            // A `const` is always narrowed. A `let`/`var` is narrowed only when
+            // the variable is *never reassigned* — i.e. it is an effectively
+            // constant reference, mirroring tsc's `isConstantReference`
+            // (`isParameterOrMutableLocalVariable(symbol) &&
+            // !isSymbolAssigned(symbol)`). A reassigned mutable local keeps its
+            // declared type so the flow graph's assignment / loop fixed-point
+            // machinery owns its evolution: narrowing the initializer of a
+            // loop-reassigned variable would evaluate the loop body's first
+            // fixed-point pass against the narrowed entry type and surface
+            // spurious diagnostics (the #8513 `Optional<r>` repro). Narrowing a
+            // never-reassigned local is unconditionally safe because it can
+            // never appear on a loop back-edge.
             if self.is_var_decl_with_type_annotation(assignment_node) {
-                let is_const = self.is_const_variable_declaration(assignment_node);
+                let initializer_narrows_declared_type = self
+                    .is_const_variable_declaration(assignment_node)
+                    || self
+                        .binder
+                        .resolve_identifier(self.arena, target)
+                        .is_some_and(|symbol_id| {
+                            self.get_last_assignment_pos(symbol_id, target) == 0
+                        });
+                if !initializer_narrows_declared_type {
+                    return None;
+                }
                 let is_structural_literal = self.arena.get(rhs).is_some_and(|rhs_node| {
                     rhs_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
                         || rhs_node.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
                 });
-                if !is_const {
-                    return None;
-                }
                 if is_structural_literal {
+                    // An object/array literal's structural type loses optional
+                    // properties and interface/readonly modifiers (e.g.
+                    // `const xs: readonly number[] = [1, 2]` must keep
+                    // `readonly number[]`), so reduce the declared union to its
+                    // compatible *declared* members via `narrow_assignment`
+                    // rather than flowing the raw literal type.
+                    //
                     // tsc's getAssignmentReducedType narrows regardless of
                     // whether the assignment is valid (no assignability guard).
                     // Skipping the guard is safe: narrow_assignment returns the
@@ -571,6 +594,11 @@ impl<'a> FlowAnalyzer<'a> {
                     }
                     return None;
                 }
+                // Non-literal initializers (`new C()`, another reference, a call
+                // result, …) fall through to the shared rhs-typing path below,
+                // which returns the initializer's type so the downstream
+                // killing-definition `narrow_assignment` reduces the declared
+                // union — identical to the `const` path.
             }
             // `undefined` identifier (not a keyword) as initializer: if the variable
             // has a type annotation that doesn't include undefined, use the declared type.

--- a/crates/tsz-checker/src/flow/control_flow/var_utils.rs
+++ b/crates/tsz-checker/src/flow/control_flow/var_utils.rs
@@ -1090,6 +1090,42 @@ impl<'a> FlowAnalyzer<'a> {
         false
     }
 
+    pub(crate) fn var_decl_redeclares_parameter_for_reference(
+        &self,
+        assignment_node: NodeIndex,
+        target: NodeIndex,
+    ) -> bool {
+        let Some(node) = self.arena.get(assignment_node) else {
+            return false;
+        };
+        if node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
+            return false;
+        }
+
+        let Some(target_symbol_id) = self.binder.resolve_identifier(self.arena, target) else {
+            return false;
+        };
+        let Some(symbol) = self.binder.get_symbol(target_symbol_id) else {
+            return false;
+        };
+
+        let mut saw_prior_parameter = false;
+        for &decl_idx in &symbol.declarations {
+            if decl_idx == assignment_node {
+                return saw_prior_parameter;
+            }
+            if self
+                .arena
+                .get(decl_idx)
+                .is_some_and(|decl| decl.kind == syntax_kind_ext::PARAMETER)
+            {
+                saw_prior_parameter = true;
+            }
+        }
+
+        false
+    }
+
     /// Check if a symbol is an unannotated mutable local whose reads should be
     /// typed from control-flow assignments instead of absorbing as explicit `any`.
     pub(crate) fn is_control_flow_typed_any_symbol(&self, sym_id: SymbolId) -> bool {

--- a/crates/tsz-checker/tests/let_var_initializer_assignment_reduced_type_tests.rs
+++ b/crates/tsz-checker/tests/let_var_initializer_assignment_reduced_type_tests.rs
@@ -1,0 +1,217 @@
+//! Regression coverage for control-flow narrowing of a `let`/`var` declaration
+//! by its *initializer*, when the declared type is a union of object/class
+//! types.
+//!
+//! Structural rule (matches `tsc`): `let x: A | B = value` gives `x` the
+//! initializer-reduced flow type for the rest of the declaration scope, exactly
+//! as `tsc`'s `getAssignmentReducedType` does — the reduction is **not**
+//! `const`-specific. The narrowed type is only the *initial* flow type: the flow
+//! graph re-widens `x` on any later assignment, and the loop fixed-point
+//! re-widens it across back-edges, so mutable-variable and loop semantics are
+//! preserved.
+//!
+//! Owner: `tsz_checker` control-flow assignment typing
+//! (`flow/control_flow/assignment.rs::get_assigned_type`). Previously the
+//! var-decl-with-annotation branch returned the *declared* union for any
+//! non-`const` declaration (`if !is_const { return None; }`), so an
+//! object/class-typed `let`/`var` kept the un-narrowed union and produced false
+//! `TS2322` (assignability) and `TS2339` (property access on a union member)
+//! diagnostics. Primitive-union initializers already narrowed through the
+//! literal-type branch, masking the gap. The fix drops the `const`-only guard so
+//! object/array literals and non-literal initializers (`new C()`, another
+//! reference, …) narrow identically to `const`.
+//!
+//! Binder names are varied per case so coverage is structural, not keyed to a
+//! particular identifier.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+const TS2322: u32 = 2322; // Type X is not assignable to type Y
+const TS2339: u32 = 2339; // Property does not exist on type
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_strict_codes(source)
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases: a `let` whose initializer pins a single union member must
+// narrow exactly like a `const`. `tsc` is clean on all of these.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn let_object_literal_initializer_narrows_union_member() {
+    let diags = codes(
+        r#"
+let x: { k: "a" } | { k: "b" } = { k: "a" };
+const t: { k: "a" } = x;
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "let object-literal initializer must narrow to {{ k: \"a\" }}, got {diags:?}"
+    );
+}
+
+#[test]
+fn var_object_literal_initializer_narrows_union_member_renamed() {
+    // `var` and different binder names: the rule is not keyed to `let`/`x`.
+    let diags = codes(
+        r#"
+var payload: { tag: "lo"; bound: number } | { tag: "hi"; label: string } = { tag: "lo", bound: 3 };
+const got: { tag: "lo"; bound: number } = payload;
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "var object-literal initializer must narrow to the assigned member, got {diags:?}"
+    );
+}
+
+#[test]
+fn let_property_access_after_initializer_narrowing_has_no_ts2339() {
+    // The narrowed member exposes its own properties; reading them must not
+    // report TS2339 against the *other* (un-narrowed) union member.
+    let diags = codes(
+        r#"
+let payload: { tag: "x"; n: number } | { tag: "y"; s: string } = { tag: "x", n: 1 };
+const nn: number = payload.n;
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2339),
+        "property access on the narrowed member must not report TS2339, got {diags:?}"
+    );
+    assert!(
+        !diags.contains(&TS2322),
+        "narrowed member access must not report TS2322, got {diags:?}"
+    );
+}
+
+#[test]
+fn let_class_instance_initializer_narrows_union_member() {
+    // Non-literal initializer (`new Cat()`): must narrow through the same path
+    // as `const`, not just object/array literals.
+    let diags = codes(
+        r#"
+class Cat { meow = 1; }
+class Dog { bark = 2; }
+let pet: Cat | Dog = new Cat();
+const c: Cat = pet;
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "let class-instance initializer must narrow to Cat, got {diags:?}"
+    );
+}
+
+#[test]
+fn let_reference_initializer_narrows_union_member() {
+    // Non-literal initializer that is another reference.
+    let diags = codes(
+        r#"
+declare const seed: { k: "a" };
+let x: { k: "a" } | { k: "b" } = seed;
+const t: { k: "a" } = x;
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "let reference initializer must narrow to {{ k: \"a\" }}, got {diags:?}"
+    );
+}
+
+#[test]
+fn let_initializer_narrowing_makes_impossible_branch_never() {
+    // Downstream consequence of narrowing: once `x` is `{ a: 1 }`, the
+    // `x.a === 1` guard is always-true, so the `else` branch is `never` and
+    // reading `x.a` there reports TS2339 — exactly as `tsc` does.
+    let diags = codes(
+        r#"
+let x: { a: 1 } | { a: 2 } = { a: 1 };
+if (x.a === 1) {
+  const y: 1 = x.a;
+} else {
+  const z: 2 = x.a;
+}
+"#,
+    );
+    assert!(
+        diags.contains(&TS2339),
+        "the impossible else branch must report TS2339 on x.a (never), got {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative / guard cases: narrowing must NOT over-fire.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn let_full_union_initializer_does_not_over_narrow() {
+    // The initializer's type is the whole union, so no member is eliminated and
+    // `x` keeps the declared union — assigning it to one member is TS2322.
+    let diags = codes(
+        r#"
+declare const v: { k: "a" } | { k: "b" };
+let x: { k: "a" } | { k: "b" } = v;
+const t: { k: "a" } = x;
+"#,
+    );
+    assert!(
+        diags.contains(&TS2322),
+        "a full-union initializer must not narrow away a member, got {diags:?}"
+    );
+}
+
+#[test]
+fn reassigned_let_initializer_is_not_narrowed() {
+    // A `let` that is reassigned anywhere is *not* an effectively constant
+    // reference, so the initializer does not narrow (the flow graph owns its
+    // evolution). `x` keeps the declared union, so the later read against one
+    // member is TS2322. (Narrowing reassigned mutable locals is deferred: it
+    // requires loop-fixed-point widening to stay sound — see the #8513 case
+    // below.)
+    let diags = codes(
+        r#"
+let x: { k: "a" } | { k: "b" } = { k: "a" };
+const u: { k: "a" } = x;
+x = { k: "b" };
+"#,
+    );
+    assert!(
+        diags.contains(&TS2322),
+        "a reassigned let must keep its declared union, got {diags:?}"
+    );
+}
+
+#[test]
+fn loop_reassigned_generic_optional_has_no_spurious_error() {
+    // Regression guard for the #8513 `Optional<r>` repro
+    // (conformance `typeGuardsAsAssertions.ts`). `result` is reassigned inside
+    // the loop, so it must keep its declared `Optional<r>` type rather than
+    // narrow to `None`. Narrowing the initializer here would evaluate the
+    // loop body's first fixed-point pass against `None`, degrading inference of
+    // the `someFrom` type argument and producing a spurious TS2322. tsc is
+    // clean.
+    let diags = codes(
+        r#"
+declare let cond: boolean;
+interface None { readonly none: string; }
+interface Some<a> { readonly some: a; }
+type Optional<a> = Some<a> | None;
+declare const none: None;
+declare function isSome<a>(value: Optional<a>): value is Some<a>;
+function someFrom<a>(some: a) { return { some }; }
+function fn<r>(makeSome: () => r): void {
+  let result: Optional<r> = none;
+  while (cond) {
+    result = someFrom(isSome(result) ? result.some : makeSome());
+  }
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2322),
+        "loop-reassigned generic Optional must not produce a spurious TS2322, got {diags:?}"
+    );
+}

--- a/crates/tsz-checker/tests/let_var_initializer_assignment_reduced_type_tests.rs
+++ b/crates/tsz-checker/tests/let_var_initializer_assignment_reduced_type_tests.rs
@@ -17,20 +17,26 @@
 //! object/class-typed `let`/`var` kept the un-narrowed union and produced false
 //! `TS2322` (assignability) and `TS2339` (property access on a union member)
 //! diagnostics. Primitive-union initializers already narrowed through the
-//! literal-type branch, masking the gap. The fix drops the `const`-only guard so
-//! object/array literals and non-literal initializers (`new C()`, another
-//! reference, …) narrow identically to `const`.
+//! literal-type branch, masking the gap. The fix narrows never-reassigned
+//! standalone `let`/`var` declarations like `const`, while preserving tsc's
+//! older function-scoped `var` redeclaration behavior for symbols merged with
+//! earlier parameters.
 //!
 //! Binder names are varied per case so coverage is structural, not keyed to a
 //! particular identifier.
 
-use tsz_checker::test_utils::check_source_strict_codes;
+use tsz_checker::test_utils::{check_source_codes, check_source_strict_codes};
 
 const TS2322: u32 = 2322; // Type X is not assignable to type Y
 const TS2339: u32 = 2339; // Property does not exist on type
+const TS2403: u32 = 2403; // Subsequent variable declarations must have the same type
 
 fn codes(source: &str) -> Vec<u32> {
     check_source_strict_codes(source)
+}
+
+fn default_codes(source: &str) -> Vec<u32> {
+    check_source_codes(source)
 }
 
 // ---------------------------------------------------------------------------
@@ -213,5 +219,57 @@ function fn<r>(makeSome: () => r): void {
     assert!(
         !diags.contains(&TS2322),
         "loop-reassigned generic Optional must not produce a spurious TS2322, got {diags:?}"
+    );
+}
+
+#[test]
+fn parameter_merged_var_initializer_does_not_narrow_parameter_symbol() {
+    // `var` declarations merge with function parameters in the same function
+    // scope. The merged symbol's checking surface remains the earlier parameter
+    // declaration, so the `var` annotation/initializer must not assignment-reduce
+    // the parameter to `Beta`. This is the structural form of conformance
+    // `functionArgShadowing.ts`.
+    let diags = default_codes(
+        r#"
+class Alpha { foo() {} }
+class Beta { bar() {} }
+function use(param: Alpha) {
+  var param: Beta = new Beta();
+  param.bar();
+}
+"#,
+    );
+    assert!(
+        diags.contains(&TS2403),
+        "merged parameter/var must report the redeclaration mismatch, got {diags:?}"
+    );
+    assert!(
+        diags.contains(&TS2339),
+        "the merged parameter surface must remain Alpha, so param.bar is TS2339; got {diags:?}"
+    );
+}
+
+#[test]
+fn constructor_parameter_property_merged_var_keeps_parameter_type() {
+    // Vary the binder name and include the parameter-property shape from the
+    // TypeScript fixture. The `var` declaration conflicts with the constructor
+    // parameter's value symbol; reads still use the parameter's number surface.
+    let diags = default_codes(
+        r#"
+class Holder {
+  constructor(public value: number) {
+    var value: string;
+    var n: number = value;
+  }
+}
+"#,
+    );
+    assert!(
+        diags.contains(&TS2403),
+        "parameter-property var redeclaration must report TS2403, got {diags:?}"
+    );
+    assert!(
+        !diags.contains(&TS2322),
+        "value keeps the constructor parameter's number type, so assigning to number is clean; got {diags:?}"
     );
 }


### PR DESCRIPTION
Fixes #14659.

Goal: hold

## Problem

A `let`/`var` declaration with a **union type annotation** and an **object/class-typed initializer** was not narrowed by its initializer, so subsequent reads saw the whole declared union instead of the assigned member — producing false `TS2322` (assignability) and `TS2339` (property access) diagnostics. `tsc` narrows the declaration via `getAssignmentReducedType`. Primitive-union initializers already narrowed (through a separate literal-type path), which masked the gap.

```ts
let x: { k: "a" } | { k: "b" } = { k: "a" };
const t: { k: "a" } = x;                 // before: TS2322 (false positive); tsc: clean

let payload: { tag: "x"; n: number } | { tag: "y"; s: string } = { tag: "x", n: 1 };
const nn: number = payload.n;            // before: TS2339 (false positive); tsc: clean

class Cat { meow = 1; } class Dog { bark = 2; }
let pet: Cat | Dog = new Cat();
const c: Cat = pet;                      // before: TS2322; tsc: clean
```

The same gap also suppressed a true **negative**: once `x` narrows to `{ a: 1 }`, the `x.a === 1` guard is always-true so the `else` branch is `never`, and `tsc` reports `TS2339` on the read there — now matched.

## Structural rule

When a variable declaration `x: T = init` has a union type annotation `T` and an initializer whose type is assignable to a proper subset of `T`'s members, `tsc` gives `x` the `getAssignmentReducedType(T, typeof init)` flow type for subsequent reads — for `const`, `let`, and `var` alike. tsz applied this only for `const` (and primitive-literal initializers via the `literal_type_from_node` branch); object/array literals and non-literal initializers (`new C()`, another reference, a call result) of a `let`/`var` returned the un-narrowed declared union.

## Owner layer

Checker control-flow assignment typing only — `crates/tsz-checker/src/flow/control_flow/assignment.rs::get_assigned_type`. The var-decl-with-annotation branch returned `None` (declared union) for any non-`const` declaration; it now narrows the initializer for never-reassigned `let`/`var` too. The narrowing reuses the existing `narrow_assignment` (object/array literals, to preserve declared `readonly`/optional members) and the shared rhs-typing fall-through (non-literal initializers, reduced downstream by the killing-definition `narrow_assignment`) — the identical paths `const` already used. No relation/inference/solver change.

The `let`/`var` gate is `is_const_variable_declaration || get_last_assignment_pos(symbol, target) == 0`, i.e. narrow only when the variable is **never reassigned** — an effectively constant reference, mirroring tsc's `isConstantReference` (`isParameterOrMutableLocalVariable && !isSymbolAssigned`). A reassigned mutable local keeps its declared type so the flow graph's assignment / loop fixed-point machinery owns its evolution: narrowing the initializer of a loop-reassigned variable would evaluate the loop body's first fixed-point pass against the narrowed entry type and surface spurious diagnostics (the #8513 `Optional<r>` repro, conformance `typeGuardsAsAssertions.ts`). Narrowing reassigned/loop locals soundly requires loop-fixed-point widening of loop-assigned variables to their declared type — a deliberately deferred follow-up. No new user-name/file-name predicate, no formatted-string predicate; the gate is purely structural (declaration kind + reassignment count). Tests vary the binder name and the variable kind (`let`/`var`).

## Adjacent matrix

Object-literal, class-instance, and reference initializers; renamed binders; `let` and `var`; the never-`else` `TS2339`; the over-narrow guard (a full-union-typed initializer keeps the declared union); the deferred reassigned-`let` case; and a #8513 loop+type-guard generic no-regression case.

## Verification

- New regression suite `let_var_initializer_assignment_reduced_type_tests` (9 tests) — all pass.
- Targeted narrowing/assignment regression suites (`conditional_initializer_preserves_narrowing_tests`, `assignment_branch_merge_narrowing_tests`, `flow_narrowing_finalization_tests`, `try_finally_pre_try_narrowing_tests`, `nested_discriminant_narrowing_tests`, `const_alias_discriminant_narrowing_tests`, `destructuring_default_flow_assignment_tests`, `control_flow_type_guard_tests`, `return_literal_union_widening_tests`, `object_union_assignability_fast_path_tests`, `this_rooted_discriminant_narrowing_tests`) — all pass.
- `cargo fmt -p tsz-checker --check`, `python3 scripts/arch/arch_guard.py` — clean.
- Differential check vs `tsc` 6.0.2 on the witnesses above plus the #8513 loop repro — tsz now matches `tsc`. Conformance shard sampling (4 shards over the v6.0.3 corpus) shows no new code-set regressions; the only local failures are JSX/react-environment artifacts of the standalone harness, and `controlFlow/typeGuardsAsAssertions.ts` flips fail→pass.
- Ready-review CI owns the full conformance / JS-emit / DTS / fourslash parity floors.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_015wYBY7rrbhrWK2AfU8hVaf

---
_Generated by [Claude Code](https://claude.ai/code/session_015wYBY7rrbhrWK2AfU8hVaf)_