### PR TITLE
fix(solver): union tuple element types before relating to array element (TS2345)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
@@ -365,82 +365,132 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
     /// Check if a tuple type is a subtype of an array type.
     ///
-    /// Tuple is subtype of array if all tuple elements are subtypes of the array element type.
+    /// Tuple is subtype of array if the *union* of the tuple's element types is a
+    /// subtype of the array element type. tsc collects every positional/rest
+    /// element type, forms a single union, and relates it once to the array
+    /// element. Relating element-wise instead is observably different whenever the
+    /// union normalizes to something the individual members are not subtypes of:
+    /// most importantly `any | undefined` collapses to `any` (so
+    /// `[any, undefined] <: IObject[]` holds, where the per-element `undefined <:
+    /// IObject` would spuriously fail). Collect the expanded element types into a
+    /// union and relate that union once.
+    ///
     /// Handles both regular elements and rest elements (with expansion).
     ///
     /// ## Examples:
     /// - `[number, number]` <: `number[]` ✅
     /// - `[number, string]` <: `number[]` ❌ (string is not subtype of number)
     /// - `[number, ...string[]]` <: `(number | string)[]` ✅
+    /// - `[any, undefined]` <: `IObject[]` ✅ (`any | undefined` = `any`)
     pub(crate) fn check_tuple_to_array_subtype(
         &mut self,
         elems: TupleListId,
         t_elem: TypeId,
     ) -> SubtypeResult {
+        // Accumulate every expanded scalar element type so they can be unioned and
+        // related to the array element type *once*, reproducing tsc's union-then-
+        // relate behavior (notably `any` absorption).
+        let mut element_types: Vec<TypeId> = Vec::new();
         let elems = self.interner.tuple_list(elems);
         for elem in elems.iter() {
             if elem.rest {
                 let expansion = self.expand_tuple_rest(elem.type_id);
                 for fixed in expansion.fixed {
-                    if !self.check_subtype(fixed.type_id, t_elem).is_true() {
-                        return SubtypeResult::False;
+                    element_types.push(fixed.type_id);
+                }
+                if let Some(variadic) = expansion.variadic {
+                    // `expand_tuple_rest` reduces a plain element spread
+                    // (`...undefined[]`, `...string[]`) to its element type, but
+                    // keeps an *instantiable* spread (`...X` where `X` is a type
+                    // parameter or deferred conditional) unreduced as the variadic.
+                    //
+                    // A plain element folds into the element union alongside the
+                    // other scalar elements, so `...undefined[]`'s `undefined`
+                    // participates in the `any` absorption. An unreduced array-like
+                    // spread instead needs the array-form `[...X] <: E[]` ⇒
+                    // `X <: E[]` handling below, which can resolve the spread
+                    // through its constraint; only if none of those array-form
+                    // probes apply do we fold the spread in as a single element
+                    // (matching the original direct `variadic <: E` relation).
+                    if array_element_type(self.interner, elem.type_id).is_some() {
+                        // Concrete array/tuple spread (`...undefined[]`): `variadic`
+                        // is its element type. Fold it into the union.
+                        element_types.push(variadic);
+                    } else {
+                        // `[...X] <: E[]` reduces to `X <: E[]` when the spread `X`
+                        // is itself array-like. expand_tuple_rest keeps such a
+                        // spread unreduced as the variadic — a type parameter
+                        // constrained to an array/tuple or a deferred conditional
+                        // like `Parameters<F>` whose base constraint is array-like.
+                        // Relate the spread to the array form `E[]` (which resolves
+                        // an instantiable spread through its constraint), or fall
+                        // back to the constraint's rest-spread element type.
+                        let variadic_as_array = self.interner.array(t_elem);
+                        let array_form_ok = self
+                            .check_subtype(variadic, variadic_as_array)
+                            .is_true()
+                            || type_param_info(self.interner, variadic).is_some_and(|info| {
+                                info.constraint.is_some_and(|c| {
+                                    let e = crate::type_queries::rest_spread_element_type(
+                                        self.interner,
+                                        c,
+                                    );
+                                    // `rest_spread_element_type` returns its input
+                                    // unchanged for a non-array-like constraint;
+                                    // `e != c` means the constraint actually
+                                    // decomposed to an element type.
+                                    e != c && self.check_subtype(e, t_elem).is_true()
+                                })
+                            })
+                            // A deferred infer-extraction conditional spread element
+                            // (`[...Parameters<F>] <: never[]`) decomposes only after
+                            // `getConstraintFromConditionalType` resolves it to its
+                            // array base; check that base's element type against the
+                            // target.
+                            || self.infer_extraction_conditional_constraint(variadic).is_some_and(
+                                |c| {
+                                    let e = crate::type_queries::rest_spread_element_type(
+                                        self.interner,
+                                        c,
+                                    );
+                                    e != c && self.check_subtype(e, t_elem).is_true()
+                                },
+                            );
+                        if !array_form_ok {
+                            // Not an array-like spread that resolved through its
+                            // constraint: treat the spread as a single element and
+                            // fold it into the union (e.g. bare `...T`), so the
+                            // single union relation decides — and `any` still
+                            // absorbs it when present.
+                            element_types.push(variadic);
+                        }
                     }
                 }
-                if let Some(variadic) = expansion.variadic
-                    && !self.check_subtype(variadic, t_elem).is_true()
-                {
-                    // `[...X] <: E[]` reduces to `X <: E[]` when the spread `X` is
-                    // itself array-like. expand_tuple_rest keeps such a spread
-                    // unreduced as the variadic — a type parameter constrained to
-                    // an array/tuple or a deferred conditional like `Parameters<F>`
-                    // whose base constraint is array-like. Relate the spread to the
-                    // array form `E[]` (which resolves an instantiable spread
-                    // through its constraint), or fall back to the constraint's
-                    // rest-spread element type.
-                    let variadic_as_array = self.interner.array(t_elem);
-                    let ok = self.check_subtype(variadic, variadic_as_array).is_true()
-                        || type_param_info(self.interner, variadic).is_some_and(|info| {
-                            info.constraint.is_some_and(|c| {
-                                let e =
-                                    crate::type_queries::rest_spread_element_type(self.interner, c);
-                                // `rest_spread_element_type` returns its input unchanged
-                                // for a non-array-like constraint; `e != c` means the
-                                // constraint actually decomposed to an element type.
-                                 e != c && self.check_subtype(e, t_elem).is_true()
-                             })
-                         })
-                        // A deferred infer-extraction conditional spread element
-                        // (`[...Parameters<F>] <: never[]`) decomposes only after
-                        // `getConstraintFromConditionalType` resolves it to its
-                        // array base; check that base's element type against the
-                        // target.
-                        || self
-                            .infer_extraction_conditional_constraint(variadic)
-                            .is_some_and(|c| {
-                                let e = crate::type_queries::rest_spread_element_type(
-                                    self.interner,
-                                    c,
-                                );
-                                e != c && self.check_subtype(e, t_elem).is_true()
-                            });
-                    if !ok {
-                        return SubtypeResult::False;
-                    }
-                }
-                // Check tail elements from nested tuple spreads
+                // Tail elements from nested tuple spreads
                 for tail_elem in expansion.tail {
-                    if !self.check_subtype(tail_elem.type_id, t_elem).is_true() {
-                        return SubtypeResult::False;
-                    }
+                    element_types.push(tail_elem.type_id);
                 }
             } else {
-                // Regular element: T <: U
-                if !self.check_subtype(elem.type_id, t_elem).is_true() {
-                    return SubtypeResult::False;
-                }
+                // Regular element
+                element_types.push(elem.type_id);
             }
         }
-        SubtypeResult::True
+
+        if element_types.is_empty() {
+            // `[] <: E[]` (or a tuple that expanded only to array-form spreads,
+            // already validated above): no scalar elements to constrain.
+            return SubtypeResult::True;
+        }
+
+        // Union the collected element types once. `interner.union` applies tsc's
+        // universal absorptions (`any | T` = `any`, literal/primitive collapse),
+        // so `any | undefined` becomes `any` and the single relation succeeds.
+        let union = self.interner.union(element_types);
+        if self.check_subtype(union, t_elem).is_true() {
+            SubtypeResult::True
+        } else {
+            SubtypeResult::False
+        }
     }
 
     /// Expand a tuple rest element into its constituent parts.

--- a/crates/tsz-solver/tests/subtype_tests.rs
+++ b/crates/tsz-solver/tests/subtype_tests.rs
@@ -27,3 +27,4 @@ include!("subtype_tests_parts/part_13.rs");
 include!("subtype_tests_parts/part_14.rs");
 include!("subtype_tests_parts/part_15.rs");
 include!("subtype_tests_parts/part_16.rs");
+include!("subtype_tests_parts/part_17.rs");

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_17.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_17.rs
@@ -1,0 +1,243 @@
+// ============================================================================
+// Tuple-to-Array Union-of-Elements Tests
+//
+// tsc relates a tuple to an array element type by unioning the tuple's element
+// types and relating that union *once* (not element-by-element). This matters
+// whenever the union normalizes to something the individual members are not
+// subtypes of — most importantly `any | undefined` collapses to `any`, so
+// `[any, undefined] <: IObject[]` holds even though `undefined <: IObject`
+// fails on its own. These tests vary binder names (`IObject`/`Bag`/`Dict`,
+// `T`/`U`) to confirm the rule is structural, with negative controls that must
+// keep rejecting.
+// ============================================================================
+
+/// Build a structural object type like `interface IObject { <prop>: number }`.
+/// The binder name is irrelevant to the structural rule; only the shape (a
+/// non-`undefined`, non-`any` object) matters.
+fn object_with_prop(interner: &TypeInterner, prop: &str) -> TypeId {
+    let name = interner.intern_string(prop);
+    interner.object(vec![PropertyInfo::new(name, TypeId::NUMBER)])
+}
+
+fn fixed(type_id: TypeId) -> TupleElement {
+    TupleElement {
+        type_id,
+        name: None,
+        optional: false,
+        rest: false,
+    }
+}
+
+fn rest(type_id: TypeId) -> TupleElement {
+    TupleElement {
+        type_id,
+        name: None,
+        optional: false,
+        rest: true,
+    }
+}
+
+// --- Negative controls: heterogeneous tuples to a too-narrow array stay rejected ---
+
+#[test]
+fn test_tuple_union_string_number_to_string_array_rejects() {
+    // [string, number] <: string[] must REJECT (number is not string).
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let string_array = interner.array(TypeId::STRING);
+    let source = interner.tuple(vec![fixed(TypeId::STRING), fixed(TypeId::NUMBER)]);
+
+    assert!(
+        !checker.is_subtype_of(source, string_array),
+        "[string, number] should NOT be assignable to string[]"
+    );
+}
+
+#[test]
+fn test_tuple_union_number_string_to_number_array_rejects() {
+    // [number, string] <: number[] must REJECT (string is not number).
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let number_array = interner.array(TypeId::NUMBER);
+    let source = interner.tuple(vec![fixed(TypeId::NUMBER), fixed(TypeId::STRING)]);
+
+    assert!(
+        !checker.is_subtype_of(source, number_array),
+        "[number, string] should NOT be assignable to number[]"
+    );
+}
+
+// --- Positive: union widening / coverage cases ---
+
+#[test]
+fn test_tuple_string_literal_to_string_array_accepts() {
+    // [string, "x"] <: string[] ACCEPT ("x" widens into the string union).
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let x_lit = interner.literal_string("x");
+    let string_array = interner.array(TypeId::STRING);
+    let source = interner.tuple(vec![fixed(TypeId::STRING), fixed(x_lit)]);
+
+    assert!(
+        checker.is_subtype_of(source, string_array),
+        "[string, \"x\"] should be assignable to string[]"
+    );
+}
+
+#[test]
+fn test_tuple_number_string_to_union_array_accepts() {
+    // [number, string] <: (number | string)[] ACCEPT.
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let union_elem = interner.union(vec![TypeId::NUMBER, TypeId::STRING]);
+    let union_array = interner.array(union_elem);
+    let source = interner.tuple(vec![fixed(TypeId::NUMBER), fixed(TypeId::STRING)]);
+
+    assert!(
+        checker.is_subtype_of(source, union_array),
+        "[number, string] should be assignable to (number | string)[]"
+    );
+}
+
+// --- The fix: `any` absorbs `undefined` in the element union ---
+
+#[test]
+fn test_tuple_any_undefined_to_object_array_accepts() {
+    // [any, undefined] <: IObject[] ACCEPT.
+    // The element union `any | undefined` collapses to `any`, and `any` relates
+    // to any element type. Previously tsz checked element-wise and `undefined <:
+    // IObject` failed, producing a spurious TS2345 (ts-deepmerge witness).
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let iobject_array = interner.array(object_with_prop(&interner, "value"));
+    let source = interner.tuple(vec![fixed(TypeId::ANY), fixed(TypeId::UNDEFINED)]);
+
+    assert!(
+        checker.is_subtype_of(source, iobject_array),
+        "[any, undefined] should be assignable to IObject[] (any|undefined = any)"
+    );
+}
+
+#[test]
+fn test_tuple_undefined_any_to_object_array_accepts() {
+    // [undefined, any] <: Bag[] ACCEPT (order-independent: union absorbs `any`).
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let bag_array = interner.array(object_with_prop(&interner, "item"));
+    let source = interner.tuple(vec![fixed(TypeId::UNDEFINED), fixed(TypeId::ANY)]);
+
+    assert!(
+        checker.is_subtype_of(source, bag_array),
+        "[undefined, any] should be assignable to Bag[] (undefined|any = any)"
+    );
+}
+
+#[test]
+fn test_tuple_any_rest_undefined_array_to_object_array_accepts() {
+    // [any, ...undefined[]] <: Dict[] ACCEPT.
+    // The rest spread's element type `undefined` folds into the union with
+    // `any`, again collapsing to `any`.
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let dict_array = interner.array(object_with_prop(&interner, "entry"));
+    let undefined_array = interner.array(TypeId::UNDEFINED);
+    let source = interner.tuple(vec![fixed(TypeId::ANY), rest(undefined_array)]);
+
+    assert!(
+        checker.is_subtype_of(source, dict_array),
+        "[any, ...undefined[]] should be assignable to Dict[] (any|undefined = any)"
+    );
+}
+
+#[test]
+fn test_tuple_any_undefined_to_readonly_object_array_accepts() {
+    // [any, undefined] <: readonly IObject[] ACCEPT (readonly target form).
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let iobject_readonly = interner.readonly_array(object_with_prop(&interner, "value"));
+    let source = interner.tuple(vec![fixed(TypeId::ANY), fixed(TypeId::UNDEFINED)]);
+
+    assert!(
+        checker.is_subtype_of(source, iobject_readonly),
+        "[any, undefined] should be assignable to readonly IObject[] (any|undefined = any)"
+    );
+}
+
+// --- Regression canary: no `any` present => still rejects (matches tsc) ---
+
+#[test]
+fn test_tuple_object_undefined_to_object_array_still_rejects() {
+    // [IObject, undefined] <: IObject[] must STILL REJECT when there is no `any`
+    // to absorb `undefined`. This is the `merge(o, undefined)` shape WITHOUT an
+    // `any` argument — both compilers reject it.
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let iobject = object_with_prop(&interner, "value");
+    let iobject_array = interner.array(iobject);
+    let source = interner.tuple(vec![fixed(iobject), fixed(TypeId::UNDEFINED)]);
+
+    assert!(
+        !checker.is_subtype_of(source, iobject_array),
+        "[IObject, undefined] should NOT be assignable to IObject[] (no any to absorb undefined)"
+    );
+}
+
+// --- Generic element: `[any, T] <: T[]` accepts via `any` absorption ---
+
+#[test]
+fn test_tuple_any_typeparam_to_typeparam_array_accepts() {
+    // [any, T] <: T[] ACCEPT. The union `any | T` collapses to `any`, which is
+    // assignable to the element type `T`.
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let t_param_info = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    };
+    let t_param = interner.intern(TypeData::TypeParameter(t_param_info));
+    let t_array = interner.array(t_param);
+    let source = interner.tuple(vec![fixed(TypeId::ANY), fixed(t_param)]);
+
+    assert!(
+        checker.is_subtype_of(source, t_array),
+        "[any, T] should be assignable to T[] (any|T = any)"
+    );
+}
+
+#[test]
+fn test_tuple_object_typeparam_to_typeparam_array_rejects() {
+    // [U, T] <: T[] must REJECT when U is an unrelated object type with no `any`
+    // to absorb it (negative control for the generic case).
+    let interner = TypeInterner::new();
+    let mut checker = SubtypeChecker::new(&interner);
+
+    let t_param_info = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    };
+    let t_param = interner.intern(TypeData::TypeParameter(t_param_info));
+    let t_array = interner.array(t_param);
+    let u_object = object_with_prop(&interner, "u");
+    let source = interner.tuple(vec![fixed(u_object), fixed(t_param)]);
+
+    assert!(
+        !checker.is_subtype_of(source, t_array),
+        "[U, T] should NOT be assignable to T[] (U is unrelated, no any to absorb)"
+    );
+}


