### PR TITLE
fix(checker): match tsc checkNonNullType operand diagnostics for unary +/-/~ and unnamed nullish operands

### DIFF
--- a/crates/tsz-checker/src/error_reporter/operator_errors.rs
+++ b/crates/tsz-checker/src/error_reporter/operator_errors.rs
@@ -303,45 +303,40 @@ impl<'a> CheckerState<'a> {
                 };
                 self.emit_render_request(idx, DiagnosticRenderRequest::simple_msg(code, &[name]));
             } else {
-                // Non-identifier expression with nullish type — fall back to TS18050
-                let value_name = if cause == TypeId::NULL {
-                    "null"
-                } else if cause == TypeId::UNDEFINED {
-                    "undefined"
-                } else {
-                    "null | undefined"
-                };
-                self.emit_render_request(
-                    idx,
-                    DiagnosticRenderRequest::simple_msg(
-                        diagnostic_codes::THE_VALUE_CANNOT_BE_USED_HERE,
-                        &[value_name],
-                    ),
-                );
+                // Unnamed non-literal expression with a nullish type (a call result,
+                // parenthesized expression, etc.). tsc's `checkNonNullType` reports
+                // these through `reportObjectPossiblyNullOrUndefinedError`, which has no
+                // entity name and so emits TS2531/TS2532/TS2533 ("Object is possibly
+                // 'null'/'undefined'/...") — not the literal-value TS18050. The literal
+                // `null`/`undefined` keyword is handled by the `is_literal` branch above.
+                self.report_nullish_object(idx, cause, false);
             }
         }
     }
 
-    /// Under `strictNullChecks`, emit TS18047/TS18048 if `operand_type` contains
-    /// a nullish union member AND the non-nullish part is arithmetic (number/bigint/enum).
+    /// Under `strictNullChecks`, emit the "possibly null/undefined" operand
+    /// diagnostic when the operand of a unary `+`/`-`/`~` is nullable.
     ///
