### PR TITLE
fix(emit): qualify nested-namespace refs to enclosing exports by the declaring namespace

### DIFF
--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
@@ -973,12 +973,34 @@ impl<'a> NamespaceES5Transformer<'a> {
 
     /// Transform namespace body into IR nodes
     fn transform_namespace_body(&self, body_idx: NodeIndex, name_parts: &[String]) -> Vec<IRNode> {
+        self.transform_namespace_body_with_prior(body_idx, name_parts, true)
+    }
+
+    /// Transform a namespace body into IR nodes, choosing whether the
+    /// cross-block `prior_exported_vars` set participates in reference
+    /// qualification.
+    ///
+    /// `prior_exported_vars` records the exported variables of the *outermost*
+    /// namespace being dispatched (so that a later top-level block of the same
+    /// namespace qualifies `x` as `N.x`). It must **not** leak into a nested
+    /// child namespace's body: a reference there to an outer-namespace export
+    /// is qualified by the *enclosing* namespace's own
+    /// `rewrite_exported_var_refs` pass (which descends into nested IIFEs with
+    /// the correct enclosing name), never by the inner namespace name. Applying
+    /// it inside the child would mis-qualify `N.a` as `Inner.a` — a runtime
+    /// `undefined`. So nested recursion passes `apply_prior = false`.
+    fn transform_namespace_body_with_prior(
+        &self,
+        body_idx: NodeIndex,
+        name_parts: &[String],
+        apply_prior: bool,
+    ) -> Vec<IRNode> {
         let mut result = Vec::new();
         let mut runtime_exported_vars = collect_runtime_exported_var_names(self.arena, body_idx);
         // Merge in exported vars from prior blocks of the same namespace.
         // This enables cross-block substitution: `x` → `M.x` when `export var x`
         // was declared in a prior block.
-        if !self.prior_exported_vars.is_empty() {
+        if apply_prior && !self.prior_exported_vars.is_empty() {
             runtime_exported_vars.extend(self.prior_exported_vars.iter().cloned());
             // Remove locally-declared non-exported names — they shadow prior exports
             let local_names = collect_local_var_names(self.arena, body_idx);
@@ -1757,8 +1779,11 @@ impl<'a> NamespaceES5Transformer<'a> {
                 .arena
                 .has_modifier(&ns_data.modifiers, SyntaxKind::ExportKeyword);
 
-        // Transform body
-        let mut body = self.transform_namespace_body(ns_data.body, &name_parts);
+        // Transform body. A nested namespace must not inherit the outer
+        // namespace's `prior_exported_vars`: references to the outer namespace's
+        // exports are qualified by the enclosing namespace's own rewrite pass
+        // (with the correct enclosing name), not by this inner namespace name.
+        let mut body = self.transform_namespace_body_with_prior(ns_data.body, &name_parts, false);
         self.rewrite_const_enum_accesses(&mut body, &name_parts);
 
         // Skip non-instantiated namespaces (only contain types).

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir_helpers.rs
@@ -1010,11 +1010,54 @@ pub(super) fn detect_and_apply_param_rename_with_extra(
     })
 }
 
+/// Collect the names a nested namespace (or class) IIFE body declares at its
+/// own top level. Such a binding shadows a same-named export of an *enclosing*
+/// namespace, so the enclosing namespace's `rewrite_exported_var_refs` pass must
+/// not qualify references resolved to the inner binding. Covers locals (`var`,
+/// `let`, `const`), functions, classes, enums, and nested namespaces.
+fn collect_shadowing_binding_names(body: &[IRNode]) -> std::collections::HashSet<String> {
+    let mut names = std::collections::HashSet::new();
+    for node in body {
+        collect_shadowing_binding_names_in_node(node, &mut names);
+    }
+    names
+}
+
+fn collect_shadowing_binding_names_in_node(
+    node: &IRNode,
+    names: &mut std::collections::HashSet<String>,
+) {
+    match node {
+        IRNode::VarDecl { name, .. }
+        | IRNode::FunctionDecl { name, .. }
+        | IRNode::ES5ClassIIFE { name, .. }
+        | IRNode::EnumIIFE { name, .. }
+        | IRNode::NamespaceIIFE { name, .. } => {
+            names.insert(name.to_string());
+        }
+        // Non-exported namespace members are emitted as `Sequence([VarDecl, ...])`
+        // (and merged declarations as `VarDeclList`); a binding-pattern local is
+        // an opaque `ASTRef`, so it cannot be conservatively named here.
+        IRNode::Sequence(items) | IRNode::VarDeclList(items) => {
+            for item in items {
+                collect_shadowing_binding_names_in_node(item, names);
+            }
+        }
+        _ => {}
+    }
+}
+
 pub(super) fn rewrite_exported_var_refs(
     node: &mut IRNode,
     ns_name: &str,
     names: &std::collections::HashSet<String>,
 ) {
+    // No exported names to qualify ⇒ the whole subtree is a no-op (the only
+    // mutating arm rewrites an `Identifier` found in `names`). Bail before any
+    // traversal or shadow-set allocation.
+    if names.is_empty() {
+        return;
+    }
     match node {
         IRNode::Identifier(name) if names.contains(&**name) => {
             let property = name.clone();
@@ -1095,8 +1138,18 @@ pub(super) fn rewrite_exported_var_refs(
             }
         }
         IRNode::NamespaceIIFE { body, .. } | IRNode::ES5ClassIIFE { body, .. } => {
+            // A name re-declared inside the nested scope shadows the enclosing
+            // namespace's export, so references to it must stay unqualified.
+            // (An emptied set is handled by the no-op guard on the recursive
+            // call, mirroring the parameter-subtraction in the function arm.)
+            let shadowed = collect_shadowing_binding_names(body);
+            let inner = if shadowed.is_empty() {
+                std::borrow::Cow::Borrowed(names)
+            } else {
+                std::borrow::Cow::Owned(names.difference(&shadowed).cloned().collect())
+            };
             for stmt in body {
-                rewrite_exported_var_refs(stmt, ns_name, names);
+                rewrite_exported_var_refs(stmt, ns_name, &inner);
             }
         }
         IRNode::VarDecl {

--- a/crates/tsz-emitter/tests/namespace_es5_ir.rs
+++ b/crates/tsz-emitter/tests/namespace_es5_ir.rs
@@ -816,3 +816,116 @@ fn test_namespace_inline_block_comment_preserved() {
         "Block comment should be preserved. Got: {output}"
     );
 }
+
+// =========================================================================
+// Nested-namespace reference qualification (outer export vs inner scope)
+// =========================================================================
+
+#[test]
+fn nested_namespace_qualifies_outer_export_by_declaring_namespace() {
+    // A reference inside a nested namespace to a variable exported by the
+    // *enclosing* namespace must be qualified by the enclosing namespace
+    // name, not the inner one (which would be a runtime `undefined`).
+    let output = transform_and_emit(
+        r#"namespace Root {
+    export const value = 1;
+    export namespace Inner {
+        export function read() { return value; }
+    }
+}"#,
+    );
+    assert!(
+        output.contains("return Root.value"),
+        "Outer export must be qualified by the declaring namespace.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return Inner.value"),
+        "Outer export must not be qualified by the inner namespace.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn deeply_nested_namespace_qualifies_by_outermost_declaring_namespace() {
+    // Renamed binders (anti-hardcoding): the qualifier is the structurally
+    // declaring namespace regardless of identifier text.
+    let output = transform_and_emit(
+        r#"namespace Alpha {
+    export let total = 10;
+    export namespace Beta {
+        export namespace Gamma {
+            export function fetch() { return total; }
+        }
+    }
+}"#,
+    );
+    assert!(
+        output.contains("return Alpha.total"),
+        "Three-level-deep reference must resolve to the outermost declarer.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("Beta.total") && !output.contains("Gamma.total"),
+        "Must not qualify by an intermediate or inner namespace.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn nested_namespace_local_shadow_keeps_reference_unqualified() {
+    // A local (non-exported) binding in the nested namespace shadows the
+    // enclosing export, so the reference must stay unqualified.
+    let output = transform_and_emit(
+        r#"namespace Wrap {
+    export const item = 1;
+    export namespace Box {
+        const item = 9;
+        export function pick() { return item; }
+    }
+}"#,
+    );
+    assert!(
+        output.contains("return item")
+            && !output.contains("return Wrap.item")
+            && !output.contains("return Box.item"),
+        "A nested local must shadow the enclosing export (no qualification).\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn nested_namespace_own_export_shadows_outer_export() {
+    // When the nested namespace itself exports the same name, references
+    // resolve to (and are qualified by) the inner namespace.
+    let output = transform_and_emit(
+        r#"namespace Top {
+    export const slot = 1;
+    export namespace Sub {
+        export const slot = 2;
+        export function use() { return slot; }
+    }
+}"#,
+    );
+    assert!(
+        output.contains("return Sub.slot"),
+        "An inner re-export shadows the outer export and is qualified by the inner name.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return Top.slot"),
+        "Inner re-export must not be qualified by the outer namespace.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn nested_namespace_multiple_outer_exports_qualified() {
+    // Several enclosing exports referenced from a nested namespace.
+    let output = transform_and_emit(
+        r#"namespace Env {
+    export const a = 1;
+    export const b = 2;
+    export namespace Use {
+        export function sum() { return a + b; }
+    }
+}"#,
+    );
+    assert!(
+        output.contains("return Env.a + Env.b"),
+        "All enclosing exports must be qualified by the declaring namespace.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #14680.

Goal: hold

## Problem

When a namespace is downlevelled to the ES5 IIFE form (`--target es5`, or any
target driving the ES5 IR namespace path), a reference **inside a nested
namespace** to a `var`/`let`/`const` **exported by an enclosing namespace** was
qualified with the **innermost** namespace object instead of the **declaring**
one. The emitted member access points at a namespace that does not own the
binding, so it is `undefined` at runtime — a correctness (not cosmetic) emit
defect. The ES2015+ path was already correct.

```ts
// --target es5
namespace N { export const a = 1; export namespace M { export function f() { return a; } } }
// tsc:          function f() { return N.a; }
// tsz (before): function f() { return M.a; }   // M.a is undefined

namespace Outer { export let v = 10; export namespace Mid { export namespace Inner { export function read() { return v; } } } }
// tsc:          return Outer.v;     tsz (before): return Inner.v;

namespace U { export const a = 1; export namespace V { export const b = a + 1; export namespace W { export const c = a + b; } } }
// tsc:          V.b = U.a + 1; W.c = U.a + V.b;
// tsz (before): V.b = V.a + 1; W.c = W.a + V.b;
```

Functions and classes are unaffected — they emit a local closure binding that
is in scope inside nested namespaces, so they are never qualified.

## Structural rule

When the ES5 namespace transform qualifies a reference to a namespace-exported
`var`/`let`/`const`, `tsc` qualifies it by the namespace that **declares** the
binding (the enclosing namespace, walking up the namespace scope chain), not by
the innermost namespace. A binding **re-declared inside the nested scope** (a
local `var`/`let`/`const`, function, class, enum, or nested namespace) shadows
the enclosing export, so a reference resolved to the inner binding stays
unqualified.

tsz carried the dispatched namespace's exported-variable set in a single
`prior_exported_vars` field — intended only for cross-*block* merging of the
**same** namespace name — and re-applied it while transforming **nested child**
namespace bodies, qualifying outer exports with the inner namespace name.
References to an enclosing export are instead resolved by the enclosing
namespace's own `rewrite_exported_var_refs` pass, which descends into nested
IIFEs with the correct enclosing name.

## Owner layer

Emitter only — `crates/tsz-emitter/src/transforms/`:

- `namespace_es5_ir.rs::transform_namespace_body` — split into
  `transform_namespace_body_with_prior(.., apply_prior)`; the nested recursion
  (`transform_nested_namespace_core`) passes `apply_prior = false` so a child
  namespace body no longer inherits the outer namespace's `prior_exported_vars`.
- `namespace_es5_ir_helpers.rs::rewrite_exported_var_refs` — when the enclosing
  rewrite descends into a nested `NamespaceIIFE`/`ES5ClassIIFE`, it subtracts
  the names the nested scope re-declares locally (new
  `collect_shadowing_binding_names`, which sees the `Sequence([VarDecl, …])`
  form non-exported locals lower to) so a shadowing local stays unqualified.

No relation/inference/checker change. The gate is purely structural (namespace
nesting + declared-binding shape), never keyed on identifiers or rendered type
text. Binder names are varied across the regression tests per the
anti-hardcoding contract.

## Adjacent matrix (all byte-identical to `tsc 6.0.2` after the fix)

- one-level / two-level / three-level nested namespace referencing an enclosing
  `const`/`let`/`var`; multiple enclosing exports in one reference; renamed
  binders.
- nested-namespace local shadow keeps the reference unqualified; nested-namespace
  own re-export shadows the outer export (qualified by the inner name).
- class/getter in a nested namespace referencing an outer export
  (`ES5ClassIIFE` descent path) — unchanged, correct.
- cross-block merge of the same namespace name (`prior_exported_vars` still
  applies at the top level) and dotted-name namespaces — unchanged.

## Verification

- New regression suite in `crates/tsz-emitter/tests/namespace_es5_ir.rs`
  (5 tests, binder-varied): outer-export qualification, three-level deep,
  local-shadow-unqualified, inner-re-export shadow, multiple-outer-exports.
- `cargo test --profile dev-fast -p tsz-emitter --lib` — 3825 passed, 0 failed
  (full emitter lib suite; namespace filter 359 passed).
- Differential vs `tsc 6.0.2` across the matrix above at `es5`/`es2015`/`es2017`
  — every previously-divergent witness now byte-identical; a captured
  pre-change baseline confirms **zero regressions** (the residual diffs in
  exotic cases — single-line function-body formatting, IIFE-param-rename
  over-trigger on `(N as any).x`, outer→nested-namespace cross-block
  qualification, dotted-nested-namespace drop — are pre-existing separate bugs,
  byte-identical before and after).
- `cargo fmt -p tsz-emitter --check`, `cargo clippy --profile dev-fast
  -p tsz-emitter` (0 warnings), `python3 scripts/arch/arch_guard.py` — all clean.
- Rebased on `origin/main` (`main` does not touch the namespace files); no
  conflicts.
- Ready-review CI owns the full conformance / JS-emit / DTS / fourslash parity
  floors.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01CnJ4GLwDQat8WbfxFuTrG3

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJ4GLwDQat8WbfxFuTrG3)_