### PR TITLE
fix(scanner): recognize a shebang after a leading UTF-8 BOM (#14806)

### DIFF
--- a/crates/tsz-scanner/src/scanner_impl/jsdoc.rs
+++ b/crates/tsz-scanner/src/scanner_impl/jsdoc.rs
@@ -209,13 +209,26 @@ impl ScannerState {
             return 0;
         }
 
+        // A leading UTF-8 BOM is transparent: tsc still recognizes a shebang that
+        // immediately follows it. Probe past the BOM, but only commit `self.pos`
+        // when a shebang actually follows, so a BOM without a shebang is left for
+        // the normal trivia path unchanged.
+        let bom_len = if self.pos < self.end
+            && self.char_code_unchecked(self.pos) == CharacterCodes::BYTE_ORDER_MARK
+        {
+            3 // BOM is 3 bytes in UTF-8
+        } else {
+            0
+        };
+        let shebang_start = self.pos + bom_len;
+
         // Check for #!
-        if self.pos + 1 < self.end
-            && self.char_code_unchecked(self.pos) == CharacterCodes::HASH
-            && self.char_code_unchecked(self.pos + 1) == CharacterCodes::EXCLAMATION
+        if shebang_start + 1 < self.end
+            && self.char_code_unchecked(shebang_start) == CharacterCodes::HASH
+            && self.char_code_unchecked(shebang_start + 1) == CharacterCodes::EXCLAMATION
         {
             let start = self.pos;
-            self.pos += 2;
+            self.pos = shebang_start + 2;
 
             // Scan to end of line
             while self.pos < self.end {

--- a/crates/tsz-scanner/tests/scanner_comprehensive_tests_parts/part_01.rs
+++ b/crates/tsz-scanner/tests/scanner_comprehensive_tests_parts/part_01.rs
@@ -87,6 +87,30 @@ mod shebang_scanning {
         let len = scanner.scan_shebang_trivia();
         assert!(len > 0);
     }
+
+    // Regression for #14806: a leading UTF-8 BOM (U+FEFF, 3 bytes) before a
+    // shebang must be transparent. The shebang previously went unrecognized
+    // because pos 0 is the BOM byte, so the parser later fired a spurious
+    // TS18026 + TS1005. tsc accepts a BOM before the shebang.
+    #[test]
+    fn shebang_after_bom() {
+        let mut scanner =
+            ScannerState::new("\u{FEFF}#!/usr/bin/env node\nvar x".to_string(), true);
+        let len = scanner.scan_shebang_trivia();
+        assert!(len > 0, "shebang after a BOM must be recognized");
+        // 3 BOM bytes + "#!/usr/bin/env node\n" (20 bytes) consumed.
+        assert_eq!(scanner.get_pos(), 23);
+    }
+
+    #[test]
+    fn bom_without_shebang_leaves_pos_at_zero() {
+        // A BOM with no following shebang must NOT be consumed here; it is left
+        // for the normal trivia path (next_token), so pos stays at 0.
+        let mut scanner = ScannerState::new("\u{FEFF}var x".to_string(), true);
+        let len = scanner.scan_shebang_trivia();
+        assert_eq!(len, 0);
+        assert_eq!(scanner.get_pos(), 0);
+    }
 }
 mod full_token_stream {
     use super::*;


### PR DESCRIPTION
Fixes #14806.

## Goal
Goal: green

Removes a false `TS18026` (+ cascading `TS1005`) when a file begins with a UTF-8 BOM immediately followed by a `#!` shebang. tsc accepts a BOM before the shebang.

## Structural rule
A leading UTF-8 BOM (U+FEFF) is transparent for shebang recognition: a `#!` line that immediately follows a BOM still counts as starting the file. tsc skips a leading BOM before testing for the shebang; tsz now does the same in the scanner.

## Root cause (wrong op + file:line)
`crates/tsz-scanner/src/scanner_impl/jsdoc.rs` `scan_shebang_trivia` is called first in `parse_source_file` while `pos == 0`, but byte 0 is the BOM (`EF BB BF` → U+FEFF), so the `char_code_unchecked(pos) == HASH` test fails and the function returns 0 without consuming. `next_token` then skips the BOM (the BOM branch in `scanner_impl.rs`) and the `#` at offset 3 becomes a `HashToken` at `token_pos != 0`. The parser's invalid-shebang recovery (`crates/tsz-parser/src/parser/state_statements.rs`) sees `#!` not at offset 0 and emits `TS18026` + `TS1005`.

## Fix
Probe past a leading BOM in `scan_shebang_trivia` and test for `#!` at the post-BOM offset. `self.pos` is committed (BOM + shebang line consumed) ONLY when a shebang actually follows; a BOM with no shebang returns 0 with `pos` unchanged, so it is still handled by the normal trivia path. No-BOM cases are byte-for-byte unchanged.

## Adjacent matrix (tsz now matches tsc, `--noEmit --strict`)
- BOM + `#!/usr/bin/env node` + `\n` + code -> clean (was false TS18026 + TS1005). Fixed.
- BOM + shebang + CRLF (`\r\n`) -> clean. Fixed.
- shebang without BOM -> clean (control, unchanged).
- BOM + code, no shebang -> clean (BOM still handled as trivia; `pos` not consumed by the shebang scan).
- no BOM, no shebang -> unchanged.

## Owner layer
Scanner (`tsz-scanner`). No parser/checker change.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
- New scanner unit tests in `crates/tsz-scanner/tests/scanner_comprehensive_tests_parts/part_01.rs`: `shebang_after_bom` (pos advances past BOM + shebang line) and `bom_without_shebang_leaves_pos_at_zero` (BOM alone is not consumed). Existing `shebang_*` tests guard the no-BOM cases.
- CLI before/after vs tsc 5.9.3 on the matrix above: tsz now matches tsc (exit 0) for BOM+shebang (LF and CRLF); before, both emitted TS18026 + TS1005.

Assistant: M1FableArchitect
