### PR TITLE
fix(checker): allow protected access through a subclass this-type parameter (TS2445)

### DIFF
--- a/crates/tsz-checker/src/checkers/property_checker.rs
+++ b/crates/tsz-checker/src/checkers/property_checker.rs
@@ -325,12 +325,20 @@ impl<'a> CheckerState<'a> {
                     )
                 } else {
                     // In free functions with an explicit `this: Class` parameter,
-                    // TypeScript allows protected access through contextual `this`.
+                    // TypeScript allows protected access through contextual `this`
+                    // whenever the `this` type is the declaring class or derives
+                    // from it (transitively), mirroring the `super.x` branch above.
+                    // Equality alone would wrongly reject an inherited protected
+                    // member reached through a subclass `this` type.
                     self.is_this_expression(object_expr)
                         && self
                             .resolve_class_for_access(object_expr, object_type)
                             .is_some_and(|(receiver_class_idx, _)| {
                                 receiver_class_idx == access_info.declaring_class_idx
+                                    || self.is_class_derived_from(
+                                        receiver_class_idx,
+                                        access_info.declaring_class_idx,
+                                    )
                             })
                 }
             }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1495,6 +1495,9 @@ mod ts2341_private_access_via_type_param_constraint_tests;
 #[path = "tests/ts2353_generic_constraint_tests.rs"]
 mod ts2353_generic_constraint_tests;
 #[cfg(test)]
+#[path = "tests/ts2445_protected_access_via_subclass_this_tests.rs"]
+mod ts2445_protected_access_via_subclass_this_tests;
+#[cfg(test)]
 #[path = "tests/ts2564_constructor_throw_guard_tests.rs"]
 mod ts2564_constructor_throw_guard_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/ts2445_protected_access_via_subclass_this_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2445_protected_access_via_subclass_this_tests.rs
@@ -1,0 +1,103 @@
+//! Regression tests for TS2445 enforcement when a free function declares a
+//! `this` parameter typed as a subclass of the class that declares a
+//! `protected` member.
+//!
+//! tsc allows protected access through a `this` expression whenever the `this`
+//! type is the declaring class itself *or derives from it* (transitively).
+//! tsz previously gated the free-function/contextual-`this` fallback in
+//! `property_checker.rs` on exact class equality
+//! (`receiver_class_idx == declaring_class_idx`), so an inherited protected
+//! member reached through a subclass `this` type was wrongly rejected with
+//! TS2445. The fallback now also accepts `is_class_derived_from`, mirroring the
+//! `super.x` branch. Private members stay equality-gated (not inherited).
+
+use crate::test_utils::check_source_diagnostics;
+
+fn diag_codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+/// Inherited protected member reached through a direct-subclass `this` type is
+/// allowed — no TS2445.
+#[test]
+fn no_ts2445_on_protected_access_via_subclass_this() {
+    let source = "\
+class Base { protected x = 1; }
+class Derived extends Base { }
+function f(this: Derived) { return this.x; }
+";
+    let codes = diag_codes(source);
+    assert!(
+        !codes.contains(&2445),
+        "Protected access through `this: Derived` must not fire TS2445. Got: {codes:?}"
+    );
+}
+
+/// Anti-hardcoding cover: renamed binders, same structural shape.
+#[test]
+fn no_ts2445_on_protected_access_via_subclass_this_renamed() {
+    let source = "\
+class Vehicle { protected speed = 0; }
+class Car extends Vehicle { wheels = 4; }
+function accelerate(this: Car) { return this.speed; }
+";
+    let codes = diag_codes(source);
+    assert!(
+        !codes.contains(&2445),
+        "Renamed variant: protected access through subclass `this` must not fire TS2445. Got: {codes:?}"
+    );
+}
+
+/// Multi-level inheritance: protected access through a grandchild `this` type is
+/// allowed via transitive derivation.
+#[test]
+fn no_ts2445_on_protected_access_via_grandchild_this() {
+    let source = "\
+class A { protected v = 1; }
+class B extends A { }
+class C extends B { }
+function g(this: C) { return this.v; }
+";
+    let codes = diag_codes(source);
+    assert!(
+        !codes.contains(&2445),
+        "Protected access through a multi-level subclass `this` must not fire TS2445. Got: {codes:?}"
+    );
+}
+
+/// The declaring-class `this` type was already accepted — keep it green.
+#[test]
+fn no_ts2445_on_protected_access_via_declaring_class_this() {
+    let source = "\
+class Base { protected x = 1; }
+function f(this: Base) { return this.x; }
+";
+    let codes = diag_codes(source);
+    assert!(
+        !codes.contains(&2445),
+        "Protected access through `this: Base` (declaring class) must not fire TS2445. Got: {codes:?}"
+    );
+}
+
+/// Private members are *not* inherited: access through a subclass `this` type
+/// must still report TS2341 (parity control — the widening is protected-only).
+#[test]
+fn ts2341_still_fires_on_private_access_via_subclass_this() {
+    let source = "\
+class P { private p = 1; }
+class C extends P { }
+function bad(this: C) { return this.p; }
+";
+    let codes = diag_codes(source);
+    assert!(
+        codes.contains(&2341),
+        "Private access through subclass `this` must still fire TS2341. Got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2445),
+        "Private access must report TS2341, not TS2445. Got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes #14795. When a free function declares a `this` parameter typed as a subclass of the class that declares a `protected` member, accessing the inherited member through `this` was wrongly rejected with TS2445 (false positive). tsc permits it.

```ts
class Base { protected x = 1; }
class Derived extends Base { }
function f(this: Derived) { return this.x; }   // tsc OK; tsz previously TS2445
function g(this: Base) { return this.x; }      // both OK
```

## Structural rule
When a `protected` member is accessed through a `this` expression, tsc allows it when the receiver `this` type is the declaring class **or derives from it (transitively)**; tsz enforces this in the property accessibility gate (`crates/tsz-checker/src/checkers/property_checker.rs`).

The free-function/contextual-`this` fallback gated on exact class equality (`receiver_class_idx == declaring_class_idx`), unlike the `super.x` branch directly above it which already accepts `is_class_derived_from`. The fix widens the fallback to mirror the `super` branch, so inherited and multi-level-inherited protected members reached through a subclass `this` type are accepted. The fix is the general derivation rule (covers arbitrary inheritance depth), not a witness-specific patch.

Private members stay equality-gated (private is not inherited), so private access through a subclass `this` still reports TS2341.

## Owner layer
`tsz-checker` property accessibility gate (`property_checker.rs`). No solver/printer changes; no name/file-name predicates.

## Adjacent-case matrix (all verified vs tsc 5.9.3)
- `this: Derived` (direct subclass, inherited protected) → now accepted ✓
- `this: GrandChild` (multi-level, transitive derivation) → accepted ✓
- `this: Base` (declaring class) → still accepted (unchanged) ✓
- renamed binders (`Vehicle`/`Car`/`speed`) → accepted (structural, not name-keyed) ✓
- private member through subclass `this` → still TS2341 (parity control) ✓

## Verification
- New unit suite `crates/tsz-checker/src/tests/ts2445_protected_access_via_subclass_this_tests.rs` (5 cases): `cargo test -p tsz-checker --lib ts2445_protected_access_via_subclass_this` → 5 passed.
- Regression of adjacent accessibility tests: `super_call_ts2376_ts17009_priority_tests`, `ts2341_private_access_via_type_param_constraint_tests`, `union_protected_intersection_property_tests`, `ts2513_abstract_super_access_tests` → all pass.
- Manual repro (`--strict --target es2022 --lib es2022 --noEmit`): only the private-access line reports (TS2341), matching tsc; protected-through-subclass lines are clean.
- Confirmed the 10 unrelated lib failures observed during a broad filter run are pre-existing on `main` (mapped-type/index-access/JSX/architecture-contract tests; reproduced with the change stashed).

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01TFUBr9k8KAJ9jFAVStgnG3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFUBr9k8KAJ9jFAVStgnG3)_