### PR TITLE
fix(checker): any-fill bare generic instanceof narrowing in loop bodies (#14945)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "instanceof_generic_loop_any_fill_narrowing_tests"
+path = "tests/instanceof_generic_loop_any_fill_narrowing_tests.rs"
+[[test]]
 name = "sibling_defaulted_conditional_constraint_tests"
 path = "tests/sibling_defaulted_conditional_constraint_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/flow/control_flow/narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/narrowing.rs
@@ -647,17 +647,30 @@ impl<'a> FlowAnalyzer<'a> {
             // Falling back to `reference(SymbolRef)` would create Lazy(DefId(symbol_id)),
             // which can point at an unrelated definition because SymbolId and DefId
             // are independent identity spaces.
-            return self.resolve_symbol_to_lazy(symbol_ref);
+            //
+            // A bare `x instanceof Box` (no type arguments) on a generic class narrows
+            // to `Box<any>` in tsc; `any`-fill the resolved generic so a loop-body
+            // re-narrowing pass (where the fast path below misses) does not leave the
+            // class's type parameters free (#14945).
+            let lazy = self.resolve_symbol_to_lazy(symbol_ref)?;
+            return Some(self.any_fill_bare_generic_instance(lazy));
         }
 
         // Global constructor variables (e.g., `declare var Array: ArrayConstructor`)
         // have both INTERFACE and VARIABLE flags. The interface type IS the instance type
         // since interfaces describe instances, not constructors.
         // This handles `x instanceof Array`, `x instanceof Date`, etc.
+        //
+        // For generic global interfaces (`Map`, `Set`, `WeakMap`, `ReadonlyMap`, …) a
+        // bare `instanceof` narrows to the fully-`any` instance (`Map<any, any>`); the
+        // fast `node_types` path reads that off the constructor's `prototype`, but the
+        // loop back-edge re-narrowing pass misses it and resolves the bare generic
+        // `Map<K, V>`, so `any`-fill recovers the `Map<any, any>` shape (#14945).
         if symbol.has_any_flags(symbol_flags::INTERFACE)
             && symbol.has_any_flags(symbol_flags::VARIABLE)
         {
-            return self.resolve_symbol_to_lazy(symbol_ref);
+            let lazy = self.resolve_symbol_to_lazy(symbol_ref)?;
+            return Some(self.any_fill_bare_generic_instance(lazy));
         }
 
         // For FUNCTION symbols (e.g., JS constructor functions with @constructor),
@@ -700,6 +713,25 @@ impl<'a> FlowAnalyzer<'a> {
         }
 
         None
+    }
+
+    /// Apply tsc's bare-`instanceof` `any`-fill to a symbol-resolved instance
+    /// type. When `instance_type` is a generic interface/class `Lazy(DefId)` with
+    /// N > 0 type parameters and no supplied arguments, return
+    /// `Application(Lazy(DefId), [any; N])` (`Map<any, any>`); otherwise return it
+    /// unchanged. See `flow_query::any_fill_bare_generic_instance` for the full
+    /// rationale and guardrails (#14945).
+    fn any_fill_bare_generic_instance(&self, instance_type: TypeId) -> TypeId {
+        self.type_environment
+            .as_ref()
+            .and_then(|env| {
+                flow_query::any_fill_bare_generic_instance(
+                    self.interner,
+                    &env.borrow(),
+                    instance_type,
+                )
+            })
+            .unwrap_or(instance_type)
     }
 
     /// For VARIABLE symbols, follow the type annotation on the variable

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -1046,6 +1046,44 @@ pub(crate) fn instance_type_from_constructor(
     tsz_solver::type_queries::instance_type_from_constructor(db, type_id)
 }
 
+/// tsc narrows a bare `x instanceof GenericCtor` (one written with no explicit
+/// type arguments) to the constructor's instance type instantiated with `any`
+/// for every type parameter — the `prototype`-derived `Map<any, any>` shape — so
+/// member calls such as `m.set(k, v)` accept any argument.
+///
+/// The flow path's fast `node_types` lookup already yields that `any`-filled
+/// shape, because a generic constructor interface declares its `prototype`
+/// member as the fully-`any` instance (`MapConstructor.prototype: Map<any, any>`)
+/// and `instance_type_from_constructor` reads it. But when the constructor *value*
+/// expression is untyped or typed `error` — which happens on the loop back-edge
+/// re-narrowing pass while the flow graph is still reaching its fixed point
+/// (#14945) — that fast path misses and the symbol fallback resolves only the
+/// *bare generic* interface `Lazy(DefId)` with its type parameters still free
+/// (`Map<K, V>`). Member access then rejects arguments against the free `K`/`V`,
+/// a spurious TS2345/TS2322. Filling the N parameters with `any` here recovers
+/// the `Map<any, any>` shape the non-loop path already produces, so both paths
+/// agree and match tsc.
+///
+/// Returns `None` (caller keeps the resolved type unchanged) when `instance_type`
+/// is not a bare `Lazy(DefId)` (it is already concrete or an `Application`, e.g.
+/// the prototype-derived `Map<any, any>` from the fast path), or when the
+/// definition is non-generic (`Date`, `RegExp`; N = 0). Leaving non-generic and
+/// already-instantiated shapes untouched keeps union sources — whose concrete
+/// members (`Set<number>`) are preserved by the relation, independent of the
+/// instance type's arguments — and the unsupported false-branch unaffected.
+pub(crate) fn any_fill_bare_generic_instance(
+    db: &dyn QueryDatabase,
+    env: &tsz_solver::relations::subtype::TypeEnvironment,
+    instance_type: TypeId,
+) -> Option<TypeId> {
+    let def_id = tsz_solver::type_queries::get_lazy_def_id(db.as_type_database(), instance_type)?;
+    let param_count = env.get_def_params_owned(def_id)?.len();
+    if param_count == 0 {
+        return None;
+    }
+    Some(db.application(instance_type, vec![TypeId::ANY; param_count]))
+}
+
 /// Return the predicate type from `[Symbol.hasInstance](v: ...): v is T` if present.
 ///
 /// Mirrors the solver's `instance_type_from_symbol_has_instance` so the checker

--- a/crates/tsz-checker/tests/instanceof_generic_loop_any_fill_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/instanceof_generic_loop_any_fill_narrowing_tests.rs
@@ -1,0 +1,188 @@
+//! A bare `x instanceof GenericCtor` (written with no type arguments) narrows an
+//! unconstrained source (`unknown`/`any`) to the constructor's instance type
+//! instantiated with `any` for every type parameter — tsc's `prototype`-derived
+//! `Map<any, any>` shape — so member calls like `m.set(k, v)` accept any
+//! argument.
+//!
+//! Outside a loop tsz already produced that shape: the flow path's fast
+//! `node_types` lookup reads the `any`-filled `prototype` member off the
+//! constructor type. But inside a loop body the back-edge re-narrowing pass runs
+//! while the flow graph is still reaching its fixed point, so the constructor
+//! *value* expression is untyped / typed `error`, the fast path misses, and the
+//! symbol fallback resolved only the *bare generic* interface `Map<K, V>` with
+//! its type parameters still free. Member access then rejected its arguments
+//! against the free `K`/`V` — a spurious TS2345 that tsc never emits (#14945).
+//!
+//! These tests pin the structural rule (`any`-fill the bare generic instance at
+//! the symbol fallback) and its guardrails:
+//!   - non-generic globals (`Date`, N = 0) are untouched;
+//!   - a union source keeps its concrete members (`Set<number>` still rejects a
+//!     string argument), because the relation filters union members by
+//!     subtype/instantiation independent of the instance type's arguments;
+//!   - the rule covers the whole generic-global family (`Map`/`Set`/`WeakMap`)
+//!     and user-defined generic classes alike.
+
+use tsz_checker::context::CheckerOptions;
+
+fn strict_diagnostics(source: &str) -> Vec<(u32, String)> {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            no_implicit_any: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn codes(diags: &[(u32, String)]) -> Vec<u32> {
+    diags.iter().map(|(c, _)| *c).collect()
+}
+
+/// The exact witness from #14945: `value instanceof Map` inside a loop body must
+/// narrow `value` to `Map<any, any>`, so `value.set(k, v)` with `k: string |
+/// number` is accepted, matching tsc 5.9.3.
+#[test]
+fn map_instanceof_in_loop_narrows_to_any_filled_instance() {
+    let diags = strict_diagnostics(
+        r#"
+function f(value: unknown) {
+  const entries: Iterable<[string | number, unknown]> = [] as any;
+  for (let [k, v] of entries) {
+    if (value instanceof Map) {
+      value.set(k, v);
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        !codes(&diags).contains(&2345),
+        "bare `instanceof Map` in a loop must narrow to Map<any, any>; got: {diags:?}"
+    );
+}
+
+/// The no-loop control already worked through the fast path; lock it in so the
+/// fix keeps both paths in agreement.
+#[test]
+fn map_instanceof_without_loop_stays_clean() {
+    let diags = strict_diagnostics(
+        r#"
+function g(value: unknown) {
+  if (value instanceof Map) {
+    value.set(1, 2);
+  }
+}
+"#,
+    );
+    assert!(
+        !codes(&diags).contains(&2345),
+        "bare `instanceof Map` outside a loop must stay clean; got: {diags:?}"
+    );
+}
+
+/// The rule is not Map-specific: `Set` in a loop must narrow to `Set<any>`.
+#[test]
+fn set_instanceof_in_loop_narrows_to_any_filled_instance() {
+    let diags = strict_diagnostics(
+        r#"
+function h(value: unknown) {
+  const xs: Iterable<number> = [] as any;
+  for (const x of xs) {
+    if (value instanceof Set) {
+      value.add(x);
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        !codes(&diags).contains(&2345),
+        "bare `instanceof Set` in a loop must narrow to Set<any>; got: {diags:?}"
+    );
+}
+
+/// A user-defined generic class behaves the same way: `value instanceof Box`
+/// narrows `unknown` to `Box<any>` in a loop, accepting any argument.
+#[test]
+fn user_generic_class_instanceof_in_loop_narrows_to_any_filled_instance() {
+    let diags = strict_diagnostics(
+        r#"
+class Box<T> { item!: T; put(x: T): void {} }
+function b(value: unknown) {
+  const xs: Iterable<number> = [] as any;
+  for (const x of xs) {
+    if (value instanceof Box) {
+      value.put(x);
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        !codes(&diags).contains(&2345),
+        "bare `instanceof Box` in a loop must narrow to Box<any>; got: {diags:?}"
+    );
+}
+
+/// GUARDRAIL: a non-generic global (`Date`, zero type parameters) is left
+/// untouched by the `any`-fill — and was always clean here. The point is to pin
+/// that the fill does not perturb the N = 0 case.
+#[test]
+fn non_generic_global_instanceof_in_loop_unchanged() {
+    let diags = strict_diagnostics(
+        r#"
+function d(value: unknown) {
+  const xs: Iterable<number> = [] as any;
+  for (const _x of xs) {
+    if (value instanceof Date) {
+      value.getTime();
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        !codes(&diags).contains(&2339) && !codes(&diags).contains(&2345),
+        "non-generic `instanceof Date` must stay clean; got: {diags:?}"
+    );
+}
+
+/// GUARDRAIL: a *union* source keeps its concrete member. `Set<number> | string`
+/// narrowed by `instanceof Set` is `Set<number>`, so `value.add("x")` must STILL
+/// report TS2345 — the `any`-fill only supplies the fallback instance type and
+/// must not erase a concrete member's arguments. This holds both inside and
+/// outside a loop.
+#[test]
+fn union_source_keeps_concrete_member_and_still_errors() {
+    let diags = strict_diagnostics(
+        r#"
+function u(value: Set<number> | string) {
+  if (value instanceof Set) {
+    value.add("x");
+  }
+}
+function uloop(value: Set<number> | string) {
+  const xs: Iterable<number> = [] as any;
+  for (const _x of xs) {
+    if (value instanceof Set) {
+      value.add("x");
+    }
+  }
+}
+"#,
+    );
+    let ts2345 = diags.iter().filter(|(c, _)| *c == 2345).count();
+    assert!(
+        ts2345 >= 2,
+        "union source `Set<number> | string` must keep Set<number> and reject a string arg \
+         in both the plain and loop forms; got: {diags:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #14945. A bare `x instanceof Map` (written with no type arguments) on an
unconstrained source must narrow to the constructor's instance type
instantiated with `any` for every type parameter — tsc's prototype-derived
`Map<any, any>` shape — so member calls like `m.set(k, v)` accept any argument.

```ts
function f(value: unknown) {
  const entries: Iterable<[string | number, unknown]> = [] as any;
  for (let [k, v] of entries) {
    if (value instanceof Map) { value.set(k, v); }   // tsz before: TS2345 on K; tsc: clean
  }
}
```

Outside a loop tsz already produced the right shape via the flow path's fast
`node_types` lookup, which reads the `any`-filled `prototype` member off the
constructor type (`MapConstructor.prototype: Map<any, any>`). Inside a loop the
back-edge re-narrowing pass runs while the flow graph is still reaching its
fixed point, so the constructor *value* expression is untyped / typed `error`,
the fast path misses, and the symbol fallback resolved only the **bare generic**
interface `Map<K, V>` with its type parameters still free → spurious TS2345.

## Structural rule

When a bare `instanceof X` (no type arguments) narrows an unconstrained source
and the resolved instance type is a generic `Lazy(DefId)` with N > 0 parameters,
tsc instantiates it as `X<any, …>`; tsz does this through the flow narrowing
boundary by returning `Application(Lazy(DefId), [any; N])` at the symbol
fallback in `instance_type_from_constructor`.

## Owner layer

Checker flow narrowing → solver flow query boundary. No solver type-algorithm
change; the fix threads an existing `TypeEnvironment` def-arity query
(`get_def_params_owned`) and the interner's `application` constructor through the
`flow_query` boundary. A checker-layer suppression was avoided — the fix recovers
the same shape the non-loop fast path already produces, so both paths agree.

## Adjacent matrix

Applied to **both** the CLASS and INTERFACE+VARIABLE branches, so the rule
covers the whole family rather than the single reported witness:

- generic global interfaces: `Map`, `Set`, `WeakMap`, `ReadonlyMap`, … in a loop
- user-defined generic classes (`class Box<T>`) in a loop
- no-loop control (fast path) unchanged

## Guardrails (fallback / negative cases)

- non-generic globals (`Date`, `RegExp`; N = 0) → helper returns `None`, instance
  type untouched;
- union source keeps its concrete member: `Set<number> | string` narrowed by
  `instanceof Set` stays `Set<number>`, so `value.add("x")` still reports TS2345
  (the relation filters union members by subtype/instantiation independent of
  the instance type's arguments);
- false branch on `unknown` short-circuits before the instance type, unaffected.

## Goal

Goal: green

The witness is the superstruct benchmark row (non-green); this removes a
residual `instanceof`-in-loop false positive blocking parity with tsc.

## Verification

- New regression suite `instanceof_generic_loop_any_fill_narrowing_tests` (6
  cases: Map/Set/user-class in a loop, no-loop control, non-generic guardrail,
  union-source guardrail) — all pass.
- `cargo test -p tsz-checker --release` across 25 existing narrowing/flow/
  instanceof integration suites (incl. `ts2345_instanceof_narrowed_union_display_tests`,
  `generic_union_function_guard_narrowing_tests`,
  `imported_ctor_alias_predicate_narrowing_tests`, `control_flow_type_guard_tests`)
  — all green, no regressions.
- Architecture contract `test_instanceof_constructor_branches_avoid_raw_symbol_reference_fallback`
  — passes (call sites keep the `DefId`-backed lazy resolution).
- `cargo fmt --check` and `cargo clippy -p tsz-checker` — clean.
- CLI repro: only the intentional union-source guardrail diagnostic remains;
  Map/Set/Box/Date-in-loop cases are clean, matching tsc 5.9.3.

Note: two pre-existing dev-profile unit-test failures
(`ts2860_*`, `ts2861_*` in `binary_tests`) reproduce on clean `main` and are
unrelated to this change.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9UufBq5Whg9vDKef3C7A4)_