### PR TITLE
fix(checker): substitute omitted defaulted siblings before validating type-arg constraints (#14754)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "sibling_defaulted_conditional_constraint_tests"
+path = "tests/sibling_defaulted_conditional_constraint_tests.rs"
+[[test]]
 name = "cannot_find_name_lib_hint_parity_tests"
 path = "tests/cannot_find_name_lib_hint_parity_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -22,9 +22,31 @@ impl CheckerState<'_> {
                 self.get_type_from_type_node(arg_idx)
             })
             .collect();
+        // Pad the supplied arguments with each omitted trailing parameter's
+        // resolved default (declaration order, so a later default may reference an
+        // earlier parameter), matching how tsc fills defaults before instantiating.
+        // Without this, a constraint that references an omitted SIBLING parameter —
+        // e.g. `K extends S extends 'wide' ? ... : keyof O` where `S` is defaulted —
+        // keeps the sibling free, so the conditional never reduces and the check is
+        // silently skipped (#14754). `fill_application_defaults` returns the supplied
+        // args verbatim when nothing is omitted, so the all-supplied path is
+        // unchanged. The loop below still iterates the SUPPLIED args, so diagnostics
+        // stay on explicitly-written positions.
+        // Only the under-supplied case allocates a padded vector; when every
+        // parameter has an explicit argument `full_type_args` borrows `type_args`.
+        let padded_type_args = (type_args.len() < type_params.len())
+            .then(|| {
+                crate::query_boundaries::type_defaults::fill_application_defaults(
+                    self.ctx.types.as_type_database(),
+                    &type_args,
+                    type_params,
+                )
+            })
+            .flatten();
+        let full_type_args: &[TypeId] = padded_type_args.as_deref().unwrap_or(&type_args);
         let type_arg_substitutions = type_params
             .iter()
-            .zip(type_args.iter())
+            .zip(full_type_args.iter())
             .map(|(param, &arg)| (param.name, arg))
             .collect::<Vec<_>>();
 
@@ -41,7 +63,7 @@ impl CheckerState<'_> {
         // and therefore every diagnostic — is unchanged. (#13250)
         let type_arg_subst = {
             let mut subst = crate::query_boundaries::common::TypeSubstitution::new();
-            for (param, &arg) in type_params.iter().zip(type_args.iter()) {
+            for (param, &arg) in type_params.iter().zip(full_type_args.iter()) {
                 subst.insert(param.name, arg);
             }
             subst
@@ -311,7 +333,7 @@ impl CheckerState<'_> {
                         type_arg,
                         arg_idx,
                         type_params,
-                        &type_args,
+                        full_type_args,
                         constraint,
                     )
                 {
@@ -543,7 +565,7 @@ impl CheckerState<'_> {
                         base,
                         constraint,
                         type_params,
-                        &type_args,
+                        full_type_args,
                     )
                 {
                     continue;
@@ -627,7 +649,7 @@ impl CheckerState<'_> {
                                             .instantiate_constraint_for_type_args(
                                                 constraint_resolved,
                                                 type_params,
-                                                &type_args,
+                                                full_type_args,
                                             );
                                         if self
                                             .conditional_true_type_parameter_base_satisfies_constraint(
@@ -677,23 +699,11 @@ impl CheckerState<'_> {
                                             .unwrap_or(TypeId::UNKNOWN);
 
                                             // Instantiate for accurate error messages.
-                                            let mut subst =
-                                                crate::query_boundaries::common::TypeSubstitution::new(
-                                                );
-                                            for (j, p) in type_params.iter().enumerate() {
-                                                if let Some(&arg) = type_args.get(j) {
-                                                    subst.insert(p.name, arg);
-                                                }
-                                            }
-                                            let inst_constraint = if subst.is_empty() {
-                                                constraint_resolved
-                                            } else {
-                                                crate::query_boundaries::common::instantiate_type(
-                                                    self.ctx.types,
+                                            let inst_constraint = self
+                                                .instantiate_constraint_with_subst(
                                                     constraint_resolved,
-                                                    &subst,
-                                                )
-                                            };
+                                                    &type_arg_subst,
+                                                );
 
                                             // Concrete constraints are checked here too:
                                             // `unknown` infer bases fail constraints like `string`.
@@ -797,23 +807,11 @@ impl CheckerState<'_> {
                                         // extends type does NOT satisfy the constraint. tsc
                                         // reports TS2344 in this case. Instantiate constraint
                                         // with type args for accurate error messages.
-                                        let mut subst =
-                                            crate::query_boundaries::common::TypeSubstitution::new(
-                                            );
-                                        for (j, p) in type_params.iter().enumerate() {
-                                            if let Some(&arg) = type_args.get(j) {
-                                                subst.insert(p.name, arg);
-                                            }
-                                        }
-                                        let inst_constraint = if subst.is_empty() {
-                                            constraint_resolved
-                                        } else {
-                                            crate::query_boundaries::common::instantiate_type(
-                                                self.ctx.types,
+                                        let inst_constraint = self
+                                            .instantiate_constraint_with_subst(
                                                 constraint_resolved,
-                                                &subst,
-                                            )
-                                        };
+                                                &type_arg_subst,
+                                            );
                                         if let Some(&arg_idx) = type_args_list.nodes.get(i)
                                             && !self
                                                 .type_argument_is_narrowed_by_conditional_true_branch(
@@ -1196,22 +1194,8 @@ impl CheckerState<'_> {
                                 && query::is_infer_type(db, cond_true)
                             {
                                 let constraint_resolved = self.resolve_lazy_type(constraint);
-                                let mut subst =
-                                    crate::query_boundaries::common::TypeSubstitution::new();
-                                for (j, p) in type_params.iter().enumerate() {
-                                    if let Some(&arg) = type_args.get(j) {
-                                        subst.insert(p.name, arg);
-                                    }
-                                }
-                                let inst_constraint = if subst.is_empty() {
-                                    constraint_resolved
-                                } else {
-                                    crate::query_boundaries::common::instantiate_type(
-                                        self.ctx.types,
-                                        constraint_resolved,
-                                        &subst,
-                                    )
-                                };
+                                let inst_constraint = self
+                                    .instantiate_constraint_with_subst(constraint_resolved, &type_arg_subst);
                                 let infer_base =
                                     query::get_type_parameter_constraint(db, cond_true)
                                         .unwrap_or(TypeId::UNKNOWN);
@@ -1362,7 +1346,7 @@ impl CheckerState<'_> {
                             type_arg,
                             constraint,
                             type_params,
-                            &type_args,
+                            full_type_args,
                         )
                     {
                         continue;
@@ -1483,22 +1467,10 @@ impl CheckerState<'_> {
                             }
 
                             let constraint_resolved = self.resolve_lazy_type(constraint);
-                            let mut subst =
-                                crate::query_boundaries::common::TypeSubstitution::new();
-                            for (j, p) in type_params.iter().enumerate() {
-                                if let Some(&arg) = type_args.get(j) {
-                                    subst.insert(p.name, arg);
-                                }
-                            }
-                            let inst_constraint = if subst.is_empty() {
-                                constraint_resolved
-                            } else {
-                                crate::query_boundaries::common::instantiate_type(
-                                    self.ctx.types,
-                                    constraint_resolved,
-                                    &subst,
-                                )
-                            };
+                            let inst_constraint = self.instantiate_constraint_with_subst(
+                                constraint_resolved,
+                                &type_arg_subst,
+                            );
                             // Skip trivial constraints (unknown/any) and bare type
                             // parameter constraints (deferred to instantiation).
                             let is_checkable = inst_constraint != TypeId::UNKNOWN
@@ -1715,7 +1687,7 @@ impl CheckerState<'_> {
 
                 let mut subst = crate::query_boundaries::common::TypeSubstitution::new();
                 for (j, p) in type_params.iter().enumerate() {
-                    if let Some(&arg) = type_args.get(j) {
+                    if let Some(&arg) = full_type_args.get(j) {
                         let evaluated_arg = self.evaluate_type_with_env(arg);
                         subst.insert(p.name, evaluated_arg);
                     }
@@ -1731,7 +1703,10 @@ impl CheckerState<'_> {
                 };
                 let mut display_subst = query_common::TypeSubstitution::new();
                 for (j, p) in type_params.iter().enumerate() {
-                    if let Some(&arg) = type_args.get(j) {
+                    if let Some(&arg) = full_type_args.get(j) {
+                        // Supplied positions keep their written reference form; an
+                        // omitted (defaulted) sibling has no argument node, so its
+                        // resolved default type is rendered directly.
                         let arg_node = type_args_list.nodes.get(j).copied();
                         display_subst.insert(p.name, self.type_arg_reference_form(arg, arg_node));
                     }

--- a/crates/tsz-checker/tests/sibling_defaulted_conditional_constraint_tests.rs
+++ b/crates/tsz-checker/tests/sibling_defaulted_conditional_constraint_tests.rs
@@ -1,0 +1,170 @@
+//! Repro + adjacent matrix for the false-negative where a generic type's
+//! type-parameter constraint is a CONDITIONAL that references a SIBLING type
+//! parameter which is OMITTED at the use site (relies on its default). The
+//! constraint must be evaluated against the sibling's resolved default so the
+//! conditional reduces and the type-argument constraint check (TS2344) runs.
+//! See issue #14754 (`TanStack` Query `OmitKeyof`).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "repro.ts",
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+fn count_code(diags: &[u32], expected: u32) -> usize {
+    diags.iter().filter(|&&c| c == expected).count()
+}
+
+/// Core witness (issue root-cause-direct reduction): the sibling `S` is omitted
+/// and defaults to `'narrow'`, so the conditional constraint
+/// `S extends 'wide' ? keyof O | string : keyof O` reduces to `keyof O`. The bad
+/// key `"z"` violates `keyof A`, so tsc reports TS2344. tsz used to skip the
+/// check because the defaulted sibling was never substituted.
+#[test]
+fn defaulted_sibling_conditional_constraint_emits_ts2344() {
+    let diags = codes(
+        r#"
+type G<
+  O,
+  K extends S extends 'wide' ? keyof O | string : keyof O,
+  S extends 'narrow' | 'wide' = 'narrow',
+> = [O, K, S]
+type A = { x: 1; y: 2 }
+type T = G<A, "z">
+export type _ = T
+"#,
+    );
+    assert_eq!(
+        count_code(&diags, 2344),
+        1,
+        "defaulted-sibling conditional constraint must still emit TS2344; got {diags:#?}"
+    );
+}
+
+/// Anti-hardcoding: rename every binder. The rule is structural, not name-driven.
+#[test]
+fn defaulted_sibling_conditional_constraint_is_binder_name_independent() {
+    let diags = codes(
+        r#"
+type Pick2<
+  Obj,
+  Key extends Mode extends 'loose' ? keyof Obj | string : keyof Obj,
+  Mode extends 'tight' | 'loose' = 'tight',
+> = [Obj, Key, Mode]
+type Rec = { a: 1; b: 2 }
+type Out = Pick2<Rec, "c">
+export type _ = Out
+"#,
+    );
+    assert_eq!(
+        count_code(&diags, 2344),
+        1,
+        "renamed-binder form must also emit TS2344; got {diags:#?}"
+    );
+}
+
+/// Positive control: a valid key satisfies the reduced constraint, so no TS2344.
+#[test]
+fn defaulted_sibling_conditional_constraint_valid_key_is_clean() {
+    let diags = codes(
+        r#"
+type G<
+  O,
+  K extends S extends 'wide' ? keyof O | string : keyof O,
+  S extends 'narrow' | 'wide' = 'narrow',
+> = [O, K, S]
+type A = { x: 1; y: 2 }
+type T = G<A, "x">
+export type _ = T
+"#,
+    );
+    assert_eq!(
+        count_code(&diags, 2344),
+        0,
+        "a valid key must satisfy the reduced constraint; got {diags:#?}"
+    );
+}
+
+/// The `'wide'`/`'loose'` true branch widens the constraint to also accept a
+/// `string`, so the same `"z"` that fails under the default is accepted when the
+/// sibling is explicitly the wide mode.
+#[test]
+fn explicit_wide_sibling_accepts_extra_key() {
+    let diags = codes(
+        r#"
+type G<
+  O,
+  K extends S extends 'wide' ? keyof O | string : keyof O,
+  S extends 'narrow' | 'wide' = 'narrow',
+> = [O, K, S]
+type A = { x: 1; y: 2 }
+type T = G<A, "z", 'wide'>
+export type _ = T
+"#,
+    );
+    assert_eq!(
+        count_code(&diags, 2344),
+        0,
+        "the wide branch accepts an extra string key; got {diags:#?}"
+    );
+}
+
+/// Explicit narrow sibling, bad key: still TS2344 (the conditional reduces to the
+/// false branch `keyof O`).
+#[test]
+fn explicit_narrow_sibling_bad_key_emits_ts2344() {
+    let diags = codes(
+        r#"
+type G<
+  O,
+  K extends S extends 'wide' ? keyof O | string : keyof O,
+  S extends 'narrow' | 'wide' = 'narrow',
+> = [O, K, S]
+type A = { x: 1; y: 2 }
+type T = G<A, "z", 'narrow'>
+export type _ = T
+"#,
+    );
+    assert_eq!(
+        count_code(&diags, 2344),
+        1,
+        "explicit narrow sibling with a bad key must emit TS2344; got {diags:#?}"
+    );
+}
+
+/// `@ts-expect-error` regression mirroring `OmitKeyof.test-d.ts`: the directive
+/// is consumed by the TS2344, so there must be no TS2578 (unused directive).
+#[test]
+fn ts_expect_error_on_constraint_violation_is_consumed() {
+    let diags = codes(
+        r#"
+type OmitKeyof<
+  TObject,
+  TKey extends TStrictly extends 'safely'
+    ? keyof TObject | (string & Record<never, never>)
+    : keyof TObject,
+  TStrictly extends 'strictly' | 'safely' = 'strictly',
+> = [TObject, TKey, TStrictly]
+type A = { x: string; y: number }
+// @ts-expect-error 'z' is not in keyof A
+type T = OmitKeyof<A, 'z'>
+export type _ = T
+"#,
+    );
+    assert_eq!(
+        count_code(&diags, 2578),
+        0,
+        "the @ts-expect-error must be consumed by TS2344, not reported as unused; got {diags:#?}"
+    );
+}


### PR DESCRIPTION
Fixes #14754.

Goal: green

## Problem

`validate_type_args_against_params` built its `type-param -> type-arg`
substitution from the **explicitly-supplied** arguments only
(`type_params.iter().zip(type_args.iter())`). When a generic's constraint
references an **omitted (defaulted) sibling** type parameter, that sibling
stays free, so a conditional constraint over it never reduces and the
type-argument constraint check is silently skipped.

Witness (TanStack Query `OmitKeyof`): a violating key is accepted (missing
`TS2344`), which leaves the test's `@ts-expect-error` unconsumed and produces a
spurious `TS2578` "Unused '@ts-expect-error' directive".

```ts
type G<
  O,
  K extends S extends 'wide' ? keyof O | string : keyof O,
  S extends 'narrow' | 'wide' = 'narrow',
> = [O, K, S]
type A = { x: 1; y: 2 }
type T = G<A, "z">   // tsc: TS2344 "keyof A";  tsz (before): clean (missed)
```

## Structural rule

When validating type arguments, `tsc` fills each omitted trailing parameter's
default (in declaration order, so a later default may reference an earlier
parameter) **before** instantiating any constraint. tsz now does the same: it
pads the supplied arguments with resolved defaults via the canonical
`fill_application_defaults` solver helper (the same routine `tsc`'s default
filling mirrors) and routes that padded view through every
constraint-substitution site in the function.

The validation loop still iterates the *supplied* arguments, so diagnostics
stay on explicitly-written positions; defaulted positions are not re-validated
here. The all-supplied path borrows the original `type_args` (no extra
allocation), so the common case is unchanged.

Owner layer: solver-backed query boundary
(`query_boundaries::type_defaults::fill_application_defaults`) consumed by the
checker's generic constraint validator. No raw `TypeKey` construction, no
name/file-string predicates.

## Adjacent matrix (all covered by tests)

| Variant | tsc | tsz (after) |
|---|---|---|
| Sibling defaulted, bad key | TS2344 | TS2344 |
| Sibling defaulted, valid key | clean | clean |
| Explicit narrow sibling, bad key | TS2344 | TS2344 |
| Explicit wide sibling, extra key | clean | clean |
| `@ts-expect-error` on the violation | consumed | consumed (no TS2578) |
| Renamed binders (anti-hardcoding) | TS2344 | TS2344 |

The constraint **display** facet (matrix row 2 of the issue: the conditional
printed unreduced) is handled by the complementary #14880 / #14786 fix already
on `main` (`error_reporter/generics.rs` prints the reduced branch); this PR is
rebased on top of it and the two compose.

## Cleanup

Collapses four inline substitution rebuilds onto the shared
`instantiate_constraint_with_subst` helper (the reuse form #13250 introduced),
so the net diff is a reduction (+50/-72 in the validator).

## Verification

- New `crates/tsz-checker/tests/sibling_defaulted_conditional_constraint_tests.rs`
  (6 cases incl. binder-renamed and `@ts-expect-error` regression). Confirmed
  the two core witnesses **fail without** the substitution change and **pass
  with** it.
- Regression: `ts2344_*`, `conditional_*`, `keyof_type_param_default_conditional_repro`,
  `variance_skip_type_param_default_tests`, `failed_generic_call_default_type_args_tests`,
  and the new `ts2344_conditional_constraint_display_tests` all green locally
  (the only 2 failures in the swept set are pre-existing on `main`, unrelated).
- `cargo clippy -p tsz-checker` clean; `cargo fmt --check` clean.
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Vc7cbvxYDVTWnhSAMiAQpq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vc7cbvxYDVTWnhSAMiAQpq)_
