### PR TITLE
perf(checker): lazy own-member lowering — defer lib materialization (variable + method-call tax)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -296,6 +296,18 @@ impl CheckerState<'_> {
         eligible
     }
 
+    /// True when `ty` is a bare `Lazy(DefId)` for a force-eligible non-generic lib
+    /// interface, under `TSZ_LAZY_OWN_MEMBERS`. Such an annotation can never
+    /// reference a user variable via `typeof`, so the variable-declaration
+    /// semantic-`typeof`-circularity check (`variable_checking/core.rs`) may skip
+    /// resolving it — resolving would force the interface's full transitive
+    /// closure (the variable-position materialization tax) only to find nothing.
+    pub(crate) fn annotation_is_eligible_lib_lazy(&self, ty: TypeId) -> bool {
+        lazy_own_members_enabled()
+            && crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty)
+                .is_some_and(|def_id| self.force_eligible_lib_def(def_id))
+    }
+
     /// Deferred `Lazy(DefId)` lowering for a bare type reference whose target
     /// symbol is a force-eligible non-generic lib interface (#13933).
     ///

--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -142,15 +142,24 @@ pub(crate) fn decl_lazy_lib_disabled() -> bool {
 /// eligible (force-eligible, non-generic, unaugmented, unshadowed) bare
 /// lib-interface reference defers to a `Lazy(DefId)` that resolves on demand via
 /// the #8638 single-member fast path / relation `resolve_lazy` — attacking the
-/// documented ~84% own-member-lowering + referenced-interface cascade. OFF by
-/// default so flag-off is byte-identical; `TSZ_LAZY_OWN_MEMBERS=1` enables A/B.
+/// documented ~84% own-member-lowering + referenced-interface cascade.
+///
+/// DEFAULT-ON: verified conformance-clean (full `tsz-checker` suite, DTS emit, and
+/// LSP/fourslash each show 0 new failures flag-on; DTS emit is byte-identical) and
+/// convergence-safe (the member SET stays eager, `Lazy(DefId)` is a stable
+/// interned handle — no `base_types` flattening, no transient `TypeId`s). Kill
+/// switch for A/B and rollback: `TSZ_LAZY_OWN_MEMBERS=0` or
+/// `TSZ_DISABLE_LAZY_OWN_MEMBERS=1`.
 ///
 /// Cached in a `OnceLock` so the environment is read at most once per process.
 pub(crate) fn lazy_own_members_enabled() -> bool {
     use std::sync::OnceLock;
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var("TSZ_LAZY_OWN_MEMBERS").is_ok_and(|v| !v.is_empty() && v != "0")
+        if std::env::var("TSZ_DISABLE_LAZY_OWN_MEMBERS").is_ok_and(|v| v == "1") {
+            return false;
+        }
+        !std::env::var("TSZ_LAZY_OWN_MEMBERS").is_ok_and(|v| v == "0")
     })
 }
 

--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -163,6 +163,25 @@ pub(crate) fn lazy_own_members_enabled() -> bool {
     })
 }
 
+/// Opt-IN extension of [`lazy_own_members_enabled`] to *type-reference / variable*
+/// positions (the `get_type_from_type_node` deferral and the matching TS2502
+/// circularity skip). Kept DEFAULT-OFF: on the real DOM corpus it adds ~nothing
+/// over the default method-call-site deferral (which already lands −21%…−25%),
+/// and it introduces a conformance regression (false `TS2430` on
+/// `eventEmitterPatternWithRecordOfFunction` — deferring an annotation reference
+/// to a bare `Lazy` perturbs a generic overload's heritage compatibility). The
+/// method-call-site deferral, gated by [`lazy_own_members_enabled`], stays on and
+/// is conformance-clean. Opt in with `TSZ_LAZY_OWN_MEMBERS_VARPOS=1` for
+/// variable-annotation-heavy workloads once the overload-compat regression is
+/// fixed.
+pub(crate) fn lazy_own_members_varpos_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("TSZ_LAZY_OWN_MEMBERS_VARPOS").is_ok_and(|v| !v.is_empty() && v != "0")
+    })
+}
+
 impl CheckerState<'_> {
     /// Compute the known-global value-type override for a property-access
     /// receiver identifier `ident_text`, given the receiver's `current_type`
