### PR TITLE
fix(solver): keep any/error-typed discriminant property inert under value exclusion (TS2339)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -156,6 +156,9 @@ path = "tests/variadic_tuple_spread_element_type_tests.rs"
 name = "closure_boundary_property_narrowing_tests"
 path = "tests/closure_boundary_property_narrowing_tests.rs"
 [[test]]
+name = "exclusion_narrow_any_error_member_tests"
+path = "tests/exclusion_narrow_any_error_member_tests.rs"
+[[test]]
 name = "flow_property_reference_cache_tests"
 path = "tests/flow_property_reference_cache_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/exclusion_narrow_any_error_member_tests.rs
+++ b/crates/tsz-checker/tests/exclusion_narrow_any_error_member_tests.rs
@@ -1,0 +1,212 @@
+//! Tests for `x !== undefined` exclusion narrowing of `any` / error-typed
+//! members.
+//!
+//! Structural rule: when narrowing a member by excluding `undefined` (the true
+//! branch of `obj.prop !== undefined`, or the symmetric `=== undefined` false
+//! branch), a member whose type is `any` — including an alias that resolves to
+//! `any`, or an `any` written inline — or an *error* type (e.g. an unresolved
+//! type name from a failed import / a typo) is INERT: tsc keeps it unchanged
+//! (`any - X = any`; an error type stays the error type). tsz previously ran the
+//! exclusion through `is_assignable_to(member, undefined)`, which is `true` for
+//! `any` (assignable to everything) and short-circuits `true` for an error type,
+//! so the member was dropped and the property collapsed to `never`. Re-reading
+//! the guarded property then drew a spurious TS2339 ("property does not exist on
+//! never") / TS18048. Owner layer: solver narrowing `member_excluded_by`.
+//!
+//! The negative controls prove the fix does not blanket-suppress real
+//! exclusion: a genuine optional `string` property still narrows to `string`
+//! (and excess `undefined` is still removed), and a local variable of union type
+//! still narrows correctly. Binder names are varied across the tests so the
+//! behavior cannot depend on a particular identifier (anti-hardcoding).
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+// ---------------------------------------------------------------------------
+// Positive cases: `any` / error members must stay INERT (no spurious error).
+// ---------------------------------------------------------------------------
+
+/// Reported repro: an optional member whose type is an *unresolved* name
+/// (`DoesNotExist`) — an error type. After `o.validate !== undefined` the member
+/// must remain readable, not collapse to `never`.
+#[test]
+fn error_typed_member_inert_under_undefined_exclusion() {
+    let codes = check_source_strict_codes(
+        r#"
+declare const o: { validate?: DoesNotExist };
+if (o.validate !== undefined) {
+  const x = o.validate;
+}
+"#,
+    );
+    // The only legitimate diagnostic is TS2304 for the unresolved `DoesNotExist`
+    // name itself. There must be NO TS2339 (property on `never`) or TS18048.
+    assert!(
+        !codes.contains(&2339) && !codes.contains(&18048),
+        "error-typed member must stay inert under `!== undefined`, got: {codes:?}"
+    );
+}
+
+/// Equivalent shape: an unresolved name reached through a *failed import*. Same
+/// error-type path, different binder spelling.
+#[test]
+fn imported_unresolved_member_inert_under_undefined_exclusion() {
+    let codes = check_source_strict_codes(
+        r#"
+import { Missing } from "./nowhere";
+declare const config: { handler?: Missing };
+if (config.handler !== undefined) {
+  const ref = config.handler;
+  void ref;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2339) && !codes.contains(&18048),
+        "member typed by a failed import must stay inert under `!== undefined`, got: {codes:?}"
+    );
+}
+
+/// Inline `any` member: `any - undefined = any`. Reading the guarded property
+/// must be fine.
+#[test]
+fn inline_any_member_inert_under_undefined_exclusion() {
+    let codes = check_source_strict_codes(
+        r#"
+declare const bag: { payload?: any };
+if (bag.payload !== undefined) {
+  const taken = bag.payload;
+  void taken;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2339) && !codes.contains(&18048),
+        "inline-any member must stay `any` under `!== undefined`, got: {codes:?}"
+    );
+}
+
+/// Alias-`any` member: a type alias that resolves to `any`. Must be caught by
+/// resolving the member before classifying it (not just literal `TypeId::ANY`).
+/// Different identifier spellings again.
+#[test]
+fn alias_any_member_inert_under_undefined_exclusion() {
+    let codes = check_source_strict_codes(
+        r#"
+type Loose = any;
+declare const container: { slot?: Loose };
+if (container.slot !== undefined) {
+  const grabbed = container.slot;
+  void grabbed;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2339) && !codes.contains(&18048),
+        "alias-any member must stay inert under `!== undefined`, got: {codes:?}"
+    );
+}
+
+/// Symmetric form: the `=== undefined` false branch performs the same exclusion.
+#[test]
+fn any_member_inert_under_equality_false_branch() {
+    let codes = check_source_strict_codes(
+        r#"
+declare const record: { entry?: any };
+if (record.entry === undefined) {
+} else {
+  const used = record.entry;
+  void used;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2339) && !codes.contains(&18048),
+        "any member must stay inert in the `=== undefined` else branch, got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: real exclusion narrowing MUST still happen.
+// ---------------------------------------------------------------------------
+
+/// A genuine optional `string` property still narrows: after `v !== undefined`
+/// the member is `string`, so `.toUpperCase()` is fine and there is NO TS18048.
+/// This proves excess-`undefined` removal still works on real members.
+#[test]
+fn optional_string_member_still_narrows() {
+    let codes = check_source_strict_codes(
+        r#"
+declare const settings: { label?: string };
+if (settings.label !== undefined) {
+  const upper = settings.label.toUpperCase();
+  void upper;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&18048) && !codes.contains(&2339),
+        "optional string member must narrow to string (no diagnostic), got: {codes:?}"
+    );
+}
+
+/// Negative guard for the OTHER direction: without the guard, the optional
+/// `string` member is possibly `undefined`, so reading `.toUpperCase()`
+/// unguarded MUST still report TS18048. The fix must not suppress real
+/// undefined-handling.
+#[test]
+fn optional_string_member_unguarded_still_reports() {
+    let codes = check_source_strict_codes(
+        r#"
+declare const settings: { title?: string };
+const upper = settings.title.toUpperCase();
+void upper;
+"#,
+    );
+    assert!(
+        codes.contains(&18048),
+        "unguarded possibly-undefined string member must still report TS18048, got: {codes:?}"
+    );
+}
+
+/// A local variable of a union type still narrows correctly through the
+/// exclusion path (the literal-`any` local guard must not be the only thing
+/// keeping locals working). After `n !== undefined`, `n` is `number`.
+#[test]
+fn local_union_variable_still_narrows() {
+    let codes = check_source_strict_codes(
+        r#"
+declare const maybeNum: number | undefined;
+const n = maybeNum;
+if (n !== undefined) {
+  const fixed = n.toFixed(2);
+  void fixed;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&18048) && !codes.contains(&2339),
+        "local union variable must narrow to number after `!== undefined`, got: {codes:?}"
+    );
+}
+
+/// A `void` member is still excluded by `!== undefined` (the pre-existing
+/// `void`-vs-`undefined` special case must survive the new guard): after the
+/// guard the union collapses to `boolean`, assignable to a `boolean` target with
+/// no TS2322.
+#[test]
+fn void_member_still_excluded_by_undefined() {
+    let codes = check_source_strict_codes(
+        r#"
+declare const flag: boolean | void;
+let target: boolean;
+if (flag !== undefined) {
+  target = flag;
+}
+void target;
+"#,
+    );
+    assert!(
+        !codes.contains(&2322),
+        "`void` member must still be excluded by `!== undefined`, got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/narrowing/discriminants.rs
+++ b/crates/tsz-solver/src/narrowing/discriminants.rs
@@ -36,7 +36,7 @@ use crate::type_queries::{
 };
 use crate::types::{PropertyLookup, TypeId};
 use crate::visitor::{
-    intersection_list_id, is_literal_type_through_type_constraints, object_shape_id,
+    intersection_list_id, is_error_type, is_literal_type_through_type_constraints, object_shape_id,
     object_with_index_shape_id, union_list_id,
 };
 use rustc_hash::FxHashSet;
@@ -45,6 +45,36 @@ use tracing::{Level, span, trace};
 use tsz_common::interner::Atom;
 
 impl<'a> NarrowingContext<'a> {
+    /// Whether a discriminant *property* type is inert for value-exclusion
+    /// narrowing of the enclosing object — i.e. the member must be KEPT because
+    /// we cannot prove the property is *always* one of the excluded values.
+    ///
+    /// This holds when the property type is `any` (it can hold any value,
+    /// including a non-excluded one) or an *error* type (an unresolved /
+    /// failed-import name stays inert, matching tsc, which never discriminates a
+    /// union member away on an error-typed property). A literal `TypeId::ANY`
+    /// already collapses absorbed unions (`any | undefined` -> `any`), but an
+    /// alias that resolves to `any` and an error type do not, so resolve the
+    /// type first and inspect union members structurally rather than relying on
+    /// `TypeId` identity alone.
+    fn discriminant_property_inert_for_exclusion(&self, resolved_prop_type: TypeId) -> bool {
+        let type_db = self.db.as_type_database();
+        let is_inert_atom = |t: TypeId| t.is_any() || is_error_type(type_db, t);
+        if is_inert_atom(resolved_prop_type) {
+            return true;
+        }
+        // A `T | undefined` property where `T` resolves to `any`/error keeps the
+        // any/error facet, so the property is not *always* the excluded value.
+        if let Some(members_id) = union_list_id(self.db, resolved_prop_type) {
+            return self
+                .db
+                .type_list(members_id)
+                .iter()
+                .any(|&m| is_inert_atom(self.resolve_type(m)));
+        }
+        false
+    }
+
     /// Resolve a type into its union members and build a property evaluator.
     ///
     /// This is the shared setup for all discriminant/property-based narrowing:
@@ -467,7 +497,7 @@ impl<'a> NarrowingContext<'a> {
                         .and_then(|prop_type| construct_return_type_for_type(self.db, prop_type))
                         .unwrap_or(raw_prop_type),
                 );
-                if prop_type == TypeId::ANY {
+                if self.discriminant_property_inert_for_exclusion(prop_type) {
                     continue;
                 }
                 let is_excluded = if prop_type == literal_value {
@@ -511,7 +541,7 @@ impl<'a> NarrowingContext<'a> {
                     .and_then(|prop_type| construct_return_type_for_type(self.db, prop_type))
                     .unwrap_or(raw_prop_type),
             );
-            if !keep_matching && prop_type == TypeId::ANY {
+            if !keep_matching && self.discriminant_property_inert_for_exclusion(prop_type) {
                 kept.push(member);
                 continue;
             }
@@ -1308,11 +1338,14 @@ impl<'a> NarrowingContext<'a> {
                 // CRITICAL: Resolve Lazy types in property type before comparison.
                 let resolved_prop_type = self.resolve_type(prop_type);
 
-                // `any` properties can hold any value, so we can never prove the
-                // property is ALWAYS the excluded value. is_subtype_of(any, T)
-                // returns true for every non-never T (any is universally
-                // assignable), which would incorrectly drop the member here.
-                if resolved_prop_type == TypeId::ANY {
+                // `any`/error properties can hold any value, so we can never
+                // prove the property is ALWAYS the excluded value.
+                // is_subtype_of(any, T) returns true for every non-never T (any
+                // is universally assignable) and an error type short-circuits
+                // assignability to true, either of which would incorrectly drop
+                // the member here. Catches alias-`any` and `T | undefined` whose
+                // `T` is any/error, not just the literal `TypeId::ANY`.
+                if self.discriminant_property_inert_for_exclusion(resolved_prop_type) {
                     return true;
                 }
 
@@ -1581,11 +1614,14 @@ impl<'a> NarrowingContext<'a> {
                 let resolved_prop_type = self.resolve_type(prop_type);
                 let resolved_prop_type = normalize_constructor_property_type(resolved_prop_type);
 
-                // `any` properties can hold any value, so we can never prove the
-                // property is ALWAYS one of the excluded values. is_subtype_of(any, T)
-                // returns true for every non-never T, which would incorrectly drop
-                // the member in this batch path too.
-                if resolved_prop_type == TypeId::ANY {
+                // `any`/error properties can hold any value, so we can never
+                // prove the property is ALWAYS one of the excluded values.
+                // is_subtype_of(any, T) returns true for every non-never T and
+                // an error type short-circuits assignability to true, either of
+                // which would incorrectly drop the member in this batch path
+                // too. Catches alias-`any` and `T | undefined` whose `T` is
+                // any/error, not just the literal `TypeId::ANY`.
+                if self.discriminant_property_inert_for_exclusion(resolved_prop_type) {
                     return true;
                 }
 


### PR DESCRIPTION
Goal: green

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Summary
When narrowing an object by excluding a discriminant property value — the true branch of `obj.prop !== undefined` (and the symmetric `=== undefined` false branch) — tsc keeps the member inert when the property type is `any` or an *error* type: such a property can hold a non-excluded value, so the member is not provably the excluded value. tsz only guarded the literal `TypeId::ANY`, so an alias that resolves to `any` (`type Loose = any`) and an error type (an unresolved / failed-import name) fell through to the assignability test — which is `true` for `any` (universally assignable) and short-circuits `true` for error types — dropping the member and collapsing the receiver to `never`, then drawing a spurious TS2339 ("property does not exist on type 'never'") when the guarded property was re-read. Fixed in the solver discriminant value-exclusion path: a shared structural classifier (`discriminant_property_inert_for_exclusion`) resolves the property type and inspects union members for any/error (catching `T | undefined` where `T` is any/error), applied at all four exclusion sites (fast-path scan + general kept-loop in `fast_narrow_top_level_discriminant`, plus `narrow_by_excluding_discriminant` and the batched `narrow_by_excluding_discriminant_values`). No identifier/file-name/printer-string checks; uses the solver's structural `is_any` / `is_error_type` classifiers. Owner layer: solver narrowing. Adjacent cases: inline-any / alias-any / error-typed (bare-undeclared and failed-import) members guarded, equality false-branch covered; real optional-`string` property narrowing, unguarded TS18048, local-variable union narrowing, and `void`-vs-`undefined` exclusion all preserved (negative controls).

## Verification
New test file `crates/tsz-checker/tests/exclusion_narrow_any_error_member_tests.rs` (9 tests, binder names varied per test):

```
cargo nextest run -p tsz-checker --test exclusion_narrow_any_error_member_tests
  -> 9 passed, 0 skipped
```

Repro goes error -> clean: `declare const o: { validate?: DoesNotExist }; if (o.validate !== undefined) { const x = o.validate; }` previously reported TS2339 ("Property 'validate' does not exist on type 'never'") on the guarded read; now only the legitimate TS2304 for the unresolved name remains (no TS2339/TS18048). Same for alias-`any` (`type Loose = any; { slot?: Loose }`), inline `any`, and failed-import members.

Negative controls still narrow / still report:
- optional `string` member narrows to `string` after `!== undefined` (no diagnostic);
- unguarded possibly-undefined `string` member still reports TS18048;
- local union variable (`number | undefined`) still narrows to `number`;
- `void` member still excluded by `!== undefined` (no spurious TS2322).

Regression runs (targeted, all pre-existing failures/timeouts confirmed unrelated by stashing the change):
```
cargo nextest run -p tsz-checker -E 'binary(/narrow/)'   -> 246 passed, 0 failed
cargo nextest run -p tsz-solver  --lib -E 'test(narrow) or test(discriminant) or test(exclud)' -> 367 passed
cargo nextest run -p tsz-checker -E 'binary(/discriminant/)+binary(/union/)+binary(/flow/)+binary(/optional/)'
  -> only pre-existing failures (optional_property_required_elaboration TS2327, indexed_access quickinfo, union_origin_display TS2859 fixture timeouts) — all reproduce on main with the change stashed
```
`cargo clippy -p tsz-solver --lib` clean.
