### PR TITLE
fix(emit): lower ES5 private method/accessor member access correctly

### DIFF
--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -25,11 +25,34 @@ mod control_flow;
 mod expressions;
 #[path = "class_es5_ast_to_ir_for_in_of.rs"]
 mod for_in_of;
+#[path = "class_es5_ast_to_ir_private_members.rs"]
+mod private_members;
 
 #[derive(Clone)]
 enum ThisSubstitution {
     Identifier(String),
     Raw(String),
+}
+
+/// Resolved lowering for a private member access inside an ES5 class body.
+///
+/// `__classPrivateFieldGet`/`Set` take a `state` brand argument and a `kind`
+/// (`"f"` field, `"a"` accessor, `"m"` method). Accessors and methods also
+/// require a trailing function reference (the getter/setter/method), so the
+/// brand for an *instance* accessor or method is the class's `_C_instances`
+/// `WeakSet`, not the function variable itself. The legacy static-accessor
+/// shape (and plain fields) brand against their own storage var and carry no
+/// trailing reference (`member_ref: None`).
+#[derive(Clone)]
+struct PrivateMemberSlot {
+    /// The brand argument: a field's `WeakMap`, or an instance member's
+    /// `WeakSet` (`_C_instances`).
+    state_var: String,
+    /// The `__classPrivateFieldGet/Set` kind discriminant: `"a"` or `"m"`.
+    kind: &'static str,
+    /// The trailing function reference (getter/setter/method var) for the
+    /// 4-arg get / 5-arg set form, or `None` for the 3-arg form.
+    member_ref: Option<String>,
 }
 
 /// Convert an AST node to IR, avoiding `ASTRef` when possible
@@ -88,10 +111,14 @@ pub struct AstToIr<'a> {
     /// Maps clean private field name → `WeakMap` variable name for `__classPrivateFieldGet/Set`.
     /// Populated from the enclosing class's `PrivateFieldInfo` collection.
     private_field_map: rustc_hash::FxHashMap<String, String>,
-    /// Maps clean private accessor name → getter `WeakMap` variable name.
-    private_get_accessor_map: rustc_hash::FxHashMap<String, String>,
-    /// Maps clean private accessor name → setter `WeakMap` variable name.
-    private_set_accessor_map: rustc_hash::FxHashMap<String, String>,
+    /// Maps a clean private accessor/method name to the brand + reference used
+    /// to *read* it (`__classPrivateFieldGet`). Instance getters and methods
+    /// resolve to the class's `_C_instances` `WeakSet` brand; a private method
+    /// stored here is read as a function value (and called via `.call`).
+    private_read_slots: rustc_hash::FxHashMap<String, PrivateMemberSlot>,
+    /// Maps a clean private accessor name to the brand + setter reference used
+    /// to *write* it (`__classPrivateFieldSet`).
+    private_write_slots: rustc_hash::FxHashMap<String, PrivateMemberSlot>,
 }
 
 impl<'a> AstToIr<'a> {
@@ -121,57 +148,9 @@ impl<'a> AstToIr<'a> {
             generated_disposable_env_names: RefCell::new(Vec::new()),
             outer_rename_map: rustc_hash::FxHashMap::default(),
             private_field_map: rustc_hash::FxHashMap::default(),
-            private_get_accessor_map: rustc_hash::FxHashMap::default(),
-            private_set_accessor_map: rustc_hash::FxHashMap::default(),
+            private_read_slots: rustc_hash::FxHashMap::default(),
+            private_write_slots: rustc_hash::FxHashMap::default(),
         }
-    }
-
-    /// Provide private field and accessor storage maps so that `this.#x` references
-    /// inside method/accessor bodies lower to `__classPrivateFieldGet/Set` calls.
-    pub fn with_private_field_maps(
-        mut self,
-        fields: &[crate::transforms::private_fields_es5::PrivateFieldInfo],
-        accessors: &[crate::transforms::private_fields_es5::PrivateAccessorInfo],
-    ) -> Self {
-        for field in fields {
-            self.private_field_map
-                .insert(field.name.clone(), field.weakmap_name.clone());
-        }
-        for accessor in accessors {
-            if let Some(ref get_var) = accessor.get_var_name {
-                self.private_get_accessor_map
-                    .insert(accessor.name.clone(), get_var.clone());
-            }
-            if let Some(ref set_var) = accessor.set_var_name {
-                self.private_set_accessor_map
-                    .insert(accessor.name.clone(), set_var.clone());
-            }
-        }
-        self
-    }
-
-    /// Look up private-field storage info for a read of `this.#name`.
-    /// Returns `(weakmap_var, kind)` where kind is `"f"` for fields or `"a"` for accessors.
-    pub(super) fn private_read_info(&self, clean_name: &str) -> Option<(String, &'static str)> {
-        if let Some(var) = self.private_field_map.get(clean_name) {
-            return Some((var.clone(), "f"));
-        }
-        if let Some(var) = self.private_get_accessor_map.get(clean_name) {
-            return Some((var.clone(), "a"));
-        }
-        None
-    }
-
-    /// Look up private-field storage info for a write `this.#name = v`.
-    /// Returns `(weakmap_var, kind)` where kind is `"f"` for fields or `"a"` for accessors.
-    pub(super) fn private_write_info(&self, clean_name: &str) -> Option<(String, &'static str)> {
-        if let Some(var) = self.private_field_map.get(clean_name) {
-            return Some((var.clone(), "f"));
-        }
-        if let Some(var) = self.private_set_accessor_map.get(clean_name) {
-            return Some((var.clone(), "a"));
-        }
-        None
     }
 
     /// Set the outer rename map: original → emitted name for block-scoped

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
@@ -133,6 +133,22 @@ impl<'a> AstToIr<'a> {
                 return optional_call;
             }
 
