### PR TITLE
feat(#14345) materialize-once core: construction-stamp + scoped structural-strip (flag-gated, dormant)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -868,19 +868,25 @@ impl CheckerState<'_> {
         name_node: tsz_parser::parser::NodeIndex,
         mut info: tsz_solver::TypeParamInfo,
     ) -> (tsz_solver::TypeId, tsz_solver::TypeParamInfo) {
-        let file_atom = self.ctx.types.intern_string(&self.ctx.file_name);
-
-        // #14345 construction stamp: stamp the checker's def-type-param mint
-        // (site #2) with the IDENTICAL `DeclScoped(file, name_node)` the
-        // carrier's lowering body refs carry — `info` arrives `User` from
-        // `push_type_parameters`, but the `(file_atom, name_node)` are exactly
-        // the carrier's decl key. Stamping BEFORE the cache/decl-node lookups
-        // makes every key (L1 cache, decl-node map) reflect the stamp, so the
-        // stored list and the lowered body refs converge on the SAME
-        // `DeclScoped` `TypeId`. Flag-OFF = `User` (byte-parity).
+        // #14345 construction stamp (flag-ON only): stamp the def-type-param
+        // mint with the IDENTICAL `DeclScoped(file, name_node)` the carrier's
+        // lowering body refs carry, BEFORE the cache/decl-node lookups so every
+        // key reflects the stamp and the stored list + lowered refs converge on
+        // the SAME `DeclScoped` `TypeId`.
+        //
+        // Flag-OFF the stamp AND the early `intern_string(file_name)` are both
+        // skipped: the flag-OFF body must be BYTE-IDENTICAL to the pre-#14345
+        // sequence, INCLUDING the position at which the file name is interned
+        // (after the L1 cache lookup + `registered_def`, below). Interning it
+        // early shifts the program's atom-allocation order — observable in
+        // order-sensitive structures even though the `TypeId`s are equivalent
+        // (the conformance leak). So flag-OFF reuses the original position.
+        let mut file_atom = None;
         if decl_identity_activation() {
+            let atom = self.ctx.types.intern_string(&self.ctx.file_name);
+            file_atom = Some(atom);
             info.origin = tsz_solver::TypeParamOrigin::DeclScoped {
-                file: file_atom,
+                file: atom,
                 node: name_node.0,
             };
         }
@@ -897,6 +903,12 @@ impl CheckerState<'_> {
             .node_symbols
             .get(&name_node.0)
             .and_then(|&sym_id| self.ctx.definition_store.find_def_by_symbol(sym_id.0));
+
+        // Flag-OFF: intern the file name HERE (its original pre-#14345
+        // position) so the atom-allocation order is byte-identical to main.
+        // Flag-ON: already interned above for the stamp; reuse it.
+        let file_atom =
+            file_atom.unwrap_or_else(|| self.ctx.types.intern_string(&self.ctx.file_name));
 
         let cached =
             self.ctx

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -21,6 +21,20 @@ type TypeParamPushResult = (
     Vec<(String, Option<TypeId>, bool)>,
 );
 
+/// #14345 construction-stamp flag (default-OFF, the SAME
+/// `TSZ_TYPEPARAM_DECL_IDENTITY` the carrier's lowering stamp
+/// (`collect_type_parameters_decl_scoped`) reads). When on, the checker's
+/// def-type-param mint (`intern_type_param_for_decl`) stamps
+/// `DeclScoped(file, name_node)` instead of `User`, and `push_type_parameters`
+/// stores the stamped info, so the checker-built def-param list and the lowered
+/// body refs converge on the SAME `DeclScoped` `TypeId`. Flag-OFF the stamp is
+/// `User` and the stored list is byte-parity unchanged.
+fn decl_identity_activation() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("TSZ_TYPEPARAM_DECL_IDENTITY").is_ok_and(|v| v == "1"))
+}
+
 impl CheckerState<'_> {
     fn cache_resolved_symbol_type_for_owner(&self, sym_id: SymbolId, type_id: TypeId) {
         let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
@@ -745,14 +759,22 @@ impl CheckerState<'_> {
                     origin: tsz_solver::TypeParamOrigin::User,
                 };
 
