### PR TITLE
fix(solver) #14345: bind HKT-Application placeholder to bare outer param in return-context (flag-ON)

### DIFF
--- a/crates/tsz-solver/src/operations/generic_call/return_context.rs
+++ b/crates/tsz-solver/src/operations/generic_call/return_context.rs
@@ -18,6 +18,25 @@ thread_local! {
         const { RefCell::new(None) };
 }
 
+/// #14345 HKT-Application unknown-drop flag (default-OFF, reuses
+/// `TSZ_TYPEPARAM_DECL_IDENTITY`). When OFF the `target_contains_untracked`
+/// relaxation below is never applied, so the return-context substitution is
+/// byte-identical to pre-#14345. Under the construction stamp a generic call's
+/// own type param (e.g. `Functor.map<A, B>`'s `B`, placeholder-renamed) and the
+/// OUTER-scope param it should bind to (e.g. the `B` of an enclosing
+/// `flap<F>(): <A>(a) => <B>(...) => HKT<F, B>`) intern to DISTINCT `DeclScoped`
+/// ids, so the call return `HKT<F, B_call>` and the contextual `HKT<F, B_outer>`
+/// are distinct Applications whose arg-by-arg match reaches `B_call` (a tracked
+/// placeholder) vs `B_outer` (a bare outer param). Flag-OFF those two `B`s are
+/// the SAME structural id, so the call return == the contextual type and the
+/// substitution binds `B` trivially; flag-ON the bind is blocked by the
+/// untracked-target guard and `B_call` collapses to `unknown` (`HKT<F, unknown>`).
+fn hkt_application_unknown_drop_fix_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("TSZ_TYPEPARAM_DECL_IDENTITY").is_ok_and(|v| v == "1"))
+}
+
 #[inline]
 fn with_return_context_visited<R>(f: impl FnOnce(&mut FxHashSet<TypeId>) -> R) -> R {
     let mut visited = RETURN_CONTEXT_VISITED_POOL
@@ -366,6 +385,25 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return;
         }
 
+        // #14345 (flag-ON only): a target that is a BARE outer-scope `DeclScoped`
+        // type parameter is a legitimate contextual binding, not nested-signature
+        // contamination. The `target_contains_untracked` guard keys on the
+        // tracked set (the call's placeholder-renamed param names), so an
+        // outer-scope param like the `B` of an enclosing `flap` reads as
+        // "untracked" and is rejected — leaving the call's own `B` (`source`, a
+        // tracked placeholder) with no binding, so it collapses to `unknown`
+        // inside the HKT Application (`HKT<F, unknown>`). Binding the placeholder
+        // to that single bare outer param recovers the flag-OFF identity (where
+        // both `B`s share one structural id and the bind is trivial) without
+        // relating distinct decls: it is a direct 1:1 param-to-param binding with
+        // no surrounding structure to contaminate. Restricted to a BARE target
+        // param so structured targets (Applications/unions that could carry a
+        // genuine nested-signature contaminant) keep the original guard.
+        let target_is_bare_outer_param = hkt_application_unknown_drop_fix_enabled()
+            && matches!(
+                self.interner.lookup(target),
+                Some(TypeData::TypeParameter(t)) if !tracked_type_params.contains(&t.name)
+            );
         if let Some(TypeData::TypeParameter(tp)) = self.interner.lookup(source)
             && tracked_type_params.contains(&tp.name)
             && target != TypeId::UNKNOWN
@@ -374,7 +412,10 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             // Don't insert if target contains untracked type parameters from
             // nested generic signatures (e.g., Promise.catch's TResult parameter
             // when matching through .then()). These would contaminate inference.
-            && !self.target_contains_untracked_type_params(target, tracked_type_params)
+            // A bare outer-scope param target is exempt (flag-ON): it is the
+            // contextual binding itself, not a nested contaminant.
+            && (target_is_bare_outer_param
+                || !self.target_contains_untracked_type_params(target, tracked_type_params))
             // Don't insert if target contains OTHER tracked type parameters.
             // This prevents incorrect mappings when both TResult1 and TResult2
             // from a source union would be mapped to the same target that


