### PR TITLE
fix(checker): emit TS2312 when an interface extends a generic deferred alias base

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -710,6 +710,9 @@ path = "tests/reserved_await_multiple_ts1262_tests.rs"
 name = "interface_heritage_display_tests"
 path = "tests/interface_heritage_display_tests.rs"
 [[test]]
+name = "interface_extends_generic_deferred_base_ts2312_tests"
+path = "tests/interface_extends_generic_deferred_base_ts2312_tests.rs"
+[[test]]
 name = "ts2430_tests"
 path = "tests/ts2430_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/heritage.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage.rs
@@ -852,10 +852,26 @@ impl<'a> CheckerState<'a> {
                                                     &enclosing_type_params,
                                                 )
                                             });
-                                        if class_query::is_generic_mapped_type(
-                                            self.ctx.types,
-                                            symbol_type,
-                                        ) && args_reference_enclosing_type_param
+                                        // tsc's `isValidBaseType` rejects any generic
+                                        // deferred alias body that lacks the `Object`
+                                        // flag — a generic mapped type, a conditional
+                                        // (`T extends X ? A : B`), an indexed access
+                                        // (`T[keyof T]`), `keyof`, a union, etc. When
+                                        // such an alias is applied to the enclosing
+                                        // interface's own type parameters the base stays
+                                        // deferred and `instantiated_type` erases to
+                                        // `Error`/`Any`, so classify it from the
+                                        // un-instantiated alias body. A body that *is* a
+                                        // valid base (object/intersection of objects)
+                                        // never trips this, so an unrelated resolution
+                                        // failure is not masked as TS2312.
+                                        let body_is_invalid_base =
+                                            !crate::query_boundaries::class::is_valid_interface_base_type(
+                                                self.ctx.types,
+                                                symbol_type,
+                                            );
+                                        if body_is_invalid_base
+                                            && args_reference_enclosing_type_param
                                         {
                                             use crate::diagnostics::{
                                                 diagnostic_codes, diagnostic_messages,

--- a/crates/tsz-checker/tests/interface_extends_generic_deferred_base_ts2312_tests.rs
+++ b/crates/tsz-checker/tests/interface_extends_generic_deferred_base_ts2312_tests.rs
@@ -1,0 +1,185 @@
+//! TS2312 on an interface that extends a *generic deferred* alias base.
+//!
+//! Structural rule: an interface heritage base must resolve to an object type
+//! (or an intersection of object types) with statically known members. When an
+//! interface extends a generic type alias whose body is a deferred non-object
+//! type — a generic conditional (`T extends X ? A : B`), an indexed access
+//! (`T[keyof T]`), `keyof`, or a union — applied to the interface's own type
+//! parameters, the base stays deferred and `tsc` reports TS2312
+//! ("An interface can only extend an object type or intersection of object
+//! types with statically known members").
+//!
+//! tsz previously accepted these silently: the heritage validation classified
+//! a *generic mapped* alias body but not a generic conditional / indexed-access
+//! / `keyof` / union body, and the deferred base erased to `Error`, so the
+//! whole heritage clause was skipped. The check now classifies any
+//! non-object alias body via the shared `is_valid_interface_base_type`
+//! gateway, not just the mapped case.
+//!
+//! The matrix varies the alias kind, binder names, and the
+//! generic-vs-concrete distinction so the rule is exercised structurally
+//! rather than for one fixture.
+
+use tsz_checker::test_utils::check_source_code_messages as diagnostics;
+
+const TS2312: u32 = 2312;
+
+fn ts2312_count(source: &str) -> usize {
+    diagnostics(source)
+        .into_iter()
+        .filter(|(code, _)| *code == TS2312)
+        .count()
+}
+
+// ───────────────────────── positive (must emit TS2312) ─────────────────────
+
+#[test]
+fn extends_generic_conditional_alias() {
+    let source = r#"
+type Cond<T> = T extends string ? { a: 1 } : { b: 2 };
+interface I<T> extends Cond<T> {}
+"#;
+    assert_eq!(
+        ts2312_count(source),
+        1,
+        "extends a generic conditional alias must emit TS2312"
+    );
+}
+
+#[test]
+fn extends_generic_conditional_alias_renamed_binders() {
+    // Same shape as above with different binder names — the rule is structural,
+    // not keyed on any identifier.
+    let source = r#"
+type Pick2<Elem> = Elem extends number ? { hit: 1 } : { miss: 0 };
+interface Box<Elem> extends Pick2<Elem> {}
+"#;
+    assert_eq!(
+        ts2312_count(source),
+        1,
+        "renamed binders must not change the TS2312 outcome"
+    );
+}
+
+#[test]
+fn extends_generic_indexed_access_alias() {
+    let source = r#"
+type Values<T> = T[keyof T];
+interface I<T> extends Values<T> {}
+"#;
+    assert_eq!(
+        ts2312_count(source),
+        1,
+        "extends a generic indexed-access alias must emit TS2312"
+    );
+}
+
+#[test]
+fn extends_generic_keyof_alias() {
+    let source = r#"
+type Keys<T> = keyof T;
+interface I<T> extends Keys<T> {}
+"#;
+    assert_eq!(
+        ts2312_count(source),
+        1,
+        "extends a generic keyof alias must emit TS2312"
+    );
+}
+
+#[test]
+fn extends_generic_union_alias() {
+    let source = r#"
+type Eith<T> = { a: T } | { b: T };
+interface I<T> extends Eith<T> {}
+"#;
+    assert_eq!(
+        ts2312_count(source),
+        1,
+        "extends a generic union alias must emit TS2312"
+    );
+}
+
+#[test]
+fn extends_generic_conditional_with_infer() {
+    let source = r#"
+type Elem<T> = T extends (infer U)[] ? { u: U } : {};
+interface I<T> extends Elem<T> {}
+"#;
+    assert_eq!(
+        ts2312_count(source),
+        1,
+        "extends a generic conditional with infer must emit TS2312"
+    );
+}
+
+// ───────────────────────── negative (must stay clean) ──────────────────────
+
+#[test]
+fn extends_concrete_conditional_resolving_to_object() {
+    // A concrete argument reduces the conditional to an object type, which is a
+    // valid base — no TS2312.
+    let source = r#"
+type Cond<T> = T extends string ? { a: 1 } : { b: 2 };
+interface I extends Cond<number> {}
+"#;
+    assert_eq!(
+        ts2312_count(source),
+        0,
+        "a concrete conditional resolving to an object is a valid base"
+    );
+}
+
+#[test]
+fn extends_generic_object_alias() {
+    let source = r#"
+type Obj<T> = { x: T };
+interface I<T> extends Obj<T> {}
+"#;
+    assert_eq!(
+        ts2312_count(source),
+        0,
+        "a generic object-shaped alias is a valid base"
+    );
+}
+
+#[test]
+fn extends_generic_array_alias() {
+    let source = r#"
+type Arr<T> = T[];
+interface I<T> extends Arr<T> {}
+"#;
+    assert_eq!(
+        ts2312_count(source),
+        0,
+        "a generic array alias is a valid (object) base"
+    );
+}
+
+#[test]
+fn extends_generic_interface_application() {
+    let source = r#"
+interface Base<T> { x: T }
+interface I<T> extends Base<T> {}
+"#;
+    assert_eq!(
+        ts2312_count(source),
+        0,
+        "a generic interface application is a valid base"
+    );
+}
+
+#[test]
+fn extends_mapped_over_concrete_object() {
+    // `Partial<{ x: T }>` is a homomorphic mapped type over a concrete object,
+    // which resolves to an object type with statically known members.
+    let source = r#"
+type P<T> = Partial<{ x: T }>;
+interface I<T> extends P<T> {}
+"#;
+    assert_eq!(
+        ts2312_count(source),
+        0,
+        "a mapped type over a concrete object is a valid base"
+    );
+}


### PR DESCRIPTION
## Summary

An interface heritage base must resolve to an object type (or an intersection of object types) with statically known members. When an interface extended a **generic deferred non-object** alias body applied to its own type parameters, tsz silently accepted it where `tsc` reports **TS2312**.

Witnesses (each `tsc`-error, previously tsz-clean):

```ts
type Cond<T> = T extends string ? { a: 1 } : { b: 2 };
interface I<T> extends Cond<T> {}     // generic conditional
type Values<T> = T[keyof T];
interface J<T> extends Values<T> {}   // indexed access
type Keys<T> = keyof T;
interface K<T> extends Keys<T> {}     // keyof
type Eith<T> = { a: T } | { b: T };
interface L<T> extends Eith<T> {}     // union
```

## Structural rule

When an interface heritage base resolves (through an alias applied to the enclosing interface's own type parameters) to a type that is **not** an object type / intersection of object types with statically known members — a generic conditional, indexed access, `keyof`, or union — `tsc` emits TS2312; tsz must too. Owner: checker heritage validation (`crates/tsz-checker/src/state/state_checking/heritage.rs`).

## Root cause / fix

Such a generic deferred base instantiates to `Error`, taking the error/any heritage branch. That branch classified only a generic **mapped** alias body (`is_generic_mapped_type`), so conditional/indexed-access/`keyof`/union bodies fell through silently. The fix generalizes the trigger to the shared structural gateway `is_valid_interface_base_type` (negated), so any non-object alias body is rejected like `tsc`, while a valid object/intersection base — and any **concrete** application that reduces to one (`extends Cond<number>`, `extends Partial<{ x: T }>`) — stays accepted. No new identifier/name/file-string literals drive the decision; it reuses the existing structural validity query.

## Adjacent-case matrix (new tests)

Positive (emit TS2312): generic conditional, conditional with `infer`, renamed binders, indexed access, `keyof`, union. Negative (stay clean): concrete conditional → object, generic object alias, generic array alias, generic interface application, mapped-over-concrete-object.

## Known residual

A same-file double generic-alias wrapper (`type D<T> = C<T>; interface I<T> extends D<T>` where `C` is a conditional) is still accepted: the body is an `Application(Lazy(C), …)` and `resolve_lazy` returns `None` for a generic alias, so the conditional body is not reached. Cross-file imported conditional aliases **are** caught. This is strictly narrower than the prior behavior and left for a focused follow-up rather than risking the over-broad `Application`-resolution path (a concrete `Partial<ConcreteObj>` must remain valid).

Goal: hold

## Verification

- `cargo test -p tsz-checker --test interface_extends_generic_deferred_base_ts2312_tests` — 11 new tests green.
- Interface/class/heritage test sweep (77 binaries): no new failures; the 3 failing binaries (`cross_file_generic_interface_mapped_filter_tests`, `cross_module_nested_interface_tests`, `declare_global_interface_keyof_merge_tests`) fail identically on clean `main` (pre-existing, unrelated).
- Differential check vs `tsc` 6.0.2 on the witness + negative matrix: tsz now matches `tsc` on every case.
- Broad conformance / emit / fourslash owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUbMPkoowngufPGUxZHqxD)_