### PR TITLE
fix(cli): probe triple-slash reference extensions for relative-prefixed paths (#14852)

### DIFF
--- a/crates/tsz-cli/src/driver/sources.rs
+++ b/crates/tsz-cli/src/driver/sources.rs
@@ -1064,7 +1064,17 @@ pub(super) fn read_source_files(
                     let mut candidates = Vec::new();
                     let direct_reference = base_dir.join(&reference_path);
                     candidates.push(direct_reference);
-                    if !reference_path.contains('.') {
+                    // Probe `.ts`/`.tsx`/`.d.ts` when the reference's FILE NAME has no
+                    // extension. Testing the whole string for `.` misfires on a `./` or
+                    // `../` relative prefix, silently skipping the probe. Mirror the
+                    // diagnostic path in state_checking/directive.rs, which uses
+                    // `Path::file_name()`.
+                    let file_name_lacks_extension = !Path::new(&reference_path)
+                        .file_name()
+                        .and_then(|f| f.to_str())
+                        .unwrap_or(reference_path.as_str())
+                        .contains('.');
+                    if file_name_lacks_extension {
                         for ext in
                             tsz::checker::triple_slash_validator::reference_path_probe_extensions(
                                 options.allow_js,

--- a/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
@@ -871,3 +871,81 @@ export { makeSink };
         result.diagnostics
     );
 }
+
+// Regression for #14852: a triple-slash `/// <reference path="./x" />` whose path
+// begins with a `./` or `../` relative prefix must still probe `.ts`/`.tsx`/`.d.ts`
+// extensions. The old guard tested the whole path for `.`, so the `.` in the
+// relative prefix skipped probing and the referenced file was never pulled,
+// producing a downstream TS2304. The referenced declaration is reachable ONLY via
+// the reference (it is not listed in tsconfig `files`), so a regression resurfaces
+// the TS2304. tsc resolves both relative and bare forms.
+#[test]
+fn triple_slash_reference_dot_slash_prefix_probes_extensions() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "es2022",
+            "strict": true,
+            "noEmit": true
+          },
+          "files": ["main.ts"]
+        }"#,
+    );
+    write_file(&base.join("dep.d.ts"), "declare const DEP_VAL: number;\n");
+    write_file(
+        &base.join("main.ts"),
+        "/// <reference path=\"./dep\" />\nconst y: number = DEP_VAL;\n",
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::CANNOT_FIND_NAME),
+        "`./dep` reference must pull dep.d.ts (no TS2304). Diagnostics: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        result.diagnostics.is_empty(),
+        "the program must be clean, matching tsc. Diagnostics: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn triple_slash_reference_dot_dot_slash_prefix_probes_extensions() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "es2022",
+            "strict": true,
+            "noEmit": true
+          },
+          "files": ["sub/main.ts"]
+        }"#,
+    );
+    write_file(&base.join("dep.d.ts"), "declare const DEP_VAL: number;\n");
+    write_file(
+        &base.join("sub/main.ts"),
+        "/// <reference path=\"../dep\" />\nconst y: number = DEP_VAL;\n",
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    assert!(
+        result.diagnostics.is_empty(),
+        "`../dep` reference must pull dep.d.ts from the parent dir (no TS2304). \
+         Diagnostics: {:?}",
+        result.diagnostics
+    );
+}


### PR DESCRIPTION
Fixes #14852.

## Goal
Goal: hold

Removes a false `TS2304` when a triple-slash `/// <reference path="..." />` uses a `./` or `../` relative prefix on an extensionless path.

## Structural rule
A triple-slash reference path is resolved by probing `.ts`/`.tsx`/`.d.ts` (and `.js`/`.jsx` under `allowJs`) when the path's **file-name component** has no extension. tsc resolves both `path="dep"` and `path="./dep"` this way. tsz now does the same in the CLI source-discovery driver.

## Root cause (wrong op + file:line)
`crates/tsz-cli/src/driver/sources.rs:1067` gated the extension-probe loop on `!reference_path.contains('.')` over the WHOLE path string. The `.` inside a `./` (or `../`) relative prefix makes that whole-string check true, so the probe branch is skipped: only the literal `base_dir.join("./dep")` candidate is tried, it is not a file, the loop `continue`s, and the referenced declaration file is silently never added to the program. Downstream, its declarations are missing and a `TS2304` follows. The diagnostic path at `crates/tsz-checker/src/state/state_checking/directive.rs:110` already does this correctly via `Path::file_name()`; the resolver disagreed with it.

## Fix
Replace the whole-string guard with a file-name-component extension check, mirroring `directive.rs`:
```rust
let file_name_lacks_extension = !Path::new(&reference_path)
    .file_name()
    .and_then(|f| f.to_str())
    .unwrap_or(reference_path.as_str())
    .contains('.');
```
Resolver and directive diagnostic now agree.

## Adjacent matrix (tsz now matches tsc, `--noEmit --strict`; referenced file pulled ONLY via the reference)
- `path="./dep"`  -> `dep.d.ts` resolved, clean (was false TS2304). Fixed.
- `path="../dep"` (from a subdir) -> parent `dep.d.ts` resolved, clean (was false TS2304). Fixed.
- `path="dep"` (bare, no prefix) -> clean (unchanged control).
- `path="./dep.d.ts"` (explicit extension) -> clean (file-name HAS an extension, probe correctly skipped; direct candidate hits).

## Owner layer
CLI source-discovery driver (`tsz-cli`). No checker/solver change.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- New driver tests in `crates/tsz-cli/tests/driver_tests_parts/part_13.rs`: `triple_slash_reference_dot_slash_prefix_probes_extensions` and `triple_slash_reference_dot_dot_slash_prefix_probes_extensions` (referenced decl reachable only via the reference; assert no TS2304 / clean). Both pass.
- CLI before/after vs tsc 5.9.3 on all four reference forms above: tsz now matches tsc (exit 0) everywhere; before, `./dep` and `../dep` emitted TS2304.
- `scripts/arch/check-checker-boundaries.sh`: passes (touched files under the size cap).

Assistant: M1FableArchitect