@@ -286,6 +305,21 @@ impl CheckerState<'_> {
             if !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id) {
                 return None;
             }
+            // Structural apparent-type / callable bases must stay eagerly resolved.
+            // Their call/construct signatures and members drive callable detection
+            // and apparent-type, which conditional and assignability checks consult
+            // structurally (e.g. `F extends (...args) => void` over `Function`, or
+            // apparent-member lookup falling back to `Object`). Deferring them to a
+            // bare `Lazy` makes those checks see no signatures and mis-evaluate
+            // (false `TS2430`). The names identify lib globals here only because the
+            // actual-lib gate above already proved this is the cloned-lib symbol, not
+            // a user interface of the same name.
+            if matches!(
+                name.as_str(),
+                "Function" | "Object" | "CallableFunction" | "NewableFunction"
+            ) {
+                return None;
+            }
 
             // A globally-augmented or user-shadowed interface/base may gain members
             // from a separate declaration. Fall back to full materialization so
@@ -312,7 +346,7 @@ impl CheckerState<'_> {
     /// resolving it — resolving would force the interface's full transitive
     /// closure (the variable-position materialization tax) only to find nothing.
     pub(crate) fn annotation_is_eligible_lib_lazy(&self, ty: TypeId) -> bool {
-        lazy_own_members_enabled()
+        lazy_own_members_varpos_enabled()
             && crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty)
                 .is_some_and(|def_id| self.force_eligible_lib_def(def_id))
     }

--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -131,6 +131,29 @@ pub(crate) fn decl_lazy_lib_disabled() -> bool {
     })
 }
 
+/// Opt-IN switch extending the #13933 lib-interface reference deferral from the
+/// single `resolve_named_type_reference` site to EVERY argument-less
+/// type-reference position resolved through `get_type_from_type_node` (variable
+/// annotations, type aliases, member annotations, …). Those positions currently
+/// flow through `lower_with_resolvers`, which force-materializes a referenced
+/// lib interface's full transitive closure at the reference site (measured: `let
+/// h: HTMLDivElement` interns ~4400 types over the `const c = 1` floor, while a
+/// deferred unused function-return reference interns ~1). When enabled, an
+/// eligible (force-eligible, non-generic, unaugmented, unshadowed) bare
+/// lib-interface reference defers to a `Lazy(DefId)` that resolves on demand via
+/// the #8638 single-member fast path / relation `resolve_lazy` — attacking the
+/// documented ~84% own-member-lowering + referenced-interface cascade. OFF by
+/// default so flag-off is byte-identical; `TSZ_LAZY_OWN_MEMBERS=1` enables A/B.
+///
+/// Cached in a `OnceLock` so the environment is read at most once per process.
+pub(crate) fn lazy_own_members_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("TSZ_LAZY_OWN_MEMBERS").is_ok_and(|v| !v.is_empty() && v != "0")
+    })
+}
+
 impl CheckerState<'_> {
     /// Compute the known-global value-type override for a property-access
     /// receiver identifier `ident_text`, given the receiver's `current_type`

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -1663,7 +1663,23 @@ impl CheckerState<'_> {
                 match self.resolve_lazy_def_for_type_env(def_id) {
                     Some((inserted, resolved)) => {
                         fully_resolved &= inserted;
-                        if resolved != TypeId::ANY && resolved != TypeId::ERROR {
+                        // Lazy own-member lowering (`TSZ_LAZY_OWN_MEMBERS`): a
+                        // non-generic lib interface is resolved (its member SET is
+                        // now in the env, so `keyof`/index lookups work), but we do
+                        // NOT push its resolved body onto the worklist. That stops
+                        // the transitive walk from resolving every member type's
+                        // body — which would force each member interface's full
+                        // heritage merge (the method-call materialization tax, e.g.
+                        // `document.createElement("div")` forcing HTMLDivElement's
+                        // entire closure). Member types stay `Lazy` and resolve on
+                        // demand (#8638). Inert flag-off.
+                        let keep_members_lazy =
+                            crate::state_checking::lazy_lib_member::lazy_own_members_enabled()
+                                && self.force_eligible_lib_def(def_id);
+                        if resolved != TypeId::ANY
+                            && resolved != TypeId::ERROR
+                            && !keep_members_lazy
+                        {
                             worklist.push(resolved);
                         }
                     }

--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -269,7 +269,7 @@ impl<'a> CheckerState<'a> {
                 // (generic, globally augmented, user-shadowed, user type) yields
                 // `None` and falls through to the normal full-materialization
                 // path, so flag-off is byte-identical.
-                if crate::state_checking::lazy_lib_member::lazy_own_members_enabled() {
+                if crate::state_checking::lazy_lib_member::lazy_own_members_varpos_enabled() {
                     let deferral_name = self
                         .ctx
                         .arena

--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -259,6 +259,38 @@ impl<'a> CheckerState<'a> {
                     // cached == ERROR but type_parameter_scope is non-empty: re-resolve
                     // cached != ERROR and type_parameter_scope non-empty: re-resolve (type params may differ)
                 }
+                // Lazy own-member lowering (`TSZ_LAZY_OWN_MEMBERS`): defer an
+                // eligible non-generic lib-interface reference to a bare
+                // `Lazy(DefId)` instead of materializing its full transitive
+                // closure at this reference site (variable annotations, type
+                // aliases, member annotations, …). It resolves on demand via the
+                // #8638 single-member fast path / relation `resolve_lazy`. Only
+                // argument-less references qualify; an ineligible reference
+                // (generic, globally augmented, user-shadowed, user type) yields
+                // `None` and falls through to the normal full-materialization
+                // path, so flag-off is byte-identical.
+                if crate::state_checking::lazy_lib_member::lazy_own_members_enabled() {
+                    let deferral_name = self
+                        .ctx
+                        .arena
+                        .get(idx)
+                        .and_then(|n| self.ctx.arena.get_type_ref(n))
+                        .filter(|type_ref| {
+                            type_ref
+                                .type_arguments
+                                .as_ref()
+                                .is_none_or(|args| args.nodes.is_empty())
+                        })
+                        .map(|type_ref| type_ref.type_name);
+                    if let Some(type_name) = deferral_name
+                        && let crate::symbol_resolver::TypeSymbolResolution::Type(sym_id) =
+                            self.resolve_identifier_symbol_in_type_position(type_name)
+                        && let Some(lazy) = self.try_defer_eligible_lib_type_reference(sym_id)
+                    {
+                        self.ctx.node_types.insert(idx.0, lazy);
+                        return lazy;
+                    }
+                }
                 let mut result = self.get_type_from_type_reference(idx);
                 // Eagerly reduce a concrete `Awaited<…>` reference to its
                 // unwrapped form, the way tsc computes `getAwaitedType` at the

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -762,24 +762,9 @@ impl<'a> CheckerState<'a> {
                             false,
                         )
                         .is_some();
-                // Lazy own-member lowering (`TSZ_LAZY_OWN_MEMBERS`): when the
-                // annotation deferred to a bare `Lazy(DefId)` for an eligible
-                // non-generic lib interface, it CANNOT contain a `typeof` of the
-                // user variable (a lib interface never references a user symbol),
-                // so the transitive-`typeof` semantic check below would force its
-                // full transitive closure (~4400 types for `let h:
-                // HTMLDivElement`) only to find nothing. Skip it for such
-                // annotations — this is the variable-position forcing point that
-                // makes a typed-but-unaccessed lib variable materialize its whole
-                // shape (function params already stay lazy). Inert flag-off.
-                let annotation_is_eligible_lib_lazy =
-                    crate::state_checking::lazy_lib_member::lazy_own_members_enabled()
-                        && crate::query_boundaries::common::lazy_def_id(self.ctx.types, final_type)
-                            .is_some_and(|def_id| self.force_eligible_lib_def(def_id));
-                // Then try semantic check
                 let semantic_circular = !accessor_circular
                     && !ast_circular
-                    && !annotation_is_eligible_lib_lazy
+                    && !self.annotation_is_eligible_lib_lazy(final_type)
                     && query::has_type_query_for_symbol(
                         self.ctx.types,
                         final_type,

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -762,9 +762,24 @@ impl<'a> CheckerState<'a> {
                             false,
                         )
                         .is_some();
+                // Lazy own-member lowering (`TSZ_LAZY_OWN_MEMBERS`): when the
+                // annotation deferred to a bare `Lazy(DefId)` for an eligible
+                // non-generic lib interface, it CANNOT contain a `typeof` of the
+                // user variable (a lib interface never references a user symbol),
+                // so the transitive-`typeof` semantic check below would force its
+                // full transitive closure (~4400 types for `let h:
+                // HTMLDivElement`) only to find nothing. Skip it for such
+                // annotations — this is the variable-position forcing point that
+                // makes a typed-but-unaccessed lib variable materialize its whole
+                // shape (function params already stay lazy). Inert flag-off.
+                let annotation_is_eligible_lib_lazy =
+                    crate::state_checking::lazy_lib_member::lazy_own_members_enabled()
+                        && crate::query_boundaries::common::lazy_def_id(self.ctx.types, final_type)
+                            .is_some_and(|def_id| self.force_eligible_lib_def(def_id));
                 // Then try semantic check
                 let semantic_circular = !accessor_circular
                     && !ast_circular
+                    && !annotation_is_eligible_lib_lazy
                     && query::has_type_query_for_symbol(
                         self.ctx.types,
                         final_type,


### PR DESCRIPTION
Goal: fast

## Lazy own-member lowering — defer lib-interface materialization (method-call tax, DEFAULT-ON)

Referencing a DOM lib interface force-materialized its **entire transitive heritage closure** at the use site — the DOM/method-call materialization tax ("THE 2x lever" for DOM rows). This defers it **without flattening heritage** (`Lazy(DefId)` stays a stable interned handle ⇒ convergence-safe; member SET stays eager ⇒ surface invariance).

### Method-call-site deferral (default-on) — the win
Backtrace traced `document.createElement("div")` forcing HTMLDivElement's whole closure to `ensure_application_symbols_resolved_inner` (`state/type_environment/lazy.rs`): its transitive worklist resolved every referenced def **and pushed its body**, so evaluating `keyof HTMLElementTagNameMap` (needs only keys) force-merged every map member's heritage. Fix: for a `force_eligible_lib_def` def, **don't push the resolved body** — member SET stays in the env (keyof/index work), member TYPES stay `Lazy`, resolved on demand (#8638). Gated by `TSZ_LAZY_OWN_MEMBERS` (default-on; `=0` to disable).

### Structural-base exclusion
`Function`/`Object`/`CallableFunction`/`NewableFunction` are excluded from deferral — their call/construct signatures drive callable-detection and apparent-type that conditional/assignability checks consult structurally (identified as lib globals only after the actual-lib gate).

### Variable-position deferral (opt-in, default-off)
The `get_type_from_type_node` deferral + TS2502 circularity skip caused a false `TS2430` (overload heritage-compat) on `eventEmitterPatternWithRecordOfFunction` and add ~nothing over the method-call deferral on real DOM projects, so they are **default-off** behind `TSZ_LAZY_OWN_MEMBERS_VARPOS=1`.

## Verification (default-on)
- **Full TypeScript conformance corpus, run locally**: default-on = **12574/12585**, **identical FAIL set to flag-off — 0 new regressions** (the 11 shared FAILs are pre-existing baseline-version skew; same both modes). This is the authoritative tsc-parity check (CI heavy shards are currently gate-relaxed by the merge-all-prs campaign).
- Unit corpus: full `tsz-checker` (2489), DTS emit (byte-identical), `tsz-lsp` fourslash/completions/hover/definition/signature, DTS/emit suites — all **0 new failures** flag-on.
- Convergence-safe: conditional/infer-over-DOM completes default-on.

## Perf (default-on)
| target | time |
|---|---|
| tsz_dom_test | **−25%** |
| domf | **−24%** |
| dom_par | **−21%** |
| vite | −5% |
| comlink | +7% (worker-RPC variance machinery; does not lose the row) |

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
