### PR TITLE
fix(emit): infer .d.ts return of function values from solver body type

### DIFF
--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -120,6 +120,10 @@ name = "inferred_const_literal_union_dts_emit_tests"
 path = "tests/inferred_const_literal_union_dts_emit_tests.rs"
 
 [[test]]
+name = "inferred_function_value_apparent_member_return_dts_emit_tests"
+path = "tests/inferred_function_value_apparent_member_return_dts_emit_tests.rs"
+
+[[test]]
 name = "overload_call_node_type_cache_dts_emit_tests"
 path = "tests/overload_call_node_type_cache_dts_emit_tests.rs"
 

--- a/crates/tsz-cli/tests/inferred_function_value_apparent_member_return_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/inferred_function_value_apparent_member_return_dts_emit_tests.rs
@@ -1,0 +1,264 @@
+//! DTS emit: inferred return type of an unannotated arrow / function-expression
+//! initializer whose body return depends on the solver.
+//!
+//! Structural rule: when declaration emit infers the return type of an
+//! unannotated function *value* (a `const`-assigned arrow or function
+//! expression) and the AST-walking inference cannot spell the body return type
+//! from source, `tsc` reports the checker's computed body return type. tsz's
+//! source-faithful AST paths cannot resolve a body expression that the checker
+//! resolves through the solver — a member access through a primitive's apparent
+//! type (`(x: string) => x.length`), an un-called method reference
+//! (`(x: string) => x.toUpperCase`), or a generic instantiation
+//! (`(x: number[]) => x.length`). Before the fix the fallback was a bare `any`,
+//! and because the source-derived `(params) => any` text is *preferred* over the
+//! canonical solver type, the precise return was lost
+//! (`(x: string) => any` instead of `(x: string) => number`).
+//!
+//! The fix consults the checker-computed body return type as the last resort
+//! before `any`. These run the full checker pipeline (the unit-level
+//! declaration-emit harness uses an empty type cache and cannot infer the body
+//! return type). Each behavioural case is exercised with at least two distinct
+//! binder / member spellings so a regression keyed on a particular identifier
+//! rather than the structural shape would fail.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_fn_value_member_return_dts_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+fn emit_dts(name: &str, source: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let src_path = temp.path.join("repro.ts");
+    std::fs::write(&src_path, source).expect("write repro file");
+
+    let output = Command::new(tsz_bin)
+        .args([
+            "repro.ts",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--strict",
+            "--target",
+            "esnext",
+            "--lib",
+            "esnext",
+            "--pretty",
+            "false",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz declaration emit");
+
+    let dts = std::fs::read_to_string(temp.path.join("repro.d.ts")).unwrap_or_else(|_| {
+        panic!(
+            "expected repro.d.ts to be emitted.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    Some(dts)
+}
+
+// =============================================================================
+// Member access through a primitive's apparent type (the primary repro)
+// =============================================================================
+
+/// `(x: string) => x.length` must infer `=> number`, not `=> any`. Exercised in
+/// both the concise-arrow and block-body forms, and with renamed binders.
+#[test]
+fn string_length_member_return_infers_number() {
+    let Some(dts) = emit_dts(
+        "string_length",
+        concat!(
+            "export const a = (x: string) => x.length;\n",
+            "export const b = (value: string) => { return value.length; };\n",
+            "export const c = function (s: string) { return s.length; };\n",
+        ),
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+    assert!(
+        dts.contains("export declare const a: (x: string) => number;"),
+        "concise arrow member access through apparent type must infer number:\n{dts}"
+    );
+    assert!(
+        dts.contains("export declare const b: (value: string) => number;"),
+        "block-body member access through apparent type must infer number:\n{dts}"
+    );
+    assert!(
+        dts.contains("export declare const c: (s: string) => number;"),
+        "function-expression member access through apparent type must infer number:\n{dts}"
+    );
+    assert!(
+        !dts.contains("=> any"),
+        "no inferred return should fall back to any:\n{dts}"
+    );
+}
+
+/// An un-called method reference (`x.toUpperCase`) keeps its method type, and a
+/// numeric apparent-type method (`x.toFixed`) keeps its signature — both were
+/// `any` before the fix.
+#[test]
+fn uncalled_method_reference_keeps_method_type() {
+    let Some(dts) = emit_dts(
+        "method_ref",
+        concat!(
+            "export const upper = (x: string) => x.toUpperCase;\n",
+            "export const fixed = (n: number) => n.toFixed;\n",
+        ),
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+    assert!(
+        dts.contains("export declare const upper: (x: string) => () => string;"),
+        "un-called string method reference must keep its method type:\n{dts}"
+    );
+    assert!(
+        dts.contains("fractionDigits") && dts.contains("=> string"),
+        "un-called number method reference must keep its signature:\n{dts}"
+    );
+    assert!(
+        !dts.contains("=> any"),
+        "no inferred return should fall back to any:\n{dts}"
+    );
+}
+
+/// `Array<T>.length` and other generic-instantiation members resolve too: an
+/// array `.length` and a `Map.size` both infer `number`.
+#[test]
+fn generic_instantiation_member_return_infers_number() {
+    let Some(dts) = emit_dts(
+        "generic_member",
+        concat!(
+            "export const len = (xs: number[]) => xs.length;\n",
+            "export const sz = (m: Map<string, number>) => m.size;\n",
+        ),
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+    assert!(
+        dts.contains("export declare const len: (xs: number[]) => number;"),
+        "array length must infer number:\n{dts}"
+    );
+    assert!(
+        dts.contains("export declare const sz: (m: Map<string, number>) => number;"),
+        "Map size must infer number:\n{dts}"
+    );
+}
+
+// =============================================================================
+// async / nested forms reuse the same body return type
+// =============================================================================
+
+/// An `async` arrow whose body reads an apparent-type member must wrap exactly
+/// once: `async (s: string) => s.length` -> `=> Promise<number>` (the body type
+/// is unwrapped before the async wrapper re-wraps it, so it must not
+/// double-wrap to `Promise<Promise<number>>`).
+#[test]
+fn async_member_return_wraps_promise_once() {
+    let Some(dts) = emit_dts(
+        "async_member",
+        concat!(
+            "export const a = async (s: string) => s.length;\n",
+            "export const b = async (text: string) => { return text.trim(); };\n",
+        ),
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+    assert!(
+        dts.contains("export declare const a: (s: string) => Promise<number>;"),
+        "async member access must wrap the body return in a single Promise:\n{dts}"
+    );
+    assert!(
+        dts.contains("export declare const b: (text: string) => Promise<string>;"),
+        "async block-body member access must wrap once:\n{dts}"
+    );
+    assert!(
+        !dts.contains("Promise<Promise<"),
+        "async wrapper must not double-wrap the body return:\n{dts}"
+    );
+}
+
+/// A nested arrow whose inner body reads an apparent-type member resolves at the
+/// inner level too: `(s: string) => () => s.length` -> `=> () => number`.
+#[test]
+fn nested_arrow_inner_member_return_infers_number() {
+    let Some(dts) = emit_dts(
+        "nested_arrow",
+        "export const make = (s: string) => () => s.length;\n",
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+    assert!(
+        dts.contains("export declare const make: (s: string) => () => number;"),
+        "nested arrow inner member access must infer number:\n{dts}"
+    );
+}
+
+// =============================================================================
+// Unchanged behaviour: a genuinely untyped body still emits `any`
+// =============================================================================
+
+/// A body that reads a member of `any` is genuinely `any`; the solver fallback
+/// must not invent a type, and an `unknown`-typed identity body stays `unknown`.
+#[test]
+fn untyped_body_still_emits_any() {
+    let Some(dts) = emit_dts(
+        "untyped",
+        concat!(
+            "export const a = (x: any) => x.whatever;\n",
+            "export const b = (x: unknown) => x;\n",
+        ),
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+    assert!(
+        dts.contains("export declare const a: (x: any) => any;"),
+        "a member of any is genuinely any:\n{dts}"
+    );
+    assert!(
+        dts.contains("export declare const b: (x: unknown) => unknown;"),
+        "an unknown identity body stays unknown:\n{dts}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -601,6 +601,9 @@ impl<'a> DeclarationEmitter<'a> {
                 scratch.function_body_preferred_return_type_text(func.body)
             {
                 return_type
+            } else if let Some(return_type) = self.function_expression_solver_return_type_text(func)
+            {
+                return_type
             } else {
                 "any".to_string()
             };
@@ -619,6 +622,37 @@ impl<'a> DeclarationEmitter<'a> {
             scratch.write(&inferred_return);
         }
         Some(scratch.writer.take_output())
+    }
+
+    /// Last-resort return-type text for an arrow/function-expression initializer
+    /// whose body the source-faithful AST paths could not spell — a body
+    /// expression resolved through the solver (a primitive apparent-type member
+    /// `(x: string) => x.length`, an un-called method reference, a generic
+    /// instantiation). Without this the fallback was a bare `any`, which is then
+    /// *preferred* over the canonical solver type in
+    /// `declaration_emittable_type_text`, losing the precise return.
+    ///
+    /// Reads the *unwrapped* body return type the checker already computed
+    /// (`function_body_return_value_type_id`); returning the unwrapped type, not
+    /// the signature return, keeps the caller's async wrapper from double-wrapping
+    /// (`wrap_async_function_return_type_text` re-wraps it in `Promise<…>`). Only
+    /// emits a concrete (non-`any`/`error`) type, so a genuinely untyped body
+    /// still falls through to `any`.
+    fn function_expression_solver_return_type_text(
+        &self,
+        func: &tsz_parser::parser::node::FunctionData,
+    ) -> Option<String> {
+        let return_type_id = self.function_body_return_value_type_id(func).filter(|&t| {
+            t != tsz_solver::types::TypeId::ANY && t != tsz_solver::types::TypeId::ERROR
+        })?;
+        let text = if let Some(ref type_params) = func.type_parameters
+            && !type_params.nodes.is_empty()
+        {
+            self.print_type_id_with_outer_type_params(return_type_id, type_params)
+        } else {
+            self.print_type_id_for_inferred_declaration(return_type_id)
+        };
+        (!text.is_empty() && text != "any").then_some(text)
     }
 
     fn expression_body_parameter_return_type_text(


### PR DESCRIPTION
Fixes #14689.

Goal: hold

## Problem

In declaration (`.d.ts`) emit, an **unannotated arrow / function expression
assigned to a `const`/`let`/`var`** (or used as an object-literal property
value) whose body return type is resolved by the **solver** inferred `any`
instead of the precise type. The checker itself is correct (it reports the same
`TS2322` at a call site exercising the inferred return), so this is purely a
declaration-emit defect.

```ts
// --target esnext --lib esnext --declaration --emitDeclarationOnly
export const a = (x: string) => x.length;
// tsc:          (x: string) => number
// tsz (before): (x: string) => any

export const upper = (x: string) => x.toUpperCase;   // un-called method ref
// tsc:          (x: string) => () => string
// tsz (before): (x: string) => any

export const len = (xs: number[]) => xs.length;      // generic instantiation
// tsc:          (xs: number[]) => number
// tsz (before): (xs: number[]) => any

export const fn = async (s: string) => s.length;
// tsc:          (s: string) => Promise<number>
// tsz (before): (s: string) => Promise<any>
```

Direct object-literal-typed members (`(x: {p:number}) => x.p`), element access,
and any *call* (`(x: string) => x.charAt(0)`) were already correct — only the
member / method-reference access resolved through a primitive's *apparent* type
(the `String`/`Number`/`Symbol` wrapper) or a generic instantiation
(`Array<T>.length`, `Map<…>.size`) fell back to `any`.

## Structural rule

When declaration emit infers the return type of an unannotated function *value*
and its source-faithful AST inference cannot spell the body return type, `tsc`
reports the checker-computed body return type. tsz builds the
arrow/function-expression type text from the AST (to preserve source-faithful
parameter names, defaults, and comments); when the body return is a member
access the AST walk cannot resolve, the AST fallback was a bare `any`, and
because that source-derived `(params) => any` text is *preferred* over the
canonical solver type in `declaration_emittable_type_text`, the precise return
was lost.

## Owner layer

Emitter only — `crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs`
(`function_expression_type_text_from_ast_at`). A new last-resort
`function_expression_solver_return_type_text` consults the checker-computed
*unwrapped* body return type (`function_body_return_value_type_id`) before
giving up to `any`. The **unwrapped** (not signature) return is used so the
caller's async wrapper (`wrap_async_function_return_type_text`) re-wraps it in
exactly one `Promise<…>` rather than double-wrapping. Only a concrete
(non-`any`/`error`) type is emitted, so a genuinely untyped body still yields
`any` and the currently-correct AST paths are untouched.

No relation/inference/checker change; the gate is purely structural (the AST
inference exhausting before the solver fallback), never keyed on identifiers or
rendered type text. Parameter text continues to come from the source-faithful
AST path; only the return half consults the solver.

This is parity-safe for the DTS floor: every currently-passing baseline that
emits `any` in an inferred-function-return position has `tsc` agreeing on `any`
(a genuinely untyped body), which the `!= ANY` filter preserves unchanged — so
no passing baseline can flip.

## Adjacent matrix (all byte-identical to tsc 6.0.2 after the fix)

- `x.length` on `string`/literal/array; method references (`x.toUpperCase`,
  `n.toFixed`); `Symbol.description`; `Map.size`; concise arrow, block body,
  and `function` expression forms; `let`/`var`/non-exported `const`; arrow-valued
  object property; nested arrow inner member; generic `<T extends string>`.
- async single Promise wrap (`async (s) => s.length` → `Promise<number>`, not
  `Promise<Promise<number>>`).
- Negative controls unchanged: `(x: any) => x.whatever` → `any`,
  `(x: unknown) => x` → `unknown`; direct `{p:number}` member, element access,
  and call returns unchanged.
- Binder names varied across the regression cases (anti-hardcoding contract).

## Out-of-scope residuals (separate roots, documented in #14689)

- Object-literal **method shorthand** (`{ go(x: string) { return x.length; } }`)
  flows through the distinct `emit_method_function_type_return` path.
- Multi-return literal unions over-widen (`… ? return 1 : return "s"` → tsz
  `string` vs tsc `1 | "s"`).
- Generator yield types short-circuit on the no-`return` void path.
- The solver type printer orders `undefined | null` where `tsc` keeps the lib's
  `null | undefined` source order (surfaced only for a `Promise.then`-style
  method-reference return; a pre-existing printer-normalization root).

## Verification

- New full-pipeline regression suite
  `crates/tsz-cli/tests/inferred_function_value_apparent_member_return_dts_emit_tests.rs`
  (6 tests, binder-varied, runs the real checker→DTS pipeline) — all pass.
- `cargo test --profile dev-fast -p tsz-emitter --lib` — 3820 passed, 0 failed.
- Differential vs `tsc 6.0.2` (`--declaration --emitDeclarationOnly`) over a
  ~40-case matrix (primitives, arrays, generics, method refs, async, nested,
  let/var/non-exported, object-property, negatives) — byte-identical after the
  fix; every witness above was divergent before.
- `cargo fmt -p tsz-emitter -p tsz-cli --check`, `cargo clippy --profile
  dev-fast -p tsz-emitter` (0 warnings), `python3 scripts/arch/arch_guard.py`
  — all clean.
- Ready-review CI owns the full conformance / JS-emit / DTS / fourslash parity floors.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_016ZPz1gYQaNC9AW14K2b7KH

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZPz1gYQaNC9AW14K2b7KH)_