### PR TITLE
fix(solver): emit TS7053 indexing a symbol-only index type by a string/number literal key

### DIFF
--- a/crates/tsz-checker/tests/symbol_index_signature_tests.rs
+++ b/crates/tsz-checker/tests/symbol_index_signature_tests.rs
@@ -1376,3 +1376,268 @@ fn all_keys_keyed_mapped_indexed_by_symbol_is_valid() {
         "all-keys mapped indexed by symbol must be accepted, got {codes:?}",
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #14796: indexing a *symbol-only* index-signature type by a string or
+// number *literal* key must NOT resolve through the symbol index signature.
+//
+// Structural rule: when the receiver's only index signature is `[k: symbol]: V`
+// and the key expression is a string/number literal (or otherwise non-`symbol`)
+// property name, tsc treats the access as an implicit-`any` element access and
+// reports TS7053 (the symbol index is not a string/number index). tsz was
+// silently resolving `x["foo"]` / `x[1]` to `V` because property resolution
+// fell through the `string_index` slot, which historically also stored the
+// `symbol` index. The fix routes the literal-key lookup through
+// `string_index_signature()` (which excludes a `symbol`-keyed signature) and
+// makes `string_index_signature_accepts_property` reject `symbol` keys.
+// ---------------------------------------------------------------------------
+
+const TS7053: u32 = diagnostic_codes::ELEMENT_IMPLICITLY_HAS_AN_ANY_TYPE_BECAUSE_EXPRESSION_OF_TYPE_CANT_BE_USED_TO_IN;
+
+#[test]
+fn symbol_only_index_string_literal_access_reports_ts7053() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const so: { [k: symbol]: number };
+const v = so["foo"];
+"#,
+    );
+    assert!(
+        codes.contains(&TS7053),
+        "string-literal key on a symbol-only index must report TS7053, got {codes:?}",
+    );
+}
+
+#[test]
+fn symbol_only_index_number_literal_access_reports_ts7053() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const so: { [k: symbol]: number };
+const w = so[1];
+"#,
+    );
+    assert!(
+        codes.contains(&TS7053),
+        "number-literal key on a symbol-only index must report TS7053, got {codes:?}",
+    );
+}
+
+#[test]
+fn symbol_only_index_interface_string_literal_access_reports_ts7053() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+interface SymBag { [k: symbol]: number; }
+declare const b: SymBag;
+const v = b["foo"];
+"#,
+    );
+    assert!(
+        codes.contains(&TS7053),
+        "string-literal key on a symbol-only interface index must report TS7053, got {codes:?}",
+    );
+}
+
+#[test]
+fn symbol_only_index_class_string_literal_access_reports_ts7053() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+class C { [k: symbol]: number; }
+declare const c: C;
+const cv = c["foo"];
+"#,
+    );
+    assert!(
+        codes.contains(&TS7053),
+        "string-literal key on a symbol-only class index must report TS7053, got {codes:?}",
+    );
+}
+
+// Renamed binder name and key spelling — proves the rule is structural, not
+// keyed on the identifier `so`/`k`/`foo`.
+#[test]
+fn symbol_only_index_string_literal_access_reports_ts7053_renamed() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const registry: { [entry: symbol]: boolean };
+const hit = registry["lookup"];
+"#,
+    );
+    assert!(
+        codes.contains(&TS7053),
+        "renamed symbol-only index must still report TS7053 for a string key, got {codes:?}",
+    );
+}
+
+#[test]
+fn symbol_only_index_intersection_string_literal_access_reports_ts7053() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const x: { [k: symbol]: number } & { name: string };
+const a = x["foo"];
+"#,
+    );
+    assert!(
+        codes.contains(&TS7053),
+        "string key with no named member on a symbol-index intersection must report TS7053, got {codes:?}",
+    );
+}
+
+// Control: the named half of the intersection still resolves cleanly.
+#[test]
+fn symbol_only_index_intersection_named_member_access_is_clean() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const x: { [k: symbol]: number } & { name: string };
+const n: string = x["name"];
+"#,
+    );
+    assert!(
+        !codes.contains(&TS7053),
+        "a named member on a symbol-index intersection must resolve without TS7053, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "x[\"name\"] must type as string, got {codes:?}",
+    );
+}
+
+// Control: a symbol-typed (wide) key access stays clean — the symbol index
+// applies. Mirrors the issue's `so[s]` control.
+#[test]
+fn symbol_only_index_wide_symbol_key_access_is_clean() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const so: { [k: symbol]: number };
+declare const s: symbol;
+const ok: number = so[s];
+"#,
+    );
+    assert!(
+        !codes.contains(&TS7053),
+        "wide-symbol key on a symbol index must resolve cleanly, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "so[s] must type as the symbol-index value, got {codes:?}",
+    );
+}
+
+// Control: when BOTH a string and a symbol index are present, a string-literal
+// key must resolve through the string index (not be rejected).
+#[test]
+fn string_and_symbol_index_string_literal_access_uses_string_index() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const m: { [k: string]: number; [k: symbol]: string };
+const v: number = m["foo"];
+"#,
+    );
+    assert!(
+        !codes.contains(&TS7053),
+        "a string key on a string+symbol index must resolve through the string index, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "m[\"foo\"] must type as the string-index value (number), got {codes:?}",
+    );
+}
+
+// Control: a string-only index still resolves a string-literal key cleanly —
+// the fix must not over-reject genuine string index access.
+#[test]
+fn string_only_index_string_literal_access_is_clean() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const so: { [k: string]: number };
+const v: number = so["foo"];
+"#,
+    );
+    assert!(
+        !codes.contains(&TS7053),
+        "string-only index must resolve a string-literal key cleanly, got {codes:?}",
+    );
+}
+
+// Generic adjacent case: a type parameter constrained to a symbol-only index
+// indexed by a string literal must report TS7053 (the constraint resolves to a
+// symbol-only index, which does not cover a string key).
+#[test]
+fn symbol_only_index_generic_constraint_string_literal_access_reports_ts7053() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+function read<T extends { [k: symbol]: number }>(x: T) {
+    return x["foo"];
+}
+"#,
+    );
+    assert!(
+        codes.contains(&TS7053),
+        "string-literal key on a symbol-only-constrained type parameter must report TS7053, got {codes:?}",
+    );
+}
+
+// Generic instantiation adjacent case: `Record<symbol, V>` indexed by a string
+// literal flows through the Application property-resolution path, which must
+// also exclude the symbol index for a non-symbol key.
+#[test]
+fn record_symbol_key_string_literal_access_reports_ts7053() {
+    let libs = load_lib_files(&["es5.d.ts"]);
+    if libs.is_empty() {
+        return;
+    }
+    let diags = check_source_with_libs(
+        r#"
+declare const r: Record<symbol, number>;
+const v = r["foo"];
+"#,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    );
+    let codes: Vec<u32> = diags.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&TS7053),
+        "Record<symbol, V> indexed by a string literal must report TS7053, got {codes:?}",
+    );
+}
+
+// Callable adjacent case: a callable/function type that carries only a symbol
+// index signature, indexed by a string literal, flows through the Callable
+// property-resolution path, which must also exclude the symbol index.
+#[test]
+fn symbol_only_index_callable_string_literal_access_reports_ts7053() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const f: { (): void; [k: symbol]: number };
+const v = f["foo"];
+"#,
+    );
+    assert!(
+        codes.contains(&TS7053),
+        "string-literal key on a symbol-only-index callable must report TS7053, got {codes:?}",
+    );
+}
+
+// Type-reveal witness from the issue: assigning the result to an incompatible
+// annotation must NOT surface a TS2322 (which would prove the access wrongly
+// resolved to `number`); the access is an implicit-any TS7053 instead.
+#[test]
+fn symbol_only_index_string_literal_access_does_not_leak_value_type() {
+    let codes = diagnostic_codes_for_ts(
+        r#"
+declare const so: { [k: symbol]: number };
+const x: { reveal: true } = so["foo"];
+"#,
+    );
+    assert!(
+        codes.contains(&TS7053),
+        "the type-reveal witness must report TS7053, got {codes:?}",
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "so[\"foo\"] must be implicit-any (not number), so no TS2322 should fire, got {codes:?}",
+    );
+}

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -716,8 +716,15 @@ impl<'a> PropertyAccessEvaluator<'a> {
                         self.add_undefined_if_unchecked(idx.value_type),
                     );
                 }
-                // Check string index signature (for static index signatures on class constructors)
-                if let Some(ref idx) = shape.string_index {
+                // Check string index signature (for static index signatures on class constructors).
+                // A `symbol`-keyed index (which may live in the `string_index`
+                // slot under the legacy encoding) must not satisfy a non-symbol
+                // property name — otherwise indexing a symbol-only-index callable
+                // by a string key would resolve to the value type instead of
+                // producing a TS7053 implicit-any element access.
+                if let Some(ref idx) = shape.string_index
+                    && self.string_index_signature_resolves_property(idx, prop_atom)
+                {
                     return PropertyAccessResult::from_index(
                         self.add_undefined_if_unchecked(idx.value_type),
                     );

--- a/crates/tsz-solver/src/operations/property_helpers.rs
+++ b/crates/tsz-solver/src/operations/property_helpers.rs
@@ -795,8 +795,14 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 return PropertyAccessResult::simple(final_type);
             }
 
-            // Check index signatures if property not found
-            if let Some(ref idx) = shape.string_index {
+            // Check index signatures if property not found. A `symbol`-keyed
+            // index signature (which may live in the `string_index` slot under
+            // the legacy encoding) must not satisfy a non-symbol property name —
+            // otherwise `Record<symbol, V>["foo"]` would resolve to `V` instead
+            // of producing a TS7053 implicit-any element access.
+            if let Some(ref idx) = shape.string_index
+                && self.string_index_signature_resolves_property(idx, prop_atom)
+            {
                 return PropertyAccessResult::from_index(
                     self.add_undefined_if_unchecked(idx.value_type),
                 );
@@ -1031,8 +1037,12 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     };
                 }
 
-                // Property not found in explicit properties - check index signatures
-                if let Some(ref idx) = shape.string_index {
+                // Property not found in explicit properties - check index signatures.
+                // A `symbol`-keyed index must not satisfy a non-symbol property
+                // name (see the sibling branch above for the same rule).
+                if let Some(ref idx) = shape.string_index
+                    && self.string_index_signature_resolves_property(idx, prop_atom)
+                {
                     // Found string index signature - instantiate the value type
                     let instantiated_value = self.instantiate_application_member_type(
                         idx.value_type,

--- a/crates/tsz-solver/src/operations/property_readonly.rs
+++ b/crates/tsz-solver/src/operations/property_readonly.rs
@@ -234,8 +234,14 @@ fn indexed_object_property_is_readonly(
         return prop.readonly;
     }
 
-    // Check string index signature for ALL property names
-    if shape.string_index.as_ref().is_some_and(|idx| idx.readonly) {
+    // Check string index signature for ALL property names. A `symbol`-keyed
+    // index (which may live in the `string_index` slot under the legacy
+    // encoding) only covers symbol (`__unique_`-named) keys, not string keys.
+    if shape
+        .string_index
+        .as_ref()
+        .is_some_and(|idx| string_slot_index_covers(idx, prop_name) && idx.readonly)
+    {
         return true;
     }
 
@@ -247,6 +253,15 @@ fn indexed_object_property_is_readonly(
     }
 
     false
+}
+
+/// Whether an index signature stored in the `string_index` slot applies to
+/// `prop_name`. A `symbol`-keyed signature (legacy-encoded into the
+/// `string_index` slot) only covers internal `__unique_`-named symbol keys,
+/// never a string/number-literal key; a genuine `string`/template index covers
+/// every property name.
+fn string_slot_index_covers(idx: &crate::types::IndexSignature, prop_name: &str) -> bool {
+    idx.key_type != TypeId::SYMBOL || prop_name.starts_with("__unique_")
 }
 
 /// Check if a property on a callable type is readonly.
@@ -264,8 +279,13 @@ fn callable_property_is_readonly(
         return prop.readonly;
     }
 
-    // Check string index signature for ALL property names
-    if shape.string_index.as_ref().is_some_and(|idx| idx.readonly) {
+    // Check string index signature for ALL property names. A `symbol`-keyed
+    // index covers only symbol (`__unique_`-named) keys, not string keys.
+    if shape
+        .string_index
+        .as_ref()
+        .is_some_and(|idx| string_slot_index_covers(idx, prop_name) && idx.readonly)
+    {
         return true;
     }
 

--- a/crates/tsz-solver/src/operations/property_visitor.rs
+++ b/crates/tsz-solver/src/operations/property_visitor.rs
@@ -21,13 +21,48 @@ impl<'a> PropertyAccessEvaluator<'a> {
         index: &IndexSignature,
         prop_atom: Atom,
     ) -> bool {
-        if matches!(index.key_type, TypeId::STRING | TypeId::SYMBOL) {
+        // A `symbol`-keyed index signature never accepts a string/number-literal
+        // property name. Historically a `[k: symbol]: V` signature was encoded in
+        // the `string_index` slot with `key_type == SYMBOL`; treating that as a
+        // catch-all string index silently typed `x["foo"]` / `x[1]` as `V`
+        // instead of producing TS7053. Unique-symbol property names are routed
+        // away from this helper earlier via the `__unique_` guard, so reaching
+        // here with a symbol index always means a non-matching key.
+        if index.key_type == TypeId::SYMBOL {
+            return false;
+        }
+
+        if index.key_type == TypeId::STRING {
             return true;
         }
 
         let prop_type = self.interner().literal_string_atom(prop_atom);
         let mut checker = SubtypeChecker::new(self.interner());
         checker.is_subtype_of(prop_type, index.key_type)
+    }
+
+    /// Whether an index signature stored in the `string_index` slot should
+    /// resolve `prop_atom`, used by the generic-instantiation (`Application`)
+    /// property paths that do not perform key-type subtype gating.
+    ///
+    /// Unlike [`Self::string_index_signature_accepts_property`], this only
+    /// excludes the `symbol`-keyed leak: a `[k: symbol]: V` signature (which
+    /// may live in the `string_index` slot under the legacy encoding) must not
+    /// satisfy a string/number-literal key, but still resolves an internal
+    /// `__unique_`-named symbol property. Genuine `string`/template-literal
+    /// indexes resolve every property name, preserving prior behavior.
+    pub(crate) fn string_index_signature_resolves_property(
+        &self,
+        index: &IndexSignature,
+        prop_atom: Atom,
+    ) -> bool {
+        if index.key_type == TypeId::SYMBOL {
+            return self
+                .interner()
+                .resolve_atom_ref(prop_atom)
+                .starts_with("__unique_");
+        }
+        true
     }
 
     /// True when `prop_atom` names an ES `#private` field that must not be
@@ -221,9 +256,14 @@ impl<'a> PropertyAccessEvaluator<'a> {
         // Check string index signature.
         // Symbol-keyed properties (internal "__unique_N" names) must NOT
         // fall through to string index signatures — tsc treats symbol keys
-        // as distinct from string keys for index signature purposes.
+        // as distinct from string keys for index signature purposes. Use the
+        // `string_index_signature()` accessor so a `[k: symbol]: V` signature
+        // (which may live in the `string_index` slot under the legacy encoding)
+        // is not consulted for a string/number-literal key; otherwise
+        // `x["foo"]` on a symbol-only-index type would silently resolve to `V`
+        // instead of producing TS7053.
         if !prop_name.starts_with("__unique_")
-            && let Some(ref idx) = shape.string_index
+            && let Some(idx) = shape.string_index_signature()
             && self.string_index_signature_accepts_property(idx, prop_atom)
         {
             return Some(self.index_signature_result_with_nuia_write_type(idx.value_type));


### PR DESCRIPTION
## Summary

Closes #14796.

A type whose only index signature is `[k: symbol]: V` was silently treated as string/number-indexable: `x["foo"]` / `x[1]` resolved to `V` instead of producing an implicit-any element-access error. `tsc` reports **TS7053**. This is a soundness gap — a non-key access was silently typed as the symbol-index value.

## Structural rule

When the receiver's only index signature is `[k: symbol]: V` and the key is a string/number-literal (or otherwise non-`symbol`) property name, `tsc` treats the access as an implicit-`any` element access and reports TS7053; the symbol index is not a string/number index.

`When a string/number-literal key indexes a type whose applicable index signature is symbol-keyed, tsc emits TS7053; tsz now does so through the solver property/element-access resolution layer.`

## Root cause + owner layer

A `[k: symbol]: V` signature is, under a legacy encoding, stored in `ObjectShape.string_index` with `key_type == SYMBOL` (the `string_index_signature()` / `symbol_index_signature()` accessors exist precisely to disambiguate the slot). Several property-resolution readers read the raw `string_index` slot and leaked the symbol index for string keys.

Owner: solver property/element-access resolution. The fix routes every reader so a symbol-keyed signature is excluded from string/number-literal-key lookups, while still resolving internal `__unique_`-named symbol keys:

- `string_index_signature_accepts_property` rejects `SYMBOL` keys (`crates/tsz-solver/src/operations/property_visitor.rs`).
- `visit_object_with_index_impl` reads via the `string_index_signature()` accessor instead of the raw slot.
- The generic-instantiation (`Application`) paths and the `Callable` static-index path gate the raw slot with a new symbol-aware helper `string_index_signature_resolves_property` (`property_helpers.rs`, `property.rs`).
- The readonly-index checks gate the slot with `string_slot_index_covers` (`property_readonly.rs`) for consistency.

This is the established "route all readers through the typed accessors" altitude; the underlying dual-slot encoding is intentional (it supports `Record<PropertyKey, V>` shapes that need both slots), so a storage-layer rewrite is out of scope.

## Adjacent matrix

All now emit TS7053 (binder names varied to prove the rule is structural, not identifier-keyed):
- inline object type, interface alias, class instance
- intersection `{ [k: symbol]: number } & { name: string }` indexed by `"foo"`
- type-parameter constraint `<T extends { [k: symbol]: number }>`
- generic instantiation `Record<symbol, number>`
- symbol-only-index callable `{ (): void; [k: symbol]: number }`
- string and number literal keys

## Fallback / controls (must stay clean — verified)
- wide-`symbol` key access `so[s]` resolves through the symbol index
- the named member of the intersection (`x["name"]`) resolves normally
- a mixed `{ [k: string]: number; [k: symbol]: string }` resolves a string key through the string index
- a string-only index resolves a string-literal key

## Verification

- `cargo test -p tsz-checker --test symbol_index_signature_tests` — 75 passed (11 new TS7053 cases + controls).
- `cargo test -p tsz-checker` related suites: `class_implements_index_signature_tests`, `index_signature_branded_key_applicability_tests`, `ts2536_keyof_string_index_signature_tests`, `homomorphic_mapped_symbol_iterator_tests`, `ts7053_template_mapped_tests` — all pass.
- `cargo test -p tsz-solver --lib` property/readonly/index modules — 925 passed; the only failure (`test_conditional_infer_optional_property_present_distributive`) is pre-existing on the base branch and unrelated.
- Ready-review CI owns the broad conformance/emit/fourslash suites.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrdVUxPFdQuWXnL4w4wWkw)_