### PR TITLE
fix(emit): serialize type-only decorator metadata refs to Object, not erased names (#14775)

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -67,6 +67,10 @@ name = "enum_metadata_number_tests"
 path = "tests/enum_metadata_number_tests.rs"
 
 [[test]]
+name = "decorator_metadata_type_only_tests"
+path = "tests/decorator_metadata_type_only_tests.rs"
+
+[[test]]
 name = "private_element_naming_tests"
 path = "tests/private_element_naming_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -564,6 +564,17 @@ pub struct Printer<'a> {
     /// resolve generic type parameters to "Object".
     pub(crate) metadata_class_type_params: Option<Vec<String>>,
 
+    /// True while serializing the *target* of a type alias for decorator metadata.
+    /// In this mode a type reference that names a runtime value (class/enum) is
+    /// serialized as its declared object type (`Object`/`Number`) instead of the
+    /// value's binding, because `tsc` resolves an alias to its declared type and
+    /// never chases the alias to a constructor value (`type A = SomeClass` -> `Object`).
+    pub(crate) metadata_in_alias_target: bool,
+
+    /// Recursion guard for alias-target metadata serialization, so a cyclic alias
+    /// (`type A = B; type B = A`) cannot loop forever; past the cap we yield `Object`.
+    pub(crate) metadata_alias_depth: u32,
+
     /// When true, the next namespace IIFE tail should fold `exports.Name` into
     /// the closing: `(N || (exports.N = N = {}))` instead of `(N || (N = {}))`.
     pub(crate) pending_cjs_namespace_export_fold: bool,

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -314,6 +314,8 @@ impl<'a> Printer<'a> {
             in_top_level_using_scope: false,
             in_system_top_level_using_prelude: false,
             metadata_class_type_params: None,
+            metadata_in_alias_target: false,
+            metadata_alias_depth: 0,
             pending_block_comment_space: false,
             pending_cjs_namespace_export_fold: false,
             pending_cjs_namespace_export_names: Vec::new(),

--- a/crates/tsz-emitter/src/emitter/declarations/class/decorators.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/decorators.rs
@@ -1,5 +1,8 @@
 use super::super::super::Printer;
 use crate::context::transform::TransformDirective;
+use crate::transforms::emit_utils::{
+    METADATA_ALIAS_MAX_DEPTH, MetadataEntityKind, classify_metadata_entity,
+};
 use tsz_parser::parser::node::{Node, NodeAccess};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
@@ -748,6 +751,30 @@ impl<'a> Printer<'a> {
             "any" | "unknown" | "object" => return "Object".to_string(),
             _ => {}
         }
+
+        // `tsc` serializes a metadata type reference from its resolved symbol's
+        // declared type rather than its (possibly erased) spelling: a type alias
+        // resolves to its target type, an interface erases to `Object`, and only a
+        // runtime value emits its binding. Emitting the bare name for a type-only
+        // reference would throw a `ReferenceError` when the metadata is read.
+        match classify_metadata_entity(self.arena, name) {
+            MetadataEntityKind::TypeAlias(target) => {
+                return self.metadata_serialize_alias_target(target);
+            }
+            MetadataEntityKind::TypeOnly => return "Object".to_string(),
+            // A local runtime value, or a name with no local type-only evidence (a
+            // global lib value, an import, …), falls through to the established
+            // value-reference emission below.
+            MetadataEntityKind::ValueOrUnknown => {}
+        }
+
+        // A value reference whose declared type is being serialized as an alias
+        // target classifies to its instance/object type, not the constructor
+        // binding (`type A = SomeClass` -> `Object`, matching `tsc`).
+        if self.metadata_in_alias_target {
+            return "Object".to_string();
+        }
+
         if !self.suppress_commonjs_named_import_substitution
             && let Some(substituted) = self.commonjs_named_import_substitutions.get(name)
         {
@@ -757,6 +784,26 @@ impl<'a> Printer<'a> {
             return self.serialize_metadata_fallback_entity(&[name.to_string()]);
         }
         name.to_string()
+    }
+
+    /// Serialize the resolved target type of a type alias for decorator metadata.
+    ///
+    /// Runs `serialize_type_for_metadata` on the alias target in "alias target"
+    /// mode so nested value references collapse to their declared object type
+    /// (`Object`) instead of the runtime binding, matching `tsc`'s
+    /// `getDeclaredTypeOfSymbol` + classify behavior. A recursion cap keeps a
+    /// cyclic alias (`type A = B; type B = A`) from looping.
+    fn metadata_serialize_alias_target(&mut self, target: NodeIndex) -> String {
+        if self.metadata_alias_depth >= METADATA_ALIAS_MAX_DEPTH {
+            return "Object".to_string();
+        }
+        let prev_mode = self.metadata_in_alias_target;
+        self.metadata_in_alias_target = true;
+        self.metadata_alias_depth += 1;
+        let result = self.serialize_type_for_metadata(target);
+        self.metadata_alias_depth -= 1;
+        self.metadata_in_alias_target = prev_mode;
+        result
     }
 
     fn metadata_entity_name_parts(&self, idx: NodeIndex) -> Option<Vec<String>> {

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_helpers.rs
@@ -1,6 +1,8 @@
 //! Helper types and functions for the ES5 class IR transformer.
 
-use crate::transforms::emit_utils::identifier_text;
+use crate::transforms::emit_utils::{
+    METADATA_ALIAS_MAX_DEPTH, MetadataEntityKind, classify_metadata_entity, identifier_text,
+};
 use rustc_hash::FxHashMap;
 use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::syntax_kind_ext;
@@ -11,6 +13,19 @@ use tsz_scanner::SyntaxKind;
 /// Serialize a type annotation to a metadata runtime type string.
 /// Mirrors the `Printer::serialize_type_for_metadata` logic for ES5 context.
 pub(super) fn serialize_type_for_metadata(arena: &NodeArena, type_idx: NodeIndex) -> String {
+    serialize_type_for_metadata_impl(arena, type_idx, false, 0)
+}
+
+/// `in_alias_target` is set while serializing the resolved target of a type
+/// alias: there a reference that names a runtime value classifies to its
+/// declared object type (`Object`) rather than the constructor binding, matching
+/// `tsc`'s "resolve the alias to its declared type, never chase it to a value".
+fn serialize_type_for_metadata_impl(
+    arena: &NodeArena,
+    type_idx: NodeIndex,
+    in_alias_target: bool,
+    alias_depth: u32,
+) -> String {
     let Some(type_node) = arena.get(type_idx) else {
         return "Object".to_string();
     };
@@ -35,20 +50,42 @@ pub(super) fn serialize_type_for_metadata(arena: &NodeArena, type_idx: NodeIndex
             "Object".to_string()
         }
         k if k == syntax_kind_ext::TYPE_REFERENCE => {
-            if let Some(type_ref) = arena.get_type_ref(type_node) {
-                let name = get_identifier_text(arena, type_ref.type_name).unwrap_or_default();
-                match name.as_str() {
-                    "string" => "String".to_string(),
-                    "number" => "Number".to_string(),
-                    "boolean" => "Boolean".to_string(),
-                    "symbol" => "Symbol".to_string(),
-                    "bigint" => "BigInt".to_string(),
-                    "void" | "undefined" | "null" | "never" => "void 0".to_string(),
-                    "any" | "unknown" | "object" => "Object".to_string(),
-                    _ => name,
+            let Some(type_ref) = arena.get_type_ref(type_node) else {
+                return "Object".to_string();
+            };
+            let name = get_identifier_text(arena, type_ref.type_name).unwrap_or_default();
+            match name.as_str() {
+                "string" => return "String".to_string(),
+                "number" => return "Number".to_string(),
+                "boolean" => return "Boolean".to_string(),
+                "symbol" => return "Symbol".to_string(),
+                "bigint" => return "BigInt".to_string(),
+                "void" | "undefined" | "null" | "never" => return "void 0".to_string(),
+                "any" | "unknown" | "object" => return "Object".to_string(),
+                _ => {}
+            }
+            // A type-only reference (interface / alias) has no runtime binding;
+            // emitting its bare name would throw a `ReferenceError` when the
+            // metadata is read. Classify it like `tsc` does.
+            match classify_metadata_entity(arena, name.as_str()) {
+                MetadataEntityKind::TypeAlias(target) => {
+                    if alias_depth >= METADATA_ALIAS_MAX_DEPTH {
+                        return "Object".to_string();
+                    }
+                    serialize_type_for_metadata_impl(arena, target, true, alias_depth + 1)
                 }
-            } else {
-                "Object".to_string()
+                MetadataEntityKind::TypeOnly => "Object".to_string(),
+                // A local runtime value, or a name with no local type-only
+                // evidence (a global lib value, an import, …). Inside an alias
+                // target it classifies to its declared object type (`Object`);
+                // otherwise it emits its binding verbatim.
+                MetadataEntityKind::ValueOrUnknown => {
+                    if in_alias_target {
+                        "Object".to_string()
+                    } else {
+                        name
+                    }
+                }
             }
         }
         k if k == syntax_kind_ext::ARRAY_TYPE || k == syntax_kind_ext::TUPLE_TYPE => {
@@ -90,14 +127,25 @@ pub(super) fn serialize_type_for_metadata(arena: &NodeArena, type_idx: NodeIndex
                     })
                     .collect();
                 if meaningful.len() == 1 {
-                    return serialize_type_for_metadata(arena, meaningful[0]);
+                    return serialize_type_for_metadata_impl(
+                        arena,
+                        meaningful[0],
+                        in_alias_target,
+                        alias_depth,
+                    );
                 }
                 if meaningful.len() > 1 {
-                    let first = serialize_type_for_metadata(arena, meaningful[0]);
+                    let first = serialize_type_for_metadata_impl(
+                        arena,
+                        meaningful[0],
+                        in_alias_target,
+                        alias_depth,
+                    );
                     if first != "Object"
-                        && meaningful[1..]
-                            .iter()
-                            .all(|&m| serialize_type_for_metadata(arena, m) == first)
+                        && meaningful[1..].iter().all(|&m| {
+                            serialize_type_for_metadata_impl(arena, m, in_alias_target, alias_depth)
+                                == first
+                        })
                     {
                         return first;
                     }
@@ -110,7 +158,12 @@ pub(super) fn serialize_type_for_metadata(arena: &NodeArena, type_idx: NodeIndex
         }
         k if k == syntax_kind_ext::PARENTHESIZED_TYPE => {
             if let Some(wrapped) = arena.get_wrapped_type(type_node) {
-                return serialize_type_for_metadata(arena, wrapped.type_node);
+                return serialize_type_for_metadata_impl(
+                    arena,
+                    wrapped.type_node,
+                    in_alias_target,
+                    alias_depth,
+                );
             }
             "Object".to_string()
         }
@@ -137,20 +190,40 @@ pub(super) fn serialize_type_for_metadata(arena: &NodeArena, type_idx: NodeIndex
         k if k == syntax_kind_ext::TEMPLATE_LITERAL_TYPE => "String".to_string(),
         k if k == syntax_kind_ext::TYPE_OPERATOR => {
             if let Some(type_op) = arena.get_type_operator(type_node) {
-                return serialize_type_for_metadata(arena, type_op.type_node);
+                return serialize_type_for_metadata_impl(
+                    arena,
+                    type_op.type_node,
+                    in_alias_target,
+                    alias_depth,
+                );
             }
             "Object".to_string()
         }
         k if k == syntax_kind_ext::OPTIONAL_TYPE => {
             if let Some(wrapped) = arena.get_wrapped_type(type_node) {
-                return serialize_type_for_metadata(arena, wrapped.type_node);
+                return serialize_type_for_metadata_impl(
+                    arena,
+                    wrapped.type_node,
+                    in_alias_target,
+                    alias_depth,
+                );
             }
             "Object".to_string()
         }
         k if k == syntax_kind_ext::CONDITIONAL_TYPE => {
             if let Some(cond) = arena.get_conditional_type(type_node) {
-                let true_type = serialize_type_for_metadata(arena, cond.true_type);
-                let false_type = serialize_type_for_metadata(arena, cond.false_type);
+                let true_type = serialize_type_for_metadata_impl(
+                    arena,
+                    cond.true_type,
+                    in_alias_target,
+                    alias_depth,
+                );
+                let false_type = serialize_type_for_metadata_impl(
+                    arena,
+                    cond.false_type,
+                    in_alias_target,
+                    alias_depth,
+                );
                 if true_type == false_type {
                     return true_type;
                 }

--- a/crates/tsz-emitter/src/transforms/emit_utils.rs
+++ b/crates/tsz-emitter/src/transforms/emit_utils.rs
@@ -187,6 +187,79 @@ pub(crate) fn identifier_text_or_empty(arena: &NodeArena, idx: NodeIndex) -> Str
     identifier_text(arena, idx).unwrap_or_default()
 }
 
+/// Maximum alias-target recursion depth for decorator-metadata serialization, so
+/// a cyclic alias (`type A = B; type B = A`) cannot loop forever; past the cap a
+/// metadata type reference yields `Object`.
+pub(crate) const METADATA_ALIAS_MAX_DEPTH: u32 = 32;
+
+/// How an entity-name reference in a `design:type`/`design:paramtypes`/
+/// `design:returntype` annotation resolves, for runtime metadata serialization.
+///
+/// `tsc` serializes such a reference from its resolved symbol's *declared type*
+/// rather than its (possibly erased) spelling; emitting the bare name of a
+/// type-only binding produces a runtime `ReferenceError` when the metadata is
+/// read. This classification reproduces that decision from positive, file-local
+/// syntactic evidence (the model the rest of the metadata serializer uses).
+pub(crate) enum MetadataEntityKind {
+    /// A local runtime value (class / enum / function), **or** a name with no
+    /// local type-only declaration (a global lib value such as `Map`, an import,
+    /// …). Both emit the binding verbatim; the syntactic value-declaration set
+    /// cannot tell a global value from a type-only one, so an over-eager `Object`
+    /// here would drop a real constructor from the metadata.
+    ValueOrUnknown,
+    /// A type alias; carries its target type node so the caller can serialize the
+    /// aliased type instead of the erased alias name.
+    TypeAlias(NodeIndex),
+    /// A purely type-only binding (interface): erased to `Object`.
+    TypeOnly,
+}
+
+/// Classify the declaration(s) named `name` for decorator-metadata serialization
+/// using only positive, file-local evidence. A value declaration outranks a
+/// merged type-only one (`class C` + `interface C` is a runtime value), an
+/// interface is type-only, and a type alias carries its target node. Shared by
+/// the `Printer` and ES5 transform metadata serializers so they cannot drift.
+pub(crate) fn classify_metadata_entity(arena: &NodeArena, name: &str) -> MetadataEntityKind {
+    if name.is_empty() {
+        return MetadataEntityKind::ValueOrUnknown;
+    }
+    let matches = |idx: NodeIndex| identifier_text_or_empty(arena, idx) == name;
+    let mut has_interface = false;
+    let mut alias_target: Option<NodeIndex> = None;
+    for node in &arena.nodes {
+        let kind = node.kind;
+        if kind == syntax_kind_ext::CLASS_DECLARATION {
+            if arena.get_class(node).is_some_and(|c| matches(c.name)) {
+                return MetadataEntityKind::ValueOrUnknown;
+            }
+        } else if kind == syntax_kind_ext::ENUM_DECLARATION {
+            if arena.get_enum(node).is_some_and(|e| matches(e.name)) {
+                return MetadataEntityKind::ValueOrUnknown;
+            }
+        } else if kind == syntax_kind_ext::FUNCTION_DECLARATION {
+            if arena.get_function(node).is_some_and(|f| matches(f.name)) {
+                return MetadataEntityKind::ValueOrUnknown;
+            }
+        } else if kind == syntax_kind_ext::INTERFACE_DECLARATION {
+            if arena.get_interface(node).is_some_and(|i| matches(i.name)) {
+                has_interface = true;
+            }
+        } else if kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+            && let Some(alias) = arena.get_type_alias(node)
+            && matches(alias.name)
+        {
+            alias_target = Some(alias.type_node);
+        }
+    }
+    if let Some(target) = alias_target {
+        return MetadataEntityKind::TypeAlias(target);
+    }
+    if has_interface {
+        return MetadataEntityKind::TypeOnly;
+    }
+    MetadataEntityKind::ValueOrUnknown
+}
+
 /// Collect the runtime (non-type-only) bindings of an import clause as
 /// `(name node, name)` pairs: the default name, the namespace name, and each
 /// named specifier's local name. Shared by the printer's and the lowering

--- a/crates/tsz-emitter/tests/decorator_metadata_type_only_tests.rs
+++ b/crates/tsz-emitter/tests/decorator_metadata_type_only_tests.rs
@@ -1,0 +1,214 @@
+//! `design:type` / `design:paramtypes` / `design:returntype` decorator metadata
+//! must not serialize a type-only reference (interface, type alias, type
+//! parameter, type-only import) to its bare erased spelling — that binding does
+//! not exist at runtime and reading the metadata throws a `ReferenceError`.
+//!
+//! Structural rule: when a metadata type reference resolves to a declaration
+//! with no runtime value (an interface or type parameter), `tsc` serializes it
+//! as `Object`; when it resolves to a type alias, `tsc` resolves the alias to
+//! its target type and serializes *that* type (`type S = string` -> `String`,
+//! `type O = {a: number}` -> `Object`, `type R = SomeClass` -> `Object`, since
+//! `tsc` never chases an alias to a constructor value). Only a reference that
+//! names a runtime value usable as a type (a class) serializes to its binding.
+//!
+//! Tests vary the declaration names so they pin the structural rule rather than
+//! a particular spelling.
+
+use tsz_common::ScriptTarget;
+use tsz_emitter::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use tsz_parser::ParserState;
+
+fn emit_source(source: &str, options: PrinterOptions) -> String {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut printer = EmitterPrinter::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+fn legacy_metadata_options() -> PrinterOptions {
+    PrinterOptions {
+        legacy_decorators: true,
+        emit_decorator_metadata: true,
+        target: ScriptTarget::ES2017,
+        ..Default::default()
+    }
+}
+
+fn assert_design_type(output: &str, member: &str, serialized: &str) {
+    let needle = format!("__metadata(\"design:type\", {serialized})\n], C.prototype, \"{member}\"");
+    assert!(
+        output.contains(&needle),
+        "expected `{member}` design:type to serialize to `{serialized}`.\nOutput:\n{output}"
+    );
+}
+
+/// The repro from the issue: an interface and four type aliases plus an alias to
+/// a class. None may emit the erased type-only name.
+#[test]
+fn type_only_references_do_not_emit_erased_names() {
+    let source = r#"declare const dec: any;
+interface IFace { x: number; }
+type StrAlias = string;
+type NumAlias = number;
+type ObjAlias = { a: number };
+type UnionAlias = string | number;
+class Real {}
+type RealAlias = Real;
+class C {
+  @dec a: IFace;
+  @dec b: StrAlias;
+  @dec c: NumAlias;
+  @dec d: ObjAlias;
+  @dec e: UnionAlias;
+  @dec f: RealAlias;
+  @dec g: Real;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options());
+    assert_design_type(&output, "a", "Object"); // interface
+    assert_design_type(&output, "b", "String"); // alias -> string
+    assert_design_type(&output, "c", "Number"); // alias -> number
+    assert_design_type(&output, "d", "Object"); // alias -> object literal
+    assert_design_type(&output, "e", "Object"); // alias -> string | number
+    assert_design_type(&output, "f", "Object"); // alias -> class (not chased to value)
+    assert_design_type(&output, "g", "Real"); // direct class reference (positive control)
+
+    // No erased type-only name may appear as a metadata argument.
+    for erased in [
+        "IFace",
+        "StrAlias",
+        "NumAlias",
+        "ObjAlias",
+        "UnionAlias",
+        "RealAlias",
+    ] {
+        let bad = format!("__metadata(\"design:type\", {erased})");
+        assert!(
+            !output.contains(&bad),
+            "erased type-only name `{erased}` leaked into metadata.\nOutput:\n{output}"
+        );
+    }
+}
+
+/// Renamed binders prove the fix is structural, not keyed on a spelling.
+#[test]
+fn renamed_binders_classify_the_same_way() {
+    let source = r#"declare const deco: any;
+interface Shape { x: number; }
+type Aliased = boolean;
+class Widget {}
+type WidgetAlias = Widget;
+class C {
+  @deco p: Shape;
+  @deco q: Aliased;
+  @deco r: WidgetAlias;
+  @deco s: Widget;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options());
+    assert_design_type(&output, "p", "Object"); // interface
+    assert_design_type(&output, "q", "Boolean"); // alias -> boolean
+    assert_design_type(&output, "r", "Object"); // alias -> class
+    assert_design_type(&output, "s", "Widget"); // direct class
+}
+
+/// A generic alias resolves to its target's structure (`Box<T> = T[]` -> Array),
+/// and an alias chain follows transitively to the eventual primitive.
+#[test]
+fn generic_alias_and_alias_chain() {
+    let source = r#"declare const dec: any;
+type Box<T> = T[];
+type First = Second;
+type Second = string;
+class C {
+  @dec a: Box<number>;
+  @dec b: First;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options());
+    assert_design_type(&output, "a", "Array"); // generic alias -> array
+    assert_design_type(&output, "b", "String"); // alias chain -> string
+}
+
+/// `design:paramtypes` and `design:returntype` use the same serializer, so a
+/// type-only parameter/return type must also be `Object`, never the erased name.
+#[test]
+fn paramtypes_and_returntype_classify_type_only_as_object() {
+    let source = r#"declare const dec: any;
+interface IFace { x: number; }
+type StrAlias = string;
+class C {
+  @dec method(a: IFace, b: StrAlias): IFace { return {} as any; }
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options());
+    assert!(
+        output.contains("__metadata(\"design:paramtypes\", [Object, String])"),
+        "paramtypes should classify interface->Object and alias->String.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__metadata(\"design:returntype\", Object)"),
+        "returntype of an interface should be Object.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("IFace") && !output.contains("StrAlias"),
+        "no erased type-only name may leak into method metadata.\nOutput:\n{output}"
+    );
+}
+
+/// The ES5 downlevel decorator path uses a separate serializer, so it must
+/// classify type-only references the same way.
+#[test]
+fn es5_target_classifies_type_only_references() {
+    let source = r#"declare const dec: any;
+interface IFace { x: number; }
+type StrAlias = string;
+class Real {}
+type RealAlias = Real;
+class C {
+  @dec a: IFace;
+  @dec b: StrAlias;
+  @dec f: RealAlias;
+  @dec g: Real;
+}
+"#;
+    let options = PrinterOptions {
+        legacy_decorators: true,
+        emit_decorator_metadata: true,
+        target: ScriptTarget::ES5,
+        ..Default::default()
+    };
+    let output = emit_source(source, options);
+    assert!(
+        output.contains("__metadata(\"design:type\", Object)")
+            && output.contains("__metadata(\"design:type\", String)"),
+        "ES5 metadata should classify interface->Object and alias->String.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__metadata(\"design:type\", Real)"),
+        "ES5 metadata should keep a direct class reference.\nOutput:\n{output}"
+    );
+    for erased in ["IFace", "StrAlias", "RealAlias"] {
+        let bad = format!("__metadata(\"design:type\", {erased})");
+        assert!(
+            !output.contains(&bad),
+            "ES5: erased type-only name `{erased}` leaked into metadata.\nOutput:\n{output}"
+        );
+    }
+}
+
+/// A cyclic alias must not loop forever; it resolves to `Object`.
+#[test]
+fn cyclic_alias_terminates_as_object() {
+    let source = r#"declare const dec: any;
+type A = B;
+type B = A;
+class C {
+  @dec a: A;
+}
+"#;
+    let output = emit_source(source, legacy_metadata_options());
+    assert_design_type(&output, "a", "Object");
+}


### PR DESCRIPTION
Fixes #14775.

## Problem

With `--experimentalDecorators --emitDecoratorMetadata`, tsz serialized a
decorated declaration's type annotation for `design:type` / `design:paramtypes`
/ `design:returntype` by emitting the bare entity-name identifier for any
non-keyword type reference. When that reference named an **interface** or a
**type alias** — both fully erased at runtime — the emitted metadata referenced
a binding that does not exist, producing a `ReferenceError` the moment the
metadata is read (e.g. via `Reflect.getMetadata`).

## Structural rule

When a metadata type reference resolves to a declaration with no runtime value,
`tsc` serializes its *declared type*, not its spelling:

- a **type alias** resolves to its target type and that type is serialized
  (`type S = string` → `String`, `type O = {a: number}` → `Object`,
  `type R = SomeClass` → `Object` — `tsc` never chases an alias to a constructor
  value);
- an **interface** / type parameter → `Object`;
- only a reference that names a **runtime value usable as a type** (a class)
  serializes to its binding.

tsz now does the same: `serialize_*_for_metadata` classifies the entity name and
either resolves the alias target, erases to `Object`, or keeps the binding.

## Owner layer

The whole decorator-metadata serializer is syntactic and file-local in the
emitter (it already resolves numeric enums and uses a value-declaration-name set
this way); the emitter has no checker/solver access at emit time. The fix
extends that existing mechanism rather than adding a special case: a single
shared `classify_metadata_entity` in `transforms/emit_utils.rs` classifies a
name from positive, file-local declaration evidence, and is used by **both** the
`Printer` path (`design:*` at ES2015+) and the ES5 downlevel decorator transform
(which had the identical defect in its own serializer). Classification is by
declaration kind, never by name string, so renamed binders behave identically.

## Adjacent cases covered (tests)

- interface, `type = string|number|object-literal|union`, and `type = Class`
  (alias-to-class → `Object`, not the class);
- positive control: a direct class annotation still emits the class binding;
- renamed binders (proves no name-string fast path);
- generic alias (`type Box<T> = T[]` → `Array`) and a transitive alias chain;
- `design:paramtypes` and `design:returntype` (same serializer);
- a cyclic alias terminates at `Object` (recursion cap);
- the ES5 downlevel path classifies the same way;
- a global lib value (`Map`) and the no-lib/isolated `typeof` guard are
  preserved — the syntactic value-name set cannot distinguish a global value
  from a type-only name, so non-local names keep the established
  guard/verbatim handling and a real constructor is never dropped from metadata.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-emitter --test decorator_metadata_type_only_tests` (new, 6 cases)
- `cargo test -p tsz-emitter --test enum_metadata_number_tests`
- `cargo test -p tsz-emitter --test legacy_decorator_member_order_tests`
- `cargo test -p tsz-emitter --lib` (3837 passed, incl. existing decorator-metadata
  unit tests and the no-lib/isolated `Map` guard test)
- `cargo test -p tsz-emitter` (full emitter target sweep; the one unrelated
  pre-existing `generator_object_literal_emit` failure also fails on clean `main`)
- `cargo clippy -p tsz-emitter --all-targets` (clean)