### PR TITLE
fix(checker): collapse application-backed `P & {}` to bare primitive in diagnostics (#14834)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/primitive_intersection_display.rs
+++ b/crates/tsz-checker/src/error_reporter/primitive_intersection_display.rs
@@ -30,6 +30,53 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    /// When an application-backed intersection is `P & {}` — a single
+    /// non-nullable primitive `P` intersected only with empty object types
+    /// (`{}`) — tsc collapses it to the bare primitive `P`. This is the
+    /// `NonNullable<P>` shape (the lib defines `NonNullable<T> = T & {}`) and
+    /// any user helper of the form `type Helper<T> = T & {}`. The empty
+    /// `{}` co-member is identity on a non-nullable primitive, so the spelling
+    /// that survives is just the primitive.
+    ///
+    /// Returns the collapsed primitive display, or `None` when the
+    /// intersection has a real property-bag co-member (the branded #5195 case
+    /// `{ __brand: B }`) that must keep the expanded, capitalized spelling
+    /// (`Number & { __brand: B }`). Keying on the structural shape — an
+    /// empty-object co-member plus one primitive — rather than on the alias
+    /// name keeps `NonNullable<T>` and arbitrary `T & {}` helpers in sync
+    /// without inspecting any user-chosen identifier.
+    fn collapse_application_empty_object_intersection(
+        &mut self,
+        type_id: TypeId,
+    ) -> Option<String> {
+        let members =
+            crate::query_boundaries::common::intersection_members(self.ctx.types, type_id)?;
+        let mut had_empty_object = false;
+        let mut kept: Option<TypeId> = None;
+        for &member in members.iter() {
+            if crate::query_boundaries::common::is_empty_object_type(self.ctx.types, member) {
+                had_empty_object = true;
+            } else if kept.replace(member).is_some() {
+                // More than one non-empty member (e.g. `P & Q & {}`): not the
+                // `P & {}` identity shape, so leave the expanded form alone.
+                return None;
+            }
+        }
+        if !had_empty_object {
+            return None;
+        }
+        let primitive = kept?;
+        // Only collapse a genuinely non-nullable primitive — the wide
+        // intrinsics where `& {}` is a no-op and tsc prints the bare keyword.
+        if !crate::query_boundaries::common::is_widening_primitive_intrinsic(
+            self.ctx.types,
+            primitive,
+        ) {
+            return None;
+        }
+        Some(self.format_type_for_assignability_message(primitive))
+    }
+
     pub(in crate::error_reporter) fn application_backed_primitive_intersection_display(
         &mut self,
         type_id: TypeId,
@@ -49,6 +96,9 @@ impl<'a> CheckerState<'a> {
                     crate::query_boundaries::common::is_generic_application(self.ctx.types, alias)
                 })
         {
+            if let Some(collapsed) = self.collapse_application_empty_object_intersection(type_id) {
+                return Some(collapsed);
+            }
             return Some(self.format_intersection_expanding_application_alias(type_id));
         }
 
@@ -56,6 +106,10 @@ impl<'a> CheckerState<'a> {
             && evaluated != type_id
             && is_primitive_intersection(self, evaluated)
         {
+            if let Some(collapsed) = self.collapse_application_empty_object_intersection(evaluated)
+            {
+                return Some(collapsed);
+            }
             return Some(self.format_intersection_expanding_application_alias(evaluated));
         }
 

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -318,6 +318,12 @@ pub(crate) fn is_empty_object_type(db: &dyn TypeDatabase, type_id: TypeId) -> bo
     tsz_solver::is_empty_object_type(db, type_id)
 }
 
+/// True for the wide, non-nullable primitive intrinsics (`string`, `number`,
+/// `boolean`, `bigint`, `symbol`) — the ones whose `T & {}` brand is identity.
+pub(crate) fn is_widening_primitive_intrinsic(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::is_widening_primitive_intrinsic(db, type_id)
+}
+
 /// True when a type would render with a user-visible name (interface, class,
 /// type alias, type parameter, application, lazy ref, intrinsic, etc.). False
 /// for anonymous structural shapes like `{ p: number; q: string; }`. Used by

--- a/crates/tsz-checker/tests/intersection_primitive_member_assignability_tests.rs
+++ b/crates/tsz-checker/tests/intersection_primitive_member_assignability_tests.rs
@@ -163,6 +163,92 @@ fn branded_primitive_application_source_displays_structural_intersection_in_ts27
     );
 }
 
