### PR TITLE
fix(checker): materialize alias-wrapped re-exported generic interface receiver (#13212)

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/application.rs
+++ b/crates/tsz-checker/src/state/type_environment/application.rs
@@ -87,6 +87,79 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    /// Materialize a property-access receiver that is a generic *type-alias*
+    /// application forwarding its arguments into a cross-file generic interface
+    /// (`type L<T> = Box<T>` where `Box` is reached through a barrel re-export,
+    /// then `b: L<number>`).
+    ///
+    /// The shared evaluator substitutes the alias's own parameters correctly
+    /// (`L<number>` → its body `Box<number>`), but evaluating that inner
+    /// cross-arena interface application then drops the interface's parameter
+    /// substitution (the inherited member surfaces as the unsubstituted declared
+    /// `T`, a false `TS2322`). A *direct* interface receiver avoids this because
+    /// `evaluate_application_type_for_property_access` materializes it through
+    /// `resolve_application_base_body`; the alias wrapper never reaches that path
+    /// because its base is a `TypeAlias`, not an `Interface`.
+    ///
+    /// This expands the alias one level — substituting the concrete arguments
+    /// into the alias body — and, when the result is a cross-file generic
+    /// interface/class application, routes it through the same interface
+    /// materialization the direct receiver uses. Returns `None` for every other
+    /// shape so the caller keeps the shared evaluator. Gated on *concrete*
+    /// arguments so a still-generic receiver (whose free parameters are
+    /// legitimately preserved) is untouched. Refs #13212 / #10663.
+    pub(crate) fn materialize_alias_wrapped_interface_receiver(
+        &mut self,
+        type_id: TypeId,
+    ) -> Option<TypeId> {
+        use tsz_solver::def::DefKind;
+        let db = self.ctx.types.as_type_database();
+        let (alias_base, alias_args) = query::application_info(self.ctx.types, type_id)?;
+        if alias_args.is_empty()
+            || alias_args
+                .iter()
+                .any(|&arg| crate::query_boundaries::common::contains_type_parameters(db, arg))
+        {
+            return None;
+        }
+        let alias_def_id = query::lazy_def_id(self.ctx.types, alias_base)?;
+        let alias_info = self.ctx.definition_store.get(alias_def_id)?;
+        if alias_info.kind != DefKind::TypeAlias {
+            return None;
+        }
+        let alias_params = self.ctx.get_def_type_params(alias_def_id)?;
+        if alias_params.is_empty() || alias_params.len() != alias_args.len() {
+            return None;
+        }
+        let alias_body = self.ctx.definition_store.get_body(alias_def_id)?;
+        // A self-`Lazy(def)` placeholder body carries no structural shape to
+        // expand; bail so the shared evaluator keeps ownership.
+        if query::lazy_def_id(self.ctx.types, alias_body) == Some(alias_def_id) {
+            return None;
+        }
+        let substitution =
+            query::TypeSubstitution::from_args(self.ctx.types, &alias_params, &alias_args);
+        let underlying = query::instantiate_type(self.ctx.types, alias_body, &substitution);
+
+        // The expanded body must itself be a *cross-file* generic interface/class
+        // application — exactly the shape the shared evaluator mis-substitutes and
+        // the interface materialization handles. Same-file or lib bases already
+        // resolve correctly through the shared path.
+        let (underlying_base, _) = query::application_info(self.ctx.types, underlying)?;
+        let underlying_def_id = query::lazy_def_id(self.ctx.types, underlying_base)?;
+        let underlying_info = self.ctx.definition_store.get(underlying_def_id)?;
+        if underlying_info
+            .file_id
+            .is_none_or(|file_id| file_id == self.ctx.current_file_idx as u32)
+            || underlying_info.is_declare
+            || !matches!(underlying_info.kind, DefKind::Interface | DefKind::Class)
+        {
+            return None;
+        }
+        let materialized = self.evaluate_application_type_for_property_access(underlying);
+        (materialized != underlying).then_some(materialized)
+    }
+
     /// Instantiate a generic interface/class body with its type parameters bound
     /// to an application's arguments, then env-evaluate the result.
     ///

--- a/crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs
+++ b/crates/tsz-checker/src/tests/reexported_generic_interface_property_tests.rs
@@ -43,6 +43,155 @@ fn assert_clean(files: &[(&str, &str)], entry: &str) {
     assert!(diags.is_empty(), "expected no diagnostics, got: {diags:?}");
 }
 
+// --- a local generic type alias wrapping a re-exported generic interface ---
+//
+// `type L<T> = Box<T>` forwards its argument into `Box`, reached through a
+// barrel re-export. The shared evaluator substitutes the *alias* parameter
+// correctly (`L<number>` -> `Box<number>`) but then drops the *interface*
+// parameter substitution on the cross-arena `Box<number>`, surfacing the
+// inherited member as the unsubstituted declared `T` (a false TS2322). A direct
+// interface receiver avoids this because it is materialized through
+// `resolve_application_base_body`; the alias wrapper now reaches the same
+// materialization via `materialize_alias_wrapped_interface_receiver`.
+
+#[test]
+fn member_access_through_alias_over_value_reexport() {
+    assert_clean(
+        &[
+            ("./decl.ts", "export interface Box<T> { value: T; }\n"),
+            ("./barrel.ts", "export { Box } from './decl';\n"),
+            (
+                "./main.ts",
+                "import type { Box } from './barrel';\ntype Wrap<T> = Box<T>;\ndeclare const h: Wrap<number>;\nconst n: number = h.value;\n",
+            ),
+        ],
+        "./main.ts",
+    );
+}
+
+#[test]
+fn member_access_through_alias_over_type_only_reexport() {
+    assert_clean(
+        &[
+            ("./model.ts", "export interface Cell<V> { payload: V; }\n"),
+            ("./index.ts", "export type { Cell } from './model';\n"),
+            (
+                "./consumer.ts",
+                "import type { Cell } from './index';\ntype Slot<V> = Cell<V>;\ndeclare const c: Slot<string>;\nconst s: string = c.payload;\n",
+            ),
+        ],
+        "./consumer.ts",
+    );
+}
+
+#[test]
+fn member_access_through_alias_renames_parameter() {
+    // The alias parameter name differs from the interface parameter name; the
+    // forwarding must still bind the concrete argument to the inherited member.
+    assert_clean(
+        &[
+            ("./store.ts", "export interface Holder<T> { item: T; }\n"),
+            ("./gateway.ts", "export type { Holder } from './store';\n"),
+            (
+                "./app.ts",
+                "import type { Holder } from './gateway';\ntype Keep<Q> = Holder<Q>;\ndeclare const h: Keep<number>;\nconst n: number = h.item;\n",
+            ),
+        ],
+        "./app.ts",
+    );
+}
+
+#[test]
+fn member_access_through_alias_two_type_args() {
+    assert_clean(
+        &[
+            (
+                "./pair.ts",
+                "export interface Pair<A, B> { left: A; right: B; }\n",
+            ),
+            ("./barrel.ts", "export type { Pair } from './pair';\n"),
+            (
+                "./use.ts",
+                "import type { Pair } from './barrel';\ntype Combo<A, B> = Pair<A, B>;\ndeclare const c: Combo<number, string>;\nconst l: number = c.left;\nconst r: string = c.right;\n",
+            ),
+        ],
+        "./use.ts",
+    );
+}
+
+#[test]
+fn member_access_through_alias_wrong_arg_still_errors() {
+    // Negative control: a genuine mismatch must still report TS2322 — the
+    // forwarding applies the substitution rather than skipping the check.
+    let diags = check(
+        &[
+            ("./carrier.ts", "export interface Carrier<T> { load: T; }\n"),
+            ("./hub.ts", "export type { Carrier } from './carrier';\n"),
+            (
+                "./bad.ts",
+                "import type { Carrier } from './hub';\ntype Wrap<T> = Carrier<T>;\ndeclare const c: Wrap<string>;\nconst n: number = c.load;\n",
+            ),
+        ],
+        "./bad.ts",
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|(code, _)| *code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "expected TS2322 for string-vs-number mismatch through the alias, got: {diags:?}"
+    );
+}
+
+#[test]
+fn member_access_through_alias_over_direct_import_control() {
+    // Control: the same alias over a *direct* import already resolved correctly;
+    // it must stay clean (the fix only adds a recovery for the re-export hop).
+    assert_clean(
+        &[
+            ("./decl.ts", "export interface Box<T> { value: T; }\n"),
+            (
+                "./main.ts",
+                "import type { Box } from './decl';\ntype Wrap<T> = Box<T>;\ndeclare const h: Wrap<number>;\nconst n: number = h.value;\n",
+            ),
+        ],
+        "./main.ts",
+    );
+}
+
+#[test]
+fn member_access_through_alias_over_local_interface_control() {
+    // Control: an all-local alias-over-interface was already correct.
+    assert_clean(
+        &[(
+            "./main.ts",
+            "interface Box<T> { value: T; }\ntype Wrap<T> = Box<T>;\ndeclare const h: Wrap<number>;\nconst n: number = h.value;\n",
+        )],
+        "./main.ts",
+    );
+}
+
+#[test]
+#[ignore = "open follow-up: the assignment-target form (`const h: Wrap<number> = \
+            { value: 1 }`) does not route through the property-access receiver \
+            materialization, so the cross-arena interface application still drops \
+            its parameter substitution during relation evaluation. That is the \
+            general cross-file generic-interface instantiation root (#14344 \
+            type-parameter identity), not the property-access facet this slice \
+            fixes."]
+fn assignment_to_alias_over_reexport_target() {
+    assert_clean(
+        &[
+            ("./decl.ts", "export interface Box<T> { value: T; }\n"),
+            ("./barrel.ts", "export type { Box } from './decl';\n"),
+            (
+                "./main.ts",
+                "import type { Box } from './barrel';\ntype Wrap<T> = Box<T>;\nconst h: Wrap<number> = { value: 1 };\n",
+            ),
+        ],
+        "./main.ts",
+    );
+}
+
 // --- member access through each re-export form (consumer uses `import type`) ---
 
 #[test]

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -378,6 +378,14 @@ impl<'a> CheckerState<'a> {
             // see `recover_arena_collided_application_for_property_access`. Returns
             // `None` (and falls through) for every well-formed receiver.
             recovered
+        } else if let Some(materialized) =
+            self.materialize_alias_wrapped_interface_receiver(original_object_type)
+        {
+            // Recover a `type L<T> = Box<T>`-style receiver that forwards concrete
+            // arguments into a cross-file generic interface reached through a
+            // barrel re-export; the shared evaluator drops the interface's
+            // parameter substitution. Returns `None` for every other shape.
+            materialized
         } else {
             self.evaluate_application_type(original_object_type)
         };


### PR DESCRIPTION
## Summary

A local generic **type alias** that forwards its argument into a generic
**interface reached through a barrel re-export** produced a false `TS2339`/
`TS2322` on the inherited member:

```ts
// decl.ts
export interface Box<T> { value: T; }
// barrel.ts
export type { Box } from './decl';   // also `export { Box }` / `export *`
// main.ts
import type { Box } from './barrel';
type Wrap<T> = Box<T>;
declare const h: Wrap<number>;
const n: number = h.value;            // tsz: TS2322 'T' is not assignable to 'number'; tsc: clean
```

A **direct** import of `Box` already resolved correctly; only the re-export hop
under an alias wrapper regressed. This is the documented residual (a) from
#13212 ("a local alias wrapping a barrel-re-exported generic").

## Structural rule

When a property-access receiver is a generic type-alias application `Wrap<Args>`
whose body forwards those arguments into a **cross-file** generic interface/class
application (`Box<Args>`), `tsc` materializes the instantiated interface body and
reads the member off it. tsz substitutes the *alias* parameter correctly
(`Wrap<number>` → `Box<number>`) but the shared evaluator then drops the
*interface* parameter substitution on the cross-arena `Box<number>`, leaving the
inherited member as the unsubstituted declared `T`.

A **direct** interface receiver avoids this because it is materialized through
`resolve_application_base_body`; the alias wrapper never reached that path
because its base is a `TypeAlias`, not an `Interface`.

## Owner layer

Checker — property-access receiver evaluation
(`crates/tsz-checker/src/state/type_environment/application.rs`,
`types/property_access_type/resolve.rs`). New
`materialize_alias_wrapped_interface_receiver` expands the alias one level
(substituting the concrete arguments into the alias body) and, when the result
is a cross-file generic interface/class application, routes it through the same
`evaluate_application_type_for_property_access` materialization the direct
receiver uses — the structural generalization of the prior #14578 slice.

No fixture-name / source-text / printer predicates. Gated on **concrete**
arguments (a still-generic receiver keeps its free parameters) and on the
expanded base being a cross-file (non-lib, non-`declare`) `Interface`/`Class`,
so same-file generics, lib aliases (`Partial`/`Pick`/`Record`), and mapped-type
aliases keep the shared evaluator untouched. Returns `None` for every other
shape.

## Adjacent matrix (all now clean; `tsc`-clean)

- `export { Box }` / `export type { Box }` / value re-export forms
- alias renames the forwarded parameter (`type Keep<Q> = Holder<Q>`)
- two type parameters forwarded
- **negative control**: a genuine arg mismatch still reports `TS2322`
- **controls** (already passed, pinned): direct import, all-local interface

## Out of scope (documented `#[ignore]`d follow-up)

The **assignment-target** form (`const h: Wrap<number> = { value: 1 }`) does not
route through the property-access receiver path, so the cross-arena interface
application still drops its substitution during relation evaluation. That is the
general cross-file generic-interface instantiation root (#14344 type-parameter
identity), not the property-access facet this slice fixes.

## Verification

- `cargo test -p tsz-checker --lib reexported_generic_interface` — 16 existing + 7 new green, 2 ignored
- targeted `tsz-checker` property-access / generic-interface / re-export suites green (the one pre-existing `mapped_enum_discriminant_application_exposes_member_property` failure reproduces on clean `main` and is unrelated)
- `cargo fmt` + `cargo clippy -p tsz-checker` clean
- Broad conformance/emit/project-compile owned by ready-review CI.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Wora2LwMrcXsQMZy18tKJ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wora2LwMrcXsQMZy18tKJ7)_