### PR TITLE
fix(checker): keep a pinned callback return when a contextual target would clamp it (TS2322) (#14823)

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -303,11 +303,15 @@ impl<'a> CheckerState<'a> {
                 is_method: sig.is_method,
             };
             let sig_contextual_type = if contextual_type.is_some()
-                && self.suppress_generic_return_context_for_direct_arg_overlap(
+                && (self.suppress_generic_return_context_for_direct_arg_overlap(
                     &sig_shape,
                     args,
                     contextual_type,
-                ) {
+                ) || self.suppress_generic_return_context_for_pinned_callback_return(
+                    &sig_shape,
+                    args,
+                    contextual_type,
+                )) {
                 None
             } else {
                 contextual_type
@@ -1060,11 +1064,15 @@ impl<'a> CheckerState<'a> {
                 is_method: sig.is_method,
             };
             let sig_contextual_type = if contextual_type.is_some()
-                && self.suppress_generic_return_context_for_direct_arg_overlap(
+                && (self.suppress_generic_return_context_for_direct_arg_overlap(
                     &sig_shape,
                     args,
                     contextual_type,
-                ) {
+                ) || self.suppress_generic_return_context_for_pinned_callback_return(
+                    &sig_shape,
+                    args,
+                    contextual_type,
+                )) {
                 None
             } else {
                 contextual_type

--- a/crates/tsz-checker/src/checkers/call_context.rs
+++ b/crates/tsz-checker/src/checkers/call_context.rs
@@ -671,6 +671,123 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Suppress the contextual return type when a callback argument's return
+    /// type is FIXED by an explicit return-type annotation or an `as`/type
+    /// assertion in its concise body, and that return position pins one of the
+    /// call's return type parameters.
+    ///
+    /// `tsc` ranks inferences made from an argument above inferences made from
+    /// the contextual return type (`InferencePriority.ReturnType`). When a
+    /// generic call such as `xs.map((x): string | undefined => x)` is assigned
+    /// or returned directly into a narrower target (`string[]`), the callback's
+    /// explicit return annotation pins `U = string | undefined`; the contextual
+    /// `string[]` must NOT clamp `U` back down to `string`. Without this
+    /// suppression `tsz` lets the contextual return specialize the wrapped
+    /// return parameter, silently coercing the `(string | undefined)[]` result
+    /// to the `string[]` target and dropping the result-level relation — a
+    /// false negative for `TS2322` (#14823).
+    ///
+    /// Once the contextual return is suppressed, the call resolves `U` purely
+    /// from the callback's authoritative explicit return, and the normal
+    /// assignment/return relation reports any residual mismatch at the
+    /// assignment/return site, exactly as `tsc` does. The trigger is confined
+    /// to callbacks whose return type does not depend on the contextual type
+    /// (annotation or concise-body assertion); inferred-return callbacks keep
+    /// their existing contextual-typing behavior.
+    pub(crate) fn suppress_generic_return_context_for_pinned_callback_return(
+        &mut self,
+        shape: &tsz_solver::FunctionShape,
+        args: &[NodeIndex],
+        contextual_type: Option<TypeId>,
+    ) -> bool {
+        if contextual_type.is_none() {
+            return false;
+        }
+
+        let return_type_params =
+            self.collect_type_param_names_for_context_overlap(shape.return_type);
+        if return_type_params.is_empty() {
+            return false;
+        }
+
+        for (i, &arg_idx) in args.iter().enumerate() {
+            let Some(param_type) = shape.params.get(i).map(|p| p.type_id).or_else(|| {
+                shape
+                    .params
+                    .last()
+                    .and_then(|p| p.rest.then_some(p.type_id))
+            }) else {
+                break;
+            };
+
+            // Cheap syntactic gate first: every callback function reachable
+            // through this argument (including both branches of a conditional
+            // callback) must pin its return type explicitly. If any branch
+            // infers its return, the contextual return still legitimately
+            // informs that branch and must not be dropped. Rejecting here skips
+            // the expensive type-shape extraction below for every non-callback
+            // argument and every inferred-return callback (the common case).
+            let callbacks = self.callback_function_indices(arg_idx);
+            if callbacks.is_empty()
+                || !callbacks
+                    .iter()
+                    .all(|&cb| self.callback_return_is_explicitly_pinned(cb))
+            {
+                continue;
+            }
+
+            // The matching parameter must be a callback whose RETURN position
+            // mentions a return type parameter — that is the parameter the
+            // callback's explicit return type pins. A parameter that mentions
+            // the return type parameter only in argument position does not
+            // qualify (its inference is owned by argument typing, not by the
+            // callback's return annotation).
+            let Some(param_shape) = self.contextual_signature_after_evaluation(param_type) else {
+                continue;
+            };
+            let param_return_names =
+                self.collect_type_param_names_for_context_overlap(param_shape.return_type);
+            if param_return_names
+                .iter()
+                .any(|name| return_type_params.contains(name))
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Returns `true` when the callback function's return type is fixed
+    /// independently of the contextual type: it carries an explicit return-type
+    /// annotation, or it is an arrow with a concise body that is a type
+    /// assertion (`expr as T`, `<T>expr`, `expr satisfies T`). Block-bodied and
+    /// bare-expression arrows infer their return type and still consume the
+    /// contextual return type, so they are not "pinned".
+    fn callback_return_is_explicitly_pinned(&self, func_idx: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(func_idx) else {
+            return false;
+        };
+        let Some(func) = self.ctx.arena.get_function(node) else {
+            return false;
+        };
+        if func.type_annotation.is_some() {
+            return true;
+        }
+        if !func.equals_greater_than_token {
+            return false;
+        }
+        let body = self.ctx.arena.skip_parenthesized(func.body);
+        self.ctx.arena.get(body).is_some_and(|body_node| {
+            matches!(
+                body_node.kind,
+                syntax_kind_ext::AS_EXPRESSION
+                    | syntax_kind_ext::TYPE_ASSERTION
+                    | syntax_kind_ext::SATISFIES_EXPRESSION
+            )
+        })
+    }
+
     fn wrapped_return_context_has_stable_overlap_arg(
         &mut self,
         shape: &tsz_solver::FunctionShape,

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -936,6 +936,32 @@ impl<'a> CheckerState<'a> {
         } else {
             Vec::new()
         };
+        // When an argument is a callback whose return type is FIXED by an
+        // explicit return annotation or `as`/type assertion that pins a return
+        // type parameter, the contextual return must not clamp that parameter
+        // back down (e.g. `xs.map((x): string | undefined => x)` into `string[]`
+        // must keep `U = string | undefined`, not be coerced to `string`). tsc
+        // ranks the callback's authoritative return above the contextual return,
+        // so suppress the contextual return in the final solve AND skip the
+        // assignability-recovery retry below; the result then relates to the
+        // outer target normally and a genuine mismatch surfaces as TS2322
+        // (#14823).
+        //
+        // Both sites are required (unlike the sibling
+        // `suppress_generic_return_context_for_direct_arg_overlap`, which only
+        // gates inference seeding): the `should_retry_generic_call` path below
+        // re-resolves with the raw contextual type whenever the result fails to
+        // relate to it, which would re-seed the contextual return and re-clamp
+        // the parameter — re-hiding the very TS2322 this suppression exposes.
+        let suppress_pinned_callback_context = is_generic_call
+            && contextual_type.is_some()
+            && original_callee_shape.as_ref().is_some_and(|shape| {
+                self.suppress_generic_return_context_for_pinned_callback_return(
+                    shape,
+                    args,
+                    contextual_type,
+                )
+            });
         let call_resolution_contextual_type = if is_generic_call {
             // Generic calls in contextual positions need the outer request at the
             // solver boundary, even when they have arguments. The checker-side
@@ -944,7 +970,11 @@ impl<'a> CheckerState<'a> {
             // `consumeClass(createClass(x => ...))` still require return-context
             // seeding in the final generic solve step to instantiate parameter and
             // callback types from the contextual result.
-            contextual_type
+            if suppress_pinned_callback_context {
+                None
+            } else {
+                contextual_type
+            }
         } else {
             contextual_type
         };
@@ -1096,6 +1126,7 @@ impl<'a> CheckerState<'a> {
             )
         });
         let should_retry_generic_call = if is_generic_call
+            && !suppress_pinned_callback_context
             && (!had_return_context_substitution || has_contextual_signature_instantiation_arg)
             && has_contextual_refresh_arg
         {

--- a/crates/tsz-checker/src/types/computation/call/inner/argument_collection.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner/argument_collection.rs
@@ -145,6 +145,11 @@ impl<'a> CheckerState<'a> {
                             &shape,
                             args,
                             contextual_type,
+                        )
+                        || self.suppress_generic_return_context_for_pinned_callback_return(
+                            &shape,
+                            args,
+                            contextual_type,
                         ));
                 let generic_inference_contextual_type = if suppress_generic_return_context {
                     None


### PR DESCRIPTION
## Summary
Fixes the false negative in #14823. When a generic call such as
`xs.map((x): string | undefined => x)` or
`call(1, (x) => undefined as string | undefined)` is returned/assigned directly
into a narrower target (e.g. `string[]`), the callback's explicit return-type
annotation or `as`-cast pins the return type parameter `U` to
`string | undefined`. `tsc` ranks this argument inference above the
contextual-return inference (`InferencePriority.ReturnType`), so the result
`(string | undefined)[]` is then related to `string[]` and reports **TS2322**.

tsz instead let the contextual return type clamp `U` down to `string`, silently
coercing the result to the target and dropping the result-level relation — a
false negative.

## Structural rule
When an argument is a callback whose return type is fixed independently of the
contextual type — an explicit return annotation, or a concise arrow body that is
an `as`/type/`satisfies` assertion — and that return position pins one of the
call's return type parameters, `tsc` does not apply the contextual return type
to that generic solve; tsz now does the same through
`suppress_generic_return_context_for_pinned_callback_return`. The callback's
authoritative return then determines the parameter, and the normal
assignment/return relation reports any residual mismatch at the
assignment/return site.

## Owner layer
Checker — `crates/tsz-checker/src/checkers/call_context.rs`
(`suppress_generic_return_context_for_pinned_callback_return`), applied wherever
the contextual return is fed into generic inference:
- the generic gate (`types/computation/call/inner/argument_collection.rs`),
- both overload-resolution passes (`call_checker/overload_resolution.rs`),
- the final generic solve and the assignability-recovery retry
  (`types/computation/call/inner.rs`) — the retry is unique to this helper
  because it would otherwise re-seed the contextual return and re-clamp the
  parameter, re-hiding the TS2322.

This follows the established `suppress_generic_return_context_*` checker-side
pattern. The deeper, durable fix is a solver inference-priority rule
(argument-pinned returns outranking `ReturnType`-priority contextual
candidates) that would eventually let the whole
`suppress_generic_return_context_*` family collapse into one solver decision;
that is tracked as follow-up debt and is out of scope here.

## Adjacent-case matrix (all match `tsc`)
- annotated callback return that **matches** the target -> no error (positive control)
- inferred-return callbacks -> behavior unchanged (the #14792 facet is separate)
- `as`-cast concise body wider than target -> TS2322 (FN B / FN C)
- block-bodied annotated callback wider than target -> TS2322
- conditional callback with **all** branches pinned wider -> TS2322
- annotated callback wider into a wide-enough target -> no error
- no contextual target on the call -> result keeps `(string | undefined)[]`

Goal: hold

## Verification
- Standalone repros from the issue (FN A/B/C) now emit TS2322 verbatim against
  `tsc` 5.9.3 (`--strict --target es2022 --lib es2022,dom,dom.iterable --noEmit`).
- `cargo clippy -p tsz-checker --tests` clean.
- No regressions across the contextual/callback/inference/overload checker
  suites (`context_sensitive_callback_inference_tests`,
  `contextual_return_value_arg_pinned_tests`,
  `contextual_return_callback_param_only_inference_tests`,
  `covariant_callbacks_tests`, `contextual_ts2345_conformance_tests`,
  `overload_inference_literal_preservation_tests`,
  `satisfies_generic_inference_literal_widening_tests`). The only failures in
  the broader sweep — 5 in `generic_call_inference_tests`, 3 in
  `kysely_callback_context_tests` — are pre-existing and reproduce on `main`.
- Ready-review CI owns the full conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01DQBJ2tBfHByrgkzKP7ZpUJ