### PR TITLE
fix(checker): value-based TS2367 overlap for an enum vs a matching member literal

### DIFF
--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -1138,6 +1138,15 @@ impl<'a> CheckerState<'a> {
             );
         }
 
+        // Enum overlap is value-based against a non-enum operand but nominal
+        // against another enum: a whole enum overlaps a primitive / matching-member
+        // literal, while two distinct enums stay non-overlapping (see
+        // `enum_value_overlap_rewrite`). A single enum member already unwraps to
+        // its literal in the fast path above; this covers the whole-enum operand.
+        if let Some(no_overlap) = self.enum_value_overlap_rewrite(effective_left, effective_right) {
+            return no_overlap;
+        }
+
         // Check union types: if any member of one union overlaps with the other, they overlap
         if let query::UnionMembersKind::Union(left_members) =
             query::classify_for_union_members(self.ctx.types, effective_left)

--- a/crates/tsz-checker/src/types/utilities/overlap_relation_helpers.rs
+++ b/crates/tsz-checker/src/types/utilities/overlap_relation_helpers.rs
@@ -38,6 +38,43 @@ impl<'a> CheckerState<'a> {
         (left_to_right, right_to_left)
     }
 
+    /// Rewrite an enum operand to its member-value domain for TS2367 overlap,
+    /// but only when the *other* operand is not itself an enum.
+    ///
+    /// tsc relates an enum to a primitive/literal through its member *values*:
+    /// `Color === "red"` overlaps because `"red"` is a member value, while
+    /// `Color === "blue"` reports TS2367. It treats two distinct enums as
+    /// nominal, though — `Color === Hue` reports TS2367 even when both declare a
+    /// `"red"` member — and the nominal enum-vs-enum cases are already handled by
+    /// the assignability fallback. A *single* enum member already unwraps to its
+    /// literal in `classify_simple_overlap_type` (so `Color.Red === "red"` is
+    /// correct); this covers the whole-enum (member-union) operand the same way,
+    /// fixing the string/const-enum-vs-matching-member-literal false positive.
+    ///
+    /// Returns `Some(no_overlap)` when a value-based rewrite applies (recursing
+    /// through `types_have_no_overlap`), or `None` to fall through to the nominal
+    /// assignability path.
+    pub(super) fn enum_value_overlap_rewrite(
+        &mut self,
+        left: TypeId,
+        right: TypeId,
+    ) -> Option<bool> {
+        use crate::query_boundaries::flow_analysis::enum_member_domain;
+
+        // `enum_member_domain` returns the enum's member-value union for an enum
+        // type and the type unchanged otherwise, so `domain != ty` is exactly
+        // "ty is an enum". Rewrite only when one side is an enum and the other is
+        // not; that asymmetry also guarantees the recursion makes progress.
+        let left_domain = enum_member_domain(self.ctx.types, left);
+        let right_domain = enum_member_domain(self.ctx.types, right);
+        let left_is_enum = left_domain != left;
+        let right_is_enum = right_domain != right;
+        if left_is_enum == right_is_enum {
+            return None;
+        }
+        Some(self.types_have_no_overlap(left_domain, right_domain))
+    }
+
     /// Check if any pair of signatures (one from each side) is related in a
     /// single direction across all shared-arity params and the return type.
     /// Generic signatures (with non-empty `type_params`) are always treated as

--- a/crates/tsz-checker/tests/ts2367_comparison_overlap_tests.rs
+++ b/crates/tsz-checker/tests/ts2367_comparison_overlap_tests.rs
@@ -716,3 +716,169 @@ function f<T extends "a" | "b">(input: NoInfer<T>) {
         "Expected no TS2367 for switch on NoInfer<T> with case in constraint; got {codes:?}"
     );
 }
