### PR TITLE
fix(checker): widen fresh object/array literal structure in inferred return types

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -322,6 +322,9 @@ mod index_signature_symbol_keyspace_tests;
 #[path = "../tests/indexed_access_alias_application_relation_tests.rs"]
 mod indexed_access_alias_application_relation_tests;
 #[cfg(test)]
+#[path = "tests/inferred_return_object_array_widening_tests.rs"]
+mod inferred_return_object_array_widening_tests;
+#[cfg(test)]
 #[path = "tests/instanceof_indexed_access_lhs_tests.rs"]
 mod instanceof_indexed_access_lhs_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/inferred_return_object_array_widening_tests.rs
+++ b/crates/tsz-checker/src/tests/inferred_return_object_array_widening_tests.rs
@@ -1,0 +1,247 @@
+//! Tests for inferred function-return-type literal widening of object and array
+//! literals (block-bodied functions).
+//!
+//! tsc infers a function's return type as `getWidenedType(getUnionType(returns))`.
+//! `getUnionType` de-freshes *primitive* literal members (so a multi-branch
+//! `"a" | "b"` survives unwidened), but fresh **object/array** literal structure
+//! is still widened by `getWidenedType` regardless of union membership:
+//!
+//! ```ts
+//! function f() { return { a: 1, b: "x" }; } // () => { a: number; b: string }
+//! function g() { return [1, 2, 3]; }        // () => number[]
+//! function h(c: boolean) { if (c) return { v: 1 }; return { v: 2 }; } // () => { v: number }
+//! ```
+//!
+//! tsz previously widened these only when the inferred union collapsed to a
+//! single *primitive* literal, so block-bodied object/array returns kept their
+//! fresh literal members (`{ a: 1 }`, `(1 | 2 | 3)[]`). That under-widening was a
+//! semantic divergence — it suppressed the `TS2322` tsc reports when such a
+//! return is assigned to a narrower literal target — not merely a `.d.ts`
+//! cosmetic. Per-property `as const` subtrees stay preserved, and a multi-branch
+//! primitive literal union is still preserved.
+//!
+//! Binder names are varied across cases per the anti-hardcoding contract.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322(src: &str) -> Vec<String> {
+    check_source_diagnostics(src)
+        .iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+#[test]
+fn object_literal_return_widens_property_literals() {
+    // The inferred return type is `{ a: number; b: string }`, so assigning it to
+    // a narrower `{ a: 1 }` target is a TS2322 (tsc parity). Without widening the
+    // return would be `{ a: 1; b: "x" }` and this assignment would wrongly pass.
+    let errs = ts2322(
+        r#"
+function makeConfig() { return { a: 1, b: "x" }; }
+const narrowed: { a: 1 } = makeConfig();
+"#,
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected one TS2322 from the widened object return, got: {errs:?}"
+    );
+    assert!(
+        errs[0].contains("number"),
+        "TS2322 should report the widened `number` property, got: {errs:?}"
+    );
+}
+
+#[test]
+fn object_literal_return_widened_target_is_clean() {
+    // The widened return `{ id: number; label: string }` is assignable to the
+    // matching target — no false positive from over-widening.
+    let errs = ts2322(
+        r#"
+function buildEntry() { return { id: 1, label: "n" }; }
+const accepted: { id: number; label: string } = buildEntry();
+"#,
+    );
+    assert!(errs.is_empty(), "expected no TS2322, got: {errs:?}");
+}
+
+#[test]
+fn array_literal_return_widens_element_literals() {
+    let narrow = ts2322(
+        r#"
+function listNumbers() { return [1, 2, 3]; }
+const onlyOnes: 1[] = listNumbers();
+"#,
+    );
+    assert_eq!(
+        narrow.len(),
+        1,
+        "expected TS2322: widened `number[]` is not assignable to `1[]`, got: {narrow:?}"
+    );
+
+    let wide = ts2322(
+        r#"
+function listValues() { return [10, 20]; }
+const anyNumbers: number[] = listValues();
+"#,
+    );
+    assert!(
+        wide.is_empty(),
+        "widened `number[]` must be assignable to `number[]`, got: {wide:?}"
+    );
+}
+
+#[test]
+fn multiple_object_returns_widen_and_dedupe() {
+    // `{ v: 1 } | { v: 2 }` widens to `{ v: number }` (each fresh member widens,
+    // then dedupes), so the narrow `{ v: 1 }` target is a TS2322.
+    let errs = ts2322(
+        r#"
+function selectPayload(flag: boolean) {
+    if (flag) return { v: 1 };
+    return { v: 2 };
+}
+const pinned: { v: 1 } = selectPayload(true);
+"#,
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected one TS2322 from the collapsed widened union, got: {errs:?}"
+    );
+}
+
+#[test]
+fn nested_object_and_array_return_widen_deeply() {
+    let errs = ts2322(
+        r#"
+function shape() { return { outer: { inner: 1 }, tags: [true] }; }
+const deep: { outer: { inner: 1 }; tags: true[] } = shape();
+"#,
+    );
+    assert!(
+        !errs.is_empty(),
+        "expected TS2322: nested `inner`/`tags` widen to `number`/`boolean[]`, got: {errs:?}"
+    );
+}
+
+#[test]
+fn array_of_object_literals_return_widens_elements() {
+    let narrow = ts2322(
+        r#"
+function makeRows() { return [{ id: 1 }]; }
+const literalRows: { id: 1 }[] = makeRows();
+"#,
+    );
+    assert_eq!(
+        narrow.len(),
+        1,
+        "expected TS2322: element widens to a `number` id property, got: {narrow:?}"
+    );
+
+    let wide = ts2322(
+        r#"
+function makeRecords() { return [{ id: 1 }]; }
+const widenedRows: { id: number }[] = makeRecords();
+"#,
+    );
+    assert!(wide.is_empty(), "expected no TS2322, got: {wide:?}");
+}
+
+#[test]
+fn per_property_const_assertion_in_return_is_preserved() {
+    // `{ kind: "tracked" as const, count: 1 }` widens the fresh `count` to
+    // `number` while preserving the const-asserted `kind: "tracked"`.
+    let keep = ts2322(
+        r#"
+function describeState() { return { kind: "tracked" as const, count: 1 }; }
+const matching: { kind: "tracked"; count: number } = describeState();
+"#,
+    );
+    assert!(
+        keep.is_empty(),
+        "const-asserted `kind` must stay `\"tracked\"`, got: {keep:?}"
+    );
+
+    let mismatch = ts2322(
+        r#"
+function describeMode() { return { kind: "tracked" as const, total: 1 }; }
+const wrong: { kind: "other"; total: number } = describeMode();
+"#,
+    );
+    assert_eq!(
+        mismatch.len(),
+        1,
+        "expected TS2322: preserved `kind: \"tracked\"` is not `\"other\"`, got: {mismatch:?}"
+    );
+}
+
+#[test]
+fn whole_expression_const_assertion_return_is_preserved() {
+    // `return { a: 1 } as const` keeps `{ readonly a: 1 }` — not widened.
+    let errs = ts2322(
+        r#"
+function frozen() { return { a: 1 } as const; }
+const literal: { readonly a: 1 } = frozen();
+"#,
+    );
+    assert!(
+        errs.is_empty(),
+        "const-asserted return must not widen, got: {errs:?}"
+    );
+}
+
+#[test]
+fn multi_branch_primitive_literal_return_union_is_preserved() {
+    // A primitive literal union is NOT widened (tsc parity): `choose` returns
+    // `"a" | "b"`, so a single-member `"a"` target is a TS2322.
+    let errs = ts2322(
+        r#"
+function chooseTag(flag: boolean) {
+    if (flag) return "a";
+    return "b";
+}
+const onlyA: "a" = chooseTag(true);
+"#,
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected TS2322: `\"a\" | \"b\"` is not assignable to `\"a\"`, got: {errs:?}"
+    );
+}
+
+#[test]
+fn single_primitive_literal_return_widens() {
+    // A lone fresh primitive literal still widens (`return 1` → `number`).
+    let errs = ts2322(
+        r#"
+function answer() { return 1; }
+const pinnedOne: 1 = answer();
+"#,
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected TS2322: widened `number` is not assignable to `1`, got: {errs:?}"
+    );
+}
+
+#[test]
+fn renamed_binders_take_the_same_widening_path() {
+    // Anti-hardcoding: identical structure, fully renamed binders — the widening
+    // must be structural, not keyed on identifier text.
+    let errs = ts2322(
+        r#"
+function ζ_builder() { return { ωkey: 1, λname: "n" }; }
+const ψ_target: { ωkey: 1 } = ζ_builder();
+"#,
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "renamed binders must widen identically, got: {errs:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -1113,14 +1113,18 @@ impl<'a> CheckerState<'a> {
             return_types.retain(|c| c.type_id != TypeId::ERROR);
         }
 
-        // Union the UNWIDENED contributions, then widen ONLY when the union
-        // collapses to a single literal (tsc's `getWidenedType(getUnionType(...))`).
-        // `factory.union` dedups and flattens a single surviving member to a
-        // scalar, so a multi-member literal union (`"a" | "b"`, `1 | 2`,
-        // `"a" | undefined`) is NOT a literal type and is returned unwidened,
-        // while a single fresh literal (`return "x"`, or `return "a"; return "a"`
-        // deduped to one) is widened via its originating expression's AST-aware
-        // widener — preserving per-property `const` subtrees (#14530).
+        // Union the contributions and apply the remaining primitive-collapse
+        // widen (tsc's `getWidenedType(getUnionType(...))`). Fresh object/array
+        // contributions were already structure-widened during collection (so
+        // `{ a: 1 } | { a: 2 }` arrives as `{ a: number }`); the only widen left
+        // here is the bare primitive literal that was deferred to preserve a
+        // multi-branch literal union. `factory.union` dedups and flattens a
+        // single surviving member to a scalar, so a multi-member literal union
+        // (`"a" | "b"`, `1 | 2`, `"a" | undefined`) is NOT a literal type and is
+        // returned unwidened, while a single fresh literal (`return "x"`, or
+        // `return "a"; return "a"` deduped to one) is widened via its originating
+        // expression's AST-aware widener — preserving per-property `const`
+        // subtrees (#14530).
         let widen_expr = return_types.iter().find_map(|c| c.widen_expr);
         let union = factory.union(return_types.iter().map(|c| c.type_id).collect());
         if let Some(expr_idx) = widen_expr
@@ -1337,19 +1341,52 @@ impl<'a> CheckerState<'a> {
                             return_type,
                             return_context,
                         );
-                        // Collect the contribution UNWIDENED, recording whether it
-                        // would have been widened. The union of two distinct fresh
-                        // literals must stay a literal union (`"a" | "b"`); only a
-                        // union that collapses to a single literal is widened, in
-                        // `infer_return_type_from_body_inner` (tsc parity, #14530).
+                        // Apply tsc's `getWidenedType(getUnionType(returns))` per
+                        // contribution, splitting on freshness kind:
+                        //
+                        // - A bare **primitive** literal (`return 1`, `return "a"`)
+                        //   is collected UNWIDENED, recording the originating
+                        //   expression. tsc's `getUnionType` de-freshes primitive
+                        //   literal members, so a multi-branch literal union
+                        //   (`"a" | "b"`, `1 | 2`) must survive unwidened; only a
+                        //   union that collapses to a single literal is widened, in
+                        //   `infer_return_type_from_body_inner` (#14530).
+                        // - A fresh **object/array** literal (`return { a: 1 }`,
+                        //   `return [1, 2]`) is widened EAGERLY here. tsc widens
+                        //   fresh object/array literal *structure* regardless of
+                        //   union membership (`{ a: 1 } | { a: 2 }` → `{ a: number }`),
+                        //   because `getUnionType` does not de-fresh those leaves —
+                        //   `getWidenedType` still reaches them. The widen is
+                        //   freshness/`as const`-respecting, so per-property const
+                        //   subtrees (`{ k: "x" as const, n: 1 }` → `{ k: "x"; n: number }`)
+                        //   are preserved exactly as the single-collapse path does.
+                        //   (Conditional-expression returns keep `widenable == false`
+                        //   via the carve-out in `return_contribution_is_widenable`,
+                        //   so a discriminant-preserving `return c ? a : b` is left
+                        //   to its existing path and not eagerly collapsed here.)
                         let widenable = self.return_contribution_is_widenable(
                             return_data.expression,
                             return_type,
                             return_context,
                         );
+                        let (contribution_type, widen_expr) = if widenable
+                            && !crate::query_boundaries::common::is_literal_type(
+                                self.ctx.types,
+                                return_type,
+                            ) {
+                            (
+                                crate::query_boundaries::widening::widen_const_initializer(
+                                    self.ctx.types,
+                                    return_type,
+                                ),
+                                None,
+                            )
+                        } else {
+                            (return_type, widenable.then_some(return_data.expression))
+                        };
                         return_types.push(ReturnContribution {
-                            type_id: return_type,
-                            widen_expr: widenable.then_some(return_data.expression),
+                            type_id: contribution_type,
+                            widen_expr,
                         });
                     }
                 }


