### PR TITLE
fix(checker): recover declared type for reference-RHS reassignment in inferred return (#14728)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
@@ -11,7 +11,9 @@ use crate::query_boundaries::flow_analysis::{
     is_promise_like_type, literal_value, union_members_for_type, unwrap_promise_type_argument,
     widen_literal_to_primitive,
 };
-use crate::types_domain::queries::lib_resolution::keyword_syntax_to_type_id;
+use crate::types_domain::queries::lib_resolution::{
+    keyword_name_to_type_id, keyword_syntax_to_type_id,
+};
 use tsz_common::interner::Atom;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
@@ -234,8 +236,51 @@ impl<'a> FlowAnalyzer<'a> {
                     elem,
                 ))
             }
+            k if k == syntax_kind_ext::TYPE_LITERAL => {
+                // Resolve an inline object type annotation (`{ v: string }`) so a
+                // reference whose declared type is a structural object resolves to a
+                // real object type the property-access fallback can read, instead of
+                // an opaque `Lazy`. Conservative: bail to `None` (keep the `Lazy`) if
+                // any member is not a plain typed property signature, so partial or
+                // unsupported shapes never produce a structurally wrong object type.
+                let type_literal = self.arena.get_type_literal(node)?;
+                let mut properties = Vec::with_capacity(type_literal.members.nodes.len());
+                for &member in &type_literal.members.nodes {
+                    let member_node = self.arena.get(member)?;
+                    if member_node.kind != syntax_kind_ext::PROPERTY_SIGNATURE {
+                        return None;
+                    }
+                    let signature = self.arena.get_signature(member_node)?;
+                    if signature.type_annotation.is_none() {
+                        return None;
+                    }
+                    let name_atom = self.fallback_object_property_name_atom(signature.name)?;
+                    let member_type =
+                        self.fallback_type_from_type_node_syntax(signature.type_annotation)?;
+                    properties.push(if signature.question_token {
+                        PropertyInfo::opt(name_atom, member_type)
+                    } else {
+                        PropertyInfo::new(name_atom, member_type)
+                    });
+                }
+                Some(self.interner.factory().object(properties))
+            }
             k if k == syntax_kind_ext::TYPE_REFERENCE => {
                 let type_ref = self.arena.get_type_ref(node)?;
+                // Primitive keyword types (`string`, `number`, `boolean`, …) are
+                // parsed as bare type references whose name is a reserved keyword,
+                // not as dedicated keyword type nodes. They carry no binder symbol,
+                // so the symbol-resolution path below would bail and the syntactic
+                // fallback would return `None` whenever the annotation node has not
+                // been cached in `node_types`. Map the reserved keyword name to its
+                // built-in `TypeId` directly. These names cannot be user-declared,
+                // so this is a true-builtin lookup, not an identifier-string heuristic.
+                if type_ref.type_arguments.is_none()
+                    && let Some(name) = self.arena.get_identifier_at(type_ref.type_name)
+                    && let Some(builtin) = keyword_name_to_type_id(&name.escaped_text)
+                {
+                    return Some(builtin);
+                }
                 let sym_id = self
                     .binder
                     .resolve_identifier(self.arena, type_ref.type_name)
@@ -649,6 +694,23 @@ impl<'a> FlowAnalyzer<'a> {
                 self.resolve_symbol_to_lazy(SymbolRef(sym_id.0))
                     .map(|ty| self.resolve_lazy_via_env(ty))
             });
+        // Recover from an unresolved `Lazy` declared type. A parameter or
+        // block-scoped local whose declaration statement has not been checked in
+        // this pass (e.g. during inferred-return inference, which evaluates only
+        // return expressions and `if` conditions — not sibling assignment
+        // statements) resolves its symbol to a `Lazy(DefId)` that the
+        // `TypeEnvironment` cannot resolve here, so it leaks out opaque. An opaque
+        // `Lazy` is "subtype of nothing" for `narrow_assignment`, so an assignment
+        // RHS that reads such a reference (`x = param`, `x = local`) would silently
+        // contribute nothing to the flow type and the declared union would survive.
+        // Read the declaration's syntactic type annotation directly to recover the
+        // concrete declared type without depending on `node_types`/env priming.
+        let declared_type = match declared_type {
+            Some(ty) if self.is_unresolved_lazy_type(ty) => {
+                self.fallback_declared_annotation_type(decl).or(Some(ty))
+            }
+            other => other,
+        };
         if let (Some(initial_type), Some(flow_node)) =
             (declared_type, self.binder.get_node_flow(reference))
         {
@@ -658,6 +720,35 @@ impl<'a> FlowAnalyzer<'a> {
             }
         }
         declared_type.or_else(|| self.fallback_declaration_type(decl))
