### PR TITLE
fix(checker): unknown type-arg satisfies top-type constraints ({} | null | undefined) (#14733)

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -64,7 +64,15 @@ impl CheckerState<'_> {
                     // apparent constraint (`string[][number]` -> `string`) for the
                     // diagnostic display on a genuine violation.
                     let reduced_constraint = self.evaluate_type_for_assignability(inst_constraint);
-                    if !matches!(reduced_constraint, TypeId::ANY | TypeId::UNKNOWN) {
+                    // A constraint is a top type not only when it reduces to the
+                    // canonical `any`/`unknown`, but also when it is structurally
+                    // equal to `unknown` — e.g. `{} | null | undefined` (TypeScript's
+                    // `NonReducibleUnknown` idiom), which `unknown` is assignable to.
+                    // Defer to the assignability relation so `unknown` satisfies any
+                    // such top-type constraint, matching tsc (xstate `NonReducibleUnknown`).
+                    if !matches!(reduced_constraint, TypeId::ANY | TypeId::UNKNOWN)
+                        && !self.is_assignable_to(TypeId::UNKNOWN, reduced_constraint)
+                    {
                         let constraint_str =
                             self.format_type_diagnostic_constraint(reduced_constraint);
                         self.error_at_node_msg(

--- a/crates/tsz-checker/src/tests/generic_unknown_type_arg_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_unknown_type_arg_tests.rs
@@ -61,6 +61,59 @@ type RQ = Qq<unknown[], unknown>;
 }
 
 #[test]
+fn unknown_type_arg_satisfies_non_reducible_unknown_top_type_constraint() {
+    // `{} | null | undefined` (TypeScript's `NonReducibleUnknown` idiom) is
+    // structurally equal to `unknown`, so the top-type `unknown` argument
+    // satisfies it (`unknown ⊑ {} | null | undefined`), matching tsc. Covers the
+    // canonical form, a reordered union, and renamed binders (not name-driven).
+    let diagnostics = check_source_diagnostics(
+        r#"
+type NonReducibleUnknown = {} | null | undefined;
+type Box<T extends NonReducibleUnknown> = { value: T };
+type A = Box<unknown>;
+
+type Reordered<Q extends null | {} | undefined> = { v: Q };
+type B = Reordered<unknown>;
+"#,
+    );
+
+    let matches = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2344)
+        .collect::<Vec<_>>();
+    assert!(
+        matches.is_empty(),
+        "expected no TS2344 when the constraint is a top type ({{}} | null | undefined), got: {matches:?}"
+    );
+}
+
+#[test]
+fn unknown_type_arg_still_fails_near_top_constraints_missing_null_or_undefined() {
+    // `{}` and `{} | null` are NOT top types (they exclude `null`/`undefined` or
+    // `undefined`), so `unknown` is not assignable to them and TS2344 must still
+    // fire — the top-type acceptance is precise, not a blanket unknown pass.
+    let diagnostics = check_source_diagnostics(
+        r#"
+type Obj<T extends {}> = { v: T };
+type Bad1 = Obj<unknown>;
+
+type ObjN<U extends {} | null> = { v: U };
+type Bad2 = ObjN<unknown>;
+"#,
+    );
+
+    let matches = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 2344)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matches.len(),
+        2,
+        "expected TS2344 for both non-top constraints ({{}} and {{}} | null), got: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn unknown_type_arg_still_fails_indexed_access_constraint_reducing_to_proper_type() {
     // `A[number]` with `A = string[]` reduces to `string`; the top-type
     // `unknown` argument is not assignable to `string`, so TS2344 must still


### PR DESCRIPTION
Fixes #14733.

## Problem
`tsz` emitted a false `TS2344` when the `unknown` keyword was passed as a type argument to a parameter constrained by `{} | null | undefined` (TypeScript's `NonReducibleUnknown` idiom). `{} | null | undefined` is structurally equal to `unknown`, so `unknown` satisfies it; `tsc` 5.9.3 is clean. Hit 6× in **xstate** `guards.ts` (`TOutput extends NonReducibleUnknown`, `TInput = NonReducibleUnknown`).

```ts
type NonReducibleUnknown = {} | null | undefined;
type Box<T extends NonReducibleUnknown> = { value: T };
type A = Box<unknown>;   // tsz: TS2344 (wrong); tsc: clean
```

## Structural rule
A top-type `unknown` argument satisfies a constraint `C` **iff `unknown` is assignable to `C`** (i.e. `C` is a top type). The relation and assignability already model this correctly (`unknown extends {} | null | undefined ? Y : N` resolves `Y`; `const x: {} | null | undefined = someUnknown` is clean). Only the dedicated `unknown`-keyword **type-argument fast-path** decided "top type" syntactically — `matches!(reduced_constraint, TypeId::ANY | TypeId::UNKNOWN)` — which misses structurally-equal unions like `{} | null | undefined`.

## Fix
`When the type argument is the unknown keyword and the reduced constraint is not the canonical ANY/UNKNOWN, tsz now also accepts it when unknown is assignable to the reduced constraint` — extending the syntactic top-type test to the semantic one. Owner layer: checker `generic_checker/constraint_validation.rs` (the same site that already reduces the constraint for the diagnostic). Single-line predicate addition; no widening, no printer-string matching, no name/file fast paths.

## Adjacent matrix / fallback (precise, not a blanket pass)
- Accept: `Box<unknown>` vs `{} | null | undefined`; reordered `null | {} | undefined`; `extends unknown`; `extends any`.
- Still reject (`TS2344`): `extends {}` (excludes null/undefined), `extends {} | null` (missing undefined), `extends string` — `unknown` is not assignable to these, so they correctly still fire with the reduced-constraint display.

## Verification
- Repro + adjacent + 3 negative controls on the rebuilt dev-fast binary: fix cases clean, all negative controls still `TS2344`.
- Unit tests added to `generic_unknown_type_arg_tests.rs`: `unknown_type_arg_satisfies_non_reducible_unknown_top_type_constraint`, `unknown_type_arg_still_fails_near_top_constraints_missing_null_or_undefined` (renamed binders, not name-driven).
- Conformance (targeted): `unknown`, `constraint` filters; ready-review CI owns the full suite.

Goal: green

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
