### PR TITLE
fix(checker): TS2367 for `(X | undefined) === lit` with a disjoint non-nullish part

### DIFF
--- a/crates/tsz-checker/src/types/computation/binary.rs
+++ b/crates/tsz-checker/src/types/computation/binary.rs
@@ -868,7 +868,7 @@ impl<'a> CheckerState<'a> {
                 && right_narrow != TypeId::ERROR
                 && left_narrow != TypeId::NEVER
                 && right_narrow != TypeId::NEVER
-                && self.types_have_no_overlap(left_narrow, right_narrow)
+                && self.equality_operands_have_no_overlap(left_narrow, right_narrow)
                 // Suppress TS2367 when the DECLARED type of either operand has overlap
                 // with the other. This handles loop narrowing: e.g., `code: 0 | 1 = 0;
                 // while (...) { code = code === 1 ? 0 : 1; }` — flow narrows `code` to `0`

--- a/crates/tsz-checker/src/types/computation/binary_support.rs
+++ b/crates/tsz-checker/src/types/computation/binary_support.rs
@@ -853,14 +853,50 @@ impl CheckerState<'_> {
             }
         }
 
+        // A union belongs to a primitive family when all of its non-`null`/
+        // `undefined` constituents share one family (`1 | 2`, `"a" | undefined`).
+        // `null`/`undefined` members are ignored — they ride along unwidened in
+        // tsc's display (`number | undefined`) — but a union of *only*
+        // `null`/`undefined`, an empty union, or a union spanning multiple
+        // families has no single family. This mirrors tsc widening
+        // `(1 | undefined) === "x"` operands to `number | undefined` / `string`
+        // while leaving `(1 | undefined) === 2` (same family) as literals.
+        if let Some(members) =
+            crate::query_boundaries::common::union_members(self.ctx.types, type_id)
+        {
+            let mut common: Option<TypeId> = None;
+            for &member in &members {
+                if member == TypeId::NULL || member == TypeId::UNDEFINED {
+                    continue;
+                }
+                let family = self.get_primitive_family(member);
+                if family == TypeId::ERROR {
+                    return TypeId::ERROR;
+                }
+                match common {
+                    None => common = Some(family),
+                    Some(existing) if existing == family => {}
+                    Some(_) => return TypeId::ERROR,
+                }
+            }
+            return common.unwrap_or(TypeId::ERROR);
+        }
+
         TypeId::ERROR // Non-primitive types
     }
 
-    /// Widen types for TS2367 display when they are from different primitive families.
+    /// Widen operands for TS2367 display.
     ///
-    /// tsc's rule: when comparing types from different primitive families (e.g., string vs number),
-    /// both types are widened to their base primitives in the error message. For same-family
-    /// comparisons (e.g., `"foo"` vs `"bar"`), literal types are preserved.
+    /// tsc preserves literal types in the message only when both operands belong
+    /// to the *same* single primitive family (`"foo"` vs `"bar"` → `"foo"` /
+    /// `"bar"`; `1 | undefined` vs `2` → `1 | undefined` / `2`). Otherwise it
+    /// shows each operand widened to its base type via `getBaseTypeOfLiteralType`
+    /// — distributing over unions and leaving non-literals (objects,
+    /// `null`/`undefined`) unchanged: `1 | 2` vs `"x"` → `number` / `string`;
+    /// `1 | undefined` vs `"x"` → `number | undefined` / `string`; `{ a }` vs
+    /// `"x"` → `{ a }` / `string`. A `null`/`undefined`-only or mixed-family
+    /// operand has no family (`ERROR`), so it never matches the other side and
+    /// the pair is widened.
     pub(super) fn widen_for_ts2367_cross_family_display(
         &self,
         left: TypeId,
@@ -869,18 +905,15 @@ impl CheckerState<'_> {
         let left_family = self.get_primitive_family(left);
         let right_family = self.get_primitive_family(right);
 
-        // Both are primitives, but from different families → widen both
-        if left_family != TypeId::ERROR
-            && right_family != TypeId::ERROR
-            && left_family != right_family
-        {
+        if left_family != TypeId::ERROR && left_family == right_family {
+            // Same single primitive family: preserve literal types.
+            (left, right)
+        } else {
+            // Differing or absent family: widen both to their base types.
             (
                 crate::query_boundaries::common::widen_literal_type(self.ctx.types, left),
                 crate::query_boundaries::common::widen_literal_type(self.ctx.types, right),
             )
-        } else {
-            // Same family (or non-primitives): preserve literal types
-            (left, right)
         }
     }
 

--- a/crates/tsz-checker/src/types/computation/binary_tests.rs
+++ b/crates/tsz-checker/src/types/computation/binary_tests.rs
@@ -868,9 +868,11 @@ fn ts2367_widens_cross_family_literal_against_constrained_intersection() {
 }
 
 #[test]
-fn ts2367_preserves_literal_types_in_display() {
-    // tsc preserves literal types in TS2367 messages: `1 | 2` and `"hello"`
-    // rather than widening to `number` and `string`.
+fn ts2367_widens_cross_family_literals_in_display() {
+    // tsc widens both operands to their base types in TS2367 messages when they
+    // belong to different primitive families: `1 | 2` vs `"hello"` is displayed
+    // as `number` and `string` (verified against tsc 6.0.2), distributing the
+    // base-of-literal widening over the union.
     let diags = check_source_diagnostics(r#"declare let x: 1 | 2; if (x === "hello") {}"#);
     let relevant: Vec<_> = diags.iter().filter(|d| d.code == 2367).collect();
     assert_eq!(
@@ -885,8 +887,33 @@ fn ts2367_preserves_literal_types_in_display() {
     assert!(
         relevant[0]
             .message_text
-            .contains("types '1 | 2' and '\"hello\"' have no overlap"),
-        "Expected narrow type display matching tsc, got: {:?}",
+            .contains("types 'number' and 'string' have no overlap"),
+        "Expected cross-family widened display matching tsc, got: {:?}",
+        relevant[0].message_text
+    );
+}
+
+#[test]
+fn ts2367_preserves_same_family_literals_in_display() {
+    // When both operands share a single primitive family, tsc preserves the
+    // literal types in the message: `1` vs `2` stays `1` and `2` rather than
+    // widening to `number` (verified against tsc 6.0.2).
+    let diags = check_source_diagnostics(r#"const unused = (1 as 1) === (2 as 2);"#);
+    let relevant: Vec<_> = diags.iter().filter(|d| d.code == 2367).collect();
+    assert_eq!(
+        relevant.len(),
+        1,
+        "Expected exactly one TS2367, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.as_str()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        relevant[0]
+            .message_text
+            .contains("types '1' and '2' have no overlap"),
+        "Expected same-family literal display matching tsc, got: {:?}",
         relevant[0].message_text
     );
 }

--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -920,6 +920,29 @@ impl<'a> CheckerState<'a> {
         Some(self.simple_overlap_types_overlap(left_simple, right_simple))
     }
 
+    /// Whole-comparison TS2367 predicate for an equality operator: the operands
+    /// have no overlap *and* neither is a bare `null`/`undefined` operand.
+    ///
+    /// Use this instead of a raw `types_have_no_overlap` at equality sites. The
+    /// bare-operand exemption mirrors tsc's `isTypeEqualityComparableTo`, whose
+    /// `target.flags & TypeFlags.Nullable` term suppresses TS2367 whenever a
+    /// *whole operand* of `==`/`!=`/`===`/`!==` is the bare `null`/`undefined`
+    /// intrinsic (`undefined === x`). It is applied here, once at the comparison
+    /// — not inside the overlap relation — so a *union* that merely contains
+    /// `null`/`undefined` (`null | undefined`, `1 | undefined`) is not exempt and
+    /// its overlap is decided structurally by `types_have_no_overlap`.
+    pub(crate) fn equality_operands_have_no_overlap(
+        &mut self,
+        left: TypeId,
+        right: TypeId,
+    ) -> bool {
+        let is_bare_nullable = |t: TypeId| t == TypeId::NULL || t == TypeId::UNDEFINED;
+        if is_bare_nullable(left) || is_bare_nullable(right) {
+            return false;
+        }
+        self.types_have_no_overlap(left, right)
+    }
+
     /// Check if two types have no overlap (for TS2367 validation).
     /// Returns true if the types can never be equal in a comparison.
     pub(crate) fn types_have_no_overlap(&mut self, left: TypeId, right: TypeId) -> bool {
@@ -1014,16 +1037,22 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        // null/undefined are always comparable with any type (TSC's "comparable relation").
-        // Even with strictNullChecks enabled, `null === x` and `undefined === x` should
-        // never trigger TS2367.
-        if left == TypeId::NULL
-            || left == TypeId::UNDEFINED
-            || right == TypeId::NULL
-            || right == TypeId::UNDEFINED
-        {
-            return false;
-        }
+        // `null`/`undefined` are *not* given a blanket "overlaps everything" pass
+        // here. tsc's whole-operand exemption for a bare `null`/`undefined`
+        // operand lives in `isTypeEqualityComparableTo` (the `target.flags &
+        // Nullable` term), applied once at the equality-comparison site, *not*
+        // inside the comparable/overlap relation. Modelling it here would also
+        // exempt `null`/`undefined` reached as a *union member* during the
+        // recursion below (e.g. `(1 | undefined) === "x"`), which `tsc` reports
+        // as TS2367 because the non-nullish part `1` has no overlap with `"x"`.
+        //
+        // So inside this routine `null`/`undefined` are genuine types: they
+        // overlap `any`/`unknown` (handled above), themselves (the same-type
+        // check below), and — through the assignability fallback — every type
+        // under non-`strictNullChecks` (matching tsc's comparable relation),
+        // but not a disjoint non-nullish type under `strictNullChecks`. The
+        // bare-operand exemption is applied by `nullable_equality_operand`
+        // at the TS2367 call sites.
 
         // Weak types (all-optional properties) overlap with anything.
         // tsc never emits TS2367 when comparing against weak types.

--- a/crates/tsz-checker/tests/ts2367_comparison_overlap_tests.rs
+++ b/crates/tsz-checker/tests/ts2367_comparison_overlap_tests.rs
@@ -767,6 +767,36 @@ if (shade === "violet") {}
     );
 }
 
+// ── `null`/`undefined` union members (tsc `isTypeEqualityComparableTo`) ───────
+//
+// A `null`/`undefined` member of a union must not grant the union blanket
+// overlap with everything: `tsc` decides overlap on the non-nullish part and
+// exempts a comparison only when a *whole operand* is the bare `null`/
+// `undefined` intrinsic (the `target.flags & Nullable` term). Binder names are
+// varied so the rule is structural, not name-driven.
+
+#[test]
+fn test_undefined_union_vs_disjoint_literal_keeps_ts2367() {
+    assert!(
+        has_ts2367(
+            r#"
+declare const shade: 1 | undefined;
+if (shade === "x") {}
+"#
+        ),
+        "Expected TS2367: the non-nullish part `1` has no overlap with \"x\""
+    );
+    // Different binder/literal families, both operand orders.
+    assert!(
+        has_ts2367(r#"declare const rank: number | undefined; if (rank === "lo") {}"#),
+        "Expected TS2367 for number|undefined === string literal"
+    );
+    assert!(
+        has_ts2367(r#"declare const heading: "n" | undefined; if ("s" === heading) {}"#),
+        "Expected TS2367 for string literal === string-union|undefined (reversed)"
+    );
+}
+
 #[test]
 fn test_const_string_enum_vs_matching_member_literal_no_ts2367() {
     assert!(
@@ -880,5 +910,64 @@ if (Color.Red === Color.Green) {}
 "#
         ),
         "Expected TS2367: distinct members of the same enum can never be equal"
+    );
+}
+
+#[test]
+fn test_null_union_vs_disjoint_literal_keeps_ts2367() {
+    assert!(
+        has_ts2367(r#"declare const access: 1 | null; if (access === "x") {}"#),
+        "Expected TS2367: `null` member does not grant overlap with \"x\""
+    );
+    assert!(
+        has_ts2367(r#"declare const grade: 1 | null | undefined; if (grade === "x") {}"#),
+        "Expected TS2367 for 1|null|undefined === string literal"
+    );
+}
+
+#[test]
+fn test_nullish_only_union_vs_literal_keeps_ts2367() {
+    // `null | undefined` is a union, not the bare nullable intrinsic, so it is
+    // not exempt: tsc reports TS2367 against a disjoint literal.
+    assert!(
+        has_ts2367(r#"declare const slot: null | undefined; if (slot === "x") {}"#),
+        "Expected TS2367 for null|undefined === string literal"
+    );
+}
+
+#[test]
+fn test_bare_nullable_operand_is_exempt() {
+    // A whole bare `undefined`/`null` operand is always equality-comparable.
+    assert!(
+        !has_ts2367(r#"declare const probe: undefined; if (probe === "x") {}"#),
+        "Expected NO TS2367: bare `undefined` operand is exempt"
+    );
+    assert!(
+        !has_ts2367(r#"declare const beacon: null; if (beacon === 42) {}"#),
+        "Expected NO TS2367: bare `null` operand is exempt"
+    );
+    assert!(
+        !has_ts2367(r#"declare const tag: 1 | undefined; if (undefined === tag) {}"#),
+        "Expected NO TS2367: bare `undefined` operand exempt against a union"
+    );
+}
+
+#[test]
+fn test_undefined_union_real_overlap_no_ts2367() {
+    // Shared non-nullish member → genuine overlap.
+    assert!(
+        !has_ts2367(r#"declare const code: 1 | undefined; if (code === 1) {}"#),
+        "Expected NO TS2367: `1` overlaps `1 | undefined`"
+    );
+    // Two unions overlapping only on `undefined` still overlap.
+    assert!(
+        !has_ts2367(
+            r#"
+declare const lhs: 1 | undefined;
+declare const rhs: 2 | undefined;
+if (lhs === rhs) {}
+"#
+        ),
+        "Expected NO TS2367: both operands share the `undefined` member"
     );
 }


### PR DESCRIPTION
Closes #14722.

## Failure family

Diagnostic conformance — false-**negative** **TS2367** ("This comparison
appears to be unintentional because the types 'X' and 'Y' have no overlap").
When one operand of an equality comparison is a **union containing
`null`/`undefined`** whose **non-nullish part has no overlap** with the other
operand, `tsc` (6.0.2) reports TS2367; tsz emitted nothing. Found by
differential-testing tsz against the bench `tsc`. This is the
`(T | undefined) === lit` family explicitly scoped out as a follow-up by #14719
(the enum-vs-member-literal TS2367 fix).

```ts
declare const a: 1 | undefined;      a === "x";   // tsc: TS2367   tsz (before): (none)
declare const b: number | undefined; b === "x";   // tsc: TS2367   tsz (before): (none)
declare const c: 1 | null;           c === "x";   // tsc: TS2367   tsz (before): (none)
declare const d: null | undefined;   d === "x";   // tsc: TS2367   tsz (before): (none)
```

## Root cause (wrong operation: relation — overlap/comparability)

The TS2367 owner is `types_have_no_overlap_inner`
(`crates/tsz-checker/src/types/utilities/enum_utils.rs`). It carried a blanket
short-circuit: *if `left` or `right` is `null`/`undefined`, return "overlaps"*.
That over-models tsc. In tsc the whole-operand `null`/`undefined` exemption
lives in `isTypeEqualityComparableTo` (the `target.flags & TypeFlags.Nullable`
term), applied **once at the equality-comparison site** — not inside the
comparable/overlap relation. Because tsz applied it inside the recursive
routine, a `null`/`undefined` reached as a **union member** during the
member-overlap iteration (`(1 | undefined)` → member `undefined`) was treated as
"overlaps everything", so the whole union spuriously overlapped any type and
TS2367 was suppressed.

## Structural rule

> A `null`/`undefined` member of a union does not grant the union blanket
> overlap. `tsc` decides overlap on the **non-nullish part** of each operand:
> `(1 | undefined) === "x"` has no overlap (`1` ⟂ `"x"`), while
> `(1 | undefined) === (2 | undefined)` overlaps on the shared `undefined`
> member. A comparison is exempt from TS2367 only when a **whole operand** is
> the bare `null`/`undefined` intrinsic (`undefined === x`); a *union* that
> merely contains `null`/`undefined` (`null | undefined`, `1 | undefined`) is
> **not** exempt.

## Owner layer

Checker only — `crates/tsz-checker/src/types/`.

- `utilities/enum_utils.rs` — the blanket `null`/`undefined` short-circuit is
  removed from `types_have_no_overlap_inner`, so `null`/`undefined` are genuine
  types in the overlap relation (overlapping `any`/`unknown`/themselves, and —
  through the assignability fallback — everything under non-`strictNullChecks`,
  matching tsc's comparable relation). The whole-operand exemption moves to a new
  `equality_operands_have_no_overlap`.
- `computation/binary.rs` — the TS2367 site calls
  `equality_operands_have_no_overlap` (the exemption-aware predicate) instead of
  a raw `types_have_no_overlap`.
- `computation/binary_support.rs` — TS2367 **display**: `get_primitive_family`
  now classifies a union by the common family of its non-nullish constituents,
  and `widen_for_ts2367_cross_family_display` preserves literals only when both
  operands share one primitive family, else widens both via
  `getBaseTypeOfLiteralType`. This also repairs the **pre-existing** cross-family
  display for non-nullable unions (`1 | 2` was shown unwidened) and
  object-vs-literal (`{ a } === "x"`).

No solver change. No printer-output inspection.

## Anti-hardcoding

The decision is structural — bare-nullable is `TypeId::{NULL,UNDEFINED}` (true
builtins), overlap is the existing value-based routine, and the display family
is derived from constituent kinds. No identifier/type-name/file-name literals,
no formatted-message predicate. The regression suite varies binder names
(`shade`/`rank`/`heading`/`access`/`grade`/`slot`/`probe`/`beacon`/`code`).

## Adjacent-case matrix (verified byte-for-diagnostics against `tsc` 6.0.2, `--strict`)

| Comparison | tsc | tsz before | tsz after |
|---|---|---|---|
| `(1 \| undefined) === "x"` | TS2367 | (none) ❌ | TS2367 ✓ |
| `(number \| undefined) === "x"` | TS2367 | (none) ❌ | TS2367 ✓ |
| `(1 \| null) === "x"` | TS2367 | (none) ❌ | TS2367 ✓ |
| `(null \| undefined) === "x"` | TS2367 | (none) ❌ | TS2367 ✓ |
| `(1 \| null \| undefined) === "x"` | TS2367 | (none) ❌ | TS2367 ✓ |
| `"x" === (1 \| undefined)` (reversed) | TS2367 | (none) ❌ | TS2367 ✓ |
| `undefined === "x"` (bare operand) | OK | OK | OK ✓ |
| `null === 42` (bare operand) | OK | OK | OK ✓ |
| `(1 \| undefined) === 1` (real overlap) | OK | OK | OK ✓ |
| `(1 \| undefined) === (2 \| undefined)` | OK | OK | OK ✓ |
| display `(1 \| undefined) === "x"` | `number \| undefined` / `string` | — | matches ✓ |
| display `(1 \| 2) === "x"` (pre-existing) | `number` / `string` | `1 \| 2` / `"x"` ❌ | matches ✓ |
| display `{ a } === "x"` (pre-existing) | `{ a }` / `string` | `{ a }` / `"x"` ❌ | matches ✓ |
| display `1 === 2` (same family) | `1` / `2` | `1` / `2` | matches ✓ |

## Scope / follow-up

Out of scope (separate, pre-existing): under non-`strictNullChecks`, tsc
*absorbs* `null`/`undefined` from union types at construction (`1 | undefined`
becomes `1`), so `(1 | undefined) === "x"` is TS2367 there too; tsz keeps the
member — a non-strict union-construction difference unrelated to this routine
(unchanged here, not a regression). Also out of scope: TS2367 union member
**display ordering** (`2 | 1` vs `1 | 2`).

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New regression suite (binder names varied; positive + negative controls) in
  `crates/tsz-checker/tests/ts2367_comparison_overlap_tests.rs` (5 new test
  fns) — full file `cargo test -p tsz-checker --test
  ts2367_comparison_overlap_tests` → 37/37 pass.
- Display rule: `ts2367_widens_cross_family_literals_in_display` (corrected from
  a test that asserted behavior contradicting `tsc` 6.0.2) +
  `ts2367_preserves_same_family_literals_in_display` in
  `src/types/computation/binary_tests.rs` — pass.
- Differential vs `tsc 6.0.2` (`--strict --target esnext`) over a 19-case
  null/undefined-union × literal/object/mixed/same-family matrix: every case now
  matches `tsc` (codes, locations, and message text); the only residual delta is
  the out-of-scope union member-ordering (`2 | 1`).
- No regressions in the overlap/comparison subsystem:
  `ts2367_deferred_conditional_overlap_tests`, `enum_equality_narrowing_tests`,
  `ts2352_nested_literal_overlap_tests`, `conformance_issues_errors` (296),
  `conformance_issues_types` (422), `conformance_issues_features` (370) all pass.
  Broad checker-lib failures observed locally (`async_*`, `ts2589_*`,
  `ts2540_readonly_*`, `ts2860/2861_instanceof_*`) fail identically on clean
  `main` (stash-verified) and are environment-related, unrelated to this change.
- `cargo fmt -p tsz-checker --check`, `cargo clippy -p tsz-checker --lib`
  (clean). Rebased on current `main` (f534c70), conflict-free. Broad
  conformance / JS-emit / DTS / fourslash owned by ready-review CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_015RpjtBSw88FDzjHATRD4p8)_