### PR TITLE
fix(emit): mirror tsc enum evaluator for type-only wrappers (#14665)

### DIFF
--- a/crates/tsz-emitter/src/transforms/enum_es5.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5.rs
@@ -1781,30 +1781,24 @@ impl<'a> EnumES5Transformer<'a> {
     /// `visitParenthesizedExpression` (`skipOuterExpressions(..., ~Assertions)`
     /// followed by `isAssertionExpression(inner) || isSatisfiesExpression(inner)`).
     fn paren_wraps_assertion(&self, idx: NodeIndex) -> bool {
-        let mut cur = idx;
-        // Bounded peel through nested parentheses; the arena is acyclic so this
-        // terminates, but cap iterations as a defensive guard.
-        for _ in 0..256 {
-            let Some(node) = self.arena.get(cur) else {
-                return false;
-            };
-            match node.kind {
-                k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
-                    let Some(paren) = self.arena.get_parenthesized(node) else {
-                        return false;
-                    };
-                    cur = paren.expression;
-                }
-                k if k == syntax_kind_ext::AS_EXPRESSION
-                    || k == syntax_kind_ext::TYPE_ASSERTION
-                    || k == syntax_kind_ext::SATISFIES_EXPRESSION =>
-                {
-                    return true;
-                }
-                _ => return false,
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+        match node.kind {
+            // Peel nested parentheses (mirrors the recursive paren handling in the
+            // sibling `evaluate_*` helpers above).
+            k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => self
+                .arena
+                .get_parenthesized(node)
+                .is_some_and(|paren| self.paren_wraps_assertion(paren.expression)),
+            k if k == syntax_kind_ext::AS_EXPRESSION
+                || k == syntax_kind_ext::TYPE_ASSERTION
+                || k == syntax_kind_ext::SATISFIES_EXPRESSION =>
+            {
+                true
             }
+            _ => false,
         }
-        false
     }
 
     /// Check if an expression is syntactically string-valued per tsc's rules

--- a/crates/tsz-emitter/src/transforms/enum_es5.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5.rs
@@ -901,7 +901,16 @@ impl<'a> EnumES5Transformer<'a> {
             }
             k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
                 if let Some(paren) = self.arena.get_parenthesized(node) {
-                    IRNode::Parenthesized(Box::new(self.transform_expression(paren.expression)))
+                    // tsc's `visitParenthesizedExpression` drops the now-redundant
+                    // parentheses that wrap an erased assertion/`satisfies` expression
+                    // (`(1 as number)` -> `1`, `("x" as any)` -> `"x"`), but keeps
+                    // parentheses around any other inner expression (so `(2 + 3) * 4`
+                    // and a non-null `("y")!` are preserved).
+                    if self.paren_wraps_assertion(paren.expression) {
+                        self.transform_expression(paren.expression)
+                    } else {
+                        IRNode::Parenthesized(Box::new(self.transform_expression(paren.expression)))
+                    }
                 } else {
                     IRNode::NumericLiteral("0".to_string().into())
                 }
@@ -1189,17 +1198,9 @@ impl<'a> EnumES5Transformer<'a> {
                 let paren = self.arena.get_parenthesized(node)?;
                 self.evaluate_constant_float_expression(paren.expression)
             }
-            k if k == syntax_kind_ext::AS_EXPRESSION
-                || k == syntax_kind_ext::TYPE_ASSERTION
-                || k == syntax_kind_ext::SATISFIES_EXPRESSION =>
-            {
-                let assertion = self.arena.get_type_assertion(node)?;
-                self.evaluate_constant_float_expression(assertion.expression)
-            }
-            k if k == syntax_kind_ext::NON_NULL_EXPRESSION => {
-                let unary = self.arena.get_unary_expr_ex(node)?;
-                self.evaluate_constant_float_expression(unary.expression)
-            }
+            // Type-only wrappers (`as`/`<T>`/`satisfies`/`!`) are intentionally not
+            // folded: tsc's evaluator does not traverse them (see
+            // `evaluate_constant_expression`).
             _ => None,
         }
     }
@@ -1599,17 +1600,9 @@ impl<'a> EnumES5Transformer<'a> {
                 let paren = self.arena.get_parenthesized(node)?;
                 self.evaluate_constant_expression(paren.expression)
             }
-            k if k == syntax_kind_ext::AS_EXPRESSION
-                || k == syntax_kind_ext::TYPE_ASSERTION
-                || k == syntax_kind_ext::SATISFIES_EXPRESSION =>
-            {
-                let assertion = self.arena.get_type_assertion(node)?;
-                self.evaluate_constant_expression(assertion.expression)
-            }
-            k if k == syntax_kind_ext::NON_NULL_EXPRESSION => {
-                let unary = self.arena.get_unary_expr_ex(node)?;
-                self.evaluate_constant_expression(unary.expression)
-            }
+            // Type-only wrappers (`as`/`<T>`/`satisfies`/`!`) are intentionally not
+            // folded: tsc's evaluator does not traverse them, so the member is treated
+            // as computed (reverse-mapped) and emits its type-erased initializer.
             _ => None,
         }
     }
@@ -1671,17 +1664,9 @@ impl<'a> EnumES5Transformer<'a> {
                 let paren = self.arena.get_parenthesized(node)?;
                 self.evaluate_string_expression(paren.expression)
             }
-            k if k == syntax_kind_ext::AS_EXPRESSION
-                || k == syntax_kind_ext::TYPE_ASSERTION
-                || k == syntax_kind_ext::SATISFIES_EXPRESSION =>
-            {
-                let assertion = self.arena.get_type_assertion(node)?;
-                self.evaluate_string_expression(assertion.expression)
-            }
-            k if k == syntax_kind_ext::NON_NULL_EXPRESSION => {
-                let unary = self.arena.get_unary_expr_ex(node)?;
-                self.evaluate_string_expression(unary.expression)
-            }
+            // Type-only wrappers (`as`/`<T>`/`satisfies`/`!`) are intentionally not
+            // folded: tsc's evaluator does not traverse them, so such a member has no
+            // constant value and emits the (type-erased) initializer expression.
             k if k == SyntaxKind::Identifier as u16 => {
                 let id = self.arena.get_identifier(node)?;
                 // Check current enum members first
@@ -1789,10 +1774,53 @@ impl<'a> EnumES5Transformer<'a> {
         None
     }
 
-    /// Check if an expression is syntactically string-valued per tsc's rules.
-    /// String-valued enum members do NOT get reverse mappings.
-    /// Handles: string literals, template literals, string concatenation (`"x" + expr`),
-    /// references to other string-valued enum members, and parenthesized wrappers.
+    /// Whether a parenthesized expression's contents are an `as`/`<T>`/`satisfies`
+    /// assertion (peeling any further nested parentheses). tsc removes the
+    /// parentheses around such an erased assertion but keeps them around any other
+    /// inner expression, including a non-null `!` assertion. Mirrors tsc's
+    /// `visitParenthesizedExpression` (`skipOuterExpressions(..., ~Assertions)`
+    /// followed by `isAssertionExpression(inner) || isSatisfiesExpression(inner)`).
+    fn paren_wraps_assertion(&self, idx: NodeIndex) -> bool {
+        let mut cur = idx;
+        // Bounded peel through nested parentheses; the arena is acyclic so this
+        // terminates, but cap iterations as a defensive guard.
+        for _ in 0..256 {
+            let Some(node) = self.arena.get(cur) else {
+                return false;
+            };
+            match node.kind {
+                k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
+                    let Some(paren) = self.arena.get_parenthesized(node) else {
+                        return false;
+                    };
+                    cur = paren.expression;
+                }
+                k if k == syntax_kind_ext::AS_EXPRESSION
+                    || k == syntax_kind_ext::TYPE_ASSERTION
+                    || k == syntax_kind_ext::SATISFIES_EXPRESSION =>
+                {
+                    return true;
+                }
+                _ => return false,
+            }
+        }
+        false
+    }
+
+    /// Check if an expression is syntactically string-valued per tsc's rules
+    /// (the `isSyntacticallyString` flag tsc's evaluator threads through
+    /// `getEnumMemberValue`). String-valued enum members do NOT get reverse
+    /// mappings; everything else does.
+    ///
+    /// Handles: string literals, template literals, string concatenation
+    /// (`"x" + expr`, where *either* operand being string makes the whole
+    /// string), references to other string-valued enum members, and
+    /// parenthesized wrappers.
+    ///
+    /// Type-only wrappers — `as`/`<T>`/`satisfies`/`!` — are deliberately NOT
+    /// traversed: tsc's evaluator does not recurse through them (they fall to
+    /// its `default` arm, yielding `isSyntacticallyString = false`), so
+    /// `"x" as any` is a computed (reverse-mapped) member, not a string member.
     fn is_syntactically_string(&self, idx: NodeIndex) -> bool {
         let Some(node) = self.arena.get(idx) else {
             return false;
@@ -1809,32 +1837,17 @@ impl<'a> EnumES5Transformer<'a> {
                     false
                 }
             }
-            k if k == syntax_kind_ext::AS_EXPRESSION
-                || k == syntax_kind_ext::TYPE_ASSERTION
-                || k == syntax_kind_ext::SATISFIES_EXPRESSION =>
-            {
-                if let Some(assertion) = self.arena.get_type_assertion(node) {
-                    self.is_syntactically_string(assertion.expression)
-                } else {
-                    false
-                }
-            }
-            k if k == syntax_kind_ext::NON_NULL_EXPRESSION => {
-                if let Some(unary) = self.arena.get_unary_expr_ex(node) {
-                    self.is_syntactically_string(unary.expression)
-                } else {
-                    false
-                }
-            }
             k if k == syntax_kind_ext::BINARY_EXPRESSION => {
-                // String concatenation: "x" + expr is syntactically string
+                // String concatenation is syntactically string when *either* operand
+                // is, and the operator is `+` (tsc:
+                // `isSyntacticallyString = (left.isSyntacticallyString ||
+                // right.isSyntacticallyString) && operator === PlusToken`). This holds
+                // even when the value cannot be constant-folded, e.g. `"x" + (y as any)`.
                 if let Some(bin) = self.arena.get_binary_expr(node) {
                     let is_plus = bin.operator_token == SyntaxKind::PlusToken as u16;
-                    if is_plus {
-                        self.is_syntactically_string(bin.left)
-                    } else {
-                        false
-                    }
+                    is_plus
+                        && (self.is_syntactically_string(bin.left)
+                            || self.is_syntactically_string(bin.right))
                 } else {
                     false
                 }

--- a/crates/tsz-emitter/tests/enum_es5.rs
+++ b/crates/tsz-emitter/tests/enum_es5.rs
@@ -483,6 +483,94 @@ fn test_enum_initializer_erases_type_only_wrappers() {
 }
 
 #[test]
+fn test_string_member_behind_type_wrapper_gets_reverse_mapping() {
+    // tsc's enum evaluator does not traverse `as`/`<T>`/`satisfies`/`!`, so a string
+    // value behind such a wrapper has no constant value and is a *computed* member
+    // that DOES get a reverse mapping — unlike a bare string literal. The emitted
+    // value is the type-erased operand.
+    let output = transform_enum(
+        "enum E { Bare = \"x\", AsAny = \"a\" as any, AsConst = \"b\" as const, \
+         TypeAssert = <any>\"d\", Sat = \"e\" satisfies string, NonNull = \"f\"! }",
+    );
+    assert!(
+        output.contains("E[\"Bare\"] = \"x\"") && !output.contains("E[E[\"Bare\"]"),
+        "bare string literal keeps no reverse mapping, got: {output}"
+    );
+    for (member, value) in [
+        ("AsAny", "\"a\""),
+        ("AsConst", "\"b\""),
+        ("TypeAssert", "\"d\""),
+        ("Sat", "\"e\""),
+        ("NonNull", "\"f\""),
+    ] {
+        let expected = format!("E[E[\"{member}\"] = {value}] = \"{member}\"");
+        assert!(
+            output.contains(&expected),
+            "wrapped string member {member} should get a reverse mapping ({expected}), got: {output}"
+        );
+    }
+}
+
+#[test]
+fn test_parenthesized_assertion_drops_redundant_parens() {
+    // tsc removes the parentheses around an erased assertion/`satisfies`
+    // (`("g" as any)` -> `"g"`) but keeps them around other inner expressions.
+    let output = transform_enum(
+        "enum E { ParenAs = (\"g\" as any), NestedParen = ((\"h\" as const)), \
+         ParenNum = (5 as const) }",
+    );
+    assert!(
+        output.contains("E[E[\"ParenAs\"] = \"g\"] = \"ParenAs\""),
+        "paren around `as` is dropped, got: {output}"
+    );
+    assert!(
+        output.contains("E[E[\"NestedParen\"] = \"h\"] = \"NestedParen\""),
+        "nested parens around `as const` are dropped, got: {output}"
+    );
+    assert!(
+        output.contains("E[E[\"ParenNum\"] = 5] = \"ParenNum\""),
+        "paren around numeric `as const` is dropped, got: {output}"
+    );
+    assert!(
+        !output.contains("(\"g\")") && !output.contains("(5)"),
+        "redundant parens must not survive, got: {output}"
+    );
+}
+
+#[test]
+fn test_concat_with_wrapped_operand_is_string_member() {
+    // `+` is syntactically string when *either* operand is, even when the value
+    // cannot be folded (a wrapped operand). Such a member is a string member (no
+    // reverse mapping) and emits its type-erased expression unfolded.
+    let lhs = transform_enum("enum E { C = \"p\" + (\"q\" as any) }");
+    assert!(
+        lhs.contains("E[\"C\"] = \"p\" + \"q\"") && !lhs.contains("E[E[\"C\"]"),
+        "string-left concat with wrapped right has no reverse mapping, got: {lhs}"
+    );
+    let rhs = transform_enum("enum E { C = (1 as any) + \"q\" }");
+    assert!(
+        !rhs.contains("E[E[\"C\"]"),
+        "concat whose right operand is string has no reverse mapping, got: {rhs}"
+    );
+}
+
+#[test]
+fn test_reference_to_wrapped_member_is_not_constant_folded() {
+    // A reference to a member whose value is behind a wrapper is itself non-constant:
+    // tsc emits the qualified reference (`E.A`) and a reverse mapping, instead of
+    // folding to the wrapped member's underlying value.
+    let output = transform_enum("enum E { A = 1 as any, B = A }");
+    assert!(
+        output.contains("E[E[\"A\"] = 1] = \"A\""),
+        "wrapped numeric member keeps its erased value + reverse mapping, got: {output}"
+    );
+    assert!(
+        output.contains("E[E[\"B\"] = E.A] = \"B\""),
+        "reference to wrapped member B should emit `E.A`, not a folded literal, got: {output}"
+    );
+}
+
+#[test]
 fn test_no_folding_for_non_constant_expressions() {
     // External function call cannot be folded
     let output = transform_enum("enum E { A = foo() }");


### PR DESCRIPTION
Fixes #14665.

## What

Enum members whose initializer is wrapped in a **type-only wrapper** (`x as T`, `<T>x`, `x satisfies T`, `x!`) diverged from `tsc` in two ways:

1. A wrapped string value (`"x" as any`) was emitted as a plain string member `E["A"] = "x"` (no reverse mapping); `tsc` emits `E[E["A"] = "x"] = "A"`.
2. A reference to a wrapped member (`B = A`, `D = A as any`) was constant-folded to the underlying literal; `tsc` keeps the qualified reference (`E.A`) because the wrapped member is non-constant.

## Structural rule

`tsc`'s enum evaluator computes a constant `value` and an `isSyntacticallyString` flag and **never traverses** `as`/`<T>`/`satisfies`/`!` (they hit the evaluator's `default` arm). A member gets **no** reverse mapping iff `typeof value === "string"` **or** `isSyntacticallyString`; the value is the constant when present, else the type-erased initializer with the redundant parentheses around an erased assertion dropped.

When `<structural condition>`: an enum member initializer is (or transitively contains, through `+`) a type-only wrapper, `tsc` treats it as a computed/non-constant member — reverse-mapped, value erased-not-folded — and tsz now does so through the emitter's enum constant-evaluation helpers.

## Owner layer

Emitter only — `crates/tsz-emitter/src/transforms/enum_es5.rs`:
- `is_syntactically_string`, `evaluate_constant_expression`, `evaluate_constant_float_expression`, `evaluate_string_expression` no longer fold through the four wrapper kinds (mirroring `createEvaluator`).
- `is_syntactically_string` for `+` now uses `left || right` (was left-only), matching `isSyntacticallyString`.
- `transform_expression` drops the redundant parentheses around an erased assertion/`satisfies` (`visitParenthesizedExpression`); parens around other expressions and a non-null `("y")!` are preserved.

No checker change — tsz already reports the matching `TS18033` diagnostics.

## Adjacent-case matrix (all byte-identical to tsc 6.0.2)

- Wrappers: `"x" as any`, `"x" as const`, `<any>"x"`, `"x" satisfies string`, `"x"!`, numeric `1 as any`.
- Concatenation: `"p" + ("q" as any)` (string member, unfolded), `(1 as any) + "x"` (right-string).
- Parentheses: `(1 as number)`→`1`, `("g" as any)`→`"g"`, `(("h" as const))`→`"h"`, `("y")!`→`("y")` (kept), `(5 + (6 as any))`→`(5 + 6)`, `-(9 as any)`→`-9`.
- References: `B = A` / `D = A as any` → `E.A`; top-level const refs (`const KW = 8 as any; B = KW` → `KW`).
- Namespaced enums (the IR path) and a broad sweep (numeric, string, mixed, const enum, merged, float, negative, computed) unchanged.

## Verification

- `cargo test --profile dev-fast -p tsz-emitter --lib` → 3824 passed, 0 failed (incl. 4 new regression tests).
- `cargo clippy --profile dev-fast -p tsz-emitter` → clean.
- Manual diff of tsz vs `tsc 6.0.2` JS emit on the matrices above → byte-identical; original witness `enum E { C = "x" as any }` now matches.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01EUR3RfrUZ8818aYmqFnCt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUR3RfrUZ8818aYmqFnCt1)_