### PR DESCRIPTION
Stacks on #14895 (construction-stamp + scoped-strip, flag-OFF inert). Targets the #14345/#14351 flag-flip's bin-(ii) HKT-Application unknown-drop residual.

Goal: green

## Summary

#14345 HKT-Application unknown-drop: resolve a placeholder wrapped in an HKT application to its proper outer binding flag-ON, so DeclScoped distinctness no longer collapses it to `unknown`.

Under the construction stamp (`TSZ_TYPEPARAM_DECL_IDENTITY`) a generic call's own type param (e.g. `Functor.map<A, B>`'s `B`, placeholder-renamed during inference) and the OUTER-scope param it should bind to (e.g. the `B` of an enclosing `flap<F>(): <A>(a) => <B>(fab: HKT<F, (a: A) => B>) => HKT<F, B>`) intern to DISTINCT `DeclScoped` ids. The call return `HKT<F, B_call>` and the contextual `HKT<F, B_outer>` are then distinct Applications whose return-context arg-by-arg match reaches `B_call` (a tracked placeholder) against `B_outer` (a bare outer param). The `target_contains_untracked` guard keys on the call's placeholder-renamed tracked set, so `B_outer` reads as untracked contamination and the bind is rejected, leaving `B_call` with no candidate. It then collapses to `unknown` (`HKT<F, unknown>`) — the bin-(ii) regression. Flag-OFF the two `B`s share ONE structural id, so the call return is structurally identical to the contextual type and the bind is trivial; the regression is exposed only by the stamp's DeclScoped distinctness.

## Structural rule

When the return-context substitution matches a generic call's return-type template against the contextual type and reaches a tracked placeholder (source) against a BARE outer-scope type parameter (target), tsc binds the placeholder to that outer param (recovering the value the placeholder would otherwise infer); tsz now does the same through `collect_return_context_substitution` by exempting a bare non-tracked outer-scope param from the `target_contains_untracked_type_params` rejection (flag-ON only). A bare param target is the contextual binding itself — a direct 1:1 param-to-param bind with no surrounding structure to contaminate — not a nested-signature contaminant; structured targets (Applications/unions) keep the original guard so distinct decls are never related.

Owner layer: solver (generic-call return-context inference).

## Scope and residual

This clears the cleanest bin-(ii) witness (`Functor.ts(154)` `HKT<F, unknown>`) plus 6 adjacent HKT FPs (Map/ReadonlyMap/Array), with ZERO over-relate. It does NOT clear the full bin-(ii) family: 47 of 48 fp-ts regressions persist because they collapse through the PARAM-context / higher-order `pipe` inference paths (e.g. `(a: A) => unknown` contextual parameter types), a distinct site that does not minimize to a standalone witness (real-workload-only). Those remain the documented equiv-through-Application representation rework. The flag-flip is NOT yet viable from this change alone.

## Verification

- flag-OFF byte-parity: fp-ts flag-OFF unchanged (1475 loc+code, IDENTICAL to #14895 baseline). Conformance `types/` 844/844 + 481 family tests (typeInference/conditionalType/instantiate/keyofAndIndexed/mappedType/higherOrder/typeRelationships/genericFunction/inference/variance) all pass == flag-OFF baseline.
- flag-ON soundness (the make-or-break +16 over-relate gate): conformance `types/` 844/844 + 481 families IDENTICAL flag-ON vs flag-OFF — ZERO new `missing=` (over-relate), ZERO `extra=` (new FP).
- flag-ON improvement: fp-ts bin-(ii) regressions 49 -> 48 (cleared `Functor.ts(154)`), fixes 276 -> 282 (+6 newly-cleared HKT FPs, zero fixes lost), net loc+code 1248 -> 1241.
- determinism: fp-ts flag-ON md5 IDENTICAL across RAYON 1/4/8.
- crash: fp-ts flag-ON 8x, no crash, stable diag count.
- solver suite: same 4 pre-existing main-baseline fails at base and with this change; zero new.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