### PR DESCRIPTION
Fixes #14678.

Goal: hold

## Problem

A **block-bodied** function whose body returns an **object or array literal**
inferred a return type that kept the *fresh* literal property/element types,
where `tsc` widens them. This is a **semantic** divergence (a missing `TS2322`),
not a `.d.ts` cosmetic.

```ts
function f() { return { a: 1, b: "x" }; }
// tsc:          () => { a: number; b: string }
// tsz (before): () => { a: 1; b: "x" }

function g() { return [1, 2, 3]; }
// tsc:          () => number[]
// tsz (before): () => (1 | 2 | 3)[]

// downstream witness — the missing diagnostic:
function h() { return { a: 1 }; }
const t: { a: 1 } = h();
// tsc:          TS2322 — Type '{ a: number; }' is not assignable to type '{ a: 1; }'.
// tsz (before): clean (false negative — inferred return is `{ a: 1 }`)
```

The concise-arrow path (`() => ({ a: 1 })`, `() => [1, 2, 3]`) was already
correct; only the block-body path under-widened.

## Structural rule

`tsc` infers a function's return type as `getWidenedType(getUnionType(returns))`.
`getUnionType` de-freshes **primitive** literal members (so a multi-branch
`"a" | "b"` / `1 | 2` survives unwidened), but fresh **object/array** literal
*structure* is still widened by `getWidenedType` regardless of union membership
(`{ a: 1 } | { a: 2 }` → `{ a: number }`, `1[] | (2 | 3)[]` → `number[]`).

tsz widened the inferred return union only when it collapsed to a single
**primitive** literal (`is_literal_type(union)`), so object/array literal
returns kept their fresh members. Per-property and whole-expression `as const`
subtrees must still be preserved, and a multi-branch primitive literal union
must stay unwidened.

When a block-body return contribution is a fresh, widenable object/array literal
(no contextual-return / `satisfies` / `preserve_literal_types` / `const`-assertion
carve-out, and not a ternary), `tsc` widens its structure; tsz now widens it
eagerly during collection through the freshness/`as const`-respecting
`widen_const_initializer`, so it widens even when it joins a union. A bare
primitive literal stays deferred to the single-literal collapse.

## Owner layer

Checker return-type inference only —
`crates/tsz-checker/src/types/utilities/return_type.rs`
(`collect_return_types_in_statement`). Widenable fresh object/array contributions
are structure-widened eagerly; bare primitive literals keep the existing
deferred single-literal-collapse widen. No relation/inference/solver change; the
gate is purely structural (freshness + literal kind), never keyed on identifiers
or rendered type text. The concise-arrow path is unchanged (already correct).

## Adjacent matrix

New suite `inferred_return_object_array_widening_tests` (11 tests, binder-varied
incl. non-ASCII):

- object property + array element widening; nested object/array; array of object
  literals; widened-target clean negative (no over-widening false positive);
- multi-return objects widen and dedupe (`{ v: 1 } | { v: 2 }` → `{ v: number }`);
- per-property `as const` preserved (`{ kind: "tracked" as const, count: 1 }`) and
  whole-expression `as const` preserved (`{ a: 1 } as const`);
- multi-branch primitive literal union preserved (`"a" | "b"` not widened);
- single fresh primitive literal still widens (`return 1` → `number`);
- fully renamed binders take the identical structural path (anti-hardcoding).

## Out-of-scope residuals (separate roots, documented in #14678)

- Generator yield over-widening (`function* () { yield 1; yield 2; }` →
  `Generator<number>` vs tsc `Generator<1 | 2>`): the yield operands are widened
  during the generator body walk before collection — a distinct root entangled
  with the `TS7055`/`TS7057` implicit-any path. (A patch at the yield-union step
  was prototyped and confirmed a no-op precisely because the operands arrive
  pre-widened; reverted.)
- Ternary-expression returns keep their discriminant-preserving carve-out
  (widening them is coupled with a freshness-loss-through-conditional-union bug,
  e.g. `return c ? { k: "a" as const } : …`).
- tsc's complementary `?: undefined` property synthesis when unioning
  disjoint-key object literals is a separate `getUnionType` normalization.

## Verification

- New suite `inferred_return_object_array_widening_tests` — **11 passed**
  (`cargo test --profile dev-fast -p tsz-checker --lib
  inferred_return_object_array_widening`).
- Differential vs `tsc 6.0.2` (`--declaration --emitDeclarationOnly` and
  `--noEmit`) over a ~40-case matrix (single/multi return; object/array/nested/
  array-of-objects; `as const` whole + per-property; primitive single vs union;
  mixed primitive+object returns; widened-target negatives) — every object/array
  return case is now byte-identical, and the previously-missing `TS2322`
  diagnostics now match exactly (location + message text).
- Full-tree regression diff vs clean `main` across the `tsz-checker --lib`
  `return_type` / `return_inference` / `widening` / `narrowing` / `const_assert` /
  `satisfies_callback_return` / `block_body_callback` / `object_literal` filters:
  **zero net-new failures** — the only locals (`const_assertion_preserves_later_data_literal`,
  `imported_generator_return_type_is_iterable_in_for_of`,
  `test_ts2322_async_return_via_return_type_promise_infer`,
  `yield_star_generator_callback_mismatch_reports_outer_ts2345`) reproduce
  identically on a clean `git stash` baseline and are unrelated.
- `cargo fmt -p tsz-checker --check`, `cargo clippy --profile dev-fast
  -p tsz-checker` (0 warnings), `python3 scripts/arch/arch_guard.py` — all clean.
- Rebased onto current `main` (`28acc70`), conflict-free.
- Ready-review CI owns the full conformance / JS-emit / DTS / fourslash parity floors.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Q6VZbomAY74H4ExUkGBz3M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6VZbomAY74H4ExUkGBz3M)_