### PR TITLE
fix(test): inline format args broken into main by #14918 (clippy)

### DIFF
--- a/crates/tsz-checker/src/tests/window_self_globalthis_resolution_tests.rs
+++ b/crates/tsz-checker/src/tests/window_self_globalthis_resolution_tests.rs
@@ -86,8 +86,7 @@ export {};
     assert_eq!(
         count(&diags, TS2322),
         2,
-        "an `any` collapse would drop both assignments: {:?}",
-        diags
+        "an `any` collapse would drop both assignments: {diags:?}"
     );
     assert!(
         messages(&diags, TS2322)
@@ -190,8 +189,7 @@ function f() {
     assert_eq!(
         count(&diags, TS2454),
         0,
-        "definite-assignment must see the declared `undefined` through `(typeof X)['opt']`: {:?}",
-        diags
+        "definite-assignment must see the declared `undefined` through `(typeof X)['opt']`: {diags:?}"
     );
 }
 


### PR DESCRIPTION
Goal: hold

## Summary
#14918 landed two `assert_eq!` calls with positional `{:?}` + `diags` args in
`window_self_globalthis_resolution_tests.rs` (lines 86, 190). Under `-D warnings`
these trip `clippy::uninlined_format_args`, breaking main's `lint` job — and
therefore every open PR, since PR CI builds against the branch merged with main.
Both are inlined to `{diags:?}`.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- The two flagged sites are the only `uninlined_format_args` with simple-var
  args in the file (the other four `{:?}` sites take expression args clippy
  cannot inline).
- main CI `lint` job re-run after merge.