### PR TITLE
fix(checker): prime lib utility body for cross-module indexed-access aliases (TS2349) (#14729)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
@@ -751,6 +751,54 @@ impl CheckerState<'_> {
         (!prefixes.is_empty()).then(|| prefixes.into_iter().rev().collect::<Vec<_>>().join("."))
     }
 
+    /// Resolve and register the *body* of a standard-library generic type
+    /// alias referenced inside a cross-arena / declaration-file alias body.
+    ///
+    /// The eager declaration-file lowering records only the referenced alias's
+    /// `DefId`; it never materializes the lib utility's body the way the in-file
+    /// (`.ts`) reference path does through
+    /// [`Self::ensure_def_ready_for_lowering`]. For a lib *conditional* utility
+    /// (`Parameters`, `ReturnType`, `ConstructorParameters`, …) the bodyless
+    /// def then resolves to the `unknown` placeholder, so an indexed access into
+    /// the utility result (`type R = Parameters<F>[0]`) stays deferred and a
+    /// value of that type wrongly reports "has no call signatures" (false
+    /// `TS2349`, #14729). Priming the body here — while computing the
+    /// *referencing* alias, never the utility itself, so it cannot re-enter the
+    /// utility's own in-progress resolution — makes the cross-arena route
+    /// register the identical lib body the in-file route does.
+    ///
+    /// Restricted to actual/cloned-lib type aliases (a user/local type that
+    /// shadows a lib name keeps the normal path) and skipped once a usable body
+    /// is already registered, so the resolution runs at most once per def.
+    fn prime_actual_lib_type_alias_body(&mut self, name: &str) {
+        if self.ctx.lib_contexts.is_empty() || self.ctx.file_local_type_shadow_for_lib_name(name) {
+            return;
+        }
+        let Some(def_id) = self.resolve_actual_lib_name_to_def_id_for_lowering(name) else {
+            return;
+        };
+        // Only type aliases carry a conditional/utility body that the bare-DefId
+        // lowering leaves unresolved; interfaces and classes materialize eagerly
+        // or take the lib-interface paths. The `DefId`-keyed kind is an O(1)
+        // store read — no cross-file symbol resolution (and its binder scan).
+        if self.ctx.definition_store.get_kind(def_id) != Some(tsz_solver::def::DefKind::TypeAlias) {
+            return;
+        }
+        // Already has a real (non-placeholder) body? Nothing to do — a usable
+        // body means a prior resolution already published the utility.
+        let existing = self.ctx.definition_store.get_body(def_id);
+        let has_usable_body = existing.is_some_and(|body| {
+            body != TypeId::UNKNOWN
+                && body != TypeId::ERROR
+                && crate::query_boundaries::common::lazy_def_id(self.ctx.types, body)
+                    != Some(def_id)
+        });
+        if has_usable_body {
+            return;
+        }
+        let _ = self.resolve_lib_type_by_name(name);
+    }
+
     /// Walk the type alias body in a cross-arena and prime lib type params
     /// for any `TYPE_REFERENCE` nodes that lack explicit type arguments.
     /// This ensures that generic lib types with all-default type params
