### PR TITLE
fix(checker): run checkNonNullType on both `in` operands

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1016,6 +1016,9 @@ path = "tests/in_chain_narrows_unconstrained_type_param_tests.rs"
 name = "in_operator_lhs_key_type_tests"
 path = "tests/in_operator_lhs_key_type_tests.rs"
 [[test]]
+name = "in_operator_non_null_operand_tests"
+path = "tests/in_operator_non_null_operand_tests.rs"
+[[test]]
 name = "in_operator_narrows_alias_union_member_tests"
 path = "tests/in_operator_narrows_alias_union_member_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/binary_support.rs
+++ b/crates/tsz-checker/src/types/computation/binary_support.rs
@@ -1220,6 +1220,14 @@ impl CheckerState<'_> {
         if matches!(left_type, TypeId::ANY | TypeId::ERROR) {
             return;
         }
+        // An `unknown` key operand is reported as TS18046 (named) / TS2571
+        // (unnamed) "is of type 'unknown'", the same as the RHS object operand —
+        // not as a TS2322 key mismatch. tsc applies this regardless of
+        // `strictNullChecks`.
+        if left_type == TypeId::UNKNOWN {
+            self.error_is_of_type_unknown(left_idx);
+            return;
+        }
         // Mirror tsc's checkNonNullType: strip the nullish part before the key check
         // so `string | undefined` is not spuriously rejected. A purely nullish operand
         // contributes no key and is left to the existing nullish diagnostics.
@@ -1251,6 +1259,32 @@ impl CheckerState<'_> {
             tsz_common::diagnostics::diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             &[&source_str, &target_str],
         );
+    }
+
+    /// Mirror tsc's `checkNonNullType` for an `in`-operator operand.
+    ///
+    /// Under `strictNullChecks`, a nullable operand is reported as
+    /// TS18047/18048/18049 for a named entity (identifier, property access,
+    /// `this`), TS2531/2532/2533 for an unnamed expression (call result,
+    /// parenthesized expression, …), or TS18050 for the literal
+    /// `null`/`undefined` keyword — exactly the routing `report_nullish_object`
+    /// already implements. The non-nullish remainder is returned so the caller's
+    /// structural check (key type for the LHS, object shape for the RHS) runs on
+    /// the stripped type; `None` means the operand was purely nullish, so no
+    /// structural check applies. `any`/`error`/`unknown` carry no nullish part
+    /// and pass through unchanged.
+    fn check_in_operand_non_null(&mut self, idx: NodeIndex, ty: TypeId) -> Option<TypeId> {
+        if !self.ctx.compiler_options.strict_null_checks
+            || matches!(ty, TypeId::ANY | TypeId::ERROR | TypeId::UNKNOWN)
+        {
+            return Some(ty);
+        }
+        let (non_nullish, nullish_cause) = self.split_nullish_type(ty);
+        let Some(cause) = nullish_cause else {
+            return Some(ty);
+        };
+        self.report_nullish_object(idx, cause, non_nullish.is_none());
+        non_nullish
     }
 
     /// Check the `in` operator.
@@ -1288,43 +1322,19 @@ impl CheckerState<'_> {
         } else if left_node_kind == SyntaxKind::PrivateIdentifier as u16 {
             // Direct private identifier as LHS — validate it
             self.check_private_identifier_in_expression(left_stripped, right_idx, right_type);
-        } else {
-            self.check_in_operator_lhs_key_type(left_idx, left_type);
+        } else if let Some(left_key_type) = self.check_in_operand_non_null(left_idx, left_type) {
+            // The key check runs on the non-nullish remainder so e.g.
+            // `string | undefined` is not also rejected as a bad key.
+            self.check_in_operator_lhs_key_type(left_idx, left_key_type);
         }
 
