### PR TITLE
fix(emit): always emit lowered static-block IIFE body multi-line

### DIFF
--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -464,6 +464,15 @@ pub struct Printer<'a> {
     /// Marker that the next block emission is a function body.
     pub(crate) emitting_function_body_block: bool,
 
+    /// Marker that the next function-body block is a *synthesized* body (e.g. the
+    /// arrow/function IIFE that lowers a `static {}` class block to a target
+    /// below ES2022). tsc builds these bodies as fresh synthesized blocks with no
+    /// source range, so they always print multi-line regardless of how the
+    /// original braces were laid out in source. Without this, the source
+    /// single-line heuristic (`is_single_line`) leaks into the synthesized IIFE
+    /// and emits `(() => { stmt; })()` where tsc emits the multi-line form.
+    pub(crate) force_function_body_multiline: bool,
+
     /// Set while emitting the expression that is the synthesized `return`
     /// argument of a concise-body arrow function converted to a block body
     /// (e.g. `=> classExpr` lowered to `=> { var _a; return _a = classExpr,

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -293,6 +293,7 @@ impl<'a> Printer<'a> {
             enum_namespace_export: None,
             namespace_export_inner: false,
             emitting_function_body_block: false,
+            force_function_body_multiline: false,
             emitting_concise_arrow_return_argument: false,
             pending_function_body_parameters: Vec::new(),
             current_new_target_substitution: None,

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
@@ -789,16 +789,24 @@ impl<'a> Printer<'a> {
                 continue;
             };
             if member_node.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION {
+                // Emit the lowered IIFE into the writer at the target body indent
+                // (one level deeper than the surrounding class IIFE), then capture
+                // the multi-line text verbatim. Emitting at native indent — rather
+                // than re-indenting a single-line capture by string surgery —
+                // keeps each statement on its own line (matching tsc) and avoids
+                // corrupting multi-line literals (e.g. template strings) in the
+                // body.
                 let before = self.writer.len();
+                self.increase_indent();
                 self.emit_static_block_iife_expression_with_class_this(member_idx);
-                let captured = self.format_tc39_es5_static_block_iife(
-                    self.writer.get_output()[before..].trim(),
-                    &body_indent,
-                );
-                self.writer.truncate(before);
+                self.decrease_indent();
+                // Push the captured IIFE text straight into `out` (no owned copy):
+                // the borrow of the writer output ends before `truncate` rolls the
+                // staging emission back out of the writer.
                 out.push_str(&body_indent);
-                out.push_str(&captured);
+                out.push_str(self.writer.get_output()[before..].trim());
                 out.push_str(";\n");
+                self.writer.truncate(before);
                 continue;
             }
             if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION {
@@ -846,17 +854,6 @@ impl<'a> Printer<'a> {
             }
         }
         out
-    }
-
-    fn format_tc39_es5_static_block_iife(&self, captured: &str, body_indent: &str) -> String {
-        let Some(inner) = captured
-            .strip_prefix("(function () { ")
-            .and_then(|text| text.strip_suffix(" })()"))
-        else {
-            return captured.to_string();
-        };
-        let statement_indent = format!("{body_indent}    ");
-        format!("(function () {{\n{statement_indent}{inner}\n{body_indent}}})()")
     }
 
     fn emit_static_block_iife_expression_with_class_this(&mut self, static_block_idx: NodeIndex) {

--- a/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
@@ -420,8 +420,13 @@ impl<'a> Printer<'a> {
         self.comment_emit_idx = saved_comment_idx;
         if let Some(static_node) = self.arena.get(static_block_idx) {
             let prev = self.emitting_function_body_block;
+            let prev_force_multiline = self.force_function_body_multiline;
             let saved_await_as_yield = self.ctx.emit_await_as_yield;
             self.emitting_function_body_block = true;
+            // The IIFE body is a synthesized function body: tsc never preserves
+            // the original static-block braces' single-line layout here, so force
+            // multi-line emission regardless of the source `is_single_line` hint.
+            self.force_function_body_multiline = true;
             self.ctx.emit_await_as_yield = true;
             // Save and restore hoisted temps so outer-scope vars (e.g. private
             // field WeakMap names) don't get re-declared inside the IIFE body.
@@ -432,6 +437,7 @@ impl<'a> Printer<'a> {
             self.hoisted_assignment_temps = saved_temps;
             self.ctx.emit_await_as_yield = saved_await_as_yield;
             self.emitting_function_body_block = prev;
+            self.force_function_body_multiline = prev_force_multiline;
         } else {
             self.write("{ }");
         }

--- a/crates/tsz-emitter/src/emitter/statements/core.rs
+++ b/crates/tsz-emitter/src/emitter/statements/core.rs
@@ -17,6 +17,12 @@ impl<'a> Printer<'a> {
         // Reset the flag so nested blocks (for/if/while inside this function)
         // are not treated as function body blocks.
         self.emitting_function_body_block = false;
+        // Consume the synthesized-body marker (e.g. a lowered `static {}` IIFE
+        // body) so it applies only to this block, not nested ones. When set, the
+        // body always prints multi-line — tsc synthesizes a fresh block here and
+        // never inherits the source's single-line brace layout.
+        let force_multiline = self.force_function_body_multiline;
+        self.force_function_body_multiline = false;
 
         // For non-function-body blocks (bare `{}`, if/for/while bodies),
         // save/restore declared_namespace_names so that block-scoped `let`
@@ -91,7 +97,7 @@ impl<'a> Printer<'a> {
                         .all_comments
                         .get(self.comment_emit_idx)
                         .is_some_and(|c| c.end <= closing_brace_pos);
-                    if self.is_single_line(node) && !has_remaining_comments {
+                    if !force_multiline && self.is_single_line(node) && !has_remaining_comments {
                         self.map_opening_brace(node);
                         self.write("{ }");
                     } else if has_remaining_comments {
@@ -141,7 +147,8 @@ impl<'a> Printer<'a> {
                     self.map_closing_brace(node);
                     self.write_with_end_marker("}");
                 }
-            } else if self.is_single_line(node) || (is_function_body_block && node.pos == node.end)
+            } else if !force_multiline
+                && (self.is_single_line(node) || (is_function_body_block && node.pos == node.end))
             {
                 // Single-line empty block: { }
                 self.map_opening_brace(node);
@@ -175,6 +182,7 @@ impl<'a> Printer<'a> {
         // this;`, captured `new.target`, hoisted assignment/for-of temps) forces
         // multi-line.
         let should_emit_single_line = !block.statements.nodes.is_empty()
+            && !force_multiline
             && self.is_single_line(node)
             && !needs_this_capture
             && !self.has_pending_new_target_capture()

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -164,12 +164,10 @@ impl<'a> IRPrinter<'a> {
     }
 
     fn emit_static_block_iife_expression(&mut self, statements: &[IRNode]) {
+        // The lowered static-block IIFE body is a synthesized function body: tsc
+        // always prints it multi-line, including the empty case
+        // (`(function () {\n})()`), never the single-line `{ }` form.
         self.write("(function () {");
-        if statements.is_empty() {
-            self.write(" })()");
-            return;
-        }
-
         self.write_line();
         self.increase_indent();
         for stmt in statements {

--- a/crates/tsz-emitter/tests/printer/modules_namespaces_recovery.rs
+++ b/crates/tsz-emitter/tests/printer/modules_namespaces_recovery.rs
@@ -877,8 +877,10 @@ fn test_lowered_static_block_uses_static_initializer_context() {
         output.contains("C.c = Reflect.get("),
         "Static field super access should use Reflect.get, got: {output}"
     );
+    // The lowered static-block IIFE body is synthesized, so tsc always prints it
+    // multi-line regardless of the single-line source braces.
     assert!(
-        output.contains("(() => { _a.c; Reflect.get(_b, \"a\", _a); })();"),
+        output.contains("(() => {\n    _a.c;\n    Reflect.get(_b, \"a\", _a);\n})();"),
         "Lowered static block should reuse static this/super aliases, got: {output}"
     );
 }


### PR DESCRIPTION
## Summary

Closes #14758.

A `class` `static {}` initialization block downleveled to an arrow/function IIFE (target below ES2022) is a **synthesized** function body that `tsc` always prints multi-line. tsz reused the original `static {}` `Block` node and let the source-derived `is_single_line` heuristic decide, so a single-line source block leaked into a single-line IIFE body where `tsc` emits the multi-line form.

```ts
class C { static x = 1; static { console.log("init"); } }
```

`tsc --target es2017`:
```js
(() => {
    console.log("init");
})();
```

tsz (before):
```js
(() => { console.log("init"); })();
```

## Structural rule

When lowering a `ClassStaticBlockDeclaration` to an arrow/function IIFE, `tsc` builds a fresh synthesized body (no source range) and always prints it multi-line. tsz must not derive single-line-ness from the original source braces here.

## Owner layer

Emitter. A transient `force_function_body_multiline` `Printer` marker (mirroring the existing `emitting_function_body_block`) is set around the static-block IIFE body emit and consumed in `emit_block` to suppress the three source single-line branches. The IR-printer empty static-block IIFE is made multi-line too. The ES5 TC39-decorated path's single-line string-surgery reformatter (`format_tc39_es5_static_block_iife`) is replaced with native multi-line emit at the target indent.

The transient flag is the proportionate mechanism: the AST emit path reuses the real source node (there is no synthesized-block node to attach a "no source range" property to), so the decision is made at the synthesizing caller, exactly like the sibling `emitting_function_body_block` marker.

## Adjacent-case matrix (verified against `tsc` 6.0.2)

- Non-decorated static block — empty, single-statement, multi-statement, nested `if`, multi-line template literal — across ES5, ES2015, ES2017, ES2021: match.
- ES2022+ native static block: keeps source layout (already matches `tsc`), unaffected.
- ES5 TC39-decorated static block (single- and multi-statement): match (multi-statement collapse fixed).
- Nested arrow/function bodies inside the static block keep their own source single-line layout: match.

## Known separate issue (out of scope)

ES2015+ **TC39-decorated** classes lower static blocks via a distinct text-based subsystem (`lower_static_block_text_to_iife`) that splits source by lines; it collapses multi-statement single-line blocks and reindents multi-line template literals. That needs an AST-native decorator-emit fix and is tracked separately, not patched with string surgery here.

## Verification

- `cargo build --release -p tsz-cli --bin tsz`
- Differential emit vs `tsc` 6.0.2 over the matrix above (`--target {es5,es2015,es2017,es2021,es2022}`): all match.
- `cargo test --release -p tsz-emitter`: green except one pre-existing unrelated failure (`generator_object_literal_prefix_before_yield_omits_source_trailing_comma`, fails on `main` too). The two static-block tests touched by this change pass.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbKjFEqSvDpz5f45aisK86)_