### PR TITLE
refactor(checker): route 7 raw try_borrow_mut dual-writes through register_in_envs (#14348)

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -1081,54 +1081,6 @@ impl CheckerContext<'_> {
         self.register_in_envs(DeferredFlowEnvWrite::InsertDefKind { def_id, kind });
     }
 
-    /// Register a merged interface+value symbol's `typeof` value-space type in
-    /// **both** type environments through the race-safe deferral discipline.
-    ///
-    /// Replaces the raw dual `try_borrow_mut` blocks that silently dropped the
-    /// registration on a borrow conflict; the write is now deferred and replayed
-    /// instead of lost (#14348).
-    pub(crate) fn register_typeof_value_type_in_envs(
-        &self,
-        symbol: tsz_solver::SymbolRef,
-        value_type: TypeId,
-    ) {
-        self.register_in_envs(DeferredFlowEnvWrite::InsertTypeofValueType { symbol, value_type });
-    }
-
-    /// Register a `[Symbol.*]` computed property name's backing `SymbolRef` in
-    /// **both** type environments through the race-safe deferral discipline.
-    pub(crate) fn register_well_known_symbol_name_in_envs(
-        &self,
-        name: String,
-        symbol_ref: tsz_solver::SymbolRef,
-    ) {
-        self.register_in_envs(DeferredFlowEnvWrite::RegisterWellKnownSymbolName {
-            name,
-            symbol_ref,
-        });
-    }
-
-    /// Register an enum's namespace object type in **both** type environments
-    /// through the race-safe deferral discipline.
-    pub(crate) fn register_enum_namespace_type_in_envs(&self, def_id: DefId, ns_type: TypeId) {
-        self.register_in_envs(DeferredFlowEnvWrite::RegisterEnumNamespaceType { def_id, ns_type });
-    }
-
-    /// Register an enum member's parent enum in **both** type environments
-    /// through the race-safe deferral discipline.
-    pub(crate) fn register_enum_parent_in_envs(&self, member_def_id: DefId, parent_def_id: DefId) {
-        self.register_in_envs(DeferredFlowEnvWrite::RegisterEnumParent {
-            member_def_id,
-            parent_def_id,
-        });
-    }
-
-    /// Register a symbol's resolved type (`SymbolRef -> TypeId`) in **both** type
-    /// environments through the race-safe deferral discipline.
-    pub(crate) fn register_symbol_type_in_envs(&self, symbol: tsz_solver::SymbolRef, ty: TypeId) {
-        self.register_in_envs(DeferredFlowEnvWrite::InsertSymbolType { symbol, ty });
-    }
-
     /// Create a Lazy type reference from a symbol.
     ///
     /// This returns `TypeData::Lazy(DefId)` for use in the new `DefId` system.

--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -1081,6 +1081,54 @@ impl CheckerContext<'_> {
         self.register_in_envs(DeferredFlowEnvWrite::InsertDefKind { def_id, kind });
     }
 
