### PR TITLE
fix(checker): emit TS17004 when JSX is used without the jsx flag (#14978)

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
@@ -252,6 +252,7 @@ impl<'a> CheckerState<'a> {
             return TypeId::ANY;
         }
 
+        self.check_jsx_flag_provided(idx);
         self.check_jsx_factory_in_scope(idx);
         self.check_jsx_import_source(idx);
 
@@ -1753,6 +1754,7 @@ impl<'a> CheckerState<'a> {
     ///
     /// Rule #36: Fragments resolve to JSX.Element type.
     pub(crate) fn get_jsx_element_type(&mut self, node_idx: NodeIndex) -> TypeId {
+        self.check_jsx_flag_provided(node_idx);
         self.check_jsx_factory_in_scope(node_idx);
         self.check_jsx_fragment_factory(node_idx);
         self.check_jsx_import_source(node_idx);

--- a/crates/tsz-checker/src/checkers/jsx/runtime.rs
+++ b/crates/tsz-checker/src/checkers/jsx/runtime.rs
@@ -325,6 +325,34 @@ impl<'a> CheckerState<'a> {
         candidate_start < current_start
     }
 
+    /// TS17004 — using JSX syntax requires the `jsx` compiler option to be set.
+    ///
+    /// tsc's `checkJsxPreconditions` reports this grammar error once per JSX
+    /// opening element, self-closing element, and fragment whenever the
+    /// effective `compilerOptions.jsx` is `JsxEmit.None` (i.e. the `--jsx`
+    /// flag was not provided). The gate is the raw option only: a per-file
+    /// `@jsx` / `@jsxImportSource` pragma does NOT satisfy it (verified against
+    /// tsc 6.0), so this reads `compiler_options.jsx_mode` directly rather than
+    /// the pragma-adjusted `effective_jsx_mode()`.
+    ///
+    /// The diagnostics layer dedupes on `(span, code, message)`, so emitting
+    /// from each opening-like / fragment precondition site yields exactly one
+    /// diagnostic per element — matching tsc's cardinality even when an
+    /// element's type is requested more than once during checking.
+    pub(crate) fn check_jsx_flag_provided(&mut self, node_idx: NodeIndex) {
+        use tsz_common::checker_options::JsxMode;
+
+        if self.ctx.compiler_options.jsx_mode != JsxMode::None {
+            return;
+        }
+        use crate::diagnostics::diagnostic_codes;
+        self.error_at_node_msg(
+            node_idx,
+            diagnostic_codes::CANNOT_USE_JSX_UNLESS_THE_JSX_FLAG_IS_PROVIDED,
+            &[],
+        );
+    }
+
     /// Check that the JSX import source module can be resolved (TS2875).
     pub(crate) fn check_jsx_import_source(&mut self, node_idx: NodeIndex) {
         use tsz_common::checker_options::JsxMode;

--- a/crates/tsz-checker/src/checkers/jsx/tests.rs
+++ b/crates/tsz-checker/src/checkers/jsx/tests.rs
@@ -101,3 +101,4 @@ declare namespace JSX {
 mod part_00;
 mod part_01;
 mod part_02;
+mod part_03_jsx_flag;

--- a/crates/tsz-checker/src/checkers/jsx/tests/part_03_jsx_flag.rs
+++ b/crates/tsz-checker/src/checkers/jsx/tests/part_03_jsx_flag.rs
@@ -1,0 +1,84 @@
+//! Tests for TS17004 ("Cannot use JSX unless the '--jsx' flag is provided").
+//!
+//! tsz must emit TS17004 once per JSX opening element, self-closing element,
+//! and fragment when `compilerOptions.jsx` is unset (`JsxMode::None`), matching
+//! tsc's `checkJsxPreconditions`. When any `jsx` mode is set, the diagnostic
+//! must not appear.
+
+use super::*;
+use crate::context::CheckerOptions;
+use tsz_common::checker_options::JsxMode;
+
+const TS17004: u32 = 17004;
+
+fn jsx_codes_with_mode(source: &str, jsx_mode: JsxMode) -> Vec<u32> {
+    let opts = CheckerOptions {
+        jsx_mode,
+        ..CheckerOptions::default()
+    };
+    check_source(source, "test.tsx", opts)
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn ts17004_emitted_for_element_when_jsx_flag_absent() {
+    let codes = jsx_codes_with_mode("const a = <div />;\n", JsxMode::None);
+    assert_eq!(
+        codes.iter().filter(|&&c| c == TS17004).count(),
+        1,
+        "expected exactly one TS17004 for a self-closing element, got {codes:?}"
+    );
+}
+
+#[test]
+fn ts17004_emitted_once_per_opening_self_closing_and_fragment() {
+    // Two opening/self-closing elements (`div`, `span`) plus one fragment.
+    let source = "const a = <div></div>;\nconst b = <span />;\nconst c = <></>;\n";
+    let codes = jsx_codes_with_mode(source, JsxMode::None);
+    assert_eq!(
+        codes.iter().filter(|&&c| c == TS17004).count(),
+        3,
+        "expected one TS17004 per opening-like element and fragment, got {codes:?}"
+    );
+}
+
+#[test]
+fn ts17004_counts_nested_elements() {
+    // Outer `div`, inner `span`, and a nested fragment => three JSX nodes.
+    let source = "const t = <div><span /><></></div>;\n";
+    let codes = jsx_codes_with_mode(source, JsxMode::None);
+    assert_eq!(
+        codes.iter().filter(|&&c| c == TS17004).count(),
+        3,
+        "expected TS17004 for each nested JSX node, got {codes:?}"
+    );
+}
+
+#[test]
+fn ts17004_absent_when_jsx_preserve() {
+    let codes = jsx_codes_with_mode("const a = <div />;\n", JsxMode::Preserve);
+    assert!(
+        !codes.contains(&TS17004),
+        "TS17004 must not fire when jsx=preserve, got {codes:?}"
+    );
+}
+
+#[test]
+fn ts17004_absent_when_jsx_react() {
+    let codes = jsx_codes_with_mode("const a = <div />;\n", JsxMode::React);
+    assert!(
+        !codes.contains(&TS17004),
+        "TS17004 must not fire when jsx=react, got {codes:?}"
+    );
+}
+
+#[test]
+fn ts17004_absent_when_jsx_react_jsx() {
+    let codes = jsx_codes_with_mode("const a = <div />;\n", JsxMode::ReactJsx);
+    assert!(
+        !codes.contains(&TS17004),
+        "TS17004 must not fire when jsx=react-jsx, got {codes:?}"
+    );
+}


### PR DESCRIPTION
Fixes #14978.

tsz type-checked JSX in `.tsx` files even when `compilerOptions.jsx` was unset
(`JsxMode::None`), but never reported tsc's grammar error **TS17004**
("Cannot use JSX unless the '--jsx' flag is provided."). The diagnostic constant
existed and the LSP even shipped a quick-fix for it, yet no checker code path
emitted it — a dead diagnostic / false-negative versus tsc.

**Structural rule:** when a JSX opening element / self-closing element / fragment
is checked and the effective `compilerOptions.jsx` is `JsxEmit.None` (the `--jsx`
flag was not provided), tsc (`checkJsxPreconditions`) emits TS17004 once per JSX
node at the element's opening position, independent of any per-file
`@jsx`/`@jsxImportSource` pragma. tsz now does this through the checker JSX
precondition sites that already host the factory-in-scope (TS2874) and
import-source (TS2875) checks.

Implementation: a new `check_jsx_flag_provided` gated on the raw
`jsx_mode == None` option, called from
`get_type_of_jsx_opening_element_with_children` (opening + self-closing) and
`get_jsx_element_type` (fragments). The diagnostics layer dedupes on
`(span, code, message)`, so this yields exactly one TS17004 per JSX node,
matching tsc's cardinality and positions. No semantic/solver changes.

## Goal
Goal: hold

## Verification
- Differential vs tsc 6.0.2 on element / self-closing / fragment / nested forms:
  TS17004 lines now byte-for-byte identical; TS7026 cardinality unchanged.
- No spurious TS17004 when `jsx` is set (preserve / react / react-jsx /
  react-jsxdev) — verified 0 occurrences each.
- New unit shard `checkers::jsx::tests::part_03_jsx_flag` (6 tests, all pass):
  per-element/self-closing/fragment cardinality, nested counting, and absence
  under each jsx mode.
- `cargo test -p tsz-checker --test jsx_component_attribute_tests`: 216 pass; the
  2 remaining failures are pre-existing on `main` (cross-file react-class
  TS2322 elaboration, no JSX-flag involvement — confirmed by stash + rebuild).
- Ready-review CI owns the broad conformance/emit suites; conformance compares
  against a real-tsc golden cache, so activating this diagnostic moves toward
  parity.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvvKovHHc12J44QjoxsqAA)_