### PR TITLE
chore(release): bump try-tsz publish version to 0.1.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-binder"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-checker"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "dashmap",
  "globset",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-cli"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "anyhow",
  "clap",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-common"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-core"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-emitter"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lowering"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "indexmap",
  "rustc-hash",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lsp"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "globset",
  "json5",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-parser"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-scanner"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "serde",
  "tsz-common",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-solver"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "bitflags",
  "dashmap",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-wasm"
-version = "0.1.36"
+version = "0.1.37"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-website"
-version = "0.1.36"
+version = "0.1.37"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/.target"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.36"
+version = "0.1.37"
 edition = "2024"
 repository = "https://github.com/tsz-org/tsz"
 homepage = "https://github.com/tsz-org/tsz"
@@ -16,16 +16,16 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal workspace crates
-tsz = { path = "crates/tsz-core", version = "0.1.36", package = "tsz-core" }
-tsz-common = { path = "crates/tsz-common", version = "0.1.36" }
-tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.36" }
-tsz-parser = { path = "crates/tsz-parser", version = "0.1.36" }
-tsz-binder = { path = "crates/tsz-binder", version = "0.1.36" }
-tsz-solver = { path = "crates/tsz-solver", version = "0.1.36" }
-tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.36" }
-tsz-checker = { path = "crates/tsz-checker", version = "0.1.36" }
-tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.36", default-features = false }
-tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.36" }
+tsz = { path = "crates/tsz-core", version = "0.1.37", package = "tsz-core" }
+tsz-common = { path = "crates/tsz-common", version = "0.1.37" }
+tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.37" }
+tsz-parser = { path = "crates/tsz-parser", version = "0.1.37" }
+tsz-binder = { path = "crates/tsz-binder", version = "0.1.37" }
+tsz-solver = { path = "crates/tsz-solver", version = "0.1.37" }
+tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.37" }
+tsz-checker = { path = "crates/tsz-checker", version = "0.1.37" }
+tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.37", default-features = false }
+tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.37" }
 
 # External dependencies (shared versions)
 anyhow = "1.0"


### PR DESCRIPTION
Daily automated release PR.

## Goal
Goal: hold

## Invariant
Daily automated release of `try-tsz` to npm. Bumps the workspace
version from `0.1.36` to `0.1.37` and lets the merge queue
land it. The follow-up `tag-on-merge` job in `daily-release.yml`
tags the merge commit and dispatches `release.yml` plus
`npm-publish.yml`.

Commits accumulated since `v0.1.36`: 38.

## Scope
Mechanical version bump only:
- `Cargo.toml`: `workspace.package.version` plus every `tsz-*`
  pin in `[workspace.dependencies]` move `0.1.36` → `0.1.37`.
- `Cargo.lock`: each `tsz-*` workspace crate's `version` line
  moves `0.1.36` → `0.1.37`. Replacements are structurally
  paired to the preceding `name = "tsz-*"` line; a paired-count
  mismatch fails the workflow.

No semantic, build, or script changes.

## Verification
- Cargo.toml occurrence count of `0.1.36` before vs. `0.1.37`
  after must match (enforced by the workflow).
- Cargo.lock replacements are paired with their `name = "tsz-*"`
  header (Python pairing script in the workflow).

## Coordination Notes
- On merge, `daily-release.yml`'s `tag-on-merge` job pushes
  `v0.1.37` and dispatches `release.yml` and `npm-publish.yml`.
- To skip a day's release, close this PR; the next scheduled run
  opens a new one with the next patch.

## Provenance
Machine: cloud
Assistant: bot
Model: github-actions
Effort: low