### PR TITLE
fix(emit): print asserted type annotation for as-assertion const/field d.ts (#14762)

### DIFF
--- a/crates/tsz-cli/tests/const_assertion_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/const_assertion_dts_emit_tests.rs
@@ -301,3 +301,72 @@ fn class_readonly_fresh_literal_stays_inline() {
     assert!(dts.contains("readonly p = \"plain\";"), "{dts}");
     assert!(dts.contains("q: string;"), "{dts}");
 }
+
+// =============================================================================
+// A *mutable* class field with a const assertion: the assertion strips the
+// literal's freshness, so the field's declared type is the literal (it does not
+// widen). tsc emits the `: T` literal annotation, identical to the readonly
+// case. A plain mutable literal still widens, and `satisfies` keeps freshness.
+// =============================================================================
+
+#[test]
+fn class_field_as_const_emits_literal_annotation() {
+    // A mutable field with a primitive `as const`/`<const>` initializer keeps the
+    // literal type; a widening cast uses the asserted type; `satisfies` and plain
+    // literals stay inline / widen as before.
+    let dts = dts_or_skip!(
+        "class_mut_as_const",
+        "export class Box {\n    mutStr = \"hi\" as const;\n    mutNum = 5 as const;\n    mutBool = true as const;\n    mutNeg = -5 as const;\n    mutBig = 10n as const;\n    mutAngle = <const>\"ang\";\n    mutParen = (\"hi\" as const);\n    mutWiden = 5 as number;\n    mutSatisfies = \"ok\" satisfies string;\n    mutPlain = \"lit\";\n    readonly roStr = \"hi\" as const;\n}\n"
+    );
+    assert!(dts.contains("mutStr: \"hi\";"), "{dts}");
+    assert!(dts.contains("mutNum: 5;"), "{dts}");
+    assert!(dts.contains("mutBool: true;"), "{dts}");
+    assert!(dts.contains("mutNeg: -5;"), "{dts}");
+    assert!(dts.contains("mutBig: 10n;"), "{dts}");
+    assert!(dts.contains("mutAngle: \"ang\";"), "{dts}");
+    assert!(dts.contains("mutParen: \"hi\";"), "{dts}");
+    assert!(dts.contains("mutWiden: number;"), "{dts}");
+    assert!(dts.contains("mutSatisfies: string;"), "{dts}");
+    assert!(dts.contains("mutPlain: string;"), "{dts}");
+    assert!(dts.contains("readonly roStr: \"hi\";"), "{dts}");
+}
+
+#[test]
+fn class_field_object_array_as_const_keep_inferred_form() {
+    // Object/array `as const` on a *mutable* field go through the inferred-type
+    // path (`{ readonly ... }` / `readonly [...]`), exactly like readonly fields;
+    // the mutable-literal generalisation must not regress them.
+    let dts = dts_or_skip!(
+        "class_mut_obj_arr",
+        "export class C {\n    mutObj = { x: 1 } as const;\n    mutArr = [1, 2] as const;\n}\n"
+    );
+    assert!(dts.contains("readonly x: 1;"), "{dts}");
+    assert!(dts.contains("mutArr: readonly [1, 2];"), "{dts}");
+}
+
+// =============================================================================
+// An explicit type annotation always wins over the initializer's assertion.
+// =============================================================================
+
+#[test]
+fn explicit_annotation_wins_over_const_assertion() {
+    let dts = dts_or_skip!(
+        "explicit_annotation",
+        "export const total: number = 5 as const;\n"
+    );
+    assert!(dts.contains("export declare const total: number;"), "{dts}");
+}
+
+// =============================================================================
+// An exported generic identity call preserves the `as const` argument literal
+// in the inferred result type.
+// =============================================================================
+
+#[test]
+fn exported_generic_call_of_as_const_arg_keeps_literal() {
+    let dts = dts_or_skip!(
+        "generic_call_as_const",
+        "export function id<T>(value: T) {\n    return value;\n}\nexport const got = id(\"ok\" as const);\n"
+    );
+    assert!(dts.contains("export declare const got: \"ok\";"), "{dts}");
+}

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_class_properties.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_class_properties.rs
@@ -187,6 +187,19 @@ impl<'a> DeclarationEmitter<'a> {
                 self.write(" | undefined");
             }
         } else if !is_private {
+            // tsc preserves the (non-fresh) literal type of a class field whose
+            // declared type *is* a literal: always for a `readonly` field, and
+            // for a *mutable* field when the initializer carries a top-level type
+            // assertion (`as const`, `<const>`, including through parentheses,
+            // non-null `!`, and `const` aliases). The assertion strips the
+            // literal's freshness so it does not widen (`mutable = "hi" as const`
+            // -> `mutable: "hi"`). A plain mutable literal (`x = "a"`) stays
+            // fresh and widens to the primitive, and `satisfies` keeps freshness,
+            // so neither carries an assertion here.
+            let preserve_literal_initializer = is_readonly
+                || (prop.initializer.is_some()
+                    && self.const_initializer_carries_type_assertion(prop.initializer, 0));
+
             // For a readonly property whose initializer is a simple enum-member
             // access (e.g. `readonly kind = E.A`), tsc uses the initializer form
             // in class declarations and a literal-typed annotation in object-
@@ -253,8 +266,11 @@ impl<'a> DeclarationEmitter<'a> {
                 self.write(": ");
                 self.write(&type_text);
             } else if let Some(type_id) = self.get_node_type_or_names(&[prop_idx, prop.name]) {
-                // Readonly literal preservation (matches tsc `const`-like emit).
-                if is_readonly
+                // Literal preservation (matches tsc `const`-like emit): readonly
+                // fields, and mutable fields whose initializer carries an `as
+                // const`/`<const>` assertion (tracked by
+                // `preserve_literal_initializer`).
+                if preserve_literal_initializer
                     && !is_abstract
                     && !prop.question_token
                     && let Some(interner) = self.type_interner
@@ -262,7 +278,7 @@ impl<'a> DeclarationEmitter<'a> {
                 {
                     self.write(self.readonly_literal_separator_for(prop.initializer));
                     self.write(&Self::format_literal_initializer(&lit, interner));
-                } else if is_readonly
+                } else if preserve_literal_initializer
                     && !is_abstract
                     && !prop.question_token
                     && prop.initializer.is_some()
@@ -393,13 +409,14 @@ impl<'a> DeclarationEmitter<'a> {
                         self.write(" | undefined");
                     }
                 }
-            } else if is_readonly
+            } else if preserve_literal_initializer
                 && !is_abstract
                 && !prop.question_token
                 && prop.initializer.is_some()
                 && let Some(lit_text) = self.const_literal_initializer_text_deep(prop.initializer)
             {
-                // Readonly literal preservation via initializer source text.
+                // Literal preservation via initializer source text (no computed
+                // type): readonly fields, and mutable `as const`/`<const>` fields.
                 self.write(self.readonly_literal_separator_for(prop.initializer));
                 self.write(&lit_text);
             } else if prop.initializer.is_some()

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_const_assertions.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_const_assertions.rs
@@ -97,8 +97,13 @@ impl<'a> DeclarationEmitter<'a> {
             }
 
             let assertion = self.arena.get_type_assertion(node)?;
