### PR TITLE
fix(emit): keep ES5 object-rest parameter function bodies single-line

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs
@@ -127,6 +127,65 @@ impl<'a> Printer<'a> {
         !self.ctx.target_es5 && !self.binding_target_contains_object_rest(pattern)
     }
 
+    /// True when every transformed parameter is destructured purely through an
+    /// object-rest (`__rest`) lowering — no `...args` rest parameter and no
+    /// top-level parameter default.
+    ///
+    /// `tsc` lowers a parameter binding pattern that contains an object rest
+    /// through the ES2018 transform, whose injected prologue statements are
+    /// *not* marked `startOnNewLine`. So when the source function body is on a
+    /// single line, `tsc` keeps it single-line and writes the preamble inline
+    /// (`function f(_a) { var a = _a.a, rest = __rest(_a, ["a"]); return rest; }`).
+    /// Simple/array binding patterns and default-valued parameters instead go
+    /// through the ES2015 transform, whose statements *are* `startOnNewLine`,
+    /// forcing the body multi-line. Mixing the two (any non-object-rest
+    /// transformed parameter, any `...args`, any top-level default) reintroduces
+    /// a `startOnNewLine` statement and so must stay multi-line.
+    pub(in crate::emitter) fn param_prologue_is_object_rest_only(
+        &self,
+        transforms: &ParamTransformPlan,
+    ) -> bool {
+        transforms.rest.is_none()
+            && !transforms.params.is_empty()
+            && transforms.params.iter().all(|param| {
+                param.initializer.is_none()
+                    && param
+                        .pattern
+                        .is_some_and(|pattern| self.binding_target_contains_object_rest(pattern))
+            })
+    }
+
+    /// Emit the object-rest parameter prologue inline (no line breaks) for a
+    /// single-line function body. Each parameter contributes one combined
+    /// `var <assignments>;` statement; multiple object-rest parameters are
+    /// separated by a single space, mirroring `tsc`
+    /// (`var a = _a.a, r1 = __rest(_a, ["a"]); var c = _b.c, r2 = __rest(_b, ["c"]);`).
+    ///
+    /// Returns whether anything was written so the caller can place the single
+    /// separating space before the first body statement. Only valid when
+    /// [`Self::param_prologue_is_object_rest_only`] holds for `transforms`.
+    pub(in crate::emitter) fn emit_param_prologue_inline_es5(
+        &mut self,
+        transforms: &ParamTransformPlan,
+    ) -> bool {
+        let mut wrote_any = false;
+        for param in &transforms.params {
+            let Some(pattern) = param.pattern else {
+                continue;
+            };
+            if wrote_any {
+                self.write(" ");
+            }
+            let mut started = false;
+            self.emit_param_binding_assignments(pattern, &param.name, &mut started);
+            if started {
+                self.write(";");
+                wrote_any = true;
+            }
+        }
+        wrote_any
+    }
+
     fn emit_native_param_binding_prologue(
         &mut self,
         param_name: &str,

--- a/crates/tsz-emitter/src/emitter/functions.rs
+++ b/crates/tsz-emitter/src/emitter/functions.rs
@@ -409,6 +409,15 @@ impl<'a> Printer<'a> {
             return;
         };
 
+        // tsc keeps a single-line source body single-line when the only injected
+        // prologue is an object-rest (`__rest`) lowering (its ES2018-transform
+        // statements are not `startOnNewLine`). Route those bodies through the
+        // inline emitter; everything else keeps the multi-line layout below.
+        if self.block_with_param_prologue_emits_single_line(block_idx, block_node, transforms) {
+            self.emit_single_line_block_with_param_prologue(block_node, transforms);
+            return;
+        }
+
         self.write("{");
         self.write_line();
         self.increase_indent();
@@ -446,6 +455,92 @@ impl<'a> Printer<'a> {
         }
         self.decrease_indent();
         self.write("}");
+    }
+
+    /// Whether an ES5 function body with a parameter prologue should be emitted
+    /// on a single line: the source body is single-line, the only prologue is an
+    /// object-rest lowering, and no other state forces line-leading declarations
+    /// (`var _this = this;`, captured `new.target`, an async-arrow `super`
+    /// capture, or hoisted assignment/for-of temps).
+    fn block_with_param_prologue_emits_single_line(
+        &self,
+        block_idx: NodeIndex,
+        block_node: &Node,
+        transforms: &ParamTransformPlan,
+    ) -> bool {
+        self.emitting_function_body_block
+            && self.param_prologue_is_object_rest_only(transforms)
+            && self.is_single_line(block_node)
+            && self.transforms.this_capture_name(block_idx).is_none()
+            && !self.has_pending_new_target_capture()
+            && self.pending_lowered_async_arrow_super_capture.is_none()
+            && self.hoisted_assignment_value_temps.is_empty()
+            && self.hoisted_for_of_temps.is_empty()
+    }
+
+    /// Emit an ES5 function body with an object-rest parameter prologue on a
+    /// single line, matching `tsc`:
+    /// `function f(_a) { var a = _a.a, rest = __rest(_a, ["a"]); return rest; }`.
+    /// The preamble is written inline; any temps the body itself hoists
+    /// (optional-chaining / logical-assignment value temps) are spliced in right
+    /// after `{ `, ahead of the preamble.
+    fn emit_single_line_block_with_param_prologue(
+        &mut self,
+        block_node: &Node,
+        transforms: &ParamTransformPlan,
+    ) {
+        let Some(block) = self.arena.get_block(block_node) else {
+            return;
+        };
+        let statements = block.statements.nodes.to_vec();
+
+        self.emitting_function_body_block = false;
+        let private_static_shadow =
+            self.block_shadows_private_static_class_alias(&statements, true);
+        if private_static_shadow {
+            self.private_static_class_alias_shadow_depth += 1;
+        }
+        self.ctx.block_scope_state.enter_function_scope();
+        self.seed_block_scope_value_binding_names(&block.statements);
+        self.register_pending_function_body_parameters();
+
+        self.map_opening_brace(block_node);
+        self.write("{ ");
+        // Anchor for inline hoisted temp declarations, captured right after `{ `
+        // and ahead of the object-rest preamble (matching the ES2018 single-line
+        // path in `emit_block`).
+        let var_insert_pos = self.writer.len();
+        let wrote_prologue = self.emit_param_prologue_inline_es5(transforms);
+
+        let block_close_pos = self
+            .find_block_closing_brace_end(block_node)
+            .saturating_sub(1);
+        // A single space separates the inline prologue from the first statement
+        // and each statement from the next (matching the ES2018 path in
+        // `emit_block`).
+        if wrote_prologue {
+            self.write(" ");
+        }
+        for (si, &stmt_idx) in statements.iter().enumerate() {
+            if si > 0 {
+                self.write(" ");
+            }
+            let previous_trailing_comment_scan_max = self.trailing_comment_scan_max_pos;
+            self.trailing_comment_scan_max_pos = Some(block_close_pos);
+            self.emit(stmt_idx);
+            self.trailing_comment_scan_max_pos = previous_trailing_comment_scan_max;
+        }
+
+        let prologue = self.take_single_line_hoisted_temp_prologue();
+        if !prologue.is_empty() {
+            self.writer.insert_at(var_insert_pos, &prologue);
+        }
+        self.map_closing_brace(block_node);
+        self.write(" }");
+        self.ctx.block_scope_state.exit_scope();
+        if private_static_shadow {
+            self.private_static_class_alias_shadow_depth -= 1;
+        }
     }
 
     /// Emit the statements of a downleveled async body block (the body that