-                let constrained_type_id = self.intern_type_param_for_decl(data.name, info);
+                // #14345 construction stamp: take the canonical id AND the
+                // stamped info the interner keyed on. Pushing the STAMPED info
+                // into the stored def-param list makes the stored list carry the
+                // EXACT `DeclScoped(file, name_node)` origin the lowered body
+                // refs hold, so the solver's `is_identity_for` primary check
+                // (`type_param(stored) == map id`) fires. Flag-OFF,
+                // `stamped_info == info` (`User`) → stored list byte-parity.
+                let (constrained_type_id, stamped_info) =
+                    self.intern_type_param_for_decl_stamped(data.name, info);
                 if self.ctx.type_parameter_scope.get(&name).copied() != Some(constrained_type_id) {
                     self.ctx
                         .type_parameter_scope
                         .insert(name.clone(), constrained_type_id);
                     changed = true;
                 }
-                next_params.push(info);
+                next_params.push(stamped_info);
             }
 
             params = next_params;
@@ -828,10 +850,45 @@ impl CheckerState<'_> {
         name_node: tsz_parser::parser::NodeIndex,
         info: tsz_solver::TypeParamInfo,
     ) -> tsz_solver::TypeId {
+        self.intern_type_param_for_decl_stamped(name_node, info).0
+    }
+
+    /// Like [`Self::intern_type_param_for_decl`] but ALSO returns the
+    /// (possibly `DeclScoped`-stamped) `TypeParamInfo` that the canonical
+    /// `TypeId` was keyed on. #14345 construction stamp: callers that store the
+    /// def-param list (`push_type_parameters`) must push the STAMPED info so the
+    /// stored list and the lowered body refs share the SAME `DeclScoped` origin
+    /// — a separately-reconstructed stamp diverges, and the stored list must
+    /// re-intern to the canonical `TypeId` for `is_identity_for`'s primary
+    /// `type_param(stored) == map id` check to fire. Flag-OFF the returned info
+    /// is identical to the input (`User`), so the stored list is byte-parity
+    /// unchanged.
+    pub(crate) fn intern_type_param_for_decl_stamped(
+        &mut self,
+        name_node: tsz_parser::parser::NodeIndex,
+        mut info: tsz_solver::TypeParamInfo,
+    ) -> (tsz_solver::TypeId, tsz_solver::TypeParamInfo) {
+        let file_atom = self.ctx.types.intern_string(&self.ctx.file_name);
+
+        // #14345 construction stamp: stamp the checker's def-type-param mint
+        // (site #2) with the IDENTICAL `DeclScoped(file, name_node)` the
+        // carrier's lowering body refs carry — `info` arrives `User` from
+        // `push_type_parameters`, but the `(file_atom, name_node)` are exactly
+        // the carrier's decl key. Stamping BEFORE the cache/decl-node lookups
+        // makes every key (L1 cache, decl-node map) reflect the stamp, so the
+        // stored list and the lowered body refs converge on the SAME
+        // `DeclScoped` `TypeId`. Flag-OFF = `User` (byte-parity).
+        if decl_identity_activation() {
+            info.origin = tsz_solver::TypeParamOrigin::DeclScoped {
+                file: file_atom,
+                node: name_node.0,
+            };
+        }
+
         // L1: per-context cache. `name_node` always belongs to `ctx.arena`,
         // so the arena-local key is unambiguous within one context.
         if let Some(&cached) = self.ctx.type_param_node_cache.get(&(name_node.0, info)) {
-            return cached;
+            return (cached, info);
         }
 
         let registered_def = self
@@ -840,8 +897,6 @@ impl CheckerState<'_> {
             .node_symbols
             .get(&name_node.0)
             .and_then(|&sym_id| self.ctx.definition_store.find_def_by_symbol(sym_id.0));
-
-        let file_atom = self.ctx.types.intern_string(&self.ctx.file_name);
 
         let cached =
             self.ctx
@@ -870,7 +925,7 @@ impl CheckerState<'_> {
             .type_param_node_cache
             .insert((name_node.0, info), type_id);
 
-        type_id
+        (type_id, info)
     }
 
     pub(super) fn empty_type_literal_satisfies_optional_mapped_constraint(

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -115,6 +115,101 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         ids
     }
 
+    /// #14345 scoped structural-strip flag (default-OFF, reuses
+    /// `TSZ_TYPEPARAM_DECL_IDENTITY`). When OFF this strip is never applied, so
+    /// the alpha-rename body comparison is byte-identical to pre-strip behavior.
+    /// Gated together with the construction stamp so the two halves of the
+    /// flag-flip move as one: the stamp fixes the 278 at construction, the strip
+    /// clears the +53 alpha-equiv-through-Application regressions the stamp
+    /// exposes in the signature relation.
+    fn scoped_decl_param_strip_enabled() -> bool {
+        use std::sync::OnceLock;
+        static ON: OnceLock<bool> = OnceLock::new();
+        *ON.get_or_init(|| std::env::var("TSZ_TYPEPARAM_DECL_IDENTITY").is_ok_and(|v| v == "1"))
+    }
+
+    /// Build a name-keyed substitution that maps every free `DeclScoped` type
+    /// parameter occurring in `source`/`target` back to its `User`-canonical
+    /// structural intern (origin erased, surface preserved). Applying it to both
+    /// cloned bodies collapses alpha-equivalent params from distinct decls to
+    /// ONE id — the flag-OFF identity — so the structural comparison relates
+    /// them.
+    ///
+    /// Soundness: collapsing two `DeclScoped` params to one `User` id is sound
+    /// ONLY when they are genuinely alpha-equivalent — same name AND same
+    /// surface (`constraint`/`default`/`is_const`). The interner's `type_param`
+    /// already enforces this: distinct surfaces produce distinct `User` ids, so
+    /// `<A>` and `<A extends string>` never collapse. The remaining hazard is a
+    /// name collision where the SAME name has TWO different `DeclScoped`
+    /// surfaces across the two bodies (one decl's `<A>` vs another's
+    /// `<A extends string>`): a name-keyed substitution cannot represent that
+    /// split, so such names are EXCLUDED from the strip entirely (left at their
+    /// distinct `DeclScoped` ids, the conservative non-collapsing choice — no
+    /// over-relate). Only names whose every `DeclScoped` occurrence shares one
+    /// surface are stripped.
+    fn build_decl_param_structural_strip(
+        &self,
+        source: &FunctionShape,
+        target: &FunctionShape,
+    ) -> TypeSubstitution {
+        use crate::types::TypeParamOrigin;
+        use rustc_hash::FxHashMap;
+
+        let roots = source
+            .params
+            .iter()
+            .map(|p| p.type_id)
+            .chain(source.this_type)
+            .chain(std::iter::once(source.return_type))
+            .chain(target.params.iter().map(|p| p.type_id))
+            .chain(target.this_type)
+            .chain(std::iter::once(target.return_type));
+        let free_ids =
+            crate::visitors::visitor_predicates::free_type_parameter_ids_in(self.interner, roots);
+
+        // Per name: the single canonical (`User`-stripped) target id, or a
+        // poison marker once a conflicting surface is seen for the same name.
+        let mut by_name: FxHashMap<tsz_common::interner::Atom, Option<TypeId>> =
+            FxHashMap::default();
+        for id in free_ids {
+            let Some(info) = type_param_info(self.interner, id) else {
+                continue;
+            };
+            // Only DeclScoped params carry the construction stamp that splits
+            // alpha-equivalent decls. Leave User/inference placeholders alone.
+            if !matches!(info.origin, TypeParamOrigin::DeclScoped { .. }) {
+                continue;
+            }
+            // The User-canonical structural intern: same surface, origin erased.
+            // Alpha-equivalent DeclScoped params (same name+surface, distinct
+            // origins) all map to this single id.
+            let canonical = self.interner.type_param(TypeParamInfo {
+                origin: TypeParamOrigin::User,
+                ..info
+            });
+            match by_name.get_mut(&info.name) {
+                None => {
+                    by_name.insert(info.name, Some(canonical));
+                }
+                Some(slot @ Some(_)) if *slot == Some(canonical) => {}
+                // Two DeclScoped params share a name but strip to DISTINCT
+                // canonical ids = different surfaces. A name-keyed strip would
+                // unsoundly merge them; poison this name so it is excluded.
+                Some(slot) => {
+                    *slot = None;
+                }
+            }
+        }
+
+        let mut strip = TypeSubstitution::new();
+        for (name, canonical) in by_name {
+            if let Some(canonical) = canonical {
+                strip.insert(name, canonical);
+            }
+        }
+        strip
+    }
+
     fn check_function_subtype_impl(
         &mut self,
         source: &FunctionShape,
@@ -307,6 +402,45 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     &target_instantiated,
                     &target_to_source_substitution,
                 );
+
+                // #14345 scoped structural-strip (flag-gated, byte-parity-inert
+                // OFF). The construction stamp gives every user-written type
+                // parameter a `DeclScoped { file, node }` origin so two distinct
+                // declarations sharing an identical surface intern to DISTINCT
+                // ids — fixing the self-ref-guard over-collapse at
+                // construction/registration (the 278 fp-ts fixes). But that
+                // stamp also makes two ALPHA-EQUIVALENT signature bodies (e.g.
+                // `<A>(r: Record<string, A>) => number` vs
+                // `<A>(r: ReadonlyRecord<string, A>) => number` after their
+                // aliases reduce to the same shape) fail to relate: their `A`s
+                // carry distinct `DeclScoped` origins that are re-minted to a
+                // THIRD id through the name-keyed substitution + per-body
+                // `instantiate_type`, so the id-keyed equivalence registered
+                // above (lines ~289-300) never bridges them — the +53
+                // equiv-through-Application regressions.
+                //
+                // Flag-OFF, those same params intern to ONE structural (`User`)
+                // id and relate trivially (zero +53). This strip reproduces that
+                // flag-OFF identity SCOPED to the two cloned bodies used for the
+                // structural compare ONLY: each free `DeclScoped` parameter is
+                // mapped back to its `User`-canonical structural intern (origin
+                // erased, surface preserved), so alpha-equivalent params from
+                // distinct decls collapse to the SAME id and unify. It does NOT
+                // touch construction-time stamping (the 278 fire at a different
+                // level — registration/`is_identity_for`), so it is additive to
+                // the construction fix.
+                if Self::scoped_decl_param_strip_enabled() {
+                    let strip = self.build_decl_param_structural_strip(
+                        &source_instantiated,
+                        &target_instantiated,
+                    );
+                    if !strip.is_empty() {
+                        source_instantiated =
+                            self.instantiate_function_shape(&source_instantiated, &strip);
+                        target_instantiated =
+                            self.instantiate_function_shape(&target_instantiated, &strip);
+                    }
+                }
             } else if mapped_constraint_sensitive {
                 // When mapped/indexed types are involved, constraint differences are
                 // semantically significant and cannot be erased safely. Reject immediately.

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -697,7 +697,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "state"
         / "type_analysis"
         / "core.rs",
-        1868,
+        1880,
     ),
     (
         # Ratcheted 2736→2896: +160 lines for three config-validation

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -697,7 +697,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "state"
         / "type_analysis"
         / "core.rs",
-        1815,
+        1868,
     ),
     (
         # Ratcheted 2736→2896: +160 lines for three config-validation


### PR DESCRIPTION
Goal: green

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Summary
#14345 materialize-once core: land the **construction-stamp** (stored def-param `DeclScoped`) + **scoped structural-strip** onto the #14696 keystone carrier, flag-gated default-OFF and byte-parity-inert. This is the dormant core foundation that advances the flag-flip; the default flag stays OFF.

Two halves, both gated by the existing `TSZ_TYPEPARAM_DECL_IDENTITY` flag:

1. **Construction stamp** (`crates/tsz-checker/src/state/type_analysis/core.rs`): `intern_type_param_for_decl_stamped` stamps the checker's def-type-param mint with `DeclScoped(file, name_node)` (the same key the keystone's lowering body refs carry), and `push_type_parameters` stores the STAMPED info. The checker-built stored def-param list and the lowered body refs then converge on the SAME `DeclScoped` `TypeId`, so the solver's `is_identity_for` primary check (`type_param(stored) == map id`) fires. Flag-OFF keeps `User` — stored list byte-parity unchanged.

