### PR TITLE
fix(checker): catch-clause variable must not shadow enclosing block-scoped binding (TS2451/2300/2481)

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/core_tests.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core_tests.rs
@@ -1895,9 +1895,9 @@ mod catch_clause_scope_tests {
 
     #[test]
     fn genuine_var_shadow_still_reports() {
-        // Negative: a real `var` in a nested block shadowing an outer let must
-        // still emit TS2481 — the catch guard must not over-suppress.
-        let source = "function v() {\n  let y = 1;\n  { var y = 2; }\n  y;\n}";
+        // Negative: a real `var` in a nested block shadowing an outer block-scoped
+        // `let` must still emit TS2481 — the catch guard must not over-suppress.
+        let source = "{\n  let x;\n  {\n    var x = 1;\n  }\n}";
         let errors = check_and_collect(source, 2481);
         assert_eq!(errors.len(), 1, "expected 1 TS2481, got {errors:?}");
     }

--- a/crates/tsz-checker/src/state/variable_checking/core_tests.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core_tests.rs
@@ -1821,3 +1821,84 @@ mod function_type_nested_check_tests {
         );
     }
 }
+
+/// A `catch (e)` clause variable introduces its own lexical scope and never
+/// shadows an enclosing block-scoped binding (it is not a hoisting `var`).
+/// These cases must stay clean of TS2451/TS2300/TS2481 (#14734), while a
+/// genuine redeclaration *inside* the catch body still reports TS2492.
+#[cfg(test)]
+mod catch_clause_scope_tests {
+    use super::test_utils::check_and_collect;
+
+    fn assert_no_redeclare(source: &str) {
+        for code in [2451u32, 2300, 2481] {
+            let errors = check_and_collect(source, code);
+            assert!(
+                errors.is_empty(),
+                "expected no TS{code} for catch-clause shadow, got {errors:?}\nsource:\n{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn const_before_catch_same_function_scope() {
+        // tsc: clean. Previously emitted TS2451 x2.
+        assert_no_redeclare(
+            "function f() {\n  const err = 1;\n  try {\n  } catch (err) {\n    err;\n  }\n}",
+        );
+    }
+
+    #[test]
+    fn const_before_catch_nested_block() {
+        // tsc: clean. Previously emitted TS2481.
+        assert_no_redeclare(
+            "function g() {\n  const err = 2;\n  {\n    try {} catch (err) { err; }\n  }\n}",
+        );
+    }
+
+    #[test]
+    fn catch_before_const_same_scope() {
+        // tsc: clean. Previously emitted TS2300 x2 (catch ordered before const).
+        assert_no_redeclare("function h() {\n  try {} catch (err) { err; }\n  const err = 3;\n}");
+    }
+
+    #[test]
+    fn destructured_catch_binding_vs_enclosing_const() {
+        // tsc: clean. Catch binding pattern names get their own scope too.
+        assert_no_redeclare(
+            "function d() {\n  const a = 1;\n  try {} catch ({ message: a }) { a; }\n}",
+        );
+    }
+
+    #[test]
+    fn let_param_shadowed_by_catch() {
+        // A catch variable may shadow an enclosing parameter without conflict.
+        assert_no_redeclare("function p(err: unknown) {\n  try {} catch (err) { err; }\n}");
+    }
+
+    #[test]
+    fn sibling_catches_same_name_are_clean() {
+        assert_no_redeclare(
+            "function s() {\n  try {} catch (e) { e; }\n  try {} catch (e) { e; }\n}",
+        );
+    }
+
+    #[test]
+    fn let_inside_catch_body_still_redeclares() {
+        // Negative: a let/const inside the catch body collides with the catch
+        // binding. tsc reports TS2492 ("Cannot redeclare identifier in catch
+        // clause"); the shadow-check skip must not suppress it.
+        let source = "function n() {\n  try {} catch (e) { let e = 1; e; }\n}";
+        let errors = check_and_collect(source, 2492);
+        assert_eq!(errors.len(), 1, "expected 1 TS2492, got {errors:?}");
+    }
+
+    #[test]
+    fn genuine_var_shadow_still_reports() {
+        // Negative: a real `var` in a nested block shadowing an outer let must
+        // still emit TS2481 — the catch guard must not over-suppress.
+        let source = "function v() {\n  let y = 1;\n  { var y = 2; }\n  y;\n}";
+        let errors = check_and_collect(source, 2481);
+        assert_eq!(errors.len(), 1, "expected 1 TS2481, got {errors:?}");
+    }
+}

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
@@ -61,10 +61,7 @@ impl<'a> CheckerState<'a> {
         // name collection below. A genuine redeclaration *inside* the catch body
         // (`catch (x) { let x }`) is reported separately as TS2492 by
         // `check_catch_clause_variable_redeclaration`. (#14734)
-        if let Some(ext) = self.ctx.arena.get_extended(decl_idx)
-            && let Some(parent_node) = self.ctx.arena.get(ext.parent)
-            && parent_node.kind == syntax_kind_ext::CATCH_CLAUSE
-        {
+        if self.is_catch_clause_variable_declaration(decl_idx) {
             return;
         }
 

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
@@ -50,6 +50,24 @@ impl<'a> CheckerState<'a> {
         use tsz_binder::symbol_flags;
         use tsz_parser::parser::node_flags;
 
+        // A `catch (e)` clause variable introduces its own lexical scope (ES2015+);
+        // it is not a hoisting `var` and never shadows an enclosing block-scoped
+        // binding. tsc structurally never runs this check on a catch variable
+        // (`checkCatchClause` calls `checkVariableLikeDeclaration`, not
+        // `checkVariableDeclaration`/`checkVarDeclaredNamesNotShadowed`), so a
+        // `const x` outside the `catch` plus `catch (x)` must stay clean rather
+        // than producing TS2451/TS2300/TS2481. The same holds for a destructuring
+        // catch binding (`catch ({ x })`), which is why this guard precedes the
+        // name collection below. A genuine redeclaration *inside* the catch body
+        // (`catch (x) { let x }`) is reported separately as TS2492 by
+        // `check_catch_clause_variable_redeclaration`. (#14734)
+        if let Some(ext) = self.ctx.arena.get_extended(decl_idx)
+            && let Some(parent_node) = self.ctx.arena.get(ext.parent)
+            && parent_node.kind == syntax_kind_ext::CATCH_CLAUSE
+        {
+            return;
+        }
+
         // Skip block-scoped variables (let/const) and parameters — only var triggers TS2481
         if let Some(ext) = self.ctx.arena.get_extended(decl_idx)
             && let Some(parent_node) = self.ctx.arena.get(ext.parent)


### PR DESCRIPTION
## Summary

A `catch (e)` clause variable introduces its own lexical scope (ES2015+); it is **not** a hoisting `var` and never shadows an enclosing `let`/`const` of the same name. tsz routed the catch variable through `check_var_declared_names_not_shadowed`, which treats every non-`let`/`const` `VariableDeclaration` as a hoisting `var` and walks up the scope chain. Finding an enclosing block-scoped binding, it emitted **TS2451** ("Cannot redeclare block-scoped variable"), **TS2300** ("Duplicate identifier"), or **TS2481** ("Cannot initialize outer scoped variable…") depending on declaration order/nesting. Witnessed in **xstate** `createActor.ts:452`. `tsc` 5.9.3 is clean.

Closes #14734.

## Structural rule

When a `VariableDeclaration` is a `catch (e)` clause variable, `tsc` does **not** run the var-shadowing check on it: `checkCatchClause` calls `checkVariableLikeDeclaration`, not `checkVariableDeclaration`/`checkVarDeclaredNamesNotShadowed`. tsz now mirrors this — `check_var_declared_names_not_shadowed` (owner: checker, `variable_checking`) early-returns for catch-clause variables via the existing `is_catch_clause_variable_declaration` query helper. Genuine same-scope redeclarations are unaffected: they are owned by `check_duplicate_identifiers` (two `let`/`const` in a block → TS2451) and `check_catch_clause_variable_redeclaration` (`catch (x) { let x }` → TS2492).

## Adjacent-case matrix

All verified clean against `tsc` 5.9.3 with the fixed binary, and covered by new unit tests in `catch_clause_scope_tests`:

- `const x` before `catch (x)` in the same function scope — was TS2451 ×2, now clean.
- `const x` before `catch (x)` in a nested `{ }` block — was TS2481, now clean.
- `catch (x)` before `const x` (catch ordered first) — was TS2300 ×2, now clean.
- Destructuring catch binding `catch ({ message: x })` vs enclosing `const x` — no redeclare diagnostic (the `unknown`-destructure TS2339 is correct `tsc` parity).
- Catch variable shadowing an enclosing parameter of the same name — clean.
- Sibling `try/catch (e)` … `try/catch (e)` — clean.

Negative cases preserved (still error):

- `let x; let x;` in the same block → TS2451 ×2 (`check_duplicate_identifiers`).
- `catch (e) { let e }` inside the catch body → TS2492.
- `{ let x; { var x = 1; } }` genuine `var` shadow → TS2481.

## Verification

- `cargo test -p tsz-checker --lib catch_clause_scope_tests` → 8 passed (new tests).
- `cargo test -p tsz-checker --lib variable_checking::core::core_tests` → 103 passed.
- `cargo test -p tsz-checker --lib duplicate` → 62 passed; `--lib catch` → 27 passed (no regressions).
- Manual repro of all witnessed shapes against the built `tsz` binary: false positives gone, genuine diagnostics retained.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01LQGqjtkbGBLBorrTxCjJT9

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQGqjtkbGBLBorrTxCjJT9)_