+    /// Register a merged interface+value symbol's `typeof` value-space type in
+    /// **both** type environments through the race-safe deferral discipline.
+    ///
+    /// Replaces the raw dual `try_borrow_mut` blocks that silently dropped the
+    /// registration on a borrow conflict; the write is now deferred and replayed
+    /// instead of lost (#14348).
+    pub(crate) fn register_typeof_value_type_in_envs(
+        &self,
+        symbol: tsz_solver::SymbolRef,
+        value_type: TypeId,
+    ) {
+        self.register_in_envs(DeferredFlowEnvWrite::InsertTypeofValueType { symbol, value_type });
+    }
+
+    /// Register a `[Symbol.*]` computed property name's backing `SymbolRef` in
+    /// **both** type environments through the race-safe deferral discipline.
+    pub(crate) fn register_well_known_symbol_name_in_envs(
+        &self,
+        name: String,
+        symbol_ref: tsz_solver::SymbolRef,
+    ) {
+        self.register_in_envs(DeferredFlowEnvWrite::RegisterWellKnownSymbolName {
+            name,
+            symbol_ref,
+        });
+    }
+
+    /// Register an enum's namespace object type in **both** type environments
+    /// through the race-safe deferral discipline.
+    pub(crate) fn register_enum_namespace_type_in_envs(&self, def_id: DefId, ns_type: TypeId) {
+        self.register_in_envs(DeferredFlowEnvWrite::RegisterEnumNamespaceType { def_id, ns_type });
+    }
+
+    /// Register an enum member's parent enum in **both** type environments
+    /// through the race-safe deferral discipline.
+    pub(crate) fn register_enum_parent_in_envs(&self, member_def_id: DefId, parent_def_id: DefId) {
+        self.register_in_envs(DeferredFlowEnvWrite::RegisterEnumParent {
+            member_def_id,
+            parent_def_id,
+        });
+    }
+
+    /// Register a symbol's resolved type (`SymbolRef -> TypeId`) in **both** type
+    /// environments through the race-safe deferral discipline.
+    pub(crate) fn register_symbol_type_in_envs(&self, symbol: tsz_solver::SymbolRef, ty: TypeId) {
+        self.register_in_envs(DeferredFlowEnvWrite::InsertSymbolType { symbol, ty });
+    }
+
     /// Create a Lazy type reference from a symbol.
     ///
     /// This returns `TypeData::Lazy(DefId)` for use in the new `DefId` system.

--- a/crates/tsz-checker/src/context/def_mapping_env_writes.rs
+++ b/crates/tsz-checker/src/context/def_mapping_env_writes.rs
@@ -1,0 +1,63 @@
+//! Race-safe dual-environment registration wrappers for `CheckerContext`.
+//!
+//! These thin `*_in_envs` helpers replace the raw dual `try_borrow_mut` blocks
+//! that silently dropped a registration on a borrow conflict; each write is now
+//! deferred and replayed instead of lost (#14348). They live in a sibling module
+//! to keep `def_mapping.rs` under the 2000-line ceiling; behavior is identical to
+//! defining them inline on `impl CheckerContext`.
+
+use tsz_solver::TypeId;
+use tsz_solver::def::DefId;
+
+use crate::context::CheckerContext;
+use crate::context::deferred_flow_env_write::DeferredFlowEnvWrite;
+
+impl CheckerContext<'_> {
+    /// Register a merged interface+value symbol's `typeof` value-space type in
+    /// **both** type environments through the race-safe deferral discipline.
+    ///
+    /// Replaces the raw dual `try_borrow_mut` blocks that silently dropped the
+    /// registration on a borrow conflict; the write is now deferred and replayed
+    /// instead of lost (#14348).
+    pub(crate) fn register_typeof_value_type_in_envs(
+        &self,
+        symbol: tsz_solver::SymbolRef,
+        value_type: TypeId,
+    ) {
+        self.register_in_envs(DeferredFlowEnvWrite::InsertTypeofValueType { symbol, value_type });
+    }
+
+    /// Register a `[Symbol.*]` computed property name's backing `SymbolRef` in
+    /// **both** type environments through the race-safe deferral discipline.
+    pub(crate) fn register_well_known_symbol_name_in_envs(
+        &self,
+        name: String,
+        symbol_ref: tsz_solver::SymbolRef,
+    ) {
+        self.register_in_envs(DeferredFlowEnvWrite::RegisterWellKnownSymbolName {
+            name,
+            symbol_ref,
+        });
+    }
+
+    /// Register an enum's namespace object type in **both** type environments
+    /// through the race-safe deferral discipline.
+    pub(crate) fn register_enum_namespace_type_in_envs(&self, def_id: DefId, ns_type: TypeId) {
+        self.register_in_envs(DeferredFlowEnvWrite::RegisterEnumNamespaceType { def_id, ns_type });
+    }
+
+    /// Register an enum member's parent enum in **both** type environments
+    /// through the race-safe deferral discipline.
+    pub(crate) fn register_enum_parent_in_envs(&self, member_def_id: DefId, parent_def_id: DefId) {
+        self.register_in_envs(DeferredFlowEnvWrite::RegisterEnumParent {
+            member_def_id,
+            parent_def_id,
+        });
+    }
+
+    /// Register a symbol's resolved type (`SymbolRef -> TypeId`) in **both** type
+    /// environments through the race-safe deferral discipline.
+    pub(crate) fn register_symbol_type_in_envs(&self, symbol: tsz_solver::SymbolRef, ty: TypeId) {
+        self.register_in_envs(DeferredFlowEnvWrite::InsertSymbolType { symbol, ty });
+    }
+}

--- a/crates/tsz-checker/src/context/deferred_flow_env_write.rs
+++ b/crates/tsz-checker/src/context/deferred_flow_env_write.rs
@@ -56,6 +56,32 @@ pub enum DeferredFlowEnvWrite {
         def_id: DefId,
         kind: tsz_solver::def::DefKind,
     },
+    /// `insert_typeof_value_type` — register a merged interface+value symbol's
+    /// `typeof` value-space type.
+    InsertTypeofValueType {
+        symbol: tsz_solver::SymbolRef,
+        value_type: TypeId,
+    },
+    /// `register_well_known_symbol_name` — register a `[Symbol.*]` computed
+    /// property name's backing `SymbolRef`.
+    RegisterWellKnownSymbolName {
+        name: String,
+        symbol_ref: tsz_solver::SymbolRef,
+    },
+    /// `register_enum_namespace_type` — register an enum's namespace object type
+    /// for `typeof Enum` / `keyof typeof Enum`.
+    RegisterEnumNamespaceType { def_id: DefId, ns_type: TypeId },
+    /// `register_enum_parent` — register an enum member's parent enum for member
+    /// widening and discriminant narrowing.
+    RegisterEnumParent {
+        member_def_id: DefId,
+        parent_def_id: DefId,
+    },
+    /// `insert` — register a symbol's resolved type (`SymbolRef -> TypeId`).
+    InsertSymbolType {
+        symbol: tsz_solver::SymbolRef,
+        ty: TypeId,
+    },
 }
 
 impl DeferredFlowEnvWrite {
@@ -121,6 +147,20 @@ impl DeferredFlowEnvWrite {
                 is_class,
             } => apply_augmented_def(env, *def_id, *augmented, *is_class),
             Self::InsertDefKind { def_id, kind } => env.insert_def_kind(*def_id, *kind),
+            Self::InsertTypeofValueType { symbol, value_type } => {
+                env.insert_typeof_value_type(*symbol, *value_type);
+            }
+            Self::RegisterWellKnownSymbolName { name, symbol_ref } => {
+                env.register_well_known_symbol_name(name.clone(), *symbol_ref);
+            }
+            Self::RegisterEnumNamespaceType { def_id, ns_type } => {
+                env.register_enum_namespace_type(*def_id, *ns_type);
+            }
+            Self::RegisterEnumParent {
+                member_def_id,
+                parent_def_id,
+            } => env.register_enum_parent(*member_def_id, *parent_def_id),
+            Self::InsertSymbolType { symbol, ty } => env.insert(*symbol, *ty),
         }
     }
 }

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -41,6 +41,7 @@ pub mod lifetime_shells;
 pub use lifetime_shells::{FileSession, LspPersistentCache, SpeculationScope, WorkerContext};
 mod def_declaration;
 mod def_mapping;
