### PR TITLE
fix(solver): exclude-narrow into union-bodied alias members

### DIFF
--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -1774,6 +1774,38 @@ impl<'a> NarrowingContext<'a> {
                     {
                         return narrowed.non_never();
                     }
+                    // A union member that is itself an alias (`Lazy`/`Application`)
+                    // whose body is a *union* must be descended into, not kept
+                    // whole. tsc's `filterType` excludes per top-level constituent,
+                    // so a member like `Updater<P, R> = R | ((p) => R)` has its
+                    // callable constituent stripped in the `!isFunction(x)` branch
+                    // — instead of surviving because the *whole* alias is not
+                    // assignable to the excluded type (the shallow
+                    // `member_excluded_by` check below). The descent is the dual of
+                    // the `intersection`/type-parameter member recursion already
+                    // handled above, and is bounded by the shared exclusion budget
+                    // and the `narrow_excluding_visiting` cycle guard. Only adopt it
+                    // when the alias expands to a union: a non-union alias is left to
+                    // the assignability check below, which already sees through it
+                    // (#14739).
+                    if matches!(
+                        self.db.lookup(member),
+                        Some(TypeData::Lazy(_) | TypeData::Application(_))
+                    ) {
+                        let resolved_member = self.resolve_type(member);
+                        if resolved_member != member
+                            && union_list_id(self.db, resolved_member).is_some()
+                        {
+                            let narrowed =
+                                self.narrow_excluding_type(resolved_member, excluded_type);
+                            // Preserve the alias member's identity/display when
+                            // nothing inside it was excluded.
+                            if narrowed == resolved_member {
+                                return Some(member);
+                            }
+                            return narrowed.non_never();
+                        }
+                    }
                     // A `boolean` (or `true`/`false`) union member is the implicit
                     // `true | false` union; excluding one boolean literal must leave
                     // the other rather than keeping the whole member. The top-level

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_01.rs
@@ -719,3 +719,65 @@ fn test_narrow_excluding_function_shares_the_budget() {
     bounded_ctx.set_narrow_excluding_budget(1);
     assert_eq!(bounded_ctx.narrow_excluding_function(param), param);
 }
+
+/// Regression (#14739): the false branch of a `x is Function` guard exclude-
+/// narrows the source by the global `Function`. When a top-level union member is
+/// itself an alias (`Lazy`/`Application`) whose body is a *union* carrying both a
+/// non-callable and a callable constituent (`Updater<P, R> = R | ((p) => R)`),
+/// the callable must be stripped from *inside* that member — tsc's `filterType`
+/// excludes per top-level constituent. Before the fix the whole alias member
+/// survived because it was not, *as a whole*, assignable to `Function`, leaving
+/// the callable in the false branch (false TS2322 in tanstack-router
+/// `functionalUpdate`). The descent is structural, so two differently numbered
+/// alias `DefId`s narrow identically.
+#[test]
+fn test_narrow_excluding_function_descends_into_union_bodied_alias_members() {
+    use crate::def::DefId;
+
+    let interner = TypeInterner::new();
+
+    let callable = interner.function(FunctionShape {
+        params: Vec::new(),
+        this_type: None,
+        return_type: TypeId::VOID,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    // Two distinct aliases, each `<non-callable> | <callable>`.
+    let def_a = DefId(101);
+    let def_b = DefId(102);
+    let alias_a = interner.intern(TypeData::Lazy(def_a));
+    let alias_b = interner.intern(TypeData::Lazy(def_b));
+    let body_a = interner.union(vec![TypeId::STRING, callable]);
+    let body_b = interner.union(vec![TypeId::NUMBER, callable]);
+
+    struct AliasResolver {
+        entries: [(DefId, TypeId); 2],
+    }
+    impl TypeResolver for AliasResolver {
+        fn resolve_ref(&self, _symbol: SymbolRef, _interner: &dyn TypeDatabase) -> Option<TypeId> {
+            None
+        }
+        fn resolve_lazy(&self, def_id: DefId, _interner: &dyn TypeDatabase) -> Option<TypeId> {
+            self.entries
+                .iter()
+                .find_map(|&(d, t)| (d == def_id).then_some(t))
+        }
+    }
+
+    let resolver = AliasResolver {
+        entries: [(def_a, body_a), (def_b, body_b)],
+    };
+    let ctx = NarrowingContext::new(&interner).with_resolver(&resolver);
+
+    let source = interner.union(vec![alias_a, alias_b]);
+    let function_type = ctx.function_type();
+
+    // The callable constituents are stripped from inside each alias body,
+    // leaving only the non-callable residual `string | number`.
+    let expected = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+    assert_eq!(ctx.narrow_excluding_type(source, function_type), expected);
+}


### PR DESCRIPTION
## Summary
The false branch of a `x is Function` user type-guard exclude-narrows the source
by the global `Function` through `narrow_excluding_type`. Its union-member filter
already descends into `intersection` and type-parameter members, but kept a
member that is itself an alias (`Lazy`/`Application`) **whole** — because the
alias *as a whole* is not assignable to the excluded type. For a member like
`Updater<P, R> = R | ((p) => R)` the callable constituent then survived in the
`!isFunction(x)` branch, yielding a false `TS2322` (tanstack-router
`functionalUpdate`, `packages/router-core/src/utils.ts`).

Closes #14739.

## Structural rule
When excluding a type from a union and a top-level union member is itself an
alias whose body is a union, `tsc` excludes per top-level constituent
(`filterType`): the excluded constituents are stripped from *inside* the alias
body. tsz did X (kept the whole alias) through the solver narrowing owner
(`narrow_excluding_type_uncached`); it now descends into the resolved union body
and recurses `narrow_excluding_type`, the dual of the existing
intersection/type-parameter member recursion.

- Owner layer: solver — `crates/tsz-solver/src/narrowing/core.rs`,
  `narrow_excluding_type_uncached` union-member filter.
- Generality: the fix is **not** function-specific. It repairs every exclusion
  family routed through `narrow_excluding_type` (e.g. excluding `undefined` from
  `Alias | x` whose alias body itself carries `undefined`), not only the
  `Function` predicate witness.
- Identity preserved: when nothing inside the alias is excluded, the original
  alias member is returned unchanged, so display/identity are stable.
- Termination: bounded by the shared exclusion-work budget and the
  `narrow_excluding_visiting` cycle guard already used by this family.

## Adjacent cases (verified clean, matching tsc 5.9.3)
- Original repro (generic union of two union-bodied aliases).
- Renamed guard (`looksCallable`) — identical behavior, no name dependence.
- Non-generic alias union `(string | (() => void)) | (number | ((x: number) => void))`.
- `typeof x === "function"` negation over the same shape (dual path).
- Negative guard with **no** callable constituent — source left unchanged (no over-strip).

## Verification
- New solver unit test:
  `narrowing::tests::test_narrow_excluding_function_descends_into_union_bodied_alias_members`
  (`cargo test -p tsz-solver --lib` — passes).
- Full narrowing suite: `cargo test -p tsz-solver --lib narrowing::` → 205 passed, 0 failed.
- Full solver lib: 6947 passed; the 4 remaining failures
  (`evaluate::...optional_property_present_distributive`,
  `intern::normalize::...literal_mask_preserves_object_vs_literal_reduction`,
  `operations::...higher_order_generic_pipe_regeneralizes...`,
  `solver_file_size_ceiling_tests::test_solver_oversized_file_size_ceilings` for
  `src/types.rs`) reproduce identically on the unmodified base — pre-existing,
  unrelated to this change (none touch narrowing exclusion; `types.rs` is not
  touched here).
- CLI repro (`--strict --target es2022 --noEmit`) now clean; tsc 5.9.3 agrees.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019hnPiPUy5P2vHua63xgSaC)_