### PR TITLE
fix(checker): optional class property initialized to undefined at declaration site (prop?: T = undefined) (#14737)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -371,12 +371,13 @@ impl<'a> CheckerState<'a> {
             let init_is_nullish = init_type == TypeId::NULL || init_type == TypeId::UNDEFINED;
             let nested_err =
                 declared_type != TypeId::ERROR && self.type_contains_error(declared_type);
+            let relation_target = self.class_property_init_relation_target(prop, declared_type);
             if declared_type != TypeId::ANY
                 && declared_type != TypeId::ERROR
                 && (!nested_err || init_is_nullish)
                 && self.check_assignable_or_report_at(
                     init_type,
-                    declared_type,
+                    relation_target,
                     prop.initializer,
                     prop.name,
                 )

--- a/crates/tsz-checker/src/tests/optional_private_field_undefined_tests.rs
+++ b/crates/tsz-checker/src/tests/optional_private_field_undefined_tests.rs
@@ -326,3 +326,81 @@ class A {
         "expected undefined-write rejection under exactOptionalPropertyTypes. Got: {c:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #14737: optional class field initialized to `undefined` at the DECLARATION
+// site (`prop?: T = undefined`). This is a distinct path from #10749's
+// write/assignment path: an optional property's declared type includes
+// `| undefined` under strictNullChecks (without exactOptionalPropertyTypes),
+// so the declaration-site initializer is assignable. tsc 5.9.3 accepts it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_false_2322_optional_field_initialized_to_undefined_at_declaration() {
+    // Public + private, primitive + union-typed; renamed binders prove the rule
+    // is structural, not name-based.
+    let c = check_source_codes(
+        "
+interface VTO { types: string[] }
+class Router {
+    shouldViewTransition?: boolean | VTO = undefined;
+    plain?: string = undefined;
+    #secret?: number = undefined;
+}
+",
+    );
+    assert!(
+        !c.contains(&2322),
+        "unexpected TS2322 on optional field initialized to undefined. Got: {c:?}"
+    );
+}
+
+#[test]
+fn optional_field_undefined_init_still_rejects_wrong_value_type() {
+    // The widening adds only `undefined`; a value outside `T | undefined` must
+    // still be rejected.
+    let c = check_source_codes(
+        "
+class A {
+    p?: string = 42;
+}
+",
+    );
+    assert!(
+        c.contains(&2322),
+        "expected TS2322 for a wrong-typed optional field initializer. Got: {c:?}"
+    );
+}
+
+#[test]
+fn non_optional_field_undefined_init_at_declaration_still_rejected() {
+    // No `?` → the declared type does not include `undefined`.
+    let c = check_source_codes(
+        "
+class A {
+    req: number = undefined;
+}
+",
+    );
+    assert!(
+        c.contains(&2322),
+        "expected TS2322 for a non-optional field initialized to undefined. Got: {c:?}"
+    );
+}
+
+#[test]
+fn exact_optional_property_types_rejects_undefined_init_at_declaration() {
+    // With the flag on, the optional property type is exactly `T`, so the
+    // declaration-site `= undefined` remains an error (mirrors the write path).
+    let c = codes_exact_optional(
+        "
+class A {
+    p?: string = undefined;
+}
+",
+    );
+    assert!(
+        c.contains(&2322),
+        "expected TS2322 on optional field = undefined under exactOptionalPropertyTypes. Got: {c:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
+++ b/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
@@ -280,6 +280,33 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// The assignability target for a class property's declaration-site
+    /// initializer. An optional property (`prop?: T`) has declared type
+    /// `T | undefined` under `strictNullChecks` without
+    /// `exactOptionalPropertyTypes`, so its initializer (e.g. `= undefined`) is
+    /// checked against `T | undefined`; otherwise the bare declared type is used.
+    /// Scoped to the initializer relation — it does not change the member's
+    /// stored type, the contextual type, or the excess-property shape. (#14737)
+    pub(crate) fn class_property_init_relation_target(
+        &mut self,
+        prop: &PropertyDeclData,
+        declared_type: TypeId,
+    ) -> TypeId {
+        if prop.question_token
+            && declared_type != TypeId::ANY
+            && declared_type != TypeId::ERROR
+            && self.ctx.strict_null_checks()
+            && !self.ctx.exact_optional_property_types()
+        {
+            self.ctx
+                .types
+                .factory()
+                .union2(declared_type, TypeId::UNDEFINED)
+        } else {
+            declared_type
+        }
+    }
+
     /// Lift a `symbol`-typed `static readonly p: unique symbol` annotation to
     /// `unique_symbol(SymbolRef(prop_sym))` so downstream `typeof Class.p`
     /// queries see a distinct unique-symbol identity, mirroring the wrapping


### PR DESCRIPTION
Fixes #14737.

## Problem
A class field declared optional and initialized to `undefined` at the declaration site — `prop?: T = undefined` — was wrongly rejected with `TS2322: Type 'undefined' is not assignable to type 'T'`. `tsc` 5.9.3 accepts it: an optional property's declared type implicitly includes `undefined` under `strictNullChecks` (without `exactOptionalPropertyTypes`), so the initializer is trivially assignable. Hit in **tanstack-router** `router.ts:973` (`shouldViewTransition?: boolean | ViewTransitionOptions = undefined`).

```ts
class Router {
  shouldViewTransition?: boolean | ViewTransitionOptions = undefined  // tsz: TS2322 (wrong); tsc: clean
}
```

This is a distinct site from the closed #10749 (which fixed the *write/assignment* path `this.#x = undefined`); the declaration-site initializer path was uncovered.

## Structural rule
`When a class property is optional (prop?: T) under strictNullChecks without exactOptionalPropertyTypes, its declared type includes | undefined, so its declaration-site initializer must be checked against T | undefined.` The declared-type helper (`class_property_relation_declared_type`) returns the bare annotation `T`; the initializer assignability check used it directly and never applied `?`-optionality.

## Fix
At the declaration-site initializer assignability check (checker `state_checking_members/ambient_signature_checks.rs`), widen **only the relation target** to `T | undefined` when `prop.question_token && strictNullChecks && !exactOptionalPropertyTypes` (and the type is not `any`/`error`). The contextual type, the excess-property shape, and the broadly-used `class_property_relation_declared_type` are left untouched — keeping the change scoped to the initializer relation. No widening of a member's stored type, no name/file fast paths, no printer-string matching.

## Adjacent matrix / fallback (precise, not a blanket pass)
- Accept: `x?: T = undefined` (public and `#private`), primitive and union-typed; valid `x?: number = 5`.
- Still reject (`TS2322`): `x?: string = 42` (value outside `T | undefined`); `x: T = undefined` (non-optional); `x?: T = undefined` under `exactOptionalPropertyTypes` (optional type is exactly `T`).

## Verification
- Repro + adjacent + 3 negative controls on the rebuilt dev-fast binary (`--strict --target es2022`): optional+undefined clean, all negative controls still `TS2322`.
- Unit tests added to `optional_private_field_undefined_tests.rs` (declaration-site section, renamed binders + EOPT case).
- Conformance (targeted): `exactOptionalPropertyTypes` (2/2), `optionalProperties`, `strictNullChecks`; ready-review CI owns the full suite.

Goal: green

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
