### PR TITLE
fix(checker): any-fill generic instance type for instanceof narrowing in loops

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -437,6 +437,9 @@ path = "tests/await_thenable_this_context_tests.rs"
 name = "await_structural_thenable_object_literal_tests"
 path = "tests/await_structural_thenable_object_literal_tests.rs"
 [[test]]
+name = "instanceof_loop_generic_any_fill_tests"
+path = "tests/instanceof_loop_generic_any_fill_tests.rs"
+[[test]]
 name = "for_await_promise_array_tests"
 path = "tests/for_await_promise_array_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/flow/control_flow/narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/narrowing.rs
@@ -646,18 +646,26 @@ impl<'a> FlowAnalyzer<'a> {
             // Class symbols must narrow through a real DefId-backed lazy type.
             // Falling back to `reference(SymbolRef)` would create Lazy(DefId(symbol_id)),
             // which can point at an unrelated definition because SymbolId and DefId
-            // are independent identity spaces.
-            return self.resolve_symbol_to_lazy(symbol_ref);
+            // are independent identity spaces. For a generic class
+            // (`class Box<T>`), `tsc` narrows `x instanceof Box` to `Box<any>`, so
+            // fill its type parameters with `any` (no-op for non-generic classes).
+            return self.resolve_symbol_to_instance_type(symbol_ref);
         }
 
         // Global constructor variables (e.g., `declare var Array: ArrayConstructor`)
-        // have both INTERFACE and VARIABLE flags. The interface type IS the instance type
-        // since interfaces describe instances, not constructors.
-        // This handles `x instanceof Array`, `x instanceof Date`, etc.
+        // have both INTERFACE and VARIABLE flags. The interface type IS the instance
+        // type since interfaces describe instances, not constructors. The raw
+        // interface is generic (`Map<K, V>`, `Array<T>`), so fill its type
+        // parameters with `any` — `x instanceof Map` narrows to `Map<any, any>`,
+        // matching tsc's prototype-derived instance type and the node_types fast
+        // path. Non-generic globals (`Date`, `RegExp`) resolve to the bare
+        // interface unchanged. This handles `x instanceof Array`, `x instanceof
+        // Date`, etc., including inside loops where the fast path is unavailable
+        // (issue #14945).
         if symbol.has_any_flags(symbol_flags::INTERFACE)
             && symbol.has_any_flags(symbol_flags::VARIABLE)
         {
-            return self.resolve_symbol_to_lazy(symbol_ref);
+            return self.resolve_symbol_to_instance_type(symbol_ref);
         }
 
         // For FUNCTION symbols (e.g., JS constructor functions with @constructor),

--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -990,6 +990,30 @@ impl<'a> FlowAnalyzer<'a> {
         }
     }
 
