### PR TITLE
fix(checker): iterate deferred conditional spread through its apparent type (TS2345)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -827,6 +827,9 @@ path = "tests/ts2322_empty_array_assertion_source_display_tests.rs"
 name = "ts2322_pair_disambiguation_widening_tests"
 path = "tests/ts2322_pair_disambiguation_widening_tests.rs"
 [[test]]
+name = "spread_deferred_conditional_apparent_tests"
+path = "tests/spread_deferred_conditional_apparent_tests.rs"
+[[test]]
 name = "spread_rest_tests"
 path = "tests/spread_rest_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/call_checker/applicability.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/applicability.rs
@@ -62,7 +62,44 @@ impl<'a> CheckerState<'a> {
         let spread_type = self.evaluate_type_with_env(spread_type);
         let spread_type = self.resolve_type_for_property_access(spread_type);
         let spread_type = self.resolve_lazy_type(spread_type);
-        self.evaluate_application_type(spread_type)
+        let spread_type = self.evaluate_application_type(spread_type);
+        self.apparent_type_of_deferred_conditional_spread(spread_type)
+    }
+
+    /// A value typed as a deferred (uninstantiated generic) conditional has no
+    /// tuple/array/iterator shape of its own, so the spread element-extraction
+    /// paths in `candidate_collection` would relate the whole conditional to the
+    /// rest-parameter element and emit a false `TS2345`.
+    ///
+    /// `tsc` iterates such a spread through the conditional's *apparent* type —
+    /// the union of its branch constraints with the true branch's check
+    /// parameter narrowed to `check & extends` (`getApparentType` ->
+    /// `getDefaultConstraintOfConditionalType`). Adopt that apparent type here
+    /// when it is itself iterable, so the existing array/tuple/iterable branches
+    /// recover the real element type. This is scoped to the spread normalization
+    /// path: a non-conditional type, a conditional with no reducible constraint,
+    /// or one whose apparent type is not iterable is left untouched so unrelated
+    /// diagnostics are unchanged.
+    fn apparent_type_of_deferred_conditional_spread(&mut self, spread_type: TypeId) -> TypeId {
+        if !crate::query_boundaries::common::is_conditional_type(self.ctx.types, spread_type) {
+            return spread_type;
+        }
+        let Some(apparent) =
+            crate::query_boundaries::conditional_constraints::conditional_apparent_value_constraint(
+                self.ctx.types,
+                spread_type,
+            )
+        else {
+            return spread_type;
+        };
+        // Only adopt the apparent type when it actually yields an iterable shape;
+        // otherwise the conditional was not standing in for a spreadable value and
+        // the original (deferred) type drives the unchanged diagnostic path.
+        if self.is_iterable_type(apparent) {
+            apparent
+        } else {
+            spread_type
+        }
     }
 
     /// Const object/array literal bindings do not benefit from flow narrowing at

--- a/crates/tsz-checker/src/query_boundaries/conditional_constraints.rs
+++ b/crates/tsz-checker/src/query_boundaries/conditional_constraints.rs
@@ -12,6 +12,20 @@ pub(crate) fn conditional_branch_union_constraint(
     tsz_solver::type_queries::conditional_branch_union_constraint(db, type_id)
 }
 
+/// Apparent **value** type of a deferred conditional, for spread / iteration
+/// element extraction (tsc's `getApparentType` ->
+/// `getDefaultConstraintOfConditionalType`). The inferred true branch narrows
+/// the check type parameter to `check & extends` throughout, so a wrapped
+/// occurrence (`T extends U ? [T] : Y`) iterates to the narrowed element type
+/// `T & U` rather than the unconstrained `T`. `None` when `type_id` is not a
+/// deferred conditional or the reduction makes no progress.
+pub(crate) fn conditional_apparent_value_constraint(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    tsz_solver::type_queries::get_conditional_apparent_value_constraint(db, type_id)
+}
+
 /// Apparent base constraint of a deferred conditional type (tsc's
 /// `getDefaultConstraintOfConditionalType`): the union of its inferred
 /// true-branch and false-branch result types. `None` when `type_id` is not a

