### PR TITLE
fix(solver): narrow truthy-unknown `{}` to `object` under `typeof === "object"` guard

### DIFF
--- a/crates/tsz-checker/src/types/computation/binary_support.rs
+++ b/crates/tsz-checker/src/types/computation/binary_support.rs
@@ -628,176 +628,6 @@ impl CheckerState<'_> {
         }
     }
 
-    fn expression_is_object_string_literal(&self, expr_idx: NodeIndex) -> bool {
-        let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(expr_idx);
-        let Some(node) = self.ctx.arena.get(expr_idx) else {
-            return false;
-        };
-        node.kind == SyntaxKind::StringLiteral as u16
-            && self
-                .ctx
-                .arena
-                .get_literal(node)
-                .is_some_and(|literal| literal.text == "object")
-    }
-
-    fn expression_is_typeof_identifier_symbol(
-        &mut self,
-        expr_idx: NodeIndex,
-        symbol_id: tsz_binder::SymbolId,
-    ) -> bool {
-        let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(expr_idx);
-        let Some(node) = self.ctx.arena.get(expr_idx) else {
-            return false;
-        };
-        if node.kind != syntax_kind_ext::PREFIX_UNARY_EXPRESSION {
-            return false;
-        }
-        let Some(unary) = self.ctx.arena.get_unary_expr(node) else {
-            return false;
-        };
-        unary.operator == SyntaxKind::TypeOfKeyword as u16
-            && self.expression_is_identifier_symbol(unary.operand, symbol_id)
-    }
-
-    fn expression_is_typeof_object_guard_for_symbol(
-        &mut self,
-        expr_idx: NodeIndex,
-        symbol_id: tsz_binder::SymbolId,
-    ) -> bool {
-        let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(expr_idx);
-        let Some(node) = self.ctx.arena.get(expr_idx) else {
-            return false;
-        };
-        if node.kind != syntax_kind_ext::BINARY_EXPRESSION {
-            return false;
-        }
-        let Some(binary) = self.ctx.arena.get_binary_expr(node) else {
-            return false;
-        };
-        if binary.operator_token != SyntaxKind::EqualsEqualsEqualsToken as u16
-            && binary.operator_token != SyntaxKind::EqualsEqualsToken as u16
-        {
-            return false;
-        }
-
-        (self.expression_is_typeof_identifier_symbol(binary.left, symbol_id)
-            && self.expression_is_object_string_literal(binary.right))
-            || (self.expression_is_object_string_literal(binary.left)
-                && self.expression_is_typeof_identifier_symbol(binary.right, symbol_id))
-    }
-
-    fn expression_contains_typeof_object_guard_for_symbol(
-        &mut self,
-        expr_idx: NodeIndex,
-        symbol_id: tsz_binder::SymbolId,
-    ) -> bool {
-        let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(expr_idx);
-        if self.expression_is_typeof_object_guard_for_symbol(expr_idx, symbol_id) {
-            return true;
-        }
-
-        let Some(node) = self.ctx.arena.get(expr_idx) else {
-            return false;
-        };
-        if node.kind == syntax_kind_ext::BINARY_EXPRESSION
-            && let Some(binary) = self.ctx.arena.get_binary_expr(node)
-            && binary.operator_token == SyntaxKind::AmpersandAmpersandToken as u16
-        {
-            return self.expression_contains_typeof_object_guard_for_symbol(binary.left, symbol_id)
-                || self
-                    .expression_contains_typeof_object_guard_for_symbol(binary.right, symbol_id);
-        }
-
-        false
-    }
-
-    fn in_rhs_has_typeof_object_guard(&mut self, right_idx: NodeIndex) -> bool {
-        let stripped_right = self.ctx.arena.skip_parenthesized_and_assertions(right_idx);
-        let Some(right_node) = self.ctx.arena.get(stripped_right) else {
-            return false;
-        };
-        if right_node.kind != SyntaxKind::Identifier as u16 {
-            return false;
-        }
-        let Some(right_symbol) = self.resolve_identifier_symbol(stripped_right) else {
-            return false;
-        };
-
-        let mut current = right_idx;
-        let in_expression = loop {
-            let Some(parent_idx) = self.ctx.arena.get_extended(current).map(|ext| ext.parent)
-            else {
-                return false;
-            };
-            let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
-                return false;
-            };
-            if parent_node.kind == syntax_kind_ext::BINARY_EXPRESSION
-                && let Some(parent_binary) = self.ctx.arena.get_binary_expr(parent_node)
-                && parent_binary.operator_token == SyntaxKind::InKeyword as u16
-                && self.node_matches_after_outer_expressions(parent_binary.right, current)
-            {
-                break parent_idx;
-            }
-
-            if matches!(
-                parent_node.kind,
-                syntax_kind_ext::PARENTHESIZED_EXPRESSION
-                    | syntax_kind_ext::AS_EXPRESSION
-                    | syntax_kind_ext::SATISFIES_EXPRESSION
-                    | syntax_kind_ext::NON_NULL_EXPRESSION
-                    | syntax_kind_ext::TYPE_ASSERTION
-            ) {
-                current = parent_idx;
-                continue;
-            }
-
-            return false;
-        };
-
-        current = in_expression;
-        loop {
-            let Some(parent_idx) = self.ctx.arena.get_extended(current).map(|ext| ext.parent)
-            else {
-                return false;
-            };
-            let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
-                return false;
-            };
-
-            if parent_node.kind == syntax_kind_ext::BINARY_EXPRESSION
-                && let Some(parent_binary) = self.ctx.arena.get_binary_expr(parent_node)
-                && parent_binary.operator_token == SyntaxKind::AmpersandAmpersandToken as u16
-            {
-                if self.node_matches_after_outer_expressions(parent_binary.right, current)
-                    && self.expression_contains_typeof_object_guard_for_symbol(
-                        parent_binary.left,
-                        right_symbol,
-                    )
-                {
-                    return true;
-                }
-                current = parent_idx;
-                continue;
-            }
-
-            if matches!(
-                parent_node.kind,
-                syntax_kind_ext::PARENTHESIZED_EXPRESSION
-                    | syntax_kind_ext::AS_EXPRESSION
-                    | syntax_kind_ext::SATISFIES_EXPRESSION
-                    | syntax_kind_ext::NON_NULL_EXPRESSION
-                    | syntax_kind_ext::TYPE_ASSERTION
-            ) {
-                current = parent_idx;
-                continue;
-            }
-
-            return false;
-        }
-    }
-
     /// Get the operator name for a unary operator token (for TS17006 error messages).
     ///
     /// Returns the string representation of unary operators that are not allowed
