### PR TITLE
fix(checker): classify readonly delete/assignment through a type parameter's apparent type

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -704,6 +704,9 @@ path = "tests/ts2430_tests.rs"
 name = "ts2430_cross_file_generic_heritage_tests"
 path = "tests/ts2430_cross_file_generic_heritage_tests.rs"
 [[test]]
+name = "readonly_apparent_type_generic_constraint_tests"
+path = "tests/readonly_apparent_type_generic_constraint_tests.rs"
+[[test]]
 name = "ts2540_readonly_tests"
 path = "tests/ts2540_readonly_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/readonly.rs
+++ b/crates/tsz-checker/src/state/state_checking/readonly.rs
@@ -279,7 +279,9 @@ impl<'a> CheckerState<'a> {
         }
 
         let obj_type = self.get_type_of_node(access.expression);
-        let readonly_check_type = self.evaluate_type_for_assignability(obj_type);
+        let evaluated = self.evaluate_type_for_assignability(obj_type);
+        let readonly_check_type =
+            self.apparent_type_for_readonly_named_property(evaluated, &prop_name);
 
         if self.is_namespace_const_property(access.expression, &prop_name) {
             self.error_delete_readonly_property_at(target_idx);
@@ -534,6 +536,12 @@ impl<'a> CheckerState<'a> {
         // resolve it through the checker's TypeEnvironment to get concrete
         // property readonly flags.
         readonly_check_type = self.resolve_deferred_mapped_type(readonly_check_type);
+        // A generic type-parameter receiver carries its `readonly` modifiers on
+        // its constraint (apparent type); resolve to the constraint so a write
+        // to `t.a` where `T extends { readonly a }` reports TS2540, matching
+        // `tsc`'s `getApparentType`/`isReadonlySymbol`.
+        readonly_check_type =
+            self.apparent_type_for_readonly_named_property(readonly_check_type, &prop_name);
 
         // When the object type is `any` or `error` (e.g., unresolved module import
         // with TS2307), skip readonly checks entirely. TSC doesn't emit TS2540 for
@@ -1566,6 +1574,59 @@ impl<'a> CheckerState<'a> {
             resolved
         } else {
             type_id
+        }
+    }
+
+    /// Resolve a receiver type to the apparent type used to classify a readonly
+    /// *named-property* delete/assignment target.
+    ///
+    /// A generic type parameter carries its `readonly` modifiers on its
+    /// constraint (apparent type); `tsc` resolves the assigned/deleted property
+    /// symbol against `getApparentType`, so when the receiver is a type
+    /// parameter whose constraint declares `prop_name` as a *named* member,
+    /// resolve the constraint through the environment — which resolves the
+    /// interface / library `Lazy` `DefId`s the standalone solver cannot — and
+    /// classify against it. This is what makes `t.a` (with
+    /// `T extends { readonly a }`, `T extends RA`, `T extends Readonly<{ a }>`,
+    /// or `T extends RA & RB`) report TS2540 / TS2704 instead of falling through
+    /// to TS2322 / TS2790.
+    ///
+    /// The apparent type is adopted only when the resolved constraint exposes
+    /// `prop_name` as a named (non-index-signature) property, so an
+    /// index-signature-only constraint
+    /// (`T extends { readonly [k: string]: number }`) keeps `tsc`'s TS2339
+    /// "property does not exist on type 'T'" behavior for `t.k` rather than
+    /// gaining a spurious readonly diagnostic.
+    fn apparent_type_for_readonly_named_property(
+        &mut self,
+        type_id: TypeId,
+        prop_name: &str,
+    ) -> TypeId {
+        use crate::query_boundaries::common::PropertyAccessResult;
+        use crate::query_boundaries::common::type_param_info;
+
+        // `type_param_info` returns `None` for any non-type-parameter, so it also
+        // serves as the "is this a type parameter?" gate.
+        let Some(info) = type_param_info(self.ctx.types, type_id) else {
+            return type_id;
+        };
+        let Some(constraint) = info.constraint else {
+            return type_id;
+        };
+        // `evaluate_type_for_assignability` resolves the constraint's interface /
+        // library `Lazy` members to concrete shapes (the same resolution that
+        // makes a `declare const x: RA & RB` receiver classify correctly), which
+        // the standalone solver readonly query cannot do on its own.
+        let resolved = self.evaluate_type_for_assignability(constraint);
+        if resolved == type_id {
+            return type_id;
+        }
+        match self.resolve_property_access_with_env(resolved, prop_name) {
+            PropertyAccessResult::Success {
+                from_index_signature: false,
+                ..
+            } => resolved,
+            _ => type_id,
         }
     }
 

--- a/crates/tsz-checker/tests/readonly_apparent_type_generic_constraint_tests.rs
+++ b/crates/tsz-checker/tests/readonly_apparent_type_generic_constraint_tests.rs
@@ -1,0 +1,196 @@
+//! Readonly classification through a generic type parameter's *apparent type*.
+//!
+//! `tsc` resolves the deleted/assigned property's symbol against
+//! `getApparentType`, so a property reached through a type parameter's
+//! constraint (`T extends { readonly a }`, `T extends RA`, `T extends RA & RB`,
+//! `T & { readonly a }`) carries the constraint member's `readonly` modifier:
+//!
+//! - `delete t.a`  -> TS2704 ("operand of 'delete' cannot be read-only")
+//! - `t.a = v`     -> TS2540 ("cannot assign to read-only property")
+//!
+//! Before the apparent-type resolution the type parameter stayed opaque, so the
+//! `readonly` modifier was invisible: `delete` fell through to TS2790 ("must be
+//! optional") and the assignment was silently accepted.
+//!
+//! Binder names are varied across cases so the classification cannot be keyed
+//! on any identifier (anti-hardcoding gate).
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+fn count(source: &str, code: u32) -> usize {
+    check_source_strict_codes(source)
+        .into_iter()
+        .filter(|c| *c == code)
+        .count()
+}
+
+// ---------------------------------------------------------------------------
+// delete -> TS2704 through the apparent type
+// ---------------------------------------------------------------------------
+
+#[test]
+fn delete_readonly_named_property_via_inline_object_constraint() {
+    let source = r#"
+function clear<Box extends { readonly slot: number }>(box: Box) {
+    delete box.slot;
+}
+"#;
+    assert_eq!(count(source, 2704), 1, "expected TS2704");
+    assert_eq!(
+        count(source, 2790),
+        0,
+        "TS2790 must be suppressed by TS2704"
+    );
+}
+
+#[test]
+fn delete_readonly_named_property_via_interface_constraint() {
+    let source = r#"
+interface Frozen { readonly value: string }
+function drop<Cell extends Frozen>(cell: Cell) {
+    delete cell.value;
+}
+"#;
+    assert_eq!(
+        count(source, 2704),
+        1,
+        "expected TS2704 for interface constraint"
+    );
+    assert_eq!(count(source, 2790), 0);
+}
+
+#[test]
+fn delete_readonly_named_property_via_intersection_constraint() {
+    // Only `Locked` declares `key`, and it is readonly: the intersection's
+    // synthesized property is readonly even though `Tag` lacks the property.
+    let source = r#"
+interface Locked { readonly key: number }
+interface Tag { label: string }
+function unset<Rec extends Locked & Tag>(rec: Rec) {
+    delete rec.key;
+}
+"#;
+    assert_eq!(
+        count(source, 2704),
+        1,
+        "expected TS2704 for intersection constraint"
+    );
+    assert_eq!(count(source, 2790), 0);
+}
+
+#[test]
+fn delete_readonly_named_property_via_intersection_with_free_type_parameter() {
+    // `Base & { readonly id }`: the free type parameter `Base` does not declare
+    // `id`, so only the readonly literal member contributes -> readonly.
+    let source = r#"
+function strip<Base>(value: Base & { readonly id: number }) {
+    delete value.id;
+}
+"#;
+    assert_eq!(
+        count(source, 2704),
+        1,
+        "expected TS2704 for intersection with free type parameter"
+    );
+    assert_eq!(count(source, 2790), 0);
+}
+
+#[test]
+fn delete_readonly_takes_precedence_over_optional_via_constraint() {
+    // `readonly a?` is both readonly and optional; `tsc` reports the readonly
+    // error (TS2704), not the must-be-optional one, and never accepts it.
+    let source = r#"
+function wipe<Holder extends { readonly maybe?: number }>(holder: Holder) {
+    delete holder.maybe;
+}
+"#;
+    assert_eq!(count(source, 2704), 1, "readonly wins over optional");
+    assert_eq!(count(source, 2790), 0);
+}
+
+// ---------------------------------------------------------------------------
+// assignment -> TS2540 through the apparent type
+// ---------------------------------------------------------------------------
+
+#[test]
+fn assign_readonly_named_property_via_inline_object_constraint() {
+    let source = r#"
+function setIt<Node extends { readonly count: number }>(node: Node) {
+    node.count = 5;
+}
+"#;
+    assert_eq!(
+        count(source, 2540),
+        1,
+        "expected TS2540 for write through constraint"
+    );
+}
+
+#[test]
+fn assign_readonly_named_property_via_interface_intersection_constraint() {
+    let source = r#"
+interface ReadView { readonly total: number }
+interface Named { name: string }
+function bump<Agg extends ReadView & Named>(agg: Agg) {
+    agg.total = 9;
+}
+"#;
+    assert_eq!(
+        count(source, 2540),
+        1,
+        "expected TS2540 for intersection constraint write"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative / non-regression cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn delete_mutable_named_property_via_constraint_is_must_be_optional_not_readonly() {
+    // A mutable, required property still reports TS2790 (must be optional), and
+    // never the readonly error.
+    let source = r#"
+function remove<Bag extends { open: number }>(bag: Bag) {
+    delete bag.open;
+}
+"#;
+    assert_eq!(count(source, 2704), 0, "mutable property is not readonly");
+    assert_eq!(
+        count(source, 2790),
+        1,
+        "mutable required property -> TS2790"
+    );
+}
+
+#[test]
+fn assign_mutable_named_property_via_constraint_is_accepted() {
+    let source = r#"
+function assign<Obj extends { writable: number }>(obj: Obj) {
+    obj.writable = 7;
+}
+"#;
+    assert_eq!(
+        count(source, 2540),
+        0,
+        "writable property must not report TS2540"
+    );
+}
+
+#[test]
+fn write_through_readonly_index_signature_constraint_is_not_a_named_readonly() {
+    // A property reached only through the constraint's index signature resolves
+    // no named symbol on the type parameter, so the write must NOT gain a
+    // spurious TS2542 / TS2540 (it is TS2339 in `tsc`).
+    let source = r#"
+function put<Dict extends { readonly [k: string]: number }>(dict: Dict) {
+    dict.entry = 1;
+}
+"#;
+    assert_eq!(
+        count(source, 2542),
+        0,
+        "no spurious readonly-index-signature error"
+    );
+    assert_eq!(count(source, 2540), 0, "no spurious named-readonly error");
+}

--- a/crates/tsz-solver/src/operations/property_readonly.rs
+++ b/crates/tsz-solver/src/operations/property_readonly.rs
@@ -67,18 +67,138 @@ pub(crate) fn property_is_readonly(
                 .any(|t| property_is_readonly(interner, *t, prop_name))
         }
         Some(TypeData::Intersection(types)) => {
-            // For intersections: property is readonly ONLY if it's readonly in ALL constituent types
-            // This allows assignment to `{ readonly a: number } & { a: number }` (mixed readonly/mutable)
             let types = interner.type_list(types);
-            types
-                .iter()
-                .all(|t| property_is_readonly(interner, *t, prop_name))
+            intersection_property_is_readonly(interner, &types, prop_name)
         }
         Some(TypeData::Mapped(mapped_id)) => {
             // Mapped types with explicit readonly modifier (e.g., Readonly<T>)
             // have ALL properties readonly.
             let mapped = interner.get_mapped(mapped_id);
             mapped.readonly_modifier == Some(MappedModifier::Add)
+        }
+        // A property reached through a generic type parameter is classified on
+        // the parameter's *apparent type* (its base constraint), mirroring
+        // `tsc`'s `getApparentType`/`isReadonlySymbol`: `delete`/assignment of
+        // `t.a` where `T extends { readonly a }` must see the constraint's
+        // `readonly` modifier. A bare type parameter leaves the modifier
+        // invisible, so resolve to the constraint and re-classify — but only
+        // when the constraint declares the property as a *named* member. A
+        // constraint exposing the property solely through an index signature
+        // (`T extends { readonly [k: string]: number }`) resolves no named
+        // symbol on the type parameter, so `tsc` reports TS2339 for `t.k`
+        // rather than a readonly diagnostic; keep that by not treating the
+        // index-signature match as a readonly named property here.
+        //
+        // Interface / library-alias constraints arrive as unresolved
+        // `Lazy(DefId)` that the standalone evaluator cannot resolve; those are
+        // resolved to a concrete apparent type by the checker (which owns the
+        // `DefId -> TypeId` environment) before this query runs.
+        Some(TypeData::TypeParameter(info)) => match info.constraint {
+            Some(constraint)
+                if constraint != type_id
+                    && type_declares_property(interner, constraint, prop_name) =>
+            {
+                property_is_readonly(interner, constraint, prop_name)
+            }
+            _ => false,
+        },
+        // A substitution `base & constraint` (from conditional-flow narrowing)
+        // observes the readonly modifier of either constituent, just like the
+        // base-constraint computation it mirrors (`getSubstitutionIntersection`).
+        Some(TypeData::Substitution {
+            base_type,
+            constraint,
+        }) => intersection_property_is_readonly(interner, &[base_type, constraint], prop_name),
+        _ => false,
+    }
+}
+
+/// Classify a property reached through an *intersection* of constituents.
+///
+/// `tsc` synthesizes the intersection's property symbol from the constituents
+/// that actually declare it (`getPropertyOfUnionOrIntersectionType`): the
+/// property is readonly iff at least one constituent declares it and *every*
+/// declaring constituent declares it `readonly`. A constituent that does not
+/// declare the property — an unrelated member, or a type parameter whose
+/// apparent type lacks it — does not contribute. The earlier `all()` over *all*
+/// constituents wrongly treated a non-declaring member's `false` as "mutable",
+/// so e.g. `T & { readonly a }` (apparent `unknown & { readonly a }`) and
+/// `T extends RA & RB` (only `RA` declares `a`) lost the `readonly` modifier.
+fn intersection_property_is_readonly(
+    interner: &dyn TypeDatabase,
+    members: &[TypeId],
+    prop_name: &str,
+) -> bool {
+    let mut any_declared = false;
+    let mut all_readonly = true;
+    for &member in members {
+        if type_declares_property(interner, member, prop_name) {
+            any_declared = true;
+            if !property_is_readonly(interner, member, prop_name) {
+                all_readonly = false;
+            }
+        }
+    }
+    any_declared && all_readonly
+}
+
+/// Whether `type_id` declares a *named* member `prop_name`, resolving the same
+/// surface-preserving wrappers as [`property_is_readonly`] (interfaces/aliases,
+/// `readonly` wrappers, unions/intersections, and the apparent type of a
+/// generic type parameter). Index-signature-only matches are intentionally
+/// excluded: they synthesize no named symbol, so `tsc` reports them through the
+/// TS2542 index-signature path rather than the named-property TS2540/TS2704
+/// path that consults this classifier.
+fn type_declares_property(interner: &dyn TypeDatabase, type_id: TypeId, prop_name: &str) -> bool {
+    if type_id.is_intrinsic() {
+        return false;
+    }
+    match interner.lookup(type_id) {
+        Some(TypeData::Lazy(_)) => {
+            let resolved = evaluate_type(interner, type_id);
+            resolved != type_id && type_declares_property(interner, resolved, prop_name)
+        }
+        Some(TypeData::ReadonlyType(inner)) => {
+            if let Some(TypeData::Array(_) | TypeData::Tuple(_)) = interner.lookup(inner)
+                && (is_numeric_index_name(prop_name) || prop_name == "length")
+            {
+                return true;
+            }
+            type_declares_property(interner, inner, prop_name)
+        }
+        Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+            let shape = interner.object_shape(shape_id);
+            let prop_atom = interner.intern_string(prop_name);
+            shape.properties.iter().any(|prop| prop.name == prop_atom)
+        }
+        Some(TypeData::Callable(shape_id)) => {
+            let shape = interner.callable_shape(shape_id);
+            let prop_atom = interner.intern_string(prop_name);
+            shape.properties.iter().any(|prop| prop.name == prop_atom)
+        }
+        Some(TypeData::Union(types) | TypeData::Intersection(types)) => {
+            let types = interner.type_list(types);
+            types
+                .iter()
+                .any(|t| type_declares_property(interner, *t, prop_name))
+        }
+        // A homomorphic `+readonly` mapped type (e.g. `Readonly<T>`) maps over
+        // its source keys, so it declares the property `tsc` would readonly-flag.
+        Some(TypeData::Mapped(mapped_id)) => {
+            interner.get_mapped(mapped_id).readonly_modifier == Some(MappedModifier::Add)
+        }
+        Some(TypeData::TypeParameter(info)) => match info.constraint {
+            Some(constraint) if constraint != type_id => {
+                type_declares_property(interner, constraint, prop_name)
+            }
+            _ => false,
+        },
+        Some(TypeData::Substitution {
+            base_type,
+            constraint,
+        }) => {
+            type_declares_property(interner, base_type, prop_name)
+                || type_declares_property(interner, constraint, prop_name)
         }
         _ => false,
     }


### PR DESCRIPTION
Closes #14713.

## Failure family

Conformance — false negatives on readonly violations reached **through a generic
type parameter's constraint (apparent type)**. `tsc` (6.0.2) resolves a
delete/assignment target's property symbol against `getApparentType`, so a
property declared `readonly` on a type parameter's constraint carries that
modifier. tsz left the type parameter opaque, so the modifier was invisible:

| Expression | `tsc` | tsz (before) | tsz (after) |
|---|---|---|---|
| `<T extends { readonly a: number }>` `delete t.a` | TS2704 | TS2790 | TS2704 |
| `<T extends Readonly<{ a: number }>>` `delete t.a` | TS2704 | TS2790 | TS2704 |
| `<T extends { readonly a?: number }>` `delete t.a` | TS2704 | (none) | TS2704 |
| `interface RA{readonly a} RB{b}` `<T extends RA & RB>` `delete t.a` | TS2704 | (none) | TS2704 |
| `<T>(t: T & { readonly a: number })` `delete t.a` | TS2704 | TS2790 | TS2704 |
| `<T extends { readonly a: number }>` `t.a = 1` | TS2540 | (none) | TS2540 |

The reported witness is the `delete`-of-readonly code-selection divergence
flagged as a follow-up in #14707 ("TS2790 vs TS2704"); a `tsc`-vs-tsz
differential probe over operand-kind × constraint-shape showed it is one symptom
of a shared root that also affects assignment (TS2540) and the
intersection-property readonly rule.

## Structural rule

> When a `delete`/assignment target is a property reached through the apparent
> type of a generic type parameter, `tsc` classifies `readonly` on that apparent
> type (`getApparentType` → the constraint). For an **intersection** apparent
> type the synthesized property is `readonly` iff at least one constituent
> declares it and *every* declaring constituent declares it `readonly`
> (`getPropertyOfUnionOrIntersectionType`); a constituent that does not declare
> the property does not contribute.

tsz's solver readonly query had no type-parameter arm (a bare type parameter
classified as mutable), and its intersection arm used `all()` over **all**
constituents — a member that lacks the property returned `false` and was wrongly
read as "mutable", dropping the modifier for `T & { readonly a }` and
`T extends RA & RB`.

## Owner layer

- **Solver** `crates/tsz-solver/src/operations/property_readonly.rs`:
  `property_is_readonly` gains apparent-type (`TypeParameter`/`Substitution`)
  arms and a corrected `Intersection` arm implementing the declaring-members
  rule (shared by both arms via `intersection_property_is_readonly`).
  Type-parameter resolution is gated on the constraint declaring the property as
  a *named* member (`type_declares_property`, which excludes index-signature
  matches), so an index-signature-only constraint
  (`T extends { readonly [k: string]: number }`) keeps `tsc`'s TS2339 behavior
  for `t.k` rather than gaining a spurious readonly diagnostic.
- **Checker** `crates/tsz-checker/src/state/state_checking/readonly.rs`:
  `apparent_type_for_readonly_named_property` resolves the receiver's apparent
  type before the named-property readonly classification at both the `delete`
  and assignment sites. Interface / library-alias constraints arrive as
  `Lazy(DefId)` that the standalone solver cannot resolve; the checker owns the
  `DefId -> TypeId` environment and pre-resolves the constraint to a concrete
  apparent type first.

## Anti-hardcoding

Decisions are structural (named vs index-signature member, apparent-type
constraint, nullability) — no identifier/file-name literals and no
formatted-diagnostic-string predicates. The new regression suite varies binder
names across cases.

## Adjacent-case matrix

`crates/tsz-checker/tests/readonly_apparent_type_generic_constraint_tests.rs`
covers, with varied binder names: delete → TS2704 via inline-object, interface,
intersection, and `T & { readonly … }` constraints, plus the readonly-wins-over-
optional case; assignment → TS2540 via inline and interface-intersection
constraints; and negatives — mutable-via-constraint stays TS2790 (delete) /
accepted (assignment), and the index-signature-only constraint emits no spurious
TS2542/TS2540.

## Scope / follow-up

The `delete`-through-a-**readonly index signature** reached on a generic
constraint (`delete t.k` with `T extends { readonly [k: string]: number }`,
`tsc` TS2542) is a distinct site with a delete-vs-assignment asymmetry (`tsc`
reports TS2339 for the corresponding assignment), left as a follow-up.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New regression suite (binder names varied):
  `cargo test -p tsz-checker --test readonly_apparent_type_generic_constraint_tests`
  — 10/10 pass.
- Differential vs `tsc 6.0.2` over a delete/assignment × constraint-shape probe
  (`--strict --target esnext`): every named-readonly case now byte-matches `tsc`
  (the one remaining delta is the out-of-scope readonly-index-signature delete).
- No regressions: the broad readonly/narrowing/intersection/constraint/assign/
  delete lib filter shows an identical failure set on this branch and on clean
  `main` (1773 passed both; the 3 shared failures —
  `ts2540_readonly_tests` ×2, `ts2542_readonly_index_coemission_tests` ×1 — are
  pre-existing and unrelated). `conformance_issues_errors` (296),
  `conformance_issues_types` (422) green.
- `cargo fmt -p tsz-solver -p tsz-checker --check`,
  `cargo clippy -p tsz-solver -p tsz-checker --lib` clean,
  `python3 scripts/arch/arch_guard.py` passed. Rebased conflict-free on current
  `main`. Broad conformance / emit / fourslash owned by ready-review CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfTpSX6EfAqyhrZwA5vpnk)_