### PR TITLE
fix(checker): TS2344 prints the reduced branch of a concrete conditional constraint (#14786)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1253,6 +1253,9 @@ path = "tests/ts2344_keyof_bare_tparam_defer_tests.rs"
 name = "ts2344_keyof_constraint_display_tests"
 path = "tests/ts2344_keyof_constraint_display_tests.rs"
 [[test]]
+name = "ts2344_conditional_constraint_display_tests"
+path = "tests/ts2344_conditional_constraint_display_tests.rs"
+[[test]]
 name = "keyof_call_parameter_display_tests"
 path = "tests/keyof_call_parameter_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/generics.rs
+++ b/crates/tsz-checker/src/error_reporter/generics.rs
@@ -597,6 +597,27 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // A type-parameter constraint written as a conditional reduces to a
+        // single branch once its check/extends types are concrete. After
+        // type-argument substitution `string extends string ? Box<string> :
+        // string` becomes `Box<string>` and `number extends string ?
+        // number[] : number` becomes `number`. tsc instantiates the
+        // conditional eagerly, so its TS2344 message prints the reduced
+        // branch; tsz keeps the conditional deferred. Mirror tsc by displaying
+        // the evaluated constraint when a conditional constraint actually
+        // reduced to a non-conditional type. A constraint that stays a
+        // conditional (a genuinely deferred conditional with free type
+        // parameters) and every non-conditional constraint (aliases, unions,
+        // object shapes) keep their original display so alias names survive.
+        let display_constraint = if common::is_conditional_type(self.ctx.types, constraint)
+            && !common::is_conditional_type(self.ctx.types, ready_constraint)
+            && ready_constraint != TypeId::ERROR
+        {
+            ready_constraint
+        } else {
+            constraint
+        };
+
         // tsc widens a literal type-arg to its primitive base when the
         // constraint is a primitive base type that the literal's primitive
         // class doesn't match (e.g. `Uppercase<42>` shows `Type 'number'`
@@ -604,7 +625,7 @@ impl<'a> CheckerState<'a> {
         // the literal display (`Foo<"false">` against `"true"` shows
         // `Type '"false"'`).
         let display_type_arg =
-            self.widen_literal_type_arg_for_constraint_display(type_arg, constraint);
+            self.widen_literal_type_arg_for_constraint_display(type_arg, display_constraint);
         let mut type_str = self.format_type_diagnostic(display_type_arg);
         // When the type arg node is a `typeof expr<Args>` (TYPE_QUERY with type args),
         // tsc includes "typeof" in the TS2344 message. The type formatter strips
@@ -633,7 +654,7 @@ impl<'a> CheckerState<'a> {
             }
         }
         let constraint_str = constraint_display
-            .unwrap_or_else(|| self.format_type_diagnostic_constraint(constraint));
+            .unwrap_or_else(|| self.format_type_diagnostic_constraint(display_constraint));
         // Structural check: `IndexedAccess(M, K)` where K is a bounded
         // type parameter satisfies any constraint that ALL of M's property
         // value types are assignable to. tsc's `getApparentType` reduces

--- a/crates/tsz-checker/tests/ts2344_conditional_constraint_display_tests.rs
+++ b/crates/tsz-checker/tests/ts2344_conditional_constraint_display_tests.rs
@@ -1,0 +1,113 @@
+//! Regression tests for #14786: a failing type-parameter constraint that is a
+//! conditional type must render the *evaluated* (reduced) branch in the TS2344
+//! message once the conditional's check/extends types are concrete, matching
+//! tsc.
+//!
+//! Structural rule: tsc instantiates a conditional type-parameter constraint
+//! eagerly, so a constraint like `number extends string ? number[] : number`
+//! (after type-argument substitution it has no remaining type parameters)
+//! reduces to its single branch (`number`) before being formatted. tsz used to
+//! keep the conditional deferred and print the raw, unevaluated conditional.
+//! The relation CHECK was already correct — the right argument was rejected at
+//! the right site — so this is a display-only divergence. The fix lives in the
+//! TS2344 constraint-violation diagnostic path, which now formats the evaluated
+//! constraint when a conditional constraint reduces to a non-conditional type.
+//!
+//! A genuinely deferred conditional (free type parameters remain) and every
+//! non-conditional constraint (aliases, unions, object shapes) keep their
+//! original display, so alias names survive.
+
+fn ts2344_messages(source: &str) -> Vec<String> {
+    tsz_checker::test_utils::check_source_code_messages(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2344)
+        .map(|(_, msg)| msg)
+        .collect()
+}
+
+#[test]
+fn conditional_constraint_false_branch_reduces_to_primitive() {
+    // `number extends string` is false → constraint reduces to `number`.
+    let messages = ts2344_messages(
+        r#"
+type F<U extends (number extends string ? number[] : number)> = U;
+type Bad = F<string>;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "expected one TS2344, got: {messages:?}");
+    assert_eq!(
+        messages[0],
+        "Type 'string' does not satisfy the constraint 'number'."
+    );
+}
+
+#[test]
+fn conditional_constraint_true_branch_reduces_to_array() {
+    // `string extends string` is true → constraint reduces to `string[]`.
+    let messages = ts2344_messages(
+        r#"
+type F<U extends (string extends string ? string[] : number)> = U;
+type Bad = F<number>;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "expected one TS2344, got: {messages:?}");
+    assert_eq!(
+        messages[0],
+        "Type 'number' does not satisfy the constraint 'string[]'."
+    );
+}
+
+#[test]
+fn conditional_constraint_reduces_after_type_argument_substitution() {
+    // After substituting `T = string`, the constraint
+    // `T extends string ? Box<T> : T` becomes the concrete conditional
+    // `string extends string ? Box<string> : string` → `Box<string>`.
+    let messages = ts2344_messages(
+        r#"
+interface Box<T> { value: T; }
+type G<T, U extends (T extends string ? Box<T> : T)> = U;
+type Bad = G<string, string>;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "expected one TS2344, got: {messages:?}");
+    assert_eq!(
+        messages[0],
+        "Type 'string' does not satisfy the constraint 'Box<string>'."
+    );
+}
+
+#[test]
+fn nested_conditional_constraint_reduces_to_single_branch() {
+    // Nested conditional, both levels concrete → reduces to `"yes"`.
+    let messages = ts2344_messages(
+        r#"
+type H<U extends (1 extends number ? (2 extends number ? "yes" : "no") : "x")> = U;
+type Bad = H<number>;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "expected one TS2344, got: {messages:?}");
+    assert_eq!(
+        messages[0],
+        "Type 'number' does not satisfy the constraint '\"yes\"'."
+    );
+}
+
+#[test]
+fn non_conditional_alias_constraint_keeps_alias_name() {
+    // Negative control: a non-conditional alias constraint must keep its alias
+    // name (`Keys`), proving the reduction is scoped to conditional constraints
+    // and does not expand or rewrite other constraint kinds.
+    let messages = ts2344_messages(
+        r#"
+type Keys = "a" | "b";
+type K<X extends Keys> = X;
+type Bad = K<boolean>;
+"#,
+    );
+    assert_eq!(messages.len(), 1, "expected one TS2344, got: {messages:?}");
+    assert!(
+        messages[0].contains("'Keys'"),
+        "plain alias constraint should display `Keys`, got: {:?}",
+        messages[0]
+    );
+}


### PR DESCRIPTION
Fixes #14786.

## Summary
When a type-parameter constraint is a conditional type whose check/extends
types become concrete after type-argument substitution, `tsc` instantiates
the conditional eagerly and prints the *reduced* branch in the TS2344
message. `tsz` kept the conditional deferred and printed the raw,
unevaluated conditional.

Examples (tsz before → after, matching `tsc`):
- `number extends string ? number[] : number` → `number`
- `string extends string ? string[] : number` → `string[]`
- `T extends string ? Box<T> : T` with `T = string` → `Box<string>`
- `1 extends number ? (2 extends number ? "yes" : "no") : "x"` → `"yes"`

The constraint CHECK was already correct (the right argument is rejected at
the right site); only the rendered constraint diverged — a verbatim-message
divergence.

## Structural rule
When a type-parameter constraint is a conditional type whose check and
extends operands contain no remaining type parameters, `tsc` reduces it to a
single branch before formatting; `tsz` must display the same reduced type
through the TS2344 constraint-violation diagnostic path
(`error_reporter::generics` → type printer). Per the architecture rule, the
printer reads the evaluated type rather than the deferred conditional.

## Owner layer
Checker — `crates/tsz-checker/src/error_reporter/generics.rs`,
`error_type_constraint_not_satisfied_with_constraint_display`. The function
already computes the resolved+evaluated constraint (`ready_constraint`); the
fix reuses it for display when, and only when, a conditional constraint
actually reduced to a non-conditional type. No new evaluation work is added.

## Adjacent-case matrix
- Conditional reducing to the **false** branch (primitive) — covered.
- Conditional reducing to the **true** branch (array) — covered.
- Conditional reduced **after type-argument substitution** (`Box<string>`) — covered.
- **Nested** conditional reducing to a single branch — covered.
- **Fallback / negative control:** a non-conditional alias constraint
  (`Keys = "a" | "b"`) keeps its alias name; a genuinely deferred conditional
  (free type parameters remain) and `keyof`/union/object-shape constraints
  keep their original display. The gate is a structural `is_conditional_type`
  TypeData check — no identifier/alias/file-name or printed-string predicate.

## Verification
- New: `cargo test -p tsz-checker --test ts2344_conditional_constraint_display_tests` (5 cases, all pass).
- No regressions across the existing TS2344 display suites
  (`ts2344_keyof_constraint_display_tests`, `ts2344_literal_type_message`,
  `ts2344_widen_literal_arg_display_tests`, `ts2344_generic_ref_scoped_param_concrete_constraint`,
  `ts2344_infer_positional_constraint_tests`, `ts2344_infer_result_application_constraint_tests`,
  `ts2344_typeof_merged_tests`, `ts2344_self_referential_interface_constraint`,
  `ts2344_accessor_constraint`). Two pre-existing failures in this local
  sandbox are caused by the embedded lib not loading
  (`Cannot find global type 'CallableFunction'`) and reproduce identically on
  a clean checkout; ready-review CI owns the broad suites.
- `cargo clippy -p tsz-checker --tests` — zero warnings.
- Manual parity check against `tsc` for all matrix cases (identical output).

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsQJVkbddxRttpqJDezkcn)_