### PR TITLE
fix(checker): flatten nested conditional-flow substitutions for TS2344

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/conditional_flow.rs
+++ b/crates/tsz-checker/src/state/type_resolution/conditional_flow.rs
@@ -39,6 +39,19 @@ impl CheckerState<'_> {
         // `None` until a structured check operand matches (0 or 1 is the common
         // case, so avoid a heap `Vec`).
         let mut whole_constraint: Option<TypeId> = None;
+        // Naked-check-param channel: collect every enclosing true-branch
+        // `extends` constraint per narrowed type parameter as a FLAT
+        // intersection, then form a single substitution per parameter after the
+        // walk. Mirrors tsc's `getConditionalFlowTypeOfType`, which appends each
+        // implied constraint to one list and builds ONE
+        // `getSubstitutionType(type, getIntersectionType([...constraints, type]))`.
+        // Wrapping the prior substitution as the next intersection base inside
+        // the loop instead nests substitution types (`Sub(T, Sub(T, T & A) & B)`)
+        // that the subtype relation cannot see through, producing spurious
+        // `TS2344` for nested conditionals such as
+        // `T extends A ? Wrap<T extends B ? F<T> : never> : never`.
+        // Entries are `(type-param name, type-param id, accumulated extends)`.
+        let mut naked: Vec<(tsz_common::interner::Atom, TypeId, TypeId)> = Vec::new();
 
         let arg_actual = tsz_solver::type_queries::substitution_base_or_self(
             self.ctx.types.as_type_database(),
@@ -68,13 +81,13 @@ impl CheckerState<'_> {
                     && let Some(info) =
                         query_common::type_param_info(self.ctx.types.as_type_database(), type_param)
                 {
-                    let current = subst.get(info.name).unwrap_or(type_param);
                     let extends = self.get_type_from_type_node(cond.extends_type);
-                    let constraint = self.ctx.types.intersection2(current, extends);
-                    subst.insert(
-                        info.name,
-                        self.ctx.types.substitution(type_param, constraint),
-                    );
+                    if let Some(pos) = naked.iter().position(|(n, _, _)| *n == info.name) {
+                        let acc = self.ctx.types.intersection2(naked[pos].2, extends);
+                        naked[pos].2 = acc;
+                    } else {
+                        naked.push((info.name, type_param, extends));
+                    }
                 } else {
                     // Structured check operand: narrow the whole argument when it
                     // is the conditional's check operand (compared by actual type
@@ -99,6 +112,13 @@ impl CheckerState<'_> {
                 .arena
                 .get_extended(parent)
                 .map_or(NodeIndex::NONE, |info| info.parent);
+        }
+
+        // Form one substitution per narrowed parameter from the flattened
+        // constraints: `Sub(T, T & extends1 & extends2 & …)`.
+        for (name, type_param, acc_extends) in naked {
+            let constraint = self.ctx.types.intersection2(type_param, acc_extends);
+            subst.insert(name, self.ctx.types.substitution(type_param, constraint));
         }
 
         if subst.is_empty() && whole_constraint.is_none() {

--- a/crates/tsz-checker/src/tests/conditional_flow_substitution_ts2344_tests.rs
+++ b/crates/tsz-checker/src/tests/conditional_flow_substitution_ts2344_tests.rs
@@ -114,6 +114,53 @@ fn inferred_tail_satisfies_tuple_rest_helper_constraint() {
     );
 }
 
+#[test]
+fn wrapped_nested_conditional_true_branch_narrows_through_alias_wrapper() {
+    // Regression for the ts-rest `ClientInferRequest` shape (#14337): the inner
+    // `T extends Mut` true branch is wrapped in a `Pretty<{...}>` alias inside an
+    // OUTER `T extends Route` conditional. The conditional-flow substitution must
+    // compose the implied constraints into ONE flat intersection
+    // (`Sub(T, T & Route & Mut)`); building a fresh substitution per conditional
+    // nests them (`Sub(T, Sub(T, T & Route) & Mut)`), which the subtype relation
+    // cannot see through, so the inner `Mut` narrowing is lost and `NeedMut<T>`
+    // wrongly reports TS2344. `Mut` is an intersection to mirror the row's
+    // deeply-aliased route type.
+    assert_no_2344!(
+        "type Base = { tag: 0 };\n\
+         type Mut = Base & { kind: 'm'; payload: unknown };\n\
+         type Route = Mut | (Base & { kind: 'q' });\n\
+         type Pretty<X> = { [K in keyof X]: X[K] } & {};\n\
+         type NeedMut<M extends Mut> = M['payload'];\n\
+         type Req<T extends Route> = T extends Route\n\
+           ? Pretty<{ body: T extends Mut ? NeedMut<T> : never }>\n\
+           : never;\n\
+         type C = Req<Mut>;\n\
+         export {};",
+        "wrapped NeedMut<T> inside an outer conditional must be clean."
+    );
+}
+
+#[test]
+fn wrapped_nested_conditional_incompatible_inner_constraint_still_emits_2344() {
+    // Same wrapper+outer-conditional shape as above, but the inner helper needs a
+    // constraint the inner narrowing does NOT supply (`Other`, disjoint from the
+    // inner `Mut` branch). Flattening must not over-accept: TS2344 still fires.
+    assert_2344!(
+        "type Base = { tag: 0 };\n\
+         type Mut = Base & { kind: 'm'; payload: unknown };\n\
+         type Other = { brand: 'x'; n: number };\n\
+         type Route = Mut | (Base & { kind: 'q' });\n\
+         type Pretty<X> = { [K in keyof X]: X[K] } & {};\n\
+         type NeedOther<O extends Other> = O['n'];\n\
+         type Req<T extends Route> = T extends Route\n\
+           ? Pretty<{ body: T extends Mut ? NeedOther<T> : never }>\n\
+           : never;\n\
+         type C = Req<Mut>;\n\
+         export {};",
+        "`NeedOther<T>` (needs `Other`, not supplied by the `Mut` narrowing) must still emit TS2344."
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Negative cases: the narrowing must not over-accept.
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Goal: green

## Summary

Fixes a spurious **TS2344** (`Type 'T' does not satisfy the constraint ...`)
false positive in conditional-flow constraint narrowing for **nested
conditionals separated by an alias/mapped wrapper**.

Structural rule: inside the true branch of `T extends C ? … T … : …`, every
reference to the check variable `T` carries the implied constraint `T & C`
(tsc's `getConditionalFlowTypeOfType`). When a check variable is narrowed by
**more than one** enclosing true branch — e.g.

```ts
type Req<T extends Route> = T extends Route
  ? Prettify<{ body: T extends Mut ? NeedMut<T> : never }>
  : never;
```

tsc collects every implied constraint into a single list and forms **one**
substitution `Sub(T, intersection([...constraints, T]))`. tsz instead built a
fresh substitution per conditional inside the walk, reusing the previous
substitution as the next intersection base, which **nests** substitution types:
`Sub(T, Sub(T, T & Route) & Mut)`. The subtype relation cannot see through the
nested substitution, so the inner `Mut` narrowing is lost and `NeedMut<T>`
(whose parameter is constrained by `Mut`) wrongly reports TS2344.

Owner layer: checker — `CheckerState::apply_conditional_flow_to_type_arg`
(`crates/tsz-checker/src/state/type_resolution/conditional_flow.rs`), the
implementation of tsc's `getConditionalFlowTypeOfType`.

Fix: the naked-check-param channel now accumulates each enclosing true branch's
`extends` constraint into a **flat** per-parameter intersection and forms one
substitution `Sub(T, T & extends1 & extends2 & …)` after the walk — matching
tsc. The whole-argument (structured-operand) channel already flattened, so it is
unchanged.

This is a structural fix, not a row-specific one: it corrects narrowing for any
multiply-nested conditional whose inner true branch is separated from the outer
one by a wrapper (`Prettify`/`Pick`/object-literal/alias). It is the structural
root behind the ts-rest canary row's `ServerInferRequest`/`ClientInferRequest`
TS2344 (#14337); on that row it removes the `infer-types.ts`
`BodyWithoutFileIfMultiPart<T>` false positive. The row's residual `params`/`body`
TS2339 come from a separate mapped/`Without`-evaluation deferral and are out of
scope here.

## Adjacent cases

- Positive: single-level narrowing (existing tests) still clean.
- Positive (new): nested conditional through a `Prettify<{...}>` wrapper inside
  an outer conditional, with the inner constraint an intersection (mirrors the
  row) — now clean.
- Negative (new): same wrapper shape but the inner helper needs a **disjoint**
  constraint the narrowing does not supply — still emits TS2344 (no
  over-acceptance from flattening).
- Negative (existing): incompatible single-level constraint, unconstrained
  reference — still emit TS2344.

## Verification

- `cargo test -p tsz-checker --lib conditional_flow_substitution_ts2344` — 10/10
  pass, including the two new nested-wrapper cases (positive + negative).
- No-regression check: ran the affected filters (`2344`, `constraint`,
  `conditional`, `narrow`, `mapped`, `infer_`, `keyof`, `index_access`) on the
  branch base vs. with this change and diffed the FAILED set — **byte-identical**
  (16 pre-existing environment failures on this branch, 0 new). This change
  introduces no new failures in its blast radius. The ready-review CI nextest
  suite owns the full run.
- ts-rest canary guard config (`scripts/ci/project-compile-guard.sh`,
  `ts-rest-project`): the `infer-types.ts:179`
  `BodyWithoutFileIfMultiPart<T>` TS2344 false positive is cleared (row error
  count 4 → 3; the 3 residual diagnostics are a separate mapped/`Without`
  evaluation deferral, unaffected by this change).

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_017L7SzydMJGCGbpcyT9bP5P)_