--- a/crates/tsz-checker/tests/spread_deferred_conditional_apparent_tests.rs
+++ b/crates/tsz-checker/tests/spread_deferred_conditional_apparent_tests.rs
@@ -1,0 +1,138 @@
+//! A value whose type is a deferred (uninstantiated generic) conditional that is
+//! spread as a rest argument (`f(...v)`, `arr.push(...v)`) must be iterated
+//! through its *apparent* type — the union of its branch base-constraints —
+//! before the spread element is related to the rest-parameter element. `tsc`
+//! reduces the conditional to its apparent type; relating the whole conditional
+//! produces a false `TS2345`. See issue #14946.
+//!
+//! These run against the real default lib bundle (target ES2020) so `Array`,
+//! `Iterable`, and `Symbol.iterator` resolve exactly as in a real check. Binder
+//! names are varied across tests to keep the rule structural, not name-driven.
+
+use std::sync::{Arc, OnceLock};
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs, load_default_lib_files};
+use tsz_common::common::ScriptTarget;
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    static LIBS: OnceLock<Vec<Arc<LibFile>>> = OnceLock::new();
+    let libs = LIBS.get_or_init(load_default_lib_files);
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2020,
+            strict: true,
+            strict_null_checks: true,
+            no_implicit_any: true,
+            ..CheckerOptions::default()
+        },
+        libs,
+    )
+    .iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+#[test]
+fn push_spread_of_deferred_conditional_is_iterated_to_element() {
+    // The exact witness from #14946 (binder names preserved from the report).
+    let codes = strict_codes(
+        r#"
+type Cond<P> = P extends string ? [P] : (string | number)[];
+function g<P>(p: P) {
+  const result: (string | number)[] = [];
+  const v: Cond<P> = null as any;
+  result.push(...v);
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2345),
+        "spread of a deferred conditional must reduce to its apparent element type, got {codes:?}",
+    );
+}
+
+#[test]
+fn call_spread_of_deferred_conditional_uses_apparent_branch_union() {
+    // Same rule through a plain rest-parameter call with renamed binders. The
+    // true branch narrows the check parameter to `string`, so the apparent
+    // element union stays assignable to the `string | number` rest element.
+    let codes = strict_codes(
+        r#"
+type Pick2<Q> = Q extends string ? [Q, Q] : (string | number)[];
+declare function sink(...entries: (string | number)[]): void;
+function relay<Q>(seed: Q) {
+  const payload: Pick2<Q> = null as any;
+  sink(...payload);
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2345),
+        "deferred conditional spread into a rest call must not emit TS2345, got {codes:?}",
+    );
+}
+
+#[test]
+fn deferred_conditional_with_array_branches_both_sides_assignable() {
+    // Both branches are concrete array-likes; the apparent element union must
+    // stay assignable to the wider rest element. Renamed binders again.
+    let codes = strict_codes(
+        r#"
+type Branchy<R> = R extends boolean ? boolean[] : number[];
+function collect<R>(flag: R) {
+  const bucket: (number | boolean)[] = [];
+  const items: Branchy<R> = null as any;
+  bucket.push(...items);
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2345),
+        "both array branches of a deferred conditional must iterate to assignable elements, got {codes:?}",
+    );
+}
+
+#[test]
+fn nongeneric_array_alias_spread_still_clean_control() {
+    // Control: a non-conditional generic alias resolving to an array spreads
+    // without any change in behavior.
+    let codes = strict_codes(
+        r#"
+type Plain<S> = S[];
+function feed<S extends string>(token: S) {
+  const out: string[] = [];
+  const xs: Plain<S> = null as any;
+  out.push(...xs);
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&2345),
+        "non-conditional array alias spread must remain clean, got {codes:?}",
+    );
+}
+
+#[test]
+fn deferred_conditional_element_mismatch_still_reported() {
+    // Negative parity guard: when the apparent element type genuinely does not
+    // fit the rest-parameter element, the call must still be rejected. The false
+    // branch iterates to `boolean`, which is not assignable to a `number` rest
+    // element, so TS2345 must remain.
+    let codes = strict_codes(
+        r#"
+type Mixed<U> = U extends never ? number[] : boolean[];
+declare function onlyNumbers(...values: number[]): void;
+function dispatch<U>(key: U) {
+  const data: Mixed<U> = null as any;
+  onlyNumbers(...data);
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "an apparent element that does not fit the rest element must still emit TS2345, got {codes:?}",
+    );
+}

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -278,6 +278,74 @@ pub fn conditional_default_constraint_from_data(
     Some(constraint)
 }
 
+/// Apparent **value** type of a deferred conditional, for spread / iteration
+/// element extraction.
+///
+/// Mirrors tsc's `getApparentType` -> `getDefaultConstraintOfConditionalType`,
+/// where `getInferredTrueTypeFromConditionalType` narrows the check type
+/// parameter to `check & extends` throughout the *whole* true branch. Unlike
+/// [`get_conditional_default_constraint`] — which narrows only when the true
+/// branch **is** the check type (enough for indexed-access key-space
+/// validation, where a wrapped occurrence such as `[T]` keeps the same key
+/// space) — this instantiates the entire true branch with `check := check &
+/// extends`, so a wrapped occurrence carries the narrowed element type.
+///
+/// For `v: T extends U ? [T] : Y`, the iterated element of the true branch is
+/// then `T & U` (assignable to `U`) rather than the unconstrained `T`, which is
+/// what a spread `...v` must relate to the rest-parameter element. The false
+/// branch is used unchanged, mirroring tsc. When one branch is `any`, tsc keeps
+/// the other branch (a union with `any` would otherwise erase the constraint).
+///
+/// Returns `None` when `type_id` is not a deferred conditional, or when the
+/// constraint makes no progress (so the caller keeps the type deferred).
+pub fn get_conditional_apparent_value_constraint(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    let cond_id = crate::type_queries::get_conditional_type_id(db, type_id)?;
+    let cond = db.conditional_type(cond_id);
+
+    let check_type_param = match db.lookup(cond.check_type) {
+        Some(TypeData::TypeParameter(info)) => Some(info),
+        _ => None,
+    };
+
+    // Deferred-ness guard: if neither operand carries type parameters the
+    // evaluator would already have selected a branch, so there is nothing to
+    // reduce here.
+    if check_type_param.is_none()
+        && !contains_type_parameters_db(db, cond.check_type)
+        && !contains_type_parameters_db(db, cond.extends_type)
+    {
+        return None;
+    }
+
+    // Inferred true branch: instantiate with `check := check & extends` so a
+    // wrapped occurrence (`[T]`, `T[]`, an alias over `T`, ...) carries the
+    // narrowed element type. A branch that does not mention the check parameter
+    // (e.g. a concrete `number[]`) is returned unchanged by the instantiator.
+    let inferred_true = if let Some(info) = check_type_param {
+        let narrowed = db.intersection2(cond.check_type, cond.extends_type);
+        let subst =
+            crate::instantiation::instantiate::TypeSubstitution::single(info.name, narrowed);
+        crate::instantiation::instantiate::instantiate_type(db, cond.true_type, &subst)
+    } else {
+        cond.true_type
+    };
+
+    // Union the branches, but collapse to the non-`any` branch when one is
+    // `any` (tsc's `getDefaultConstraintOfConditionalType`): a `X | any` union
+    // would otherwise erase the constraint to `any`.
+    let constraint = if inferred_true == TypeId::ANY {
+        cond.false_type
+    } else if cond.false_type == TypeId::ANY {
+        inferred_true
+    } else {
+        db.union2(inferred_true, cond.false_type)
+    };
+    (constraint != type_id).then_some(constraint)
+}
+
 /// Substitute a deferred conditional's check-type parameter with its own base
 /// constraint, returning the substituted (still unevaluated) conditional.
 ///


### PR DESCRIPTION
When a value typed as a deferred (uninstantiated generic) conditional is spread as a rest argument (`f(...v)`, `arr.push(...v)`), tsc iterates it through its **apparent** type before relating the spread element to the rest-parameter element. tsz related the whole conditional to the rest element, producing a false `TS2345` (witnessed by the remeda benchmark row). Closes #14946.

**Structural rule:** When the spread argument's type is a deferred conditional `T extends U ? X : Y`, tsc reduces it to `getApparentType` — the true branch instantiated with the check parameter narrowed to `T & U`, unioned with the false branch — and extracts the iteration element from that. tsz did not reduce the conditional and related `Cond<T>` itself to the rest element. The fix lives in the checker's shared spread-argument normalizer (`normalized_spread_argument_type`), the single chokepoint feeding candidate collection, overload selection, and non-tuple spread signatures.

For the witness `Cond<P> = P extends string ? [P] : (string | number)[]`, the apparent type is `[P & string] | (string | number)[]`, whose element `(P & string) | string | number` is assignable to the `string | number` rest element — matching tsc.

### Owner layers
- **solver:** new `get_conditional_apparent_value_constraint` query computes a deferred conditional's apparent *value* type, narrowing the **whole** true branch with `check := check & extends` (unlike the key-space-only `get_conditional_default_constraint`, which narrows only when the true branch *is* the check type). The `any`-branch collapse mirrors tsc's `getDefaultConstraintOfConditionalType`.
- **checker:** `normalized_spread_argument_type` adopts that apparent type only when it is itself iterable, so non-conditional, non-iterable, or otherwise-opaque forms are left untouched and unrelated diagnostics are unchanged.

### Adjacent-case matrix (new test `spread_deferred_conditional_apparent_tests`, varied binder names, real default libs)
- `arr.push(...v)` witness — clean (was false `TS2345`).
- plain rest-call `f(...v)` with renamed binders — clean.
- both-branch concrete-array conditional — clean.
- non-conditional generic array alias spread (control) — clean, unchanged.
- negative parity: apparent element that does not fit the rest element still emits `TS2345`.

## Goal
Goal: grow

## Verification
- `cargo nextest run -p tsz-checker --test spread_deferred_conditional_apparent_tests` — 5/5 pass.
- `cargo clippy -p tsz-solver -p tsz-checker --tests` — clean.
- Regression sweep across 667 spread/rest/overload/iterable/conditional/variadic tests in `tsz-checker`: zero new failures (the 4 failing under the local stripped-lib harness — async for-await `TS2504`, one overload `TS2322`, one aggregate-rest case — were confirmed pre-existing on clean `origin/main`).
- ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8eZ739isfs6W7FLMGP1Cx)_