+    }
+
+    /// True when `ty` is a `Lazy(DefId)` that no `TypeEnvironment` resolution has
+    /// collapsed to a concrete type. Such a type carries no structural shape, so
+    /// flow narrowing (`narrow_assignment`, truthiness filtering) cannot reduce a
+    /// union against it; callers must recover a concrete declared type instead.
+    fn is_unresolved_lazy_type(&self, ty: TypeId) -> bool {
+        tsz_solver::type_queries::get_lazy_def_id(self.interner.as_type_database(), ty).is_some()
+    }
+
+    /// Resolve a declaration's declared type from its syntactic type annotation.
+    ///
+    /// Handles parameters and variable declarations — the binding forms whose
+    /// `Lazy(DefId)` can leak unresolved during inferred-return inference. Returns
+    /// `None` when the declaration has no annotation or the annotation syntax is
+    /// not one the syntactic resolver understands (callers then keep the `Lazy`).
+    fn fallback_declared_annotation_type(&self, decl: NodeIndex) -> Option<TypeId> {
+        let node = self.arena.get(decl)?;
+        let annotation = match node.kind {
+            k if k == syntax_kind_ext::PARAMETER => self.arena.get_parameter(node)?.type_annotation,
+            k if k == syntax_kind_ext::VARIABLE_DECLARATION => {
+                self.arena.get_variable_declaration(node)?.type_annotation
+            }
+            _ => return None,
+        };
+        if annotation.is_none() {
+            return None;
+        }
+        self.fallback_type_from_type_node_syntax(annotation)
     }
 
     fn fallback_declaration_type(&self, decl: NodeIndex) -> Option<TypeId> {

--- a/crates/tsz-checker/tests/assignment_branch_merge_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/assignment_branch_merge_narrowing_tests.rs
@@ -104,3 +104,138 @@ const n: number = getConfig().a;
         "object-literal branch assignment should narrow value to {{ a: number }}, got {diagnostics:?}"
     );
 }
+
+#[test]
+fn branch_parameter_identifier_assignment_narrows_inferred_return() {
+    // #14728 (kysely camel-case `memoize`): a guard reassignment whose RHS is a
+    // plain parameter identifier must narrow away `undefined` for the INFERRED
+    // return type. The inferred-return walk evaluates only return expressions and
+    // `if` conditions, so the sibling `mapped = fallback` is never checked; the
+    // flow fallback resolver must still recover the parameter's declared type
+    // (`string`) instead of leaking an opaque, unresolved `Lazy`.
+    let diagnostics = codes(
+        r#"
+declare function maybeLabel(): string | undefined;
+
+function pickLabel(fallback: string) {
+    let mapped = maybeLabel();
+    if (!mapped) {
+        mapped = fallback;
+    }
+    return mapped;
+}
+
+const label: string = pickLabel("x");
+"#,
+    );
+
+    assert!(
+        !diagnostics.contains(&TS2322),
+        "parameter-identifier branch assignment should narrow the inferred return to string, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn branch_local_const_assignment_narrows_inferred_return() {
+    // Same family with a block-scoped `const` local as the reassignment RHS, and
+    // deliberately renamed binders so the fix cannot key on identifier text.
+    let diagnostics = codes(
+        r#"
+declare function maybeTitle(): string | undefined;
+
+function resolveTitle(raw: string) {
+    const trimmed: string = raw;
+    let chosen = maybeTitle();
+    if (!chosen) {
+        chosen = trimmed;
+    }
+    return chosen;
+}
+
+const title: string = resolveTitle("x");
+"#,
+    );
+
+    assert!(
+        !diagnostics.contains(&TS2322),
+        "local-const branch assignment should narrow the inferred return to string, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn branch_property_access_assignment_narrows_inferred_return() {
+    // The reassignment RHS is a property access on an annotated object parameter.
+    // The flow fallback must resolve the object type-literal annotation so the
+    // property read yields `string`, not `any` over an opaque `Lazy`.
+    let diagnostics = codes(
+        r#"
+declare function maybeName(): string | undefined;
+
+function resolveName(source: { key: string }) {
+    let picked = maybeName();
+    if (!picked) {
+        picked = source.key;
+    }
+    return picked;
+}
+
+const name: string = resolveName({ key: "x" });
+"#,
+    );
+
+    assert!(
+        !diagnostics.contains(&TS2322),
+        "property-access branch assignment should narrow the inferred return to string, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn branch_generic_identifier_assignment_infers_type_parameter() {
+    // Generic body: the inferred return must be `T`, not `T | undefined`, when the
+    // guard reassigns the binding from another `T`-typed parameter.
+    let diagnostics = codes(
+        r#"
+function coalesce<T>(input: T | undefined, fallback: T) {
+    let resolved = input;
+    if (!resolved) {
+        resolved = fallback;
+    }
+    return resolved;
+}
+
+const out: number = coalesce<number>(undefined, 1);
+"#,
+    );
+
+    assert!(
+        !diagnostics.contains(&TS2322),
+        "generic identifier branch assignment should infer the return as T, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn branch_genuine_undefined_path_keeps_possibly_undefined_inferred_return() {
+    // Negative/fallback: when a path genuinely leaves the binding `undefined`
+    // (the guard does not cover every entry), the inferred return must REMAIN
+    // `string | undefined` so the assignment to a `string` still reports TS2322.
+    let diagnostics = codes(
+        r#"
+declare function maybeLabel(): string | undefined;
+
+function pickLabel(fallback: string, flag: boolean) {
+    let mapped = maybeLabel();
+    if (flag) {
+        mapped = fallback;
+    }
+    return mapped;
+}
+
+const label: string = pickLabel("x", true);
+"#,
+    );
+
+    assert!(
+        diagnostics.contains(&TS2322),
+        "a genuine undefined path must keep the inferred return possibly-undefined, got {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
Fixes #14728.

## Summary
When a function/arrow has an **inferred** return type, the return-type walk
(`collect_return_types_in_statement`) evaluates only return expressions and `if`
conditions — never the sibling assignment statements inside conditional blocks.
So for a returned `let` that is reassigned in a guard from a **reference RHS**
(`if (!mapped) { mapped = param }`), the flow query later resolves that RHS
through the *syntactic flow fallback* because `node_types` is cold for the
never-checked assignment. That fallback resolved a parameter / block-scoped local
to an **unresolved `Lazy(DefId)`** that the `TypeEnvironment` cannot collapse in
that context. An opaque `Lazy` is "subtype of nothing" for `narrow_assignment`,
so the assignment contributed nothing and the inferred return wrongly stayed
`string | undefined`, producing a false **TS2322** (the kysely camel-case
`memoize` row).

## Structural rule
When a `let` is reassigned inside a guard from a reference whose declared type is
recoverable from its annotation, `tsc` narrows the post-block merge to the
reference's type. tsz now does the same — through the flow fallback resolver
(`crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs`), the same
layer that already synthesizes types for array/object/call/new/await/binary RHS
forms when the main pipeline hasn't cached them.

## Owner layer
Solver-backed flow fallback resolver in the checker's control-flow module. No
checker pattern-matching of raw solver internals; built-in keyword resolution
uses the existing `keyword_name_to_type_id` helper, and `Lazy` detection uses the
solver's `get_lazy_def_id` classifier.

## Fix
All in the syntactic flow fallback resolver:
- Detect an unresolved `Lazy` declared type and recover the concrete declared
  type from the declaration's syntactic annotation (`fallback_declared_annotation_type`,
  parameters and variable declarations).
- Resolve primitive keyword type-references (`string`, `number`, …) — parsed as
  bare type references with no binder symbol — via `keyword_name_to_type_id`
  (true-builtin lookup, not an identifier-string heuristic).
- Resolve inline object type literals (`{ v: string }`) to a real object type so
  property-access RHS reads resolve, bailing conservatively on any non-trivial
  member.

## Adjacent-case matrix (new tests, binder names varied)
- parameter-identifier RHS (the #14728 repro)
- block-scoped `const` local RHS
- annotated object property-access RHS
- generic body must infer `T` (not `T | undefined`)
- negative/fallback: a genuine `undefined` path keeps the inferred return
  possibly-undefined, so TS2322 is still reported

Out of scope: a *contextually-typed* parameter with **no** syntactic annotation
(`const m: SM = (o) => { ... o.v ... }`) — there is no annotation to recover, a
separate root cause around contextual parameter priming.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-checker --test assignment_branch_merge_narrowing_tests` — 9
  passed (4 existing + 5 new).
- Manual repro under `--strict --target es2022 --moduleResolution bundler
  --module esnext --types ''`: issue repro and adjacent cases now clean; the
  genuine-undefined negative case still reports TS2322 (parity with `tsc`).
- Regression sweep (all green): `flow_narrowing_finalization_tests`,
  `conditional_initializer_preserves_narrowing_tests`,
  `flow_captured_let_memoization_tests`, `flow_property_reference_cache_tests`,
  `return_type_literal_union_widening_tests`,
  `destructuring_default_flow_assignment_tests`,
  `discriminant_narrow_function_lazy_preserved_tests`,
  `flow_call_divert_memoization_tests`, `block_body_callback_literal_widening_tests`,
  `contextual_return_callback_param_only_inference_tests`,
  `conditional_branch_array_literal_widening_tests`.
- `cargo clippy -p tsz-checker` — no new warnings in the touched file.

https://claude.ai/code/session_015s73QYeWPSmDJNTU9uXRjp

---
_Generated by [Claude Code](https://claude.ai/code/session_015s73QYeWPSmDJNTU9uXRjp)_