-            let asserted_type = self.arena.get(assertion.type_node)?;
-            if asserted_type.kind == SyntaxKind::ConstKeyword as u16 {
+            // A const assertion (`as const`, `<const>`) does not name a printable
+            // asserted type; its declared type is the literal-preserving inferred
+            // type, recovered by the literal/inferred branches downstream. Use the
+            // shared structural predicate so both the `ConstKeyword` (`as const`)
+            // and the angle-bracket `<const>` (parsed as a `const` type reference)
+            // forms are recognised, not just the former.
+            if self.type_assertion_is_const(assertion.type_node) {
                 return None;
             }
             if let Some(alias_text) =


### PR DESCRIPTION
Fixes #14762.

## Summary
When a `const` (or class field) initializer carries a top-level type assertion
(`expr as T`, `<T>expr`, or `as const`), the variable's declared type is the
*asserted* type, so `.d.ts` emit must print the `: T` annotation instead of the
inline `= literal` form. tsz emitted the inline literal, which dropped the
`as const` literal annotation and — for widening casts (`5 as number`,
`1 as 1 | 2`, `true as boolean`, `5 as unknown as string`) — wrote an outright
**wrong, narrower** type into the `.d.ts`. A `satisfies` initializer does not
change the declared type, so its inline form is preserved.

```ts
export const a = "hello" as const;   // was: = "hello"   now: : "hello"
export const b = 5 as number;        // was: = 5         now: : number
export const e = ("hi" as const);    // was: : string    now: : "hi"
const base = "x" as const;
export const f = base;               // was: = "x"       now: : "x"
export const g = "ok" satisfies string; //                     = "ok"  (unchanged)
```

## Structural rule
When a `const`/class-field initializer reaches its literal through an `as`/`<T>`
type assertion, `tsc` prints the asserted-type annotation (`: T`) because the
assertion strips literal *freshness*; `satisfies` keeps freshness and stays
inline. tsz now applies the same rule. Owner layer: declaration emitter
(`crates/tsz-emitter`); no semantic validation moved out of the solver.

## Owner / depth
- `const_initializer_reaches_literal_through_assertion`
  (`helpers/literal_initializers.rs`) gates the inline `= literal` path. It looks
  through parentheses, `await`, `satisfies` (transparent), and const-alias
  identifier references to detect an `as`/`<T>` assertion.
- `const_assertion_primitive_type_text`
  (`helpers/type_inference_const_assertions.rs`) recovers the literal-preserving
  annotation for **primitive** `as const` (string/number/bigint/boolean/
  no-substitution-template/negative literal, incl. parenthesized and const-alias
  forms) from the AST — the solver can widen a parenthesized `as const`
  (`("hi" as const)`) back to `string`, so the AST assertion is ground truth.
  Object/array/tuple/substitution-template `as const` keep the existing
  inferred-type path (`readonly {...}` / `readonly [...]`).
- The annotation branch is wired into both the variable-decl
  (`helpers/variable_decl.rs`) and class-property
  (`core/emit_class_properties.rs`) emit paths; the rule applies to readonly and
  mutable fields alike.
- Shared helpers `const_decl_initializer_for_identifier` and
  `is_const_primitive_literal_node` were extracted to remove duplication, and the
  existing pub `arena.skip_parenthesized` is reused.

## Adjacent matrix (all verified byte-for-byte vs `tsc` 6.0.2)
- `as const` on string / number / bigint / boolean / negative literal -> `: T`.
- Widening casts `as number` / `as 1 | 2` / `as boolean` / double
  `as unknown as string` -> `: T`.
- Parenthesized `("hi" as const)` -> `: "hi"`; angle `<const>"angle"` -> `: "angle"`.
- Const alias to `as const` (`f = base`) -> `: "x"`; plain-literal alias stays
  inline (`= "p"`).
- `satisfies` stays inline; explicit annotation wins (`x: number = 5 as const`).
- Object/array/tuple `as const` unchanged (`readonly {...}` / `readonly [...]`).
- Class readonly + mutable fields, `static readonly`; `satisfies`/plain fields
  stay inline.
- Exported generic identity call `generic("ok" as const)` keeps `: "ok"`.

## Fallback
Non-primitive and non-assertion initializers fall through to the existing
inferred-type / inline-literal paths unchanged.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo test -p tsz-cli --test const_assertion_dts_emit_tests` (new, 14 tests).
- `cargo test -p tsz-emitter` — green except one pre-existing, unrelated
  failure (`generator_object_literal_prefix_before_yield_omits_source_trailing_comma`,
  also fails on a clean tree).
- `cargo test -p tsz-cli` dts-emit suites: `inferred_const_literal_union`,
  `recursive_const_arrow`, `inferred_function_value_apparent_member_return`,
  `parenthesized_type`.
- `cargo clippy -p tsz-emitter` clean.
- Byte-for-byte `diff` of tsz vs `tsc 6.0.2` `--declaration --emitDeclarationOnly`
  output across the full matrix above.

https://claude.ai/code/session_01XwBfrfcRzmErQznjo4AssU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwBfrfcRzmErQznjo4AssU)_
