### PR TITLE
fix(solver): elaborate sole-real-member nullable targets against the resolved leaf

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1004,6 +1004,9 @@ path = "tests/recursive_conditional_mapped_infer_tests.rs"
 name = "deep_pick_inline_application_contextual_tests"
 path = "tests/deep_pick_inline_application_contextual_tests.rs"
 [[test]]
+name = "deep_partial_optional_leaf_elaboration_tests"
+path = "tests/deep_partial_optional_leaf_elaboration_tests.rs"
+[[test]]
 name = "in_chain_narrows_unconstrained_type_param_tests"
 path = "tests/in_chain_narrows_unconstrained_type_param_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/deep_partial_optional_leaf_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/deep_partial_optional_leaf_elaboration_tests.rs
@@ -1,0 +1,185 @@
+//! Regression: an object-literal value matched against an **optional** property
+//! whose declared type is a still-deferred generic application (the canonical
+//! shape being the recursive `DeepPartial`-style mapped type
+//! `{ [K in keyof T]?: DP<T[K]> }`) must elaborate to the single deepest leaf
+//! mismatch the way `tsc` does — not a duplicate/mis-rendered diagnostic.
+//!
+//! Root cause: the optional property gives the relation target a union member
+//! `DP<number> | undefined`. The subtype-failure explanation collapsed to a
+//! `NoUnionMemberMatches` over `[DP<number>, undefined]`, rendering the
+//! *unevaluated* application `DP<number>` instead of the leaf it resolves to
+//! (`number`). Because the assignment elaboration separately reports the
+//! evaluated `number` leaf at the same anchor, the differing message defeated
+//! diagnostic dedup and surfaced a spurious second TS2322. The required
+//! (non-optional) form never built the `| undefined` union, so it was clean —
+//! which masked the gap.
+//!
+//! Fix: when a `T | undefined`-shaped target has a sole non-nullish member `T`
+//! and the source is a scalar (primitive / literal), elaborate `S` against `T`
+//! directly (resolving `T`), exactly as `tsc` does for a nullable target.
+
+use tsz_checker::test_utils::check_source_strict_messages_without_missing_libs;
+
+/// `(code, message)` pairs anchored at the `n`th 1-based line, with the
+/// surrounding test noise (TS2318 missing-lib) already filtered out.
+fn ts2322_messages(source: &str) -> Vec<String> {
+    check_source_strict_messages_without_missing_libs(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, msg)| msg)
+        .collect()
+}
+
+fn all_codes(source: &str) -> Vec<u32> {
+    check_source_strict_messages_without_missing_libs(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+/// Single recursion level: the optional `b?` value resolves to `number`.
+/// Exactly one TS2322 against `number`, with no `DP<number>` aggregate.
+#[test]
+fn recursive_optional_mapped_leaf_reports_resolved_number_once() {
+    let msgs = ts2322_messages(
+        r#"
+type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };
+const v: DeepPartial<{ b: number }> = { b: "x" };
+"#,
+    );
+    assert_eq!(
+        msgs,
+        vec!["Type 'string' is not assignable to type 'number'.".to_string()],
+        "must report the resolved leaf once, not a duplicate `DeepPartial<number>` aggregate",
+    );
+}
+
+/// Nested object value: the deepest optional leaf still resolves to `number`.
+#[test]
+fn nested_recursive_optional_mapped_leaf_reports_resolved_number_once() {
+    let msgs = ts2322_messages(
+        r#"
+type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };
+const v: DeepPartial<{ outer: { inner: number } }> = { outer: { inner: "x" } };
+"#,
+    );
+    assert_eq!(
+        msgs,
+        vec!["Type 'string' is not assignable to type 'number'.".to_string()],
+        "the deepest leaf must resolve and report once: {msgs:?}",
+    );
+}
+
+/// Anti-hardcoding: renamed alias / type-parameter / property binders take the
+/// identical structural path — the fix must not key on any name.
+#[test]
+fn recursive_optional_mapped_leaf_independent_of_binder_names() {
+    let msgs = ts2322_messages(
+        r#"
+type Loose<Shape> = { [Key in keyof Shape]?: Loose<Shape[Key]> };
+const payload: Loose<{ amount: number }> = { amount: "x" };
+"#,
+    );
+    assert_eq!(
+        msgs,
+        vec!["Type 'string' is not assignable to type 'number'.".to_string()],
+        "renamed binders must reach the same resolved-leaf elaboration: {msgs:?}",
+    );
+}
+
+/// `undefined` is a valid value for the optional property — the `| undefined`
+/// member must be preserved (no spurious error).
+#[test]
+fn recursive_optional_mapped_accepts_undefined_value() {
+    let codes = all_codes(
+        r#"
+type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };
+const v: DeepPartial<{ b: number }> = { b: undefined };
+"#,
+    );
+    assert!(
+        !codes.contains(&2322),
+        "an explicit `undefined` for an optional property is valid: {codes:?}",
+    );
+}
+
+/// A valid leaf value must stay clean (the fix must not over-report).
+#[test]
+fn recursive_optional_mapped_valid_leaf_is_clean() {
+    let codes = all_codes(
+        r#"
+type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };
+const v: DeepPartial<{ b: number }> = { b: 5 };
+"#,
+    );
+    assert!(
+        !codes.contains(&2322),
+        "a matching leaf value must not error: {codes:?}",
+    );
+}
+
+/// The non-optional (required) recursive mapped form was already correct; pin it
+/// so the optional fix keeps parity with it.
+#[test]
+fn required_recursive_mapped_leaf_reports_resolved_number_once() {
+    let msgs = ts2322_messages(
+        r#"
+type DeepReq<T> = { [K in keyof T]: DeepReq<T[K]> };
+const v: DeepReq<{ b: number }> = { b: "x" };
+"#,
+    );
+    assert_eq!(
+        msgs,
+        vec!["Type 'string' is not assignable to type 'number'.".to_string()],
+        "required and optional recursive mapped leaves must agree: {msgs:?}",
+    );
+}
+
+/// Sole-real-member nullable target with a close string literal: `tsc`
+/// elaborates `"appel"` against `"apple"` directly (TS2322), never the TS2820
+/// `… | undefined` "Did you mean" form. Same root, surfaced without a mapped
+/// type at all.
+#[test]
+fn sole_member_nullable_literal_uses_direct_mismatch_not_suggestion() {
+    let pairs: Vec<(u32, String)> = check_source_strict_messages_without_missing_libs(
+        r#"
+type Fruit = "apple" | undefined;
+const f: Fruit = "appel";
+"#,
+    );
+    assert_eq!(
+        pairs,
+        vec![(
+            2322,
+            "Type '\"appel\"' is not assignable to type '\"apple\"'.".to_string()
+        )],
+        "a sole-real-member nullable target must elaborate against the real member directly: {pairs:?}",
+    );
+}
+
+/// Object sources keep their per-property elaboration: a sole-member nullable
+/// object target with a property-type mismatch still anchors the leaf, and a
+/// missing required property still surfaces TS2741 — neither path is disturbed.
+#[test]
+fn sole_member_nullable_object_source_unaffected() {
+    let leaf = ts2322_messages(
+        r#"
+const o: { a: number } | undefined = { a: "x" };
+"#,
+    );
+    assert_eq!(
+        leaf,
+        vec!["Type 'string' is not assignable to type 'number'.".to_string()],
+        "object property mismatch still anchors the leaf: {leaf:?}",
+    );
+
+    let missing = all_codes(
+        r#"
+const o: { a: number; b: string } | undefined = { a: 1 };
+"#,
+    );
+    assert!(
+        missing.contains(&2741),
+        "a missing required property still surfaces TS2741: {missing:?}",
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -963,12 +963,36 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         if self.check_subtype(source_member, sole_member).is_true() {
                             continue;
                         }
-                        if let Some(
-                            reason @ (SubtypeFailureReason::MissingProperty { .. }
-                            | SubtypeFailureReason::MissingProperties { .. }),
-                        ) = self.explain_failure_guarded(source_member, sole_member)
+                        if let Some(reason) =
+                            self.explain_failure_guarded(source_member, sole_member)
                         {
-                            return Some(reason);
+                            let promote = match &reason {
+                                // Object/array source missing a required property:
+                                // surface the missing-property reason directly
+                                // (TS2741 / TS2739 / TS2345).
+                                SubtypeFailureReason::MissingProperty { .. }
+                                | SubtypeFailureReason::MissingProperties { .. } => true,
+                                // Scalar source (a primitive / string-literal property
+                                // value): tsc elaborates `S` against the sole real member
+                                // `T` directly instead of a `NoUnionMemberMatches` over
+                                // `[T, undefined]`. The bare reason both (a) renders the
+                                // evaluated leaf (`number`) where `T` is a still-deferred
+                                // application (e.g. the `DP<number>` value of a recursive
+                                // `DeepPartial`-style mapped type), and (b) drops the
+                                // spurious `| undefined` and "Did you mean" suggestion tsc
+                                // never shows for a sole-real-member nullable target. Object
+                                // sources are excluded so their per-property elaboration is
+                                // unaffected.
+                                SubtypeFailureReason::TypeMismatch { .. }
+                                | SubtypeFailureReason::IntrinsicTypeMismatch { .. }
+                                | SubtypeFailureReason::LiteralTypeMismatch { .. } => {
+                                    !self.is_object_like(source_member)
+                                }
+                                _ => false,
+                            };
+                            if promote {
+                                return Some(reason);
+                            }
                         }
                     }
                 }

