### PR TITLE
fix(checker): match tsc TS2791 bigint-exponentiation result-type precedence

### DIFF
--- a/crates/tsz-checker/src/assignability/compound_assignment.rs
+++ b/crates/tsz-checker/src/assignability/compound_assignment.rs
@@ -315,27 +315,48 @@ impl<'a> CheckerState<'a> {
         }
 
         // TS2791: bigint exponentiation assignment requires target >= ES2016.
-        // Skip when either type is any/unknown (TSC skips the bigint branch for those).
+        //
+        // Same result-type precedence as the binary `**` path (see
+        // `types/computation/binary.rs`): fire only when the arithmetic result is
+        // `bigint`. `any`/`unknown`/`error`/`never` are wildcards that resolve to
+        // the number branch unless paired with a genuine `bigint`, so a wildcard
+        // pair (`x: never; x **= y`) must not fire while `x: any; x **= 1n` must.
         if operator == SyntaxKind::AsteriskAsteriskEqualsToken as u16
             && (self.ctx.compiler_options.target as u32)
                 < (tsz_common::common::ScriptTarget::ES2016 as u32)
-            && left_read_type != TypeId::ANY
-            && right_type != TypeId::ANY
-            && left_read_type != TypeId::UNKNOWN
-            && right_type != TypeId::UNKNOWN
-            && self
-                .diagnostic_subtype_outcome(left_read_type, TypeId::BIGINT)
-                .related
-            && self
-                .diagnostic_subtype_outcome(right_type, TypeId::BIGINT)
-                .related
         {
-            self.error_at_node_msg(
-                expr_idx,
-                crate::diagnostics::diagnostic_codes::EXPONENTIATION_CANNOT_BE_PERFORMED_ON_BIGINT_VALUES_UNLESS_THE_TARGET_OPTION_IS,
-                &[],
-            );
-            emitted_operator_error = true;
+            let left_wild = left_read_type == TypeId::ANY
+                || left_read_type == TypeId::UNKNOWN
+                || left_read_type == TypeId::ERROR
+                || left_read_type == TypeId::NEVER;
+            let right_wild = right_type == TypeId::ANY
+                || right_type == TypeId::UNKNOWN
+                || right_type == TypeId::ERROR
+                || right_type == TypeId::NEVER;
+            let left_bigint = left_wild
+                || self
+                    .diagnostic_subtype_outcome(left_read_type, TypeId::BIGINT)
+                    .related;
+            let right_bigint = right_wild
+                || self
+                    .diagnostic_subtype_outcome(right_type, TypeId::BIGINT)
+                    .related;
+            let left_number = left_wild
+                || self
+                    .diagnostic_subtype_outcome(left_read_type, TypeId::NUMBER)
+                    .related;
+            let right_number = right_wild
+                || self
+                    .diagnostic_subtype_outcome(right_type, TypeId::NUMBER)
+                    .related;
+            if left_bigint && right_bigint && !(left_number && right_number) {
+                self.error_at_node_msg(
+                    expr_idx,
+                    crate::diagnostics::diagnostic_codes::EXPONENTIATION_CANNOT_BE_PERFORMED_ON_BIGINT_VALUES_UNLESS_THE_TARGET_OPTION_IS,
+                    &[],
+                );
+                emitted_operator_error = true;
+            }
         }
 
         // Check bitwise compound assignments: &=, |=, ^=, <<=, >>=, >>>=

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -685,6 +685,9 @@ mod assign_to_import_shadowing_local_tests;
 #[path = "tests/base_type_param_default_inheritance_tests.rs"]
 mod base_type_param_default_inheritance_tests;
 #[cfg(test)]
+#[path = "../tests/bigint_exponentiation_target_tests.rs"]
+mod bigint_exponentiation_target_tests;
+#[cfg(test)]
 #[path = "../tests/bigint_target_ts2737_tests.rs"]
 mod bigint_target_ts2737_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/types/computation/binary.rs
+++ b/crates/tsz-checker/src/types/computation/binary.rs
@@ -671,26 +671,53 @@ impl<'a> CheckerState<'a> {
                 }
 
                 // TS2791: bigint exponentiation requires target >= ES2016.
