### PR TITLE
feat(#14344): dormant decl-identity type-param carrier (flag-default-OFF)

### DIFF
--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -26,6 +26,18 @@ use tsz_solver::types::{
 
 use super::host::{ClosureLoweringHost, LoweringHost};
 
+/// #14344 STEP-B flag (default-OFF). When `TSZ_TYPEPARAM_DECL_IDENTITY=1`, the
+/// dominant lowering construction path (`collect_type_parameters`) stamps each
+/// user type parameter's origin with its declaration site `(file, name_node)`,
+/// so distinct declarations sharing identical surface info intern distinctly —
+/// the activation that reaches the fp-ts self-ref-guard collapse (the 257).
+/// Measure-only until the activation gate holds; flag-OFF = `User` (byte-parity).
+fn decl_identity_activation() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("TSZ_TYPEPARAM_DECL_IDENTITY").is_ok_and(|v| v == "1"))
+}
+
 mod signature_members;
 
 #[cfg(test)]
@@ -1385,7 +1397,33 @@ impl<'a> TypeLowering<'a> {
         (params, result)
     }
 
+    /// #14344 dispatch-split: a zero-cost dispatcher that reads the activation
+    /// flag once and tail-calls the matching leaf. The split is a CODEGEN
+    /// requirement, not just organization: prepending the flag-branch inside the
+    /// recursive body pulled the decl-scoped path into the same mutual-recursion
+    /// SCC as `lower_type_parameter`, defeating the baseline inlining of the
+    /// flag-OFF path and growing its hot frame enough to overflow fp-ts's
+    /// at-the-limit recursion (even at a 2 GB stack). With `inline(always)` here
+    /// and `inline(never)` on both leaves, the flag-OFF leaf
+    /// (`collect_type_parameters_user`) keeps codegen byte-identical to the
+    /// pre-`#14344` baseline (no flag, no branch, no `DeclScoped`), so its frame
+    /// matches baseline and the overflow does not occur; the flag-ON leaf carries
+    /// the decl-identity logic in isolation.
+    #[inline(always)]
     pub fn collect_type_parameters(&self, list: &NodeList) -> Vec<TypeParamInfo> {
+        if decl_identity_activation() {
+            self.collect_type_parameters_decl_scoped(list)
+        } else {
+            self.collect_type_parameters_user(list)
+        }
+    }
+
+    /// Flag-OFF leaf: byte-identical to the pre-`#14344` `collect_type_parameters`
+    /// body (no flag read, no branch, no `DeclScoped`). `inline(never)` keeps it
+    /// out of the decl-scoped path's SCC so its codegen — and thus its stack
+    /// frame across the deep `lower_type_parameter` recursion — matches baseline.
+    #[inline(never)]
+    fn collect_type_parameters_user(&self, list: &NodeList) -> Vec<TypeParamInfo> {
         let mut param_names = Vec::with_capacity(list.nodes.len());
         for &idx in &list.nodes {
             let Some(node) = self.arena.get(idx) else {
@@ -1430,6 +1468,104 @@ impl<'a> TypeLowering<'a> {
             }
         }
         params
+    }
+
+    /// #14344 STEP-B (flag-ON only): like `collect_type_parameters` but stamps
+    /// each param's origin with its declaration site `(file, name_node)` so two
+    /// distinct declarations sharing identical surface info intern distinctly.
+    /// Separate from the flag-OFF path so the hot recursion there is unchanged.
+    /// `inline(never)` keeps this flag-ON leaf out of the flag-OFF leaf's codegen
+    /// (the dispatch-split's other half — see `collect_type_parameters`).
+    #[inline(never)]
+    fn collect_type_parameters_decl_scoped(&self, list: &NodeList) -> Vec<TypeParamInfo> {
+        let mut param_names = Vec::with_capacity(list.nodes.len());
+        for &idx in &list.nodes {
+            let Some(node) = self.arena.get(idx) else {
+                continue;
+            };
+            let Some(data) = self.arena.get_type_parameter(node) else {
+                continue;
+            };
+            let name = self
+                .arena
+                .get(data.name)
+                .and_then(|name_node| self.arena.get_identifier(name_node))
+                .map_or_else(
+                    || self.interner.intern_string("T"),
+                    |id_data| self.interner.intern_string(&id_data.escaped_text),
+                );
+            let is_const = self
+                .arena
+                .has_modifier(&data.modifiers, tsz_scanner::SyntaxKind::ConstKeyword);
+            let origin = self.decl_scoped_origin(data.name);
+            let placeholder = TypeParamInfo {
+                is_const,
+                name,
+                constraint: None,
+                default: None,
+                origin,
+            };
+            self.add_type_param_binding(name, self.interner.type_param(placeholder));
+            param_names.push((idx, name, is_const, origin));
+        }
+
+        let mut params = Vec::with_capacity(param_names.len());
+        for (idx, name, is_const, origin) in param_names {
+            if let Some(mut info) = self.lower_type_parameter(idx) {
+                info.name = name;
+                info.is_const = is_const;
+                info.origin = origin;
+                let type_id = self.interner.type_param(info);
+                self.update_type_param_binding(info.name, type_id);
+                params.push(info);
+            }
+        }
+        params
+    }
+
+    /// #14344 STEP-B: the decl-scoped origin for a type-param name node — stamps
+    /// `(file, name_node)` under the activation flag, else `User` (byte-parity).
+    ///
+    /// `file` is the interned source-file name (deterministic + stable across
+    /// re-lowerings of the same declaration), recovered by walking `name_node`
+    /// up to its root source-file node — mirroring the checker's existing
+    /// `intern_string(&ctx.file_name)` decl-node key. `node` is the parse-stable
+    /// name `NodeIndex`. Two distinct declarations differ in `(file, node)` so
+    /// they intern distinctly; the SAME declaration lowered repeatedly yields the
+    /// SAME `(file, node)` so it stays a single identity (no over-split).
+    fn decl_scoped_origin(&self, name_node: NodeIndex) -> TypeParamOrigin {
+        if decl_identity_activation() {
+            let file = self.source_file_atom_for(name_node);
+            TypeParamOrigin::DeclScoped {
+                file,
+                node: name_node.0,
+            }
+        } else {
+            TypeParamOrigin::User
+        }
+    }
+
+    /// The interned source-file-name `Atom` for a node, by walking up the
+    /// extended-parent chain to the root source-file node. Deterministic and
+    /// stable across re-lowerings (the file name is the canonical compile path),
+    /// unlike a per-run arena pointer. Falls back to a fixed sentinel atom when
+    /// no source-file root is reachable (synthetic/detached arenas), which keeps
+    /// the `(file, node)` key well-defined without leaking a heap address.
+    fn source_file_atom_for(&self, start: NodeIndex) -> Atom {
+        let mut current = start;
+        while let Some(ext) = self.arena.get_extended(current) {
+            if ext.parent.is_none() {
+                break;
+            }
+            current = ext.parent;
+        }
+        self.arena
+            .get(current)
+            .and_then(|node| self.arena.get_source_file(node))
+            .map_or_else(
+                || self.interner.intern_string("__no_source_file"),
+                |source| self.interner.intern_string(&source.file_name),
+            )
     }
 
     /// Collect type parameters without adding scope bindings.

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -1722,10 +1722,7 @@ impl TypeParamOrigin {
     pub const fn is_infer_placeholder(self) -> bool {
         // `DeclScoped` is a user-written param (decl-stamped for identity), NOT
         // an inference placeholder — classify it with `User` (#14344 STEP-B).
-        !matches!(
-            self,
-            TypeParamOrigin::User | TypeParamOrigin::DeclScoped { .. }
-        )
+        !matches!(self, Self::User | Self::DeclScoped { .. })
     }
 
     /// Higher-order *source* inference placeholder only.

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -1692,6 +1692,14 @@ pub enum TypeParamOrigin {
     /// A type parameter written in user source (or any non-inference synthetic).
     #[default]
     User,
+    /// #14344 STEP-B: a user-written type parameter stamped with its declaration
+    /// site `(file, name_node)`, so two distinct declarations sharing an
+    /// identical surface `TypeParamInfo` intern to DISTINCT ids (the bare info
+    /// now differs per-decl) — fixing the self-ref-guard over-collapse. Stamped
+    /// at the dominant lowering construction path (`collect_type_parameters`)
+    /// under `TSZ_TYPEPARAM_DECL_IDENTITY`; flag-OFF keeps `User` (byte-parity).
+    /// Behaves as `User` for all classification (NOT an inference placeholder).
+    DeclScoped { file: Atom, node: u32 },
     /// A call-local inference placeholder minted for a generic call's own type
     /// parameter (`__infer_{id}` historically). `id` keeps it program-unique.
     InferPlaceholder { id: u64 },
@@ -1712,7 +1720,12 @@ impl TypeParamOrigin {
     /// Replaces the historical `starts_with("__infer_")` scan.
     #[inline]
     pub const fn is_infer_placeholder(self) -> bool {
-        !matches!(self, TypeParamOrigin::User)
+        // `DeclScoped` is a user-written param (decl-stamped for identity), NOT
+        // an inference placeholder — classify it with `User` (#14344 STEP-B).
+        !matches!(
+            self,
+            TypeParamOrigin::User | TypeParamOrigin::DeclScoped { .. }
+        )
     }
 
     /// Higher-order *source* inference placeholder only.

--- a/crates/tsz-solver/tests/types_tests.rs
+++ b/crates/tsz-solver/tests/types_tests.rs
@@ -578,3 +578,27 @@ fn test_property_info_eq_ignores_single_quoted_name() {
         "PropertyInfo hash must ignore single_quoted_name"
     );
 }
+
+/// #14344 layout guard: the `DeclScoped { file: Atom, node: u32 }` decl-identity
+/// variant must stay SIZE-NEUTRAL — its `(Atom, u32)` = 8-byte payload fits inside
+/// the pre-existing `InferSource { id: u64, origin_name: Option<Atom> }` 16-byte
+/// envelope, so `TypeParamOrigin` stays 16 bytes and `TypeParamInfo` stays 40.
+/// `TypeParamInfo` rides every `collect_type_parameters` frame in the deep
+/// `lower_type_parameter` recursion; any growth re-introduces the fp-ts
+/// stack-overflow the dispatch-split fixes. Keep this assertion green.
+#[test]
+fn typeparam_origin_layout_is_size_neutral() {
+    use std::mem::{align_of, size_of};
+    assert_eq!(
+        size_of::<TypeParamOrigin>(),
+        16,
+        "TypeParamOrigin must stay 16 bytes (DeclScoped fits inside InferSource's envelope)"
+    );
+    assert_eq!(align_of::<TypeParamOrigin>(), 8);
+    assert_eq!(
+        size_of::<TypeParamInfo>(),
+        40,
+        "TypeParamInfo must stay 40 bytes; it rides every collect_type_parameters frame"
+    );
+    assert!(size_of::<(Atom, u32)>() <= size_of::<(u64, Option<Atom>)>());
+}

--- a/scripts/arch/clippy-warn-baseline.json
+++ b/scripts/arch/clippy-warn-baseline.json
@@ -25,7 +25,7 @@
   "clippy::implicit_hasher": 28,
   "clippy::inconsistent_struct_constructor": 4,
   "clippy::inefficient_to_string": 14,
-  "clippy::inline_always": 36,
+  "clippy::inline_always": 38,
   "clippy::items_after_statements": 1079,
   "clippy::large_stack_arrays": 5,
   "clippy::manual_assert": 49,


### PR DESCRIPTION
Lands the **dormant** `#14344` decl-identity type-parameter carrier — the
foundational identity core the campaign located and measured — gated behind
`TSZ_TYPEPARAM_DECL_IDENTITY` (**default-OFF**). Flag-OFF is byte-parity inert
in production; this PR carries **zero regression risk** until the flag is
flipped (which is deferred — see the hand-off below).

Goal: green

## What this is

`#14344`: tsz models type-parameter identity at the allocation-order /
arena-local level, so two **distinct** declarations sharing an identical
surface `TypeParamInfo` structurally collapse to one `TypeId`. On fp-ts this
collapse makes the inference self-reference guard over-fire and widen 257+
generic results to `unknown` (the dominant 88% of fp-ts's diagnostics).

This carrier stamps each user type parameter's origin with its **declaration
site** `(file_atom, name_node)` so distinct declarations intern distinctly:

- `crates/tsz-solver/src/types.rs`: `TypeParamOrigin::DeclScoped { file, node }`
  — a size-neutral 4th variant (its 8-byte payload fits inside the pre-existing
  `InferSource` 16-byte envelope; `TypeParamOrigin` stays 16 bytes,
  `TypeParamInfo` stays 40). Classified with `User` in `is_infer_placeholder`
  (it is a user-written param, not an inference placeholder).
- `crates/tsz-lowering/src/lower/core.rs`: stamps the origin at the dominant
  construction path `collect_type_parameters` (the lowering-crate path the 257
  collapsing params are born on). `decl_scoped_origin` derives the `file` atom
  deterministically by walking the type-param name node to its root source-file
  node (mirrors the checker's `intern_string(&ctx.file_name)` decl-node key —
  **not** a per-run arena pointer). A **dispatch-split** keeps the flag-OFF path
  codegen-neutral: an `#[inline(always)]` dispatcher reads the flag once and
  tail-calls one of two `#[inline(never)]` leaves; the flag-OFF leaf
  (`collect_type_parameters_user`) is byte-identical to the pre-`#14344`
  baseline body, so the deep `lower_type_parameter` recursion frame is
  unchanged (belt-and-suspenders margin against the fp-ts stack edge).
- `crates/tsz-solver/tests/types_tests.rs`: a layout-guard test enforcing the
  16/40-byte size-neutrality invariant that keeps the recursion frame unchanged.

## The flag-ON measurement (NOT flipped in this PR)

Activating the flag on fp-ts: **278 fixed / 49 regressed** (loc+code-filtered).
The 278 fixed are **100% the TS2345/TS2322 unknown-widening family** (zero
off-target). The 49 regressions are **real** typeclass-instance alpha-equivalence
FPs: when a stamped param is re-minted during HKT indexed-access reduction
(`URItoKind<A>["Array"] -> Array<A>`) the distinct stamp collapses back to the
structural canonical, so the relation's alpha-rename equivalence misses. Three
bounded prototypes (same-base-Application equivalence, selective stamping,
`instantiate_key` identity-preserve) each gauged **0/49** — the 49 are the
`#14345` materialize-once root surfacing, **not** a bounded tweak.

**Hand-off:** do **not** flip `TSZ_TYPEPARAM_DECL_IDENTITY` to default-ON until
the `#14345` materialize-once work resolves the 49. This PR lands the carrier
**dormant** as the staged `#14344` foundation.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Local gate: flag-OFF fp-ts=1477 byte-parity + NO overflow 3/3; flag-ON=1248, 278-fix (88 TS2322 + 190 TS2345, 100% on-target) / 49-regress; determinism md5 identical across RAYON 1/2/4/8/16; layout-guard test (TypeParamOrigin 16B size-neutral) passes; `cargo check -p tsz-checker --tests` clean.
- Gate-harness (independent): net -229, determinism PASS (arena-ptr 9 distinct md5s -> real-DeclId 1 stable md5), wall-time ratio 1.089.
- CI gates: nextest -p tsz-checker + unit-checker-integration (flag-OFF byte-parity); conformance + conformance-aggregate + conformance-snapshot-gate (flag-OFF byte-parity).
