### PR TITLE
fix(emit): hoist ES5 private storage out of non-CommonJS class IIFE (#14767)

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
@@ -621,3 +621,103 @@ class Conf {
         "auto-accessor storage must not trail after the static field.\nOutput:\n{output}"
     );
 }
+
+// Rule: at `--target es5`, a class with private storage but NO static private
+// member needs no class-value alias, so tsc hoists `var _C_x;` before the class
+// IIFE and runs `_C_x = new WeakMap();` after it (issue #14767). This applies to
+// every non-CommonJS class shape (plain script, ESM, non-exported); the CommonJS
+// export path already drove the same lift. Classes WITH a static private member
+// keep storage inside the IIFE alongside the `_a = C` alias.
+
+#[test]
+fn es5_instance_private_field_storage_hoists_around_iife() {
+    // The reported repro: a single instance private field.
+    let source = r#"
+class C {
+  #x = 1;
+  read() { return this.#x; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES5);
+    assert!(
+        output.contains("var _C_x;\nvar C = /** @class */"),
+        "WeakMap decl must be hoisted immediately before the IIFE.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("}());\n_C_x = new WeakMap();"),
+        "WeakMap init must run immediately after the IIFE.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_instance_private_field_storage_hoists_with_renamed_binders() {
+    // Same rule, different class/field spellings: the lift is structural, not
+    // keyed on the reported `C`/`#x` names.
+    let source = r#"
+class Widget {
+  #value = 1;
+  peek() { return this.#value; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES5);
+    assert!(
+        output.contains("var _Widget_value;\nvar Widget = /** @class */"),
+        "renamed WeakMap decl must hoist before the IIFE.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("}());\n_Widget_value = new WeakMap();"),
+        "renamed WeakMap init must run after the IIFE.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_instance_private_method_weakset_hoists_around_iife() {
+    // A private instance method adds a `_C_instances = new WeakSet()` brand and a
+    // `_C_m = function ...` slot. With no static private member they hoist out of
+    // the IIFE together with the field WeakMap, matching tsc.
+    let source = r#"
+class C {
+  #x = 1;
+  #m() { return this.#x; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES5);
+    assert!(
+        output.contains("var _C_instances, _C_x, _C_m;\nvar C = /** @class */"),
+        "instance method storage bundle must hoist before the IIFE.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "}());\n_C_x = new WeakMap(), _C_instances = new WeakSet(), _C_m = function _C_m()"
+        ),
+        "instance method storage inits must run after the IIFE.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es5_static_private_member_keeps_storage_inside_iife() {
+    // Counter-case: a static private member forces the `_a = C` class alias, so
+    // tsc keeps the whole storage bundle inside the IIFE. The lift must NOT fire.
+    let source = r#"
+class C {
+  static #s = 1;
+  read() { return C.#s; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES5);
+    let iife = output
+        .find("var C = /** @class */")
+        .expect("expected ES5 class IIFE");
+    let ret = output.find("return C;").expect("expected IIFE return");
+    let storage = output
+        .find("var _a, _C_s;")
+        .expect("expected in-IIFE storage decl");
+    assert!(
+        iife < storage && storage < ret,
+        "static private storage must stay inside the IIFE.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("var _a, _C_s;\nvar C ="),
+        "static private storage must not be hoisted before the IIFE.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/transforms/class_es5.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5.rs
@@ -730,7 +730,17 @@ impl<'a> ClassES5Emitter<'a> {
         override_name: Option<&str>,
         mut ir: IRNode,
     ) -> String {
-        if !self.externally_hoisted_decls.is_empty() {
+        // tsc hoists a class's private-field/method WeakMap/WeakSet storage out
+        // of the generated IIFE — `var _C_x;` before it and `_C_x = new WeakMap();`
+        // after it — whenever the class needs no class-value alias, i.e. it has no
+        // static private member. Classes WITH static private lowering keep their
+        // storage (and the `_a = C` class alias the static brand check depends on)
+        // inside the IIFE, also matching tsc. The CommonJS-export path requests the
+        // same lift through `externally_hoisted_decls`, which additionally relocates
+        // the `var` declaration to module scope.
+        if !self.externally_hoisted_decls.is_empty()
+            || !self.transformer.has_static_private_lowering()
+        {
             Self::lift_private_storage_from_iife_body(&mut ir);
         }
 

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
@@ -44,7 +44,7 @@ impl<'a> ES5ClassTransformer<'a> {
     /// Whether the class has any static private member (field, method, or
     /// accessor). Such members force a class-value alias and route private
     /// storage through the IIFE-local `var _a; ...` block.
-    pub(super) fn has_static_private_lowering(&self) -> bool {
+    pub(in crate::transforms) fn has_static_private_lowering(&self) -> bool {
         self.private_fields.iter().any(|field| field.is_static)
             || self.private_methods.iter().any(|method| method.is_static)
             || self


### PR DESCRIPTION
Fixes #14767.

## Summary
At `--target es5`, a class's private-field/method `WeakMap`/`WeakSet` storage was declared and initialized **inside** the generated IIFE for any class that is not a CommonJS named export (plain script, ESM, or non-exported). `tsc` instead hoists `var _C_x;` before the IIFE and runs `_C_x = new WeakMap();` after it. The field-only case still executed correctly but diverged byte-for-byte from `tsc`, and the storage was invisible to references outside the IIFE scope.

## Structural rule
When an ES5 class has private storage but **no static private member** — so no `_a = C` class-value alias is required — `tsc` hoists the storage out of the IIFE (`var` decl before, `= new WeakMap()/WeakSet()` init after). Classes **with** a static private member keep the storage and its `_a = C` alias inside the IIFE, because the static brand check depends on the alias referencing the local class binding.

tsz did the lift only on the CommonJS-export path, where `externally_hoisted_decls` is populated. That set is empty for non-CommonJS classes, so the lift was skipped.

## Owner layer
Emitter (`crates/tsz-emitter`). The fix decouples the existing `lift_private_storage_from_iife_body` from the CommonJS-only `externally_hoisted_decls` gate and instead also runs it when `!ES5ClassTransformer::has_static_private_lowering()` — a structural predicate over the class's collected private members (no name/file-string checks). The CommonJS path is unchanged; it still additionally relocates the `var` declaration to module scope.

## Adjacent-case matrix (all verified against `tsc 5.9.3 --target es5`)
- Instance private field (the reported repro) → hoisted.
- Instance private field with renamed binders (`Widget`/`#value`) → hoisted (proves the lift is structural, not keyed on the reported spelling).
- Instance private method → `_C_instances = new WeakSet()` + `_C_m = function ...` hoisted together with the field WeakMap.
- Static private member (counter-case) → storage and `_a = C` alias stay inside the IIFE; the lift does not fire.
- CommonJS-exported class → unchanged (still hoisted via `externally_hoisted_decls`).

Out of scope (noted in the issue as distinct, unfiled converter gaps): ES5 lowering of the private-`in` brand check `#x in o` to `__classPrivateFieldIn`.

## Verification
- `cargo test -p tsz-emitter --lib private_field_helper_order` — 25 passed (includes 4 new tests covering the matrix above and the existing `es5_private_name_bundle_stays_inside_plain_class_iife` static-private case, unchanged).
- `cargo test -p tsz-emitter --lib` — 3850 passed.
- Full `cargo test -p tsz-emitter` integration suite — no new failures (one pre-existing unrelated failure in `generator_object_literal_emit`, confirmed present on `main` before this change).
- `cargo clippy -p tsz-emitter --all-targets` — clean.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01YSaRBE52We6zTP4NShC4Ho

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSaRBE52We6zTP4NShC4Ho)_