### PR TITLE
feat(#14345): name-aware alpha-rename pairing for same-name-reordered signatures (flag-gated, dormant)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -17,10 +17,13 @@ use super::erase_type_params_to_constraints;
 
 mod context_instantiation;
 mod generic_constraints;
+mod name_pairing;
 mod overloads;
 mod params;
 
 type HoistedTypeParams = (Vec<TypeParamInfo>, Vec<(TypeId, TypeId)>);
+
+use name_pairing::{alpha_name_pair_enabled, name_aware_target_permutation};
 
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     pub(crate) fn check_function_subtype(
@@ -302,13 +305,50 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
             }
 
+            // #14345 Stage-3: pair the source/target type params for the
+            // alpha-rename. By default this is positional (`source[i]` with
+            // `target[i]`). When the name multisets are equal but the order
+            // differs (`<E,A>` vs `<A,E>`), positional pairing renames the
+            // target body onto the wrong source identities and produces
+            // spurious mismatches; under `TSZ_ALPHA_NAME_PAIR=1`, pair by name
+            // instead so same-named params line up across the reorder. Every
+            // downstream consumer (constraint classification, equivalence
+            // registration, fallback canonicalization) iterates this single
+            // pairing so the chosen alignment is used uniformly.
+            let name_aware_perm = if alpha_name_pair_enabled() {
+                name_aware_target_permutation(
+                    &source_instantiated.type_params,
+                    &target_instantiated.type_params,
+                )
+            } else {
+                None
+            };
+            // Materialize the paired `(source_tp, target_tp)` once so all sites
+            // below agree on the alignment. `TypeParamInfo` is `Copy`, so own
+            // the pairs rather than borrow -- `source_instantiated` /
+            // `target_instantiated` are reassigned by the alpha-rename below.
+            let paired_type_params: Vec<(TypeParamInfo, TypeParamInfo)> = match &name_aware_perm {
+                Some(perm) => perm
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &j)| {
+                        (
+                            source_instantiated.type_params[i],
+                            target_instantiated.type_params[j],
+                        )
+                    })
+                    .collect(),
+                None => source_instantiated
+                    .type_params
+                    .iter()
+                    .zip(target_instantiated.type_params.iter())
+                    .map(|(s, t)| (*s, *t))
+                    .collect(),
+            };
+
             let mut target_to_source_substitution = TypeSubstitution::new();
             let mut source_identity_substitution = TypeSubstitution::new();
-            for (source_tp, target_tp) in source_instantiated
-                .type_params
-                .iter()
-                .zip(target_instantiated.type_params.iter())
-            {
+            for (source_tp, target_tp) in &paired_type_params {
                 let source_type_param_type = self.interner.type_param(*source_tp);
                 target_to_source_substitution.insert(target_tp.name, source_type_param_type);
                 source_identity_substitution.insert(source_tp.name, source_type_param_type);
@@ -347,11 +387,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // merely wraps the target's recursive constraint in extra application
             // layers. For mapped/indexed contexts both directions must hold so
             // apparent-member facts are preserved.
-            let constraints_allow_alpha_rename = source_instantiated
-                .type_params
-                .iter()
-                .zip(target_instantiated.type_params.iter())
-                .all(|(source_tp, target_tp)| {
+            let constraints_allow_alpha_rename =
+                paired_type_params.iter().all(|(source_tp, target_tp)| {
                     let relation = self.classify_generic_tp_constraint(
                         source_tp,
                         target_tp,
@@ -381,11 +418,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // allow structural comparison to treat the original source/target type params
                 // as identical, fixing false mismatches for structurally identical generic
                 // method signatures with different type param names.
-                for (source_tp, target_tp) in source_instantiated
-                    .type_params
-                    .iter()
-                    .zip(target_instantiated.type_params.iter())
-                {
+                for (source_tp, target_tp) in &paired_type_params {
                     let source_tp_type = self.interner.type_param(*source_tp);
                     let target_tp_type = self.interner.type_param(*target_tp);
                     if source_tp_type != target_tp_type {
@@ -479,11 +512,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // (`T` clamps to `{p: string}`, source param becomes `{p: string}[]`,
                 // which the opaque `S extends {p: string}[]` marker accepts).
                 let mut source_substitution = TypeSubstitution::new();
-                for (source_tp, target_tp) in source_instantiated
-                    .type_params
-                    .iter()
-                    .zip(target_instantiated.type_params.iter())
-                {
+                for (source_tp, target_tp) in &paired_type_params {
                     let relation = self.classify_generic_tp_constraint(
                         source_tp,
                         target_tp,

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/name_pairing.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/name_pairing.rs
@@ -1,0 +1,129 @@
+//! #14345 Stage-3 name-aware alpha-rename pairing.
+//!
+//! When two same-arity generic signatures are related, the alpha-rename that
+//! normalizes them onto one set of type-parameter identities historically
+//! pairs the source/target type parameters by declaration POSITION (a `.zip`
+//! of the two `type_params` lists). When the signatures use the SAME multiset
+//! of names in a DIFFERENT order (e.g. `<E,A>` vs `<A,E>`), positional pairing
+//! renames the target body onto the wrong source identities and produces a
+//! spurious mismatch (TS2322/TS2345). Under `TSZ_ALPHA_NAME_PAIR=1` the pairing
+//! is done by NAME instead, so same-named params line up across the reorder.
+
+use crate::types::TypeParamInfo;
+
+/// Gate for name-aware alpha-rename pairing (flag `TSZ_ALPHA_NAME_PAIR=1`).
+///
+/// Byte-parity-inert when OFF (the default): the pairing falls back to the
+/// historical positional `.zip`. The mis-pairing this flag fixes only becomes
+/// observable under the dormant `TSZ_TYPEPARAM_DECL_IDENTITY` keystone
+/// (#14696), whose distinct `DeclScoped` ids stop same-name source params from
+/// interning to a single id that masks the reorder.
+pub(super) fn alpha_name_pair_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("TSZ_ALPHA_NAME_PAIR").is_ok_and(|v| v == "1"))
+}
+
+/// Compute a name-aware pairing of source/target type parameters.
+///
+/// When the source and target type-parameter lists carry the SAME multiset of
+/// names, return a permutation `perm` such that `target[perm[i]]` has the same
+/// name as `source[i]`. This lets the alpha-rename pair same-name params across
+/// a reordered declaration (`<E,A>` vs `<A,E>`) instead of by position, which
+/// would otherwise rename the target body onto the wrong source identities.
+///
+/// Returns `None` when the lists differ in length or the name multisets are not
+/// equal (caller falls back to positional pairing). The comparison is over
+/// `Atom` name identities only -- no surface-text or user-name string
+/// inspection.
+pub(super) fn name_aware_target_permutation(
+    source_type_params: &[TypeParamInfo],
+    target_type_params: &[TypeParamInfo],
+) -> Option<Vec<usize>> {
+    if source_type_params.len() != target_type_params.len() {
+        return None;
+    }
+    let mut used = vec![false; target_type_params.len()];
+    let mut perm = Vec::with_capacity(source_type_params.len());
+    for source_tp in source_type_params {
+        let matched = target_type_params
+            .iter()
+            .enumerate()
+            .find(|(idx, target_tp)| !used[*idx] && target_tp.name == source_tp.name);
+        match matched {
+            Some((idx, _)) => {
+                used[idx] = true;
+                perm.push(idx);
+            }
+            // A source name has no unused same-named target counterpart ->
+            // the name multisets are not equal; abort, keep positional.
+            None => return None,
+        }
+    }
+    Some(perm)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::name_aware_target_permutation;
+    use crate::types::TypeParamInfo;
+    use tsz_common::interner::Atom;
+
+    fn tp(name: u32) -> TypeParamInfo {
+        TypeParamInfo::simple(Atom(name))
+    }
+
+    #[test]
+    fn identity_order_yields_identity_permutation() {
+        let src = [tp(1), tp(2), tp(3)];
+        let tgt = [tp(1), tp(2), tp(3)];
+        assert_eq!(
+            name_aware_target_permutation(&src, &tgt),
+            Some(vec![0, 1, 2])
+        );
+    }
+
+    #[test]
+    fn reordered_same_names_pair_by_name() {
+        // source <A,E> (1,2) vs target <E,A> (2,1): source[0]=A pairs target[1],
+        // source[1]=E pairs target[0].
+        let src = [tp(1), tp(2)];
+        let tgt = [tp(2), tp(1)];
+        assert_eq!(name_aware_target_permutation(&src, &tgt), Some(vec![1, 0]));
+    }
+
+    #[test]
+    fn different_names_fall_back_to_positional() {
+        // source <A,E> (1,2) vs target <T,U> (3,4): no shared names -> None.
+        let src = [tp(1), tp(2)];
+        let tgt = [tp(3), tp(4)];
+        assert_eq!(name_aware_target_permutation(&src, &tgt), None);
+    }
+
+    #[test]
+    fn length_mismatch_is_none() {
+        let src = [tp(1), tp(2)];
+        let tgt = [tp(1)];
+        assert_eq!(name_aware_target_permutation(&src, &tgt), None);
+    }
+
+    #[test]
+    fn repeated_names_consume_each_target_once() {
+        // multiset {A,A,E} vs {A,E,A}: each source consumes one unused same-named
+        // target in order.
+        let src = [tp(1), tp(1), tp(2)];
+        let tgt = [tp(1), tp(2), tp(1)];
+        assert_eq!(
+            name_aware_target_permutation(&src, &tgt),
+            Some(vec![0, 2, 1])
+        );
+    }
+
+    #[test]
+    fn unequal_multiset_same_len_is_none() {
+        // {A,A} vs {A,E}: second source A finds no second target A -> None.
+        let src = [tp(1), tp(1)];
+        let tgt = [tp(1), tp(2)];
+        assert_eq!(name_aware_target_permutation(&src, &tgt), None);
+    }
+}


### PR DESCRIPTION
Banks the conclusively-diagnosed fix for the #14345 flag-flip's positional
alpha-rename mis-pairing as a **dormant, flag-gated, byte-parity-inert** brick
on current main — the same pattern as the #14344 keystone (#14696). Default
OFF = exact prior behavior; no user-visible change until the campaign flips it.

## Structural rule
When two generic call signatures being related have the **same type-parameter
name set in a different order** (e.g. `extract: <E,A>(wa: readonly [A,E]) => A`
vs `fst: <A,E>(...) => A`), the signature-relation alpha-rename must pair the
params **by name**, not by declaration position. The prior `.zip()` pairs
positionally (`E↔A`, `A↔E`), rewriting the target body `[A,E]`→`[E,A]` ≠ source
`[A,E]` → a false TS2322. tsc accepts (both return the first tuple element). The
body relation still gates acceptance, so this is a **pairing correction**, not a
blanket relaxation. Owner: solver signature-relation (`relations/subtype/rules/functions`).

## What changed (flag `TSZ_ALPHA_NAME_PAIR`, default OFF, inert)
- new `functions/checking/name_pairing.rs`: name-aware permutation of the
  target signature's type-params when the two signatures share a name set but
  differ in order; falls back to positional otherwise
- `functions/checking.rs`: when `alpha_name_pair_enabled()`, use the name-aware
  pairing to build the alpha-rename substitution; when OFF, `paired_type_params`
  is the exact prior positional `.zip` (structural no-op)

## Verification
- Release build OK; `name_pairing::tests::*` 6/6 pass
- **Byte-parity-inert OFF**: default run = baseline (fp-ts 1488); the gate makes
  it a no-op with the flag unset
- **Reach (flag-ON, with the keystone)**: fp-ts 1242 → 1235 = **−7 fixes, 0
  genuine regressions** (by loc:code; the 3 raw-text-diff lines are union-member
  render-order only). `TSZ_ALPHA_NAME_PAIR=1` alone (keystone OFF) clears 5
  (1488→1483). Witnesses: ReadonlyTuple.ts:218 (`extract`/`fst`), IOEither/
  ReaderEither/ReaderTaskEither/StateReaderTaskEither reorders, FromEither TS2394
- Soundness note: flag-ON over-relate is fp-ts-invisible and gauged on full
  conformance at flip-time (a later campaign step); landing dormant carries no
  behavior change to gauge

Goal: green

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