@@ -1341,9 +1171,15 @@ impl CheckerState<'_> {
         } else {
             let type_may_represent_primitive =
                 in_operator::type_may_represent_primitive(self, right_type);
-            let truthiness_narrowed_unknown = self
-                .truthiness_narrowed_from_unknown(right_idx, right_type)
-                && !self.in_rhs_has_typeof_object_guard(right_idx);
+            // The flow type is the source of truth: when a `typeof x ===
+            // "object"` guard (in the same `&&` chain, an outer `if` body, a
+            // nested `if`, or via a stored boolean) has narrowed the RHS, the
+            // solver already produces `object` here, so
+            // `truthiness_narrowed_from_unknown` is false and TS2638 is not
+            // emitted. Only a still-`{}` flow type (truthiness alone, no
+            // `typeof` guard) reaches the diagnostic.
+            let truthiness_narrowed_unknown =
+                self.truthiness_narrowed_from_unknown(right_idx, right_type);
             if type_may_represent_primitive || truthiness_narrowed_unknown {
                 let truthiness_guarded_type_parameter =
                     in_operator::in_rhs_is_type_parameter_assignability_shape(

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -1200,12 +1200,63 @@ impl<'a> NarrowingContext<'a> {
             "bigint" => TypeId::BIGINT,
             "symbol" => TypeId::SYMBOL,
             "undefined" => TypeId::UNDEFINED,
-            "object" => TypeId::OBJECT, // includes null
+            "object" => return self.narrow_to_typeof_object(source_type),
             "function" => return self.narrow_to_function(source_type),
             _ => return source_type,
         };
 
         self.narrow_to_type(source_type, target_type)
+    }
+
+    /// Narrow a type to its `typeof x === "object"` (true-branch) facet.
+    ///
+    /// `narrow_to_type(source, object)` owns the union and type-parameter
+    /// narrowing, but it leaves the empty object type `{}` unchanged: tsz treats
+    /// `{}` as assignable to `object`, so the assignability short-circuit
+    /// returns the broader `{}`. `typeof` of a primitive is never `"object"`,
+    /// though, so the object facet of `{}` is the non-primitive `object` type —
+    /// never `{}` itself. Canonicalizing any `{}` left in the narrowed result to
+    /// `object` is therefore always correct here, and is what lets
+    /// `if (value && typeof value === "object")` narrow an `unknown`/`{}` value
+    /// to `object` so a subsequent `"k" in value` is a valid `in` right operand
+    /// rather than a spurious TS2638.
+    fn narrow_to_typeof_object(&self, source_type: TypeId) -> TypeId {
+        let narrowed = self.narrow_to_type(source_type, TypeId::OBJECT);
+        self.map_empty_object_to_object(narrowed)
+    }
+
+    /// Replace empty object type `{}` constituents with the non-primitive
+    /// `object` intrinsic, recursing through unions. Every other shape
+    /// (including non-empty object literals, intersections, and type
+    /// parameters) is returned unchanged.
+    fn map_empty_object_to_object(&self, source_type: TypeId) -> TypeId {
+        let resolved = self.resolve_type(source_type);
+
+        if let Some(members_id) = union_list_id(self.db, resolved) {
+            let members = self.db.type_list(members_id);
+            let mut mapped: Option<Vec<TypeId>> = None;
+            for (index, &member) in members.iter().enumerate() {
+                let replacement = self.map_empty_object_to_object(member);
+                if replacement != member && mapped.is_none() {
+                    let mut acc = Vec::with_capacity(members.len());
+                    acc.extend_from_slice(&members[..index]);
+                    mapped = Some(acc);
+                }
+                if let Some(acc) = mapped.as_mut() {
+                    acc.push(replacement);
+                }
+            }
+            return match mapped {
+                Some(acc) => self.db.union(acc),
+                None => source_type,
+            };
+        }
+
+        if crate::type_queries::is_empty_object_type(self.db, resolved) {
+            return TypeId::OBJECT;
+        }
+
+        source_type
     }
 
     /// Narrow a type to include only members assignable to target.


### PR DESCRIPTION
## Summary
`if (value && typeof value === "object")` where `value: unknown` left the flow
type as the empty object type `{}` instead of `object`, so a later
`"k" in value` in the `if` body raised a spurious **TS2638** (`'{}' may
represent a primitive value …`). Witnessed in xstate `StateMachine.ts:673`.

Fixes #14732.

The checker previously masked the common same-`&&`-chain shape with a syntactic
walker (`in_rhs_has_typeof_object_guard`) that searched the AST for an enclosing
`typeof x === "object"` guard. That walker could not see guards in an outer `if`
body, nested `if`s, or stored-boolean aliases — exactly the failing xstate
shape. The fix moves the truth to the flow type and removes the walker (and its
four helpers).

## Structural rule
When `typeof x === "object"` narrows a type, the result must exclude primitives.
The empty object type `{}` structurally accepts primitives (a value of type `{}`
may be a `string`), and `typeof` of a primitive is never `"object"`, so the
object facet of `{}` is the non-primitive `object` type, not `{}`. tsz's
`narrow_to_type(source, object)` returned the broader `{}` because tsz treats
`{}` as assignable to `object` (assignability short-circuit). `typeof === object`
now routes through `narrow_to_typeof_object`, which canonicalizes any `{}` left
in the narrowed result to `object`. So the flow type itself distinguishes the
guarded case (`object`, clean `in`) from plain truthiness (`{}`, still TS2638).

**Owner layer:** solver narrowing (`narrow_by_typeof` → `narrow_to_typeof_object`).
Both `if (typeof …)` and `switch (typeof …)` route through `narrow_by_typeof`,
so the fix covers both. The checker gate reduces to the flow type alone.

## Adjacent matrix (all verified, `--strict`)
- xstate `if (v && typeof v === "object") { if ("k" in v) }` — CLEAN (was FP)
- same `&&` chain `v && typeof v === "object" && "k" in v` — CLEAN
- typeof first `if (typeof v === "object" && v) { "k" in v }` — CLEAN
- split/nested `if (v) { if (typeof v === "object") { "k" in v } }` — CLEAN
- stored boolean `const isObj = typeof v === "object"; if (v && isObj) { "k" in v }` — CLEAN (old walker could not see this)
- renamed binder — CLEAN (no name dependence)
- declared `{} | null | undefined` reaching the same `in` — CLEAN
- **Negative** `if (v) { "k" in v }` (no guard) — still **TS2638** (true positive preserved)

## Verification
- `cargo build -p tsz-cli --bin tsz`; ran the repro + 8 adjacent cases above.
- `cargo test -p tsz-solver --lib` narrowing: 331 passed. Full solver lib: the
  only failures are 4 pre-existing tests, confirmed identical on `origin/main`
  with the change stashed (`types.rs` ratchet drift + 3 unrelated generic/eval
  tests) — none touched by this change.
- `cargo test -p tsz-checker --lib` in-operator / narrowing suites green
  (`in_narrow*`: 27 passed).
- Rebased on `origin/main`; no conflict.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgK6imWi8CJD8fpYTWi5Fx)_