### PR TITLE
fix(parser): emit TS1110 for a missing required type constituent (#14836)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -63,6 +63,9 @@ path = "tests/object_literal_unique_symbol_member_tests.rs"
 name = "unique_symbol_grammar_tests"
 path = "tests/unique_symbol_grammar_tests.rs"
 [[test]]
+name = "type_operator_missing_operand_recovery_tests"
+path = "tests/type_operator_missing_operand_recovery_tests.rs"
+[[test]]
 name = "top_level_await_grammar_diagnostics_tests"
 path = "tests/top_level_await_grammar_diagnostics_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -585,10 +585,14 @@ impl<'a> CheckerState<'a> {
             k if k == syntax_kind_ext::TYPE_OPERATOR => {
                 if let Some(op) = self.ctx.arena.get_type_operator(node) {
                     // TS1354: 'readonly' type modifier is only permitted on array and tuple literal types.
+                    // A missing operand (`let v: readonly ;`) already produced TS1110
+                    // `Type expected` in the parser; tsc does not also report the
+                    // array/tuple grammar error, so skip it for the recovery node.
                     if op.operator == tsz_scanner::SyntaxKind::ReadonlyKeyword as u16
                         && let Some(operand_node) = self.ctx.arena.get(op.type_node)
                         && operand_node.kind != syntax_kind_ext::ARRAY_TYPE
                         && operand_node.kind != syntax_kind_ext::TUPLE_TYPE
+                        && !self.ctx.arena.is_missing_recovery_identifier(op.type_node)
                     {
                         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                         self.ctx.error(

--- a/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
@@ -762,10 +762,14 @@ impl<'a> CheckerState<'a> {
             }
             k if k == syntax_kind_ext::TYPE_OPERATOR => {
                 if let Some(op) = self.ctx.arena.get_type_operator(node) {
+                    // A missing operand (`type U = readonly ;`) already produced TS1110
+                    // `Type expected` in the parser; tsc does not also report the
+                    // array/tuple grammar error, so skip it for the recovery node.
                     if op.operator == SyntaxKind::ReadonlyKeyword as u16
                         && let Some(operand_node) = self.ctx.arena.get(op.type_node)
                         && operand_node.kind != syntax_kind_ext::ARRAY_TYPE
                         && operand_node.kind != syntax_kind_ext::TUPLE_TYPE
+                        && !self.ctx.arena.is_missing_recovery_identifier(op.type_node)
                     {
                         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                         self.ctx.error(

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -48,10 +48,16 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             // Handle readonly operator
             if operator == SyntaxKind::ReadonlyKeyword as u16 {
                 // TS1354: 'readonly' type modifier is only permitted on array and tuple literal types.
+                // A missing operand (`readonly ;`) already produced TS1110 `Type expected`
+                // in the parser; tsc does not also report the array/tuple grammar error.
                 if let Some(operand_node) = self.ctx.arena.get(type_op.type_node) {
                     let operand_kind = operand_node.kind;
                     if operand_kind != syntax_kind_ext::ARRAY_TYPE
                         && operand_kind != syntax_kind_ext::TUPLE_TYPE
+                        && !self
+                            .ctx
+                            .arena
+                            .is_missing_recovery_identifier(type_op.type_node)
                     {
                         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                         self.ctx.error(

--- a/crates/tsz-checker/src/types/unique_symbol_arena.rs
+++ b/crates/tsz-checker/src/types/unique_symbol_arena.rs
@@ -199,6 +199,13 @@ pub(crate) fn unique_symbol_grammar_violation(
         return None;
     }
 
+    // A missing operand (`unique ;`) already produced TS1110 `Type expected` in
+    // the parser; tsc does not also pile on the operand-shape grammar error, so
+    // neither do we.
+    if arena.is_missing_recovery_identifier(type_op.type_node) {
+        return None;
+    }
+
     // `unique` is only permitted over the `symbol` keyword. tsc reports the
     // operand position with TS1005 "'symbol' expected" otherwise (e.g.
     // `unique number`, `unique symbol[]`).

--- a/crates/tsz-checker/tests/type_operator_missing_operand_recovery_tests.rs
+++ b/crates/tsz-checker/tests/type_operator_missing_operand_recovery_tests.rs
@@ -1,0 +1,94 @@
+//! End-to-end recovery for a *missing required type operand* on a type
+//! operator (`unique`/`readonly`).
+//!
+//! When the operand is absent (`type U = unique ;`), the parser already emits
+//! TS1110 `Type expected` (covered by the parser-side unit tests). tsc does not
+//! *also* fire the operand-shape grammar errors — TS1005 `'symbol' expected`
+//! for `unique`, TS1354 (array/tuple) for `readonly` — on that missing node.
+//! This suite pins the checker half of the behavior: the grammar errors are
+//! suppressed for a missing operand but still fire for a *present* wrong operand.
+//!
+//! (TS1110 itself is a parse diagnostic and is asserted in
+//! `tsz-parser`'s `missing_required_constituent_tests`; the checker test
+//! harness here returns only checker diagnostics.)
+//!
+//! Owners: the missing-recovery guards in
+//! `crates/tsz-checker/src/types/unique_symbol_arena.rs` and
+//! `crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs`.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+const SYMBOL_EXPECTED: u32 = 1005;
+const READONLY_ONLY_ON_ARRAY_TUPLE: u32 = 1354;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn unique_without_operand_does_not_report_symbol_expected() {
+    let c = codes("type U = unique ;");
+    assert!(
+        !c.contains(&SYMBOL_EXPECTED),
+        "a missing `unique` operand must not report TS1005 (TS1110 already fired); got {c:?}"
+    );
+}
+
+#[test]
+fn readonly_without_operand_does_not_report_array_tuple_error() {
+    // A type-alias body routes through the alias missing-name sweep.
+    let alias = codes("type U = readonly ;");
+    assert!(
+        !alias.contains(&READONLY_ONLY_ON_ARRAY_TUPLE),
+        "a missing `readonly` operand must not report TS1354 (TS1110 already fired); got {alias:?}"
+    );
+    // An annotation position routes through `get_type_from_type_operator`.
+    let annot = codes("let v: readonly ;");
+    assert!(
+        !annot.contains(&READONLY_ONLY_ON_ARRAY_TUPLE),
+        "a missing `readonly` operand in an annotation must not report TS1354; got {annot:?}"
+    );
+}
+
+#[test]
+fn unique_over_real_non_symbol_still_reports_symbol_expected() {
+    // The missing-operand guard must not weaken the genuine grammar error:
+    // a *present* non-symbol operand is still TS1005. Vary the operand keyword.
+    for operand in ["number", "string", "boolean"] {
+        let c = codes(&format!("declare const bad: unique {operand};"));
+        assert!(
+            c.contains(&SYMBOL_EXPECTED),
+            "`unique {operand}` must still report TS1005; got {c:?}"
+        );
+    }
+}
+
+#[test]
+fn readonly_over_real_non_array_still_reports_array_tuple_error() {
+    for operand in ["string", "number", "Foo"] {
+        let c = codes(&format!("type U = readonly {operand};"));
+        assert!(
+            c.contains(&READONLY_ONLY_ON_ARRAY_TUPLE),
+            "`readonly {operand}` must still report TS1354; got {c:?}"
+        );
+    }
+}
+
+#[test]
+fn well_formed_type_operators_report_no_grammar_error() {
+    for source in [
+        "type K = keyof number;",
+        "type R = readonly string[];",
+        "type R2 = readonly [string, number];",
+        "declare const s: unique symbol;",
+    ] {
+        let c = codes(source);
+        assert!(
+            !c.contains(&SYMBOL_EXPECTED) && !c.contains(&READONLY_ONLY_ON_ARRAY_TUPLE),
+            "`{source}` should not report an operand-shape grammar error; got {c:?}"
+        );
+    }
+}

--- a/crates/tsz-parser/src/parser/state_types.rs
+++ b/crates/tsz-parser/src/parser/state_types.rs
@@ -375,8 +375,9 @@ impl ParserState {
         // Handle optional leading | (e.g., type T = | A | B)
         let has_leading_bar = self.parse_optional(SyntaxKind::BarToken);
 
-        // Parse first constituent
-        let first = self.parse_intersection_type();
+        // Parse first constituent. A consumed leading `|` makes it required, so a
+        // missing constituent (`type T = |;`) surfaces TS1110.
+        let first = self.parse_intersection_type_required(has_leading_bar);
 
         // Check for | to form union
         if !has_leading_bar && !self.is_token(SyntaxKind::BarToken) {
@@ -385,8 +386,10 @@ impl ParserState {
 
         let mut types = vec![first];
 
+        // A consumed `|` always requires a following constituent; a trailing `|`
+        // (`type T = string |;`) is a missing required constituent -> TS1110.
         while self.parse_optional(SyntaxKind::BarToken) {
-            types.push(self.parse_intersection_type());
+            types.push(self.parse_intersection_type_required(true));
         }
 
         // Use token_full_start() (start of next un-consumed token's trivia) rather than
@@ -404,15 +407,19 @@ impl ParserState {
         )
     }
 
-    /// Parse intersection type: A & B & C
-    pub(crate) fn parse_intersection_type(&mut self) -> NodeIndex {
+    /// Parse intersection type: A & B & C, threading whether the *first*
+    /// constituent is required (set by the union parser when a `|`/leading-`|`
+    /// was consumed). A consumed `&` always makes its following constituent
+    /// required.
+    pub(crate) fn parse_intersection_type_required(&mut self, first_required: bool) -> NodeIndex {
         let start_pos = self.token_pos();
 
         // Handle optional leading & (e.g., type T = & A & B)
         let has_leading_amp = self.parse_optional(SyntaxKind::AmpersandToken);
 
-        // Parse first constituent
-        let first = self.parse_primary_type();
+        // Parse first constituent. It is required when the caller demands it
+        // (after a `|`) or when a leading `&` was just consumed (`type T = &;`).
+        let first = self.parse_primary_type_required(first_required || has_leading_amp);
 
         let mut fallback_next_import_type_options = false;
         if self.abort_intersection_continuation {
@@ -430,9 +437,11 @@ impl ParserState {
 
         let mut types = vec![first];
 
+        // A consumed `&` always requires a following constituent; a trailing `&`
+        // (`type T = string &;`) is a missing required constituent -> TS1110.
         while self.parse_optional(SyntaxKind::AmpersandToken) {
             self.fallback_import_type_options_once = fallback_next_import_type_options;
-            types.push(self.parse_primary_type());
+            types.push(self.parse_primary_type_required(true));
             self.fallback_import_type_options_once = false;
             fallback_next_import_type_options = false;
         }
@@ -449,7 +458,22 @@ impl ParserState {
     }
 
     /// Parse primary type (keywords, references, parenthesized, tuples, arrays, function types)
+    /// in an *optional* type position (the missing-type suppression for terminator
+    /// tokens applies, e.g. `let x: ;` and `f(a: )` reach an earlier guard).
     pub(crate) fn parse_primary_type(&mut self) -> NodeIndex {
+        self.parse_primary_type_required(false)
+    }
+
+    /// Parse primary type, threading whether this constituent is *required*.
+    ///
+    /// A constituent is required when the parser has just consumed a union/
+    /// intersection separator (`|`/`&`) or a type operator (`keyof`/`unique`/
+    /// `readonly`): in those positions tsc parses the constituent unconditionally
+    /// and `createMissingNode(Identifier, /*reportAtCurrentPosition*/ true,
+    /// Diagnostics.Type_expected)` fires TS1110 even when the next token is a
+    /// type terminator. The terminator-suppression below must therefore be
+    /// limited to genuinely-optional positions (`required == false`).
+    pub(crate) fn parse_primary_type_required(&mut self, required: bool) -> NodeIndex {
         let start_pos = self.token_pos();
 
         // Handle JSDoc-style leading `?` before a type (e.g., `?string`).
@@ -587,11 +611,13 @@ impl ParserState {
         }
 
         // If we encounter a token that can't start a type, emit TS1110 (Type expected).
-        // However, suppress the error for delimiter/terminator tokens that indicate a
-        // *missing* type rather than an *incorrect* token used as a type. TSC silently
-        // creates a missing node for these cases (e.g., `(a: ) =>`, `x: ;`).
+        // For genuinely-optional positions, suppress the error for delimiter/terminator
+        // tokens that indicate a *missing* type rather than an *incorrect* token used as
+        // a type (e.g. the first/optional type in `(a: ) =>`, `x: ;`). In a *required*
+        // constituent position (after a consumed `|`/`&`/`keyof`/`unique`/`readonly`),
+        // tsc still emits TS1110, so the terminator-suppression must not apply.
         if !self.can_token_start_type() {
-            if !self.is_type_terminator_token() {
+            if required || !self.is_type_terminator_token() {
                 self.error_type_expected();
             }
             // Return a synthetic identifier node to allow parsing to continue
@@ -1130,4 +1156,85 @@ impl ParserState {
     }
 
     // Parenthesized, tuple, literal, import, mapped, and type-argument parsing -> state_types_advanced.rs
+}
+
+#[cfg(test)]
+mod missing_required_constituent_tests {
+    use crate::parser::state::ParserState;
+    use tsz_common::diagnostics::diagnostic_codes;
+
+    /// Parse `source` as a full file and return the list of diagnostic codes.
+    fn codes(source: &str) -> Vec<u32> {
+        let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+        parser.parse_source_file();
+        parser
+            .parse_diagnostics
+            .iter()
+            .map(|diag| diag.code)
+            .collect()
+    }
+
+    fn count_type_expected(source: &str) -> usize {
+        codes(source)
+            .iter()
+            .filter(|&&code| code == diagnostic_codes::TYPE_EXPECTED)
+            .count()
+    }
+
+    /// A consumed union/intersection separator or type operator with no following
+    /// constituent must surface TS1110, regardless of the (varied) binder name.
+    #[test]
+    fn missing_constituent_after_separator_or_operator_reports_ts1110() {
+        // Vary the leading type name so the rule is structural, not name-keyed.
+        for lhs in ["string", "number", "Foo", "ns.Bar"] {
+            assert_eq!(
+                count_type_expected(&format!("type T = {lhs} |;")),
+                1,
+                "trailing `|` after `{lhs}` should report exactly one TS1110"
+            );
+            assert_eq!(
+                count_type_expected(&format!("type T = {lhs} &;")),
+                1,
+                "trailing `&` after `{lhs}` should report exactly one TS1110"
+            );
+        }
+
+        // Chained separators anchor the error at the final missing constituent.
+        assert_eq!(count_type_expected("type T = string | number |;"), 1);
+        // A consumed leading `|`/`&` is also a required constituent.
+        assert_eq!(count_type_expected("type T = |;"), 1);
+        assert_eq!(count_type_expected("type T = &;"), 1);
+
+        // Required constituents reached through annotation/parameter positions.
+        assert_eq!(count_type_expected("let x: string |;"), 1);
+        assert_eq!(count_type_expected("function f(a: number |) {}"), 1);
+
+        // Type operators require an operand.
+        assert_eq!(count_type_expected("type U = keyof ;"), 1);
+        assert_eq!(count_type_expected("type U = unique ;"), 1);
+        assert_eq!(count_type_expected("type U = readonly ;"), 1);
+        assert_eq!(count_type_expected("type U = keyof number |;"), 1);
+    }
+
+    /// Well-formed unions/intersections and a leading `|`/`&` followed by a real
+    /// constituent must not regress into a spurious TS1110.
+    #[test]
+    fn well_formed_types_report_no_ts1110() {
+        for source in [
+            "type T = string | number;",
+            "type T = string & number;",
+            "type V = | string;",
+            "type V = | string | number;",
+            "type W = & Base;",
+            "type K = keyof number;",
+            "type R = readonly string[];",
+            "declare const s: unique symbol;",
+        ] {
+            assert_eq!(
+                count_type_expected(source),
+                0,
+                "`{source}` should not report TS1110"
+            );
+        }
+    }
 }

--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -634,8 +634,8 @@ impl ParserState {
         let operator = self.token() as u16;
         self.parse_expected(SyntaxKind::KeyOfKeyword);
 
-        // Parse the type operand
-        let type_node = self.parse_primary_type();
+        // The operand is required: `type U = keyof ;` surfaces TS1110.
+        let type_node = self.parse_primary_type_required(true);
 
         let end_pos = self.token_full_start();
 
@@ -656,8 +656,9 @@ impl ParserState {
         let operator = self.token() as u16;
         self.parse_expected(SyntaxKind::UniqueKeyword);
 
-        // Parse the type operand (unique symbol)
-        let type_node = self.parse_primary_type();
+        // The operand is required: `type U = unique ;` surfaces TS1110 (a missing
+        // operand, not the TS1005 `'symbol' expected` grammar error).
+        let type_node = self.parse_primary_type_required(true);
 
         let end_pos = self.token_full_start();
 
@@ -678,8 +679,9 @@ impl ParserState {
         let operator = self.token() as u16;
         self.parse_expected(SyntaxKind::ReadonlyKeyword);
 
-        // Parse the type operand
-        let type_node = self.parse_primary_type();
+        // The operand is required: `type U = readonly ;` surfaces TS1110 (a missing
+        // operand, not the TS1354 array/tuple grammar error).
+        let type_node = self.parse_primary_type_required(true);
 
         let end_pos = self.token_full_start();
 


### PR DESCRIPTION
Fixes #14836.

## Summary
tsz silently dropped TS1110 `Type expected` whenever a type constituent was
*structurally required* — after a consumed `|`/`&` separator or a
`keyof`/`unique`/`readonly` type operator — but the next token was a type
terminator (`;`, `)`, `,`, EOF, ...). The blanket `is_type_terminator_token()`
suppression in `parse_primary_type` was meant only for genuinely-optional
positions (`let x: ;`, `f(a: )`), so it was over-broad.

For `unique`/`readonly` with a missing operand the parser additionally
suppressed TS1110 and the checker reported the *wrong* follow-on grammar error
(TS1005 `'symbol' expected`, TS1354 array/tuple). tsc emits only TS1110 there.

## Structural rule
When the parser has just consumed a union/intersection separator or a type
operator and the next token cannot start a type, tsc parses the constituent
unconditionally and fires TS1110 via
`createMissingNode(Identifier, /*reportAtCurrentPosition*/ true, Type_expected)`
— mirroring `parseUnionOrIntersectionType` / `parseTypeOperatorOrHigher`. The
terminator-suppression must not apply in that required-constituent context.

## Owner layers
- Parser (`tsz-parser`): a `required` flag is threaded through
  `parse_primary_type_required` / `parse_intersection_type_required`. The
  union parser marks the constituent required after a consumed/leading `|`; the
  intersection parser after a consumed/leading `&`; `keyof`/`unique`/`readonly`
  mark their operand required. Optional positions (`let x: ;`, `f(a: )`) are
  unchanged — they reach an earlier missing-type guard.
- Checker (`tsz-checker`): the `unique` (TS1005) and `readonly` (TS1354)
  operand-shape grammar checks skip a *missing recovery node* (the parser
  already emitted TS1110), via the existing
  `arena.is_missing_recovery_identifier`. A *present* wrong operand
  (`unique number`, `readonly string`) still reports TS1005/TS1354.

## Adjacent-case matrix (verified against tsc 5.9.3 via the issue)
| input | before | after / tsc |
|---|---|---|
| `type T = string \|;` | (none) | TS1110 |
| `type T = string &;` | (none) | TS1110 |
| `type T = string \| number \|;` | (none) | TS1110 (col 27) |
| `type T = \|;` (leading sep) | (none) | TS1110 |
| `let x: string \|;` | (none) | TS1110 |
| `function f(a: number \|) {}` | (none) | TS1110 |
| `type U = keyof ;` | (none) | TS1110 |
| `type U = unique ;` | TS1005 (wrong) | TS1110 |
| `type U = readonly ;` | TS1354 (wrong) | TS1110 |
| `let v: readonly ;` | TS1354 (wrong) | TS1110 |
| `let x: ;` / `f(a: )` (optional) | TS1110 | TS1110 (unchanged) |
| `type V = \| string;` (valid) | (none) | (none) |
| `unique number` / `readonly string` (present wrong operand) | TS1005 / TS1354 | TS1005 / TS1354 (unchanged) |

Conditional-branch (`? :`), mapped-type constraint/`as`, and type-argument
positions were empirically confirmed to already emit TS1110 (those delimiters
are not in the terminator set), so they need no change.

Goal: hold

## Verification
- `cargo test -p tsz-parser --lib` (1432 passed) — includes new
  `missing_required_constituent_tests` (varies binder names; positive +
  negative cases).
- `cargo test -p tsz-checker --test type_operator_missing_operand_recovery_tests`
  (5 passed) and `--test unique_symbol_grammar_tests` (11 passed, no regression).
- `cargo clippy -p tsz-parser -p tsz-checker --tests` clean.
- Manual CLI (`--strict --noEmit`) over the full matrix above matches tsc.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01BJ63ZxcHKrzT8tQwqnxZQ3