### PR TITLE
[WIP] perf(solver): lazy-heritage ObjectShape base_types model (opt-in TSZ_LAZY_HERITAGE)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1187,6 +1187,29 @@ pub(crate) fn get_merged_object_shape_for_type(
         }
     }
 
+    // Lazy heritage (`TSZ_LAZY_HERITAGE`): include members inherited through
+    // `base_types`. Own and intersection members already collected above win —
+    // heritage SHADOWS, it does not intersect — so a base only contributes names
+    // not yet present. Recursing through this same helper walks each base's own
+    // bases, so one pass resolves the whole inherited surface (heritage is a
+    // DAG, bounded by the producer's `heritage_merge_depth` guard). `base_types`
+    // is empty under the flattened model, so this is inert (byte-identical)
+    // there. This is the boundary counterpart to the solver's
+    // `collect_target_properties` / `collect_properties` base-walk, so the
+    // checker's excess-property "known member" set matches the solver's.
+    for &base in &base_shape.base_types {
+        if let Some(base_merged) = get_merged_object_shape_for_type(db, base) {
+            for prop in base_merged.properties.iter() {
+                if !merged_props.iter().any(|p| p.name == prop.name) {
+                    merged_props.push(prop.clone());
+                }
+            }
+            has_string_index = has_string_index || base_merged.string_index.is_some();
+            has_number_index = has_number_index || base_merged.number_index.is_some();
+            has_symbol_index = has_symbol_index || base_merged.symbol_index.is_some();
+        }
+    }
+
     // Sort properties by declaration order for consistent results
     merged_props.sort_by_key(|p| p.declaration_order);
 

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1191,6 +1191,7 @@ pub(crate) fn get_merged_object_shape_for_type(
     merged_props.sort_by_key(|p| p.declaration_order);
 
     Some(ObjectShape {
+        base_types: Vec::new(),
         flags: base_shape.flags,
         properties: merged_props,
         string_index: if has_string_index {

--- a/crates/tsz-checker/src/query_boundaries/js_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports.rs
@@ -198,6 +198,7 @@ impl JsExportSurface {
             Self::normalize_property_declaration_order(&mut merged_props);
 
             let merged_shape = ObjectShape {
+                base_types: Vec::new(),
                 flags: shape.flags,
                 properties: merged_props,
                 string_index: shape.string_index,

--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -109,6 +109,24 @@ pub(crate) fn on_demand_forcing_disabled() -> bool {
     })
 }
 
+/// Opt-IN switch for the lazy-heritage `ObjectShape::base_types` model: when set,
+/// `interface Derived extends Base` records the (instantiated) base `TypeId` in
+/// the derived `ObjectShape`'s `base_types` — inherited members resolve per-member
+/// on demand by walking those bases in `collect_properties` — instead of eagerly
+/// flattening the base's whole heritage closure into `properties`. This dissolves
+/// the full-closure materialization (and the `REFS_RESOLUTION_FUEL` cap bounding
+/// it). OFF by default during migration so the flattened model stays the shipping
+/// behavior and flag-off is byte-identical; `TSZ_LAZY_HERITAGE=1` enables the new
+/// model for A/B verification.
+///
+/// Cached in a `OnceLock` so the environment is read at most once per process.
+pub(crate) fn lazy_heritage_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED
+        .get_or_init(|| std::env::var("TSZ_LAZY_HERITAGE").is_ok_and(|v| !v.is_empty() && v != "0"))
+}
+
 /// Kill-switch for the type-position lazy lib-interface lowering (#13933): when
 /// a bare (no-type-argument) type reference resolves to a force-eligible
 /// non-generic lib interface, the resolver returns a `Lazy(DefId)` instead of

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_collection.rs
@@ -750,6 +750,7 @@ impl<'a> CheckerState<'a> {
         }
 
         self.ctx.types.factory().object_with_index(ObjectShape {
+            base_types: Vec::new(),
             flags: shape.flags,
             properties: properties.into_values().collect(),
             string_index: shape.string_index,

--- a/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_commonjs/exports_resolution.rs
@@ -778,6 +778,7 @@ impl<'a> CheckerState<'a> {
                 || shape.symbol_index.is_some()
             {
                 return self.ctx.types.factory().object_with_index(ObjectShape {
+                    base_types: Vec::new(),
                     flags: shape.flags,
                     properties: merged_props,
                     string_index: shape.string_index,

--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -783,6 +783,7 @@ impl<'a> CheckerState<'a> {
         }
 
         self.ctx.types.factory().object_with_index(ObjectShape {
+            base_types: Vec::new(),
             flags: shape.flags,
             properties,
             string_index: shape.string_index,

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -826,6 +826,21 @@ impl<'a> CheckerState<'a> {
             .first()
             .and_then(|&decl_idx| self.ctx.binder.get_node_symbol(decl_idx));
 
+        // Lazy-heritage producer (`TSZ_LAZY_HERITAGE`): when enabled and the
+        // derived interface is a plain object shape, record each `extends`
+        // base's instantiated `TypeId` in `lazy_bases` (attached to the shape's
+        // `base_types` after the walk) instead of eagerly folding the base's
+        // members into `derived_type`. Inherited members then resolve per-member
+        // on demand in `collect_properties`. Callable interfaces keep their
+        // signatures in `CallableShape` (which has no `base_types` slot), so they
+        // fall through to the flattening merge; flag-off is byte-identical.
+        let lazy_heritage = crate::state_checking::lazy_lib_member::lazy_heritage_enabled()
+            && matches!(
+                self.ctx.types.lookup(derived_type),
+                Some(tsz_solver::TypeData::Object(_) | tsz_solver::TypeData::ObjectWithIndex(_))
+            );
+        let mut lazy_bases: Vec<TypeId> = Vec::new();
+
         for &decl_idx in declarations {
             let Some(node) = self.ctx.arena.get(decl_idx) else {
                 continue;
@@ -1233,13 +1248,32 @@ impl<'a> CheckerState<'a> {
                             &type_args,
                             current_sym,
                         );
-                        derived_type = self.merge_interface_types_heritage(derived_type, base_type);
+                        if lazy_heritage {
+                            lazy_bases.push(base_type);
+                        } else {
+                            derived_type =
+                                self.merge_interface_types_heritage(derived_type, base_type);
+                        }
                         continue;
                     }
 
-                    derived_type = self.merge_interface_types_heritage(derived_type, base_type);
+                    if lazy_heritage {
+                        lazy_bases.push(base_type);
+                    } else {
+                        derived_type = self.merge_interface_types_heritage(derived_type, base_type);
+                    }
                 }
             }
+        }
+
+        // Attach the accumulated lazy-heritage bases to the derived object shape
+        // (variant-preserving). Inherited members now resolve on demand through
+        // `collect_properties`' base-walk rather than being flattened in here.
+        if lazy_heritage && !lazy_bases.is_empty() {
+            derived_type = self
+                .ctx
+                .types
+                .with_object_base_types(derived_type, lazy_bases);
         }
 
         if pushed_derived {

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -1255,6 +1255,7 @@ impl<'a> CheckerState<'a> {
                     crate::interface_type::InterfaceMergeMode::Declaration,
                 );
                 factory.object_with_index(ObjectShape {
+                    base_types: Vec::new(),
                     flags: base_shape.flags,
                     properties: merged_properties,
                     string_index: base_shape.string_index,

--- a/crates/tsz-checker/src/types/property_access_helpers/iterator_methods.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/iterator_methods.rs
@@ -78,6 +78,7 @@ impl<'a> CheckerState<'a> {
                 && let Some(shape) = object_shape_for_type(self.ctx.types, instantiated)
             {
                 Some(self.ctx.types.factory().object_with_index(ObjectShape {
+                    base_types: Vec::new(),
                     flags: shape.flags,
                     properties: shape.properties.clone(),
                     string_index: shape.string_index,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members_tests.rs
@@ -290,6 +290,7 @@ fn synthesized_index_signature_uses_solver_key_and_value_types() {
 
     let interner = TypeInterner::new();
     let object_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: Vec::new(),
         string_index: None,
@@ -326,6 +327,7 @@ fn synthesized_string_index_signature_uses_key_param_name_and_readonly() {
 
     let interner = TypeInterner::new();
     let object_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: Vec::new(),
         string_index: Some(IndexSignature {
@@ -362,6 +364,7 @@ fn synthesized_index_signature_absent_without_solver_index_info() {
 
     let interner = TypeInterner::new();
     let object_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: Vec::new(),
         string_index: None,

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
@@ -446,6 +446,7 @@ type Bar = Foo & {
     let interner = TypeInterner::new();
     let bar_def = tsz_solver::DefId(94_501);
     let foo_surface = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: Vec::new(),
         string_index: None,
@@ -454,6 +455,7 @@ type Bar = Foo & {
         symbol: None,
     });
     let bar_surface = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: Vec::new(),
         string_index: None,
@@ -541,6 +543,7 @@ type Bar = {
     let unrelated_def = tsz_solver::DefId(94_500);
     let bar_def = tsz_solver::DefId(94_501);
     let shared_surface = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: Vec::new(),
         string_index: None,

--- a/crates/tsz-emitter/src/declaration_emitter/tests/local_alias_elision.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/local_alias_elision.rs
@@ -168,6 +168,7 @@ fn property_named_like_alias_is_untouched() {
     let app = interner.application(interner.lazy(def_id), vec![TypeId::NUMBER]);
     let prop_name = interner.intern_string("Wrapped");
     let object = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![PropertyInfo::new(prop_name, app)],
         string_index: None,
@@ -196,6 +197,7 @@ fn bare_reference_to_collected_alias_prints_elided_any() {
     let app = interner.application(interner.lazy(def_id), vec![TypeId::NUMBER]);
     let prop_name = interner.intern_string("inner");
     let object = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![PropertyInfo::new(prop_name, interner.lazy(def_id))],
         string_index: None,

--- a/crates/tsz-emitter/src/declaration_emitter/tests/misc_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/misc_features.rs
@@ -1552,6 +1552,7 @@ fn test_function_return_prefers_object_literal_over_return_type_wrapper() {
 
     let interner = TypeInterner::new();
     let object_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![
             PropertyInfo::new(interner.intern_string("a"), TypeId::NUMBER),

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_01.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_01.rs
@@ -207,6 +207,7 @@ export const ExampleFunctionalComponent = ({ "data-testid": dataTestId, [dynProp
     let data_testid = interner.intern_string("data-testid");
     let data_dyn = interner.intern_string("data-dyn");
     let param_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![
             PropertyInfo::new(data_testid, TypeId::ANY),

--- a/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_04.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/simple_declarations_parts/part_04.rs
@@ -118,6 +118,7 @@ const obj = {
 
     let interner = TypeInterner::new();
     let object_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![],
         string_index: None,
@@ -190,6 +191,7 @@ const obj = {
 
     let interner = TypeInterner::new();
     let object_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![],
         string_index: None,
@@ -257,6 +259,7 @@ const obj = {
 
     let interner = TypeInterner::new();
     let object_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![],
         string_index: None,
@@ -370,6 +373,7 @@ export const Baa = {
     let banana_type = interner.literal_string("banana");
     let banana_atom = interner.intern_string("banana");
     let object_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![PropertyInfo::new(banana_atom, TypeId::NUMBER)],
         string_index: None,
@@ -787,6 +791,7 @@ var e = new E(1);
 
     let interner = TypeInterner::new();
     let c_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: Vec::new(),
         string_index: None,
@@ -795,6 +800,7 @@ var e = new E(1);
         symbol: Some(c_sym),
     });
     let d_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: Vec::new(),
         string_index: None,
@@ -803,6 +809,7 @@ var e = new E(1);
         symbol: Some(d_sym),
     });
     let e_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: Vec::new(),
         string_index: None,

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_formatting.rs
@@ -1137,6 +1137,7 @@ export default new Enhanced();
 
     let interner = TypeInterner::new();
     let c_instance = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         properties: Vec::new(),
         string_index: None,
         number_index: None,
@@ -1241,6 +1242,7 @@ const value = new Mixed();
 
     let interner = TypeInterner::new();
     let instance = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         properties: Vec::new(),
         string_index: None,
         number_index: None,
@@ -1338,6 +1340,7 @@ export const o = (p1: typeof nImported, p2: typeof nNotImported, p3: typeof nPri
 
     let interner = TypeInterner::new();
     let return_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![
             PropertyInfo::new(interner.intern_string("foo"), TypeId::STRING),

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_info.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_info.rs
@@ -73,6 +73,7 @@ export function middle() {
     accessor.declaration_order = 1;
 
     let instance_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![accessor],
         string_index: None,
@@ -123,6 +124,7 @@ fn test_structural_setter_only_property_uses_write_type() {
     setter_only.write_type = TypeId::NUMBER;
 
     let point_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![setter_only],
         string_index: None,
@@ -157,6 +159,7 @@ fn test_structural_authored_split_accessor_uses_get_set() {
     accessor.declaration_order = 1;
 
     let point_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![accessor],
         string_index: None,
@@ -302,6 +305,7 @@ export function wrapClass(param: any) {
     foo.declaration_order = 1;
 
     let instance_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![foo],
         string_index: None,
@@ -364,6 +368,7 @@ export class Derived extends mixin(Base) {}
 
     let interner = TypeInterner::new();
     let mixed_base_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: Vec::new(),
         string_index: None,
@@ -421,6 +426,7 @@ export default class extends getGreeterBase() {}
 
     let interner = TypeInterner::new();
     let greeter_ctor_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: Vec::new(),
         string_index: None,
@@ -911,6 +917,7 @@ fn test_abstract_constructor_with_static_members_parenthesizes_in_intersection()
 
     let void_method = interner.function(FunctionShape::new(Vec::new(), TypeId::VOID));
     let instance_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![PropertyInfo::method(mixin_method, void_method)],
         string_index: Some(IndexSignature {
@@ -1177,6 +1184,7 @@ namespace Test {
 
     let interner = TypeInterner::new();
     let instance_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: Vec::new(),
         string_index: None,
@@ -1267,6 +1275,7 @@ export class A {
     duplicate_property.declaration_order = 2;
 
     let instance_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![method, duplicate_property],
         string_index: None,
@@ -1335,6 +1344,7 @@ export class A {
     method.declaration_order = 1;
 
     let instance_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![method],
         string_index: None,
@@ -1378,6 +1388,7 @@ fn test_synthesized_computed_method_index_signatures_widen_nested_literal_return
         )),
     ]);
     let instance_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: Vec::new(),
         string_index: Some(IndexSignature {
@@ -1392,6 +1403,7 @@ fn test_synthesized_computed_method_index_signatures_widen_nested_literal_return
     });
 
     let static_true_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![PropertyInfo::new(
             interner.intern_string("static"),
@@ -1403,6 +1415,7 @@ fn test_synthesized_computed_method_index_signatures_widen_nested_literal_return
         symbol: None,
     });
     let static_string_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![PropertyInfo::new(
             interner.intern_string("static"),
@@ -1506,6 +1519,7 @@ const Value = class {
         construct_signatures: vec![CallSignature::new(
             Vec::new(),
             interner.object_with_index(ObjectShape {
+                base_types: Vec::new(),
                 flags: ObjectFlags::default(),
                 properties: Vec::new(),
                 string_index: None,
@@ -1627,6 +1641,7 @@ export namespace C {
     let b_def = tsz_solver::DefId(9202);
     let app_type = interner.application(interner.lazy(a_def), vec![interner.lazy(b_def)]);
     let evaluated_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: Vec::new(),
         string_index: None,

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_info_accessor_names.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_info_accessor_names.rs
@@ -24,6 +24,7 @@ function makeThing() {
     let mut other = PropertyInfo::new(interner.intern_string("other"), TypeId::STRING);
     other.write_type = TypeId::NUMBER;
     let object_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![value, other],
         string_index: None,

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_info_constructor_objects.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_info_constructor_objects.rs
@@ -289,6 +289,7 @@ fn build_abstract_constructor_with_index_sig(
     let x = interner.intern_string("x");
     let void_fn = interner.function(FunctionShape::new(Vec::new(), TypeId::VOID));
     let instance_shape = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::default(),
         properties: vec![PropertyInfo::method(method, void_fn)],
         string_index: Some(IndexSignature {

--- a/crates/tsz-lowering/src/lower/core/signature_members.rs
+++ b/crates/tsz-lowering/src/lower/core/signature_members.rs
@@ -452,6 +452,7 @@ impl<'a> TypeLowering<'a> {
                 return TypeId::ERROR;
             }
             return self.interner.object_with_index(ObjectShape {
+                base_types: Vec::new(),
                 properties,
                 string_index: parts.string_index,
                 number_index: parts.number_index,

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -794,6 +794,36 @@ pub trait TypeDatabase:
         self.object_fresh(widened_properties)
     }
     fn object_with_index(&self, shape: ObjectShape) -> TypeId;
+    /// Re-intern `original` (an `Object` / `ObjectWithIndex`) with its heritage
+    /// `base_types` replaced by `base_types`, PRESERVING the `Object` vs
+    /// `ObjectWithIndex` variant; returns `original` unchanged for any other
+    /// type. The lazy-heritage producer uses this to attach a derived
+    /// interface's instantiated `extends` bases to its own shape without
+    /// flattening the bases' members (see `ObjectShape::base_types`). A default
+    /// method composed from the existing trait surface, so no implementor needs
+    /// to change. `object_with_index` interns + sorts the shape idempotently (an
+    /// already-formed interface shape is already sorted with declaration order
+    /// assigned), then we select the original variant.
+    fn with_object_base_types(&self, original: TypeId, base_types: Vec<TypeId>) -> TypeId {
+        match self.lookup(original) {
+            Some(TypeData::Object(shape_id)) => {
+                let mut shape = (*self.object_shape(shape_id)).clone();
+                shape.base_types = base_types;
+                match self.lookup(self.object_with_index(shape)) {
+                    // `object_with_index` always yields `ObjectWithIndex`; map it
+                    // back to the `Object` variant to match `original`.
+                    Some(TypeData::ObjectWithIndex(new_id)) => self.object_type_from_shape(new_id),
+                    _ => original,
+                }
+            }
+            Some(TypeData::ObjectWithIndex(shape_id)) => {
+                let mut shape = (*self.object_shape(shape_id)).clone();
+                shape.base_types = base_types;
+                self.object_with_index(shape)
+            }
+            _ => original,
+        }
+    }
     fn function(&self, shape: FunctionShape) -> TypeId;
     fn callable(&self, shape: CallableShape) -> TypeId;
     fn template_literal(&self, spans: Vec<TemplateSpan>) -> TypeId;

--- a/crates/tsz-solver/src/caches/query_cache_spread.rs
+++ b/crates/tsz-solver/src/caches/query_cache_spread.rs
@@ -161,7 +161,23 @@ impl QueryCache<'_> {
 
         let props = match key {
             TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
-                self.interner.object_shape(shape_id).properties.to_vec()
+                let shape = self.interner.object_shape(shape_id);
+                let mut props = shape.properties.to_vec();
+                // Lazy heritage: object spread copies INHERITED members too. Walk
+                // `base_types` (own / earlier-base win — heritage shadows); the
+                // `visited` set guards cycles. Empty -> own props (byte-identical).
+                if !shape.base_types.is_empty() {
+                    let mut seen: rustc_hash::FxHashSet<Atom> =
+                        props.iter().map(|prop| prop.name).collect();
+                    for base in shape.base_types.clone() {
+                        for prop in self.collect_object_spread_properties_inner(base, visited) {
+                            if seen.insert(prop.name) {
+                                props.push(prop);
+                            }
+                        }
+                    }
+                }
+                props
             }
             TypeData::Callable(shape_id) => {
                 self.interner.callable_shape(shape_id).properties.to_vec()

--- a/crates/tsz-solver/src/canonicalize/mod.rs
+++ b/crates/tsz-solver/src/canonicalize/mod.rs
@@ -685,6 +685,7 @@ impl<'a, R: TypeResolver> Canonicalizer<'a, R> {
 
         // Create new object shape with canonicalized types but preserved metadata
         let new_shape = crate::types::ObjectShape {
+            base_types: Vec::new(),
             flags: shape.flags,
             properties: new_props,
             string_index: new_string_index,

--- a/crates/tsz-solver/src/def/core/definition_info.rs
+++ b/crates/tsz-solver/src/def/core/definition_info.rs
@@ -43,6 +43,7 @@ impl DefinitionInfo {
         properties: Vec<PropertyInfo>,
     ) -> Self {
         let shape = ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties,
             string_index: None,
@@ -81,6 +82,7 @@ impl DefinitionInfo {
         static_properties: Vec<PropertyInfo>,
     ) -> Self {
         let instance_shape = ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: instance_properties,
             string_index: None,
@@ -89,6 +91,7 @@ impl DefinitionInfo {
             symbol: None,
         };
         let static_shape = ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: static_properties,
             string_index: None,

--- a/crates/tsz-solver/src/diagnostics/format/compound/object_with_index.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/object_with_index.rs
@@ -175,6 +175,7 @@ mod tests {
         ));
 
         let shape = crate::types::ObjectShape {
+            base_types: Vec::new(),
             properties: vec![
                 PropertyInfo::new(db.intern_string("includes"), includes),
                 PropertyInfo::new(db.intern_string("toString"), method),
@@ -244,6 +245,7 @@ mod tests {
         });
 
         let shape = crate::types::ObjectShape {
+            base_types: Vec::new(),
             properties,
             string_index: None,
             number_index: Some(crate::types::IndexSignature {

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_00.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_00.rs
@@ -694,6 +694,7 @@ fn format_intersection_drops_redundant_index_signature_member() {
         param_name: None,
     };
     let with_props = db.object_with_index(crate::types::ObjectShape {
+        base_types: Vec::new(),
         properties: vec![
             PropertyInfo::new(db.intern_string("a"), TypeId::NUMBER),
             PropertyInfo::new(db.intern_string("b"), TypeId::NUMBER),
@@ -705,6 +706,7 @@ fn format_intersection_drops_redundant_index_signature_member() {
         flags: Default::default(),
     });
     let index_only = db.object_with_index(crate::types::ObjectShape {
+        base_types: Vec::new(),
         properties: vec![],
         string_index: None,
         number_index: Some(index_sig),
@@ -985,6 +987,7 @@ fn format_object_with_string_index_signature() {
     let mut fmt = TypeFormatter::new(&db);
 
     let shape = crate::types::ObjectShape {
+        base_types: Vec::new(),
         properties: vec![],
         string_index: Some(crate::types::IndexSignature {
             key_type: TypeId::STRING,
@@ -1011,6 +1014,7 @@ fn format_object_with_index_hides_duplicate_internal_default_alias() {
     let mut fmt = TypeFormatter::new(&db);
 
     let shape = crate::types::ObjectShape {
+        base_types: Vec::new(),
         properties: vec![
             PropertyInfo::new(db.intern_string("default"), TypeId::NUMBER),
             PropertyInfo::new(db.intern_string("_default"), TypeId::NUMBER),
@@ -1049,6 +1053,7 @@ fn format_object_with_number_index_signature() {
     let mut fmt = TypeFormatter::new(&db);
 
     let shape = crate::types::ObjectShape {
+        base_types: Vec::new(),
         properties: vec![],
         string_index: None,
         number_index: Some(crate::types::IndexSignature {
@@ -1075,6 +1080,7 @@ fn format_object_with_readonly_number_index_signature() {
     let mut fmt = TypeFormatter::new(&db);
 
     let shape = crate::types::ObjectShape {
+        base_types: Vec::new(),
         properties: vec![],
         string_index: None,
         number_index: Some(crate::types::IndexSignature {
@@ -1101,6 +1107,7 @@ fn format_object_with_readonly_string_index_signature() {
     let mut fmt = TypeFormatter::new(&db);
 
     let shape = crate::types::ObjectShape {
+        base_types: Vec::new(),
         properties: vec![],
         string_index: Some(crate::types::IndexSignature {
             key_type: TypeId::STRING,
@@ -1130,6 +1137,7 @@ fn format_object_with_symbol_index_signature() {
     // The printer must display `symbol` (not `string`) as the key type.
     for param_name in [None, Some("key"), Some("sym")] {
         let shape = crate::types::ObjectShape {
+            base_types: Vec::new(),
             properties: vec![],
             string_index: Some(crate::types::IndexSignature {
                 key_type: TypeId::SYMBOL,
@@ -1174,6 +1182,7 @@ fn format_object_with_index_many_properties_truncated() {
     props.push(tail);
 
     let shape = crate::types::ObjectShape {
+        base_types: Vec::new(),
         properties: props,
         string_index: None,
         number_index: Some(crate::types::IndexSignature {
@@ -1220,6 +1229,7 @@ fn format_object_with_index_truncation_skips_omitted_property_formatting() {
         .collect();
 
     let shape = crate::types::ObjectShape {
+        base_types: Vec::new(),
         properties: props,
         string_index: None,
         number_index: Some(crate::types::IndexSignature {
@@ -1270,6 +1280,7 @@ fn format_object_with_index_prefers_symbol_tail_over_later_string_member() {
     props.push(PropertyInfo::new(db.intern_string("flat"), TypeId::NUMBER));
 
     let shape = crate::types::ObjectShape {
+        base_types: Vec::new(),
         properties: props,
         string_index: None,
         number_index: Some(crate::types::IndexSignature {
@@ -1307,6 +1318,7 @@ fn format_object_with_symbol_index_signature_renders_symbol_key_type() {
     // The `key_type` field stores TypeId::SYMBOL; the formatter must use it
     // rather than hardcoding "string" based on the storage slot name.
     let shape = crate::types::ObjectShape {
+        base_types: Vec::new(),
         properties: vec![],
         string_index: Some(crate::types::IndexSignature {
             key_type: TypeId::SYMBOL,
@@ -1350,6 +1362,7 @@ fn format_array_like_object_with_index_expands_to_locale_string_overload_display
     unscopables.readonly = true;
 
     let shape = crate::types::ObjectShape {
+        base_types: Vec::new(),
         properties: vec![
             PropertyInfo::new(db.intern_string("toString"), method),
             PropertyInfo::new(db.intern_string("toLocaleString"), method),
@@ -1402,6 +1415,7 @@ fn format_array_like_object_without_symbol_tail_preserves_array_display_shape() 
     properties.push(PropertyInfo::new(db.intern_string("reduceRight"), method));
 
     let shape = crate::types::ObjectShape {
+        base_types: Vec::new(),
         properties,
         string_index: None,
         number_index: Some(crate::types::IndexSignature {

--- a/crates/tsz-solver/src/evaluation/evaluate/application.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/application.rs
@@ -775,6 +775,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         {
             use crate::types::{IndexSignature, ObjectShape};
             let result = self.interner.object_with_index(ObjectShape {
+                base_types: Vec::new(),
                 flags: crate::types::ObjectFlags::empty(),
                 properties: vec![],
                 string_index: Some(IndexSignature {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -132,6 +132,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         if with_index {
             self.interner().object_with_index(ObjectShape {
+                base_types: Vec::new(),
                 flags,
                 properties,
                 string_index,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -689,6 +689,7 @@ impl<'a, 'b, R: TypeResolver> IndexAccessVisitor<'a, 'b, R> {
                 let merged =
                     if string_index.is_some() || number_index.is_some() || symbol_index.is_some() {
                         let shape = ObjectShape {
+                            base_types: Vec::new(),
                             flags: crate::types::ObjectFlags::empty(),
                             properties,
                             string_index,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -806,6 +806,28 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
             .interner()
             .object_shape(ObjectShapeId(shape_id));
 
+        // Lazy heritage: `O[K]` must resolve inherited members. Resolve the full
+        // member set through the heritage-walking collector when `base_types` is
+        // present; empty -> own props (byte-identical flag-off).
+        let heritage_props;
+        let props: &[PropertyInfo] = if shape.base_types.is_empty() {
+            &shape.properties
+        } else {
+            heritage_props = match crate::objects::collect_properties(
+                self.evaluator
+                    .interner()
+                    .object_type_from_shape(ObjectShapeId(shape_id)),
+                self.evaluator.interner(),
+                self.evaluator.resolver(),
+            ) {
+                crate::objects::PropertyCollectionResult::Properties { properties, .. } => {
+                    properties
+                }
+                _ => shape.properties.to_vec(),
+            };
+            &heritage_props
+        };
+
         // Defer `O[K]` when the index is a bare type parameter `K extends keyof O`
         // (the object currently being indexed) and distributing `K`'s constraint
         // over every key would produce a lossy value-type union. tsc keeps such a
@@ -820,17 +842,14 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
         // `{ [P in keyof T]: T[P] }[keyof T]` stays a union. The deferral also
         // sidesteps the quadratic value-union expansion for large interfaces
         // (e.g. `JSX.IntrinsicElements`) independent of property count.
-        if self.keyof_constraint_distribution_is_lossy(&shape.properties) {
+        if self.keyof_constraint_distribution_is_lossy(props) {
             return None;
         }
 
         let result = self
             .evaluator
-            .evaluate_object_index_from_constraint(&shape.properties, self.index_type)
-            .unwrap_or_else(|| {
-                self.evaluator
-                    .evaluate_object_index(&shape.properties, self.index_type)
-            });
+            .evaluate_object_index_from_constraint(props, self.index_type)
+            .unwrap_or_else(|| self.evaluator.evaluate_object_index(props, self.index_type));
 
         // CRITICAL FIX: If we can't find the property, but the index is generic,
         // we must defer evaluation (return None) instead of returning UNDEFINED.

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
@@ -186,9 +186,49 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 let initial_binding_len = bindings.len();
                 let source_shape = self.interner().object_shape(source_shape_id);
                 let pattern_shape = self.interner().object_shape(pattern_shape_id);
+                // Lazy heritage: match the infer pattern against the FULL member
+                // surface (own + inherited) so the binding AGREES with the
+                // structural subtype check, which sees flattened members. An
+                // own-only mismatch here vs a flattened match there makes a
+                // conditional `T extends { ..infer.. } ? ..` never converge (the
+                // infer binds own-only, the subtype disagrees, it re-evaluates
+                // forever). Gated on `base_types` -> byte-identical flag-off; the
+                // collection is globally memoized.
+                let source_props_owned;
+                let source_props: &[PropertyInfo] = if source_shape.base_types.is_empty() {
+                    &source_shape.properties
+                } else {
+                    source_props_owned = match crate::objects::collect_properties(
+                        source,
+                        self.interner(),
+                        self.resolver(),
+                    ) {
+                        crate::objects::PropertyCollectionResult::Properties {
+                            properties, ..
+                        } => properties,
+                        _ => source_shape.properties.to_vec(),
+                    };
+                    &source_props_owned
+                };
+                let pattern_props_owned;
+                let pattern_props: &[PropertyInfo] = if pattern_shape.base_types.is_empty() {
+                    &pattern_shape.properties
+                } else {
+                    pattern_props_owned = match crate::objects::collect_properties(
+                        pattern,
+                        self.interner(),
+                        self.resolver(),
+                    ) {
+                        crate::objects::PropertyCollectionResult::Properties {
+                            properties, ..
+                        } => properties,
+                        _ => pattern_shape.properties.to_vec(),
+                    };
+                    &pattern_props_owned
+                };
                 if !self.match_infer_object_properties(
-                    &source_shape.properties,
-                    &pattern_shape.properties,
+                    source_props,
+                    pattern_props,
                     pattern,
                     bindings,
                     visited,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_substitutor.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_substitutor.rs
@@ -282,6 +282,7 @@ impl<'a> InferSubstitutor<'a> {
                 });
                 if changed {
                     self.interner.object_with_index(ObjectShape {
+                        base_types: Vec::new(),
                         flags: shape.flags,
                         properties,
                         string_index,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/keyof.rs
@@ -647,8 +647,26 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     // declaration order. Mirroring that here ensures the printer's
                     // alloc-order-based union sort displays keys in source order
                     // (e.g. `"foo" | "bar"` for `{ foo: ...; bar: ... }`).
-                    let mut props: Vec<&PropertyInfo> = shape
-                        .properties
+                    //
+                    // Lazy heritage: when the shape carries `base_types`, keyof must
+                    // include INHERITED keys; resolve the full member set through
+                    // the heritage-walking collector. Empty base_types -> own props
+                    // (byte-identical flag-off).
+                    let heritage_props;
+                    let props_src: &[PropertyInfo] = if shape.base_types.is_empty() {
+                        &shape.properties
+                    } else {
+                        heritage_props = match crate::objects::collect_properties(
+                            self.interner().object_type_from_shape(shape_id),
+                            self.interner(),
+                            self.resolver(),
+                        ) {
+                            PropertyCollectionResult::Properties { properties, .. } => properties,
+                            _ => shape.properties.to_vec(),
+                        };
+                        &heritage_props
+                    };
+                    let mut props: Vec<&PropertyInfo> = props_src
                         .iter()
                         .filter(|p| self.should_include_keyof_property(p))
                         .collect();
@@ -664,8 +682,21 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 }
                 TypeData::ObjectWithIndex(shape_id) => {
                     let shape = self.interner().object_shape(shape_id);
-                    let mut props: Vec<&PropertyInfo> = shape
-                        .properties
+                    let heritage_props;
+                    let props_src: &[PropertyInfo] = if shape.base_types.is_empty() {
+                        &shape.properties
+                    } else {
+                        heritage_props = match crate::objects::collect_properties(
+                            self.interner().object_with_index_type_from_shape(shape_id),
+                            self.interner(),
+                            self.resolver(),
+                        ) {
+                            PropertyCollectionResult::Properties { properties, .. } => properties,
+                            _ => shape.properties.to_vec(),
+                        };
+                        &heritage_props
+                    };
+                    let mut props: Vec<&PropertyInfo> = props_src
                         .iter()
                         .filter(|p| self.should_include_keyof_property(p))
                         .collect();

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -993,6 +993,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 flags |= ObjectFlags::SYMBOL_INDEX_OPTIONAL;
             }
             self.interner().object_with_index(ObjectShape {
+                base_types: Vec::new(),
                 flags,
                 properties,
                 string_index,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/string_index_helpers.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/string_index_helpers.rs
@@ -220,6 +220,7 @@ mod tests {
             TemplateSpan::Type(TypeId::STRING),
         ]);
         let object = db.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: Vec::new(),
             string_index: Some(IndexSignature {
@@ -245,6 +246,7 @@ mod tests {
 
     fn plain_string_index_object(db: &TypeInterner, value_type: TypeId) -> TypeId {
         db.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: Vec::new(),
             string_index: Some(IndexSignature {
@@ -303,6 +305,7 @@ mod tests {
     fn numeric_index_signature_takes_precedence_over_string() {
         let db = TypeInterner::new();
         let object = db.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: Vec::new(),
             string_index: Some(IndexSignature {
@@ -332,6 +335,7 @@ mod tests {
         // `E = { [k: number]: boolean }`; `E[5]` -> boolean control.
         let db = TypeInterner::new();
         let object = db.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: Vec::new(),
             string_index: None,
@@ -355,6 +359,7 @@ mod tests {
         // Negative control: no string or number index signature.
         let db = TypeInterner::new();
         let object = db.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: Vec::new(),
             string_index: None,
@@ -379,6 +384,7 @@ mod tests {
             TemplateSpan::Type(TypeId::STRING),
         ]);
         let object = db.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: Vec::new(),
             string_index: Some(IndexSignature {
@@ -414,6 +420,7 @@ mod tests {
         for value_type in [TypeId::STRING, TypeId::BOOLEAN, TypeId::NUMBER] {
             let db = TypeInterner::new();
             let object = db.object_with_index(ObjectShape {
+                base_types: Vec::new(),
                 flags: ObjectFlags::empty(),
                 properties: Vec::new(),
                 string_index: None,
@@ -453,6 +460,7 @@ mod tests {
         // key.
         let db = TypeInterner::new();
         let object = db.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: Vec::new(),
             string_index: Some(IndexSignature {
@@ -481,6 +489,7 @@ mod tests {
         // `IndexAccess` rather than collapsed to a concrete value type.
         let db = TypeInterner::new();
         let object = db.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: Vec::new(),
             string_index: None,
@@ -504,6 +513,7 @@ mod tests {
         // value type; it stays a deferred `IndexAccess`.
         let db = TypeInterner::new();
         let object = db.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: Vec::new(),
             string_index: None,
@@ -542,6 +552,7 @@ mod tests {
         let db = TypeInterner::new();
         let key = db.union(vec![TypeId::STRING, TypeId::NUMBER, TypeId::SYMBOL]);
         let object = db.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: Vec::new(),
             string_index: Some(IndexSignature {
@@ -588,6 +599,7 @@ mod tests {
     fn symbol_only_index_rejects_string_key() {
         let db = TypeInterner::new();
         let object = db.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: Vec::new(),
             string_index: Some(IndexSignature {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/substitute.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/substitute.rs
@@ -427,6 +427,7 @@ pub(crate) fn substitute_exact_type_db(
             });
             if changed {
                 db.object_with_index(ObjectShape {
+                    base_types: Vec::new(),
                     flags: shape.flags,
                     properties,
                     string_index,

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -963,6 +963,7 @@ impl<'a> TypeInstantiator<'a> {
                     || instantiated_symbol_idx.is_some()
                 {
                     let result = self.interner.object_with_index(ObjectShape {
+                        base_types: Vec::new(),
                         flags: shape.flags,
                         properties: instantiated_props.unwrap_or_else(|| shape.properties.clone()),
                         string_index: instantiated_string_idx.or(shape.string_index),

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -420,6 +420,7 @@ fn alpha_canonicalize_type(
             }
 
             let shape = ObjectShape {
+                base_types: Vec::new(),
                 flags: shape.flags,
                 properties,
                 string_index,
@@ -682,6 +683,7 @@ fn restore_alpha_type(
                 return Some(type_id);
             }
             let shape = ObjectShape {
+                base_types: Vec::new(),
                 flags: shape.flags,
                 properties,
                 string_index,

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -1640,6 +1640,7 @@ impl TypeInterner {
         // Sort by property name for consistent hashing
         properties.sort_by_key(|a| a.name);
         let shape_id = self.intern_object_shape(ObjectShape {
+            base_types: Vec::new(),
             flags,
             properties,
             string_index: None,
@@ -1667,6 +1668,7 @@ impl TypeInterner {
         // Sort by property name for consistent hashing
         properties.sort_by_key(|a| a.name);
         let shape_id = self.intern_object_shape(ObjectShape {
+            base_types: Vec::new(),
             flags,
             properties,
             string_index: None,

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -1059,6 +1059,7 @@ impl TypeInterner {
             static EMPTY_SHAPE: OnceLock<Arc<ObjectShape>> = OnceLock::new();
             Arc::clone(EMPTY_SHAPE.get_or_init(|| {
                 Arc::new(ObjectShape {
+                    base_types: Vec::new(),
                     flags: ObjectFlags::empty(),
                     properties: Vec::new(),
                     string_index: None,

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -338,6 +338,7 @@ mod shape_identity {
 
     fn shape_with_string_index(interner: &TypeInterner, param_name: Option<&str>) -> ObjectShape {
         ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: Vec::new(),
             string_index: Some(string_index_sig(interner, param_name)),

--- a/crates/tsz-solver/src/intern/intersection.rs
+++ b/crates/tsz-solver/src/intern/intersection.rs
@@ -1029,6 +1029,7 @@ impl TypeInterner {
 
         let intern_shape = |this: &Self, flags: ObjectFlags, properties: Vec<PropertyInfo>| {
             let shape_id = this.intern_object_shape(ObjectShape {
+                base_types: Vec::new(),
                 flags,
                 properties,
                 string_index: merged_string_index,

--- a/crates/tsz-solver/src/objects/apparent.rs
+++ b/crates/tsz-solver/src/objects/apparent.rs
@@ -591,6 +591,7 @@ pub fn apparent_primitive_shape(
     });
 
     ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties,
         string_index: None,

--- a/crates/tsz-solver/src/objects/collect.rs
+++ b/crates/tsz-solver/src/objects/collect.rs
@@ -429,6 +429,20 @@ impl<'a, R: TypeResolver> PropertyCollector<'a, R> {
                 Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
                     let shape = self.interner.object_shape(shape_id);
                     self.merge_shape(&shape);
+                    // Lazy heritage (`TSZ_LAZY_HERITAGE`): inherited members live
+                    // in `base_types` rather than flattened into `properties`.
+                    // Walk each base and add its members with OVERRIDE semantics
+                    // (own / earlier-base members win; a base only fills names not
+                    // already present) — heritage SHADOWS, it does not intersect
+                    // like `merge_shape`. `base_types` is empty for every shape
+                    // outside the lazy-heritage model, so this is inert (and
+                    // byte-identical) in the flattened model.
+                    if !shape.base_types.is_empty() {
+                        let bases = shape.base_types.clone();
+                        for base in bases {
+                            self.merge_base_members(base);
+                        }
+                    }
                 }
                 Some(TypeData::Mapped(mapped_id)) => {
                     // A deferred mapped type whose key constraint references
@@ -602,6 +616,7 @@ impl<'a, R: TypeResolver> PropertyCollector<'a, R> {
         }
 
         let shape = ObjectShape {
+            base_types: Vec::new(),
             flags: crate::types::ObjectFlags::empty(),
             properties,
             string_index: None,
@@ -797,6 +812,52 @@ impl<'a, R: TypeResolver> PropertyCollector<'a, R> {
         merge(&mut self.string_index, shape.string_index.as_ref());
         merge(&mut self.number_index, shape.number_index.as_ref());
         merge(&mut self.symbol_index, shape.symbol_index.as_ref());
+    }
+
+    /// Merge a lazy-heritage base's full member surface into this collection with
+    /// HERITAGE OVERRIDE semantics — the dual of [`Self::merge_shape`]'s
+    /// intersection: members already present (own members, or an earlier base)
+    /// win, and a base contributes only names not yet seen. The base's own
+    /// members AND its transitive bases are gathered by recursing through
+    /// [`collect_properties_cached`] (which itself walks the base's `base_types`
+    /// and resolves a `Lazy(DefId)` base on demand), so one call resolves the
+    /// base's entire inherited surface; the shared collector stack owns
+    /// cycle/partial-closure truncation. Index signatures are inherited only
+    /// where this collection lacks the corresponding slot.
+    fn merge_base_members(&mut self, base: TypeId) {
+        // Copy the borrowed inputs out so the `&mut self` field mutations below
+        // do not conflict with the immutable collector references.
+        let interner = self.interner;
+        let resolver = self.resolver;
+        let query_db = self.query_db;
+        let PropertyCollectionResult::Properties {
+            properties,
+            string_index,
+            number_index,
+            symbol_index,
+        } = collect_properties_cached(base, interner, resolver, query_db)
+        else {
+            // `Any` / `NonObject` bases contribute no structural members here.
+            return;
+        };
+        for prop in properties {
+            // Override: own / earlier-base members win.
+            if !self.prop_index.contains_key(&prop.name) {
+                let new_idx = self.properties.len();
+                self.prop_index.insert(prop.name, new_idx);
+                self.properties.push(prop);
+            }
+        }
+        // Inherit an index signature only when the derived surface lacks it.
+        if self.string_index.is_none() {
+            self.string_index = string_index;
+        }
+        if self.number_index.is_none() {
+            self.number_index = number_index;
+        }
+        if self.symbol_index.is_none() {
+            self.symbol_index = symbol_index;
+        }
     }
 }
 

--- a/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
+++ b/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
@@ -520,6 +520,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 ObjectFlags::empty()
             };
             self.interner.object_with_index(ObjectShape {
+                base_types: Vec::new(),
                 flags,
                 properties: reverse_properties,
                 string_index: reverse_string_index,
@@ -1244,6 +1245,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 if any_reversed {
                     if reverse_string_index.is_some() || reverse_number_index.is_some() {
                         return Some(self.interner.object_with_index(ObjectShape {
+                            base_types: Vec::new(),
                             flags: crate::types::ObjectFlags::empty(),
                             properties: reverse_properties,
                             string_index: reverse_string_index,

--- a/crates/tsz-solver/src/operations/declaration_projection.rs
+++ b/crates/tsz-solver/src/operations/declaration_projection.rs
@@ -316,6 +316,7 @@ impl Projector<'_> {
         // Index signatures are left as-is: their value is both read and written
         // through one handle, so a covariant-only rewrite would be unsound.
         Some(ObjectShape {
+            base_types: Vec::new(),
             flags: shape.flags,
             properties,
             string_index: shape.string_index,

--- a/crates/tsz-solver/src/operations/property_visitor.rs
+++ b/crates/tsz-solver/src/operations/property_visitor.rs
@@ -111,6 +111,22 @@ impl<'a> PropertyAccessEvaluator<'a> {
             });
         }
 
+        // Lazy heritage (`TSZ_LAZY_HERITAGE`): an inherited member is resolved
+        // per-name through `base_types` (own members already checked above). This
+        // is the find-member fast path — it resolves only the requested member by
+        // walking bases, never materializing the full inherited surface. An
+        // inherited NAMED member shadows the derived's own index signatures and
+        // Object.prototype apparent members, so the walk runs before both. A
+        // `Lazy` / `Application` base resolves through the recursive entry.
+        // `base_types` is empty outside the lazy-heritage model, so this is inert
+        // (byte-identical) under the flattened model.
+        for &base in &shape.base_types {
+            let inherited = self.resolve_property_access_inner(base, prop_atom);
+            if !matches!(inherited, PropertyAccessResult::PropertyNotFound { .. }) {
+                return Some(inherited);
+            }
+        }
+
         // Miss path: resolve the string form once for the leaf checks below.
         let prop_name_arc = self.interner().resolve_atom_ref(prop_atom);
         let prop_name = prop_name_arc.as_ref();
@@ -192,6 +208,22 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 write_type: write,
                 from_index_signature: false,
             });
+        }
+
+        // Lazy heritage (`TSZ_LAZY_HERITAGE`): an inherited member is resolved
+        // per-name through `base_types` (own members already checked above). This
+        // is the find-member fast path — it resolves only the requested member by
+        // walking bases, never materializing the full inherited surface. An
+        // inherited NAMED member shadows the derived's own index signatures and
+        // Object.prototype apparent members, so the walk runs before both. A
+        // `Lazy` / `Application` base resolves through the recursive entry.
+        // `base_types` is empty outside the lazy-heritage model, so this is inert
+        // (byte-identical) under the flattened model.
+        for &base in &shape.base_types {
+            let inherited = self.resolve_property_access_inner(base, prop_atom);
+            if !matches!(inherited, PropertyAccessResult::PropertyNotFound { .. }) {
+                return Some(inherited);
+            }
         }
 
         // Miss path: resolve the string form once for the leaf checks below.

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -1075,6 +1075,14 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
                 for prop_info in &shape.properties {
                     properties.insert(prop_info.name);
                 }
+                // Lazy heritage: an inherited member is a "known" property too, so
+                // walk `base_types` (empty under the flattened model). Without this
+                // the excess-property check flags inherited names (e.g. an
+                // `interface Endpoint extends EventSource`'s `addEventListener`) as
+                // excess — a false TS2353.
+                for base in shape.base_types.clone() {
+                    properties.extend(self.collect_target_properties(base));
+                }
             }
             Some(TypeData::Conditional(cond_id)) => {
                 // For unresolved conditional types (e.g. T extends U ? X : Y where T

--- a/crates/tsz-solver/src/relations/compat_weak.rs
+++ b/crates/tsz-solver/src/relations/compat_weak.rs
@@ -56,7 +56,20 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
                 let shape = self
                     .interner
                     .object_shape(crate::types::ObjectShapeId(shape_id));
-                all_target_props.extend_from_slice(&shape.properties);
+                // Lazy heritage: include the member's inherited members in the weak
+                // surface (own props only when no `base_types` -> byte-identical).
+                if shape.base_types.is_empty() {
+                    all_target_props.extend_from_slice(&shape.properties);
+                } else if let crate::objects::PropertyCollectionResult::Properties {
+                    properties,
+                    ..
+                } =
+                    crate::objects::collect_properties(member, self.interner, self.subtype.resolver)
+                {
+                    all_target_props.extend(properties);
+                } else {
+                    all_target_props.extend_from_slice(&shape.properties);
+                }
             }
             if all_target_props.is_empty() {
                 return false;
@@ -81,7 +94,25 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return false;
         }
 
-        let target_props = target_shape.properties.as_slice();
+        // Lazy heritage: the weak surface (all-optional members) includes
+        // INHERITED optional members. Resolve the full member set when the target
+        // carries `base_types`; empty -> own props (byte-identical flag-off).
+        let heritage_target_props;
+        let target_props: &[crate::types::PropertyInfo] = if target_shape.base_types.is_empty() {
+            target_shape.properties.as_slice()
+        } else {
+            heritage_target_props = match crate::objects::collect_properties(
+                target,
+                self.interner,
+                self.subtype.resolver,
+            ) {
+                crate::objects::PropertyCollectionResult::Properties { properties, .. } => {
+                    properties
+                }
+                _ => target_shape.properties.to_vec(),
+            };
+            &heritage_target_props
+        };
         if target_props.is_empty() || target_props.iter().any(|prop| !prop.optional) {
             return false;
         }

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -21,8 +21,8 @@ use crate::operations::AssignabilityChecker;
 #[cfg(test)]
 use crate::types::*;
 use crate::types::{
-    IntrinsicKind, LiteralValue, ObjectFlags, ObjectShape, PropertyInfo, RelationCacheKey,
-    SymbolRef, TemplateSpan, TypeData, TypeId, TypeListId,
+    IntrinsicKind, LiteralValue, ObjectFlags, ObjectShape, ObjectShapeId, PropertyInfo,
+    RelationCacheKey, SymbolRef, TemplateSpan, TypeData, TypeId, TypeListId,
 };
 use crate::visitor::{
     TypeVisitor, application_id, array_element_type, callable_shape_id, conditional_type_id,
@@ -358,6 +358,16 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// needed and how it preserves byte-identical diagnostics; initialized per
     /// failure by [`Self::explain_failure`].
     pub(crate) explain_eval_fuel: Option<u32>,
+    /// Lazy-heritage (`TSZ_LAZY_HERITAGE`) apparent-shape memo. Maps an interned
+    /// `ObjectShapeId` carrying `base_types` to its flattened apparent shape (own
+    /// + inherited, atom-sorted), tagged with the resolver generation it was
+    /// computed under. Without it, `apparent_object_shape` re-flattens on EVERY
+    /// object subtype check; inside a conditional / infer-pattern evaluation loop
+    /// that is an exponential blow-up (the flattened model pays the flatten once,
+    /// at materialization). Checker-scoped (interner-bound, cleared by `reset`),
+    /// so no cross-compilation staleness. Stays empty under the flattened model
+    /// (`base_types` always empty -> never inserted).
+    pub(crate) apparent_shape_cache: FxHashMap<ObjectShapeId, (u64, Arc<ObjectShape>)>,
 }
 
 /// Operation-local cache statistics for [`SubtypeChecker`].
@@ -434,6 +444,7 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             local_relation_cache: FxHashMap::default(),
             explain_budget: super::explain::EXPLAIN_EVAL_BUDGET,
             explain_eval_fuel: None,
+            apparent_shape_cache: FxHashMap::default(),
         }
     }
 }
@@ -487,6 +498,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             local_relation_cache: FxHashMap::default(),
             explain_budget: super::explain::EXPLAIN_EVAL_BUDGET,
             explain_eval_fuel: None,
+            apparent_shape_cache: FxHashMap::default(),
         }
     }
 
@@ -629,6 +641,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.eval_cache.clear();
         self.maybe_keys.clear();
         self.local_relation_cache.clear();
+        self.apparent_shape_cache.clear();
         self.explain_eval_fuel = None;
     }
 

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -1687,6 +1687,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 let mut props = callable.properties.clone();
                 props.sort_by_key(|a| a.name);
                 Some(ObjectShape {
+                    base_types: Vec::new(),
                     flags: ObjectFlags::empty(),
                     properties: props,
                     string_index: callable.string_index,
@@ -1977,6 +1978,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // name (`Atom`), matching the callable-shape path above.
         properties.sort_by_key(|p| p.name);
         ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties,
             string_index: None,

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -1001,7 +1001,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             object_shape_id(self.interner, target),
         ) {
             let s_shape = self.interner.object_shape(s_shape_id);
-            let t_shape = self.interner.object_shape(t_shape_id);
+            // Lazy heritage: pre-flatten the target's inherited members, memoized
+            // by `t_shape_id`, so `check_object_subtype` does not re-flatten the
+            // target on every check — that re-flatten is exponential inside a
+            // conditional / infer-pattern evaluation loop. No-op flag-off
+            // (`base_types` empty -> the interned shape is returned unchanged).
+            let t_shape = {
+                let raw = self.interner.object_shape(t_shape_id);
+                self.apparent_object_shape(&raw, Some(t_shape_id))
+            };
 
             // Symbol-level cycle detection for recursive interface/class types.
             // When both objects have symbols, check if we're already comparing objects
@@ -1048,7 +1056,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             object_with_index_shape_id(self.interner, target),
         ) {
             let s_shape = self.interner.object_shape(s_shape_id);
-            let t_shape = self.interner.object_shape(t_shape_id);
+            // Lazy heritage: pre-flatten the target (memoized by `t_shape_id`) so
+            // `check_object_subtype` does not re-flatten per check.
+            let t_shape = {
+                let raw = self.interner.object_shape(t_shape_id);
+                self.apparent_object_shape(&raw, Some(t_shape_id))
+            };
 
             // Symbol-level cycle detection for ObjectWithIndex types (class instances).
             // Class instance types are interned as ObjectWithIndex with a symbol. Without

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -182,6 +182,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 symbol_index,
             } => {
                 let shape = ObjectShape {
+                    base_types: Vec::new(),
                     flags: ObjectFlags::empty(),
                     properties,
                     string_index,

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -1528,6 +1528,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
             }
             let source_shape = ObjectShape {
+                base_types: Vec::new(),
                 flags: ObjectFlags::empty(),
                 properties: source_props,
                 string_index: None,
@@ -1536,6 +1537,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 symbol: None,
             };
             let target_shape = ObjectShape {
+                base_types: Vec::new(),
                 flags: ObjectFlags::empty(),
                 properties: target_props,
                 string_index: t_callable.string_index,
@@ -1833,6 +1835,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         target_props.sort_by_key(|a| a.name);
         // Create temporary ObjectShape instances for the property check
         let source_shape = ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: source_props,
             string_index: source.string_index,
@@ -1841,6 +1844,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             symbol: source.symbol,
         };
         let target_shape = ObjectShape {
+            base_types: Vec::new(),
             flags: ObjectFlags::empty(),
             properties: target_props,
             string_index: target.string_index,

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -1360,6 +1360,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 || symbol_index.is_some() =>
             {
                 let target_shape = crate::types::ObjectShape {
+                    base_types: Vec::new(),
                     flags: crate::types::ObjectFlags::empty(),
                     properties,
                     string_index,

--- a/crates/tsz-solver/src/relations/subtype/rules/mapped_expansion.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/mapped_expansion.rs
@@ -58,6 +58,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             let value_type = mapped.template;
             let readonly = mapped.readonly_modifier == Some(MappedModifier::Add);
             return Some(self.interner.object_with_index(ObjectShape {
+                base_types: Vec::new(),
                 flags: ObjectFlags::empty(),
                 properties: Vec::new(),
                 string_index: Some(IndexSignature {

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -1742,6 +1742,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             .map(|id| self.interner.object_shape(id))
             .unwrap_or_else(|| {
                 ObjectShape {
+                    base_types: Vec::new(),
                     flags: ObjectFlags::empty(),
                     properties: source.to_vec(),
                     string_index: None,

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -331,6 +331,60 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// 1. **Fast path**: Nominal inheritance check (O(1) for class instances)
     /// 2. Private brand compatibility (for nominal class typing with private fields)
     /// 3. For each target property, source must have a compatible property
+    /// The full apparent member surface of a lazy-heritage shape (own + all
+    /// inherited via `base_types`), for the structural member-comparison rules
+    /// that read `.properties` as the complete member set. Returns
+    /// `Cow::Borrowed(shape)` when `base_types` is empty (the flattened model —
+    /// byte-identical, zero allocation), else an owned `ObjectShape` whose
+    /// `properties` are merged (own / earlier-base win — heritage shadows) AND
+    /// **re-sorted by atom**: `check_object_subtype`'s member loop is an
+    /// atom-sorted merge-join, so inherited props appended out of order would
+    /// corrupt it. Per-base collection is memoized by `collect_properties_cached`.
+    fn apparent_object_shape<'s>(
+        &self,
+        shape: &'s ObjectShape,
+    ) -> std::borrow::Cow<'s, ObjectShape> {
+        if shape.base_types.is_empty() {
+            return std::borrow::Cow::Borrowed(shape);
+        }
+        use crate::objects::{PropertyCollectionResult, collect_properties_cached};
+        let mut properties = shape.properties.clone();
+        let mut seen: rustc_hash::FxHashSet<tsz_common::interner::Atom> =
+            properties.iter().map(|prop| prop.name).collect();
+        let mut string_index = shape.string_index;
+        let mut number_index = shape.number_index;
+        let mut symbol_index = shape.symbol_index;
+        for &base in &shape.base_types {
+            if let PropertyCollectionResult::Properties {
+                properties: base_props,
+                string_index: bsi,
+                number_index: bni,
+                symbol_index: bsy,
+            } = collect_properties_cached(base, self.interner, self.resolver, self.query_db)
+            {
+                for prop in base_props {
+                    if seen.insert(prop.name) {
+                        properties.push(prop);
+                    }
+                }
+                string_index = string_index.or(bsi);
+                number_index = number_index.or(bni);
+                symbol_index = symbol_index.or(bsy);
+            }
+        }
+        // Atom-sort: the member loops below are an atom-sorted merge-join.
+        properties.sort_by_key(|prop| prop.name);
+        std::borrow::Cow::Owned(ObjectShape {
+            flags: shape.flags,
+            properties,
+            string_index,
+            number_index,
+            symbol_index,
+            symbol: shape.symbol,
+            base_types: Vec::new(),
+        })
+    }
+
     pub(crate) fn check_object_subtype(
         &mut self,
         source: &ObjectShape,
@@ -339,6 +393,22 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         target: &ObjectShape,
         target_receiver: Option<TypeId>,
     ) -> SubtypeResult {
+        // Lazy heritage: resolve each side's full inherited member surface before
+        // the own-only structural comparison below. A flattened (Owned) source
+        // drops its `source_shape_id` — the transient shape is not the interned
+        // own-only shape, so reusing that id would let `lookup_property`'s
+        // per-shape-id member cache serve stale own-only results. Inert flag-off
+        // (`base_types` empty -> `Cow::Borrowed`, no allocation, no re-sort).
+        let source_apparent = self.apparent_object_shape(source);
+        let source_shape_id = if matches!(source_apparent, std::borrow::Cow::Owned(_)) {
+            None
+        } else {
+            source_shape_id
+        };
+        let source = source_apparent.as_ref();
+        let target_apparent = self.apparent_object_shape(target);
+        let target = target_apparent.as_ref();
+
         // Prefer the caller-provided receiver (which preserves type arguments,
         // e.g., Runtype<any>) over the shape-derived DefId reference (which loses
         // them, e.g., bare Runtype). This ensures `this` type substitution in

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -340,13 +340,36 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// **re-sorted by atom**: `check_object_subtype`'s member loop is an
     /// atom-sorted merge-join, so inherited props appended out of order would
     /// corrupt it. Per-base collection is memoized by `collect_properties_cached`.
-    fn apparent_object_shape<'s>(
-        &self,
-        shape: &'s ObjectShape,
-    ) -> std::borrow::Cow<'s, ObjectShape> {
+    pub(crate) fn apparent_object_shape(
+        &mut self,
+        shape: &ObjectShape,
+        shape_id: Option<ObjectShapeId>,
+    ) -> std::sync::Arc<ObjectShape> {
+        // Flattened model (and every non-heritage shape): no work. Return the
+        // already-interned `Arc` when the id is known (a cheap interner cache
+        // hit), else a one-off clone (rare synthetic-shape callers).
         if shape.base_types.is_empty() {
-            return std::borrow::Cow::Borrowed(shape);
+            return match shape_id {
+                Some(id) => self.interner.object_shape(id),
+                None => std::sync::Arc::new(shape.clone()),
+            };
         }
+        // Memo: re-flattening on every object subtype check is exponential inside
+        // a conditional / infer-pattern evaluation loop. Key by interned
+        // `ObjectShapeId` + resolver generation (the generation guards against a
+        // `Lazy` base resolving after a cached entry was built).
+        let generation = self.resolver.resolver_generation();
+        if let Some(id) = shape_id
+            && let Some((cached_generation, cached)) = self.apparent_shape_cache.get(&id)
+            && *cached_generation == generation
+        {
+            return cached.clone();
+        }
+        // Copy the borrowed inputs out so the cache insert below does not conflict
+        // with the immutable collector references.
+        let interner = self.interner;
+        let resolver = self.resolver;
+        let query_db = self.query_db;
         use crate::objects::{PropertyCollectionResult, collect_properties_cached};
         let mut properties = shape.properties.clone();
         let mut seen: rustc_hash::FxHashSet<tsz_common::interner::Atom> =
@@ -360,7 +383,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 string_index: bsi,
                 number_index: bni,
                 symbol_index: bsy,
-            } = collect_properties_cached(base, self.interner, self.resolver, self.query_db)
+            } = collect_properties_cached(base, interner, resolver, query_db)
             {
                 for prop in base_props {
                     if seen.insert(prop.name) {
@@ -374,7 +397,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
         // Atom-sort: the member loops below are an atom-sorted merge-join.
         properties.sort_by_key(|prop| prop.name);
-        std::borrow::Cow::Owned(ObjectShape {
+        let flat = std::sync::Arc::new(ObjectShape {
             flags: shape.flags,
             properties,
             string_index,
@@ -382,7 +405,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             symbol_index,
             symbol: shape.symbol,
             base_types: Vec::new(),
-        })
+        });
+        if let Some(id) = shape_id {
+            self.apparent_shape_cache
+                .insert(id, (generation, flat.clone()));
+        }
+        flat
     }
 
     pub(crate) fn check_object_subtype(
@@ -394,19 +422,24 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         target_receiver: Option<TypeId>,
     ) -> SubtypeResult {
         // Lazy heritage: resolve each side's full inherited member surface before
-        // the own-only structural comparison below. A flattened (Owned) source
-        // drops its `source_shape_id` — the transient shape is not the interned
-        // own-only shape, so reusing that id would let `lookup_property`'s
-        // per-shape-id member cache serve stale own-only results. Inert flag-off
-        // (`base_types` empty -> `Cow::Borrowed`, no allocation, no re-sort).
-        let source_apparent = self.apparent_object_shape(source);
-        let source_shape_id = if matches!(source_apparent, std::borrow::Cow::Owned(_)) {
+        // the own-only structural comparison below. The SOURCE is memoized by its
+        // `source_shape_id` (and that id is then dropped — the flattened shape is
+        // not the interned own-only shape, so reusing the id would let
+        // `lookup_property`'s per-shape-id member cache serve stale own-only
+        // results). The TARGET has no shape id here, so it flattens un-memoized;
+        // the hot object-vs-object dispatch pre-flattens the target (memoized by
+        // its `t_shape_id`) so this is a no-op on that path, and only cold paths
+        // pay a per-call target flatten. Inert flag-off (`base_types` empty -> the
+        // interned/borrowed shape is returned unchanged).
+        let source_was_lazy = !source.base_types.is_empty();
+        let source_apparent = self.apparent_object_shape(source, source_shape_id);
+        let target_apparent = self.apparent_object_shape(target, None);
+        let source_shape_id = if source_was_lazy {
             None
         } else {
             source_shape_id
         };
         let source = source_apparent.as_ref();
-        let target_apparent = self.apparent_object_shape(target);
         let target = target_apparent.as_ref();
 
         // Prefer the caller-provided receiver (which preserves type arguments,

--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -432,6 +432,7 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                             || symbol_index.is_some()
                         {
                             self.checker.interner.object_with_index(ObjectShape {
+                                base_types: Vec::new(),
                                 flags: ObjectFlags::empty(),
                                 properties,
                                 string_index,
@@ -878,6 +879,7 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 .callable_shape(CallableShapeId(shape_id));
             let t_shape = self.checker.interner.object_shape(t_shape_id);
             let s_shape = ObjectShape {
+                base_types: Vec::new(),
                 flags: ObjectFlags::empty(),
                 properties: s_callable.properties.clone(),
                 string_index: s_callable.string_index,
@@ -902,6 +904,7 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 .callable_shape(CallableShapeId(shape_id));
             let t_shape = self.checker.interner.object_shape(t_shape_id);
             let s_shape = ObjectShape {
+                base_types: Vec::new(),
                 flags: ObjectFlags::empty(),
                 properties: s_callable.properties.clone(),
                 string_index: s_callable.string_index,

--- a/crates/tsz-solver/src/tests/type_queries_spread_tests.rs
+++ b/crates/tsz-solver/src/tests/type_queries_spread_tests.rs
@@ -793,6 +793,7 @@ fn readonly_string_and_number_index_signatures_detected() {
     let db = TypeInterner::new();
     // `{ readonly [x: string]: string }`
     let ro_string_index = db.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -812,6 +813,7 @@ fn readonly_string_and_number_index_signatures_detected() {
 
     // `{ readonly [n: number]: number }`
     let ro_number_index = db.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -831,6 +833,7 @@ fn readonly_string_and_number_index_signatures_detected() {
 
     // `{ [x: string]: string }` (mutable index) — not detected.
     let mutable_index = db.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/src/tests/visitor_tests.rs
+++ b/crates/tsz-solver/src/tests/visitor_tests.rs
@@ -579,6 +579,7 @@ fn test_object_shape_extractors() {
     assert!(object_with_index_shape_id(&interner, obj).is_none());
 
     let obj_with_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -883,6 +883,7 @@ pub fn rewrite_function_error_slots_to_any(db: &dyn TypeDatabase, type_id: TypeI
                 });
                 if changed {
                     db.object_with_index(crate::types::ObjectShape {
+                        base_types: Vec::new(),
                         flags: shape.flags,
                         properties,
                         string_index,

--- a/crates/tsz-solver/src/type_queries/data/tests.rs
+++ b/crates/tsz-solver/src/type_queries/data/tests.rs
@@ -562,6 +562,7 @@ fn test_get_object_symbol() {
 
     // Object with symbol — use object_with_index to comply with intern quarantine
     let obj_with_sym = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![PropertyInfo {
             name: interner.intern_string("x"),

--- a/crates/tsz-solver/src/type_queries/mapped.rs
+++ b/crates/tsz-solver/src/type_queries/mapped.rs
@@ -1076,6 +1076,7 @@ pub fn evaluate_identity_mapped_passthrough(
         if arg == TypeId::ANY {
             use crate::types::{IndexSignature, ObjectShape};
             return Some(db.object_with_index(ObjectShape {
+                base_types: Vec::new(),
                 flags: crate::types::ObjectFlags::empty(),
                 properties: vec![],
                 string_index: Some(IndexSignature {

--- a/crates/tsz-solver/src/type_queries/mapped_declaration_surface.rs
+++ b/crates/tsz-solver/src/type_queries/mapped_declaration_surface.rs
@@ -165,6 +165,7 @@ fn mapped_surface_with_optional_undefined_inner(
     if changed {
         if with_index {
             db.object_with_index(ObjectShape {
+                base_types: Vec::new(),
                 flags: shape.flags,
                 properties,
                 string_index: shape.string_index,

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -1370,6 +1370,20 @@ pub struct ObjectShape {
     pub symbol_index: Option<IndexSignature>,
     /// Nominal identity for class instance types (prevents structural interning of distinct classes)
     pub symbol: Option<tsz_binder::SymbolId>,
+    /// Lazy heritage bases (`interface Derived extends Base, ...`). EMPTY for
+    /// every shape except an interface materialized under the lazy-heritage
+    /// model (`TSZ_LAZY_HERITAGE`): rather than flattening a base's members into
+    /// `properties`, the base's `TypeId` is recorded here and inherited members
+    /// are resolved on demand by walking `base_types` in property collection
+    /// (own members override base members by name). A base entry may be an
+    /// `Object`/`ObjectWithIndex` (resolved base), an `Application` (instantiated
+    /// generic base `Base<Args>`), or a `Lazy(DefId)` (demand-driven, unresolved
+    /// base) — so it is a `TypeId`, not a raw `ObjectShapeId`. This makes a
+    /// derived shape own-members-only and shared bases interned once, dissolving
+    /// the eager full-closure flatten (and the `REFS_RESOLUTION_FUEL` cap that
+    /// bounded it). Identity-bearing: two shapes with identical own members but
+    /// different bases are distinct types (see `shape_identity.rs`).
+    pub base_types: Vec<TypeId>,
 }
 
 impl ObjectShape {

--- a/crates/tsz-solver/src/types/shape_identity.rs
+++ b/crates/tsz-solver/src/types/shape_identity.rs
@@ -223,9 +223,17 @@ impl std::hash::Hash for ObjectShape {
         hash_index_signature_display(number_index, state);
         hash_index_signature_display(symbol_index, state);
         symbol.hash(state);
-        // Empty for non-lazy-heritage shapes -> contributes nothing -> flag-off
-        // hashes are byte-identical to pre-base_types.
-        base_types.hash(state);
+        // `base_types` is INTENTIONALLY omitted from the hash. `Hash`/`Eq`
+        // consistency only requires `a == b ⟹ hash(a) == hash(b)`; equal shapes
+        // have equal `base_types` (compared in `PartialEq`), so omitting it here
+        // stays consistent. Hashing it would write an empty-`Vec` length for
+        // every flattened-model shape, perturbing the interner's bucket
+        // distribution and TypeId-assignment order vs pre-`base_types` main —
+        // observable to order-sensitive interning/normalization tests. Two shapes
+        // differing only in `base_types` simply share a bucket and are
+        // disambiguated by `PartialEq` (a benign extra collision confined to the
+        // lazy-heritage model).
+        let _ = base_types;
     }
 }
 

--- a/crates/tsz-solver/src/types/shape_identity.rs
+++ b/crates/tsz-solver/src/types/shape_identity.rs
@@ -177,6 +177,10 @@ impl PartialEq for ObjectShape {
             number_index,
             symbol_index,
             symbol,
+            // Identity-bearing: heritage bases distinguish two shapes with
+            // identical own members but different `extends` lists. Empty for
+            // every non-lazy-heritage shape, so flag-off interning is unchanged.
+            base_types,
         } = self;
         *flags == other.flags
             && *properties == other.properties
@@ -189,6 +193,7 @@ impl PartialEq for ObjectShape {
             && index_signature_display_eq(number_index, &other.number_index)
             && index_signature_display_eq(symbol_index, &other.symbol_index)
             && *symbol == other.symbol
+            && *base_types == other.base_types
     }
 }
 
@@ -205,6 +210,7 @@ impl std::hash::Hash for ObjectShape {
             number_index,
             symbol_index,
             symbol,
+            base_types,
         } = self;
         flags.hash(state);
         properties.hash(state);
@@ -217,6 +223,9 @@ impl std::hash::Hash for ObjectShape {
         hash_index_signature_display(number_index, state);
         hash_index_signature_display(symbol_index, state);
         symbol.hash(state);
+        // Empty for non-lazy-heritage shapes -> contributes nothing -> flag-off
+        // hashes are byte-identical to pre-base_types.
+        base_types.hash(state);
     }
 }
 

--- a/crates/tsz-solver/tests/canonicalize_tests.rs
+++ b/crates/tsz-solver/tests/canonicalize_tests.rs
@@ -1323,6 +1323,7 @@ fn canonicalize_object_with_index_signature() {
 
     use crate::types::{IndexSignature, ObjectShape};
     let shape = ObjectShape {
+        base_types: Vec::new(),
         properties: vec![],
         string_index: Some(IndexSignature {
             key_type: TypeId::STRING,
@@ -2140,6 +2141,7 @@ fn canonicalize_index_signature_key_name_alpha_equivalent() {
     // `{ [<key>: string]: number }` — only the cosmetic key name varies.
     let make = |key_name: &str| {
         interner.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             properties: vec![],
             string_index: Some(IndexSignature {
                 key_type: TypeId::STRING,
@@ -2173,6 +2175,7 @@ fn canonicalize_index_signature_readonly_and_value_stay_distinct() {
 
     let make = |value: TypeId, readonly: bool| {
         interner.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             properties: vec![],
             string_index: Some(IndexSignature {
                 key_type: TypeId::STRING,

--- a/crates/tsz-solver/tests/class_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/class_comprehensive_tests.rs
@@ -493,6 +493,7 @@ fn test_class_with_string_index() {
     let interner = TypeInterner::new();
 
     let obj = interner.object_with_index(crate::types::ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: crate::types::ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/compat_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/compat_tests_parts/part_00.rs
@@ -1657,6 +1657,7 @@ fn test_no_unchecked_indexed_access_toggle() {
     let mut checker = CompatChecker::new(&interner);
 
     let indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1720,6 +1721,7 @@ fn test_no_unchecked_object_index_signature_assignable() {
     let mut checker = CompatChecker::new(&interner);
 
     let indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/compat_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/compat_tests_parts/part_01.rs
@@ -716,6 +716,7 @@ fn test_apparent_string_number_index_assignable() {
     let mut checker = CompatChecker::new(&interner);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -738,6 +739,7 @@ fn test_apparent_string_rejects_string_index_signature() {
     let mut checker = CompatChecker::new(&interner);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -857,6 +859,7 @@ fn test_optional_property_rejects_string_index_signature() {
     }]);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -884,6 +887,7 @@ fn test_template_literal_index_signature_tracks_excess_properties() {
     let allowed_suffix =
         interner.union2(interner.literal_string("A"), interner.literal_string("B"));
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -978,6 +982,7 @@ fn test_exact_optional_property_allows_string_index_signature() {
     }]);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1293,6 +1298,7 @@ fn test_keyof_union_index_signature_assignable() {
     let mut checker = CompatChecker::new(&interner);
 
     let string_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1306,6 +1312,7 @@ fn test_keyof_union_index_signature_assignable() {
         number_index: None,
     });
     let number_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1445,6 +1452,7 @@ fn test_weak_type_with_index_signature_not_weak() {
 
     // Target with optional property + index signature - NOT weak
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/compat_tests_parts/part_02.rs
+++ b/crates/tsz-solver/tests/compat_tests_parts/part_02.rs
@@ -633,6 +633,7 @@ fn test_compiler_options_independent_toggles() {
 
     // Toggle no_unchecked_indexed_access
     let indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/compat_tests_parts/part_03.rs
+++ b/crates/tsz-solver/tests/compat_tests_parts/part_03.rs
@@ -134,6 +134,7 @@ fn test_explain_object_to_tuple_missing_property() {
     let prop0 = PropertyInfo::new(interner.intern_string("0"), TypeId::STRING);
     let prop1 = PropertyInfo::new(interner.intern_string("1"), TypeId::NUMBER);
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         properties: vec![prop0, prop1],
         number_index: Some(IndexSignature {
             key_type: TypeId::NUMBER,

--- a/crates/tsz-solver/tests/concurrent_tests.rs
+++ b/crates/tsz-solver/tests/concurrent_tests.rs
@@ -220,6 +220,7 @@ fn test_concurrent_property_map_building() {
         .collect();
 
     let shape = ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/constraint_tests.rs
+++ b/crates/tsz-solver/tests/constraint_tests.rs
@@ -1191,6 +1191,7 @@ fn test_eopt_preserves_explicit_undefined_in_index_signature_inference() {
     }));
 
     let param_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1270,6 +1271,7 @@ fn test_no_eopt_preserves_explicit_undefined_in_index_signature_inference() {
     }));
 
     let param_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1553,6 +1555,7 @@ fn test_object_entries_like_callable_any_arg_uses_first_overload() {
     // { [s: string]: T }
     let s_name = interner.intern_string("s");
     let str_index_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1568,6 +1571,7 @@ fn test_object_entries_like_callable_any_arg_uses_first_overload() {
     // Simulate ArrayLike<T>: { readonly length: number; readonly [n: number]: T }
     let n_name = interner.intern_string("n");
     let array_like_t = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1762,6 +1766,7 @@ fn test_any_arg_index_sig_t_infers_unknown() {
         origin: crate::types::TypeParamOrigin::User,
     }));
     let param_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/def_tests.rs
+++ b/crates/tsz-solver/tests/def_tests.rs
@@ -601,6 +601,7 @@ fn test_find_def_by_shape_via_register() {
 
     // Build the same shape for lookup.
     let lookup_shape = ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: props,
         string_index: None,
@@ -624,6 +625,7 @@ fn test_find_def_by_shape_no_match() {
 
     // Type aliases have no instance_shape, so lookup should return None.
     let empty_shape = ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: None,
@@ -668,6 +670,7 @@ fn test_find_def_by_shape_via_set_instance_shape() {
 
     let z_name = interner.intern_string("z");
     let shape = ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![PropertyInfo {
             name: z_name,
@@ -711,6 +714,7 @@ fn test_find_def_by_shape_cleared() {
     store.register(info);
 
     let empty_shape = ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: None,
@@ -876,6 +880,7 @@ fn test_invalidate_file_cleans_shape_index() {
     let store = DefinitionStore::new();
 
     let empty_shape = ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: None,

--- a/crates/tsz-solver/tests/evaluate_tests_parts/application_template_literal.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/application_template_literal.rs
@@ -94,6 +94,7 @@ fn test_application_ref_expansion_with_index_signature() {
 
     // Define: type Dict<T> = { [key: string]: T }
     let dict_body = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -122,6 +123,7 @@ fn test_application_ref_expansion_with_index_signature() {
 
     // Expected: { [key: string]: number }
     let expected = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -165,6 +167,7 @@ fn test_application_ref_expansion_with_number_index_signature() {
 
     // Define: type NumericDict<T> = { [index: number]: T }
     let numeric_dict_body = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -193,6 +196,7 @@ fn test_application_ref_expansion_with_number_index_signature() {
 
     // Expected: { [index: number]: string }
     let expected = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_objects.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_objects.rs
@@ -910,6 +910,7 @@ fn test_conditional_infer_object_index_signature_distributive() {
 
     // T extends { [key: string]: infer R } ? R : never, with T = { a: string } | { b: number }.
     let extends_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -959,6 +960,7 @@ fn test_conditional_infer_number_index_signature_distributive() {
 
     // T extends { [key: number]: infer R } ? R : never, with T = { 0: string } | { 1: number }.
     let extends_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1008,6 +1010,7 @@ fn test_conditional_infer_number_index_signature_non_distributive_union_input() 
 
     // T extends { [key: number]: infer R } ? R : never, with T = { 0: string } | { 1: number } (no distribution).
     let extends_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1057,6 +1060,7 @@ fn test_conditional_infer_number_index_signature_non_distributive_union_branch()
 
     // T extends { [key: number]: infer R } ? R : never, with T = { 0: string } | number (no distribution).
     let extends_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1101,6 +1105,7 @@ fn test_conditional_infer_object_index_signature_non_object_union_branch() {
 
     // T extends { [key: string]: infer R } ? R : never, with T = { a: string } | number.
     let extends_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1145,6 +1150,7 @@ fn test_conditional_infer_object_index_signature_non_distributive_union_input() 
 
     // T extends { [key: string]: infer R } ? R : never, with T = { a: string } | { b: number } (no distribution).
     let extends_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1194,6 +1200,7 @@ fn test_conditional_infer_object_index_signature_non_distributive_union_branch()
 
     // T extends { [key: string]: infer R } ? R : never, with T = { a: string } | number (no distribution).
     let extends_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/indexed_access_conditionals.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/indexed_access_conditionals.rs
@@ -593,6 +593,7 @@ fn test_conditional_infer_object_string_index_signature() {
     let (_r_name, infer_r) = test_infer_param(&interner, "R");
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -606,6 +607,7 @@ fn test_conditional_infer_object_string_index_signature() {
         number_index: None,
     });
     let pattern = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -875,6 +877,7 @@ fn test_index_access_object_with_string_index_signature() {
     let key_y = interner.literal_string("y");
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -912,6 +915,7 @@ fn test_index_access_object_with_string_index_signature_optional_property() {
     let key_y = interner.literal_string("y");
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -944,6 +948,7 @@ fn test_index_access_object_with_string_index_signature_optional_property_no_unc
     let interner = TypeInterner::new();
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -988,6 +993,7 @@ fn test_no_unchecked_object_index_signature_evaluate() {
     let interner = TypeInterner::new();
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1014,6 +1020,7 @@ fn test_index_access_object_with_number_index_signature() {
     let interner = TypeInterner::new();
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1040,6 +1047,7 @@ fn test_index_access_object_with_number_index_signature_no_unchecked() {
     let interner = TypeInterner::new();
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1171,6 +1179,7 @@ fn test_index_access_with_no_unchecked_indexed_access() {
     let interner = TypeInterner::new();
 
     let indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1203,6 +1212,7 @@ fn test_index_access_with_options_helper_no_unchecked_indexed_access() {
     let interner = TypeInterner::new();
 
     let indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/indexed_access_template_recursive.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/indexed_access_template_recursive.rs
@@ -629,6 +629,7 @@ fn test_indexed_access_string_index_signature() {
     let interner = TypeInterner::new();
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -654,6 +655,7 @@ fn test_indexed_access_number_index_signature() {
     let interner = TypeInterner::new();
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -679,6 +681,7 @@ fn test_indexed_access_property_overrides_index_signature() {
     let interner = TypeInterner::new();
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/keyof_indexed_access.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/keyof_indexed_access.rs
@@ -525,6 +525,7 @@ fn test_keyof_object_with_string_index_signature() {
 
     let key_x = interner.intern_string("x");
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -553,6 +554,7 @@ fn test_keyof_object_with_number_index_signature() {
 
     let key_x = interner.intern_string("x");
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -635,6 +637,7 @@ fn test_keyof_union_string_index_overlap_literal() {
     let interner = TypeInterner::new();
 
     let obj_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -663,6 +666,7 @@ fn test_keyof_union_index_signature_intersection() {
     let interner = TypeInterner::new();
 
     let string_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -676,6 +680,7 @@ fn test_keyof_union_index_signature_intersection() {
         number_index: None,
     });
     let number_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1353,6 +1358,7 @@ fn test_keyof_both_index_signatures() {
     let interner = TypeInterner::new();
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1536,6 +1542,7 @@ fn test_keyof_union_with_index_signature_and_literal() {
     )]);
 
     let obj_indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1569,6 +1576,7 @@ fn test_keyof_intersection_with_index_signature() {
     )]);
 
     let obj_indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/literal_satisfies_intrinsics.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/literal_satisfies_intrinsics.rs
@@ -290,6 +290,7 @@ fn test_satisfies_record_type() {
 
     // Record<string, number> is an object with string index signature
     let record = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/mapped_keyof_template.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/mapped_keyof_template.rs
@@ -247,6 +247,7 @@ fn test_keyof_intersection_both_index_signatures() {
     let interner = TypeInterner::new();
 
     let string_indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -261,6 +262,7 @@ fn test_keyof_intersection_both_index_signatures() {
     });
 
     let number_indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -288,6 +290,7 @@ fn test_keyof_union_index_and_literal() {
     let interner = TypeInterner::new();
 
     let string_indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/recursive_infer_awaited.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/recursive_infer_awaited.rs
@@ -634,6 +634,7 @@ fn test_recursive_type_json_value() {
 
     // Create { [key: string]: JsonValue } index signature object
     let json_object = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -719,6 +720,7 @@ fn test_recursive_type_dom_node() {
 
     // Create Record<string, string> for attributes
     let attrs_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_infer_distribution.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_infer_distribution.rs
@@ -969,6 +969,7 @@ fn test_infer_from_index_signature_value() {
 
     // Pattern: { [k: string]: infer V }
     let pattern = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -984,6 +985,7 @@ fn test_infer_from_index_signature_value() {
 
     // Input: { [k: string]: number }
     let input = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1194,6 +1196,7 @@ fn test_infer_with_keyof_constraint() {
 
     // Pattern: { [key: infer K]: number } where K extends string
     let pattern = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1209,6 +1212,7 @@ fn test_infer_with_keyof_constraint() {
 
     // Input: { [key: string]: number }
     let input = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_utility.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/template_literal_utility.rs
@@ -4,6 +4,7 @@ fn test_readonly_with_index_signature() {
     let interner = TypeInterner::new();
 
     let readonly_indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/evaluate_tests_parts/utility_mapped_infer.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/utility_mapped_infer.rs
@@ -1086,6 +1086,7 @@ fn test_record_string_keys() {
 
     // Record with string keys creates an index signature
     let record = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1118,6 +1119,7 @@ fn test_record_number_keys() {
     let interner = TypeInterner::new();
 
     let record = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1176,6 +1178,7 @@ fn test_record_with_object_value() {
     let inner_obj = interner.object(vec![PropertyInfo::new(name_prop, TypeId::STRING)]);
 
     let record = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1701,6 +1704,7 @@ fn test_record_with_union_value() {
     let value_union = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
 
     let record = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/expression_ops_tests.rs
+++ b/crates/tsz-solver/tests/expression_ops_tests.rs
@@ -204,6 +204,7 @@ fn test_conditional_fresh_object_literals_get_complementary_optional_properties(
 
 fn string_index_record(interner: &TypeInterner, value: TypeId) -> TypeId {
     interner.object_with_index(crate::types::ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: Vec::new(),
         string_index: Some(crate::types::IndexSignature {

--- a/crates/tsz-solver/tests/extended_constructors_tests.rs
+++ b/crates/tsz-solver/tests/extended_constructors_tests.rs
@@ -169,6 +169,7 @@ fn class_decl_object_returns_object_shape() {
 fn class_decl_object_with_index_returns_object_shape_via_shared_arm() {
     let interner = TypeInterner::new();
     let owi = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: Some(IndexSignature {
@@ -656,6 +657,7 @@ fn base_instance_merge_object_returns_object_shape() {
 fn base_instance_merge_object_with_index_shares_object_arm() {
     let interner = TypeInterner::new();
     let owi = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: Some(IndexSignature {

--- a/crates/tsz-solver/tests/generics_rules_tests.rs
+++ b/crates/tsz-solver/tests/generics_rules_tests.rs
@@ -67,6 +67,7 @@ fn test_try_get_keyof_keys_object_with_index_returns_properties() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1453,6 +1454,7 @@ fn test_t_subtype_of_partial_t_with_constraint() {
 
     // Create a constraint type (e.g., { [key: string]: number })
     let constraint_obj = interner.object_with_index(crate::ObjectShape {
+        base_types: Vec::new(),
         flags: Default::default(),
         properties: vec![],
         string_index: Some(crate::IndexSignature {

--- a/crates/tsz-solver/tests/index_access_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/index_access_comprehensive_tests.rs
@@ -177,6 +177,7 @@ fn test_index_access_with_string_index_signature() {
     let interner = TypeInterner::new();
 
     let obj = interner.object_with_index(crate::types::ObjectShape {
+        base_types: Vec::new(),
         symbol: None,
         flags: crate::types::ObjectFlags::empty(),
         properties: vec![],
@@ -206,6 +207,7 @@ fn test_symbol_index_signature_accepts_symbol_keys_only() {
     let interner = TypeInterner::new();
 
     let obj = interner.object_with_index(crate::types::ObjectShape {
+        base_types: Vec::new(),
         symbol: None,
         flags: crate::types::ObjectFlags::empty(),
         properties: vec![],
@@ -250,6 +252,7 @@ fn test_symbol_named_properties_do_not_satisfy_string_index_signatures() {
         ..PropertyInfo::new(interner.intern_string("__unique_7"), TypeId::NUMBER)
     }]);
     let target = interner.object_with_index(crate::types::ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: crate::types::ObjectFlags::empty(),
@@ -279,6 +282,7 @@ fn test_symbol_index_signatures_check_symbol_named_properties() {
         ..PropertyInfo::new(interner.intern_string("__unique_7"), TypeId::NUMBER)
     }]);
     let target = interner.object_with_index(crate::types::ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: crate::types::ObjectFlags::empty(),
@@ -518,6 +522,7 @@ fn test_index_access_never_key_on_string_index_signature() {
     let interner = TypeInterner::new();
 
     let obj = interner.object_with_index(crate::types::ObjectShape {
+        base_types: Vec::new(),
         symbol: None,
         flags: crate::types::ObjectFlags::empty(),
         properties: vec![],

--- a/crates/tsz-solver/tests/index_signature_tests.rs
+++ b/crates/tsz-solver/tests/index_signature_tests.rs
@@ -12,6 +12,7 @@ fn test_string_index_to_string_index() {
 
     // { [key: string]: number } <: { [key: string]: number }
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -26,6 +27,7 @@ fn test_string_index_to_string_index() {
     });
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -50,6 +52,7 @@ fn test_string_index_covariant_value() {
     let hello = interner.literal_string("hello");
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -64,6 +67,7 @@ fn test_string_index_covariant_value() {
     });
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -86,6 +90,7 @@ fn test_string_index_not_subtype_incompatible_value() {
 
     // { [key: string]: string } NOT <: { [key: string]: number }
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -100,6 +105,7 @@ fn test_string_index_not_subtype_incompatible_value() {
     });
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -127,6 +133,7 @@ fn test_object_with_props_to_index_signature() {
     ]);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -154,6 +161,7 @@ fn test_object_with_incompatible_props_not_subtype() {
     ]);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -176,6 +184,7 @@ fn test_index_with_props_to_simple_object() {
 
     // { [key: string]: number, foo: number } <: { foo: number }
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -206,6 +215,7 @@ fn test_number_index_to_number_index() {
 
     // { [key: number]: string } <: { [key: number]: string }
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -220,6 +230,7 @@ fn test_number_index_to_number_index() {
     });
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -243,6 +254,7 @@ fn test_string_and_number_index() {
     // { [key: string]: number, [key: number]: number } <: { [key: string]: number }
     // Number index must be subtype of string index
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -262,6 +274,7 @@ fn test_string_and_number_index() {
     });
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -284,6 +297,7 @@ fn test_index_signature_with_named_property() {
 
     // { [key: string]: number, length: number } <: { [key: string]: number, length: number }
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -301,6 +315,7 @@ fn test_index_signature_with_named_property() {
     });
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -326,6 +341,7 @@ fn test_index_signature_source_property_mismatch() {
 
     // { [key: string]: string, foo: number } NOT <: { [key: string]: string }
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -343,6 +359,7 @@ fn test_index_signature_source_property_mismatch() {
     });
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -365,6 +382,7 @@ fn test_number_index_signature_source_property_mismatch() {
 
     // { [key: number]: number, "0": string } NOT <: { [key: number]: number }
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -382,6 +400,7 @@ fn test_number_index_signature_source_property_mismatch() {
     });
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -406,6 +425,7 @@ fn test_empty_object_to_index_signature() {
     let source = interner.object(vec![]);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -460,6 +480,7 @@ fn test_classify_element_indexable_preserves_union_members() {
 
     // Member 2: object with string index { [s: string]: number }
     let member2 = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -507,6 +528,7 @@ fn test_object_with_string_props_assignable_to_dual_index_target() {
 
     // Source: { foo: string }
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -532,6 +554,7 @@ fn test_object_with_string_props_assignable_to_dual_index_target() {
 
     // Target: { [x: string]: string; [x: number]: string }
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -565,6 +588,7 @@ fn test_empty_object_assignable_to_dual_index_target() {
     let source = interner.object(vec![]);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -616,6 +640,7 @@ fn test_named_source_assignable_to_string_index_any_target() {
 
     // Source: a class-like named type with only a number index, e.g. `class NumberTo<any> { [x: number]: any }`.
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: Some(SymbolId(7)),
         flags: ObjectFlags::empty(),
@@ -631,6 +656,7 @@ fn test_named_source_assignable_to_string_index_any_target() {
 
     // Target: anonymous `{ [x: string]: any }`.
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -683,6 +709,7 @@ fn test_named_source_with_props_assignable_to_dual_any_index_named_target() {
 
     // Target is a NAMED interface like `StringAndNumberTo<any>`.
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: Some(SymbolId(80)),
         flags: ObjectFlags::empty(),
@@ -736,6 +763,7 @@ fn test_intersection_merged_dual_any_index_target_still_rejects_named_source() {
     // shape carries `INTERSECTION_MERGED` (how `intern/intersection.rs` stamps an
     // anonymous widening merge).
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol: None,
         flags: ObjectFlags::INTERSECTION_MERGED,
         properties: vec![],
@@ -786,6 +814,7 @@ fn test_anonymous_dual_any_index_literal_accepts_named_source() {
     );
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -834,6 +863,7 @@ fn test_anonymous_dual_index_narrow_string_value_rejects_named_source() {
     );
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol: None,
         flags: ObjectFlags::empty(),
         properties: vec![],
@@ -883,6 +913,7 @@ fn test_named_source_still_rejected_by_number_only_any_target() {
 
     // Target: `{ [n: number]: any }` -- number index only, NO string index.
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -925,6 +956,7 @@ fn test_named_class_plain_object_not_assignable_to_string_indexed_target() {
     );
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -965,6 +997,7 @@ fn test_named_class_plain_object_not_assignable_to_string_indexed_target_alt_nam
     );
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -998,6 +1031,7 @@ fn test_anonymous_plain_object_still_assignable_to_string_indexed_target_when_co
     ]);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1038,6 +1072,7 @@ fn test_string_index_source_does_not_supply_required_named_member() {
     let interner = TypeInterner::new();
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1071,6 +1106,7 @@ fn test_string_index_source_satisfies_optional_named_member_regardless_of_value(
     let interner = TypeInterner::new();
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1102,6 +1138,7 @@ fn test_number_index_source_satisfies_optional_numeric_member_regardless_of_valu
     let interner = TypeInterner::new();
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1133,6 +1170,7 @@ fn test_string_index_source_satisfies_matching_optional_named_member() {
     let interner = TypeInterner::new();
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/index_signatures_tests.rs
+++ b/crates/tsz-solver/tests/index_signatures_tests.rs
@@ -13,6 +13,7 @@ fn test_resolve_string_index() {
 
     // Object with string index
     let obj = db.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -37,6 +38,7 @@ fn test_resolve_number_index() {
 
     // Object with number index
     let obj = db.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -172,6 +174,7 @@ fn test_is_readonly() {
 
     // Readonly string index
     let obj1 = db.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -187,6 +190,7 @@ fn test_is_readonly() {
 
     // Mutable string index
     let obj2 = db.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -249,6 +253,7 @@ fn test_has_index_signature_plain_object() {
 fn test_has_index_signature_with_string_index() {
     let db = TypeInterner::new();
     let obj = db.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -279,6 +284,7 @@ fn test_has_index_signature_with_string_index() {
 fn test_has_index_signature_with_both_indexes() {
     let db = TypeInterner::new();
     let obj = db.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -524,6 +530,7 @@ fn test_numeric_key_prefers_number_index_over_string_index() {
     // { [n: number]: number, [s: string]: string | number }
     let string_or_number = db.union(vec![TypeId::STRING, TypeId::NUMBER]);
     let obj = db.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/infer_tests/bounds_core.rs
+++ b/crates/tsz-solver/tests/infer_tests/bounds_core.rs
@@ -1091,6 +1091,7 @@ fn test_resolve_bounds_object_with_index_subtype() {
     let name_a = interner.intern_string("a");
 
     let upper = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1105,6 +1106,7 @@ fn test_resolve_bounds_object_with_index_subtype() {
     });
 
     let lower = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1134,6 +1136,7 @@ fn test_resolve_bounds_string_index_property_mismatch() {
     let name_a = interner.intern_string("a");
 
     let upper = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1172,6 +1175,7 @@ fn test_resolve_bounds_index_readonly_property_mismatch() {
     let name_a = interner.intern_string("a");
 
     let upper = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1209,6 +1213,7 @@ fn test_resolve_bounds_index_readonly_signature_mismatch() {
     let var = ctx.fresh_type_param(interner.intern_string("T"), false);
 
     let upper = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1223,6 +1228,7 @@ fn test_resolve_bounds_index_readonly_signature_mismatch() {
     });
 
     let lower = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1258,6 +1264,7 @@ fn test_resolve_bounds_index_readonly_signature_allows_mutable_source() {
     let var = ctx.fresh_type_param(interner.intern_string("T"), false);
 
     let upper = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1272,6 +1279,7 @@ fn test_resolve_bounds_index_readonly_signature_allows_mutable_source() {
     });
 
     let lower = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1301,6 +1309,7 @@ fn test_resolve_bounds_number_index_allows_non_numeric_property() {
     let name_a = interner.intern_string("a");
 
     let upper = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1315,6 +1324,7 @@ fn test_resolve_bounds_number_index_allows_non_numeric_property() {
     });
 
     let lower = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1339,6 +1349,7 @@ fn test_resolve_bounds_number_index_numeric_property_mismatch() {
     let name_zero = interner.intern_string("0");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1353,6 +1364,7 @@ fn test_resolve_bounds_number_index_numeric_property_mismatch() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1384,6 +1396,7 @@ fn test_resolve_bounds_number_index_readonly_property_mismatch() {
     let name_zero = interner.intern_string("0");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1421,6 +1434,7 @@ fn test_resolve_bounds_number_index_readonly_signature_mismatch() {
     let var = ctx.fresh_type_param(interner.intern_string("T"), false);
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1435,6 +1449,7 @@ fn test_resolve_bounds_number_index_readonly_signature_mismatch() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1470,6 +1485,7 @@ fn test_resolve_bounds_number_index_readonly_signature_allows_mutable_source() {
     let var = ctx.fresh_type_param(interner.intern_string("T"), false);
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1484,6 +1500,7 @@ fn test_resolve_bounds_number_index_readonly_signature_allows_mutable_source() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/infer_tests/bounds_number_index_a.rs
+++ b/crates/tsz-solver/tests/infer_tests/bounds_number_index_a.rs
@@ -9,6 +9,7 @@ fn test_resolve_bounds_number_index_ignores_non_canonical_numeric_name() {
     let name = interner.intern_string("01");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -23,6 +24,7 @@ fn test_resolve_bounds_number_index_ignores_non_canonical_numeric_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -62,6 +64,7 @@ fn test_resolve_bounds_number_index_accepts_exponent_name() {
     let name = interner.intern_string("1e-7");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -76,6 +79,7 @@ fn test_resolve_bounds_number_index_accepts_exponent_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -122,6 +126,7 @@ fn test_resolve_bounds_number_index_accepts_infinity_name() {
     let name = interner.intern_string("Infinity");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -136,6 +141,7 @@ fn test_resolve_bounds_number_index_accepts_infinity_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -182,6 +188,7 @@ fn test_resolve_bounds_number_index_accepts_nan_name() {
     let name = interner.intern_string("NaN");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -196,6 +203,7 @@ fn test_resolve_bounds_number_index_accepts_nan_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -242,6 +250,7 @@ fn test_resolve_bounds_number_index_accepts_negative_infinity_name() {
     let name = interner.intern_string("-Infinity");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -256,6 +265,7 @@ fn test_resolve_bounds_number_index_accepts_negative_infinity_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -302,6 +312,7 @@ fn test_resolve_bounds_number_index_ignores_negative_zero_name() {
     let name = interner.intern_string("-0");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -316,6 +327,7 @@ fn test_resolve_bounds_number_index_ignores_negative_zero_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -355,6 +367,7 @@ fn test_resolve_bounds_number_index_ignores_negative_zero_property() {
     let name = interner.intern_string("-0");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -401,6 +414,7 @@ fn test_resolve_bounds_number_index_accepts_decimal_boundary_name() {
     let name = interner.intern_string("0.000001");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -415,6 +429,7 @@ fn test_resolve_bounds_number_index_accepts_decimal_boundary_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -461,6 +476,7 @@ fn test_resolve_bounds_number_index_accepts_exponent_boundary_name() {
     let name = interner.intern_string("1e+21");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -475,6 +491,7 @@ fn test_resolve_bounds_number_index_accepts_exponent_boundary_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -521,6 +538,7 @@ fn test_resolve_bounds_number_index_ignores_non_canonical_exponent_name() {
     let name = interner.intern_string("1e+021");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -535,6 +553,7 @@ fn test_resolve_bounds_number_index_ignores_non_canonical_exponent_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -574,6 +593,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_name() {
     let name = interner.intern_string("1E+21");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -588,6 +608,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -627,6 +648,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_missing_sign() {
     let name = interner.intern_string("1E21");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -641,6 +663,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_missing_sign() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -680,6 +703,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_leading_zeros() {
     let name = interner.intern_string("1E+0001");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -694,6 +718,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_leading_zeros() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -733,6 +758,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_leading_zeros_zer
     let name = interner.intern_string("1E+00");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -747,6 +773,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_leading_zeros_zer
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -786,6 +813,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_leading_zeros_wit
     let name = interner.intern_string("1E0001");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -800,6 +828,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_leading_zeros_wit
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -839,6 +868,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_negative_leading_
     let name = interner.intern_string("1E-0001");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -853,6 +883,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_negative_leading_
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -892,6 +923,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent() {
     let name = interner.intern_string("1eE1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -906,6 +938,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -945,6 +978,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_with_sign() {
     let name = interner.intern_string("1Ee+1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -959,6 +993,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_with_sign() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -998,6 +1033,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_missing_digits()
     let name = interner.intern_string("1eE");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1012,6 +1048,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_missing_digits()
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1051,6 +1088,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_missing_sign_with
     let name = interner.intern_string("1E01");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1065,6 +1103,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_missing_sign_with
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1104,6 +1143,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_double_sign() {
     let name = interner.intern_string("1eE++1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1118,6 +1158,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_double_sign() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1157,6 +1198,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_with_lowercase_e(
     let name = interner.intern_string("1eE+1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1171,6 +1213,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_with_lowercase_e(
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1210,6 +1253,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_double_minus() {
     let name = interner.intern_string("1Ee--1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1224,6 +1268,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_double_minus() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1263,6 +1308,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_plus_minus() {
     let name = interner.intern_string("1Ee+-1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1277,6 +1323,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_plus_minus() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1316,6 +1363,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_minus_plus() {
     let name = interner.intern_string("1Ee-+1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1330,6 +1378,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_minus_plus() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1369,6 +1418,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_trailing_sign() 
     let name = interner.intern_string("1Ee+");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1383,6 +1433,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_trailing_sign() 
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1422,6 +1473,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_trailing_minus()
     let name = interner.intern_string("1Ee-");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1436,6 +1488,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_trailing_minus()
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1475,6 +1528,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_trailing_double_
     let name = interner.intern_string("1Ee--");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1489,6 +1543,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_trailing_double_
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1528,6 +1583,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_leading_zeros() 
     let name = interner.intern_string("1Ee+0001");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1542,6 +1598,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_leading_zeros() 
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1581,6 +1638,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_leading_zeros_wi
     let name = interner.intern_string("1Ee0001");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1595,6 +1653,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_leading_zeros_wi
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1634,6 +1693,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_missing_sign_wit
     let name = interner.intern_string("1Ee01");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1648,6 +1708,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_missing_sign_wit
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1687,6 +1748,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_negative_exponent_zero() 
     let name = interner.intern_string("1Ee-0");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1701,6 +1763,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_negative_exponent_zero() 
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1740,6 +1803,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_positive_zero() 
     let name = interner.intern_string("1Ee+0");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1754,6 +1818,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_positive_zero() 
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/infer_tests/bounds_number_index_b.rs
+++ b/crates/tsz-solver/tests/infer_tests/bounds_number_index_b.rs
@@ -9,6 +9,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_zero_without_sig
     let name = interner.intern_string("1Ee0");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -23,6 +24,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_zero_without_sig
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -62,6 +64,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_double_sign_trai
     let name = interner.intern_string("1Ee++");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -76,6 +79,7 @@ fn test_resolve_bounds_number_index_ignores_mixed_case_exponent_double_sign_trai
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -115,6 +119,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_missing_digits() 
     let name = interner.intern_string("1E+");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -129,6 +134,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_missing_digits() 
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -168,6 +174,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_minus_missing_dig
     let name = interner.intern_string("1E-");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -182,6 +189,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_minus_missing_dig
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -221,6 +229,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_double_sign() {
     let name = interner.intern_string("1E++1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -235,6 +244,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_double_sign() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -274,6 +284,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_double_minus() {
     let name = interner.intern_string("1E--1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -288,6 +299,7 @@ fn test_resolve_bounds_number_index_ignores_uppercase_exponent_double_minus() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -327,6 +339,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_leading_zeros_negative() {
     let name = interner.intern_string("1e-0001");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -341,6 +354,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_leading_zeros_negative() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -380,6 +394,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_leading_zeros_positive() {
     let name = interner.intern_string("1e+0001");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -394,6 +409,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_leading_zeros_positive() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -433,6 +449,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_leading_zeros_without_sign(
     let name = interner.intern_string("1e0001");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -447,6 +464,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_leading_zeros_without_sign(
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -486,6 +504,7 @@ fn test_resolve_bounds_number_index_ignores_missing_exponent_sign() {
     let name = interner.intern_string("1e21");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -500,6 +519,7 @@ fn test_resolve_bounds_number_index_ignores_missing_exponent_sign() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -539,6 +559,7 @@ fn test_resolve_bounds_number_index_ignores_leading_zero_decimal_name() {
     let name = interner.intern_string("01.0");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -553,6 +574,7 @@ fn test_resolve_bounds_number_index_ignores_leading_zero_decimal_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -592,6 +614,7 @@ fn test_resolve_bounds_number_index_ignores_hex_name() {
     let name = interner.intern_string("0x1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -606,6 +629,7 @@ fn test_resolve_bounds_number_index_ignores_hex_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -645,6 +669,7 @@ fn test_resolve_bounds_number_index_ignores_binary_name() {
     let name = interner.intern_string("0b1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -659,6 +684,7 @@ fn test_resolve_bounds_number_index_ignores_binary_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -698,6 +724,7 @@ fn test_resolve_bounds_number_index_ignores_octal_name() {
     let name = interner.intern_string("0o7");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -712,6 +739,7 @@ fn test_resolve_bounds_number_index_ignores_octal_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -751,6 +779,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_leading_zero_mantissa() {
     let name = interner.intern_string("01e+1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -765,6 +794,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_leading_zero_mantissa() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -804,6 +834,7 @@ fn test_resolve_bounds_number_index_ignores_leading_dot_decimal_name() {
     let name = interner.intern_string(".5");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -818,6 +849,7 @@ fn test_resolve_bounds_number_index_ignores_leading_dot_decimal_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -857,6 +889,7 @@ fn test_resolve_bounds_number_index_ignores_multiple_leading_zeros() {
     let name = interner.intern_string("00");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -871,6 +904,7 @@ fn test_resolve_bounds_number_index_ignores_multiple_leading_zeros() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -910,6 +944,7 @@ fn test_resolve_bounds_number_index_ignores_negative_hex_name() {
     let name = interner.intern_string("-0x1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -924,6 +959,7 @@ fn test_resolve_bounds_number_index_ignores_negative_hex_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -963,6 +999,7 @@ fn test_resolve_bounds_number_index_ignores_negative_binary_name() {
     let name = interner.intern_string("-0b1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -977,6 +1014,7 @@ fn test_resolve_bounds_number_index_ignores_negative_binary_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1016,6 +1054,7 @@ fn test_resolve_bounds_number_index_ignores_negative_octal_name() {
     let name = interner.intern_string("-0o7");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1030,6 +1069,7 @@ fn test_resolve_bounds_number_index_ignores_negative_octal_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1069,6 +1109,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_double_sign() {
     let name = interner.intern_string("1e++1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1083,6 +1124,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_double_sign() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1122,6 +1164,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_double_minus() {
     let name = interner.intern_string("1e--1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1136,6 +1179,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_double_minus() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1175,6 +1219,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_missing_digits() {
     let name = interner.intern_string("1e+");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1189,6 +1234,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_missing_digits() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1228,6 +1274,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_minus_missing_digits() {
     let name = interner.intern_string("1e-");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1242,6 +1289,7 @@ fn test_resolve_bounds_number_index_ignores_exponent_minus_missing_digits() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1281,6 +1329,7 @@ fn test_resolve_bounds_number_index_ignores_negative_exponent_zero() {
     let name = interner.intern_string("-0e+0");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1295,6 +1344,7 @@ fn test_resolve_bounds_number_index_ignores_negative_exponent_zero() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1334,6 +1384,7 @@ fn test_resolve_bounds_number_index_ignores_positive_exponent_zero() {
     let name = interner.intern_string("1e+0");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1348,6 +1399,7 @@ fn test_resolve_bounds_number_index_ignores_positive_exponent_zero() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1387,6 +1439,7 @@ fn test_resolve_bounds_number_index_accepts_negative_decimal_boundary_name() {
     let name = interner.intern_string("-0.000001");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1401,6 +1454,7 @@ fn test_resolve_bounds_number_index_accepts_negative_decimal_boundary_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1447,6 +1501,7 @@ fn test_resolve_bounds_number_index_ignores_trailing_decimal_name() {
     let name = interner.intern_string("1.");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1461,6 +1516,7 @@ fn test_resolve_bounds_number_index_ignores_trailing_decimal_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1500,6 +1556,7 @@ fn test_resolve_bounds_number_index_ignores_leading_plus_name() {
     let name = interner.intern_string("+1");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1514,6 +1571,7 @@ fn test_resolve_bounds_number_index_ignores_leading_plus_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1553,6 +1611,7 @@ fn test_resolve_bounds_number_index_ignores_numeric_separator_name() {
     let name = interner.intern_string("1_0");
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1567,6 +1626,7 @@ fn test_resolve_bounds_number_index_ignores_numeric_separator_name() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/infer_tests/bounds_shapes.rs
+++ b/crates/tsz-solver/tests/infer_tests/bounds_shapes.rs
@@ -8,6 +8,7 @@ fn test_resolve_bounds_inconsistent_index_signatures() {
     let var = ctx.fresh_type_param(interner.intern_string("T"), false);
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -22,6 +23,7 @@ fn test_resolve_bounds_inconsistent_index_signatures() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -62,6 +64,7 @@ fn test_resolve_bounds_object_with_index_mismatch() {
     let var = ctx.fresh_type_param(interner.intern_string("T"), false);
 
     let upper_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -76,6 +79,7 @@ fn test_resolve_bounds_object_with_index_mismatch() {
     });
 
     let lower_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/integration_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/integration_tests_parts/part_00.rs
@@ -1212,6 +1212,7 @@ mod lawyer_strict_mode_tests {
         };
 
         let obj_any = interner.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             symbol_index: None,
             symbol: None,
             flags: ObjectFlags::empty(),
@@ -1220,6 +1221,7 @@ mod lawyer_strict_mode_tests {
             number_index: None,
         });
         let obj_number = interner.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             symbol_index: None,
             symbol: None,
             flags: ObjectFlags::empty(),
@@ -1252,6 +1254,7 @@ mod lawyer_strict_mode_tests {
         };
 
         let obj_any = interner.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             symbol_index: None,
             symbol: None,
             flags: ObjectFlags::empty(),
@@ -1260,6 +1263,7 @@ mod lawyer_strict_mode_tests {
             number_index: None,
         });
         let obj_number = interner.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             symbol_index: None,
             symbol: None,
             flags: ObjectFlags::empty(),
@@ -1485,6 +1489,7 @@ mod property_access_conformance_tests {
         ));
 
         let typed_array = interner.object_with_index(ObjectShape {
+            base_types: Vec::new(),
             symbol_index: None,
             symbol: None,
             flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/interface_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/interface_comprehensive_tests.rs
@@ -231,6 +231,7 @@ fn test_interface_with_string_index() {
     let interner = TypeInterner::new();
 
     let interface = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -260,6 +261,7 @@ fn test_interface_with_number_index() {
     let interner = TypeInterner::new();
 
     let interface = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/intern_normalize_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/intern_normalize_tests_parts/part_00.rs
@@ -1082,6 +1082,7 @@ fn object_property_order_independence() {
 fn object_with_index_signature() {
     let i = TypeInterner::new();
     let shape = ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![PropertyInfo::new(i.intern_string("x"), TypeId::NUMBER)],
         string_index: Some(IndexSignature {

--- a/crates/tsz-solver/tests/iterable_classifier_tests.rs
+++ b/crates/tsz-solver/tests/iterable_classifier_tests.rs
@@ -619,6 +619,7 @@ fn async_iterable_object_with_index_returns_object_shape() {
     // ObjectWithIndex shares the Object arm. Use a property with an
     // index-signature-shaped object_with_index call.
     let shape = ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![PropertyInfo::new(
             interner.intern_string("next"),

--- a/crates/tsz-solver/tests/judge_tests.rs
+++ b/crates/tsz-solver/tests/judge_tests.rs
@@ -1500,6 +1500,7 @@ fn test_get_property_string_index_signature() {
     let judge = setup.judge();
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1663,6 +1664,7 @@ fn test_object_with_string_index_is_subtype() {
 
     // { [key: string]: number } should accept any object with compatible properties
     let indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1711,6 +1713,7 @@ fn test_function_is_not_subtype_of_number_index_target() {
     });
 
     let number_indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/keyof_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/keyof_comprehensive_tests.rs
@@ -395,6 +395,7 @@ fn test_keyof_tuple_includes_numeric_indices() {
 fn test_keyof_object_with_string_index_includes_string_and_number() {
     let interner = TypeInterner::new();
     let obj_with_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -435,6 +436,7 @@ fn test_keyof_object_with_collapsed_string_symbol_index_includes_symbol() {
     let interner = TypeInterner::new();
     let string_or_symbol = interner.union2(TypeId::STRING, TypeId::SYMBOL);
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -470,6 +472,7 @@ fn test_keyof_template_index_signature_preserves_template_key() {
         TemplateSpan::Type(TypeId::STRING),
     ]);
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -500,6 +503,7 @@ fn test_keyof_template_index_signature_with_fixed_property_excludes_plain_string
     ]);
     let fixed_key = interner.literal_string("fixed");
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -539,6 +543,7 @@ fn test_keyof_template_and_number_index_signature_includes_number() {
         TemplateSpan::Type(TypeId::STRING),
     ]);
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -575,6 +580,7 @@ fn test_keyof_template_and_number_index_signature_includes_number() {
 fn test_keyof_object_with_number_index_includes_number() {
     let interner = TypeInterner::new();
     let obj_with_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/mapped_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/mapped_comprehensive_tests.rs
@@ -945,6 +945,7 @@ fn test_mapped_type_array_remap_preserves_array_base_display_order() {
         PropertyInfo::readonly(interner.intern_string("[Symbol.unscopables]"), TypeId::ANY);
 
     let array_base = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![
             PropertyInfo::new(interner.intern_string("length"), TypeId::NUMBER),

--- a/crates/tsz-solver/tests/mapped_index_signature_modifier_tests.rs
+++ b/crates/tsz-solver/tests/mapped_index_signature_modifier_tests.rs
@@ -36,6 +36,7 @@ fn index_object(
         (Some(index), None)
     };
     interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index,

--- a/crates/tsz-solver/tests/mapped_key_remap_tests.rs
+++ b/crates/tsz-solver/tests/mapped_key_remap_tests.rs
@@ -1072,6 +1072,7 @@ fn test_finite_mapped_property_names_do_not_materialize_string_index_keys() {
     let interner = TypeInterner::new();
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: Some(IndexSignature {
@@ -1122,6 +1123,7 @@ fn test_keyof_string_indexed_object_preserves_unique_symbol_property() {
     let sym_ref = crate::SymbolRef(77);
     let sym_name = interner.intern_string("__unique_77");
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![
             PropertyInfo::new(interner.intern_string("str"), TypeId::STRING),
@@ -1168,6 +1170,7 @@ fn test_keyof_generic_remapped_mapped_type_keeps_concrete_lower_bound_keys() {
     let sym_ref = crate::SymbolRef(91);
     let sym_name = interner.intern_string("__unique_91");
     let concrete_source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![
             PropertyInfo::new(interner.intern_string("str"), TypeId::STRING),

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs
@@ -275,6 +275,7 @@ fn test_in_property_narrowing_preserves_index_signature_cache_origin() {
     let key_name = interner.intern_string("dynamic");
 
     let record_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: Some(IndexSignature {
@@ -1709,6 +1710,7 @@ fn test_narrow_by_typeof_object_with_index_signature() {
     let interner = TypeInterner::new();
 
     let record_type = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: Some(IndexSignature {

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_01.rs
@@ -485,6 +485,7 @@ fn array_isarray_substitutes_only_nonarray_any_compat_member() {
     let interner = TypeInterner::new();
     let mutable_numbers = interner.array(TypeId::NUMBER);
     let any_string_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: Some(IndexSignature {

--- a/crates/tsz-solver/tests/operations_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/operations_tests_parts/part_01.rs
@@ -643,6 +643,7 @@ fn test_property_access_index_signature_no_unchecked() {
     let mut evaluator = PropertyAccessEvaluator::new(&interner);
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -692,6 +693,7 @@ fn test_property_access_object_with_index_optional_property() {
     let evaluator = PropertyAccessEvaluator::new(&interner);
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/operations_tests_parts/part_03.rs
+++ b/crates/tsz-solver/tests/operations_tests_parts/part_03.rs
@@ -664,6 +664,7 @@ fn test_infer_generic_readonly_property_mismatch_with_index_signature() {
         params: vec![ParamInfo {
             name: Some(interner.intern_string("box")),
             type_id: interner.object_with_index(ObjectShape {
+                base_types: Vec::new(),
                 symbol_index: None,
                 symbol: None,
                 flags: ObjectFlags::empty(),
@@ -687,6 +688,7 @@ fn test_infer_generic_readonly_property_mismatch_with_index_signature() {
     };
 
     let arg = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -727,6 +729,7 @@ fn test_infer_generic_readonly_index_signature_mismatch() {
         params: vec![ParamInfo {
             name: Some(interner.intern_string("bag")),
             type_id: interner.object_with_index(ObjectShape {
+                base_types: Vec::new(),
                 symbol_index: None,
                 symbol: None,
                 flags: ObjectFlags::empty(),
@@ -750,6 +753,7 @@ fn test_infer_generic_readonly_index_signature_mismatch() {
     };
 
     let arg = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -788,6 +792,7 @@ fn test_infer_generic_readonly_number_index_signature_mismatch() {
         params: vec![ParamInfo {
             name: Some(interner.intern_string("bag")),
             type_id: interner.object_with_index(ObjectShape {
+                base_types: Vec::new(),
                 symbol_index: None,
                 symbol: None,
                 flags: ObjectFlags::empty(),
@@ -811,6 +816,7 @@ fn test_infer_generic_readonly_number_index_signature_mismatch() {
     };
 
     let arg = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1322,6 +1328,7 @@ fn test_infer_generic_index_signature() {
     let t_type = interner.intern(TypeData::TypeParameter(t_param));
 
     let indexed_t = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1351,6 +1358,7 @@ fn test_infer_generic_index_signature() {
     };
 
     let indexed_number = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1383,6 +1391,7 @@ fn test_infer_generic_index_signature_from_object_literal() {
     let t_type = interner.intern(TypeData::TypeParameter(t_param));
 
     let indexed_t = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1435,6 +1444,7 @@ fn test_infer_generic_index_signature_from_optional_property() {
     let t_type = interner.intern(TypeData::TypeParameter(t_param));
 
     let indexed_t = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1489,6 +1499,7 @@ fn test_infer_generic_number_index_from_optional_property() {
     let t_type = interner.intern(TypeData::TypeParameter(t_param));
 
     let indexed_t = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1549,6 +1560,7 @@ fn test_infer_generic_number_index_from_numeric_property() {
     let t_type = interner.intern(TypeData::TypeParameter(t_param));
 
     let indexed_t = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1601,6 +1613,7 @@ fn test_infer_generic_number_index_ignores_noncanonical_numeric_property() {
     let t_type = interner.intern(TypeData::TypeParameter(t_param));
 
     let indexed_t = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1655,6 +1668,7 @@ fn test_infer_generic_number_index_ignores_negative_zero_property() {
     let t_type = interner.intern(TypeData::TypeParameter(t_param));
 
     let indexed_t = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1709,6 +1723,7 @@ fn test_infer_generic_number_index_from_nan_property() {
     let t_type = interner.intern(TypeData::TypeParameter(t_param));
 
     let indexed_t = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1761,6 +1776,7 @@ fn test_infer_generic_number_index_from_exponent_property() {
     let t_type = interner.intern(TypeData::TypeParameter(t_param));
 
     let indexed_t = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/operations_tests_parts/part_04.rs
+++ b/crates/tsz-solver/tests/operations_tests_parts/part_04.rs
@@ -13,6 +13,7 @@ fn test_infer_generic_number_index_from_negative_infinity_property() {
     let t_type = interner.intern(TypeData::TypeParameter(t_param));
 
     let indexed_t = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -73,6 +74,7 @@ fn test_infer_generic_index_signatures_from_mixed_properties() {
     let u_type = interner.intern(TypeData::TypeParameter(u_param));
 
     let indexed_tu = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -166,6 +168,7 @@ fn test_infer_generic_index_signatures_from_optional_mixed_properties() {
     let u_type = interner.intern(TypeData::TypeParameter(u_param));
 
     let indexed_tu = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -250,6 +253,7 @@ fn test_infer_generic_index_signatures_ignore_optional_noncanonical_numeric_prop
     let u_type = interner.intern(TypeData::TypeParameter(u_param));
 
     let indexed_tu = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/property_helpers_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/property_helpers_tests_parts/part_00.rs
@@ -626,6 +626,7 @@ fn test_string_index_signature_access() {
 
     // { [key: string]: number }
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: Some(IndexSignature {
@@ -664,6 +665,7 @@ fn test_number_index_signature_with_numeric_key() {
 
     // { [key: number]: string }
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: None,
@@ -695,6 +697,7 @@ fn test_explicit_property_takes_precedence_over_index_signature() {
     let x = interner.intern_string("x");
     // { x: boolean, [key: string]: number }
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![PropertyInfo::new(x, TypeId::BOOLEAN)],
         string_index: Some(IndexSignature {
@@ -737,6 +740,7 @@ fn test_index_signature_with_no_unchecked_indexed_access() {
 
     // { [key: string]: number }
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: Some(IndexSignature {
@@ -1344,6 +1348,7 @@ fn test_object_with_both_index_signatures() {
 
     // { [key: string]: string, [key: number]: number }
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: Some(IndexSignature {
@@ -1584,6 +1589,7 @@ fn test_readonly_index_signature_access() {
 
     // { readonly [key: string]: number }
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: vec![],
         string_index: Some(IndexSignature {

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/class_context_partitioning.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/class_context_partitioning.rs
@@ -33,6 +33,7 @@ fn nominal_vs_index_pair(
         Some(source_symbol),
     );
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_00.rs
@@ -312,6 +312,7 @@ fn test_template_literal_number_index_subtyping() {
     ]);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -325,6 +326,7 @@ fn test_template_literal_number_index_subtyping() {
         }),
     });
     let mismatch = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -405,6 +407,7 @@ fn test_generic_function_mapped_apparent_constraint_not_erased_by_alpha_rename()
     let mut checker = SubtypeChecker::new(&interner);
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         flags: ObjectFlags::empty(),
         properties: Vec::new(),
         string_index: Some(IndexSignature {
@@ -521,6 +524,7 @@ fn test_apparent_string_number_index_subtyping() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -534,6 +538,7 @@ fn test_apparent_string_number_index_subtyping() {
         }),
     });
     let mismatch = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1331,6 +1336,7 @@ fn test_index_access_fresh_equivalent_type_parameter_keys_are_related() {
     let source_key = interner.fresh_type_param(key_info);
     let target_key = interner.fresh_type_param(key_info);
     let object = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1359,6 +1365,7 @@ fn test_no_unchecked_object_index_signature_subtyping() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1389,6 +1396,7 @@ fn test_no_unchecked_indexed_access_string_index_signature() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1419,6 +1427,7 @@ fn test_no_unchecked_indexed_access_union_index_signature() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_01.rs
@@ -1201,6 +1201,7 @@ fn test_number_index_signature_numeric_property() {
 
     // { [x: number]: string }
     let target_shape = ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1234,6 +1235,7 @@ fn test_number_index_signature_type_mismatch() {
 
     // { [x: number]: string }
     let target_shape = ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1265,6 +1267,7 @@ fn test_anonymous_number_index_signature_vacuously_compatible_with_no_numeric_ke
     )]);
 
     let target_shape = ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1297,6 +1300,7 @@ fn test_named_object_without_number_index_does_not_satisfy_number_index_target()
     );
 
     let target_shape = ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1369,6 +1373,7 @@ fn test_number_index_signature_method_bivariant_property() {
     )]);
 
     let target_shape = ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1418,6 +1423,7 @@ fn test_named_class_not_assignable_to_string_indexed_without_explicit_index_sig(
     );
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1455,6 +1461,7 @@ fn test_namespace_object_can_satisfy_string_index_structurally() {
     );
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1524,6 +1531,7 @@ fn test_string_index_signature_method_bivariant_property() {
     )]);
 
     let target_shape = ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1558,6 +1566,7 @@ fn test_number_index_signature_multiple_numeric_props() {
 
     // { [x: number]: string }
     let target_shape = ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1591,6 +1600,7 @@ fn test_number_and_string_index_signatures() {
 
     // { [x: number]: string; [y: string]: string }
     let target_shape = ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1620,6 +1630,7 @@ fn test_index_signature_consistency_number_vs_string_index() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1639,6 +1650,7 @@ fn test_index_signature_consistency_number_vs_string_index() {
     });
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1666,6 +1678,7 @@ fn test_readonly_index_signature_subtyping() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let readonly_source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1680,6 +1693,7 @@ fn test_readonly_index_signature_subtyping() {
     });
 
     let mutable_target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1694,6 +1708,7 @@ fn test_readonly_index_signature_subtyping() {
     });
 
     let readonly_target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1724,6 +1739,7 @@ fn test_readonly_property_with_mutable_index_signature() {
     )]);
 
     let mutable_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1738,6 +1754,7 @@ fn test_readonly_property_with_mutable_index_signature() {
     });
 
     let readonly_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1764,6 +1781,7 @@ fn test_object_with_index_properties_match_target_index() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1786,6 +1804,7 @@ fn test_object_with_index_properties_match_target_index() {
     });
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_02.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_02.rs
@@ -4,6 +4,7 @@ fn test_object_with_index_property_mismatch_string_index() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -21,6 +22,7 @@ fn test_object_with_index_property_mismatch_string_index() {
     });
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -43,6 +45,7 @@ fn test_object_with_index_property_mismatch_number_index() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -60,6 +63,7 @@ fn test_object_with_index_property_mismatch_number_index() {
     });
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -82,6 +86,7 @@ fn test_object_with_index_satisfies_named_property_string_index() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -110,6 +115,7 @@ fn test_object_with_index_named_property_mismatch_string_index() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -142,6 +148,7 @@ fn test_object_to_indexed_property_mismatch_string_index() {
     )]);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -164,6 +171,7 @@ fn test_object_with_index_satisfies_numeric_property_number_index() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -378,6 +386,7 @@ fn test_object_with_index_noncanonical_numeric_property_fails() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -405,6 +414,7 @@ fn test_object_with_index_readonly_index_to_mutable_property_fails() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_03.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_03.rs
@@ -839,6 +839,7 @@ fn test_keyof_union_index_signature_contravariant() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let string_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -852,6 +853,7 @@ fn test_keyof_union_index_signature_contravariant() {
         number_index: None,
     });
     let number_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -878,6 +880,7 @@ fn test_keyof_union_string_index_and_literal_narrows() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let string_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1181,6 +1184,7 @@ fn test_mapped_type_over_string_keys_number_index_subtyping() {
     });
 
     let number_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1194,6 +1198,7 @@ fn test_mapped_type_over_string_keys_number_index_subtyping() {
         }),
     });
     let mismatch = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_06.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_06.rs
@@ -732,6 +732,7 @@ fn test_index_signature_string_basic() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let indexed_number = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -746,6 +747,7 @@ fn test_index_signature_string_basic() {
     });
 
     let indexed_string = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -773,6 +775,7 @@ fn test_index_signature_covariant_value() {
     let hello = interner.literal_string("hello");
 
     let indexed_literal = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -787,6 +790,7 @@ fn test_index_signature_covariant_value() {
     });
 
     let indexed_string = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -813,6 +817,7 @@ fn test_index_signature_with_known_property() {
     let a_name = interner.intern_string("a");
 
     let indexed_with_prop = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -827,6 +832,7 @@ fn test_index_signature_with_known_property() {
     });
 
     let indexed_only = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -851,6 +857,7 @@ fn test_index_signature_number_index() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let number_indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -865,6 +872,7 @@ fn test_index_signature_number_index() {
     });
 
     let string_indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -892,6 +900,7 @@ fn test_index_signature_union_value() {
     let union_value = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
 
     let indexed_union = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -906,6 +915,7 @@ fn test_index_signature_union_value() {
     });
 
     let indexed_string = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -939,6 +949,7 @@ fn test_index_signature_object_to_indexed() {
     ]);
 
     let indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_08.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_08.rs
@@ -203,6 +203,7 @@ fn test_interface_vs_type_alias_index_signature() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let interface_i = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -217,6 +218,7 @@ fn test_interface_vs_type_alias_index_signature() {
     });
 
     let type_t = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1570,6 +1572,7 @@ fn test_index_signature_string_to_string() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let obj_a = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1584,6 +1587,7 @@ fn test_index_signature_string_to_string() {
     });
 
     let obj_b = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1607,6 +1611,7 @@ fn test_index_signature_number_to_number() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let obj_a = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1621,6 +1626,7 @@ fn test_index_signature_number_to_number() {
     });
 
     let obj_b = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1649,6 +1655,7 @@ fn test_index_signature_covariant_value_type() {
     ]);
 
     let obj_specific = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1663,6 +1670,7 @@ fn test_index_signature_covariant_value_type() {
     });
 
     let obj_general = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1687,6 +1695,7 @@ fn test_index_signature_both_string_and_number() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let obj_both = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1706,6 +1715,7 @@ fn test_index_signature_both_string_and_number() {
     });
 
     let obj_string_only = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1731,6 +1741,7 @@ fn test_index_signature_number_subtype_of_string() {
     let _checker = SubtypeChecker::new(&interner);
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1760,6 +1771,7 @@ fn test_index_signature_intersection_combines() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let obj_a = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1774,6 +1786,7 @@ fn test_index_signature_intersection_combines() {
     });
 
     let obj_b = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_09.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_09.rs
@@ -7,6 +7,7 @@ fn test_index_signature_with_properties() {
     let union_type = interner.union(vec![TypeId::NUMBER, TypeId::STRING]);
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -35,6 +36,7 @@ fn test_index_signature_property_must_match_index() {
     let _checker = SubtypeChecker::new(&interner);
 
     let obj_valid = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -61,6 +63,7 @@ fn test_index_signature_readonly_to_mutable() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let obj_readonly = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -75,6 +78,7 @@ fn test_index_signature_readonly_to_mutable() {
     });
 
     let obj_mutable = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -100,6 +104,7 @@ fn test_index_signature_mutable_to_readonly() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let obj_mutable = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -114,6 +119,7 @@ fn test_index_signature_mutable_to_readonly() {
     });
 
     let obj_readonly = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -140,6 +146,7 @@ fn test_index_signature_union_value_subtyping() {
     let union_value = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -154,6 +161,7 @@ fn test_index_signature_union_value_subtyping() {
     });
 
     let obj_string = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -190,6 +198,7 @@ fn test_index_signature_intersection_value() {
     let intersection_value = interner.intersection(vec![obj_a, obj_b]);
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -216,6 +225,7 @@ fn test_index_signature_empty_object_to_indexed() {
     let empty_obj = interner.object(vec![]);
 
     let indexed_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -249,6 +259,7 @@ fn test_index_signature_object_with_extra_props() {
 
     let union_value = interner.union(vec![TypeId::NUMBER, TypeId::STRING]);
     let indexed_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -277,6 +288,7 @@ fn test_index_signature_numeric_string_key() {
     ]);
 
     let number_indexed = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -301,6 +313,7 @@ fn test_index_signature_any_value() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let indexed_any = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -333,6 +346,7 @@ fn test_object_with_named_props_satisfies_number_index_any() {
     )]);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -356,6 +370,7 @@ fn test_string_is_not_subtype_of_string_index_any() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -382,6 +397,7 @@ fn test_boolean_is_not_subtype_of_number_index_any() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -409,6 +425,7 @@ fn test_index_signature_unknown_value() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let indexed_unknown = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -423,6 +440,7 @@ fn test_index_signature_unknown_value() {
     });
 
     let indexed_string = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -447,6 +465,7 @@ fn test_index_signature_never_value() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let indexed_never = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -484,6 +503,7 @@ fn test_index_signature_function_value() {
     });
 
     let indexed_fn = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -509,6 +529,7 @@ fn test_index_signature_array_value() {
     let array_type = interner.array(TypeId::NUMBER);
 
     let indexed_array = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -547,6 +568,7 @@ fn test_index_signature_tuple_value() {
     ]);
 
     let indexed_tuple = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -575,6 +597,7 @@ fn test_index_signature_nested_object_value() {
     )]);
 
     let indexed_nested = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -598,6 +621,7 @@ fn test_index_signature_intersection_objects() {
     let _checker = SubtypeChecker::new(&interner);
 
     let indexed_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_11.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_11.rs
@@ -379,6 +379,7 @@ fn test_intersection_index_signature_with_properties() {
     let x_name = interner.intern_string("x");
 
     let index_sig = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -411,6 +412,7 @@ fn test_intersection_two_index_signatures() {
     let one_or_two = interner.union(vec![one, two]);
 
     let index_number = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -425,6 +427,7 @@ fn test_intersection_two_index_signatures() {
     });
 
     let index_literal = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1051,6 +1054,7 @@ fn test_keyof_with_index_signature_includes_string() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let indexed_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1077,6 +1081,7 @@ fn test_keyof_with_number_index_signature() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let indexed_obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_12.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_12.rs
@@ -1307,6 +1307,7 @@ fn test_readonly_index_signature() {
     let interner = TypeInterner::new();
 
     let readonly_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1330,6 +1331,7 @@ fn test_readonly_index_vs_mutable() {
     let mut checker = SubtypeChecker::new(&interner);
 
     let readonly_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1344,6 +1346,7 @@ fn test_readonly_index_vs_mutable() {
     });
 
     let mutable_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -1532,6 +1535,7 @@ fn test_readonly_with_number_index() {
     let interner = TypeInterner::new();
 
     let readonly_number_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_15.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_15.rs
@@ -216,6 +216,7 @@ fn test_enum_namespace_satisfies_string_index_target() {
 
     // Target: { [x: string]: number }
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -259,6 +260,7 @@ fn test_enum_namespace_rejects_incompatible_string_index() {
 
     // Target: { [x: string]: number } — string property B is incompatible
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -295,6 +297,7 @@ fn test_regular_named_object_still_rejects_number_index() {
     );
 
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_16.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_16.rs
@@ -21,6 +21,7 @@ fn test_string_index_sig_mismatch_carries_nested_property_reason() {
     )]);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -34,6 +35,7 @@ fn test_string_index_sig_mismatch_carries_nested_property_reason() {
         }),
     });
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -85,6 +87,7 @@ fn test_string_index_sig_mismatch_nested_reason_is_name_independent() {
     )]);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -98,6 +101,7 @@ fn test_string_index_sig_mismatch_nested_reason_is_name_independent() {
         }),
     });
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -144,6 +148,7 @@ fn test_number_index_sig_mismatch_carries_nested_property_reason() {
     )]);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -157,6 +162,7 @@ fn test_number_index_sig_mismatch_carries_nested_property_reason() {
         string_index: None,
     });
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -200,6 +206,7 @@ fn test_index_sig_mismatch_primitive_value_type_carries_intrinsic_nested_reason(
     let mut checker = SubtypeChecker::new(&interner);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -213,6 +220,7 @@ fn test_index_sig_mismatch_primitive_value_type_carries_intrinsic_nested_reason(
         }),
     });
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -260,6 +268,7 @@ fn test_missing_property_in_index_sig_target_returns_missing_property_directly()
     ]);
 
     let source = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -273,6 +282,7 @@ fn test_missing_property_in_index_sig_target_returns_missing_property_directly()
         }),
     });
     let target = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/union_tests.rs
+++ b/crates/tsz-solver/tests/union_tests.rs
@@ -618,6 +618,7 @@ fn test_union_to_object_with_index_signature() {
 
     // Target has index signature, so the relaxed rule should NOT apply
     let target_with_index = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -696,6 +697,7 @@ fn test_bypass_evaluation_resolves_lazy_index_value_types() {
     //   A = { [k: string]: Lazy(100) }  -> { [k: string]: {x: number} }
     //   B = { [k: string]: Lazy(101) }  -> { [k: string]: {x: string} }
     let obj_a = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),
@@ -710,6 +712,7 @@ fn test_bypass_evaluation_resolves_lazy_index_value_types() {
     });
 
     let obj_b = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),

--- a/crates/tsz-solver/tests/variance_tests.rs
+++ b/crates/tsz-solver/tests/variance_tests.rs
@@ -860,6 +860,7 @@ fn test_variance_object_index_signature() {
     let t_param = intern_type_param(&interner, "T");
 
     let obj = interner.object_with_index(ObjectShape {
+        base_types: Vec::new(),
         symbol_index: None,
         symbol: None,
         flags: ObjectFlags::empty(),


### PR DESCRIPTION
Goal: fast

## Summary — the lazy-heritage `base_types` rearchitecture (validated foundation, opt-in flag)

This is the first **working** implementation of the `ObjectShape.base_types` model from the long-standing lazy-lib campaign (the "deep endgame" the team "could never figure out"). It gives `ObjectShape` a heritage edge so an interface's `extends` bases are *referenced*, not flattened into `properties`, and inherited members resolve **per-member on demand**. This dissolves the eager full-closure materialization that forces the `REFS_RESOLUTION_FUEL` cap (and the #12144-class determinism fragility).

**Gated behind `TSZ_LAZY_HERITAGE` (OFF by default).** Flag-off is byte-identical to main by construction — `base_types` is empty for every shape, every base-walk is `if !base_types.is_empty()`, and the producer is flag-gated. This PR lands the validated foundation + opt-in architecture; flipping it on by default is the ongoing campaign (see Status).

### What's implemented
- **Stage 0 (foundation, flag-off byte-identical):** `ObjectShape.base_types: Vec<TypeId>` (a `TypeId` — a base may be `Object`, an instantiated generic `Application`, or a `Lazy(DefId)`); identity in `shape_identity.rs` (in `PartialEq`, deliberately *omitted from `Hash`* to keep interning order identical — equal shapes have equal bases, so consistency holds); `collect_properties` walks bases with **heritage override** semantics (own/earlier wins — the dual of `merge_shape`'s intersection); ~587 `ObjectShape` literals get `base_types: Vec::new()`.
- **Stage 1 (producer):** interface heritage records each instantiated base `TypeId` in `base_types` instead of folding members (`interface_type.rs`), via a variant-preserving `with_object_base_types` re-intern helper.
- **Stage 2 (key consumers):** the **find-member** path (`property_visitor.rs`) resolves an inherited member by walking bases *per-name* (never materializing the full surface — the actual perf lever); the excess-property known-member set (`compat.rs::collect_target_properties`) walks bases.

### A/B evidence (flag on vs off)
| Workload | OFF | ON | Notes |
|---|---|---|---|
| 40-interface DOM-tax (member-access) | 125ms, 8724 types, 2 err | 114ms, 8643 types, 2 err | **~9% faster, diagnostics match** |
| comlink (real worker/DOM row) | 231ms, 17206 types, 2 err | 220ms, 16947 types, 3 err | faster; **1 excess-property regression remains** |
| inherited-member access, missing-member detection, witness errors | — | — | **correctness matches OFF exactly** |

The architecture is **proven correct** (inherited members resolve, missing members detected, errors fire) and **perf-positive**, scaling with DOM usage.

## Status / remaining campaign (why flag stays OFF)
1. One comlink excess-property regression (`comlink.ts:595`) — a *second* excess path (checker contextual typing) not yet base-walking.
2. The broader ~337 iterate-all `shape.properties` readers need migration for full flag-on corpus correctness.
3. The dominant DOM cost (~84%) is **own-member lowering + the referenced-interface cascade**, not heritage (~16%) — the full ~2x win needs lazy own-member lowering layered on this.
4. Flip default + drop the eager `ensure_refs_resolved` pre-walk + remove the fuel cap (Stages 3–4).

## Verification
- Flag-OFF byte-identical: targeted `cargo nextest -p tsz-solver --lib` object/normalize/heritage subset clean (the only 2 failures — `literal_mask_preserves_object_vs_literal_reduction`, `test_conditional_infer_optional_property_present_distributive` — **fail identically on pristine origin/main**, i.e. pre-existing, not caused by this change).
- Flag-ON A/B: table above (DOM-tax + comlink), via `--extendedDiagnostics`.
- CI owns full flag-off conformance/emit on this PR.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
