### PR TITLE
fix(solver) #14345: name-aware alpha-rename pairing (same-name-reordered generic signatures, flag-gated)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -17,10 +17,13 @@ use super::erase_type_params_to_constraints;
 
 mod context_instantiation;
 mod generic_constraints;
+mod name_pairing;
 mod overloads;
 mod params;
 
 type HoistedTypeParams = (Vec<TypeParamInfo>, Vec<(TypeId, TypeId)>);
+
+use name_pairing::{alpha_name_pair_enabled, name_aware_target_permutation};
 
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     pub(crate) fn check_function_subtype(
@@ -207,13 +210,50 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
             }
 
+            // #14345 Stage-3: pair the source/target type params for the
+            // alpha-rename. By default this is positional (`source[i]` with
+            // `target[i]`). When the name multisets are equal but the order
+            // differs (`<E,A>` vs `<A,E>`), positional pairing renames the
+            // target body onto the wrong source identities and produces
+            // spurious mismatches; under `TSZ_ALPHA_NAME_PAIR=1`, pair by name
+            // instead so same-named params line up across the reorder. Every
+            // downstream consumer (constraint classification, equivalence
+            // registration, fallback canonicalization) iterates this single
+            // pairing so the chosen alignment is used uniformly.
+            let name_aware_perm = if alpha_name_pair_enabled() {
+                name_aware_target_permutation(
+                    &source_instantiated.type_params,
+                    &target_instantiated.type_params,
+                )
+            } else {
+                None
+            };
+            // Materialize the paired `(source_tp, target_tp)` once so all sites
+            // below agree on the alignment. `TypeParamInfo` is `Copy`, so own
+            // the pairs rather than borrow -- `source_instantiated` /
+            // `target_instantiated` are reassigned by the alpha-rename below.
+            let paired_type_params: Vec<(TypeParamInfo, TypeParamInfo)> = match &name_aware_perm {
+                Some(perm) => perm
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &j)| {
+                        (
+                            source_instantiated.type_params[i],
+                            target_instantiated.type_params[j],
+                        )
+                    })
+                    .collect(),
+                None => source_instantiated
+                    .type_params
+                    .iter()
+                    .zip(target_instantiated.type_params.iter())
+                    .map(|(s, t)| (*s, *t))
+                    .collect(),
+            };
+
             let mut target_to_source_substitution = TypeSubstitution::new();
             let mut source_identity_substitution = TypeSubstitution::new();
-            for (source_tp, target_tp) in source_instantiated
-                .type_params
-                .iter()
-                .zip(target_instantiated.type_params.iter())
-            {
+            for (source_tp, target_tp) in &paired_type_params {
                 let source_type_param_type = self.interner.type_param(*source_tp);
                 target_to_source_substitution.insert(target_tp.name, source_type_param_type);
                 source_identity_substitution.insert(source_tp.name, source_type_param_type);
@@ -252,11 +292,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // merely wraps the target's recursive constraint in extra application
             // layers. For mapped/indexed contexts both directions must hold so
             // apparent-member facts are preserved.
-            let constraints_allow_alpha_rename = source_instantiated
-                .type_params
-                .iter()
-                .zip(target_instantiated.type_params.iter())
-                .all(|(source_tp, target_tp)| {
+            let constraints_allow_alpha_rename =
+                paired_type_params.iter().all(|(source_tp, target_tp)| {
                     let relation = self.classify_generic_tp_constraint(
                         source_tp,
                         target_tp,
@@ -286,11 +323,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // allow structural comparison to treat the original source/target type params
                 // as identical, fixing false mismatches for structurally identical generic
                 // method signatures with different type param names.
-                for (source_tp, target_tp) in source_instantiated
-                    .type_params
-                    .iter()
-                    .zip(target_instantiated.type_params.iter())
-                {
+                for (source_tp, target_tp) in &paired_type_params {
                     let source_tp_type = self.interner.type_param(*source_tp);
                     let target_tp_type = self.interner.type_param(*target_tp);
                     if source_tp_type != target_tp_type {
@@ -355,11 +388,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // (`T` clamps to `{p: string}`, source param becomes `{p: string}[]`,
                 // which the opaque `S extends {p: string}[]` marker accepts).
                 let mut source_substitution = TypeSubstitution::new();
-                for (source_tp, target_tp) in source_instantiated
-                    .type_params
-                    .iter()
-                    .zip(target_instantiated.type_params.iter())
-                {
+                for (source_tp, target_tp) in &paired_type_params {
                     let relation = self.classify_generic_tp_constraint(
                         source_tp,
                         target_tp,

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/name_pairing.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/name_pairing.rs
@@ -1,0 +1,129 @@
+//! #14345 Stage-3 name-aware alpha-rename pairing.
+//!
+//! When two same-arity generic signatures are related, the alpha-rename that
+//! normalizes them onto one set of type-parameter identities historically
+//! pairs the source/target type parameters by declaration POSITION (a `.zip`
+//! of the two `type_params` lists). When the signatures use the SAME multiset
+//! of names in a DIFFERENT order (e.g. `<E,A>` vs `<A,E>`), positional pairing
+//! renames the target body onto the wrong source identities and produces a
+//! spurious mismatch (TS2322/TS2345). Under `TSZ_ALPHA_NAME_PAIR=1` the pairing
+//! is done by NAME instead, so same-named params line up across the reorder.
+
+use crate::types::TypeParamInfo;
+
+/// Gate for name-aware alpha-rename pairing (flag `TSZ_ALPHA_NAME_PAIR=1`).
+///
+/// Byte-parity-inert when OFF (the default): the pairing falls back to the
+/// historical positional `.zip`. The mis-pairing this flag fixes only becomes
+/// observable under the dormant `TSZ_TYPEPARAM_DECL_IDENTITY` keystone
+/// (#14696), whose distinct `DeclScoped` ids stop same-name source params from
+/// interning to a single id that masks the reorder.
+pub(super) fn alpha_name_pair_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("TSZ_ALPHA_NAME_PAIR").is_ok_and(|v| v == "1"))
+}
+
+/// Compute a name-aware pairing of source/target type parameters.
+///
+/// When the source and target type-parameter lists carry the SAME multiset of
+/// names, return a permutation `perm` such that `target[perm[i]]` has the same
+/// name as `source[i]`. This lets the alpha-rename pair same-name params across
+/// a reordered declaration (`<E,A>` vs `<A,E>`) instead of by position, which
+/// would otherwise rename the target body onto the wrong source identities.
+///
+/// Returns `None` when the lists differ in length or the name multisets are not
+/// equal (caller falls back to positional pairing). The comparison is over
+/// `Atom` name identities only -- no surface-text or user-name string
+/// inspection.
+pub(super) fn name_aware_target_permutation(
+    source_type_params: &[TypeParamInfo],
+    target_type_params: &[TypeParamInfo],
+) -> Option<Vec<usize>> {
+    if source_type_params.len() != target_type_params.len() {
+        return None;
+    }
+    let mut used = vec![false; target_type_params.len()];
+    let mut perm = Vec::with_capacity(source_type_params.len());
+    for source_tp in source_type_params {
+        let matched = target_type_params
+            .iter()
+            .enumerate()
+            .find(|(idx, target_tp)| !used[*idx] && target_tp.name == source_tp.name);
+        match matched {
+            Some((idx, _)) => {
+                used[idx] = true;
+                perm.push(idx);
+            }
+            // A source name has no unused same-named target counterpart ->
+            // the name multisets are not equal; abort, keep positional.
+            None => return None,
+        }
+    }
+    Some(perm)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::name_aware_target_permutation;
+    use crate::types::TypeParamInfo;
+    use tsz_common::interner::Atom;
+
+    fn tp(name: u32) -> TypeParamInfo {
+        TypeParamInfo::simple(Atom(name))
+    }
+
+    #[test]
+    fn identity_order_yields_identity_permutation() {
+        let src = [tp(1), tp(2), tp(3)];
+        let tgt = [tp(1), tp(2), tp(3)];
+        assert_eq!(
+            name_aware_target_permutation(&src, &tgt),
+            Some(vec![0, 1, 2])
+        );
+    }
+
+    #[test]
+    fn reordered_same_names_pair_by_name() {
+        // source <A,E> (1,2) vs target <E,A> (2,1): source[0]=A pairs target[1],
+        // source[1]=E pairs target[0].
+        let src = [tp(1), tp(2)];
+        let tgt = [tp(2), tp(1)];
+        assert_eq!(name_aware_target_permutation(&src, &tgt), Some(vec![1, 0]));
+    }
+
+    #[test]
+    fn different_names_fall_back_to_positional() {
+        // source <A,E> (1,2) vs target <T,U> (3,4): no shared names -> None.
+        let src = [tp(1), tp(2)];
+        let tgt = [tp(3), tp(4)];
+        assert_eq!(name_aware_target_permutation(&src, &tgt), None);
+    }
+
+    #[test]
+    fn length_mismatch_is_none() {
+        let src = [tp(1), tp(2)];
+        let tgt = [tp(1)];
+        assert_eq!(name_aware_target_permutation(&src, &tgt), None);
+    }
+
+    #[test]
+    fn repeated_names_consume_each_target_once() {
+        // multiset {A,A,E} vs {A,E,A}: each source consumes one unused same-named
+        // target in order.
+        let src = [tp(1), tp(1), tp(2)];
+        let tgt = [tp(1), tp(2), tp(1)];
+        assert_eq!(
+            name_aware_target_permutation(&src, &tgt),
+            Some(vec![0, 2, 1])
+        );
+    }
+
+    #[test]
+    fn unequal_multiset_same_len_is_none() {
+        // {A,A} vs {A,E}: second source A finds no second target A -> None.
+        let src = [tp(1), tp(1)];
+        let tgt = [tp(1), tp(2)];
+        assert_eq!(name_aware_target_permutation(&src, &tgt), None);
+    }
+}


### PR DESCRIPTION
## Summary

Name-aware alpha-rename pairing for **same-name-different-order** generic
signatures, the bounded first slice of the #14345 flag-flip (#14351).

When two same-arity generic signatures use the SAME multiset of type-parameter
names in a DIFFERENT declaration order, the signature-relation alpha-rename in
`relations/subtype/rules/functions/checking.rs` pairs them by declaration
POSITION (a `.zip` of the two `type_params` lists). For the witness
`fp-ts ReadonlyTuple.ts:218` — `extract: <E,A>(wa: readonly [A,E]) => A = fst`
where `fst: <A,E>(...) => A` — positional pairing maps `extract[0]=E` ↔
`fst[0]=A`, rewriting the target body `[A,E] → [E,A] != source [A,E]` and
producing a spurious `TS2322`. Flag-OFF the same-surface `A`/`E` intern to one
id and mask it; under the dormant `TSZ_TYPEPARAM_DECL_IDENTITY` keystone
(#14696) the distinct `DeclScoped` ids expose it.

**Structural rule:** When two same-arity generic signatures carry the same
multiset of type-param names in a different order, `tsc` relates them by name;
tsz related them by position through the signature-relation alpha-rename. This
PR pairs by name when the name multisets are equal.

**Owner layer:** solver, signature subtype relation (`SubtypeChecker`,
`checking.rs` / new `checking/name_pairing.rs`). Atom-name-set structural
comparison only — no surface-text / user-name / file-name string checks.

**Fix (gated `TSZ_ALPHA_NAME_PAIR=1`, byte-parity-inert OFF):** compute one
shared `paired_type_params` alignment. When the source/target type-param NAME
multisets are equal, pair by name (`target[perm[i]]` has the same name as
`source[i]`); otherwise keep the positional fallback. The single alignment is
consumed uniformly by all four sites: substitution build, constraint
classification, equivalence registration, and the Strategy-2 fallback
canonicalization. Does NOT flip the default.

## Scope / honest result (the STEP-1 binning)

This slice clears the **same-name-different-order** family only — **2 of the 53**
flag-ON regressions (the named witnesses). The other **51** are a different,
deeper family and are **out of scope** for name-pairing:

- HKT typeclass-instance object→interface relations (`{ URI: "Array"; map:
  Monad1<URI>["map"]; ... }` not assignable to `Applicative1<URI>`) — nested
  member-signature relation through indexed-access, the equiv-through-Application
  case.
- Instantiation drops where an inner type param falls to `unknown` / loses its
  args (`HKT<F, unknown>` vs `HKT<F, B>`; `HKT` vs `HKT<F, A>`).
- Different-name re-mint drift (`Type 'A' is not assignable to type 'T'`).

Probe over all alpha-rename pairings (decl-identity ON regime): 22461
same-name-same-order, **150 same-name-reordered**, 963 different-name. The 51
residual are NOT reordered-signature cases — they need the equiv-through-eval /
nested-Application representation wave, not this bounded pairing.

## Verification (the full gauge)

fp-ts guard (`tsconfig.tsz-guard.json`), decl-identity ON; `np` = `TSZ_ALPHA_NAME_PAIR`:

| metric | base (np=0) | with fix (np=1) |
| --- | --- | --- |
| total FPs (decl-identity ON) | 1252 | **1245** |
| flag-ON regressions vs OFF | 53 | **51** (2 cleared, the witnesses) |
| fixes kept (off-only) | 280 | **285** (+5) |
| NEW regressions introduced by fix | — | **0** |

Net on fp-ts: −7 FPs, zero new regressions.

**Soundness (the invisible +16 over-relate side — gauged on solver/conformance,
NOT fp-ts):**

- Targeted solver nextest `relate+subtype+generic+variance+type_param+
  application+signature+alpha+name_pairing`: **identical flag-OFF vs flag-ON** —
  2285 pass, 1 pre-existing base-branch failure
  (`higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`),
  0 new from this change. + 6 new `name_pairing` unit tests (identity,
  reordered, different-names fallback, length mismatch, repeated names, unequal
  multiset).
- Full solver nextest: flag-OFF and flag-ON byte-identical (same 4 pre-existing
  base-branch failures, 0 new).
- Conformance byte-parity flag-ON vs OFF, ~620 tests across signature-relation /
  variance / type-param families (`typeRelationships` 265, `assignmentCompat`
  128, `typeParameter` 101, `typeArgument` 43, `override` 34, `variance` 16,
  `genericFunction` 16, `subtypingWithCallSignatures` 8, `contravariant` 6,
  `genericContextualTyping`, `covariant`, `bivarian`): **IDENTICAL, 0 failures
  in both** → no new `missing=` → **no over-relate**.
- byte-parity flag-OFF (pure default): fp-ts **1479 unchanged**.
- Determinism: identical md5 across RAYON 1/4/8 for both flag states.

## Base-branch note

Stacked on `team-lead/14345-stage2-instantiate-key-origin` (the brick
`9a94c97a95` measurement branch). That base already carries probe
instrumentation that fails 4 solver tests (incl. the `checking.rs` file-size
ceiling, already 2044 > 2000 lines on base) and 7 pre-existing clippy warnings —
none introduced here. This change adds no new solver-test failures and no new
clippy warnings.

Goal: green

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
