### PR TITLE
fix(checker): detect global Object/Function target by full member set, not a prototype-name subset (#14849)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -1690,40 +1690,15 @@ fn is_global_object_or_function_shape(
     db: &dyn TypeDatabase,
     shape: &tsz_solver::ObjectShape,
 ) -> bool {
-    static OBJECT_PROTO: &[&str] = &[
-        "constructor",
-        "toString",
-        "toLocaleString",
-        "valueOf",
-        "hasOwnProperty",
-        "isPrototypeOf",
-        "propertyIsEnumerable",
-    ];
-    static FUNCTION_PROTO: &[&str] = &[
-        "apply",
-        "call",
-        "bind",
-        "toString",
-        "length",
-        "arguments",
-        "caller",
-        "prototype",
-        "constructor",
-        "toLocaleString",
-        "valueOf",
-        "hasOwnProperty",
-        "isPrototypeOf",
-        "propertyIsEnumerable",
-    ];
-
-    if shape.properties.is_empty() {
-        return false;
-    }
-
-    shape.properties.iter().all(|prop| {
-        let name = db.resolve_atom_ref(prop.name);
-        OBJECT_PROTO.contains(&name.as_ref()) || FUNCTION_PROTO.contains(&name.as_ref())
-    })
+    // Delegate to the canonical shared sniff (issue #13090), which requires the
+    // *full* distinguishing member set under a property-count cap. The previous
+    // local copy instead asked whether *every* property name was drawn from a
+    // merged Object/Function prototype list — a subset test, so a user type
+    // whose sole property is a prototype-member name (`{ length: number }`,
+    // `{ toString: number }`) was misclassified as the global interface and had
+    // its fresh-literal excess-property check (TS2353) suppressed (#14849).
+    tsz_solver::type_queries::object_shape_matches_global_object_interface(db, shape)
+        || tsz_solver::type_queries::object_shape_matches_global_function_interface(db, shape)
 }
 
 /// Explain a same-generic application failure (`C<A..>` vs `C<B..>`) via the

--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_02.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_02.rs
@@ -644,7 +644,12 @@ fn test_simple_object_epc_uses_boundary_classification() {
     );
 }
 
-/// The boundary must own the canonical `is_global_object_or_function_shape` logic.
+/// The boundary must own the `is_global_object_or_function_shape` entry point
+/// and delegate the actual recognition to the canonical `global_interfaces`
+/// sniff rather than maintaining its own divergent prototype-member name list.
+/// (A subset check over a hand-rolled name list misclassified user types such
+/// as `{ length: number }` / `{ toString: number }` as the global interface —
+/// see #14849 and the unifying `global_interfaces` module from #13090.)
 #[test]
 fn test_boundary_owns_global_object_function_shape_check() {
     let source = fs::read_to_string("src/query_boundaries/assignability.rs")
@@ -655,12 +660,19 @@ fn test_boundary_owns_global_object_function_shape_check() {
         "assignability.rs boundary must own is_global_object_or_function_shape"
     );
     assert!(
-        source.contains("OBJECT_PROTO"),
-        "boundary must contain the canonical Object.prototype property list"
+        source.contains("object_shape_matches_global_object_interface"),
+        "boundary must delegate Object recognition to the canonical \
+         global_interfaces sniff (no local prototype-name list)"
     );
     assert!(
-        source.contains("FUNCTION_PROTO"),
-        "boundary must contain the canonical Function.prototype property list"
+        source.contains("object_shape_matches_global_function_interface"),
+        "boundary must delegate Function recognition to the canonical \
+         global_interfaces sniff (no local prototype-name list)"
+    );
+    assert!(
+        !source.contains("OBJECT_PROTO") && !source.contains("FUNCTION_PROTO"),
+        "boundary must not reintroduce a hand-rolled prototype-member name list; \
+         the subset check it enabled misclassified user types (#14849)"
     );
 }
 