+mod def_mapping_env_writes;
 mod def_mapping_flow_mirror;
 mod def_mapping_formatters;
 mod def_mapping_resolved_env;

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -1159,44 +1159,46 @@ impl<'a> CheckerState<'a> {
             // This avoids per-member `get_type_of_symbol` overhead in
             // hot paths such as large enum property-access switches.
             //
-            // Collect (member_def_id, member_enum_type) pairs so we can mirror
-            // them into type_environment after releasing the type_env borrow.
-            let mut member_def_entries: Vec<(tsz_solver::DefId, TypeId)> = Vec::new();
-            {
-                let mut maybe_env = self.ctx.type_env.try_borrow_mut().ok();
-                for &(member_type, ref member_name, _member_idx) in &member_entries {
-                    if let Some(name) = member_name
-                        && let Some(member_sym_id) = self
-                            .ctx
-                            .binder
-                            .get_symbol(sym_id)
-                            .and_then(|enum_symbol| enum_symbol.exports.as_ref())
-                            .and_then(|exports| exports.get(name))
-                    {
-                        let member_def_id = self.ctx.get_or_create_def_id(member_sym_id);
-                        let member_enum_type = factory.enum_type(member_def_id, member_type);
-                        self.ctx
-                            .symbol_types
-                            .insert(member_sym_id, member_enum_type);
-                        if let Some(env) = maybe_env.as_mut() {
-                            env.insert(tsz_solver::SymbolRef(member_sym_id.0), member_enum_type);
-                            if member_def_id != tsz_solver::DefId::INVALID {
-                                env.insert_def(member_def_id, member_enum_type);
-                                // Register parent-child relationship for enum member widening
-                                env.register_enum_parent(member_def_id, def_id);
-                                member_def_entries.push((member_def_id, member_enum_type));
-                            }
-                        }
-                    }
+            // Collect (member_sym_id, member_def_id, member_enum_type) tuples and
+            // apply the env writes after this loop. The dual-env registration
+            // wrappers take `&self.ctx` and manage their own race-safe borrows,
+            // so we must not hold a `type_env` borrow across the wrapper calls.
+            let mut member_env_entries: Vec<(tsz_solver::SymbolRef, tsz_solver::DefId, TypeId)> =
+                Vec::new();
+            for &(member_type, ref member_name, _member_idx) in &member_entries {
+                if let Some(name) = member_name
+                    && let Some(member_sym_id) = self
+                        .ctx
+                        .binder
+                        .get_symbol(sym_id)
+                        .and_then(|enum_symbol| enum_symbol.exports.as_ref())
+                        .and_then(|exports| exports.get(name))
+                {
+                    let member_def_id = self.ctx.get_or_create_def_id(member_sym_id);
+                    let member_enum_type = factory.enum_type(member_def_id, member_type);
+                    self.ctx
+                        .symbol_types
+                        .insert(member_sym_id, member_enum_type);
+                    member_env_entries.push((
+                        tsz_solver::SymbolRef(member_sym_id.0),
+                        member_def_id,
+                        member_enum_type,
+                    ));
                 }
             }
-            // Mirror enum member DefId entries into type_environment for consistency
-            if !member_def_entries.is_empty()
-                && let Ok(mut env) = self.ctx.type_environment.try_borrow_mut()
-            {
-                for &(member_def_id, member_enum_type) in &member_def_entries {
-                    env.insert_def(member_def_id, member_enum_type);
-                    env.register_enum_parent(member_def_id, def_id);
+            // Apply the per-member env writes through the dual-env deferral
+            // discipline (mirrors to both `type_env` and `type_environment`,
+            // replaying instead of dropping on a borrow conflict). The order
+            // preserves the prior per-member sequence: symbol type, then def
+            // body, then enum-parent.
+            for &(member_ref, member_def_id, member_enum_type) in &member_env_entries {
+                self.ctx
+                    .register_symbol_type_in_envs(member_ref, member_enum_type);
+                if member_def_id != tsz_solver::DefId::INVALID {
+                    self.ctx
+                        .register_def_in_envs(member_def_id, member_enum_type);
+                    // Register parent-child relationship for enum member widening.
+                    self.ctx.register_enum_parent_in_envs(member_def_id, def_id);
                 }
             }
 
@@ -1230,13 +1232,11 @@ impl<'a> CheckerState<'a> {
             let ns_type = self.merge_namespace_exports_into_object(sym_id, enum_type);
             self.ctx.enum_namespace_types.insert(sym_id, ns_type);
             // Register in both TypeEnvironment instances so the solver's evaluator
-            // and the flow analyzer can both access enum namespace types.
-            if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
-                env.register_enum_namespace_type(def_id, ns_type);
-            }
-            if let Ok(mut env) = self.ctx.type_environment.try_borrow_mut() {
-                env.register_enum_namespace_type(def_id, ns_type);
-            }
+            // and the flow analyzer can both access enum namespace types. Routed
+            // through the dual-env deferral discipline so a borrow conflict
+            // replays the write instead of dropping it.
+            self.ctx
+                .register_enum_namespace_type_in_envs(def_id, ns_type);
             // Register DefId <-> SymbolId mapping for enum type resolution
             self.ctx
                 .register_resolved_type(sym_id, enum_type, Vec::new());

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1535,11 +1535,13 @@ impl CheckerState<'_> {
                         if let Some(&parent_sym) = parents.first()
                             && let Some(parent_def_id) = self.ctx.get_existing_def_id(parent_sym)
                         {
-                            env.register_class_extends(def_id, parent_def_id);
-                            // Also register in type_environment so FlowAnalyzer sees it.
-                            if let Ok(mut te) = self.ctx.type_environment.try_borrow_mut() {
-                                te.register_class_extends(def_id, parent_def_id);
-                            }
+                            // Register the class `extends` edge in BOTH envs through
+                            // the dual-env deferral discipline. The held `type_env`
+                            // borrow makes the evaluator-env write defer-and-replay
+                            // rather than drop, and the flow-analyzer mirror is applied
+                            // (or deferred) the same way, so the FlowAnalyzer sees it.
+                            self.ctx
+                                .register_class_extends_in_envs(def_id, parent_def_id);
                         }
                     }
                 } else if type_params.is_empty() {

--- a/crates/tsz-checker/src/state/type_analysis/core_typeof_value.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_typeof_value.rs
@@ -99,11 +99,7 @@ impl CheckerState<'_> {
         value_type: TypeId,
     ) {
         let symbol_ref = tsz_solver::SymbolRef(sym_id.0);
-        if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
-            env.insert_typeof_value_type(symbol_ref, value_type);
-        }
-        if let Ok(mut env) = self.ctx.type_environment.try_borrow_mut() {
-            env.insert_typeof_value_type(symbol_ref, value_type);
-        }
+        self.ctx
+            .register_typeof_value_type_in_envs(symbol_ref, value_type);
     }
 }

--- a/crates/tsz-checker/src/types/queries/core_names.rs
+++ b/crates/tsz-checker/src/types/queries/core_names.rs
@@ -599,12 +599,8 @@ impl<'a> CheckerState<'a> {
         }
         let name_key = name.to_string();
 
-        if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
-            env.register_well_known_symbol_name(name_key.clone(), symbol_ref);
-        }
-        if let Ok(mut env) = self.ctx.type_environment.try_borrow_mut() {
-            env.register_well_known_symbol_name(name_key, symbol_ref);
-        }
+        self.ctx
+            .register_well_known_symbol_name_in_envs(name_key, symbol_ref);
     }
 
     pub(crate) fn register_well_known_symbol_name_from_canonical(

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking/type_query_flow.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking/type_query_flow.rs
@@ -285,11 +285,7 @@ impl CheckerState<'_> {
             return;
         }
         let symbol_ref = tsz_solver::SymbolRef(sym_id.0);
