### PR TITLE
fix(checker): relate enum operands through member-value union for TS2367/TS2678

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -36,6 +36,9 @@ stacker = "0.1.23"
 name = "sibling_defaulted_conditional_constraint_tests"
 path = "tests/sibling_defaulted_conditional_constraint_tests.rs"
 [[test]]
+name = "enum_literal_comparison_overlap_tests"
+path = "tests/enum_literal_comparison_overlap_tests.rs"
+[[test]]
 name = "cannot_find_name_lib_hint_parity_tests"
 path = "tests/cannot_find_name_lib_hint_parity_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/assignability/assignability_diagnostics/type_comparability.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics/type_comparability.rs
@@ -382,6 +382,20 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
+        // An enum operand is comparable to a *non-enum* operand through its
+        // member-value union (`switch(c: Color){ case "red": }` is comparable
+        // because `"red"` is a member value), while enum-vs-enum stays nominal.
+        // Without this, the nominal enum type reaches neither the assignability
+        // fast path nor the union decomposition below, so a valid string-enum
+        // case wrongly reports TS2678.
+        if let Some((src, tgt)) = crate::query_boundaries::enum_analysis::enum_comparison_operands(
+            self.ctx.types,
+            source_apparent,
+            target_apparent,
+        ) {
+            return self.is_type_comparable_to(src, tgt);
+        }
+
         // TSC's comparable relation decomposes unions and checks if ANY member
         // is related to the other type. This handles cases like:
         // - `User.A | User.B` comparable to `User.A` (User.A member matches)

--- a/crates/tsz-checker/src/query_boundaries/enum_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/enum_analysis.rs
@@ -15,6 +15,39 @@ pub(crate) fn enum_def_id(
     super::common::enum_def_id(db, type_id)
 }
 
+/// The structural member-value union of an enum type (e.g. `"red" | "blue"` for
+/// a string enum, `0 | 1` for a numeric enum). Returns `None` when `type_id` is
+/// not an enum type. This is the enum's comparison/overlap value-set.
+pub(crate) fn enum_member_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
+    super::common::enum_member_type(db, type_id)
+}
+
+/// When exactly one of `(left, right)` is an enum (and the other is not),
+/// returns the operand pair with the enum side replaced by its member-value
+/// union — the form an overlap/comparability check should relate. Returns `None`
+/// otherwise (neither is an enum, or both are).
+///
+/// `tsc` relates an enum to a non-enum literal/primitive/union through this
+/// member union, so `Color === "red"` overlaps (a member value) while
+/// `Color === "green"` does not. Enum-vs-enum comparisons stay nominal — two
+/// different enums never overlap even with equal member values, and two members
+/// of the same enum compare by their (distinct) values — so the both-enum case
+/// is left to the nominal path.
+pub(crate) fn enum_comparison_operands(
+    db: &dyn TypeDatabase,
+    left: TypeId,
+    right: TypeId,
+) -> Option<(TypeId, TypeId)> {
+    match (
+        enum_def_id(db, left).is_some(),
+        enum_def_id(db, right).is_some(),
+    ) {
+        (true, false) => enum_member_type(db, left).map(|members| (members, right)),
+        (false, true) => enum_member_type(db, right).map(|members| (left, members)),
+        _ => None,
+    }
+}
+
 pub(crate) fn type_parameter_constraint(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
     super::common::type_parameter_constraint(db, type_id)
 }

--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -1063,6 +1063,20 @@ impl<'a> CheckerState<'a> {
             return self.types_have_no_overlap(apparent_left, apparent_right);
         }
 
+        // An enum operand overlaps a *non-enum* operand exactly when one of its
+        // member values does, so relate it through its member-value union
+        // (`Color` vs `"red"` → `"red" | "blue"` vs `"red"` → overlap). Without
+        // this, a string enum reaches the assignability fall-through below where
+        // a string literal is never assignable to the nominal enum, producing a
+        // false TS2367. Enum-vs-enum stays nominal (the helper returns `None`).
+        if let Some((l, r)) = crate::query_boundaries::enum_analysis::enum_comparison_operands(
+            self.ctx.types,
+            left,
+            right,
+        ) {
+            return self.types_have_no_overlap(l, r);
+        }
+
         // For type parameters, delegate to the comparability check which correctly handles:
         // - T vs {} → comparable (overlap exists, return false)
         // - T vs U (unrelated) → not comparable (no overlap, return true)

