### PR TITLE
fix(checker): decide index-signature key TS1337/TS1268 on the resolved type (#14735)

### DIFF
--- a/crates/tsz-checker/src/tests/index_sig_param_intersection_validity_tests.rs
+++ b/crates/tsz-checker/src/tests/index_sig_param_intersection_validity_tests.rs
@@ -322,3 +322,45 @@ interface Box<X> {
         "TS1337 expected for `Brand<X, 'g'>` with a free type parameter: {codes:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #14735 adjacent coverage: sites/keys not exercised above. Binder names are
+// varied to guard against any name-keyed fast path.
+// ---------------------------------------------------------------------------
+
+/// A branded-string alias application used as an index key in an *inline type
+/// literal in a function-parameter position* (and in a bare type-literal alias)
+/// is clean — neither TS1337 nor TS1268. Covers the type-literal grammar path
+/// in addition to the interface/alias sites above.
+#[test]
+fn branded_key_in_function_parameter_type_literal_is_clean() {
+    let codes = check_source_codes(
+        r#"
+type Stamp<Base, Marker> = Base & { __kind: Marker };
+type EventKey = Stamp<string, 'evt'>;
+declare function take(x: { [k: EventKey]: number }): void;
+type LitForm = { [k: EventKey]: number };
+"#,
+    );
+    assert!(
+        !codes.contains(&1337) && !codes.contains(&1268),
+        "a branded index key in a function-parameter type literal must be clean: {codes:?}"
+    );
+}
+
+/// Negative parity: the fix must not over-accept. A bare type parameter and a
+/// literal union are still generic/literal index keys (TS1337).
+#[test]
+fn bare_type_param_and_literal_union_index_keys_still_emit_ts1337() {
+    let bare = check_source_codes(r#"interface G<K> { [k: K]: number }"#);
+    assert!(
+        bare.contains(&1337),
+        "bare type parameter key must still emit TS1337: {bare:?}"
+    );
+
+    let lit = check_source_codes(r#"interface L { [k: 'a' | 'b']: number }"#);
+    assert!(
+        lit.contains(&1337),
+        "literal-union key must still emit TS1337: {lit:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #14735. An index signature keyed by a **generic type-alias application that evaluates to a branded string** — `[key: SerializedEvent]` where `type SerializedEvent = Brand<string, 'event'>` and `type Brand<T, Tag> = T & { __tag: Tag }` — was wrongly rejected with **TS1337** ("An index signature parameter type cannot be a literal type or generic type"). The evaluated key type is `string & { __tag: 'event' }`, which tsc accepts as a valid (string-subtype) index key. Witnessed in **xstate** `packages/core/src/graph/types.ts:284`/`:292`.

## Wrong operation

Relation/grammar decision computed from the **AST spelling** instead of the **resolved type**. `is_type_param_or_literal_in_index_sig` recursed the *uninstantiated* alias declaration body (`Brand`'s `T & { __tag: Tag }`), saw the bound type parameter `T`, and mis-fired TS1337 — even though the **application** `Brand<string, 'event'>` instantiates `T := string` to a concrete intersection.

## Structural rule

> When an index-signature key is a generic type-alias application, `tsc` evaluates (instantiates) the application and decides the TS1337 literal/generic condition — `someType(type, isLiteralType) || isGenericType(type)` — on the **resolved** type. A free type parameter makes the key generic; a union-distributed literal constituent makes it literal. The uninstantiated alias body's *bound* type parameter does not. `tsz` did this through the checker's AST recursion; it now does it through a solver-backed query over the evaluated key type.

## Owner layer

Checker query boundary. New solver-backed query `resolved_index_key_is_literal_or_generic` (`crates/tsz-checker/src/query_boundaries/index_signature.rs`) mirrors tsc on the evaluated type:
- **generic** — resolved type still contains a free type parameter (`contains_type_parameters_db`): bare `K`, `T & {...}`, `keyof T`, generic conditional/mapped.
- **literal** — `someType` distributes over unions; a constituent is literal when it is a `string`/`number`/`bigint`/`boolean` literal. Intersections are not split by `someType`, so a branded intersection is not a literal key.

The shared `index_sig_param_is_literal_or_generic` helper consults the AST spelling **only** as a fallback when evaluation leaves an opaque reference (e.g. an unresolved cross-file `Lazy`). Both `classify_index_sig_param_type` (interface/class/type-literal sites) and `check_index_sig_param_type_in_type_literal` (type-alias type-literal site) route through it, evaluating the key **once** (removing a double-evaluation the old `index_key_type_is_valid` incurred).

## Adjacent-case matrix (verified)

| Index key | tsc | tsz before | tsz after |
|---|---|---|---|
| `Brand<string, 'event'>` (branded string) | OK | TS1337 ❌ | OK ✓ |
| `Brand<number, 'n'>` / `Brand<symbol, 's'>` | OK | TS1337 ❌ | OK ✓ |
| alias-to-alias of an application (`type S2 = S`) | OK | TS1337 ❌ | OK ✓ |
| type-literal form `{ [k: EventKey]: V }` + inline fn-param | OK | TS1337 ❌ | OK ✓ |
| bare type parameter `[key: K]` | TS1337 | TS1337 | TS1337 ✓ |
| literal union `[key: 'a' \| 'b']` | TS1337 | TS1337 | TS1337 ✓ |
| generic intersection `[key: T & string]` | TS1337 | TS1337 | TS1337 ✓ |
| literal-based brand `Brand<'a','x'>` (`'a' & {...}`) | TS1268 | TS1268 | TS1268 ✓ |
| `string & Brand`, template-literal intersection, `PropertyKey` | OK | OK | OK ✓ |

Binder names are varied in the tests to satisfy the anti-hardcoding gate.

## Out of scope

The `keyof { [k: Brand<string,'x'>]: V }` / `readonly { ... }[]` wrapper path (reached via `TypeNodeChecker`, a separate struct without the checker's fuel/env evaluator) emits a **pre-existing, distinct TS1268** for the un-reduced application; it is not the reported TS1337 family and is not a regression. Fixing it requires wiring full evaluation into `TypeNodeChecker` and is left for a follow-up.

## Verification

- New regression tests in `crates/tsz-checker/src/tests/index_sig_param_intersection_validity_tests.rs` (3 tests): `cargo test -p tsz-checker --lib index_sig_param_intersection` → 14 passed, 0 failed.
- Broader `index_signature` lib suite: 167 passed, same 4 pre-existing failures as `main` (relation-routing architecture + symbol-keyspace tests; confirmed identical on stashed baseline — zero new failures).
- `cargo clippy -p tsz-checker --lib`: clean on changed files.
- CLI matrix (`--strict --target es2022`): branded interface/class/type-literal keys clean; bare-param / literal-union / generic-intersection keep TS1337; literal-based brand keeps TS1268; `PropertyKey` clean.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_0162ARkcVfcp9bAbegV8ZT43)_