### PR TITLE
fix(checker): collapse application-alias `T & {}` primitive to bare primitive in diagnostics (#14834)

### DIFF
--- a/crates/tsz-checker/tests/conformance_issues/types/mod.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/mod.rs
@@ -18,6 +18,7 @@ mod interface_merge_alias_application_2322;
 mod membership_semantics;
 mod narrowing;
 mod noinfer_intersection_transparency_14499;
+mod nonnullable_empty_object_display_14834;
 mod optional_chain;
 mod predicate_alias_typeof_2677_2304;
 mod spread_param_constraint_2345;

--- a/crates/tsz-checker/tests/conformance_issues/types/nonnullable_empty_object_display_14834.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/nonnullable_empty_object_display_14834.rs
@@ -1,0 +1,178 @@
+//! `NonNullable<T>` (and any user `type Helper<T> = T & {}`) applied to a
+//! non-nullable primitive must display in diagnostics as the bare primitive
+//! (`number` / `string` / `boolean`), matching tsc — not the boxed,
+//! capitalized intersection spelling `Number & {}` / `String & {}`.
+//!
+//! The `& {}` co-member is the identity element on a non-nullable primitive,
+//! so tsc collapses the application alias to the bare primitive. The genuine
+//! branded case (`number & { __brand: B }`, #5195) keeps the expanded,
+//! capitalized form and must remain unchanged. Source-written `number & {}`
+//! annotations also keep the lowercase intersection form in both compilers.
+//! (#14834)
+
+use super::super::core::*;
+
+/// `NonNullable<number>` assigned to a literal `0` target prints `number`,
+/// not `Number & {}`.
+#[test]
+fn nonnullable_number_displays_bare_primitive() {
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        r#"
+declare const a: NonNullable<number>;
+const x: 0 = a;
+"#,
+    );
+    let message = diagnostic_message(&diagnostics, 2322)
+        .expect("TS2322 expected for `NonNullable<number>` assigned to `0`");
+    assert!(
+        message.contains("Type 'number' is not assignable to type '0'"),
+        "`NonNullable<number>` source type must render as bare `number`, got: {message}"
+    );
+    assert!(
+        !message.contains("Number") && !message.contains('&'),
+        "must not render the boxed/expanded `Number & {{}}` spelling, got: {message}"
+    );
+}
+
+/// `NonNullable<string>` prints `string`.
+#[test]
+fn nonnullable_string_displays_bare_primitive() {
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        r#"
+declare const a: NonNullable<string>;
+const x: 0 = a;
+"#,
+    );
+    let message = diagnostic_message(&diagnostics, 2322)
+        .expect("TS2322 expected for `NonNullable<string>` assigned to `0`");
+    assert!(
+        message.contains("Type 'string' is not assignable to type '0'"),
+        "`NonNullable<string>` source type must render as bare `string`, got: {message}"
+    );
+}
+
+/// `NonNullable<boolean>` prints `boolean`.
+#[test]
+fn nonnullable_boolean_displays_bare_primitive() {
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        r#"
+declare const a: NonNullable<boolean>;
+const x: 0 = a;
+"#,
+    );
+    let message = diagnostic_message(&diagnostics, 2322)
+        .expect("TS2322 expected for `NonNullable<boolean>` assigned to `0`");
+    assert!(
+        message.contains("Type 'boolean' is not assignable to type '0'"),
+        "`NonNullable<boolean>` source type must render as bare `boolean`, got: {message}"
+    );
+}
+
+/// Null/undefined stripped: `NonNullable<string | null>` still collapses the
+/// surviving `string & {}` to bare `string`.
+#[test]
+fn nonnullable_strips_nullish_then_displays_bare_primitive() {
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        r#"
+declare const a: NonNullable<string | null>;
+const x: 0 = a;
+declare const b: NonNullable<number | undefined>;
+const y: 0 = b;
+"#,
+    );
+    let messages: Vec<&str> = diagnostics
+        .iter()
+        .filter(|(c, _)| *c == 2322)
+        .map(|(_, m)| m.as_str())
+        .collect();
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Type 'string' is not assignable to type '0'")),
+        "`NonNullable<string | null>` must render as bare `string`, got: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Type 'number' is not assignable to type '0'")),
+        "`NonNullable<number | undefined>` must render as bare `number`, got: {messages:?}"
+    );
+}
+
+/// Anti-hardcoding: a user-defined `T & {}` helper with a non-lib name must
+/// behave identically — the fix is structural (empty-object identity), not
+/// keyed on the `NonNullable` name.
+#[test]
+fn user_t_and_empty_object_helper_displays_bare_primitive() {
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        r#"
+type MyNN<T> = T & {};
+declare const a: MyNN<string>;
+const x: 0 = a;
+"#,
+    );
+    let message = diagnostic_message(&diagnostics, 2322)
+        .expect("TS2322 expected for `MyNN<string>` assigned to `0`");
+    assert!(
+        message.contains("Type 'string' is not assignable to type '0'"),
+        "user `T & {{}}` helper must render as bare `string`, got: {message}"
+    );
+}
+
+/// The collapse is display-only: the value really is the primitive, so
+/// assigning `NonNullable<string>` to `string` produces no error.
+#[test]
+fn nonnullable_primitive_remains_assignable_to_bare_primitive() {
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        r#"
+type MyNN<T> = T & {};
+declare const a: MyNN<string>;
+const s: string = a;
+declare const b: NonNullable<number>;
+const n: number = b;
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2322),
+        "`T & {{}}` of a primitive is assignable to the bare primitive; no TS2322 expected. \
+         Actual: {diagnostics:#?}"
+    );
+}
+
+/// Control 1: a source-written `number & {}` annotation keeps the lowercase
+/// intersection form (no application alias drives the boxed spelling).
+#[test]
+fn source_written_intersection_keeps_lowercase_form() {
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        r#"
+declare const b: number & {};
+const y: 0 = b;
+"#,
+    );
+    let message = diagnostic_message(&diagnostics, 2322)
+        .expect("TS2322 expected for `number & {}` assigned to `0`");
+    assert!(
+        message.contains("Type 'number & {}' is not assignable to type '0'"),
+        "source-written `number & {{}}` must keep the lowercase intersection form, got: {message}"
+    );
+}
+
+/// Control 2: the genuine branded primitive (#5195) keeps the expanded,
+/// capitalized intersection form, including the real property bag.
+#[test]
+fn genuine_branded_primitive_keeps_expanded_capitalized_form() {
+    let diagnostics = compile_and_get_diagnostics_with_lib(
+        r#"
+type Brand<B extends string> = number & { __brand: B };
+declare const u: Brand<"usd">;
+const w: { x: number } = u;
+"#,
+    );
+    let message = diagnostic_message(&diagnostics, 2741)
+        .expect("TS2741 expected — branded `number` is missing property `x`");
+    assert!(
+        message.contains("Number & { __brand: \"usd\"; }"),
+        "genuine branded primitive must keep the expanded `Number & {{ __brand: ... }}` form, \
+         got: {message}"
+    );
+}


