### PR TITLE
fix(solver): combine union arms in return-context substitution (TS2322, #14731)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -120,6 +120,9 @@ path = "tests/assertion_source_literal_display_tests.rs"
 name = "return_context_identity_wrapper_literal_tests"
 path = "tests/return_context_identity_wrapper_literal_tests.rs"
 [[test]]
+name = "nested_generic_union_callback_return_tests"
+path = "tests/nested_generic_union_callback_return_tests.rs"
+[[test]]
 name = "nested_mapped_optional_modifier_inline_application_tests"
 path = "tests/nested_mapped_optional_modifier_inline_application_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs
@@ -337,20 +337,63 @@ impl<'a> CheckerState<'a> {
 
         if let Some(target_members) = common::union_members(self.ctx.types, target) {
             let before_len = substitution.len();
+            // Probe *every* non-nullish union arm and only bind a tracked
+            // parameter from the return context when the arms agree on a single
+            // value — rather than stopping at the first arm that produces a
+            // binding.
+            //
+            // A nested generic call whose signature return is `U[]` checked
+            // against a contextual union like `string[] | string[][]` matches
+            // both arms but binds `U` differently (`U := string` from the
+            // `string[]` arm, `U := string[]` from the `string[][]` arm). Taking
+            // only the first arm pinned `U := string`, which contextually typed
+            // the callback's return as `string` and spuriously rejected its body
+            // (and, in a nested `U | U[]` callback target, leaked the outer type
+            // parameter into the result — issue #14731). The arms are genuinely
+            // ambiguous, so the return context must not pin `U`; leaving it
+            // unbound lets argument inference (the callback body) decide it, as
+            // `tsc` does. When every contributing arm agrees on the same value,
+            // binding it is unambiguous and preserved.
+            let mut per_param: rustc_hash::FxHashMap<Atom, Vec<TypeId>> =
+                rustc_hash::FxHashMap::default();
+            let mut param_order: Vec<Atom> = Vec::new();
             for member in target_members
                 .into_iter()
                 .filter(|member| *member != TypeId::NULL && *member != TypeId::UNDEFINED)
             {
+                let mut member_substitution = TypeSubstitution::new();
+                let mut member_visited = FxHashSet::default();
                 self.collect_return_context_substitution(
                     source,
                     member,
                     tracked_type_params,
-                    substitution,
-                    visited,
+                    &mut member_substitution,
+                    &mut member_visited,
                 );
-                if substitution.len() > before_len {
-                    return;
+                for (&name, &member_ty) in member_substitution.map() {
+                    let values = per_param.entry(name).or_insert_with(|| {
+                        param_order.push(name);
+                        Vec::new()
+                    });
+                    if !values.contains(&member_ty) {
+                        values.push(member_ty);
+                    }
                 }
+            }
+            for name in param_order {
+                // Earlier blocks (and an outer arm) may have already bound this
+                // parameter; never override an existing binding, and skip
+                // parameters the arms disagree on (genuine ambiguity).
+                if substitution.get(name).is_some() {
+                    continue;
+                }
+                let values = &per_param[&name];
+                if values.len() == 1 {
+                    substitution.insert(name, values[0]);
+                }
+            }
+            if substitution.len() > before_len {
+                return;
             }
         }
 

--- a/crates/tsz-checker/tests/nested_generic_union_callback_return_tests.rs
+++ b/crates/tsz-checker/tests/nested_generic_union_callback_return_tests.rs
@@ -1,0 +1,172 @@
+//! Return-context inference for a generic call whose signature return is checked
+//! against a *union* contextual type must combine its union arms, not pin the
+//! type parameter to whichever arm matched first.
+//!
+//! Structural rule: when a generic call's return type (`U[]`) is matched against
+//! a contextual union whose arms bind the call's type parameter differently
+//! (`string[]` binds `U := string`, `string[][]` binds `U := string[]`), the
+//! arms are genuinely ambiguous. `tsc` does not let the return context pin `U`
+//! from a single arm; argument inference (the callback body) decides it. Taking
+//! only the first arm pinned `U := string`, contextually typed a nested
+//! callback's return as `string`, and spuriously rejected its body — and for a
+//! `U | U[]` callback target it leaked the outer type parameter into the result
+//! (`U[]`). Owner: the return-context substitution in the generic-call solver
+//! boundary (and its checker counterpart), which now skips a parameter the
+//! union arms disagree on.
+//!
+//! Witness family: the `ofetch` canary `withQuery` (issue #14731), and the lib
+//! `Array.prototype.flatMap` shape `U | ReadonlyArray<U>`. Type-parameter names
+//! are varied across cases so no fix can key on a specific binder name.
+
+use tsz_checker::context::{CheckerOptions, ScriptTarget};
+use tsz_checker::test_utils::{check_multi_file_with_libs, load_default_lib_files};
+use tsz_common::diagnostics::Diagnostic;
+
+fn ts_options() -> CheckerOptions {
+    CheckerOptions {
+        target: ScriptTarget::ES2017,
+        ..CheckerOptions::default()
+    }
+}
+
+fn check(files: &[(&str, &str)]) -> Vec<Diagnostic> {
+    let libs = load_default_lib_files();
+    check_multi_file_with_libs(files, files[0].0, ts_options(), &libs)
+}
+
+fn assert_clean(src: &str, context: &str) {
+    let diags = check(&[("case.ts", src)]);
+    assert!(
+        diags.is_empty(),
+        "{context}: expected no diagnostics, got: {:#?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+fn assert_reports_2322(src: &str, context: &str) {
+    let diags = check(&[("case.ts", src)]);
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "{context}: expected a TS2322, got: {:#?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The minimal witness: a generic `.map` over an `any[]` receiver checked against
+/// a concrete union contextual type. The inner callback returns `string[]`; with
+/// the first-arm pin it was typed against `string` and rejected.
+#[test]
+fn map_over_any_under_concrete_union_context_is_clean() {
+    assert_clean(
+        r#"
+declare const inner: any[];
+const r: string[] | string[][] = inner.map((item) => [String(item)]);
+"#,
+        "map over any[] under string[] | string[][]",
+    );
+}
+
+/// The receiver element type must not matter: a concrete `number[]` receiver
+/// reproduces the same first-arm pin.
+#[test]
+fn map_over_number_under_concrete_union_context_is_clean() {
+    assert_clean(
+        r#"
+declare const inner: number[];
+const r: string[] | string[][] = inner.map((item) => [String(item)]);
+"#,
+        "map over number[] under string[] | string[][]",
+    );
+}
+
+/// The issue's exact repro: a hand-written `cb: (x) => U | U[]` callback target
+/// whose body is a nested generic call over an `any[]` receiver. The outer `U`
+/// must be inferred as `string[]` (result `string[][]`), not leaked as `U[]`.
+#[test]
+fn hand_written_union_callback_target_does_not_leak_param() {
+    assert_clean(
+        r#"
+declare function myFlatMap<U>(cb: (x: number) => U | U[]): U[];
+const result = myFlatMap((value) => {
+  const inner: any[] = [];
+  return inner.map((item) => [String(item)]);
+});
+const probe: string[][] = result;
+"#,
+        "U | U[] callback target with nested any[] map",
+    );
+}
+
+/// Same shape with a differently-named type parameter and the lib
+/// `ReadonlyArray<E>` arm, proving the fix is neither name- nor
+/// `Array`-literal-scoped.
+#[test]
+fn readonly_array_union_callback_target_does_not_leak_param() {
+    assert_clean(
+        r#"
+declare function expand<E>(cb: (x: number) => E | ReadonlyArray<E>): E[];
+const out = expand((value) => {
+  const src: any[] = [];
+  return src.map((item) => [String(item)]);
+});
+const probe: string[][] = out;
+"#,
+        "E | ReadonlyArray<E> callback target with nested any[] map",
+    );
+}
+
+/// The lib `Array.prototype.flatMap` is the production witness (ofetch
+/// `withQuery`): its callback return target is `U | ReadonlyArray<U>`.
+#[test]
+fn lib_flatmap_with_nested_any_map_is_clean() {
+    assert_clean(
+        r#"
+const inner: any[] = [];
+const result = [1, 2].flatMap((value) => {
+  return inner.map((item) => [String(item)]);
+});
+const probe: string[][] = result;
+"#,
+        "Array.prototype.flatMap with nested any[] map",
+    );
+}
+
+/// The result must be inferred as the *correct* `string[][]`, not merely be
+/// error-free: assigning it to an incompatible annotation must still report
+/// TS2322. This guards against a fix that simply suppresses the diagnostic.
+#[test]
+fn result_type_is_string_array_array_not_silenced() {
+    assert_reports_2322(
+        r#"
+declare function myFlatMap<U>(cb: (x: number) => U | U[]): U[];
+const result = myFlatMap((value) => {
+  const inner: any[] = [];
+  return inner.map((item) => [String(item)]);
+});
+const probe: number[] = result;
+"#,
+        "result string[][] is not assignable to number[]",
+    );
+}
+
+/// When the contextual union arms agree on a single binding for the parameter,
+/// the return context still pins it (no regression in the unambiguous case).
+/// Here both arms drive `T := string`, and the callback's `() => "x"` body is
+/// accepted by the pinned contextual return.
+#[test]
+fn agreeing_union_arms_still_pin_parameter() {
+    assert_clean(
+        r#"
+declare function pickOne<T>(cb: () => T): T | T[];
+const value = pickOne(() => "x");
+const probe: string | string[] = value;
+"#,
+        "agreeing union arms keep pinning T",
+    );
+}

--- a/crates/tsz-solver/src/operations/generic_call/return_context.rs
+++ b/crates/tsz-solver/src/operations/generic_call/return_context.rs
@@ -429,20 +429,61 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             crate::type_queries::get_union_members(self.interner.as_type_database(), target)
         {
             let before_len = substitution.len();
+            // Probe *every* non-nullish union arm and only bind a tracked
+            // parameter from the return context when the arms agree on a single
+            // value — rather than stopping at the first arm that produces a
+            // binding.
+            //
+            // A nested generic call whose signature return is `U[]` checked
+            // against a contextual union like `string[] | string[][]` matches
+            // both arms but binds `U` differently (`U := string` from the
+            // `string[]` arm, `U := string[]` from the `string[][]` arm). Taking
+            // only the first arm pinned `U := string`, which contextually typed
+            // the callback's return as `string` and spuriously rejected its body
+            // (and, for a `U | U[]` callback target, leaked the outer type
+            // parameter into the result — issue #14731). The arms are genuinely
+            // ambiguous, so the return context must not pin `U`; leaving it
+            // unbound lets argument inference (the callback body) decide it, as
+            // `tsc` does. When every contributing arm agrees on the same value,
+            // binding it is unambiguous and preserved.
+            let mut per_param: FxHashMap<tsz_common::Atom, Vec<TypeId>> = FxHashMap::default();
+            let mut param_order: Vec<tsz_common::Atom> = Vec::new();
             for member in target_members
                 .into_iter()
                 .filter(|member| *member != TypeId::NULL && *member != TypeId::UNDEFINED)
             {
+                let mut member_substitution = TypeSubstitution::new();
+                let mut member_visited = FxHashSet::default();
                 self.collect_return_context_substitution(
                     source,
                     member,
                     tracked_type_params,
-                    substitution,
-                    visited,
+                    &mut member_substitution,
+                    &mut member_visited,
                 );
-                if substitution.len() > before_len {
-                    return;
+                for (&name, &member_ty) in member_substitution.map() {
+                    let values = per_param.entry(name).or_insert_with(|| {
+                        param_order.push(name);
+                        Vec::new()
+                    });
+                    if !values.contains(&member_ty) {
+                        values.push(member_ty);
+                    }
                 }
+            }
+            for name in param_order {
+                // Never override a binding an earlier block already produced,
+                // and skip parameters the arms disagree on (genuine ambiguity).
+                if substitution.get(name).is_some() {
+                    continue;
+                }
+                let values = &per_param[&name];
+                if values.len() == 1 {
+                    substitution.insert(name, values[0]);
+                }
+            }
+            if substitution.len() > before_len {
+                return;
             }
         }
 


### PR DESCRIPTION
Fixes #14731.

## Summary
When a generic call's signature return type (e.g. `U[]`) is matched against a contextual **union** type whose arms bind the call's type parameter differently — `string[]` binds `U := string`, `string[][]` binds `U := string[]` — the return-context substitution stopped at the **first** arm that produced a binding and pinned `U := string`. That contextually typed a nested callback's return as `string` and spuriously rejected its body, and for a `U | U[]` callback target it leaked the outer type parameter into the result as `U[]` (the ofetch `withQuery` canary, TS2345/TS2322).

`tsc` infers `string[][]` and is clean.

## Structural rule
When the contextual union arms disagree on a tracked type parameter's binding, the arms are genuinely ambiguous, so `tsc` does **not** let the return context pin the parameter — argument inference (the callback body) decides it. tsz now matches this through the return-context substitution gateway: probe **every** non-nullish arm and only bind a parameter when the arms agree on a single value; otherwise leave it unbound for argument inference. When the arms agree, the binding is unambiguous and is preserved (no regression to the existing single-arm / `querySelector` / `Promise.then` paths).

## Owner layer
- `crates/tsz-solver/src/operations/generic_call/return_context.rs` — `collect_return_context_substitution` (round-1 contextual seeding).
- `crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs` — the checker counterpart (argument contextual typing).

No anti-hardcoding violations: the decision is purely structural (union-arm agreement), with no identifier / file-name / printer-text predicates; the regression tests vary the type-parameter binder name (`U`, `E`, `T`).

## Adjacent matrix
All clean, with the result correctly inferred as `string[][]`:
- hand-written `cb: (x) => U | U[]` callback target with a nested generic `.map` over `any[]`;
- hand-written `cb: (x) => E | ReadonlyArray<E>` (not `flatMap`-name- or array-literal-scoped);
- the lib `Array.prototype.flatMap` (ofetch's exact shape);
- `any[]` and `number[]` receivers (the bug was receiver-independent at the minimal level);
- negative probe: assigning the `string[][]` result to `number[]` still reports TS2322 (the fix is not a suppression);
- agreeing-arm union (`() => T` against `T | T[]`) still pins `T`.

## Verification
- New: `cargo test -p tsz-checker --test nested_generic_union_callback_return_tests` — 7/7 pass.
- `cargo test -p tsz-checker --test generic_call_inference_tests`: this checkout's baseline had 5 failures in this file; with the change only the 2 pre-existing generator failures remain (the fix additionally repairs `pipe_contextual_return_flows_through_nested_generic_call_chain`, `noinfer_array_alias_widens_to_primitive`, and `generic_rest_parameter_infers_literal_tuple_under_primitive_array_constraint`).
- Related suites green: `array_element_naked_inference_tests`, `contextual_return_value_arg_pinned_tests`, `contextual_return_callback_param_only_inference_tests`, `contextual_return_tuple_generic_member_tests`, `tuple_union_contextual_typing_tests`, `context_sensitive_callback_inference_tests`, `object_literal_union_contextual_typing_tests`, `return_context_identity_wrapper_literal_tests`, `issue_3768_generic_callback_outer_inference_tests`, `new_generic_callback_contextual_infer_tests`.
- `cargo test -p tsz-solver --lib`: no new failures (the 4 failures are pre-existing on the base commit).
- Broad conformance / emit / fourslash owned by ready-review CI.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01DcqCjeHRBESzAuUD2DAKfg