### PR TITLE
fix(solver): union contextual-return arms through a placeholder array

### DIFF
--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -1221,9 +1221,49 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     // so structural decomposition can extract inference candidates.
                     member_visited.clear();
                     if self.type_contains_placeholder(source, var_map, &mut member_visited) {
-                        for &member in t_members.iter() {
-                            if !is_nullish(member) {
-                                self.constrain_types(ctx, var_map, source, member, priority);
+                        // When the source is array-like with a placeholder element
+                        // and every arm is array-like, the source's placeholder must
+                        // be bounded by the UNION of the arms' element types, not by
+                        // each arm separately. Constraining `R[]` against `string[]`
+                        // and `string[][]` independently records two upper bounds that
+                        // resolve via intersection (`R <: string & string[]`); but the
+                        // source can satisfy ANY arm, so the bound is the union
+                        // `R <: string | string[]`. This surfaced once a `U | U[]`
+                        // callback-return context was fed back as a concrete union of
+                        // arrays into a nested `.map` over `any[]` (#14731).
+                        member_visited.clear();
+                        let src_elem =
+                            self.array_like_element_for_constraint(source)
+                                .filter(|&src_elem| {
+                                    self.type_contains_placeholder(
+                                        src_elem,
+                                        var_map,
+                                        &mut member_visited,
+                                    )
+                                });
+                        let arm_elems = src_elem.and_then(|_| {
+                            t_members
+                                .iter()
+                                .copied()
+                                .filter(|&member| !is_nullish(member))
+                                .map(|member| self.array_like_element_for_constraint(member))
+                                .collect::<Option<Vec<TypeId>>>()
+                        });
+                        if let (Some(src_elem), Some(arm_elems)) = (src_elem, arm_elems) {
+                            // Record the union as a candidate (lower bound) for the
+                            // source element rather than an upper bound: it is a
+                            // contextual hint at this `priority` (`ReturnType`), so a
+                            // higher-priority `NakedTypeVariable` candidate from the
+                            // actual argument (e.g. the `.map` callback returning
+                            // `string[]`) must still win and pin `R = string[]`
+                            // (giving `string[][]`), not leave `R = string | string[]`.
+                            let unioned = self.interner.union(arm_elems);
+                            self.constrain_types(ctx, var_map, unioned, src_elem, priority);
+                        } else {
+                            for &member in t_members.iter() {
+                                if !is_nullish(member) {
+                                    self.constrain_types(ctx, var_map, source, member, priority);
+                                }
                             }
                         }
                     }

--- a/crates/tsz-solver/src/operations/generic_call/return_context.rs
+++ b/crates/tsz-solver/src/operations/generic_call/return_context.rs
@@ -428,21 +428,54 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         if let Some(target_members) =
             crate::type_queries::get_union_members(self.interner.as_type_database(), target)
         {
+            // Collect each non-nullish arm's contribution independently and
+            // union the per-type-parameter results. A contextual return type
+            // that is a union of structured shapes (e.g. `string[] | string[][]`
+            // matched against a return type `U[]`) constrains the type parameter
+            // to the union of what every arm implies (`string | string[]`), not
+            // just the first arm. tsc reaches the same result by unioning the
+            // equal-priority inference candidates each constituent produces;
+            // returning after the first contributing arm instead pinned `U` to
+            // one arm's element (`string`) and mis-typed the callback's
+            // contextual return (#14731).
             let before_len = substitution.len();
+            let mut merged: FxHashMap<tsz_common::Atom, Vec<TypeId>> = FxHashMap::default();
             for member in target_members
                 .into_iter()
                 .filter(|member| *member != TypeId::NULL && *member != TypeId::UNDEFINED)
             {
+                // A fresh `visited` per arm keeps arms from masking each other's
+                // structural recursion; the outer set already guards re-entry on
+                // `(source, target)`.
+                let mut member_visited = FxHashSet::default();
+                let mut member_subst = TypeSubstitution::new();
                 self.collect_return_context_substitution(
                     source,
                     member,
                     tracked_type_params,
-                    substitution,
-                    visited,
+                    &mut member_subst,
+                    &mut member_visited,
                 );
-                if substitution.len() > before_len {
-                    return;
+                for (&name, &ty) in member_subst.map().iter() {
+                    let candidates = merged.entry(name).or_default();
+                    if !candidates.contains(&ty) {
+                        candidates.push(ty);
+                    }
                 }
+            }
+            for (name, candidates) in merged {
+                if substitution.get(name).is_some() {
+                    continue;
+                }
+                let unioned = if candidates.len() == 1 {
+                    candidates[0]
+                } else {
+                    self.interner.union(candidates)
+                };
+                substitution.insert(name, unioned);
+            }
+            if substitution.len() > before_len {
+                return;
             }
         }
 


### PR DESCRIPTION
## Summary

Advances #14731. When a generic call's return type embeds a type parameter inside an array (`U[]`) and the **contextual type is a union of structured shapes** (e.g. `string[] | string[][]`), the contextual-return inference must bound the type parameter by the **union** of what every arm implies (`string | string[]`), not by a single arm or by intersecting per-arm bounds.

## Structural rule

When the contextual return target is a union and the signature's return type contains a tracked type parameter, `tsc` records an inference candidate for that parameter from **every** structurally-matching union arm and unions the equal-priority results. `tsz` did this through two paths that were first-arm / per-arm biased:

- **`solver/operations/generic_call/return_context.rs` — `collect_return_context_substitution`**: returned after the *first* union arm that produced a substitution, pinning `U` to one arm's element (`string`) and mis-typing the callback's contextual return. Now it collects every arm's contribution and unions per type-parameter name. This is the general fix to the union-target decomposition.
- **`solver/operations/constraints/walker.rs` — `constrain_types_impl` (`placeholder_count == 0` branch)**: constrained a placeholder-bearing source against each union arm separately, recording upper bounds that resolve via **intersection** (`R <: string & string[]`). When the source is array-like with a placeholder element and every arm is array-like, it now unions the arms' element types into a single contextual (`ReturnType`-priority) candidate, so a higher-priority `NakedTypeVariable` argument candidate still wins. Non-array shapes keep the original per-arm behaviour (e.g. `Promise<_> <: Obj | PromiseLike<Obj>` is unchanged).

Owner layer: solver (inference / constraint walker). No checker pattern-matching of solver internals.

## Adjacent cases verified

- `const x: string[] | string[][] = arr.map(item => [String(item)])` (concrete receiver) — now clean.
- `const x: string[] | number[] = arr.map(item => item)` — clean.
- The spurious `string & string[]` intersection from a `U | U[]` callback-return context is removed.
- `Promise.then`-style `T | PromiseLike<T>` decomposition and other non-array union targets are unaffected.

## Scope / remaining work

This fixes the union-contextual-return-arm family. The original #14731 witness (ofetch `withQuery`) additionally exercises a **separate, pre-existing layer**: an `any`-element receiver makes the context-sensitive callback arrive at solver inference as an `unknown` deferred sentinel, so the callback's actual return is never inferred into the `.map` element variable (reproducible without unions: `declare function f<R>(cb:(v:any)=>R):R[]; const x: number[] = f(item => "s")` leaks `R[]`). That layer is checker↔solver argument-typing protocol and is left for a follow-up; #14731 stays open with the full layered analysis recorded.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo build --bin tsz` clean.
- `cargo test -p tsz-solver --lib`: 6958 passed; the only 4 failures are pre-existing on `origin/main` (verified by stashing this change and rebuilding) and unrelated (file-size ceiling + 3 environment-dependent tests).
- Targeted repro matrix (concrete-receiver union-return callbacks, `Promise.then` decomposition, nullable-union targets) checked against `tsc` 5.9.3 behaviour with `target/debug/tsz --strict`.
- Broad conformance/emit/fourslash owned by ready-review CI.

https://claude.ai/code/session_01JLiZHWEsXVsPLpykiUzo5H

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLiZHWEsXVsPLpykiUzo5H)_