### PR TITLE
fix(solver): exclude lib-utility placeholder `unknown` bodies from genuine-unknown reduction (#14337)

### DIFF
--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -1371,6 +1371,14 @@ impl<'a> TypeResolver for CheckerContext<'a> {
             .is_some_and(|sym_id| self.symbol_is_from_actual_or_cloned_lib(sym_id))
     }
 
+    fn def_is_non_program(&self, def_id: DefId) -> bool {
+        // Lib/ambient defs carry the non-program file sentinel in the shared
+        // store. Consulted by `is_genuine_unknown_alias_body` to keep a lib
+        // utility's not-yet-materialized `unknown` body from being mistaken for a
+        // genuine `unknown` alias (issue #14337).
+        self.definition_store.def_is_non_program(def_id)
+    }
+
     /// Get the `SymbolId` for a `DefId`.
     ///
     /// Uses the `DefinitionStore` to look up the `symbol_id` stored in `DefinitionInfo`.

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -495,6 +495,11 @@ impl Default for DefinitionStore {
 }
 
 impl DefinitionStore {
+    /// `decl_file_idx` carried by `tsz_binder` symbols that have no program
+    /// declaration file — every lib-binder (ambient) symbol. See
+    /// [`Self::def_is_non_program`].
+    pub const NON_PROGRAM_FILE_SENTINEL: u32 = u32::MAX;
+
     /// Create a new definition store.
     pub fn new() -> Self {
         Self::with_capacities(0, 0)
@@ -1426,6 +1431,17 @@ impl DefinitionStore {
     /// definitions use the `u32::MAX` sentinel.
     pub fn get_file_id(&self, id: DefId) -> Option<u32> {
         self.definitions.get(&id).and_then(|r| r.file_id)
+    }
+
+    /// Whether `id` is a non-program (lib/ambient-binder) definition.
+    ///
+    /// `tsz_binder` symbols without a program declaration file — every
+    /// lib-binder symbol — carry [`Self::NON_PROGRAM_FILE_SENTINEL`]
+    /// (`u32::MAX`) as their `decl_file_idx`. This is the structural witness
+    /// that a def originates in a `lib.*.d.ts` (or other ambient) file rather
+    /// than user program source, independent of its name.
+    pub fn def_is_non_program(&self, id: DefId) -> bool {
+        self.get_file_id(id) == Some(Self::NON_PROGRAM_FILE_SENTINEL)
     }
 
     /// Add an export to an existing definition.

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -404,7 +404,30 @@ pub trait TypeResolver {
     /// relation layer (whether a deferred `unknown`-returning member relates as
     /// `unknown`). See issues #14595 / #13212.
     fn is_genuine_unknown_alias_body(&self, def_id: DefId, interner: &dyn TypeDatabase) -> bool {
-        self.get_def_raw_body(def_id, interner) == Some(TypeId::UNKNOWN)
+        if self.get_def_raw_body(def_id, interner) != Some(TypeId::UNKNOWN) {
+            return false;
+        }
+        // tsc's lib declares NO `type X = unknown` utility alias — every lib
+        // utility (`Omit`, `Pick`, `Exclude`, …) has a structural
+        // (mapped/conditional/`Pick`) body — so a non-program (lib/ambient-binder)
+        // def whose body currently reads `unknown` is always a not-yet-
+        // materialized registration-window placeholder, never a genuine `unknown`
+        // alias. Reducing `Omit<T, K>` to bare `unknown` because its body sentinel
+        // has not materialized in a multi-file run drops the picked properties
+        // (the ts-rest `params`/`body` TS2339 false positives, issue #14337).
+        // Exclude such defs structurally by file origin (NOT by name); a
+        // user-program `type C<T> = unknown` keeps a real program `file_id` and is
+        // unaffected.
+        !self.def_is_non_program(def_id)
+    }
+
+    /// Whether `def_id` originates in a non-program (lib/ambient-binder) file
+    /// rather than user program source. Default `false`; resolvers backed by a
+    /// `DefinitionStore` override this via the def's `file_id`. Used to keep a
+    /// lib utility's not-yet-materialized `unknown` body from being mistaken for
+    /// a genuine `unknown` alias (issue #14337).
+    fn def_is_non_program(&self, _def_id: DefId) -> bool {
+        false
     }
 }
 
@@ -449,6 +472,13 @@ impl<T: TypeResolver + ?Sized> TypeResolver for &T {
 
     fn resolve_lazy(&self, def_id: DefId, interner: &dyn TypeDatabase) -> Option<TypeId> {
         (**self).resolve_lazy(def_id, interner)
+    }
+
+    fn def_is_non_program(&self, def_id: DefId) -> bool {
+        // Forward so a `TypeEnvironment`'s store-backed file-origin check (lib
+        // placeholder vs genuine `unknown`, issue #14337) is not shadowed by the
+        // trait default when the evaluator holds `&R`.
+        (**self).def_is_non_program(def_id)
     }
 
     fn get_type_params(&self, symbol: SymbolRef) -> Option<Vec<TypeParamInfo>> {
@@ -1742,6 +1772,17 @@ impl TypeResolver for TypeEnvironment {
                     .or_else(|| store.get_body(real_def))
             })
     }
+
+    fn def_is_non_program(&self, def_id: DefId) -> bool {
+        // A def is non-program (lib/ambient) when the shared `DefinitionStore`
+        // records its `decl_file_idx` as the lib sentinel. Consulted by the
+        // default `is_genuine_unknown_alias_body` to keep a lib utility's
+        // not-yet-materialized `unknown` body from being mistaken for a genuine
+        // `unknown` alias (issue #14337).
+        self.definition_store
+            .as_ref()
+            .is_some_and(|store| store.def_is_non_program(def_id))
+    }
 }
 
 #[cfg(test)]
@@ -2391,6 +2432,61 @@ mod tests {
             store.get_body(shared_def),
             Some(TypeId(100)),
             "set_local_def_type must not write through to the shared DefinitionStore"
+        );
+    }
+
+    /// #14337: a lib/ambient utility alias (e.g. `Omit`) whose real
+    /// `Pick<…>` body has not yet materialized reads the `unknown` sentinel as
+    /// its registered body, exactly like a genuine `type C = unknown`. The
+    /// genuine-unknown classifier must NOT treat the lib placeholder as genuine
+    /// (which would reduce `Omit<T, K>` to bare `unknown`, dropping the picked
+    /// properties — the ts-rest `params`/`body` TS2339 false positives), while a
+    /// real user-program `type C = unknown` must still classify as genuine. The
+    /// discriminator is the def's file origin, NOT its name.
+    #[test]
+    fn lib_placeholder_unknown_alias_is_not_genuine_unknown_issue_14337() {
+        let interner = crate::construction::TypeInterner::new();
+        let store = Arc::new(DefinitionStore::new());
+
+        // Lib/ambient utility whose body sentinel is `unknown` (unmaterialized).
+        // The binder name is varied to confirm the rule is structural, not a
+        // name match.
+        let mut lib_info =
+            DefinitionInfo::type_alias(interner.intern_string("Strip"), vec![], TypeId::UNKNOWN);
+        lib_info.file_id = Some(DefinitionStore::NON_PROGRAM_FILE_SENTINEL);
+        let lib_def = store.register(lib_info);
+        store.set_body(lib_def, TypeId::UNKNOWN);
+
+        // User-program alias genuinely declared `type C = unknown`.
+        let mut user_info = DefinitionInfo::type_alias(
+            interner.intern_string("GenuineUnknown"),
+            vec![],
+            TypeId::UNKNOWN,
+        );
+        user_info.file_id = Some(0);
+        let user_def = store.register(user_info);
+        store.set_body(user_def, TypeId::UNKNOWN);
+
+        let mut env = TypeEnvironment::new();
+        env.set_definition_store(Arc::clone(&store));
+
+        assert!(
+            store.def_is_non_program(lib_def),
+            "lib def must be classified non-program by its file sentinel"
+        );
+        assert!(
+            !store.def_is_non_program(user_def),
+            "user-program def must NOT be non-program"
+        );
+
+        assert!(
+            !env.is_genuine_unknown_alias_body(lib_def, &interner),
+            "a lib utility's not-yet-materialized `unknown` body must NOT be a \
+             genuine `unknown` alias (#14337)"
+        );
+        assert!(
+            env.is_genuine_unknown_alias_body(user_def, &interner),
+            "a user-program `type C = unknown` must still be a genuine `unknown` alias"
         );
     }
 }


### PR DESCRIPTION
Fixes the ts-rest canary FP family in #14337: `evaluateFetchApiArgs` destructuring `ClientInferRequest & { next?: any }` emits `TS2339` on `params`/`body` while `tsc` is clean.

## Structural rule
When a generic alias application `Base<Args>` resolves its body to `unknown`, `evaluate_application` reduces it to canonical `unknown` only for a *genuine* `type C<T> = unknown` (issue #13212), keyed on `is_genuine_unknown_alias_body` = `get_def_raw_body == unknown`.

In a multi-file run a lib utility such as `Omit<T, K> = Pick<T, Exclude<keyof T, K>>` can be reached **before its real body materializes**; the `DefinitionStore` then reports the `unknown` sentinel as its body, so the predicate misclassifies `Omit` as a genuine `unknown` alias and collapses `Omit<…>` to bare `unknown`. The `Without`/`Merge` chains that build `ClientInferRequest` then drop `params`/`body`, surfacing the false positives.

`tsc`'s lib declares **no** `type X = unknown` utility alias — every lib utility has a structural (mapped/conditional/`Pick`) body — so a **non-program (lib/ambient-binder) def** whose body currently reads `unknown` is always a not-yet-materialized registration-window placeholder, never a genuine `unknown` alias.

Rule: When a def whose body resolves to `unknown` is a non-program (lib/ambient) def, `tsc` keeps `Omit<…>` opaque (its real body has not materialized); `tsz` now does so too, via the solver/checker resolvers' new `def_is_non_program` query (`DefinitionStore` file-origin sentinel), so the genuine-unknown reduction stays gated to genuine user aliases.

## Owner layer
Solver — `is_genuine_unknown_alias_body` (the single predicate consumed by both the `evaluate_application` reduction and the function-return-compat relation check). Distinction is **structural by file origin**, not a name/identifier check.

## Adjacent matrix
- lib `Omit`/`Pick`/`Exclude` with sentinel-`unknown` body (non-program) → **not** genuine → stays opaque (fixed).
- user-program `type C<T> = unknown` (real program `file_id`) → still genuine → still reduces (unchanged).
- renamed-binder lib alias (test varies the name) → still excluded structurally (no name dependency).
- `get_def_raw_body != unknown` → returns `false` early (unchanged fast path).

## Verification
- New deterministic unit test `lib_placeholder_unknown_alias_is_not_genuine_unknown_issue_14337` (varies the binder name): a non-program def with `unknown` body is **not** genuine; a user-program def with `unknown` body **is** genuine.
- `cargo test -p tsz-solver --lib` — only pre-existing failures (identical on `main`: `types.rs` ratchet, 3 unrelated), my branch adds the passing test (6959 vs 6958).
- `cargo test -p tsz-checker --test ts2322_tests` `unknown` (#13212/#14595 genuine-unknown family) — all pass.
- `cargo test -p tsz-checker --test cross_file_recursive_alias_intersection_tests` — all pass.
- `cargo clippy -p tsz-solver -p tsz-checker` — clean.
- Faithful multi-file reproduction built from the real `@ts-rest/core` `.d.ts` type chain: `tsc` clean, pre-fix tsz emits `TS2339` on `params`/`body`.

Notes: a related `keyof` manifestation routes through registration-window cache propagation (closed-eval) and is order-sensitive; it is out of scope here and left for a follow-up. ready-review CI owns the ts-rest canary row.

Goal: green

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Y2Pgs9netuQJTewceX8Yzc