### PR TITLE
fix(checker): single TS2322 over the union for fresh-literal excess through ?:/?? (#14832)

### DIFF
--- a/crates/tsz-checker/src/tests/excess_prop_object_union_display_tests.rs
+++ b/crates/tsz-checker/src/tests/excess_prop_object_union_display_tests.rs
@@ -36,3 +36,170 @@ const propB1: IProps | number = { INVALID_PROP_NAME: 'share', iconProp: 'test' }
         "TS2353 should not display the full union 'IProps | number'; got: {msg}"
     );
 }
+
+// --- Issue #14832: fresh-literal excess through `?:` / `??` is a single TS2322
+// over the union, not a per-branch TS2353 ---
+//
+// Structural rule: when a fresh object literal flows through `?:` / `??` / `||`
+// and the assigned target makes the result a *union* of differing members, tsc
+// runs assignability against the target, fails, and reports ONE TS2322 against
+// the union type with a nested excess-property elaboration for the first
+// offending member. tsz previously walked each branch literal and emitted a
+// separate TS2353 per branch. The single-TS2353 shape is correct only when every
+// fresh member shares the identical shape (the union collapses to one type).
+
+/// All TS2353 plus TS2322 excess-property diagnostics, with their elaboration
+/// (related-information) messages flattened in for substring assertions.
+fn excess_shape(src: &str) -> Vec<(u32, String)> {
+    check_source_diagnostics(src)
+        .into_iter()
+        .filter(|d| d.code == 2322 || d.code == 2353)
+        .map(|d| {
+            let mut text = d.message_text.clone();
+            for related in &d.related_information {
+                text.push('\n');
+                text.push_str(&related.message_text);
+            }
+            (d.code, text)
+        })
+        .collect()
+}
+
+#[test]
+fn ts14832_ternary_differing_branches_single_ts2322_over_union() {
+    // One branch carries an excess property, the other does not → the union has
+    // two distinct members. tsc: ONE TS2322 over the union with the excess
+    // message nested as elaboration.
+    let shape = excess_shape(
+        "interface I { a: number }\n\
+         declare const cond: boolean;\n\
+         const i: I = cond ? { a: 1, b: 2 } : { a: 3 };",
+    );
+    assert_eq!(
+        shape.len(),
+        1,
+        "expected exactly one diagnostic, got: {shape:?}"
+    );
+    assert_eq!(
+        shape[0].0, 2322,
+        "expected TS2322 over the union, got: {shape:?}"
+    );
+    assert!(
+        shape[0].1.contains("is not assignable to type 'I'"),
+        "TS2322 head should name target 'I', got: {shape:?}"
+    );
+    assert!(
+        shape[0].1.contains(
+            "Object literal may only specify known properties, and 'b' does not exist in type 'I'."
+        ),
+        "TS2322 should carry the excess-property elaboration for 'b', got: {shape:?}"
+    );
+}
+
+#[test]
+fn ts14832_both_branches_differing_excess_single_ts2322() {
+    // Both branches carry a *different* excess property → still ONE TS2322
+    // (previously tsz emitted TWO TS2353).
+    let shape = excess_shape(
+        "interface I { a: number }\n\
+         declare const cond: boolean;\n\
+         const i: I = cond ? { a: 1, a2: 2 } : { a: 3, b: 4 };",
+    );
+    assert_eq!(
+        shape.len(),
+        1,
+        "expected exactly one diagnostic, got: {shape:?}"
+    );
+    assert_eq!(shape[0].0, 2322, "expected a single TS2322, got: {shape:?}");
+}
+
+#[test]
+fn ts14832_nullish_coalescing_nonliteral_lhs_single_ts2322() {
+    // `d ?? { excess }` with a non-literal LHS → union `I | { a; b }`. tsc emits
+    // ONE TS2322; the source display keeps the nominal `I` member.
+    let shape = excess_shape(
+        "interface I { a: number }\n\
+         declare const d: I | undefined;\n\
+         const i: I = d ?? { a: 1, b: 2 };",
+    );
+    assert_eq!(
+        shape.len(),
+        1,
+        "expected exactly one diagnostic, got: {shape:?}"
+    );
+    assert_eq!(shape[0].0, 2322, "expected a single TS2322, got: {shape:?}");
+    assert!(
+        shape[0].1.contains("'I |"),
+        "source display should keep the nominal 'I' union member, got: {shape:?}"
+    );
+}
+
+#[test]
+fn ts14832_assignment_expression_ternary_single_ts2322() {
+    // The same rule on an assignment expression (not a declaration).
+    let shape = excess_shape(
+        "interface I { a: number }\n\
+         declare const cond: boolean;\n\
+         let i: I;\n\
+         i = cond ? { a: 1, b: 2 } : { a: 3 };",
+    );
+    assert_eq!(
+        shape.len(),
+        1,
+        "expected exactly one diagnostic, got: {shape:?}"
+    );
+    assert_eq!(shape[0].0, 2322, "expected a single TS2322, got: {shape:?}");
+}
+
+#[test]
+fn ts14832_uniform_excess_branches_stay_single_ts2353() {
+    // Control: identical shape in both branches → the union collapses to one
+    // object type → tsc (and tsz) report ONE TS2353, unchanged by this fix.
+    let shape = excess_shape(
+        "interface I { a: number }\n\
+         declare const cond: boolean;\n\
+         const i: I = cond ? { a: 1, z: 2 } : { a: 1, z: 3 };",
+    );
+    assert_eq!(
+        shape.len(),
+        1,
+        "expected exactly one diagnostic, got: {shape:?}"
+    );
+    assert_eq!(
+        shape[0].0, 2353,
+        "uniform-excess branches stay TS2353, got: {shape:?}"
+    );
+    assert!(shape[0].1.contains("'z'"), "got: {shape:?}");
+}
+
+#[test]
+fn ts14832_nested_branch_excess_still_reported() {
+    // Regression guard for #9681: the excess is on a *nested* literal that the
+    // top-level relation cannot surface, so the per-branch fallback walk must
+    // still report it (TS2353 or TS2322).
+    let shape = excess_shape(
+        "interface I { a: { b: number } }\n\
+         declare const c: boolean;\n\
+         const v: I = c ? { a: { b: 1, c: 2 } } : { a: { b: 2 } };",
+    );
+    assert!(
+        shape
+            .iter()
+            .any(|(code, msg)| (*code == 2353 || *code == 2322) && msg.contains("'c'")),
+        "nested branch excess 'c' must still be reported, got: {shape:?}"
+    );
+}
+
+#[test]
+fn ts14832_clean_ternary_branches_emit_nothing() {
+    // Control: no excess in either branch → no TS2322/TS2353.
+    let shape = excess_shape(
+        "interface I { a: number }\n\
+         declare const cond: boolean;\n\
+         const v: I = cond ? { a: 1 } : { a: 2 };",
+    );
+    assert!(
+        shape.is_empty(),
+        "clean ternary must not emit excess diagnostics, got: {shape:?}"
+    );
+}


