### PR TITLE
fix(parser): pair backslashes in regex escape validator (no phantom \u/\x, TS1125)

### DIFF
--- a/crates/tsz-parser/src/parser/state_diagnostics.rs
+++ b/crates/tsz-parser/src/parser/state_diagnostics.rs
@@ -441,7 +441,14 @@ impl ParserState {
                     }
                 }
                 _ => {
-                    j += 1;
+                    // `\X` (where X is neither `x` nor `u`) is a single escape
+                    // atom: the backslash escapes the following byte. Consume
+                    // BOTH bytes so an escaped backslash `\\` cannot leave its
+                    // second `\` to seed a phantom `\u`/`\x` escape on the next
+                    // iteration (e.g. `\\u005` is a literal backslash followed
+                    // by literal `u005`, not a `\u` escape). This mirrors the
+                    // escape-pairing the body-scan loop above already tracks.
+                    j += 2;
                 }
             }
         }

--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -1410,6 +1410,15 @@ impl ParserState {
                             continue;
                         }
                     }
+                    if bytes[i] == b'\\' {
+                        // `\X` is one escape atom: the backslash escapes the
+                        // next byte. Skip both so an escaped backslash `\\`
+                        // cannot leave its second `\` to seed a phantom `\u{`
+                        // extended escape (e.g. `\\u{abc}` is a literal
+                        // backslash followed by literal `u{abc}`).
+                        i += 2;
+                        continue;
+                    }
                     i += 1;
                 }
                 errors

--- a/crates/tsz-parser/tests/parser_improvement_regex_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_regex_recovery_tests.rs
@@ -572,6 +572,86 @@ fn test_regex_trailing_flag_scan_uses_es_identifier_part() {
 }
 
 #[test]
+fn test_regex_escaped_backslash_does_not_seed_phantom_unicode_or_hex_escape() {
+    // In a regex literal, `\\` is a single literal-backslash atom; the chars
+    // after it are literals, not a `\u`/`\x` escape. The regex escape validator
+    // previously did not pair backslashes, so the second `\` of `\\u005` seeded
+    // a phantom `\u` validation -> false TS1125. These are clean under tsc.
+    for source in [
+        "const r = /\\\\u005[Ff]/;\n", // /\\u005[Ff]/
+        "const r = /[\\\\u005]/;\n",   // /[\\u005]/
+        "const r = /\\\\xA/;\n",       // /\\xA/
+        // destr's proto/constructor guard regex shape (escaped backslashes).
+        "const r = /\"(?:_|\\\\u005[Ff])(?:_|\\\\u005[Ff])(?:p|\\\\u0070)\"/;\n",
+    ] {
+        let (parser, _root) = parse_source(source);
+        let diagnostics = parser.get_diagnostics();
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.code == diagnostic_codes::HEXADECIMAL_DIGIT_EXPECTED),
+            "escaped backslash `\\\\` must not seed a phantom `\\u`/`\\x` escape (TS1125) in {source:?}, got {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn test_regex_plain_escapes_and_valid_escapes_stay_clean() {
+    // Unchanged-clean controls: ordinary regex and valid escapes never emit
+    // TS1125, before or after the backslash-pairing fix.
+    for source in [
+        "const r = /A/;\n",
+        "const r = /\\u{1F600}/u;\n",
+        "const r = /\\xAB/;\n",
+    ] {
+        let (parser, _root) = parse_source(source);
+        let diagnostics = parser.get_diagnostics();
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.code == diagnostic_codes::HEXADECIMAL_DIGIT_EXPECTED),
+            "valid regex escape must stay clean of TS1125 in {source:?}, got {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn test_regex_genuine_incomplete_escapes_still_report_ts1125() {
+    // Genuine incomplete `\u`/`\x` escapes (unescaped backslash) must STILL
+    // fire TS1125 after the backslash-pairing fix.
+    for source in [
+        "const r = /\\u00G1/;\n", // non-hex G at slot 3
+        "const r = /\\u00/;\n",   // truncated \u
+        "const r = /\\xZZ/;\n",   // non-hex Z after \x
+    ] {
+        let (parser, _root) = parse_source(source);
+        let diagnostics = parser.get_diagnostics();
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code == diagnostic_codes::HEXADECIMAL_DIGIT_EXPECTED),
+            "genuine incomplete regex `\\u`/`\\x` escape must still emit TS1125 in {source:?}, got {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn test_string_context_unicode_escape_validation_unchanged() {
+    // The backslash-pairing fix is scoped to the regex escape loop only;
+    // string-literal escapes are validated on a different path and stay
+    // unchanged. `"\u005"` is a genuinely incomplete string `\u` escape.
+    let source = "const s = \"\\u005\";\n";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::HEXADECIMAL_DIGIT_EXPECTED),
+        "incomplete string `\\u` escape must still emit TS1125, got {diagnostics:?}"
+    );
+}
+
+#[test]
 fn test_regex_trailing_non_identifier_codepoint_ends_flag_scan() {
     // Negative guard: U+2117 SOUND RECORDING COPYRIGHT is not in ES
     // `ID_Continue`, so tsc ends the flag scan before it and never reports


### PR DESCRIPTION
Goal: green

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Summary
Structural rule: in a regex literal, an escaped backslash `\\` is a single literal-backslash atom; the following chars are literals, not a `\u`/`\x` escape. tsz's regex escape validator did not pair backslashes, so the second `\` of `\\u005` seeded a phantom `\u` validation -> false TS1125 ("Hexadecimal digit expected"). Fixed by pairing backslashes in `report_invalid_regular_expression_escape_errors` (the second/live loop): the default escape arm now consumes BOTH the backslash and its escaped byte (`j += 2`), mirroring the body-scan loop's escape pairing. Same defect (and same trivial fix) applied to the `\u{...}` extended-escape scan in `state_expressions_literals_regex.rs` so `\\u{...}` is not mis-detected. Owner: parser regex-escape diagnostics. Genuine incomplete `\u`/`\x` escapes (unescaped backslash) still error; string-context escapes are validated on a different path and are unchanged. Low blast radius (TS1125-in-regex path only).

Witness: destr's proto/constructor guard regexes (`/"(?:_|\\u005[Ff])(?:_|\\u005[Ff])(?:p|\\u0070).../`) drew 9 false TS1125; tsc is clean.

## Verification
Targeted `cargo nextest run -p tsz-parser` (filters `test(regex) + test(escape) + test(invalid_regular) + test(numeric_separator) + test(unicode_escape)`): 70/70 pass. Broader sweep (`regex|escape|literal|unicode|numeric`): 199/199 pass. `cargo clippy -p tsz-parser --all-targets`: clean.

Matrix (added to `parser_improvement_regex_recovery_tests.rs`):
- FP -> clean (no TS1125): `/\\u005[Ff]/`, `/[\\u005]/`, `/\\xA/`, and the destr guard-regex shape.
- Unchanged clean: `/A/`, `/\u{1F600}/u`, `/\xAB/`.
- Genuine errors STILL fire TS1125: `/\u00G1/`, `/\u00/`, `/\xZZ/`.
- String-context control unchanged: `"\u005"` still emits TS1125 (different path).

numericSeparators regex smoke: `test_regex_hex_escape_with_numeric_separator_no_ts1125` (`/\xf_f/u`, `/\uff_ff/u`, `/\u_ffff/u` stay clean) and `test_regex_hex_escape_keeps_real_hex_digit_validation` (`/\u\i\c/` still TS1125) both pass.
