### PR TITLE
fix(checker): anchor TS1225 at the asserted identifier for assertion predicates

### DIFF
--- a/crates/tsz-checker/src/checkers/signature_builder.rs
+++ b/crates/tsz-checker/src/checkers/signature_builder.rs
@@ -758,9 +758,17 @@ impl<'a> CheckerState<'a> {
                 }
                 use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
                 let name_text = self.ctx.types.resolve_atom(*name);
+                // Report on the asserted identifier, not the whole predicate node.
+                // For an `asserts X is T` / `asserts X` predicate the TYPE_PREDICATE
+                // node begins at the `asserts` modifier, so `node.pos` points at the
+                // keyword while tsc points at the named identifier. The
+                // `parameter_name` node always spans exactly that identifier (for a
+                // plain `X is T` predicate it coincides with `node.pos`, so this is a
+                // no-op there). Mirrors the rest-parameter branch below.
+                let error_node = self.ctx.arena.get(data.parameter_name).unwrap_or(node);
                 self.ctx.error(
-                    node.pos,
-                    node.end.saturating_sub(node.pos),
+                    error_node.pos,
+                    error_node.end.saturating_sub(error_node.pos),
                     diagnostic_messages::CANNOT_FIND_PARAMETER.replace("{0}", &name_text),
                     diagnostic_codes::CANNOT_FIND_PARAMETER,
                 );

--- a/crates/tsz-checker/src/tests/assertion_type_predicate_diagnostics_tests.rs
+++ b/crates/tsz-checker/src/tests/assertion_type_predicate_diagnostics_tests.rs
@@ -4,7 +4,8 @@ use crate::context::CheckerOptions;
 use crate::module_resolution::build_module_resolution_maps;
 use crate::state::CheckerState;
 use crate::test_utils::{
-    check_js_source_diagnostics, check_source, check_source_codes, check_source_strict_codes,
+    check_js_source_diagnostics, check_source, check_source_codes, check_source_strict,
+    check_source_strict_codes,
 };
 use std::sync::Arc;
 use tsz_binder::BinderState;
@@ -183,6 +184,56 @@ function useThisAssert() {
     assert!(
         !codes.contains(&2322),
         "explicitly annotated assertion receiver should narrow value, got {codes:?}"
+    );
+}
+
+/// Assert that the single TS1225 diagnostic covers exactly the asserted
+/// identifier `expected_ident` in `source`. Returns the diagnostic span as a
+/// substring of the source so callers see what was actually flagged.
+fn assert_ts1225_points_at(source: &str, expected_ident: &str) {
+    let diagnostics = check_source_strict(source);
+    let ts1225: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == 1225)
+        .collect();
+    assert_eq!(
+        ts1225.len(),
+        1,
+        "expected exactly one TS1225 for {source:?}, got {diagnostics:#?}"
+    );
+    let diagnostic = ts1225[0];
+    let start = diagnostic.start as usize;
+    let end = start + diagnostic.length as usize;
+    let flagged = &source[start..end];
+    assert_eq!(
+        flagged, expected_ident,
+        "TS1225 should flag the asserted identifier {expected_ident:?}, but flagged {flagged:?} in {source:?}"
+    );
+}
+
+#[test]
+fn ts1225_asserts_predicate_points_at_identifier_not_keyword() {
+    // Regression (#14808): for an assertion predicate naming a non-parameter,
+    // tsc points TS1225 at the asserted identifier; tsz previously pointed at
+    // the `asserts` keyword (the start of the whole TYPE_PREDICATE node).
+    assert_ts1225_points_at("function bad(x: unknown): asserts y is string {}", "y");
+}
+
+#[test]
+fn ts1225_asserts_bare_predicate_points_at_identifier() {
+    // Bare `asserts X` (no `is T`) takes the same code path and must also
+    // flag the identifier rather than the `asserts` keyword.
+    assert_ts1225_points_at("function bad(x: unknown): asserts zzz {}", "zzz");
+}
+
+#[test]
+fn ts1225_plain_predicate_still_points_at_identifier() {
+    // A plain `X is T` predicate (no `asserts`) already flagged the identifier;
+    // the fix must not regress it. Binder name varied (`q`) to keep the check
+    // structural rather than keyed on a specific identifier.
+    assert_ts1225_points_at(
+        "function bad(x: unknown): q is string { return true; }",
+        "q",
     );
 }
 


### PR DESCRIPTION
Fixes #14808.

When an assertion predicate (`asserts X is T` / `asserts X`) names a target `X` that is not a parameter, tsz emitted TS1225 `Cannot find parameter` over the whole `TYPE_PREDICATE` node — which, for an `asserts` predicate, begins at the `asserts` modifier rather than the asserted identifier. tsc 5.9.3 anchors the caret on the identifier.

Structural rule: when a type predicate names a non-parameter, tsc reports TS1225 on the asserted identifier's span; tsz now reports on the `parameter_name` node's span through the signature builder (`crates/tsz-checker/src/checkers/signature_builder.rs`). For a plain `X is T` predicate the `TYPE_PREDICATE` node already starts at the identifier, so the change is a no-op there; for `asserts ...` it moves the caret onto the name. This aligns the signature-builder site with the two sibling diagnostics that already anchor on `parameter_name`: the rest-parameter branch (TS1229) immediately below it, and the function-type-node site in `crates/tsz-checker/src/types/type_checking/core.rs`.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib assertion_type_predicate` — 26 passed (3 new span-asserting tests: `asserts X is T`, bare `asserts X`, and the plain `X is T` no-op; binder names varied to keep the assertions structural).
- `cargo fmt -p tsz-checker -- --check` — clean.
- Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: medium

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyJBD5sJVeB5Wup7kxf69M)_