### PR TITLE
fix(emit): only pre-count ??= value temps for property/element targets

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -346,6 +346,10 @@ path = "tests/dynamic_import_amd_umd_parity_tests.rs"
 name = "es5_instance_field_init_order_tests"
 path = "tests/es5_instance_field_init_order_tests.rs"
 
+[[test]]
+name = "logical_assignment_temp_numbering_tests"
+path = "tests/logical_assignment_temp_numbering_tests.rs"
+
 [lints]
 workspace = true
 

--- a/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/binary_downlevel.rs
@@ -348,9 +348,7 @@ impl<'a> Printer<'a> {
 
         match self.arena.get(left) {
             Some(left_node) => {
-                if left_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-                    || left_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
-                {
+                if is_property_or_element_access(left_node) {
                     self.emit_logical_assignment_access(
                         left,
                         left_node,
@@ -397,6 +395,22 @@ impl<'a> Printer<'a> {
             self.emit_expression_for_logical_assignment(binary.right);
             self.write(")");
         }
+    }
+
+    /// Whether lowering a non-es2020 `??=` with target `left` consumes a hoisted
+    /// value temp. Only a property/element-access target does (its reference is
+    /// captured: `(_a = obj.p) !== null && ...`); a bare identifier/`this`/`super`
+    /// is lowered inline with no temp. Shares the `is_property_or_element_access`
+    /// dispatch with `emit_logical_assignment_expression` so the pre-count cannot
+    /// drift from emit and desync the shared temp counter from `tsc`.
+    pub(in crate::emitter) fn nullish_assignment_consumes_value_temp(
+        &self,
+        left: NodeIndex,
+    ) -> bool {
+        let left = self.unwrap_parenthesized_logical_assignment_left(left);
+        self.arena
+            .get(left)
+            .is_some_and(is_property_or_element_access)
     }
 
     fn unwrap_parenthesized_logical_assignment_left(&self, mut left: NodeIndex) -> NodeIndex {
@@ -907,6 +921,17 @@ impl<'a> Printer<'a> {
             _ => "=".to_string(),
         }
     }
+}
+
+/// Whether `node` is a property- or element-access expression — the two
+/// logical-assignment targets that capture their reference into a value temp
+/// during downlevel lowering. Single source of truth for the dispatch in
+/// `emit_logical_assignment_expression` and the `??=` value-temp pre-count.
+const fn is_property_or_element_access(node: &Node) -> bool {
+    matches!(
+        node.kind,
+        syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION | syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+    )
 }
 
 /// Strip up to `count` leading space/tab characters from `s`.

--- a/crates/tsz-emitter/src/emitter/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/helpers.rs
@@ -1047,6 +1047,7 @@ impl<'a> Printer<'a> {
 
             if let Some(binary) = self.arena.get_binary_expr(node)
                 && binary.operator_token == SyntaxKind::QuestionQuestionEqualsToken as u16
+                && self.nullish_assignment_consumes_value_temp(binary.left)
             {
                 count += 1;
             }

--- a/crates/tsz-emitter/tests/logical_assignment_temp_numbering_tests.rs
+++ b/crates/tsz-emitter/tests/logical_assignment_temp_numbering_tests.rs
@@ -1,0 +1,94 @@
+//! Regression tests for generated temp-variable numbering in `??=` (nullish
+//! logical assignment) downlevel emit.
+//!
+//! When a `??=` target is a bare identifier (or `this`/`super`), tsc lowers it
+//! inline — `y !== null && y !== void 0 ? y : (y = rhs)` — and allocates NO
+//! temporary. tsz previously pre-allocated a hoisted value temp for *every*
+//! `??=` regardless of its target, which advanced the shared temp counter and
+//! shifted every later generated name by one (`_b` where tsc emits `_a`). These
+//! tests pin the counter to tsc's behavior. See the `count_logical_assignment_
+//! value_temps` gate in `helpers.rs`.
+
+use tsz_common::common::ScriptTarget;
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::parse_and_lower_print;
+
+fn emit_es2017(source: &str) -> String {
+    let opts = PrintOptions {
+        target: ScriptTarget::ES2017,
+        ..Default::default()
+    };
+    parse_and_lower_print(source, opts)
+}
+
+/// A bare-identifier `??=` allocates no temp, so the following optional chain
+/// must take the first generated name `_a` (not `_b`).
+#[test]
+fn identifier_nullish_assignment_does_not_consume_temp() {
+    let source = "declare const obj: any;\nlet y: any;\ny ??= 5;\nconst x = obj?.p?.q;\n";
+    let output = emit_es2017(source);
+    assert!(
+        output.contains("(_a = obj === null"),
+        "optional chain must use `_a` after a bare-identifier `??=`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_b"),
+        "no `_b` should be generated — the `??=` must not reserve a temp.\nOutput:\n{output}"
+    );
+}
+
+/// Two consecutive bare-identifier `??=` still reserve nothing: the chain stays
+/// at `_a`.
+#[test]
+fn multiple_identifier_nullish_assignments_do_not_consume_temps() {
+    let source =
+        "declare const obj: any;\nlet y: any, z: any;\ny ??= 5;\nz ??= 6;\nconst x = obj?.p?.q;\n";
+    let output = emit_es2017(source);
+    assert!(
+        output.contains("(_a = obj === null"),
+        "optional chain must use `_a` after two bare-identifier `??=`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("_b") && !output.contains("_c"),
+        "no extra temps should be generated for identifier `??=`.\nOutput:\n{output}"
+    );
+}
+
+/// A property-access `??=` *does* capture its target into a value temp `_a`, so
+/// the following optional chain must take `_b`. This guards against the fix
+/// over-correcting and dropping the temp the property path genuinely needs.
+#[test]
+fn property_nullish_assignment_still_consumes_temp() {
+    let source = "declare const obj: any;\nlet o: any;\no.k ??= 5;\nconst x = obj?.p?.q;\n";
+    let output = emit_es2017(source);
+    assert!(
+        output.contains("(_a = o.k) !== null"),
+        "property `??=` must capture its target into `_a`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("(_b = obj === null"),
+        "optional chain must use `_b` after a property `??=`.\nOutput:\n{output}"
+    );
+}
+
+/// A bare-identifier `??=` whose RHS is a non-simple `??` coalescing still
+/// numbers correctly: the value temp consumed by the RHS `??` is `_a` and the
+/// trailing chain is `_b`.
+#[test]
+fn identifier_nullish_assignment_with_coalescing_rhs() {
+    let source =
+        "declare const obj: any;\nlet y: any, b: any;\ny ??= obj.x ?? b;\nconst x = obj?.p?.q;\n";
+    let output = emit_es2017(source);
+    assert!(
+        output.contains("(_a = obj.x)"),
+        "RHS `??` value temp must be `_a`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("(_b = obj === null"),
+        "optional chain must use `_b`.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Fixes #14726.

Goal: hold

## Problem

When downleveling `??=` (nullish logical assignment) below `es2020`, tsz pre-counts how many hoisted **value temps** the lowering will consume so it can pre-allocate temp names (`_a`, `_b`, …) that line up with `tsc`. `count_logical_assignment_value_temps` counted *every* `??=`, but at emit time only a **property/element-access** target consumes a value temp — a bare identifier/`this`/`super` target lowers inline (`y !== null && y !== void 0 ? y : (y = rhs)`) with no temp.

The over-reserved name advances the shared temp-name counter, so every later generated name is shifted by one. Minimal witness (`--target es2017`):

```ts
declare const obj: any;
let y: any;
y ??= 5;
const x = obj?.p?.q;
```

`tsc` emits `_a` for the optional chain; tsz emitted `_b` (and `var _b;`). Two consecutive identifier `??=` shifted it to `_c`, and a temp-consuming construct placed *before* the `??=` came out mis-ordered.

## Structural rule

> When lowering a non-es2020 `??=`, `tsc` allocates a value temp only when the target is a property/element access (capturing the reference: `(_a = obj.p) !== null && ...`); a bare identifier/`this`/`super` target lowers inline with no temp. tsz pre-counted a value temp for every `??=` regardless of target.

## Fix

Gate the pre-count on `nullish_assignment_consumes_value_temp`, which checks whether the paren-unwrapped target is a property/element access — the exact condition under which `emit_logical_assignment_expression` routes to `emit_logical_assignment_access` (where the value temp is taken). The predicate `is_property_or_element_access` is now the single source of truth shared by both the emit dispatch and the pre-count, so the count cannot drift from emit. The RHS-`??` value-temp path and property/element `??=` targets are unaffected (they fall through to the shared counter, which my change keeps in sync).

Owner layer: emitter (`crates/tsz-emitter`); no semantic/type changes.

## Adjacent matrix (all `--target es2017`, diffed vs tsc 6.0.2)

| Form | value temp | result |
|---|---|---|
| `y ??= 5` (identifier) | none | chain `_a` ✓ |
| `y ??= 5; z ??= 6;` | none | chain `_a` ✓ |
| `o.k ??= 5` (property) | `_a` | chain `_b` ✓ |
| `o[k()] ??= 5` (element) | value + index | ✓ |
| `y ??= obj.x ?? b` (coalescing RHS) | RHS `??` temp | `_a`, chain `_b` ✓ |
| `this.v ??= 5` (method) | none | chain `_b` ✓ |

## Out of scope

For property/element `??=` the code body is now byte-identical to tsc, but the hoisted `var` *declaration* grouping (tsc merges `var _a, _b;`) is a separate pre-existing root in how `hoisted_assignment_value_temps` is flushed; tracked in #14726, not addressed here.

## Verification

- `cargo test -p tsz-emitter --test logical_assignment_temp_numbering_tests` — 4 new tests pass (identifier / multiple-identifier / property / coalescing-RHS).
- Full `cargo test -p tsz-emitter` — 4210 passed; the single failure (`generator_object_literal_prefix_before_yield_omits_source_trailing_comma`) is pre-existing and fails identically on a clean tree (the source contains no `??=`).
- `cargo clippy -p tsz-emitter` — clean.
- Repro matrix diffed byte-for-byte against `tsc 6.0.2`.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01EsCkgULdyGEwRvbokaNxKc

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsCkgULdyGEwRvbokaNxKc)_