### PR TITLE
fix(checker): emit TS2456 for tuple self-spread type aliases (#14815)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -590,6 +590,9 @@ path = "tests/jsx_import_source_namespace_tests.rs"
 name = "type_alias_namespace_merge_tests"
 path = "tests/type_alias_namespace_merge_tests.rs"
 [[test]]
+name = "tuple_spread_circular_alias_tests"
+path = "tests/tuple_spread_circular_alias_tests.rs"
+[[test]]
 name = "type_alias_typeof_circular_tests"
 path = "tests/type_alias_typeof_circular_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -251,6 +251,11 @@ impl<'a> CheckerState<'a> {
                     && !decl_has_parse_error;
                 let is_non_generic_mapped_cycle = params.is_empty()
                     && self.is_non_generic_mapped_type_circular(sym_id, type_alias.type_node);
+                // A non-array tuple spread that re-enters the alias forces
+                // resolution and is circular (`type T = [number, ...T]`), unlike
+                // a plain element or an array spread (`...T[]`), which defer.
+                let is_tuple_self_spread_cycle = params.is_empty()
+                    && self.tuple_alias_body_forces_resolution_chain(sym_id, type_alias.type_node);
                 let is_jsx_runtime_bridge_alias = self
                     .is_jsx_import_source_runtime_bridge_alias(decl_arena, type_alias.type_node);
                 let is_circular = circularity_eligible
@@ -266,7 +271,8 @@ impl<'a> CheckerState<'a> {
                     ) || self.ctx.circular_type_aliases.contains(&sym_id)
                         || (self.is_simple_type_reference(type_alias.type_node)
                             && self.is_cross_file_circular_alias(sym_id, alias_type))
-                        || is_non_generic_mapped_cycle);
+                        || is_non_generic_mapped_cycle
+                        || is_tuple_self_spread_cycle);
                 if is_circular && !self.has_parse_errors() {
                     use crate::diagnostics::{
                         diagnostic_codes, diagnostic_messages, format_message,
@@ -299,6 +305,7 @@ impl<'a> CheckerState<'a> {
                     // avoid SymbolId/arena collisions during driver-mode runs.
                     let body_is_deferred = self.alias_ast_is_deferred(sym_id)
                         && !is_non_generic_mapped_cycle
+                        && !is_tuple_self_spread_cycle
                         && !generic_self_circular;
                     if !file_has_any_parse_diag && !has_import_partner && !body_is_deferred {
                         let name = escaped_name;

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
@@ -57,6 +57,280 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// True when a type-alias body is a tuple whose self-reference forces
+    /// resolution of an on-resolution-chain alias, making the alias circularly
+    /// reference itself (TS2456).
+    ///
+    /// `tsc` defers tuple *element* resolution — `type T = [T]`, `type T = [T?]`,
+    /// and `type T = [number, T[]]` are all accepted — so a plain or optional
+    /// element never makes a tuple circular. A *spread* element is different:
+    /// splicing `...X` into the enclosing tuple forces `X` to be resolved to a
+    /// concrete tuple, and that forcing re-enters any alias `X` reaches. The
+    /// single exception is a spread whose operand is written directly as an
+    /// array type `...Y[]`: the array fast-path keeps `Y` deferred, so
+    /// `type T = [number, ...T[]]` stays acceptable.
+    ///
+    /// The walk runs over the body AST (never the possibly-collapsed body type)
+    /// and reports a hit when a non-array spread element forces resolution of an
+    /// alias in `symbol_resolution_set` (or `sym_id` itself). It deliberately
+    /// stops at generic instantiations (`Foo<...>`) and structural-deferral
+    /// wrappers, which create their own deferral boundary; those remain
+    /// (conservative) false negatives rather than risk a false positive.
+    pub(crate) fn tuple_alias_body_forces_resolution_chain(
+        &self,
+        sym_id: SymbolId,
+        body_node: NodeIndex,
+    ) -> bool {
+        let Some(tuple_idx) = self.unwrap_to_tuple_type(body_node) else {
+            return false;
+        };
+        let Some(node) = self.ctx.arena.get(tuple_idx) else {
+            return false;
+        };
+        let Some(tuple) = self.ctx.arena.get_tuple_type(node) else {
+            return false;
+        };
+        let mut visited = FxHashSet::default();
+        // Only spread elements force resolution; plain/optional elements defer.
+        tuple.elements.nodes.iter().any(|&element_idx| {
+            self.tuple_spread_element_operand(element_idx).is_some()
+                && self.forced_tuple_member_reaches_resolution_chain(
+                    sym_id,
+                    element_idx,
+                    &mut visited,
+                )
+        })
+    }
+
+    /// Unwrap parentheses and a `readonly` operator to reach a tuple type node.
+    fn unwrap_to_tuple_type(&self, type_node: NodeIndex) -> Option<NodeIndex> {
+        let inner = self.unwrap_parenthesized_type(type_node)?;
+        let node = self.ctx.arena.get(inner)?;
+        if node.kind == syntax_kind_ext::TUPLE_TYPE {
+            return Some(inner);
+        }
+        if node.kind == syntax_kind_ext::TYPE_OPERATOR
+            && let Some(op) = self.ctx.arena.get_type_operator(node)
+            && op.operator == SyntaxKind::ReadonlyKeyword as u16
+        {
+            return self.unwrap_to_tuple_type(op.type_node);
+        }
+        None
+    }
+
+    /// The operand of a tuple spread element (`...X` rest type or a `...`-marked
+    /// named tuple member), or `None` for a plain/optional element.
+    fn tuple_spread_element_operand(&self, element_idx: NodeIndex) -> Option<NodeIndex> {
+        let node = self.ctx.arena.get(element_idx)?;
+        if node.kind == syntax_kind_ext::REST_TYPE {
+            return self.ctx.arena.get_wrapped_type(node).map(|w| w.type_node);
+        }
+        if node.kind == syntax_kind_ext::NAMED_TUPLE_MEMBER
+            && let Some(member) = self.ctx.arena.get_named_tuple_member(node)
+            && member.dot_dot_dot_token
+        {
+            return Some(member.type_node);
+        }
+        None
+    }
+
+    /// The underlying type node of a plain (non-spread) tuple member, unwrapping
+    /// an optional element or a named member.
+    fn tuple_plain_member_type(&self, element_idx: NodeIndex) -> Option<NodeIndex> {
+        let inner = self.unwrap_parenthesized_type(element_idx)?;
+        let node = self.ctx.arena.get(inner)?;
+        if node.kind == syntax_kind_ext::OPTIONAL_TYPE {
+            return self.ctx.arena.get_wrapped_type(node).map(|w| w.type_node);
+        }
+        if node.kind == syntax_kind_ext::NAMED_TUPLE_MEMBER {
+            return self
+                .ctx
+                .arena
+                .get_named_tuple_member(node)
+                .map(|member| member.type_node);
+        }
+        Some(inner)
+    }
+
+    /// A tuple member encountered while a whole tuple is being forced (spliced).
+    /// A spread member re-enters the forcing walk and may follow an aliased
+    /// operand's body; a plain/optional member is forced without chasing an
+    /// off-chain alias into a structural body, matching `tsc`
+    /// (`type P = [...[Q]]; type Q = [P]` is accepted).
+    fn forced_tuple_member_reaches_resolution_chain(
+        &self,
+        sym_id: SymbolId,
+        element_idx: NodeIndex,
+        visited: &mut FxHashSet<SymbolId>,
+    ) -> bool {
+        if let Some(operand) = self.tuple_spread_element_operand(element_idx) {
+            // A directly-written array operand (`...Y[]`) keeps `Y` deferred.
+            if self.spread_operand_is_array(operand) {
+                return false;
+            }
+            return self.forced_position_reaches_resolution_chain(sym_id, operand, true, visited);
+        }
+        let Some(plain) = self.tuple_plain_member_type(element_idx) else {
+            return false;
+        };
+        self.forced_position_reaches_resolution_chain(sym_id, plain, false, visited)
+    }
+
+    /// True when `operand` (parenthesis-unwrapped) is written directly as an
+    /// array type `Y[]`, the one spread form `tsc` keeps deferred.
+    fn spread_operand_is_array(&self, operand: NodeIndex) -> bool {
+        self.unwrap_parenthesized_type(operand)
+            .and_then(|idx| self.ctx.arena.get(idx))
+            .is_some_and(|node| node.kind == syntax_kind_ext::ARRAY_TYPE)
+    }
+
+    /// Walk a type node at a forcing position — a tuple spread operand, a
+    /// spliced tuple element, or a generic type argument — returning true when
+    /// it reaches an alias on the current resolution chain.
+    ///
+    /// Splicing/instantiation forces arrays, tuples, unions, intersections, type
+    /// operators, and generic type arguments, so the walk descends through them.
+    /// It stops at structural-deferral wrappers (object/function/constructor/
+    /// mapped/conditional types), which keep their members deferred.
+    /// `follow_alias_hops` distinguishes the two forcing flavors: a tuple spread
+    /// operand resolves an aliased operand's whole body
+    /// (`type T = [...M]; type M = [T]`), whereas a spliced element or a type
+    /// argument does not chase an off-chain alias into a structural body
+    /// (`type P = [...[Q]]; type Q = [P]` stays acceptable).
+    fn forced_position_reaches_resolution_chain(
+        &self,
+        sym_id: SymbolId,
+        type_idx: NodeIndex,
+        follow_alias_hops: bool,
+        visited: &mut FxHashSet<SymbolId>,
+    ) -> bool {
+        let Some(idx) = self.unwrap_parenthesized_type(type_idx) else {
+            return false;
+        };
+        let Some(node) = self.ctx.arena.get(idx) else {
+            return false;
+        };
+        let kind = node.kind;
+        if kind == syntax_kind_ext::ARRAY_TYPE {
+            return self
+                .ctx
+                .arena
+                .get_array_type(node)
+                .map(|array| array.element_type)
+                .is_some_and(|element| {
+                    self.forced_position_reaches_resolution_chain(
+                        sym_id,
+                        element,
+                        follow_alias_hops,
+                        visited,
+                    )
+                });
+        }
+        if kind == syntax_kind_ext::TYPE_OPERATOR {
+            return self.ctx.arena.get_type_operator(node).is_some_and(|op| {
+                self.forced_position_reaches_resolution_chain(
+                    sym_id,
+                    op.type_node,
+                    follow_alias_hops,
+                    visited,
+                )
+            });
+        }
+        if kind == syntax_kind_ext::TUPLE_TYPE {
+            let Some(tuple) = self.ctx.arena.get_tuple_type(node) else {
+                return false;
+            };
+            return tuple.elements.nodes.iter().any(|&element| {
+                self.forced_tuple_member_reaches_resolution_chain(sym_id, element, visited)
+            });
+        }
+        if kind == syntax_kind_ext::UNION_TYPE || kind == syntax_kind_ext::INTERSECTION_TYPE {
+            return self.ctx.arena.get_children(idx).into_iter().any(|child| {
+                self.forced_position_reaches_resolution_chain(
+                    sym_id,
+                    child,
+                    follow_alias_hops,
+                    visited,
+                )
+            });
+        }
+        if kind == syntax_kind_ext::TYPE_REFERENCE || kind == SyntaxKind::Identifier as u16 {
+            return self.forced_reference_reaches_resolution_chain(
+                sym_id,
+                idx,
+                follow_alias_hops,
+                visited,
+            );
+        }
+        false
+    }
+
+    /// A type reference at a forcing position. A reference carrying type
+    /// arguments is a generic instantiation: its name is a new instantiation
+    /// boundary, but each argument is forced (without following an off-chain
+    /// alias hop). A bare reference is a hit when it names an on-chain alias, and
+    /// when `follow_alias_hops` it otherwise resolves an off-chain alias's body
+    /// once (cycle-guarded), since spreading an alias forces its declared type.
+    fn forced_reference_reaches_resolution_chain(
+        &self,
+        sym_id: SymbolId,
+        idx: NodeIndex,
+        follow_alias_hops: bool,
+        visited: &mut FxHashSet<SymbolId>,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(idx) else {
+            return false;
+        };
+        let name_idx = if node.kind == syntax_kind_ext::TYPE_REFERENCE {
+            let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
+                return false;
+            };
+            if let Some(args) = type_ref.type_arguments.as_ref() {
+                return args.nodes.iter().any(|&arg| {
+                    self.forced_position_reaches_resolution_chain(sym_id, arg, false, visited)
+                });
+            }
+            type_ref.type_name
+        } else {
+            idx
+        };
+        let Some(raw) = self.resolve_type_symbol_for_lowering(name_idx) else {
+            return false;
+        };
+        let target = SymbolId(raw);
+        if self.symbol_is_resolution_chain_alias(sym_id, target) {
+            return true;
+        }
+        if !follow_alias_hops {
+            return false;
+        }
+        if self
+            .ctx
+            .binder
+            .get_symbol(target)
+            .is_none_or(|symbol| symbol.flags & tsz_binder::symbol_flags::TYPE_ALIAS == 0)
+        {
+            return false;
+        }
+        if !visited.insert(target) {
+            return false;
+        }
+        let Some((_, body)) = self.type_alias_decl_parts(target) else {
+            return false;
+        };
+        self.forced_position_reaches_resolution_chain(sym_id, body, true, visited)
+    }
+
+    /// True when `target` is a type alias that is `sym_id` itself or otherwise
+    /// on the current resolution chain.
+    fn symbol_is_resolution_chain_alias(&self, sym_id: SymbolId, target: SymbolId) -> bool {
+        self.ctx
+            .binder
+            .get_symbol(target)
+            .is_some_and(|symbol| symbol.flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0)
+            && (target == sym_id || self.ctx.symbol_resolution_set.contains(&target))
+    }
+
     /// `(has_type_parameters, body_node)` for `sym_id`'s type-alias
     /// declaration, if it is a type alias with a declaration node.
     fn type_alias_decl_parts(&self, sym_id: SymbolId) -> Option<(bool, NodeIndex)> {
@@ -1501,7 +1775,9 @@ impl<'a> CheckerState<'a> {
                             // but keep TS2456 for non-generic mapped-type key
                             // cycles like `type T = { [K in keyof T]: ... }`.
                             let body_is_deferred = self.alias_ast_is_deferred(sym_id)
-                                && !self.is_non_generic_mapped_type_circular(sym_id, ta.type_node);
+                                && !self.is_non_generic_mapped_type_circular(sym_id, ta.type_node)
+                                && !self
+                                    .tuple_alias_body_forces_resolution_chain(sym_id, ta.type_node);
                             let is_jsx_runtime_bridge_alias = self
                                 .is_jsx_import_source_runtime_bridge_alias(
                                     self.ctx.arena,

--- a/crates/tsz-checker/tests/tuple_spread_circular_alias_tests.rs
+++ b/crates/tsz-checker/tests/tuple_spread_circular_alias_tests.rs
@@ -1,0 +1,121 @@
+//! Tests for TS2456 circular-type-alias detection through tuple spread
+//! elements.
+//!
+//! `tsc` defers tuple *element* resolution, so a plain or optional element
+//! never makes a tuple alias circular (`type T = [T]`, `type T = [T?]`, and
+//! `type T = [number, T[]]` are all accepted). A *spread* element is different:
+//! splicing `...X` into the enclosing tuple forces `X` to be resolved to a
+//! concrete tuple, re-entering any alias `X` reaches. The single exception is a
+//! spread whose operand is written directly as an array type `...Y[]`, which the
+//! array fast-path keeps deferred. These tests lock that behavior to match
+//! `tsc` 6.0.2, including renamed binders so no name-literal drives the logic.
+
+use tsz_checker::test_utils::check_source_codes as get_error_codes;
+
+fn assert_ts2456(src: &str) {
+    let codes = get_error_codes(src);
+    assert!(
+        codes.contains(&2456),
+        "Expected TS2456 (circularly references itself) for:\n{src}\ngot: {codes:?}"
+    );
+}
+
+fn assert_no_ts2456(src: &str) {
+    let codes = get_error_codes(src);
+    assert!(
+        !codes.contains(&2456),
+        "Expected no TS2456 for:\n{src}\ngot: {codes:?}"
+    );
+}
+
+#[test]
+fn direct_tuple_self_spread_is_circular() {
+    assert_ts2456("type T = [number, ...T];");
+}
+
+#[test]
+fn bare_tuple_self_spread_is_circular() {
+    assert_ts2456("type U = [...U];");
+}
+
+#[test]
+fn renamed_binder_self_spread_is_circular() {
+    // No dependence on a particular alias name.
+    assert_ts2456("type Rec = [string, ...Rec];");
+    assert_ts2456("type SomethingElse = [boolean, ...SomethingElse];");
+}
+
+#[test]
+fn named_tuple_member_self_spread_is_circular() {
+    assert_ts2456("type Named = [a: number, ...Named];");
+}
+
+#[test]
+fn readonly_tuple_self_spread_is_circular() {
+    assert_ts2456("type ReadonlyRec = readonly [number, ...ReadonlyRec];");
+}
+
+#[test]
+fn parenthesized_self_spread_is_circular() {
+    assert_ts2456("type SelfRef = [...(SelfRef)];");
+}
+
+#[test]
+fn nested_inline_tuple_self_spread_is_circular() {
+    // Splicing an inline tuple forces all of its elements.
+    assert_ts2456("type Y = [...[Y]];");
+    assert_ts2456("type X = [...[...X]];");
+    assert_ts2456("type V = [...[number, V]];");
+}
+
+#[test]
+fn alias_hop_self_spread_is_circular() {
+    // Spreading a bare alias resolves its declared body.
+    assert_ts2456("type ViaAlias = [...Alias2];\ntype Alias2 = ViaAlias;");
+    assert_ts2456("type Q = [...M];\ntype M = [Q];");
+}
+
+#[test]
+fn generic_array_self_spread_is_circular() {
+    // `Array<T>` / `ReadonlyArray<T>` are not the deferred `T[]` array fast-path,
+    // so the type argument is forced.
+    assert_ts2456("type T = [...Array<T>];");
+    assert_ts2456("type R = [number, ...ReadonlyArray<R>];");
+}
+
+#[test]
+fn array_wrapped_spread_is_not_circular() {
+    // The one deferred spread form: `...Y[]`.
+    assert_no_ts2456("type T2 = [number, ...T2[]];");
+    assert_no_ts2456("type RO = readonly [number, ...RO[]];");
+}
+
+#[test]
+fn plain_and_optional_tuple_elements_are_not_circular() {
+    assert_no_ts2456("type Self = [Self];");
+    assert_no_ts2456("type SelfOpt = [Self2?];\ntype Self2 = [Self2?];");
+}
+
+#[test]
+fn object_or_function_wrapped_spread_arg_is_not_circular() {
+    // A structural wrapper inside the forced operand defers its members.
+    assert_no_ts2456("type T = [...Array<{ next: T }>];");
+    assert_no_ts2456("type T = [...({ next: T })[]];");
+}
+
+#[test]
+fn alias_to_tuple_plain_element_is_not_circular() {
+    // A plain element behind an alias boundary defers (no forcing into the body).
+    assert_no_ts2456("type P = [...[Q]];\ntype Q = [P];");
+}
+
+#[test]
+fn non_self_spread_tuple_is_not_circular() {
+    assert_no_ts2456("type Ok = [number, ...Other];\ntype Other = [string, string];");
+}
+
+#[test]
+fn control_simple_self_alias_still_circular() {
+    // The pre-existing simple self-cycle path is unaffected.
+    assert_ts2456("type A = A;");
+}


### PR DESCRIPTION
Fixes #14815.

## Summary
A type alias whose body is a tuple with a **non-array spread of itself**
(`type T = [number, ...T]`, `type U = [...U]`) circularly references itself.
`tsc` reports `TS2456`; tsz silently accepted it — the alias collapsed to an
error type with no diagnostic.

## Structural rule
When a non-generic type-alias body is a tuple (optionally `readonly`) and one
of its elements is a spread `...X` whose operand `X` is **not** written directly
as an array type `Y[]`, `tsc` forces full resolution of `X`; if that forcing
re-enters an alias on the current resolution chain, the alias is circular
(`TS2456`). tsz emitted nothing because tuple bodies are treated as
unconditionally deferred. Owner layer: **checker** —
`crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs`.

`tsc` defers tuple *element* resolution, so a plain or optional element never
makes a tuple circular (`type T = [T]`, `type T = [T?]`). Only a *spread*
forces, because splicing a tuple needs its concrete elements. The single
deferred spread form is a syntactic array operand `...Y[]`, which keeps `Y`
deferred (`type T = [number, ...T[]]` stays acceptable).

## Implementation
`tuple_alias_body_forces_resolution_chain` walks the alias-body **AST** (never
the possibly-collapsed body type, mirroring tsc's syntactic rule). At a forcing
position it descends through arrays, nested tuples, unions/intersections, type
operators, and generic type arguments (forced on instantiation), follows bare
type-alias references into their bodies for spread operands, and stops at
structural-deferral wrappers (object/function/constructor/mapped/conditional
types) and at generic-instantiation argument boundaries. It is wired in as a
parallel circular disjunct with a `body_is_deferred` carve-out, mirroring the
existing non-generic mapped-type-cycle handling (`is_non_generic_mapped_cycle`).

## Adjacent-case matrix (verified against `tsc` 6.0.2)
| Body | tsc | tsz before | tsz after |
|---|---|---|---|
| `[number, ...T]` | TS2456 | — | TS2456 |
| `[...U]` / `[...(Self)]` | TS2456 | — | TS2456 |
| `[a: number, ...Named]` | TS2456 | — | TS2456 |
| `readonly [number, ...R]` | TS2456 | — | TS2456 |
| `[...[Y]]` / `[...[...X]]` | TS2456 | — | TS2456 |
| `[...M]; M = [Q]` (alias hop) | TS2456 | — | TS2456 |
| `[...Array<T>]` / `[...ReadonlyArray<T>]` | TS2456 | — | TS2456 |
| `[number, ...T[]]` (array spread) | OK | OK | OK |
| `[Self]` / `[Self?]` (plain/optional) | OK | OK | OK |
| `[...Array<{ next: T }>]` (wrapped) | OK | OK | OK |
| `[...[Q]]; Q = [P]` (alias-boundary defer) | OK | OK | OK |
| `type A = A` (control) | TS2456 | TS2456 | TS2456 |

No name-literal drives the logic — renamed binders (`Rec`, `SomethingElse`) are
covered by tests.

## Verification
- `cargo test -p tsz-checker --test tuple_spread_circular_alias_tests` (15 new
  cases, all green).
- Differential run vs `tsc` 6.0.2 over ~77 hand-built cases: **0 false
  positives**; the only remaining divergences are conservative false negatives
  (conditional-type spread operands and a contrived bare-alias chain), left
  deferred to avoid any false-positive risk.
- Regression: `type_alias_typeof_circular_tests`, `generic_self_circular_alias_tests`,
  `stable_identity_helpers_tests`, `recursive_alias_resolution_tests`,
  `cross_file_recursive_alias_intersection_tests`, and a broad set of
  `variadic_tuple_*` / `readonly_tuple_*` / `recursive_*` suites all pass
  (the two `recursive_type_references_tests` failures are pre-existing on
  `main`, unrelated to this change).
- `cargo clippy -p tsz-checker` clean.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01CGiFAYXJYkZYCLvPndQh3G

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGiFAYXJYkZYCLvPndQh3G)_