### PR TITLE
fix(checker): unwrap structural object-literal/type-alias thenables in await (#14813)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -428,6 +428,9 @@ path = "tests/await_call_identifier_diagnostics_tests.rs"
 name = "await_thenable_this_context_tests"
 path = "tests/await_thenable_this_context_tests.rs"
 [[test]]
+name = "await_structural_thenable_object_literal_tests"
+path = "tests/await_structural_thenable_object_literal_tests.rs"
+[[test]]
 name = "for_await_promise_array_tests"
 path = "tests/for_await_promise_array_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -637,10 +637,15 @@ impl<'a> CheckerState<'a> {
             };
         }
 
-        // Get call signatures of `then`
-        let Some(sigs) = query::call_signatures_for_type(self.ctx.types, then_type) else {
-            return ThenableAwaitInfo::default();
-        };
+        // Call signatures of `then`. A `then` declared as a *method* (the
+        // object-literal and `type`-alias thenable forms) lowers to a bare
+        // `Function` shape rather than a `Callable`, which `get_call_signatures`
+        // alone misses; `member_call_signatures` recovers either form so a
+        // structural thenable unwraps regardless of how `then` was declared —
+        // mirroring tsc's `getAwaitedType`, which inspects `then`/`onfulfilled`
+        // structurally, not by declaration form.
+        let sigs =
+            crate::query_boundaries::class::member_call_signatures(self.ctx.types, then_type);
         if sigs.is_empty() {
             return ThenableAwaitInfo::default();
         }

