### PR TITLE
fix(emit): qualify nested-namespace refs to enclosing exports by the declaring namespace (ES5)

### DIFF
--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
@@ -442,8 +442,10 @@ impl<'a> NamespaceES5Transformer<'a> {
                 .replace(Some((env_name.clone(), *using_async)));
         }
 
-        // Transform the innermost body - use the last name part for member exports
-        let mut body = self.transform_namespace_body(innermost_body, &name_parts);
+        // Transform the innermost body - use the last name part for member exports.
+        // This is the dispatched (top-level) namespace body, so prior-block
+        // exported vars of this same namespace apply here.
+        let mut body = self.transform_namespace_body(innermost_body, &name_parts, true);
         self.active_namespace_using_env.replace(None);
         if let Some((env_name, _using_async, error_name, result_name)) = using_region {
             body = self.wrap_namespace_using_region(body, env_name, error_name, result_name);
@@ -971,14 +973,30 @@ impl<'a> NamespaceES5Transformer<'a> {
         }
     }
 
-    /// Transform namespace body into IR nodes
-    fn transform_namespace_body(&self, body_idx: NodeIndex, name_parts: &[String]) -> Vec<IRNode> {
+    /// Transform a namespace body into IR nodes.
+    ///
+    /// `apply_prior` controls whether `self.prior_exported_vars` (the exported
+    /// vars carried across *blocks of the same dispatched namespace*) are merged
+    /// into this body's substitution set. It must be `true` only for the
+    /// dispatched (top-level) namespace body and `false` for every *nested
+    /// child* namespace body: a nested namespace `M` inside `N` has its own
+    /// exported-var set, and re-applying `N`'s exports here would qualify a
+    /// reference to `N`'s export by the inner name (`M.a`) instead of the
+    /// declaring name (`N.a`). References to an enclosing namespace's exports are
+    /// instead qualified by that enclosing namespace's own
+    /// `rewrite_exported_var_refs` pass, which descends into nested IIFEs (#14680).
+    fn transform_namespace_body(
+        &self,
+        body_idx: NodeIndex,
+        name_parts: &[String],
+        apply_prior: bool,
+    ) -> Vec<IRNode> {
         let mut result = Vec::new();
         let mut runtime_exported_vars = collect_runtime_exported_var_names(self.arena, body_idx);
         // Merge in exported vars from prior blocks of the same namespace.
         // This enables cross-block substitution: `x` → `M.x` when `export var x`
         // was declared in a prior block.
-        if !self.prior_exported_vars.is_empty() {
+        if apply_prior && !self.prior_exported_vars.is_empty() {
             runtime_exported_vars.extend(self.prior_exported_vars.iter().cloned());
             // Remove locally-declared non-exported names — they shadow prior exports
             let local_names = collect_local_var_names(self.arena, body_idx);
@@ -1757,8 +1775,11 @@ impl<'a> NamespaceES5Transformer<'a> {
                 .arena
                 .has_modifier(&ns_data.modifiers, SyntaxKind::ExportKeyword);
 
-        // Transform body
-        let mut body = self.transform_namespace_body(ns_data.body, &name_parts);
+        // Transform body. This is a *nested child* namespace body, so the
+        // dispatched namespace's prior-block exported vars must NOT be applied
+        // here — references to an enclosing export are qualified by the
+        // enclosing namespace's own rewrite pass (#14680).
+        let mut body = self.transform_namespace_body(ns_data.body, &name_parts, false);
         self.rewrite_const_enum_accesses(&mut body, &name_parts);
 
         // Skip non-instantiated namespaces (only contain types).
@@ -1835,3 +1856,7 @@ fn mark_invalid_namespace_static(node: &mut IRNode) {
 #[cfg(test)]
 #[path = "../../tests/namespace_es5_ir.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "../../tests/namespace_es5_nested_enclosing_var_qualification_tests.rs"]
+mod nested_enclosing_var_qualification_tests;

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir_helpers.rs
@@ -948,6 +948,45 @@ pub(super) fn collect_member_names_from_node(
     }
 }
 
+/// Collect the names a nested namespace/class IIFE body declares at its own top
+/// level (vars, functions, classes, enums, nested namespaces).
+///
+/// When an enclosing namespace's exported-var rewrite descends into such a body
+/// (`rewrite_exported_var_refs`), any of its enclosing-export names that the
+/// nested scope re-declares locally are shadowed and must stay unqualified — a
+/// nested `const a` / `function a` / `namespace a` shadows the enclosing
+/// `export const a` (#14680).
+pub(super) fn collect_nested_scope_declared_names(
+    body: &[IRNode],
+) -> std::collections::HashSet<String> {
+    let mut names = std::collections::HashSet::new();
+    for node in body {
+        collect_nested_scope_declared_name(node, &mut names);
+    }
+    names
+}
+
+fn collect_nested_scope_declared_name(
+    node: &IRNode,
+    names: &mut std::collections::HashSet<String>,
+) {
+    match node {
+        IRNode::ES5ClassIIFE { name, .. }
+        | IRNode::FunctionDecl { name, .. }
+        | IRNode::VarDecl { name, .. }
+        | IRNode::EnumIIFE { name, .. }
+        | IRNode::NamespaceIIFE { name, .. } => {
+            names.insert(name.to_string());
+        }
+        IRNode::VarDeclList(items) | IRNode::Sequence(items) => {
+            for item in items {
+                collect_nested_scope_declared_name(item, names);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Rename namespace references in body IR nodes.
 /// Updates `NamespaceExport.namespace` and nested `NamespaceIIFE.parent_name`
 /// from `old_name` to `new_name`.
@@ -1095,8 +1134,20 @@ pub(super) fn rewrite_exported_var_refs(
             }
         }
         IRNode::NamespaceIIFE { body, .. } | IRNode::ES5ClassIIFE { body, .. } => {
+            // Descend into the nested scope, but drop any enclosing-export names
+            // the nested scope re-declares locally: a shadowing local binding
+            // keeps the reference unqualified (#14680). Reuse `names` directly
+            // when nothing is shadowed (the common case) to avoid a clone.
+            let shadowed = collect_nested_scope_declared_names(body);
+            let reduced;
+            let active = if shadowed.is_empty() {
+                names
+            } else {
+                reduced = names.difference(&shadowed).cloned().collect();
+                &reduced
+            };
             for stmt in body {
-                rewrite_exported_var_refs(stmt, ns_name, names);
+                rewrite_exported_var_refs(stmt, ns_name, active);
             }
         }
         IRNode::VarDecl {

--- a/crates/tsz-emitter/tests/namespace_es5_nested_enclosing_var_qualification_tests.rs
+++ b/crates/tsz-emitter/tests/namespace_es5_nested_enclosing_var_qualification_tests.rs
@@ -1,0 +1,116 @@
+//! ES5 namespace emit: references inside a nested namespace to a `var`/`let`/
+//! `const` exported by an *enclosing* namespace must be qualified by the
+//! *declaring* namespace, not the innermost one (issue #14680).
+//!
+//! Full-pipeline (`Printer`) tests: the divergence only manifests when the
+//! dispatch layer seeds `prior_exported_vars` from the enclosing namespace's
+//! exported-variable set, which the nested-body recursion previously re-applied
+//! under the inner namespace name.
+
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use tsz_common::common::ScriptTarget;
+use tsz_parser::ParserState;
+
+fn emit_es5(source: &str) -> String {
+    let mut parser = ParserState::new_with_language_version(
+        "test.ts".to_string(),
+        source.to_string(),
+        ScriptTarget::ES5,
+    );
+    let root = parser.parse_source_file();
+    let mut printer = EmitterPrinter::with_options(
+        &parser.arena,
+        PrinterOptions {
+            always_strict: true,
+            target: ScriptTarget::ES5,
+            ..Default::default()
+        },
+    );
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+/// w1: a nested-namespace function referencing an enclosing `const` export must
+/// qualify it by the declaring namespace (`N.a`), never the inner one (`M.a`).
+#[test]
+fn nested_fn_reference_to_enclosing_const_qualified_by_declaring_namespace() {
+    let output = emit_es5(
+        "namespace N {\n  export const a = 1;\n  export namespace M { export function f() { return a; } }\n}",
+    );
+    assert!(
+        output.contains("return N.a;"),
+        "reference to enclosing export must be `N.a`. Got:\n{output}"
+    );
+    assert!(
+        !output.contains("return M.a;"),
+        "must not qualify enclosing export by the inner namespace. Got:\n{output}"
+    );
+}
+
+/// w2: two nesting levels deep — `Outer.v`, not `Inner.v`.
+#[test]
+fn doubly_nested_fn_reference_to_enclosing_let_qualified_by_declaring_namespace() {
+    let output = emit_es5(
+        "namespace Outer {\n  export let v = 10;\n  export namespace Mid { export namespace Inner { export function read() { return v; } } }\n}",
+    );
+    assert!(
+        output.contains("return Outer.v;"),
+        "two-level nested reference must be `Outer.v`. Got:\n{output}"
+    );
+    assert!(
+        !output.contains("Inner.v") && !output.contains("Mid.v"),
+        "must not qualify by an inner namespace. Got:\n{output}"
+    );
+}
+
+/// w3: nested+sibling exports — each reference qualifies by its declaring level
+/// (`V.b = U.a + 1; W.c = U.a + V.b;`).
+#[test]
+fn nested_sibling_const_exports_qualify_by_declaring_level() {
+    let output = emit_es5(
+        "namespace U {\n  export const a = 1;\n  export namespace V { export const b = a + 1; export namespace W { export const c = a + b; } }\n}",
+    );
+    assert!(
+        output.contains("V.b = U.a + 1;"),
+        "`b`'s initializer must read `U.a`. Got:\n{output}"
+    );
+    assert!(
+        output.contains("W.c = U.a + V.b;"),
+        "`c`'s initializer must read `U.a` and `V.b`. Got:\n{output}"
+    );
+}
+
+/// w4 (shadow): a nested namespace that re-declares the name locally as a
+/// non-exported `var` shadows the enclosing export, so the reference stays
+/// unqualified (bare `a`).
+#[test]
+fn nested_local_redeclaration_shadows_enclosing_export() {
+    let output = emit_es5(
+        "namespace N {\n  export const a = 1;\n  export namespace M { const a = 2; export function f() { return a; } }\n}",
+    );
+    assert!(
+        output.contains("return a;"),
+        "shadowed reference must stay bare `a`. Got:\n{output}"
+    );
+    assert!(
+        !output.contains("return N.a;") && !output.contains("return M.a;"),
+        "a locally shadowed name must not be qualified. Got:\n{output}"
+    );
+}
+
+/// Renamed binders take the identical structural path (anti-hardcoding).
+#[test]
+fn nested_enclosing_var_qualification_is_binder_name_agnostic() {
+    let output = emit_es5(
+        "namespace Box {\n  export const seed = 42;\n  export namespace Lid { export function peek() { return seed; } }\n}",
+    );
+    assert!(
+        output.contains("return Box.seed;"),
+        "renamed binders must qualify by the declaring namespace. Got:\n{output}"
+    );
+    assert!(
+        !output.contains("Lid.seed"),
+        "renamed binders must not qualify by the inner namespace. Got:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #14680.

Goal: hold

## Problem

Under the ES5 namespace IIFE transform, a reference **inside a nested namespace**
to a `var`/`let`/`const` **exported by an enclosing namespace** was qualified by
the **innermost** namespace object instead of the **declaring** one. The emitted
member access pointed at a namespace that does not own the binding, so it
evaluated to `undefined` at runtime — a correctness (not cosmetic) emit defect.
The ES2015+ path was already correct; only the ES5 IR path diverged.

```ts
// --target es5
namespace N {
  export const a = 1;
  export namespace M { export function f() { return a; } }
}
// tsc:          function f() { return N.a; }
// tsz (before): function f() { return M.a; }   // M.a is undefined

namespace U {
  export const a = 1;
  export namespace V { export const b = a + 1; export namespace W { export const c = a + b; } }
}
// tsc:          V.b = U.a + 1;   W.c = U.a + V.b;
// tsz (before): V.b = V.a + 1;   W.c = W.a + V.b;
```

## Structural rule

When the ES5 namespace transform qualifies a reference to a namespace-exported
`var`/`let`/`const`, `tsc` qualifies it by the namespace that **declares** the
binding (the enclosing namespace, found by walking up the namespace scope
chain), not by the innermost namespace. A binding **re-declared inside the
nested scope** (a local `var`/`let`/`const`, function, class, enum, or nested
namespace) shadows the enclosing export, so a reference resolved to the inner
binding stays unqualified.

tsz's ES5 IR transform carried the dispatched namespace's exported-variable set
in a single `prior_exported_vars` field (intended only for cross-*block* merging
of the **same** namespace name) and re-applied it while transforming **nested
child** namespace bodies, qualifying outer exports with the inner namespace name.
References to an enclosing export are now qualified by the enclosing namespace's
own `rewrite_exported_var_refs` pass, which descends into nested IIFEs with the
correct enclosing name.

## Owner layer

Emitter only — `crates/tsz-emitter/src/transforms/`:

- `namespace_es5_ir.rs::transform_namespace_body` gains an `apply_prior` flag:
  `true` for the dispatched (top-level) namespace body, `false` for every nested
  child body, so the enclosing namespace's prior-block exported vars no longer
  leak into nested bodies under the inner name.
- `namespace_es5_ir_helpers.rs::rewrite_exported_var_refs` — when the enclosing
  rewrite descends into a nested `NamespaceIIFE`/`ES5ClassIIFE`, it subtracts the
  names that nested scope re-declares locally (new
  `collect_nested_scope_declared_names`), so a shadowing local stays unqualified.

No relation/inference/checker change. The gate is purely structural (namespace
nesting + declared-binding shape), never keyed on identifiers or rendered text.

## Adjacent matrix

New suite `nested_enclosing_var_qualification_tests` (5 tests, full `Printer`
pipeline at ES5 so the dispatch layer seeds `prior_exported_vars`):

- nested function reference to an enclosing `const` export → `N.a`;
- doubly-nested reference to an enclosing `let` → `Outer.v`;
- nested+sibling exports each qualify by their declaring level
  (`V.b = U.a + 1; W.c = U.a + V.b;`);
- a nested non-exported `var` re-declaration shadows the enclosing export →
  reference stays bare `a`;
- renamed binders take the identical structural path (anti-hardcoding).

## Verification

- New suite `nested_enclosing_var_qualification_tests` — 5 passed.
- Full `cargo test -p tsz-emitter --lib` (3825 tests incl. the new ones) — 0
  failed, no regressions; the whole `namespace` filter (359 tests) green.
- Differential vs `tsc 6.0.2 --target es5`: byte-identical output across the
  nested, doubly-nested, nested+sibling, and shadow cases (all divergent before).
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --lib`
  (0 warnings), `python3 scripts/arch/arch_guard.py` — all clean.
- Rebased onto current `main` (`e030423c`), conflict-free.
- Ready-review CI owns the full conformance / JS-emit / DTS / fourslash parity floors.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFTVi4GUDzFz3oWMsTc7f5)_