### PR TITLE
perf(solver): #14351 type-param-id-cardinality diagnostic probe (measure-only)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz/diagnostics_report.rs
+++ b/crates/tsz-cli/src/bin/tsz/diagnostics_report.rs
@@ -247,6 +247,11 @@ fn build_diagnostics_report(
     report
         .perf_counter_dump
         .push_str(&tsz_solver::observability::eval_materialization_probe_report());
+    // #14351 measurement-only: type-parameter divergence report (empty unless
+    // TSZ_TYPEPARAM_DIVERGENCE_PROBE=1 was set, which the driver honors).
+    report
+        .perf_counter_dump
+        .push_str(&tsz_solver::observability::type_param_divergence_report());
 
     report
 }

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -2102,6 +2102,22 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
         );
     }
 
+    // #14351 measurement-only: stash the type-parameter divergence report from
+    // the live shared interner so the extendedDiagnostics path can render it.
+    // Gated on a dedicated probe env var (off by default; does not affect
+    // verdicts or normal perf runs).
+    if std::env::var("TSZ_TYPEPARAM_DIVERGENCE_PROBE").is_ok_and(|v| v == "1") {
+        let decl_sites = program_context
+            .shared_definition_store
+            .as_ref()
+            .map_or(0, |store| store.type_param_decl_node_count());
+        let mut report = format!(
+            "TypeParameter decl-site canonical-map entries: {decl_sites} (compare to distinct-id count: map<<ids => fresh-mint bypass = tractable; map~=ids => genuinely-distinct decls = XL)\n"
+        );
+        report.push_str(&program.type_interner.type_param_divergence_report(20));
+        tsz_solver::observability::set_type_param_divergence_report(report);
+    }
+
     CollectDiagnosticsResult {
         diagnostics,
         request_cache_counters,

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -1274,6 +1274,16 @@ impl DefinitionStore {
             .map(|r| *r)
     }
 
+    /// #14351 measurement-only: number of distinct decl-site canonical type-param
+    /// entries `(file, name_node, info)`. Comparing this to the count of distinct
+    /// interned `TypeParameter` ids decides whether the divergent ids are
+    /// fresh-mints that BYPASS the decl-site map (map-len << distinct-ids =>
+    /// tractable re-mint convergence) or genuinely-distinct decl-sites
+    /// (map-len ~= distinct-ids => XL relation-level).
+    pub fn type_param_decl_node_count(&self) -> usize {
+        self.type_param_for_decl_node.len()
+    }
+
     /// Register the canonical `TypeId` for a type-parameter declaration
     /// identified by `(file, name_node, info)`.
     ///

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -1606,6 +1606,65 @@ impl TypeInterner {
         total
     }
 
+    /// #14351 measurement (diagnostic-only): scan all interned types and report,
+    /// per type-parameter name `Atom`, how many DISTINCT `TypeData::TypeParameter`
+    /// `TypeId`s share that name, and which `TypeParamInfo` field varies among
+    /// them. A name with many distinct ids means the same logical `<A>` does NOT
+    /// content-dedup — pinning the divergent component (`constraint`/`default`/
+    /// `origin`/`is_const`). Returns a human-readable report of the worst offenders.
+    pub fn type_param_divergence_report(&self, top_n: usize) -> String {
+        use rustc_hash::{FxHashMap, FxHashSet};
+        // name Atom -> Vec of info for each distinct interned TypeParameter
+        let mut by_name: FxHashMap<Atom, Vec<crate::types::TypeParamInfo>> = FxHashMap::default();
+        let n = self.len();
+        for raw in (TypeId::FIRST_USER as usize)..n {
+            let id = TypeId(raw as u32);
+            if let Some(crate::types::TypeData::TypeParameter(info)) = self.lookup(id) {
+                by_name.entry(info.name).or_default().push(info);
+            }
+        }
+        let mut rows: Vec<(Atom, Vec<crate::types::TypeParamInfo>)> =
+            by_name.into_iter().filter(|(_, v)| v.len() > 1).collect();
+        rows.sort_by_key(|b| std::cmp::Reverse(b.1.len()));
+        let total_names = rows.len();
+        let total_excess: usize = rows.iter().map(|(_, v)| v.len() - 1).sum();
+        use std::fmt::Write as _;
+        let mut out = String::new();
+        let _ = writeln!(
+            out,
+            "TypeParameter divergence: {total_names} names with >1 distinct id, total excess ids {total_excess}"
+        );
+        for (name, infos) in rows.into_iter().take(top_n) {
+            let name_s = self.resolve_atom(name);
+            let dc = infos
+                .iter()
+                .map(|i| i.constraint.map(|t| t.0))
+                .collect::<FxHashSet<_>>()
+                .len();
+            let dd = infos
+                .iter()
+                .map(|i| i.default.map(|t| t.0))
+                .collect::<FxHashSet<_>>()
+                .len();
+            let dorigin = infos
+                .iter()
+                .map(|i| format!("{:?}", i.origin))
+                .collect::<FxHashSet<_>>()
+                .len();
+            let dconst = infos
+                .iter()
+                .map(|i| i.is_const)
+                .collect::<FxHashSet<_>>()
+                .len();
+            let _ = writeln!(
+                out,
+                "  '{name_s}': {} distinct ids | varies: constraint={dc} default={dd} origin={dorigin} is_const={dconst}",
+                infos.len()
+            );
+        }
+        out
+    }
+
     /// Check if the interner is empty (only has intrinsics)
     pub fn is_empty(&self) -> bool {
         self.len() <= TypeId::FIRST_USER as usize

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -216,6 +216,28 @@ pub mod observability {
     pub fn eval_materialization_probe_report() -> String {
         crate::evaluation::eval_materialization_probe::dump_report()
     }
+
+    /// #14351 measurement-only stash: the driver sets the type-parameter
+    /// divergence report (computed from the live `TypeInterner` at end-of-check)
+    /// here so the CLI extendedDiagnostics path can append it without threading
+    /// the interner through the report struct. Gated by the driver on
+    /// `TSZ_TYPEPARAM_DIVERGENCE_PROBE`; empty otherwise.
+    static TYPEPARAM_DIVERGENCE: std::sync::Mutex<String> = std::sync::Mutex::new(String::new());
+
+    /// Store the divergence report (called by the driver where the interner is live).
+    pub fn set_type_param_divergence_report(report: String) {
+        if let Ok(mut slot) = TYPEPARAM_DIVERGENCE.lock() {
+            *slot = report;
+        }
+    }
+
+    /// Read the stashed divergence report (called by the CLI report builder).
+    pub fn type_param_divergence_report() -> String {
+        TYPEPARAM_DIVERGENCE
+            .lock()
+            .map(|s| s.clone())
+            .unwrap_or_default()
+    }
 }
 
 /// Tier 4: Type construction — building new types.


### PR DESCRIPTION
## Summary

A permanent, opt-in, zero-behavior diagnostic for the `#14351` cross-arena
materialize-once signal: it measures type-parameter identity divergence — how
many DISTINCT `TypeData::TypeParameter` `TypeId`s share each name `Atom`, which
`TypeParamInfo` field varies among them, and the decl-site canonical-map
cardinality. Gated on `TSZ_TYPEPARAM_DIVERGENCE_PROBE=1` (the report renders only
then; nothing is computed otherwise), analogous to the `#14658` variance-fallthrough
counter as a permanent measurement instrument.

Pieces:
- `TypeInterner::type_param_divergence_report` — scans interned types, groups
  `TypeParameter` by name, reports distinct-id counts + which `info` field varies.
- `DefinitionStore::type_param_decl_node_count` — the decl-site canonical-map
  (`(file, name_node, info)`) cardinality.
- `observability` set/get stash + a gated driver setter + the
  `--extendedDiagnostics` appender (mirrors the eval-materialization probe).

This is the same single diagnostic commit previously on PR #14663 (which shared a
head branch with in-flight prototype work); it is re-homed here on a clean,
lint-passing, prototype-free branch so the landable measure-only diagnostic is
isolated from the reorder prototype. The `format_push_string` lint regression in
the original commit is fixed here (`push_str(&format!(..))` → `writeln!`).

## Why (the measured #14351 tractability verdict)

The instrument answered the central tractability question for the fp-ts
foundational fix by measurement, not hypothesis. On fp-ts it reports:

- 578 type-parameter names with >1 distinct id, 30,729 total excess ids
  (e.g. `'A'`: 4952 distinct ids for at most ~64 distinct `TypeParamInfo` combos
  — i.e. the same `info` interned as many distinct non-deduped ids).
- decl-site canonical-map entries: 22,041 ≈ distinct ids (ratio ~0.70, same
  order of magnitude).

The decl-site-vs-distinct-id ratio is the decider: it shows the divergent
type-params are largely GENUINELY-DISTINCT declarations (each typeclass method's
own `<A>`), not one decl-site re-minted. So converging them at construction would
be over-collapse (unsound); the fp-ts fix bottoms out in relation-level
alpha-invariance for positionally-equivalent distinct-decl params — the
multi-week construction+relation lockstep core.

## Verification

- `cargo clippy -p tsz-solver -p tsz-cli --release`: clean.
- Clippy warn-ratchet: 59 below baseline (the `format_push_string` +2 from the
  original commit is fixed via `writeln!`).
- Builds clean; the probe is an interner scan + map-len read behind the env gate,
  with the report stashed via a process-global `Mutex<String>` and appended to the
  existing `perf_counter_dump` field. Zero behavior change with the gate off.
- fp-ts `--extendedDiagnostics` with the gate on renders the report above
  (deterministic across runs).

Goal: fast

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Project Corpus Impact
- Row: n/a (opt-in zero-behavior diagnostic; no row status change)
- Bug family: #14351 cross-arena materialize-once / type-param identity divergence measurement
- Evidence: fp-ts 578 names / 30,729 excess ids / 22,041 decl-sites (the measured tractability verdict); clippy clean; warn-ratchet 59 below baseline