-        // TS18047/TS18049: RHS of `in` must not be possibly null (or null|undefined).
-        // When strict null checks is enabled and the RHS includes null, emit TS18047.
-        // tsc only emits this when there is a name for the expression (identifier etc.).
-        if self.ctx.compiler_options.strict_null_checks && right_type != TypeId::UNKNOWN {
-            let (_, nullish_cause) = self.split_nullish_type(right_type);
-            if let Some(cause) = nullish_cause {
-                // Only emit for null-involving cases (not pure undefined).
-                // TS18047 = "is possibly null", TS18049 = "is possibly null or undefined"
-                let includes_null = cause == TypeId::NULL
-                    || (cause != TypeId::UNDEFINED
-                        && crate::query_boundaries::common::union_members(self.ctx.types, cause)
-                            .is_some_and(|members| members.contains(&TypeId::NULL)));
-                if includes_null {
-                    let name = self.expression_text(right_idx);
-                    if let Some(ref name) = name {
-                        use crate::diagnostics::diagnostic_codes;
-                        let code = if cause == TypeId::NULL {
-                            diagnostic_codes::IS_POSSIBLY_NULL
-                        } else {
-                            diagnostic_codes::IS_POSSIBLY_NULL_OR_UNDEFINED
-                        };
-                        self.emit_render_request(
-                            right_idx,
-                            crate::error_reporter::DiagnosticRenderRequest::simple_msg(
-                                code,
-                                &[name],
-                            ),
-                        );
-                    }
-                    return TypeId::BOOLEAN;
-                }
-            }
-        }
+        // `checkNonNullType` on the RHS, then the object-shape check on the
+        // non-nullish remainder: `object | undefined` keeps only the nullish
+        // diagnostic, while `string | undefined` also reports the `string`
+        // remainder's structural mismatch. A purely-nullish RHS has no remainder.
+        let Some(right_type) = self.check_in_operand_non_null(right_idx, right_type) else {
+            return TypeId::BOOLEAN;
+        };
 
         if right_type == TypeId::UNKNOWN {
             self.error_is_of_type_unknown(right_idx);

--- a/crates/tsz-checker/tests/in_operator_lhs_key_type_tests.rs
+++ b/crates/tsz-checker/tests/in_operator_lhs_key_type_tests.rs
@@ -77,15 +77,22 @@ fn bigint_lhs_reports_ts2322() {
 }
 
 #[test]
-fn unknown_lhs_reports_ts2322() {
-    let diags =
-        in_lhs_errors("declare const o: object;\ndeclare const u: unknown;\nconst x = u in o;\n");
-    assert_eq!(
-        diags,
-        vec![(
-            TS2322,
-            "Type 'unknown' is not assignable to type 'string | number | symbol'.".to_string()
-        )]
+fn unknown_lhs_reports_ts18046_not_ts2322() {
+    // An `unknown` key operand is "of type 'unknown'" (TS18046 for a named
+    // entity), the same as an `unknown` object operand — tsc does not route it
+    // through the TS2322 key-mismatch path. Verified against tsc 6.0.2.
+    let all = check_source_code_messages(
+        "declare const o: object;\ndeclare const u: unknown;\nconst x = u in o;\n",
+    );
+    assert!(
+        all.iter().all(|(code, _)| *code != TS2322),
+        "unknown key should not report the TS2322 key mismatch, got {all:#?}"
+    );
+    assert!(
+        all.iter()
+            .any(|(code, msg)| *code == diagnostic_codes::IS_OF_TYPE_UNKNOWN
+                && msg == "'u' is of type 'unknown'."),
+        "expected TS18046 for the unknown key operand, got {all:#?}"
     );
 }
 

--- a/crates/tsz-checker/tests/in_operator_non_null_operand_tests.rs
+++ b/crates/tsz-checker/tests/in_operator_non_null_operand_tests.rs
@@ -1,0 +1,186 @@
+//! `in`-operator operand `checkNonNullType` parity.
+//!
+//! Under `strictNullChecks`, tsc runs `checkNonNullType` on **both** the key
+//! (LHS) and object (RHS) operands of `in`, then runs the structural key/object
+//! check on the **non-nullish remainder**. A nullable operand is reported as
+//! TS18047/18048/18049 (named entity), TS2531/2532/2533 (unnamed expression),
+//! or TS18050 (literal `null`/`undefined` keyword). An `unknown` operand is
+//! reported as TS18046 (named) / TS2571 (unnamed) on either side. All codes and
+//! messages below were verified against tsc 6.0.2.
+
+use tsz_checker::diagnostics::diagnostic_codes;
+use tsz_checker::test_utils::check_source_code_messages;
+
+const TS2322: u32 = diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE;
+const TS18046: u32 = diagnostic_codes::IS_OF_TYPE_UNKNOWN;
+const TS2571: u32 = diagnostic_codes::OBJECT_IS_OF_TYPE_UNKNOWN;
+const TS18047: u32 = diagnostic_codes::IS_POSSIBLY_NULL;
+const TS18048: u32 = diagnostic_codes::IS_POSSIBLY_UNDEFINED;
+const TS18049: u32 = diagnostic_codes::IS_POSSIBLY_NULL_OR_UNDEFINED;
+const TS2532: u32 = diagnostic_codes::OBJECT_IS_POSSIBLY_UNDEFINED;
+const TS18050: u32 = diagnostic_codes::THE_VALUE_CANNOT_BE_USED_HERE;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut v: Vec<u32> = check_source_code_messages(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect();
+    v.sort_unstable();
+    v
+}
+
+fn msgs(source: &str) -> Vec<(u32, String)> {
+    check_source_code_messages(source)
+}
+
+const PRELUDE: &str = concat!(
+    "declare const obj: object;\n",
+    "declare const su: string | undefined;\n",
+    "declare const sn: string | null;\n",
+    "declare const snu: string | null | undefined;\n",
+    "declare const ou: object | undefined;\n",
+    "declare const on: object | null;\n",
+    "declare const u: undefined;\n",
+    "declare const n: null;\n",
+    "declare function gkey(): string | undefined;\n",
+    "declare function gobj(): object | undefined;\n",
+);
+
+fn src(expr: &str) -> String {
+    format!("{PRELUDE}const r = {expr};\n")
+}
+
+// ---- LHS (key side): checkNonNullType, previously entirely unreported. ----
+
+#[test]
+fn lhs_named_nullish_reports_18047_48_49() {
+    assert_eq!(codes(&src("su in obj")), vec![TS18048]);
+    assert_eq!(codes(&src("sn in obj")), vec![TS18047]);
+    assert_eq!(codes(&src("snu in obj")), vec![TS18049]);
+    assert_eq!(codes(&src("u in obj")), vec![TS18048]);
+    assert_eq!(codes(&src("n in obj")), vec![TS18047]);
+}
+
+#[test]
+fn lhs_unnamed_nullish_reports_object_possibly_codes() {
+    // A call result has no nameable text → TS2531/2532/2533, not TS18047-9.
+    assert_eq!(codes(&src("gkey() in obj")), vec![TS2532]);
+}
+
+#[test]
+fn lhs_literal_keyword_reports_18050() {
+    assert_eq!(codes(&src("null in obj")), vec![TS18050]);
+    assert_eq!(codes(&src("undefined in obj")), vec![TS18050]);
+}
+
+#[test]
+fn lhs_non_key_remainder_coemits_with_nullish() {
+    // `boolean | undefined`: the nullish part is reported AND the `boolean`
+    // remainder still fails the key check.
+    let got = codes(
+        "declare const obj: object;\ndeclare const bu: boolean | undefined;\nconst r = bu in obj;\n",
+    );
+    assert_eq!(got, vec![TS2322, TS18048]);
+}
+
+#[test]
+fn lhs_named_property_access_uses_dotted_name() {
+    let m = msgs(
+        "declare const obj: object;\ndeclare const p: { k: string | undefined };\nconst r = p.k in obj;\n",
+    );
+    assert!(
+        m.iter()
+            .any(|(c, s)| *c == TS18048 && s == "'p.k' is possibly 'undefined'."),
+        "expected named TS18048 on `p.k`, got {m:#?}"
+    );
+}
+
+// ---- RHS (object side): formerly TS2719/TS2322 spurious or wrong code. ----
+
+#[test]
+fn rhs_object_with_nullish_reports_only_nullish_not_self_mismatch() {
+    // `object | undefined` previously surfaced a spurious TS2719; the stripped
+    // `object` remainder is a valid RHS, so only the nullish diagnostic remains.
+    assert_eq!(codes(&src("\"a\" in ou")), vec![TS18048]);
+    assert_eq!(codes(&src("\"a\" in on")), vec![TS18047]);
+}
+
+#[test]
+fn rhs_unnamed_nullish_reports_object_possibly_undefined() {
+    assert_eq!(codes(&src("\"a\" in gobj()")), vec![TS2532]);
+}
+
+#[test]
+fn rhs_string_remainder_coemits_structural_and_nullish() {
+    // `string | null | undefined`: `string` is not a valid object RHS (TS2322)
+    // and the operand is also possibly null|undefined (TS18049).
+    assert_eq!(codes(&src("\"a\" in snu")), vec![TS2322, TS18049]);
+}
+
+#[test]
+fn rhs_literal_keyword_reports_18050() {
+    assert_eq!(codes(&src("\"a\" in null")), vec![TS18050]);
+    assert_eq!(codes(&src("\"a\" in undefined")), vec![TS18050]);
+}
+
+#[test]
+fn rhs_pure_nullish_named_reports_18047_48() {
+    assert_eq!(codes(&src("\"a\" in u")), vec![TS18048]);
+    assert_eq!(codes(&src("\"a\" in n")), vec![TS18047]);
+}
+
+// ---- unknown operand: TS18046 (named) / TS2571 (unnamed) on either side. ----
+
+#[test]
+fn unknown_operand_reports_of_type_unknown_on_both_sides() {
+    let lhs =
+        codes("declare const obj: object;\ndeclare const unk: unknown;\nconst r = unk in obj;\n");
+    assert_eq!(lhs, vec![TS18046]);
+    let rhs = codes("declare const unk: unknown;\nconst r = \"a\" in unk;\n");
+    assert_eq!(rhs, vec![TS18046]);
+    let rhs_unnamed = codes("declare function g(): unknown;\nconst r = \"a\" in g();\n");
+    assert_eq!(rhs_unnamed, vec![TS2571]);
+}
+
+// ---- Anti-hardcoding: decision is structural, not name/text based. ----
+
+#[test]
+fn renamed_binders_still_report_nullish_operand() {
+    // Same shape, different binder names — the diagnostic must still fire.
+    let a = codes(
+        "declare const wibble: object;\ndeclare const wobble: string | undefined;\nconst r = wobble in wibble;\n",
+    );
+    assert_eq!(a, vec![TS18048]);
+}
+
+// ---- Negative controls: valid non-nullish operands stay clean. ----
+
+#[test]
+fn non_nullish_operands_produce_no_in_diagnostics() {
+    assert!(
+        codes("declare const obj: object;\ndeclare const s: string;\nconst r = s in obj;\n")
+            .is_empty()
+    );
+    assert!(codes("declare const o: { a: number };\nconst r = \"a\" in o;\n").is_empty());
+}
+
+#[test]
+fn without_strict_null_checks_no_nullish_operand_diagnostics() {
+    // checkNonNullType's TS18047-49 / TS2531-3 are strictNullChecks-only.
+    let source = format!("{PRELUDE}const r = su in obj;\n");
+    let got: Vec<u32> = tsz_checker::test_utils::check_with_options_code_messages(
+        &source,
+        tsz_checker::context::CheckerOptions {
+            strict_null_checks: false,
+            ..tsz_checker::context::CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|(c, _)| c)
+    .collect();
+    assert!(
+        got.iter()
+            .all(|c| *c != TS18048 && *c != TS18047 && *c != TS18049),
+        "no nullish-operand diagnostics without strictNullChecks, got {got:#?}"
+    );
+}


### PR DESCRIPTION
Closes #14707.

## Failure family

Checker diagnostics — `checkNonNullType` on `in`-operator operands. tsc runs
`checkNonNullType` on **both** the key (LHS) and object (RHS) operands of `in`,
then runs the structural key/object check on the **non-nullish remainder**. tsz
only handled a narrow slice of the RHS (null-involving *named* operands) and
never ran the check on the LHS, so a 25-case differential probe over
operand-kind × side (vs the bench `tsc` 6.0.2) isolated several families of
divergence at once.

### Witnesses (`--strict --target esnext`; `tsc` → tsz before)

```ts
declare const obj: object;
declare const su: string | undefined;
declare const ou: object | undefined;
declare function gobj(): object | undefined;
declare function gkey(): string | undefined;

// LHS (key side) — tsz emitted NOTHING for any of these
su in obj;        // tsc TS18048              tsz: (none)
gkey() in obj;    // tsc TS2532               tsz: (none)
null in obj;      // tsc TS18050              tsz: (none)

// RHS (object side)
"a" in ou;        // tsc TS18048              tsz: TS2719 (spurious self-mismatch)
"a" in gobj();    // tsc TS2532               tsz: TS2719 (spurious)
"a" in undefined; // tsc TS18050              tsz: TS2322
"a" in (string|null|undefined); // tsc TS2322 + TS18049   tsz: TS18049 only
unk in obj;       // tsc TS18046              tsz: TS2322 (unknown key mismatch)
```

## Structural rule

> Under `strictNullChecks`, `tsc` runs `checkNonNullType` on each `in` operand.
> A nullable operand is reported as **TS18047/18048/18049** when it is a named
> entity (identifier, property access, `this`), as **TS2531/2532/2533** when it
> is an unnamed expression (call result, parenthesized expression, …), and as
> **TS18050** only for the literal `null`/`undefined` keyword. An `unknown`
> operand is **TS18046** (named) / **TS2571** (unnamed) on either side. The
> structural check (LHS assignable to `string | number | symbol`; RHS assignable
> to `object`) then runs on the **non-nullish remainder**, so a purely-nullish
> operand yields only the nullish diagnostic while a mixed operand
> (`string | null | undefined`) co-emits both the structural mismatch and the
> nullish diagnostic.

tsz ran the structural check on the full (un-stripped) RHS — which made an
`object | undefined` RHS fail reflexive assignability and surface a spurious
TS2719 — and never reported the LHS nullish operand.

## Owner layer

Checker only — `crates/tsz-checker/src/types/computation/binary_support.rs`,
`check_in_operator`. A new `check_in_operand_non_null` runs the
`checkNonNullType` reporting (delegating the named/unnamed/literal routing to the
existing `report_nullish_object`, which already implements exactly that routing)
and returns the stripped remainder that the existing key/object checks consume;
it is applied symmetrically to both operands. The bespoke RHS-only null-named
block (which also early-returned, dropping the co-emitted structural TS2322) is
removed. The LHS `unknown` case routes through the shared
`error_is_of_type_unknown` (TS18046/TS2571), the same helper the RHS already
uses. No relation/inference change; decisions are structural (nullability +
named vs unnamed expression), never keyed on identifiers or rendered text.

## Adjacent-case matrix

`crates/tsz-checker/tests/in_operator_non_null_operand_tests.rs` (new, 14 tests):
LHS and RHS × {named null/undefined/null|undefined, unnamed call result, literal
keyword, pure-nullish, mixed non-key/object remainder co-emission}; `unknown` on
both sides (named TS18046 / unnamed TS2571); a renamed-binder anti-hardcoding
control; negative controls for valid non-nullish operands; and a
`strictNullChecks: false` control. `in_operator_lhs_key_type_tests.rs`'s
`unknown_lhs_reports_ts2322` is renamed/corrected to assert TS18046 — it
previously pinned tsz's pre-existing wrong behavior (verified against tsc 6.0.2).

## Anti-hardcoding

No new user-name/file-name literals; no formatted-message predicate. The
named-vs-unnamed decision is structural (entity-name presence, via
`report_nullish_object`) and the nullability decision is the shared
`split_nullish_type` query. Tests vary binder names.

## Out of scope

The unary `+`/`-`/`~` and binary arithmetic operand sites were fixed separately
(#14704). The `delete`-of-readonly-named-property code-selection divergence
(TS2790 vs TS2704) is a distinct `checkNonNullType`-adjacent site, left as a
follow-up.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New suite `cargo test -p tsz-checker --test in_operator_non_null_operand_tests` — 14/14 pass; updated `in_operator_lhs_key_type_tests` — 14/14; `--lib in_operator` (incl. the relation-routing arch test) — 19/19.
- Differential vs `tsc` 6.0.2 over 6 probe files × {strict, non-strict} = 12 runs: **all byte-identical** (was diverging on every LHS-nullish, the TS2719 RHS family, the literal-keyword RHS, the co-emit case, and the unknown-LHS case).
- `cargo fmt -p tsz-checker --check`, `cargo clippy -p tsz-checker --tests` (clean), `python3 scripts/arch/arch_guard.py` (passed). Rebased conflict-free onto current `main` (`122d240`, which includes #14704); rebuilt and re-verified — no interaction with the `operator_errors.rs` changes there.
- Broad conformance / emit / fourslash floor owned by ready-review CI.

https://claude.ai/code/session_01Apbe6L8TG4uHzWcxEALgte

---
_Generated by [Claude Code](https://claude.ai/code/session_01Apbe6L8TG4uHzWcxEALgte)_