### PR TITLE
fix(emit): declare type-asserted const initializers with the asserted annotation

### DIFF
--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -116,6 +116,10 @@ name = "inferred_object_index_signature_dts_emit_tests"
 path = "tests/inferred_object_index_signature_dts_emit_tests.rs"
 
 [[test]]
+name = "const_assertion_dts_emit_tests"
+path = "tests/const_assertion_dts_emit_tests.rs"
+
+[[test]]
 name = "inferred_const_literal_union_dts_emit_tests"
 path = "tests/inferred_const_literal_union_dts_emit_tests.rs"
 

--- a/crates/tsz-cli/tests/const_assertion_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/const_assertion_dts_emit_tests.rs
@@ -1,0 +1,303 @@
+//! DTS emit: a `const` (or class `readonly`) initializer wrapped in a type
+//! assertion is declared with the *asserted* type annotation, not the inline
+//! `= literal` form.
+//!
+//! Structural rule: tsc emits the inline `= literal` form in `.d.ts` only for a
+//! *fresh* literal const (`isLiteralConstDeclaration` / `isFreshLiteralType`).
+//! A top-level type assertion — `as T`, `as const`, or `<T>` — gives the
+//! declaration an asserted / non-fresh declared type, so tsc prints the `: T`
+//! annotation:
+//!
+//! ```ts
+//! const a = "hello" as const;  // declare const a: "hello";
+//! const b = 5 as number;       // declare const b: number;
+//! const g = "ok" satisfies string; // declare const g = "ok"; (satisfies stays inline)
+//! ```
+//!
+//! Before the fix the declaration emitter unwrapped the assertion and emitted
+//! the bare literal inline (`= "hello"` / `= 5`), which both loses the `: T`
+//! form for `as const` and, for widening casts (`as number`, `as 1 | 2`),
+//! emits an outright WRONG (narrower) type in the `.d.ts`.
+//!
+//! These run the full checker pipeline (the unit-level declaration-emit harness
+//! uses an empty type cache and cannot infer the asserted/aliased const types).
+//! Each behavioural case is exercised with more than one spelling so a
+//! regression keyed on a particular literal value rather than the structural
+//! shape would fail.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_const_assertion_dts_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+fn emit_dts(name: &str, source: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let src_path = temp.path.join("repro.ts");
+    std::fs::write(&src_path, source).expect("write repro file");
+
+    let output = Command::new(tsz_bin)
+        .args([
+            "repro.ts",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--strict",
+            "--target",
+            "es2020",
+            "--lib",
+            "es2020",
+            "--pretty",
+            "false",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz declaration emit");
+
+    let dts = std::fs::read_to_string(temp.path.join("repro.d.ts")).unwrap_or_else(|_| {
+        panic!(
+            "expected repro.d.ts to be emitted.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    Some(dts)
+}
+
+macro_rules! dts_or_skip {
+    ($name:expr, $src:expr) => {
+        match emit_dts($name, $src) {
+            Some(dts) => dts,
+            None => {
+                println!("skipping: tsz binary not found");
+                return;
+            }
+        }
+    };
+}
+
+// =============================================================================
+// `as const` on a primitive literal -> the (non-fresh) literal annotation
+// =============================================================================
+
+#[test]
+fn as_const_string_uses_literal_annotation() {
+    let dts = dts_or_skip!("as_const_str", "export const a = \"hello\" as const;\n");
+    assert!(
+        dts.contains("export declare const a: \"hello\";"),
+        "`as const` string must annotate the literal type, not inline it:\n{dts}"
+    );
+    assert!(
+        !dts.contains("const a = "),
+        "the inline `= literal` form must not be used for an `as const` const:\n{dts}"
+    );
+}
+
+#[test]
+fn as_const_number_and_bigint_and_negative_use_literal_annotation() {
+    // Number, bigint, and negative literals all go non-fresh under `as const`.
+    let dts = dts_or_skip!(
+        "as_const_nums",
+        "export const n = 5 as const;\nexport const b = 10n as const;\nexport const m = -3 as const;\n"
+    );
+    assert!(dts.contains("export declare const n: 5;"), "{dts}");
+    assert!(dts.contains("export declare const b: 10n;"), "{dts}");
+    assert!(dts.contains("export declare const m: -3;"), "{dts}");
+}
+
+#[test]
+fn as_const_boolean_uses_literal_annotation() {
+    let dts = dts_or_skip!(
+        "as_const_bool",
+        "export const a = true as const;\nexport const b = false as const;\n"
+    );
+    assert!(dts.contains("export declare const a: true;"), "{dts}");
+    assert!(dts.contains("export declare const b: false;"), "{dts}");
+}
+
+// =============================================================================
+// Widening / conversion `as T` casts -> the asserted type (was WRONG before)
+// =============================================================================
+
+#[test]
+fn widening_cast_to_primitive_uses_asserted_type() {
+    // `5 as number` must declare `: number`, never the narrower `= 5`.
+    let dts = dts_or_skip!(
+        "as_number",
+        "export const b = 5 as number;\nexport const s = \"x\" as string;\n"
+    );
+    assert!(dts.contains("export declare const b: number;"), "{dts}");
+    assert!(!dts.contains("const b = 5"), "{dts}");
+    assert!(dts.contains("export declare const s: string;"), "{dts}");
+}
+
+#[test]
+fn cast_to_literal_union_uses_asserted_union() {
+    let dts = dts_or_skip!(
+        "as_union",
+        "export const c = 1 as 1 | 2;\nexport const d = \"a\" as \"a\" | \"b\";\n"
+    );
+    assert!(dts.contains("export declare const c: 1 | 2;"), "{dts}");
+    assert!(
+        dts.contains("export declare const d: \"a\" | \"b\";"),
+        "{dts}"
+    );
+}
+
+#[test]
+fn cast_to_keyword_type_uses_asserted_type() {
+    let dts = dts_or_skip!("as_keyword", "export const d = true as boolean;\n");
+    assert!(dts.contains("export declare const d: boolean;"), "{dts}");
+    assert!(!dts.contains("const d = true"), "{dts}");
+}
+
+#[test]
+fn double_assertion_uses_outermost_asserted_type() {
+    let dts = dts_or_skip!(
+        "double_as",
+        "export const o = \"x\" as unknown as string;\n"
+    );
+    assert!(dts.contains("export declare const o: string;"), "{dts}");
+    assert!(!dts.contains("const o = \"x\""), "{dts}");
+}
+
+#[test]
+fn angle_bracket_const_assertion_uses_literal_annotation() {
+    let dts = dts_or_skip!("angle_const", "export const n = <const>\"ang\";\n");
+    assert!(dts.contains("export declare const n: \"ang\";"), "{dts}");
+}
+
+// =============================================================================
+// Parenthesized and aliased assertions propagate non-freshness
+// =============================================================================
+
+#[test]
+fn parenthesized_as_const_keeps_literal_annotation() {
+    // Regression: the parenthesized form previously widened to `: string`.
+    let dts = dts_or_skip!("paren_as_const", "export const e = (\"hi\" as const);\n");
+    assert!(dts.contains("export declare const e: \"hi\";"), "{dts}");
+    assert!(
+        !dts.contains(": string"),
+        "must not widen the literal:\n{dts}"
+    );
+}
+
+#[test]
+fn const_alias_of_as_const_inherits_literal_annotation() {
+    // `const f = base` where `base` is `as const`: `f` inherits base's
+    // non-fresh literal type, so it annotates `: "x"` (not inline `= "x"`).
+    let dts = dts_or_skip!(
+        "alias_as_const",
+        "const base = \"x\" as const;\nexport const f = base;\n"
+    );
+    assert!(dts.contains("export declare const f: \"x\";"), "{dts}");
+    assert!(!dts.contains("const f = "), "{dts}");
+}
+
+// =============================================================================
+// Must stay inline: fresh literals and `satisfies`
+// =============================================================================
+
+#[test]
+fn fresh_literal_const_stays_inline() {
+    let dts = dts_or_skip!(
+        "fresh",
+        "export const k = 5;\nexport const l = \"plain\";\nexport const t = true;\n"
+    );
+    assert!(dts.contains("export declare const k = 5;"), "{dts}");
+    assert!(dts.contains("export declare const l = \"plain\";"), "{dts}");
+    assert!(dts.contains("export declare const t = true;"), "{dts}");
+}
+
+#[test]
+fn const_alias_of_fresh_literal_stays_inline() {
+    // `const m = plain` where `plain = 7` (fresh): `m` is still a fresh literal,
+    // so the inline form is preserved.
+    let dts = dts_or_skip!("alias_fresh", "const plain = 7;\nexport const m = plain;\n");
+    assert!(dts.contains("export declare const m = 7;"), "{dts}");
+}
+
+#[test]
+fn satisfies_stays_inline() {
+    // `satisfies` does not change the declared type/freshness, so the inline
+    // `= literal` form is kept (tsc parity).
+    let dts = dts_or_skip!(
+        "satisfies",
+        "export const g = \"ok\" satisfies string;\nexport const h = 42 satisfies number;\n"
+    );
+    assert!(dts.contains("export declare const g = \"ok\";"), "{dts}");
+    assert!(dts.contains("export declare const h = 42;"), "{dts}");
+}
+
+#[test]
+fn as_const_object_array_keep_readonly_annotation() {
+    // `as const` object/array literals already annotate `: readonly {...}` /
+    // `: readonly [...]`; this must remain unchanged.
+    let dts = dts_or_skip!(
+        "as_const_obj",
+        "export const o = { a: 1 } as const;\nexport const arr = [1, 2] as const;\n"
+    );
+    assert!(dts.contains("readonly a: 1;"), "object as const:\n{dts}");
+    assert!(dts.contains("readonly [1, 2]"), "array as const:\n{dts}");
+}
+
+// =============================================================================
+// Class `readonly` properties follow the same rule
+// =============================================================================
+
+#[test]
+fn class_readonly_as_const_uses_literal_annotation() {
+    let dts = dts_or_skip!(
+        "class_as_const",
+        "export class C {\n  readonly a = \"hello\" as const;\n  static readonly s = 1 as 1 | 2;\n  readonly t = 10n as const;\n}\n"
+    );
+    assert!(dts.contains("readonly a: \"hello\";"), "{dts}");
+    assert!(dts.contains("static readonly s: 1 | 2;"), "{dts}");
+    assert!(dts.contains("readonly t: 10n;"), "{dts}");
+}
+
+#[test]
+fn class_readonly_fresh_literal_stays_inline() {
+    // A plain `readonly p = "plain"` is a fresh literal and keeps the inline
+    // form; a mutable property widens to the primitive.
+    let dts = dts_or_skip!(
+        "class_fresh",
+        "export class C {\n  readonly p = \"plain\";\n  q = \"mutable\";\n}\n"
+    );
+    assert!(dts.contains("readonly p = \"plain\";"), "{dts}");
+    assert!(dts.contains("q: string;"), "{dts}");
+}

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_class_properties.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_class_properties.rs
@@ -73,6 +73,24 @@ impl<'a> DeclarationEmitter<'a> {
         }
     }
 
+    /// Separator for a preserved `readonly` literal value. tsc emits the inline
+    /// `= literal` form only for a *fresh* literal (`readonly x = "a"`); when the
+    /// initializer carries a type assertion (`readonly x = "a" as const`) the
+    /// declared type is asserted / non-fresh and tsc prints the `: T`
+    /// annotation instead. The recovered literal text is reused verbatim as the
+    /// annotation: a `const`-asserted primitive's declared type *is* that
+    /// literal (`"a" as const` -> `: "a"`). Widening casts (`x as number`,
+    /// `x as 1 | 2`) never reach this path — they are emitted from the asserted
+    /// type node earlier via `explicit_asserted_type_text`, so only the
+    /// literal-preserving `as const` case lands here.
+    fn readonly_literal_separator_for(&self, initializer: NodeIndex) -> &'static str {
+        if initializer.is_some() && self.const_initializer_carries_type_assertion(initializer, 0) {
+            ": "
+        } else {
+            self.readonly_literal_value_separator()
+        }
+    }
+
     pub(in crate::declaration_emitter) fn emit_property_declaration(
         &mut self,
         prop_idx: NodeIndex,
@@ -242,7 +260,7 @@ impl<'a> DeclarationEmitter<'a> {
                     && let Some(interner) = self.type_interner
                     && let Some(lit) = tsz_solver::visitor::literal_value(interner, type_id)
                 {
-                    self.write(self.readonly_literal_value_separator());
+                    self.write(self.readonly_literal_separator_for(prop.initializer));
                     self.write(&Self::format_literal_initializer(&lit, interner));
                 } else if is_readonly
                     && !is_abstract
@@ -253,7 +271,7 @@ impl<'a> DeclarationEmitter<'a> {
                 {
                     // Type system widened the literal (e.g. `false` → `boolean`);
                     // recover the original from the initializer source text.
-                    self.write(self.readonly_literal_value_separator());
+                    self.write(self.readonly_literal_separator_for(prop.initializer));
                     self.write(&lit_text);
                 } else if let Some(typeof_text) = self.typeof_prefix_for_value_entity(
                     prop.initializer,
@@ -382,7 +400,7 @@ impl<'a> DeclarationEmitter<'a> {
                 && let Some(lit_text) = self.const_literal_initializer_text_deep(prop.initializer)
             {
                 // Readonly literal preservation via initializer source text.
-                self.write(self.readonly_literal_value_separator());
+                self.write(self.readonly_literal_separator_for(prop.initializer));
                 self.write(&lit_text);
             } else if prop.initializer.is_some()
                 && let Some(type_text) = self.allowlisted_initializer_type_text(prop.initializer)

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/literal_initializers.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/literal_initializers.rs
@@ -118,6 +118,13 @@ impl<'a> DeclarationEmitter<'a> {
         }
         // Unwrap as/satisfies expressions
         let expr_node = self.arena.get(expr_idx)?;
+        // Look through parentheses so `("x" as const)` / `(alias)` reach the
+        // same as/satisfies/identifier unwrapping that the bare forms do.
+        if expr_node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+            && let Some(paren) = self.arena.get_parenthesized(expr_node)
+        {
+            return self.const_literal_initializer_text_deep_guarded(paren.expression, guard);
+        }
         if expr_node.kind == syntax_kind_ext::AS_EXPRESSION
             || expr_node.kind == syntax_kind_ext::SATISFIES_EXPRESSION
         {
@@ -129,19 +136,90 @@ impl<'a> DeclarationEmitter<'a> {
         // tsc behavior when a const variable references another const whose
         // literal value is known (e.g. `const a = "abc"; const b = a` ->
         // `declare const b = "abc"`).
-        if expr_node.kind == SyntaxKind::Identifier as u16 {
-            if self.binder.is_some() {
-                let sym_id = self.value_reference_symbol(expr_idx)?;
-                let initializer = self.const_variable_initializer_for_symbol(sym_id)?;
-                return self.const_literal_initializer_text_deep_guarded(initializer, guard);
-            }
-
-            if let Some(initializer) = self.top_level_const_initializer_for_identifier(expr_idx) {
-                return self.const_literal_initializer_text_deep_guarded(initializer, guard);
-            }
+        if expr_node.kind == SyntaxKind::Identifier as u16
+            && let Some(initializer) = self.const_alias_initializer(expr_idx)
+        {
+            return self.const_literal_initializer_text_deep_guarded(initializer, guard);
         }
 
         None
+    }
+
+    /// Inline `= literal` text for a `const` declaration, but only when the
+    /// const's declared type is a *fresh* literal (tsc's
+    /// `isLiteralConstDeclaration` / `isFreshLiteralType`). A top-level type
+    /// assertion (`x as T` / `<T>x`, including `as const`, and including through
+    /// parentheses or a `const` alias) gives the declaration an asserted /
+    /// non-fresh declared type, which `tsc` prints as the `: T` annotation
+    /// instead of the inline initializer. A `satisfies` expression preserves the
+    /// operand's freshness, so it stays inline.
+    pub(in crate::declaration_emitter) fn const_inline_literal_initializer_text(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<String> {
+        if self.const_initializer_carries_type_assertion(expr_idx, 0) {
+            return None;
+        }
+        self.const_literal_initializer_text_deep(expr_idx)
+    }
+
+    /// True when the declared type of a `const`/`readonly` initializer comes
+    /// from a type assertion (`as T` / `<T>`, including `as const`) rather than
+    /// a fresh literal. Looks through parentheses, non-null `!`, and `const`
+    /// aliases (`const b = a` inherits `a`'s freshness); `satisfies` is
+    /// transparent for freshness and is looked through, not treated as an
+    /// assertion.
+    pub(in crate::declaration_emitter) fn const_initializer_carries_type_assertion(
+        &self,
+        expr_idx: NodeIndex,
+        depth: u32,
+    ) -> bool {
+        // On a pathologically deep wrapper/alias chain, assume no assertion so
+        // the caller falls back to its normal (inline-literal) handling rather
+        // than dropping a literal it could otherwise preserve.
+        if depth > 64 {
+            return false;
+        }
+        let Some(node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+        match node.kind {
+            k if k == syntax_kind_ext::AS_EXPRESSION || k == syntax_kind_ext::TYPE_ASSERTION => {
+                true
+            }
+            k if k == syntax_kind_ext::SATISFIES_EXPRESSION => self
+                .arena
+                .get_type_assertion(node)
+                .is_some_and(|assertion| {
+                    self.const_initializer_carries_type_assertion(assertion.expression, depth + 1)
+                }),
+            k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
+                self.arena.get_parenthesized(node).is_some_and(|paren| {
+                    self.const_initializer_carries_type_assertion(paren.expression, depth + 1)
+                })
+            }
+            k if k == syntax_kind_ext::NON_NULL_EXPRESSION => {
+                self.arena.get_unary_expr_ex(node).is_some_and(|unary| {
+                    self.const_initializer_carries_type_assertion(unary.expression, depth + 1)
+                })
+            }
+            k if k == SyntaxKind::Identifier as u16 => self
+                .const_alias_initializer(expr_idx)
+                .is_some_and(|init| self.const_initializer_carries_type_assertion(init, depth + 1)),
+            _ => false,
+        }
+    }
+
+    /// The initializer of the `const` declaration `expr_idx` resolves to, if it
+    /// is a reference to a `const` binding (so freshness/assertion state can be
+    /// propagated through `const b = a` aliases).
+    fn const_alias_initializer(&self, expr_idx: NodeIndex) -> Option<NodeIndex> {
+        if self.binder.is_some() {
+            let sym_id = self.value_reference_symbol(expr_idx)?;
+            self.const_variable_initializer_for_symbol(sym_id)
+        } else {
+            self.top_level_const_initializer_for_identifier(expr_idx)
+        }
     }
 
     fn const_variable_initializer_for_symbol(&self, sym_id: SymbolId) -> Option<NodeIndex> {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -300,7 +300,7 @@ impl<'a> DeclarationEmitter<'a> {
             && !exported_call_initializer
             && const_asserted_enum_member.is_none()
             && !js_has_jsdoc_type)
-            .then(|| self.const_literal_initializer_text_deep(initializer))
+            .then(|| self.const_inline_literal_initializer_text(initializer))
             .flatten();
 
         // Determine if we should emit a literal initializer for const
@@ -1209,7 +1209,7 @@ impl<'a> DeclarationEmitter<'a> {
                 self.write(&typeof_text);
             } else if keyword == "const"
                 && has_initializer
-                && let Some(lit_text) = self.const_literal_initializer_text_deep(initializer)
+                && let Some(lit_text) = self.const_inline_literal_initializer_text(initializer)
             {
                 // For const declarations where the type cache missed,
                 // preserve the literal value: `declare const X = 123;`


### PR DESCRIPTION
Fixes #14762.

## Summary
The declaration emitter used the inline `= literal` form for any `const` whose
initializer reduced to a literal, unwrapping `as`/`<T>` assertions to recover the
bare literal. `tsc` only uses the inline form for a **fresh** literal const
(`isLiteralConstDeclaration` / `isFreshLiteralType`); a top-level type assertion
gives the declaration an asserted / non-fresh declared type, which `tsc` prints
as the `: T` annotation.

This restores the `: "hello"` annotation form for `as const` primitives **and**
fixes outright-wrong narrowed types for widening casts — `5 as number`
previously emitted `= 5` (a wrong, narrower type in the `.d.ts`) instead of
`: number`.

```ts
export const a = "hello" as const; // was: = "hello"   now: a: "hello"
export const b = 5 as number;      // was: = 5         now: b: number
export const c = 1 as 1 | 2;       // was: = 1         now: c: 1 | 2
export const e = ("hi" as const);  // was: : string    now: e: "hi"
const base = "x" as const;
export const f = base;             // was: = "x"        now: f: "x"
export const g = "ok" satisfies string; // = "ok" (satisfies stays inline)
```

## Structural rule
When a `const`/`readonly` initializer carries a top-level type assertion
(`as T`, `as const`, `<T>`, including through parentheses, non-null `!`, and
`const` aliases), the declaration emitter emits `: T`, not the inline
`= literal`. `satisfies` preserves the operand's freshness and stays inline.

## Owner layer
Declaration emitter. A new AST predicate `const_initializer_carries_type_assertion`
gates `const_inline_literal_initializer_text`, consistent with the existing
AST-based freshness proxies the emit boundary already uses
(`const_initializer_literals_are_fresh`, `expression_contains_const_assertion`) —
the emit boundary frequently runs with an empty type cache, so an AST predicate
is the right altitude here, not solver per-literal freshness. Class `readonly`
properties follow the same rule via an assertion-aware value separator;
widening `as T` casts on class props were already correct (handled earlier by
`explicit_asserted_type_text`), so only the literal-preserving `as const` case
changes there.

## Adjacent matrix
Covered by full-pipeline dts emit tests (the unit-level harness uses an empty
type cache and cannot infer the asserted/aliased const types), each with more
than one spelling:
- `as const` on string / number / bigint / boolean / negative literals
- widening casts `as number` / `as 1 | 2` / `as boolean`, double `as unknown as string`, `<const>`
- parenthesized `("x" as const)`, `const` alias of an `as const` const
- must-stay-inline: fresh literals, fresh-literal alias, `satisfies`, `as const` object/array (already `: readonly {...}`/`[...]`)
- class `readonly` `as const` + fresh-literal/mutable variants

## Verification
- `cargo test -p tsz-cli --test const_assertion_dts_emit_tests` — 16 passed (new)
- `cargo test -p tsz-emitter --lib` — 3846 passed
- `cargo test -p tsz-cli --test inferred_const_literal_union_dts_emit_tests --test parenthesized_type_dts_emit_tests --test recursive_const_arrow_dts_emit_tests --test declaration_type_walk_boundary_dts_emit_tests` — all green
- `cargo test -p tsz-checker --test ambient_readonly_literal_initializer_tests` — green
- `cargo fmt --check` clean; `cargo clippy -p tsz-emitter` clean
- Manual repro from the issue now matches `tsc 5.9.3` exactly (top-level const and class `readonly`).

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Mxu5xMqieUEyLQJhjSvcBS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mxu5xMqieUEyLQJhjSvcBS)_