### PR TITLE
fix(checker): fold fresh-literal `?:`/`??` union excess into one TS2322 (#14832)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1,8 +1,8 @@
 //! Type assignability error reporting (TS2322 and related).
 
 use crate::diagnostics::{
-    DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes, diagnostic_messages,
-    format_message,
+    Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes,
+    diagnostic_messages, format_message,
 };
 use crate::error_reporter::assignability_literal_display::display_has_boolean_member_literal_assignability;
 use crate::error_reporter::fingerprint_policy::{
@@ -414,6 +414,100 @@ impl<'a> CheckerState<'a> {
         self.diagnose_assignment_failure_with_anchor(source, target, anchor_idx);
     }
 
+    /// Report a fresh-object **union** source whose excess belongs to tsc's
+    /// single-`TS2322` shape.
+    ///
+    /// When a fresh object literal flows through `?:`/`??`/`||`/return and the
+    /// assignment source stays a union of distinct members (e.g.
+    /// `cond ? { a: 1, b: 2 } : { a: 3 }` → `{ … } | { … }`), tsc reports ONE
+    /// `TS2322` — `Type '<union>' is not assignable to type '<target>'.` — with
+    /// the first offending member's excess-property message attached as a nested
+    /// elaboration, anchored at the excess property. (When the branches widen to
+    /// one shape the conditional collapses to a single object type,
+    /// `union_members` is `None`, and the caller keeps the standalone `TS2353`.)
+    ///
+    /// `display_anchor_idx` selects the source/target display; `walk_start_idx`
+    /// is the wrapper expression to descend for branch literals. Returns `true`
+    /// when it emitted the union `TS2322` (the caller must then stop).
+    pub(crate) fn report_fresh_object_union_excess(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        display_anchor_idx: NodeIndex,
+        walk_start_idx: NodeIndex,
+    ) -> bool {
+        if crate::query_boundaries::diagnostics::union_members(self.ctx.types, source).is_none() {
+            return false;
+        }
+        // Run the canonical per-literal excess detector on the branch literals
+        // reachable through the wrapper, stopping at the first offending member
+        // (tsc reports only the first). The detector keys off the literal AST
+        // node, so it still surfaces excess after contextual typing has stripped
+        // freshness from the cached branch type — which a freshness-gated type
+        // relation would miss.
+        let diags_before = self.ctx.diagnostics.len();
+        for obj_idx in self.collect_rhs_object_literals(walk_start_idx) {
+            let literal_type = self.get_type_of_node(obj_idx);
+            self.check_object_literal_excess_properties(literal_type, target, obj_idx);
+            if self.ctx.diagnostics.len() > diags_before {
+                break;
+            }
+        }
+        if self.ctx.diagnostics.len() == diags_before {
+            return false;
+        }
+        // Refold the offending member's excess diagnostic into tsc's single union
+        // shape: the same property-anchored excess message becomes a nested
+        // elaboration beneath a `Type '<union>' is not assignable to type '<T>'.`
+        // head. Only a plain excess emit (TS2353/TS2561) refolds; anything else
+        // is left as the caller emitted it.
+        let captured = self.ctx.diagnostics.split_off(diags_before);
+        let head = &captured[0];
+        if !matches!(
+            head.code,
+            diagnostic_codes::OBJECT_LITERAL_MAY_ONLY_SPECIFY_KNOWN_PROPERTIES_AND_DOES_NOT_EXIST_IN_TYPE
+                | diagnostic_codes::OBJECT_LITERAL_MAY_ONLY_SPECIFY_KNOWN_PROPERTIES_BUT_DOES_NOT_EXIST_IN_TYPE_DID
+        ) {
+            self.ctx.diagnostics.extend(captured);
+            return false;
+        }
+        let (source_str, target_str) = self.format_top_level_assignability_message_types_at(
+            source,
+            target,
+            display_anchor_idx,
+        );
+        let main_message = format_message(
+            diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+            &[&source_str, &target_str],
+        );
+        let mut diag = Diagnostic::error(
+            head.file.clone(),
+            head.start,
+            head.length,
+            main_message,
+            diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
+        );
+        diag.push_elaboration(head.message_text.clone(), head.code, 0);
+        // Preserve any deeper chain the excess diagnostic already carried (nested
+        // excess produces its own related-information trail).
+        for related in &head.related_information {
+            diag.push_elaboration_at(
+                related.file.clone(),
+                related.start,
+                related.length,
+                related.message_text.clone(),
+                related.code,
+                u32::from(related.depth).saturating_add(1),
+            );
+        }
+        // The excess diagnostic was removed from the buffer; rebuild the auxiliary
+        // dedup index so its recorded excess-property position no longer suppresses
+        // the overlapping TS2322 we are about to push.
+        self.ctx.rebuild_diagnostic_aux_indices();
+        self.ctx.push_diagnostic(diag);
+        true
+    }
+
     /// Internal helper that reports a detailed assignability failure using an
     /// already-resolved diagnostic anchor.
     pub(super) fn diagnose_assignment_failure_with_anchor(
@@ -652,6 +746,17 @@ impl<'a> CheckerState<'a> {
                     } else {
                         anchor_idx
                     };
+                    // A fresh object literal flowing through `?:`/`??`/`||`/return
+                    // is a union for differing branches (tsc folds the excess into a
+                    // single TS2322) but collapses to one object type for branches
+                    // that widen alike (tsc keeps the standalone TS2353). The helper
+                    // emits the union shape and returns `true`; otherwise the
+                    // per-branch walk below emits the property-anchored TS2353. See
+                    // `report_fresh_object_union_excess`.
+                    if self.report_fresh_object_union_excess(source, target, anchor_idx, start_idx)
+                    {
+                        return;
+                    }
                     let diags_before = self.ctx.diagnostics.len();
                     for obj_idx in self.collect_rhs_object_literals(start_idx) {
                         let literal_type = self.get_type_of_node(obj_idx);

--- a/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
+++ b/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
@@ -637,36 +637,51 @@ impl<'a> CheckerState<'a> {
                                 // the contextual type into multiple candidate
                                 // object literals (`?:`, `??`, `||`, parens,
                                 // `,`, `=`), the call above sees the composite
-                                // source and cannot iterate its shape. Run the
-                                // per-literal excess check on every fresh
-                                // object literal reachable through those
-                                // wrappers so nested excess properties on
-                                // branch literals are surfaced (e.g. `c ? { a:
-                                // { b:1, c:2 } } : { a: { b:2 } }` should
-                                // still emit TS2353 for the inner `c`). See
-                                // #9681. Skip when the initializer is itself
-                                // an object literal — the canonical
-                                // `check_object_literal_excess_properties`
-                                // call above already runs against the literal
-                                // and rerunning it via
-                                // `get_type_of_node(literal)` can disagree on
-                                // the source type for symbol-named computed
-                                // keys / sibling-initializer destructuring
-                                // shapes.
+                                // source and cannot iterate its shape. Skip when
+                                // the initializer is itself an object literal —
+                                // the canonical
+                                // `check_object_literal_excess_properties` call
+                                // above already runs against the literal and
+                                // rerunning it via `get_type_of_node(literal)`
+                                // can disagree on the source type for
+                                // symbol-named computed keys / sibling-initializer
+                                // destructuring shapes.
                                 if self.ctx.diagnostics.len() == diags_before
                                     && !self.ctx.arena.get(facts.initializer).is_some_and(|n| {
                                         n.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
                                     })
                                 {
-                                    let literals =
-                                        self.collect_rhs_object_literals(facts.initializer);
-                                    for obj_idx in literals {
-                                        let lit_type = self.get_type_of_node(obj_idx);
-                                        self.check_object_literal_excess_properties(
-                                            lit_type,
-                                            excess_property_target,
-                                            obj_idx,
-                                        );
+                                    // When the composite source stays a UNION of
+                                    // distinct members (`cond ? {a:1,b:2} : {a:3}`
+                                    // → `{ … } | { … }`), tsc reports ONE TS2322
+                                    // over the union with the excess message as a
+                                    // nested elaboration — not a per-branch TS2353
+                                    // (#14832). `report_fresh_object_union_excess`
+                                    // emits that shape and returns `true`. It
+                                    // returns `false` when the source is not a
+                                    // union (branches widen to one shape, so the
+                                    // source collapses to a single object type) or
+                                    // has only nested excess; in both cases run the
+                                    // per-literal walk so each fresh branch literal
+                                    // still gets its standalone TS2353 (e.g.
+                                    // `c ? { a: { b:1, c:2 } } : { a: { b:2 } }`
+                                    // surfaces the inner `c`). See #9681.
+                                    if !self.report_fresh_object_union_excess(
+                                        checked_init_type,
+                                        excess_property_target,
+                                        facts.initializer,
+                                        facts.initializer,
+                                    ) {
+                                        let literals =
+                                            self.collect_rhs_object_literals(facts.initializer);
+                                        for obj_idx in literals {
+                                            let lit_type = self.get_type_of_node(obj_idx);
+                                            self.check_object_literal_excess_properties(
+                                                lit_type,
+                                                excess_property_target,
+                                                obj_idx,
+                                            );
+                                        }
                                     }
                                 }
                                 if self.ctx.diagnostics.len() == diags_before {

--- a/crates/tsz-checker/tests/ts2353_tests.rs
+++ b/crates/tsz-checker/tests/ts2353_tests.rs
@@ -17,6 +17,27 @@ fn get_diagnostics(source: &str) -> Vec<(u32, String)> {
         .collect()
 }
 
+/// Like [`get_diagnostics`], but flattens each diagnostic's related-information
+/// (elaboration) messages into the text. A fresh-literal excess that flows
+/// through `?:`/`??` and yields a union surfaces as a single TS2322 whose excess
+/// message is a nested elaboration (#14832), so the property name lives in the
+/// related information rather than the head message.
+fn get_diagnostics_with_elaboration(source: &str) -> Vec<(u32, String)> {
+    let libs = load_lib_files(&["es5.d.ts"]);
+    check_source_with_libs(source, "test.ts", CheckerOptions::default(), &libs)
+        .iter()
+        .filter(|d| d.code != 2318)
+        .map(|d| {
+            let mut text = d.message_text.clone();
+            for related in &d.related_information {
+                text.push('\n');
+                text.push_str(&related.message_text);
+            }
+            (d.code, text)
+        })
+        .collect()
+}
+
 #[test]
 fn record_number_rejects_non_numeric_object_literal_key() {
     let source = r#"
@@ -1560,39 +1581,54 @@ const sc: StringContainer = {
 
 #[test]
 fn ternary_branch_object_literal_reports_excess_property() {
-    let diags = get_diagnostics(
+    // When the branches differ so the conditional source stays a union, tsc
+    // reports a single TS2322 over the union with the excess message as a nested
+    // elaboration — not a per-branch TS2353 (#14832).
+    let diags = get_diagnostics_with_elaboration(
         r#"
 interface I { a: number }
 declare const cond: boolean;
 const v: I = cond ? { a: 1, b: 2 } : { a: 3 };
 "#,
     );
-    let excess: Vec<_> = diags
+    let union_excess: Vec<_> = diags
         .iter()
-        .filter(|d| (d.0 == 2353 || d.0 == 2322) && d.1.contains("'b'"))
+        .filter(|d| d.0 == 2322 && d.1.contains("'b'"))
         .collect();
+    assert_eq!(
+        union_excess.len(),
+        1,
+        "Expected one TS2322 over the union with a nested 'b' excess elaboration, got: {diags:?}",
+    );
     assert!(
-        !excess.is_empty(),
-        "Expected excess-property diagnostic for 'b' in a ternary branch, got: {diags:?}",
+        diags.iter().all(|d| d.0 != 2353),
+        "Expected no standalone per-branch TS2353 for the union conditional, got: {diags:?}",
     );
 }
 
 #[test]
 fn nullish_coalescing_right_object_literal_reports_excess_property() {
-    let diags = get_diagnostics(
+    // `d ?? { … }` with a non-literal left operand keeps the result a union
+    // (`I | { … }`), so tsc reports one TS2322 with a nested excess elaboration.
+    let diags = get_diagnostics_with_elaboration(
         r#"
 interface I { a: number }
 declare const d: I | undefined;
 const v: I = d ?? { a: 1, b: 2 };
 "#,
     );
-    let excess: Vec<_> = diags
+    let union_excess: Vec<_> = diags
         .iter()
-        .filter(|d| (d.0 == 2353 || d.0 == 2322) && d.1.contains("'b'"))
+        .filter(|d| d.0 == 2322 && d.1.contains("'b'"))
         .collect();
+    assert_eq!(
+        union_excess.len(),
+        1,
+        "Expected one TS2322 over `I | {{ … }}` with a nested 'b' excess elaboration, got: {diags:?}",
+    );
     assert!(
-        !excess.is_empty(),
-        "Expected excess-property diagnostic for 'b' on the right of `??`, got: {diags:?}",
+        diags.iter().all(|d| d.0 != 2353),
+        "Expected no standalone TS2353 on the right of `??`, got: {diags:?}",
     );
 }
 
@@ -1615,41 +1651,50 @@ const v: I = (0 as any) + { a: 1, b: 2 };
 
 #[test]
 fn ternary_branch_excess_property_uses_renamed_property() {
-    // Test matrix item: the rule applies regardless of property spelling.
-    let diags = get_diagnostics(
+    // Test matrix item: the rule applies regardless of property spelling. The
+    // branches differ, so the union TS2322 carries the excess elaboration.
+    let diags = get_diagnostics_with_elaboration(
         r#"
 interface MyShape { name: string }
 declare const cond: boolean;
 const v: MyShape = cond ? { name: "a", age: 30 } : { name: "b" };
 "#,
     );
-    let excess: Vec<_> = diags
+    let union_excess: Vec<_> = diags
         .iter()
-        .filter(|d| (d.0 == 2353 || d.0 == 2322) && d.1.contains("'age'"))
+        .filter(|d| d.0 == 2322 && d.1.contains("'age'"))
         .collect();
+    assert_eq!(
+        union_excess.len(),
+        1,
+        "Expected one TS2322 with a nested 'age' excess elaboration, got: {diags:?}",
+    );
     assert!(
-        !excess.is_empty(),
-        "Expected excess-property diagnostic for 'age' in a renamed-property ternary, got: {diags:?}",
+        diags.iter().all(|d| d.0 != 2353),
+        "Expected no standalone TS2353 for the renamed-property union conditional, got: {diags:?}",
     );
 }
 
 #[test]
 fn ternary_branch_nested_object_literal_reports_inner_excess_property() {
-    // Test matrix item: nested literal in a branch must still be checked.
-    let diags = get_diagnostics(
+    // Test matrix item: nested literal in a branch must still be checked. The
+    // union conditional reports a single TS2322 whose elaboration carries the
+    // inner excess (#14832).
+    let diags = get_diagnostics_with_elaboration(
         r#"
 interface I { a: { b: number } }
 declare const c: boolean;
 const v: I = c ? { a: { b: 1, c: 2 } } : { a: { b: 2 } };
 "#,
     );
-    let excess: Vec<_> = diags
+    let union_excess: Vec<_> = diags
         .iter()
-        .filter(|d| (d.0 == 2353 || d.0 == 2322) && d.1.contains("'c'"))
+        .filter(|d| d.0 == 2322 && d.1.contains("'c'"))
         .collect();
-    assert!(
-        !excess.is_empty(),
-        "Expected excess-property diagnostic for inner 'c' in a nested ternary literal, got: {diags:?}",
+    assert_eq!(
+        union_excess.len(),
+        1,
+        "Expected one TS2322 with a nested inner-'c' excess elaboration, got: {diags:?}",
     );
 }
 
@@ -1668,6 +1713,63 @@ const v: I = cond ? { a: 1 } : { a: 2 };
     assert!(
         diags.iter().all(|d| d.0 != 2353 && d.0 != 2322),
         "Did not expect any excess-property diagnostic for a clean ternary, got: {diags:?}",
+    );
+}
+
+#[test]
+fn ternary_uniform_excess_branches_report_single_ts2353() {
+    // Control for #14832: when both branches widen to the SAME shape (here both
+    // `{ a: number; z: number; }`), the conditional source collapses to a single
+    // object type — not a union — so tsc reports ONE standalone TS2353, exactly
+    // as for a direct object literal. No TS2322 union wrapper is produced.
+    let diags = get_diagnostics_with_elaboration(
+        r#"
+interface I { a: number }
+declare const cond: boolean;
+const v: I = cond ? { a: 1, z: 2 } : { a: 1, z: 3 };
+"#,
+    );
+    let ts2353: Vec<_> = diags
+        .iter()
+        .filter(|d| d.0 == 2353 && d.1.contains("'z'"))
+        .collect();
+    assert_eq!(
+        ts2353.len(),
+        1,
+        "Expected one standalone TS2353 for the collapsed uniform-excess conditional, got: {diags:?}",
+    );
+    assert!(
+        diags.iter().all(|d| d.0 != 2322),
+        "Did not expect a union TS2322 when the branches collapse to one shape, got: {diags:?}",
+    );
+}
+
+#[test]
+fn ternary_differing_excess_branches_report_single_union_ts2322() {
+    // #14832: when BOTH branches carry excess but the excess properties differ
+    // (`a2` vs `b`), the source stays a union and tsc reports a SINGLE TS2322
+    // over the union — not two per-branch TS2353. The elaboration names the
+    // first offending member's excess property.
+    let diags = get_diagnostics_with_elaboration(
+        r#"
+interface I { a: number }
+declare const cond: boolean;
+const v: I = cond ? { a: 1, a2: 2 } : { a: 3, b: 4 };
+"#,
+    );
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.0 == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "Expected exactly one union TS2322 for differing-excess branches, got: {diags:?}",
+    );
+    assert!(
+        ts2322[0].1.contains("'a2'"),
+        "Expected the union TS2322 elaboration to name the first member's excess 'a2', got: {diags:?}",
+    );
+    assert!(
+        diags.iter().all(|d| d.0 != 2353),
+        "Expected no per-branch TS2353 for differing-excess union branches, got: {diags:?}",
     );
 }
 


### PR DESCRIPTION
Fixes #14832.

## Summary
When a fresh object literal flows through `?:`/`??`/`||` and the assigned target
makes the result a union of differing members, `tsc` reports a single **TS2322**
against the union type with a nested excess-property elaboration. tsz reported a
separate **TS2353** per branch literal — different code, different diagnostic
count, different anchored type display (incomplete fix of #9681, which landed the
wrong diagnostic shape).

```ts
interface I { a: number }
declare const cond: boolean;
const i: I = cond ? { a: 1, b: 2 } : { a: 3 };
```
- Before: `TS2353: Object literal may only specify known properties, and 'b' does not exist in type 'I'.`
- After (matches `tsc` 5.9.3): `TS2322: Type '… | …' is not assignable to type 'I'.` with a nested `Object literal may only specify known properties, and 'b' …` elaboration anchored at the excess property.

## Structural rule
When the assignment source stays a **union of distinct members**
(`cond ? { a, b } : { a }` → `{ … } | { … }`), report one **TS2322** anchored at
the first offending member's excess property, with the excess message as a nested
elaboration. When every branch widens to the same shape the conditional collapses
to a single object type (`union_members` is `None`) and the standalone **TS2353**
is kept — exactly as `tsc` does for `cond ? { a, z } : { a, z }`.

Owner layer: `tsz_checker::error_reporter::report_fresh_object_union_excess`, a
shared helper invoked from both the variable-initializer excess path
(`state::variable_checking::initializer_policy`) and the assignment-failure path
(`diagnose_assignment_failure_with_anchor`). The helper runs the canonical
per-literal excess detector (`check_object_literal_excess_properties`, which keys
off the AST node so it surfaces excess after contextual typing strips freshness),
then refolds the offending member's excess diagnostic into the single union
TS2322. No printer output is parsed; the decision is the structural `union_members`
query plus the solver-derived excess reason.

## Adjacent matrix
- differing-excess branches → one TS2322
- `?? { excess }` with a non-literal LHS (`I | { … }`) → one TS2322
- uniform-excess branches that collapse to one shape → one TS2353 (control)
- nested-branch excess (`c ? { a: { b, c } } : { a: { b } }`) → one TS2322
- renamed property (binder-name varied) → one TS2322
- clean conditional → no excess diagnostic

## Known follow-up (out of scope)
The union *display* still shows tsz's synthesized `b?: undefined` member for the
two-object `?:` case (a pre-existing conditional-union construction artifact, not
specific to this diagnostic). The diagnostic **shape** (code, count, anchor,
elaboration) now matches `tsc`.

Goal: hold

## Provenance
Machine: cloud · Assistant: claude-code · Model: claude-opus-4-8 · Effort: high

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-checker --test ts2353_tests` → 81 passed (4 #9681 tests updated to the tsc-correct shape; 2 new matrix tests added: `ternary_uniform_excess_branches_report_single_ts2353`, `ternary_differing_excess_branches_report_single_union_ts2322`).
- `cargo clippy -p tsz-checker --lib` → clean.
- Manual repro of the issue's matrix confirms: differing/`??`/nested → one TS2322 + nested elaboration; uniform/direct → one TS2353.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RrYEfrGJBaQffEVuhbY8Nb)_