### PR TITLE
fix(checker): match tsc's cannot-find-name lib/install hint sets (TS2584/2591/2592/2593)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "cannot_find_name_lib_hint_parity_tests"
+path = "tests/cannot_find_name_lib_hint_parity_tests.rs"
+[[test]]
 name = "generic_interface_target_property_elaboration_tests"
 path = "tests/generic_interface_target_property_elaboration_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/name_resolution.rs
+++ b/crates/tsz-checker/src/error_reporter/name_resolution.rs
@@ -1073,21 +1073,22 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// Emit the "install @types/X" diagnostic for a missing global whose
-    /// category is reported the same way in value and type position: Node.js
-    /// (TS2591), jQuery, a test runner, or Bun. Returns `true` if a diagnostic
-    /// was emitted; `false` when `name` is not such a global (or a Node
-    /// special-case falls through), so callers emit their own position-correct
-    /// plain `Cannot find name` (TS2304).
+    /// Emit the position-independent "cannot find name" hint for a missing
+    /// global whose category tsc reports the same way in value and type
+    /// position: Node.js (TS2591), jQuery, a test runner, Bun, or a `dom`-lib
+    /// global (TS2584, the fixed `{document, console}` set). Returns `true` if a
+    /// diagnostic was emitted; `false` when `name` is not such a global (or a
+    /// Node special-case falls through), so callers emit their own
+    /// position-correct plain `Cannot find name` (TS2304).
     ///