+
+// ── Enum vs literal/primitive overlap (value-based against non-enum operands) ──
+//
+// An enum overlaps another type through its member *values* when the other
+// operand is not itself an enum: a whole enum overlaps a primitive (`string`/
+// `number`) and a literal whose value matches a member, but not a literal whose
+// value matches no member. Two distinct enums stay nominal (handled elsewhere).
+// Binder names are varied so the rule is not name- or shape-specific.
+
+#[test]
+fn test_string_enum_vs_matching_member_literal_no_ts2367() {
+    assert!(
+        !has_ts2367(
+            r#"
+enum Palette { Crimson = "crimson", Jade = "jade" }
+declare const shade: Palette;
+if (shade === "crimson") {}
+"#
+        ),
+        "Expected NO TS2367: \"crimson\" is a member value of the string enum"
+    );
+}
+
+#[test]
+fn test_string_enum_vs_matching_member_literal_reversed_no_ts2367() {
+    assert!(
+        !has_ts2367(
+            r#"
+enum Direction { North = "north", South = "south" }
+declare const heading: Direction;
+if ("south" === heading) {}
+"#
+        ),
+        "Expected NO TS2367 with the enum on the right-hand side"
+    );
+}
+
+#[test]
+fn test_string_enum_vs_non_member_literal_keeps_ts2367() {
+    assert!(
+        has_ts2367(
+            r#"
+enum Palette { Crimson = "crimson", Jade = "jade" }
+declare const shade: Palette;
+if (shade === "violet") {}
+"#
+        ),
+        "Expected TS2367: \"violet\" is not a member value of the enum"
+    );
+}
+
+#[test]
+fn test_const_string_enum_vs_matching_member_literal_no_ts2367() {
+    assert!(
+        !has_ts2367(
+            r#"
+const enum Mode { Read = "read", Write = "write" }
+declare const access: Mode;
+if (access === "read") {}
+"#
+        ),
+        "Expected NO TS2367: const enum compared with a matching member value"
+    );
+}
+
+#[test]
+fn test_const_string_enum_vs_non_member_literal_keeps_ts2367() {
+    assert!(
+        has_ts2367(
+            r#"
+const enum Mode { Read = "read", Write = "write" }
+declare const access: Mode;
+if (access === "delete") {}
+"#
+        ),
+        "Expected TS2367: const enum compared with a non-member value"
+    );
+}
+
+#[test]
+fn test_string_enum_vs_string_primitive_no_ts2367() {
+    assert!(
+        !has_ts2367(
+            r#"
+enum Palette { Crimson = "crimson", Jade = "jade" }
+declare const shade: Palette;
+declare const text: string;
+if (shade === text) {}
+"#
+        ),
+        "Expected NO TS2367: a string enum overlaps the string primitive"
+    );
+}
+
+#[test]
+fn test_numeric_enum_vs_matching_member_literal_no_ts2367() {
+    assert!(
+        !has_ts2367(
+            r#"
+enum Level { Low = 1, High = 2 }
+declare const rank: Level;
+if (rank === 1) {}
+"#
+        ),
+        "Expected NO TS2367: 1 is a member value of the numeric enum"
+    );
+}
+
+#[test]
+fn test_numeric_enum_vs_non_member_literal_keeps_ts2367() {
+    assert!(
+        has_ts2367(
+            r#"
+enum Level { Low = 1, High = 2 }
+declare const rank: Level;
+if (rank === 9) {}
+"#
+        ),
+        "Expected TS2367: 9 is not a member value of the numeric enum"
+    );
+}
+
+#[test]
+fn test_distinct_string_enums_keep_ts2367_despite_shared_value() {
+    // Nominal: two different enums do not overlap even when a member value
+    // coincides (both declare a "red" member).
+    assert!(
+        has_ts2367(
+            r#"
+enum Color { Red = "red", Green = "green" }
+enum Hue { Red = "red", Blue = "blue" }
+declare const c: Color;
+declare const h: Hue;
+if (c === h) {}
+"#
+        ),
+        "Expected TS2367: distinct enums are nominal even with a shared member value"
+    );
+}
+
+#[test]
+fn test_whole_enum_overlaps_own_member_no_ts2367() {
+    assert!(
+        !has_ts2367(
+            r#"
+enum Color { Red = "red", Green = "green" }
+declare const c: Color;
+if (c === Color.Red) {}
+"#
+        ),
+        "Expected NO TS2367: a whole enum overlaps one of its own members"
+    );
+}
+
+#[test]
+fn test_distinct_members_same_enum_keep_ts2367() {
+    assert!(
+        has_ts2367(
+            r#"
+enum Color { Red = "red", Green = "green" }
+if (Color.Red === Color.Green) {}
+"#
+        ),
+        "Expected TS2367: distinct members of the same enum can never be equal"
+    );
+}


### PR DESCRIPTION
Closes #14719.

## Failure family

Diagnostic conformance — false-positive **TS2367** ("This comparison appears to
be unintentional because the types 'X' and 'Y' have no overlap"). When an
**enum** value is compared (`===`/`!==`/`==`/`!=`) against a **plain
string/number literal whose value matches one of the enum's members**, tsz
emitted TS2367 where `tsc` (6.0.2) emits nothing. Found by differential-testing
tsz against the bench `tsc`; this is the "string-enum-vs-string-literal
comparability gap in `enum_utils.rs`" explicitly scoped out as a follow-up by
#14712 (the template-literal TS2367 fix).

```ts
enum Color { Red = "red", Green = "green" }
const enum Mode { Read = "read", Write = "write" }
declare const c: Color;
declare const m: Mode;

c === "red";    // tsc: OK    tsz (before): TS2367   ("red" IS a member value)
"red" === c;    // tsc: OK    tsz (before): TS2367
m === "read";   // tsc: OK    tsz (before): TS2367   (const enum)
```

## Root cause (wrong operation: relation — overlap)

The TS2367 owner is `types_have_no_overlap_inner`
(`crates/tsz-checker/src/types/utilities/enum_utils.rs`). A **single** enum
member already unwraps to its literal value in `classify_simple_overlap_type`
(so `Color.Red === "red"` was correct), but a **whole** enum type (the
member-literal union) was never expanded: `classify_for_union_members` does not
treat `TypeData::Enum` as a union, so `Color`/`Mode` fell through to the
**nominal assignability** fallback. A plain `"red"` literal is not assignable to
the nominal string enum, so both assignability directions failed → "no overlap"
→ false TS2367. Numeric enums avoided the bug only incidentally (number literals
*are* assignable to numeric enums, so the fallback happened to be right).

## Structural rule

> When exactly one operand of an equality comparison is an enum and the other is
> not, `tsc` relates them by the enum's member **values** (apparent type): the
> enum overlaps the `string`/`number` primitive and any literal matching a
> member, and is disjoint from a literal matching no member. When **both**
> operands are enums, `tsc` keeps them **nominal**: two distinct enums have no
> overlap even on a shared member value (`Color === Hue` → TS2367), and distinct
> members of one enum never overlap (`Color.Red === Color.Green` → TS2367).

## Owner layer

Checker only — `crates/tsz-checker/src/types/utilities/`. New
`enum_value_overlap_rewrite` (in `overlap_relation_helpers.rs`, beside the other
overlap helpers) unwraps an enum operand to its member-value domain
(`query_boundaries::flow_analysis::enum_member_domain`) **only when the other
operand is not itself an enum**, then recurses through the existing overlap
routine. Enum-vs-enum stays on the nominal assignability path, so the nominal
cases are untouched. `types_have_no_overlap_inner` gains a single call before
the union arms. No solver change, no diagnostic-display change.

## Anti-hardcoding

The decision is structural — enum-ness is derived from `enum_member_domain`
(`domain != ty` ⇔ enum), and overlap is decided by the existing value-based
routine; no identifier / enum-name / file-name literals and no
formatted-message predicates. The regression suite varies enum and binder names
(`Palette`/`Direction`/`Mode`/`Level`, `shade`/`heading`/`access`/`rank`).

## Adjacent-case matrix (verified byte-for-diagnostics against `tsc` 6.0.2)

| Comparison | tsc | tsz before | tsz after |
|---|---|---|---|
| `Color === "red"` (member) | OK | TS2367 ❌ | OK ✓ |
| `"green" === Color` | OK | TS2367 ❌ | OK ✓ |
| `Mode === "read"` (const enum) | OK | TS2367 ❌ | OK ✓ |
| `Color === "blue"` (non-member) | TS2367 | TS2367 | TS2367 ✓ |
| `Color === string` | OK | OK | OK ✓ |
| `Level === 1` / `=== 9` (numeric) | OK / TS2367 | OK / TS2367 | OK / TS2367 ✓ |
| `Color === Hue` (distinct enums, shared `"red"`) | TS2367 | TS2367 | TS2367 ✓ |
| `Color.Red === Color.Green` (same enum) | TS2367 | TS2367 | TS2367 ✓ |
| `c === Color.Red` (whole vs own member) | OK | OK | OK ✓ |

## Scope / follow-up

Out of scope (separate, pre-existing, enum-independent): `(T | undefined) === lit`
where the non-`undefined` members are disjoint from `lit` — `tsc` reports TS2367
but tsz does not, because a `null`/`undefined` union member short-circuits the
overlap check to "overlaps everything". This reproduces for non-enum unions too
(`(1 | undefined) === "x"`) and belongs to the null/undefined comparability
family, not this enum fix.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New regression suite (enum + binder names varied; positive + negative
  controls) in `crates/tsz-checker/tests/ts2367_comparison_overlap_tests.rs` —
  12 new cases; full file `cargo test -p tsz-checker --test
  ts2367_comparison_overlap_tests` → 43/43 pass.
- Differential vs `tsc 6.0.2` (`--strict --target esnext`) over an enum
  overlap matrix (whole/const/numeric enums × member / non-member / primitive /
  distinct-enum / same-enum-member operands): every enum case now matches `tsc`;
  the only residual delta is the out-of-scope `(T | undefined)` family above.
- No regressions: `cargo test -p tsz-checker --lib -- overlap enum_ comparison
  ts2367` — the 4 failing tests (`mapped_*_enum_*_display`,
  `mapped_enum_discriminant_application_exposes_member_property`) fail
  identically on clean `main` (stash-verified) and are unrelated.
- `cargo fmt -p tsz-checker --check`, `cargo clippy -p tsz-checker --lib`
  (clean), `python3 scripts/arch/arch_guard.py` (passed; the new helper routes
  through `query_boundaries::flow_analysis`, adding no `query_boundaries::common`
  quarantine reference). Rebased conflict-free on current `main`. Broad
  conformance / JS-emit / DTS / fourslash owned by ready-review CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_015Hj6wj8sKUjyc8GkZ32EWf)_