+    /// Resolve a global constructor-variable symbol (e.g. the lib `Map`/`Set`
+    /// interface+var) to its instance type for `instanceof` narrowing. The raw
+    /// interface is generic (`Map<K, V>`); tsc narrows `x instanceof Map` to the
+    /// prototype-derived `Map<any, any>`, so fill the interface's type parameters
+    /// with `any`. This matters inside loops, where the `node_types` fast path has
+    /// not yet typed the constructor expression and narrowing reaches the bare
+    /// generic interface (issue #14945). Non-generic globals (`Date`, `RegExp`)
+    /// have zero parameters and resolve to the bare interface unchanged.
+    pub(crate) fn resolve_symbol_to_instance_type(&self, symbol_ref: SymbolRef) -> Option<TypeId> {
+        let lazy = self.resolve_symbol_to_lazy(symbol_ref)?;
+        if let Some(env) = self.type_environment.as_ref() {
+            let env_borrowed = env.borrow();
+            if let Some(def_id) = env_borrowed.symbol_to_def_id(symbol_ref) {
+                let arity = env_borrowed
+                    .get_lazy_type_params(def_id)
+                    .map_or(0, |params| params.len());
+                if arity > 0 {
+                    return Some(self.interner.application(lazy, vec![TypeId::ANY; arity]));
+                }
+            }
+        }
+        Some(lazy)
+    }
+
     /// Check if a call is `ArrayBuffer.isView(x)` and return a predicate guard.
     fn check_array_buffer_is_view(&self, call: &CallExprData) -> Option<(TypeGuard, NodeIndex)> {
         let callee_node = self.arena.get(call.expression)?;

--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_02.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_02.rs
@@ -1858,8 +1858,9 @@ fn test_instanceof_constructor_branches_avoid_raw_symbol_reference_fallback() {
         .expect("failed to isolate instanceof class-symbol branch");
 
     assert!(
-        class_branch.contains("self.resolve_symbol_to_lazy(symbol_ref)"),
-        "instanceof class-symbol branch should resolve through the DefId-backed lazy helper"
+        class_branch.contains("self.resolve_symbol_to_instance_type(symbol_ref)"),
+        "instanceof class-symbol branch should resolve through the DefId-backed instance-type helper \
+         (which wraps resolve_symbol_to_lazy and any-fills generic type parameters)"
     );
     assert!(
         !class_branch.contains(".reference("),
@@ -1873,8 +1874,9 @@ fn test_instanceof_constructor_branches_avoid_raw_symbol_reference_fallback() {
         .expect("failed to isolate instanceof global-constructor branch");
 
     assert!(
-        global_constructor_branch.contains("self.resolve_symbol_to_lazy(symbol_ref)"),
-        "instanceof global-constructor branch should resolve through the DefId-backed lazy helper"
+        global_constructor_branch.contains("self.resolve_symbol_to_instance_type(symbol_ref)"),
+        "instanceof global-constructor branch should resolve through the DefId-backed instance-type \
+         helper (which wraps resolve_symbol_to_lazy and any-fills generic type parameters)"
     );
     assert!(
         !global_constructor_branch.contains(".reference("),

--- a/crates/tsz-checker/tests/instanceof_loop_generic_any_fill_tests.rs
+++ b/crates/tsz-checker/tests/instanceof_loop_generic_any_fill_tests.rs
@@ -1,0 +1,133 @@
+//! Regression for #14945: `instanceof` of a generic global (`Map`/`Set`) or a
+//! generic class inside a loop must narrow to the all-`any` instantiation
+//! (`Map<any, any>`), not the bare generic interface (`Map<K, V>`).
+//!
+//! Outside a loop the `node_types` fast path already produces `Map<any, any>`;
+//! inside a loop the flow fixed-point reaches the symbol-based instance-type
+//! extraction with the constructor expression still typed as `error`, so the
+//! INTERFACE+VARIABLE / CLASS branches must fill the interface's type
+//! parameters with `any`. `tsc` narrows `x instanceof Map` to `Map<any, any>`.
+//!
+//! Binder names are varied (Map/Set/user `Box<T>`) so the fix cannot key on any
+//! identifier.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
+use tsz_common::common::ScriptTarget;
+
+fn codes(source: &str) -> Vec<(u32, String)> {
+    let libs = load_default_lib_files();
+    assert!(!libs.is_empty(), "default lib files must be available");
+    check_source_with_libs_code_messages(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2022,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+}
+
+fn assert_no_2345(source: &str, label: &str) {
+    let diags = codes(source);
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 2345),
+        "{label}: instanceof-in-loop must narrow the generic instance to `<any>` \
+         (no false TS2345). Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn instanceof_map_in_loop_narrows_to_any_args() {
+    assert_no_2345(
+        r#"
+export {};
+function f(value: unknown, entries: [string, number][]) {
+    for (const [k, v] of entries) {
+        if (value instanceof Map) {
+            value.set(k, v);
+        }
+    }
+}
+"#,
+        "Map in for-of loop",
+    );
+}
+
+#[test]
+fn instanceof_set_in_loop_narrows_to_any_args() {
+    assert_no_2345(
+        r#"
+export {};
+function f(value: unknown, xs: number[]) {
+    for (const x of xs) {
+        if (value instanceof Set) {
+            value.add(x);
+        }
+    }
+}
+"#,
+        "Set in for-of loop",
+    );
+}
+
+#[test]
+fn instanceof_user_generic_class_in_loop_narrows_to_any_args() {
+    assert_no_2345(
+        r#"
+export {};
+class Box<T> {
+    constructor(public v: T) {}
+    set(x: T) {}
+}
+function f(value: unknown, xs: number[]) {
+    for (const x of xs) {
+        if (value instanceof Box) {
+            value.set(x);
+        }
+    }
+}
+"#,
+        "user generic class in loop",
+    );
+}
+
+#[test]
+fn instanceof_no_loop_control_still_clean() {
+    // The no-loop path already narrowed to Map<any, any> via the fast path;
+    // it must stay clean.
+    assert_no_2345(
+        r#"
+export {};
+function g(value: unknown) {
+    if (value instanceof Map) {
+        value.set(1, 2);
+    }
+}
+"#,
+        "no-loop control",
+    );
+}
+
+#[test]
+fn instanceof_union_source_member_still_errors() {
+    // Guard: a concrete union-member source must NOT be widened to `Set<any>`;
+    // adding a string to `Set<number>` must still report TS2345.
+    let diags = codes(
+        r#"
+export {};
+function neg(value: Set<number> | string) {
+    if (value instanceof Set) {
+        value.add("nope");
+    }
+}
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2345),
+        "union-source `Set<number>` must keep its element type (adding a string errors TS2345). \
+         Got: {diags:#?}"
+    );
+}


### PR DESCRIPTION
## Summary

`x instanceof Map` (or any generic global / generic class) **inside a loop** narrowed to the bare generic interface `Map<K, V>` with unsubstituted type parameters, so a subsequent `value.set(k, v)` rejected its arguments against the bare `K`/`V` — a false `TS2345`. Outside a loop the same code is clean. Fixes #14945 (superstruct row).

## Structural rule

`When narrowing `x instanceof C` where C is a generic global constructor variable (`Map`/`Set`/`WeakMap`, an INTERFACE+VARIABLE symbol) or a generic class, tsc narrows to the prototype-derived all-`any` instance type (`Map<any, any>`); tsz now does the same through the flow `instance_type_from_constructor` symbol path.`

Inside a loop, the flow fixed-point evaluates the `instanceof` narrowing before the `node_types` fast path has typed the constructor expression (it is transiently `error`), so narrowing falls to the symbol-based instance-type extraction in `flow/control_flow/narrowing.rs`. That path returned `resolve_symbol_to_lazy` = the bare generic interface `Map<K, V>`. The no-loop path hits the `node_types` fast path and already yields `Map<any, any>`.

## Owner layer

Checker flow narrowing. New helper `resolve_symbol_to_instance_type` (in `flow/control_flow/type_guards.rs`) wraps the existing DefId-backed `resolve_symbol_to_lazy` and, when the resolved interface/class def has N>0 type parameters and no supplied args, returns `Application(Lazy(def), [any; N])` via the interner factory; arity comes from the flow env's `get_lazy_type_params`. Both the CLASS branch and the INTERFACE+VARIABLE branch of `instance_type_from_constructor` now call it. Non-generic globals (`Date`, `RegExp`; arity 0) resolve to the bare interface unchanged. No name/file fast paths — the discriminator is the def's declared type-parameter arity.

The instanceof arch-contract test (`architecture_contract_tests/part_02.rs`) is updated to recognize the new DefId-backed helper (it still forbids raw `.reference(SymbolRef)` fallback, so the no-raw-SymbolRef invariant is preserved).

## Adjacent-case matrix (tsz output now identical to tsc 5.9.3)

| Case (in a loop) | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `value instanceof Map` → `.set(k,v)` | clean | **TS2345 on K** | clean ✓ |
| `value instanceof Set` → `.add(x)` | clean | **TS2345** | clean ✓ |
| `value instanceof WeakMap` → `.set(k,1)` | clean | **TS2345** | clean ✓ |
| `value instanceof Box<T>` (user class) → `.set(x)` | clean | **TS2345 on T** | clean ✓ |
| `value instanceof Date` → `.getTime()` | clean | clean | clean ✓ |
| no-loop `instanceof Map` (control) | clean | clean | clean ✓ |
| union src `Set<number> \| string`, `.add("x")` | TS2345 | TS2345 | TS2345 ✓ |

The union-source row is the key guard: a concrete union member keeps its element type (narrowing preserves members independent of the instance type), so it must still error — and does.

## Goal

Goal: green

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- Behavioral matrix (`/tmp/v14945.ts`, 7 cases incl. negatives): tsz output **identical** to `tsc@5.9.3` (only the union-source negative reports TS2345).
- Unit: new `tests/instanceof_loop_generic_any_fill_tests.rs` (Map/Set/user-generic-class in loop + no-loop control + union-source guard) → 5/5 pass.
- Arch contract: `test_instanceof_constructor_branches_avoid_raw_symbol_reference_fallback` updated + passes (no raw SymbolRef fallback).
- clippy `--lib --test instanceof_loop_generic_any_fill_tests`: clean.
- Conformance: `--filter instanceof` 14/14, 0 known/crashed.
- Revert-test note: `ts2860`/`ts2861` (instanceof `[Symbol.hasInstance]`) fail identically on clean origin/main in narrow local filters (pre-existing lib-isolation drift), not introduced here.