-        if let Ok(mut env) = self.ctx.type_environment.try_borrow_mut() {
-            env.insert_typeof_value_type(symbol_ref, value_type);
-        }
-        if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
-            env.insert_typeof_value_type(symbol_ref, value_type);
-        }
+        self.ctx
+            .register_typeof_value_type_in_envs(symbol_ref, value_type);
     }
 }

--- a/crates/tsz-checker/src/types/type_node_property_names.rs
+++ b/crates/tsz-checker/src/types/type_node_property_names.rs
@@ -29,12 +29,8 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
 
         let name_key = name.to_string();
 
-        if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
-            env.register_well_known_symbol_name(name_key.clone(), symbol_ref);
-        }
-        if let Ok(mut env) = self.ctx.type_environment.try_borrow_mut() {
-            env.register_well_known_symbol_name(name_key, symbol_ref);
-        }
+        self.ctx
+            .register_well_known_symbol_name_in_envs(name_key, symbol_ref);
     }
 
     fn register_well_known_symbol_name_mapping(&mut self, name: &str, sym_id: SymbolId) {


### PR DESCRIPTION
Goal: hold

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Summary
Route 7 raw `try_borrow_mut` dual-write sites (#14348 silent-drop divergence sources) through the consolidated `register_in_envs` deferral discipline + 5 new `DeferredFlowEnvWrite` variants. Behavior-preserving: converts drop-on-conflict into deferred-replay (strictly more writes, never fewer; deletes a literal duplicate `register_well_known_symbol_name` site). One coverage increase flagged: the D:1182 `insert` (per-enum-member `SymbolRef -> TypeId`) now also mirrors to the flow env. `global.rs` left untouched (architecture-contract guard). Owner: checker context. The field-collapse end-state stays deep/gated behind #14344/#14345.

Structural rule: When a dual-environment registration loses the `RefCell` borrow race, `tsc` parity requires the write to survive (it changes no type, only env coverage); `tsz` now defers-and-replays it through `CheckerContext::register_in_envs` / `DeferredFlowEnvWrite` instead of dropping it on the floor.

### 5 new `DeferredFlowEnvWrite` variants (+ `apply()` arm + 1-line wrapper)
- `InsertTypeofValueType` -> `register_typeof_value_type_in_envs`
- `RegisterWellKnownSymbolName` -> `register_well_known_symbol_name_in_envs`
- `RegisterEnumNamespaceType` -> `register_enum_namespace_type_in_envs`
- `RegisterEnumParent` -> `register_enum_parent_in_envs`
- `InsertSymbolType` -> `register_symbol_type_in_envs`

### 7 converted raw sites
- A. `state/type_analysis/core_typeof_value.rs` (insert_typeof_value_type)
- F. `types/type_checking/type_alias_checking/type_query_flow.rs` (same op, opposite borrow order)
- B. `types/queries/core_names.rs` (register_well_known_symbol_name; dropped the `.clone()`)
- C. `types/type_node_property_names.rs` (literal duplicate of B)
- D. `state/type_analysis/computed/mod.rs` enum-member loop (insert/insert_def/register_enum_parent + deleted the separate flow-mirror block; restructured to collect-then-apply after releasing the `type_env` borrow, mirroring the existing `member_def_entries` pattern, since the wrappers manage their own race-safe borrows)
- E. `state/type_analysis/computed/mod.rs` (register_enum_namespace_type)
- G. `state/type_analysis/core.rs` class-extends mirror (nested inside a held `type_env` borrow) -> reuses the existing `register_class_extends_in_envs`; the held borrow makes the eval-env write defer-and-replay rather than drop

`global.rs:418/460` (boxed-type / global-init writes) deliberately untouched: the architecture-contract test at `tests/.../architecture_contract_tests/part_00.rs:349` asserts `type_environment.try_borrow_mut()` is PRESENT in `src/types/type_checking/global.rs`. Confirmed present and unchanged.

## Verification
- Build: `cargo build -p tsz-checker --lib` clean.
- Witness tests (all 5 PASS with the change applied):
  - `flow_env_mirror_is_deferred_under_borrow_then_replayed`
  - `flow_env_backlog_drains_on_next_successful_mirror`
  - `eval_env_class_instance_is_deferred_under_borrow_then_replayed`
  - `both_envs_defer_then_replay_under_simultaneous_borrow`
  - `resolved_def_mirror_is_deferred_under_borrow_then_envs_reconcile`
- Family baseline (parity-shaped, byte-identical expectation): the enum / typeof / well-known / unique-symbol / class-extends / instanceof checker test families produce an **identical** result before and after the change: pristine `origin/main` = 1169 pass / 13 fail; with this change = 1169 pass / 13 fail (the same 13 names). Those 13 (plus the broader arch-source-scan failures) are pre-existing local-environment scan/display drifts on `main`, owned by ready-review CI, not introduced here.
- Ready-review CI owns the broad conformance/emit/fourslash suites.
