### PR TITLE
perf(solver): make #14661 cross-base heritage probe zero-cost when disabled

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -851,36 +851,54 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // branch can only REMOVE the eager member walk on pairs the
                 // variance check accepts — it can never flip a `False` to `True`
                 // or vice versa. Flag-OFF is byte-identical to `main`.
-                let reachable = self.nominal_heritage_reachable(s_def, t_def);
-                let heritage_base = if reachable && lazy_ref_relation_enabled() {
-                    self.resolver.get_heritage_instantiation(s_def, t_def)
-                } else {
-                    None
-                };
-                let mut accessor_resolved = false;
-                if let Some(base) = heritage_base
-                    && let Some(base_app_id) = application_id(self.interner, base)
-                {
-                    accessor_resolved = true;
-                    if matches!(
-                        self.try_variance_fast_path(base_app_id, t_app_id),
-                        Some(SubtypeResult::True)
-                    ) {
+                //
+                // The reachability probe (`nominal_heritage_reachable`, an
+                // `InheritanceGraph` transitive-derivation walk) is computed ONLY
+                // when it can be observed: behind the relation flag (which gates
+                // the verdict short-circuit) OR the perf-counter probe (the
+                // measure-only denominator). The default production config — both
+                // off — takes the unchanged structural `return None` with NO extra
+                // graph traversal on this hot cross-base seam, so flag-off is now
+                // cost-identical to `main`, not merely verdict-identical.
+                let lazy_ref_on = lazy_ref_relation_enabled();
+                let probe_on = tsz_common::perf_counters::enabled_fast();
+                if lazy_ref_on || probe_on {
+                    let reachable = self.nominal_heritage_reachable(s_def, t_def);
+                    // Resolve the instantiated heritage base once when reachable;
+                    // both the (flag-gated) verdict short-circuit and the
+                    // (counter-gated) measure-only probe read this single result,
+                    // so the accessor map is never queried twice for one pair.
+                    let heritage_base = if reachable {
+                        self.resolver.get_heritage_instantiation(s_def, t_def)
+                    } else {
+                        None
+                    };
+                    // Flag-gated, acceptance-only verdict short-circuit: relate the
+                    // source's INSTANTIATED target-base by per-argument variance via
+                    // the existing same-base fast path. Only a conclusive `True`
+                    // short-circuits; any other outcome falls through to the
+                    // structural `return None` below, so it can never flip a verdict
+                    // (and `application_id`/variance only run under the flag).
+                    if lazy_ref_on
+                        && let Some(base) = heritage_base
+                        && let Some(base_app_id) = application_id(self.interner, base)
+                        && matches!(
+                            self.try_variance_fast_path(base_app_id, t_app_id),
+                            Some(SubtypeResult::True)
+                        )
+                    {
                         return Some(SubtypeResult::True);
                     }
-                }
-                // Measure-only accessor probe (only when counters enabled): the
-                // resolved/reachable ratio on fp-ts proves the capture populates
-                // the map for real heritage edges. Independent of the flag so the
-                // denominator is observable even with the relation OFF.
-                if tsz_common::perf_counters::enabled_fast() {
-                    let resolved = accessor_resolved
-                        || (reachable
-                            && self
-                                .resolver
-                                .get_heritage_instantiation(s_def, t_def)
-                                .is_some());
-                    tsz_common::perf_counters::record_relation_lazy_ref_probe(reachable, resolved);
+                    // Measure-only accessor probe (only when counters enabled): the
+                    // resolved/reachable ratio on fp-ts proves the capture populates
+                    // the map for real heritage edges. Independent of the flag so
+                    // the denominator is observable even with the relation OFF.
+                    if probe_on {
+                        tsz_common::perf_counters::record_relation_lazy_ref_probe(
+                            reachable,
+                            heritage_base.is_some(),
+                        );
+                    }
                 }
                 return None;
             }


### PR DESCRIPTION
Goal: fast

## Why this lands now

`main` was red at HEAD (#14675): the post-merge CI for #14661 hit an infra
OOM/timeout in the `dist-binaries` (dist-fast release build) step. The code
itself is fine — `lint` (clippy, all targets) and `unit` were green, and a local
`dist-fast` build of every CI binary reproduces clean in 6m09s. #14672 has since
merged on top of the same base (its merge-group rebuilt the dist binaries green),
confirming the failure was a transient infra flake and the queue is draining.
This PR is rebased onto current `main` (`f767edc`), conflict-free.

It pairs that with a real, adjacent `fast`-goal cleanup of the commit that was at
red HEAD.

## Problem

#14661's lazy-reference scaffold computed `nominal_heritage_reachable` (an
`InheritanceGraph` transitive-derivation walk) **unconditionally** at the
cross-base variance fast-path seam — on every relating pair that reaches the
structural `return None` fallthrough — even when both the
`TSZ_LAZY_REF_RELATION` flag and perf counters are off (the default production
config). Flag-off was *verdict*-identical to `main` but not *cost*-identical: it
added a hot-path graph walk for all users on a seam fp-ts alone hits thousands of
times.

## Structural rule

When neither the lazy-reference relation flag nor the perf-counter probe is
enabled, the cross-base variance seam must take the unchanged structural
`return None` with **no** added graph traversal. The reachability walk and the
heritage-accessor lookup are observable only behind those two gates, so they are
computed only when one is on.

## Change

- Gate the whole block on `lazy_ref_on || probe_on` — the default path does zero
  extra work.
- Resolve the instantiated heritage base **once** (the counters-on path queried
  the accessor map twice for one pair).
- Drop the now-redundant `accessor_resolved` bool (`accessor_resolved ||
  heritage_base.is_some()` collapses to `heritage_base.is_some()`, since the
  former implies the latter) and fold the verdict short-circuit into a single
  flag-guarded let-chain, so `application_id`/variance run only under the flag.

Verdict-preserving across all three configs (both off / flag on / counters on);
flag-off is now cost-identical to `main`, not merely byte-identical. No
relation/inference/evaluation change; the gate is purely the existing env flag +
counter flag, never keyed on identifiers or rendered type text.

Owner layer: solver subtype relation only —
`crates/tsz-solver/src/relations/subtype/rules/generics.rs`.

## Verification

- `cargo clippy -p tsz-solver` (dev-fast, against rebased `main`): clean, 0 warnings.
- `cargo fmt -p tsz-solver --check`: clean. `python3 scripts/arch/arch_guard.py`:
  passed.
- `cargo test -p tsz-solver --lib`: 6946 passed; the only 3 failures are
  pre-existing on clean `main` — verified by `git stash` — and are unrelated
  (conditional-infer / normalize / operations). **Zero net-new.**
- E2E: built `tsz` and diffed `--noEmit` on a cross-base generic-heritage repro
  (`interface Apply1<A> extends Functor1<A>`, `Box<Dog>` vs `Box<string>`) with
  `TSZ_LAZY_REF_RELATION` unset vs `=1` — **byte-identical**, and identical to the
  output before this change.
- Local `dist-fast` build of all CI binaries reproduces green (6m09s), confirming
  the `dist-binaries` red was infra (OOM/timeout), not code.
- Ready-review CI owns the full conformance / JS-emit / DTS / fourslash parity
  floors and the dist build.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Refs #14675.

https://claude.ai/code/session_01TSugwupxqJpMVvdJBmQGwB