+/// `NonNullable<number>` (lib `type NonNullable<T> = T & {}`) applied to a
+/// non-nullable primitive must render as the bare primitive `number`, matching
+/// tsc — not the capitalized/expanded branded spelling `Number & {}`. The
+/// empty `{}` co-member is identity on a non-nullable primitive, so tsc
+/// collapses the application alias to the bare keyword.
+#[test]
+fn nonnullable_primitive_application_collapses_to_bare_primitive() {
+    for (annot, expected) in [
+        ("NonNullable<number>", "number"),
+        ("NonNullable<string>", "string"),
+        ("NonNullable<boolean>", "boolean"),
+    ] {
+        let source = format!("declare const a: {annot};\nconst x: 0 = a;\n");
+        let diags = check_with_lib_strict(&source, true);
+        let ts2322 = messages_for_code(&diags, 2322);
+        assert!(
+            ts2322
+                .iter()
+                .any(|m| m.contains(&format!("Type '{expected}' is not assignable"))),
+            "{annot} source should display bare `{expected}` in TS2322, got: {ts2322:?}"
+        );
+        assert!(
+            ts2322.iter().all(|m| !m.contains("& {}")),
+            "{annot} must not leave a residual `& {{}}` in the display, got: {ts2322:?}"
+        );
+    }
+}
+
+/// A user helper of the form `type Helper<T> = T & {}` exercises the same
+/// application-alias collapse without keying on the lib `NonNullable` name:
+/// the structural shape (generic application + empty-object co-member +
+/// primitive) is what drives the collapse. Renamed type parameters and
+/// helper names must not change the outcome.
+#[test]
+fn user_empty_object_application_helper_collapses_to_bare_primitive() {
+    let source = r#"
+        type MyNN<Wrapped> = Wrapped & {};
+        declare const a: MyNN<string>;
+        const x: 0 = a;
+        declare const b: MyNN<number>;
+        const y: 0 = b;
+    "#;
+    let diags = check_with_lib_strict(source, true);
+    let ts2322 = messages_for_code(&diags, 2322);
+    assert!(
+        ts2322
+            .iter()
+            .any(|m| m.contains("Type 'string' is not assignable")),
+        "user `Wrapped & {{}}` helper over string should display bare `string`, got: {ts2322:?}"
+    );
+    assert!(
+        ts2322
+            .iter()
+            .any(|m| m.contains("Type 'number' is not assignable")),
+        "user `Wrapped & {{}}` helper over number should display bare `number`, got: {ts2322:?}"
+    );
+    assert!(
+        ts2322
+            .iter()
+            .all(|m| !m.contains("& {}") && !m.contains("MyNN<")),
+        "collapsed application display must not leak `& {{}}` or the alias name, got: {ts2322:?}"
+    );
+}
+
+/// Control: a *source-written* `number & {}` annotation (no generic
+/// application alias) must keep printing lowercase `number & {}` — the
+/// branded-widening preservation is correct there, and the collapse only
+/// applies to the application-alias path. This is the line-4 control from
+/// the bug report.
+#[test]
+fn source_written_primitive_empty_object_intersection_keeps_lowercase_form() {
+    let source = "declare const b: number & {};\nconst y: 0 = b;\n";
+    let diags = check_with_lib_strict(source, true);
+    let ts2322 = messages_for_code(&diags, 2322);
+    assert!(
+        ts2322
+            .iter()
+            .any(|m| m.contains("Type 'number & {}' is not assignable")),
+        "source-written `number & {{}}` must keep lowercase `number & {{}}` display, got: {ts2322:?}"
+    );
+    assert!(
+        ts2322.iter().all(|m| !m.contains("Number & {}")),
+        "source-written control must never capitalize to `Number & {{}}`, got: {ts2322:?}"
+    );
+}
+
 /// `{ __typename?: 'TypeTwo' } & { a: boolean }` is NOT assignable to
 /// `{ __typename?: 'TypeOne' } & { a: boolean }` — the literal property
 /// types differ. Exercises the all-object intersection path (no primitive

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -274,13 +274,13 @@ pub use visitors::visitor::{
     is_merged_intersection_object, is_module_namespace_type, is_object_like_type,
     is_object_like_type_through_type_constraints, is_primitive_type, is_structurally_deferred_type,
     is_template_literal_type, is_this_type, is_tuple_type, is_type_parameter, is_type_query_type,
-    is_type_reference, is_union_type, keyof_inner_type, lazy_def_id, literal_number,
-    literal_string, literal_value, mapped_type_id, module_namespace_symbol_ref,
-    no_infer_inner_type, object_shape_id, object_with_index_shape_id, readonly_inner_type,
-    recursive_index, references_any_type_param_named, resolve_default_type_args,
-    string_intrinsic_components, template_literal_id, tuple_list_id, type_param_info,
-    type_query_symbol, union_list_id, unique_symbol_ref, unwrap_readonly_or_noinfer,
-    walk_referenced_types,
+    is_type_reference, is_union_type, is_widening_primitive_intrinsic, keyof_inner_type,
+    lazy_def_id, literal_number, literal_string, literal_value, mapped_type_id,
+    module_namespace_symbol_ref, no_infer_inner_type, object_shape_id, object_with_index_shape_id,
+    readonly_inner_type, recursive_index, references_any_type_param_named,
+    resolve_default_type_args, string_intrinsic_components, template_literal_id, tuple_list_id,
+    type_param_info, type_query_symbol, union_list_id, unique_symbol_ref,
+    unwrap_readonly_or_noinfer, walk_referenced_types,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #14834.

## Summary
`NonNullable<P>` (the lib defines `type NonNullable<T> = T & {}`) and any user helper of the form `type H<T> = T & {}`, applied to a non-nullable primitive, rendered in tsz diagnostics as the capitalized, expanded branded spelling `Number & {}` / `String & {}` instead of tsc's bare `number` / `string`. The empty `{}` co-member is identity on a non-nullable primitive, so tsc collapses the application alias to the bare keyword. Semantics were already correct (the value really is the primitive); this was display-only divergence on the **application-alias** path.

Before:
```
p_nn6.ts(2,7): error TS2322: Type 'Number & {}' is not assignable to type '0'.
```
After (matches tsc 5.9.3):
```
p_nn6.ts(2,7): error TS2322: Type 'number' is not assignable to type '0'.
```

## Structural rule
When an intersection that carries a generic-application display alias has exactly one non-empty-object member, and that member is a wide non-nullable primitive intrinsic (`string`/`number`/`boolean`/`bigint`/`symbol`), tsc displays the bare primitive; tsz now does the same through the checker `error_reporter` display layer (`application_backed_primitive_intersection_display` → new `collapse_application_empty_object_intersection`). The collapse is gated on the **structural shape** (generic-application alias + empty-object co-member + one widening primitive), not on any alias name, so the lib `NonNullable<T>` and arbitrary user `T & {}` helpers stay in sync. No user-chosen identifier, alias, or file-name string drives the decision.

## Owner layer
Checker `error_reporter` (diagnostic display). The solver is deliberately untouched: `crates/tsz-solver/src/intern/intersection.rs` preserves `string & {}` brands so unions like `(string & {}) | "literal"` keep their literal members — collapsing in the solver would break that and the source-written control. This is display-only policy, conditional on the application alias.

## Adjacent-case matrix
- `NonNullable<number>` → `number`, `NonNullable<string>` → `string`, `NonNullable<boolean>` → `boolean` (collapse).
- User `type MyNN<Wrapped> = Wrapped & {}` over `string`/`number` → bare primitive (renamed type param / helper name does not change the outcome — structural, not name-based).
- **Fallback / control (unchanged):** source-written `number & {}` annotation (no application alias) keeps lowercase `number & {}` — matches tsc.
- **Preserved branded case (unchanged):** genuine `number & { __brand: B }` (#5195) keeps the capitalized, expanded TS2739 spelling `Number & { __brand: ... }` — its co-member is a real property bag, not empty `{}`, so the collapse does not fire.

## Reuse
Reuses the existing `is_widening_primitive_intrinsic` solver predicate (re-exported through the checker `query_boundaries` boundary) instead of an inline primitive-id match — its doc already describes this exact `T & {}` branded-primitive idiom.

## Verification
- `cargo test -p tsz-checker --test intersection_primitive_member_assignability_tests` — 8 passed (3 new: `nonnullable_primitive_application_collapses_to_bare_primitive`, `user_empty_object_application_helper_collapses_to_bare_primitive`, `source_written_primitive_empty_object_intersection_keeps_lowercase_form`; existing branded TS2739 + commonTypeIntersection controls preserved).
- `cargo test -p tsz-checker --test conformance_issues_types branded_primitive` — 2 passed (branded-primitive idiom display unchanged).
- `cargo clippy -p tsz-checker -p tsz-solver --lib` — clean.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_014UfLDQTY81NXjSVQLcNDqU