### PR TITLE
fix(solver): treat infer bound by a generic signature as not-free in the assignability suppression gate (#14784)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1420,6 +1420,9 @@ mod satisfies_callback_return_widening_tests;
 #[path = "tests/satisfies_relation_routing_arch_tests.rs"]
 mod satisfies_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/self_referential_conditional_infer_soundness_tests.rs"]
+mod self_referential_conditional_infer_soundness_tests;
+#[cfg(test)]
 #[path = "tests/shadowed_type_param_identity_tests.rs"]
 mod shadowed_type_param_identity_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/self_referential_conditional_infer_soundness_tests.rs
+++ b/crates/tsz-checker/src/tests/self_referential_conditional_infer_soundness_tests.rs
@@ -1,0 +1,142 @@
+//! Regression coverage for issue #14784 — a self-referential generic-method
+//! conditional return whose `extends` clause carries an `infer` variable must
+//! not silence `TS2322` when the call result is assigned to a *different*
+//! instantiation of the same constructor.
+//!
+//! Structural rule: an `infer V` declared inside a *generic* signature's body
+//! (e.g. the conditional return `m<U>(): U extends … ? Box<T> : Box<T>`) is a
+//! definitional binder scoped to that signature/conditional, not a live
+//! transient inference placeholder. So an object type that merely *contains*
+//! such a method (a self-referential class `Box<T>` whose conditional branch
+//! re-includes `m`) must NOT be treated as carrying a free `infer`, which would
+//! wrongly route `should_suppress_assignability_diagnostic` into suppressing a
+//! real `TS2322`.
+//!
+//! The trigger requires the *intersection* of (a) an `infer` in the `extends`
+//! clause and (b) a self-referential class branch; with either removed tsz
+//! already reported correctly, so the controls below pin the boundary. The
+//! tuple `[infer V]` extends form keeps these lib-free (`check_source_strict`
+//! does not load lib).
+
+use crate::test_utils::{check_source_strict, diagnostic_count};
+
+fn ts2322_count(source: &str) -> usize {
+    diagnostic_count(&check_source_strict(source), 2322)
+}
+
+/// Reported repro (method form): assigning the `Box<number>` call result to
+/// `Box<string>` and to `string` must both error.
+#[test]
+fn self_ref_conditional_infer_method_assignment_errors() {
+    let source = r#"
+class Box<T> {
+  m<U>(f: (t: T) => U): U extends [infer V] ? Box<T> : Box<T> { return null as any; }
+}
+declare const b: Box<number>;
+const r = b.m(x => x);
+const bad1: Box<string> = r;
+const bad2: string = r;
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        2,
+        "self-ref conditional with infer must still report both TS2322s"
+    );
+}
+
+/// Same false-negative when `m` is an arrow-function class property rather than
+/// a method — the binder shape differs but the `infer` is still signature-bound.
+#[test]
+fn self_ref_conditional_infer_arrow_property_assignment_errors() {
+    let source = r#"
+class Box<T> {
+  m: <U>(f: (t: T) => U) => U extends [infer V] ? Box<T> : Box<T> = null as any;
+}
+declare const b: Box<number>;
+const r = b.m(x => x);
+const bad1: Box<string> = r;
+const bad2: string = r;
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        2,
+        "arrow-property form must report both TS2322s, like the method form"
+    );
+}
+
+/// Renamed binders (class param `K`, method param `W`, infer `Q`, value `boxed`)
+/// — the rule is structural, not tied to any identifier.
+#[test]
+fn self_ref_conditional_infer_renamed_binders_errors() {
+    let source = r#"
+class Container<K> {
+  pick<W>(g: (k: K) => W): W extends [infer Q] ? Container<K> : Container<K> { return null as any; }
+}
+declare const c: Container<number>;
+const boxed = c.pick(k => k);
+const wrong: Container<string> = boxed;
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "renamed binders must not change the structural outcome"
+    );
+}
+
+/// Control: with NO `infer` in the `extends` clause, tsz already reported — the
+/// fix must not change that.
+#[test]
+fn self_ref_conditional_without_infer_still_errors() {
+    let source = r#"
+class Box<T> {
+  m<U>(f: (t: T) => U): U extends [number] ? Box<T> : Box<T> { return null as any; }
+}
+declare const b: Box<number>;
+const r = b.m(x => x);
+const bad1: Box<string> = r;
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "no-infer control must still report TS2322"
+    );
+}
+
+/// Control: a non-self-referential sibling-class branch (`Other<T>`) with the
+/// same `infer` — tsz already reported, and must keep doing so.
+#[test]
+fn sibling_class_branch_with_infer_still_errors() {
+    let source = r#"
+class Other<T> { o!: T; }
+class Box<T> {
+  m<U>(f: (t: T) => U): U extends [infer V] ? Other<T> : Other<T> { return null as any; }
+}
+declare const b: Box<number>;
+const r = b.m(x => x);
+const bad1: Other<string> = r;
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "sibling-class branch with infer must still report TS2322"
+    );
+}
+
+/// Guard: a genuinely matching same-instantiation assignment must NOT error —
+/// the fix removes a false negative, it must not introduce a false positive.
+#[test]
+fn matching_same_instantiation_assignment_is_accepted() {
+    let source = r#"
+class Box<T> {
+  m<U>(f: (t: T) => U): U extends [infer V] ? Box<T> : Box<T> { return null as any; }
+}
+declare const b: Box<number>;
+const r = b.m(x => x);
+const ok: Box<number> = r;
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        0,
+        "assigning to the same instantiation must remain accepted"
+    );
+}

