### PR TITLE
chore(arch): record live merged arch-guard baselines (lint hotfix)

### DIFF
--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -858,7 +858,9 @@ FILE_LINE_LIMIT_CHECKS = [
         / "state"
         / "variable_checking"
         / "core.rs",
-        1979,
+        # Bumped 1979→1982 to record the live merged size after checker fixes
+        # landed during a merge-queue (dist-binaries) outage window.
+        1982,
     ),
     (
         "Emitter boundary: emitter/helpers.rs size ratchet",
@@ -1468,7 +1470,13 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # Ratcheted 3079→3073 after #14306 moved the spread constraint probe
         # through the narrower call boundary. The merge queue picked up
         # neighboring main changes while preserving a six-reference reduction.
-        3073,
+        #
+        # Bumped 3073→3078 to record the live merged count after a batch of
+        # checker fixes landed during a merge-queue (dist-binaries) outage
+        # window; each added a small number of existing-pattern
+        # `query_boundaries::common` reads. No new quarantine entry; #8225
+        # narrowing remains the removal condition.
+        3078,
     ),
 ]
 


### PR DESCRIPTION
Goal: hold

## Summary
Two arch-guard baselines drifted below the live merged count because checker
fixes landed via admin-merge during the `dist-binaries` merge-queue outage (so
the per-PR baseline bumps never ran), failing main's `lint` job:
- `state/variable_checking/core.rs` ratchet 1979 → live 1982.
- `#8225` `query_boundaries::common` quarantine 3073 → live 3078.

Both are existing-pattern growth from real merged fixes (no new quarantine
entries, no logic change). Recording the live counts so main's arch-guard is
green again. #8225 narrowing remains the removal condition.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `python3 scripts/arch/arch_guard.py` → exit 0, "Architecture guardrails passed."
- Config-only change (scripts/arch/), no Rust touched.