### PR TITLE
fix(checker): reduce deep nested generic indexed access to apparent base before TS2536 key check

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -583,6 +583,9 @@ mod ts2536_deferred_conditional_indexed_access_tests;
 #[path = "tests/ts2536_error_type_contagion_tests.rs"]
 mod ts2536_error_type_contagion_tests;
 #[cfg(test)]
+#[path = "tests/ts2536_nested_generic_indexed_access_constraint_tests.rs"]
+mod ts2536_nested_generic_indexed_access_constraint_tests;
+#[cfg(test)]
 #[path = "../tests/ts2540_readonly_tests.rs"]
 mod ts2540_readonly_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/ts2536_nested_generic_indexed_access_constraint_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2536_nested_generic_indexed_access_constraint_tests.rs
@@ -1,0 +1,141 @@
+//! Regression coverage for TS2536 on *arbitrarily-deep* generic indexed accesses
+//! into a concrete object base: `T[K1][K2][K3]…` where each `Ki` is a type
+//! parameter constrained to the appropriate level's key space.
+//!
+//! tsc validates the outer key against the apparent type of the deferred base
+//! (`getApparentType` / `getConstraintOfIndexedAccessType`): every reachable type
+//! parameter is reduced to its constraint and the access is evaluated, so the
+//! base carries a concrete key space even while staying syntactically deferred.
+//! The single-level recovery only fired when the access *base* was itself a type
+//! parameter (`K[idx]`); a nested access such as `T[K1][K2]` has an indexed-access
+//! base, so prior to this fix its key space stayed deferred and a literal outer
+//! key — e.g. `K3 extends keyof T[keyof T][keyof T[keyof T]]`, which reduces to a
+//! concrete literal — could not be validated, yielding a spurious TS2536. This is
+//! the depth-≥3 generalization of the depth-2 #13720 recovery, surfaced by the
+//! valibot/kysely cross-arena families (#13212).
+//!
+//! Binder names vary across cases so no fixture/identifier string drives the
+//! decision; a genuinely-missing key still emits TS2536 (the negative cases).
+
+use crate::test_utils::check_source_codes;
+
+/// Depth-3 access whose K-constraints are rooted at `keyof T` over a multi-key
+/// (union-valued) base — the original false positive. tsc is clean.
+#[test]
+fn depth3_keyof_t_rooted_union_base_does_not_emit_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Registry = { alpha: { inner: { leaf: 1 } }; beta: { inner: { leaf: 2 } } };
+type Get<
+  A extends keyof Registry,
+  B extends keyof Registry[keyof Registry],
+  C extends keyof Registry[keyof Registry][keyof Registry[keyof Registry]],
+> = Registry[A][B][C];
+type Probe = Get<"alpha", "inner", "leaf">;
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "TS2536 should not fire for `Registry[A][B][C]` rooted at `keyof Registry`: {codes:?}"
+    );
+}
+
+/// Depth-3 access whose K-constraints are rooted at the `K1` chain
+/// (`keyof T[K1]`) over a multi-key base. tsc is clean.
+#[test]
+fn depth3_k_chain_rooted_union_base_does_not_emit_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Shape = { left: { mid: { tip: 1 } }; right: { mid: { tip: 2 } } };
+type Pick3<
+  P extends keyof Shape,
+  Q extends keyof Shape[P],
+  R extends keyof Shape[P][Q],
+> = Shape[P][Q][R];
+type Out = Pick3<"left", "mid", "tip">;
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "TS2536 should not fire for `Shape[P][Q][R]` rooted at the `P` chain: {codes:?}"
+    );
+}
+
+/// Depth-4 access — the reduction must follow the full chain, not a fixed depth.
+#[test]
+fn depth4_nested_indexed_access_does_not_emit_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Tree = { root: { branch: { twig: { leaf: 1 } } } };
+type Reach<
+  W extends keyof Tree,
+  X extends keyof Tree[W],
+  Y extends keyof Tree[W][X],
+  Z extends keyof Tree[W][X][Y],
+> = Tree[W][X][Y][Z];
+type Leaf = Reach<"root", "branch", "twig", "leaf">;
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "TS2536 should not fire for depth-4 `Tree[W][X][Y][Z]`: {codes:?}"
+    );
+}
+
+/// Multiple valid leaf keys at depth 3: indexing by a different-but-valid key
+/// stays clean.
+#[test]
+fn depth3_multi_key_leaf_does_not_emit_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Catalog = { one: { slot: { keep: 1; drop: 2 } }; two: { slot: { keep: 3; drop: 4 } } };
+type Read<
+  H extends keyof Catalog,
+  I extends keyof Catalog[keyof Catalog],
+  J extends keyof Catalog[keyof Catalog][keyof Catalog[keyof Catalog]],
+> = Catalog[H][I][J];
+type Kept = Read<"one", "slot", "drop">;
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "TS2536 should not fire when the leaf key is a valid member: {codes:?}"
+    );
+}
+
+/// Negative: a leaf key outside the apparent key space must still emit TS2536,
+/// matching tsc. The reduction validates against the real apparent type, so it
+/// cannot mask a genuinely-missing key.
+#[test]
+fn depth3_bogus_leaf_key_emits_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Store = { up: { mid: { only: 1 } }; down: { mid: { only: 2 } } };
+type Bad<
+  M extends keyof Store,
+  N extends keyof Store[keyof Store],
+  O extends "absent",
+> = Store[M][N][O];
+"#,
+    );
+    assert!(
+        codes.contains(&2536),
+        "TS2536 must still fire for a leaf key absent from the apparent type: {codes:?}"
+    );
+}
+
+/// Negative: a concrete literal leaf key that is not a member of the depth-3
+/// apparent type must still emit TS2536.
+#[test]
+fn depth3_concrete_missing_literal_emits_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type Graph = { n0: { edge: { weight: 1 } } };
+type Weight<S extends keyof Graph, T extends keyof Graph[S]> = Graph[S][T]["missing"];
+"#,
+    );
+    assert!(
+        codes.contains(&2536),
+        "TS2536 must still fire for a concrete missing literal at depth 3: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -19,6 +19,18 @@ use indexed_access_helpers::{
     same_type_param_name,
 };
 
+/// Default-on; `TSZ_DISABLE_NESTED_INDEXED_ACCESS_CONSTRAINT_REDUCTION=1` is the
+/// kill switch for the arbitrarily-deep deferred-indexed-access base-constraint
+/// reduction in [`CheckerState::check_indexed_access_type`]. The env read is
+/// cached so the (hot) per-indexed-access-node check is a plain bool load.
+fn nested_indexed_access_constraint_reduction_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        !std::env::var("TSZ_DISABLE_NESTED_INDEXED_ACCESS_CONSTRAINT_REDUCTION")
+            .is_ok_and(|v| v == "1")
+    })
+}
+
 impl<'a> CheckerState<'a> {
     /// Check if two AST nodes have the same text representation.
     fn nodes_have_same_text(&self, a: NodeIndex, b: NodeIndex) -> bool {
@@ -646,21 +658,53 @@ impl<'a> CheckerState<'a> {
                 self.ctx.types,
                 object_type_for_check,
             )
-            && let Some(base_constraint) =
+        {
+            if let Some(base_constraint) =
                 crate::query_boundaries::common::type_parameter_constraint(
                     self.ctx.types,
                     base_object_type,
                 )
-        {
-            let constrained_access = self
-                .ctx
-                .types
-                .factory()
-                .index_access(base_constraint, access_index_type);
-            let evaluated_constrained_access =
-                self.evaluate_type_for_assignability(constrained_access);
-            if evaluated_constrained_access != TypeId::ERROR {
-                object_type_for_check = evaluated_constrained_access;
+            {
+                // Single-level `K[idx]`: the access base is itself a type
+                // parameter, so substitute its constraint and evaluate.
+                let constrained_access = self
+                    .ctx
+                    .types
+                    .factory()
+                    .index_access(base_constraint, access_index_type);
+                let evaluated_constrained_access =
+                    self.evaluate_type_for_assignability(constrained_access);
+                if evaluated_constrained_access != TypeId::ERROR {
+                    object_type_for_check = evaluated_constrained_access;
+                }
+            } else if nested_indexed_access_constraint_reduction_enabled() {
+                // Arbitrarily-deep deferred indexed access (`T[K1][K2][K3]…`):
+                // the access base is itself an indexed access, not a bare type
+                // parameter, so the single-level branch above does not apply and
+                // the key space stays deferred. A literal outer key — e.g.
+                // `T[K1][K2][K3]` with `K3 extends keyof T[keyof T][keyof
+                // T[keyof T]]`, which reduces to a concrete literal — then cannot
+                // be validated, yielding a spurious TS2536 (the depth-≥3
+                // generalization of the depth-2 #13720 recovery). Reduce every
+                // reachable type parameter to its constraint and evaluate,
+                // mirroring tsc's `getApparentType` /
+                // `getConstraintOfIndexedAccessType`; full parameter substitution
+                // leaves no free parameters, so the result is the concrete
+                // apparent base. It is used only for key-space validation here —
+                // `object_type` keeps the original surface for diagnostics, and a
+                // genuinely-missing key still fails the relation below, so a real
+                // TS2536 is preserved.
+                let reduced =
+                    crate::query_boundaries::type_computation::complex::instantiate_type_params_to_constraints(
+                        self.ctx.types,
+                        object_type_for_check,
+                    );
+                if reduced != object_type_for_check {
+                    let evaluated = self.evaluate_type_for_assignability(reduced);
+                    if evaluated != TypeId::ERROR && evaluated != TypeId::ANY {
+                        object_type_for_check = evaluated;
+                    }
+                }
             }
         }
         if crate::query_boundaries::common::is_generic_application(


### PR DESCRIPTION
## Summary

`T[K1][K2][K3]…` — a nested **generic** indexed access whose `Ki` are type
parameters each constrained to that level's key space — emitted a spurious
**TS2536** (`'K3' cannot be used to index type 'T[K1][K2]'`) when the base
carried union-valued members and the `K`-constraints were rooted at `keyof T`.
`tsc` accepts these.

Minimal witness (tsc-clean; tsz emitted a false TS2536 before this change):

```ts
type T = { a: { x: { p: 1 } }; b: { x: { p: 2 } } };
type G<
  K1 extends keyof T,
  K2 extends keyof T[keyof T],
  K3 extends keyof T[keyof T][keyof T[keyof T]],
> = T[K1][K2][K3];
```

## Structural rule

When a generic indexed-access **base** is itself a deferred indexed access
(`T[K1][K2]`), `tsc` validates the outer key against the base's *apparent type*
(`getApparentType` / `getConstraintOfIndexedAccessType`): every reachable type
parameter is reduced to its constraint and the access is evaluated, so the base
exposes a concrete key space even while staying syntactically deferred. tsz's
`check_indexed_access_type` only reduced an indexed-access base whose own base is
a bare type parameter (`K[idx]`, the depth-2 #13720 recovery); a nested access
has an indexed-access base, so its key space stayed deferred and a concrete outer
key (here `K3 extends keyof T[keyof T][keyof T[keyof T]]`, which reduces to the
literal `"p"`) could not be validated → false TS2536.

## Owner layer

Checker — `crates/tsz-checker/src/types/type_checking/indexed_access.rs`
(`check_indexed_access_type`). When `object_type_for_check` is still a deferred
indexed access containing type parameters, reduce every reachable parameter to
its constraint via the existing solver query boundary
`instantiate_type_params_to_constraints` and evaluate. Depth-independent
(verified through depth 4). The reduced form is used **only** for key-space
validation; `object_type` keeps the original diagnostic surface, and a
genuinely-missing key still fails the relation, so a real TS2536 is preserved.
No raw solver internals are pattern-matched — only query-boundary helpers are
called, per the architecture rule.

## Adjacent matrix (all match `tsc`)

- Positive: depth-3 rooted at `keyof T`, depth-3 rooted at the `K1` chain,
  depth-4, multi-key leaf — no TS2536.
- Negative (TS2536 preserved): leaf key outside the apparent key space
  (`K3 extends "absent"`), concrete missing literal at depth 3
  (`T[K1][K2]["missing"]`).
- Unchanged: depth-2 (`T[K1][K2]`), single-key base, single-level `T[K]`,
  index-signature base, mapped-type `T[K]`.

Behind kill switch `TSZ_DISABLE_NESTED_INDEXED_ACCESS_CONSTRAINT_REDUCTION=1`.

Surfaced by the valibot/kysely cross-arena indexed-access families (#13212).

Goal: green

## Verification

- New regression suite (6 tests, binder names varied per the anti-hardcoding
  gate): `cargo test -p tsz-checker --lib ts2536_nested_generic` — 6 passed.
- Differential vs `tsc` 6.0.2 on the positive/negative/adjacent matrix above —
  exact parity.
- Kill-switch verified: witness regresses to the false TS2536 with
  `TSZ_DISABLE_NESTED_INDEXED_ACCESS_CONSTRAINT_REDUCTION=1`.
- `cargo clippy -p tsz-checker --lib` — 0 warnings.
- Targeted suites `ts2536` / `indexed_access` / `keyof` show no new failures;
  the two pre-existing failures (`mapped_type_generic_indexed_access_class_member`,
  `keyof_keeps_computed_unique_like_string_property_as_string_key`) reproduce on
  clean `main` and with the kill switch on — main-baseline drift, not this PR.
- Full conformance/emit/project-compile gates owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_0114gK94nE6bgHfJSFkzKZws)_