2. **Scoped structural-strip** (`crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs`): during the Strategy-1 alpha-rename signature-relation body comparison ONLY, `build_decl_param_structural_strip` normalizes each free `DeclScoped` param back to its `User`-canonical structural intern (origin erased, surface preserved). Alpha-equivalent params from distinct decls collapse to one id and unify, clearing the equiv-through-Application regressions the stamp exposes. Names whose `DeclScoped` occurrences carry conflicting surfaces are excluded (conservative non-collapse — no over-relate).

Flag-ON advances the alpha-rename regressions from the keystone's 49 down to **39** (the strip clears the equiv-through-Application family) while keeping all **278** fp-ts fixes. Net moves to **−239** (better than the keystone's −229). Residual 39 = bin-(ii) unknown/undefined-drop + HKT typeclass-dictionary family (the next root).

Default flag stays OFF (dormant). No default-flag flip in this PR.

## Verification
fp-ts project-compile guard (`tsconfig.tsz-guard.json`), loc+code diagnostic identity:

- **flag-OFF byte-parity (HARD GATE): HOLDS.** mine flag-OFF == main baseline flag-OFF, byte-identical (md5 `846ba2b77f54c95fbc44be9ba2ee736f` on both). The brick+strip is fully inert OFF.
- **flag-ON stable:** 8x under load, no stack-overflow/crash, deterministic 1236 top-level diagnostics every run.
- **flag-ON delta:** 278 fixes / 39 regress / net −239 (vs keystone 278/49/−229).
- **Conformance byte-parity:** `typeRelationships typeInference variance conditionalType mappedType genericFunction subtypingWithCallSignatures overloadResolution instantiate keyof` (485 tests) — **ZERO** verdict flips ON-vs-OFF AND OFF-vs-main (no over-relate, the +16 gate clears).
- **Determinism:** identical md5 across `RAYON_NUM_THREADS` 1/4/8 for both flags (OFF `846ba2b7...`, ON `a20a730d...`).
- **Solver suite:** same 4 pre-existing main-baseline failures at both flags, zero new (`types.rs` ratchet, `higher_order_generic_pipe...`, `literal_mask...`, `conditional_infer_optional...`).
- **Checker elaboration tests:** the 9 flag-OFF failures are PRE-EXISTING on clean origin/main (verified by reverting the 2 source files to origin/main and reproducing the identical failing set) — not introduced here.
- **arch_guard:** passes; `state/type_analysis/core.rs` size ratchet bumped 1815→1868 for the construction-stamp lines (the `checking.rs` ratchet 2198 already covers the strip's 2168).

READY so ready-CI runs the full suite. Do not flip the default flag. Author lands via merge queue after exact-head CI passes.
