### PR TITLE
fix(checker): recover cross-file unresolved-application residue before discriminant narrowing (TS2339)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -1246,7 +1246,20 @@ impl<'a> FlowAnalyzer<'a> {
         let is_strict = comparison.is_strict;
 
         let effective_truth = comparison.effective_truth(is_true_branch);
-        let mut type_id = type_id;
+        // Recover any `Application(UnresolvedTypeName(name), args)` residue left by
+        // cross-file alias lowering before equality/discriminant narrowing reads
+        // the members. An imported `type Either<E, A> = Left<E> | Right<A>` lowers
+        // its alias body before the merged binder exists, so the inner `Left`/
+        // `Right` refs stay unresolved; the solver-side `NarrowingContext`
+        // resolver (a `TypeEnvironment`) only knows names it was explicitly seeded
+        // with and cannot resolve such imports, so a guard like
+        // `a._tag === 'Right'` fails to read `_tag` and keeps the whole union,
+        // surfacing a false `TS2339` on a later `.right`. The `CheckerContext`
+        // resolver walks the merged binder graph and recovers the members, so
+        // discriminant filtering then works (benefits any cross-file discriminated
+        // union). Gated structurally on the residue, so resolved flow types are
+        // untouched.
+        let mut type_id = self.recover_unresolved_application_for_narrowing(type_id);
 
         // Optional-chain equality transport:
         // when an optional-chain comparison is known-equal to a value that cannot

--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -990,6 +990,50 @@ impl<'a> FlowAnalyzer<'a> {
         }
     }
 
+    /// Recover an `Application(UnresolvedTypeName(name), args)` residue left in a
+    /// flow type by cross-file alias lowering, so equality/discriminant narrowing
+    /// can read the now-concrete members.
+    ///
+    /// When an imported alias such as `type Either<E, A> = Left<E> | Right<A>` is
+    /// lowered before the merged binder is available, the alias body's inner
+    /// references (`Left`/`Right`) stay as `Application(UnresolvedTypeName, args)`
+    /// instead of `Lazy(DefId)`. The solver-side `NarrowingContext` resolver is a
+    /// `TypeEnvironment`, which only resolves names it was explicitly seeded with
+    /// and returns `None` for such imports; a guard like `a._tag === 'Right'`
+    /// then cannot read `_tag` off the members, keeps the whole union, and a
+    /// later `.right` access reports a false `TS2339`. The `CheckerContext`
+    /// resolver walks the merged binder graph and resolves the names, so running
+    /// the type evaluator with it as the resolver recovers concrete members.
+    ///
+    /// Gated structurally on `contains_unresolved_application` (no name/file-string
+    /// check), so a resolved flow type is returned unchanged. If recovery cannot
+    /// resolve every name (e.g. a qualified `S.Separated` reference), the original
+    /// type is kept so no partially-recovered type leaks into narrowing.
+    pub(crate) fn recover_unresolved_application_for_narrowing(&self, type_id: TypeId) -> TypeId {
+        if !crate::query_boundaries::spread::contains_unresolved_application(
+            self.interner.as_type_database(),
+            type_id,
+        ) {
+            return type_id;
+        }
+        let Some(ctx) = self.checker_context else {
+            return type_id;
+        };
+        let recovered =
+            crate::query_boundaries::state::type_environment::evaluate_type_with_resolver(
+                self.interner,
+                ctx,
+                type_id,
+            );
+        if crate::query_boundaries::spread::contains_unresolved_application(
+            self.interner.as_type_database(),
+            recovered,
+        ) {
+            return type_id;
+        }
+        recovered
+    }
+
     /// Resolve a global constructor-variable symbol (e.g. the lib `Map`/`Set`
     /// interface+var) to its instance type for `instanceof` narrowing. The raw
     /// interface is generic (`Map<K, V>`); tsc narrows `x instanceof Map` to the


### PR DESCRIPTION
Cross-file discriminated-union narrowing emitted a false `TS2339`. When an imported alias like `type Either<E, A> = Left<E> | Right<A>` is lowered before the merged binder is available, the alias body's inner refs (`Left`/`Right`) stay as `Application(UnresolvedTypeName, args)` instead of `Lazy(DefId)`. The solver-side narrowing resolver (a `TypeEnvironment`) only resolves seeded names and returns `None` for such imports, so a guard like `if (a._tag === 'Right')` cannot read `_tag`, keeps the whole union, and a later `a.right` reports a false `TS2339: Property 'right' does not exist on type 'Left<E> | Right<A>'`.

## Structural rule
When a flow-narrowed reference's type contains an `Application(UnresolvedTypeName(name), args)` member from cross-file alias lowering, `tsc` resolves it (the alias body's inner refs point to the declaring module's decls); `tsz` must run the existing `UnresolvedTypeName` recovery before discriminant narrowing / property access.

Owner layer: checker flow-narrowing (`FlowAnalyzer`). The fix recovers the residue at the `narrow_by_binary_expr` entry via the `CheckerContext` resolver (which walks the merged binder graph), then the existing discriminant logic filters members correctly. This is NOT the `#14344` cross-arena distinct-`DefId` issue: the names resolve to single `DefId`s cleanly (fp-ts: `Left` -> one `DefId` 36x, `Right` -> one `DefId` 36x).

- Gated structurally on `contains_unresolved_application` (no name/file-string predicate), so resolved flow types are returned unchanged (no perf impact on the common path).
- If any name remains unresolved after recovery (e.g. a qualified `S.Separated` reference), the original type is kept so no partially-recovered type leaks into narrowing.

## Adjacent matrix
Verified against `tsc` 5.5.4: renamed binders (`Left<E>|Right<A>`, `Left<A>|Right<B>`, `Left<B>|Right<C>`), string/number/boolean-literal discriminants, 3-member unions, negative/`else` and `!==` branches, switch over the discriminant, aliased re-export + alias-of-alias, nested union members, mixed `Either|null`, and the qualified-name gate fallback. Both branches narrow correctly (else -> `Left`, no over-narrow); wrong-branch property access still errors with the correctly-narrowed type (no under-narrow / no error suppression); shared-discriminant unions keep all matching members.

Goal: green

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Minimal 2-file repro (`Either` imported from another file, `if (a._tag === 'Right') a.right`) now compiles clean; 1-file (same-file) stays clean; `tsc` 5.5.4 reports 0 on both.
- fp-ts bench (flags off, `tsc` 5.5.4 = 0 errors): total 1332 -> 1316 (-16), `TS2339` 34 -> 18; precise `file(line,col)`+code diff = 16 cleared / 0 new. Cleared cluster spans `Array`/`ReadonlyArray`/`ReadonlyRecord`/`ReadonlySet`/`Set` with renamed binders (structural, not name-specific).
- `cargo nextest -p tsz-solver` (narrow/discriminant/relation/flow) and `-p tsz-checker` (narrow/flow/cross-file/tagged): failure set byte-identical to clean main (0 new failures); `clippy --release -p tsz-checker` clean; both changed files < 2000 lines.
