### PR TITLE
refactor(arch): route globalThis-surface object through a solver builder (clear last lint-debt boundary)

### DIFF
--- a/crates/tsz-checker/src/context/lib_queries.rs
+++ b/crates/tsz-checker/src/context/lib_queries.rs
@@ -99,7 +99,7 @@ impl<'a> CheckerContext<'a> {
     /// interning and the file-local cache, so it can be consulted from the
     /// `Fn`-typed `typeof` lowering overrides.
     pub(crate) fn global_this_surface_type(&self) -> TypeId {
-        use tsz_solver::{ObjectShape, PropertyInfo, SymbolRef};
+        use tsz_solver::{PropertyInfo, SymbolRef};
 
         let cache = &self.type_reference_validation_caches.type_node_surface;
         if let Some(cached) = cache.global_this_type.get() {
@@ -151,11 +151,7 @@ impl<'a> CheckerContext<'a> {
             properties.push(prop);
         }
 
-        let global_this_type = self.types.factory().object_with_index(ObjectShape {
-            properties,
-            flags: tsz_solver::ObjectFlags::GLOBAL_THIS_SURFACE,
-            ..ObjectShape::default()
-        });
+        let global_this_type = self.types.factory().global_this_surface_object(properties);
         // Record the synthetic surface so diagnostics render it as
         // `typeof globalThis` rather than its full member body.
         self.types

--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -9,7 +9,7 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::Visibility;
 use tsz_solver::{CallSignature, CallableShape};
-use tsz_solver::{ObjectShape, PropertyInfo, TypeId};
+use tsz_solver::{PropertyInfo, TypeId};
 
 impl<'a> CheckerState<'a> {
     // =========================================================================
@@ -840,11 +840,10 @@ impl<'a> CheckerState<'a> {
             properties.push(prop);
         }
 
-        self.ctx.types.factory().object_with_index(ObjectShape {
-            properties,
-            flags: tsz_solver::ObjectFlags::GLOBAL_THIS_SURFACE,
-            ..ObjectShape::default()
-        })
+        self.ctx
+            .types
+            .factory()
+            .global_this_surface_object(properties)
     }
 
     fn is_global_this_surface_candidate(&self, name: &str) -> bool {

--- a/crates/tsz-solver/src/intern/type_factory.rs
+++ b/crates/tsz-solver/src/intern/type_factory.rs
@@ -159,6 +159,19 @@ impl<'db> TypeFactory<'db> {
         self.db.object_with_index(shape)
     }
 
+    /// Create the synthetic `typeof globalThis` surface object. It carries the
+    /// `GLOBAL_THIS_SURFACE` flag so diagnostics render it as `typeof
+    /// globalThis` rather than its full member body. Builder method so checker
+    /// call sites do not name `ObjectFlags` directly.
+    #[inline]
+    pub fn global_this_surface_object(&self, properties: Vec<PropertyInfo>) -> TypeId {
+        self.object_with_index(ObjectShape {
+            properties,
+            flags: ObjectFlags::GLOBAL_THIS_SURFACE,
+            ..ObjectShape::default()
+        })
+    }
+
     /// Create an object whose declaration order should be preserved for
     /// stable spread display.
     #[inline]


### PR DESCRIPTION
Clears the **last** arch-guard violation keeping main's `lint` job red. The
four oversized-file violations this branch originally also addressed were
fixed independently by other PRs landing in main; only the `ObjectFlags`
checker-boundary breach remained.

## Structural rule
When the checker needs the `GLOBAL_THIS_SURFACE` object flag, it must go
through a solver `TypeFactory` builder rather than naming `tsz_solver::ObjectFlags::`
directly (checker→solver boundary, owned by `tsz-solver`; enforced by
`scripts/arch/arch_guard.py`). Two globalThis-surface sites violated it.

## What changed (behavior-preserving)
- add `TypeFactory::global_this_surface_object(properties)` in `tsz-solver`,
  mirroring the existing `object_preserve_declaration_order` builder — it sets
  `GLOBAL_THIS_SURFACE` inside the solver so checker call sites never name
  `ObjectFlags`
- route `context/lib_queries.rs` and
  `state/type_environment/type_node_resolution.rs` through it; drop their
  now-unused `ObjectShape` imports

Same `ObjectShape`/flag construction, moved one layer down. No new clippy
suppressions, no allowlist entries.

## Verification
- `cargo check -p tsz-checker --lib --tests`: clean, 0 warnings
- `python3 scripts/arch/arch_guard.py`: "Architecture guardrails passed." (was failing on these 2 sites)

Goal: hold

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