### PR DESCRIPTION
Goal: green

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Summary
Structural rule: when relating a tuple to an array type, tsc unions the tuple's element types and relates the union once to the array element type, so `[any, undefined] <: IObject[]` holds because `any | undefined` collapses to `any` (and `any` relates to any element). tsz was relating element-wise (`any` ✓ then `undefined` ✗), which rejected the assignment and made an inferred tuple fail its own constraint, producing a spurious TS2345 (witness: ts-deepmerge `src/index.ts:92` `merge(current[key], undefined)`).

Fix is in the solver tuple→array subtype rule, `check_tuple_to_array_subtype` (`crates/tsz-solver/src/relations/subtype/rules/tuples.rs`): collect every expanded fixed/variadic/tail element type into a `Vec<TypeId>`, build `self.interner.union(elems)` once (the interner's union builder applies tsc's universal absorptions, including `any | T = any`), and relate that union once to the array element. The pre-existing array-form spread handling for instantiable `[...X] <: E[]` (type-parameter array constraints, `infer`-extraction conditionals like `Parameters<F>`) is preserved: a concrete-array spread element (`...undefined[]`) folds its element type into the union, while an unreduced array-like spread keeps the constraint-resolving array-form path; only when no array-form probe applies is the spread folded in as a single element (matching the original direct `variadic <: E` relation).

Owner: solver relations (subtype).

Anti-hardcoding: no identifier/file-name/printer-string checks. The decision is purely structural — `interner.union` member absorption + `array_element_type`/`type_param_info` shape queries. The `IObject`/`Bag`/`Dict`/`T`/`U` names in tests are varied to confirm the rule does not depend on any binder name.

Adjacent matrix (all match tsc), added as solver unit tests in `crates/tsz-solver/tests/subtype_tests_parts/part_17.rs`:
- `[string, number] <: string[]` — REJECT (negative control)
- `[number, string] <: number[]` — REJECT (negative control)
- `[string, "x"] <: string[]` — ACCEPT (literal widens into the union)
- `[number, string] <: (number | string)[]` — ACCEPT
- `[any, undefined] <: IObject[]` — ACCEPT (the fix)
- `[undefined, any] <: Bag[]` — ACCEPT (order-independent absorption)
- `[any, ...undefined[]] <: Dict[]` — ACCEPT (rest-spread element folds into the union)
- `[any, undefined] <: readonly IObject[]` — ACCEPT (readonly target form)
- `[IObject, undefined] <: IObject[]` — STILL REJECTS (no-`any` regression canary: `merge(o, undefined)` without `any` rejects in both compilers)
- `[any, T] <: T[]` — ACCEPT (generic element via `any` absorption); `[U, T] <: T[]` — REJECT (generic negative control)

Shared assignability path: TS2345/TS2322 flow through this solver subtype rule, so the full tsz-checker regression delta (the ~20-hidden-regression family) cannot be measured locally (ENOSPC on the checker test build). Solver-targeted validation was run locally; the full checker delta runs in ready CI.

## Verification
- `cargo nextest run -p tsz-solver -E 'test(/tuple/) and test(/array/)'` — 156 passed, 0 failed (includes all 11 new matrix tests).
- `cargo nextest run -p tsz-solver -E 'test(/tuple/) or test(/subtype/) or test(/variadic/) or test(/spread/) or test(/array/) or test(/rest/)'` — 2198 passed, 0 failed.
- Full `cargo nextest run -p tsz-solver` — 6975 passed; the only 4 failures (`test_solver_oversized_file_size_ceilings` on `src/types.rs`, `literal_mask_preserves_object_vs_literal_reduction`, `test_conditional_infer_optional_property_present_distributive`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`) are pre-existing on clean `origin/main` (verified by stashing this change) and unrelated to this fix.
- `cargo clippy -p tsz-solver --tests` — clean, no warnings.
- Full tsz-checker regression delta: deferred to ready CI (shared assignability path; local checker build ENOSPCs).