--- a/crates/tsz-solver/src/relations/subtype/overlap.rs
+++ b/crates/tsz-solver/src/relations/subtype/overlap.rs
@@ -391,7 +391,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// - Plain objects with properties
     /// - Objects with index signatures
     /// - Intersections (which may contain objects)
-    fn is_object_like(&self, type_id: TypeId) -> bool {
+    pub(crate) fn is_object_like(&self, type_id: TypeId) -> bool {
         use crate::visitor::{intersection_list_id, object_shape_id, object_with_index_shape_id};
 
         object_shape_id(self.interner, type_id).is_some()


### PR DESCRIPTION
Fixes #14673.

Goal: hold

## Problem

When an object-literal value is matched against an **optional** property whose
declared type is a still-deferred generic application — the canonical shape being
the recursive `DeepPartial`-style mapped type `{ [K in keyof T]?: DeepPartial<T[K]> }` —
tsz's TS2322 diverged from `tsc` in two ways that share one root:

```ts
type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };

const a: DeepPartial<{ b: number }> = { b: "x" };
// tsc:          one error at `"x"` -> Type 'string' is not assignable to type 'number'.
// tsz (before): TWO errors at `"x"`:
//   Type 'string' is not assignable to type 'DeepPartial<number>'.   (spurious aggregate)
//   Type 'string' is not assignable to type 'number'.

const b: DeepPartial<{ outer: { inner: number } }> = { outer: { inner: "x" } };
// tsc:          deepest leaf -> string not assignable to number.
// tsz (before): single error rendering the unevaluated `DeepPartial<number>`.

type Fruit = "apple" | undefined;
const f: Fruit = "appel";
// tsc:          TS2322 -> Type '"appel"' is not assignable to type '"apple"'.
// tsz (before): TS2820 -> ... to type '"apple" | undefined'. Did you mean '"apple"'?
```

The **required** (non-optional) recursive mapped form was already correct, which
masked the gap. `{ b: undefined }` / `{ b: 5 }` stay valid in both (the
`| undefined` from optionality is preserved).

## Structural rule

When a `T | undefined`-shaped relation target has a **sole non-nullish member**
`T` and the source is a **scalar** (a primitive / string-literal property value),
`tsc` elaborates `S` against `T` directly — resolving `T` to its leaf — exactly
as if the target were `T` alone. tsz instead collapsed to a
`NoUnionMemberMatches` over `[T, undefined]`, which (a) rendered the *unevaluated*
application member (`DeepPartial<number>` instead of the `number` it resolves to)
and (b) kept the `| undefined` / "Did you mean" shape. Because the assignment
elaboration separately reports the evaluated leaf at the same anchor, the
differing aggregate message defeated diagnostic dedup and surfaced the spurious
second TS2322.

## Owner layer

Solver subtype-failure explanation only —
`crates/tsz-solver/src/relations/subtype/explain.rs`, the sole-non-nullish-member
arm of the union-target failure path. That arm already promoted
`MissingProperty`/`MissingProperties` to the real member (TS2741/TS2739/TS2345);
it now also promotes the scalar-leaf mismatch reasons (`TypeMismatch` /
`IntrinsicTypeMismatch` / `LiteralTypeMismatch`) **for non-object sources**,
returning the resolved-leaf reason instead of `NoUnionMemberMatches`. The
`is_object_like` gate keeps object/array sources on their existing per-property
elaboration. No relation/inference/evaluation change; the gate is purely
structural (sole-member + source object-likeness + reason kind), never keyed on
identifiers or rendered type text. (`is_object_like` is widened from module-
private to `pub(crate)` so the explain arm can reuse it.)

## Adjacent matrix

New suite `deep_partial_optional_leaf_elaboration_tests` (8 tests):

- single- and nested-level recursive optional mapped leaves report the resolved
  `number` exactly once (no `DeepPartial<number>` aggregate);
- renamed alias / type-parameter / property binders take the identical path
  (anti-hardcoding);
- `undefined` and a matching leaf value stay clean (the `| undefined` member is
  preserved, no over-report);
- the required (non-optional) recursive mapped form keeps parity;
- the sole-member nullable string-literal target uses the direct TS2322, not the
  TS2820 `… | undefined` "Did you mean" form;
- object sources are unaffected — a property mismatch still anchors the leaf and
  a missing required property still surfaces TS2741.

## Verification

- New suite `deep_partial_optional_leaf_elaboration_tests` — 8 passed.
- Differential vs `tsc` 6.0.2 over the witnesses above plus a ~20-case matrix
  (single/nested DeepPartial, `Record`/conditional/indexed leaves, optional vs
  required, scalar vs object sources, valid/`undefined` values, the TS2820
  literal-suggestion case) — tsz now matches `tsc` on every case it previously
  diverged on, with no change to the named-property, required-mapped, or
  object-source paths.
- Full-tree regression diff vs clean `main` across `tsz-solver --lib` and the
  `tsz-checker` `assignab` / `mapped` / `elaborat` / `object_literal` / `union` /
  `optional` / `nullable` / `excess` / `ts2741` / `ts2739` / `ts2820` filters —
  **zero net-new failures** (the only locals are pre-existing, identical on the
  clean tree).
- `cargo fmt -p tsz-solver -p tsz-checker --check`, `cargo clippy -p tsz-solver`
  (clean), `python3 scripts/arch/arch_guard.py` — all pass.
- Ready-review CI owns the full conformance / JS-emit / DTS / fourslash parity
  floors.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01UU7gnRbQ72idSmvUDJFDqd)_