### PR TITLE
fix(checker): reduce deferred conditional spread to branch-union before element extraction

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -437,6 +437,9 @@ path = "tests/await_thenable_this_context_tests.rs"
 name = "await_structural_thenable_object_literal_tests"
 path = "tests/await_structural_thenable_object_literal_tests.rs"
 [[test]]
+name = "spread_deferred_conditional_tests"
+path = "tests/spread_deferred_conditional_tests.rs"
+[[test]]
 name = "for_await_promise_array_tests"
 path = "tests/for_await_promise_array_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/call_checker/applicability.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/applicability.rs
@@ -62,7 +62,22 @@ impl<'a> CheckerState<'a> {
         let spread_type = self.evaluate_type_with_env(spread_type);
         let spread_type = self.resolve_type_for_property_access(spread_type);
         let spread_type = self.resolve_lazy_type(spread_type);
-        self.evaluate_application_type(spread_type)
+        let spread_type = self.evaluate_application_type(spread_type);
+        // A deferred conditional spread (`...v` where `v: T extends U ? X : Y`)
+        // is not itself array/tuple-shaped, so the spread expansion cannot
+        // extract its iteration element type and would relate the whole
+        // conditional to the parameter (false TS2345). Reduce it to its
+        // branch-union base constraint (`X | Y`, tsc's getBaseConstraintOfType
+        // of a conditional) so the element type is recoverable. (#14946)
+        if let Some(branch_union) =
+            crate::query_boundaries::conditional_constraints::conditional_branch_union_constraint(
+                self.ctx.types,
+                spread_type,
+            )
+        {
+            return branch_union;
+        }
+        spread_type
     }
 
     /// Const object/array literal bindings do not benefit from flow narrowing at

--- a/crates/tsz-checker/tests/spread_deferred_conditional_tests.rs
+++ b/crates/tsz-checker/tests/spread_deferred_conditional_tests.rs
@@ -1,0 +1,116 @@
+//! Regression for #14946: spreading a deferred conditional type as a call/rest
+//! argument (`f(...v)` / `arr.push(...v)` where `v: T extends U ? X : Y`) must
+//! reduce the conditional to its branch-union base constraint (`X | Y`, tsc's
+//! `getBaseConstraintOfType` of a conditional) before extracting the iteration
+//! element type. Otherwise the bare deferred conditional is related to the
+//! parameter, producing a false `TS2345`.
+//!
+//! Scope note: this handles the branch-union-compatible family (the remeda
+//! witness). A conditional whose check is decidable from the check-type's
+//! constraint (e.g. `Q extends number ? Q[] : string[]` with `Q extends
+//! number`, where tsc reduces to the true branch `Q[]`) is a separate, deeper
+//! conditional-reduction gap (tsz does not reduce constraint-satisfiable
+//! deferred conditionals — see `evaluate_rules/conditional.rs`) and is not
+//! addressed here.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
+use tsz_common::common::ScriptTarget;
+
+fn codes(source: &str) -> Vec<(u32, String)> {
+    let libs = load_default_lib_files();
+    assert!(!libs.is_empty(), "default lib files must be available");
+    check_source_with_libs_code_messages(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2022,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+}
+
+#[test]
+fn spread_deferred_conditional_compatible_branches_no_ts2345() {
+    let diags = codes(
+        r#"
+export {};
+type Cond<P> = P extends string ? [P] : (string | number)[];
+function g<P extends string>(p: P) {
+    const result: (string | number)[] = [];
+    const v: Cond<P> = null as any;
+    result.push(...v);
+}
+"#,
+    );
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 2345),
+        "deferred-conditional spread with element-compatible branches must not error TS2345. \
+         Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn spread_deferred_conditional_renamed_binders_no_ts2345() {
+    // Same shape, different binder names — the fix must be structural.
+    let diags = codes(
+        r#"
+export {};
+type Pick<Q> = Q extends string ? Q[] : string[];
+function h<Q extends string>(q: Q) {
+    const out: string[] = [];
+    const z: Pick<Q> = null as any;
+    out.push(...z);
+}
+"#,
+    );
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 2345),
+        "renamed-binder deferred-conditional spread must not error TS2345. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn spread_deferred_conditional_incompatible_branch_still_errors() {
+    // Guard: both branches yield `boolean` elements, not assignable to
+    // `(string | number)[]`, so the spread must still report TS2345.
+    let diags = codes(
+        r#"
+export {};
+type Cond<P> = P extends string ? boolean[] : boolean[];
+function g<P extends string>(p: P) {
+    const result: (string | number)[] = [];
+    const v: Cond<P> = null as any;
+    result.push(...v);
+}
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2345),
+        "deferred-conditional spread with an incompatible element type must still error TS2345. \
+         Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn spread_non_conditional_generic_array_control_no_ts2345() {
+    // Control: a non-conditional generic array alias spread is unaffected
+    // (the conditional reduction is a no-op) and stays clean.
+    let diags = codes(
+        r#"
+export {};
+type Arr<T> = T[];
+function g<T extends number>(t: T) {
+    const out: number[] = [];
+    const z: Arr<T> = null as any;
+    out.push(...z);
+}
+"#,
+    );
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 2345),
+        "non-conditional generic array spread must stay clean. Got: {diags:#?}"
+    );
+}


