### PR TITLE
fix(checker): resolve named references in JSDoc member/param/return positions

### DIFF
--- a/crates/tsz-checker/src/jsdoc/params_type_strings.rs
+++ b/crates/tsz-checker/src/jsdoc/params_type_strings.rs
@@ -568,9 +568,12 @@ impl<'a> CheckerState<'a> {
                     &sub_parent,
                     is_sub_array_object,
                 )
-                .or_else(|| self.jsdoc_type_from_expression(eff_type))
+                .or_else(|| self.resolve_jsdoc_reference(eff_type))
             } else {
-                self.jsdoc_type_from_expression(eff_type)
+                // Full resolver (see `jsdoc_type_from_expression` docs): a
+                // nested member with a named type must resolve, not collapse to
+                // `any` (#14850).
+                self.resolve_jsdoc_reference(eff_type)
             };
 
             if let Some(mut prop_type_id) = prop_type_id {

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -291,6 +291,17 @@ impl<'a> CheckerState<'a> {
         Ok(current)
     }
     /// Parse a JSDoc-style `@type` expression into a concrete type.
+    ///
+    /// This is the *structural* step only: unions, intersections, arrays,
+    /// tuples, primitives, `function(...)`/arrow syntax, indexed access, etc. It
+    /// deliberately does **not** perform named-reference resolution — a bare
+    /// name such as a `@callback`, a sibling `@typedef`, or a class/interface
+    /// returns `None` here. Callers resolving a member/parameter/return type
+    /// expression must use [`Self::resolve_jsdoc_reference`] (the full resolver:
+    /// structural step → object-literal → name resolution); using this function
+    /// directly silently collapses named references to `any` (see issue
+    /// #14850). It is `pub(crate)` only so `resolve_jsdoc_reference` and the
+    /// recursive structural sub-parsers can call it.
     pub(crate) fn jsdoc_type_from_expression(&mut self, type_expr: &str) -> Option<TypeId> {
         let type_expr = type_expr.trim();
         // Skip union/intersection splitting for `function(...)` types, since the

--- a/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/type_construction.rs
@@ -1289,7 +1289,7 @@ impl<'a> CheckerState<'a> {
         let params_inner = after_open[..close_idx].trim();
         let after_close = after_open[close_idx + 1..].trim();
         let return_type = if let Some(rest) = after_close.strip_prefix(':') {
-            self.jsdoc_type_from_expression(rest.trim())
+            self.resolve_jsdoc_reference(rest.trim())
                 .unwrap_or(TypeId::VOID)
         } else {
             TypeId::VOID
@@ -1306,9 +1306,7 @@ impl<'a> CheckerState<'a> {
                 } else {
                     (None, p)
                 };
-                let p_type = self
-                    .jsdoc_type_from_expression(t_str)
-                    .unwrap_or(TypeId::ANY);
+                let p_type = self.resolve_jsdoc_reference(t_str).unwrap_or(TypeId::ANY);
                 let atom = name.map(|n| self.ctx.types.intern_string(n));
                 params.push(ParamInfo {
                     name: atom,
@@ -1369,7 +1367,7 @@ impl<'a> CheckerState<'a> {
         // Return type follows ':'
         let return_type = if let Some(rest) = after_close.strip_prefix(':') {
             let return_type_str = rest.trim();
-            self.jsdoc_type_from_expression(return_type_str)
+            self.resolve_jsdoc_reference(return_type_str)
                 .unwrap_or(TypeId::VOID)
         } else {
             TypeId::VOID
@@ -1387,9 +1385,7 @@ impl<'a> CheckerState<'a> {
                 } else {
                     (None, p)
                 };
-                let p_type = self
-                    .jsdoc_type_from_expression(t_str)
-                    .unwrap_or(TypeId::ANY);
+                let p_type = self.resolve_jsdoc_reference(t_str).unwrap_or(TypeId::ANY);
                 let atom = name.map(|n| self.ctx.types.intern_string(n));
                 params.push(ParamInfo {
                     name: atom,
@@ -1739,10 +1735,10 @@ impl<'a> CheckerState<'a> {
                         &param.name,
                         is_array_object_base,
                     )
-                    .or_else(|| self.jsdoc_type_from_expression(effective_expr))
+                    .or_else(|| self.resolve_jsdoc_reference(effective_expr))
                     .unwrap_or(TypeId::ANY)
                 } else {
-                    self.jsdoc_type_from_expression(effective_expr)
+                    self.resolve_jsdoc_reference(effective_expr)
                         .unwrap_or(TypeId::ANY)
                 };
 
@@ -1768,7 +1764,7 @@ impl<'a> CheckerState<'a> {
         let return_type = if let Some((is_asserts, param_name, type_str)) = cb.predicate {
             let pred_type = type_str
                 .as_deref()
-                .and_then(|s| self.jsdoc_type_from_expression(s));
+                .and_then(|s| self.resolve_jsdoc_reference(s));
             let target = if param_name == "this" {
                 TypePredicateTarget::This
             } else {
@@ -1797,14 +1793,11 @@ impl<'a> CheckerState<'a> {
             }
         } else if let Some(ref ret_expr) = cb.return_type {
             let ret_expr = ret_expr.trim();
-            self.jsdoc_type_from_expression(ret_expr)
-                .or_else(|| {
-                    if ret_expr.starts_with('{') && ret_expr.ends_with('}') {
-                        self.parse_jsdoc_object_literal_type(ret_expr)
-                    } else {
-                        None
-                    }
-                })
+            // Full resolver: it already covers the structural step *and*
+            // top-level object literals (the previous `.or_else` fallback) plus
+            // named-reference resolution, so a named return type resolves
+            // instead of collapsing to `any` (#14850).
+            self.resolve_jsdoc_reference(ret_expr)
                 .unwrap_or(TypeId::ANY)
         } else {
             TypeId::VOID
@@ -1850,7 +1843,9 @@ impl<'a> CheckerState<'a> {
             let mut prop_type = if prop.type_expr.trim().is_empty() {
                 TypeId::ANY
             } else {
-                self.jsdoc_type_from_expression(&prop.type_expr)
+                // Full resolver (see `jsdoc_type_from_expression` docs): a named
+                // `@property` type must resolve, not collapse to `any` (#14850).
+                self.resolve_jsdoc_reference(&prop.type_expr)
                     .unwrap_or(TypeId::ANY)
             };
             let effective_expr = prop.type_expr.trim_end_matches('=').trim();

--- a/crates/tsz-checker/tests/jsdoc_callback_rest_tests.rs
+++ b/crates/tsz-checker/tests/jsdoc_callback_rest_tests.rs
@@ -1,6 +1,22 @@
 //! Tests for JSDoc @callback rest parameter and @typedef nested property handling.
 
-use crate::test_utils::{check_js_source_diagnostics, diagnostic_codes};
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_js_source_diagnostics, check_source, diagnostic_codes};
+
+/// Strict JS check (no lib contexts) so `noImplicitAny`-driven TS7006 and
+/// assignability diagnostics surface for the named-reference resolution tests.
+fn check_strict_js(source: &str) -> Vec<crate::diagnostics::Diagnostic> {
+    check_source(
+        source,
+        "test.js",
+        CheckerOptions {
+            allow_js: true,
+            check_js: true,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
 
 /// @callback with @param {...string} should create a rest parameter accepting
 /// variable string arguments. No TS2554 should be emitted for extra arguments.
@@ -101,6 +117,225 @@ foo(false, '', 1, 2, 3);
         ts2554,
         0,
         "Expected no TS2554 for Closure function type rest param, got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Named references in `@typedef {Object}` `@property`, `@callback` params, and
+// inline method/call signatures must resolve through the full reference
+// resolver, not the structural-only step. A bare name (`@callback`, sibling
+// `@typedef`, class/interface) previously collapsed to `any`, silently
+// dropping contextual typing and assignment checks. See issue #14850.
+// ---------------------------------------------------------------------------
+
+/// `@typedef {Object} Opts` + `@property {Cb} fn` where `Cb` is a named
+/// `@callback`: assigning a non-function value must report TS2322, not be
+/// silently accepted (the property type must be `Cb`, not `any`).
+#[test]
+fn jsdoc_object_typedef_property_callback_checks_assignment() {
+    let source = r#"
+/**
+ * @callback Cb
+ * @param {number} n
+ * @returns {string}
+ */
+/**
+ * @typedef {Object} Opts
+ * @property {Cb} fn
+ */
+/** @type {Opts} */
+const o = { fn: 123 };
+"#;
+    let diagnostics = check_strict_js(source);
+    let ts2322 = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322,
+        1,
+        "Expected TS2322 assigning a number to a @callback-typed @property, got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
+/// Same shape, but the property value is an arrow: its parameter must be
+/// contextually typed by `Cb` (no false TS7006), and the wrong return type
+/// must surface a TS2322 — matching the inline-object typedef path.
+#[test]
+fn jsdoc_object_typedef_property_callback_contextually_types_arrow() {
+    let source = r#"
+/**
+ * @callback Cb
+ * @param {number} n
+ * @returns {string}
+ */
+/**
+ * @typedef {Object} Opts
+ * @property {Cb} fn
+ */
+/** @type {Opts} */
+const o = { fn: (n) => n };
+"#;
+    let diagnostics = check_strict_js(source);
+    let codes = diagnostic_codes(&diagnostics);
+    assert!(
+        !codes.contains(&7006),
+        "Parameter should be contextually typed by the callback (no TS7006), got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&2322),
+        "Returning the number param where a string is expected should report TS2322, got: {codes:?}"
+    );
+}
+
+/// The defect generalizes to *any* named alias, not just `@callback`. A
+/// `@property` whose type is a sibling `@typedef {string}` must resolve to
+/// that alias (here: a number assigned to a string property → TS2322).
+#[test]
+fn jsdoc_object_typedef_property_named_alias_resolves() {
+    let source = r#"
+/** @typedef {string} Name */
+/**
+ * @typedef {Object} Box
+ * @property {Name} label
+ */
+/** @type {Box} */
+const b = { label: 42 };
+"#;
+    let diagnostics = check_strict_js(source);
+    let ts2322 = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322,
+        1,
+        "Expected TS2322: a sibling @typedef alias @property must not collapse to any, got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
+/// Anti-hardcoding: the fix is structural, not keyed on the names `Cb`/`Opts`.
+/// Renaming every binder must produce the same TS2322.
+#[test]
+fn jsdoc_object_typedef_property_callback_renamed_binders() {
+    let source = r#"
+/**
+ * @callback Zzz
+ * @param {number} q
+ * @returns {string}
+ */
+/**
+ * @typedef {Object} Qqq
+ * @property {Zzz} ww
+ */
+/** @type {Qqq} */
+const vv = { ww: 999 };
+"#;
+    let diagnostics = check_strict_js(source);
+    let ts2322 = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322,
+        1,
+        "Renamed binders must still report TS2322, got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
+/// Regression guard: the inline-object typedef form `@typedef {{ fn: Cb }}`
+/// — which already worked — must keep reporting TS2322.
+#[test]
+fn jsdoc_inline_object_typedef_property_callback_still_checks() {
+    let source = r#"
+/**
+ * @callback Cb
+ * @param {number} n
+ * @returns {string}
+ */
+/** @typedef {{ fn: Cb }} Opts */
+/** @type {Opts} */
+const o = { fn: 123 };
+"#;
+    let diagnostics = check_strict_js(source);
+    let ts2322 = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322,
+        1,
+        "Inline-object typedef form must keep checking the callback property, got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
+/// A `@callback` *parameter* that references a named `@typedef` must resolve to
+/// that type (so a bad property access reports TS2339), instead of the
+/// parameter collapsing to `any`.
+#[test]
+fn jsdoc_callback_param_resolves_named_typedef() {
+    let source = r#"
+/** @typedef {{ id: number }} User */
+/**
+ * @callback Handler
+ * @param {User} u
+ * @returns {number}
+ */
+/** @type {Handler} */
+const h = (u) => u.nope;
+"#;
+    let diagnostics = check_strict_js(source);
+    let ts2339 = diagnostics.iter().filter(|d| d.code == 2339).count();
+    assert_eq!(
+        ts2339,
+        1,
+        "A @callback param typed by a named @typedef must report TS2339 on a missing property, got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
+/// A *nested* `@property` (dotted name) typed by a named `@callback` must also
+/// resolve through the full resolver — the nested-object builder previously
+/// used the structural-only step, collapsing `nested.fn` to `any`.
+#[test]
+fn jsdoc_nested_property_callback_resolves() {
+    let source = r#"
+/**
+ * @callback Cb
+ * @param {number} n
+ * @returns {string}
+ */
+/**
+ * @typedef {Object} Opts
+ * @property {Object} nested
+ * @property {Cb} nested.fn
+ */
+/** @type {Opts} */
+const o = { nested: { fn: 123 } };
+"#;
+    let diagnostics = check_strict_js(source);
+    let ts2322 = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322,
+        1,
+        "A nested @property typed by a named @callback must report TS2322, got: {:?}",
+        diagnostic_codes(&diagnostics)
+    );
+}
+
+/// An inline method/call signature inside a `@property` whose return type is a
+/// named `@typedef` must resolve that name (a mismatched returned value reports
+/// TS2322), rather than collapsing the return to `void`/`any`.
+#[test]
+fn jsdoc_inline_method_signature_return_resolves_named_typedef() {
+    let source = r#"
+/** @typedef {{ id: number }} User */
+/**
+ * @typedef {Object} Api
+ * @property {{ get(): User }} client
+ */
+/** @type {Api} */
+const a = { client: { get: () => ({ id: "x" }) } };
+"#;
+    let diagnostics = check_strict_js(source);
+    let ts2322 = diagnostics.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322,
+        1,
+        "An inline method signature return typed by a named @typedef must report TS2322, got: {:?}",
         diagnostic_codes(&diagnostics)
     );
 }


### PR DESCRIPTION
## Summary

Fixes #14850.

JSDoc `@typedef {Object}` `@property`, `@callback` parameters/returns, nested
`@property` members, and inline method/call signatures resolved their type
expressions through the structural-only `jsdoc_type_from_expression`, which
returns `None` for a bare named reference — a `@callback`, a sibling `@typedef`,
or a class/interface/enum. Those names silently collapsed to `any`, dropping
both contextual typing (false **TS7006**) and assignability checks (missing
**TS2322** / **TS2339**). The inline-object typedef path
(`parse_jsdoc_object_literal_type`) already used the full resolver, which is why
`@typedef {{ fn: Cb }}` worked but `@typedef {Object}` + `@property {Cb} fn`
did not.

## Structural rule

When a JSDoc member/parameter/return type expression is a bare named reference
(`@callback`, sibling `@typedef`, class/interface/enum/import), `tsc` resolves
it to that type; tsz resolved it through the structural-only step
(`jsdoc_type_from_expression`), which performs no name resolution, so the
reference became `any`. The fix routes every such site through
`resolve_jsdoc_reference` (the canonical resolver: structural step →
object-literal → name resolution), matching the inline-object typedef path.

## Owner layer

Checker JSDoc resolution (`crates/tsz-checker/src/jsdoc/...`). No solver/relation
changes; the resolved `TypeId` flows into the existing assignability/contextual
machinery unchanged.

## Sites changed (one bug family)

- `type_construction.rs`: object-typedef `@property`, `@callback`
  param/predicate/return, inline call/method signature param + return.
- `params_type_strings.rs`: nested (dotted) `@property` member types.
- `name_resolution.rs`: documents the structural-vs-full boundary on
  `jsdoc_type_from_expression` so direct callers in these positions are not
  reintroduced.

## Adjacent matrix (all match `tsc` 6.0.2, verified via CLI)

- `@property {Cb} fn = 123` → TS2322 (was: no diagnostic).
- `@property {Cb} fn = (n) => n` → contextually typed, TS2322 on bad return
  (was: false TS7006).
- `@property {Name} label` (named `@typedef {string}` alias) → TS2322.
- `@property {Animal} pet` (class) → TS2322.
- Nested `@property {Cb} nested.fn = 123` → TS2322 (was: no diagnostic).
- `@callback` param `@param {User} u` → TS2339 on a missing property.
- Inline `@property {{ get(): User }}` return → TS2322.
- Renamed binders (`Zzz`/`Qqq`/`ww`) → same TS2322 (anti-hardcoding).
- Regression guard: inline `@typedef {{ fn: Cb }}` still TS2322.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- `cargo test -p tsz-checker --lib jsdoc_callback_rest_tests` — 12 passed
  (8 new tests covering the matrix above + 4 existing).
- `cargo test -p tsz-checker --lib jsdoc` — 413 passed; the only 2 failures
  (`jsdoc_cross_file_typedef_tests::jsdoc_class_self_param_uses_instance_type_across_commonjs_file`,
  `jsdoc_type_from_required_js_es_module_export_resolves_class_instance`) are
  pre-existing and reproduce identically on the unmodified base (they depend on
  the full TS lib/submodule absent in this local checkout); ready-review CI owns
  the broad suites.
- `cargo clippy -p tsz-checker --lib` — clean.
- CLI parity check against `tsc` for every case in the matrix above.

https://claude.ai/code/session_01Pj9GYe6w3wzWj9VscMqoEF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pj9GYe6w3wzWj9VscMqoEF)_