### PR TITLE
fix(checker): substitute new.target in TS17013 instead of leaking {0} placeholder

### DIFF
--- a/crates/tsz-checker/src/dispatch/mod.rs
+++ b/crates/tsz-checker/src/dispatch/mod.rs
@@ -1409,7 +1409,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
             }
             // MetaProperty: `new.target` (import.meta is parsed as PROPERTY_ACCESS_EXPRESSION)
             k if k == syntax_kind_ext::META_PROPERTY => {
-                use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+                use crate::diagnostics::diagnostic_codes;
                 use tsz_parser::parser::syntax_kind_ext::{
                     CONSTRUCTOR, FUNCTION_DECLARATION, FUNCTION_EXPRESSION,
                 };
@@ -1429,10 +1429,18 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                     )
                 });
                 if invalid_context {
-                    self.checker.error_at_node(
+                    // Route through the substituting emitter so the `{0}`
+                    // placeholder is filled with the meta-property's canonical
+                    // text rather than leaked verbatim (#14840). A `META_PROPERTY`
+                    // node is only ever produced for `new.<name>` (the parser
+                    // lowers `import.meta` to a `PROPERTY_ACCESS_EXPRESSION`), and
+                    // tsc's `checkNewTargetMetaProperty` always reports the
+                    // canonical `new.target` here — even for a misspelled name
+                    // like `new.foo`.
+                    self.checker.error_at_node_msg(
                         idx,
-                        diagnostic_messages::META_PROPERTY_IS_ONLY_ALLOWED_IN_THE_BODY_OF_A_FUNCTION_DECLARATION_FUNCTION_EXP,
                         diagnostic_codes::META_PROPERTY_IS_ONLY_ALLOWED_IN_THE_BODY_OF_A_FUNCTION_DECLARATION_FUNCTION_EXP,
+                        &["new.target"],
                     );
                     return TypeId::ANY;
                 }

--- a/crates/tsz-checker/tests/new_expression_regression_tests.rs
+++ b/crates/tsz-checker/tests/new_expression_regression_tests.rs
@@ -89,3 +89,82 @@ fn new_dot_target_correct_spelling_no_ts17012() {
         "No TS17012 for correctly-spelled new.target: {diagnostics:?}",
     );
 }
+
+/// TS17013's `{0}` placeholder must be substituted with the canonical
+/// meta-property text (`new.target`), not leaked verbatim (#14840).
+#[test]
+fn ts17013_top_level_new_target_substitutes_meta_property_name() {
+    let source = "console.log(new.target);";
+    let diagnostics = check_source_diagnostics(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| {
+            d.code
+                == diagnostic_codes::META_PROPERTY_IS_ONLY_ALLOWED_IN_THE_BODY_OF_A_FUNCTION_DECLARATION_FUNCTION_EXP
+        })
+        .expect("expected TS17013 at top level");
+    assert!(
+        diag.message_text.contains("'new.target'"),
+        "TS17013 must name the meta-property: {diag:?}",
+    );
+    assert!(
+        !diag.message_text.contains("{0}"),
+        "TS17013 must not leak the raw placeholder: {diag:?}",
+    );
+}
+
+/// tsc reports the *canonical* `new.target` even for a misspelled name like
+/// `new.foo` (its `checkNewTargetMetaProperty` hardcodes `"new.target"`).
+#[test]
+fn ts17013_misspelled_new_meta_property_still_names_new_target() {
+    let source = "const x = new.foo;";
+    let diagnostics = check_source_diagnostics(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| {
+            d.code
+                == diagnostic_codes::META_PROPERTY_IS_ONLY_ALLOWED_IN_THE_BODY_OF_A_FUNCTION_DECLARATION_FUNCTION_EXP
+        })
+        .expect("expected TS17013 for new.foo at top level");
+    assert!(
+        diag.message_text.contains("'new.target'") && !diag.message_text.contains("{0}"),
+        "TS17013 for a misspelled meta-property must still name 'new.target': {diag:?}",
+    );
+}
+
+/// A `new.target` in a non-function owner (here a class field initializer) hits
+/// the same invalid-context branch and must substitute the placeholder too.
+#[test]
+fn ts17013_in_class_field_initializer_substitutes_meta_property_name() {
+    let source = "class C { f = new.target; }";
+    let diagnostics = check_source_diagnostics(source);
+    let diag = diagnostics
+        .iter()
+        .find(|d| {
+            d.code
+                == diagnostic_codes::META_PROPERTY_IS_ONLY_ALLOWED_IN_THE_BODY_OF_A_FUNCTION_DECLARATION_FUNCTION_EXP
+        })
+        .expect("expected TS17013 in class field initializer");
+    assert!(
+        diag.message_text.contains("'new.target'") && !diag.message_text.contains("{0}"),
+        "TS17013 in a field initializer must name 'new.target': {diag:?}",
+    );
+}
+
+/// `new.target` inside a function body is valid: no TS17013.
+#[test]
+fn ts17013_not_emitted_for_new_target_in_function_body() {
+    let source = "function f() { return new.target; }";
+    let diagnostics = check_source_diagnostics(source);
+    let count = diagnostics
+        .iter()
+        .filter(|d| {
+            d.code
+                == diagnostic_codes::META_PROPERTY_IS_ONLY_ALLOWED_IN_THE_BODY_OF_A_FUNCTION_DECLARATION_FUNCTION_EXP
+        })
+        .count();
+    assert_eq!(
+        count, 0,
+        "No TS17013 for new.target in a function body: {diagnostics:?}",
+    );
+}


### PR DESCRIPTION
Fixes #14840.

When `new.target` (or a misspelled `new.<name>`) is used outside a function/constructor body, tsz emitted TS17013 with the **unsubstituted** `{0}` placeholder:

```
error TS17013: Meta-property '{0}' is only allowed in the body of a function declaration, function expression, or constructor.
```

tsc 5.9.3 substitutes the meta-property name:

```
error TS17013: Meta-property 'new.target' is only allowed in the body of a function declaration, function expression, or constructor.
```

Structural rule: when a meta-property is used in an invalid context, tsc's `checkNewTargetMetaProperty` substitutes `{0}` with the keyword's canonical meta-property text (`new.target`) before reporting; tsz must do the same through the checker's substituting diagnostic emitter.

The site at `crates/tsz-checker/src/dispatch/mod.rs` emitted the diagnostic via `error_at_node`, which takes a pre-formatted message and does **not** fill placeholders, while passing it the raw template constant. Routing it through `error_at_node_msg` (which formats the template with args) and passing the canonical `new.target` fixes it. A `META_PROPERTY` node is only ever produced for `new.<name>` — the parser lowers `import.meta` to a `PROPERTY_ACCESS_EXPRESSION` — and tsc reports the canonical `new.target` here even for a misspelled name like `new.foo`, so the argument is exact-parity.

Breadth: I audited every `error_at_node` / `error_at_anchor` / raw `error(` call site in `tsz-checker` against its template text. TS17013 was the **only** site passing a placeholder-bearing template to a non-substituting emitter; all other sites pre-format via `format_message` or `.replace("{0}", …)`. So this is the complete fix for the placeholder-leak class in the checker, not just the reported witness.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test new_expression_regression_tests` — 8/8 pass, including 4 new cases: top-level `new.target`, misspelled `new.foo` (still names `new.target`), a class field initializer (non-function owner), and the valid in-function negative (no TS17013).
- `cargo clippy -p tsz-checker` — clean, no new warnings.
- Confirmed no conformance/emit/fourslash baseline encodes the old `{0}` output.
- ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_014rJmtZrJeM3nP9Q5qyjJc5)_