### PR TITLE
perf(solver): #14351 cross-base heritage lazy-reference relation (flag-gated, acceptance-only)

### DIFF
--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -1244,6 +1244,11 @@ impl<'a> TypeResolver for CheckerContext<'a> {
         None
     }
 
+    fn get_heritage_instantiation(&self, derived: DefId, target: DefId) -> Option<TypeId> {
+        self.definition_store
+            .get_heritage_instantiation(derived, target)
+    }
+
     /// Check if a `DefId` corresponds to a numeric enum (not a string enum).
     ///
     /// This determines whether an enum allows bidirectional number assignability (Rule #7).

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -1187,6 +1187,31 @@ impl<'a> CheckerState<'a> {
                         );
                         instantiate_type(self.ctx.types, base_type, &substitution)
                     };
+
+                    // #14351 lazy-reference relation capture (inert data — read
+                    // only by the flag-gated variance branch, so an unread map
+                    // keeps flag-OFF byte-identical to main). Record the
+                    // instantiated heritage edge `(derived, parent) -> base_type`
+                    // so the relation layer can relate `Apply1<A>` to
+                    // `Functor1<B>` by per-argument variance on the instantiated
+                    // base (`Functor1<F>` here, with the derived interface's args
+                    // already substituted above) without materializing members.
+                    // Only meaningful for generic heritage edges (the eager
+                    // member walk is the cost there); skip when no arguments flow.
+                    if !type_args.is_empty()
+                        && let Some(current_sym) = current_sym
+                    {
+                        let derived_def = self.ctx.get_or_create_def_id(current_sym);
+                        let parent_def = self.ctx.get_or_create_def_id(base_sym_id);
+                        if derived_def != parent_def {
+                            self.ctx.definition_store.add_heritage_instantiation(
+                                derived_def,
+                                parent_def,
+                                base_type,
+                            );
+                        }
+                    }
+
                     let is_builtin_array_heritage =
                         matches!(base_symbol_name.as_str(), "Array" | "ReadonlyArray");
                     let requires_self = !is_builtin_array_heritage

