### PR TITLE
test(checker): re-enable renamed re-export heritage test (#14621); correct two-level-chain ignore note

### DIFF
--- a/crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs
+++ b/crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs
@@ -112,14 +112,14 @@ fn member_access_value_consumer() {
 
 // --- renamed re-export through nested barrels ---
 //
-// Follow-up: a *renamed* re-export (`export type { Original as Renamed }`)
-// forwarded again through `export *` keys the application base to the renaming
-// hop rather than the declaration, so the receiver is not recognized as a
-// non-lib interface application and the type argument is still dropped. This is
-// the re-export-chain def-identity gap (resolution layer), distinct from the
-// receiver-materialization path fixed here. Pinned (ignored) so it is tracked.
+// A *renamed* re-export (`export type { Original as Renamed }`) forwarded again
+// through `export *` previously keyed the application base to the renaming hop
+// rather than the declaration, so the receiver was not recognized as a non-lib
+// interface application and the type argument was dropped. The re-export-chain
+// def-identity gap (resolution layer) was closed in #14621, which canonicalizes
+// a re-exported generic interface/class alias to its declaration def; the
+// receiver now resolves `field` to the supplied `number`. Re-enabled here.
 #[test]
-#[ignore = "renamed re-export forwarded through export * keys the base def to the renaming hop (#13212 / #10663 resolution-layer follow-up)"]
 fn member_access_through_renamed_nested_barrels() {
     assert_clean(
         &[
@@ -319,10 +319,17 @@ fn extends_cross_file_generic_interface_two_type_args() {
 }
 
 #[test]
-#[ignore = "deeper residual: the inherited member reaches through TWO chained \
-            cross-file generic interfaces (Crate extends Wrap<number>, \
-            Wrap<V> extends Box<V>); the second hop's type argument is not yet \
-            threaded through the chained heritage materialization (#13212)"]
+#[ignore = "harness artifact, not a compiler residual (corrects the prior \
+            'second-hop type-arg threading' attribution). Root cause is the \
+            #14344 raw-`SymbolId` collision, reproducible ONLY in the entry-only \
+            harness: `Crate` (local) and `Wrap` (cross-file) get the same raw id \
+            (base_offset 0 after lib-merge), so registering `Wrap` cross-file \
+            mis-attributes `Crate` to `Wrap`'s file and `get_type_of_symbol` \
+            returns the cross-arena ERROR sentinel, dropping the inherited \
+            member. The production CLI is clean (verified: 2-/3-level chains, \
+            structural-wrap, class, barrel). No bounded slice exists — a raw \
+            `SymbolId` is ambiguous; a read-site guard and a collision-safe \
+            index each regress other cross-file tests. Needs #14344 identity."]
 fn extends_cross_file_generic_interface_two_level_chain() {
     // The inherited member reaches through *two* cross-file generic interfaces:
     // `Crate extends Wrap<number>` (cross-file) and `Wrap<V> extends Box<V>`


### PR DESCRIPTION
## Summary

Two test-suite accuracy fixes in `reexported_generic_interface_property_tests.rs`, no compiler behavior change.

1. **Re-enable `member_access_through_renamed_nested_barrels`.** It was pinned `#[ignore]` as a "resolution-layer follow-up". #14621 (canonicalize a re-exported generic interface/class alias to its declaration def) closed that gap, so the test now passes **deterministically (verified 3×)**. Re-enabling it makes it a live regression guard for that fix instead of silently rotting.

2. **Correct the misleading `#[ignore]` note on `extends_cross_file_generic_interface_two_level_chain`.** The prior note attributed it to "second-hop type-arg threading not yet threaded through chained heritage materialization (#13212)". That root is **wrong**, and chasing it wastes effort (it already misled prior investigations). The accurate root, established below, is the **#14344 raw-`SymbolId` collision**, reproducible **only** under the entry-only multi-file unit harness — not in the production CLI.

## Structural rule / root cause (two-level chain)

When `interface Crate extends Wrap<number>` and `interface Wrap<V> extends Box<V>` are declared in three separate modules, `tsc` resolves `c.item` to `number`. In the entry-only unit harness, `Crate` (local) and a `wrap.ts` symbol are minted with the **same raw `SymbolId`** (every binder uses `base_offset 0` after lib-merge). Registering `Wrap` as a cross-file target then writes that raw id into the symbol-file overlay pointing at `wrap.ts`, so `resolve_symbol_file_index(Crate)` reports `Crate` as cross-file. `get_type_of_symbol(Crate)` delegates to an arena that has no body for it and returns the cross-arena `ERROR` sentinel, which drops every member inherited through the chained heritage → false `TS2322 'V' is not assignable to 'number'`.

This is owned by the solver/checker cross-arena **identity** layer (#14344), not heritage materialization. The production driver builds its index from genuinely cross-file `symbol_file_targets` (not a raw-id scan) and primes the shared cache by checking every file, so it is unaffected.

## Verification

- `cargo test -p tsz-checker --lib reexported_generic_interface_property` → 16 passed, 0 failed, 1 ignored (the two-level chain, with the corrected note).
- `member_access_through_renamed_nested_barrels` confirmed deterministic across 3 runs.
- Production CLI confirmed **clean** (`tsz --noEmit -p`) for the failing repro and adjacent variants — 2-level and 3-level chains, structural-wrap base, cross-file generic **class** chain, and barrel/value/type-only re-exports — including a deliberate wrong-type assignment that correctly errors.
- No bounded compiler slice exists: a read-site current-file-ownership guard and a collision-safe harness index were each prototyped and **regress other cross-file tests** (a raw `SymbolId` is ambiguous and cannot be disambiguated locally). The real fix is #14344's content/declaration-based identity.
- `cargo fmt -p tsz-checker --check`: clean.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_013RxspKgyVPhRj5hLVnGr6B)_