### PR TITLE
fix(checker): self-referential class member triggers circular implicit-any return (TS7023/TS7024) (#14805)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -163,6 +163,9 @@ mod class_implements_generic_override_variance_tests;
 #[path = "tests/class_implements_index_relation_routing_arch_tests.rs"]
 mod class_implements_index_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/class_member_circular_return_tests.rs"]
+mod class_member_circular_return_tests;
+#[cfg(test)]
 #[path = "../tests/class_member_closure_tests.rs"]
 mod class_member_closure_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -838,6 +838,10 @@ impl<'a> CheckerState<'a> {
             self.check_class_member(member_idx);
         }
 
+        // TS7023 / TS7024: un-annotated members whose inferred return type is
+        // circular through a `this.`/`Class.` self-invocation (issue #14805).
+        self.check_class_member_circular_returns(stmt_idx, &class.members.nodes);
+
         self.ctx.async_depth = saved_async_depth;
 
         // Check for duplicate member names (TS2300, TS2393)
@@ -1219,6 +1223,10 @@ impl<'a> CheckerState<'a> {
         }
 
         self.ctx.async_depth = saved_async_depth;
+
+        // TS7023 / TS7024: un-annotated members whose inferred return type is
+        // circular through a `this.`/`Class.` self-invocation (issue #14805).
+        self.check_class_member_circular_returns(class_idx, &class.members.nodes);
 
         // Check strict property initialization (TS2564) for class expressions
         // Class expressions should have the same property initialization checks as class declarations

--- a/crates/tsz-checker/src/tests/class_member_circular_return_tests.rs
+++ b/crates/tsz-checker/src/tests/class_member_circular_return_tests.rs
@@ -1,0 +1,220 @@
+//! Regression tests for #14805: a self-referential **class** member whose
+//! return type is inferred (un-annotated) must trigger the circular
+//! implicit-`any` diagnostic — TS7023 for named members (methods / getters),
+//! TS7024 for anonymous arrow-function fields — exactly as `tsc` does.
+//!
+//! Detection is symbol/receiver gated: only a `this.`/`Class.` self-reference
+//! whose receiver resolves to the enclosing class counts. An unrelated
+//! `obj.member` access that merely shares a name must stay clean (the inverse of
+//! the object-literal FP tracked by #14730).
+//!
+//! Binder names are varied across cases (anti-hardcoding): the logic keys off
+//! structure (receiver + resolved member), never a specific identifier.
+
+use crate::test_utils::check_source_strict_codes;
+
+fn codes(src: &str) -> Vec<u32> {
+    check_source_strict_codes(src)
+}
+
+fn assert_clean(src: &str) {
+    let got = codes(src);
+    assert!(
+        got.is_empty(),
+        "expected no diagnostics, got: {got:?}\n{src}"
+    );
+}
+
+fn assert_codes(src: &str, expected: &[u32]) {
+    let mut got = codes(src);
+    got.sort_unstable();
+    let mut want = expected.to_vec();
+    want.sort_unstable();
+    assert_eq!(got, want, "for source:\n{src}");
+}
+
+// ---------------------------------------------------------------------------
+// The reported witnesses.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn instance_arrow_field_self_call_is_ts7024() {
+    // `class C { f = () => this.f(); }` — anonymous arrow → TS7024.
+    assert_codes("class Alpha { run = () => this.run(); }", &[7024]);
+}
+
+#[test]
+fn instance_method_self_call_is_ts7023() {
+    assert_codes("class Beta { step() { return this.step(); } }", &[7023]);
+}
+
+#[test]
+fn static_arrow_field_self_call_via_class_name_is_ts7024() {
+    assert_codes("class Gamma { static go = () => Gamma.go(); }", &[7024]);
+}
+
+#[test]
+fn static_method_self_call_via_class_name_is_ts7023() {
+    assert_codes(
+        "class Delta { static tick() { return Delta.tick(); } }",
+        &[7023],
+    );
+}
+
+#[test]
+fn static_arrow_field_self_call_via_this_is_ts7024() {
+    // In a static field initializer `this` is the constructor, so `this.go`
+    // selects the static member.
+    assert_codes("class Eta { static go = () => this.go(); }", &[7024]);
+}
+
+// ---------------------------------------------------------------------------
+// Getters: a property *read* invokes the accessor, so it is circular too.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn getter_self_read_is_ts7023() {
+    assert_codes("class Zeta { get value() { return this.value; } }", &[7023]);
+}
+
+#[test]
+fn getter_self_call_is_ts7023() {
+    assert_codes(
+        "class Theta { get value() { return this.value(); } }",
+        &[7023],
+    );
+}
+
+#[test]
+fn getter_wrapped_self_read_is_ts7023() {
+    assert_codes(
+        "class Iota { get value() { return [this.value][0]; } }",
+        &[7023],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Indirect / mutual cycles.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mutually_recursive_methods_both_report() {
+    assert_codes(
+        "class Kappa { a() { return this.b(); } b() { return this.a(); } }",
+        &[7023, 7023],
+    );
+}
+
+#[test]
+fn three_member_cycle_reports_all() {
+    assert_codes(
+        "class Lambda { a() { return this.b(); } b() { return this.c(); } c() { return this.a(); } }",
+        &[7023, 7023, 7023],
+    );
+}
+
+#[test]
+fn generator_method_return_self_call_is_ts7023() {
+    // A generator method is circular through its `Generator` return value when
+    // it returns a self-call — `tsc` reports TS7023.
+    assert_codes("class Pi { *gen() { return this.gen(); } }", &[7023]);
+}
+
+#[test]
+fn plain_generator_method_stays_clean() {
+    assert_clean("class Rho { *gen() { yield 1; } }");
+}
+
+#[test]
+fn self_call_buried_in_return_expression() {
+    // The self-call need not be the whole return value.
+    assert_codes("class Mu { a() { return this.a() + 1; } }", &[7023]);
+    assert_codes(
+        "class Nu { a() { return wrap(this.a()); } } declare function wrap(x: any): any;",
+        &[7023],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Only the member actually on a cycle is reported.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn caller_of_circular_member_is_not_itself_circular() {
+    // `runner` calls the circular `loop`, but `runner` is not on a cycle.
+    assert_codes(
+        "class Xi { loop = () => this.loop(); runner() { return this.loop(); } }",
+        &[7024],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Must stay clean — false-positive guards.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn annotated_return_type_is_not_circular() {
+    assert_clean("class C1 { step(): number { return this.step(); } }");
+    assert_clean("class C2 { go = (): number => this.go(); }");
+}
+
+#[test]
+fn method_value_read_without_call_is_not_circular() {
+    // Reading `this.step` (a method) yields its function value, not its return
+    // type — not circular.
+    assert_clean("class C3 { step() { return this.step; } }");
+}
+
+#[test]
+fn arrow_field_value_read_without_call_is_not_circular() {
+    assert_clean("class C4 { go = () => this.go; }");
+}
+
+#[test]
+fn self_call_through_unrelated_receiver_is_not_circular() {
+    // Same member name on an unrelated object — not a self-reference.
+    assert_clean(
+        "class C5 { run() { return other.run(); } } declare const other: { run(): number };",
+    );
+}
+
+#[test]
+fn calling_a_different_annotated_member_is_not_circular() {
+    assert_clean("class C6 { a() { return this.b(); } b(): number { return 1; } }");
+}
+
+#[test]
+fn function_expression_field_rebinds_this_not_circular_return() {
+    // A `function` expression field gets its own `this` (TS2683), not a circular
+    // return-type diagnostic.
+    assert_codes(
+        "class C7 { f = function () { return this.f(); }; }",
+        &[2683],
+    );
+}
+
+#[test]
+fn self_call_in_nested_object_literal_with_same_name_is_not_circular() {
+    assert_clean("class C8 { build = () => { const o = { build: () => 1 }; return o.build(); }; }");
+}
+
+#[test]
+fn self_reference_outside_return_position_is_not_circular() {
+    // A self-call as a statement (not contributing to the return value) is not
+    // circular — matches `tsc`.
+    assert_clean("class C9 { step() { this.step(); return 1; } }");
+}
+
+#[test]
+fn member_read_passed_as_argument_is_not_circular() {
+    assert_clean(
+        "class C10 { run = () => helper(this.run); } declare function helper(x: any): number;",
+    );
+}
+
+#[test]
+fn non_self_referential_members_stay_clean() {
+    assert_clean(
+        "class C11 { value = 1; total() { return this.value; } get half() { return this.value / 2; } }",
+    );
+}

--- a/crates/tsz-checker/src/types/computation/class_member_circularity.rs
+++ b/crates/tsz-checker/src/types/computation/class_member_circularity.rs
@@ -1,0 +1,379 @@
+//! Circular implicit-`any` return detection for **class** members (TS7023 /
+//! TS7024).
+//!
+//! `tsc` reports an implicit-`any`-circularity diagnostic when an un-annotated
+//! class member's inferred return type is referenced, directly or indirectly,
+//! in one of its own return expressions:
+//!
+//! ```ts
+//! class C { m() { return this.m(); } }          // TS7023 'm'
+//! class C { f = () => this.f(); }               // TS7024 (anonymous arrow)
+//! class C { static f = () => C.f(); }           // TS7024
+//! class C { get g() { return this.g; } }        // TS7023 'g'  (read invokes getter)
+//! class C { a() { return this.b(); } b() { return this.a(); } } // TS7023 a, TS7023 b
+//! ```
+//!
+//! The variable / object-literal forms are already handled (the resolving-symbol
+//! tracker in `function_type_circular.rs` and the object-literal graph in
+//! `object_literal_circularity.rs`). Class member symbols carry neither the
+//! function/block-scoped variable flags that the former keys on, nor do they go
+//! through the object-literal path, so a self-referential class member was a
+//! silent false negative (issue #14805).
+//!
+//! Detection here is **symbol/receiver gated**, never name-keyed against an
+//! arbitrary receiver: a `recv.X` self-reference is only a self-invocation when
+//! `recv` resolves to the enclosing class (`this`, or the class name for the
+//! static side). An unrelated `obj.X` access whose name merely collides with a
+//! member is not a self-reference — the same lesson the object-literal `this`
+//! gate encodes, and the inverse of the FP tracked by #14730.
+
+use crate::state::CheckerState;
+use rustc_hash::{FxHashMap, FxHashSet};
+use tsz_binder::SymbolId;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeAccess;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+/// What kind of self-reference makes a member's inferred return type circular,
+/// and how the diagnostic is anchored.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ClassCircularMemberKind {
+    /// `m() {...}` — a self-invocation requires a **call** `this.m()`. A bare
+    /// read `this.m` is just the method's function value and is not circular.
+    /// Diagnostic: TS7023 at the method name.
+    Method,
+    /// `get g() {...}` — reading `this.g` *invokes* the getter, so a property
+    /// **read** (or call) counts. Diagnostic: TS7023 at the accessor name.
+    Getter,
+    /// `f = () => ...` — a self-invocation requires a **call** `this.f()`.
+    /// Diagnostic: TS7024 (anonymous) at the arrow-function node. A
+    /// `function` expression field instead rebinds `this` (TS2683) and is not a
+    /// candidate.
+    ArrowField,
+}
+
+struct ClassCircularMember {
+    /// Body whose return expressions are scanned (method/accessor body, or the
+    /// arrow body for an arrow field).
+    body_idx: NodeIndex,
+    kind: ClassCircularMemberKind,
+    is_static: bool,
+    /// Node the diagnostic is anchored at (member name, or arrow node).
+    diagnostic_node: NodeIndex,
+    /// Member name, used both as the self-reference lookup key and (for named
+    /// members) as the TS7023 message argument. Anonymous arrow fields report
+    /// TS7024 and ignore this for display — see [`ClassCircularMemberKind`].
+    name: String,
+}
+
+impl<'a> CheckerState<'a> {
+    /// Emit TS7023 / TS7024 for un-annotated class members whose inferred return
+    /// type is circular through a `this.`/`Class.` self-invocation. Runs once
+    /// per class, after the members have been checked.
+    pub(crate) fn check_class_member_circular_returns(
+        &mut self,
+        class_idx: NodeIndex,
+        members: &[NodeIndex],
+    ) {
+        if !self.ctx.no_implicit_any() || self.has_syntax_parse_errors() || self.is_js_file() {
+            return;
+        }
+
+        let candidates = self.collect_class_circular_candidates(members);
+        if candidates.is_empty() {
+            return;
+        }
+
+        // (is_static, name) -> candidate index, used to resolve `this.X` /
+        // `Class.X` back to a member. Private names already carry a `#`, so they
+        // never collide with public members of the same spelling.
+        let mut by_key: FxHashMap<(bool, String), usize> = FxHashMap::default();
+        for (idx, member) in candidates.iter().enumerate() {
+            by_key
+                .entry((member.is_static, member.name.clone()))
+                .or_insert(idx);
+        }
+
+        let class_sym = self.ctx.binder.get_node_symbol(class_idx);
+
+        // Edge i -> j when member i's return expressions self-invoke member j.
+        let mut adjacency: Vec<Vec<usize>> = vec![Vec::new(); candidates.len()];
+        for (i, member) in candidates.iter().enumerate() {
+            let mut return_exprs = Vec::new();
+            self.collect_initializer_return_expressions_in_function_body(
+                member.body_idx,
+                &mut return_exprs,
+            );
+            let mut targets: FxHashSet<usize> = FxHashSet::default();
+            for &expr_idx in &return_exprs {
+                self.collect_class_self_invocations(
+                    expr_idx,
+                    member.is_static,
+                    class_sym,
+                    &by_key,
+                    &candidates,
+                    &mut targets,
+                );
+            }
+            adjacency[i] = targets.into_iter().collect();
+        }
+
+        let cyclic = cyclic_member_indices(&adjacency);
+        for idx in cyclic {
+            self.emit_class_circular_member_diagnostic(&candidates[idx]);
+        }
+    }
+
+    fn emit_class_circular_member_diagnostic(&mut self, member: &ClassCircularMember) {
+        use crate::diagnostics::diagnostic_codes;
+        // Arrow-function fields are anonymous (TS7024); methods and getters are
+        // named (TS7023 with the member name).
+        if member.kind == ClassCircularMemberKind::ArrowField {
+            self.error_at_node_msg(
+                member.diagnostic_node,
+                diagnostic_codes::FUNCTION_IMPLICITLY_HAS_RETURN_TYPE_ANY_BECAUSE_IT_DOES_NOT_HAVE_A_RETURN_TYPE_A,
+                &[],
+            );
+        } else {
+            self.error_at_node_msg(
+                member.diagnostic_node,
+                diagnostic_codes::IMPLICITLY_HAS_RETURN_TYPE_ANY_BECAUSE_IT_DOES_NOT_HAVE_A_RETURN_TYPE_ANNOTATION,
+                &[&member.name],
+            );
+        }
+    }
+
+    fn collect_class_circular_candidates(&self, members: &[NodeIndex]) -> Vec<ClassCircularMember> {
+        let mut candidates = Vec::new();
+        for &member_idx in members {
+            let Some(node) = self.ctx.arena.get(member_idx) else {
+                continue;
+            };
+
+            // Method: un-annotated return type, with a body. Generator methods
+            // are included — `*m() { return this.m(); }` is circular through its
+            // `Generator` return value, exactly as `tsc` reports (a `yield`
+            // self-reference is not detected here, matching the object-literal
+            // mechanism's return-expression scope).
+            if node.kind == syntax_kind_ext::METHOD_DECLARATION {
+                if let Some(method) = self.ctx.arena.get_method_decl(node)
+                    && method.type_annotation.is_none()
+                    && method.body.is_some()
+                    && let Some(name) = self.get_property_name(method.name)
+                {
+                    candidates.push(ClassCircularMember {
+                        body_idx: method.body,
+                        kind: ClassCircularMemberKind::Method,
+                        is_static: self.has_static_modifier(&method.modifiers),
+                        diagnostic_node: method.name,
+                        name,
+                    });
+                }
+                continue;
+            }
+
+            // Getter: un-annotated return type, with a body. (Setters have no
+            // return value and cannot be return-type circular.)
+            if node.kind == syntax_kind_ext::GET_ACCESSOR {
+                if let Some(accessor) = self.ctx.arena.get_accessor(node)
+                    && accessor.type_annotation.is_none()
+                    && accessor.body.is_some()
+                    && let Some(name) = self.get_property_name(accessor.name)
+                {
+                    candidates.push(ClassCircularMember {
+                        body_idx: accessor.body,
+                        kind: ClassCircularMemberKind::Getter,
+                        is_static: self.has_static_modifier(&accessor.modifiers),
+                        diagnostic_node: accessor.name,
+                        name,
+                    });
+                }
+                continue;
+            }
+
+            // Arrow-function field: `f = () => ...` with no return-type
+            // annotation. A `function` expression field rebinds `this` and is
+            // reported as TS2683 instead, so it is not a candidate.
+            if node.kind == syntax_kind_ext::PROPERTY_DECLARATION
+                && let Some(prop) = self.ctx.arena.get_property_decl(node)
+                && prop.type_annotation.is_none()
+                && prop.initializer.is_some()
+            {
+                let init_idx = self
+                    .ctx
+                    .arena
+                    .skip_parenthesized_and_assertions(prop.initializer);
+                if let Some(init_node) = self.ctx.arena.get(init_idx)
+                    && init_node.kind == syntax_kind_ext::ARROW_FUNCTION
+                    && let Some(func) = self.ctx.arena.get_function(init_node)
+                    && func.type_annotation.is_none()
+                    && func.body.is_some()
+                    && let Some(name) = self.get_property_name(prop.name)
+                {
+                    candidates.push(ClassCircularMember {
+                        body_idx: func.body,
+                        kind: ClassCircularMemberKind::ArrowField,
+                        is_static: self.has_static_modifier(&prop.modifiers),
+                        diagnostic_node: init_idx,
+                        name,
+                    });
+                }
+            }
+        }
+        candidates
+    }
+
+    /// Walk a single return expression subtree, recording which candidate
+    /// members it self-invokes. Stops at nested function/class boundaries that
+    /// rebind `this` or introduce a fresh lexical scope; arrow functions are
+    /// deliberately *not* descended into here — a self-call hidden inside a
+    /// nested closure makes the closure circular, not the enclosing member
+    /// (matching the object-literal `this`-member graph).
+    fn collect_class_self_invocations(
+        &self,
+        expr_idx: NodeIndex,
+        current_is_static: bool,
+        class_sym: Option<SymbolId>,
+        by_key: &FxHashMap<(bool, String), usize>,
+        candidates: &[ClassCircularMember],
+        targets: &mut FxHashSet<usize>,
+    ) {
+        if self.expression_is_void_prefix_unary(expr_idx) {
+            return;
+        }
+        let Some(node) = self.ctx.arena.get(expr_idx) else {
+            return;
+        };
+
+        if matches!(
+            node.kind,
+            syntax_kind_ext::FUNCTION_DECLARATION
+                | syntax_kind_ext::FUNCTION_EXPRESSION
+                | syntax_kind_ext::ARROW_FUNCTION
+                | syntax_kind_ext::METHOD_DECLARATION
+                | syntax_kind_ext::GET_ACCESSOR
+                | syntax_kind_ext::SET_ACCESSOR
+                | syntax_kind_ext::CLASS_DECLARATION
+                | syntax_kind_ext::CLASS_EXPRESSION
+        ) {
+            return;
+        }
+
+        // A call whose callee is `this.X` / `Class.X` invokes member X — valid
+        // for any member kind (method, getter, or arrow field).
+        if node.kind == syntax_kind_ext::CALL_EXPRESSION
+            && let Some(call) = self.ctx.arena.get_call_expr(node)
+        {
+            let callee = self
+                .ctx
+                .arena
+                .skip_parenthesized_and_assertions(call.expression);
+            if let Some((target_static, name)) =
+                self.class_self_member_access(callee, current_is_static, class_sym)
+                && let Some(&j) = by_key.get(&(target_static, name))
+            {
+                targets.insert(j);
+            }
+        }
+
+        // A bare read `this.X` / `Class.X` invokes member X only when X is a
+        // getter (property access triggers the accessor); a method/field read is
+        // just the member's value and is not circular.
+        if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            && let Some((target_static, name)) =
+                self.class_self_member_access(expr_idx, current_is_static, class_sym)
+            && let Some(&j) = by_key.get(&(target_static, name))
+            && candidates[j].kind == ClassCircularMemberKind::Getter
+        {
+            targets.insert(j);
+        }
+
+        for child_idx in self.ctx.arena.get_children(expr_idx) {
+            self.collect_class_self_invocations(
+                child_idx,
+                current_is_static,
+                class_sym,
+                by_key,
+                candidates,
+                targets,
+            );
+        }
+    }
+
+    /// If `access_idx` is a property access `recv.NAME` whose receiver resolves
+    /// to the enclosing class (`this`, or the class name on the static side),
+    /// return `(target_is_static, NAME)`. `this` selects the instance side from
+    /// an instance member and the static side from a static member; the bare
+    /// class name always selects the static side.
+    fn class_self_member_access(
+        &self,
+        access_idx: NodeIndex,
+        current_is_static: bool,
+        class_sym: Option<SymbolId>,
+    ) -> Option<(bool, String)> {
+        let node = self.ctx.arena.get(access_idx)?;
+        if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+        let access = self.ctx.arena.get_access_expr(node)?;
+        let receiver = self
+            .ctx
+            .arena
+            .skip_parenthesized_and_assertions(access.expression);
+        let receiver_node = self.ctx.arena.get(receiver)?;
+
+        let target_static = if receiver_node.kind == SyntaxKind::ThisKeyword as u16 {
+            current_is_static
+        } else if receiver_node.kind == SyntaxKind::Identifier as u16
+            && class_sym.is_some()
+            && self.resolve_identifier_symbol_without_tracking(receiver) == class_sym
+        {
+            true
+        } else {
+            return None;
+        };
+
+        let name = self
+            .ctx
+            .arena
+            .get_identifier_at(access.name_or_argument)
+            .map(|ident| ident.escaped_text.clone())?;
+        Some((target_static, name))
+    }
+}
+
+/// Indices of candidates that lie on a self-invocation cycle (including direct
+/// self-loops). DFS path-stack collection, mirroring the object-literal
+/// `collect_circular_return_graph_sites` cycle walk.
+fn cyclic_member_indices(adjacency: &[Vec<usize>]) -> FxHashSet<usize> {
+    let mut cyclic = FxHashSet::default();
+    let mut visited = vec![false; adjacency.len()];
+    let mut stack = Vec::new();
+    for start in 0..adjacency.len() {
+        collect_cycle(start, adjacency, &mut visited, &mut stack, &mut cyclic);
+    }
+    cyclic
+}
+
+fn collect_cycle(
+    node: usize,
+    adjacency: &[Vec<usize>],
+    visited: &mut [bool],
+    stack: &mut Vec<usize>,
+    cyclic: &mut FxHashSet<usize>,
+) {
+    if let Some(pos) = stack.iter().position(|&n| n == node) {
+        cyclic.extend(stack[pos..].iter().copied());
+        return;
+    }
+    if visited[node] {
+        return;
+    }
+    stack.push(node);
+    for &target in &adjacency[node] {
+        collect_cycle(target, adjacency, visited, stack, cyclic);
+    }
+    stack.pop();
+    visited[node] = true;
+}

--- a/crates/tsz-checker/src/types/computation/mod.rs
+++ b/crates/tsz-checker/src/types/computation/mod.rs
@@ -38,6 +38,7 @@ pub(crate) mod call_helpers;
 pub(crate) mod call_inference;
 pub(crate) mod call_result;
 mod call_result_signatures;
+pub(crate) mod class_member_circularity;
 pub(crate) mod complex;
 mod complex_constructor_inference;
 pub(crate) mod complex_constructors;

--- a/crates/tsz-checker/src/types/function_type_circular.rs
+++ b/crates/tsz-checker/src/types/function_type_circular.rs
@@ -284,7 +284,7 @@ impl<'a> CheckerState<'a> {
         })
     }
 
-    fn collect_initializer_return_expressions_in_function_body(
+    pub(crate) fn collect_initializer_return_expressions_in_function_body(
         &self,
         body_idx: NodeIndex,
         return_exprs: &mut Vec<NodeIndex>,
@@ -1280,7 +1280,7 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn expression_is_void_prefix_unary(&self, expr_idx: NodeIndex) -> bool {
+    pub(crate) fn expression_is_void_prefix_unary(&self, expr_idx: NodeIndex) -> bool {
         let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(expr_idx);
         self.ctx.arena.get(expr_idx).is_some_and(|node| {
             node.kind == syntax_kind_ext::PREFIX_UNARY_EXPRESSION


### PR DESCRIPTION
Fixes #14805.

## Summary

`tsc` reports a circular implicit-`any`-return diagnostic when an un-annotated
class member's inferred return type is referenced, directly or indirectly, in
one of its own return expressions. tsz emitted nothing for class members (silent
false negative), while the variable (`const f = () => f()`) and object-literal
(`{ f() { return this.f() } }`) forms were already handled.

The existing resolving-symbol tracker keys on `FUNCTION_SCOPED_VARIABLE |
BLOCK_SCOPED_VARIABLE` symbols; class member symbols carry neither flag and do
not flow through the object-literal graph, so a self-referential class member was
never recorded as a circular-return site.

## Structural rule

When an un-annotated class member's return value depends on its own (still being
inferred) return type via a `this.`/`Class.` self-invocation, `tsc` reports
TS7023 (named member: method / getter) or TS7024 (anonymous arrow-function
field). tsz now does the same through a new owner,
`check_class_member_circular_returns` (checker, class-check phase).

Per member kind:
- **method** `m() { return this.m(); }` — a **call** is required; a bare read
  `this.m` is the method value, not circular. TS7023 at the method name.
- **getter** `get g() { return this.g; }` — a property **read** invokes the
  accessor, so read or call counts. TS7023 at the accessor name.
- **arrow field** `f = () => this.f();` — a **call** is required. TS7024
  (anonymous) at the arrow node. A `function`-expression field rebinds `this`
  (TS2683) and is not a candidate. Generator methods are included via their
  `Generator` return value.

## Owner layer

Detection lives in the checker's class-check phase
(`crates/tsz-checker/src/types/computation/class_member_circularity.rs`), invoked
from both `check_class_declaration` and `check_class_expression_with_request`. It
builds a per-class self-invocation graph over un-annotated value members and
reports every member on a cycle (direct self-loops and mutual / N-cycles),
mirroring the accepted object-literal circularity graph.

## Anti-hardcoding / no new FP

Detection is **symbol/receiver gated**, never a name-string predicate: a
`recv.X` reference counts only when `recv` is `this` (instance side from an
instance member, static side from a static member) or an identifier that
**resolves to the enclosing class symbol** (static side). An unrelated
`obj.X`/`other.X` access that merely shares a name stays clean — the inverse of
the object-literal FP tracked by #14730, and the same lesson the object-literal
`this` gate already encodes. Diagnostic anchor positions and message text match
`tsc` exactly.

## Adjacent matrix (all verified against tsc 6.0.2)

Reported: instance/static method, instance/static arrow field (`this.`/`Class.`),
private `#field`, getter read & call, wrapped getter read (`[this.g][0]`), call
buried in a larger return expression (`this.m() + 1`, `wrap(this.m())`), mutual
and 3-member cycles, generator method return self-call, generic method.

Stays clean: annotated return type, method/arrow value read without call,
unrelated-receiver same-name access, calling a different annotated member,
`function`-expression field (TS2683), nested object-literal same-name member,
self-call outside return position (`this.m(); return 1;`), member read passed as
an argument, plain generator (`*g() { yield 1; }`).

Known boundary (matches the established object-literal mechanism, pre-existing
and out of scope): a self-call reachable only through a nested closure
(`return [1].map(() => this.m())`), a `this`-aliased local
(`const self = this; return self.m()`), an element-access self-call
(`this["m"]()`), or a `yield` self-reference is not reported. These are false
negatives, never false positives.

## Verification

- New unit suite `class_member_circular_return_tests` (24 cases, binder names
  varied per the anti-hardcoding gate):
  `cargo test -p tsz-checker --lib class_member_circular_return` — all pass.
- No regressions: the full `cargo test -p tsz-checker --lib` failure set was
  diffed against a fresh `origin/main` worktree — every failure reproduces on
  the base commit (environment baseline), and none are in this change's area.
- CLI parity spot-check against `tsc 6.0.2 --noEmit --strict --target es2022
  --lib es2022` on the full repro + adjacent matrix: exact code, position, and
  message all match.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcxrhrfBCFsBt6BX9LzSqM)_