@@ -1693,6 +1788,83 @@ mod tests {
         assert!(
             output.contains("var _b, _c; var { a } = _a, rest = __rest(_a, [\"a\"]);"),
             "Hoisted optional-chaining temps must precede the object-rest preamble on the single line.\nOutput:\n{output}"
+        );
+    }
+
+    /// At ES5 the object-rest parameter preamble is lowered to property-access
+    /// reads (`var a = _a.a, rest = __rest(_a, ["a"])`) instead of staying a
+    /// binding pattern, and that lowering previously routed exclusively through
+    /// the multi-line `emit_block_with_param_prologue` path. tsc still keeps a
+    /// single-line source body single-line here (the object-rest prologue is not
+    /// `startOnNewLine`), so the ES5 path must match.
+    #[test]
+    fn object_rest_param_keeps_single_line_function_body_es5() {
+        use crate::output::printer::{PrintOptions, lower_and_print};
+
+        let source = "function f({ a, ...rest }: { a: number; b: string }) { return rest; }";
+        let (parser, root) = parse_test_source(source);
+        let output = lower_and_print(&parser.arena, root, PrintOptions::es5()).code;
+
+        assert!(
+            output.contains(
+                "function f(_a) { var a = _a.a, rest = __rest(_a, [\"a\"]); return rest; }"
+            ),
+            "ES5 object-rest parameter must keep a single-line body on one line (matching tsc).\nOutput:\n{output}"
+        );
+    }
+
+    /// Two object-rest parameters at ES5 produce two combined `var` statements;
+    /// tsc keeps the single-line body single-line, the statements separated by a
+    /// single space (`var a = _a.a, r1 = __rest(...); var c = _b.c, r2 = ...;`).
+    #[test]
+    fn two_object_rest_params_keep_single_line_function_body_es5() {
+        use crate::output::printer::{PrintOptions, lower_and_print};
+
+        let source = "function f({ a, ...r1 }: { a: number; b: string }, { c, ...r2 }: { c: number; d: string }) { return r1; }";
+        let (parser, root) = parse_test_source(source);
+        let output = lower_and_print(&parser.arena, root, PrintOptions::es5()).code;
+
+        assert!(
+            output.contains(
+                "function f(_a, _b) { var a = _a.a, r1 = __rest(_a, [\"a\"]); var c = _b.c, r2 = __rest(_b, [\"c\"]); return r1; }"
+            ),
+            "Two ES5 object-rest parameters must keep a single-line body on one line.\nOutput:\n{output}"
+        );
+    }
+
+    /// A non-object-rest transformed parameter (a plain destructure, an array
+    /// pattern, or a default value) goes through the ES2015 transform, whose
+    /// statements ARE `startOnNewLine`, so tsc emits the body multi-line. The
+    /// single-line fast path must not fire for those, including when mixed with
+    /// an object-rest parameter.
+    #[test]
+    fn simple_destructure_param_stays_multi_line_es5() {
+        use crate::output::printer::{PrintOptions, lower_and_print};
+
+        let source = "function f({ a }: { a: number }) { return a; }";
+        let (parser, root) = parse_test_source(source);
+        let output = lower_and_print(&parser.arena, root, PrintOptions::es5()).code;
+
+        assert!(
+            output.contains("function f(_a) {\n    var a = _a.a;\n    return a;\n}"),
+            "ES5 simple destructure parameter must keep the body multi-line (matching tsc).\nOutput:\n{output}"
+        );
+    }
+
+    /// A `...args` rest parameter contributes an `arguments`-copy loop (a
+    /// `startOnNewLine` prologue), so tsc keeps the body multi-line even when an
+    /// object-rest parameter is also present.
+    #[test]
+    fn rest_param_with_object_rest_stays_multi_line_es5() {
+        use crate::output::printer::{PrintOptions, lower_and_print};
+
+        let source = "function f({ a, ...rest }: { a: number; b: string }, ...args: number[]) { return rest; }";
+        let (parser, root) = parse_test_source(source);
+        let output = lower_and_print(&parser.arena, root, PrintOptions::es5()).code;
+
+        assert!(
+            output.contains("function f(_a) {\n"),
+            "An ES5 `...args` rest parameter must keep the body multi-line.\nOutput:\n{output}"
         );
     }
 


### PR DESCRIPTION
Closes #14709.

## Failure family

JS emit — printer layout for ES5 function/method bodies. At `--target es5` a
function or method with an **object-rest parameter** (`{ a, ...rest }`) and a
**single-line source body** was expanded to multiple lines, while `tsc` (6.0.2)
keeps it on one line. Found by differential-testing tsz against the bench `tsc`.
This is the ES5 function/method counterpart of the constructor bug in
#14705/#14706 — that work explicitly scoped out ES5 and stated "method and
plain-function bodies were already correct," which is false for the ES5
object-rest preamble.

```ts
function f({ a, ...rest }: { a: number; b: string }) { return rest; }
```
```js
// tsc
function f(_a) { var a = _a.a, rest = __rest(_a, ["a"]); return rest; }
// tsz (before) — body wrongly expanded
function f(_a) {
    var a = _a.a, rest = __rest(_a, ["a"]);
    return rest;
}
```

At es2015–es2017 the same case is already single-line in tsz (it routes through
the ES2018 `pending_object_rest_params` single-line path in `emit_block`); only
the ES5 lowering path — which rewrites the binding into property-access reads
(`var a = _a.a, rest = __rest(...)`) and lived solely on the multi-line
`emit_block_with_param_prologue` branch — diverged.

## Structural rule

> `tsc` lowers a parameter binding pattern that contains an object rest through
> the **ES2018 transform**, whose injected prologue statements are *not* marked
> `startOnNewLine`. So a single-line source body stays single-line and the
> preamble is written inline. Simple/array binding patterns and default-valued
> parameters go through the **ES2015 transform**, whose statements *are*
> `startOnNewLine`, forcing the body multi-line. Mixing the two (any
> non-object-rest transformed parameter, any `...args` rest parameter, any
> top-level parameter default) reintroduces a `startOnNewLine` statement and so
> stays multi-line.

## Owner layer

Emitter only:
- `crates/tsz-emitter/src/emitter/functions.rs` — `emit_block_with_param_prologue`
  gains an early single-line branch, gated by
  `block_with_param_prologue_emits_single_line` (the structural object-rest-only
  predicate plus the same line-leading-declaration guards the ES2018 single-line
  path uses: `this` capture, captured `new.target`, async-arrow `super`, hoisted
  assignment / for-of temps). `emit_single_line_block_with_param_prologue` writes
  the preamble inline and splices any body-hoisted temps via the existing
  `take_single_line_hoisted_temp_prologue`, mirroring the ES2018 path.
- `crates/tsz-emitter/src/emitter/es5/bindings_param_patterns.rs` —
  `param_prologue_is_object_rest_only` (the structural predicate) and
  `emit_param_prologue_inline_es5` (inline variant of the existing prologue,
  reusing `emit_param_binding_assignments`; swaps `write_line()` for a space).

No checker/solver involvement; no semantic validation; no already-emitted-output
surgery. The ES2018 single-line path is untouched.

## Anti-hardcoding

The single-line decision is a structural transform-shape predicate
(`rest.is_none()`, `initializer.is_none()`, `binding_target_contains_object_rest`)
— no identifier / file-name string checks, no rendered-output inspection. Tests
vary binder names and cover both positive (object-rest) and negative
(simple-destructure, `...args`-mixed) cases.

## Adjacent-case matrix (verified byte-identical to `tsc 6.0.2`)

A 23-case `tsc`-vs-tsz matrix at es5 (and cross-checked at es2015/es2017): single
and double object-rest params; `{ ...rest }`-only; nested defaults
(`{ a = 5, ...rest }`); nested arrays (`{ a: [x, y], ...rest }`); computed keys
(`{ [k]: v, ...rest }`); array-wrapped object-rest (`[{ a, ...rest }]`, incl.
`--downlevelIteration`); object-rest + plain sibling; leading plain param
(`x, { a, ...rest }`); empty body; multi-line source body (stays multi-line);
and the negative controls `{ a }`, `[a, b]`, `a = 1`, `...args`, and mixed
simple+object-rest — all match `tsc`.

## Scope / follow-up

Two pre-existing, independent ES5 divergences surfaced in the same matrix are
left out of scope (they reproduce regardless of the single-line wrapping and are
noted in #14709): the `{ a, ...rest }, ...args` preamble-vs-args-loop ordering,
and the nested-property-access extra-temp (`_b = _a.a, _c = _b.b` vs
`_b = _a.a.b`).

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New regression tests (binder-name-varied; positive + negative) in
  `crates/tsz-emitter/src/emitter/functions.rs`:
  `object_rest_param_keeps_single_line_function_body_es5`,
  `two_object_rest_params_keep_single_line_function_body_es5`,
  `simple_destructure_param_stays_multi_line_es5`,
  `rest_param_with_object_rest_stays_multi_line_es5` — all pass; the pre-existing
  `object_rest_param_keeps_single_line_function_body` (es6) still passes.
- `cargo test -p tsz-emitter --lib` — 3839 passed, 0 failed (the only repo-wide
  emitter failure, `generator_object_literal_prefix_before_yield_omits_source_trailing_comma`
  in `tests/`, fails identically on clean `main` and is unrelated).
- Built `tsz` (dist-fast) byte-compared to `tsc 6.0.2` over the matrix above:
  every in-scope case identical.
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter` (clean),
  `python3 scripts/arch/arch_guard.py` (passed). Rebased conflict-free on current
  `main` (122d240). Broad conformance / JS-emit / DTS / fourslash owned by
  ready-review CI.

https://claude.ai/code/session_01FkEySrKAKKbEQxmH8SstBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkEySrKAKKbEQxmH8SstBQ)_