### PR TITLE
fix(checker): widen TS2367 operands via tsc's getBaseTypesIfUnrelated

### DIFF
--- a/crates/tsz-checker/src/types/computation/binary.rs
+++ b/crates/tsz-checker/src/types/computation/binary.rs
@@ -917,7 +917,7 @@ impl<'a> CheckerState<'a> {
                         type_param,
                     )
                 } else {
-                    self.widen_for_ts2367_cross_family_display(left_narrow, right_narrow)
+                    self.widen_operands_for_ts2367_display(left_narrow, right_narrow)
                 };
                 // tsc shows unique symbols as `typeof varName` in comparison overlap errors
                 // (distinct from index-type errors like TS2538/TS7053 where it uses `unique symbol`).

--- a/crates/tsz-checker/src/types/computation/binary_support.rs
+++ b/crates/tsz-checker/src/types/computation/binary_support.rs
@@ -4,8 +4,7 @@
 
 use crate::context::TypingRequest;
 use crate::query_boundaries::type_computation::core::{
-    WriteTargetLogicalOperator, WriteTargetLogicalResult, enum_components, evaluate_type_structure,
-    is_keyof_type, type_parameter_constraint,
+    WriteTargetLogicalOperator, WriteTargetLogicalResult,
 };
 use crate::query_boundaries::type_computation::in_operator::{self, InOperatorRhsClassifier};
 use crate::state::CheckerState;
@@ -786,151 +785,72 @@ impl CheckerState<'_> {
         false
     }
 
-    /// Get the primitive type family of a type: `TypeId::STRING` for string/string literals,
-    /// `TypeId::NUMBER` for number/number literals, `TypeId::BOOLEAN` for boolean/boolean literals,
-    /// `TypeId::BIGINT` for bigint/bigint literals, or `TypeId::ERROR` for non-primitive types.
+    /// Compute one operand's TS2367 display base, mirroring tsc's
+    /// `getBaseTypeOfLiteralType`.
     ///
