### PR TITLE
data(ci): promote io-ts to the green project-compat ratchet baseline

### DIFF
--- a/scripts/ci/project-compat-baseline.json
+++ b/scripts/ci/project-compat-baseline.json
@@ -11,6 +11,7 @@
     "comlink-project": "green",
     "hotscript-project": "green",
     "infisical-project": "green",
+    "io-ts-project": "green",
     "nextjs-fresh-app": "green",
     "rxjs-project": "green",
     "ts-essentials-project": "green",


### PR DESCRIPTION
Promotes `io-ts-project` into the project-compile no-regression baseline (`scripts/ci/project-compat-baseline.json`). io-ts now compiles **green** — tsz emits exactly tsc's diagnostics (0 tsz-only false positives) on current main. The only diagnostic either compiler reports is the shared `TS5101` `baseUrl` deprecation line on the guard tsconfig, which tsc emits identically. Adding it to the baseline protects the row from green→non-green regressions once the canary becomes blocking, growing the protected set from 12 to 13 rows. No compiler change.

Goal: green

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Summary
Promote io-ts-project to the compat green baseline — now byte-parity-clean vs tsc (only the shared TS5101 baseUrl line). No compiler change.

## Verification
- `scripts/ci/project-compile-guard.sh` with `TSZ_PROJECT_COMPILE_FILTER=io-ts-project` (dist-fast binary `tsz.42fbbe7ada626deb` + tsc oracle): **"io-ts-project matches tsc (tsc also reports errors; 0 tsz-only diagnostics)."** The tsz and tsc logs are byte-identical — both report exactly one line:
  ```
  tsconfig.tsz-guard.json(14,5): error TS5101: Option 'baseUrl' is deprecated ...
  ```
  Compatibility summary records `state: green`, `oracle_classification: tsc-fails-only`, `diagnostic_status: none` (no tsz-only diagnostics).
- Baseline validity: `node -e "require('./scripts/ci/project-compat-baseline.json')"` → valid JSON, 13 rows, alphabetically sorted, `io-ts-project: green`.
- `node scripts/ci/test-project-compat-ratchet.mjs` → all 9 ratchet tests pass.
- Live ratchet against the real guard summary with the updated baseline: `node scripts/ci/project-compat-ratchet.mjs --baseline scripts/ci/project-compat-baseline.json <summary>` → **13 baseline-green rows, exit 0, no regression** (io-ts measured green, not inconclusive).
- `node scripts/bench/project-row-summary.mjs` (project-row-drift gate) → "All 65 rows consistent across surfaces." io-ts already defined in every surface; baseline-only edit introduces no drift.
