### PR TITLE
fix(checker): infer open array for non-tuple array spread into a bare type-param rest (#14794)

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
@@ -870,6 +870,29 @@ impl<'a> CheckerState<'a> {
                                 effective_index += 1;
                                 continue;
                             }
+                            // The spread lands on a rest position. When that rest
+                            // parameter is a *bare type parameter* (`...args: T`),
+                            // its open-ended length feeds the inference variable
+                            // `T`; the open array must be preserved as a
+                            // spread-argument marker so rest-tuple inference
+                            // reconstructs `T` as the open `E[]` (variadic) rather
+                            // than collapsing the single representative element into
+                            // a fixed-length `[E]` tuple — which makes arity-
+                            // dependent reads (indexing, `.length`, fixed-tuple
+                            // assignment) spuriously fail (e.g. TS2493). This mirrors
+                            // the open-ended tuple-spread tail handled by
+                            // `preserve_open_tail` above. A plain array rest
+                            // (`...rest: E[]`) keeps the historical single-element
+                            // materialization, and a rest *tuple* (`...args: [...,
+                            // cb]`) keeps the aggregate-rest path; neither is
+                            // remarked here.
+                            if self.array_spread_rest_param_is_bare_type_param(
+                                callable_ctx.callable_type,
+                            ) {
+                                arg_types.push(self.spread_argument_marker_type(spread_type));
+                                effective_index += 1;
+                                continue;
+                            }
                             // Continue processing - push the element type for assignability checking
                             if let Some(elem_type) =
                                 array_element_type_for_type(self.ctx.types, spread_type)
@@ -1645,24 +1668,55 @@ impl<'a> CheckerState<'a> {
     /// type or rest parameter cannot be determined, fall back to the historical
     /// materialization (no marker).
     fn open_spread_tail_needs_marker(&self, callable_type: Option<TypeId>) -> bool {
-        let Some(callable_type) = callable_type else {
+        let Some(rest_type) = self.unwrapped_callable_rest_parameter_type(callable_type) else {
+            // No determinable rest parameter — fall back to the historical
+            // materialization (no marker).
             return false;
         };
-        // Inspect the *whole* declared rest-parameter type rather than indexing
-        // into it: `get_rest_parameter_type(index)` resolves a type-parameter rest
-        // to its constraint (`...args: T` -> `unknown[]`), which would look like a
-        // plain array and defeat the distinction. The rest parameter is the last
-        // parameter of the contextual signature.
-        let Some(rest_type) = self.callable_rest_parameter_type(callable_type) else {
-            return false;
-        };
-        let rest_type =
-            crate::query_boundaries::common::unwrap_readonly_or_noinfer(self.ctx.types, rest_type)
-                .unwrap_or(rest_type);
         let is_plain_array = array_element_type_for_type(self.ctx.types, rest_type).is_some()
             && tuple_elements_for_type(self.ctx.types, rest_type).is_none()
             && !is_type_parameter_type(self.ctx.types, rest_type);
         !is_plain_array
+    }
+
+    /// Whether a *bare non-tuple array/iterable* spread (`f(...arrayValue)`)
+    /// landing on this callable's rest parameter must be preserved as an
+    /// open-ended spread-argument marker.
+    ///
+    /// This is narrower than [`Self::open_spread_tail_needs_marker`]: it fires
+    /// only when the rest parameter is a *bare type parameter* (`...args: T`),
+    /// where the open array's indeterminate length directly feeds the inference
+    /// variable `T`. Without the marker, the single representative element
+    /// collapses `T` into a fixed-length `[E]` tuple, breaking every
+    /// arity-dependent read of the result (TS2493, `.length`, fixed-tuple
+    /// assignment). A plain array rest (`...rest: E[]`) needs no marker (its
+    /// element type is inferred positionally), and a rest *tuple* (`...args:
+    /// [..., cb]`) must keep the aggregate-rest path — marking it would compare
+    /// the whole array against the tuple and surface a spurious TS2345. When the
+    /// callee type or rest parameter cannot be determined, no marker is added.
+    fn array_spread_rest_param_is_bare_type_param(&self, callable_type: Option<TypeId>) -> bool {
+        self.unwrapped_callable_rest_parameter_type(callable_type)
+            .is_some_and(|rest_type| is_type_parameter_type(self.ctx.types, rest_type))
+    }
+
+    /// The callable's declared rest-parameter type with `readonly`/`NoInfer`
+    /// wrappers stripped, or `None` when the callee has no determinable rest
+    /// parameter.
+    ///
+    /// The *whole* declared rest-parameter type is inspected rather than indexing
+    /// into it: `get_rest_parameter_type(index)` resolves a type-parameter rest to
+    /// its constraint (`...args: T` -> `unknown[]`), which would look like a plain
+    /// array and erase the bare-type-parameter / rest-tuple / plain-array
+    /// distinction the spread-marker callers depend on.
+    fn unwrapped_callable_rest_parameter_type(
+        &self,
+        callable_type: Option<TypeId>,
+    ) -> Option<TypeId> {
+        let rest_type = self.callable_rest_parameter_type(callable_type?)?;
+        Some(
+            crate::query_boundaries::common::unwrap_readonly_or_noinfer(self.ctx.types, rest_type)
+                .unwrap_or(rest_type),
+        )
     }
 
     /// The declared type of the contextual signature's rest parameter (`...args`),

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -448,6 +448,9 @@ mod return_alias_unknown_eval_assignability_tests;
 #[path = "tests/return_relation_routing_arch_tests.rs"]
 mod return_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/spread_array_rest_param_inference_tests.rs"]
+mod spread_array_rest_param_inference_tests;
+#[cfg(test)]
 #[path = "../tests/spread_rest_diagnostics_tests.rs"]
 mod spread_rest_diagnostics_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/spread_array_rest_param_inference_tests.rs
+++ b/crates/tsz-checker/src/tests/spread_array_rest_param_inference_tests.rs
@@ -1,0 +1,187 @@
+//! Tests for issue #14794: spreading a non-tuple array (`E[]`) into a rest type
+//! parameter `...args: T` must infer `T = E[]` (open, variadic), never the
+//! length-1 tuple `[E]`.
+//!
+//! Structural rule: when a spread argument's value is a non-tuple array/iterable
+//! and it lands on a rest parameter whose open-ended length feeds an inference
+//! variable (a bare type-parameter rest `...args: T`, or a rest tuple), the spread
+//! must contribute an open-ended rest element (`...E[]`) to the synthetic argument
+//! tuple used for rest-parameter inference. Collapsing it into a single
+//! representative element makes `T` infer as a fixed-length `[E]`, so any
+//! arity-dependent read — out-of-bounds indexing (TS2493), `.length`, or
+//! fixed-tuple assignment — then diverges from `tsc`. Owner: the call-checker
+//! argument collector (`candidate_collection`), reusing the same
+//! spread-argument-marker mechanism already used for open-ended tuple-spread
+//! tails.
+//!
+//! Binder names are varied across the cases to prove the fix is structural and
+//! not keyed on any identifier.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn filtered(source: &str, wanted: &[u32]) -> Vec<u32> {
+    codes(source)
+        .into_iter()
+        .filter(|c| wanted.contains(c))
+        .collect()
+}
+
+/// The exact witness from the issue: indexing the result past element 0 must not
+/// produce TS2493 — `T` is `number[]`, not `[number]`.
+#[test]
+fn array_spread_into_rest_type_param_indexes_without_ts2493() {
+    let found = filtered(
+        r#"
+declare function apply<Args extends unknown[]>(...args: Args): Args;
+declare const xs: number[];
+const out = apply(...xs);
+const a = out[2];
+const b = out[5];
+"#,
+        &[2493],
+    );
+    assert!(
+        found.is_empty(),
+        "expected no TS2493 (result is number[], not [number]), got: {found:?}"
+    );
+}
+
+/// The inferred result is genuinely the open array `number[]`, not a length-1
+/// tuple: it is assignable to `number[]` but NOT to the fixed tuple `[number]`
+/// (which a length-1 tuple would satisfy). The TS2322 on the fixed-tuple target
+/// is the discriminator that proves the open-array shape.
+#[test]
+fn array_spread_into_rest_type_param_infers_open_array_not_fixed_tuple() {
+    let open = filtered(
+        r#"
+declare function collect<List extends unknown[]>(...items: List): List;
+declare const values: string[];
+const gathered = collect(...values);
+const asArray: string[] = gathered;
+"#,
+        &[2322],
+    );
+    assert!(
+        open.is_empty(),
+        "expected number[] result assignable to string[], got: {open:?}"
+    );
+
+    let fixed = filtered(
+        r#"
+declare function collect<List extends unknown[]>(...items: List): List;
+declare const values: string[];
+const gathered = collect(...values);
+const asFixed: [string] = gathered;
+"#,
+        &[2322],
+    );
+    assert!(
+        fixed.contains(&2322),
+        "expected open string[] result NOT assignable to fixed [string], got: {fixed:?}"
+    );
+}
+
+/// The `const`/`readonly` form (`...args: T`, `T extends readonly unknown[]`)
+/// behaves the same: the readonly array spread stays open, so out-of-bounds
+/// indexing is clean.
+#[test]
+fn readonly_array_spread_into_rest_type_param_indexes_without_ts2493() {
+    let found = filtered(
+        r#"
+declare function freeze<Tup extends readonly unknown[]>(...parts: Tup): Tup;
+declare const ro: readonly number[];
+const frozen = freeze(...ro);
+const x = frozen[3];
+"#,
+        &[2493],
+    );
+    assert!(
+        found.is_empty(),
+        "expected no TS2493 for readonly-array spread, got: {found:?}"
+    );
+}
+
+/// Regression: a *tuple* value spread still expands positionally, so `T` is the
+/// fixed tuple and per-position element types are preserved. The fixed-tuple
+/// target is assignable (no TS2322) and a real out-of-bounds index still errors.
+#[test]
+fn tuple_spread_still_expands_to_fixed_tuple() {
+    let assignable = filtered(
+        r#"
+declare function pack<Slots extends unknown[]>(...slots: Slots): Slots;
+declare const pair: [number, string];
+const packed = pack(...pair);
+const same: [number, string] = packed;
+"#,
+        &[2322],
+    );
+    assert!(
+        assignable.is_empty(),
+        "expected tuple spread to infer the fixed [number, string], got: {assignable:?}"
+    );
+
+    let oob = filtered(
+        r#"
+declare function pack<Slots extends unknown[]>(...slots: Slots): Slots;
+declare const pair: [number, string];
+const packed = pack(...pair);
+const beyond = packed[2];
+"#,
+        &[2493],
+    );
+    assert!(
+        oob.contains(&2493),
+        "expected TS2493 for a genuine out-of-bounds index on a fixed 2-tuple, got: {oob:?}"
+    );
+}
+
+/// Regression / negative control: a plain array rest parameter (`...rest: E[]`)
+/// carries no inference variable that depends on the spread's exact length, so a
+/// non-tuple array spread is accepted with no TS2556 and no TS2493 — the
+/// historical materialization is unchanged.
+#[test]
+fn plain_array_rest_parameter_accepts_array_spread() {
+    let found = filtered(
+        r#"
+declare function sink(...rest: number[]): void;
+declare const ns: number[];
+sink(...ns);
+"#,
+        &[2556, 2493, 2345],
+    );
+    assert!(
+        found.is_empty(),
+        "expected a plain array rest parameter to accept the array spread cleanly, got: {found:?}"
+    );
+}
+
+/// Regression: a generic *element* rest parameter (`...rest: E[]`) infers the
+/// element type `E` from the array element, independent of arity — the array
+/// spread must not be remarked here.
+#[test]
+fn generic_element_rest_parameter_infers_element_type() {
+    let found = filtered(
+        r#"
+declare function firstKind<E>(...rest: E[]): E;
+declare const ds: number[];
+const k = firstKind(...ds);
+const asNumber: number = k;
+const asString: string = k;
+"#,
+        &[2322],
+    );
+    // `E = number`: `number` target is clean, `string` target errors. Exactly one
+    // TS2322 proves the element type was inferred (not collapsed to a tuple).
+    assert_eq!(
+        found,
+        vec![2322],
+        "expected E inferred as number (one TS2322 on the string target), got: {found:?}"
+    );
+}


### PR DESCRIPTION
Fixes #14794.

## Summary
Spreading a **non-tuple array** (`E[]`) into a rest type parameter `...args: T`
made tsz infer `T = [E]` (a fixed length-1 tuple) instead of `T = E[]`. Every
arity-dependent read of the result then diverged from `tsc`: out-of-bounds
indexing emitted a spurious `TS2493`, `.length` narrowed to the literal `1`, and
the result was wrongly assignable to a fixed 1-tuple.

```ts
declare function f<T extends unknown[]>(...args: T): T;
const arr: number[] = [1, 2, 3];
const r = f(...arr);
const third = r[2]; // tsz: spurious TS2493; tsc: number  (now fixed)
```

## Structural rule
When a spread argument's value is a non-tuple array and it lands on a rest
parameter that is a **bare type parameter** (`...args: T`), the spread's
open-ended length feeds the inference variable `T`. The call-argument collector
(owner: `crates/tsz-checker/.../call_checker/candidate_collection.rs`) now
preserves the spread as a spread-argument marker (`[...E[]]`) rather than
collapsing it to a single representative element, so the existing rest-tuple
inference (`rest_tuple_inference_target` in `tsz-solver`) reconstructs `T` as the
open `E[]`.

## Owner layer / depth
The marker mechanism (`spread_argument_marker_type` →
`spread_argument_marker_inner` → `rest_tuple_inference_target`) already backs the
open-ended tuple-spread tail (`preserve_open_tail`) and the aggregate-rest path.
This change routes the bare-array case into that **same** path instead of adding
a new one — it is a peer to the existing tuple/aggregate branches, not a special
case.

The gate is deliberately narrow (`array_spread_rest_param_is_bare_type_param`):

- **plain array rest** (`...rest: E[]`) keeps positional element inference — no marker;
- **rest tuple** (`...args: [..., cb]`) keeps the aggregate-rest path, which runs
  *before* this branch — marking either would surface a spurious `TS2345`
  (this is exactly what an over-broad first attempt regressed, now guarded).

## Adjacent-case matrix (all in the new test module)
- out-of-bounds indexing → no `TS2493`;
- open-array vs fixed-tuple discriminator (assignable to `E[]`, **not** to `[E]`);
- `readonly`/`const` form (`T extends readonly unknown[]`);
- tuple spread still expands positionally (and a genuine OOB index still errors);
- plain-array-rest negative control (no marker, accepted cleanly);
- generic element-rest (`...rest: E[]`) negative control (still infers `E`).

Binder names are varied across the tests to keep the witnesses structural
(anti-hardcoding gate).

## Verification
- New module `spread_array_rest_param_inference_tests` (6 tests) — all pass:
  `cargo nextest run -p tsz-checker --lib -E 'test(spread_array_rest_param_inference)'`
- No new regressions: the spread/rest/tuple/variadic/call unit-test set has the
  **identical** failure set with and without this change (the pre-existing
  failures reproduce on `main` HEAD under nextest and are unrelated to this
  diff); the two genuine regressions an over-broad first attempt introduced
  (`variadic_rest_callback_spread_middle_uses_aggregate_rest_check`,
  `generic_spread_rest_tuple_with_trailing_callback_uses_aggregate_display`) now
  pass.
- `cargo clippy -p tsz-checker --lib` clean; `cargo fmt -p tsz-checker --check` clean.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01EtfiLBTMSXQZGA89N9SDXK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtfiLBTMSXQZGA89N9SDXK)_