### PR TITLE
fix(checker): see through NoInfer wrapper in comparison/switch overlap (TS2367/TS2678)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics/type_comparability.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics/type_comparability.rs
@@ -341,6 +341,31 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
+        // `NoInfer<T>` is a transparent wrapper: it preserves the underlying
+        // value set, so it must be peeled before classifying type-parameter-ness
+        // and resolving apparent types. Otherwise a wrapped constrained
+        // parameter (e.g. `NoInfer<T extends 'a' | 'b'>`) is not recognized as
+        // type-parameter-like, its constraint is never consulted, and
+        // comparisons against a constraint member are wrongly rejected (false
+        // TS2678 on `case 'a'`, TS2365, and the TS2367 type-parameter
+        // delegation). tsc unwraps `NoInfer` before its `areTypesComparable`
+        // relation.
+        let mut source = source;
+        let mut target = target;
+        while let Some(inner) =
+            crate::query_boundaries::common::no_infer_inner_type(self.ctx.types, source)
+        {
+            source = inner;
+        }
+        while let Some(inner) =
+            crate::query_boundaries::common::no_infer_inner_type(self.ctx.types, target)
+        {
+            target = inner;
+        }
+        if source == target {
+            return true;
+        }
+
         // Resolve type parameters to their apparent types for comparison.
         // In tsc, `isTypeComparableTo` uses `getReducedApparentType` for TypeParam sources,
         // and has a carve-out when BOTH source and target are type parameters (only comparable

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -412,6 +412,9 @@ mod no_filename_based_behavior_tests;
 #[path = "tests/no_index_element_implicit_any_tests.rs"]
 mod no_index_element_implicit_any_tests;
 #[cfg(test)]
+#[path = "../tests/noinfer_comparability_overlap_tests.rs"]
+mod noinfer_comparability_overlap_tests;
+#[cfg(test)]
 #[path = "tests/noUIA_any_index_emits_ts2322_tests.rs"]
 mod nuia_any_index_emits_ts2322_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/types/utilities/enum_utils.rs