-                // Only fire when both types are specifically bigint-like,
-                // not when either is `any`/`unknown` (TSC skips the bigint branch for those).
+                //
+                // tsc emits this only when the arithmetic *result* type is
+                // `bigint`. `checkBinaryLikeExpression` resolves the result by
+                // trying the number branch before the bigint branch, where `any`,
+                // `unknown`, `error`, and `never` are wildcards that satisfy both
+                // branches (the number branch wins for them). So a wildcard pair
+                // (`error ** error`, `never ** never`, `any ** any`) resolves to
+                // `number` and must NOT fire, while a wildcard paired with a
+                // genuine `bigint` (`any ** bigint`, `unknown ** bigint`) resolves
+                // to `bigint` and must fire. Mirror that branch precedence rather
+                // than firing whenever both operands are merely bigint-related.
                 if (self.ctx.compiler_options.target as u32)
                     < (tsz_common::common::ScriptTarget::ES2016 as u32)
-                    && left_type != TypeId::ANY
-                    && right_type != TypeId::ANY
-                    && left_type != TypeId::UNKNOWN
-                    && right_type != TypeId::UNKNOWN
-                    && self
-                        .diagnostic_subtype_outcome(left_type, TypeId::BIGINT)
-                        .related
-                    && self
-                        .diagnostic_subtype_outcome(right_type, TypeId::BIGINT)
-                        .related
                 {
-                    self.error_at_node_msg(
-                        node_idx,
-                        crate::diagnostics::diagnostic_codes::EXPONENTIATION_CANNOT_BE_PERFORMED_ON_BIGINT_VALUES_UNLESS_THE_TARGET_OPTION_IS,
-                        &[],
-                    );
+                    let left_wild = left_type == TypeId::ANY
+                        || left_type == TypeId::UNKNOWN
+                        || left_type == TypeId::ERROR
+                        || left_type == TypeId::NEVER;
+                    let right_wild = right_type == TypeId::ANY
+                        || right_type == TypeId::UNKNOWN
+                        || right_type == TypeId::ERROR
+                        || right_type == TypeId::NEVER;
+                    let left_bigint = left_wild
+                        || self
+                            .diagnostic_subtype_outcome(left_type, TypeId::BIGINT)
+                            .related;
+                    let right_bigint = right_wild
+                        || self
+                            .diagnostic_subtype_outcome(right_type, TypeId::BIGINT)
+                            .related;
+                    let left_number = left_wild
+                        || self
+                            .diagnostic_subtype_outcome(left_type, TypeId::NUMBER)
+                            .related;
+                    let right_number = right_wild
+                        || self
+                            .diagnostic_subtype_outcome(right_type, TypeId::NUMBER)
+                            .related;
+                    let number_branch = left_number && right_number;
+                    let bigint_branch = left_bigint && right_bigint;
+                    if bigint_branch && !number_branch {
+                        self.error_at_node_msg(
+                            node_idx,
+                            crate::diagnostics::diagnostic_codes::EXPONENTIATION_CANNOT_BE_PERFORMED_ON_BIGINT_VALUES_UNLESS_THE_TARGET_OPTION_IS,
+                            &[],
+                        );
+                    }
                 }
             }
 

