### PR TITLE
fix(parser): emit TS1110 for a missing required type constituent (#14836)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -792,6 +792,15 @@ impl CheckerState<'_> {
         use crate::diagnostics::diagnostic_messages;
         use crate::types_domain::unique_symbol_arena::unique_symbol_grammar_violation;
 
+        // tsc's `checkGrammarTypeOperatorNode` reports every `unique` grammar
+        // violation (TS1005/TS1330-1335) through `grammarErrorOnNode`, which is
+        // suppressed for the whole file when `hasParseDiagnostics(sourceFile)` is
+        // true. Mirror that: a malformed `unique` operand already produced a parse
+        // diagnostic (e.g. TS1110 `Type expected`), so no grammar error is added.
+        if self.ctx.has_syntax_parse_errors {
+            return;
+        }
+
         for i in 0..self.ctx.arena.len() {
             let idx = NodeIndex(i as u32);
             let Some(node) = self.ctx.arena.get(idx) else {

--- a/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
@@ -766,6 +766,10 @@ impl<'a> CheckerState<'a> {
                         && let Some(operand_node) = self.ctx.arena.get(op.type_node)
                         && operand_node.kind != syntax_kind_ext::ARRAY_TYPE
                         && operand_node.kind != syntax_kind_ext::TUPLE_TYPE
+                        // Grammar check: tsc suppresses TS1354 file-wide when the source
+                        // file has parse diagnostics, so a missing/malformed operand
+                        // (already reporting TS1110) emits only the parser error.
+                        && !self.ctx.has_syntax_parse_errors
                     {
                         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                         self.ctx.error(

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -48,10 +48,15 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             // Handle readonly operator
             if operator == SyntaxKind::ReadonlyKeyword as u16 {
                 // TS1354: 'readonly' type modifier is only permitted on array and tuple literal types.
+                // This is a grammar check; tsc's `grammarErrorOnFirstToken` suppresses it
+                // for the whole file when `hasParseDiagnostics(sourceFile)` is true, so a
+                // missing/malformed operand (which already produced a parse diagnostic such
+                // as TS1110) emits only the parser error.
                 if let Some(operand_node) = self.ctx.arena.get(type_op.type_node) {
                     let operand_kind = operand_node.kind;
                     if operand_kind != syntax_kind_ext::ARRAY_TYPE
                         && operand_kind != syntax_kind_ext::TUPLE_TYPE
+                        && !self.ctx.has_syntax_parse_errors
                     {
                         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                         self.ctx.error(

--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -142,6 +142,9 @@ mod parser_improvement_primitive_type_recovery_tests;
 #[path = "../../tests/parser_improvement_regex_recovery_tests.rs"]
 mod parser_improvement_regex_recovery_tests;
 #[cfg(test)]
+#[path = "../../tests/parser_improvement_required_type_constituent_recovery_tests.rs"]
+mod parser_improvement_required_type_constituent_recovery_tests;
+#[cfg(test)]
 #[path = "../../tests/parser_improvement_satisfies_generic_chain_tests.rs"]
 mod parser_improvement_satisfies_generic_chain_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/speculation.rs
+++ b/crates/tsz-parser/src/parser/speculation.rs
@@ -39,6 +39,7 @@ pub(crate) struct ParserCheckpoint {
     scanner_diagnostics_high_water_mark: usize,
     deferred_module_close_braces: u32,
     abort_intersection_continuation: bool,
+    require_type_constituent_once: bool,
     fallback_import_type_options_once: bool,
     in_import_type_options_context: bool,
     import_attribute_tail_recovered: bool,
@@ -69,6 +70,7 @@ impl ParserState {
             scanner_diagnostics_high_water_mark: self.scanner_diagnostics_high_water_mark,
             deferred_module_close_braces: self.deferred_module_close_braces,
             abort_intersection_continuation: self.abort_intersection_continuation,
+            require_type_constituent_once: self.require_type_constituent_once,
             fallback_import_type_options_once: self.fallback_import_type_options_once,
             in_import_type_options_context: self.in_import_type_options_context,
             import_attribute_tail_recovered: self.import_attribute_tail_recovered,
@@ -101,6 +103,7 @@ impl ParserState {
             scanner_diagnostics_high_water_mark,
             deferred_module_close_braces,
             abort_intersection_continuation,
+            require_type_constituent_once,
             fallback_import_type_options_once,
             in_import_type_options_context,
             import_attribute_tail_recovered,
@@ -125,6 +128,7 @@ impl ParserState {
         self.scanner_diagnostics_high_water_mark = scanner_diagnostics_high_water_mark;
         self.deferred_module_close_braces = deferred_module_close_braces;
         self.abort_intersection_continuation = abort_intersection_continuation;
+        self.require_type_constituent_once = require_type_constituent_once;
         self.fallback_import_type_options_once = fallback_import_type_options_once;
         self.in_import_type_options_context = in_import_type_options_context;
         self.import_attribute_tail_recovered = import_attribute_tail_recovered;

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -206,6 +206,14 @@ pub struct ParserState {
     /// stop consuming `&`-continued intersections so the tail falls back to
     /// statement-level recovery like TypeScript.
     pub(crate) abort_intersection_continuation: bool,
+    /// One-shot flag: the next `parse_primary_type` is a *structurally required*
+    /// type constituent (it follows a consumed `|`/`&` separator or a
+    /// `keyof`/`unique`/`readonly` type operator). When set and the constituent
+    /// is missing, `parse_primary_type` emits TS1110 `Type expected` even for a
+    /// type-terminator token, matching tsc's unconditional constituent parse.
+    /// The genuinely-optional first/top-level type position leaves this `false`,
+    /// preserving the terminator suppression for `let x: ;` and `f(a: )`.
+    pub(crate) require_type_constituent_once: bool,
     /// When statement-like recovery inside a type-member container should leave
     /// actual `}` tokens for statement-level TS1128 recovery, skip this many
     /// enclosing close-brace expectations.
@@ -410,6 +418,7 @@ impl ParserState {
             current_specifier_recovered_braced_unicode_escape_debris: false,
             deferred_module_close_braces: 0,
             abort_intersection_continuation: false,
+            require_type_constituent_once: false,
             deferred_type_member_close_braces: 0,
             fallback_import_type_options_once: false,
             pending_array_binding_tail_recovery: false,
@@ -470,6 +479,7 @@ impl ParserState {
         self.deferred_module_close_braces = 0;
         self.deferred_type_member_close_braces = 0;
         self.abort_intersection_continuation = false;
+        self.require_type_constituent_once = false;
         self.fallback_import_type_options_once = false;
         self.pending_array_binding_tail_recovery = false;
         self.in_import_type_options_context = false;

--- a/crates/tsz-parser/src/parser/state_types.rs
+++ b/crates/tsz-parser/src/parser/state_types.rs
@@ -370,12 +370,17 @@ impl ParserState {
 
     /// Parse union type: A | B | C
     pub(crate) fn parse_union_type(&mut self) -> NodeIndex {
+        // Forward any "required constituent" intent from the caller to the first
+        // constituent; a consumed leading `|` also makes that constituent required.
+        let required_first = self.require_type_constituent_once;
+        self.require_type_constituent_once = false;
         let start_pos = self.token_pos();
 
         // Handle optional leading | (e.g., type T = | A | B)
         let has_leading_bar = self.parse_optional(SyntaxKind::BarToken);
 
         // Parse first constituent
+        self.require_type_constituent_once = required_first || has_leading_bar;
         let first = self.parse_intersection_type();
 
         // Check for | to form union
@@ -386,6 +391,9 @@ impl ParserState {
         let mut types = vec![first];
 
         while self.parse_optional(SyntaxKind::BarToken) {
+            // A constituent after a consumed `|` is required: tsc emits TS1110 when
+            // it is missing (`A |;`, `A | number |;`).
+            self.require_type_constituent_once = true;
             types.push(self.parse_intersection_type());
         }
 
@@ -406,12 +414,17 @@ impl ParserState {
 
     /// Parse intersection type: A & B & C
     pub(crate) fn parse_intersection_type(&mut self) -> NodeIndex {
+        // Forward any "required constituent" intent from the caller to the first
+        // constituent; a consumed leading `&` also makes that constituent required.
+        let required_first = self.require_type_constituent_once;
+        self.require_type_constituent_once = false;
         let start_pos = self.token_pos();
 
         // Handle optional leading & (e.g., type T = & A & B)
         let has_leading_amp = self.parse_optional(SyntaxKind::AmpersandToken);
 
         // Parse first constituent
+        self.require_type_constituent_once = required_first || has_leading_amp;
         let first = self.parse_primary_type();
 
         let mut fallback_next_import_type_options = false;
@@ -432,6 +445,9 @@ impl ParserState {
 
         while self.parse_optional(SyntaxKind::AmpersandToken) {
             self.fallback_import_type_options_once = fallback_next_import_type_options;
+            // A constituent after a consumed `&` is required: tsc emits TS1110 when
+            // it is missing (`A &;`).
+            self.require_type_constituent_once = true;
             types.push(self.parse_primary_type());
             self.fallback_import_type_options_once = false;
             fallback_next_import_type_options = false;
@@ -450,6 +466,12 @@ impl ParserState {
 
     /// Parse primary type (keywords, references, parenthesized, tuples, arrays, function types)
     pub(crate) fn parse_primary_type(&mut self) -> NodeIndex {
+        // A *required* constituent (set by a union/intersection separator or a
+        // `keyof`/`unique`/`readonly` operator) must report TS1110 even before a
+        // type-terminator token. Consume the one-shot flag here so nested/optional
+        // primary types parsed below keep the default (suppressing) behavior.
+        let required_constituent = self.require_type_constituent_once;
+        self.require_type_constituent_once = false;
         let start_pos = self.token_pos();
 
         // Handle JSDoc-style leading `?` before a type (e.g., `?string`).
@@ -590,8 +612,15 @@ impl ParserState {
         // However, suppress the error for delimiter/terminator tokens that indicate a
         // *missing* type rather than an *incorrect* token used as a type. TSC silently
         // creates a missing node for these cases (e.g., `(a: ) =>`, `x: ;`).
+        //
+        // The suppression only applies when the type is genuinely *optional*. When the
+        // constituent is structurally required (after a consumed `|`/`&` separator or a
+        // `keyof`/`unique`/`readonly` operator), tsc parses it unconditionally and the
+        // missing node reports TS1110, so we must not suppress it. This mirrors tsc's
+        // `parseUnionOrIntersectionType`/`parseTypeOperator` reaching
+        // `parseTypeReference` → `Type_expected` for the absent constituent.
         if !self.can_token_start_type() {
-            if !self.is_type_terminator_token() {
+            if required_constituent || !self.is_type_terminator_token() {
                 self.error_type_expected();
             }
             // Return a synthetic identifier node to allow parsing to continue

--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -634,7 +634,8 @@ impl ParserState {
         let operator = self.token() as u16;
         self.parse_expected(SyntaxKind::KeyOfKeyword);
 
-        // Parse the type operand
+        // Parse the type operand. The operand is required: `keyof ;` reports TS1110.
+        self.require_type_constituent_once = true;
         let type_node = self.parse_primary_type();
 
         let end_pos = self.token_full_start();
@@ -656,7 +657,10 @@ impl ParserState {
         let operator = self.token() as u16;
         self.parse_expected(SyntaxKind::UniqueKeyword);
 
-        // Parse the type operand (unique symbol)
+        // Parse the type operand (unique symbol). The operand is required:
+        // `unique ;` reports TS1110 (not the TS1005 `'symbol' expected` grammar
+        // error, which tsc suppresses on a missing operand).
+        self.require_type_constituent_once = true;
         let type_node = self.parse_primary_type();
 
         let end_pos = self.token_full_start();
@@ -678,7 +682,10 @@ impl ParserState {
         let operator = self.token() as u16;
         self.parse_expected(SyntaxKind::ReadonlyKeyword);
 
-        // Parse the type operand
+        // Parse the type operand. The operand is required: `readonly ;` reports
+        // TS1110 (not the TS1354 grammar error, which tsc suppresses on a missing
+        // operand).
+        self.require_type_constituent_once = true;
         let type_node = self.parse_primary_type();
 
         let end_pos = self.token_full_start();

--- a/crates/tsz-parser/tests/parser_improvement_required_type_constituent_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_required_type_constituent_recovery_tests.rs
@@ -1,0 +1,153 @@
+//! Parser recovery for a *structurally required* type constituent that is
+//! missing before a type-terminator token.
+//!
+//! tsc parses the constituent after a consumed `|`/`&` separator or a
+//! `keyof`/`unique`/`readonly` type operator unconditionally; the absent
+//! constituent goes through `createMissingNode(... Type_expected)` so TS1110
+//! fires even before `;`/`)`/EOF. tsz historically suppressed TS1110 for any
+//! type-terminator token, which over-applied the genuinely-optional recovery
+//! (`let x: ;`, `f(a: )`) to required positions. See issue #14836.
+
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+
+/// Number of TS1110 `Type expected` diagnostics whose reported start equals
+/// the byte offset of `needle` in `source` (the terminator token position).
+fn type_expected_at(source: &str, needle: &str) -> usize {
+    let pos = source
+        .rfind(needle)
+        .unwrap_or_else(|| panic!("needle {needle:?} not found in {source:?}"))
+        as u32;
+    let (parser, _root) = parse_source(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::TYPE_EXPECTED && d.start == pos)
+        .count()
+}
+
+fn type_expected_count(source: &str) -> usize {
+    let (parser, _root) = parse_source(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::TYPE_EXPECTED)
+        .count()
+}
+
+#[test]
+fn trailing_union_bar_reports_type_expected() {
+    assert_eq!(type_expected_at("type T = string |;", ";"), 1);
+}
+
+#[test]
+fn trailing_intersection_amp_reports_type_expected() {
+    assert_eq!(type_expected_at("type T = string &;", ";"), 1);
+}
+
+#[test]
+fn multi_union_trailing_bar_reports_type_expected() {
+    assert_eq!(type_expected_at("type T = string | number |;", ";"), 1);
+}
+
+#[test]
+fn keyof_missing_operand_reports_type_expected() {
+    assert_eq!(type_expected_at("type T = keyof ;", ";"), 1);
+}
+
+#[test]
+fn unique_missing_operand_reports_type_expected() {
+    // The parser reports TS1110; the `'symbol' expected` grammar error lives in
+    // the checker and is suppressed when the file has parse diagnostics.
+    assert_eq!(type_expected_at("type T = unique ;", ";"), 1);
+}
+
+#[test]
+fn readonly_missing_operand_reports_type_expected() {
+    assert_eq!(type_expected_at("type T = readonly ;", ";"), 1);
+}
+
+#[test]
+fn union_in_annotation_position_reports_type_expected() {
+    assert_eq!(type_expected_at("let x: string |;", ";"), 1);
+}
+
+#[test]
+fn union_in_parameter_position_reports_type_expected() {
+    assert_eq!(type_expected_at("function f(a: number |) {}", ")"), 1);
+}
+
+#[test]
+fn leading_bar_then_missing_reports_type_expected() {
+    // `type T = | ;` — leading bar makes the first constituent required.
+    assert_eq!(type_expected_at("type T = | ;", ";"), 1);
+}
+
+#[test]
+fn leading_amp_then_missing_reports_type_expected() {
+    assert_eq!(type_expected_at("type T = & ;", ";"), 1);
+}
+
+#[test]
+fn nested_keyof_missing_operand_reports_type_expected() {
+    assert_eq!(type_expected_at("type T = keyof keyof ;", ";"), 1);
+}
+
+#[test]
+fn union_missing_member_inside_type_literal_reports_type_expected() {
+    assert_eq!(type_expected_at("type T = { x: string | };", "}"), 1);
+}
+
+// Binder-name variance: the surrounding alias/parameter names must not affect
+// the structural recovery.
+#[test]
+fn required_constituent_recovery_is_name_independent() {
+    for name in ["Alpha", "_zz", "Renamed"] {
+        let src = format!("type {name} = string |;");
+        assert_eq!(
+            type_expected_at(&src, ";"),
+            1,
+            "expected TS1110 for {src:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Contrast: genuinely-optional positions and well-formed types must be
+// unchanged (no spurious TS1110). These exercise the suppression that the fix
+// must preserve.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn well_formed_union_has_no_type_expected() {
+    assert_eq!(type_expected_count("type T = string | number;"), 0);
+}
+
+#[test]
+fn well_formed_keyof_has_no_type_expected() {
+    assert_eq!(type_expected_count("type T = keyof string;"), 0);
+}
+
+#[test]
+fn leading_bar_union_has_no_type_expected() {
+    assert_eq!(type_expected_count("type T = | string | number;"), 0);
+}
+
+#[test]
+fn tuple_trailing_comma_has_no_type_expected() {
+    // A trailing comma in a tuple is a valid optional position, not a missing
+    // required constituent.
+    assert_eq!(type_expected_count("type T = [string, ];"), 0);
+}
+
+#[test]
+fn parameter_trailing_comma_has_no_type_expected() {
+    assert_eq!(type_expected_count("function h(a: string, ) {}"), 0);
+}
+
+#[test]
+fn optional_annotation_omission_still_reports_single_type_expected() {
+    // `let y: ;` is the genuinely-optional omission and already reported TS1110;
+    // the fix must keep exactly one (no duplicate from the constituent path).
+    assert_eq!(type_expected_count("let y: ;"), 1);
+}


### PR DESCRIPTION
Fixes #14836.

## Summary
The type parser dropped TS1110 `Type expected` whenever a type was *structurally required* — after a consumed `|`/`&` separator or a `keyof`/`unique`/`readonly` operator — but the next token was a type-terminator (`;`, `)`, EOF, …). tsc parses that constituent unconditionally (`parseUnionOrIntersectionType`/`parseTypeOperator` reach `parseTypeReference` → `Type_expected`), so the absent node reports TS1110. tsz's terminator suppression over-applied the genuinely-optional recovery (`let x: ;`, `f(a: )`) to required positions.

## Structural rule
When the parser has just consumed a union/intersection separator or a `keyof`/`unique`/`readonly` operator and the next token cannot start a type, tsc emits TS1110 `Type expected`; the terminator suppression must not apply in that required-constituent context. Owner layer: parser (`tsz_parser`), with a companion grammar-suppression alignment in the checker.

## Approach
- **Parser**: thread a one-shot `require_type_constituent_once` flag (consistent with the existing `*_once` recovery flags) from the `parse_union_type`/`parse_intersection_type` loops and the `keyof`/`unique`/`readonly` operand parsers into `parse_primary_type`, which then reports TS1110 even before a terminator. The optional first/top-level position leaves the flag unset, preserving suppression for `let x: ;` and `f(a: )`. The flag is captured into the speculation checkpoint alongside its sibling flags.
- **Checker**: the `unique`/`readonly` grammar checks (TS1005 `'symbol' expected`, TS1354) are gated on `has_syntax_parse_errors`, mirroring tsc's `grammarErrorOnNode`/`grammarErrorOnFirstToken`, which suppress **all** grammar diagnostics for the whole file when `hasParseDiagnostics(sourceFile)` is true. A missing operand already reported TS1110, so tsc emits only that.

## Adjacent-case matrix (tsz now == tsc 6.0.2, verbatim incl. columns)
| input | result |
| --- | --- |
| `type A = string \|;` / `string &;` / `string \| number \|;` | TS1110 |
| `type D = keyof ;` / `keyof keyof ;` | TS1110 |
| `type E = unique ;` (was TS1005) | TS1110 only |
| `type F = readonly ;` (was TS1354) | TS1110 only |
| `let x: string \|;` / `function f(a: number \|) {}` | TS1110 |
| `type T = \| ;` / `type T = & ;` (leading-op first constituent) | TS1110 |
| `readonly (string \|)` (nested) / cross-file parse error suppresses TS1354 | TS1110 only |

Preserved (no change): `let y: ;`, `function g(a: )` → TS1110; `string \| number`, `keyof string`, `readonly string[]`, leading-bar union, tuple/param trailing comma → no diagnostic; `readonly number` → TS1354, `unique number` → TS1005 (no parse error present). Recovery is binder-name-independent (covered by a test).

## Verification
- New parser suite `parser_improvement_required_type_constituent_recovery_tests.rs` (19 tests): required-position TS1110 cases, nested/leading-operator cases, name-variance, and optional-position contrast cases. `cargo test -p tsz-parser` → 1449 passed, 0 failed.
- `cargo clippy -p tsz-parser -p tsz-checker --lib --tests` → clean.
- Differential check against `tsc 6.0.2` on the full repro + contrast + nested + cross-line matrix: 16/16 exact match (codes and columns).
- The 5 pre-existing `ts2540`/`ts2542`/`synthetic_unique_atom` checker test failures were confirmed to fail on `main` without this change (unrelated).
- Broad conformance / emit / fourslash owned by ready-review CI.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_015v5dhhRsLEZF5B9gQaqFdj