+++ b/crates/tsz-checker/src/types/utilities/enum_utils.rs
@@ -1025,6 +1025,26 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
+        // `NoInfer<T>` is a transparent wrapper for overlap: it preserves the
+        // underlying set of values, so the operands overlap exactly when their
+        // unwrapped forms do. Peel it first so a wrapped *constrained type
+        // parameter* still reaches the type-parameter-like delegation below.
+        // Without this, `NoInfer<T extends string | true>` compared to `true` is
+        // not recognized as type-parameter-like, skips the comparability
+        // delegation, and falls through to the concrete-shape checks that
+        // wrongly report no overlap (false TS2367) — while tsc accepts the
+        // comparison via `T`'s constraint.
+        let unwrapped_left =
+            crate::query_boundaries::common::no_infer_inner_type(self.ctx.types, left);
+        let unwrapped_right =
+            crate::query_boundaries::common::no_infer_inner_type(self.ctx.types, right);
+        if unwrapped_left.is_some() || unwrapped_right.is_some() {
+            return self.types_have_no_overlap(
+                unwrapped_left.unwrap_or(left),
+                unwrapped_right.unwrap_or(right),
+            );
+        }
+
         // Weak types (all-optional properties) overlap with anything.
         // tsc never emits TS2367 when comparing against weak types.
         if self.is_weak_type_for_overlap(left) || self.is_weak_type_for_overlap(right) {

--- a/crates/tsz-checker/tests/noinfer_comparability_overlap_tests.rs
+++ b/crates/tsz-checker/tests/noinfer_comparability_overlap_tests.rs
@@ -1,0 +1,175 @@
+//! Regression tests for comparability/overlap through transparent wrappers.
+//!
+//! `NoInfer<T>` is a transparent wrapper: it preserves the underlying set of
+//! values. A comparison or `switch`/`case` whose operand is `NoInfer<T>` for a
+//! *constrained* type parameter `T` must consult `T`'s constraint exactly as a
+//! bare `T` would.
+//! Before the wrappers were peeled, `NoInfer<T>` was not recognized as
+//! type-parameter-like, its constraint was never reached, and the comparison
+//! was wrongly rejected with a false TS2367 (`===`/`!==`) or TS2678
+//! (`switch`/`case`) — while tsc 6.0.3 accepts it.
+//!
+//! The unwrap must NOT over-accept: a literal *outside* the constraint is still
+//! a true-positive TS2367/TS2678 (the wrapped parameter still recurses into the
+//! constraint, which reports no overlap). Binder names are varied across the
+//! fixtures so the behavior cannot key off a specific type-parameter identifier.
+//!
+//! These fixtures reference the `NoInfer<T>` global utility (from the default
+//! lib), so they run through the lib-loading harness.
+use crate::test_utils::{
+    check_source_with_libs_code_messages, load_default_lib_files, strict_checker_options,
+};
+
+fn check_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs_code_messages(source, "test.ts", strict_checker_options(), &libs)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+/// `input === true` where `input: NoInfer<T>` and `T extends string | true` is
+/// clean in tsc: the constraint includes `true`. The wrapper must not hide it.
+#[test]
+fn noinfer_constrained_param_equality_against_constraint_member_no_ts2367() {
+    let source = r#"
+function search<TInput extends string | true>(input: NoInfer<TInput>) {
+  if (input === true) {
+    return 1;
+  }
+  return 0;
+}
+"#;
+    let codes = check_codes(source);
+    assert!(
+        !codes.contains(&2367),
+        "`true` is in the constraint `string | true`; expected no TS2367, got: {codes:?}"
+    );
+}
+
+/// `!==` exercises the same overlap predicate as `===`; also clean.
+#[test]
+fn noinfer_constrained_param_inequality_against_constraint_member_no_ts2367() {
+    let source = r#"
+function pick<K extends string | true>(value: NoInfer<K>) {
+  if (value !== true) {
+    return 1;
+  }
+  return 0;
+}
+"#;
+    let codes = check_codes(source);
+    assert!(
+        !codes.contains(&2367),
+        "`!==` over a constraint member must not emit TS2367, got: {codes:?}"
+    );
+}
+
+/// A string-literal constraint vs a matching literal overlaps — no TS2367.
+#[test]
+fn noinfer_string_literal_union_constraint_matching_literal_no_ts2367() {
+    let source = r#"
+function route<S extends "x" | "y">(seg: NoInfer<S>) {
+  if (seg === "x") {
+    return 1;
+  }
+  return 0;
+}
+"#;
+    let codes = check_codes(source);
+    assert!(
+        !codes.contains(&2367),
+        "`\"x\"` is in the constraint; expected no TS2367, got: {codes:?}"
+    );
+}
+
+/// A literal NOT in the constraint is a true-positive TS2367 — the unwrap must
+/// not suppress it.
+#[test]
+fn noinfer_constrained_param_equality_against_non_member_still_ts2367() {
+    let source = r#"
+function guard<TName extends "a" | "b">(input: NoInfer<TName>) {
+  if (input === "c") {
+    return 1;
+  }
+  return 0;
+}
+"#;
+    let codes = check_codes(source);
+    assert!(
+        codes.contains(&2367),
+        "`\"c\"` is not in the constraint `\"a\" | \"b\"`; expected TS2367, got: {codes:?}"
+    );
+}
+
+/// `switch` on a `NoInfer<T>` scrutinee: a `case` inside the constraint is
+/// comparable (no TS2678) while a `case` outside it stays a true-positive
+/// TS2678 — matching tsc 6.0.3.
+#[test]
+fn noinfer_switch_case_in_constraint_no_ts2678_out_of_constraint_ts2678() {
+    let source = r#"
+function dispatch<TKey extends "a" | "b">(input: NoInfer<TKey>) {
+  switch (input) {
+    case "a":
+      return 1;
+    case "z":
+      return 2;
+  }
+  return 0;
+}
+"#;
+    let codes = check_codes(source);
+    let ts2678 = codes.iter().filter(|&&c| c == 2678).count();
+    assert_eq!(
+        ts2678, 1,
+        "exactly one TS2678 expected (`\"z\"` out of constraint, `\"a\"` in); got: {codes:?}"
+    );
+}
+
+/// `NoInfer<>` over a concrete literal union (no type parameter) was already
+/// correct; keep it as a control: in-union literal is clean, out-of-union is
+/// still TS2367.
+#[test]
+fn noinfer_over_concrete_union_preserves_overlap_decisions() {
+    let ok = check_codes(
+        r#"
+function f(input: NoInfer<"a" | "b">) {
+  if (input === "a") {}
+}
+"#,
+    );
+    assert!(
+        !ok.contains(&2367),
+        "`\"a\"` overlaps `\"a\" | \"b\"`; expected no TS2367, got: {ok:?}"
+    );
+    let bad = check_codes(
+        r#"
+function f(input: NoInfer<"a" | "b">) {
+  if (input === "c") {}
+}
+"#,
+    );
+    assert!(
+        bad.contains(&2367),
+        "`\"c\"` does not overlap `\"a\" | \"b\"`; expected TS2367, got: {bad:?}"
+    );
+}
+
+/// Control: the same comparison without the `NoInfer` wrapper has always been
+/// accepted; the wrapped form must now match it.
+#[test]
+fn bare_constrained_param_equality_against_constraint_member_no_ts2367() {
+    let source = r#"
+function h<T extends string | true>(input: T) {
+  if (input === true) {
+    return 1;
+  }
+  return 0;
+}
+"#;
+    let codes = check_codes(source);
+    assert!(
+        !codes.contains(&2367),
+        "bare `T` against a constraint member must not emit TS2367, got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/overlap.rs
+++ b/crates/tsz-solver/src/relations/subtype/overlap.rs
@@ -64,6 +64,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let a_resolved = self.strip_overlap_transparent_wrappers(a);
         let b_resolved = self.strip_overlap_transparent_wrappers(b);
 
+        // `NoInfer<T>` is a transparent wrapper for overlap: it preserves the
+        // underlying set of values, so `NoInfer<T>` overlaps `x` exactly when
+        // `T` does. Peel it and recurse so a wrapped *constrained type
+        // parameter* still consults its constraint in the arm below. Without
+        // this, `NoInfer<T extends string | true>` compared to `true` never
+        // reaches the TypeParameter arm (the wrapper is neither a TypeParameter
+        // nor an intrinsic), falls through to the subtype/intrinsic checks with
+        // no constraint visible, and is wrongly rejected with TS2367 — while tsc
+        // accepts it because the constraint overlaps the literal. `NoInfer` is
+        // already treated as kind-transparent during traversal (see `visitor.rs`).
+        if let Some(a_inner) = crate::visitor::no_infer_inner_type(self.interner, a_resolved) {
+            return self.are_types_overlapping(a_inner, b_resolved);
+        }
+        if let Some(b_inner) = crate::visitor::no_infer_inner_type(self.interner, b_resolved) {
+            return self.are_types_overlapping(a_resolved, b_inner);
+        }
+
         // Special handling for TypeParameter and Infer
         if let Some(
             crate::types::TypeData::TypeParameter(info) | crate::types::TypeData::Infer(info),


### PR DESCRIPTION
Fixes #14738.

## Summary
A `===`/`!==` comparison or `switch`/`case` whose operand is `NoInfer<T>` for a **constrained** type parameter `T` wrongly reported no overlap, emitting a false **TS2367** (comparison) / **TS2678** (case clause). The `NoInfer<T>` wrapper is neither a type parameter nor an intrinsic, so the overlap/comparability routines never recursed into `T`'s constraint — while bare `T` worked. tsc accepts the comparison when the constraint overlaps the literal.

Witnessed in the **tanstack-router** canary row (`packages/router-core/src/searchMiddleware.ts`), where the false TS2367 cascaded into TS2339/TS7006 because the `if` branch collapsed to `never`.

## Structural rule
When an overlap/comparability operand is `NoInfer<T>`, tsc unwraps the transparent wrapper and reasons about `T` (and thus its constraint); tsz now does the same. `NoInfer` is already kind-transparent during traversal (`visitor.rs`) — this completes that treatment for the overlap relation, exactly as the existing `TypeParameter`/`Infer` arms already recurse into constraints.

## Owner layers
`NoInfer` is peeled at the three overlap/comparability boundaries before the type-parameter constraint recursion:
- solver `are_types_overlapping` (`crates/tsz-solver/src/relations/subtype/overlap.rs`) — canonical set-theoretic overlap; also covers `NoInfer` over template-literal operands routed in via `are_types_overlapping_with_env`.
- checker `types_have_no_overlap` (`crates/tsz-checker/src/types/utilities/enum_utils.rs`) — the TS2367 authority.
- checker `is_type_comparable_to` (`crates/tsz-checker/src/assignability/.../type_comparability.rs`) — TS2678 case clauses, TS2365, and the TS2367 type-parameter delegation.

Reuses the existing `no_infer_inner_type` extractor; no new abstraction. The speculative `readonly`-modifier unwrap from the issue's "path to fixing" was deliberately dropped: `TypeData::ReadonlyType` is the readonly array/tuple modifier (not a constrained-parameter wrapper), it is not the bug, and unwrapping it is out of scope.

## Adjacent-case matrix (all verified against pinned tsc 6.0.3)
| case | tsc 6.0.3 | tsz (after) |
|---|---|---|
| `NoInfer<T extends string \| true>`, `=== true` | clean | clean |
| same, `!== true` | clean | clean |
| `NoInfer<S extends "x" \| "y">`, `=== "x"` | clean | clean |
| `NoInfer<T extends "a" \| "b">`, `=== "c"` (non-member) | TS2367 | TS2367 |
| `switch (NoInfer<T extends "a" \| "b">)` `case "a"` / `case "z"` | one TS2678 | one TS2678 |
| `NoInfer<"a" \| "b">` (concrete union) `=== "a"` / `=== "c"` | clean / TS2367 | clean / TS2367 |
| `NoInfer<` `` `a${string}` `` `>` `=== "abc"` / `=== "zzz"` | clean / TS2367 | clean / TS2367 |
| bare `T extends string \| true`, `=== true` (control) | clean | clean |

True positives are preserved: a literal outside the constraint still recurses into the constraint and reports no overlap.

## Verification
- Targeted unit tests (new `crates/tsz-checker/tests/noinfer_comparability_overlap_tests.rs`, 7 cases; binder names varied): `cargo test -p tsz-checker --lib -- noinfer_comparability` → 7 passed.
- Regression suites: `cargo test -p tsz-solver --lib -- overlap comparab relation` → 1599 passed, 0 failed; `cargo test -p tsz-checker --lib -- comparab` → all passed. The 3 `ts2540`/`ts2542` readonly failures in the broad checker filter are **pre-existing on the clean baseline** (confirmed by stashing this change) and unrelated.
- End-to-end repro built with `tsz` and diffed against `tsc 6.0.3`: codes and positions match exactly.
- `cargo fmt --check` clean; `cargo clippy -p tsz-solver -p tsz-checker --lib` clean.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fu6qd41kPAqTQwjiXCxKNJ)_