--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -114,7 +114,10 @@ impl PerfCounters {
              Relation hot path (#14351):\n  \
              app<->app pairs total      {:>12}\n  \
              variance fallthrough       {:>12}\n  \
-             ... cross-base (HKT)       {:>12}\n",
+             ... cross-base (HKT)       {:>12}\n\
+             Lazy-ref relation (#14351):\n  \
+             heritage-reachable pairs   {:>12}\n  \
+             accessor resolved base     {:>12}\n",
             snap.delegate.calls,
             snap.delegate.cache_hits_lib,
             snap.delegate.cache_hits_cross_file,
@@ -205,6 +208,8 @@ impl PerfCounters {
             snap.identity.relation_app_pair_total,
             snap.identity.relation_app_pair_variance_fallthrough,
             snap.identity.relation_app_pair_variance_fallthrough_cross_base,
+            snap.identity.relation_lazy_ref_heritage_reachable,
+            snap.identity.relation_lazy_ref_accessor_resolved,
         ) + &Self::dump_compute_type_of_symbol_outcomes()
             + &Self::dump_shared_instantiation_cache(&snap)
             + &Self::dump_relation_limit_cache(&snap)

--- a/crates/tsz-common/src/perf_counters/recorders/solver.rs
+++ b/crates/tsz-common/src/perf_counters/recorders/solver.rs
@@ -59,6 +59,28 @@ pub fn record_relation_app_pair(fell_through: bool, cross_base: bool) {
     }
 }
 
+/// #14351 lazy-reference-relation accessor correctness probe (measure-only, no
+/// verdict change). Record one cross-base relation pair that is nominal-heritage
+/// reachable (`reachable`), partitioned by whether the instantiated-heritage
+/// accessor resolved a base for it (`resolved`). The resolved/reachable ratio on
+/// fp-ts proves the lowering capture populates the map for the real heritage
+/// edges BEFORE any verdict-affecting relation flip uses it.
+#[inline]
+pub fn record_relation_lazy_ref_probe(reachable: bool, resolved: bool) {
+    if !enabled_fast() {
+        return;
+    }
+    let c = counters();
+    if reachable {
+        c.relation_lazy_ref_heritage_reachable
+            .fetch_add(1, Ordering::Relaxed);
+        if resolved {
+            c.relation_lazy_ref_accessor_resolved
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
 /// Record a budget-conditional `LimitTrue` relation cache hit (a limit-hit
 /// relation verdict was reused instead of re-burning the relation chain).
 #[inline]

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -97,6 +97,16 @@ pub struct PerfCounters {
     /// the empirical signal that relating lazy references by per-arg variance
     /// across heritage (without member expansion) is the fix.
     pub relation_app_pair_variance_fallthrough_cross_base: AtomicU64,
+    /// #14351 lazy-reference-relation accessor correctness probe (measure-only,
+    /// no verdict change). Cross-base relation pairs that are nominal-heritage
+    /// reachable (`is_derived_from`) AND for which the instantiated-heritage
+    /// accessor RESOLVED a base (`get_heritage_instantiation` returned Some) —
+    /// the subset the lazy-reference relation branch would handle. A healthy
+    /// ratio vs [`Self::relation_lazy_ref_heritage_reachable`] proves the
+    /// capture populates the map for the real fp-ts heritage edges.
+    pub relation_lazy_ref_accessor_resolved: AtomicU64,
+    /// #14351 denominator: cross-base pairs that are nominal-heritage reachable.
+    pub relation_lazy_ref_heritage_reachable: AtomicU64,
     /// Why each `cached_cross_file_*` reader returned `None`. See
     /// [`CrossFileCacheMissCause`] for the bucket semantics. Sum of
     /// all buckets equals the flat miss count for the four reader
@@ -448,6 +458,8 @@ impl PerfCounters {
             relation_app_pair_total: AtomicU64::new(0),
             relation_app_pair_variance_fallthrough: AtomicU64::new(0),
             relation_app_pair_variance_fallthrough_cross_base: AtomicU64::new(0),
+            relation_lazy_ref_accessor_resolved: AtomicU64::new(0),
+            relation_lazy_ref_heritage_reachable: AtomicU64::new(0),
             cross_file_cache_miss_cause: [const { AtomicU64::new(0) };
                 CROSS_FILE_CACHE_MISS_CAUSE_COUNT],
             source_file_symbol_arena_cache_eligibility_outcome: [const { AtomicU64::new(0) };

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -382,6 +382,11 @@ pub struct IdentityCounters {
     /// #14351 sub-numerator: fall-through pairs whose two `Application` bases
     /// differ (cross-base HKT).
     pub relation_app_pair_variance_fallthrough_cross_base: u64,
+    /// #14351 lazy-ref-relation accessor probe: heritage-reachable cross-base
+    /// pairs for which the instantiated-heritage accessor resolved a base.
+    pub relation_lazy_ref_accessor_resolved: u64,
+    /// #14351 denominator: heritage-reachable cross-base pairs (lever candidates).
+    pub relation_lazy_ref_heritage_reachable: u64,
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
@@ -750,6 +755,12 @@ impl PerfCounters {
                 ),
                 relation_app_pair_variance_fallthrough_cross_base: load(
                     &c.relation_app_pair_variance_fallthrough_cross_base,
+                ),
+                relation_lazy_ref_accessor_resolved: load(
+                    &c.relation_lazy_ref_accessor_resolved,
+                ),
+                relation_lazy_ref_heritage_reachable: load(
+                    &c.relation_lazy_ref_heritage_reachable,
                 ),
             },
             lib_bootstrap: LibBootstrapCounters {

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -481,6 +481,8 @@ mod json_tests {
                 "relation_app_pair_total",
                 "relation_app_pair_variance_fallthrough",
                 "relation_app_pair_variance_fallthrough_cross_base",
+                "relation_lazy_ref_accessor_resolved",
+                "relation_lazy_ref_heritage_reachable",
             ],
         );
         assert_eq!(json["wired"]["stable_identity"], true);

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -306,6 +306,21 @@ pub struct DefinitionStore {
     /// the structural form (e.g., show "A" instead of "{ a: string }").
     type_to_def: DefDashMap<TypeId, DefId>,
 
+    /// #14351 lazy-reference relation: instantiated heritage edges.
+    ///
+    /// Maps a derived `DefId` to the list of `(parent DefId, instantiated base
+    /// TypeId)` for each direct `extends` clause, where the base `TypeId` is the
+    /// parent reference *as written in the derived type's own scope* (e.g.
+    /// `Functor1<F>` from `interface Apply1<F> extends Functor1<F>`, lowered with
+    /// `Apply1`'s type parameter `F`). Both the `InheritanceGraph` (SymbolId
+    /// edges) and `DefinitionInfo::extends`/`implements` (`DefId` only) are
+    /// type-argument-erased, so this is the only place the heritage edge's
+    /// argument expression survives for the variance fast path to relate
+    /// `Apply1<A>` to `Functor1<B>` without materializing members. Populated at
+    /// lowering (`class_inheritance.rs`); read only by the flag-gated
+    /// lazy-reference relation branch, so an empty/unread map is behavior-neutral.
+    heritage_instantiations: DefDashMap<DefId, Vec<(DefId, TypeId)>>,
+
     /// Shared `(file, type-parameter name node, TypeParamInfo)` -> `TypeId`
     /// canonical identity map for type-parameter declarations that have no
     /// `DefId` registration (class, method, and interface type parameters
@@ -498,6 +513,7 @@ impl DefinitionStore {
             generation: AtomicU64::new(1),
             alias_forwards: DefDashMap::default(),
             type_to_def: DefDashMap::default(),
+            heritage_instantiations: DefDashMap::default(),
             type_param_for_decl_node: DefDashMap::default(),
             symbol_def_index: DefDashMap::with_capacity_and_hasher(id_capacity, Default::default()),
             symbol_only_index: DefDashMap::with_capacity_and_hasher(
@@ -760,6 +776,29 @@ impl DefinitionStore {
             entry.implements = implements;
             self.bump_generation();
         }
+    }
+
+    /// #14351: record one instantiated heritage edge for the lazy-reference
+    /// relation. `derived` extends `parent`, and `base_type` is the parent
+    /// reference as written in `derived`'s own scope (e.g. `Functor1<F>` from
+    /// `interface Apply1<F> extends Functor1<F>`). First writer per
+    /// `(derived, parent)` wins; later equal writes are idempotent. This is
+    /// inert data — only the flag-gated lazy-reference relation branch reads it.
+    pub fn add_heritage_instantiation(&self, derived: DefId, parent: DefId, base_type: TypeId) {
+        let mut entry = self.heritage_instantiations.entry(derived).or_default();
+        if entry.iter().any(|&(p, _)| p == parent) {
+            return;
+        }
+        entry.push((parent, base_type));
+    }
+
+    /// #14351: the instantiated base `TypeId` for a DIRECT `extends` edge
+    /// `derived extends target`, or `None` if `target` is not a direct parent
+    /// of `derived` (the first slice handles single-hop heritage only).
+    pub fn get_heritage_instantiation(&self, derived: DefId, target: DefId) -> Option<TypeId> {
+        self.heritage_instantiations
+            .get(&derived)
+            .and_then(|edges| edges.iter().find(|&&(p, _)| p == target).map(|&(_, t)| t))
     }
 
     /// Update the body `TypeId` for a definition (for lazy evaluation).

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -352,6 +352,17 @@ pub trait TypeResolver {
         None
     }
 
+    /// #14351 lazy-reference relation: the instantiated base `TypeId` for a
+    /// DIRECT `extends` edge `derived extends target`, as written in `derived`'s
+    /// scope (e.g. `Functor1<F>` for `interface Apply1<F> extends Functor1<F>`).
+    /// `None` if `target` is not a direct parent of `derived` (the first slice
+    /// is single-hop). Unlike `get_base_type` this is keyed by the
+    /// `(derived, target)` def pair (selects the specific parent, not
+    /// `parents.first()`) and carries the heritage edge's type arguments.
+    fn get_heritage_instantiation(&self, _derived: DefId, _target: DefId) -> Option<TypeId> {
+        None
+    }
+
     /// Get the variance mask for type parameters of a generic type (Task #41).
     ///
     /// Used by `check_application_to_application_subtype` to optimize generic
@@ -542,6 +553,10 @@ impl<T: TypeResolver + ?Sized> TypeResolver for &T {
 
     fn get_base_type(&self, type_id: TypeId, interner: &dyn TypeDatabase) -> Option<TypeId> {
         (**self).get_base_type(type_id, interner)
+    }
+
+    fn get_heritage_instantiation(&self, derived: DefId, target: DefId) -> Option<TypeId> {
+        (**self).get_heritage_instantiation(derived, target)
     }
 
     fn get_type_param_variance(

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -32,6 +32,19 @@ fn args_contain_type_parameters(
         .any(|arg| crate::visitor::contains_type_parameters(interner, *arg))
 }
 
+/// #14351 lazy-reference relation kill switch. Default-OFF (opt-in via
+/// `TSZ_LAZY_REF_RELATION=1`) so flag-off is byte-identical to `main` — the
+/// cross-base heritage branch at the variance fast path takes the unchanged
+/// `return None` (structural-expansion) path when this is false. A dedicated
+/// env flag, NOT `perf_counters::enabled_fast`, because that gates pre-existing
+/// behavior; this must be a pure feature toggle so flag-off-vs-on is a clean
+/// single-variable delta.
+fn lazy_ref_relation_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("TSZ_LAZY_REF_RELATION").is_ok_and(|v| v == "1"))
+}
+
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Helper for resolving two Ref/TypeQuery symbols and checking subtype.
     ///
@@ -819,21 +832,54 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 {
                     return Some(result);
                 }
-                // #14351 lazy-reference-relation accessor probe (measure-only,
-                // NO verdict change — falls through to the unchanged `return
-                // None` below). For cross-base pairs whose source nominally
-                // derives from the target's def (`Apply1<A>` vs `Functor1<B>`),
-                // record whether the instantiated-heritage accessor resolves the
-                // source's instantiated target-base. The resolved/reachable ratio
-                // on fp-ts proves the lowering capture populates the map for real
-                // heritage edges before any verdict-affecting flip uses it.
+                // #14351 lazy-reference relation. For cross-base pairs whose
+                // source nominally derives from the target's def
+                // (`Apply1<A>` <: `Functor1<B>`), relate them by per-argument
+                // variance on the source's INSTANTIATED target-base
+                // (`Functor1<A>`, captured at lowering) instead of eagerly
+                // expanding both to structural objects and walking members. The
+                // instantiated base shares the target's base, so the EXISTING
+                // same-base variance fast path (`try_variance_fast_path`) does
+                // the per-arg variance read of `A` vs `B` — verdict-preserving
+                // (it reads the actual bound-var identity, never a canonicalized
+                // representative, so it cannot reproduce the alpha/brand
+                // representative-substitution corruption of the refuted levers).
+                //
+                // ACCEPTANCE-ONLY: only a conclusive `True` short-circuits; any
+                // other outcome (`False`/`Unknown`/no instantiated base) falls
+                // through to the unchanged structural `return None` below, so the
+                // branch can only REMOVE the eager member walk on pairs the
+                // variance check accepts — it can never flip a `False` to `True`
+                // or vice versa. Flag-OFF is byte-identical to `main`.
+                let reachable = self.nominal_heritage_reachable(s_def, t_def);
+                let heritage_base = if reachable && lazy_ref_relation_enabled() {
+                    self.resolver.get_heritage_instantiation(s_def, t_def)
+                } else {
+                    None
+                };
+                let mut accessor_resolved = false;
+                if let Some(base) = heritage_base
+                    && let Some(base_app_id) = application_id(self.interner, base)
+                {
+                    accessor_resolved = true;
+                    if matches!(
+                        self.try_variance_fast_path(base_app_id, t_app_id),
+                        Some(SubtypeResult::True)
+                    ) {
+                        return Some(SubtypeResult::True);
+                    }
+                }
+                // Measure-only accessor probe (only when counters enabled): the
+                // resolved/reachable ratio on fp-ts proves the capture populates
+                // the map for real heritage edges. Independent of the flag so the
+                // denominator is observable even with the relation OFF.
                 if tsz_common::perf_counters::enabled_fast() {
-                    let reachable = self.nominal_heritage_reachable(s_def, t_def);
-                    let resolved = reachable
-                        && self
-                            .resolver
-                            .get_heritage_instantiation(s_def, t_def)
-                            .is_some();
+                    let resolved = accessor_resolved
+                        || (reachable
+                            && self
+                                .resolver
+                                .get_heritage_instantiation(s_def, t_def)
+                                .is_some());
                     tsz_common::perf_counters::record_relation_lazy_ref_probe(reachable, resolved);
                 }
                 return None;

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -75,6 +75,26 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ///
     /// A generic target reached through an interface edge returns `false` here so
     /// the caller falls through to the structural check, which honors variance.
+    /// #14351: pure nominal-heritage REACHABILITY — does `s_def` derive from
+    /// `t_def` via the `InheritanceGraph` (transitive `extends`/`implements`)?
+    /// Unlike [`Self::nominal_heritage_subtype`] this does NOT apply the
+    /// `both_classes || target_non_generic` authoritativeness gate: reachability
+    /// alone does not settle a *generic* relation (the per-argument variance
+    /// still has to run), but it is the candidate predicate for the
+    /// lazy-reference relation, which relates the instantiated bases by variance.
+    pub(crate) fn nominal_heritage_reachable(&self, s_def: DefId, t_def: DefId) -> bool {
+        let Some(graph) = self.inheritance_graph else {
+            return false;
+        };
+        let (Some(s_sym), Some(t_sym)) = (
+            self.resolver.def_to_symbol_id(s_def),
+            self.resolver.def_to_symbol_id(t_def),
+        ) else {
+            return false;
+        };
+        graph.is_derived_from(s_sym, t_sym)
+    }
+
     pub(crate) fn nominal_heritage_subtype(&self, s_def: DefId, t_def: DefId) -> bool {
         let Some(graph) = self.inheritance_graph else {
             return false;
@@ -798,6 +818,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     self.try_pass_through_alias_any_unification(&s_app, &t_app, s_def, t_def)
                 {
                     return Some(result);
+                }
+                // #14351 lazy-reference-relation accessor probe (measure-only,
+                // NO verdict change — falls through to the unchanged `return
+                // None` below). For cross-base pairs whose source nominally
+                // derives from the target's def (`Apply1<A>` vs `Functor1<B>`),
+                // record whether the instantiated-heritage accessor resolves the
+                // source's instantiated target-base. The resolved/reachable ratio
+                // on fp-ts proves the lowering capture populates the map for real
+                // heritage edges before any verdict-affecting flip uses it.
+                if tsz_common::perf_counters::enabled_fast() {
+                    let reachable = self.nominal_heritage_reachable(s_def, t_def);
+                    let resolved = reachable
+                        && self
+                            .resolver
+                            .get_heritage_instantiation(s_def, t_def)
+                            .is_some();
+                    tsz_common::perf_counters::record_relation_lazy_ref_probe(reachable, resolved);
                 }
                 return None;
             }


### PR DESCRIPTION
## Summary

Adds a flag-gated (`TSZ_LAZY_REF_RELATION`, default-OFF), acceptance-only
lazy-reference relation at the cross-base variance fast-path seam
(`relations/subtype/rules/generics.rs`). When the source application nominally
derives from the target's definition (`Apply1<A>` <: `Functor1<B>`, related by
interface heritage) and the new instantiated-heritage accessor resolves the
source's instantiated target-base (`Functor1<A>`, captured at lowering), the
relation is decided by per-argument variance on that base — via the existing
same-base `try_variance_fast_path` — instead of eagerly evaluating both
operands to structural objects and walking members.

This relates lazy references by their type-arguments through the real heritage
chain (reading each argument's actual binding), the way `tsc`'s `relateVariances`
does — distinct from, and not subject to, the four refuted downstream
representative-substitution levers (it never swaps a canonicalized representative
for a result; it reads the actual bound-var identity).

The change is layered: a `DefinitionStore.heritage_instantiations` side-map
(`(derived, parent) -> instantiated base`), a `TypeResolver::get_heritage_instantiation`
query, the interface-heritage capture in `merge_interface_heritage_types_inner`,
and the flag-gated relation branch (acceptance-only).

## What this is (honest framing)

This lands the proven, verdict-preserving **first piece** of the #14351
construction-side fix plus the hot-path byte-parity heritage-bridge model. It is
explicitly **not** a speedup or row-flip claim:

- **Performance-neutral on fp-ts**: the ~60 heritage-reachable pairs this branch
  decides are dwarfed by the ~14,341 conditional-alias (`Kind<URI,A>`) pairs,
  which are the #14344 result-identity root and are untouched here. The fp-ts
  row flip needs that larger gate (tracked separately as the cross-arena
  materialize-once effort).
- **First construction-side-adjacent change to survive the full gate**: the four
  prior downstream-substitution levers (cache-key DefId canon, alpha-result
  dedup, brand collapse, relation-cache verdict-keying) were all refuted by
  prototype for corrupting relations; this relate-by-variance mechanism does not.
- **Flag-gated default-OFF**: zero behavior change in `main` until explicitly
  enabled; the branch is a verified-sound scaffold for the foundational work.

## Verification

Authoritative gate (canonkey, full run on this branch's binary) — all four pass:

1. **Byte-parity** (flag-OFF vs flag-ON, same binary, single-variable toggle):
   fp-ts diagnostics md5-identical (1477 diags); explicit witness-line diff
   empty. The acceptance-only design (only a conclusive `True` short-circuits;
   anything else falls through to the unchanged `return None`) means it can only
   remove the eager member walk on pairs the variance check accepts — it cannot
   flip a verdict.
2. **Negative controls** (the four refuted FP-sets as a leak-detector): the +14
   `Kind<F,B>`/HKT lines are zero-movement (identical OFF/ON), Stage-1's +46 are
   absent, #37's HTMLOptionElement is pre-existing in `main` (not flag-introduced)
   — the heritage branch does not leak into the conditional-alias path.
3. **Full `cargo nextest -p tsz-checker`** (not narrow-filtered): identical
   fail-set flag-OFF vs flag-ON, zero net-new, zero flips.
4. **Determinism**: identical md5 across `RAYON_NUM_THREADS` 1/2/4/8/16.

Local: rebased onto current `main`, builds clean, `identity_section_field_shape`
perf-counter lock passes; flag-OFF==flag-ON byte-parity re-confirmed on the
rebased binary. Ready-CI re-runs the full suite authoritatively on push.

Goal: fast

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Project Corpus Impact
- Row: n/a (flag-gated default-OFF; byte-parity verified; no row status change)
- Bug family: #14351 cross-base heritage lazy-reference relation (first construction-side-adjacent piece)
- Evidence: canonkey full gate (byte-parity + negative controls + full nextest + determinism); fp-ts flag-OFF==ON md5-identical
