### PR TITLE
fix(checker): anchor block-bodied function-value TS2322 at the binding target

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs
@@ -1198,23 +1198,48 @@ impl<'a> CheckerState<'a> {
                     // (e.g., show `() => string` instead of `() => "foo"`)
                     let widened_func_type =
                         crate::query_boundaries::common::widen_type_deep(self.ctx.types, func_type);
-                    // For functions that are the RHS of an assignment (e.g., `A.prototype.foo = function() {}`),
-                    // use the assignment LHS as the anchor to match tsc behavior.
-                    // Otherwise, use the function position as the anchor.
-                    let diag_anchor = if self.is_rhs_of_assignment(func_idx) {
-                        let lhs = self.find_assignment_lhs_for_rhs(func_idx);
-                        lhs.unwrap_or(func_idx)
+                    // `tsc`'s `elaborateArrowFunction` never drills into a block
+                    // body, so this function-level mismatch is anchored at the
+                    // function value's *binding target*, not the function node:
+                    // the assignment LHS (`A.prototype.foo = function() {}`), the
+                    // variable declaration's name (`const f: () => number = () =>
+                    // { return "x"; }`), or the enclosing `return` statement.
+                    // Fall back to the function position only when the value is
+                    // in a context where that anchor already matches `tsc` (call
+                    // argument, object-literal property, …).
+                    //
+                    // For the variable-initializer / return-statement binding
+                    // targets, the report must also stay at the binding without
+                    // drilling into the source shape: `tsc` reports the single
+                    // function-level mismatch even when the returned value is an
+                    // object literal (`() => { return { a: "x" }; }`), which the
+                    // default source-elaboration path would otherwise drill into.
+                    if let Some(binding_anchor) = self.function_value_binding_anchor(func_idx) {
+                        !self
+                            .check_assignable_or_report_at_exact_anchor_without_source_elaboration_with_display_types(
+                                return_type,
+                                expected_return_type,
+                                widened_func_type,
+                                param_type,
+                                ret.expression,
+                                binding_anchor,
+                            )
                     } else {
-                        func_idx
-                    };
-                    !self.check_assignable_or_report_at_with_display_types(
-                        return_type,
-                        expected_return_type,
-                        widened_func_type,
-                        param_type,
-                        ret.expression,
-                        diag_anchor, // Use appropriate anchor based on context
-                    )
+                        let diag_anchor = if self.is_rhs_of_assignment(func_idx) {
+                            self.find_assignment_lhs_for_rhs(func_idx)
+                                .unwrap_or(func_idx)
+                        } else {
+                            func_idx
+                        };
+                        !self.check_assignable_or_report_at_with_display_types(
+                            return_type,
+                            expected_return_type,
+                            widened_func_type,
+                            param_type,
+                            ret.expression,
+                            diag_anchor, // Use appropriate anchor based on context
+                        )
+                    }
                 } else {
                     !self.check_assignable_or_report_at_without_source_elaboration(
                         return_type,

--- a/crates/tsz-checker/src/types/function_type/js_prototype.rs
+++ b/crates/tsz-checker/src/types/function_type/js_prototype.rs
@@ -108,6 +108,55 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// Anchor for a function-level return-type mismatch surfaced while
+    /// elaborating a block-bodied function value, when that value is the
+    /// initializer of a variable declaration or the expression of a `return`
+    /// statement.
+    ///
+    /// `tsc`'s `elaborateArrowFunction` never drills into a block body, so the
+    /// resulting function-level `TS2322` is reported at the *binding target* of
+    /// the function value, not at the function expression. For an assignment
+    /// RHS that target is the LHS (handled by [`Self::is_rhs_of_assignment`] /
+    /// [`Self::find_assignment_lhs_for_rhs`]); this helper covers the two other
+    /// binding contexts:
+    /// - `const f: () => number = () => { return "x"; }` anchors at the
+    ///   variable declaration (whose error span is the binding name), and
+    /// - `function g(): () => number { return () => { return "x"; }; }` anchors
+    ///   at the enclosing `return` statement.
+    ///
+    /// Returns `None` for every other context (call argument, object-literal
+    /// property, …), where the function-expression anchor is already correct.
+    pub(crate) fn function_value_binding_anchor(&self, func_idx: NodeIndex) -> Option<NodeIndex> {
+        let mut current = func_idx;
+        for _ in 0..6 {
+            let parent = self.ctx.arena.get_extended(current)?.parent;
+            if parent.is_none() {
+                return None;
+            }
+            let parent_node = self.ctx.arena.get(parent)?;
+            match parent_node.kind {
+                // Look through parentheses around the function value
+                // (`const f: T = (() => { ... })`).
+                syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
+                    current = parent;
+                }
+                syntax_kind_ext::VARIABLE_DECLARATION => {
+                    let var_decl = self.ctx.arena.get_variable_declaration(parent_node)?;
+                    // Only when the function value is this declaration's
+                    // initializer (the parenthesized chain above guarantees
+                    // `current` is the initializer or a paren wrapper of it).
+                    return (var_decl.initializer == current).then_some(parent);
+                }
+                syntax_kind_ext::RETURN_STATEMENT => {
+                    let ret = self.ctx.arena.get_return_statement(parent_node)?;
+                    return (ret.expression == current).then_some(parent);
+                }
+                _ => return None,
+            }
+        }
+        None
+    }
+
     fn js_prototype_owner_expression_from_assignment_left(
         &self,
         left_idx: NodeIndex,

--- a/crates/tsz-checker/src/types/function_type/tests.rs
+++ b/crates/tsz-checker/src/types/function_type/tests.rs
@@ -363,3 +363,87 @@ fn async_generic_return_call_does_not_get_promise_union_context() {
         "async generic return call should not be over-constrained by PromiseLike contextual unions: {diags:?}"
     );
 }
+
+/// A block-bodied function/arrow value assigned to a function-typed variable
+/// whose body's return type does not match anchors `TS2322` at the variable
+/// **binding name** with the function-level message — `tsc`'s
+/// `elaborateArrowFunction` never drills into a block body, so the error is
+/// reported at the original declaration error node (whose span is its name),
+/// not at the function expression. Binder names are varied to keep the gate
+/// structural (anti-hardcoding contract).
+#[test]
+fn block_body_function_initializer_return_mismatch_anchors_at_binding_name() {
+    let cases = [
+        (
+            "const handler: () => number = () => { return \"x\"; };",
+            "handler",
+        ),
+        (
+            "const makeCount: () => number = function () { return \"x\"; };",
+            "makeCount",
+        ),
+        (
+            "const run: () => number = () => { if (1) return \"x\"; return 1; };",
+            "run",
+        ),
+        // Parenthesized initializer is looked through to the same binding.
+        ("const cb: () => number = (() => { return \"x\"; });", "cb"),
+        // Object-literal block return still reports the single function-level
+        // mismatch at the binding (no per-property drill).
+        (
+            "const build: () => { a: number } = () => { return { a: \"x\" }; };",
+            "build",
+        ),
+    ];
+    for (source, name) in cases {
+        let diagnostics = diagnostics_with_spans(source);
+        let diag = diagnostics
+            .iter()
+            .find(|d| d.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+            .unwrap_or_else(|| panic!("expected TS2322 for `{source}`, got: {diagnostics:?}"));
+        let name_offset = source
+            .find(name)
+            .expect("binding name must appear in source") as u32;
+        assert_eq!(
+            diag.start, name_offset,
+            "TS2322 for a block-bodied function initializer must anchor at the \
+             binding name `{name}` for `{source}`: {diag:?}"
+        );
+        assert!(
+            diag.message_text.contains("is not assignable to type"),
+            "expected the function-level assignability message for `{source}`: {diag:?}"
+        );
+    }
+}
+
+/// The same rule applies when the block-bodied function value is the expression
+/// of a `return` statement: the function-level `TS2322` anchors at the enclosing
+/// `return` statement, not at the inner function expression.
+#[test]
+fn block_body_returned_function_return_mismatch_anchors_at_return_statement() {
+    let source = "function outer(): () => number { return () => { return \"x\"; }; }";
+    let diagnostics = diagnostics_with_spans(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .expect("expected TS2322");
+    let return_offset = source.find("return () =>").expect("outer return statement") as u32;
+    assert_eq!(
+        diag.start, return_offset,
+        "TS2322 for a returned block-bodied function must anchor at the enclosing \
+         `return` statement: {diag:?}"
+    );
+}
+
+/// Negative control: a block-bodied function initializer whose body return type
+/// matches the declared function type must not emit `TS2322`.
+#[test]
+fn block_body_function_initializer_matching_return_no_ts2322() {
+    let diagnostics = diagnostics_with_spans("const ok: () => number = () => { return 1; };");
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "a matching block-body return must not emit TS2322: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
Fixes an isolated diagnostic source-location divergence found by differential
testing against `tsc 6.0.2` (surfaced while triaging #13212's residual families;
this is a clean, independent slice, not the F1 identity work).

Goal: hold

## Problem

When a block-bodied function/arrow value is assigned to a function-typed
variable and the body's **return type** does not match, `tsc` reports a single
function-level `TS2322` anchored at the **binding target**, never drilling into
the block body (its `elaborateArrowFunction` returns `false` for block bodies).
tsz anchored these at the function expression instead, and for object-literal
returns additionally drilled into the returned shape.

```ts
// --target esnext, strict
const f: () => number = () => { return "x"; };
// tsc:          f.ts(1,7)  Type '() => string' is not assignable to type '() => number'.
// tsz (before): f.ts(1,25) (anchored at the arrow, not the binding name `f`)

function outer(): () => number { return () => { return "x"; }; }
// tsc:          (1,34)  anchored at the `return` statement
// tsz (before): (1,41)  (anchored at the inner arrow)

const g: () => { a: number } = () => { return { a: "x" }; };
// tsc:          (1,7)  function-level mismatch at the binding name
// tsz (before): (1,45) (drilled into the returned object literal)
```

## Structural rule

When `tsc` reports a function-level `TS2322` for a block-bodied function value,
it anchors at the value's binding target — the assignment LHS, the variable
declaration (whose error span is the binding name), or the enclosing `return`
statement — and does not drill into the block body. tsz already re-anchored an
assignment RHS to its LHS (`A.prototype.foo = function () {}`); this extends the
same rule to variable initializers and returned function values, and reports the
single function-level mismatch without source-drilling.

## Owner layer

Checker diagnostic source location only:

- `function_value_binding_anchor` (new, in
  `crates/tsz-checker/src/types/function_type/js_prototype.rs`) next to the
  existing `is_rhs_of_assignment` / `find_assignment_lhs_for_rhs`, walking
  through parentheses to a `VARIABLE_DECLARATION` initializer or a
  `RETURN_STATEMENT` expression.
- `try_elaborate_function_block_returns_with_param_type`
  (`crates/tsz-checker/src/error_reporter/call_errors/elaboration.rs`) consults
  it and, for those binding targets, reports via the existing
  no-source-elaboration display path so object-literal returns are not drilled.

No relation, inference, or display-type computation changes. Concise-body,
parameter-mismatch, call-argument, object-literal-property, and assignment-RHS
anchors are unchanged. The gate is purely structural (AST shape), never keyed on
identifiers or rendered type text.

## Adjacent matrix (all byte-identical to `tsc 6.0.2` after the fix)

- arrow and `function` expression initializers; single return, multiple returns,
  nested/`if`-`else` returns; parenthesized initializer; object-literal block
  return; returned-function (`return () => {...}`) context.
- Unchanged controls: concise-body return (`() => "x"`), parameter-count/type
  mismatch, call-argument (`take(() => {...})` → TS2345 at the arg),
  object-literal property, assignment RHS (`o.foo = () => {...}` → LHS),
  matching block (no diagnostic).
- Binder names varied across the regression cases (anti-hardcoding contract).

## Verification

- New regression suite in
  `crates/tsz-checker/src/types/function_type/tests.rs` (3 tests:
  `block_body_function_initializer_return_mismatch_anchors_at_binding_name`
  over 5 binder-varied cases,
  `block_body_returned_function_return_mismatch_anchors_at_return_statement`,
  `block_body_function_initializer_matching_return_no_ts2322`) — all pass.
- `cargo test --profile dev-fast -p tsz-checker --lib function_type` and
  `--lib elaborat`: no new failures vs a clean-tree baseline (the pre-existing
  `async_inferred_return_*` / `ts2322_same_generic_*` / index-access
  elaboration failures reproduce identically on `main` without this change and
  are unrelated — async return-type inference and the #13979/#13212 lazy-ref
  campaign).
- `cargo fmt -p tsz-checker --check`, `cargo clippy --profile dev-fast
  -p tsz-checker` (0 warnings), `python3 scripts/arch/arch_guard.py` — all clean.
- Differential vs `tsc 6.0.2` across the adjacent matrix above — byte-identical
  after the fix; the three witnesses above were divergent before.
- Ready-review CI owns the full conformance / JS-emit / DTS / fourslash floors.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01KKfaxWLMZyUWFZ3yTpRXrR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKfaxWLMZyUWFZ3yTpRXrR)_