### PR TITLE
fix(checker): widen inferred return literals for namespace-local function declarations (#14773)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -261,6 +261,9 @@ path = "tests/ts2371_binding_pattern_default_tests.rs"
 name = "return_type_literal_union_widening_tests"
 path = "tests/return_type_literal_union_widening_tests.rs"
 [[test]]
+name = "namespace_local_inferred_return_widening_tests"
+path = "tests/namespace_local_inferred_return_widening_tests.rs"
+[[test]]
 name = "block_body_callback_literal_widening_tests"
 path = "tests/block_body_callback_literal_widening_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -781,18 +781,18 @@ impl<'a> CheckerState<'a> {
         // within an expression's contextual flow where the ambient flag is
         // load-bearing (e.g. an `async () => makePromise()` argument typed under
         // argument inference). Their nested-widening is already handled at the
-        // function-expression branch of `return_expression_type`.
-        let function_is_named_declaration = self.ctx.arena.get(function_idx).is_some_and(|node| {
+        // function-expression branch of `return_expression_type`. Setters return
+        // `void` and never reach literal widening, so only the value-returning
+        // named kinds are listed.
+        let prev_preserve_literals = self.ctx.preserve_literal_types;
+        if self.ctx.arena.get(function_idx).is_some_and(|node| {
             matches!(
                 node.kind,
                 syntax_kind_ext::FUNCTION_DECLARATION
                     | syntax_kind_ext::METHOD_DECLARATION
                     | syntax_kind_ext::GET_ACCESSOR
-                    | syntax_kind_ext::SET_ACCESSOR
             )
-        });
-        let prev_preserve_literals = self.ctx.preserve_literal_types;
-        if function_is_named_declaration {
+        }) {
             self.ctx.preserve_literal_types = false;
         }
         let result = self.infer_return_type_from_body_inner(body_idx, return_context);

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -760,7 +760,43 @@ impl<'a> CheckerState<'a> {
         // the function itself is a `const` initializer.
         let prev_preserve_logical = self.ctx.preserve_logical_operand_literals;
         self.ctx.preserve_logical_operand_literals = false;
+        // A named function/method/accessor's signature is a property of its
+        // *declaration*, independent of whichever expression first forces it to
+        // be computed. Its `getReturnTypeFromBody` literal-widening policy is
+        // therefore decided only from *this* declaration's context (a contextual
+        // `return_context`, a `const` assertion, or a `satisfies` operand) — never
+        // inherited from the outer expression that happened to trigger the
+        // inference. `preserve_literal_types` is exactly such an outer-expression
+        // flag: `return_expression_type` sets it true while typing a non-function
+        // return expression such as `return helper()`. Resolving that call forces
+        // `helper`'s signature to be computed *under* the leaked flag, so a fresh
+        // literal return in `helper` fails to widen (`(): 1` instead of
+        // `(): number`). The leak only surfaces for declarations whose signature
+        // is computed lazily during another body's inference — e.g. a
+        // non-exported namespace-local function reached only through a sibling
+        // call — because top-level and exported declarations are resolved (and
+        // widened) independently first.
+        //
+        // Function expressions / arrows are NOT reset here: they are typed inline
+        // within an expression's contextual flow where the ambient flag is
+        // load-bearing (e.g. an `async () => makePromise()` argument typed under
+        // argument inference). Their nested-widening is already handled at the
+        // function-expression branch of `return_expression_type`.
+        let function_is_named_declaration = self.ctx.arena.get(function_idx).is_some_and(|node| {
+            matches!(
+                node.kind,
+                syntax_kind_ext::FUNCTION_DECLARATION
+                    | syntax_kind_ext::METHOD_DECLARATION
+                    | syntax_kind_ext::GET_ACCESSOR
+                    | syntax_kind_ext::SET_ACCESSOR
+            )
+        });
+        let prev_preserve_literals = self.ctx.preserve_literal_types;
+        if function_is_named_declaration {
+            self.ctx.preserve_literal_types = false;
+        }
         let result = self.infer_return_type_from_body_inner(body_idx, return_context);
+        self.ctx.preserve_literal_types = prev_preserve_literals;
         self.ctx.preserve_logical_operand_literals = prev_preserve_logical;
 
         // Direct self-recursive functions with no base case return `never`.

--- a/crates/tsz-checker/tests/namespace_local_inferred_return_widening_tests.rs
+++ b/crates/tsz-checker/tests/namespace_local_inferred_return_widening_tests.rs
@@ -1,0 +1,189 @@
+//! Regression tests for issue #14773.
+//!
+//! tsc widens an unannotated function's inferred return literal
+//! (`getReturnTypeFromBody` → `getWidenedType`) regardless of where the
+//! function is declared. A non-exported function declared inside a `namespace`
+//! that is reached only through a sibling call (`return privFn()`) is widened
+//! exactly like a top-level or exported function.
+//!
+//! tsz previously left such a callee's signature un-widened (`(): 1` instead of
+//! `(): number`) because the callee's `infer_return_type_from_body` was first
+//! triggered *during* the caller's return-expression typing, which sets the
+//! ambient `preserve_literal_types` flag — and that leaked flag suppressed the
+//! callee's own literal widening. The flag is an outer-expression concern; a
+//! named declaration's signature is context-independent, so its widening must
+//! not inherit it. Binder names are varied so the rule is structural, not
+//! name-keyed.
+
+use tsz_checker::test_utils::check_source_code_messages as diagnostics;
+
+fn ts2322(source: &str) -> Vec<String> {
+    diagnostics(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2322)
+        .map(|(_, msg)| msg)
+        .collect()
+}
+
+/// The reported witness: a non-exported namespace sibling returning a `const`
+/// literal, reached only through `pubFn`, must infer `number`.
+#[test]
+fn non_exported_namespace_sibling_const_return_widens() {
+    let source = r#"
+namespace M {
+  const priv = 1;
+  function privFn() { return priv; }
+  export function pubFn() { return privFn(); }
+}
+const ok: number = M.pubFn();
+"#;
+    assert!(
+        ts2322(source).is_empty(),
+        "non-exported namespace sibling chain must widen `1` to `number`, got: {:?}",
+        ts2322(source)
+    );
+}
+
+/// And the inferred type really is the widened `number` — assigning to the
+/// narrower literal `0` must report `number`, exactly as tsc does (it previously
+/// reported `1`).
+#[test]
+fn non_exported_namespace_sibling_reports_widened_source() {
+    let source = r#"
+namespace Box {
+  const seed = 1;
+  function make() { return seed; }
+  export function take() { return make(); }
+}
+const bad: 0 = Box.take();
+"#;
+    let msgs = ts2322(source);
+    assert_eq!(msgs.len(), 1, "expected exactly one TS2322, got: {msgs:?}");
+    assert!(
+        msgs[0].contains("Type 'number'"),
+        "inferred return must widen to `number`, got: {}",
+        msgs[0]
+    );
+}
+
+/// A fresh literal return (`return 1`) through the same non-exported sibling
+/// chain widens too.
+#[test]
+fn non_exported_namespace_sibling_fresh_literal_widens() {
+    let source = r#"
+namespace Ns {
+  function helper() { return 7; }
+  export function entry() { return helper(); }
+}
+const ok: number = Ns.entry();
+"#;
+    assert!(
+        ts2322(source).is_empty(),
+        "non-exported namespace sibling returning a fresh literal must widen, got: {:?}",
+        ts2322(source)
+    );
+}
+
+/// String and boolean literals follow the same rule.
+#[test]
+fn non_exported_namespace_sibling_string_and_boolean_widen() {
+    let string_src = r#"
+namespace S {
+  function inner() { return "tag"; }
+  export function outer() { return inner(); }
+}
+const ok: string = S.outer();
+"#;
+    assert!(
+        ts2322(string_src).is_empty(),
+        "string-literal sibling chain must widen to `string`, got: {:?}",
+        ts2322(string_src)
+    );
+
+    let bool_src = r#"
+namespace B {
+  function inner() { return true; }
+  export function outer() { return inner(); }
+}
+const ok: boolean = B.outer();
+"#;
+    assert!(
+        ts2322(bool_src).is_empty(),
+        "boolean-literal sibling chain must widen to `boolean`, got: {:?}",
+        ts2322(bool_src)
+    );
+}
+
+/// Multi-hop non-exported chains and nested namespaces widen as well.
+#[test]
+fn nested_namespace_multi_hop_widens() {
+    let source = r#"
+namespace Outer {
+  namespace Inner {
+    function deep() { return 5; }
+    export function mid() { return deep(); }
+  }
+  export function top() { return Inner.mid(); }
+}
+const ok: number = Outer.top();
+"#;
+    assert!(
+        ts2322(source).is_empty(),
+        "nested namespace multi-hop chain must widen, got: {:?}",
+        ts2322(source)
+    );
+}
+
+/// Over-widening guard: an explicit `as const` return through the same chain
+/// must still be preserved (assignable to the narrow literal, not widened).
+#[test]
+fn const_assertion_through_namespace_sibling_is_preserved() {
+    let source = r#"
+namespace M {
+  function privFn() { return 1 as const; }
+  export function pubFn() { return privFn(); }
+}
+const pinned: 1 = M.pubFn();
+"#;
+    assert!(
+        ts2322(source).is_empty(),
+        "`as const` literal must be preserved through the sibling chain, got: {:?}",
+        ts2322(source)
+    );
+}
+
+/// Over-widening guard: an explicit literal return-type annotation on the
+/// non-exported sibling is preserved.
+#[test]
+fn explicit_literal_annotation_through_namespace_sibling_is_preserved() {
+    let source = r#"
+namespace M {
+  function privFn(): 1 { return 1; }
+  export function pubFn() { return privFn(); }
+}
+const pinned: 1 = M.pubFn();
+"#;
+    assert!(
+        ts2322(source).is_empty(),
+        "explicit literal annotation must be preserved through the sibling chain, got: {:?}",
+        ts2322(source)
+    );
+}
+
+/// Over-widening guard: two distinct fresh literals through the chain stay a
+/// literal union (the #14530 invariant must survive the widening-context reset).
+#[test]
+fn distinct_literal_union_through_namespace_sibling_is_preserved() {
+    let source = r#"
+namespace M {
+  function classify(n: number) { if (n > 0) return "a"; return "b"; }
+  export function pub(n: number) { return classify(n); }
+}
+const u: "a" | "b" = M.pub(0);
+"#;
+    assert!(
+        ts2322(source).is_empty(),
+        "distinct-literal union must be preserved through the sibling chain, got: {:?}",
+        ts2322(source)
+    );
+}


### PR DESCRIPTION
Fixes #14773.

When a named function/method/accessor declaration has an unannotated body that returns a fresh (or const-ref) literal, tsc widens the inferred return type (`getReturnTypeFromBody` → `getWidenedType`): `(): 1` becomes `(): number`. tsz did this for top-level and exported declarations but **not** for a non-exported function declared inside a `namespace` that is reached only through a sibling call.

**Structural rule:** When a named declaration's signature is computed *lazily* (first forced while typing another body's `return helper()` expression), tsc widens its inferred return literal exactly as it would at top level; tsz must do the same through the checker's return-type inference, independent of the outer expression's literal-preservation context.

**Root cause:** `return_expression_type` sets the ambient `preserve_literal_types` flag true while typing a non-function return expression such as `return privFn()`. Resolving that call forces `privFn`'s signature to be computed *under* the leaked flag, and `return_contribution_is_widenable` bails when the flag is set — so `privFn`'s fresh literal `1` was cached un-widened, and every caller (and the DTS emit) inherited `1`. The leak never bit top-level or exported callees because their signatures are resolved (and widened) independently first; only namespace-local non-exported callees are computed lazily during the caller's body inference.

**Fix (owner: checker return-type inference):** A named declaration's signature is a property of its declaration, so its widening policy must come only from its own context (`return_context` / `in_const_assertion` / `satisfies`), never from an ambient outer-expression flag. `infer_return_type_from_body` now resets `preserve_literal_types` around a named function/method/accessor body's inference, mirroring the existing `preserve_logical_operand_literals` reset. Function expressions/arrows are intentionally left untouched — they are typed inline where the flag is load-bearing (e.g. an `async () => makePromise()` argument), and their nested widening is already handled at the function-expression branch of `return_expression_type`.

This is broad, not repro-scoped: it fixes the same leak for any named declaration reached lazily (functions, class methods, getters), and is verified to preserve `as const`, explicit literal annotations, and distinct-literal unions (#14530) through the same chain.

## Goal
Goal: hold

## Verification
- New `crates/tsz-checker/tests/namespace_local_inferred_return_widening_tests.rs` (8 tests): witness + fresh/const-ref/string/boolean returns, multi-hop and nested namespaces, plus over-widening guards (`as const`, explicit annotation, distinct-literal union preserved). All pass.
- Regression suites pass locally: `return_literal_union_widening_tests`, `return_type_literal_union_widening_tests`, `block_body_callback_literal_widening_tests`, `conditional_branch_array_literal_widening_tests`, `as_const_object_property_inference_tests`, `class_interface_namespace_merge_tests`, `generic_callback_local_literal_widening_tests`, `generator_return_type_widening_tests`, `context_sensitive_callback_inference_tests`, `inferred_getter_return_property_access_tests`, `class_arrow_property_type_inference_tests`, `function_terminal_return_flow_tests`, `contextual_return_callback_param_only_inference_tests`, `generic_return_fingerprint_tests`, `implicit_any_nullish_return_tests`.
- CLI parity vs `tsc` 6.0.2 on all bisection variants from the issue (non-exported/exported namespace sibling, top-level, direct return, nested namespaces, class method, getter) plus negative/over-widening cases — all match.
- Full conformance / emit / fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpGxZocdb5GMAKRdTd8BnE)_