--- a/crates/tsz-checker/tests/await_structural_thenable_object_literal_tests.rs
+++ b/crates/tsz-checker/tests/await_structural_thenable_object_literal_tests.rs
@@ -1,0 +1,197 @@
+//! `await` must unwrap a *structural* thenable regardless of how the `then`
+//! member was declared. A `then(...)` declared as a **method** (object-literal
+//! type, `type` alias, or inline object-literal value) lowers to a bare
+//! `Function` shape, while a named `interface` lowers to a `Callable`; the
+//! awaited-type extractor previously only recognized the `Callable` form, so the
+//! method forms were left un-unwrapped and produced a false `TS2322`.
+//!
+//! Regression for #14813. Binder names are varied so the fix cannot rely on any
+//! identifier/alias string.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
+use tsz_common::common::ScriptTarget;
+
+fn await_diagnostics(source: &str) -> Vec<(u32, String)> {
+    let libs = load_default_lib_files();
+    assert!(!libs.is_empty(), "default lib files must be available");
+    check_source_with_libs_code_messages(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2022,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+}
+
+fn assert_no_2322(source: &str, label: &str) {
+    let diags = await_diagnostics(source);
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 2322),
+        "{label}: structural thenable must unwrap in `await` (no false TS2322). Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn await_object_literal_value_thenable_unwraps() {
+    // The inline object-literal value form: `then` is a method -> Function shape.
+    assert_no_2322(
+        r#"
+export {};
+async function run() {
+    const value = await { then(onFulfil: (payload: number) => void) {} };
+    const checked: number = value;
+    return checked;
+}
+"#,
+        "object-literal value thenable",
+    );
+}
+
+#[test]
+fn await_type_alias_method_thenable_unwraps() {
+    assert_no_2322(
+        r#"
+export {};
+type Settler = { then(onFulfil: (payload: number) => void): void };
+declare const settler: Settler;
+async function run() {
+    const value = await settler;
+    const checked: number = value;
+    return checked;
+}
+"#,
+        "type-alias (method) thenable",
+    );
+}
+
+#[test]
+fn await_type_alias_property_thenable_unwraps() {
+    // Property-style `then` (already a function-typed property) must keep working.
+    assert_no_2322(
+        r#"
+export {};
+type Settler = { then: (onFulfil: (payload: number) => void) => void };
+declare const settler: Settler;
+async function run() {
+    const value = await settler;
+    const checked: number = value;
+    return checked;
+}
+"#,
+        "type-alias (property) thenable",
+    );
+}
+
+#[test]
+fn await_anonymous_object_type_annotation_thenable_unwraps() {
+    assert_no_2322(
+        r#"
+export {};
+declare const settler: { then(onFulfil: (payload: number) => void): void };
+async function run() {
+    const value = await settler;
+    const checked: number = value;
+    return checked;
+}
+"#,
+        "anonymous object-type annotation thenable",
+    );
+}
+
+#[test]
+fn await_promise_of_alias_thenable_unwraps_recursively() {
+    // `Promise<Th>` where `Th` is itself an alias-thenable must unwrap to the
+    // inner payload, not stop at `Th`.
+    assert_no_2322(
+        r#"
+export {};
+type Settler = { then(onFulfil: (payload: number) => void): void };
+declare const wrapped: Promise<Settler>;
+async function run() {
+    const value = await wrapped;
+    const checked: number = value;
+    return checked;
+}
+"#,
+        "Promise<alias-thenable> recursive unwrap",
+    );
+}
+
+#[test]
+fn await_union_with_object_literal_thenable_unwraps_each_member() {
+    assert_no_2322(
+        r#"
+export {};
+declare const settler: { then(onFulfil: (payload: number) => void): void } | string;
+async function run() {
+    const value = await settler;
+    const checked: number | string = value;
+    return checked;
+}
+"#,
+        "union member object-literal thenable",
+    );
+}
+
+#[test]
+fn await_named_interface_thenable_still_unwraps_control() {
+    // Control: the already-working named-interface form must keep unwrapping.
+    assert_no_2322(
+        r#"
+export {};
+interface Settler { then(onFulfil: (payload: number) => void): void }
+declare const settler: Settler;
+async function run() {
+    const value = await settler;
+    const checked: number = value;
+    return checked;
+}
+"#,
+        "named-interface thenable control",
+    );
+}
+
+#[test]
+fn await_non_callable_then_member_does_not_unwrap() {
+    // Guard: a `then` that is not callable is NOT a thenable; the operand type
+    // must survive so assigning it to `number` still reports TS2322.
+    let diags = await_diagnostics(
+        r#"
+export {};
+declare const notThenable: { then: number };
+async function run() {
+    const value = await notThenable;
+    const checked: number = value;
+    return checked;
+}
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2322),
+        "non-callable `then` must not be treated as a thenable. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn await_plain_object_does_not_unwrap() {
+    // Guard: a plain object with no `then` must pass through unchanged.
+    let diags = await_diagnostics(
+        r#"
+export {};
+declare const plain: { payload: number };
+async function run() {
+    const value = await plain;
+    const checked: number = value;
+    return checked;
+}
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2322),
+        "plain object (no `then`) must not unwrap. Got: {diags:#?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #14813. `await` did not unwrap a *structural* thenable when its `then`
was declared as a **method** on an object-literal type, a `type` alias, or an
inline object-literal value — only the named `interface` form worked. The
operand was left un-unwrapped, producing a false `TS2322` (`Promise<{ then... }>`
not assignable to `Promise<number>`, etc.). `tsc` is clean on all these forms.

## Structural rule

When an operand exposes a callable `then` member whose `onfulfilled` callback's
first parameter is `T`, `tsc`'s `getAwaitedType` unwraps `await x` to `T`
**regardless of how `then` was declared**. tsz only matched it when `then`
resolved to a `Callable` shape. A `then` *method* lowers to a bare `Function`
shape, which `get_call_signatures` (and therefore the thenable extractor)
ignores, so the structural unwrap silently failed and the thenable survived.

## Fix and owner layer

Rule: when an await operand has a callable `then` member, tsc unwraps to its
`onfulfilled` payload; tsz now does so through the checker promise/await query
boundary. The awaited-type extractor (`extract_awaited_type_from_valid_thenable`
in `crates/tsz-checker/src/checkers/promise_checker.rs`) now sources `then`'s
signatures through the existing Function-aware
`query_boundaries::class::member_call_signatures` helper — the same
member-call-signature query interfaces/classes already use, which recovers both
the `Callable` and `Function` member forms — instead of the `Callable`-only
`get_call_signatures`. No new types are synthesized and the broadly-shared
`get_call_signatures` is left untouched (its ~17 callers in generic inference /
call resolution / `Judge` are deliberately not perturbed), so the change stays
scoped to the await/thenable path.

## Adjacent-case matrix (all now match tsc)

- object-literal value `await { then(cb:(x:number)=>void){} }` — fixed
- `type T = { then(cb):void }` (method) — fixed
- `type T = { then: (cb) => void }` (property) — fixed
- anonymous object-type annotation `declare const t: { then(cb):void }` — fixed
- `Promise<Th>` where `Th` is an alias-thenable — recursively unwraps to payload
- union `{ then(...) } | string` — each member unwrapped
- control (named `interface`, lib `Promise`/`PromiseLike`) — still unwraps
- guard: non-callable `then` (`{ then: number }`) — correctly does **not** unwrap
- guard: plain object (no `then`) — correctly does **not** unwrap

## Anti-hardcoding

No identifier/alias/file-name literals; the fix is a structural member-signature
query. The new test varies binder names (`Settler`, `payload`, `onFulfil`, ...).

## Verification

- New test (binder-name-varied matrix + guards):
  `cargo test -p tsz-checker --test await_structural_thenable_object_literal_tests`
  → 9 passed.
- Await/promise regression suites:
  `await_thenable_this_context_tests` (12), `awaited_generic_application_fold_tests` (8),
  `await_generic_non_promise_no_false_ts2339_tests` (4), `promise_callback_variance_tests` (8),
  `async_return_promise_identity_tests` (2), `for_await_promise_array_tests` (2),
  `no_lib_async_promise_tests` (2), `ts2852_await_using_context_tests` (6) → all pass.
- `cargo clippy -p tsz-checker --tests` → 0 warnings.
- Full conformance/emit/fourslash owned by ready-review CI.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