--- a/crates/tsz-checker/tests/enum_literal_comparison_overlap_tests.rs
+++ b/crates/tsz-checker/tests/enum_literal_comparison_overlap_tests.rs
@@ -1,0 +1,278 @@
+//! Enum-vs-literal comparison overlap parity (TS2367 / TS2678).
+//!
+//! Owner layer: checker comparability/overlap (`enum_utils::types_have_no_overlap`
+//! for `===`/`!==` TS2367, and `type_comparability::is_type_comparable_to` for
+//! `switch`/`case` TS2678). Both reach the enum's member-value union through the
+//! shared `enum_comparison_member_union` helper.
+//!
+//! Structural rule (matches `tsc` 6.0.2): an enum operand overlaps a **non-enum**
+//! literal/primitive/union operand exactly when one of the enum's member *values*
+//! does — a string enum overlaps `"red"` iff `"red"` is a member value, a numeric
+//! enum overlaps `5` iff `5` is a member value. Enum-vs-enum comparisons stay
+//! nominal: two different enums never overlap even with equal member values, and
+//! two members of the same enum compare by their (distinct) values.
+//!
+//! Before the fix, a string enum reached the assignability fall-through where a
+//! string literal is never assignable to the nominal enum, producing a false
+//! TS2367/TS2678 for the *valid* member-value cases (the
+//! `enum_utils.rs` comparability gap noted as out of scope in #14712).
+//!
+//! §25 anti-hardcoding: binder names (enum, member, and variable identifiers)
+//! are varied across cases so the rule is name-independent. Both positive
+//! (overlap → clean) and negative (no overlap → diagnostic) cases are covered.
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn codes(src: &str) -> Vec<u32> {
+    let mut c = check_source_codes(src);
+    c.sort_unstable();
+    c
+}
+
+// ---------------------------------------------------------------------------
+// TS2367: `===` / `!==` / `==` / `!=`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn string_enum_equals_matching_member_value_is_clean() {
+    // `Palette === "crimson"` overlaps because "crimson" is a member value.
+    let src = r#"
+enum Palette { Crimson = "crimson", Azure = "azure" }
+declare const shade: Palette;
+const ok = shade === "crimson";
+"#;
+    assert!(
+        !codes(src).contains(&2367),
+        "string enum vs matching member value must overlap (no TS2367): {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn string_enum_equals_non_member_value_reports_ts2367() {
+    let src = r#"
+enum Palette { Crimson = "crimson", Azure = "azure" }
+declare const shade: Palette;
+const bad = shade === "viridian";
+"#;
+    assert!(
+        codes(src).contains(&2367),
+        "string enum vs non-member literal must report TS2367: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn string_enum_inequality_operators_follow_overlap() {
+    // `==` matching → clean; `!=` non-member → TS2367 (overlap rule is operator
+    // independent for the equality family).
+    let matching = r#"
+enum Direction { North = "N", South = "S" }
+declare const heading: Direction;
+const a = heading == "N";
+const b = heading != "S";
+"#;
+    assert!(
+        !codes(matching).contains(&2367),
+        "matching member values under == / != must be clean: {:?}",
+        codes(matching)
+    );
+    let non_member = r#"
+enum Direction { North = "N", South = "S" }
+declare const heading: Direction;
+const a = heading != "E";
+"#;
+    assert!(
+        codes(non_member).contains(&2367),
+        "non-member literal under != must report TS2367: {:?}",
+        codes(non_member)
+    );
+}
+
+#[test]
+fn string_enum_vs_literal_union_overlaps_when_any_member_matches() {
+    let overlapping = r#"
+enum Fruit { Apple = "apple", Pear = "pear" }
+declare const pick: Fruit;
+declare const choice: "apple" | "kiwi";
+const ok = pick === choice;
+"#;
+    assert!(
+        !codes(overlapping).contains(&2367),
+        "enum vs union with a matching member must overlap: {:?}",
+        codes(overlapping)
+    );
+    let disjoint = r#"
+enum Fruit { Apple = "apple", Pear = "pear" }
+declare const pick: Fruit;
+declare const choice: "kiwi" | "mango";
+const bad = pick === choice;
+"#;
+    assert!(
+        codes(disjoint).contains(&2367),
+        "enum vs fully-disjoint union must report TS2367: {:?}",
+        codes(disjoint)
+    );
+}
+
+#[test]
+fn numeric_enum_equality_unchanged_by_member_union_path() {
+    // Numeric enums already matched `tsc`; the member-union path must keep that.
+    let src = r#"
+enum Level { Low = 1, High = 2 }
+declare const lvl: Level;
+const ok = lvl === 1;
+const bad = lvl === 3;
+"#;
+    let c = codes(src);
+    assert_eq!(
+        c.iter().filter(|&&x| x == 2367).count(),
+        1,
+        "numeric enum: only the non-member comparison reports TS2367: {c:?}"
+    );
+}
+
+#[test]
+fn mixed_enum_overlaps_each_member_value_kind() {
+    let src = r#"
+enum Token { Word = "w", Count = 1 }
+declare const tok: Token;
+const okStr = tok === "w";
+const okNum = tok === 1;
+const badStr = tok === "z";
+const badNum = tok === 9;
+"#;
+    let c = codes(src);
+    assert_eq!(
+        c.iter().filter(|&&x| x == 2367).count(),
+        2,
+        "mixed enum: only the two non-member comparisons report TS2367: {c:?}"
+    );
+}
+
+#[test]
+fn enum_member_vs_own_value_is_clean_but_other_member_value_reports() {
+    let own = r#"
+enum Suit { Spade = "spade", Heart = "heart" }
+const ok = Suit.Spade === "spade";
+"#;
+    assert!(
+        !codes(own).contains(&2367),
+        "enum member vs its own value must overlap: {:?}",
+        codes(own)
+    );
+    let other = r#"
+enum Suit { Spade = "spade", Heart = "heart" }
+const bad = Suit.Spade === "heart";
+"#;
+    assert!(
+        codes(other).contains(&2367),
+        "enum member vs another member's value must report TS2367: {:?}",
+        codes(other)
+    );
+}
+
+#[test]
+fn distinct_enums_with_equal_values_stay_nominal() {
+    // Two different enums whose members share the value "x" do NOT overlap
+    // (nominal). This guards against the member-union path leaking into the
+    // enum-vs-enum case.
+    let src = r#"
+enum Left { Mark = "x", Other = "y" }
+enum Right { Mark = "x", Other = "z" }
+declare const lhs: Left;
+declare const rhs: Right;
+const bad = lhs === rhs;
+"#;
+    assert!(
+        codes(src).contains(&2367),
+        "distinct enums with equal member values must stay nominal (TS2367): {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn same_enum_distinct_members_report_ts2367() {
+    let src = r#"
+enum Phase { Start = "start", Stop = "stop" }
+const bad = Phase.Start === Phase.Stop;
+"#;
+    assert!(
+        codes(src).contains(&2367),
+        "two distinct members of the same enum must report TS2367: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn string_enum_vs_string_primitive_overlaps() {
+    let src = r#"
+enum Mode { Dev = "dev", Prod = "prod" }
+declare const m: Mode;
+declare const s: string;
+const ok = m === s;
+"#;
+    assert!(
+        !codes(src).contains(&2367),
+        "string enum vs `string` must overlap: {:?}",
+        codes(src)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TS2678: `switch` / `case`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn switch_case_matching_member_value_is_clean() {
+    let src = r#"
+enum Signal { Red = "red", Green = "green" }
+declare const sig: Signal;
+switch (sig) {
+  case "red": break;
+  case "green": break;
+}
+"#;
+    assert!(
+        !codes(src).contains(&2678),
+        "switch cases with member values must be clean (no TS2678): {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn switch_case_non_member_value_reports_ts2678() {
+    let src = r#"
+enum Signal { Red = "red", Green = "green" }
+declare const sig: Signal;
+switch (sig) {
+  case "red": break;
+  case "amber": break;
+}
+"#;
+    let c = codes(src);
+    assert_eq!(
+        c.iter().filter(|&&x| x == 2678).count(),
+        1,
+        "only the non-member case reports TS2678: {c:?}"
+    );
+}
+
+#[test]
+fn switch_mixed_enum_case_value_kinds() {
+    let src = r#"
+enum Kind { Name = "name", Id = 1 }
+declare const k: Kind;
+switch (k) {
+  case "name": break;
+  case 1: break;
+  case "bogus": break;
+}
+"#;
+    let c = codes(src);
+    assert_eq!(
+        c.iter().filter(|&&x| x == 2678).count(),
+        1,
+        "only the non-member case reports TS2678 for a mixed enum: {c:?}"
+    );
+}


### PR DESCRIPTION
## Failure family

Diagnostic conformance — **TS2367** ("This comparison appears to be
unintentional because the types … have no overlap") and **TS2678** ("Type 'X'
is not comparable to type 'Y'") **false positives** when a **string (or mixed)
enum** is compared against a **string literal / literal union** that *is* one of
its member values. Found by differential-testing tsz against the bench `tsc`
(6.0.2); this is the **string-enum-vs-string-literal comparability gap** noted
verbatim as an out-of-scope follow-up in #14712 ("a distinct `enum_utils.rs`
comparability gap").

```ts
enum Color { Red = "red", Blue = "blue" }
declare const c: Color;

c === "red";                 // tsc: clean   tsz (before): TS2367 (false positive)
c === "green";               // tsc: TS2367  tsz: TS2367
switch (c) { case "red": }   // tsc: clean   tsz (before): TS2678 (false positive)
```

Numeric enums happened to be correct only because a matching number literal is
assignable to a numeric enum; a string literal is never assignable to a nominal
string enum, so the comparability check treated `Color` and `"red"` as disjoint
even though `"red"` is a member value.

## Structural rule

> When an enum operand is compared (`===`/`!==`/`==`/`!=` or `switch`/`case`)
> against a **non-enum** literal/primitive/union, `tsc` relates the enum through
> its **member-value union** — the enum overlaps the other operand exactly when
> one of its member *values* does. **Enum-vs-enum** comparisons stay **nominal**:
> two different enums never overlap even with equal member values, and two
> members of the same enum compare by their distinct values.

Verified against `tsc` 6.0.2 — including the nominal case
`enum L { M = "x" } enum R { M = "x" }; (l: L) === (r: R)` → TS2367 (no overlap
despite equal values), which the fix preserves.

## Owner layer

Checker comparability/overlap only. A single shared query-boundary helper
`enum_comparison_operands` (`crates/tsz-checker/src/query_boundaries/enum_analysis.rs`)
rewrites the enum side to its member-value union **when exactly one operand is an
enum**, and is consulted by both checker entry points that previously left the
nominal enum opaque:

- `types_have_no_overlap` (`types/utilities/enum_utils.rs`) → TS2367 binary
  equality.
- `is_type_comparable_to`
  (`assignability/.../type_comparability.rs`) → TS2678 switch/case, plus equality
  narrowing / relational checks.

This mirrors the enum→member-union unwrap the **solver** already performs in its
own overlap (`relations/subtype/overlap.rs`) and comparability
(`type_queries/flow/comparability.rs`) paths, while preserving the nominal
enum-vs-enum rule the solver's unconditional unwrap does not (so the checker
keeps its stricter, diagnostic-facing semantics). No solver/emitter change; no
semantic validation moved; no rendered-output predicates.

## Anti-hardcoding

The decision is structural — `enum_def_id` / `enum_member_type` over the type
arena (`TypeData::Enum(def, member_union)`), never identifier/file-name strings
or formatted-message predicates. The new regression suite varies enum, member,
and variable binder names across every case.

## Adjacent-case matrix (verified byte-identical to `tsc` 6.0.2)

`crates/tsz-checker/tests/enum_literal_comparison_overlap_tests.rs` (13 tests,
binder names varied): string enum `===` matching/non-member; `==`/`!=`; enum vs
literal **union** (overlapping and disjoint); numeric enum unchanged; mixed enum
across both value kinds; enum **member** vs own/other value; two **distinct**
enums with equal values stay nominal; two members of the **same** enum; enum vs
`string` primitive; and `switch`/`case` matching, non-member, and mixed.
Differential matrix (truth + stress, 28 cases) matches `tsc` except one
**pre-existing, enum-independent** divergence — `(C | undefined) === "x"`, which
reproduces identically without any enum (`("red" | undefined) === "x"`,
`(1 | undefined) === 5`) and is a separate `undefined`/`null`-in-union
comparability gap, left out of scope.

## Scope / follow-up

Out of scope (pre-existing, unrelated): the `undefined`/`null`-in-union
comparability under-report described above (reproduces with no enum involved).

Advances the valibot (#13212) and kysely (#10663) project-row false-positive
families (both list enum/comparison false positives) by closing this slice.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New regression suite (binder names varied; positive + negative; TS2367 and
  TS2678): `cargo test -p tsz-checker --test enum_literal_comparison_overlap_tests`
  — 13/13 pass.
- No regressions in adjacent suites:
  `ts2367_comparison_overlap_tests` (32), `ts2367_deferred_conditional_overlap_tests`,
  `enum_nominality_tests` (17), `enum_equality_narrowing_tests` (40),
  `enum_discriminant_excess_property_tests` (22), `enum_indexed_access_tests`,
  `enum_recursion_tests`, `enum_merge_tests`,
  `wide_symbol_equality_no_unique_narrowing_tests` — all green. (The 2 failures in
  `relational_operator_type_display_tests` are pre-existing on clean `main` —
  stash-verified — and unrelated to this change.)
- Built `tsz` (debug) and byte-compared diagnostics to `tsc` 6.0.2 over a
  38-case enum-comparison matrix: every in-scope case matches (only the
  pre-existing `undefined`-in-union case differs, which also differs without any
  enum). Broad single-file differential sweep (75 cases) unchanged: 0 diverged.
- `cargo fmt -p tsz-checker --check`, `cargo clippy -p tsz-checker --lib` clean,
  `python3 scripts/arch/arch_guard.py` passed. Rebased conflict-free on current
  `main` (f534c70). Broad conformance / JS-emit / DTS / fourslash owned by
  ready-review CI.

https://claude.ai/code/session_01L8o4EariRimUVkUuw9QnDF

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8o4EariRimUVkUuw9QnDF)_