+            // Private member call `recv.#m(args)`: a private method, a private
+            // field holding a function, or a private getter invoked in call
+            // position. The member is read through `__classPrivateFieldGet(...)`
+            // and invoked with `.call(recv, args)` so the original receiver is
+            // preserved as `this` (mirroring tsc and the main, non-ES5 emitter).
+            // Without `.call`, a private method read (`kind: "m"`) would emit the
+            // bare callee `recv.()` because a private identifier has no plain
+            // property name; the `.call` form is what makes the lowering valid.
+            if let Some(private_call) = self.try_convert_private_member_call(
+                call.expression,
+                &args,
+                node.is_optional_chain(),
+            ) {
+                return private_call;
+            }
+
             let callee = self.convert_expression(call.expression);
             IRNode::CallExpr {
                 callee: Box::new(callee),
@@ -141,6 +157,62 @@ impl<'a> AstToIr<'a> {
         } else {
             IRNode::ASTRef(idx)
         }
+    }
+
+    /// Lower `recv.#name(args)` where `#name` is a private member with a read
+    /// slot (method, function-valued field, or getter) to
+    /// `__classPrivateFieldGet(recv, brand, kind[, fn]).call(recv, args)`.
+    ///
+    /// The receiver is referenced twice (once to read the member, once as the
+    /// `.call` `this`), so a side-effecting receiver is captured once into a
+    /// hoisted temp: `(_a = side()).….call(_a, args)`. Returns `None` for a
+    /// non-private callee, an optional chain (handled separately), or a private
+    /// name with no read slot (e.g. a static private method, left to the
+    /// fallthrough).
+    fn try_convert_private_member_call(
+        &self,
+        callee_idx: NodeIndex,
+        args: &[IRNode],
+        is_optional_chain: bool,
+    ) -> Option<IRNode> {
+        if is_optional_chain {
+            return None;
+        }
+        let (receiver_idx, clean) = self.private_access_target(callee_idx)?;
+        // A private name with no read slot (e.g. a static private method) is
+        // left to the fallthrough. Checked before any temp is allocated so the
+        // fallthrough cannot leak a hoisted `var`.
+        if !self.has_private_read_slot(&clean) {
+            return None;
+        }
+
+        // Capture a side-effecting receiver once so it is evaluated a single
+        // time and shared between the member read and the `.call` `this`.
+        let (get_ir, call_receiver) =
+            if crate::transforms::emit_utils::is_simple_copiable_expression(
+                self.arena,
+                receiver_idx,
+            ) {
+                (
+                    self.private_field_get_ir(receiver_idx, &clean)?,
+                    self.convert_expression(receiver_idx),
+                )
+            } else {
+                let temp = self.generate_hoisted_temp();
+                let captured = IRNode::Parenthesized(Box::new(IRNode::assign(
+                    IRNode::id(temp.clone()),
+                    self.convert_expression(receiver_idx),
+                )));
+                (
+                    self.private_field_get_ir_with_receiver(captured, &clean)?,
+                    IRNode::id(temp),
+                )
+            };
+
+        let mut call_args = Vec::with_capacity(args.len() + 1);
+        call_args.push(call_receiver);
+        call_args.extend(args.iter().cloned());
+        Some(IRNode::call(IRNode::prop(get_ir, "call"), call_args))
     }
 
     fn convert_wrapped_dynamic_import(&self, args: Option<&NodeList>) -> IRNode {
@@ -424,18 +496,8 @@ impl<'a> AstToIr<'a> {
                 if let Some(ident) = self.arena.get_identifier(name_node) {
                     let raw = &ident.escaped_text;
                     let clean = raw.strip_prefix('#').unwrap_or(raw.as_str());
-                    if let Some((storage_var, kind)) = self.private_read_info(clean) {
-                        let object = self.convert_expression(access.expression);
-                        return IRNode::call(
-                            IRNode::RuntimeHelper(std::borrow::Cow::Borrowed(
-                                "__classPrivateFieldGet",
-                            )),
-                            vec![
-                                object,
-                                IRNode::id(storage_var),
-                                IRNode::StringLiteral(kind.into()),
-                            ],
-                        );
+                    if let Some(get_ir) = self.private_field_get_ir(access.expression, clean) {
+                        return get_ir;
                     }
                 }
                 // Unknown private name — fall through to ASTRef
@@ -547,18 +609,10 @@ impl<'a> AstToIr<'a> {
         }
     }
 
-    /// If `idx` is a `recv.#name` property access whose member is a private
-    /// field or accessor with **both** a read and a write slot, and whose
-    /// receiver is a simple, side-effect-free expression safe to evaluate more
-    /// than once, return `(receiver_idx, clean_name)`.
-    ///
-    /// Compound assignment (`this.#x += v`) and `++`/`--` mutation read the slot
-    /// and then write it, so they reference the receiver twice. A non-simple
-    /// receiver (which must be evaluated exactly once) and a private *method*
-    /// (no field slot) are intentionally rejected here and left to the existing
-    /// fallthrough. The rule keys on the member being a `PrivateIdentifier` with
-    /// a storage entry, never on its spelling.
-    fn private_mutation_target(&self, idx: NodeIndex) -> Option<(NodeIndex, String)> {
+    /// Decompose a `recv.#name` property access into `(receiver_idx,
+    /// clean_name)`, or `None` when `idx` is not a private-identifier property
+    /// access. Pure AST shape — it does not consult the storage maps.
+    fn private_access_target(&self, idx: NodeIndex) -> Option<(NodeIndex, String)> {
         let node = self.arena.get(idx)?;
         if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
             return None;
@@ -571,33 +625,61 @@ impl<'a> AstToIr<'a> {
         let ident = self.arena.get_identifier(name_node)?;
         let raw = &ident.escaped_text;
         let clean = raw.strip_prefix('#').unwrap_or(raw.as_str()).to_string();
-        // Read-modify-write needs both a get slot and a set slot.
-        self.private_read_info(&clean)?;
-        self.private_write_info(&clean)?;
-        if !crate::transforms::emit_utils::is_simple_copiable_expression(
-            self.arena,
-            access.expression,
-        ) {
-            return None;
-        }
         Some((access.expression, clean))
     }
 
-    /// `__classPrivateFieldGet(receiver, <read_var>, "<read_kind>")` for a known
-    /// private field/accessor read. `None` when the name has no read slot.
+    /// If `idx` is a `recv.#name` property access whose member is a private
+    /// field or accessor with **both** a read and a write slot, and whose
+    /// receiver is a simple, side-effect-free expression safe to evaluate more
+    /// than once, return `(receiver_idx, clean_name)`.
+    ///
+    /// Compound assignment (`this.#x += v`) and `++`/`--` mutation read the slot
+    /// and then write it, so they reference the receiver twice. A non-simple
+    /// receiver (which must be evaluated exactly once) and a private *method*
+    /// (no field slot) are intentionally rejected here and left to the existing
+    /// fallthrough. The rule keys on the member being a `PrivateIdentifier` with
+    /// a storage entry, never on its spelling.
+    fn private_mutation_target(&self, idx: NodeIndex) -> Option<(NodeIndex, String)> {
+        let (receiver_idx, clean) = self.private_access_target(idx)?;
+        // Read-modify-write needs both a get slot and a set slot.
+        self.private_read_info(&clean)?;
+        self.private_write_info(&clean)?;
+        if !crate::transforms::emit_utils::is_simple_copiable_expression(self.arena, receiver_idx) {
+            return None;
+        }
+        Some((receiver_idx, clean))
+    }
+
+    /// `__classPrivateFieldGet(receiver, <brand>, "<kind>"[, <fn>])` for a known
+    /// private field/accessor/method read. `None` when the name has no read slot.
     fn private_field_get_ir(&self, receiver_idx: NodeIndex, clean_name: &str) -> Option<IRNode> {
-        let (storage_var, kind) = self.private_read_info(clean_name)?;
+        self.private_field_get_ir_with_receiver(self.convert_expression(receiver_idx), clean_name)
+    }
+
+    /// Like [`Self::private_field_get_ir`] but with a pre-built receiver node,
+    /// so a side-effecting receiver can be captured once (e.g.
+    /// `(_a = side())`) before it is reused by a `.call`.
+    fn private_field_get_ir_with_receiver(
+        &self,
+        receiver: IRNode,
+        clean_name: &str,
+    ) -> Option<IRNode> {
+        let (brand_var, kind, member_ref) = self.private_read_info(clean_name)?;
+        let mut args = vec![
+            receiver,
+            IRNode::id(brand_var),
+            IRNode::StringLiteral(kind.into()),
+        ];
+        if let Some(member_ref) = member_ref {
+            args.push(IRNode::id(member_ref));
+        }
         Some(IRNode::call(
             IRNode::RuntimeHelper(std::borrow::Cow::Borrowed("__classPrivateFieldGet")),
-            vec![
-                self.convert_expression(receiver_idx),
-                IRNode::id(storage_var),
-                IRNode::StringLiteral(kind.into()),
-            ],
+            args,
         ))
     }
 
-    /// `__classPrivateFieldSet(receiver, <write_var>, value, "<write_kind>")` for
+    /// `__classPrivateFieldSet(receiver, <brand>, value, "<kind>"[, <fn>])` for
     /// a known private field/accessor write. `None` when the name has no write
     /// slot (e.g. a getter-only accessor).
     fn private_field_set_ir(
@@ -606,15 +688,19 @@ impl<'a> AstToIr<'a> {
         clean_name: &str,
         value: IRNode,
     ) -> Option<IRNode> {
-        let (storage_var, kind) = self.private_write_info(clean_name)?;
+        let (brand_var, kind, member_ref) = self.private_write_info(clean_name)?;
+        let mut args = vec![
+            self.convert_expression(receiver_idx),
+            IRNode::id(brand_var),
+            value,
+            IRNode::StringLiteral(kind.into()),
+        ];
+        if let Some(member_ref) = member_ref {
+            args.push(IRNode::id(member_ref));
+        }
         Some(IRNode::call(
             IRNode::RuntimeHelper(std::borrow::Cow::Borrowed("__classPrivateFieldSet")),
-            vec![
-                self.convert_expression(receiver_idx),
-                IRNode::id(storage_var),
-                value,
-                IRNode::StringLiteral(kind.into()),
-            ],
+            args,
         ))
     }
 
@@ -686,7 +772,7 @@ impl<'a> AstToIr<'a> {
         };
         // Short-circuit assignment may only be folded into an unconditional set
         // for a plain field; accessors keep their conditional-write semantics.
-        if self.private_write_info(&clean).map(|(_, kind)| kind) != Some("f") {
+        if self.private_write_info(&clean).map(|(_, kind, _)| kind) != Some("f") {
             return None;
         }
         let get_ir = self.private_field_get_ir(receiver_idx, &clean)?;
@@ -791,19 +877,24 @@ impl<'a> AstToIr<'a> {
                     if let Some(ident) = self.arena.get_identifier(name_node) {
                         let raw = &ident.escaped_text;
                         let clean = raw.strip_prefix('#').unwrap_or(raw.as_str());
-                        if let Some((storage_var, kind)) = self.private_write_info(clean) {
+                        if let Some((brand_var, kind, member_ref)) = self.private_write_info(clean)
+                        {
                             let receiver = self.convert_expression(lhs_access.expression);
                             let value = self.convert_expression(bin.right);
+                            let mut set_args = vec![
+                                receiver,
+                                IRNode::id(brand_var),
+                                value,
+                                IRNode::StringLiteral(kind.into()),
+                            ];
+                            if let Some(member_ref) = member_ref {
+                                set_args.push(IRNode::id(member_ref));
+                            }
                             return IRNode::call(
                                 IRNode::RuntimeHelper(std::borrow::Cow::Borrowed(
                                     "__classPrivateFieldSet",
                                 )),
-                                vec![
-                                    receiver,
-                                    IRNode::id(storage_var),
-                                    value,
-                                    IRNode::StringLiteral(kind.into()),
-                                ],
+                                set_args,
                             );
                         }
                     }
@@ -1105,6 +1196,120 @@ mod optional_chain_in_class_member_tests {
         printer.get_output().to_string()
     }
 
+    // Structural rule: at ES5 a `recv.#name(args)` call where `#name` is a
+    // private member with a read slot (method, function-valued field, or
+    // getter) lowers to `__classPrivateFieldGet(recv, brand, kind[, fn])
+    // .call(recv, args)`. The brand for an instance method/getter is the
+    // class's `_instances` WeakSet (never the function var), and the call is
+    // routed through `.call` so the receiver is preserved as `this`. Without
+    // this the private method read had no brand entry and emitted the invalid
+    // bare callee `recv.()`. The rule keys on the member's read slot and kind,
+    // not on its spelling — these tests vary class/member/binder names.
+
+    #[test]
+    fn instance_private_method_call_uses_instances_brand_and_call() {
+        let output = emit_es5(
+            "class Counter {\n    #step(n: number) { return n; }\n    bump() { return this.#step(2); }\n}\n",
+        );
+        assert!(
+            output.contains(
+                "__classPrivateFieldGet(this, _Counter_instances, \"m\", _Counter_step).call(this, 2)"
+            ),
+            "Instance `this.#step(2)` must read through the `_instances` brand and invoke via `.call`.\nOutput:\n{output}"
+        );
+        assert!(
+            !output.contains("this.()") && !output.contains(".()"),
+            "Lowered output must not contain the invalid bare private callee.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn instance_private_method_reference_without_call_reads_function_value() {
+        // A private method read in value position (not called) lowers to the
+        // bare 4-arg get with no `.call`.
+        let output = emit_es5(
+            "class Registry {\n    #lookup() { return 1; }\n    handle() { const f = this.#lookup; return f; }\n}\n",
+        );
+        assert!(
+            output.contains(
+                "__classPrivateFieldGet(this, _Registry_instances, \"m\", _Registry_lookup)"
+            ),
+            "A private-method reference must read the 4-arg function value.\nOutput:\n{output}"
+        );
+        assert!(
+            !output.contains("_Registry_lookup).call"),
+            "A bare reference must not synthesize a `.call`.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn instance_private_getter_in_call_position_preserves_receiver() {
+        // Distinct binder names (anti-hardcoding): the call lowering keys on the
+        // read slot, not the member spelling.
+        let output = emit_es5(
+            "class Service {\n    get #handler() { return () => 1; }\n    run() { return this.#handler(); }\n}\n",
+        );
+        assert!(
+            output.contains(
+                "__classPrivateFieldGet(this, _Service_instances, \"a\", _Service_handler_get).call(this)"
+            ),
+            "A private getter invoked in call position must brand against `_instances` and `.call`.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn instance_private_method_call_captures_side_effecting_receiver_once() {
+        // The receiver is referenced twice (read + `.call` this), so a
+        // side-effecting receiver must be captured into a single hoisted temp.
+        let output = emit_es5(
+            "class Node {\n    #weight() { return 1; }\n    total(make: () => Node) { return make().#weight(); }\n}\n",
+        );
+        assert!(
+            output.contains("(_a = make())")
+                && output.contains(
+                    "__classPrivateFieldGet((_a = make()), _Node_instances, \"m\", _Node_weight).call(_a)"
+                ),
+            "A side-effecting receiver must be captured once and reused by the `.call`.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn instance_private_accessor_read_uses_instances_brand_and_getter_ref() {
+        let output = emit_es5(
+            "class Cell {\n    get #value() { return 7; }\n    peek() { return this.#value; }\n}\n",
+        );
+        assert!(
+            output
+                .contains("__classPrivateFieldGet(this, _Cell_instances, \"a\", _Cell_value_get)"),
+            "An instance accessor read must brand against `_instances` and pass the getter ref.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn instance_private_accessor_write_uses_instances_brand_and_setter_ref() {
+        let output = emit_es5(
+            "class Slot {\n    set #value(v: number) {}\n    fill() { this.#value = 9; }\n}\n",
+        );
+        assert!(
+            output.contains(
+                "__classPrivateFieldSet(this, _Slot_instances, 9, \"a\", _Slot_value_set)"
+            ),
+            "An instance accessor write must brand against `_instances` and pass the setter ref.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn private_field_function_call_routes_through_call_to_preserve_this() {
+        // A private field holding a function is still read with kind "f", but a
+        // call must use `.call(this)` like tsc (preserving the receiver).
+        let output =
+            emit_es5("class Box {\n    #run = () => 1;\n    go() { return this.#run(); }\n}\n");
+        assert!(
+            output.contains("__classPrivateFieldGet(this, _Box_run, \"f\").call(this)"),
+            "A private field-function call must route through `.call(this)`.\nOutput:\n{output}"
+        );
+    }
+
     // Structural rule: when the ES5 class-IR converter sees a property/element
     // access (or `recv?.m()` method call) carrying `?.`, it must lower the
     // nullish short-circuit guard rather than dropping the token. The rule keys
@@ -1294,18 +1499,18 @@ mod optional_chain_in_class_member_tests {
     }
 
     #[test]
-    fn private_accessor_compound_uses_distinct_get_set_storage() {
-        // Accessor read/write use different storage vars and kind "a"; a compound
-        // assignment must thread the get-storage into the read and the
-        // set-storage into the write.
+    fn private_accessor_compound_uses_instances_brand_and_get_set_refs() {
+        // An instance accessor brands against `_Box_instances` and threads the
+        // getter as the trailing read argument and the setter as the trailing
+        // write argument (tsc's 4-arg get / 5-arg set forms).
         let output = emit_es5(
             "class Box {\n    get #val() { return 1; }\n    set #val(v: number) {}\n    add() {\n        this.#val += 3;\n    }\n}\n",
         );
         assert!(
-            output.contains("__classPrivateFieldGet(this, _Box_val_get, \"a\")")
-                && output.contains("__classPrivateFieldSet(this, _Box_val_set, ")
-                && output.contains(", \"a\")"),
-            "Accessor `#val += 3` must read get-storage and write set-storage with kind \"a\".\nOutput:\n{output}"
+            output.contains(
+                "__classPrivateFieldSet(this, _Box_instances, __classPrivateFieldGet(this, _Box_instances, \"a\", _Box_val_get) + 3, \"a\", _Box_val_set)"
+            ),
+            "Accessor `#val += 3` must brand against `_Box_instances` and pass the getter/setter refs.\nOutput:\n{output}"
         );
     }
 
@@ -1346,16 +1551,17 @@ mod optional_chain_in_class_member_tests {
 
     #[test]
     fn private_accessor_exponent_assign_threads_get_and_set_storage() {
-        // `**=` is unconditional, so it is also correct for accessors: read from
-        // get-storage, write to set-storage, kind "a".
+        // `**=` is unconditional, so it is also correct for accessors: read
+        // through the getter and write through the setter, both branded against
+        // the `_instances` `WeakSet` with kind "a".
         let output = emit_es5(
             "class Box {\n    get #v() { return 2; }\n    set #v(x: number) {}\n    grow() {\n        this.#v **= 4;\n    }\n}\n",
         );
         assert!(
             output.contains(
-                "__classPrivateFieldSet(this, _Box_v_set, Math.pow(__classPrivateFieldGet(this, _Box_v_get, \"a\"), 4), \"a\")"
+                "__classPrivateFieldSet(this, _Box_instances, Math.pow(__classPrivateFieldGet(this, _Box_instances, \"a\", _Box_v_get), 4), \"a\", _Box_v_set)"
             ),
-            "Accessor `#v **= 4` must read get-storage and write set-storage.\nOutput:\n{output}"
+            "Accessor `#v **= 4` must brand against `_Box_instances` and thread the getter/setter refs.\nOutput:\n{output}"
         );
     }
 

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_private_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_private_members.rs
@@ -1,0 +1,130 @@
+//! Private-member storage maps for the ES5 class-to-IR converter.
+//!
+//! Resolves `this.#x` references inside member bodies to the
+//! `__classPrivateFieldGet`/`Set` brand + kind (+ trailing function) form that
+//! `tsc` emits at sub-ES2022 targets. Owns the read/write slot model consumed
+//! by the expression converter.
+
+use super::{AstToIr, PrivateMemberSlot};
+
+/// Build the read/write slot for a private accessor. An instance accessor
+/// brands against `_C_instances` and threads `func_var` (the getter/setter) as
+/// the trailing helper argument; the legacy static-accessor shape brands
+/// against `func_var` itself with no trailing reference.
+fn accessor_slot(instance_brand: Option<&str>, func_var: &str) -> PrivateMemberSlot {
+    match instance_brand {
+        Some(brand) => PrivateMemberSlot {
+            state_var: brand.to_string(),
+            kind: "a",
+            member_ref: Some(func_var.to_string()),
+        },
+        None => PrivateMemberSlot {
+            state_var: func_var.to_string(),
+            kind: "a",
+            member_ref: None,
+        },
+    }
+}
+
+impl<'a> AstToIr<'a> {
+    /// Provide private field, accessor, and method storage maps so that
+    /// `this.#x` references inside member bodies lower to
+    /// `__classPrivateFieldGet/Set` calls.
+    ///
+    /// Instance accessors and methods brand against `instances_weakset`
+    /// (`_C_instances`) and carry the getter/setter/method function reference,
+    /// matching tsc's 4-arg get / 5-arg set forms. Static accessors keep their
+    /// historical lowering (the function var as the brand, no trailing
+    /// reference); static methods are intentionally left to the existing
+    /// fallthrough.
+    pub fn with_private_member_maps(
+        mut self,
+        fields: &[crate::transforms::private_fields_es5::PrivateFieldInfo],
+        accessors: &[crate::transforms::private_fields_es5::PrivateAccessorInfo],
+        methods: &[crate::transforms::private_fields_es5::PrivateMethodInfo],
+        instances_weakset: Option<&str>,
+    ) -> Self {
+        for field in fields {
+            self.private_field_map
+                .insert(field.name.clone(), field.weakmap_name.clone());
+        }
+        for accessor in accessors {
+            // An instance accessor brands against `_C_instances` and passes the
+            // getter/setter as the trailing helper argument. A static accessor
+            // (or any accessor without an instance brand) retains the legacy
+            // form where the function var itself is the brand and there is no
+            // trailing reference.
+            let instance_brand = (!accessor.is_static).then_some(instances_weakset).flatten();
+            if let Some(ref get_var) = accessor.get_var_name {
+                self.private_read_slots.insert(
+                    accessor.name.clone(),
+                    accessor_slot(instance_brand, get_var),
+                );
+            }
+            if let Some(ref set_var) = accessor.set_var_name {
+                self.private_write_slots.insert(
+                    accessor.name.clone(),
+                    accessor_slot(instance_brand, set_var),
+                );
+            }
+        }
+        for method in methods {
+            // A private method is read as a function value branded against
+            // `_C_instances`, then invoked with `.call`. Static private methods
+            // brand against the class alias and are left to the fallthrough.
+            if method.is_static {
+                continue;
+            }
+            if let Some(instances) = instances_weakset {
+                self.private_read_slots.insert(
+                    method.name.clone(),
+                    PrivateMemberSlot {
+                        state_var: instances.to_string(),
+                        kind: "m",
+                        member_ref: Some(method.fn_var_name.clone()),
+                    },
+                );
+            }
+        }
+        self
+    }
+
+    /// Look up private-member storage info for a read of `this.#name`. Returns
+    /// `(brand_var, kind, member_ref)`: `member_ref` is the trailing
+    /// getter/method function for the 4-arg `__classPrivateFieldGet` form, or
+    /// `None` for a plain field (`kind == "f"`) and the legacy static-accessor
+    /// shape where the function var is the brand.
+    pub(super) fn private_read_info(
+        &self,
+        clean_name: &str,
+    ) -> Option<(String, &'static str, Option<String>)> {
+        if let Some(var) = self.private_field_map.get(clean_name) {
+            return Some((var.clone(), "f", None));
+        }
+        if let Some(slot) = self.private_read_slots.get(clean_name) {
+            return Some((slot.state_var.clone(), slot.kind, slot.member_ref.clone()));
+        }
+        None
+    }
+
+    /// Whether `this.#name` has a private read slot, without cloning it.
+    pub(super) fn has_private_read_slot(&self, clean_name: &str) -> bool {
+        self.private_field_map.contains_key(clean_name)
+            || self.private_read_slots.contains_key(clean_name)
+    }
+
+    /// Look up private-member storage info for a write `this.#name = v`.
+    /// Returns `(brand_var, kind, member_ref)`; see [`Self::private_read_info`].
+    pub(super) fn private_write_info(
+        &self,
+        clean_name: &str,
+    ) -> Option<(String, &'static str, Option<String>)> {
+        if let Some(var) = self.private_field_map.get(clean_name) {
+            return Some((var.clone(), "f", None));
+        }
+        if let Some(slot) = self.private_write_slots.get(clean_name) {
+            return Some((slot.state_var.clone(), slot.kind, slot.member_ref.clone()));
+        }
+        None
+    }
+}

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_private_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_private_members.rs
@@ -26,7 +26,7 @@ fn accessor_slot(instance_brand: Option<&str>, func_var: &str) -> PrivateMemberS
     }
 }
 
-impl<'a> AstToIr<'a> {
+impl AstToIr<'_> {
     /// Provide private field, accessor, and method storage maps so that
     /// `this.#x` references inside member bodies lower to
     /// `__classPrivateFieldGet/Set` calls.

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -687,7 +687,12 @@ impl<'a> ES5ClassTransformer<'a> {
             .with_downlevel_iteration(self.downlevel_iteration)
             .with_module_kind(self.module_kind)
             .with_target_es5(self.target_es5)
-            .with_private_field_maps(&self.private_fields, &self.private_accessors);
+            .with_private_member_maps(
+                &self.private_fields,
+                &self.private_accessors,
+                &self.private_methods,
+                self.private_instances_weakset_name.as_deref(),
+            );
         if let Some(source_text) = self.source_text {
             converter = converter.with_source_text(source_text);
         }

--- a/crates/tsz-emitter/src/transforms/es_decorators_private_members.rs
+++ b/crates/tsz-emitter/src/transforms/es_decorators_private_members.rs
@@ -23,7 +23,7 @@ use tsz_parser::parser::{NodeIndex, NodeList};
 #[allow(unused_imports)]
 use tsz_scanner::SyntaxKind;
 
-impl<'a> TC39DecoratorEmitter<'a> {
+impl TC39DecoratorEmitter<'_> {
     pub(super) fn emit_es_decorate_call(
         &self,
         member: &DecoratedMember,


### PR DESCRIPTION
Closes #14717.

## Failure family

JS emit — the ES5 class-to-IR converter's private-member access lowering. At
`--target es5` every private **method** call emitted the invalid bare callee
`recv.()`, and every private **accessor** read/write produced a
runtime-`TypeError`-throwing `__classPrivateFieldGet(recv, _C_a_get, "a")` (the
getter fn passed where the WeakSet brand belongs). `tsc` (6.0.2) and tsz at
es2015–esnext are both correct — only the ES5 lowering path diverged. Found by
differential-testing tsz against the bench `tsc`.

```ts
class C { #m() { return 1; } reg() { return this.#m(); } }
```
```js
// tsc
C.prototype.reg = function () { return __classPrivateFieldGet(this, _C_instances, "m", _C_m).call(this); };
// tsz (before) — invalid JS
C.prototype.reg = function () { return this.(); };
```

The whole instance private-member family was affected: method calls, method
references in value position, getter/setter reads/writes, compound accessor
assignment (`#a += 1`, `#a **= 2`), function-valued private field calls
(missing `.call(this)`), and side-effecting receivers (`make().#m()`).

## Structural rule

> At a sub-ES2022 target `tsc` lowers `recv.#name` through
> `__classPrivateFieldGet/Set(recv, brand, kind[, fn])`. An **instance**
> accessor or method brands against the class's `_C_instances` WeakSet and
> threads the getter/setter/method function as the trailing argument; a private
> member invoked in call position is read through the helper and invoked via
> `.call(recv, args)` so the receiver is preserved as `this`. A side-effecting
> receiver is captured once into a hoisted temp.

## Root cause

`AstToIr` (the ES5 converter) carried a private **field** map plus an accessor
map that stored the getter/setter var **as the brand**, and had **no map for
private methods**. A private method read therefore had no storage entry and
fell through to a raw property access on a private identifier (rendered empty →
`recv.()`); accessors emitted the 3-arg form with the function var as the brand
instead of the 4-arg `_C_instances`-branded form.

## Owner layer

Emitter only:
- `crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs` —
  `PrivateMemberSlot { state_var, kind, member_ref }` read/write model.
- `crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_private_members.rs`
  (new) — `with_private_member_maps` registration + `private_read_info` /
  `private_write_info` / `has_private_read_slot` queries (extracted to keep the
  parent file under its arch-guard size ratchet).
- `crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs` —
  `try_convert_private_member_call` (routes private member calls through
  `.call`, capturing a side-effecting receiver once) and the 4-arg/5-arg get/set
  builders.
- `crates/tsz-emitter/src/transforms/class_es5_ir.rs` — passes the private
  methods and `_C_instances` brand into the converter.

No checker/solver involvement; no semantic validation; no already-emitted-output
surgery. ES2015+ targets are untouched (they route through the main emitter).

## Anti-hardcoding

The lowering keys on the member's structural read/write slot and kind
(`"f"`/`"a"`/`"m"`), never on identifier/file-name strings or rendered output.
Tests vary class/member/binder names and cover positive (instance) and negative
(scoped-out static, bare reference vs call) cases.

## Scope / follow-up

Two pre-existing, independent ES5 divergences are intentionally left out of
scope (documented in #14717): **static** private methods/accessors (which brand
against the class self-alias and need receiver substitution), and the
private-storage **var-hoisting placement** (a separate commonjs-export-gated
subsystem that affects even field-only classes).

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New regression suite (binder names varied; instance method call / reference /
  getter-in-call / side-effecting-receiver capture / accessor read / accessor
  write / field-function call) in
  `crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs`
  (`optional_chain_in_class_member_tests`) — all pass; the two pre-existing
  accessor-compound tests were updated to assert the corrected
  `_instances`-branded forms.
- `cargo test -p tsz-emitter --lib` — 3844 passed, 0 failed.
- Built `tsz` (debug) and byte-compared to `tsc 6.0.2` over a private-member
  matrix at es5 (instance method/accessor/field-function calls, references,
  compound assignment, side-effecting receivers): every in-scope access form is
  now identical (residual whole-file diffs are only the out-of-scope var-hoisting
  placement). es2015/es2017/es2022/esnext remain byte-identical to `tsc`.
- `cargo fmt -p tsz-emitter --check`, `cargo clippy -p tsz-emitter --lib`
  (clean), `python3 scripts/arch/arch_guard.py` (passed — converter file kept
  under its size ratchet via the new submodule). Rebased conflict-free on current
  `main`. Broad conformance / JS-emit / DTS / fourslash owned by ready-review CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_019SQjXLizcRbwwtPtpnJmEJ)_