-    /// Used to determine if two types are from different primitive families (e.g., string vs number)
-    /// for TS2367 display purposes. When types are from different families, tsc widens literals
-    /// to their base primitive types in error messages.
-    fn get_primitive_family(&self, type_id: TypeId) -> TypeId {
-        use crate::query_boundaries::common::LiteralTypeKind;
-        use crate::query_boundaries::common::{
-            classify_literal_type, is_string_intrinsic_type, is_template_literal_type,
-            is_unique_symbol_type,
-        };
-
-        // Check direct primitive type IDs
-        if type_id == TypeId::STRING
-            || type_id == TypeId::NUMBER
-            || type_id == TypeId::BOOLEAN
-            || type_id == TypeId::BIGINT
-            || type_id == TypeId::SYMBOL
-        {
-            return type_id;
-        }
-
-        // Boolean literal intrinsics (`true` / `false`) belong to the boolean
-        // family. classify_literal_type below short-circuits on intrinsics,
-        // so we'd otherwise miss them and TS2367 cross-family widening
-        // would skip — leaving messages like `'symbol' and 'true'` instead
-        // of tsc's `'symbol' and 'boolean'`.
-        if type_id == TypeId::BOOLEAN_TRUE || type_id == TypeId::BOOLEAN_FALSE {
-            return TypeId::BOOLEAN;
-        }
-
-        // Check literal types via query boundary
-        match classify_literal_type(self.ctx.types, type_id) {
-            LiteralTypeKind::String(_) => return TypeId::STRING,
-            LiteralTypeKind::Number(_) => return TypeId::NUMBER,
-            LiteralTypeKind::Boolean(_) => return TypeId::BOOLEAN,
-            LiteralTypeKind::BigInt(_) => return TypeId::BIGINT,
-            LiteralTypeKind::NotLiteral => {}
-        }
-
-        // Unique symbol literal types belong to the symbol family.
-        if is_unique_symbol_type(self.ctx.types, type_id) {
-            return TypeId::SYMBOL;
-        }
-
-        // Check template literals and string intrinsics
-        if is_template_literal_type(self.ctx.types, type_id)
-            || is_string_intrinsic_type(self.ctx.types, type_id)
-        {
-            return TypeId::STRING;
-        }
-
-        if let Some((_def_id, member_type)) = enum_components(self.ctx.types, type_id) {
-            return self.get_primitive_family(member_type);
-        }
-        if is_keyof_type(self.ctx.types, type_id) {
-            return TypeId::STRING;
-        }
-        if let Some(constraint) = type_parameter_constraint(self.ctx.types, type_id) {
-            return self.get_primitive_family(constraint);
-        }
-
-        // Intersections narrow their members; if any member sits in a primitive
-        // family, treat the intersection as belonging to that family (e.g.
-        // `T & number` should count as number-family for TS2367 widening).
-        if let Some(list_id) =
-            crate::query_boundaries::common::intersection_list_id(self.ctx.types, type_id)
-        {
-            for member in self.ctx.types.type_list(list_id).iter() {
-                let family = self.get_primitive_family(*member);
-                if family != TypeId::ERROR {
-                    return family;
-                }
-            }
-        }
-
-        // A union belongs to a primitive family when every primitive member
-        // shares one family (`1 | 2`, `"a" | undefined`). `null`/`undefined`
-        // and non-primitive members are ignored for the family decision: they
-        // ride along unwidened in tsc's display (`number | undefined`,
-        // `Refrigerator | "foo"`). A union of only ignored members, an empty
-        // union, or a union spanning multiple primitive families has no single
-        // family. This mirrors tsc widening `(1 | undefined) === "x"` operands
-        // to `number | undefined` / `string` while leaving `(1 | undefined) === 2`
-        // and `(Refrigerator | "foo") === "bar"` as literals.
+    /// A bare primitive literal widens to its primitive (`1` → `number`, `"x"`
+    /// → `string`); an enum *member* widens to its parent enum (`E.A` → `E`); a
+    /// union maps every member through the same rule (`E.A | 1` → `E | number`);
+    /// and everything else — a whole enum, an object/function/`void`, a type
+    /// parameter, `keyof`, an intersection — is returned unchanged.
+    fn ts2367_display_base_type(&mut self, type_id: TypeId) -> TypeId {
+        // Distribute the base-of-literal over a union's members so a mixed
+        // operand widens member-by-member, matching tsc's `mapType`.
         if let Some(members) =
             crate::query_boundaries::common::union_members(self.ctx.types, type_id)
         {
-            let mut common: Option<TypeId> = None;
-            for &member in &members {
-                if member == TypeId::NULL || member == TypeId::UNDEFINED {
-                    continue;
-                }
-                let family = self.get_primitive_family(member);
-                if family == TypeId::ERROR {
-                    continue;
-                }
-                match common {
-                    None => common = Some(family),
-                    Some(existing) if existing == family => {}
-                    Some(_) => return TypeId::ERROR,
-                }
-            }
-            return common.unwrap_or(TypeId::ERROR);
+            let mut changed = false;
+            let mapped: Vec<TypeId> = members
+                .iter()
+                .map(|&member| {
+                    let base = self.ts2367_display_base_type(member);
+                    changed |= base != member;
+                    base
+                })
+                .collect();
+            return if changed {
+                tsz_solver::utils::union_or_single(self.ctx.types, mapped)
+            } else {
+                type_id
+            };
         }
-
-        let evaluated = evaluate_type_structure(self.ctx.types, type_id);
-        if evaluated != type_id {
-            return self.get_primitive_family(evaluated);
+        // An enum member widens to its parent enum; `widen_enum_member_type`
+        // leaves whole enums and non-enum types untouched.
+        let widened_enum = self.widen_enum_member_type(type_id);
+        if widened_enum != type_id {
+            return widened_enum;
         }
-
-        TypeId::ERROR // Non-primitive types
+        // A bare primitive literal widens to its primitive; non-literals (objects,
+        // functions, `void`, type parameters, `null`/`undefined`) are unchanged.
+        crate::query_boundaries::common::widen_literal_type(self.ctx.types, type_id)
     }
 
-    /// Widen operands for TS2367 display.
+    /// Widen operands for TS2367 display, mirroring tsc's
+    /// `getBaseTypesIfUnrelated`.
     ///
-    /// tsc preserves literal types in the message only when both operands belong
-    /// to the *same* single primitive family (`"foo"` vs `"bar"` → `"foo"` /
-    /// `"bar"`; `1 | undefined` vs `2` → `1 | undefined` / `2`). Otherwise it
-    /// shows each operand widened to its base type via `getBaseTypeOfLiteralType`
-    /// — distributing over unions and leaving non-literals (objects,
-    /// `null`/`undefined`) unchanged: `1 | 2` vs `"x"` → `number` / `string`;
-    /// `1 | undefined` vs `"x"` → `number | undefined` / `string`; `{ a }` vs
-    /// `"x"` → `{ a }` / `string`. A `null`/`undefined`-only or mixed-family
-    /// operand has no family (`ERROR`), so it never matches the other side and
-    /// the pair is widened.
-    pub(super) fn widen_for_ts2367_cross_family_display(
-        &self,
+    /// tsc computes the base type of each operand
+    /// ([`ts2367_display_base_type`](Self::ts2367_display_base_type)) and adopts
+    /// those bases for the message **only when the bases remain unrelated**. If
+    /// widening introduces an overlap — two literals of one primitive family
+    /// (`1` / `2`), two members of one enum (`E.A` / `E.B`), or an enum against
+    /// its own primitive (`E` / `0`) — the original operand types are kept so
+    /// their precise literal/member form is displayed. Otherwise the bases are
+    /// shown: `1 | 2` vs `"x"` → `number` / `string`; `void` vs `1` → `void` /
+    /// `number`; and enum members against a disjoint operand collapse to their
+    /// parent enum (`E.A === F.X` → `'E'` / `'F'`).
+    pub(super) fn widen_operands_for_ts2367_display(
+        &mut self,
         left: TypeId,
         right: TypeId,
     ) -> (TypeId, TypeId) {
-        let left_family = self.get_primitive_family(left);
-        let right_family = self.get_primitive_family(right);
-
-        if left_family != TypeId::ERROR && left_family == right_family {
-            // Same single primitive family: preserve literal types.
-            (left, right)
+        let left_base = self.ts2367_display_base_type(left);
+        let right_base = self.ts2367_display_base_type(right);
+        if (left_base != left || right_base != right)
+            && self.equality_operands_have_no_overlap(left_base, right_base)
+        {
+            (left_base, right_base)
         } else {
-            // Differing or absent family: widen both to their base types.
-            (
-                crate::query_boundaries::common::widen_literal_type(self.ctx.types, left),
-                crate::query_boundaries::common::widen_literal_type(self.ctx.types, right),
-            )
+            (left, right)
         }
     }
 

--- a/crates/tsz-checker/src/types/computation/binary_tests.rs
+++ b/crates/tsz-checker/src/types/computation/binary_tests.rs
@@ -873,23 +873,10 @@ fn ts2367_widens_cross_family_literals_in_display() {
     // belong to different primitive families: `1 | 2` vs `"hello"` is displayed
     // as `number` and `string` (verified against tsc 6.0.2), distributing the
     // base-of-literal widening over the union.
-    let diags = check_source_diagnostics(r#"declare let x: 1 | 2; if (x === "hello") {}"#);
-    let relevant: Vec<_> = diags.iter().filter(|d| d.code == 2367).collect();
-    assert_eq!(
-        relevant.len(),
-        1,
-        "Expected exactly one TS2367, got: {:?}",
-        diags
-            .iter()
-            .map(|d| (d.code, d.message_text.as_str()))
-            .collect::<Vec<_>>()
-    );
+    let message = sole_ts2367_message(r#"declare let x: 1 | 2; if (x === "hello") {}"#);
     assert!(
-        relevant[0]
-            .message_text
-            .contains("types 'number' and 'string' have no overlap"),
-        "Expected cross-family widened display matching tsc, got: {:?}",
-        relevant[0].message_text
+        message.contains("types 'number' and 'string' have no overlap"),
+        "Expected cross-family widened display matching tsc, got: {message}"
     );
 }
 
@@ -898,23 +885,10 @@ fn ts2367_preserves_same_family_literals_in_display() {
     // When both operands share a single primitive family, tsc preserves the
     // literal types in the message: `1` vs `2` stays `1` and `2` rather than
     // widening to `number` (verified against tsc 6.0.2).
-    let diags = check_source_diagnostics(r#"const unused = (1 as 1) === (2 as 2);"#);
-    let relevant: Vec<_> = diags.iter().filter(|d| d.code == 2367).collect();
-    assert_eq!(
-        relevant.len(),
-        1,
-        "Expected exactly one TS2367, got: {:?}",
-        diags
-            .iter()
-            .map(|d| (d.code, d.message_text.as_str()))
-            .collect::<Vec<_>>()
-    );
+    let message = sole_ts2367_message(r#"const unused = (1 as 1) === (2 as 2);"#);
     assert!(
-        relevant[0]
-            .message_text
-            .contains("types '1' and '2' have no overlap"),
-        "Expected same-family literal display matching tsc, got: {:?}",
-        relevant[0].message_text
+        message.contains("types '1' and '2' have no overlap"),
+        "Expected same-family literal display matching tsc, got: {message}"
     );
 }
 
@@ -1025,6 +999,127 @@ function object_null_or_undefined<T extends {} | null | undefined>(value: T & ({
             .iter()
             .all(|diag| diag.message_text.contains("types 'T' and 'number'")),
         "Expected tsc-style `T` vs `number` display, got: {relevant:?}"
+    );
+}
+
+/// The single TS2367 message text emitted for `source`, or a panic listing the
+/// diagnostics actually produced. Centralizes the "exactly one TS2367" check the
+/// display-parity tests below all need.
+fn sole_ts2367_message(source: &str) -> String {
+    let diags = check_source_diagnostics(source);
+    let relevant: Vec<_> = diags.iter().filter(|d| d.code == 2367).collect();
+    assert_eq!(
+        relevant.len(),
+        1,
+        "Expected exactly one TS2367, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.as_str()))
+            .collect::<Vec<_>>()
+    );
+    relevant[0].message_text.to_string()
+}
+
+#[test]
+fn ts2367_enum_members_of_distinct_enums_widen_to_parent_enum() {
+    // tsc's getBaseTypesIfUnrelated widens each enum member to its parent enum
+    // when the parents are unrelated: `E.A === F.X` displays `'E' and 'F'`, not
+    // the member names (verified against tsc). Mixed numeric/string enums.
+    let message = sole_ts2367_message(
+        r#"enum E { A, B }
+enum F { X = "x" }
+const unused = E.A === F.X;"#,
+    );
+    assert!(
+        message.contains("types 'E' and 'F' have no overlap"),
+        "Expected distinct enum members to display as their parent enums, got: {message}"
+    );
+}
+
+#[test]
+fn ts2367_enum_members_of_distinct_enums_widen_with_renamed_binders() {
+    // Same rule, different binder names + both numeric: proves the widening is
+    // structural (enum-member -> parent enum), not keyed on any identifier.
+    let message = sole_ts2367_message(
+        r#"enum Direction { North, South }
+enum Weekday { Monday, Tuesday }
+const unused = Direction.North === Weekday.Monday;"#,
+    );
+    assert!(
+        message.contains("types 'Direction' and 'Weekday' have no overlap"),
+        "Expected renamed distinct enum members to display as parent enums, got: {message}"
+    );
+}
+
+#[test]
+fn ts2367_enum_member_against_disjoint_literal_widens_to_parent_enum() {
+    // A numeric enum member vs a string literal: bases `E` and `string` remain
+    // unrelated, so tsc shows `'E' and 'string'` (not `'E.A'` / `'"z"'`).
+    let message = sole_ts2367_message(
+        r#"enum E { A, B }
+const unused = E.A === "z";"#,
+    );
+    assert!(
+        message.contains("types 'E' and 'string' have no overlap"),
+        "Expected enum member vs string literal to widen to parent enum + string, got: {message}"
+    );
+}
+
+#[test]
+fn ts2367_distinct_string_enum_members_widen_to_parent_enums() {
+    let message = sole_ts2367_message(
+        r#"enum Color { Red = "red", Green = "green" }
+enum Hue { Cyan = "cyan", Magenta = "magenta" }
+const unused = Color.Red === Hue.Cyan;"#,
+    );
+    assert!(
+        message.contains("types 'Color' and 'Hue' have no overlap"),
+        "Expected distinct string enum members to display as parent enums, got: {message}"
+    );
+}
+
+#[test]
+fn ts2367_same_enum_members_preserve_member_display() {
+    // Two members of the *same* enum: their bases (`Color`/`Color`) are related,
+    // so tsc keeps the precise member display `'Color.Red' and 'Color.Green'`.
+    let message = sole_ts2367_message(
+        r#"enum Color { Red = "red", Green = "green" }
+const unused = Color.Red === Color.Green;"#,
+    );
+    assert!(
+        message.contains("types 'Color.Red' and 'Color.Green' have no overlap"),
+        "Expected same-enum members to keep their member display, got: {message}"
+    );
+    // Numeric variant of the same rule.
+    let numeric = sole_ts2367_message(
+        r#"enum Level { Low, High }
+const unused = Level.Low === Level.High;"#,
+    );
+    assert!(
+        numeric.contains("types 'Level.Low' and 'Level.High' have no overlap"),
+        "Expected same numeric-enum members to keep their member display, got: {numeric}"
+    );
+}
+
+#[test]
+fn ts2367_non_primitive_operand_widens_literal_to_base() {
+    // The other operand being non-primitive (`void`, object, function) must
+    // widen the literal to its primitive while leaving the non-primitive as-is.
+    let void_msg = sole_ts2367_message("declare const v: void;\nconst unused = v === 1;");
+    assert!(
+        void_msg.contains("types 'void' and 'number' have no overlap"),
+        "Expected `void === 1` to widen `1` to `number`, got: {void_msg}"
+    );
+    let obj_msg =
+        sole_ts2367_message("declare const o: { p: number };\nconst unused = o === \"x\";");
+    assert!(
+        obj_msg.contains("types '{ p: number; }' and 'string' have no overlap"),
+        "Expected object operand preserved and `\"x\"` widened to `string`, got: {obj_msg}"
+    );
+    let fn_msg = sole_ts2367_message("declare const f: () => void;\nconst unused = f === 1;");
+    assert!(
+        fn_msg.contains("types '() => void' and 'number' have no overlap"),
+        "Expected function operand preserved and `1` widened to `number`, got: {fn_msg}"
     );
 }
 

--- a/crates/tsz-checker/src/types/computation/binary_tests.rs
+++ b/crates/tsz-checker/src/types/computation/binary_tests.rs
@@ -1017,7 +1017,7 @@ fn sole_ts2367_message(source: &str) -> String {
             .map(|d| (d.code, d.message_text.as_str()))
             .collect::<Vec<_>>()
     );
-    relevant[0].message_text.to_string()
+    relevant[0].message_text.clone()
 }
 
 #[test]


### PR DESCRIPTION
TS2367 ("This comparison appears to be unintentional because the types 'X' and 'Y' have no overlap") rendered its operands with a primitive-"family" heuristic: same family preserved literals, otherwise both operands were widened. When an operand is an enum **member**, tsc widens it to its **parent enum** for display, which the heuristic missed.

Structural rule: when a `===`/`!==`/`==`/`!=` comparison has no overlap, tsc (`getBaseTypesIfUnrelated`) widens each operand to its display base — literal → primitive, enum member → parent enum, distributing over unions — and adopts the bases **only when they remain unrelated**; otherwise it keeps the originals. tsz now does the same through the checker display path (`widen_operands_for_ts2367_display` → `ts2367_display_base_type`), composing the existing solver-backed `widen_enum_member_type` and `widen_literal_type` helpers. No relation/overlap behavior changes — this is display-only.

What this fixes (verified against `tsc`):
- `E.A === F.X` → `'E' and 'F'` (was `'E.A' and 'F.X'`)
- `E.A === G.Y` (distinct numeric enums) → `'E' and 'G'` (was members)
- numeric enum member vs string literal `E.A === "z"` → `'E' and 'string'`

Preserved (regression-guarded):
- same-enum members `E.A === E.B` keep `'E.A' and 'E.B'`
- same-family literals `1`/`2` and enum-vs-own-primitive `E`/`0`
- already-correct non-primitive operands (`void`/object/function vs literal)

The former `widen_for_ts2367_cross_family_display` is renamed to `widen_operands_for_ts2367_display` since the logic is now overlap-gated base widening, not a "family" check; the dead `get_primitive_family` helper is removed.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ts2367` — 31 passed; new message-text tests assert `tsc` output for enum-member/non-primitive operands, and the two earlier display tests are refactored onto a shared `sole_ts2367_message` helper.
- `cargo test -p tsz-checker --test ts2367_comparison_overlap_tests --test ts2367_deferred_conditional_overlap_tests --test enum_literal_comparison_overlap_tests --test enum_nominality_tests` — green (overlap/enum suites unaffected).
- `cargo clippy -p tsz-checker --lib` — clean.
- Ground truth for every asserted message captured from local `tsc`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_012jR39VaWX2HuP4vHi8FoZd)_