--- a/crates/tsz-solver/src/visitors/child_policy.rs
+++ b/crates/tsz-solver/src/visitors/child_policy.rs
@@ -140,9 +140,21 @@ impl ChildPolicy {
     /// `TypeParameter`/`Infer` is a leaf — structural `infer` patterns inside a
     /// parameter's `constraint`/`default` are definitional, not live inference
     /// variables.
+    ///
+    /// Generic signature bodies are also skipped (`skip_generic_signature_bodies`):
+    /// an `infer V` that appears inside a *generic* signature's body — e.g. the
+    /// conditional return `U extends Promise<infer V> ? X : Y` of a method
+    /// `m<U>(…)` — is bound within that signature's scope, exactly like the
+    /// signature's own `U`. It is a committed, definitional binder, not a live
+    /// transient inference placeholder, so a free-`infer` walk must treat it as
+    /// bound (mirrors [`Self::FREE_TYPE_PARAMS`]). Without this, an object type
+    /// that merely *contains* such a method (e.g. a self-referential class
+    /// `Box<T>` whose branch re-includes `m`) would be classified as carrying a
+    /// live inference placeholder, wrongly suppressing real `TS2322`/`TS2345`.
     pub const FREE_INFER: Self = Self {
         type_param_constraint: false,
         type_param_default: false,
+        skip_generic_signature_bodies: true,
         ..Self::CONTENT_PREDICATE
     };
 

--- a/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
@@ -745,4 +745,43 @@ mod tests {
         let plain_fn = interner.function(crate::types::FunctionShape::new(vec![], t_param));
         assert!(contains_free_type_parameters(&interner, plain_fn));
     }
+
+    /// Free-`infer` checks must skip the bodies of generic signatures: an
+    /// `infer V` inside a generic method's conditional return type (e.g.
+    /// `m<U>(): U extends … ? X : Y`) is a definitional binder scoped to that
+    /// signature/conditional, not a live transient inference placeholder. An
+    /// object type that merely contains such a method must not be classified as
+    /// carrying a free `infer`, or assignability diagnostics get wrongly
+    /// suppressed (issue #14784). A non-generic signature body still exposes it.
+    #[test]
+    fn free_infer_policy_skips_generic_signature_bodies() {
+        let interner = TypeInterner::new();
+        let u_name = interner.intern_string("U");
+        let v_name = interner.intern_string("V");
+        let u_param = interner.type_param(TypeParamInfo::simple(u_name));
+        let infer_v = interner.infer(TypeParamInfo::simple(v_name));
+        // `U extends infer V ? U : U` — a deferred conditional whose `extends`
+        // declares `infer V`.
+        let cond = interner.conditional(crate::types::ConditionalType {
+            check_type: u_param,
+            extends_type: infer_v,
+            true_type: u_param,
+            false_type: u_param,
+            is_distributive: false,
+        });
+
+        // A *generic* signature binds both its own `U` and the conditional's
+        // `infer V`; the free-infer walk treats the whole body as bound.
+        let generic_fn = interner.function(crate::types::FunctionShape {
+            type_params: vec![TypeParamInfo::simple(u_name)],
+            ..crate::types::FunctionShape::new(vec![], cond)
+        });
+        assert!(!contains_free_infer_types(&interner, generic_fn));
+        // The structural `infer` is still observable to the un-scoped walk.
+        assert!(contains_infer_types(&interner, generic_fn));
+
+        // A non-generic signature body still exposes the conditional's `infer`.
+        let plain_fn = interner.function(crate::types::FunctionShape::new(vec![], cond));
+        assert!(contains_free_infer_types(&interner, plain_fn));
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the soundness false negative in #14784. A self-referential generic class whose method has a conditional return that binds an `infer` in its `extends` clause silently accepted a call result assigned to a *different* instantiation of the same constructor:

```ts
class Box<T> {
  m<U>(f: (t: T) => U): U extends [infer V] ? Box<T> : Box<T> { return null as any; }
}
declare const b: Box<number>;
const r = b.m(x => x);          // Box<number>
const bad1: Box<string> = r;    // was silently accepted — tsc errors TS2322
const bad2: string = r;         // was silently accepted — tsc errors TS2322
```

## Wrong operation + structural rule

The result `r` is the structurally-expanded `Box<number>`, which **re-includes the method `m`** whose return type is the deferred conditional carrying `infer V`. The assignability diagnostic gate `should_suppress_assignability_diagnostic` (and `should_suppress_member_assignability`) calls `contains_free_infer_types(source)` to suppress `TS2322`/`TS2345` while *transient* inference placeholders are still present. That walk descended into the generic method signature body, found the conditional's `infer V`, and treated it as a live placeholder — wrongly suppressing the real diagnostic.

**Structural rule:** an `infer V` declared inside a *generic* signature's body is a definitional binder scoped to that signature/conditional, exactly like the signature's own `U` — not a live transient inference placeholder. So an object type that merely *contains* such a method must not be classified as carrying a free `infer`. This is the same principle the sibling `FREE_TYPE_PARAMS` / `FREE_PARAM_COLLECT` policies already encode (`skip_generic_signature_bodies: true`).

This precisely explains the issue's isolation matrix: with no `infer` (no placeholder found) or a non-self-referential branch (the branch's class does not re-include the infer-bearing method), tsz already reported correctly; only the *intersection* (self-ref branch + `infer`) triggered the suppression.

## Owner layer

Solver. `contains_free_infer_types` is the only consumer of the `FREE_INFER` child policy; it now sets `skip_generic_signature_bodies: true`. Bare `infer` leaves and **non-generic** signature bodies are still walked, so genuine transient placeholders remain detected. The change only narrows *diagnostic suppression* — it never makes a *relation* more permissive (no risk of a new false positive from the relation engine).

## Adjacent-case matrix (all covered by new tests)

- Method form and arrow-function class-property form (both witnessed FN)
- Renamed binders (rule is structural, not identifier-keyed)
- No-`infer` control — must still error
- Sibling-class (non-self-referential) branch with `infer` — must still error
- Matching same-instantiation assignment — must remain accepted (false-positive guard)

## Scope note

This PR fixes the **assignment / value-position** soundness FN (the issue's primary `bad1`/`bad2` witnesses) for both the method and arrow forms. The **argument-position TS2345** variant flows through a separate call-adapter relation path (the call argument check short-circuits before a structural relation query, distinct from diagnostic suppression) and is left for a focused follow-up rather than bundling a higher-risk core-relation change here. Tracking note added to #14784.

## Verification

- New solver unit test `free_infer_policy_skips_generic_signature_bodies` (crates/tsz-solver) — passes.
- New checker test module `self_referential_conditional_infer_soundness_tests` (6 cases above) — all pass.
- Existing `tsz-solver` `visitor_predicates` tests (incl. `free_infer_policy_skips_type_param_constraints`) — pass.
- Existing `tsz-checker` `suppress` suite (94 tests) — pass.
- `cargo clippy -p tsz-solver` and `-p tsz-checker --tests` — clean.
- 3 pre-existing `tsz-checker` failures in `recursive_conditional_infer_termination_tests` / `ts2589_tests::issue_9777` were confirmed failing on clean `main` (independent of this change).
- Broad conformance/emit/fourslash owned by ready-review CI.

Commands:
```
cargo test -p tsz-solver --lib free_infer_policy_skips_generic_signature_bodies
cargo test -p tsz-checker --lib self_referential_conditional_infer_soundness
cargo test -p tsz-checker --lib suppress
```

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01QojD7hgsSenGSte6zwpNer

---
_Generated by [Claude Code](https://claude.ai/code/session_01QojD7hgsSenGSte6zwpNer)_