### PR TITLE
fix(checker): run per-operand TS2362/TS2363 arithmetic-operand check unconditionally

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -39,6 +39,9 @@ path = "tests/sibling_defaulted_conditional_constraint_tests.rs"
 name = "cannot_find_name_lib_hint_parity_tests"
 path = "tests/cannot_find_name_lib_hint_parity_tests.rs"
 [[test]]
+name = "arithmetic_operand_validity_tests"
+path = "tests/arithmetic_operand_validity_tests.rs"
+[[test]]
 name = "generic_interface_target_property_elaboration_tests"
 path = "tests/generic_interface_target_property_elaboration_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/operator_errors.rs
+++ b/crates/tsz-checker/src/error_reporter/operator_errors.rs
@@ -542,6 +542,136 @@ impl<'a> CheckerState<'a> {
         fallback
     }
 
+    /// Emit TS2362/TS2363 for each invalid operand of an arithmetic
+    /// (`- * / % **`) or bitwise (`& | ^ << >> >>>`) operator.
+    ///
+    /// This mirrors `tsc`'s `checkArithmeticOperandType`, which is invoked once
+    /// per operand and is *independent of the other operand*: tsc validates each
+    /// side by assignability to `number | bigint` (after `checkNonNullType`,
+    /// which strips `null`/`undefined` and turns an unknown-under-strict-null
+    /// operand into `error`). Numeric values — `number`, numeric enums, `bigint`
+    /// — and the wildcards `any`/`unknown`/`error`/`never` are valid; `string`,
+    /// `boolean`, object, `symbol`, `void`, string literals and *string* enums
+    /// are not.
+    ///
+    /// tsz previously only ran this check when one operand was already `any`/
+    /// `error`, and additionally treated every enum (including string enums) as
+    /// valid, so it silently accepted e.g. `stringEnum - number`, `string &
+    /// never`, and `unknown - string` (where the unknown side short-circuited
+    /// before the other side was checked). Running the check here, once, for
+    /// every operand pair restores parity with tsc.
+    ///
+    /// When both operands are boolean-like and the operator is `& | ^`, tsc
+    /// reports TS2447 instead (handled on the `emit_binary_operator_error`
+    /// path), so this skips those.
+    ///
+    /// `+` is intentionally excluded: it is string concatenation when either
+    /// side is string-like and otherwise reports the whole-expression TS2365,
+    /// never the per-operand TS2362/TS2363.
+    ///
+    /// This runs *before* the operator-specific handling (and so before the
+    /// null/undefined TS18050 and unknown TS18046 operand errors are emitted),
+    /// which is sound because a pure `null`/`undefined` operand is suppressed
+    /// here directly via the `strictNullChecks` state rather than via an
+    /// already-emitted flag.
+    pub(crate) fn emit_arithmetic_operand_errors(
+        &mut self,
+        left_idx: NodeIndex,
+        right_idx: NodeIndex,
+        left_type: TypeId,
+        right_type: TypeId,
+        op: &str,
+    ) {
+        if self.has_parse_errors() {
+            return;
+        }
+        debug_assert!(
+            matches!(
+                op,
+                "-" | "*" | "/" | "%" | "**" | "&" | "|" | "^" | "<<" | ">>" | ">>>"
+            ),
+            "emit_arithmetic_operand_errors called with non-arithmetic operator {op}"
+        );
+
+        let evaluator = crate::query_boundaries::common::new_binary_op_evaluator(self.ctx.types);
+
+        // Hot-path fast-out: when both operands are already valid arithmetic
+        // operands (the overwhelmingly common `number - number` etc.), neither
+        // side can error, so skip the conditional/mapped evaluation and
+        // nullish-split below. Resolving the operands cannot turn a valid type
+        // invalid, so this is behavior-preserving.
+        if evaluator.is_arithmetic_operand(left_type) && evaluator.is_arithmetic_operand(right_type)
+        {
+            return;
+        }
+
+        // `& | ^` with two boolean operands is reported as TS2447 ("operator is
+        // not allowed for boolean types"), not as a per-operand TS2362/TS2363.
+        // Use the strict boolean test: tsc gates TS2447 on `flags & BooleanLike`,
+        // so `boolean & any` falls through to the per-operand TS2362 instead.
+        if matches!(op, "&" | "|" | "^")
+            && evaluator.is_boolean_like_strict(left_type)
+            && evaluator.is_boolean_like_strict(right_type)
+        {
+            return;
+        }
+
+        // Resolve conditional/mapped operands and detect each side's validity the
+        // same way the `emit_binary_operator_error` mismatch path does, so the two
+        // entry points stay in lockstep.
+        let eval_left = self.evaluate_type_for_binary_ops(left_type);
+        let eval_right = self.evaluate_type_for_binary_ops(right_type);
+        let snc_off = !self.ctx.compiler_options.strict_null_checks;
+
+        let (left_non_null, left_cause) = self.split_nullish_type(eval_left);
+        let (right_non_null, right_cause) = self.split_nullish_type(eval_right);
+        let left_has_nullish = left_cause.is_some();
+        let right_has_nullish = right_cause.is_some();
+        let left_is_nullish = left_type == TypeId::NULL || left_type == TypeId::UNDEFINED;
+        let right_is_nullish = right_type == TypeId::NULL || right_type == TypeId::UNDEFINED;
+
+        let left_is_valid_arithmetic = evaluator.is_arithmetic_operand(eval_left)
+            || (snc_off && (eval_left == TypeId::NULL || eval_left == TypeId::UNDEFINED));
+        let right_is_valid_arithmetic = evaluator.is_arithmetic_operand(eval_right)
+            || (snc_off && (eval_right == TypeId::NULL || eval_right == TypeId::UNDEFINED));
+        let left_non_null_is_valid_arithmetic =
+            left_non_null.is_some_and(|t| evaluator.is_arithmetic_operand(t));
+        let right_non_null_is_valid_arithmetic =
+            right_non_null.is_some_and(|t| evaluator.is_arithmetic_operand(t));
+
+        // Every operator this method handles is in the TS18050-emitting family,
+        // so under `strictNullChecks` a pure `null`/`undefined` operand is
+        // reported by `checkNonNullType` (TS18047/TS18048) and stripped to the
+        // bottom type before the operand check — no TS2362/TS2363. A nullish
+        // *union* (e.g. `number | null`) is suppressed only when its non-null
+        // remainder is itself a valid arithmetic operand.
+        let strict_null = self.ctx.compiler_options.strict_null_checks;
+        if !(left_is_valid_arithmetic
+            || (left_has_nullish && left_non_null_is_valid_arithmetic)
+            || (strict_null && left_is_nullish))
+        {
+            self.emit_render_request(
+                left_idx,
+                DiagnosticRenderRequest::simple_msg(
+                    diagnostic_codes::THE_LEFT_HAND_SIDE_OF_AN_ARITHMETIC_OPERATION_MUST_BE_OF_TYPE_ANY_NUMBER_BIGINT,
+                    &[],
+                ),
+            );
+        }
+        if !(right_is_valid_arithmetic
+            || (right_has_nullish && right_non_null_is_valid_arithmetic)
+            || (strict_null && right_is_nullish))
+        {
+            self.emit_render_request(
+                right_idx,
+                DiagnosticRenderRequest::simple_msg(
+                    diagnostic_codes::THE_RIGHT_HAND_SIDE_OF_AN_ARITHMETIC_OPERATION_MUST_BE_OF_TYPE_ANY_NUMBER_BIGINT,
+                    &[],
+                ),
+            );
+        }
+    }
+
     /// Emit errors for binary operator type mismatches.
     /// TS2362 for left-hand side, TS2363 for right-hand side, or TS2365 for general operator errors.
     pub(crate) fn emit_binary_operator_error(
@@ -898,43 +1028,26 @@ impl<'a> CheckerState<'a> {
         }
 
         if requires_numeric_operands {
-            // For arithmetic and bitwise operators, emit specific left/right errors (TS2362, TS2363)
-            // Skip operands that already got TS18050 (null/undefined with strictNullChecks)
-            // tsc suppresses TS2362/TS2363 when TS18050 was already emitted for the operand.
-            let mut emitted_specific_error = emitted_nullish_error;
-            let mut emitted_operand_error = false;
-            if !(left_is_valid_arithmetic
+            // The per-operand TS2362/TS2363 errors are emitted up-front by
+            // `emit_arithmetic_operand_errors` (tsc's `checkArithmeticOperandType`,
+            // run once per operand independently of the other and of this
+            // evaluator-driven mismatch path). Here we only re-derive operand
+            // validity to decide whether the whole-expression TS2365 ("operator
+            // cannot be applied to types") is *additionally* warranted — i.e. the
+            // mixed number/bigint case, where tsc reports both the per-operand
+            // error and TS2365.
+            let left_operand_invalid = !(left_is_valid_arithmetic
                 || (left_has_nullish
                     && left_non_null_is_valid_arithmetic
                     && should_emit_nullish_error)
-                || (emitted_nullish_error && left_is_nullish))
-            {
-                self.emit_render_request(
-                    left_idx,
-                    DiagnosticRenderRequest::simple_msg(
-                        diagnostic_codes::THE_LEFT_HAND_SIDE_OF_AN_ARITHMETIC_OPERATION_MUST_BE_OF_TYPE_ANY_NUMBER_BIGINT,
-                        &[],
-                    ),
-                );
-                emitted_specific_error = true;
-                emitted_operand_error = true;
-            }
-            if !(right_is_valid_arithmetic
+                || (emitted_nullish_error && left_is_nullish));
+            let right_operand_invalid = !(right_is_valid_arithmetic
                 || (right_has_nullish
                     && right_non_null_is_valid_arithmetic
                     && should_emit_nullish_error)
-                || (emitted_nullish_error && right_is_nullish))
-            {
-                self.emit_render_request(
-                    right_idx,
-                    DiagnosticRenderRequest::simple_msg(
-                        diagnostic_codes::THE_RIGHT_HAND_SIDE_OF_AN_ARITHMETIC_OPERATION_MUST_BE_OF_TYPE_ANY_NUMBER_BIGINT,
-                        &[],
-                    ),
-                );
-                emitted_specific_error = true;
-                emitted_operand_error = true;
-            }
+                || (emitted_nullish_error && right_is_nullish));
+            let emitted_operand_error = left_operand_invalid || right_operand_invalid;
+            let emitted_specific_error = emitted_nullish_error || emitted_operand_error;
             // If both operands are valid arithmetic types but the operation still failed
             // (e.g., mixing number and bigint), emit TS2365. tsc also emits TS2365
             // when a bigint-capable operation has one invalid side (`"x" & 1n`,

--- a/crates/tsz-checker/src/types/computation/binary.rs
+++ b/crates/tsz-checker/src/types/computation/binary.rs
@@ -940,6 +940,46 @@ impl<'a> CheckerState<'a> {
                 );
             }
 
+            // TS2362/TS2363: validate each operand of an arithmetic (`- * / % **`)
+            // or bitwise (`& | ^ << >> >>>`) operator independently, mirroring
+            // tsc's per-operand `checkArithmeticOperandType`. This runs once, here,
+            // before the operator-specific handling — which otherwise short-circuits
+            // on an `unknown` operand (skipping the *other* operand) or defers the
+            // verdict to the binary-op evaluator (which accepts `never`-paired and
+            // string-enum operands that tsc rejects). `+` has its own rules and is
+            // excluded; boxed-primitive arithmetic operands are reported on the raw
+            // (pre-coercion) type by a dedicated path below and are skipped here to
+            // avoid a double diagnostic.
+            // `(operator string, is_arithmetic)` — `is_arithmetic` distinguishes
+            // `- * / % **` (which has the boxed-primitive carve-out below) from the
+            // bitwise `& | ^ << >> >>>`.
+            let arith_bitwise_op: Option<(&'static str, bool)> = match op_kind {
+                k if k == SyntaxKind::MinusToken as u16 => Some(("-", true)),
+                k if k == SyntaxKind::AsteriskToken as u16 => Some(("*", true)),
+                k if k == SyntaxKind::AsteriskAsteriskToken as u16 => Some(("**", true)),
+                k if k == SyntaxKind::SlashToken as u16 => Some(("/", true)),
+                k if k == SyntaxKind::PercentToken as u16 => Some(("%", true)),
+                k if k == SyntaxKind::AmpersandToken as u16 => Some(("&", false)),
+                k if k == SyntaxKind::BarToken as u16 => Some(("|", false)),
+                k if k == SyntaxKind::CaretToken as u16 => Some(("^", false)),
+                k if k == SyntaxKind::LessThanLessThanToken as u16 => Some(("<<", false)),
+                k if k == SyntaxKind::GreaterThanGreaterThanToken as u16 => Some((">>", false)),
+                k if k == SyntaxKind::GreaterThanGreaterThanGreaterThanToken as u16 => {
+                    Some((">>>", false))
+                }
+                _ => None,
+            };
+            if let Some((arith_op, is_arithmetic)) = arith_bitwise_op {
+                let boxed = is_arithmetic
+                    && (self.is_boxed_primitive_type(left_type)
+                        || self.is_boxed_primitive_type(right_type));
+                if !boxed {
+                    self.emit_arithmetic_operand_errors(
+                        left_idx, right_idx, left_type, right_type, arith_op,
+                    );
+                }
+            }
+
             let op_str = match op_kind {
                 k if k == SyntaxKind::PlusToken as u16 => "+",
                 k if k == SyntaxKind::MinusToken as u16 => "-",
@@ -1055,40 +1095,8 @@ impl<'a> CheckerState<'a> {
                                 );
                     }
 
-                    // TS2362/TS2363: Per-operand validity check for bitwise operators.
-                    // Same issue as arithmetic: when one operand is `any`, the evaluator
-                    // returns Success but tsc still validates the other operand individually.
-                    if !emitted_nullish_error {
-                        let left_any_like = eval_left == TypeId::ANY || eval_left == TypeId::ERROR;
-                        let right_any_like =
-                            eval_right == TypeId::ANY || eval_right == TypeId::ERROR;
-
-                        if (left_any_like || right_any_like)
-                            && left_type != TypeId::ERROR
-                            && right_type != TypeId::ERROR
-                        {
-                            if left_any_like
-                                && !evaluator.is_arithmetic_operand(eval_right)
-                                && !self.is_enum_type(right_type)
-                            {
-                                self.error_at_node(
-                                    right_idx,
-                                    "The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.",
-                                    crate::diagnostics::diagnostic_codes::THE_RIGHT_HAND_SIDE_OF_AN_ARITHMETIC_OPERATION_MUST_BE_OF_TYPE_ANY_NUMBER_BIGINT,
-                                );
-                            }
-                            if right_any_like
-                                && !evaluator.is_arithmetic_operand(eval_left)
-                                && !self.is_enum_type(left_type)
-                            {
-                                self.error_at_node(
-                                    left_idx,
-                                    "The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.",
-                                    crate::diagnostics::diagnostic_codes::THE_LEFT_HAND_SIDE_OF_AN_ARITHMETIC_OPERATION_MUST_BE_OF_TYPE_ANY_NUMBER_BIGINT,
-                                );
-                            }
-                        }
-                    }
+                    // (Per-operand TS2362/TS2363 validity for bitwise operators is
+                    // emitted once, up-front, by `emit_arithmetic_operand_errors`.)
 
                     let result = evaluator.evaluate(eval_left, eval_right, op_str);
                     // Equality and relational operators always produce boolean,
@@ -1337,37 +1345,8 @@ impl<'a> CheckerState<'a> {
             let eval_left = self.evaluate_type_for_binary_ops(left_type);
             let eval_right = self.evaluate_type_for_binary_ops(right_type);
 
-            // TS2362/TS2363: Per-operand validity check for arithmetic operators.
-            // When one operand is `any`, the evaluator returns Success(NUMBER) but tsc
-            // still requires the OTHER operand to be a valid arithmetic type (any, number,
-            // bigint, or enum). Without this pre-check, `any * T` silently passes.
-            if is_arithmetic_op && op_str != "+" && !emitted_nullish_error {
-                let left_any_like = eval_left == TypeId::ANY || eval_left == TypeId::ERROR;
-                let right_any_like = eval_right == TypeId::ANY || eval_right == TypeId::ERROR;
-
-                if left_any_like || right_any_like {
-                    if left_any_like
-                        && !evaluator.is_arithmetic_operand(eval_right)
-                        && !self.is_enum_type(right_type)
-                    {
-                        self.error_at_node(
-                            right_idx,
-                            "The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.",
-                            crate::diagnostics::diagnostic_codes::THE_RIGHT_HAND_SIDE_OF_AN_ARITHMETIC_OPERATION_MUST_BE_OF_TYPE_ANY_NUMBER_BIGINT,
-                        );
-                    }
-                    if right_any_like
-                        && !evaluator.is_arithmetic_operand(eval_left)
-                        && !self.is_enum_type(left_type)
-                    {
-                        self.error_at_node(
-                            left_idx,
-                            "The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.",
-                            crate::diagnostics::diagnostic_codes::THE_LEFT_HAND_SIDE_OF_AN_ARITHMETIC_OPERATION_MUST_BE_OF_TYPE_ANY_NUMBER_BIGINT,
-                        );
-                    }
-                }
-            }
+            // (Per-operand TS2362/TS2363 validity for arithmetic operators is
+            // emitted once, up-front, by `emit_arithmetic_operand_errors`.)
 
             // For relational operators, widen literal/enum types to their base types
             // before comparison (matching tsc's getBaseTypeOfLiteralTypeForComparison).

--- a/crates/tsz-checker/tests/arithmetic_operand_validity_tests.rs
+++ b/crates/tsz-checker/tests/arithmetic_operand_validity_tests.rs
@@ -1,0 +1,307 @@
+//! Conformance matrix for the per-operand TS2362/TS2363 validity check on
+//! arithmetic (`- * / % **`) and bitwise (`& | ^ << >> >>>`) operators.
+//!
+//! Structural rule: `tsc`'s `checkArithmeticOperandType` is invoked once per
+//! operand and is *independent of the other operand* — each side must be
+//! assignable to `number | bigint` after `checkNonNullType` (which turns an
+//! unknown-under-strict-null operand into `error` and strips `null`/`undefined`).
+//! Numeric values (`number`, numeric enums, `bigint`) and the wildcards
+//! `any`/`unknown`/`error`/`never` are valid; `string`, `boolean`, object,
+//! `symbol`, `void`, string literals and *string enums* are not.
+//!
+//! tsz previously only ran this check when one operand was already `any`/`error`,
+//! and additionally treated every enum (including string enums) as valid, so it
+//! silently accepted e.g. `stringEnum - number`, `string & never`, and the
+//! non-unknown side of `unknown - string`. The fix makes the check run once,
+//! up-front, for every operand pair.
+//!
+//! Anti-hardcoding: the rule is structural. Binder names (enum/alias/parameter)
+//! vary across the matrix and the behavior holds; nothing keys off identifiers.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+/// `expr;` where the operands are declared above. Returns the diagnostic codes.
+fn check_expr(decls: &str, expr: &str) -> Vec<u32> {
+    let source = format!("export {{}};\n{decls}\nconst __r = {expr};\n");
+    check_source_strict_codes(&source)
+}
+
+// ── String enums are not arithmetic operands (the headline regression) ──────
+
+#[test]
+fn string_enum_left_operand_reports_ts2362() {
+    // `StrColor.Red - 1`: left is a string enum -> TS2362, right is fine.
+    let codes = check_expr(
+        "enum StrColor { Red = \"r\", Blue = \"b\" }",
+        "StrColor.Red - 1",
+    );
+    assert_eq!(
+        count(&codes, 2362),
+        1,
+        "string-enum left operand must report TS2362: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2363),
+        0,
+        "numeric-literal right operand is valid: {codes:?}"
+    );
+}
+
+#[test]
+fn string_enum_right_operand_reports_ts2363() {
+    let codes = check_expr(
+        "enum Suit { Hearts = \"h\", Spades = \"s\" }",
+        "10 * Suit.Hearts",
+    );
+    assert_eq!(
+        count(&codes, 2363),
+        1,
+        "string-enum right operand must report TS2363: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2362),
+        0,
+        "numeric-literal left operand is valid: {codes:?}"
+    );
+}
+
+#[test]
+fn both_string_enum_operands_report_both_sides() {
+    let codes = check_expr("enum A { X = \"x\" }\nenum B { Y = \"y\" }", "A.X - B.Y");
+    assert_eq!(
+        count(&codes, 2362),
+        1,
+        "left string enum -> TS2362: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2363),
+        1,
+        "right string enum -> TS2363: {codes:?}"
+    );
+}
+
+#[test]
+fn string_enum_with_any_other_operand_still_reports() {
+    // The other operand being `any` must not suppress the invalid string enum:
+    // tsc checks each operand independently.
+    let lhs = check_expr("enum E { A = \"a\" }\ndeclare const x: any;", "E.A & x");
+    assert_eq!(
+        count(&lhs, 2362),
+        1,
+        "string-enum left + any right -> TS2362: {lhs:?}"
+    );
+    let rhs = check_expr("enum E { A = \"a\" }\ndeclare const x: any;", "x & E.A");
+    assert_eq!(
+        count(&rhs, 2363),
+        1,
+        "any left + string-enum right -> TS2363: {rhs:?}"
+    );
+}
+
+// ── Numeric enums remain valid arithmetic operands (no false positive) ──────
+
+#[test]
+fn numeric_enum_operands_are_valid() {
+    let codes = check_expr("enum Dir { Up = 1, Down = 2 }", "Dir.Up - Dir.Down");
+    assert_eq!(
+        count(&codes, 2362),
+        0,
+        "numeric enum is a valid operand: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2363),
+        0,
+        "numeric enum is a valid operand: {codes:?}"
+    );
+}
+
+#[test]
+fn numeric_enum_with_number_is_valid() {
+    let codes = check_expr("enum Lvl { Lo = 0, Hi = 9 }", "Lvl.Hi * 3");
+    assert_eq!(
+        count(&codes, 2362) + count(&codes, 2363),
+        0,
+        "numeric enum * number is valid: {codes:?}"
+    );
+}
+
+// ── never-paired: the invalid operand is still reported ─────────────────────
+
+#[test]
+fn never_paired_invalid_operand_is_reported() {
+    // `string - never`: left invalid -> TS2362; `never` is assignable to
+    // number|bigint so the right side is fine. Previously the evaluator
+    // short-circuited on `never` and emitted nothing.
+    let left = check_expr("declare const s: string;\ndeclare const n: never;", "s - n");
+    assert_eq!(
+        count(&left, 2362),
+        1,
+        "string - never must report TS2362 on the string: {left:?}"
+    );
+    assert_eq!(
+        count(&left, 2363),
+        0,
+        "never right operand is valid: {left:?}"
+    );
+
+    let right = check_expr("declare const s: string;\ndeclare const n: never;", "n - s");
+    assert_eq!(
+        count(&right, 2363),
+        1,
+        "never - string must report TS2363 on the string: {right:?}"
+    );
+    assert_eq!(
+        count(&right, 2362),
+        0,
+        "never left operand is valid: {right:?}"
+    );
+}
+
+// ── unknown-paired: the other operand is still checked alongside TS18046 ─────
+
+#[test]
+fn unknown_paired_operand_still_checks_other_side() {
+    // `unknown - string`: unknown -> TS18046 (and is treated as valid), but the
+    // string operand must still report TS2363. Previously the unknown branch
+    // short-circuited before the other operand was checked.
+    let codes = check_expr(
+        "declare const u: unknown;\ndeclare const s: string;",
+        "u - s",
+    );
+    assert_eq!(
+        count(&codes, 18046),
+        1,
+        "unknown operand reports TS18046: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2363),
+        1,
+        "the string operand is still invalid -> TS2363: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2362),
+        0,
+        "unknown side is not an arithmetic-operand error: {codes:?}"
+    );
+}
+
+// ── Other invalid primitives across the operator families ───────────────────
+
+#[test]
+fn invalid_primitive_operands_report_per_side() {
+    for op in ["-", "*", "/", "%", "**", "&", "|", "^", "<<", ">>", ">>>"] {
+        let codes = check_expr(
+            "declare const s: string;\ndeclare const n: number;",
+            &format!("s {op} n"),
+        );
+        assert_eq!(
+            count(&codes, 2362),
+            1,
+            "`string {op} number` must report TS2362: {codes:?}"
+        );
+        assert_eq!(
+            count(&codes, 2363),
+            0,
+            "number right operand is valid for `{op}`: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn object_and_void_operands_are_invalid() {
+    let obj = check_expr(
+        "declare const o: { x: number };\ndeclare const n: number;",
+        "o * n",
+    );
+    assert_eq!(count(&obj, 2362), 1, "object operand -> TS2362: {obj:?}");
+
+    let void = check_expr("declare const v: void;\ndeclare const n: number;", "v - n");
+    assert_eq!(count(&void, 2362), 1, "void operand -> TS2362: {void:?}");
+}
+
+// ── Boolean bitwise stays TS2447, not the per-operand error ─────────────────
+
+#[test]
+fn boolean_bitwise_reports_ts2447_not_per_operand() {
+    let codes = check_expr(
+        "declare const a: boolean;\ndeclare const b: boolean;",
+        "a & b",
+    );
+    assert_eq!(
+        count(&codes, 2447),
+        1,
+        "boolean & boolean -> TS2447: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2362) + count(&codes, 2363),
+        0,
+        "no per-operand error when TS2447 fires: {codes:?}"
+    );
+}
+
+#[test]
+fn boolean_with_any_bitwise_reports_per_operand_not_ts2447() {
+    // `boolean & any`: `any` is not `BooleanLike`, so tsc does NOT emit the
+    // boolean-operator suggestion; the boolean operand is reported via TS2362.
+    let left = check_expr("declare const a: boolean;\ndeclare const b: any;", "a & b");
+    assert_eq!(
+        count(&left, 2362),
+        1,
+        "boolean & any -> TS2362 on the boolean: {left:?}"
+    );
+    assert_eq!(
+        count(&left, 2447),
+        0,
+        "TS2447 must not fire when one side is any: {left:?}"
+    );
+
+    let right = check_expr("declare const a: boolean;\ndeclare const b: any;", "b & a");
+    assert_eq!(
+        count(&right, 2363),
+        1,
+        "any & boolean -> TS2363 on the boolean: {right:?}"
+    );
+}
+
+// ── Valid numeric/bigint pairs produce no per-operand error ─────────────────
+
+#[test]
+fn valid_numeric_and_bigint_pairs_have_no_operand_error() {
+    let num = check_expr(
+        "declare const a: number;\ndeclare const b: number;",
+        "a - b",
+    );
+    assert_eq!(
+        count(&num, 2362) + count(&num, 2363),
+        0,
+        "number - number is clean: {num:?}"
+    );
+
+    let big = check_expr(
+        "declare const a: bigint;\ndeclare const b: bigint;",
+        "a * b",
+    );
+    assert_eq!(
+        count(&big, 2362) + count(&big, 2363),
+        0,
+        "bigint * bigint is clean: {big:?}"
+    );
+}
+
+// ── Anti-hardcoding: rename every binder; behavior is structural ────────────
+
+#[test]
+fn string_enum_operand_rule_is_binder_name_independent() {
+    let a = check_expr("enum Palette { Crimson = \"c\" }", "Palette.Crimson - 2");
+    let b = check_expr("enum Mood { Calm = \"q\" }", "Mood.Calm - 2");
+    assert_eq!(count(&a, 2362), 1, "{a:?}");
+    assert_eq!(count(&b, 2362), 1, "{b:?}");
+    assert_eq!(
+        a, b,
+        "diagnostic codes must not depend on binder names: {a:?} vs {b:?}"
+    );
+}

--- a/crates/tsz-solver/src/operations/binary_ops.rs
+++ b/crates/tsz-solver/src/operations/binary_ops.rs
@@ -1351,6 +1351,21 @@ impl<'a> BinaryOpEvaluator<'a> {
         visitor.visit_type(self.interner, type_id)
     }
 
+    /// Strict boolean-like test mirroring tsc's `type.flags & BooleanLike`:
+    /// `boolean` and the boolean literals `true`/`false` only — NOT `any`
+    /// (which tsc classifies as `AnyOrUnknown`, never `BooleanLike`).
+    ///
+    /// This is what gates the TS2447 "operator is not allowed for boolean types"
+    /// suggestion: `boolean & any` must report the per-operand TS2362, not the
+    /// boolean-operator suggestion, so the gate cannot treat `any` as boolean.
+    pub fn is_boolean_like_strict(&self, type_id: TypeId) -> bool {
+        if type_id == TypeId::BOOLEAN {
+            return true;
+        }
+        let mut visitor = BooleanLikeVisitor { _db: self.interner };
+        visitor.visit_type(self.interner, type_id)
+    }
+
     /// Check if a type is a valid operand for string concatenation.
     /// Valid operands are: string, number, boolean, bigint, null, undefined, void, any.
     fn is_valid_string_concat_operand(&self, type_id: TypeId) -> bool {


### PR DESCRIPTION
Fixes #14699.

## What

tsc's `checkArithmeticOperandType` validates each operand of an arithmetic
(`- * / % **`) or bitwise (`& | ^ << >> >>>`) operator **independently** — each
side must be assignable to `number | bigint` (after `checkNonNullType`, which
turns an unknown-under-`strictNullChecks` operand into `error` and strips
`null`/`undefined`). Numeric values (number, **numeric** enums, bigint) and the
wildcards any/unknown/error/never are valid; string, boolean, object, symbol,
void, string literals and **string enums** are not.

tsz only ran a per-operand check when one operand was already `any`/`error`,
treated **every** enum (including string enums) as valid, and short-circuited on
an `unknown` operand before checking the other side — so it silently accepted
e.g. `stringEnum - 1`, `numEnum - stringEnum`, `stringEnum & any`,
`string - never`, `string & never`, and the string side of `unknown - string`.

## Structural rule

> When an operand of an arithmetic (`- * / % **`) or bitwise (`& | ^ << >> >>>`)
> operator is not assignable to `number | bigint` (and is not a wildcard), tsc
> reports TS2362 (left) / TS2363 (right) for that operand, independently of the
> other operand and of the operator's result type.

## Owner layer

`tsz_checker` — diagnostic ownership. A new `emit_arithmetic_operand_errors`
(`error_reporter/operator_errors.rs`) becomes the single owner of TS2362/TS2363
for arithmetic/bitwise operators and runs once, up-front, in the binary-expression
handler (`types/computation/binary.rs`), before the operator-specific code that
otherwise short-circuits on `unknown`/`never` or defers to the binary-op
evaluator. The numeric-vs-string enum distinction is delegated to the existing
structural `BinaryOpEvaluator::is_arithmetic_operand` (no enum name/shape
special-casing). The redundant `any`-gated blocks and the over-broad
`is_enum_type` acceptance are removed; `emit_binary_operator_error` keeps
ownership of the whole-expression TS2365 ("operator cannot be applied to types")
for the mixed number/bigint case. A strict `is_boolean_like_strict` (excluding
`any`) gates the TS2447 boolean-operator suggestion, so `boolean & any` reports
the per-operand TS2362 rather than TS2447.

## Adjacent-case matrix

`crates/tsz-checker/tests/arithmetic_operand_validity_tests.rs` covers: string
vs numeric enums (left/right/both, and paired with `any`), `never`-paired and
`unknown`-paired operands, object/`void` operands, every operator in the
arithmetic+bitwise family, the boolean-bitwise TS2447 path, `boolean & any`,
valid number/bigint pairs (no false positive), and binder-name independence
(anti-hardcoding).

## Anti-hardcoding

No new user-name/file-name literals; the enum decision is structural
(`is_arithmetic_operand` already classifies numeric enums via their
`NumberLiteral` members and rejects string enums) rather than a coarse
`is_enum_type` check or a formatted-message predicate. Tests vary binder names.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New conformance suite: `cargo test -p tsz-checker --test arithmetic_operand_validity_tests` → 14/14 pass.
- 1,445-case `tsc`-vs-tsz operator matrix (arithmetic+bitwise × every operand kind): strict mismatches 240 → 74, non-strict 506 → 396, with **zero** residual TS2362/TS2363 deltas (remaining deltas are the pre-existing, out-of-scope TS2365 mixed-bigint/enum, TS2469 `+`/symbol, and TS18046/18047/18048 null/undefined families). No regressions; `boolean & any` regression caught and fixed during review.
- Existing diagnostic-parity suites unaffected: `conformance_issues_errors` (296), `conformance_issues_types` (422), `conformance_issues_features` (370), `deferred_conditional_arithmetic_operand_tests` (7) all pass; the only failing checker suites (operator-display/widen/relational, generic-call-inference) fail identically on clean `main` (environment-related, unrelated to this change).
- `cargo clippy -p tsz-solver -p tsz-checker --tests` clean; broad conformance/emit/fourslash via ready-review CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J58ykajuhJJWitsisM3K3J)_