### PR TITLE
fix(emit/dts): preserve literal initializer for namespace-qualified const references

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/literal_initializers.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/literal_initializers.rs
@@ -142,7 +142,35 @@ impl<'a> DeclarationEmitter<'a> {
             return self.const_literal_initializer_text_deep_guarded(initializer, guard);
         }
 
+        // Chase a namespace-qualified value member (`N.deep`, `N.M.deep`) to its
+        // const declaration initializer, mirroring the Identifier-alias branch.
+        // `tsc` preserves the member's fresh literal the same way it preserves a
+        // plain identifier alias: `export const x = N.deep` -> `= 1`. The enum
+        // member access path (`E.A` -> `= E.A`) is handled earlier by
+        // `const_literal_initializer_text`, so this only fires for namespace
+        // value members.
+        if expr_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            && let Some(initializer) = self.const_qualified_member_initializer(expr_idx)
+        {
+            return self.const_literal_initializer_text_deep_guarded(initializer, guard);
+        }
+
         None
+    }
+
+    /// The initializer of the namespace value member that a property-access
+    /// chain (`N.deep`, `N.M.deep`) resolves to, when that member is a `const`
+    /// with no type annotation (a fresh literal). Mirrors `const_alias_initializer`
+    /// but for qualified namespace members. Requires the binder; enum members are
+    /// left to the dedicated enum-access path.
+    fn const_qualified_member_initializer(&self, expr_idx: NodeIndex) -> Option<NodeIndex> {
+        let binder = self.binder?;
+        let sym_id = self.access_reference_symbol(expr_idx)?;
+        let symbol = binder.symbols.get(sym_id)?;
+        if symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER != 0 {
+            return None;
+        }
+        self.const_variable_initializer_for_symbol(sym_id)
     }
 
     /// Inline `= literal` text for a `const` declaration, but only when the
@@ -232,7 +260,16 @@ impl<'a> DeclarationEmitter<'a> {
             let Some(decl) = self.arena.get_variable_declaration(decl_node) else {
                 continue;
             };
-            if self.arena.is_const_variable_declaration(decl_idx) && decl.initializer.is_some() {
+            // Only a `const` with NO explicit type annotation carries a fresh
+            // literal type whose initializer `tsc` inlines (`isFreshLiteralType`
+            // in `isLiteralConstDeclaration`). An annotation (`const a: number =
+            // 1`) widens the declared type, so a reference to it (`const c = a`,
+            // `N.deep`) must fall back to the `: number` annotation form rather
+            // than chasing the literal `= 1`.
+            if self.arena.is_const_variable_declaration(decl_idx)
+                && decl.type_annotation.is_none()
+                && decl.initializer.is_some()
+            {
                 return Some(decl.initializer);
             }
         }
@@ -258,6 +295,7 @@ impl<'a> DeclarationEmitter<'a> {
                     let decl_node = self.arena.get(decl_idx)?;
                     let decl = self.arena.get_variable_declaration(decl_node)?;
                     if self.arena.is_const_variable_declaration(decl_idx)
+                        && decl.type_annotation.is_none()
                         && self.get_identifier_text(decl.name).as_deref() == Some(&name)
                         && decl.initializer.is_some()
                     {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_enum_access.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_enum_access.rs
@@ -147,9 +147,7 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         let binder = self.binder?;
-        let sym_id = self
-            .value_reference_symbol(expr_idx)
-            .or_else(|| self.entity_access_chain_symbol(expr_idx))?;
+        let sym_id = self.access_reference_symbol(expr_idx)?;
         let symbol = binder.symbols.get(sym_id)?;
         if symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER == 0 {
             return None;
@@ -159,6 +157,18 @@ impl<'a> DeclarationEmitter<'a> {
         // slice: this normalizes `E["B"]` to `E.B` and prevents parenthesis /
         // non-null punctuation from leaking into the declaration output.
         self.enum_member_access_canonical_text(expr_idx)
+    }
+
+    /// Resolve a value reference or namespace-qualified property-access chain
+    /// (`N.deep`, `N.M.deep`) to its value symbol, trying the binder-tracked
+    /// node symbol first and falling back to walking the namespace export chain.
+    /// Shared by the enum-member-access and namespace-const-member paths.
+    pub(in crate::declaration_emitter) fn access_reference_symbol(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> Option<SymbolId> {
+        self.value_reference_symbol(expr_idx)
+            .or_else(|| self.entity_access_chain_symbol(expr_idx))
     }
 
     fn entity_access_chain_symbol(&self, expr_idx: NodeIndex) -> Option<SymbolId> {

--- a/crates/tsz-emitter/src/declaration_emitter/tests/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/mod.rs
@@ -315,6 +315,7 @@ mod local_alias_elision;
 mod misc_features;
 mod misc_features_import_exports;
 mod misc_inference_features;
+mod namespace_const_literal_preservation;
 mod probes_issues;
 mod probes_systematic;
 mod probes_tsc_comparison;

--- a/crates/tsz-emitter/src/declaration_emitter/tests/namespace_const_literal_preservation.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/namespace_const_literal_preservation.rs
@@ -5,7 +5,7 @@
 //! (`: number`).
 //!
 //! Owner: `crates/tsz-emitter/src/declaration_emitter/helpers/literal_initializers.rs`
-//! (`const_literal_initializer_text_deep_inner` PropertyAccess branch +
+//! (`const_literal_initializer_text_deep_inner` `PropertyAccess` branch +
 //! `const_variable_initializer_for_symbol` annotation guard).
 //!
 //! Regression: #14772.

--- a/crates/tsz-emitter/src/declaration_emitter/tests/namespace_const_literal_preservation.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/namespace_const_literal_preservation.rs
@@ -1,0 +1,157 @@
+//! Declaration emit: a `const` whose initializer is a property-access into a
+//! namespace value member (`N.deep`, `N.M.deep`) preserves the member's fresh
+//! literal initializer (`= 1`) the same way a plain identifier alias
+//! (`const c = a`) does, instead of degrading to the widened type annotation
+//! (`: number`).
+//!
+//! Owner: `crates/tsz-emitter/src/declaration_emitter/helpers/literal_initializers.rs`
+//! (`const_literal_initializer_text_deep_inner` PropertyAccess branch +
+//! `const_variable_initializer_for_symbol` annotation guard).
+//!
+//! Regression: #14772.
+
+use super::*;
+
+/// `export const x = N.deep` where `deep` is a fresh-literal `const` member:
+/// tsc preserves `= 1`. Binder names are varied across cases so no fixture
+/// name drives the logic.
+#[test]
+fn namespace_const_member_number_literal_is_preserved() {
+    let output =
+        emit_dts_with_binding("namespace N { export const deep = 1; }\nexport const x = N.deep;");
+    assert!(
+        output.contains("export declare const x = 1;"),
+        "expected namespace member literal to be inlined as `= 1`: {output}"
+    );
+    assert!(
+        !output.contains("const x: number"),
+        "must not degrade to the widened `: number` annotation: {output}"
+    );
+}
+
+/// Deeply-qualified member (`N.M.deep`) resolves through the nested namespace
+/// export chain and preserves its literal.
+#[test]
+fn nested_namespace_const_member_number_literal_is_preserved() {
+    let output = emit_dts_with_binding(
+        "namespace Outer { export namespace Inner { export const depth = 5; } }\nexport const value = Outer.Inner.depth;",
+    );
+    assert!(
+        output.contains("export declare const value = 5;"),
+        "expected nested namespace member literal to be inlined as `= 5`: {output}"
+    );
+    assert!(
+        !output.contains("const value: number") && !output.contains("const value: any"),
+        "must not degrade to `: number` / `: any`: {output}"
+    );
+}
+
+/// String and boolean literal members preserve `= "hi"` / `= true`.
+#[test]
+fn namespace_const_member_string_and_boolean_literals_are_preserved() {
+    let string_output = emit_dts_with_binding(
+        "namespace Conf { export const label = \"hi\"; }\nexport const tag = Conf.label;",
+    );
+    assert!(
+        string_output.contains("export declare const tag = \"hi\";"),
+        "expected string member literal `= \"hi\"`: {string_output}"
+    );
+
+    let bool_output = emit_dts_with_binding(
+        "namespace Flags { export const enabled = true; }\nexport const active = Flags.enabled;",
+    );
+    assert!(
+        bool_output.contains("export declare const active = true;"),
+        "expected boolean member literal `= true`: {bool_output}"
+    );
+}
+
+/// A consumer declared *inside* another namespace preserves the member literal
+/// (`const x = 1;` rather than `const x: number;`).
+#[test]
+fn namespace_const_member_preserved_when_consumer_is_namespace_local() {
+    let output = emit_dts_with_binding(
+        "namespace Src { export const seed = 1; }\nnamespace Dst { export const x = Src.seed; }",
+    );
+    assert!(
+        output.contains("const x = 1;"),
+        "expected namespace-local consumer to inline `= 1`: {output}"
+    );
+    assert!(
+        !output.contains("const x: number"),
+        "must not degrade to `: number`: {output}"
+    );
+}
+
+/// Control: an *annotated* member (`export const deep: number = 1`) widens the
+/// declared type, so the reference must keep the `: number` annotation — the
+/// literal-vs-annotated-member distinction.
+#[test]
+fn annotated_namespace_const_member_keeps_widened_annotation() {
+    let output = emit_dts_with_binding(
+        "namespace N { export const deep: number = 1; }\nexport const x = N.deep;",
+    );
+    assert!(
+        output.contains("export declare const x: number;"),
+        "an annotated member must keep `: number`, not inline `= 1`: {output}"
+    );
+    assert!(
+        !output.contains("const x = 1;"),
+        "must not inline an annotated member's initializer: {output}"
+    );
+}
+
+/// A non-`const` member (`export let`) widens to its base type, so the
+/// reference is annotated, not inlined.
+#[test]
+fn non_const_namespace_member_is_not_inlined() {
+    let output =
+        emit_dts_with_binding("namespace N { export let deep = 1; }\nexport const x = N.deep;");
+    assert!(
+        output.contains("export declare const x: number;"),
+        "a `let` member widens, so the reference keeps `: number`: {output}"
+    );
+    assert!(
+        !output.contains("const x = 1;"),
+        "must not inline a non-const member: {output}"
+    );
+}
+
+/// Adjacent: a plain identifier alias of a fresh literal is still preserved
+/// (do not regress the #3449 behavior).
+#[test]
+fn identifier_alias_of_fresh_literal_is_still_preserved() {
+    let output = emit_dts_with_binding("const a = 1;\nexport const c = a;");
+    assert!(
+        output.contains("export declare const c = 1;"),
+        "identifier alias of a fresh literal must stay inlined `= 1`: {output}"
+    );
+}
+
+/// Broad fix: an identifier alias of an *annotated* const must fall back to the
+/// widened annotation (`: number`), matching tsc — previously tsz wrongly
+/// inlined `= 1`.
+#[test]
+fn identifier_alias_of_annotated_const_keeps_widened_annotation() {
+    let output = emit_dts_with_binding("const a: number = 1;\nexport const c = a;");
+    assert!(
+        output.contains("export declare const c: number;"),
+        "alias of an annotated const must keep `: number`, not inline `= 1`: {output}"
+    );
+    assert!(
+        !output.contains("const c = 1;"),
+        "must not inline the annotated const's initializer through an alias: {output}"
+    );
+}
+
+/// Coexistence: an enum-member access (`E.A`) is still rendered as the member
+/// reference `= E.A` (handled by the enum-access path, not the new namespace
+/// branch).
+#[test]
+fn enum_member_access_still_renders_member_reference() {
+    let output = emit_dts_with_binding("enum E { A, B }\nexport const a = E.A;");
+    assert!(
+        output.contains("export declare const a = E.A;"),
+        "enum-member access must stay `= E.A`: {output}"
+    );
+}


### PR DESCRIPTION
Declaration emit dropped literal-initializer preservation for a `const` whose initializer is a property-access into a namespace value member. tsz emitted the widened annotation `: number` where tsc keeps the constant form `= 1` (and `= "hi"` / `= true`). A plain identifier alias (`const c = a`) was already preserved, so the gap was the missing PropertyAccess branch in `const_literal_initializer_text_deep_inner`.

Structural rule: when a `const` with no type annotation references a fresh literal `const` member through a (possibly nested) namespace-qualified property access (`N.deep`, `N.M.deep`), tsc inlines the member's literal initializer; tsz now does the same through the declaration emitter (`crates/tsz-emitter/src/declaration_emitter/helpers/literal_initializers.rs`), the emit owner layer.

What changed:
- Add a `PROPERTY_ACCESS_EXPRESSION` branch to `const_literal_initializer_text_deep_inner` that resolves the qualified member to its value symbol and chases its const initializer, mirroring the existing Identifier-alias branch. Enum-member access (`E.A` -> `= E.A`) stays on the dedicated enum path, which runs earlier.
- Extract `access_reference_symbol` (value-reference-then-export-chain resolution) shared by the enum-member-access and namespace-const-member paths (was duplicated).
- Respect freshness: `const_variable_initializer_for_symbol` and the no-binder fallback now inline a member/alias initializer only when the referenced const has NO explicit type annotation, matching tsc's `isFreshLiteralType` / `isLiteralConstDeclaration`.

Adjacent matrix (all asserted in the new test module):
- number / string / boolean namespace members -> `= 1` / `= "hi"` / `= true`.
- Deeply-qualified `N.M.deep` and namespace-local consumer (`namespace P { const x = N.deep }`).
- Annotated member control (`export const deep: number = 1`) keeps `: number` (fallback).
- Non-`const` member (`export let`) widens to `: number` (fallback).
- Identifier alias of a fresh literal still preserved (no #3449 regression); identifier alias of an *annotated* const now correctly emits `: number` (was wrongly `= 1`).
- Enum-member access still renders `= E.A`.

Binder names are varied across the cases so no fixture name drives the logic.

Closes #14772.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-emitter --lib -E 'test(declaration_emitter::tests::)'` — 1362 passed (incl. 9 new `namespace_const_literal_preservation` cases).
- `cargo nextest run -p tsz-emitter --lib -E 'test(enum) | test(const_enum)'` — enum/const-enum paths unaffected.
- `cargo clippy -p tsz-emitter --lib` — clean.
- Ready-review CI owns full conformance / emit / fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01BLk8QHp2HjYJZtrnPaXPST

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLk8QHp2HjYJZtrnPaXPST)_