### PR TITLE
fix(checker): gate object-literal getter TS7023 on receiver, not property name

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -773,6 +773,9 @@ path = "tests/accessor_assignment_read_surface_tests.rs"
 name = "inferred_getter_return_property_access_tests"
 path = "tests/inferred_getter_return_property_access_tests.rs"
 [[test]]
+name = "object_literal_getter_self_reference_ts7023_tests"
+path = "tests/object_literal_getter_self_reference_ts7023_tests.rs"
+[[test]]
 name = "accessor_pair_override_ts2416_tests"
 path = "tests/accessor_pair_override_ts2416_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/accessor_element.rs
@@ -250,8 +250,8 @@ impl<'a> CheckerState<'a> {
             if elem_node.kind == syntax_kind_ext::GET_ACCESSOR {
                 if accessor.type_annotation.is_none() {
                     use crate::diagnostics::diagnostic_codes;
-                    let self_refs = self.collect_property_name_references(accessor.body, &name);
-                    if !self_refs.is_empty() {
+                    if self.object_literal_getter_has_self_reference(elem_idx, accessor.body, &name)
+                    {
                         self.error_at_node_msg(
                                     accessor.name,
                                     diagnostic_codes::IMPLICITLY_HAS_RETURN_TYPE_ANY_BECAUSE_IT_DOES_NOT_HAVE_A_RETURN_TYPE_ANNOTATION,

--- a/crates/tsz-checker/src/types/queries/class.rs
+++ b/crates/tsz-checker/src/types/queries/class.rs
@@ -667,19 +667,53 @@ impl<'a> CheckerState<'a> {
         refs
     }
 
-    /// Collect property-access occurrences whose property name matches `name`.
+    /// Whether an object-literal get-accessor body contains an *indirect
+    /// self-reference* through a property access, the signal for TS7023.
     ///
-    /// This is used for accessor recursion detection (TS7023). It intentionally
-    /// ignores bare identifiers so captured outer variables like `return x` in
-    /// `get x() { ... }` are not treated as self-recursive references.
-    pub(crate) fn collect_property_name_references(
+    /// A `<receiver>.<name>` access (where `<name>` is the accessor's own name)
+    /// is a self-reference only when `<receiver>` evaluates to the object
+    /// literal currently under construction: the synthetic `this`, the variable
+    /// the literal initializes, or a transparent wrapper / index / conditional
+    /// of those. `tsc` resolves the receiver's actual member symbol, so a
+    /// `.<name>` access on an *unrelated* receiver (`ctx.path`, `mgr.clients`)
+    /// reads a different member's symbol and is not circular — it must not
+    /// trigger TS7023. A bare property-*name* match is not a sufficient signal;
+    /// this mirrors the `this`-receiver gate used for object-literal
+    /// method-call cycles (`object_literal_circularity.rs`).
+    pub(crate) fn object_literal_getter_has_self_reference(
         &self,
-        init_idx: NodeIndex,
+        accessor_idx: NodeIndex,
+        body_idx: NodeIndex,
         name: &str,
-    ) -> Vec<NodeIndex> {
-        let mut refs = Vec::new();
-        self.collect_property_name_references_recursive(init_idx, name, &mut refs);
-        refs
+    ) -> bool {
+        let binding_sym = self.object_literal_initializer_binding_symbol(accessor_idx);
+        self.getter_self_reference_in_subtree(body_idx, name, binding_sym)
+    }
+
+    /// Symbol of the variable an object-literal accessor's enclosing object
+    /// literal initializes (`const o = { get x() {…} }` → the symbol of `o`),
+    /// or `None` when the literal is not a direct variable initializer. Used to
+    /// recognize `o.x` inside `o`'s own getter as a genuine self-reference,
+    /// exactly as `this.x` is.
+    fn object_literal_initializer_binding_symbol(
+        &self,
+        accessor_idx: NodeIndex,
+    ) -> Option<tsz_binder::SymbolId> {
+        let obj_idx = self.ctx.arena.get_extended(accessor_idx)?.parent;
+        let obj_node = self.ctx.arena.get(obj_idx)?;
+        if obj_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return None;
+        }
+        let var_idx = self.ctx.arena.get_extended(obj_idx)?.parent;
+        let var_node = self.ctx.arena.get(var_idx)?;
+        if var_node.kind != syntax_kind_ext::VARIABLE_DECLARATION {
+            return None;
+        }
+        let var_decl = self.ctx.arena.get_variable_declaration(var_node)?;
+        if var_decl.initializer != obj_idx {
+            return None;
+        }
+        self.ctx.binder.get_node_symbol(var_decl.name)
     }
 
     /// Recursive helper for `collect_self_references`.
@@ -735,18 +769,21 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// Recursive helper for `collect_property_name_references`.
-    fn collect_property_name_references_recursive(
+    /// Recursive helper for `object_literal_getter_has_self_reference`: does any
+    /// `<receiver>.<name>` access in `node_idx`'s subtree have a receiver that
+    /// denotes the object under construction? Recursion stops at nested
+    /// function/class scopes, which rebind both `this` and the enclosing name.
+    fn getter_self_reference_in_subtree(
         &self,
         node_idx: NodeIndex,
         name: &str,
-        refs: &mut Vec<NodeIndex>,
-    ) {
+        binding_sym: Option<tsz_binder::SymbolId>,
+    ) -> bool {
         if node_idx.is_none() {
-            return;
+            return false;
         }
         let Some(node) = self.ctx.arena.get(node_idx) else {
-            return;
+            return false;
         };
 
         if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
@@ -754,22 +791,83 @@ impl<'a> CheckerState<'a> {
             && let Some(name_node) = self.ctx.arena.get(access.name_or_argument)
             && let Some(ident) = self.ctx.arena.get_identifier(name_node)
             && ident.escaped_text == name
+            && self.receiver_denotes_object_under_construction(access.expression, binding_sym)
         {
-            refs.push(access.name_or_argument);
+            return true;
         }
 
         match node.kind {
             syntax_kind_ext::FUNCTION_EXPRESSION
             | syntax_kind_ext::ARROW_FUNCTION
             | syntax_kind_ext::CLASS_EXPRESSION => {
-                return;
+                return false;
             }
             _ => {}
         }
 
-        let children = self.ctx.arena.get_children(node_idx);
-        for child_idx in children {
-            self.collect_property_name_references_recursive(child_idx, name, refs);
+        self.ctx
+            .arena
+            .get_children(node_idx)
+            .into_iter()
+            .any(|child_idx| self.getter_self_reference_in_subtree(child_idx, name, binding_sym))
+    }
+
+    /// Whether a property-access receiver expression evaluates to the object
+    /// literal currently under construction. True for the synthetic `this`, an
+    /// identifier resolving to the literal's own initializer binding, and any
+    /// transparent wrapper (parens / `as` / `!` / `satisfies` / comma),
+    /// array-literal index (`[this][0]`), element access, or conditional branch
+    /// that flows one of those outward. False for an unrelated receiver
+    /// (`ctx`, `mgr`, `g.sub`) or a call result (`foo(this)`), which `tsc`
+    /// resolves to a different type whose `.<name>` member is not the accessor.
+    fn receiver_denotes_object_under_construction(
+        &self,
+        receiver_idx: NodeIndex,
+        binding_sym: Option<tsz_binder::SymbolId>,
+    ) -> bool {
+        let receiver_idx = self
+            .ctx
+            .arena
+            .skip_parenthesized_and_assertions_and_comma(receiver_idx);
+        let Some(node) = self.ctx.arena.get(receiver_idx) else {
+            return false;
+        };
+
+        if node.kind == SyntaxKind::ThisKeyword as u16 {
+            return true;
+        }
+        if node.kind == SyntaxKind::Identifier as u16 {
+            return binding_sym
+                .is_some_and(|sym| self.resolve_identifier_symbol(receiver_idx) == Some(sym));
+        }
+        match node.kind {
+            // `[this][0]`: the indexed result is one of the array's elements.
+            syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => {
+                self.ctx.arena.get_literal_expr(node).is_some_and(|arr| {
+                    arr.elements
+                        .nodes
+                        .iter()
+                        .copied()
+                        .any(|el| self.receiver_denotes_object_under_construction(el, binding_sym))
+                })
+            }
+            syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => {
+                self.ctx.arena.get_access_expr(node).is_some_and(|access| {
+                    self.receiver_denotes_object_under_construction(access.expression, binding_sym)
+                })
+            }
+            syntax_kind_ext::CONDITIONAL_EXPRESSION => self
+                .ctx
+                .arena
+                .get_conditional_expr(node)
+                .is_some_and(|cond| {
+                    self.receiver_denotes_object_under_construction(cond.when_true, binding_sym)
+                        || self.receiver_denotes_object_under_construction(
+                            cond.when_false,
+                            binding_sym,
+                        )
+                }),
+            _ => false,
         }
     }
 

--- a/crates/tsz-checker/tests/object_literal_getter_self_reference_ts7023_tests.rs
+++ b/crates/tsz-checker/tests/object_literal_getter_self_reference_ts7023_tests.rs
@@ -1,0 +1,245 @@
+//! Regression coverage for #14730: TS7023 ("'{0}' implicitly has return type
+//! 'any' …") must fire for an object-literal get-accessor only when its body
+//! reads its *own* property circularly — i.e. through `this`, the variable the
+//! literal initializes, or a transparent wrapper of those. A `.<name>` access
+//! on an *unrelated* receiver (`ctx.path`, `mgr.clients`) reads a different
+//! member's symbol and is not circular; `tsc` is clean there. The previous
+//! detection keyed on the property-access *name* alone, so any same-named
+//! access mis-fired.
+//!
+//! All expectations below were confirmed against `tsc --strict`.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+fn count(source: &str, code: u32) -> usize {
+    check_source_strict_codes(source)
+        .into_iter()
+        .filter(|c| *c == code)
+        .count()
+}
+
+// ---------------------------------------------------------------------------
+// False positives that the fix must clear (unrelated receiver).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unrelated_receiver_property_access_is_clean_zod_shape() {
+    // `ctx.path` reads `ParseContext.path`, not the getter `path`.
+    let source = r#"
+type ParsePath = { readonly component: string | number };
+declare function pathToArray(path: ParsePath): (string | number)[];
+declare const ctx: { path: ParsePath };
+type RefinementCtx = { path: (string | number)[] };
+const checkCtx: RefinementCtx = {
+  get path() {
+    return pathToArray(ctx.path);
+  },
+};
+void checkCtx;
+"#;
+    assert_eq!(
+        count(source, 7023),
+        0,
+        "a getter reading an unrelated receiver's same-named property is not circular"
+    );
+}
+
+#[test]
+fn unrelated_receiver_with_trailing_methods_has_no_accessor_cascade_msw_shape() {
+    // The msw witness. The getter must not emit TS7023, and — once it stops
+    // failing — must not add any cascading TS7006 on the trailing method params
+    // beyond what the identical literal *without* the accessor already produces.
+    //
+    // tsz has a separate, pre-existing contextual-typing gap that emits one
+    // TS7006 on `broadcast(data)` in return position even with no accessor
+    // present (tsc is clean there); that gap is a distinct bug, out of scope
+    // here. What this test pins is that the accessor itself contributes neither
+    // a TS7023 nor any extra TS7006 — i.e. the cascade attributed to the
+    // accessor failure is fully cleared.
+    let with_getter = r#"
+type WebSocketLink = {
+  readonly clients: ReadonlySet<number>;
+  broadcast(data: string): void;
+};
+declare const mgr: { clients: ReadonlySet<number> };
+function make(): WebSocketLink {
+  return {
+    get clients() { return mgr.clients; },
+    broadcast(data) { console.log(data); },
+  };
+}
+void make;
+"#;
+    let without_getter = r#"
+type WebSocketLink = {
+  readonly clients: ReadonlySet<number>;
+  broadcast(data: string): void;
+};
+declare const mgr: { clients: ReadonlySet<number> };
+function make(): WebSocketLink {
+  return {
+    clients: mgr.clients,
+    broadcast(data) { console.log(data); },
+  };
+}
+void make;
+"#;
+    assert_eq!(
+        count(with_getter, 7023),
+        0,
+        "unrelated `mgr.clients` is not circular"
+    );
+    assert_eq!(
+        count(with_getter, 7006),
+        count(without_getter, 7006),
+        "the accessor must not add any cascading TS7006 over the no-accessor baseline"
+    );
+}
+
+#[test]
+fn unrelated_receiver_renamed_binders_is_clean() {
+    // Anti-hardcoding: rename the getter and the accessed property to `q`.
+    let source = r#"
+declare const src: { q: number };
+const obj = {
+  get q() { return src.q; },
+};
+void obj;
+"#;
+    assert_eq!(
+        count(source, 7023),
+        0,
+        "detection must be structural, not name-keyed"
+    );
+}
+
+#[test]
+fn shadowed_local_receiver_is_clean() {
+    // The receiver `ctx` is a getter-local binding unrelated to the object.
+    let source = r#"
+const checkCtx = {
+  get path() {
+    let ctx = { path: 1 };
+    return ctx.path;
+  },
+};
+void checkCtx;
+"#;
+    assert_eq!(
+        count(source, 7023),
+        0,
+        "a local receiver is not the object under construction"
+    );
+}
+
+#[test]
+fn bare_identifier_return_is_clean() {
+    // Reading a captured outer variable (no property access) is never a
+    // self-reference.
+    let source = r#"
+declare const path: number;
+const obj = {
+  get path() { return path; },
+};
+void obj;
+"#;
+    assert_eq!(
+        count(source, 7023),
+        0,
+        "a bare identifier read is not a self-reference"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Genuine circularities that must still report (receiver IS the object).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn this_receiver_self_reference_still_reports() {
+    let source = r#"
+const o = {
+  get x() { return this.x; },
+};
+void o;
+"#;
+    assert_eq!(
+        count(source, 7023),
+        1,
+        "`this.x` inside `get x` is genuinely circular"
+    );
+}
+
+#[test]
+fn this_receiver_in_larger_expression_still_reports() {
+    let source = r#"
+const o = {
+  get x() { return this.x + 1; },
+};
+void o;
+"#;
+    assert_eq!(count(source, 7023), 1, "`this.x + 1` is still circular");
+}
+
+#[test]
+fn wrapped_this_receiver_self_reference_still_reports() {
+    let source = r#"
+const o = {
+  get x() { return [this][0].x; },
+};
+void o;
+"#;
+    assert_eq!(
+        count(source, 7023),
+        1,
+        "`[this][0].x` flows `this` to the receiver"
+    );
+}
+
+#[test]
+fn initializer_binding_receiver_self_reference_still_reports() {
+    // `o.x` inside `o`'s own getter is circular exactly as `this.x` is.
+    let source = r#"
+const o = {
+  get x() { return o.x; },
+};
+void o;
+"#;
+    assert_eq!(
+        count(source, 7023),
+        1,
+        "reading the literal's own binding is circular"
+    );
+}
+
+#[test]
+fn conditional_this_branch_self_reference_still_reports() {
+    let source = r#"
+declare function cond(): boolean;
+declare const ctx: { x: number };
+const o = {
+  get x() { return (cond() ? this : ctx).x; },
+};
+void o;
+"#;
+    assert_eq!(
+        count(source, 7023),
+        1,
+        "a `this` conditional branch keeps the receiver circular"
+    );
+}
+
+#[test]
+fn renamed_binders_this_self_reference_still_reports() {
+    // Anti-hardcoding negative twin: genuine circularity under a renamed getter.
+    let source = r#"
+const widget = {
+  get extent() { return this.extent; },
+};
+void widget;
+"#;
+    assert_eq!(
+        count(source, 7023),
+        1,
+        "genuine self-reference reports regardless of name"
+    );
+}


### PR DESCRIPTION
Fixes #14730.

## Summary
An object-literal `get X()` with an inferred return type emitted a spurious **TS7023** whenever its body contained *any* property access spelled `.X`, even on an **unrelated** receiver. The circular-return self-reference test keyed on the property-access **name** rather than the resolved receiver, so `get path() { return pathToArray(ctx.path); }` (zod) and `get clients() { return mgr.clients; }` (msw) were mis-classified as indirect self-references and forced to `any`. `tsc` resolves the receiver's actual member symbol, sees it is not the accessor, and is clean.

## Structural rule
When an object-literal get-accessor body contains `recv.X` where `X` is the accessor's own name, `tsc` treats it as an indirect self-reference (TS7023) **only if `recv` evaluates to the object under construction**. tsz now owns this in the checker (`crates/tsz-checker/src/types/queries/class.rs`) via a receiver gate: the receiver must be the synthetic `this`, an identifier resolving to the variable the literal initializes (`const o = { get x() { return o.x } }`), or a transparent wrapper / array index / element access / conditional that flows one of those outward (`[this][0].x`, `(c ? this : ctx).x`). A bare property-name match is no longer sufficient.

This mirrors the `this`-receiver gate already used for object-literal method-call cycles in `object_literal_circularity.rs` and the symbol-based wrapped-self-call check in `function_type_circular.rs`. It is a syntactic value-flow walk rather than re-resolving the member symbol during type construction (which would risk re-entrancy into the in-progress accessor).

## Owner layer
Checker (`object_literal/accessor_element.rs` call site -> `queries/class.rs` self-reference query). No solver, emitter, or printer changes. No new user-name/file-name literals; the binding case is decided by the binder symbol, not a name string.

## Adjacent-case matrix (all confirmed against `tsc --strict`)
- `get x() { return obj.x }`, `obj` unrelated -> CLEAN (was TS7023)
- `get x() { return this.x }` and `this.x + 1` -> TS7023
- `get x() { return [this][0].x }` (wrapped this) -> TS7023
- `get x() { return o.x }`, `o` the literal's own binding -> TS7023
- shadowed local receiver / bare identifier read -> CLEAN
- renamed binders (anti-hardcoding) on both the clean and circular twins
- method form `x() { return ctx.x }` and class getters already gate correctly (unchanged)

The msw witness's cascading TS7006 on trailing method params is fully cleared: the accessor adds no diagnostic over the identical accessor-free literal. A separate, pre-existing contextual-typing gap still emits one TS7006 on a return-position object-literal method param even with no accessor present (`tsc` is clean there); that is a distinct bug, out of scope here, and the new test pins the accessor's contribution to zero rather than the absolute count.

## Verification
- New regression suite: `cargo nextest run -p tsz-checker --test object_literal_getter_self_reference_ts7023_tests` (11 cases: zod + msw shapes, renamed binders, shadowed/bare receivers, genuine `this`/binding/wrapped/conditional self-refs). Run locally with `cargo test` (nextest unavailable in this env): 11 passed.
- Adjacent targets pass: `inferred_getter_return_property_access_tests`, `object_literal_method_this_member_order_tests`, `object_literal_getter_widening_tests`, `accessor_pair_override_ts2416_tests`, `object_literal_set_only_accessor_type_tests`, `accessor_assignment_read_surface_tests`, `object_literal_union_contextual_typing_tests`.
- `cargo clippy -p tsz-checker --tests` clean; `cargo fmt --check` clean.
- Three pre-existing `--lib` failures (`split_accessor_variance_tests::type_literal_split_accessor_narrower_setter_rejected`, `object_literal_this_member_order_tests::const_assertion_preserves_later_data_literal`, `zod_type_query_regression_tests::zod_cross_file_lib_partial_omit_preserves_imported_path_property`) were verified to fail identically on the un-patched baseline (env-sensitive, unrelated to this change). Broad suites owned by ready-review CI.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4ezkxEhJ5FD9QBMA5LNBu)_