--- a/crates/tsz-checker/tests/bigint_exponentiation_target_tests.rs
+++ b/crates/tsz-checker/tests/bigint_exponentiation_target_tests.rs
@@ -1,0 +1,169 @@
+//! TS2791 — `Exponentiation cannot be performed on 'bigint' values unless the
+//! 'target' option is set to 'es2016' or later`.
+//!
+//! tsc emits TS2791 only when the *result* type of `**`/`**=` is `bigint`.
+//! `checkBinaryLikeExpression` resolves the arithmetic result by trying the
+//! number branch before the bigint branch, treating `any`/`unknown`/`error`/
+//! `never` as wildcards that satisfy both branches (the number branch wins for
+//! a wildcard pair). These tests pin that branch precedence: a wildcard pair
+//! resolves to `number` and must not fire, while a wildcard paired with a
+//! genuine `bigint` resolves to `bigint` and must fire.
+
+use crate::context::{CheckerOptions, ScriptTarget};
+use crate::test_utils::{check_source, diagnostic_count};
+
+const TS2791: u32 = 2791;
+
+fn count_2791_at(target: ScriptTarget, source: &str) -> usize {
+    let diags = check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target,
+            ..CheckerOptions::default()
+        },
+    );
+    diagnostic_count(&diags, TS2791)
+}
+
+fn count_2791_es2015(source: &str) -> usize {
+    count_2791_at(ScriptTarget::ES2015, source)
+}
+
+// ---------------------------------------------------------------------------
+// False-positive regressions: wildcard pairs resolve to `number`, never bigint.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unresolved_name_operands_do_not_fire_ts2791() {
+    // Both operands are `error` types (unresolved names). tsc reports TS2304
+    // for the names but the arithmetic result is `number`, so no TS2791.
+    assert_eq!(
+        count_2791_es2015("const out = missingLhs ** missingRhs;"),
+        0
+    );
+}
+
+#[test]
+fn unresolved_name_chain_does_not_fire_ts2791() {
+    // Right-associative `a ** b ** c` — the inner `b ** c` is `error ** error`.
+    assert_eq!(count_2791_es2015("const out = aRef ** bRef ** cRef;"), 0);
+}
+
+#[test]
+fn never_pair_does_not_fire_ts2791() {
+    let source = "declare const lo: never; declare const hi: never; const out = lo ** hi;";
+    assert_eq!(count_2791_es2015(source), 0);
+}
+
+#[test]
+fn any_pair_does_not_fire_ts2791() {
+    let source = "declare const lhs: any; declare const rhs: any; const out = lhs ** rhs;";
+    assert_eq!(count_2791_es2015(source), 0);
+}
+
+#[test]
+fn unknown_pair_does_not_fire_ts2791() {
+    let source = "declare const lhs: unknown; declare const rhs: unknown; const out = lhs ** rhs;";
+    assert_eq!(count_2791_es2015(source), 0);
+}
+
+// ---------------------------------------------------------------------------
+// False-negative regressions: a wildcard paired with a genuine bigint resolves
+// to `bigint` and must fire.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn any_times_bigint_fires_ts2791() {
+    let source = "declare const lhs: any; declare const rhs: bigint; const out = lhs ** rhs;";
+    assert_eq!(count_2791_es2015(source), 1);
+}
+
+#[test]
+fn bigint_times_any_fires_ts2791() {
+    let source = "declare const lhs: bigint; declare const rhs: any; const out = lhs ** rhs;";
+    assert_eq!(count_2791_es2015(source), 1);
+}
+
+#[test]
+fn unknown_times_bigint_fires_ts2791() {
+    let source = "declare const lhs: unknown; declare const rhs: bigint; const out = lhs ** rhs;";
+    assert_eq!(count_2791_es2015(source), 1);
+}
+
+#[test]
+fn never_times_bigint_fires_ts2791() {
+    let source = "declare const lhs: never; declare const rhs: bigint; const out = lhs ** rhs;";
+    assert_eq!(count_2791_es2015(source), 1);
+}
+
+#[test]
+fn unresolved_name_times_bigint_fires_ts2791() {
+    // `error ** bigint`: number branch fails (bigint is not number-like) but the
+    // bigint branch matches, so the result is `bigint` and TS2791 fires.
+    let source = "declare const rhs: bigint; const out = missingName ** rhs;";
+    assert_eq!(count_2791_es2015(source), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Unchanged baseline behavior.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bigint_pair_fires_ts2791_below_es2016() {
+    let source = "declare const lhs: bigint; declare const rhs: bigint; const out = lhs ** rhs;";
+    assert_eq!(count_2791_es2015(source), 1);
+}
+
+#[test]
+fn bigint_literal_pair_fires_ts2791_below_es2016() {
+    assert_eq!(count_2791_es2015("const out = 2n ** 3n;"), 1);
+}
+
+#[test]
+fn bigint_pair_is_clean_at_es2016() {
+    let source = "declare const lhs: bigint; declare const rhs: bigint; const out = lhs ** rhs;";
+    assert_eq!(count_2791_at(ScriptTarget::ES2016, source), 0);
+}
+
+#[test]
+fn bigint_times_number_does_not_fire_ts2791() {
+    // Mixed bigint/number is an arithmetic error (TS2362/TS2363 family), never a
+    // bigint result, so TS2791 must not fire.
+    let source = "declare const lhs: bigint; declare const rhs: number; const out = lhs ** rhs;";
+    assert_eq!(count_2791_es2015(source), 0);
+}
+
+#[test]
+fn numeric_enum_times_bigint_does_not_fire_ts2791() {
+    let source = "enum Unit { Base } declare const rhs: bigint; const out = Unit.Base ** rhs;";
+    assert_eq!(count_2791_es2015(source), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Compound `**=` mirrors the binary `**` precedence.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compound_never_pair_does_not_fire_ts2791() {
+    let source = "declare let acc: never; declare const step: never; acc **= step;";
+    assert_eq!(count_2791_es2015(source), 0);
+}
+
+#[test]
+fn compound_any_times_bigint_fires_ts2791() {
+    let source = "declare let acc: any; declare const step: bigint; acc **= step;";
+    assert_eq!(count_2791_es2015(source), 1);
+}
+
+#[test]
+fn compound_bigint_pair_fires_ts2791_below_es2016() {
+    let source = "declare let acc: bigint; declare const step: bigint; acc **= step;";
+    assert_eq!(count_2791_es2015(source), 1);
+}
+
+#[test]
+fn compound_bigint_pair_is_clean_at_es2016() {
+    let source = "declare let acc: bigint; declare const step: bigint; acc **= step;";
+    assert_eq!(count_2791_at(ScriptTarget::ES2016, source), 0);
+}


### PR DESCRIPTION
Closes #14692.

## Summary

TS2791 (*"Exponentiation cannot be performed on `bigint` values unless the
`target` option is set to `es2016` or later"*) fired whenever both `**`/`**=`
operands were merely **bigint-related**, excluding only `any`/`unknown`. That
diverged from `tsc` (6.0.2) in **both** directions:

- **False positives:** `error ** error` (unresolved names) and `never ** never`
  fired TS2791, because `error`/`never` are subtype-related to `bigint`.
- **False negatives:** `any ** bigint`, `unknown ** bigint`, and `never ** bigint`
  did not fire, even though `tsc` reports TS2791 for them.

## Structural rule

When the `**`/`**=` result type is `bigint` and the target is below ES2016,
`tsc` emits TS2791; otherwise it does not. `checkBinaryLikeExpression` resolves
the result by trying the **number branch before the bigint branch**, with
`any`/`unknown`/`error`/`never` acting as **wildcards** that satisfy both
branches — so a wildcard *pair* resolves to `number` (no TS2791) while a
wildcard paired with a genuine `bigint` resolves to `bigint` (TS2791). This
fix mirrors that precedence: fire iff `bigint_branch && !number_branch`.

## Owner layer

Checker only:
- `crates/tsz-checker/src/types/computation/binary.rs` — binary `**`.
- `crates/tsz-checker/src/assignability/compound_assignment.rs` — compound `**=`.

The decision stays inline through the `diagnostic_subtype_outcome` query
boundary (per the `bigint_exponentiation_target_probes_use_subtype_outcome_boundary`
architecture guard). It is **not** keyed off the solver's arithmetic result
type: `BinaryOpEvaluator::evaluate_arithmetic` collapses `never`-operand
arithmetic to `never` and `any`/`unknown` arithmetic to `number`/`unknown` for
downstream expression typing, which deliberately diverges from `tsc`'s
grammar-level TS2791 predicate, so it cannot serve as the source of truth here.

## Adjacent-case matrix

New target-aware test module
`crates/tsz-checker/tests/bigint_exponentiation_target_tests.rs` (19 cases,
varied binder names), covering for both `**` and `**=`:

- wildcard pairs (`error`/`never`/`any`/`unknown`) → no TS2791;
- wildcard × genuine `bigint` (both orders) → TS2791;
- `error ** bigint` → TS2791 (unchanged);
- genuine `bigint`/`bigint` and `2n ** 3n` → TS2791;
- `bigint ** number` and `numericEnum ** bigint` → no TS2791;
- ES2016 boundary → clean.

No anti-hardcoding concerns: no user-name/file-name literals, no formatted
diagnostic string used as a predicate; the gate is purely structural
(operand type kinds via the subtype query boundary).

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo build --profile dist-fast -p tsz-cli --bin tsz` — green; the built CLI
  matches `tsc` 6.0.2 on a 19-case `**`/`**=` oracle matrix (`--target es2015`
  and `--target es2016`), including every false-positive and false-negative case
  above.
- `cargo test -p tsz-checker --lib bigint_exponentiation_target_tests::` — 19
  passed.
- `cargo test -p tsz-checker --lib -- exponentiation bigint in_operator_relation_routing value_usage compound_assignment` — 82 passed (includes the
  `bigint_exponentiation_target_probes_use_subtype_outcome_boundary` arch guard).
- `cargo clippy -p tsz-checker --profile dist-fast` — clean.

https://claude.ai/code/session_01MJYhtNmJZumgLhG77GL4kq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJYhtNmJZumgLhG77GL4kq)_