### PR TITLE
fix(checker): report TS2349 for calls on a `never` callee

### DIFF
--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -432,6 +432,16 @@ impl<'a> CheckerState<'a> {
             let (non_nullish, cause) = self.split_nullish_type(callee_for_split);
             nullish_cause = cause;
             let Some(non_nullish) = non_nullish else {
+                // The callee is entirely nullish (`null`, `undefined`, or
+                // `null | undefined`). The chain short-circuits to `undefined`,
+                // but tsc still computes the non-nullish slice as `never`, which
+                // has no call signatures, and reports TS2349 — unless a property
+                // access on a `never` receiver already emitted the companion
+                // TS2339. Mirror that so `fn?.()` where `fn: undefined` is not
+                // silently accepted.
+                if !self.never_callee_has_companion_property_diagnostic(call.expression) {
+                    self.error_not_callable_at(TypeId::NEVER, call.expression);
+                }
                 return TypeId::UNDEFINED;
             };
             callee_type = non_nullish;

--- a/crates/tsz-checker/src/types/computation/call/mod.rs
+++ b/crates/tsz-checker/src/types/computation/call/mod.rs
@@ -1553,7 +1553,6 @@ impl<'a> CheckerState<'a> {
         args: &[NodeIndex],
     ) -> Option<TypeId> {
         use crate::call_checker::CallableContext;
-        use tsz_parser::parser::syntax_kind_ext;
 
         // TS18046: Calling an expression of type `unknown` is not allowed.
         // tsc emits TS18046 instead of TS2349 when the callee is `unknown`.
@@ -1598,26 +1597,67 @@ impl<'a> CheckerState<'a> {
             return Some(TypeId::ANY);
         }
 
-        // Calling `never` returns `never` (bottom type propagation).
-        // tsc treats `never` as having no call signatures.
-        // For method calls (e.g., `a.toFixed()` where `a: never`), TS2339 is already
-        // emitted by the property access check, so we suppress the redundant TS2349.
-        // For direct calls on `never` (e.g., `f()` where `f: never`), emit TS2349.
+        // Calling `never` returns `never` (bottom type propagation). tsc treats
+        // `never` as having no call signatures and reports TS2349 — the only
+        // exception is when a dotted property access on a `never` receiver
+        // (`a.m()` where `a: never`) already emitted the companion TS2339
+        // ("Property 'm' does not exist on type 'never'"). Element access on
+        // `never` (`a["m"]()`) is silent, and a property/index that legitimately
+        // resolves to `never` (`o.k()` / `o["k"]()` where the member is typed
+        // `never`) emits no companion, so those still warrant TS2349.
         if callee_type == TypeId::NEVER {
-            let is_method_call = matches!(
-                self.ctx.arena.kind_at(callee_expr),
-                Some(
-                    syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-                        | syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
-                )
-            );
-            if !is_method_call {
+            if !self.never_callee_has_companion_property_diagnostic(callee_expr) {
                 self.error_not_callable_at(callee_type, callee_expr);
             }
             return Some(TypeId::NEVER);
         }
 
         None
+    }
+
+    /// Whether a call with a `never` callee already has a companion TS2339
+    /// ("Property 'p' does not exist on type 'never'") and so should suppress
+    /// the redundant TS2349 ("not callable") diagnostic.
+    ///
+    /// The companion fires from the member-access leg itself. Reproduce the two
+    /// shapes that tsz's property/element-access checks already report:
+    /// - When the receiver is **entirely nullish** (`null`/`undefined`), both a
+    ///   dotted (`o?.m`) and an indexed (`o?.["m"]`) optional access narrow the
+    ///   receiver to `never` and report TS2339, so the call leg stays silent.
+    /// - A **dotted** property access additionally reports TS2339 when the
+    ///   non-nullish receiver slice is itself `never` (`x.a` where `x: never`).
+    ///
+    /// Element access on a `never` receiver (`x["a"]`) is silent, and any member
+    /// that legitimately resolves to a `never`-typed value on a non-`never`,
+    /// non-nullish receiver (`o.k` / `o["k"]` where the member is typed `never`)
+    /// emits no companion — those keep TS2349, matching tsc. Parentheses,
+    /// non-null assertions, and type assertions around the callee are unwrapped
+    /// before inspecting the access shape.
+    fn never_callee_has_companion_property_diagnostic(&mut self, callee_expr: NodeIndex) -> bool {
+        use tsz_parser::parser::syntax_kind_ext;
+
+        // `access_receiver_type` unwraps parens/assertions and yields `None`
+        // for anything that is not a property or element access.
+        let Some(receiver) = self.access_receiver_type(callee_expr) else {
+            return false;
+        };
+        let unwrapped = self
+            .ctx
+            .arena
+            .skip_parenthesized_and_assertions(callee_expr);
+        let is_property =
+            self.ctx.arena.kind_at(unwrapped) == Some(syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION);
+        let evaluated = self.evaluate_application_type(receiver);
+        match self.split_nullish_type(evaluated).0 {
+            // Receiver is entirely nullish: the optional access already
+            // narrowed it to `never` and reported TS2339.
+            None => true,
+            // A dotted property access on a `never` receiver slice reports
+            // TS2339; an indexed access on `never` does not.
+            Some(slice) => {
+                is_property && self.resolve_type_for_property_access(slice) == TypeId::NEVER
+            }
+        }
     }
 }
 

--- a/crates/tsz-checker/tests/never_absorption_call_spread_tests.rs
+++ b/crates/tsz-checker/tests/never_absorption_call_spread_tests.rs
@@ -91,6 +91,136 @@ class Holder {
 }
 
 // ---------------------------------------------------------------------------
+// Calling a `never` callee that has NO companion TS2339.
+//
+// A property access on a `never` *receiver* collapses to the any-like error
+// fallback (TS2339, no TS2349 — covered above). But a callee whose type is
+// `never` for any other reason still has no call signatures, so `tsc` reports
+// TS2349: indexed access on a `never` receiver (silent access), a member that
+// legitimately resolves to a `never`-typed value, an index signature whose
+// value is `never`, and a `never[]` element. These previously slipped through
+// because the suppression keyed on the *syntactic* member-access shape rather
+// than on whether a companion diagnostic actually fired.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn indexed_access_on_never_receiver_call_reports_ts2349() {
+    // `empty["slot"]` is `never` and emits no TS2339 (indexed access on never is
+    // silent), so the trailing call must still report TS2349.
+    let codes = check(r#"function reach(empty: never) { empty["slot"](); }"#);
+    assert_eq!(
+        count(&codes, 2349),
+        1,
+        "indexed access on a never receiver then call should report one TS2349, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2339),
+        "indexed access on a never receiver is silent — no TS2339, got: {codes:?}"
+    );
+}
+
+#[test]
+fn never_typed_member_call_reports_ts2349() {
+    // The member exists (no TS2339) but is typed `never`, so both the dotted and
+    // the indexed call have no call signatures.
+    let dotted = check("function take(holder: { slot: never }) { holder.slot(); }");
+    assert_eq!(
+        count(&dotted, 2349),
+        1,
+        "dotted call on a never-typed member should report one TS2349, got: {dotted:?}"
+    );
+    assert!(
+        !dotted.contains(&2339),
+        "the member exists — no TS2339, got: {dotted:?}"
+    );
+
+    let indexed = check(r#"function grab(carrier: { slot: never }) { carrier["slot"](); }"#);
+    assert_eq!(
+        count(&indexed, 2349),
+        1,
+        "indexed call on a never-typed member should report one TS2349, got: {indexed:?}"
+    );
+}
+
+#[test]
+fn never_index_signature_value_call_reports_ts2349() {
+    // A string index signature whose value type is `never` means every element
+    // is `never`.
+    let dotted = check("function load(table: { [k: string]: never }) { table.key(); }");
+    assert_eq!(
+        count(&dotted, 2349),
+        1,
+        "dotted call through a never index signature should report one TS2349, got: {dotted:?}"
+    );
+
+    let indexed =
+        check(r#"function fetch(registry: { [k: string]: never }) { registry["key"](); }"#);
+    assert_eq!(
+        count(&indexed, 2349),
+        1,
+        "indexed call through a never index signature should report one TS2349, got: {indexed:?}"
+    );
+}
+
+#[test]
+fn never_array_element_call_reports_ts2349() {
+    let codes = check("function scan(list: never[]) { list[0](); }");
+    assert_eq!(
+        count(&codes, 2349),
+        1,
+        "calling a never[] element should report one TS2349, got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Optional call (`?.()`) on an entirely-nullish callee.
+//
+// When the callee of an optional call is exactly `null`/`undefined` (or their
+// union), the chain short-circuits to `undefined`, but `tsc` computes the
+// non-nullish slice as `never` (no call signatures) and reports TS2349. A
+// callee that still has a callable non-nullish slice is fine.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn optional_call_on_undefined_callee_reports_ts2349() {
+    let codes = check("function ring(buzzer: undefined) { buzzer?.(); }");
+    assert_eq!(
+        count(&codes, 2349),
+        1,
+        "optional call on an `undefined` callee should report one TS2349, got: {codes:?}"
+    );
+}
+
+#[test]
+fn optional_call_on_nullish_union_callee_reports_ts2349() {
+    let codes = check("function ping(beacon: null | undefined) { beacon?.(); }");
+    assert_eq!(
+        count(&codes, 2349),
+        1,
+        "optional call on a `null | undefined` callee should report one TS2349, got: {codes:?}"
+    );
+}
+
+#[test]
+fn optional_call_on_callable_or_undefined_is_allowed() {
+    // The non-nullish slice is callable, so the optional call is valid.
+    let codes = check("function maybe(handler: (() => void) | undefined) { handler?.(); }");
+    assert!(
+        !codes.contains(&2349),
+        "optional call with a callable non-nullish slice must not report TS2349, got: {codes:?}"
+    );
+}
+
+#[test]
+fn optional_call_on_present_method_is_allowed() {
+    let codes = check("function wire(panel: { run?: () => void }) { panel.run?.(); }");
+    assert!(
+        !codes.contains(&2349),
+        "optional call on a present optional method must not report TS2349, got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Spreading `never`: allowed in array literals, rejected elsewhere.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #14724.

## Failure family

Diagnostic conformance — false-negative **TS2349** ("This expression is not
callable. Type 'never' has no call signatures."). When a call's callee type is
`never`, `tsc` (6.0.2) reports TS2349, but `tsz` silently accepted several
shapes. Found by differential-testing `tsz` against the bench `tsc`; the
originating witness was the optional-call case `fn?.()`, but the family is
broader.

```ts
declare const x: never;       x["a"]();   // tsc: TS2349   tsz (before): (none)
declare const o: { k: never };
o.k(); o["k"]();                           // tsc: TS2349   tsz (before): (none)
declare const r: { [k: string]: never };
r.key();                                   // tsc: TS2349   tsz (before): (none)
declare const a: never[];      a[0]();     // tsc: TS2349   tsz (before): (none)
const fn: undefined = undefined; fn?.();   // tsc: TS2349   tsz (before): (none)
```

## Root cause (wrong operation: diagnostic — callability of `never`)

The owner is `check_callee_unknown_or_never`
(`crates/tsz-checker/src/types/computation/call/mod.rs`). Its `callee_type ==
never` arm suppressed TS2349 for **any** property- or element-access-shaped
callee (`is_method_call`), on the assumption that "a method call already reported
TS2339." That assumption is wrong: property access on a `never` **receiver**
returns the **error** type (not `never`) and reports TS2339, so it never reaches
the `never` arm. The syntactic suppression therefore only ever fired for cases
`tsc` *does* report — indexed access on a `never` receiver (silent access), a
member legitimately typed `never`, a `never` index-signature value, and `never[]`
elements. Separately, optional calls (`call/inner.rs`) on an **entirely-nullish**
callee short-circuited to `undefined` without computing the non-nullish slice
(`never`), so `fn?.()` was silently accepted.

## Structural rule

> When a call's callee type (after optional-chain `null`/`undefined` stripping)
> is `never`, `tsc` reports TS2349 — **except** when a dotted property access on a
> `never` receiver already emitted the companion TS2339. That companion fires
> only when the access receiver, after removing nullish, is empty/`never` (dotted
> access on `never`, or any optional access on an entirely-nullish receiver).
> Indexed access on a non-nullish `never` receiver is silent, and a member /
> index / array-element that legitimately resolves to a `never`-typed value emits
> no companion — those keep TS2349.

## Owner layer

Checker only — `crates/tsz-checker/src/types/computation/call/`. A new structural
predicate `never_callee_has_companion_property_diagnostic` (in `call/mod.rs`)
reconstructs when the companion TS2339 actually fired — receiver's non-nullish
slice empty (both dotted and indexed optional access on an entirely-nullish
receiver), or a **dotted** access whose non-nullish slice resolves to `never`.
It reuses the existing `access_receiver_type` / `evaluate_application_type` /
`split_nullish_type` / `resolve_type_for_property_access` helpers. The `never`
arm and the entirely-nullish optional-call branch (`call/inner.rs`) both gate on
it before emitting TS2349. No solver/emit change, no diagnostic-display change.

## Anti-hardcoding

The decision is structural — derived from the callee's access shape and the
receiver type's nullish/`never` composition, never from identifier / type-name /
file-name literals and never from formatted-message predicates. The regression
suite varies binder names (`empty`/`holder`/`carrier`/`table`/`registry`/
`scan`/`buzzer`/`beacon`/`handler`/`panel`).

## Adjacent-case matrix (verified diagnostic-for-diagnostic against `tsc` 6.0.2)

| Call | tsc | tsz before | tsz after |
|---|---|---|---|
| `x()` (`x: never`) | TS2349 | TS2349 | TS2349 ✓ |
| `x.a()` (property on `never` receiver) | TS2339 | TS2339 | TS2339 ✓ |
| `x["a"]()` (indexed on `never` receiver) | TS2349 | (none) ❌ | TS2349 ✓ |
| `o.k()` / `o["k"]()` (member typed `never`) | TS2349 | (none) ❌ | TS2349 ✓ |
| `r.key()` / `r["key"]()` (`never` index sig) | TS2349 | (none) ❌ | TS2349 ✓ |
| `a[0]()` (`never[]` element) | TS2349 | (none) ❌ | TS2349 ✓ |
| `(x.a)()` / `(o.k)()` (parenthesized) | TS2339 / TS2349 | TS2339 / TS2349 | TS2339 / TS2349 ✓ |
| `fn?.()` (`fn: undefined` / `null` / `null\|undefined`) | TS2349 | (none) ❌ | TS2349 ✓ |
| `fn2?.()` (`(() => void) \| undefined`) | (none) | (none) | (none) ✓ |
| `panel.run?.()` (present optional method) | (none) | (none) | (none) ✓ |

## Scope / follow-up

Out of scope (separate, pre-existing, reproduces without any call): `o?.["m"]`
where `o: undefined` — `tsz` reports TS2339 on the **indexed** optional access
while `tsc` stays silent there and reports TS2349 on the call. It belongs to the
property-access (TS2339) family, not this call/TS2349 fix.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New regression cases (binder names varied; positive + negative controls) in
  `crates/tsz-checker/tests/never_absorption_call_spread_tests.rs` — indexed
  access on `never` receiver, dotted/indexed `never`-typed member, dotted/indexed
  `never` index signature, `never[]` element, entirely-nullish optional call
  (`undefined` / `null | undefined`), callable-non-nullish-slice negative,
  present-optional-method negative. `cargo test -p tsz-checker --lib --
  never_absorption_call_spread` → 18/18 pass.
- Differential vs `tsc 6.0.2` (`--strict`/non-strict, `--target esnext`) over a
  30-case never-callee matrix: every in-scope case now matches `tsc`; the only
  residual delta is the out-of-scope `o?.["m"]` indexed-optional-access TS2339
  family above. The original 45-file differential corpus that surfaced `fn?.()`
  now shows zero deltas.
- No regressions: the 20 `tsz-checker --lib` failures on this branch
  (`async_inferred_return_*`, `ts2860`/`ts2861` instanceof, `ts2540`/`ts2542`
  readonly, `ts2322` elaboration, `ts2589`, `yield_star`, `zod`) reproduce
  identically on clean `main` (stash-verified) and are unrelated.
- `cargo fmt -p tsz-checker --check` clean, `cargo clippy -p tsz-checker --lib`
  clean, `python3 scripts/arch/arch_guard.py` passed. Rebased conflict-free on
  current `main`. Broad conformance / JS-emit / DTS / fourslash owned by
  ready-review CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvPPwiz9UCQzTBFMT3YeF7)_