--- a/crates/tsz-checker/tests/conformance_issues/types/apparent_member_excess_14849.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/apparent_member_excess_14849.rs
@@ -1,0 +1,132 @@
+//! Fresh-object-literal excess-property checking (TS2353) must not be
+//! suppressed when the target's property happens to share a name with an
+//! `Object.prototype` / `Function.prototype` member (#14849).
+//!
+//! Root cause: `query_boundaries::assignability::is_global_object_or_function_shape`
+//! recognized the global `Object`/`Function` interface with a *subset* check
+//! over a merged prototype-member name list (`length`, `toString`, `valueOf`,
+//! `constructor`, `toLocaleString`, `hasOwnProperty`, `isPrototypeOf`,
+//! `propertyIsEnumerable`). A user object type whose sole property was one of
+//! those names — `{ length: number }`, `{ toString: number }` — was therefore
+//! misclassified as the global interface and had its excess-property check
+//! suppressed (reported TS2345 over the whole argument, or nothing on the
+//! assignment path, instead of tsc's TS2353 at the offending property).
+//!
+//! The boundary now delegates to the canonical `global_interfaces` sniff, which
+//! requires the *full* distinguishing member set under a property-count cap, so
+//! these user types are no longer mistaken for the global interface.
+
+use super::super::core::*;
+
+/// Every name in the historical trigger set, when it is the sole property of a
+/// plain object target, must still flag a fresh-literal excess sibling as
+/// TS2353 — exactly like an ordinary property name does.
+#[test]
+fn fresh_literal_excess_against_apparent_member_target_reports_ts2353() {
+    // Apparent-member names (the bug's exact trigger set) paired with a varied
+    // excess sibling name, so the assertion is structural rather than keyed to a
+    // single fixture string.
+    let cases = [
+        ("length", "extra"),
+        ("toString", "zzz"),
+        ("valueOf", "other"),
+        ("constructor", "spurious"),
+        ("toLocaleString", "leftover"),
+        ("hasOwnProperty", "stray"),
+        ("isPrototypeOf", "bonus"),
+        ("propertyIsEnumerable", "surplus"),
+    ];
+    for (member, excess) in cases {
+        let source = format!(
+            "declare function accept(value: {{ {member}: number }}): void;\n\
+             accept({{ {member}: 1, {excess}: 3 }});\n"
+        );
+        let diagnostics = compile_and_get_diagnostics(&source);
+        assert!(
+            has_error(&diagnostics, 2353),
+            "expected TS2353 for excess `{excess}` against `{{ {member}: number }}`, \
+             got {diagnostics:#?}"
+        );
+        assert!(
+            !has_error(&diagnostics, 2345),
+            "excess against an apparent-member target must elaborate to TS2353, \
+             not a whole-argument TS2345 (member `{member}`): {diagnostics:#?}"
+        );
+        let message = diagnostic_message(&diagnostics, 2353).unwrap_or_default();
+        assert!(
+            message.contains(excess),
+            "TS2353 must name the offending excess property `{excess}`: {message}"
+        );
+    }
+}
+
+/// The same divergence on the assignment path: previously the apparent-member
+/// target produced no diagnostic at all (the excess check was skipped after a
+/// structurally-successful relation). It must now report TS2353.
+#[test]
+fn assignment_to_apparent_member_target_reports_excess_ts2353() {
+    let diagnostics = compile_and_get_diagnostics(
+        "const widget: { length: number } = { length: 1, caption: 'x' };\n",
+    );
+    assert!(
+        has_error(&diagnostics, 2353),
+        "fresh literal assigned to `{{ length: number }}` must flag excess `caption`: {diagnostics:#?}"
+    );
+}
+
+/// Control: a non-apparent property name has always reported TS2353 — it must
+/// keep doing so (the fix changes only the misclassified apparent-member case).
+#[test]
+fn fresh_literal_excess_against_ordinary_target_still_reports_ts2353() {
+    let diagnostics = compile_and_get_diagnostics(
+        "declare function accept(value: { id: number }): void;\n\
+         accept({ id: 1, zzz: 3 });\n",
+    );
+    assert!(has_error(&diagnostics, 2353), "{diagnostics:#?}");
+}
+
+/// Control: the relation itself is fine. Routing the same value through a
+/// non-fresh variable must not produce an excess error — confirming the fix is
+/// scoped to the fresh-literal excess path, not the underlying subtype check.
+#[test]
+fn non_fresh_variable_with_apparent_member_target_has_no_excess_error() {
+    let diagnostics = compile_and_get_diagnostics(
+        "declare function accept(value: { length: number }): void;\n\
+         const source = { length: 1, zzz: 3 };\n\
+         accept(source);\n",
+    );
+    assert!(
+        !has_error(&diagnostics, 2353) && !has_error(&diagnostics, 2345),
+        "a non-fresh source is structurally assignable; no excess/relation error: {diagnostics:#?}"
+    );
+}
+
+/// Adjacent: a second, non-apparent property alongside the apparent one always
+/// reported TS2353 (the subset misclassification could not trigger). Guard that
+/// it is unchanged.
+#[test]
+fn apparent_member_with_extra_named_property_still_reports_excess() {
+    let diagnostics = compile_and_get_diagnostics(
+        "declare function accept(value: { length: number; label: string }): void;\n\
+         accept({ length: 1, label: 'a', zzz: 3 });\n",
+    );
+    assert!(has_error(&diagnostics, 2353), "{diagnostics:#?}");
+}
+
+/// Regression guard: the *real* global `Object` interface must still suppress
+/// excess-property checking — `Object` accepts any object literal, so passing
+/// `{ zzz: 3 }` to a `value: Object` parameter is not an error.
+#[test]
+fn real_global_object_target_still_skips_excess() {
+    if !lib_files_available() {
+        return;
+    }
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        "declare function accept(value: Object): void;\n\
+         accept({ zzz: 3 });\n",
+    );
+    assert!(
+        !has_error(&diagnostics, 2353),
+        "the global `Object` interface accepts arbitrary object literals (no excess check): {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -1,3 +1,4 @@
+mod apparent_member_excess_14849;
 mod computed_property_names;
 mod conditional_wrapper_alias_infer_14489;
 mod const_initializer_widening;


### PR DESCRIPTION
Fixes #14849.

## Problem

A fresh object literal whose excess property was passed/assigned to a target
type whose **only** property happened to share a name with an
`Object.prototype`/`Function.prototype` member was not getting the
property-level excess diagnostic (TS2353) that `tsc` reports. Instead `tsz`
reported a whole-argument TS2345 (call position) or silently accepted it
(assignment position).

```ts
declare function g(x: { length: number }): void;
g({ length: 1, zzz: 3 });
// tsz (before): TS2345 over the whole argument
// tsc / tsz (after): TS2353 'zzz' does not exist in type '{ length: number; }'
```

The exact trigger set was `length`, `toString`, `valueOf`, `constructor`,
`toLocaleString`, `hasOwnProperty`, `isPrototypeOf`, `propertyIsEnumerable` —
any other property name already produced the correct TS2353.

## Wrong operation + owner layer

`query_boundaries::assignability::is_global_object_or_function_shape`
recognized the global `Object`/`Function` interface with a **subset** check:
it returned true when *every* property name was drawn from a merged
Object+Function prototype name list. A user shape whose sole property was a
prototype-member name (`length` belongs to `Function`) therefore matched, was
classified as the global interface, and had its fresh-literal excess-property
elaboration short-circuited in `check_object_literal_excess_properties`.

## Structural rule

When a target's shape carries the **full distinguishing member set** of the
global `Object`/`Function` interface, `tsc` treats it as that wide interface
and skips excess checking; when it merely shares a prototype-member *name*, it
does not. `tsz` now decides this through the canonical shared `global_interfaces`
sniff (issue #13090): `Object` requires
`constructor`+`hasOwnProperty`+`isPrototypeOf`+`propertyIsEnumerable` under a
property-count cap, `Function` requires `apply`+`call`+`bind`. This removes the
divergent hand-rolled name list (an anti-hardcoding subset heuristic) and reuses
the same identity/structural recognizer the rest of the solver already uses.

The real global `Object`/`Function` shapes still match (they carry the full
member set), so legitimate excess-check suppression for `x: Object` is preserved
(regression-guarded with a `--lib` test).

## Adjacent matrix (all verified against the built `tsz`)

- All 8 apparent-member names as the sole target property → TS2353 at the
  offending property (call + assignment positions).
- Non-apparent control (`id`, `name`) → unchanged TS2353.
- Second non-apparent property alongside the apparent one → unchanged TS2353.
- Non-fresh source via a variable → no error (relation is fine; fix is scoped to
  the fresh-literal excess path).
- Wrong-typed apparent property, multiple excess props (reports first), and the
  JSDoc `@param {{ length: number }}` / `@template {{ length: number }} T` axes.
- Real `x: Object` target → excess still skipped; `x: Function` target with
  `{ zzz: 3 }` → TS2345 (genuinely lacks a call signature, matches `tsc`).

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- New regression suite `crates/tsz-checker/tests/conformance_issues/types/apparent_member_excess_14849.rs`
  (6 tests, structural — varies binder/property names): `cargo test -p tsz-checker
  --test conformance_issues_types -- apparent_member_excess_14849` → 6 passed.
- Updated architecture contract
  `architecture_contract_tests_src::part_02::test_boundary_owns_global_object_function_shape_check`
  to require delegation to the canonical sniff (no reintroduced name list) → ok.
- Regression sweep (all ok): `conformance_issues_types` (428), `conformance_issues_features`
  (370), `conformance_issues_errors` (296), `excess_property_check_recursive_intersection_tests`,
  `ts2353_omit_pick_excess_property_tests`, `intersection_target_missing_property_elaboration_tests`,
  solver `global_interfaces` unit tests, and
  `relations::subtype::core::intersection_optional_subtype_tests::test_global_object_interface_exempt_from_weak_type_check`.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib` no new warnings on changed files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UHC4SUsRbLDyQBWirq8G5P)_