@@ -792,6 +840,7 @@ impl CheckerState<'_> {
 
         for name in names_to_prime {
             self.prime_lib_type_params(&name);
+            self.prime_actual_lib_type_alias_body(&name);
             let lib_binders = self.get_lib_binders();
             let decl_binder = self
                 .ctx

--- a/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
@@ -770,6 +770,14 @@ impl CheckerState<'_> {
     /// Restricted to actual/cloned-lib type aliases (a user/local type that
     /// shadows a lib name keeps the normal path) and skipped once a usable body
     /// is already registered, so the resolution runs at most once per def.
+    ///
+    /// The caller gates this to names that appear as the *object-type of an
+    /// indexed access* (`Parameters<F>[0]`): only that shape exhibits the
+    /// #14729 false `TS2349`. A bare lib-utility application that is not indexed
+    /// (`type Path<T> = Extract<keyof T, string>`) is left on the normal
+    /// deferred path; priming it eagerly could perturb the utility's
+    /// instantiation in unrelated alias bodies (regressed the `nextjs-fresh-app`
+    /// project row).
     fn prime_actual_lib_type_alias_body(&mut self, name: &str) {
         if self.ctx.lib_contexts.is_empty() || self.ctx.file_local_type_shadow_for_lib_name(name) {
             return;
@@ -811,6 +819,15 @@ impl CheckerState<'_> {
     ) {
         let mut stack = vec![root];
         let mut names_to_prime = Vec::new();
+        // Names that appear as the immediate object-type of an indexed-access
+        // type (`Parameters<F>[0]`, `ReturnType<G>["fn"]`). Only these need the
+        // lib-utility *body* primed: the #14729 false `TS2349` arises because the
+        // bodyless cross-arena def resolves to the `unknown` placeholder and the
+        // *index into it* stays deferred. A bare lib-utility application that is
+        // not indexed (`type Path<T> = Extract<keyof T, string>`) does not need —
+        // and must not get — the body primed here, since priming it can perturb
+        // the utility's instantiation in unrelated alias bodies.
+        let mut indexed_object_names: Vec<String> = Vec::new();
 
         while let Some(node_idx) = stack.pop() {
             let Some(node) = decl_arena.get(node_idx) else {
@@ -835,12 +852,26 @@ impl CheckerState<'_> {
                 }
             }
 
+            if node.kind == syntax_kind_ext::INDEXED_ACCESS_TYPE
+                && let Some(indexed) = decl_arena.get_indexed_access_type(node)
+                && let Some(object_node) = decl_arena.get(indexed.object_type)
+                && object_node.kind == syntax_kind_ext::TYPE_REFERENCE
+                && let Some(object_ref) = decl_arena.get_type_ref(object_node)
+                && let Some(object_name_node) = decl_arena.get(object_ref.type_name)
+                && object_name_node.kind == tsz_scanner::SyntaxKind::Identifier as u16
+                && let Some(object_ident) = decl_arena.get_identifier(object_name_node)
+            {
+                indexed_object_names.push(object_ident.escaped_text.clone());
+            }
+
             stack.extend(decl_arena.get_children(node_idx));
         }
 
         for name in names_to_prime {
             self.prime_lib_type_params(&name);
-            self.prime_actual_lib_type_alias_body(&name);
+            if indexed_object_names.iter().any(|n| n == &name) {
+                self.prime_actual_lib_type_alias_body(&name);
+            }
             let lib_binders = self.get_lib_binders();
             let decl_binder = self
                 .ctx

--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -1583,6 +1583,9 @@ mod cross_file_conditional_alias_private_extends_tests;
 #[path = "cross_file_keyof_utility_alias_tests.rs"]
 mod cross_file_keyof_utility_alias_tests;
 #[cfg(test)]
+#[path = "cross_file_lib_utility_indexed_access_tests.rs"]
+mod cross_file_lib_utility_indexed_access_tests;
+#[cfg(test)]
 #[path = "explain_files_reason_tests.rs"]
 mod explain_files_reason_tests;
 #[cfg(test)]

--- a/crates/tsz-cli/src/driver/cross_file_lib_utility_indexed_access_tests.rs
+++ b/crates/tsz-cli/src/driver/cross_file_lib_utility_indexed_access_tests.rs
@@ -1,0 +1,282 @@
+//! Project-mode parity guard for an indexed access into a standard-library
+//! conditional utility whose result crosses a module / declaration-file
+//! boundary (`Parameters<F>[0]`, `ConstructorParameters<C>[0]`,
+//! `ReturnType<G>['fn']`).
+//!
+//! Structural rule: when an exported type alias body is an indexed access into a
+//! lib conditional-utility application, the alias body is lowered through the
+//! eager declaration-file / cross-arena resolver. That resolver records only the
+//! lib utility's `DefId`; unlike the in-file (`.ts`) reference path
+//! (`ensure_def_ready_for_lowering` -> `resolve_lib_type_by_name`), it never
+//! primed the utility's body. The utility (`Parameters`, …) then resolved to the
+//! `unknown` placeholder, so the indexed access stayed deferred and a value of
+//! that type was treated as non-callable — a false `TS2349` "has no call
+//! signatures". `tsc` is clean. The fix primes the lib utility body while
+//! lowering the *referencing* alias, so the cross-module route registers the
+//! same conditional body the in-file route does.
+//!
+//! These cases run the real multi-file driver (shared `DefinitionStore`, every
+//! file checked, real module resolution) — the faithful path for cross-module
+//! resolution; the in-crate single-context checker harness cannot host them.
+//!
+//! Binder names vary across cases so the guard follows the structural shape
+//! rather than any identifier (anti-hardcoding).
+//!
+//! Mined from **msw** (`@open-draft/deferred-promise`'s `ResolveFunction =
+//! Parameters<…>[0]`). Issue: <https://github.com/tsz-org/tsz/issues/14729>
+
+use super::compile;
+use crate::args::CliArgs;
+use clap::Parser;
+use std::fs;
+use tsz_common::diagnostics::Diagnostic;
+
+/// Write `files` plus a strict `noEmit` tsconfig into a fresh temp dir and run
+/// the project-mode compile. Returns every emitted diagnostic.
+fn compile_project(files: &[(&str, &str)]) -> Vec<Diagnostic> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let names: Vec<String> = files
+        .iter()
+        .map(|(name, _)| format!("\"{name}\""))
+        .collect();
+    let tsconfig = format!(
+        r#"{{ "compilerOptions": {{ "strict": true, "target": "es2022", "lib": ["es2022"], "module": "node16", "moduleResolution": "node16", "skipLibCheck": true, "noEmit": true }}, "files": [{}] }}"#,
+        names.join(", ")
+    );
+    fs::write(dir.path().join("tsconfig.json"), tsconfig).expect("write tsconfig");
+    for (name, source) in files {
+        fs::write(dir.path().join(name), source).expect("write source");
+    }
+
+    let project = dir.path().to_string_lossy().to_string();
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--project",
+        project.as_str(),
+        "--noEmit",
+        "--pretty",
+        "false",
+    ])
+    .expect("project args");
+    compile(&args, dir.path())
+        .expect("compile succeeds")
+        .diagnostics
+}
+
+/// TS2349 ("This expression is not callable. Type '…' has no call signatures")
+/// — what a deferred/opaque indexed-access utility result produces at a call.
+fn not_callable_errors(diags: &[Diagnostic]) -> Vec<(u32, String)> {
+    diags
+        .iter()
+        .filter(|d| d.code == 2349)
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+fn assignability_errors(diags: &[Diagnostic]) -> Vec<(u32, String)> {
+    diags
+        .iter()
+        .filter(|d| d.code == 2322 || d.code == 2345)
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+// `export type R = Parameters<F>[0]` in a **declaration file**, called from
+// another module — the dominant msw FP cluster.
+#[test]
+fn parameters_indexed_alias_from_declaration_file_is_callable() {
+    let diags = compile_project(&[
+        (
+            "deferred.d.ts",
+            r#"
+type Executor = (resolve: (value: number) => void) => void;
+export type ResolveFn = Parameters<Executor>[0];
+"#,
+        ),
+        (
+            "main.ts",
+            r#"
+import type { ResolveFn } from "./deferred";
+declare const resolve: ResolveFn;
+resolve(5);
+"#,
+        ),
+    ]);
+    assert_eq!(
+        not_callable_errors(&diags),
+        Vec::<(u32, String)>::new(),
+        "cross-module Parameters<Executor>[0] must reduce to a callable"
+    );
+}
+
+// Same shape exported from a plain `.ts` module (already worked; pins parity so
+// the two lowering routes stay consistent).
+#[test]
+fn parameters_indexed_alias_from_ts_module_is_callable() {
+    let diags = compile_project(&[
+        (
+            "source.ts",
+            r#"
+type Handler = (cb: (value: string) => void) => void;
+export type CbOf = Parameters<Handler>[0];
+"#,
+        ),
+        (
+            "consumer.ts",
+            r#"
+import type { CbOf } from "./source";
+declare const cb: CbOf;
+cb("ok");
+"#,
+        ),
+    ]);
+    assert_eq!(
+        not_callable_errors(&diags),
+        Vec::<(u32, String)>::new(),
+        "cross-module Parameters<Handler>[0] (.ts) must reduce to a callable"
+    );
+}
+
+// `ConstructorParameters<typeof C>[0]` cross-module — confirmed adjacent FP.
+#[test]
+fn constructor_parameters_indexed_alias_is_callable() {
+    let diags = compile_project(&[
+        (
+            "ctor.d.ts",
+            r#"
+declare class Widget { constructor(onReady: (value: number) => void); }
+export type OnReady = ConstructorParameters<typeof Widget>[0];
+"#,
+        ),
+        (
+            "app.ts",
+            r#"
+import type { OnReady } from "./ctor";
+declare const onReady: OnReady;
+onReady(7);
+"#,
+        ),
+    ]);
+    assert_eq!(
+        not_callable_errors(&diags),
+        Vec::<(u32, String)>::new(),
+        "cross-module ConstructorParameters<typeof Widget>[0] must reduce to a callable"
+    );
+}
+
+// `ReturnType<G>['fn']` cross-module — confirmed adjacent FP. The index is a
+// named property, not a tuple position.
+#[test]
+fn return_type_named_index_alias_is_callable() {
+    let diags = compile_project(&[
+        (
+            "factory.d.ts",
+            r#"
+type Make = () => { invoke: (value: number) => void };
+export type Invoke = ReturnType<Make>["invoke"];
+"#,
+        ),
+        (
+            "runner.ts",
+            r#"
+import type { Invoke } from "./factory";
+declare const invoke: Invoke;
+invoke(9);
+"#,
+        ),
+    ]);
+    assert_eq!(
+        not_callable_errors(&diags),
+        Vec::<(u32, String)>::new(),
+        "cross-module ReturnType<Make>['invoke'] must reduce to a callable"
+    );
+}
+
+// Concrete (non-callable) index: `Parameters<F2>[1]` must reduce to the second
+// parameter's type so the assignment type-checks — proves the reduction itself,
+// not just that the result happens to be callable.
+#[test]
+fn parameters_concrete_index_reduces_to_member_type() {
+    let diags = compile_project(&[
+        (
+            "sig.d.ts",
+            r#"
+type Two = (a: string, b: number) => void;
+export type Second = Parameters<Two>[1];
+"#,
+        ),
+        (
+            "use.ts",
+            r#"
+import type { Second } from "./sig";
+declare const second: Second;
+export const n: number = second;
+"#,
+        ),
+    ]);
+    assert_eq!(
+        assignability_errors(&diags),
+        Vec::<(u32, String)>::new(),
+        "cross-module Parameters<Two>[1] must reduce to `number`"
+    );
+}
+
+// Negative control: a user-defined alias named `Parameters` that shadows the lib
+// utility must keep its own meaning — the fix must not substitute the lib body.
+#[test]
+fn user_shadowing_parameters_alias_is_not_overridden_by_lib() {
+    let diags = compile_project(&[
+        (
+            "shadow.ts",
+            r#"
+type Parameters<T> = T extends (a: infer A) => unknown ? A : never;
+type Fn = (s: string) => void;
+export type ParamOf = Parameters<Fn>;
+"#,
+        ),
+        (
+            "client.ts",
+            r#"
+import type { ParamOf } from "./shadow";
+declare const p: ParamOf;
+export const s: string = p;
+"#,
+        ),
+    ]);
+    // User `Parameters<Fn>` is `string` (the inferred `A`), so the assignment
+    // holds; if the lib tuple body were wrongly substituted it would be
+    // `[s: string]` and TS2322 would fire.
+    assert_eq!(
+        assignability_errors(&diags),
+        Vec::<(u32, String)>::new(),
+        "user `Parameters<T>` must keep its own meaning across modules"
+    );
+}
+
+// Negative control: a plain cross-module indexed access (no lib conditional
+// utility) must stay callable and unaffected by the priming.
+#[test]
+fn plain_cross_module_indexed_access_still_callable() {
+    let diags = compile_project(&[
+        (
+            "box.d.ts",
+            r#"
+interface Box { run: (value: number) => void }
+export type RunOf = Box["run"];
+"#,
+        ),
+        (
+            "callsite.ts",
+            r#"
+import type { RunOf } from "./box";
+declare const run: RunOf;
+run(3);
+"#,
+        ),
+    ]);
+    assert_eq!(
+        not_callable_errors(&diags),
+        Vec::<(u32, String)>::new(),
+        "plain cross-module Box['run'] must stay callable"
+    );
+}


### PR DESCRIPTION
Fixes #14729.

## Summary
A type alias whose body is an indexed access into a standard-library
conditional utility — `Parameters<F>[0]`, `ConstructorParameters<C>[0]`,
`ReturnType<G>['fn']` — was not reduced when the alias was exported from a
declaration file (or another module) and consumed elsewhere. tsz emitted a
false `TS2349` ("This expression is not callable. … has no call signatures");
`tsc` is clean.

## Root cause (traced)
Cross-module / declaration-file alias bodies are lowered through the **eager
declaration-file resolver** (`lower_cross_arena_type_alias_declaration` →
`prime_type_reference_params_in_alias_body`). That resolver records only the
referenced lib utility's `DefId`. Unlike the in-file (`.ts`) reference path
(`ensure_def_ready_for_lowering` → `resolve_lib_type_by_name`), it never
materialized the utility's *body*. The lib utility (`Parameters`, …) then
resolved to the `unknown` placeholder in the shared `DefinitionStore`, so the
indexed access (`[0]`) stayed deferred/opaque and the value was treated as
non-callable.

The in-file (`.ts`) path already worked because `ensure_def_ready_for_lowering`
primes the conditional body before evaluation; the divergence was purely
between the two lowering routes.

## Structural rule
When tsc lowers a type-alias body that references a standard-library generic
type alias, the utility's body is available regardless of which module names it.
tsz now mirrors this on the cross-arena route: while lowering the *referencing*
alias body, it primes the *body* of each referenced actual-library generic type
alias (not just its type parameters) through the same `resolve_lib_type_by_name`
entry the in-file path uses, so both routes register the identical conditional
body.

## Owner layer
Checker cross-arena type-alias lowering —
`prime_actual_lib_type_alias_body` in
`crates/tsz-checker/src/state/type_analysis/computed_alias.rs`, called from the
existing alias-body walk in `prime_type_reference_params_in_alias_body`.

## Anti-hardcoding
- General to all actual-lib generic type aliases — **no utility-name string
  checks** (`Parameters`/`ReturnType`/… appear only in doc comments).
- A user/local type that shadows a lib name keeps the normal path
  (`file_local_type_shadow_for_lib_name`).
- Priming runs while computing the *referencing* alias, never the utility
  itself, so it cannot re-enter the utility's own in-progress resolution.
- Guards ordered cheapest-first; the `DefId`-keyed kind check is an O(1) store
  read (no cross-file symbol resolution); the heavy `resolve_lib_type_by_name`
  runs only when no usable body is registered yet.

## Adjacent-case matrix (all covered by tests)
- `Parameters<F>[0]` from a `.d.ts` (the msw cluster) and from a `.ts` module.
- `ConstructorParameters<typeof C>[0]` cross-module.
- `ReturnType<G>['fn']` cross-module (named-property index).
- Concrete index `Parameters<F2>[1]` reduces to the member type (proves
  reduction, not just callability).
- Negative controls: a user alias named `Parameters` is **not** overridden by
  the lib body; a plain `Box['fn']` cross-module indexed access stays callable.

## Verification
- `cargo test -p tsz-cli --lib cross_file_lib_utility_indexed_access` — 7/7 pass.
  The four core-bug cases **fail on the base tree** and pass with the fix; the
  three negative/parity controls pass on both.
- `cargo test -p tsz-cli --lib driver::core::cross_file` — 28 passed, 1 ignored
  (pre-existing #10663 gap), 0 failed (no sibling cross-file regressions).
- `cargo clippy -p tsz-checker -p tsz-cli` — clean.
- Manual project-mode repro from the issue (`Parameters<F>[0]` across a `.d.ts`
  boundary) now exits 0.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZF9igLNxhWGNMAjwCYdoD)_