### PR DESCRIPTION
## Summary

`result.push(...v)` (and any spread of a value typed as a **deferred conditional**, `v: T extends U ? X : Y`) reported a false `TS2345`. A deferred conditional is not array/tuple-shaped, so the spread expansion could not extract its iteration element type and instead related the whole conditional to the parameter element. Fixes the remeda benchmark-row witness (#14946).

## Structural rule

`When a deferred conditional type is spread as a call/rest argument, tsc extracts the iteration element type from the conditional's apparent type (getBaseConstraintOfType = the union of its branches); tsz now does the same in `normalized_spread_argument_type` before the spread expansion.`

## Owner layer

Checker call path: `call_checker/applicability.rs::normalized_spread_argument_type`. After the existing resolve/evaluate chain, if the operand is a deferred conditional, reduce it to its branch-union base constraint via the existing `query_boundaries::conditional_constraints::conditional_branch_union_constraint` (tsc's `getBaseConstraintOfType` of a conditional). The spread expansion then sees an array/tuple-union shape and extracts the element type. No-op for any non-conditional spread (the helper returns `None`), so non-conditional behavior is unchanged. No name/file fast paths.

## Adjacent-case matrix

| Case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `Cond<P> = P extends string ? [P] : (string\|number)[]`, push to `(string\|number)[]` | clean | **TS2345** | clean ✓ |
| renamed binders `Pick<Q> = Q extends string ? Q[] : string[]` → `string[]` | clean | **TS2345** | clean ✓ |
| incompatible branch (`boolean[]` element) → `(string\|number)[]` | TS2345 | TS2345 | TS2345 ✓ |
| non-conditional generic array `Arr<T>=T[]` (control) | clean | clean | clean ✓ |

### Known limitation (not a regression)

A conditional whose check is *decidable from the check-type's constraint* — e.g. `Q extends number ? Q[] : string[]` with `Q extends number`, which tsc reduces to the true branch `Q[]` — still reports a (pre-existing) false TS2345, because tsz does not reduce constraint-satisfiable deferred conditionals (see `evaluate_rules/conditional.rs`). The branch-union approach here does not change that case's outcome (origin/main also false-positived it via the un-reduced conditional); the proper fix is a separate, deeper conditional-reduction change. This PR is a strict improvement with zero conformance regression.

## Goal

Goal: green

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification

- Behavioral matrix (`/tmp/v14946.ts`): repro + renamed-binder + negative + control match tsc 5.9.3 (only the genuinely-incompatible branch errors; the documented constraint-reducible case is the lone known divergence, pre-existing).
- Unit: new `tests/spread_deferred_conditional_tests.rs` — 4/4 pass (compatible-branch + renamed-binder clean, incompatible-branch guard errors, non-conditional control clean).
- Conformance: `--filter spread` 71/71, `--filter rest` 69/69, `--filter conditionalType` 17/17 — 0 known/crashed (no regression).
- clippy `--lib --test spread_deferred_conditional_tests`: clean.
