### PR TITLE
fix(checker): keep per-operator TS2869/TS2871 in nested `??` chains (#14885)

### DIFF
--- a/crates/tsz-checker/src/context/diagnostic_push.rs
+++ b/crates/tsz-checker/src/context/diagnostic_push.rs
@@ -67,12 +67,25 @@ impl<'a> CheckerContext<'a> {
         }
     }
 
-    fn diagnostic_dedup_key_from_parts(&self, start: u32, code: u32, message: &str) -> (u32, u32) {
-        if code == 2318 && start == 0 {
-            use std::hash::{Hash, Hasher};
+    fn diagnostic_dedup_key_from_parts(
+        &self,
+        start: u32,
+        length: u32,
+        code: u32,
+        message: &str,
+    ) -> (u32, u32) {
+        // Fold a value into a `u32` so diagnostics that tie on `(start, code)`
+        // but differ in the hashed component (message text, or span length for
+        // the `??` family) get distinct dedup keys.
+        fn fold_u32(value: impl std::hash::Hash) -> u32 {
+            use std::hash::Hasher;
             let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            message.hash(&mut hasher);
-            (hasher.finish() as u32, code)
+            value.hash(&mut hasher);
+            hasher.finish() as u32
+        }
+
+        if code == 2318 && start == 0 {
+            (fold_u32(message), code)
         } else if code == 18047
             || code == 18048
             || code == 18049
@@ -88,17 +101,26 @@ impl<'a> CheckerContext<'a> {
             || code == 2538
             || code == 4094
         {
-            use std::hash::{Hash, Hasher};
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            message.hash(&mut hasher);
-            (start ^ (hasher.finish() as u32), code)
+            (start ^ fold_u32(message), code)
+        } else if code == 2869 || code == 2871 {
+            // The `??` operand checks classify the left operand syntactically
+            // (`getSyntacticNullishnessSemantics`), recursing through nested
+            // `??`/comma/conditional chains. A `??` chain therefore reports the
+            // never-nullish (TS2869) or always-nullish (TS2871) diagnostic once
+            // per `??` operator, every one anchored at the same leftmost token —
+            // e.g. `null ?? null ?? 1` yields two TS2871 at one start, spanning
+            // `null` and `null ?? null` respectively. tsc keys deduplication on
+            // span length as well as start/code/message, so the differing spans
+            // stay distinct. Fold the length into the key to keep each one
+            // instead of collapsing the chain to a single diagnostic.
+            (start ^ fold_u32(length), code)
         } else {
             (start, code)
         }
     }
 
     pub fn diagnostic_dedup_key(&self, diag: &Diagnostic) -> (u32, u32) {
-        self.diagnostic_dedup_key_from_parts(diag.start, diag.code, &diag.message_text)
+        self.diagnostic_dedup_key_from_parts(diag.start, diag.length, diag.code, &diag.message_text)
     }
 
     pub(crate) fn rebuild_diagnostic_aux_indices(&mut self) {
@@ -144,13 +166,17 @@ impl<'a> CheckerContext<'a> {
     ///   private/protected member of an exported anonymous class expression at the
     ///   owning variable/function name, producing one TS4094 per member at the
     ///   same span.
+    /// - TS2869/TS2871 use (start ^ `length_hash`, code) because a `??` chain
+    ///   reports the never-/always-nullish operand diagnostic once per `??`,
+    ///   all anchored at the same leftmost token but spanning successively wider
+    ///   left operands; keying on length keeps each distinct-span diagnostic.
     pub fn error(&mut self, start: u32, length: u32, message: String, code: u32) {
         if self.reconcile_name_resolution_precedence(start, code) {
             return;
         }
 
         // Check if we've already emitted this diagnostic
-        let key = self.diagnostic_dedup_key_from_parts(start, code, &message);
+        let key = self.diagnostic_dedup_key_from_parts(start, length, code, &message);
         if self.diagnostic_indices.emitted.contains(&key) {
             return;
         }

--- a/crates/tsz-checker/tests/ts2869_syntactic_never_nullish_tests.rs
+++ b/crates/tsz-checker/tests/ts2869_syntactic_never_nullish_tests.rs
@@ -70,6 +70,22 @@ fn void_typeof_and_unary_emit_ts2869() {
     assert!(check("declare const n: number;\nconst d = (!n) ?? 1;\n").contains(&2869));
 }
 
+/// A `??` chain over never-nullish operands reports TS2869 once per `??`,
+/// every one anchored at the same leftmost token but spanning a successively
+/// wider left operand. tsc keeps each because it deduplicates on span length
+/// as well as start/code; the checker's dedup key must do the same instead of
+/// collapsing `1 ?? 2 ?? 3` to a single TS2869.
+///
+/// Witness (tsc 6.0): `1 ?? 2 ?? 3` → two TS2869 at one start.
+#[test]
+fn nested_never_nullish_chain_emits_one_ts2869_per_operator() {
+    assert_eq!(
+        count("const z = 1 ?? 2 ?? 3;\n", 2869),
+        2,
+        "two `??` over never-nullish operands must emit TS2869 twice",
+    );
+}
+
 // =========================================================================
 // Binary / conditional / comma / assignment classification
 // =========================================================================

--- a/crates/tsz-checker/tests/ts2871_always_nullish_tests.rs
+++ b/crates/tsz-checker/tests/ts2871_always_nullish_tests.rs
@@ -69,6 +69,56 @@ fn deep_nullish_chain_emits_ts2871_at_top() {
     );
 }
 
+/// A bare (unparenthesised) `??` chain whose operands are all always-nullish
+/// reports TS2871 once per `??` operator, every one anchored at the leftmost
+/// `null` but spanning a successively wider left operand
+/// (`null`, then `null ?? null`, then `null ?? null ?? null`, ...). tsc keeps
+/// each because it keys deduplication on span length as well as start. The
+/// dedup key must not collapse the chain to a single diagnostic.
+///
+/// Witnesses (tsc 6.0): `null ?? null ?? 5` → 2; the four-operand chain → 3.
+#[test]
+fn nested_always_nullish_chain_emits_one_ts2871_per_operator() {
+    let two = check_source_codes("const z = null ?? null ?? 5;\n");
+    assert_eq!(
+        two.iter().filter(|&&c| c == 2871).count(),
+        2,
+        "two `??` over always-nullish operands must emit TS2871 twice; got: {:?}",
+        two.to_vec(),
+    );
+
+    let three = check_source_codes("const z = undefined ?? undefined ?? undefined ?? 1;\n");
+    assert_eq!(
+        three.iter().filter(|&&c| c == 2871).count(),
+        3,
+        "three `??` over always-nullish operands must emit TS2871 three times; got: {:?}",
+        three.to_vec(),
+    );
+}
+
+/// Mixed chain `null ?? 1 ?? 2` = `(null ?? 1) ?? 2`: the inner `??` has an
+/// always-nullish left (`null`, TS2871) while the outer `??` sees a
+/// syntactically never-nullish left (`null ?? 1` resolves to its non-nullish
+/// right, TS2869). Both anchor at the same start but carry different codes, so
+/// they were never collapsed — this guards that the length-aware key for the
+/// nullish family leaves the cross-code case intact.
+#[test]
+fn mixed_nullish_chain_keeps_both_ts2871_and_ts2869() {
+    let diags = check_source_codes("const z = null ?? 1 ?? 2;\n");
+    assert_eq!(
+        diags.iter().filter(|&&c| c == 2871).count(),
+        1,
+        "inner always-nullish `null` must emit one TS2871; got: {:?}",
+        diags.to_vec(),
+    );
+    assert_eq!(
+        diags.iter().filter(|&&c| c == 2869).count(),
+        1,
+        "outer never-nullish `null ?? 1` must emit one TS2869; got: {:?}",
+        diags.to_vec(),
+    );
+}
+
 // =========================================================================
 // Regression guards — TS2871 must NOT fire on non-nullish-only expressions
 // =========================================================================

--- a/crates/tsz-checker/tests/ts2871_always_nullish_tests.rs
+++ b/crates/tsz-checker/tests/ts2871_always_nullish_tests.rs
@@ -83,16 +83,14 @@ fn nested_always_nullish_chain_emits_one_ts2871_per_operator() {
     assert_eq!(
         two.iter().filter(|&&c| c == 2871).count(),
         2,
-        "two `??` over always-nullish operands must emit TS2871 twice; got: {:?}",
-        two.to_vec(),
+        "two `??` over always-nullish operands must emit TS2871 twice; got: {two:?}",
     );
 
     let three = check_source_codes("const z = undefined ?? undefined ?? undefined ?? 1;\n");
     assert_eq!(
         three.iter().filter(|&&c| c == 2871).count(),
         3,
-        "three `??` over always-nullish operands must emit TS2871 three times; got: {:?}",
-        three.to_vec(),
+        "three `??` over always-nullish operands must emit TS2871 three times; got: {three:?}",
     );
 }
 
@@ -108,14 +106,12 @@ fn mixed_nullish_chain_keeps_both_ts2871_and_ts2869() {
     assert_eq!(
         diags.iter().filter(|&&c| c == 2871).count(),
         1,
-        "inner always-nullish `null` must emit one TS2871; got: {:?}",
-        diags.to_vec(),
+        "inner always-nullish `null` must emit one TS2871; got: {diags:?}",
     );
     assert_eq!(
         diags.iter().filter(|&&c| c == 2869).count(),
         1,
-        "outer never-nullish `null ?? 1` must emit one TS2869; got: {:?}",
-        diags.to_vec(),
+        "outer never-nullish `null ?? 1` must emit one TS2869; got: {diags:?}",
     );
 }
 


### PR DESCRIPTION
Closes #14885.

## Goal
Goal: hold

Conformance/diagnostic parity: a nested `??` chain reported the never-/always-nullish operand diagnostic fewer times than `tsc`, diverging the emitted diagnostic count and CLI output (`Found 1 error` vs `Found 2 errors`).

## Structural rule
When a `??` operator's left operand is syntactically never-nullish (TS2869) or always-nullish (TS2871), `tsc` emits that diagnostic for **each** such operator in a chain — every one anchored at the same leftmost token but spanning a successively wider left operand (`null`, then `null ?? null`, ...). `tsc` deduplicates on `(file, start, length, code, message)`; `tsz` deduplicated on `(start, code)`, discarding the span length and collapsing the chain to a single diagnostic.

`getSyntacticNullishnessSemantics` recurses through nested `??`/comma/conditional chains, so the duplicates are legitimate per-operator diagnostics that differ only in span length. The fix folds the span length into the checker dedup key for codes 2869/2871 — the same `(start ^ hash, code)` idiom already used for TS2374/TS2411/TS2416/TS2430/TS2536–2538/TS4094.

## Owner layer
`tsz_checker::context::diagnostic_push` — `CheckerContext::diagnostic_dedup_key_from_parts` (a refactor extracts a shared `fold_u32` helper that the three special-cased branches now share).

## Adjacent cases / fallback
- `||`/`&&` always-truthy/falsy (TS2872/TS2873) do **not** recurse through logical binaries, so they already match `tsc` (one per stackable kind) — verified, no change.
- Cross-code same-start cases (`null ?? 1 ?? 2` → TS2871 + TS2869 at one start) differ by code and were never collapsed — guarded by a regression test.
- Comma/conditional left operands (`(0, null) ?? …`, `(b ? null : null) ?? …`) anchor at distinct starts and already match.
- Single-`??` forms and the possibly-nullish silent forms are unchanged.

## Verification
Validated against real `tsc` 6.0.2 (`--noEmit --strict --target esnext`), byte-identical including spans/order:

| source | tsc | tsz (after) |
| --- | --- | --- |
| `null ?? null ?? 5` | 2× TS2871 | 2× TS2871 |
| `1 ?? 2 ?? 3` | 2× TS2869 | 2× TS2869 |
| `null ?? null ?? null ?? null ?? 1` | 4× TS2871 | 4× TS2871 |
| `null ?? 1 ?? 2` | TS2871 + TS2869 | TS2871 + TS2869 |

Tests (new + existing, all green locally):
```
cargo test -p tsz-checker --test ts2871_always_nullish_tests --test ts2869_syntactic_never_nullish_tests
cargo test -p tsz-checker --lib collision_reconciliation
```
New cases: `nested_always_nullish_chain_emits_one_ts2871_per_operator`, `mixed_nullish_chain_keeps_both_ts2871_and_ts2869`, `nested_never_nullish_chain_emits_one_ts2869_per_operator`. `cargo fmt --check` and `cargo clippy -p tsz-checker --lib` clean. Full conformance/emit/fourslash left to ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_014a64XxaTapVrDrrQ7DuK6X)_