-    /// The es2015 "change target library" (TS2583) and DOM cases are
-    /// intentionally NOT handled here: tsc's choice there depends on
-    /// value-vs-type position (the es2015 value-lib gate, and
-    /// `check_missing_global_types` for type position), and type position
-    /// already matches tsc for those. This helper is the single source of truth
-    /// for the position-independent categories, shared by the value path
-    /// ([`error_cannot_find_name_at`]) and the type-position name-resolution
-    /// failure arm.
+    /// The es2015 "change target library" (TS2583) case is intentionally NOT
+    /// handled here: tsc gates it on value-vs-type position (the es2015
+    /// value-lib gate in the value path, and `check_missing_global_types` for
+    /// type position). The `{document, console}` DOM hint, by contrast, is
+    /// emitted by tsc in BOTH positions (`getCannotFindNameDiagnosticForName`
+    /// keys purely on the name), so it lives here as a position-independent
+    /// category, shared by the value path ([`error_cannot_find_name_at`]) and
+    /// the type-position name-resolution failure arm.
     pub(crate) fn try_emit_install_types_for_missing_global(
         &mut self,
         name: &str,
@@ -1098,6 +1099,14 @@ impl<'a> CheckerState<'a> {
             return false;
         };
         match cap_diag {
+            CapabilityDiagnostic::MissingDomGlobal { .. } => {
+                // `document`/`console` without the dom lib: tsc emits TS2584 in
+                // both value and type position. The value path also reaches this
+                // via its own DOM arm, but routing it here keeps the type path
+                // (which would otherwise fall to plain TS2304) at parity.
+                self.error_cannot_find_name_change_target_lib(name, idx);
+                true
+            }
             CapabilityDiagnostic::MissingNodeGlobal { .. } => {
                 // Private-name access bases and `module` amid parse errors fall
                 // through to plain TS2304, matching tsc and the value path.

--- a/crates/tsz-checker/src/query_boundaries/capabilities.rs
+++ b/crates/tsz-checker/src/query_boundaries/capabilities.rs
@@ -272,10 +272,12 @@ impl EnvironmentCapabilities {
 /// globals in tsc. They stay plain TS2304 when used as identifiers; module
 /// specifier diagnostics use [`is_known_node_module`] instead.
 pub(crate) fn is_known_node_global(name: &str) -> bool {
-    matches!(
-        name,
-        "require" | "exports" | "module" | "process" | "Buffer" | "__filename" | "__dirname"
-    )
+    // Mirror tsc's `getCannotFindNameDiagnosticForName` node case exactly:
+    // `process`, `require`, `Buffer`, `module`, `NodeJS`. Names like `exports`,
+    // `__filename`, and `__dirname` are CommonJS wrapper locals that tsc reports
+    // as plain TS2304 (they are not on the switch), so they must NOT be here or
+    // we emit a spurious "install @types/node" hint for them.
+    matches!(name, "process" | "require" | "Buffer" | "module" | "NodeJS")
 }
 
 /// Check if a module specifier is a known Node.js built-in module (TS2591).
@@ -384,97 +386,18 @@ fn is_node_scheme_only_builtin(name: &str) -> bool {
     matches!(name, "test" | "test/reporters" | "sea" | "sqlite")
 }
 
-/// Check if a name is a known DOM/ScriptHost global that requires 'dom' lib (TS2584).
+/// Check if a name is a known DOM global whose absence tsc reports with the
+/// "change your target library? Try changing the 'lib' compiler option to
+/// include 'dom'" hint (TS2584).
+///
+/// tsc does NOT suggest `dom` for every name that happens to live in the dom
+/// lib — `window`, `HTMLElement`, `fetch`, `setTimeout`, … all fall through to
+/// plain TS2304. The hint is gated to a fixed two-name set baked into
+/// `getCannotFindNameDiagnosticForName` (checker.ts): `document` and `console`.
+/// Mirror that exactly so we don't over-emit TS2584 on every front-end project
+/// compiled without the dom lib.
 pub(crate) fn is_known_dom_global(name: &str) -> bool {
-    matches!(
-        name,
-        "window"
-            | "document"
-            | "console"
-            | "setTimeout"
-            | "clearTimeout"
-            | "setInterval"
-            | "clearInterval"
-            | "requestAnimationFrame"
-            | "cancelAnimationFrame"
-            | "alert"
-            | "confirm"
-            | "prompt"
-            | "fetch"
-            | "navigator"
-            | "location"
-            | "localStorage"
-            | "sessionStorage"
-            | "XMLHttpRequest"
-            | "HTMLElement"
-            | "HTMLDivElement"
-            | "HTMLInputElement"
-            | "HTMLButtonElement"
-            | "HTMLFormElement"
-            | "HTMLImageElement"
-            | "HTMLAnchorElement"
-            | "HTMLTableElement"
-            | "HTMLCanvasElement"
-            | "HTMLVideoElement"
-            | "HTMLAudioElement"
-            | "HTMLSelectElement"
-            | "HTMLTextAreaElement"
-            | "Event"
-            | "MouseEvent"
-            | "KeyboardEvent"
-            | "TouchEvent"
-            | "FocusEvent"
-            | "CustomEvent"
-            | "EventTarget"
-            | "Node"
-            | "NodeList"
-            | "Element"
-            | "Document"
-            | "DocumentFragment"
-            | "MutationObserver"
-            | "IntersectionObserver"
-            | "ResizeObserver"
-            | "URL"
-            | "URLSearchParams"
-            | "AbortController"
-            | "AbortSignal"
-            | "FormData"
-            | "Headers"
-            | "Request"
-            | "Response"
-            | "Blob"
-            | "File"
-            | "FileReader"
-            | "FileList"
-            | "Worker"
-            | "ServiceWorker"
-            | "WebSocket"
-            | "Performance"
-            | "PerformanceObserver"
-            | "Crypto"
-            | "SubtleCrypto"
-            | "TextEncoder"
-            | "TextDecoder"
-            | "DOMParser"
-            | "Selection"
-            | "Range"
-            | "SVGElement"
-            | "CSSStyleDeclaration"
-            | "MediaQueryList"
-            | "CanvasRenderingContext2D"
-            | "WebGLRenderingContext"
-            | "AudioContext"
-            | "OfflineAudioContext"
-            | "BroadcastChannel"
-            | "MessageChannel"
-            | "MessagePort"
-            | "ReadableStream"
-            | "WritableStream"
-            | "TransformStream"
-            | "CompressionStream"
-            | "DecompressionStream"
-            | "StructuredSerializeOptions"
-    )
+    matches!(name, "document" | "console")
 }
 
 /// Check if a known environment value should be reported as plain TS2304 when
@@ -484,13 +407,19 @@ pub(crate) fn is_known_plain_missing_global_value(name: &str) -> bool {
 }
 
 /// Check if a name is a known jQuery global that requires @types/jquery (TS2581/TS2592).
+///
+/// tsc's `getCannotFindNameDiagnosticForName` only special-cases `$`; the bare
+/// `jQuery` identifier is reported as plain TS2304, so it must NOT be here.
 pub(crate) fn is_known_jquery_global(name: &str) -> bool {
-    matches!(name, "$" | "jQuery")
+    matches!(name, "$")
 }
 
 /// Check if a name is a known test runner global that requires @types/jest or @types/mocha (TS2582/TS2593).
+///
+/// Mirrors tsc's `getCannotFindNameDiagnosticForName` test-runner case exactly:
+/// `beforeEach`, `describe`, `suite`, `it`, `test`.
 pub(crate) fn is_known_test_runner_global(name: &str) -> bool {
-    matches!(name, "describe" | "suite" | "it" | "test")
+    matches!(name, "beforeEach" | "describe" | "suite" | "it" | "test")
 }
 
 #[cfg(test)]

--- a/crates/tsz-checker/src/types/computation/identifier/resolution.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/resolution.rs
@@ -104,7 +104,24 @@ impl<'a> CheckerState<'a> {
                     _ => {}
                 }
             }
-            self.error_cannot_find_name_install_node_types(name, idx);
+            // Non-JS (`.ts`) fallthrough. tsc's `getCannotFindNameDiagnosticForName`
+            // gives the "@types/node" hint (TS2591) only to `module` / `require`
+            // here; `exports`, `__dirname`, and `__filename` are CommonJS wrapper
+            // locals reported as plain TS2304 (`process` / `Buffer` / `NodeJS`
+            // never reach this branch — they are not CommonJS wrapper locals and
+            // are routed through the shared install-hint dispatch).
+            match name {
+                "module" | "require" => {
+                    self.error_cannot_find_name_install_node_types(name, idx);
+                }
+                _ => {
+                    self.error_at_node_msg(
+                        idx,
+                        crate::diagnostics::diagnostic_codes::CANNOT_FIND_NAME,
+                        &[name],
+                    );
+                }
+            }
             return TypeId::ERROR;
         }
 
@@ -256,7 +273,24 @@ impl<'a> CheckerState<'a> {
         }
 
         let first_char = name.chars().next().unwrap_or('a');
-        if first_char.is_uppercase() || self.is_known_global_value_name(name) {
+        // A genuinely-missing *known global* (lib + binder lookup already failed
+        // above, and it is not one of the lib/install-hint categories handled in
+        // the match) is a real "cannot find name": `tsc` reports TS2304 for it,
+        // e.g. `window` / `fetch` / `URL` without the `dom` lib. Only a
+        // *non-global* uppercase identifier stays `any` here — it may be a
+        // not-yet-resolved user type, where suppressing TS2304 avoids a cascade.
+        // Known globals fall through to `report_not_found_at_boundary` so the
+        // diagnostic is actually emitted (previously they returned `any` and
+        // silently dropped the error — masked only because the over-broad DOM
+        // classifier used to mis-route them to TS2584).
+        //
+        // `globalThis` is the exception: it is the ambient global-object
+        // reference, in scope under every `lib`/`target` (tsc never reports it
+        // as missing), so it keeps the `any` fallback rather than gaining a
+        // spurious TS2304.
+        if name == "globalThis"
+            || (first_char.is_uppercase() && !self.is_known_global_value_name(name))
+        {
             return TypeId::ANY;
         }
 

--- a/crates/tsz-checker/tests/cannot_find_name_lib_hint_parity_tests.rs
+++ b/crates/tsz-checker/tests/cannot_find_name_lib_hint_parity_tests.rs
@@ -1,0 +1,173 @@
+//! Parity for the "cannot find name" lib/install hint selection (TS2584 /
+//! TS2591 / TS2592 / TS2593 vs plain TS2304).
+//!
+//! Structural rule: when a value- or type-position name fails to resolve, `tsc`
+//! picks the diagnostic via `getCannotFindNameDiagnosticForName` (checker.ts) —
+//! a *fixed name switch*, not a "does this name live in some unloaded lib"
+//! query. Only a small curated set gets a hint; everything else is plain
+//! TS2304. tsz's classifier lists had drifted broad, so a front-end project
+//! compiled without the `dom` lib got a spurious "include 'dom'" (TS2584) on
+//! every `window` / `HTMLElement` / `fetch` reference. These tests pin the
+//! exact `tsc` sets:
+//!
+//! - TS2584 (`include 'dom'`): exactly `document`, `console`.
+//! - TS2591 (`@types/node`):   exactly `process`, `require`, `Buffer`,
+//!   `module`, `NodeJS` — NOT `exports` / `__filename` / `__dirname`.
+//! - TS2592 (`@types/jquery`): exactly `$` — NOT the bare `jQuery` identifier.
+//! - TS2593 (test runner):     `beforeEach`, `describe`, `suite`, `it`, `test`.
+//!
+//! Owner: `tsz_checker::query_boundaries::capabilities` classifiers + the
+//! name-resolution error reporter.
+//!
+//! The hints are keyed purely on the name, so `tsc` emits them identically in
+//! value and type position. These tests exercise **type position** because the
+//! checker-only test harness (`check_source_with_libs`) routes type-position
+//! name-resolution through the same shared
+//! `try_emit_install_types_for_missing_global` dispatch the CLI uses, whereas
+//! the value-position expression path resolves unknown uppercase/known-global
+//! identifiers to `any` without re-running the install-hint dispatch in this
+//! harness. End-to-end value-position parity is locked by the CLI driver tests
+//! (`crates/tsz-cli/tests/driver_tests_parts`). The one value-position case the
+//! checker harness does drive directly — the `{document, console}` DOM hint —
+//! is asserted below as well.
+
+use std::sync::Arc;
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_lib_files};
+
+/// es5 + es2015 base globals, but deliberately **no** `dom` lib, so DOM names
+/// are genuinely unresolved and exercise the cannot-find-name hint path.
+fn dom_less_libs() -> Vec<Arc<LibFile>> {
+    load_lib_files(&[
+        "es5.d.ts",
+        "es2015.d.ts",
+        "es2015.core.d.ts",
+        "es2015.collection.d.ts",
+        "es2015.iterable.d.ts",
+        "es2015.generator.d.ts",
+        "es2015.promise.d.ts",
+        "es2015.symbol.d.ts",
+        "es2015.symbol.wellknown.d.ts",
+    ])
+}
+
+fn strict() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..Default::default()
+    }
+}
+
+/// Return the diagnostic code emitted for the unresolved `name` referenced in
+/// `source`, restricted to the cannot-find-name family so unrelated lib noise
+/// (TS2318 missing-global-type, etc.) does not interfere.
+fn cannot_find_code(source: &str, name: &str) -> Option<u32> {
+    let libs = dom_less_libs();
+    let needle = format!("'{name}'");
+    check_source_with_libs_code_messages(source, "test.ts", strict(), &libs)
+        .into_iter()
+        .filter(|(code, _)| matches!(code, 2304 | 2584 | 2591 | 2592 | 2593 | 2583 | 2552 | 2868))
+        .find(|(_, msg)| msg.contains(&needle))
+        .map(|(code, _)| code)
+}
+
+/// Type-position probe: `let x: NAME;`. The install/lib hints key purely on the
+/// name, so this is the same selection the value path makes in the real CLI.
+fn type_code(name: &str) -> Option<u32> {
+    cannot_find_code(&format!("let v: {name};"), name)
+}
+
+/// Value-position probe: `const x: NAME = …`-style reference.
+fn value_code(name: &str) -> Option<u32> {
+    cannot_find_code(&format!("const v = {name};"), name)
+}
+
+// ---------------------------------------------------------------------------
+// DOM (TS2584): exactly `document` and `console`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dom_hint_only_for_document_and_console() {
+    // Both positions: `getCannotFindNameDiagnosticForName` keys on the name.
+    assert_eq!(value_code("document"), Some(2584));
+    assert_eq!(value_code("console"), Some(2584));
+    assert_eq!(type_code("document"), Some(2584));
+    assert_eq!(type_code("console"), Some(2584));
+}
+
+#[test]
+fn other_dom_globals_are_plain_ts2304() {
+    // The previous broad classifier emitted TS2584 for every one of these.
+    for name in [
+        "HTMLElement",
+        "Element",
+        "Event",
+        "URL",
+        "AbortController",
+        "Document",
+    ] {
+        assert_eq!(
+            type_code(name),
+            Some(2304),
+            "expected plain TS2304 for dom global `{name}`, not a TS2584 dom hint",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Node (TS2591): exactly process / require / Buffer / module / NodeJS.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn node_hint_for_curated_node_globals() {
+    for name in ["Buffer", "NodeJS"] {
+        assert_eq!(
+            type_code(name),
+            Some(2591),
+            "expected TS2591 @types/node hint for `{name}`",
+        );
+    }
+}
+
+#[test]
+fn commonjs_wrapper_locals_are_plain_ts2304() {
+    // `__filename` / `__dirname` are NOT on tsc's switch — plain TS2304, no
+    // @types/node hint.
+    for name in ["__filename", "__dirname"] {
+        assert_eq!(
+            type_code(name),
+            Some(2304),
+            "expected plain TS2304 for CommonJS wrapper local `{name}`",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// jQuery (TS2592): exactly `$`, not the bare `jQuery` identifier.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn jquery_hint_only_for_dollar() {
+    assert_eq!(type_code("$"), Some(2592));
+    assert_eq!(
+        type_code("jQuery"),
+        Some(2304),
+        "bare `jQuery` is plain TS2304 in tsc, not a jQuery install hint",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test runner (TS2593): includes `beforeEach`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_runner_hint_includes_before_each() {
+    for name in ["beforeEach", "describe", "suite", "it", "test"] {
+        assert_eq!(
+            type_code(name),
+            Some(2593),
+            "expected TS2593 test-runner hint for `{name}`",
+        );
+    }
+}

--- a/crates/tsz-checker/tests/environment_capabilities_tests.rs
+++ b/crates/tsz-checker/tests/environment_capabilities_tests.rs
@@ -64,17 +64,15 @@ fn test_node_global_process_classified_correctly() {
         Some(MissingGlobalKind::NodeGlobal)
     );
     assert_eq!(
-        caps.classify_missing_global("__filename"),
+        caps.classify_missing_global("NodeJS"),
         Some(MissingGlobalKind::NodeGlobal)
     );
-    assert_eq!(
-        caps.classify_missing_global("__dirname"),
-        Some(MissingGlobalKind::NodeGlobal)
-    );
-    assert_eq!(
-        caps.classify_missing_global("exports"),
-        Some(MissingGlobalKind::NodeGlobal)
-    );
+    // `exports`, `__filename`, and `__dirname` are CommonJS wrapper locals that
+    // tsc reports as plain TS2304 (not on `getCannotFindNameDiagnosticForName`),
+    // so they must NOT classify as Node globals.
+    assert_eq!(caps.classify_missing_global("__filename"), None);
+    assert_eq!(caps.classify_missing_global("__dirname"), None);
+    assert_eq!(caps.classify_missing_global("exports"), None);
 }
 
 // =============================================================================
@@ -337,20 +335,18 @@ fn test_capabilities_classify_global_names() {
         caps.classify_missing_global("require"),
         Some(MissingGlobalKind::NodeGlobal)
     );
-    assert_eq!(
-        caps.classify_missing_global("__dirname"),
-        Some(MissingGlobalKind::NodeGlobal)
-    );
+    // `__dirname` is a CommonJS wrapper local — plain TS2304 in tsc, not a
+    // Node-types suggestion.
+    assert_eq!(caps.classify_missing_global("__dirname"), None);
 
-    // DOM globals
+    // DOM globals: tsc gates the TS2584 "include dom" hint to exactly
+    // `document` and `console`. Other dom-lib names (`window`, `HTMLElement`,
+    // `fetch`, …) are plain TS2304.
     assert_eq!(
         caps.classify_missing_global("document"),
         Some(MissingGlobalKind::DomGlobal)
     );
-    assert_eq!(
-        caps.classify_missing_global("window"),
-        Some(MissingGlobalKind::DomGlobal)
-    );
+    assert_eq!(caps.classify_missing_global("window"), None);
     assert_eq!(
         caps.classify_missing_global("crypto"),
         Some(MissingGlobalKind::PlainGlobalValue)
@@ -445,7 +441,7 @@ fn test_capability_diagnostic_node_global_availability() {
     let caps = EnvironmentCapabilities::from_options(&CheckerOptions::default(), true);
 
     // Node globals produce the missing-node-global diagnostic via diagnose_missing_name.
-    for name in &["require", "process", "Buffer", "__filename", "__dirname"] {
+    for name in &["require", "process", "Buffer", "module", "NodeJS"] {
         let diag = caps.diagnose_missing_name(name);
         assert!(
             matches!(diag, Some(CapabilityDiagnostic::MissingNodeGlobal { .. })),


### PR DESCRIPTION
Fixes #14701

## What

When a value- or type-position name fails to resolve, `tsc` selects the "cannot find name" diagnostic via `getCannotFindNameDiagnosticForName` (checker.ts) — a **fixed name switch**, not a "does this name live in some unloaded lib" query. tsz's curated classifier lists had drifted broad, so a front-end project compiled without the `dom` lib emitted a spurious **TS2584** ("change your target library? ...include 'dom'") on *every* `window` / `HTMLElement` / `fetch` / `setTimeout` reference (~80 names), with further mismatches in the node, jQuery, and test-runner sets.

## Structural rule

`When a name fails to resolve, tsc keys the cannot-find diagnostic purely on the name (same in value and type position); tsz must mirror the exact sets.`

| Hint | tsc set (now matched) |
| --- | --- |
| TS2584 (`include 'dom'`) | `document`, `console` |
| TS2591 (`@types/node`) | `process`, `require`, `Buffer`, `module`, `NodeJS` |
| TS2592 (`@types/jquery`) | `$` |
| TS2593 (test runner) | `beforeEach`, `describe`, `suite`, `it`, `test` |
| TS2583 (`change target library`) | already correct — unchanged |

Everything else → plain TS2304.

## Changes (owner layer: checker / capability boundary)

- `query_boundaries/capabilities.rs`: narrow `is_known_dom_global` → `{document, console}`; correct `is_known_node_global` → `{process, require, Buffer, module, NodeJS}` (drop CommonJS wrapper locals, add `NodeJS`); `is_known_jquery_global` → `{$}`; add `beforeEach` to the test-runner set.
- `error_reporter/name_resolution.rs`: route the `{document, console}` DOM hint through the shared position-independent dispatch so it fires in **type** position too (previously dropped to plain TS2304).
- `types/computation/identifier/resolution.rs`: split the value-position node path so `module`/`require` keep TS2591 while `exports`/`__filename`/`__dirname` are plain TS2304; make the known-global "not found" fallback emit TS2304 instead of silently returning `any` for genuinely-missing web globals (`globalThis` keeps its `any` fallback as an always-available ambient).

## Adjacent-case matrix

Renamed/varied names exercised across both positions: web globals (`window`/`HTMLElement`/`fetch`/`URL`/`AbortController`/…), node (`process`/`require`/`Buffer`/`module`/`NodeJS` vs `exports`/`__filename`/`__dirname`), jQuery (`$` vs bare `jQuery`), test runner (incl. `beforeEach`), es2015 control set (`Map`/`Promise`/`Reflect`/`BigInt`), and ambient `globalThis`. No fixture-name or source-text predicates introduced; all decisions are name-keyed against tsc's switch.

## Verification

- Differential probe vs `tsc` over ~60 globals in **value and type** position: full parity after the fix (was 9+ mismatches); value 47/47, type 15/15.
- `cargo test -p tsz-checker --test cannot_find_name_lib_hint_parity_tests` (new, 6/6) · `--test ts2304_tests` (27/27) · `--test global_type_tests` (41/41).
- `cargo test -p tsz-checker --lib -- capabilities ts2591` (67/67, includes the updated `environment_capabilities_tests` parity assertions).
- Conformance/emit/fourslash floor: owned by ready-review CI.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2PCmTcacYH6upppr2SDTv)_