### PR TITLE
fix(checker): optional class property initialized to undefined at declaration site (TS2322)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1288,6 +1288,9 @@ mod optional_key_extraction_tests;
 #[path = "tests/optional_private_field_undefined_tests.rs"]
 mod optional_private_field_undefined_tests;
 #[cfg(test)]
+#[path = "tests/optional_property_initializer_undefined_tests.rs"]
+mod optional_property_initializer_undefined_tests;
+#[cfg(test)]
 #[path = "tests/optional_property_union_source_elaboration_tests.rs"]
 mod optional_property_union_source_elaboration_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -339,8 +339,10 @@ impl<'a> CheckerState<'a> {
         }
 
         // Use the relation-shape declared type here so a fresh-symbol
-        // initializer can flow into a `static readonly: unique symbol`.
-        let effective_declared_type = self.class_property_relation_declared_type(member_idx, prop);
+        // initializer can flow into a `static readonly: unique symbol`. For an
+        // optional property the target includes `undefined` (unless
+        // `exactOptionalPropertyTypes`), so `prop?: T = undefined` is accepted.
+        let effective_declared_type = self.class_property_initializer_target_type(member_idx, prop);
         let contextual_member_type =
             self.contextual_class_member_type_from_request(request, prop.name);
         let mut inferred_initializer_type = None;

--- a/crates/tsz-checker/src/tests/optional_property_initializer_undefined_tests.rs
+++ b/crates/tsz-checker/src/tests/optional_property_initializer_undefined_tests.rs
@@ -1,0 +1,194 @@
+//! Regression tests: a class field declared optional and initialized at the
+//! declaration site (`prop?: T = undefined`) must be accepted under
+//! `strictNullChecks` without `exactOptionalPropertyTypes`.
+//!
+//! Root cause (issue #14737): the declaration-site initializer assignability
+//! check compared the initializer against the bare annotation type `T`, never
+//! augmenting it with `| undefined` for an optional property. So
+//! `prop?: T = undefined` fired a false TS2322 even though tsc accepts it (an
+//! optional property's value type implicitly includes `undefined`). This is the
+//! declaration-site counterpart to #10749, which fixed the write/assignment
+//! path (`this.#x = undefined`) but not the initializer path.
+//!
+//! Structural rule: when a class property is declared optional under
+//! `strictNullChecks`, the value type its initializer (and assignment) is
+//! checked against is `T | undefined` — unless `exactOptionalPropertyTypes` is
+//! on, in which case it stays `T` and `= undefined` is correctly rejected.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::{check_source_codes, check_with_options};
+
+fn codes_exact_optional(src: &str) -> Vec<u32> {
+    let diags: Vec<Diagnostic> = check_with_options(
+        src,
+        CheckerOptions {
+            exact_optional_property_types: true,
+            ..CheckerOptions::default()
+        },
+    );
+    diags.into_iter().map(|d| d.code).collect()
+}
+
+// ---------------------------------------------------------------------------
+// #14737: false TS2322 on `prop?: T = undefined` at the declaration site
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_false_2322_optional_string_initialized_to_undefined() {
+    let c = check_source_codes(
+        "
+class Router {
+    plain?: string = undefined;
+}
+",
+    );
+    assert!(!c.contains(&2322), "unexpected TS2322. Got: {c:?}");
+}
+
+#[test]
+fn no_false_2322_optional_boolean_initialized_to_undefined() {
+    let c = check_source_codes(
+        "
+class Router {
+    isViewTransitionTypesSupported?: boolean = undefined;
+}
+",
+    );
+    assert!(!c.contains(&2322), "unexpected TS2322. Got: {c:?}");
+}
+
+#[test]
+fn no_false_2322_optional_union_initialized_to_undefined() {
+    // Mirrors tanstack-router router-core/src/router.ts: an optional field with
+    // a union annotation initialized to `undefined`.
+    let c = check_source_codes(
+        "
+interface ViewTransitionOptions { types: string[] }
+class Router {
+    shouldViewTransition?: boolean | ViewTransitionOptions = undefined;
+}
+",
+    );
+    assert!(!c.contains(&2322), "unexpected TS2322. Got: {c:?}");
+}
+
+#[test]
+fn no_false_2322_optional_object_initialized_to_undefined() {
+    let c = check_source_codes(
+        "
+interface Box { value: number; }
+class Holder {
+    b?: Box = undefined;
+}
+",
+    );
+    assert!(!c.contains(&2322), "unexpected TS2322. Got: {c:?}");
+}
+
+#[test]
+fn optional_initializer_undefined_matches_renamed_field() {
+    // Different field spelling proves the rule is structural, not name-based.
+    let a = check_source_codes("class A { foo?: number = undefined; }");
+    let b = check_source_codes("class B { somethingEntirelyDifferent?: number = undefined; }");
+    assert!(!a.contains(&2322), "unexpected TS2322 for `foo`: {a:?}");
+    assert!(
+        !b.contains(&2322),
+        "unexpected TS2322 for renamed field: {b:?}"
+    );
+}
+
+#[test]
+fn optional_initializer_to_undefined_valued_expression_is_accepted() {
+    // Broader than the `= undefined` literal: any `T | undefined`-valued
+    // initializer flows into an optional property without TS2322.
+    let c = check_source_codes(
+        "
+declare const maybe: number | undefined;
+class A {
+    n?: number = maybe;
+}
+",
+    );
+    assert!(!c.contains(&2322), "unexpected TS2322. Got: {c:?}");
+}
+
+#[test]
+fn optional_initializer_matches_private_field_baseline() {
+    // The write path (`this.#p = undefined`) already accepted `undefined`
+    // (#10749); the declaration-site initializer must behave identically.
+    let init = check_source_codes("class A { p?: string = undefined; }");
+    let write = check_source_codes(
+        "
+class A {
+    #p?: string;
+    m(): void { this.#p = undefined; }
+}
+",
+    );
+    assert!(
+        !write.contains(&2322),
+        "private write baseline regressed: {write:?}"
+    );
+    assert!(
+        !init.contains(&2322),
+        "initializer differs from write path: {init:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative / fallback cases that must keep erroring
+// ---------------------------------------------------------------------------
+
+#[test]
+fn non_optional_field_initialized_to_undefined_still_errors() {
+    let c = check_source_codes("class A { c: number = undefined; }");
+    assert!(
+        c.contains(&2322),
+        "expected TS2322 on non-optional `= undefined`. Got: {c:?}"
+    );
+}
+
+#[test]
+fn optional_field_initialized_to_wrong_value_still_errors() {
+    // Optionality adds `undefined`, not `any`: a genuinely wrong initializer
+    // value must still be rejected.
+    let c = check_source_codes("class A { d?: number = 'x'; }");
+    assert!(
+        c.contains(&2322),
+        "expected TS2322 on optional wrong-typed initializer. Got: {c:?}"
+    );
+}
+
+#[test]
+fn optional_field_initialized_to_matching_value_is_accepted() {
+    let c = check_source_codes("class A { b?: number = 5; }");
+    assert!(
+        !c.contains(&2322),
+        "unexpected TS2322 on `b?: number = 5`. Got: {c:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// exactOptionalPropertyTypes keeps the bare target and still rejects undefined
+// ---------------------------------------------------------------------------
+
+#[test]
+fn exact_optional_property_types_rejects_undefined_initializer() {
+    let c = codes_exact_optional("class A { p?: number = undefined; }");
+    assert!(
+        c.contains(&2322),
+        "expected TS2322 on `= undefined` under exactOptionalPropertyTypes. Got: {c:?}"
+    );
+}
+
+#[test]
+fn exact_optional_property_types_accepts_explicit_undefined_annotation() {
+    // An explicit `| undefined` in the annotation accepts `= undefined` even
+    // under exactOptionalPropertyTypes (the value type already includes it).
+    let c = codes_exact_optional("class A { q?: number | undefined = undefined; }");
+    assert!(
+        !c.contains(&2322),
+        "unexpected TS2322 on explicit `| undefined` annotation. Got: {c:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
+++ b/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
@@ -280,6 +280,41 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// The value type a class property's declaration-site initializer (and, more
+    /// generally, an assignment) is checked against.
+    ///
+    /// For an optional property (`prop?: T`) under `strictNullChecks` without
+    /// `exactOptionalPropertyTypes`, the declared value type implicitly includes
+    /// `undefined` — so `prop?: T = undefined` (and any `T | undefined`-valued
+    /// initializer) is accepted, mirroring tsc's `addOptionality`. The
+    /// optionality flag is otherwise carried separately on `PropertyInfo`, so the
+    /// bare [`class_property_relation_declared_type`] never augments the type; this
+    /// helper applies the augmentation only where the write/initializer target is
+    /// needed.
+    ///
+    /// Under `exactOptionalPropertyTypes` the bare type is kept, so initializing
+    /// an optional property to `undefined` still reports `TS2322` (only an
+    /// explicit `| undefined` in the annotation accepts it).
+    pub(crate) fn class_property_initializer_target_type(
+        &mut self,
+        member_idx: NodeIndex,
+        prop: &PropertyDeclData,
+    ) -> Option<TypeId> {
+        let declared = self.class_property_relation_declared_type(member_idx, prop)?;
+        if prop.question_token
+            && self.ctx.strict_null_checks()
+            && !self.ctx.exact_optional_property_types()
+        {
+            // `union_with_undefined` is idempotent, so an annotation that already
+            // includes `undefined` (e.g. `prop?: T | undefined`) is unchanged.
+            return Some(crate::query_boundaries::common::union_with_undefined(
+                self.ctx.types,
+                declared,
+            ));
+        }
+        Some(declared)
+    }
+
     /// Lift a `symbol`-typed `static readonly p: unique symbol` annotation to
     /// `unique_symbol(SymbolRef(prop_sym))` so downstream `typeof Class.p`
     /// queries see a distinct unique-symbol identity, mirroring the wrapping


### PR DESCRIPTION
## Summary
A class field declared optional and initialized at the declaration site — `prop?: T = undefined` — was wrongly rejected by tsz with **TS2322** (`Type 'undefined' is not assignable to type 'T'`) under `strictNullChecks`. tsc 5.9.3 accepts it: an optional property's declared value type implicitly includes `undefined` (no `exactOptionalPropertyTypes`), so `= undefined` is trivially assignable. Witnessed in **tanstack-router** `packages/router-core/src/router.ts:973` (`shouldViewTransition?: boolean | ViewTransitionOptions = undefined`).

Fixes #14737.

This is the declaration-site counterpart to the closed #10749, which fixed the *write/assignment* path (`this.#x = undefined` in a method) but not the *declaration-site initializer* path.

## Structural rule
When a class property is declared optional (`prop?: T`) under `strictNullChecks`, tsc checks its declaration-site initializer (and assignments) against `T | undefined` — tsc's `addOptionality`; tsz now does the same through the checker. Under `exactOptionalPropertyTypes` the target stays `T`, so `= undefined` still correctly reports TS2322 (only an explicit `| undefined` in the annotation accepts it).

## Root cause and owner layer
The declaration-site initializer assignability check (`crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs`) took the assignment target from `class_property_relation_declared_type`, which returns the **bare** annotation type `T` and never augments it with `| undefined` for an optional property. `PropertyDeclData.question_token` was unused on this path, so `undefined` was checked against `T` and failed.

The optionality flag is carried separately on `PropertyInfo` (the solver adds `| undefined` on the read path), so the bare relation-shape declared type must stay unchanged. The fix adds a dedicated `class_property_initializer_target_type` helper (`crates/tsz-checker/src/types/utilities/contextual_parameters.rs`) that applies the `| undefined` augmentation **only** at the write/initializer target, gated on `question_token && strictNullChecks && !exactOptionalPropertyTypes`. It reuses the existing `query_boundaries::common::union_with_undefined` boundary (idempotent, so an annotation already including `undefined` is unchanged). No identifier/file-name literals; no printer-output predicates.

## Adjacent-case matrix (new tests in `optional_property_initializer_undefined_tests`)
Positive (now clean, previously false TS2322):
- `plain?: string = undefined`, `isViewTransitionTypesSupported?: boolean = undefined`, `shouldViewTransition?: boolean | ViewTransitionOptions = undefined` (the tanstack-router union shape), `b?: Box = undefined`.
- Binder-name independence (`foo?` vs `somethingEntirelyDifferent?`) — proves the rule is structural, not name-based.
- Broader than the `= undefined` literal: any `T | undefined`-valued initializer (`n?: number = maybe`) flows in.
- Parity with the #10749 private-field write path baseline.

Negative / fallback (still error, verified preserved):
- Non-optional `c: number = undefined` → TS2322.
- Optional wrong value `d?: number = 'x'` → TS2322 (optionality adds `undefined`, not `any`).
- `exactOptionalPropertyTypes` + `p?: number = undefined` → TS2322; explicit `q?: number | undefined = undefined` accepted.
- Matching value `b?: number = 5` → clean.

## Goal
Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New module `crates/tsz-checker/src/tests/optional_property_initializer_undefined_tests.rs` (registered in `lib.rs`), 12 tests — all pass (`cargo test -p tsz-checker --lib optional_property_initializer_undefined`).
- Adjacent suites green, no regression: `optional_private_field_undefined_tests` (13 pass), `property_init` filter (33 pass).
- Manual repro via the built `tsz` binary (`--strict --target es2022 --noEmit`): the three witness fields are now clean; non-optional `= undefined`, optional wrong-typed value, and the `exactOptionalPropertyTypes` case still report TS2322; explicit `| undefined` annotation accepted.
- `cargo build -p tsz-checker` / `-p tsz-cli` clean.
- Broad conformance / emit / fourslash owned by ready-review CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_018oxLuGyvxKghoBsBMT3C73)_