### PR DESCRIPTION
## Summary
When a fresh object literal flows through `?:` / `??` / `||` into an assignment whose result is a **union of differing members**, `tsc` relates the union to the target, fails, and reports a single **TS2322** against the union type with a nested excess-property elaboration for the first offending member. tsz instead walked each branch literal and emitted a separate **TS2353** per branch — wrong code, wrong count, wrong anchored display. (This completes the partial fix from #9681, which landed the right detection but the wrong diagnostic shape.)

```ts
interface I { a: number }
declare const cond: boolean;
const i: I = cond ? { a: 1, b: 2 } : { a: 3 };
```
- `tsc`: one `TS2322: Type '{ a: number; b: number; } | { a: number; }' is not assignable to type 'I'.` with a nested `Object literal may only specify known properties, and 'b' does not exist in type 'I'.`
- tsz before: `TS2353` per branch.

## Structural rule
When the assignment source is a **union reaching object literals through `?:`/`??`/`||`** and one fresh member carries a **top-level** excess property, report one **TS2322** over the union with the excess message nested as elaboration, anchored at the offending property (same column as the standalone TS2353). Keep the single **TS2353** only when every fresh member shares the same shape (the union collapses to one type), which tsz already matched.

## Owner layer
The shared fresh-source excess gate `check_excess_properties_for_fresh_source` (used by both the variable-initializer and assignment-expression paths) now detects the union source and probes each member with excess checking enabled to pin the first top-level excess property, then renders the canonical union shape through the existing reason renderer (`render_failure_reason`'s `ExcessProperty`/union arm, now anchored at the excess property). The relation reports a union-source failure as a generic `TypeMismatch` (excess only outranks a None/Missing structural reason), so the per-member probe is what surfaces the excess; the deeper solver-ranking alternative was considered but rejected because it would import checker-level "fresh-member-of-a-`?:`" semantics into the solver. The per-literal walk remains the fallback for **nested-only** excess (#9681), which the top-level relation does not surface.

## Adjacent matrix
- differing-excess branches → one TS2322
- both branches differing excess → one TS2322 (was two TS2353)
- `?? { excess }` with a non-literal LHS → one TS2322 keeping the nominal `I` union member
- assignment-expression (not just declaration) → one TS2322
- uniform-excess branches (control) → one TS2353 (unchanged)
- nested branch excess (#9681) → still reported via the per-literal fallback
- clean branches (control) → no diagnostic

## Fallback / anti-hardcoding
No user-name/file-name/printer-string predicates: the union and member detection is structural (`union_members`, the solver's `property_classification.excess_properties`), and tests vary the binder/property names (`b`, `a2`, `age`, `z`).

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- New unit tests `crates/tsz-checker/src/tests/excess_prop_object_union_display_tests.rs::ts14832_*` (7 cases: differing branches, both-excess, nullish-coalescing non-literal LHS, assignment-expression, uniform-excess control, nested #9681 fallback, clean control).
- Updated #9681 regression tests in `crates/tsz-checker/tests/ts2353_tests.rs` to the corrected TS2322+elaboration shape.
- `cargo test -p tsz-checker --test ts2353_tests` → 79 passed.
- `cargo test -p tsz-checker --lib ts14832` → 7 passed.
- Architecture contract `test_no_push_diagnostic_outside_error_reporter` → passing (emit routed through the `error_reporter` boundary).
- `cargo clippy -p tsz-checker --lib` → clean on changed files.
- `ts2322_tests` failures observed are pre-existing on `main` (confirmed by running them on a clean tree), unrelated to this change.

https://claude.ai/code/session_018R686qJqq41uz1zMBUJW1M

---
_Generated by [Claude Code](https://claude.ai/code/session_018R686qJqq41uz1zMBUJW1M)_