### PR DESCRIPTION
## Summary
`NonNullable<T>` (= `T & {}`) and user `type Helper<T> = T & {}` aliases applied to a non-nullable primitive rendered in `TS2322` diagnostics as the boxed, capitalized intersection spelling `Number & {}` / `String & {}` instead of tsc's bare `number` / `string`. The `& {}` co-member is the identity element on a non-nullable primitive, so tsc collapses the application alias to the bare primitive. Fixes #14834.

This is **display-only**: the value really is the primitive (it stays assignable to the bare `string`/`number`), and the type-level intersection is deliberately left untouched.

### Structural rule
When an application-aliased intersection has a primitive member (`number`/`string`/`boolean`) and **every** non-primitive co-member is the empty object `{}`, the diagnostic display collapses to the bare primitive — matching tsc's `NonNullable<number> = number`.

When any non-primitive member is a real property bag (`number & { __brand: B }`, the #5195 branded case), the expanded, capitalized form (`Number & { __brand: "usd"; }`) is preserved unchanged.

### Owner layer
Checker display gate `application_backed_primitive_intersection_display` in `crates/tsz-checker/src/error_reporter/primitive_intersection_display.rs`. A new `application_alias_primitive_identity_collapse` helper pre-checks the intersection before invoking the formatter's capitalize/skip-alias path. The solver intentionally preserves the `string & {}` intersection at the type level (so `(string & {}) | "x"` keeps its literal members), so the collapse is correctly confined to the display layer — confirmed correct altitude by review.

### Adjacent matrix (all verified vs tsc 5.9.3)
- `NonNullable<number>` → `number`; `NonNullable<string>` → `string`; `NonNullable<boolean>` → `boolean`.
- `NonNullable<string | null>` / `NonNullable<number | undefined>` → bare `string` / `number` (nullish stripped, primitive collapses).
- User `type MyNN<T> = T & {}` helper (renamed binder, anti-hardcoding) → bare primitive — proves the rule is structural, not keyed on the `NonNullable` name.
- **Fallback / unchanged:** source-written `number & {}` annotation keeps lowercase `number & {}`; genuine branded `number & { __brand: B }` keeps `Number & { __brand: ... }` (`TS2741`).
- Display-only proof: `const s: string = a` where `a: MyNN<string>` emits no error in both compilers.

## Verification
- New regression module `crates/tsz-checker/tests/conformance_issues/types/nonnullable_empty_object_display_14834.rs` (8 tests, all green):
  `cargo test -p tsz-checker --test conformance_issues_types nonnullable_empty_object` → 8 passed.
- Branded-case guard unchanged: `cargo test -p tsz-checker --test intersection_primitive_member_assignability_tests` → 5 passed.
- Formatter parity unchanged: `cargo test -p tsz-solver --lib diagnostics::format` → 228 passed.
- Manual CLI repro (`--strict --target es2022 --lib es2022`) before/after confirms the four reported spellings now match tsc; the control and branded lines are byte-identical.
- 6 pre-existing `ts2322_tests` failures verified to also fail on base (`HEAD` with the source change stashed) — unrelated to this display-only change.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01HBdSjSydgLQpjqSgyUXavo

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBdSjSydgLQpjqSgyUXavo)_