### PR TITLE
fix(ci): activate GCS cache service account for gsutil

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,37 +607,36 @@ jobs:
     needs: gate
     if: needs.gate.outputs.should_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true'
     runs-on: [self-hosted, tsz-cloud-run]
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       GITHUB_SHA: ${{ github.sha }}
-      SCCACHE_GCS_KEY_JSON: ${{ secrets.SCCACHE_GCS_KEY_JSON }}
-      # The dist artifact unblocks conformance/emit/fourslash, so PRs avoid
-      # target-dir uploads. Trusted main runs publish cargo-target-deps only
-      # when Cargo.lock/profile inputs changed and the gate intentionally ran
-      # main CI to refresh the exact shared cache key.
-      TSZ_CI_CACHE_SAVE_CARGO_TARGETS: ${{ needs.gate.outputs.rust_cache_refresh == 'true' && '1' || '0' }}
-      # Opt-in, default-off broader-refresh for #13747 (constraint: #13733 OOM).
-      # When the `TSZ_CI_REFRESH_WORKSPACE_RLIBS` repo variable is set to '1',
-      # green main builds republish the workspace-rlib (dist-fast) blob on EVERY
-      # source-only push, not only on Cargo.lock/profile changes, so PR
-      # dist-binaries restores a fresher incremental base. Unset → '0' → no
-      # behavior change. gcp-cache.sh bounds this: dist-fast blob only, same
-      # cache key, gated by the MemAvailable cache-save preflight. Flip only
-      # after reading the `cargo-target-deps staleness` marker in dist-binaries
-      # logs and confirming main cache-save RSS headroom.
-      TSZ_CI_CACHE_REFRESH_WORKSPACE_RLIBS: ${{ vars.TSZ_CI_REFRESH_WORKSPACE_RLIBS || '0' }}
-      # Keep artifact production independent from sccache service hangs. The
-      # dist-fast build is short enough without sccache, and all harness suites
-      # are blocked until this artifact uploads.
-      TSZ_CI_DISABLE_SCCACHE: "1"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
-      - name: Build dist-fast binaries
-        run: scripts/ci/github-suite.sh dist-binaries
-      - name: Pack dist-fast binaries
-        run: tar -C .target/dist-fast -cf dist-fast-binaries.tar tsz tsz-lsp tsz-server tsz-conformance generate-tsc-cache
+      - name: Submit dist-fast build to Cloud Build pool
+        env:
+          # The highmem build normally completes in minutes; keep the timeout
+          # below the job timeout so the GitHub runner has time to download and
+          # publish the dist artifact.
+          CLOUDBUILD_SUBMIT_TIMEOUT: 35m
+        run: |
+          set -euo pipefail
+          dist_artifact_uri="gs://tsz-ci_cloudbuild/dist-fast-binaries/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_SHA}.tar"
+          echo "DIST_FAST_ARTIFACT_URI=${dist_artifact_uri}" >> "$GITHUB_ENV"
+          scripts/ci/cloudbuild-submit.sh \
+            --project=tsz-ci \
+            --region=us-central1 \
+            --polling-interval=10 \
+            --config=scripts/cloudbuild/cloudbuild-dist-binaries.yaml \
+            --gcs-source-staging-dir=gs://tsz-ci_cloudbuild/cb-source-staging \
+            --substitutions=_GITHUB_SHA="${GITHUB_SHA}",_DIST_FAST_ARTIFACT_URI="${dist_artifact_uri}" \
+            .
+      - name: Download dist-fast binaries
+        run: |
+          set -euo pipefail
+          gcloud config set pass_credentials_to_gsutil true >/dev/null
+          gsutil -q cp "$DIST_FAST_ARTIFACT_URI" dist-fast-binaries.tar
       - name: Upload dist-fast binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -646,6 +645,9 @@ jobs:
           retention-days: 1
           if-no-files-found: error
           compression-level: 1
+      - name: Remove staged dist-fast binaries
+        if: always() && env.DIST_FAST_ARTIFACT_URI != ''
+        run: gsutil -q rm "$DIST_FAST_ARTIFACT_URI" || true
 
   lsp-e2e:
     name: lsp-e2e

--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -727,11 +727,29 @@ impl<'a> TypeResolver for CheckerContext<'a> {
         let sym_id = tsz_binder::SymbolId(symbol.0);
         if let Some(def_id) = self.get_existing_def_id(sym_id)
             && matches!(self.definition_store.get_kind(def_id), Some(DefKind::Class))
+            && let Some(ctor_def_id) = self.definition_store.get_constructor_def(def_id)
+            && let Some(body) = self.definition_store.get_body(ctor_def_id)
+            // A self-referential `Lazy(class_constructor_def)` body (the
+            // constructor is still resolving) would route back through lazy
+            // resolution downstream; skip it and let `resolve_ref` handle the
+            // in-flight case.
+            && !crate::query_boundaries::definition_identity::is_lazy_def_identity(
+                self.types,
+                body,
+                ctor_def_id,
+            )
+        {
+            return Some(body);
+        }
+        if let Some(def_id) = self.get_existing_def_id(sym_id)
+            && matches!(self.definition_store.get_kind(def_id), Some(DefKind::Class))
             && let Some(body) = self.definition_store.get_body(def_id)
             // A self-referential `Lazy(class_def)` body (the class is still
             // resolving) would route back through `resolve_lazy` (instance)
             // downstream; skip it and let `resolve_ref` handle the in-flight case.
-            && crate::query_boundaries::common::lazy_def_id(self.types, body) != Some(def_id)
+            && !crate::query_boundaries::definition_identity::is_lazy_def_identity(
+                self.types, body, def_id,
+            )
         {
             return Some(body);
         }

--- a/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/core.rs
@@ -1,4 +1,5 @@
 use tsz_solver::construction::TypeDatabase;
+use tsz_solver::def::DefId;
 use tsz_solver::narrowing::NullishFilter;
 use tsz_solver::relations::subtype::TypeResolver;
 use tsz_solver::{PropertyInfo, TypeId};
@@ -36,6 +37,22 @@ pub(crate) fn is_bigint_like(
     type_id: TypeId,
 ) -> bool {
     tsz_solver::operations::BinaryOpEvaluator::new(db).is_bigint_like(type_id)
+}
+
+pub(crate) fn enum_components(db: &dyn TypeDatabase, type_id: TypeId) -> Option<(DefId, TypeId)> {
+    tsz_solver::visitor::enum_components(db, type_id)
+}
+
+pub(crate) fn is_keyof_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::type_queries::is_keyof_type(db, type_id)
+}
+
+pub(crate) fn type_parameter_constraint(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
+    tsz_solver::type_queries::get_type_parameter_constraint(db, type_id)
+}
+
+pub(crate) fn evaluate_type_structure(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    tsz_solver::computation::evaluate_type(db, type_id)
 }
 
 pub(crate) fn contains_application_unknown_arg(db: &dyn TypeDatabase, type_id: TypeId) -> bool {

--- a/crates/tsz-checker/src/types/computation/binary_support.rs
+++ b/crates/tsz-checker/src/types/computation/binary_support.rs
@@ -4,7 +4,8 @@
 
 use crate::context::TypingRequest;
 use crate::query_boundaries::type_computation::core::{
-    WriteTargetLogicalOperator, WriteTargetLogicalResult,
+    WriteTargetLogicalOperator, WriteTargetLogicalResult, enum_components, evaluate_type_structure,
+    is_keyof_type, type_parameter_constraint,
 };
 use crate::query_boundaries::type_computation::in_operator::{self, InOperatorRhsClassifier};
 use crate::state::CheckerState;
@@ -839,6 +840,16 @@ impl CheckerState<'_> {
             return TypeId::STRING;
         }
 
+        if let Some((_def_id, member_type)) = enum_components(self.ctx.types, type_id) {
+            return self.get_primitive_family(member_type);
+        }
+        if is_keyof_type(self.ctx.types, type_id) {
+            return TypeId::STRING;
+        }
+        if let Some(constraint) = type_parameter_constraint(self.ctx.types, type_id) {
+            return self.get_primitive_family(constraint);
+        }
+
         // Intersections narrow their members; if any member sits in a primitive
         // family, treat the intersection as belonging to that family (e.g.
         // `T & number` should count as number-family for TS2367 widening).
@@ -853,14 +864,15 @@ impl CheckerState<'_> {
             }
         }
 
-        // A union belongs to a primitive family when all of its non-`null`/
-        // `undefined` constituents share one family (`1 | 2`, `"a" | undefined`).
-        // `null`/`undefined` members are ignored — they ride along unwidened in
-        // tsc's display (`number | undefined`) — but a union of *only*
-        // `null`/`undefined`, an empty union, or a union spanning multiple
-        // families has no single family. This mirrors tsc widening
-        // `(1 | undefined) === "x"` operands to `number | undefined` / `string`
-        // while leaving `(1 | undefined) === 2` (same family) as literals.
+        // A union belongs to a primitive family when every primitive member
+        // shares one family (`1 | 2`, `"a" | undefined`). `null`/`undefined`
+        // and non-primitive members are ignored for the family decision: they
+        // ride along unwidened in tsc's display (`number | undefined`,
+        // `Refrigerator | "foo"`). A union of only ignored members, an empty
+        // union, or a union spanning multiple primitive families has no single
+        // family. This mirrors tsc widening `(1 | undefined) === "x"` operands
+        // to `number | undefined` / `string` while leaving `(1 | undefined) === 2`
+        // and `(Refrigerator | "foo") === "bar"` as literals.
         if let Some(members) =
             crate::query_boundaries::common::union_members(self.ctx.types, type_id)
         {
@@ -871,7 +883,7 @@ impl CheckerState<'_> {
                 }
                 let family = self.get_primitive_family(member);
                 if family == TypeId::ERROR {
-                    return TypeId::ERROR;
+                    continue;
                 }
                 match common {
                     None => common = Some(family),
@@ -880,6 +892,11 @@ impl CheckerState<'_> {
                 }
             }
             return common.unwrap_or(TypeId::ERROR);
+        }
+
+        let evaluated = evaluate_type_structure(self.ctx.types, type_id);
+        if evaluated != type_id {
+            return self.get_primitive_family(evaluated);
         }
 
         TypeId::ERROR // Non-primitive types

--- a/crates/tsz-checker/src/types/computation/binary_tests.rs
+++ b/crates/tsz-checker/src/types/computation/binary_tests.rs
@@ -919,6 +919,71 @@ fn ts2367_preserves_same_family_literals_in_display() {
 }
 
 #[test]
+fn ts2367_preserves_literal_against_constrained_type_parameter() {
+    let diags = check_source_diagnostics(
+        r#"function f<T extends "a" | "b">(value: T) {
+    if (value === "x") {}
+}"#,
+    );
+    let relevant: Vec<_> = diags.iter().filter(|d| d.code == 2367).collect();
+    assert_eq!(
+        relevant.len(),
+        1,
+        "Expected exactly one TS2367, got: {diags:?}"
+    );
+    assert!(
+        relevant[0]
+            .message_text
+            .contains("types 'T' and '\"x\"' have no overlap"),
+        "Expected constrained type-parameter comparison to preserve the literal display, got: {:?}",
+        relevant[0].message_text
+    );
+}
+
+#[test]
+fn ts2367_preserves_literal_against_enum_and_keyof_operands() {
+    let diags = check_source_diagnostics(
+        r#"enum E {
+    a = 1,
+    b = 2,
+}
+declare let e: E;
+if (e !== 0) {}
+
+interface O {
+    a: string;
+    b: string;
+}
+declare let k: keyof O;
+if (k === "c") {}
+"#,
+    );
+    let relevant: Vec<_> = diags.iter().filter(|d| d.code == 2367).collect();
+    assert_eq!(
+        relevant.len(),
+        2,
+        "Expected two TS2367 diagnostics, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.as_str()))
+            .collect::<Vec<_>>()
+    );
+    let messages: Vec<_> = relevant.iter().map(|d| d.message_text.as_str()).collect();
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("types 'E' and '0' have no overlap")),
+        "Expected enum comparison to preserve numeric literal display, got: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("types 'keyof O' and '\"c\"' have no overlap")),
+        "Expected keyof comparison to preserve string literal display, got: {messages:?}"
+    );
+}
+
+#[test]
 fn ts2367_for_object_or_null_constrained_intersection_compared_to_primitive() {
     let diags = check_source_diagnostics(
         r#"function unconstrained<T>(value: T & ({} | null)) {

--- a/crates/tsz-checker/src/types/queries/class.rs
+++ b/crates/tsz-checker/src/types/queries/class.rs
@@ -5,6 +5,8 @@
 //! has been extracted to `queries/lib_resolution.rs`.
 
 use crate::state::CheckerState;
+use rustc_hash::FxHashSet;
+use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
@@ -681,13 +683,21 @@ impl<'a> CheckerState<'a> {
     /// this mirrors the `this`-receiver gate used for object-literal
     /// method-call cycles (`object_literal_circularity.rs`).
     pub(crate) fn object_literal_getter_has_self_reference(
-        &self,
+        &mut self,
         accessor_idx: NodeIndex,
         body_idx: NodeIndex,
         name: &str,
     ) -> bool {
         let binding_sym = self.object_literal_initializer_binding_symbol(accessor_idx);
-        self.getter_self_reference_in_subtree(body_idx, name, binding_sym)
+        let member_names = self.object_literal_member_names_for_accessor(accessor_idx);
+        let receiver_aliases = self.object_literal_getter_receiver_aliases(body_idx, binding_sym);
+        self.getter_self_reference_in_subtree(
+            body_idx,
+            name,
+            binding_sym,
+            &receiver_aliases,
+            &member_names,
+        )
     }
 
     /// Symbol of the variable an object-literal accessor's enclosing object
@@ -698,7 +708,7 @@ impl<'a> CheckerState<'a> {
     fn object_literal_initializer_binding_symbol(
         &self,
         accessor_idx: NodeIndex,
-    ) -> Option<tsz_binder::SymbolId> {
+    ) -> Option<SymbolId> {
         let obj_idx = self.ctx.arena.get_extended(accessor_idx)?.parent;
         let obj_node = self.ctx.arena.get(obj_idx)?;
         if obj_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
@@ -714,6 +724,120 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         self.ctx.binder.get_node_symbol(var_decl.name)
+    }
+
+    fn object_literal_member_names_for_accessor(
+        &mut self,
+        accessor_idx: NodeIndex,
+    ) -> FxHashSet<String> {
+        let mut names = FxHashSet::default();
+        let Some(obj_idx) = self
+            .ctx
+            .arena
+            .get_extended(accessor_idx)
+            .map(|ext| ext.parent)
+        else {
+            return names;
+        };
+        let Some(obj_node) = self.ctx.arena.get(obj_idx) else {
+            return names;
+        };
+        if obj_node.kind != syntax_kind_ext::OBJECT_LITERAL_EXPRESSION {
+            return names;
+        }
+        let Some(obj) = self.ctx.arena.get_literal_expr(obj_node) else {
+            return names;
+        };
+        for &elem_idx in &obj.elements.nodes {
+            let Some(elem_node) = self.ctx.arena.get(elem_idx) else {
+                continue;
+            };
+            let name = if let Some(prop) = self.ctx.arena.get_property_assignment(elem_node) {
+                self.get_property_name_resolved(prop.name)
+            } else if elem_node.kind == syntax_kind_ext::METHOD_DECLARATION {
+                self.ctx
+                    .arena
+                    .get_method_decl(elem_node)
+                    .and_then(|method| self.get_property_name_resolved(method.name))
+            } else if elem_node.kind == syntax_kind_ext::GET_ACCESSOR
+                || elem_node.kind == syntax_kind_ext::SET_ACCESSOR
+            {
+                self.ctx
+                    .arena
+                    .get_accessor(elem_node)
+                    .and_then(|accessor| self.get_property_name_resolved(accessor.name))
+            } else if elem_node.kind == syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT {
+                self.ctx
+                    .arena
+                    .get_shorthand_property(elem_node)
+                    .and_then(|shorthand| self.ctx.arena.get(shorthand.name))
+                    .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
+                    .map(|ident| ident.escaped_text.clone())
+            } else {
+                None
+            };
+            if let Some(name) = name {
+                names.insert(name);
+            }
+        }
+        names
+    }
+
+    fn object_literal_getter_receiver_aliases(
+        &self,
+        body_idx: NodeIndex,
+        binding_sym: Option<SymbolId>,
+    ) -> FxHashSet<SymbolId> {
+        let mut aliases = FxHashSet::default();
+        loop {
+            let before = aliases.len();
+            self.collect_object_literal_getter_receiver_aliases(
+                body_idx,
+                binding_sym,
+                &mut aliases,
+            );
+            if aliases.len() == before {
+                return aliases;
+            }
+        }
+    }
+
+    fn collect_object_literal_getter_receiver_aliases(
+        &self,
+        node_idx: NodeIndex,
+        binding_sym: Option<SymbolId>,
+        aliases: &mut FxHashSet<SymbolId>,
+    ) {
+        if node_idx.is_none() {
+            return;
+        }
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return;
+        };
+
+        match node.kind {
+            syntax_kind_ext::FUNCTION_EXPRESSION
+            | syntax_kind_ext::ARROW_FUNCTION
+            | syntax_kind_ext::CLASS_EXPRESSION => return,
+            syntax_kind_ext::VARIABLE_DECLARATION => {
+                if let Some(decl) = self.ctx.arena.get_variable_declaration(node)
+                    && decl.initializer.is_some()
+                    && self.receiver_denotes_object_under_construction(
+                        decl.initializer,
+                        binding_sym,
+                        aliases,
+                    )
+                    && let Some(alias_sym) = self.ctx.binder.get_node_symbol(decl.name)
+                {
+                    aliases.insert(alias_sym);
+                }
+            }
+            _ => {}
+        }
+
+        for child_idx in self.ctx.arena.get_children(node_idx) {
+            self.collect_object_literal_getter_receiver_aliases(child_idx, binding_sym, aliases);
+        }
     }
 
     /// Recursive helper for `collect_self_references`.
@@ -777,7 +901,9 @@ impl<'a> CheckerState<'a> {
         &self,
         node_idx: NodeIndex,
         name: &str,
-        binding_sym: Option<tsz_binder::SymbolId>,
+        binding_sym: Option<SymbolId>,
+        receiver_aliases: &FxHashSet<SymbolId>,
+        object_member_names: &FxHashSet<String>,
     ) -> bool {
         if node_idx.is_none() {
             return false;
@@ -790,8 +916,12 @@ impl<'a> CheckerState<'a> {
             && let Some(access) = self.ctx.arena.get_access_expr(node)
             && let Some(name_node) = self.ctx.arena.get(access.name_or_argument)
             && let Some(ident) = self.ctx.arena.get_identifier(name_node)
-            && ident.escaped_text == name
-            && self.receiver_denotes_object_under_construction(access.expression, binding_sym)
+            && self.receiver_denotes_object_under_construction(
+                access.expression,
+                binding_sym,
+                receiver_aliases,
+            )
+            && (ident.escaped_text == name || !object_member_names.contains(&ident.escaped_text))
         {
             return true;
         }
@@ -809,7 +939,15 @@ impl<'a> CheckerState<'a> {
             .arena
             .get_children(node_idx)
             .into_iter()
-            .any(|child_idx| self.getter_self_reference_in_subtree(child_idx, name, binding_sym))
+            .any(|child_idx| {
+                self.getter_self_reference_in_subtree(
+                    child_idx,
+                    name,
+                    binding_sym,
+                    receiver_aliases,
+                    object_member_names,
+                )
+            })
     }
 
     /// Whether a property-access receiver expression evaluates to the object
@@ -823,7 +961,8 @@ impl<'a> CheckerState<'a> {
     fn receiver_denotes_object_under_construction(
         &self,
         receiver_idx: NodeIndex,
-        binding_sym: Option<tsz_binder::SymbolId>,
+        binding_sym: Option<SymbolId>,
+        receiver_aliases: &FxHashSet<SymbolId>,
     ) -> bool {
         let receiver_idx = self
             .ctx
@@ -837,23 +976,30 @@ impl<'a> CheckerState<'a> {
             return true;
         }
         if node.kind == SyntaxKind::Identifier as u16 {
-            return binding_sym
-                .is_some_and(|sym| self.resolve_identifier_symbol(receiver_idx) == Some(sym));
+            let receiver_sym = self.resolve_identifier_symbol(receiver_idx);
+            return binding_sym.is_some_and(|sym| receiver_sym == Some(sym))
+                || receiver_sym.is_some_and(|sym| receiver_aliases.contains(&sym));
         }
         match node.kind {
             // `[this][0]`: the indexed result is one of the array's elements.
             syntax_kind_ext::ARRAY_LITERAL_EXPRESSION => {
                 self.ctx.arena.get_literal_expr(node).is_some_and(|arr| {
-                    arr.elements
-                        .nodes
-                        .iter()
-                        .copied()
-                        .any(|el| self.receiver_denotes_object_under_construction(el, binding_sym))
+                    arr.elements.nodes.iter().copied().any(|el| {
+                        self.receiver_denotes_object_under_construction(
+                            el,
+                            binding_sym,
+                            receiver_aliases,
+                        )
+                    })
                 })
             }
             syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => {
                 self.ctx.arena.get_access_expr(node).is_some_and(|access| {
-                    self.receiver_denotes_object_under_construction(access.expression, binding_sym)
+                    self.receiver_denotes_object_under_construction(
+                        access.expression,
+                        binding_sym,
+                        receiver_aliases,
+                    )
                 })
             }
             syntax_kind_ext::CONDITIONAL_EXPRESSION => self
@@ -861,11 +1007,15 @@ impl<'a> CheckerState<'a> {
                 .arena
                 .get_conditional_expr(node)
                 .is_some_and(|cond| {
-                    self.receiver_denotes_object_under_construction(cond.when_true, binding_sym)
-                        || self.receiver_denotes_object_under_construction(
-                            cond.when_false,
-                            binding_sym,
-                        )
+                    self.receiver_denotes_object_under_construction(
+                        cond.when_true,
+                        binding_sym,
+                        receiver_aliases,
+                    ) || self.receiver_denotes_object_under_construction(
+                        cond.when_false,
+                        binding_sym,
+                        receiver_aliases,
+                    )
                 }),
             _ => false,
         }

--- a/crates/tsz-checker/tests/object_literal_getter_self_reference_ts7023_tests.rs
+++ b/crates/tsz-checker/tests/object_literal_getter_self_reference_ts7023_tests.rs
@@ -181,6 +181,55 @@ void o;
 }
 
 #[test]
+fn missing_this_member_in_getter_return_still_reports() {
+    let source = r#"
+const o = {
+  get x() { return this.missing; },
+};
+void o;
+"#;
+    assert_eq!(
+        count(source, 7023),
+        1,
+        "a getter return that reads a missing member through `this` is circular"
+    );
+}
+
+#[test]
+fn existing_this_member_in_getter_return_is_clean() {
+    let source = r#"
+const o = {
+  get x() { return this.y; },
+  y: 1,
+};
+void o;
+"#;
+    assert_eq!(
+        count(source, 7023),
+        0,
+        "a getter may read an existing sibling member through `this` without circularity"
+    );
+}
+
+#[test]
+fn this_alias_missing_member_self_reference_still_reports() {
+    let source = r#"
+const o = {
+  get x() {
+    const self = this;
+    return self.missing.deep.x;
+  },
+};
+void o;
+"#;
+    assert_eq!(
+        count(source, 7023),
+        1,
+        "aliases of `this` keep missing-member getter reads circular"
+    );
+}
+
+#[test]
 fn wrapped_this_receiver_self_reference_still_reports() {
     let source = r#"
 const o = {

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -267,22 +267,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// NOT the instance type (stored in `symbol_instance_types`).
     ///
     /// `resolve_lazy` returns the instance type for class symbols, which is correct
-    /// for `Lazy(DefId)` but wrong for `TypeQuery`. We must use `resolve_ref` first
-    /// (which looks up `symbol_types` → constructor type), and only fall back to
-    /// `resolve_lazy` for non-class symbols (e.g., module namespaces).
+    /// for `Lazy(DefId)` but wrong for `TypeQuery`. Delegate to the resolver's
+    /// dedicated value-space hook so imported classes and merged value/type symbols
+    /// resolve through the same constructor-side path as evaluation.
     pub(crate) fn resolve_type_query_symbol(&self, sym: SymbolRef) -> Option<TypeId> {
-        // First try resolve_ref which returns the value from symbol_types
-        // (constructor type for classes, function type for functions, etc.)
-        let ref_resolved = self.resolver.resolve_ref(sym, self.interner);
-        if ref_resolved.is_some() {
-            return ref_resolved;
-        }
-        // Fall back to DefId-based resolution for symbols without a symbol_types entry
-        if let Some(def_id) = self.resolver.symbol_to_def_id(sym) {
-            self.resolver.resolve_lazy(def_id, self.interner)
-        } else {
-            None
-        }
+        self.resolver.resolve_type_query(sym, self.interner)
     }
 
     /// Check `TypeQuery` to `TypeQuery` subtype with optional identity shortcut.

--- a/crates/tsz-solver/src/relations/subtype/rules/literals.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/literals.rs
@@ -9,7 +9,7 @@
 //! - Template-to-template literal subtype matching (generalized pattern matching)
 
 use crate::types::{
-    IntrinsicKind, LiteralValue, TemplateLiteralId, TemplateSpan, TypeId, TypeListId,
+    IntrinsicKind, LiteralValue, TemplateLiteralId, TemplateSpan, TypeData, TypeId, TypeListId,
 };
 use crate::visitor::{
     intersection_list_id, intrinsic_kind, literal_value, string_intrinsic_components,
@@ -230,6 +230,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                             }
                         }
                     };
+                }
+
+                if let Some(TypeData::Enum(_, member_type)) = self.interner.lookup(type_id) {
+                    let mut enum_spans = Vec::with_capacity(spans.len() - span_idx);
+                    enum_spans.push(TemplateSpan::Type(member_type));
+                    enum_spans.extend_from_slice(&spans[span_idx + 1..]);
+                    return self.match_template_literal_recursive(remaining, &enum_spans, 0);
                 }
 
                 if let Some(members) = union_list_id(self.interner, type_id) {

--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -1052,17 +1052,10 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
         // NOT the instance type (from resolve_lazy/symbol_instance_types).
         let sym = SymbolRef(symbol_ref);
 
-        // Use resolve_ref first (returns constructor type for classes),
-        // then fall back to resolve_lazy for non-class symbols.
         let resolved = self
             .checker
             .resolver
-            .resolve_ref(sym, self.checker.interner)
-            .or_else(|| {
-                self.checker
-                    .resolver
-                    .resolve_symbol_ref(sym, self.checker.interner)
-            })
+            .resolve_type_query(sym, self.checker.interner)
             .unwrap_or(self.source);
 
         // If resolution succeeded and gave us a different type, restart the check.

--- a/scripts/ci/gcp-cache.sh
+++ b/scripts/ci/gcp-cache.sh
@@ -41,12 +41,27 @@ CACHE_BUCKET="${_TSZ_CI_CACHE_BUCKET:?_TSZ_CI_CACHE_BUCKET is required}"
 CACHE_BUCKET="${CACHE_BUCKET%/}"
 
 ensure_gcs_auth() {
-  if [[ -n "${SCCACHE_GCS_KEY_JSON:-}" && -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
-    local key_file="/tmp/sccache-gcs-key.json"
-    printf '%s' "$SCCACHE_GCS_KEY_JSON" > "$key_file"
-    chmod 600 "$key_file"
-    export GOOGLE_APPLICATION_CREDENTIALS="$key_file"
-    echo "gcs-auth: using service account key from SCCACHE_GCS_KEY_JSON"
+  if [[ -n "${SCCACHE_GCS_KEY_JSON:-}" ]]; then
+    if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+      local key_file="/tmp/sccache-gcs-key.json"
+      printf '%s' "$SCCACHE_GCS_KEY_JSON" > "$key_file"
+      chmod 600 "$key_file"
+      export GOOGLE_APPLICATION_CREDENTIALS="$key_file"
+      echo "gcs-auth: using service account key from SCCACHE_GCS_KEY_JSON"
+    fi
+
+    # gsutil from the Cloud SDK does not reliably consume ADC-only JSON key
+    # files. Activate the same key in gcloud, then let gsutil reuse that
+    # account instead of falling through to anonymous GCS requests.
+    if command -v gcloud >/dev/null 2>&1; then
+      if ! gcloud auth activate-service-account \
+        --key-file="$GOOGLE_APPLICATION_CREDENTIALS" >/dev/null 2>&1; then
+        echo "error: failed to activate SCCACHE_GCS_KEY_JSON for GCS cache access" >&2
+        return 1
+      fi
+      gcloud config set pass_credentials_to_gsutil true >/dev/null 2>&1 || true
+      echo "gcs-auth: activated service account credentials for gsutil"
+    fi
   fi
 
   # Cloud Run runners can arrive with `gcloud auth` already configured. Make

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -215,17 +215,36 @@ ensure_host_tools() {
 }
 
 ensure_gcs_auth() {
-  # Set GOOGLE_APPLICATION_CREDENTIALS from SCCACHE_GCS_KEY_JSON when the
-  # caller hasn't gone through setup_sccache (e.g. conformance shards that
-  # skip Rust compilation).  gsutil respects GOOGLE_APPLICATION_CREDENTIALS,
-  # so without this the upload/download falls back to the Cloud Run metadata
-  # server, which is intermittently unavailable on self-hosted runners.
-  if [[ -n "${SCCACHE_GCS_KEY_JSON:-}" && -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
-    local key_file="/tmp/sccache-gcs-key.json"
-    printf '%s' "$SCCACHE_GCS_KEY_JSON" > "$key_file"
-    chmod 600 "$key_file"
-    export GOOGLE_APPLICATION_CREDENTIALS="$key_file"
-    echo "gcs-auth: using service account key from SCCACHE_GCS_KEY_JSON"
+  if [[ -n "${SCCACHE_GCS_KEY_JSON:-}" ]]; then
+    if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+      local key_file="/tmp/sccache-gcs-key.json"
+      printf '%s' "$SCCACHE_GCS_KEY_JSON" > "$key_file"
+      chmod 600 "$key_file"
+      export GOOGLE_APPLICATION_CREDENTIALS="$key_file"
+      echo "gcs-auth: using service account key from SCCACHE_GCS_KEY_JSON"
+    fi
+
+    # gsutil from the Cloud SDK does not reliably consume ADC-only JSON key
+    # files. Activate the same key in gcloud, then let gsutil reuse that
+    # account instead of falling through to anonymous GCS requests.
+    if command -v gcloud >/dev/null 2>&1; then
+      if ! gcloud auth activate-service-account \
+        --key-file="$GOOGLE_APPLICATION_CREDENTIALS" >/dev/null 2>&1; then
+        echo "error: failed to activate SCCACHE_GCS_KEY_JSON for GCS access" >&2
+        return 1
+      fi
+      gcloud config set pass_credentials_to_gsutil true >/dev/null 2>&1 || true
+      echo "gcs-auth: activated service account credentials for gsutil"
+    fi
+  fi
+
+  # Cloud Run runners can arrive with `gcloud auth` already configured. Make
+  # the bundled gsutil use that account instead of falling back to anonymous
+  # requests during shard artifact transfer.
+  if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] && command -v gcloud >/dev/null 2>&1; then
+    if gcloud auth print-access-token >/dev/null 2>&1; then
+      gcloud config set pass_credentials_to_gsutil true >/dev/null 2>&1 || true
+    fi
   fi
 }
 
@@ -787,7 +806,7 @@ build_test_binaries() {
   # Wrap with safe-run.sh so cargo is killed gracefully before the kernel
   # OOM-killer fires and silently kills the GitHub Actions runner process.
   set +e
-  "$ROOT_DIR/scripts/safe-run.sh" --limit "${TSZ_CI_DIST_BUILD_MEMORY_LIMIT_PCT:-88}%" -- \
+  CARGO_INCREMENTAL=0 "$ROOT_DIR/scripts/safe-run.sh" --limit "${TSZ_CI_DIST_BUILD_MEMORY_LIMIT_PCT:-88}%" -- \
     cargo build --profile dist-fast \
       --jobs "$CARGO_BUILD_JOBS" \
       -p tsz-cli \
@@ -1330,6 +1349,9 @@ run_common_setup() {
     # avoids the gitlink-vs-ref-file staleness check that's only relevant
     # when the tree is actually used.
     echo "info: skipping init_typescript_submodule (suite '$suite' does not need TS source)"
+  fi
+  if [[ -n "${_TSZ_CI_CACHE_BUCKET:-${TSZ_CI_CACHE_BUCKET:-}}" ]] && command -v gsutil >/dev/null 2>&1; then
+    ensure_gcs_auth
   fi
   if suite_needs_group "$suite" rust_compile; then
     if [[ "${TSZ_CI_DISABLE_SCCACHE:-0}" == "1" ]]; then

--- a/scripts/ci/lib/gcp-full-ci-conformance.sh
+++ b/scripts/ci/lib/gcp-full-ci-conformance.sh
@@ -94,10 +94,16 @@ run_conformance() {
   local shard_index shard_count shard_offset shard_max shard_expected_passed shard_expected_total shard_expected_weight
   local shard_weights_file timings_file
   local conformance_args=()
+  local conformance_timeout
   shard_index="$(num_or_zero "$CONFORMANCE_SHARD_INDEX")"
   shard_count="$(num_or_zero "$CONFORMANCE_SHARD_COUNT")"
+  conformance_timeout="$(num_or_zero "${TSZ_CI_CONFORMANCE_TIMEOUT:-240}")"
+  if [[ "$conformance_timeout" -lt 1 ]]; then
+    conformance_timeout=240
+  fi
   shard_weights_file=""
   timings_file="$METRICS_DIR/conformance-timings-${shard_index}.json"
+  conformance_args+=(--timeout "$conformance_timeout")
   if [[ "$shard_count" -lt 1 ]]; then
     shard_count=1
   fi
@@ -127,6 +133,7 @@ run_conformance() {
     shard_expected_weight=0
     conformance_args+=(--timings-file "$timings_file")
   fi
+  echo "Conformance per-test timeout: ${conformance_timeout}s"
 
   set +e
   run_with_heartbeat "conformance" \

--- a/scripts/ci/test-cloudbuild-config-paths.mjs
+++ b/scripts/ci/test-cloudbuild-config-paths.mjs
@@ -17,7 +17,11 @@ const workflowConfigs = new Map([
   ],
   [
     ".github/workflows/ci.yml",
-    ["cloudbuild-checker-integration.yaml", "cloudbuild-unit.yaml"],
+    [
+      "cloudbuild-checker-integration.yaml",
+      "cloudbuild-dist-binaries.yaml",
+      "cloudbuild-unit.yaml",
+    ],
   ],
   [
     ".github/workflows/runner-image.yml",

--- a/scripts/ci/test-gcp-cache-auth.mjs
+++ b/scripts/ci/test-gcp-cache-auth.mjs
@@ -10,19 +10,38 @@ const cacheScript = fs.readFileSync(
   path.join(ROOT, "scripts", "ci", "gcp-cache.sh"),
   "utf8",
 );
+const fullCiScript = fs.readFileSync(
+  path.join(ROOT, "scripts", "ci", "gcp-full-ci.sh"),
+  "utf8",
+);
 
-const authFn = cacheScript.match(/ensure_gcs_auth\(\) \{[\s\S]+?\n\}/);
-assert.ok(authFn, "gcp-cache.sh should define ensure_gcs_auth");
-assert.match(
-  authFn[0],
-  /SCCACHE_GCS_KEY_JSON[\s\S]+GOOGLE_APPLICATION_CREDENTIALS/,
-  "GCS cache auth should accept the same service-account secret used by sccache",
-);
-assert.match(
-  authFn[0],
-  /gcloud auth print-access-token[\s\S]+pass_credentials_to_gsutil true/,
-  "GCS cache auth should let gsutil use an already-authenticated gcloud account",
-);
+function shellFunction(script, name, fileName) {
+  const match = script.match(new RegExp(`${name}\\(\\) \\{[\\s\\S]+?\\n\\}`));
+  assert.ok(match, `${fileName} should define ${name}`);
+  return match[0];
+}
+
+for (const [fileName, script] of [
+  ["gcp-cache.sh", cacheScript],
+  ["gcp-full-ci.sh", fullCiScript],
+]) {
+  const authFn = shellFunction(script, "ensure_gcs_auth", fileName);
+  assert.match(
+    authFn,
+    /SCCACHE_GCS_KEY_JSON[\s\S]+GOOGLE_APPLICATION_CREDENTIALS/,
+    `${fileName} GCS auth should accept the same service-account secret used by sccache`,
+  );
+  assert.match(
+    authFn,
+    /gcloud auth activate-service-account[\s\S]+--key-file="\$GOOGLE_APPLICATION_CREDENTIALS"/,
+    `${fileName} GCS auth should activate the service-account key for gcloud`,
+  );
+  assert.match(
+    authFn,
+    /pass_credentials_to_gsutil true/,
+    `${fileName} GCS auth should let gsutil use the active gcloud account`,
+  );
+}
 
 const mainOffset = cacheScript.indexOf("main() {");
 assert.notEqual(mainOffset, -1, "gcp-cache.sh should keep a main function");
@@ -31,6 +50,13 @@ assert.match(
   mainBody,
   /ensure_gcs_auth/,
   "gcp-cache.sh should authenticate before restore/save dispatch",
+);
+
+const commonSetup = shellFunction(fullCiScript, "run_common_setup", "gcp-full-ci.sh");
+assert.match(
+  commonSetup,
+  /ensure_gcs_auth/,
+  "gcp-full-ci.sh should authenticate before suite-level gsutil transfers",
 );
 
 console.log("test-gcp-cache-auth: ok");

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -235,6 +235,45 @@ assert.match(
 
 assert.match(
   ciWorkflow,
+  /\n\s{2}dist-binaries:\n[\s\S]+?runs-on: \[self-hosted, tsz-cloud-run\][\s\S]+?Submit dist-fast build to Cloud Build pool[\s\S]+?--config=scripts\/cloudbuild\/cloudbuild-dist-binaries\.yaml[\s\S]+?Download dist-fast binaries[\s\S]+?Upload dist-fast binaries/,
+  "dist-binaries should compile on the highmem Cloud Build pool and only use the Cloud Run runner to publish the small GitHub artifact",
+);
+
+const distCloudBuild = fs.readFileSync(
+  path.join(ROOT, "scripts", "cloudbuild", "cloudbuild-dist-binaries.yaml"),
+  "utf8",
+);
+const gcpFullCi = fs.readFileSync(
+  path.join(ROOT, "scripts", "ci", "gcp-full-ci.sh"),
+  "utf8",
+);
+
+assert.match(
+  distCloudBuild,
+  /'CARGO_INCREMENTAL=0'/,
+  "dist-binaries must disable incremental compilation so restored target caches cannot ship stale semantic code into conformance artifacts",
+);
+
+assert.match(
+  distCloudBuild,
+  /'GITHUB_WORKSPACE=\/home\/runner\/_work\/tsz\/tsz'[\s\S]+?tar -C \/workspace -cf - \. \| tar -C "\$GITHUB_WORKSPACE" -xf -[\s\S]+?cd "\$GITHUB_WORKSPACE"[\s\S]+?git init --quiet/,
+  "dist-binaries Cloud Build should compile from the same workspace path used by GitHub Actions shards before creating synthetic git metadata",
+);
+
+assert.match(
+  gcpFullCi,
+  /CARGO_INCREMENTAL=0 "\$ROOT_DIR\/scripts\/safe-run\.sh"[\s\S]+cargo build --profile dist-fast/,
+  "build_test_binaries should force non-incremental dist-fast builds regardless of inherited CI environment",
+);
+
+assert.doesNotMatch(
+  ciWorkflow,
+  /\n\s{2}dist-binaries:\n[\s\S]+?Build dist-fast binaries[\s\S]+?scripts\/ci\/github-suite\.sh dist-binaries/,
+  "dist-binaries must not compile directly on the 32 GiB Cloud Run runner; cold or stale target restores can SIGKILL the runner before logs are persisted",
+);
+
+assert.match(
+  ciWorkflow,
   /\n\s{2}ci-summary:\n[\s\S]+?needs:[\s\S]+?- unit\s*\n\s+- unit-checker-integration[\s\S]+?required\.update\(\{"dist-binaries", "unit", "unit-checker-integration"\}\)/,
   "CI Summary should require both the Cloud Run unit slice and checker integration heavy slice",
 );

--- a/scripts/cloudbuild/cloudbuild-dist-binaries.yaml
+++ b/scripts/cloudbuild/cloudbuild-dist-binaries.yaml
@@ -1,0 +1,93 @@
+# Cloud Build config for the required dist-fast artifact.
+#
+# `dist-binaries` used to compile directly on the 32 GiB Cloud Run-backed
+# GitHub runner. During cache outages that runner rebuilt from a cold target dir
+# and was SIGKILLed before GitHub could persist step logs, leaving the required
+# `CI Summary` red with only the no-log timeout signature (#14948). Keep the
+# GitHub job as the artifact publisher, but do the Rust compile on the same
+# 128 GiB highmem pool used by the linker-heavy unit exceptions.
+
+substitutions:
+  _DIST_FAST_ARTIFACT_URI: gs://tsz-ci_cloudbuild/dist-fast-binaries/manual-dist-fast-binaries.tar
+  _GITHUB_SHA: unknown
+
+steps:
+  - id: dist-binaries
+    name: gcr.io/google.com/cloudsdktool/google-cloud-cli:slim
+    env:
+      - 'CARGO_BUILD_JOBS=32'
+      - 'CARGO_INCREMENTAL=0'
+      - 'RUST_MIN_STACK=16777216'
+      - 'CARGO_TERM_COLOR=always'
+      - 'CI=true'
+      - 'GITHUB_ACTIONS=true'
+      - 'GITHUB_WORKSPACE=/home/runner/_work/tsz/tsz'
+      - 'TSZ_CI_SUITE=dist-binaries'
+      - '_TSZ_CI_SUITE=dist-binaries'
+      - 'TSZ_CI_SKIP_HOST_APT=1'
+      - 'TSZ_CI_DISABLE_SCCACHE=1'
+      - 'TSZ_CI_CACHE_SAVE=0'
+      - 'TSZ_CI_CACHE_SAVE_CARGO_TARGETS=0'
+      - 'TSZ_CI_CACHE_REFRESH_WORKSPACE_RLIBS=0'
+      - 'TSZ_CI_CACHE_BUCKET=gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache'
+      - '_TSZ_CI_CACHE_BUCKET=gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache'
+      - 'GITHUB_SHA=${_GITHUB_SHA}'
+      - 'COMMIT_SHA=${_GITHUB_SHA}'
+      - '_DIST_FAST_ARTIFACT_URI=${_DIST_FAST_ARTIFACT_URI}'
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      export PATH="$HOME/.cargo/bin:/usr/local/cargo/bin:$PATH"
+
+      apt-get update -qq
+      apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        gzip \
+        jq \
+        pkg-config \
+        tar
+
+      if ! command -v cargo >/dev/null 2>&1; then
+        curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain stable
+      fi
+
+      cargo --version
+      rustc --version
+      gcloud config set pass_credentials_to_gsutil true >/dev/null
+
+      # `dist-binaries` artifacts are consumed by GitHub Actions shards. Build
+      # from the same workspace path those shards use so compile-time path
+      # fallbacks (for example `CARGO_MANIFEST_DIR`) do not point at Cloud
+      # Build-only `/workspace` paths when the binaries run in Actions.
+      mkdir -p "$GITHUB_WORKSPACE" /home/runner/_work/_temp
+      tar -C /workspace -cf - . | tar -C "$GITHUB_WORKSPACE" -xf -
+      cd "$GITHUB_WORKSPACE"
+
+      # Cloud Build source archives do not include `.git`. Create a cheap
+      # source-only commit before cache restore so later git probes do not run
+      # `git add -A` across restored multi-GB target/cache directories.
+      git init --quiet
+      git config user.email "cloud-build@tsz-ci.iam.gserviceaccount.com"
+      git config user.name "Cloud Build"
+      git add -A
+      git commit -q -m "cloud build source snapshot"
+
+      scripts/ci/github-suite.sh dist-binaries
+      tar -C .target/dist-fast -cf dist-fast-binaries.tar \
+        tsz \
+        tsz-lsp \
+        tsz-server \
+        tsz-conformance \
+        generate-tsc-cache
+      gsutil -q cp dist-fast-binaries.tar "${_DIST_FAST_ARTIFACT_URI}"
+
+options:
+  pool:
+    name: projects/tsz-ci/locations/us-central1/workerPools/tsz-ci-build-pool-highmem
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: 2700s


### PR DESCRIPTION
Goal: hold

Fixes #14948.

## Summary
- Activate `SCCACHE_GCS_KEY_JSON` with `gcloud` before `gsutil` cache restore/save.
- Run the same auth bridge in full CI before suite-level GCS artifact transfers.
- Move the required `dist-binaries` compile off the 32 GiB Cloud Run runner and onto the existing highmem Cloud Build pool, then publish the same `dist-fast-binaries` GitHub artifact for downstream suites.
- Clear the PR-head conformance drift by removing the stale accepted-regression block and aligning the affected semantic paths with `tsc`.

## Root Cause
The failing CI path wrote the service account JSON to `GOOGLE_APPLICATION_CREDENTIALS` but then invoked Cloud SDK `gsutil`. In the witness logs, `gsutil` fell through to anonymous GCS reads; the bucket policy already includes object-admin access for the expected runner service account, so the fix makes the key the active `gcloud` account and passes it to `gsutil`.

After auth was fixed and the exact target cache blob was seeded, `dist-binaries` still reproduced the no-log runner-loss failure at ~16 minutes when compiling directly on the Cloud Run runner. That remaining failure is the fragile compile surface from #14948, so the dist artifact is now built on the 128 GiB highmem Cloud Build pool while the GitHub job only orchestrates and uploads the small artifact.

## Compiler Parity Notes
- Structural rule: when a CommonJS namespace export is contextually related to an interface property typed with `typeof ImportedClass`, `tsc` resolves the `typeof` target through the value/constructor side; tsz now routes `TypeQuery` relation through the resolver's `resolve_type_query` owner path.
- Getter rule: an object-literal getter without an annotation reports TS7023 when its return expression reads an absent member through `this`, an alias of `this`, or the object binding, but not when it reads an existing sibling or an unrelated receiver.
- Adjacent matrix: alias usage, constructor-signature type argument inference, enum/keyof/type-parameter TS2367 display, getter alias/missing/existing sibling, and the stale accepted-regression rows.
- Fallback: no identifier, filename, fixture-name, or rendered-message hardcoding; shape checks stay behind resolver/query-boundary helpers where checker code needs semantic facts.

## Verification
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli -p tsz-conformance`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test object_literal_getter_self_reference_ts7023_tests this_alias_missing_member_self_reference_still_reports missing_this_member_in_getter_return_still_reports existing_this_member_in_getter_return_is_clean`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib ts2367_preserves_literal_against_constrained_type_parameter ts2367_preserves_literal_against_enum_and_keyof_operands`
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter aliasUsage --verbose`
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter accessorInferredReturnTypeErrorInReturnStatement --verbose`
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter compareTypeParameterConstrainedByLiteralToLiteral --verbose`
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter equalityWithEnumTypes --verbose`
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter stringLiteralsWithEqualityChecks --verbose`
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter exhaustiveSwitchStatements1 --verbose`
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter discriminatedUnionTypes4 --verbose`
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter typeArgumentInferenceConstructSignatures --timeout 240 --verbose`
- `node scripts/ci/test-gcp-cache-auth.mjs`
- `node scripts/ci/test-pr-ready-state.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `bash -n scripts/ci/gcp-full-ci.sh scripts/ci/gcp-cache.sh scripts/ci/cloudbuild-submit.sh`
- `ruby -ryaml -e '[".github/workflows/ci.yml", "scripts/cloudbuild/cloudbuild-dist-binaries.yaml"].each { |path| YAML.load_file(path); puts "#{path}: ok" }'`
- `git diff --check`
- Cloud Build seed `3901ee21-d04a-4876-a89f-17ec4e8799ea`: published exact `cargo-target-deps` blob for the PR-head cache key (`10.04 GiB`).

## Provenance
Machine: Mohsens-MacBook-Pro.local
Assistant: codex
Model: gpt-5
Effort: high
