### PR TITLE
fix(checker): emit TS1259 for default import of an export= module without interop

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -842,6 +842,9 @@ path = "tests/ts1203_node_esm_tests.rs"
 name = "node_esm_default_import_export_equals_callable_tests"
 path = "tests/node_esm_default_import_export_equals_callable_tests.rs"
 [[test]]
+name = "export_equals_default_import_interop_ts1259_tests"
+path = "tests/export_equals_default_import_interop_ts1259_tests.rs"
+[[test]]
 name = "ts1254_ambient_const_tests"
 path = "tests/ts1254_ambient_const_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/context/compiler_options.rs
+++ b/crates/tsz-checker/src/context/compiler_options.rs
@@ -297,6 +297,19 @@ impl<'a> CheckerContext<'a> {
         self.compiler_options.allow_synthetic_default_imports
             || self.compiler_options.es_module_interop
     }
+
+    /// The compiler flag tsc names in `export =` default-import diagnostics
+    /// (TS1259, and the TS2497 namespace/named elaboration): `esModuleInterop`
+    /// for `CommonJS`/AMD/UMD output (module < ES2015) and
+    /// `allowSyntheticDefaultImports` for ES2015+ output.
+    pub const fn synthetic_default_import_flag_name(&self) -> &'static str {
+        if (self.compiler_options.module as u32) >= (tsz_common::common::ModuleKind::ES2015 as u32)
+        {
+            "allowSyntheticDefaultImports"
+        } else {
+            "esModuleInterop"
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/tsz-checker/src/declarations/import/core/import_members.rs
+++ b/crates/tsz-checker/src/declarations/import/core/import_members.rs
@@ -270,13 +270,7 @@ impl<'a> CheckerState<'a> {
             && self.export_equals_target_is_not_module_or_variable(table)
             && !named_imports_resolve_via_export_equals_target
         {
-            let flag_name = if (self.ctx.compiler_options.module as u32)
-                >= (tsz_common::ModuleKind::ES2015 as u32)
-            {
-                "allowSyntheticDefaultImports"
-            } else {
-                "esModuleInterop"
-            };
+            let flag_name = self.ctx.synthetic_default_import_flag_name();
             let message = format_message(
                     diagnostic_messages::THIS_MODULE_CAN_ONLY_BE_REFERENCED_WITH_ECMASCRIPT_IMPORTS_EXPORTS_BY_TURNING_ON,
                     &[flag_name],
@@ -368,7 +362,40 @@ impl<'a> CheckerState<'a> {
             let is_source_file = self.is_source_file_import(module_name);
             let uses_system_namespace_default =
                 self.source_file_import_uses_system_default_namespace_fallback(module_name);
-            if exports_table.is_some() {
+            // A default import of an `export =` module binds a *synthetic* default
+            // that is only legal under esModuleInterop / allowSyntheticDefaultImports
+            // (tsc TS1259). `has_default_binding` treats `export =` as a default
+            // provider unconditionally (the fast path's resolve_export_from_table
+            // maps "default" -> the export= target), so without this branch the
+            // interop-gated TS1259 path is never reached for a plain default import.
+            // emit_no_default_export_error owns the full TS1259/TS1192 suppression
+            // matrix (node-module synthetic defaults, ESM-extension / js-with-esm
+            // targets); an `export =` module cannot also carry a real `default`
+            // export (TS2309), so delegating never masks a genuine default.
+            //
+            // Detect `export =` from the already-resolved target arena (resolved
+            // relative to the importing file) plus the binder export tables; the
+            // arena scan covers the common default-only import, whose full exports
+            // table is intentionally not built for performance. The cheap
+            // interop/system guards are checked first so that scan never runs on
+            // the common esModuleInterop-on path.
+            let export_equals_default_needs_interop = !self.ctx.allow_synthetic_default_imports()
+                && !uses_system_namespace_default
+                && (exports_table
+                    .as_ref()
+                    .is_some_and(|table| table.has("export="))
+                    || self.module_has_export_equals(module_name)
+                    || resolved_target.is_some_and(|target_idx| {
+                        let arena = self.ctx.get_arena_for_file(target_idx as u32);
+                        (0..arena.len()).any(|i| {
+                            arena
+                                .get(NodeIndex(i as u32))
+                                .is_some_and(|node| node.kind == syntax_kind_ext::EXPORT_ASSIGNMENT)
+                        })
+                    }));
+            if export_equals_default_needs_interop {
+                self.emit_no_default_export_error(module_name, clause.name, is_source_file);
+            } else if exports_table.is_some() {
                 if !has_default_binding && !uses_system_namespace_default {
                     self.emit_no_default_export_error(module_name, clause.name, is_source_file);
                 }

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -1134,12 +1134,19 @@ impl<'a> CheckerState<'a> {
             && !target_is_js_with_esm_syntax;
 
         if export_equals_provides_default {
-            // TS1259: "Module X can only be default-imported using the 'allowSyntheticDefaultImports' flag"
-            // Only emitted for export= modules when allowSyntheticDefaultImports is false.
+            // TS1259: "Module '{0}' can only be default-imported using the '{1}' flag"
+            // Only emitted for export= modules when neither esModuleInterop nor
+            // allowSyntheticDefaultImports is enabled. tsc chooses the suggested
+            // flag by module kind: `esModuleInterop` for CommonJS/AMD/UMD output
+            // (module < ES2015), `allowSyntheticDefaultImports` for ES2015+ — the
+            // same selection used for the namespace/named TS2497 elaboration above.
             if !self.ctx.allow_synthetic_default_imports() {
+                let display_name = self.imported_namespace_display_module_name(module_specifier);
+                let quoted_name = format!("\"{display_name}\"");
+                let flag_name = self.ctx.synthetic_default_import_flag_name();
                 let message = format_message(
                     diagnostic_messages::MODULE_CAN_ONLY_BE_DEFAULT_IMPORTED_USING_THE_FLAG,
-                    &[module_specifier, "allowSyntheticDefaultImports"],
+                    &[&quoted_name, flag_name],
                 );
                 self.error(
                     start,

--- a/crates/tsz-checker/tests/export_equals_default_import_interop_ts1259_tests.rs
+++ b/crates/tsz-checker/tests/export_equals_default_import_interop_ts1259_tests.rs
@@ -1,0 +1,226 @@
+//! TS1259: a default import of a CommonJS `export =` module
+//! (`import X from "m"`) binds a *synthetic* default that is only legal under
+//! `esModuleInterop` / `allowSyntheticDefaultImports`. Without either flag tsc
+//! reports:
+//!
+//! ```text
+//! error TS1259: Module '"m"' can only be default-imported using the '<flag>' flag
+//! ```
+//!
+//! where `<flag>` is `esModuleInterop` for CommonJS/AMD/UMD output
+//! (module < ES2015) and `allowSyntheticDefaultImports` for ES2015+ output —
+//! the same module-kind selection tsc uses for the namespace/named TS2497
+//! elaboration.
+//!
+//! Previously tsz silently accepted the default import: `has_default_binding`
+//! (and the default-binding fast path it relies on) treats an `export =` entry
+//! as an unconditional default provider, so the interop-gated TS1259 path was
+//! never reached. These tests pin the structural rule across module kinds,
+//! `export =` target shapes (variable / class / function), interop toggles, and
+//! varied binder names so the fix cannot regress into a name-keyed fast path.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_common::common::ModuleKind;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+/// Check `main.ts` (which imports `./dep`) under the supplied module/interop
+/// configuration and return the emitted `(code, message)` pairs.
+fn diagnostics_for_default_import(
+    dep_source: &str,
+    main_source: &str,
+    module: ModuleKind,
+    es_module_interop: bool,
+    allow_synthetic_default_imports: bool,
+) -> Vec<(u32, String)> {
+    let mut parser_dep = ParserState::new("dep.d.ts".to_string(), dep_source.to_string());
+    let root_dep = parser_dep.parse_source_file();
+    let mut binder_dep = BinderState::new();
+    binder_dep.bind_source_file(parser_dep.get_arena(), root_dep);
+
+    let mut parser_main = ParserState::new("main.ts".to_string(), main_source.to_string());
+    let root_main = parser_main.parse_source_file();
+    let mut binder_main = BinderState::new();
+    binder_main.bind_source_file(parser_main.get_arena(), root_main);
+
+    let arena_dep = Arc::new(parser_dep.get_arena().clone());
+    let arena_main = Arc::new(parser_main.get_arena().clone());
+    let all_arenas = Arc::new(vec![Arc::clone(&arena_dep), Arc::clone(&arena_main)]);
+
+    let dep_exports = binder_dep.module_exports.get("dep.d.ts").cloned();
+    if let Some(exports) = &dep_exports {
+        std::sync::Arc::make_mut(&mut binder_main.module_exports)
+            .insert("./dep".to_string(), exports.clone());
+    }
+
+    let mut cross_file_targets = FxHashMap::default();
+    if let Some(exports) = &dep_exports {
+        for (_name, &sym_id) in exports.iter() {
+            cross_file_targets.insert(sym_id, 0usize);
+        }
+    }
+
+    let binder_dep = Arc::new(binder_dep);
+    let binder_main = Arc::new(binder_main);
+    let all_binders = Arc::new(vec![Arc::clone(&binder_dep), Arc::clone(&binder_main)]);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        arena_main.as_ref(),
+        binder_main.as_ref(),
+        &types,
+        "main.ts".to_string(),
+        CheckerOptions {
+            module,
+            es_module_interop,
+            allow_synthetic_default_imports,
+            no_lib: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    checker.ctx.set_all_arenas(all_arenas);
+    checker.ctx.set_all_binders(all_binders);
+    checker.ctx.set_current_file_idx(1);
+    checker.ctx.file_is_esm = Some(false);
+    let mut file_esm_map: FxHashMap<String, bool> = FxHashMap::default();
+    file_esm_map.insert("main.ts".to_string(), false);
+    file_esm_map.insert("dep.d.ts".to_string(), false);
+    checker.ctx.file_is_esm_map = Some(Arc::new(file_esm_map));
+    for (sym_id, file_idx) in &cross_file_targets {
+        checker.ctx.register_symbol_file_target(*sym_id, *file_idx);
+    }
+
+    let mut resolved_module_paths: FxHashMap<(usize, String), usize> = FxHashMap::default();
+    resolved_module_paths.insert((1, "./dep".to_string()), 0);
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+
+    let mut resolved_modules: FxHashSet<String> = FxHashSet::default();
+    resolved_modules.insert("./dep".to_string());
+    checker.ctx.set_resolved_modules(resolved_modules);
+
+    checker.check_source_file(root_main);
+
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+fn ts1259(diagnostics: &[(u32, String)]) -> Option<&str> {
+    diagnostics
+        .iter()
+        .find(|(code, _)| *code == 1259)
+        .map(|(_, msg)| msg.as_str())
+}
+
+const DEP_VAR: &str = r#"
+declare const obj: { a: number };
+export = obj;
+"#;
+const MAIN_VAR: &str = r#"
+import obj from "./dep";
+export const a: number = obj.a;
+"#;
+
+#[test]
+fn commonjs_no_interop_reports_ts1259_with_esmoduleinterop_flag() {
+    let diagnostics =
+        diagnostics_for_default_import(DEP_VAR, MAIN_VAR, ModuleKind::CommonJS, false, false);
+    let msg = ts1259(&diagnostics).unwrap_or_else(|| {
+        panic!("expected TS1259 for default import of export= under CommonJS without interop, got: {diagnostics:#?}")
+    });
+    // CommonJS output (module < ES2015) → tsc suggests `esModuleInterop`.
+    assert!(
+        msg.contains("esModuleInterop"),
+        "TS1259 under CommonJS must suggest 'esModuleInterop', got: {msg:?}"
+    );
+    // tsc renders the module name as the bare basename, double-quoted.
+    assert!(
+        msg.contains("\"dep\""),
+        "TS1259 must render the module as '\"dep\"' (basename, quoted), got: {msg:?}"
+    );
+}
+
+#[test]
+fn esmodule_target_no_interop_reports_ts1259_with_allowsynthetic_flag() {
+    // ES2015+ output → tsc suggests `allowSyntheticDefaultImports` instead.
+    let diagnostics =
+        diagnostics_for_default_import(DEP_VAR, MAIN_VAR, ModuleKind::ES2022, false, false);
+    let msg = ts1259(&diagnostics).unwrap_or_else(|| {
+        panic!("expected TS1259 for default import of export= under ES2022 without interop, got: {diagnostics:#?}")
+    });
+    assert!(
+        msg.contains("allowSyntheticDefaultImports"),
+        "TS1259 under ES2015+ must suggest 'allowSyntheticDefaultImports', got: {msg:?}"
+    );
+}
+
+#[test]
+fn esmoduleinterop_suppresses_ts1259() {
+    let diagnostics =
+        diagnostics_for_default_import(DEP_VAR, MAIN_VAR, ModuleKind::CommonJS, true, false);
+    assert!(
+        ts1259(&diagnostics).is_none(),
+        "esModuleInterop must suppress TS1259, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn allow_synthetic_default_imports_suppresses_ts1259() {
+    let diagnostics =
+        diagnostics_for_default_import(DEP_VAR, MAIN_VAR, ModuleKind::CommonJS, false, true);
+    assert!(
+        ts1259(&diagnostics).is_none(),
+        "allowSyntheticDefaultImports must suppress TS1259, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn export_equals_class_target_reports_ts1259() {
+    // The `export =` target shape (here a class) does not change the rule: a
+    // default import still requires interop. Vary the binder names so the fix
+    // cannot key on the user-chosen identifier.
+    let dep = r#"
+declare class Widget {
+    constructor(value: number);
+    value: number;
+}
+export = Widget;
+"#;
+    let main = r#"
+import Widget from "./dep";
+export const w = new Widget(1);
+"#;
+    let diagnostics = diagnostics_for_default_import(dep, main, ModuleKind::CommonJS, false, false);
+    assert!(
+        ts1259(&diagnostics).is_some(),
+        "default import of export= class without interop must report TS1259, got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn export_equals_function_target_reports_ts1259_distinct_names() {
+    // Function target + a different identifier and parameter name: still TS1259.
+    let dep = r#"
+declare function compute(input: string): number;
+export = compute;
+"#;
+    let main = r#"
+import compute from "./dep";
+export const n: number = compute("x");
+"#;
+    let diagnostics = diagnostics_for_default_import(dep, main, ModuleKind::CommonJS, false, false);
+    assert!(
+        ts1259(&diagnostics).is_some(),
+        "default import of export= function without interop must report TS1259, got: {diagnostics:#?}"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes #14812. A default import of a CommonJS `export =` module (`import X from "m"`) binds a *synthetic* default that is only legal under `esModuleInterop` / `allowSyntheticDefaultImports`. Without either flag, `tsc` reports **TS1259**; tsz silently accepted it.

```ts
// dep.d.ts
declare const obj: { a: number };
export = obj;
// main.ts
import obj from "./dep";   // tsc: TS1259, tsz (before): accepted
```

## Structural rule
When a module's only default-like binding is an `export =` target and neither interop flag is enabled, `tsc` reports `TS1259`; tsz now does so through the checker import-member validation, delegating to the solver-backed `emit_no_default_export_error` gateway.

## Root cause / owner
`has_default_binding` — and the default-binding fast path it relies on (whose `resolve_export_from_table` maps `"default"` → the `export =` target) — treats an `export =` entry as an **unconditional** default provider, so the interop-gated TS1259 branch in `emit_no_default_export_error` was never reached for a plain default import. The default-import check (`crates/tsz-checker/src/declarations/import/core/import_members.rs`) now detects `export =` (resolved-target arena scan + binder export tables, behind the cheap interop guard) and delegates to that authoritative function, which already owns the full TS1259/TS1192 suppression matrix (node-module synthetic defaults, ESM-extension and js-with-esm targets). An `export =` module cannot also carry a real `default` export (TS2309), so delegating never masks a genuine default.

## Display parity
The TS1259 message now matches `tsc`: the module renders as the bare quoted basename (`Module '"dep"'`), and the suggested flag is selected by module kind — `esModuleInterop` for CommonJS/AMD/UMD output (module < ES2015), `allowSyntheticDefaultImports` for ES2015+ — via a new shared `synthetic_default_import_flag_name` helper now also reused by the TS2497 elaboration (removes a duplicated module-kind switch).

## Adjacent matrix / anti-hardcoding
New tests cover variable / class / function `export =` targets, **varied binder names** (no name-keyed logic), both module kinds, and the interop / `allowSyntheticDefaultImports` suppression controls. Note: tsz defaults `esModuleInterop` to `true` (tsc 6.0 behavior), so the diagnostic correctly appears only when interop is explicitly disabled — verified both directions.

Goal: hold

## Verification
- `cargo test -p tsz-checker --test export_equals_default_import_interop_ts1259_tests` — 6/6 pass
- Regression sweep (no new failures; pre-existing unrelated failures confirmed on clean tree): `node_esm_default_import_export_equals_callable_tests`, `commonjs_module_export_alias_tests`, `export_default_interface_type_import_tests`, `ts1203_node_esm_tests`, `isolated_modules_export_default_tests`, `jsdoc_import_default_and_named_tests`, `type_only_import_reexport_tests`
- `cargo clippy -p tsz-checker --tests` — clean
- CLI repro confirmed: `--module commonjs --esModuleInterop false` → TS1259 (`esModuleInterop`); `--module es2022 --esModuleInterop false` → TS1259 (`allowSyntheticDefaultImports`); interop on → clean

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Aw6HLjmQei4viTCCA4GPrr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aw6HLjmQei4viTCCA4GPrr)_