### PR TITLE
fix(checker): emit TS2748 for imported ambient const enums under isolatedModules (#14811)

### DIFF
--- a/crates/tsz-checker/src/context/compiler_options.rs
+++ b/crates/tsz-checker/src/context/compiler_options.rs
@@ -170,6 +170,19 @@ impl<'a> CheckerContext<'a> {
         self.compiler_options.isolated_modules || self.compiler_options.verbatim_module_syntax
     }
 
+    /// Check if the *raw* `isolatedModules` flag is set, excluding the value
+    /// implied by `verbatimModuleSyntax`.
+    ///
+    /// `isolated_modules` stores tsc's computed value (`isolatedModules ||
+    /// verbatimModuleSyntax`); a few checks need the raw flag tsc reads directly
+    /// — notably `checkConstEnumAccess`, where the access-site TS2748 fires on
+    /// raw `isolatedModules` while a verbatim-only import is reported at the
+    /// import statement instead.
+    pub const fn raw_isolated_modules(&self) -> bool {
+        self.compiler_options.isolated_modules
+            && !self.compiler_options.isolated_modules_from_verbatim
+    }
+
     /// Check if isolatedDeclarations is enabled.
     pub const fn isolated_declarations(&self) -> bool {
         self.compiler_options.isolated_declarations

--- a/crates/tsz-checker/src/declarations/import/verbatim.rs
+++ b/crates/tsz-checker/src/declarations/import/verbatim.rs
@@ -465,22 +465,22 @@ impl<'a> CheckerState<'a> {
     ) -> bool {
         let normalized = module_name.trim_matches('"').trim_matches('\'');
 
-        // Try resolve_import_target first (multi-file mode)
+        // Try resolve_import_target first (multi-file mode). Ambient-ness is a
+        // property of the *declaring* file, so evaluate the const enum's
+        // declarations against the target module's arena rather than the
+        // importing file. This recognizes both const enums declared in a `.d.ts`
+        // and `declare const enum` declared in a regular `.ts`.
         if let Some(target_idx) = self.ctx.resolve_import_target(normalized) {
-            // Check if the target file is a .d.ts
-            let is_ambient_file = {
-                let arena = self.ctx.get_arena_for_file(target_idx as u32);
-                arena
-                    .source_files
-                    .first()
-                    .is_some_and(|sf| sf.is_declaration_file)
-            };
-            if is_ambient_file
-                && let Some(target_binder) = self.ctx.get_binder_for_file(target_idx)
+            let target_arena = self.ctx.get_arena_for_file(target_idx as u32);
+            if let Some(target_binder) = self.ctx.get_binder_for_file(target_idx)
                 && let Some(sym_id) = target_binder.file_locals.get(import_name)
                 && let Some(sym) = target_binder.get_symbol(sym_id)
             {
-                return sym.has_any_flags(tsz_binder::symbol_flags::CONST_ENUM);
+                return sym.has_any_flags(tsz_binder::symbol_flags::CONST_ENUM)
+                    && crate::types_domain::property_access_type::helpers::declarations_are_ambient(
+                        target_arena,
+                        sym,
+                    );
             }
         }
 
@@ -492,18 +492,16 @@ impl<'a> CheckerState<'a> {
                 && let Some(sym_id) = exports.get(import_name)
                 && let Some(sym) = self.ctx.binder.get_symbol(sym_id)
             {
-                // In module_exports mode, check if any declaration is in a .d.ts
-                // We check symbol flags: if it's CONST_ENUM and declared in the current
-                // binder's d.ts file context
-                if sym.has_any_flags(tsz_binder::symbol_flags::CONST_ENUM) {
-                    // Check declarations to see if they come from ambient context
-                    let all_ambient = sym.declarations.iter().all(|&decl_idx| {
-                        self.ctx.arena.is_in_ambient_context(decl_idx)
-                            || self.ctx.is_declaration_file()
-                    });
-                    if all_ambient {
-                        return true;
-                    }
+                // Single-pass mode keeps a single arena, so the const enum's
+                // declarations are meaningful against `self.ctx.arena`. Share the
+                // same ambient determination used on the multi-file path above.
+                if sym.has_any_flags(tsz_binder::symbol_flags::CONST_ENUM)
+                    && crate::types_domain::property_access_type::helpers::declarations_are_ambient(
+                        self.ctx.arena,
+                        sym,
+                    )
+                {
+                    return true;
                 }
             }
         }

--- a/crates/tsz-checker/src/types/property_access_type/enum_namespace_access.rs
+++ b/crates/tsz-checker/src/types/property_access_type/enum_namespace_access.rs
@@ -83,7 +83,7 @@ impl<'a> CheckerState<'a> {
                 .and_then(|e| e.get(property_name));
             let value_decl = resolved_symbol.value_declaration;
             let first_decl = resolved_symbol.declarations.first().copied();
-            let is_ambient = self.is_const_enum_ambient(resolved_symbol);
+            let is_ambient = self.is_const_enum_ambient(resolved_sym_id, resolved_symbol);
             (own_member, value_decl, first_decl, is_ambient)
         };
         let (member_sym_id, resolved_flags, resolved_is_ambient) = if let Some(id) = member_sym_id {
@@ -98,7 +98,11 @@ impl<'a> CheckerState<'a> {
                     .get_cross_file_symbol(alias_target)
                     .or_else(|| self.ctx.binder.get_symbol(alias_target))?;
                 let id = alias_sym.exports.as_ref()?.get(property_name)?;
-                (id, alias_sym.flags, self.is_const_enum_ambient(alias_sym))
+                (
+                    id,
+                    alias_sym.flags,
+                    self.is_const_enum_ambient(alias_target, alias_sym),
+                )
             };
             if alias_flags & (symbol_flags::ENUM | symbol_flags::VALUE_MODULE) == 0 {
                 return None;
@@ -175,11 +179,31 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            // TS2748: Cannot access ambient const enums when isolatedModules is enabled.
-            if self.ctx.isolated_modules()
-                && resolved_flags & symbol_flags::CONST_ENUM != 0
+            // TS2748: Cannot access ambient const enums when isolatedModules /
+            // verbatimModuleSyntax is enabled.
+            //
+            // tsc gates the *access-site* diagnostic on
+            //   rawIsolatedModules || (verbatimModuleSyntax && firstId is not an alias)
+            // (`checkConstEnumAccess`). Under verbatimModuleSyntax alone an
+            // *imported* const enum is reported once at the import statement
+            // instead, so the access site stays silent when the base identifier
+            // resolves to an import alias. A locally-declared const enum (no
+            // alias) is still reported at the access site under
+            // verbatimModuleSyntax. Raw `isolatedModules` always reports here.
+            //
+            // An imported const enum can only be named through an import alias, so
+            // "first identifier is an alias" reduces to "the const enum is declared
+            // in another file". `base_sym_id` is already alias-resolved (the binder
+            // follows imports), so compare the resolved const enum's declaring file
+            // against the current file. The const-enum/ambient guards come first so
+            // the cross-file declaring-file lookup only runs for the rare
+            // verbatim-only ambient const enum access.
+            if resolved_flags & symbol_flags::CONST_ENUM != 0
                 && resolved_is_ambient
                 && !self.is_in_type_only_position(idx)
+                && (self.ctx.raw_isolated_modules()
+                    || (self.ctx.compiler_options.verbatim_module_syntax
+                        && !self.symbol_is_imported(resolved_sym_id)))
             {
                 let option_name = if self.ctx.compiler_options.verbatim_module_syntax {
                     "verbatimModuleSyntax"

--- a/crates/tsz-checker/src/types/property_access_type/helpers.rs
+++ b/crates/tsz-checker/src/types/property_access_type/helpers.rs
@@ -8,10 +8,34 @@ use crate::state::{CheckerState, MAX_INSTANTIATION_DEPTH};
 use tsz_binder::symbol_flags;
 use tsz_common::common::Visibility;
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node::{AccessExprData, NodeAccess};
+use tsz_parser::parser::node::{AccessExprData, NodeAccess, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
+
+/// Decide whether every declaration of `sym` is ambient when interpreted in the
+/// arena of the file that owns them. A const enum is ambient when it lives in a
+/// `.d.ts` file (everything there is implicitly ambient) or when each declaration
+/// carries the `declare` modifier / sits inside an ambient context.
+///
+/// `arena` must be the arena of the file that declares `sym`; the declaration
+/// indices in `sym.declarations` are only meaningful against that arena.
+pub(crate) fn declarations_are_ambient(arena: &NodeArena, sym: &tsz_binder::Symbol) -> bool {
+    // Everything inside a `.d.ts` is implicitly ambient, even without `declare`.
+    if arena
+        .source_files
+        .first()
+        .is_some_and(|sf| sf.is_declaration_file)
+    {
+        return true;
+    }
+    if sym.declarations.is_empty() {
+        return false;
+    }
+    sym.declarations
+        .iter()
+        .all(|&decl_idx| arena.is_in_ambient_context(decl_idx))
+}
 
 impl<'a> CheckerState<'a> {
     /// Handles import.meta property access.
@@ -1348,24 +1372,46 @@ impl<'a> CheckerState<'a> {
         None
     }
 
-    /// Check if a const enum symbol is "ambient" — declared with `declare` keyword
-    /// or originating from a `.d.ts` file. Ambient const enums have no runtime
-    /// representation and cannot be accessed under `isolatedModules`.
-    pub(crate) fn is_const_enum_ambient(&self, sym: &tsz_binder::Symbol) -> bool {
-        // If the file itself is a .d.ts, everything in it is ambient.
-        if self.ctx.is_declaration_file() {
-            return true;
-        }
-        // Check if all declarations are in ambient context (e.g., `declare const enum`).
-        if sym.declarations.is_empty() {
-            return false;
-        }
-        for &decl_idx in &sym.declarations {
-            if !self.ctx.arena.is_in_ambient_context(decl_idx) {
-                return false;
-            }
-        }
-        true
+    /// Check if a const enum symbol is "ambient" — declared with the `declare`
+    /// keyword or originating from a `.d.ts` file. Ambient const enums have no
+    /// runtime representation and cannot be accessed under `isolatedModules` /
+    /// `verbatimModuleSyntax`.
+    ///
+    /// Ambient-ness is a property of where the const enum is *declared*, not
+    /// where it is accessed. For an imported const enum the declarations live in
+    /// another module's arena, so the `.d.ts` and ambient-context checks must run
+    /// against the *declaring* file, never the importing file (`self.ctx.arena`).
+    /// Using the importing file's arena would look up declaration indices that do
+    /// not exist there, silently report "not ambient", and drop the TS2748 gate
+    /// for every cross-file ambient const enum.
+    pub(crate) fn is_const_enum_ambient(
+        &self,
+        sym_id: tsz_binder::SymbolId,
+        sym: &tsz_binder::Symbol,
+    ) -> bool {
+        let arena = if sym.decl_file_idx != u32::MAX {
+            // Production driver path: the binder stamps every user symbol with the
+            // file index that declares it.
+            self.ctx.get_arena_for_file(sym.decl_file_idx)
+        } else if let Some(file_idx) = self.ctx.resolve_symbol_file_index_stable(sym_id) {
+            self.ctx.get_arena_for_file(file_idx as u32)
+        } else {
+            self.ctx.arena
+        };
+        declarations_are_ambient(arena, sym)
+    }
+
+    /// Whether `sym_id` is declared in a file other than the one being checked,
+    /// i.e. it can only be named here through an import. Resolves cross-file
+    /// symbols and tolerates harnesses that have not stamped `decl_file_idx`.
+    pub(crate) fn symbol_is_imported(&self, sym_id: tsz_binder::SymbolId) -> bool {
+        self.get_cross_file_symbol(sym_id)
+            .or_else(|| self.ctx.binder.get_symbol(sym_id))
+            .map(|s| s.decl_file_idx)
+            .filter(|&f| f != u32::MAX)
+            .map(|f| f as usize)
+            .or_else(|| self.ctx.resolve_symbol_file_index_stable(sym_id))
+            .is_some_and(|f| f != self.ctx.current_file_idx)
     }
 
     /// Check if a node is in a type-only position (e.g., computed property name

--- a/crates/tsz-checker/src/types/property_access_type/mod.rs
+++ b/crates/tsz-checker/src/types/property_access_type/mod.rs
@@ -3,7 +3,7 @@
 
 mod class_recovery;
 mod enum_namespace_access;
-mod helpers;
+pub(crate) mod helpers;
 mod identifier_resolution;
 mod imported_array_to_enum;
 pub(crate) mod known_globals;

--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -56,6 +56,9 @@ mod fs_tests;
 #[path = "../tests/generic_interface_bivariant_param_relation_tests.rs"]
 mod generic_interface_bivariant_param_relation_tests;
 #[cfg(test)]
+#[path = "../tests/imported_ambient_const_enum_ts2748_cli_tests.rs"]
+mod imported_ambient_const_enum_ts2748_cli_tests;
+#[cfg(test)]
 #[path = "../tests/interface_extends_cross_module_class_cli_tests.rs"]
 mod interface_extends_cross_module_class_cli_tests;
 #[cfg(test)]

--- a/crates/tsz-cli/tests/imported_ambient_const_enum_ts2748_cli_tests.rs
+++ b/crates/tsz-cli/tests/imported_ambient_const_enum_ts2748_cli_tests.rs
@@ -1,0 +1,294 @@
+//! TS2748 ("Cannot access ambient const enums when `isolatedModules` is
+//! enabled") for *imported* ambient const enums (#14811).
+//!
+//! Structural rule: ambient-ness of a const enum is a property of the file that
+//! *declares* it, not the file that *accesses* it. `is_const_enum_ambient`
+//! previously resolved each declaration's ambient context against the importing
+//! file's arena, so a cross-file imported const enum looked non-ambient and the
+//! access-site TS2748 gate was skipped (false negative). The check now resolves
+//! the declaration against the arena of the file that owns the symbol.
+//!
+//! tsc's `checkConstEnumAccess` gates the access-site diagnostic on
+//! `rawIsolatedModules || (verbatimModuleSyntax && firstId-is-not-an-alias)`.
+//! Under `verbatimModuleSyntax` alone an imported const enum is reported once at
+//! the import statement instead, so the access site stays silent for imports; a
+//! locally-declared const enum (no alias) is still reported at the access site.
+//! Raw `isolatedModules` always reports at the access site.
+//!
+//! These run through the real multi-file driver (`crate::driver::compile`) so
+//! cross-file const enum member resolution and the production option fan-out
+//! (`verbatimModuleSyntax -> isolatedModules`) are exercised on the real path.
+//! Binder and file names are varied so the behaviour follows structure, not
+//! identifier text.
+
+use crate::args::CliArgs;
+use clap::Parser;
+use tsz_checker::diagnostics::Diagnostic;
+
+const TS2748: u32 = 2748;
+
+/// Compile `files` (written into one temp dir) with the given extra flags and
+/// root-file order.
+fn compile(files: &[(&str, &str)], extra_flags: &[&str], roots: &[&str]) -> Vec<Diagnostic> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    for (name, contents) in files {
+        std::fs::write(dir.path().join(name), contents).expect("write repro file");
+    }
+
+    let mut argv: Vec<&str> = vec![
+        "tsz",
+        "--ignoreConfig",
+        "--noEmit",
+        "--strict",
+        "--target",
+        "es2022",
+        "--module",
+        "esnext",
+        "--moduleResolution",
+        "bundler",
+        "--lib",
+        "es2022",
+    ];
+    argv.extend_from_slice(extra_flags);
+    argv.extend_from_slice(roots);
+
+    let args = CliArgs::try_parse_from(argv).expect("parse args");
+    crate::driver::compile(&args, dir.path())
+        .expect("compile should succeed")
+        .diagnostics
+}
+
+fn count_ts2748(diagnostics: &[Diagnostic]) -> usize {
+    diagnostics.iter().filter(|d| d.code == TS2748).count()
+}
+
+/// 1-based line numbers of every TS2748 anchored in the file named `basename`,
+/// derived from the diagnostic `start` offset against the known `content`.
+fn ts2748_lines_in(diagnostics: &[Diagnostic], basename: &str, content: &str) -> Vec<u32> {
+    let mut lines: Vec<u32> = diagnostics
+        .iter()
+        .filter(|d| d.code == TS2748 && d.file.ends_with(basename))
+        .map(|d| {
+            content[..d.start as usize]
+                .bytes()
+                .filter(|&b| b == b'\n')
+                .count() as u32
+                + 1
+        })
+        .collect();
+    lines.sort_unstable();
+    lines
+}
+
+/// The consuming module used by the verbatim/both-flag placement cases: the
+/// import is on line 1, the const-enum access on line 2.
+const MAIN_IMPORTS_COLOR: &str = "import { Color } from './en';\nconst c = Color.Red;\n";
+
+// ---------------------------------------------------------------------------
+// isolatedModules: access-site diagnostic, imported or local.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn iso_imported_declare_const_enum_from_dts_flags_access_site() {
+    // The reported repro.
+    let diagnostics = compile(
+        &[
+            (
+                "en.d.ts",
+                "export declare const enum Color { Red, Green, Blue }\n",
+            ),
+            (
+                "main.ts",
+                "import { Color } from './en';\nconst c = Color.Red;\n",
+            ),
+        ],
+        &["--isolatedModules"],
+        &["en.d.ts", "main.ts"],
+    );
+    assert_eq!(
+        count_ts2748(&diagnostics),
+        1,
+        "expected one TS2748 for imported ambient const enum access, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn iso_imported_declare_const_enum_from_regular_ts_flags_access_site() {
+    // `declare const enum` is ambient even in a regular `.ts` file; the ambient
+    // check must walk the source arena, not just the `.d.ts` shortcut.
+    let diagnostics = compile(
+        &[
+            (
+                "shades.ts",
+                "export declare const enum Shade { Dark, Light }\n",
+            ),
+            (
+                "main.ts",
+                "import { Shade } from './shades';\nconst s = Shade.Dark;\n",
+            ),
+        ],
+        &["--isolatedModules"],
+        &["shades.ts", "main.ts"],
+    );
+    assert_eq!(
+        count_ts2748(&diagnostics),
+        1,
+        "expected one TS2748 for imported `declare const enum` from a regular .ts, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn iso_imported_plain_const_enum_from_dts_flags_access_site() {
+    // Inside a `.d.ts` every declaration is implicitly ambient, so a `const enum`
+    // without an explicit `declare` is still ambient when imported.
+    let diagnostics = compile(
+        &[
+            ("hue.d.ts", "export const enum Hue { Warm, Cool }\n"),
+            (
+                "main.ts",
+                "import { Hue } from './hue';\nconst h = Hue.Warm;\n",
+            ),
+        ],
+        &["--isolatedModules"],
+        &["hue.d.ts", "main.ts"],
+    );
+    assert_eq!(
+        count_ts2748(&diagnostics),
+        1,
+        "expected one TS2748 for imported implicit-ambient const enum, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn iso_local_declare_const_enum_still_flags_access_site() {
+    // Control: the local case already worked; the cross-file fix must not regress it.
+    let diagnostics = compile(
+        &[(
+            "main.ts",
+            "export {};\ndeclare const enum Tone { Soft, Loud }\nconst t = Tone.Soft;\n",
+        )],
+        &["--isolatedModules"],
+        &["main.ts"],
+    );
+    assert_eq!(
+        count_ts2748(&diagnostics),
+        1,
+        "expected one TS2748 for local ambient const enum access, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn imported_const_enum_without_flags_is_clean() {
+    // No over-correction: without isolatedModules / verbatimModuleSyntax the
+    // access is allowed.
+    let diagnostics = compile(
+        &[
+            (
+                "en.d.ts",
+                "export declare const enum Color { Red, Green, Blue }\n",
+            ),
+            (
+                "main.ts",
+                "import { Color } from './en';\nconst c = Color.Red;\n",
+            ),
+        ],
+        &[],
+        &["en.d.ts", "main.ts"],
+    );
+    assert_eq!(
+        count_ts2748(&diagnostics),
+        0,
+        "expected no TS2748 without isolatedModules, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn imported_non_const_ambient_enum_is_not_flagged() {
+    // No over-correction: TS2748 is specific to *const* enums.
+    let diagnostics = compile(
+        &[
+            (
+                "dir.d.ts",
+                "export declare enum Direction { North, South }\n",
+            ),
+            (
+                "main.ts",
+                "import { Direction } from './dir';\nconst d = Direction.North;\n",
+            ),
+        ],
+        &["--isolatedModules"],
+        &["dir.d.ts", "main.ts"],
+    );
+    assert_eq!(
+        count_ts2748(&diagnostics),
+        0,
+        "expected no TS2748 for a non-const ambient enum, got: {diagnostics:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// verbatimModuleSyntax: imported -> import site only; local -> access site.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn verbatim_imported_const_enum_reports_only_at_import_site() {
+    // tsc reports the imported const enum once, at the import statement (line 1),
+    // and stays silent at the access expression (line 2).
+    let diagnostics = compile(
+        &[
+            (
+                "en.d.ts",
+                "export declare const enum Color { Red, Green, Blue }\n",
+            ),
+            ("main.ts", MAIN_IMPORTS_COLOR),
+        ],
+        &["--verbatimModuleSyntax"],
+        &["en.d.ts", "main.ts"],
+    );
+    assert_eq!(
+        ts2748_lines_in(&diagnostics, "main.ts", MAIN_IMPORTS_COLOR),
+        vec![1],
+        "expected a single import-site TS2748 (line 1) under verbatimModuleSyntax, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn verbatim_local_const_enum_reports_at_access_site() {
+    // A local const enum has no import alias, so it is reported at the access site.
+    let diagnostics = compile(
+        &[(
+            "main.ts",
+            "export {};\ndeclare const enum Tone { Soft, Loud }\nconst t = Tone.Soft;\n",
+        )],
+        &["--verbatimModuleSyntax"],
+        &["main.ts"],
+    );
+    assert_eq!(
+        count_ts2748(&diagnostics),
+        1,
+        "expected one access-site TS2748 for a local const enum under verbatimModuleSyntax, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn both_flags_imported_reports_at_both_import_and_access_sites() {
+    // With raw `isolatedModules` *and* `verbatimModuleSyntax`, tsc reports the
+    // imported const enum at both the import statement (line 1, verbatim) and the
+    // access expression (line 2, raw isolatedModules).
+    let diagnostics = compile(
+        &[
+            (
+                "en.d.ts",
+                "export declare const enum Color { Red, Green, Blue }\n",
+            ),
+            ("main.ts", MAIN_IMPORTS_COLOR),
+        ],
+        &["--isolatedModules", "--verbatimModuleSyntax"],
+        &["en.d.ts", "main.ts"],
+    );
+    assert_eq!(
+        ts2748_lines_in(&diagnostics, "main.ts", MAIN_IMPORTS_COLOR),
+        vec![1, 2],
+        "expected import-site (line 1) and access-site (line 2) TS2748 with both flags, got: {diagnostics:?}"
+    );
+}

--- a/crates/tsz-common/src/options/checker.rs
+++ b/crates/tsz-common/src/options/checker.rs
@@ -170,6 +170,17 @@ pub struct CheckerOptions {
     /// When true, do not transform or elide any imports or exports not marked as type-only.
     /// Under this mode, importing a `.d.ts` file without `import type` is an error (TS2846).
     pub verbatim_module_syntax: bool,
+    /// Set by the option fan-out when `isolated_modules` was turned on *only*
+    /// because `verbatim_module_syntax` implies it (tsc's computed
+    /// `isolatedModules = isolatedModules || verbatimModuleSyntax`).
+    ///
+    /// `isolated_modules` therefore stores the computed value (what tsc's
+    /// `getIsolatedModules` returns). A few checks need the *raw*
+    /// `isolatedModules` flag instead — notably `checkConstEnumAccess`, which
+    /// gates the access-site TS2748 on raw `isolatedModules` and reports
+    /// verbatim-only cases at the import statement. Recover the raw flag as
+    /// `isolated_modules && !isolated_modules_from_verbatim`.
+    pub isolated_modules_from_verbatim: bool,
     /// When true, suppress deprecation warnings (e.g., TS2880 for `assert` import assertions).
     /// Set when `ignoreDeprecations` is "5.0" or "6.0".
     pub ignore_deprecations: bool,
@@ -273,6 +284,7 @@ impl Default for CheckerOptions {
             implied_classic_resolution: false,
             jsx_import_source: String::new(),
             verbatim_module_syntax: false,
+            isolated_modules_from_verbatim: false,
             ignore_deprecations: false,
             allow_umd_global_access: false,
             preserve_const_enums: false,

--- a/crates/tsz-common/src/options/checker_fanout.rs
+++ b/crates/tsz-common/src/options/checker_fanout.rs
@@ -26,8 +26,14 @@ pub const fn apply_checker_fanout(options: &mut CheckerOptions) {
     // `verbatimModuleSyntax` implies `isolatedModules`
     // (tsc `computedOptions.isolatedModules`:
     // `isolatedModules || verbatimModuleSyntax`).
-    if options.verbatim_module_syntax {
+    //
+    // Record when the implication is what turned `isolated_modules` on, so
+    // checks that need tsc's *raw* `isolatedModules` flag (e.g. the const-enum
+    // access-site TS2748) can recover it as
+    // `isolated_modules && !isolated_modules_from_verbatim`.
+    if options.verbatim_module_syntax && !options.isolated_modules {
         options.isolated_modules = true;
+        options.isolated_modules_from_verbatim = true;
     }
     // `esModuleInterop` implies `allowSyntheticDefaultImports` (tsz's
     // historical coupling; tsc <= 5.x derived `allowSyntheticDefaultImports`

--- a/crates/tsz-core/tests/checker_state_tests_parts/part_16.rs
+++ b/crates/tsz-core/tests/checker_state_tests_parts/part_16.rs
@@ -392,6 +392,7 @@ fn test_tier_2_type_checker_accuracy_fixes() {
             implied_classic_resolution: false,
             jsx_import_source: String::new(),
             verbatim_module_syntax: false,
+            isolated_modules_from_verbatim: false,
             ignore_deprecations: false,
             allow_umd_global_access: false,
             preserve_const_enums: false,


### PR DESCRIPTION
Fixes #14811.

Goal: hold

## Structural rule
When a member of an ambient const enum is accessed under `isolatedModules` (or
`verbatimModuleSyntax`), tsc emits **TS2748** regardless of whether the const
enum is declared locally or imported. Ambient-ness is a property of the file
that **declares** the const enum, not the file that **accesses** it.

tsz's `is_const_enum_ambient` resolved each declaration's ambient context
against the *importing* file's arena (`self.ctx.arena`). For an imported const
enum the declaration indices belong to another module's arena, so the lookup
silently reported "not ambient" and the access-site TS2748 gate was skipped — a
false negative for every cross-file ambient const enum.

## Owner layer
`tsz_checker` solver-adjacent property-access path:
- `is_const_enum_ambient` (`types/property_access_type/helpers.rs`) now resolves
  each declaration against the arena of the file that owns the symbol — its
  stamped `decl_file_idx`, then the cross-file symbol→file index — mirroring
  `get_cross_file_symbol`. The `.d.ts`/`declare` determination is extracted into
  a shared `declarations_are_ambient` helper.
- The `verbatimModuleSyntax` import path
  (`declarations/import/verbatim.rs`) reuses the same helper, so a
  `declare const enum` in a regular `.ts` is recognized, not only a `.d.ts`.
- The access-site gate (`enum_namespace_access.rs`) now matches tsc's
  `checkConstEnumAccess` exactly:
  `rawIsolatedModules || (verbatimModuleSyntax && firstId-is-not-an-alias)`.
  Under `verbatimModuleSyntax` alone an imported const enum is reported once at
  the import statement, so the access site stays silent for imports while a
  local const enum is still flagged.
- tsc reads the **raw** `isolatedModules` flag here, which tsz's option fan-out
  conflates with the `verbatimModuleSyntax` implication. The fan-out now records
  that implication (`isolated_modules_from_verbatim`) and a `raw_isolated_modules()`
  accessor recovers the raw flag — no consumer behavior changes.

## Adjacent-case matrix (all match tsc 5.9.3)
| flag | const enum | expected |
|---|---|---|
| isolatedModules | imported `declare const enum` (.d.ts) | TS2748 at access site |
| isolatedModules | imported `declare const enum` (.ts) | TS2748 at access site |
| isolatedModules | imported plain `const enum` (.d.ts, implicit ambient) | TS2748 at access site |
| isolatedModules | local `declare const enum` (control) | TS2748 at access site |
| verbatimModuleSyntax | imported | TS2748 at import site only |
| verbatimModuleSyntax | local | TS2748 at access site |
| both flags | imported | TS2748 at both import and access sites |
| isolatedModules | non-const `declare enum` | clean (no over-correction) |
| none | imported const enum | clean |

Binder/file names are varied across the test cases so behavior follows
structure, not identifier text.

## Verification
- New driver-level regression test `crates/tsz-cli/tests/imported_ambient_const_enum_ts2748_cli_tests.rs`
  (9 cases, runs the real multi-file driver): `cargo test -p tsz-cli --lib imported_ambient_const_enum_ts2748` — all pass.
- Existing const-enum/isolated suites unaffected: `cargo test -p tsz-checker --test const_enum_merge_ts2567_tests --test ts2450_const_enum_tests --test global_augmentation_const_enum_rebind_tests --test isolated_modules_export_default_tests --test enum_merge_tests` — pass.
- Option fan-out unchanged in behavior: `cargo test -p tsz-common --lib checker_fanout` and `cargo test -p tsz-core --lib option_fanout` — pass.
- Whole-matrix parity confirmed against `tsc 5.9.3` (isolated/verbatim × imported/local, incl. redundant both-flags config).
- `cargo clippy -p tsz-checker -p tsz-common -p tsz-core -p tsz-cli` — clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_0179Pb5aXEnsuhAwbrLXJGUu