### PR TITLE
wip(solver) #14345 equiv-through-eval: id-keyed endpoint redirect at the function-sig reduction site (BUILT + MEASURED 0/51, conclusive escaped-id wall)

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -50,7 +50,11 @@ pub mod stage2_probe {
     //  7 miss_samename_both_declscoped_samedecl,
     //  8 miss_samename_has_user_origin,
     //  9 miss_diffname]
-    pub static BINS: [AtomicU64; 12] = [
+    pub static BINS: [AtomicU64; 16] = [
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
+        AtomicU64::new(0),
         AtomicU64::new(0),
         AtomicU64::new(0),
         AtomicU64::new(0),
@@ -121,6 +125,10 @@ pub mod stage2_probe {
             "miss_diffname",
             "miss_name_in_active_frame",
             "miss_name_NOT_in_frame",
+            "miss_an_id_KNOWN_to_redirect",
+            "miss_both_ids_UNKNOWN_to_redirect",
+            "unknown_id_SURFACE_matches_endpoint",
+            "unknown_id_FULLY_escaped_no_surface",
         ];
         let mut s = String::new();
         for (i, l) in labels.iter().enumerate() {
@@ -145,6 +153,131 @@ pub mod stage2_probe {
         }
     }
 }
+
+// ===========================================================================
+// #14345 equiv-through-eval (flag `TSZ_TYPEPARAM_DECL_IDENTITY=1`,
+// byte-parity-inert OFF). The relation establishes an alpha-rename equivalence
+// `(A_src, A_tgt)` between the type params of two generic signatures being
+// related, then expands their Application bodies (`R<string, A_src>` vs
+// `RR<string, A_tgt>`) to compare them structurally. The expansion drives a
+// fresh `TypeEvaluator`/instantiator that has NO knowledge of the active equiv
+// frame, so a body-ref of the TARGET endpoint `A_tgt` (DeclScoped) found with
+// no substitution entry is re-minted to its own id (or a fresh third id) — the
+// two expanded bodies then carry distinct ids for the paired param and the
+// nested bare-param consult (`cache.rs`) misses the registered pair (97/106 of
+// the fp-ts crossdecl misses have the name absent from the active frame, the
+// re-mint having escaped it). To carry the equivalence THROUGH the body
+// expansion, the relation installs a thread-local id-keyed redirect of the
+// registered endpoints; the instantiator consults it in the `TypeParameter`
+// arm so a registered TARGET endpoint mints onto the registered SOURCE id
+// instead of being re-minted. Both expanded bodies then share ONE id for the
+// paired param and the structural compare succeeds.
+//
+// SOUNDNESS: the redirect is ID-keyed ONLY (the entries are the exact interned
+// `type_param(*tp)` ids the relation registered). It NEVER matches by name or
+// surface — a name/surface match at a reduction site re-introduces the +16
+// over-relate (two genuinely distinct same-name decls). The map is scoped: the
+// relation installs it just before driving the body expansion and removes it
+// immediately after.
+mod equiv_through_eval {
+    use super::TypeId;
+    use rustc_hash::FxHashMap;
+    use std::cell::RefCell;
+    use std::sync::OnceLock;
+
+    pub fn enabled() -> bool {
+        static ON: OnceLock<bool> = OnceLock::new();
+        // Reuse the keystone flag so OFF is byte-parity-inert.
+        *ON.get_or_init(|| std::env::var("TSZ_TYPEPARAM_DECL_IDENTITY").is_ok_and(|v| v == "1"))
+    }
+
+    thread_local! {
+        // Maps a registered endpoint id -> its canonical (source) id. Both the
+        // target endpoint (target -> source) and the source endpoint
+        // (source -> source, identity) are inserted so a body-ref of either
+        // mints onto the single canonical id.
+        static REDIRECT: RefCell<FxHashMap<TypeId, TypeId>> = RefCell::new(FxHashMap::default());
+    }
+
+    /// RAII guard that installs the id-keyed endpoint redirects on construction
+    /// and removes them on drop. Used by the function-signature relation, which
+    /// has many early-return paths between registering the alpha-rename
+    /// equivalence and finishing the body comparison; a guard tied to the stack
+    /// frame restores the prior map on every exit path without a closure.
+    pub struct RedirectGuard {
+        saved: Vec<(TypeId, Option<TypeId>)>,
+    }
+
+    impl RedirectGuard {
+        /// Install redirects for `pairs`. Returns an inert guard when the flag
+        /// is OFF or there are no pairs.
+        pub fn install(pairs: &[(TypeId, TypeId)]) -> Self {
+            if !enabled() || pairs.is_empty() {
+                return RedirectGuard { saved: Vec::new() };
+            }
+            let saved = REDIRECT.with(|m| {
+                let mut m = m.borrow_mut();
+                let mut saved = Vec::with_capacity(pairs.len() * 2);
+                for &(src, tgt) in pairs {
+                    if src == tgt {
+                        continue;
+                    }
+                    saved.push((tgt, m.insert(tgt, src)));
+                    saved.push((src, m.insert(src, src)));
+                }
+                saved
+            });
+            RedirectGuard { saved }
+        }
+    }
+
+    impl Drop for RedirectGuard {
+        fn drop(&mut self) {
+            if self.saved.is_empty() {
+                return;
+            }
+            REDIRECT.with(|m| {
+                let mut m = m.borrow_mut();
+                for &(key, prev) in self.saved.iter().rev() {
+                    match prev {
+                        Some(v) => {
+                            m.insert(key, v);
+                        }
+                        None => {
+                            m.remove(&key);
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    /// Id-keyed lookup. Returns the canonical id a registered endpoint should
+    /// mint onto, or `None` when `id` is not a registered endpoint.
+    #[inline]
+    pub fn redirect(id: TypeId) -> Option<TypeId> {
+        if !enabled() {
+            return None;
+        }
+        REDIRECT.with(|m| m.borrow().get(&id).copied())
+    }
+
+    /// Whether any redirect is currently installed (cheap guard for the hot
+    /// instantiate path).
+    #[inline]
+    pub fn active() -> bool {
+        if !enabled() {
+            return false;
+        }
+        REDIRECT.with(|m| !m.borrow().is_empty())
+    }
+}
+
+pub(crate) use equiv_through_eval::{
+    RedirectGuard as EquivRedirectGuard, active as equiv_redirect_active,
+    redirect as equiv_redirect,
+};
+
 const MAX_TUPLE_SPREAD_FLATTEN_ELEMENTS: usize = 8192;
 
 /// Instantiator for applying type substitutions.
@@ -816,6 +949,25 @@ impl<'a> TypeInstantiator<'a> {
         match key {
             // Type parameters get substituted
             TypeData::TypeParameter(info) => {
+                // #14345 equiv-through-eval: id-keyed redirect of a registered
+                // alpha-rename endpoint onto its canonical (source) id. This
+                // runs BEFORE the name-keyed substitution/shadow/fallback paths
+                // so a body-ref of the TARGET endpoint mints onto the SOURCE id
+                // instead of being re-minted to its own (or a fresh third) id.
+                // Only fires when the relation installed the scoped redirect map
+                // and `type_id` is exactly a registered endpoint id (never a
+                // name/surface match — id-keyed soundness, see module docs). It
+                // is skipped when the param's NAME is locally bound/shadowed/
+                // substituted so a genuine substitution is never overridden.
+                if equiv_redirect_active()
+                    && self.lookup_local_type_param(info.name).is_none()
+                    && !self.is_shadowed(info.name)
+                    && self.substitution.get(info.name).is_none()
+                {
+                    if let Some(canonical) = equiv_redirect(type_id) {
+                        return canonical;
+                    }
+                }
                 if let Some(local_type_param) = self.lookup_local_type_param(info.name) {
                     if stage2_probe::enabled() {
                         match self.probe_decl_drift(info, local_type_param) {

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -290,6 +290,41 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                                     } else {
                                         bump(11); // miss_name_NOT_in_frame (unreachable here)
                                     }
+                                    // #14345 equiv-through-eval diagnosis: at the
+                                    // miss, would the redirect map have known
+                                    // EITHER consult id? If yes the redirect was
+                                    // installed but the consult still reached a
+                                    // pre-redirect id (mint happened before/
+                                    // outside the guard). If no, the consult ids
+                                    // are fresh third ids the redirect never saw.
+                                    use crate::instantiation::instantiate::equiv_redirect;
+                                    let src_known = equiv_redirect(source).is_some();
+                                    let tgt_known = equiv_redirect(target).is_some();
+                                    if src_known || tgt_known {
+                                        bump(12); // miss but an id was a known endpoint
+                                    } else {
+                                        bump(13); // miss with both ids unknown to redirect
+                                        // Would a SURFACE (name+origin) match to a
+                                        // registered endpoint catch them? If yes,
+                                        // surface is the only lever — the +16 trap.
+                                        let surface_catch = self
+                                            .type_param_equivalences
+                                            .iter()
+                                            .any(|&(eq_a, eq_b)| {
+                                                let sm = |id: TypeId, info: &crate::types::TypeParamInfo| {
+                                                    matches!(self.interner.lookup(id),
+                                                        Some(TypeData::TypeParameter(e))
+                                                            if e.name == info.name && e.origin == info.origin)
+                                                };
+                                                (sm(eq_a, &si) || sm(eq_b, &si))
+                                                    || (sm(eq_a, &ti) || sm(eq_b, &ti))
+                                            });
+                                        if surface_catch {
+                                            bump(14); // unknown-id but surface-matches an endpoint
+                                        } else {
+                                            bump(15); // unknown-id AND no surface match (fully escaped)
+                                        }
+                                    }
                                     // record the actual (file,node) tuples + name +
                                     // same-file flag for offline analysis.
                                     let name = self.interner.resolve_atom_ref(si.name).to_string();

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -133,6 +133,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let mut target_instantiated = target.clone();
         // Track type param equivalences scope for cleanup at end of function.
         let equiv_start = self.type_param_equivalences.len();
+        // #14345 equiv-through-eval: id-keyed endpoint redirect, installed once
+        // the alpha-rename pairs are registered below and dropped (restoring the
+        // prior map) on every exit path of this frame. See the install site.
+        let mut equiv_redirect_guard: Option<
+            crate::instantiation::instantiate::EquivRedirectGuard,
+        > = None;
+        // Touch the binding so its sole purpose (the `Drop` at scope end) is not
+        // misread as dead; the real use is the destructor on every return path.
+        let _ = &equiv_redirect_guard;
 
         // Capture and reset the callback-param-check flag at function entry so
         // it cannot be prematurely consumed by intermediate sub-checks (return
@@ -339,6 +348,37 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         }
                         self.type_param_equivalences
                             .push((source_tp_type, target_tp_type));
+                    }
+                }
+
+                // #14345 equiv-through-eval: install an id-keyed thread-local
+                // redirect of the just-registered alpha-rename endpoints
+                // (`A_tgt -> A_src`, `A_src -> A_src`) for the remainder of this
+                // signature comparison. The body instantiation below
+                // (`instantiate_function_shape`) and the structural param/return
+                // comparison it feeds drive fresh instantiator/evaluator passes
+                // that do NOT carry `type_param_equivalences`; without the
+                // redirect a body-ref of the TARGET endpoint is re-minted to its
+                // own (or a fresh third) id, so the nested bare-param consult
+                // misses the registered pair (97/106 fp-ts crossdecl misses have
+                // the name absent from the active frame). The redirect makes the
+                // instantiator mint every re-encountered endpoint onto the single
+                // canonical source id, so both bodies share one id for the paired
+                // param. ID-KEYED ONLY (never name/surface — the +16 over-relate
+                // trap); RAII-scoped to this frame so every early-return path
+                // restores the prior map. Inert when the keystone flag is OFF.
+                {
+                    let just_registered: Vec<(TypeId, TypeId)> =
+                        self.type_param_equivalences[equiv_start..].to_vec();
+                    // Held only for its `Drop` (restores the redirect map on every
+                    // exit path); the assignment reads as "unused" to the lint.
+                    #[allow(unused_assignments)]
+                    {
+                        equiv_redirect_guard = Some(
+                            crate::instantiation::instantiate::EquivRedirectGuard::install(
+                                &just_registered,
+                            ),
+                        );
                     }
                 }
 

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -24,21 +24,6 @@ mod generics_application_helpers;
 #[cfg(test)]
 pub(crate) use generics_application_helpers::ONE_SIDED_APP_EXPANSION_MAX_DEPTH;
 
-/// #14345 Stage-4 equiv-through-Application threading (flag
-/// `TSZ_EQUIV_THROUGH_APP=1`, byte-parity-inert OFF). When two applications with
-/// different bases (`RR<string, A>` vs `R<string, A>`) are relate-expanded to
-/// their structural bodies, the inner type-parameter args are re-minted by the
-/// independent instantiation passes, so the top-level alpha-rename equivalence
-/// established by the signature relation no longer covers them. When enabled,
-/// register the positional arg equivalences (the already-paired top-level args)
-/// for the duration of the expanded-body relation so the nested consult can see
-/// them. Scoped: truncated immediately after the body relation completes.
-fn equiv_through_app_enabled() -> bool {
-    use std::sync::OnceLock;
-    static ON: OnceLock<bool> = OnceLock::new();
-    *ON.get_or_init(|| std::env::var("TSZ_EQUIV_THROUGH_APP").is_ok_and(|v| v == "1"))
-}
-
 fn args_contain_type_parameters(
     interner: &dyn crate::construction::TypeDatabase,
     args: &[TypeId],
@@ -720,25 +705,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // - Generic types without variance annotations
         // - Type aliases with complex transformations
         // =======================================================================
-        // #14345 Stage-4: thread the top-level alpha-rename equivalence into the
-        // expanded-body relation by registering the positional arg pairs. Both
-        // arg lists are TypeParameter args at the same position iff the two
-        // applications carry the function-sig type params (the `A` in
-        // `RR<string, A>` / `R<string, A>`). Only register a pair when BOTH args
-        // are TypeParameters (sound: never unifies a concrete arg) and when the
-        // equiv frame already contains the outer pair (the relation is inside an
-        // active alpha-rename), so this never introduces a new surface match.
-        let equiv_thread_start = self.type_param_equivalences.len();
-        if equiv_through_app_enabled() && s_app.args.len() == t_app.args.len() {
-            for (sa, ta) in s_app.args.iter().zip(t_app.args.iter()) {
-                if sa != ta
-                    && matches!(self.interner.lookup(*sa), Some(TypeData::TypeParameter(_)))
-                    && matches!(self.interner.lookup(*ta), Some(TypeData::TypeParameter(_)))
-                {
-                    self.type_param_equivalences.push((*sa, *ta));
-                }
-            }
-        }
         let s_expanded = self.try_expand_application_type(source_type, s_app_id);
         let t_expanded = self.try_expand_application_type(target_type, t_app_id);
         let result = match (s_expanded, t_expanded) {
@@ -797,10 +763,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
             }
         };
-
-        // #14345 Stage-4: drop the threaded arg equivalences (scoped to the
-        // expanded-body relation above).
-        self.type_param_equivalences.truncate(equiv_thread_start);
 
         // Clean up cycle detection guard
         if let Some(def_pair) = app_def_pair {


### PR DESCRIPTION
Goal: green
## Summary

#14345 equiv-through-eval, built at the PRIMARY reduction site and gauged to a conclusive verdict. Threads the active alpha-rename equivalence INTO the Application/alias body expansion via a thread-local ID-keyed endpoint redirect, installed at the function-signature alpha-rename site (where `type_param_equivalences` is non-empty) and consulted in the instantiator's `TypeParameter` arm so a re-encountered registered endpoint mints onto the single canonical source id. Flag-gated (`TSZ_TYPEPARAM_DECL_IDENTITY`), byte-parity-inert OFF. Replaces the base branch's boundary-registration chokepoint probe (proven 0/51 INERT because the Application relation sees an EMPTY equiv frame 9339/9340 times — the redirect must be installed one layer up, at the signature relation).

Result: the redirect FIRES (6429x under the flag) but clears 0/51 fp-ts regressions. The probe shows WHY conclusively, identifying the exact remaining blocker.

## Structural rule

When two generic signatures are alpha-rename related (`<A>(r: Record<string,A>) => n` vs `<A>(r: ReadonlyRecord<string,A>) => n`), tsc treats the paired `A`s as one parameter; tsz registers `(A_src, A_tgt)` in the relation's equiv frame and renames the bodies. The structural compare then expands the Application bodies (`ReadonlyRecord<string,A>` -> `Readonly<Record<string,A>>` -> mapped expansion) through a fresh `TypeEvaluator` (checking.rs:2056) that carries NO equiv frame, so a body-ref of an endpoint is re-instantiated to a THIRD id and the nested bare-param consult (cache.rs) misses the registered pair. Owner: solver relation + instantiation/evaluation.

## The conclusive measurement (the make-or-break)

Of the 106 crossdecl bare-param consult MISSES that drive the +51 (probe `TSZ_STAGE2_PROBE`, fp-ts guard, flag-ON):

| bin | count |
|---|---|
| an id KNOWN to the redirect (== name-in-active-frame) | 9 |
| BOTH consult ids UNKNOWN to the redirect (fresh third ids) | 97 |
| of the 97: surface-match (name+origin) a registered endpoint | **0** |
| of the 97: FULLY escaped (different name AND/OR origin) | **97** |

The third id reaching the consult is NEITHER a registered endpoint id NOR surface-reconstructible from the registered pair. No id-keyed redirect can catch it (it is a brand-new id); the only key that would (surface name+origin) is exactly the +16 over-relate trap AND also misses 100% here. This is the 10th measured lever and the strongest evidence yet that no bounded relation/consult/redirect-layer fix exists.

## Blocker + staged plan for the remaining work

BLOCKER: the third id is born in the per-body re-instantiation inside `evaluate_type`'s fresh `TypeEvaluator` expanding nested alias/Application bodies; it pulls in a same-/different-named `<A>` from a DIFFERENT cross-file decl whose DeclScoped `(file,node)` differs from both registered endpoints, so the minted id is new and outside the redirect's known set. Threading the id-keyed redirect catches the endpoints it knows (6429 fires) but cannot anticipate ids the deep re-mint manufactures.

STAGED PLAN: the clean flip requires the upstream construction-identity canonicalization (the #14344 core / #14345 representation wave) — the same lexical param across nested alias bodies must mint to ONE id at CONSTRUCTION so the deep re-instantiation cannot fork it. The redirect carrier + measurement bins here ship dormant and feed that wave (the redirect becomes effective once construction stops forking the endpoints, because then the deep re-mint reaches an id the redirect knows).

## Verification

- fp-ts guard (tsc-clean): OFF=1479 byte-parity unchanged; ON net=-234 (285 fix / 51 regress) unchanged; `redirect_fired=6429`; escaped-id bins as above (`unknown_id_FULLY_escaped_no_surface=97`, `unknown_id_SURFACE_matches_endpoint=0`).
- `cargo nextest run -p tsz-solver` relation/subtype/generic/variance/type_param/application/instantiat/signature/hkt/conditional/mapped/evaluate: green flag-OFF except 2 failures (`test_conditional_infer_optional_property_present_distributive`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`) confirmed PRE-EXISTING on the base branch (recompiled + reproduced unmodified).
- Determinism: md5-identical RAYON 1/4/8 for BOTH flags. OFF byte-parity 1479 unchanged. The flag is NOT flipped; conformance ships OFF = base byte-parity by construction (redirect path unreachable OFF).

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
