### PR TITLE
fix(emit): emit ES5 static field initializers after private-field storage

### DIFF
--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -86,6 +86,7 @@ mod helpers;
 #[path = "class_es5_ir_members.rs"]
 mod members;
 use helpers::*;
+use members::ClassMembersEmit;
 
 use crate::context::transform::TransformContext;
 use crate::transforms::async_es5_ir::AsyncES5Transformer;
@@ -1511,12 +1512,7 @@ impl<'a> ES5ClassTransformer<'a> {
         // This must happen before constructor/member IR emission so that temps
         // are available when building property assignment IR nodes.
         self.computed_prop_temp_map.clear();
-        let has_static_private_lowering = self.private_fields.iter().any(|field| field.is_static)
-            || self.private_methods.iter().any(|method| method.is_static)
-            || self
-                .private_accessors
-                .iter()
-                .any(|accessor| accessor.is_static);
+        let has_static_private_lowering = self.has_static_private_lowering();
         self.current_static_class_alias = if self
             .static_members_need_class_alias(&class_data.members)
             || has_static_private_lowering
@@ -1728,44 +1724,15 @@ impl<'a> ES5ClassTransformer<'a> {
             } else {
                 (computed_prop_temp_decls, computed_prop_init_entries)
             };
-        // Prototype methods and static members interleaved in source order
-        let deferred_static_blocks = self.emit_all_members_ir(&mut body, class_idx);
-
-        // Legacy decorator __decorate calls (inside IIFE, before return)
-        if self.legacy_decorators {
-            self.emit_member_decorator_ir(&mut body, class_idx);
-        }
-        if !self.class_decorators.is_empty() {
-            if let Some(alias) = self.class_self_reference_alias.as_ref()
-                && !self.has_static_property_initializer(&class_data.members)
-            {
-                body.push(IRNode::VarDecl {
-                    name: alias.clone().into(),
-                    initializer: None,
-                });
-            }
-            self.emit_class_decorator_ir(&mut body, class_idx);
-        } else if self.legacy_decorators {
-            // Even without class-level decorators, constructor parameter decorators
-            // need a class-level __decorate call: C = __decorate([__param(0, dec)], C)
-            self.emit_ctor_param_decorator_ir(&mut body, class_idx);
-        }
-
-        // Emit var declarations for hoisted temp variables collected during
-        // member expression conversion (e.g., from computed property lowering
-        // inside object literals like `{ [expr]: val }` → `(_a = {}, _a[expr] = val, _a)`).
-        let extra_temps: Vec<String> = std::mem::take(&mut *self.extra_hoisted_temps.borrow_mut());
-        if !extra_temps.is_empty() {
-            let var_decls: Vec<IRNode> = extra_temps
-                .into_iter()
-                .map(|name| IRNode::VarDecl {
-                    name: name.into(),
-                    initializer: None,
-                })
-                .collect();
-            // tsc puts `var _a;` at the very top of the IIFE body, before __extends.
-            body.insert(0, IRNode::VarDeclList(var_decls));
-        }
+        // Prototype methods and static members in source order. Public static
+        // field initializers and static blocks are returned (not emitted inline)
+        // so they land AFTER the private-field storage block below, matching
+        // tsc's IIFE body order: methods -> private storage -> static field
+        // inits / static blocks -> decorators -> return.
+        let ClassMembersEmit {
+            deferred_static_prop_stmts,
+            deferred_static_blocks,
+        } = self.emit_all_members_ir(&mut body, class_idx);
 
         if self.auto_accessor_storage_decls_in_iife() {
             self.emit_auto_accessor_storage_decls_and_static_inits(&mut body);
@@ -1834,6 +1801,51 @@ impl<'a> ES5ClassTransformer<'a> {
             }
         }
         let post_weakmap_statements = Vec::new();
+
+        // Public static field initializers and static blocks come AFTER the
+        // private-field storage block (tsc order), so a static initializer that
+        // constructs an instance observes fully-initialized private storage
+        // (`var _C_x; _C_x = new WeakMap();`) rather than `undefined`.
+        body.extend(deferred_static_prop_stmts);
+
+        // Decorator __decorate calls (inside IIFE, after the static field inits,
+        // matching tsc: `C.s = 1; __decorate([...], C.prototype, "m", null);`).
+        if self.legacy_decorators {
+            self.emit_member_decorator_ir(&mut body, class_idx);
+        }
+        if !self.class_decorators.is_empty() {
+            if let Some(alias) = self.class_self_reference_alias.as_ref()
+                && !self.has_static_property_initializer(&class_data.members)
+            {
+                body.push(IRNode::VarDecl {
+                    name: alias.clone().into(),
+                    initializer: None,
+                });
+            }
+            self.emit_class_decorator_ir(&mut body, class_idx);
+        } else if self.legacy_decorators {
+            // Even without class-level decorators, constructor parameter decorators
+            // need a class-level __decorate call: C = __decorate([__param(0, dec)], C)
+            self.emit_ctor_param_decorator_ir(&mut body, class_idx);
+        }
+
+        // Emit var declarations for hoisted temp variables collected during
+        // member expression conversion (e.g., from computed property lowering
+        // inside object literals like `{ [expr]: val }` → `(_a = {}, _a[expr] = val, _a)`).
+        // Taken last so temps created while emitting members, static field inits,
+        // and decorators are all captured.
+        let extra_temps: Vec<String> = std::mem::take(&mut *self.extra_hoisted_temps.borrow_mut());
+        if !extra_temps.is_empty() {
+            let var_decls: Vec<IRNode> = extra_temps
+                .into_iter()
+                .map(|name| IRNode::VarDecl {
+                    name: name.into(),
+                    initializer: None,
+                })
+                .collect();
+            // tsc puts `var _a;` at the very top of the IIFE body, before __extends.
+            body.insert(0, IRNode::VarDeclList(var_decls));
+        }
 
         // return ClassName;
         body.push(IRNode::ret(Some(IRNode::id(self.class_name.clone()))));

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
@@ -22,7 +22,37 @@ use super::{
     has_effective_static_modifier,
 };
 
+/// Deferred output of [`ES5ClassTransformer::emit_all_members_ir`]. The members
+/// pass emits methods/accessors directly into the IIFE body but hands these two
+/// groups back so the caller can place them correctly relative to the
+/// private-field storage block, matching tsc.
+#[derive(Default)]
+pub(super) struct ClassMembersEmit {
+    /// Public static field initializer assignments and (when the class also has
+    /// static properties) source-ordered static block IIFEs, plus their
+    /// class-alias / temp-decl preamble. The caller appends these to the IIFE
+    /// body *after* the private-field storage block, so the body order matches
+    /// tsc: methods -> private storage -> static field inits -> decorators ->
+    /// `return`.
+    pub(super) deferred_static_prop_stmts: Vec<IRNode>,
+    /// Static blocks for property-less classes, rendered as IIFEs *after* the
+    /// whole class IIFE (carried through to `ES5ClassIIFE::deferred_static_blocks`).
+    pub(super) deferred_static_blocks: Vec<IRNode>,
+}
+
 impl<'a> ES5ClassTransformer<'a> {
+    /// Whether the class has any static private member (field, method, or
+    /// accessor). Such members force a class-value alias and route private
+    /// storage through the IIFE-local `var _a; ...` block.
+    pub(super) fn has_static_private_lowering(&self) -> bool {
+        self.private_fields.iter().any(|field| field.is_static)
+            || self.private_methods.iter().any(|method| method.is_static)
+            || self
+                .private_accessors
+                .iter()
+                .any(|accessor| accessor.is_static)
+    }
+
     fn member_contains_new_target(
         &self,
         body_idx: NodeIndex,
@@ -421,13 +451,8 @@ impl<'a> ES5ClassTransformer<'a> {
         if let Some(instances) = self.private_instances_weakset_name.as_ref() {
             decls.push(instances.clone());
         }
-        let has_static_private_lowering = self.private_fields.iter().any(|field| field.is_static)
-            || self.private_methods.iter().any(|method| method.is_static)
-            || self
-                .private_accessors
-                .iter()
-                .any(|accessor| accessor.is_static);
-        if has_static_private_lowering && let Some(alias) = self.current_static_class_alias.as_ref()
+        if self.has_static_private_lowering()
+            && let Some(alias) = self.current_static_class_alias.as_ref()
         {
             decls.push(alias.clone());
         }
@@ -685,12 +710,12 @@ impl<'a> ES5ClassTransformer<'a> {
         &self,
         body: &mut Vec<IRNode>,
         class_idx: NodeIndex,
-    ) -> Vec<IRNode> {
+    ) -> ClassMembersEmit {
         let Some(class_node) = self.arena.get(class_idx) else {
-            return Vec::new();
+            return ClassMembersEmit::default();
         };
         let Some(class_data) = self.arena.get_class(class_node) else {
-            return Vec::new();
+            return ClassMembersEmit::default();
         };
 
         // --- Static member preamble ---
@@ -1489,14 +1514,21 @@ impl<'a> ES5ClassTransformer<'a> {
             }
         }
 
-        // Emit deferred static property initializers and static blocks after
-        // all methods/accessors, matching tsc's ES5 class member ordering.
+        // Collect deferred static property initializers and static blocks so the
+        // caller can emit them AFTER the private-field storage block, matching
+        // tsc's ES5 class member ordering (methods -> private storage -> public
+        // static field inits / static blocks -> decorators -> return). Emitting
+        // them inline here would place public static field assignments before the
+        // `var _C_x; _C_x = new WeakMap();` storage setup, which is a runtime
+        // defect when a static initializer constructs an instance whose private
+        // fields rely on that storage.
+        let mut deferred_static_prop_stmts: Vec<IRNode> = Vec::new();
         if !deferred_static_prop_inits.is_empty() {
             if let Some(alias) = self.class_self_reference_alias.as_ref()
                 && !self.class_decorators.is_empty()
                 && self.has_static_property_initializer(&class_data.members)
             {
-                body.push(IRNode::VarDecl {
+                deferred_static_prop_stmts.push(IRNode::VarDecl {
                     name: alias.clone().into(),
                     initializer: None,
                 });
@@ -1506,7 +1538,7 @@ impl<'a> ES5ClassTransformer<'a> {
                 .as_ref()
                 .is_some_and(|alias| deferred_static_temp_decls.contains(alias));
             if !deferred_static_temp_decls.is_empty() {
-                body.push(IRNode::VarDeclList(
+                deferred_static_prop_stmts.push(IRNode::VarDeclList(
                     deferred_static_temp_decls
                         .into_iter()
                         .map(|name| IRNode::VarDecl {
@@ -1516,22 +1548,30 @@ impl<'a> ES5ClassTransformer<'a> {
                         .collect(),
                 ));
             }
-            if let Some(ref alias) = class_alias {
+            // When the class has static private lowering, the private-field
+            // storage block (emitted by the caller before these deferred static
+            // inits) already declares and assigns the class alias
+            // (`var _a; ... _a = C, ...`), so re-emitting it here would declare
+            // and assign it twice. The preamble is still required when the alias
+            // exists only because a static initializer references `this`.
+            if let Some(ref alias) = class_alias
+                && !self.has_static_private_lowering()
+            {
                 if !class_alias_declared_in_static_temp_decls {
-                    body.push(IRNode::VarDecl {
+                    deferred_static_prop_stmts.push(IRNode::VarDecl {
                         name: alias.clone().into(),
                         initializer: None,
                     });
                 }
-                body.push(IRNode::expr_stmt(IRNode::assign(
+                deferred_static_prop_stmts.push(IRNode::expr_stmt(IRNode::assign(
                     IRNode::id(alias.clone()),
                     IRNode::id(self.class_name.clone()),
                 )));
             }
-            body.append(&mut deferred_static_prop_inits);
+            deferred_static_prop_stmts.append(&mut deferred_static_prop_inits);
         }
 
-        deferred_static_block_indices
+        let deferred_static_blocks = deferred_static_block_indices
             .into_iter()
             .map(|member_idx| {
                 let statements = self.convert_block_body_with_alias_impl(
@@ -1542,7 +1582,12 @@ impl<'a> ES5ClassTransformer<'a> {
                 );
                 IRNode::StaticBlockIIFE { statements }
             })
-            .collect()
+            .collect();
+
+        ClassMembersEmit {
+            deferred_static_prop_stmts,
+            deferred_static_blocks,
+        }
     }
 
     pub(super) fn has_static_property_initializer(

--- a/crates/tsz-emitter/tests/class_es5_ir.rs
+++ b/crates/tsz-emitter/tests/class_es5_ir.rs
@@ -1309,3 +1309,83 @@ fn derived_constructor_nested_super_schedules_properties_before_body() {
         "Nested super calls should assign into the `_this` capture.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn static_field_initializer_emitted_after_private_field_storage() {
+    // tsc emits the private-field WeakMap storage (`var _X; _X = new WeakMap()`)
+    // before any public static field initializer, so a static initializer that
+    // constructs an instance observes initialized storage. Emitting
+    // `Widget.total = new Widget()...` before `_Widget_count = new WeakMap()`
+    // throws `Cannot read properties of undefined (reading 'set')` at runtime.
+    let source = r#"class Widget {
+            #count = 2;
+            static total = new Widget().read();
+            read() { return this.#count; }
+        }"#;
+    let output = transform_class(source).expect("transform should succeed");
+
+    let weakmap_decl = output.find("var _Widget_count;").expect("weakmap decl");
+    let weakmap_init = output
+        .find("_Widget_count = new WeakMap();")
+        .expect("weakmap init");
+    let static_init = output
+        .find("Widget.total = new Widget().read();")
+        .expect("static init");
+    let ret = output.find("return Widget;").expect("return");
+
+    assert!(
+        weakmap_decl < weakmap_init && weakmap_init < static_init && static_init < ret,
+        "Public static field initializers must follow the private-field WeakMap storage block.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn static_field_after_private_storage_does_not_duplicate_class_alias() {
+    // A static private field forces a class-value alias (`_a = Registry`) in the
+    // private-storage block. Because that block now precedes the deferred static
+    // initializers, the static-init preamble must not re-emit the alias, or it
+    // would be declared and assigned twice.
+    let source = r#"class Registry {
+            static #seq = 10;
+            static label = "x";
+            use() { return 0; }
+        }"#;
+    let output = transform_class(source).expect("transform should succeed");
+
+    assert_eq!(
+        output.matches("_a = Registry").count(),
+        1,
+        "The class-value alias must be assigned exactly once.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_Registry_seq = { value: 10 };\n    Registry.label = \"x\";"),
+        "The static private field init must precede the public static field init.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn deferred_static_block_and_fields_follow_private_storage_in_source_order() {
+    // The entire deferred block (public static field inits interleaved with
+    // static-block IIFEs, in source order) moves together to after the private
+    // storage, matching tsc.
+    let source = r#"class Cache {
+            #hits = 0;
+            static a = 1;
+            static { console.log("init"); }
+            static b = 2;
+            read() { return this.#hits; }
+        }"#;
+    let output = transform_class(source).expect("transform should succeed");
+
+    let weakmap_init = output
+        .find("_Cache_hits = new WeakMap();")
+        .expect("weakmap init");
+    let first = output.find("Cache.a = 1;").expect("Cache.a");
+    let block = output.find("console.log(\"init\")").expect("static block");
+    let second = output.find("Cache.b = 2;").expect("Cache.b");
+
+    assert!(
+        weakmap_init < first && first < block && block < second,
+        "Static field inits and static blocks must follow private storage in source order.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Closes #14697.

## Problem

When downleveling a class to `--target es5`/`es2015`, tsz emitted the IIFE body
in the wrong order: **public static field initializers** (`C.s = …`) and the
**decorator `__decorate` calls** were placed *before* the **private-field
`WeakMap` storage block** (`var _C_x; _C_x = new WeakMap();`). tsc emits the
storage block first. This is a **runtime correctness** defect, not cosmetic — a
static field initializer that constructs an instance touches private storage that
has not been created yet.

```ts
// --target es5
class C {
  #y = 2;
  static s = new C().getY();
  getY() { return this.#y; }
}
export const v = C.s;
// tsc:          var _C_y; _C_y = new WeakMap(); C.s = new C().getY();  → v === 2
// tsz (before): C.s = new C().getY(); var _C_y; _C_y = new WeakMap();  → TypeError:
//               Cannot read properties of undefined (reading 'set')
```

## Structural rule

`tsc` assembles the ES5 class IIFE body in a fixed order:

```
constructor
methods / accessors                                   (source order)
private-field storage: var decls + WeakMap/WeakSet inits + static-private inits
public static field initializers + static blocks      (source order)
decorator __decorate calls
return ClassName;
```

tsz interleaved the public static field initializers with the methods (so they
landed before the private-storage block) and emitted the decorator calls before
the storage block too. The fix moves the deferred static field / static-block
emission **and** the decorator emission to after the private-storage block.

A second, adjacent defect this surfaced: when a class has static-private lowering
*and* a public static field, the class-value alias (`_a = C`) was emitted twice —
once by the storage block, once by the deferred static-init preamble. The
preamble now defers to the storage block whenever `has_static_private_lowering`,
so the alias is declared and assigned exactly once.

## Owner layer

Emitter only — `crates/tsz-emitter/src/transforms/`:
- `class_es5_ir_members.rs::emit_all_members_ir` now returns a `ClassMembersEmit`
  (deferred static field inits / static blocks) instead of pushing those
  statements inline into the IIFE body.
- `class_es5_ir.rs` appends them — then the decorator calls, then hoisted temps —
  after the private-field storage block.
- New shared `has_static_private_lowering(&self)` helper replaces three inline
  copies of the same predicate (DRY) and gates the alias de-dup.

No relation/inference/checker change. The ordering is purely structural (member
kinds + private-lowering shape), never keyed on identifiers or rendered text.

## Adjacent-case matrix

Verified byte-identical to `tsc 6.0.2 --target es5` (and the ordering generalizes
to es2015) across, with varied binder names:

- instance-private field + public static field (+ static method);
- two public static fields + instance-private field;
- static field + static block + instance-private (source-order interleave);
- static-private field + public static field (the double-alias case);
- `this`-referencing static initializer with no private lowering (alias preamble
  still required);
- static block referencing the class + instance-private;
- static / instance auto-accessor + static field;
- legacy member decorator + static field + private;
- class decorator + private + static field;
- legacy decorator + private, no static field.

Three new regression tests in `crates/tsz-emitter/tests/class_es5_ir.rs`
(`#[path]`-included into the lib) pin the ordering, the no-duplicate-alias
property, and source-order interleaving of static fields with static blocks.

## Verification

- `cargo build --profile dist-fast -p tsz-cli --bin tsz` — green; the built CLI
  matches `tsc 6.0.2 --target es5` byte-for-byte on the witness and the full
  adjacent matrix above, and the previously-crashing witness now runs and yields
  `v === 2`.
- `cargo test -p tsz-emitter --profile dist-fast` — 4437 passed; the only failure
  (`generator_object_literal_prefix_before_yield_omits_source_trailing_comma`) is
  pre-existing on `main` (confirmed via `git stash`) and unrelated to this change.
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --lib` (0
  warnings), `python3 scripts/arch/arch_guard.py` — all clean.
- Rebased onto current `main` (`8f65422`), conflict-free.
- Ready-review CI owns the full conformance / JS-emit / DTS / fourslash parity floors.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019qW84TF8qgCRTfjvXdBiDf)_