### PR TITLE
fix(solver): callable-to-callable relation skips the weak-type rule on the stripped property part (#14749)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -440,6 +440,9 @@ path = "tests/await_structural_thenable_object_literal_tests.rs"
 name = "instanceof_loop_generic_any_fill_tests"
 path = "tests/instanceof_loop_generic_any_fill_tests.rs"
 [[test]]
+name = "weak_callable_target_assignability_tests"
+path = "tests/weak_callable_target_assignability_tests.rs"
+[[test]]
 name = "for_await_promise_array_tests"
 path = "tests/for_await_promise_array_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/weak_callable_target_assignability_tests.rs
+++ b/crates/tsz-checker/tests/weak_callable_target_assignability_tests.rs
@@ -1,0 +1,136 @@
+//! Regression for #14749: a callable interface assigned to another callable
+//! interface whose only non-call member is a property must NOT be rejected by
+//! the weak-type "no properties in common" rule.
+//!
+//! Root cause: `check_callable_subtype` compares the two call signatures, then
+//! decomposes each callable into an `ObjectShape` built from its property part
+//! (call/construct signatures stripped) and runs `check_object_subtype`. That
+//! object comparison applied the weak-type rule to the stripped shapes, so
+//! `{ (): void; extra: number }` <: `{ (): void; name?: string }` failed: the
+//! target looked weak (all optional) and the source shared no property name.
+//! tsc's `isWeakType` returns false for any type carrying a call/construct
+//! signature, so a callable target is never weak. The fix marks the callable
+//! property-part comparison (`in_callable_property_check`) so the direct-level
+//! weak rejection is suppressed; nested property-value comparisons re-enable it
+//! through `in_property_check`.
+//!
+//! Binder names are varied so the fix cannot key on any identifier.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_default_lib_files};
+use tsz_common::common::ScriptTarget;
+
+fn codes(source: &str) -> Vec<(u32, String)> {
+    let libs = load_default_lib_files();
+    assert!(!libs.is_empty(), "default lib files must be available");
+    check_source_with_libs_code_messages(
+        source,
+        "test.ts",
+        CheckerOptions {
+            target: ScriptTarget::ES2022,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+}
+
+fn assert_no_code(source: &str, code: u32, label: &str) {
+    let diags = codes(source);
+    assert!(
+        !diags.iter().any(|(c, _)| *c == code),
+        "{label}: expected no TS{code}. Got: {diags:#?}"
+    );
+}
+
+fn assert_has_code(source: &str, code: u32, label: &str) {
+    let diags = codes(source);
+    assert!(
+        diags.iter().any(|(c, _)| *c == code),
+        "{label}: expected TS{code}. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn callable_target_optional_prop_source_extra_no_ts2322() {
+    // tsc: clean. The target is callable, so it is not a weak type.
+    let src = r#"
+        interface T1 { (): void; name?: string }
+        interface S1 { (): void; extra: number }
+        declare const s1: S1;
+        const a1: T1 = s1;
+    "#;
+    assert_no_code(
+        src,
+        2322,
+        "callable optional-prop target, source extra prop",
+    );
+}
+
+#[test]
+fn callable_target_symbol_keyed_source_no_ts2322() {
+    // mobx witness: IReactionDisposer ([sym]: Reaction) -> Lambda (name?).
+    let src = r#"
+        declare const sym: unique symbol;
+        interface Reaction { x: 1 }
+        interface Lambda { (): void; name?: string }
+        interface IReactionDisposer { (): void; [sym]: Reaction }
+        declare const d: IReactionDisposer;
+        const l: Lambda = d;
+    "#;
+    assert_no_code(src, 2322, "callable target, symbol-keyed source extra");
+}
+
+#[test]
+fn callable_target_renamed_binders_no_ts2322() {
+    // Same structure, unrelated binder names — fix must not key on identifiers.
+    let src = r#"
+        interface Disposer { (): void; label?: string }
+        interface Worker { (): void; pid: number }
+        declare const w: Worker;
+        const job: Disposer = w;
+    "#;
+    assert_no_code(src, 2322, "renamed callable binders");
+}
+
+#[test]
+fn callable_target_no_extra_prop_control_clean() {
+    // Control: target has no property besides the call signature; always clean.
+    let src = r#"
+        interface T2 { (): void }
+        interface S2 { (): void; extra: number }
+        declare const s2: S2;
+        const a2: T2 = s2;
+    "#;
+    let diags = codes(src);
+    assert!(
+        diags.is_empty(),
+        "callable target without a property must be clean. Got: {diags:#?}"
+    );
+}
+
+#[test]
+fn genuine_weak_object_target_still_ts2559() {
+    // Negative: target is a real weak object (no call signature), source shares
+    // no property -> the weak-type rule must STILL fire. tsc: TS2559.
+    let src = r#"
+        interface Weak { a?: 1; b?: 2 }
+        declare const noCommon: { z: 3 };
+        const wk: Weak = noCommon;
+    "#;
+    assert_has_code(src, 2559, "genuine weak object target");
+}
+
+#[test]
+fn callable_target_nested_weak_property_still_errors() {
+    // Soundness: the suppression is direct-level only. A callable property whose
+    // VALUE is a genuine weak object must still fail (in_property_check
+    // re-enables the rule). tsc: TS2322 (property 'cfg' incompatible).
+    let src = r#"
+        interface Tn { (): void; cfg?: { a?: string } }
+        interface Sn { (): void; cfg: { c: number } }
+        declare const sn: Sn;
+        const n: Tn = sn;
+    "#;
+    assert_has_code(src, 2322, "nested weak property value must still error");
+}

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -267,6 +267,14 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// source may have no common properties with one member but still be assignable
     /// to the combined intersection (e.g., `A <: A & WeakType` should pass).
     pub(crate) in_intersection_member_check: bool,
+    /// When true, we're comparing the object-property part of a callable-to-callable
+    /// relation, after the call/construct signatures have already been compared.
+    /// Weak type checks are suppressed at this direct level because tsc's `isWeakType`
+    /// returns false for any type carrying a call or construct signature, so a callable
+    /// target is never a weak type. Nested property-value comparisons re-enable the
+    /// check via `in_property_check` (e.g. a callable property whose value is a genuine
+    /// weak object still triggers TS2559).
+    pub(crate) in_callable_property_check: bool,
     /// Whether recursive relation cycles and overflow should be treated as
     /// assumed-related (`true`) or definitive failure (`false`).
     pub assume_related_on_cycle: bool,
@@ -421,6 +429,7 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             enforce_weak_types: false,
             in_property_check: false,
             in_intersection_member_check: false,
+            in_callable_property_check: false,
             assume_related_on_cycle: true,
             identity_cycle_check: false,
             bypass_evaluation: false,
@@ -474,6 +483,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             enforce_weak_types: false,
             in_property_check: false,
             in_intersection_member_check: false,
+            in_callable_property_check: false,
             assume_related_on_cycle: true,
             identity_cycle_check: false,
             bypass_evaluation: false,

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -1805,13 +1805,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             }
         }
 
-        // Check properties (if any), excluding private fields.
-        // Sort by name (Atom) to match the merge scan's expectation in check_object_subtype.
-        //
-        // When both callables have construct signatures (class constructors), skip the
-        // `prototype` property. Its type is the instance type which is already validated
-        // by construct signature compatibility — checking it separately can fail when
-        // the target has generic type params that were erased only at the signature level.
+        // Check properties (excluding private `#` fields), sorted by name to match
+        // check_object_subtype's merge scan. When both callables have construct
+        // signatures, skip `prototype` (validated by construct-signature compatibility;
+        // checking it separately fails under signature-level generic erasure).
         let has_construct_sigs =
             !source.construct_signatures.is_empty() && !target.construct_signatures.is_empty();
         let should_skip_prop = |name| {
@@ -1877,19 +1874,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             symbol_index: None,
             symbol: target.symbol,
         };
-        // Both shapes are the property part of callables whose call/construct
-        // signatures already matched above. tsc's `isWeakType` returns false for
-        // any type with a call or construct signature, so the weak-type "no common
-        // property" rule must not fire on these stripped property shapes (e.g.
-        // `{ (): void; extra: number }` <: `{ (): void; name?: string }`). Mark the
-        // direct level so `check_object_subtype` suppresses it; nested property-value
-        // comparisons re-enable it through `in_property_check`.
-        let prev_in_callable_property_check = self.in_callable_property_check;
+        // Weak-type rule off for this stripped property part: a callable target is never weak in tsc. See `in_callable_property_check`.
+        let prev_callable = self.in_callable_property_check;
         self.in_callable_property_check = true;
         let props_ok = self
             .check_object_subtype(&source_shape, None, None, &target_shape, None)
             .is_true();
-        self.in_callable_property_check = prev_in_callable_property_check;
+        self.in_callable_property_check = prev_callable;
         if !props_ok {
             return SubtypeResult::False;
         }

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -1877,10 +1877,20 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             symbol_index: None,
             symbol: target.symbol,
         };
-        if !self
+        // Both shapes are the property part of callables whose call/construct
+        // signatures already matched above. tsc's `isWeakType` returns false for
+        // any type with a call or construct signature, so the weak-type "no common
+        // property" rule must not fire on these stripped property shapes (e.g.
+        // `{ (): void; extra: number }` <: `{ (): void; name?: string }`). Mark the
+        // direct level so `check_object_subtype` suppresses it; nested property-value
+        // comparisons re-enable it through `in_property_check`.
+        let prev_in_callable_property_check = self.in_callable_property_check;
+        self.in_callable_property_check = true;
+        let props_ok = self
             .check_object_subtype(&source_shape, None, None, &target_shape, None)
-            .is_true()
-        {
+            .is_true();
+        self.in_callable_property_check = prev_in_callable_property_check;
+        if !props_ok {
             return SubtypeResult::False;
         }
 

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -390,9 +390,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             && !crate::utils::has_common_property_name(&source.properties, &target.properties)
         {
             crate::relations::subtype::cache::note_weak_type_sensitivity();
-            if self.enforce_weak_types
-                && (!self.in_intersection_member_check || self.in_property_check)
-            {
+            // The weak-type rejection is suppressed at the direct level when the
+            // shapes are the property part of an intersection member or of a
+            // callable-to-callable relation (a callable target is never weak in
+            // tsc's `isWeakType`). A nested property-value comparison sets
+            // `in_property_check`, which re-enables the rule so genuine weak inner
+            // objects still fail.
+            let suppressed_at_direct_level =
+                self.in_intersection_member_check || self.in_callable_property_check;
+            if self.enforce_weak_types && (!suppressed_at_direct_level || self.in_property_check) {
                 return SubtypeResult::False;
             }
         }


### PR DESCRIPTION
Fixes #14749.

## Goal
Goal: green

Removes a false `TS2322` on the mobx canary row (`IReactionDisposer` -> `Lambda`, computedvalue.ts:327) and any callable-to-callable assignment where the target callable also carries a property.

## Structural rule
When both source and target are callable types (interfaces/object types with a call signature) and their call signatures are compatible, `tsc` checks the remaining property members with the ordinary structural object relation. It never applies the weak-type "no properties in common" rejection, because `isWeakType` returns `false` for any type that has a call or construct signature. tsz now does the same through the solver subtype relation.

## Root cause (corrected from the issue)
The issue attributed this to `CompatChecker::is_weak_type` ignoring call signatures. Tracing shows that path is **not** taken: `analyze_weak_and_explain(S1, T1)` returns `violates_union=false, violates_type=false` for the two `Callable` types, and the FP is `TS2322`, not the weak path's `TS2559`.

The real site is the structural relation. `check_callable_subtype` (`relations/subtype/rules/functions/checking.rs`) compares the two call signatures, then builds a temporary `ObjectShape` from each callable's property part (call/construct signatures **stripped** — `ObjectShape` has no signature fields) and calls `check_object_subtype`. That object comparison (`relations/subtype/rules/objects.rs`) applies the weak-type rule to the stripped shapes:

- target `{ name?: string }` looks weak (all-optional, >=1 prop, no index), and
- source `{ extra: number }` shares no property name,

so it returns `SubtypeResult::False`, which bubbles up as `TS2322`. The call signature on the original target — which makes it non-weak in tsc — is invisible to the stripped shape.

## Owner layer
Solver, subtype relation. Adds `in_callable_property_check` to `SubtypeChecker`; `check_callable_subtype` sets it around the property-part `check_object_subtype` call. The weak-type gate in `check_object_subtype` suppresses the rejection at this direct level (same mechanism as `in_intersection_member_check`). Nested property-value comparisons set `in_property_check`, which re-enables the rule, so a callable property whose value is a genuine weak object still fails.

## Adjacent matrix (tsz now matches tsc, all `--strict`)
- callable target `{ (): void; name?: string }` <- callable source `{ (): void; extra: number }` -> clean (was FP TS2322). Fixed.
- mobx: `Lambda { (): void; name?: string }` <- `IReactionDisposer { (): void; [sym]: Reaction }` (symbol-keyed source) -> clean (was FP). Fixed.
- renamed binders (`Disposer`/`Worker`) -> clean (no identifier fast path).
- control: callable target with no property `{ (): void }` <- callable source -> clean (unchanged).
- nested: callable target `{ (): void; cfg?: { a?: string } }` <- `{ (): void; cfg: { c: number } }` -> still `TS2322` (inner `{a?}` is genuinely weak; `in_property_check` re-enables). Soundness preserved.
- negative: genuine weak object target `{ a?: 1; b?: 2 }` (no call signature) <- `{ z: 3 }` -> still `TS2559`. Preserved.

## Out of scope (separate follow-up)
A callable target with a **required** property whose name is a Function apparent member (`{ (): void; name: string }` <- `{ (): void; extra: number }`) still emits `TS2741`. That is a distinct bug in source apparent-type property lookup (the source's `Function.name` is not consulted), not the weak-type rule. Noted on #14749.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- New: `crates/tsz-checker/tests/weak_callable_target_assignability_tests.rs` (6 cases: optional-prop FP fixed, symbol-keyed mobx witness, renamed binders, no-prop control, genuine-weak `TS2559` preserved, nested-weak `TS2322` preserved). All pass.
- Solver relation tests: `cargo nextest -p tsz-solver -E 'test(weak) or test(callable) or test(function_subtype) or test(is_weak)'` -> 206 passed.
- Conformance (`scripts/conformance/conformance.sh run --filter`): weak 3/3, thisType 32/32, comparable 15/15, functionType 5/5, interface 116/116, excessProperty 11/11, objectTypesIdentity 45/45.
- CLI before/after vs tsc 5.9.3 on the issue repro + matrix: FP gone, negatives preserved.

Assistant: M1FableArchitect