-    /// When the non-nullish part is non-arithmetic (e.g. `string | undefined`) or absent
-    /// (purely-nullish types like `null` or `undefined` alone), tsc emits TS2362 for the
-    /// type mismatch rather than TS18048 for the nullish member.
+    /// tsc's `checkPrefixUnaryExpression` runs `checkNonNullType(operandType, operand)`
+    /// **unconditionally** for `+`/`-`/`~` — there is no arithmetic-operand check for
+    /// unary arithmetic (that only exists for binary `- * / % **`). So a nullable
+    /// operand always reports TS18047/TS18048/TS18049 (named) or TS2531/TS2532/TS2533
+    /// (unnamed), regardless of the non-nullish remainder's kind: `null`/`undefined`
+    /// alone, `string | undefined`, `object | null`, `symbol | null` (alongside the
+    /// separate TS2469), and type parameters whose constraint is nullable all report.
+    ///
+    /// `void` is not in tsc's `Nullable` flag set, so a `void` operand never triggers
+    /// this (it is handled by the operator-specific paths instead).
     pub(crate) fn check_nullish_unary_operand(&mut self, operand: NodeIndex, operand_type: TypeId) {
         if !self.ctx.strict_null_checks() {
             return;
         }
-        let (non_nullish, nullish_cause) = self.split_nullish_type(operand_type);
-        let Some(cause) = nullish_cause else { return };
-        let evaluator = crate::query_boundaries::common::new_binary_op_evaluator(self.ctx.types);
-        let nullish_can_flow_to_arithmetic = non_nullish.is_some_and(|ty| {
-            let evaluated = self.evaluate_type_with_env(ty);
-            evaluator.is_arithmetic_operand(evaluated) || self.is_enum_like_type(ty)
-        });
-        if nullish_can_flow_to_arithmetic {
-            self.emit_nullish_operand_error(operand, cause);
+        if operand_type == TypeId::VOID {
+            return;
         }
+        let (_non_nullish, nullish_cause) = self.split_nullish_type(operand_type);
+        let Some(cause) = nullish_cause else { return };
+        self.emit_nullish_operand_error(operand, cause);
     }
 
     /// Check if a type is string-like (intrinsic `string` or a string literal).

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1243,6 +1243,9 @@ mod nullish_coalescing_discriminated_union_tests;
 #[path = "../tests/nullish_coalescing_unknown_result_tests.rs"]
 mod nullish_coalescing_unknown_result_tests;
 #[cfg(test)]
+#[path = "../tests/nullish_operand_checknonnull_parity_tests.rs"]
+mod nullish_operand_checknonnull_parity_tests;
+#[cfg(test)]
 #[path = "tests/nullish_target_relation_routing_arch_tests.rs"]
 mod nullish_target_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/tests/nullish_operand_checknonnull_parity_tests.rs
+++ b/crates/tsz-checker/tests/nullish_operand_checknonnull_parity_tests.rs
@@ -1,0 +1,255 @@
+//! Parity tests for tsc's `checkNonNullType` on operator operands.
+//!
+//! Structural rule: under `strictNullChecks`, tsc runs `checkNonNullType` on the
+//! operand(s) of unary `+`/`-`/`~` and of binary arithmetic/relational/bitwise
+//! operators. A nullable operand is reported as:
+//!   * TS18047 / TS18048 / TS18049 ("'<x>' is possibly 'null'/'undefined'/...")
+//!     when the operand is a named entity (identifier, property access, `this`);
+//!   * TS2531 / TS2532 / TS2533 ("Object is possibly 'null'/'undefined'/...")
+//!     when the operand is an unnamed expression (a call result, a parenthesized
+//!     expression, etc.);
+//!   * TS18050 ("The value '<x>' cannot be used here.") only for the literal
+//!     `null` / `undefined` keyword.
+//!
+//! For unary `+`/`-`/`~` this check is UNCONDITIONAL — there is no arithmetic-operand
+//! (TS2362) check for unary arithmetic, so the nullish diagnostic fires regardless of
+//! the non-nullish remainder's kind (`number | undefined`, bare `null`/`undefined`,
+//! `string | undefined`, `object | null`, `symbol | null`, a type parameter with a
+//! nullable constraint, …).
+//!
+//! Owner: `error_reporter/operator_errors.rs` (`check_nullish_unary_operand`,
+//! `emit_nullish_operand_error`).
+
+use crate::test_utils::check_source_strict_codes as strict;
+
+fn has(codes: &[u32], c: u32) -> bool {
+    codes.contains(&c)
+}
+
+// =========================================================================
+// Unary `+`/`-`/`~` on a *named* nullable operand of any non-null kind.
+// =========================================================================
+
+#[test]
+fn unary_on_bare_null_named_emits_ts18047() {
+    for op in ["+", "-", "~"] {
+        let codes = strict(&format!("declare const x: null;\nconst _ = {op}x;\n"));
+        assert!(
+            has(&codes, 18047),
+            "{op}x (x: null) -> TS18047; got {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn unary_on_bare_undefined_named_emits_ts18048() {
+    for op in ["+", "-", "~"] {
+        let codes = strict(&format!("declare const x: undefined;\nconst _ = {op}x;\n"));
+        assert!(
+            has(&codes, 18048),
+            "{op}x (x: undefined) -> TS18048; got {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn unary_on_null_or_undefined_named_emits_ts18049() {
+    for op in ["+", "-", "~"] {
+        let codes = strict(&format!(
+            "declare const x: number | null | undefined;\nconst _ = {op}x;\n"
+        ));
+        assert!(
+            has(&codes, 18049),
+            "{op}x (number|null|undefined) -> TS18049; got {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn unary_on_string_or_undefined_emits_ts18048_not_arithmetic() {
+    // Non-arithmetic non-null remainder: tsc still reports the nullish operand and
+    // there is NO unary TS2362 (unlike binary arithmetic).
+    for op in ["+", "-", "~"] {
+        let codes = strict(&format!(
+            "declare const s: string | undefined;\nconst _ = {op}s;\n"
+        ));
+        assert!(
+            has(&codes, 18048),
+            "{op}s (string|undefined) -> TS18048; got {codes:?}"
+        );
+        assert!(
+            !has(&codes, 2362),
+            "unary {op} must not emit TS2362; got {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn unary_on_object_or_null_emits_ts18047() {
+    for op in ["+", "-", "~"] {
+        let codes = strict(&format!(
+            "declare const o: object | null;\nconst _ = {op}o;\n"
+        ));
+        assert!(
+            has(&codes, 18047),
+            "{op}o (object|null) -> TS18047; got {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn unary_on_symbol_or_null_emits_both_ts18047_and_ts2469() {
+    // The nullish check is independent of the ESSymbol (TS2469) check; both fire.
+    for op in ["+", "-", "~"] {
+        let codes = strict(&format!(
+            "declare const y: symbol | null;\nconst _ = {op}y;\n"
+        ));
+        assert!(
+            has(&codes, 18047),
+            "{op}y (symbol|null) -> TS18047; got {codes:?}"
+        );
+        assert!(
+            has(&codes, 2469),
+            "{op}y (symbol|null) -> TS2469; got {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn unary_on_type_parameter_with_nullable_constraint_reports() {
+    let codes = strict("function f<T extends string | undefined>(t: T) {\n  const _ = +t;\n}\n");
+    assert!(
+        has(&codes, 18048),
+        "+t (T extends string|undefined) -> TS18048; got {codes:?}"
+    );
+    let codes = strict("function f<T extends number | null>(t: T) {\n  const _ = -t;\n}\n");
+    assert!(
+        has(&codes, 18047),
+        "-t (T extends number|null) -> TS18047; got {codes:?}"
+    );
+}
+
+// =========================================================================
+// Unnamed nullish operand -> TS2531/2532/2533 (NOT TS18050).
+// =========================================================================
+
+#[test]
+fn unary_on_unnamed_call_result_emits_object_possibly_code() {
+    let codes = strict("declare function g(): number | undefined;\nconst _ = +g();\n");
+    assert!(
+        has(&codes, 2532),
+        "+g() (number|undefined) -> TS2532; got {codes:?}"
+    );
+    assert!(
+        !has(&codes, 18050),
+        "must not use literal-value TS18050; got {codes:?}"
+    );
+
+    let codes = strict("declare function g(): number | null;\nconst _ = -g();\n");
+    assert!(
+        has(&codes, 2531),
+        "-g() (number|null) -> TS2531; got {codes:?}"
+    );
+}
+
+#[test]
+fn binary_on_unnamed_call_result_emits_object_possibly_code() {
+    // Same `checkNonNullType` rule for binary arithmetic / relational / bitwise.
+    let codes = strict("declare function g(): number | undefined;\nconst _ = g() - 1;\n");
+    assert!(has(&codes, 2532), "g() - 1 -> TS2532; got {codes:?}");
+    assert!(
+        !has(&codes, 18050),
+        "binary unnamed operand must not be TS18050; got {codes:?}"
+    );
+
+    let codes = strict("declare function g(): number | undefined;\nconst _ = g() < 1;\n");
+    assert!(has(&codes, 2532), "g() < 1 -> TS2532; got {codes:?}");
+
+    let codes = strict("declare function g(): number | undefined;\nconst _ = g() & 1;\n");
+    assert!(has(&codes, 2532), "g() & 1 -> TS2532; got {codes:?}");
+}
+
+#[test]
+fn binary_unnamed_nonarithmetic_emits_object_possibly_and_ts2362() {
+    // Binary arithmetic DOES additionally run the arithmetic-operand check (TS2362).
+    let codes = strict("declare function g(): string | undefined;\nconst _ = g() - 1;\n");
+    assert!(
+        has(&codes, 2532),
+        "g():string|undefined - 1 -> TS2532; got {codes:?}"
+    );
+    assert!(
+        has(&codes, 2362),
+        "g():string|undefined - 1 -> TS2362; got {codes:?}"
+    );
+    assert!(!has(&codes, 18050), "got {codes:?}");
+}
+
+// =========================================================================
+// Literal `null`/`undefined` keyword still -> TS18050 (unchanged path).
+// =========================================================================
+
+#[test]
+fn unary_on_literal_null_keyword_keeps_ts18050() {
+    let codes = strict("const _ = +null;\n");
+    assert!(
+        has(&codes, 18050),
+        "+null literal keyword -> TS18050; got {codes:?}"
+    );
+    assert!(
+        !has(&codes, 18047),
+        "literal keeps TS18050 not TS18047; got {codes:?}"
+    );
+}
+
+// =========================================================================
+// Negatives: no false positives.
+// =========================================================================
+
+#[test]
+fn unary_on_void_no_nullish_error() {
+    // `void` is not in tsc's Nullable flag set.
+    for op in ["+", "-", "~"] {
+        let codes = strict(&format!("declare const v: void;\nconst _ = {op}v;\n"));
+        assert!(!has(&codes, 18047) && !has(&codes, 18048) && !has(&codes, 18049));
+        assert!(!has(&codes, 2531) && !has(&codes, 2532) && !has(&codes, 2533));
+    }
+}
+
+#[test]
+fn unary_on_any_no_nullish_error() {
+    for op in ["+", "-", "~"] {
+        let codes = strict(&format!("declare const a: any;\nconst _ = {op}a;\n"));
+        assert!(
+            !has(&codes, 18047) && !has(&codes, 18048) && !has(&codes, 18049),
+            "{codes:?}"
+        );
+    }
+}
+
+#[test]
+fn unary_on_plain_number_no_nullish_error() {
+    for op in ["+", "-", "~"] {
+        let codes = strict(&format!("declare const n: number;\nconst _ = {op}n;\n"));
+        assert!(!has(&codes, 18047) && !has(&codes, 18048), "{codes:?}");
+    }
+}
+
+#[test]
+fn unary_after_narrowing_no_nullish_error() {
+    let codes = strict(
+        "declare const a: number | undefined;\nif (a !== undefined) {\n  const _ = -a;\n}\n",
+    );
+    assert!(
+        !has(&codes, 18048),
+        "narrowed operand -> no TS18048; got {codes:?}"
+    );
+}
+
+#[test]
+fn intersection_with_empty_object_strips_nullability_no_error() {
+    let codes = strict("declare const x: (number | null) & {};\nconst _ = +x;\n");
+    assert!(
+        !has(&codes, 18047),
+        "(number|null) & {{}} is non-null; got {codes:?}"
+    );
+}

--- a/crates/tsz-checker/tests/ts18048_unary_arithmetic_nullish_tests.rs
+++ b/crates/tsz-checker/tests/ts18048_unary_arithmetic_nullish_tests.rs
@@ -1,9 +1,12 @@
 //! Tests for TS18048/TS18047: unary arithmetic operators on possibly-null/undefined operands.
 //!
-//! Structural rule: under `strictNullChecks`, applying a unary arithmetic operator
-//! (`-`, `~`, `+`) to an operand whose type contains `null` or `undefined` as a union
-//! member must emit TS18048 ("possibly 'undefined'") or TS18047 ("possibly 'null'"),
-//! matching the same nullish-operand check that binary arithmetic already runs.
+//! Structural rule: under `strictNullChecks`, tsc runs `checkNonNullType` on the
+//! operand of a unary `+`/`-`/`~` **unconditionally** (there is no arithmetic-operand
+//! check for unary arithmetic — that only exists for binary `- * / % **`). So any
+//! nullable operand emits TS18048 ("possibly 'undefined'") / TS18047 ("possibly
+//! 'null'") / TS18049, regardless of the non-nullish remainder's kind: a union like
+//! `number | undefined`, the bare `null`/`undefined` types, a non-arithmetic union
+//! like `string | undefined`, or a type parameter with a nullable constraint.
 //!
 //! Fixes issue #9745.
 
@@ -169,42 +172,44 @@ fn binary_arithmetic_on_possibly_undefined_still_emits_ts18048() {
 }
 
 // =========================================================================
-// Purely-nullish types: no TS18047/18048 — tsc emits TS2362 instead
+// Purely-nullish and non-arithmetic-union operands: tsc still emits the
+// "possibly null/undefined" diagnostic (checkNonNullType is unconditional for
+// unary +/-/~; there is NO unary TS2362 arithmetic-operand check).
 // =========================================================================
 
 #[test]
-fn unary_minus_on_pure_null_no_ts18047() {
+fn unary_minus_on_pure_null_emits_ts18047() {
     let codes = check_source_strict_codes("declare const x: null;\nconst _ = -x;\n");
     assert!(
-        !codes.contains(&18047),
-        "unary - on purely-null type must not emit TS18047 (tsc emits TS2362); got: {codes:?}"
+        codes.contains(&18047),
+        "unary - on purely-null type must emit TS18047 (tsc: `-x` where x: null → TS18047); got: {codes:?}"
     );
 }
 
 #[test]
-fn unary_minus_on_pure_undefined_no_ts18048() {
+fn unary_minus_on_pure_undefined_emits_ts18048() {
     let codes = check_source_strict_codes("declare const x: undefined;\nconst _ = -x;\n");
     assert!(
-        !codes.contains(&18048),
-        "unary - on purely-undefined type must not emit TS18048 (tsc emits TS2362); got: {codes:?}"
+        codes.contains(&18048),
+        "unary - on purely-undefined type must emit TS18048; got: {codes:?}"
     );
 }
 
 #[test]
-fn unary_minus_on_nonarithmetic_union_no_ts18048() {
+fn unary_minus_on_nonarithmetic_union_emits_ts18048() {
     let codes = check_source_strict_codes("declare const s: string | undefined;\nconst _ = -s;\n");
     assert!(
-        !codes.contains(&18048),
-        "unary - on `string | undefined` must not emit TS18048 (tsc emits TS2362); got: {codes:?}"
+        codes.contains(&18048),
+        "unary - on `string | undefined` must emit TS18048 (no unary TS2362); got: {codes:?}"
     );
 }
 
 #[test]
-fn unary_tilde_on_pure_null_no_ts18047() {
+fn unary_tilde_on_pure_null_emits_ts18047() {
     let codes = check_source_strict_codes("declare const y: null;\nconst _ = ~y;\n");
     assert!(
-        !codes.contains(&18047),
-        "unary ~ on purely-null type must not emit TS18047 (tsc emits TS2362); got: {codes:?}"
+        codes.contains(&18047),
+        "unary ~ on purely-null type must emit TS18047; got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Fixes #14703.

## What

tsc runs `checkNonNullType` on operator operands under `strictNullChecks`. A
nullable operand is reported as **TS18047/18048/18049** when it is a named entity
(identifier, property access, `this`), as **TS2531/2532/2533** when it is an
unnamed expression (a call result, a parenthesized expression, …), and as
**TS18050** only for the literal `null`/`undefined` keyword. For unary `+`/`-`/`~`
the check is **unconditional** — there is no unary arithmetic-operand (TS2362)
check (that exists only for binary `- * / % **`).

A 1,400+-case differential probe over operator × operand-kind isolated two tsz
divergences in this single `checkNonNullType` family:

1. **Unary `+`/`-`/`~` under-reported (false negatives).** `check_nullish_unary_operand`
   only emitted when the operand's non-nullish remainder was *arithmetic*
   (number/bigint/enum), so bare `null`/`undefined`, `string | undefined`,
   `object | null`, `symbol | null`, and type parameters with nullable
   constraints produced **no** diagnostic. (21/35 strict mismatches.)
2. **Unnamed nullish operands emitted the wrong code.** `emit_nullish_operand_error`
   collapsed every unnamed nullish operand to the literal-value **TS18050**
   instead of **TS2531/2532/2533**, across **both** unary `+`/`-`/`~` **and** the
   whole binary arithmetic/relational/bitwise family. (14/14 mismatches.)

## Structural rule

> When an operator operand is nullable under `strictNullChecks`, tsc reports
> TS18047/18048/18049 (named) / TS2531/2532/2533 (unnamed) / TS18050 (literal
> keyword). For unary `+`/`-`/`~` this is unconditional (no unary TS2362). tsz
> (a) gated the unary check on the non-null remainder being arithmetic and
> (b) collapsed all unnamed nullish operands to TS18050.

## Owner layer

Checker only — `crates/tsz-checker/src/error_reporter/operator_errors.rs`:

- `check_nullish_unary_operand`: drop the `nullish_can_flow_to_arithmetic` gate;
  emit whenever the operand is nullable, guarding `void` (not in tsc's `Nullable`
  flag set). Independent of the ESSymbol TS2469 check, so `+symn` now reports
  TS18047 **and** TS2469.
- `emit_nullish_operand_error`: route the unnamed, non-literal fallback through
  the existing `report_nullish_object` (TS2531/2532/2533). The literal
  `null`/`undefined` keyword keeps TS18050 via the existing `is_literal` branch.

No relation/inference change; decisions are structural (nullability + named vs
unnamed expression), never keyed on identifiers or rendered text.

## Adjacent-case matrix

`crates/tsz-checker/tests/nullish_operand_checknonnull_parity_tests.rs` (new):
unary `+`/`-`/`~` on null / undefined / null|undefined / string|undefined /
object|null / symbol|null (+TS2469) / type-param-with-nullable-constraint;
unnamed call-result operands across unary and binary (`g() - 1`, `g() < 1`,
`g() & 1`); binary non-arithmetic unnamed (`g():string|undefined - 1` →
TS2532 + TS2362); literal `null` keyword keeps TS18050; negatives (void, any,
plain number, post-narrowing, `(number|null) & {}`).

`ts18048_unary_arithmetic_nullish_tests.rs` updated: its "purely-nullish /
non-arithmetic-union" cases previously asserted the **incorrect** premise that
"tsc emits TS2362 instead" — `tsc` emits TS18047/18048 there with no TS2362
(verified against `tsc` 6.0.2). Tests now assert the correct codes.

## Anti-hardcoding

No new user-name/file-name literals; no formatted-message predicate. The
named-vs-unnamed decision is structural (entity-name presence) and the
nullability decision is the shared `split_nullish_type` query. Tests vary binder
names and operator.

## Out of scope (related, separate `checkNonNullType` sites; tracked as follow-ups in #14703)

- `in`-operator RHS pure-`undefined` (TS2322 vs TS18048) and `in`-operator LHS
  nullish.
- `delete` of a readonly named property (TS2790 vs TS2704).

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New suite `cargo test -p tsz-checker --lib nullish_operand_checknonnull_parity` — 18/18 pass; updated `ts18048_unary_arithmetic_nullish_tests` + `this_prop_nullish_operand_code_tests` — all pass (37/37 across the three).
- Differential probe vs `tsc` 6.0.2: unary `+`/`-`/`~` matrix **0/35** mismatch (was 21/35); unnamed-operand probe **0/14** (was 14/14); type-param/alias/intersection probe 0 mismatch.
- Broad regression sweep (`possibly nullish property_access ts2531 ts2532 ts2533 ts18047 ts18048 ts18049 ts18050 increment` and `value_usage arithmetic operator relational binary ts2362 ts2363 ts2469`): no new failures. The 3 unit-test failures observed (`direct_reassign_maybe_after_join_keeps_ts18048`, `ts2860/ts2861` instanceof Symbol.hasInstance, `mapped_enum_discriminant_application_exposes_member_property`) reproduce identically on clean `main` (sandbox lib/environment) and are unrelated to this change.
- `cargo fmt -p tsz-checker --check`, `cargo clippy -p tsz-checker --lib` (clean), `python3 scripts/arch/arch_guard.py` (passed). Rebased onto current `main` (`3d819be`), conflict-free.
- Broad conformance / emit / fourslash floor owned by ready-review CI.

https://claude.ai/code/session_01N4MwPKtXPWCg4yRUdJuVKq

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4MwPKtXPWCg4yRUdJuVKq)_