### PR TITLE
fix(checker): explicit this: parameter governs this in object-literal members (TS7023/TS2339 #14843)

### DIFF
--- a/crates/tsz-checker/src/tests/this_context_self_type_tests.rs
+++ b/crates/tsz-checker/src/tests/this_context_self_type_tests.rs
@@ -137,3 +137,170 @@ class Consumer {
         "expected no diagnostics when this annotation refers to a differently-named class; got {codes:?}"
     );
 }
+
+// --- Issue #14843 -----------------------------------------------------------
+// An object-literal method with an explicit `this:` parameter and NO return
+// annotation must resolve `this` against that declared parameter type during
+// speculative return-type inference (tsc's `getThisTypeOfSignature`), not
+// against the in-construction object-literal type. Otherwise an absent member
+// access re-enters the method being inferred (spurious TS7023) and the TS2339
+// "property does not exist" prints the object literal instead of the `this:`
+// type.
+
+use crate::test_utils::check_source_strict_messages;
+
+/// Assert that `source` produces exactly one TS2339 whose displayed receiver is
+/// `expected_receiver` and no TS7023 — the fixed shape for an explicit-`this:`
+/// member accessing a member absent on the declared receiver.
+fn assert_single_ts2339_on_receiver(source: &str, expected_receiver: &str) {
+    let diags = check_source_strict_messages(source);
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 7023),
+        "explicit `this:` must not produce a spurious TS7023; got {diags:?}"
+    );
+    let ts2339: Vec<&String> = diags
+        .iter()
+        .filter(|(code, _)| *code == 2339)
+        .map(|(_, msg)| msg)
+        .collect();
+    assert_eq!(
+        ts2339.len(),
+        1,
+        "expected exactly one TS2339 for the absent member; got {diags:?}"
+    );
+    assert!(
+        ts2339[0].contains(expected_receiver),
+        "TS2339 receiver must be the explicit `this:` type {expected_receiver}; got {:?}",
+        ts2339[0]
+    );
+}
+
+#[test]
+fn object_literal_method_explicit_this_no_spurious_circular_return() {
+    // Witness A: `x` exists on the object literal but not on `Ctx`.
+    // tsc 5.9.3: a single TS2339 against `Ctx`; tsz previously added TS7023 and
+    // printed the object-literal type as the receiver.
+    assert_single_ts2339_on_receiver(
+        r#"
+interface Ctx { kind: string; }
+const obj = {
+  x: 1,
+  bad(this: Ctx) { return this.x; }
+};
+"#,
+        "'Ctx'",
+    );
+}
+
+#[test]
+fn object_literal_method_explicit_this_void_no_spurious_circular_return() {
+    // Witness B: `this: void`, member on neither side.
+    assert_single_ts2339_on_receiver(
+        r#"
+const obj2 = {
+  x: 1,
+  bad(this: void) { return this.x; }
+};
+"#,
+        "'void'",
+    );
+}
+
+#[test]
+fn object_literal_method_explicit_this_member_present_is_clean() {
+    // Control from the triage note: when the member is present on the `this:`
+    // type both tools are clean — must remain clean.
+    let diags = check_source_strict_messages(
+        r#"
+interface Ctx { x: number; }
+const obj = { x: 1, bad(this: Ctx) { return this.x; } };
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "member present on the `this:` type must be clean; got {diags:?}"
+    );
+}
+
+#[test]
+fn object_literal_method_explicit_inline_this_resolves_members() {
+    // The explicit `this:` may be an inline object type whose member differs
+    // from the object literal; it must resolve against the inline type.
+    let diags = check_source_strict_messages(
+        r#"
+const obj = { x: 1, bad(this: { y: string }) { return this.y; } };
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "inline explicit `this:` member access must resolve cleanly; got {diags:?}"
+    );
+}
+
+#[test]
+fn object_literal_getter_genuine_self_reference_still_reports_circular() {
+    // Negative case: a getter with NO explicit `this:` that genuinely references
+    // its own inferred return type must still report TS7023.
+    let diags = check_source_strict_messages(
+        r#"
+const obj = {
+  get x() { return this.x + 1; }
+};
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 7023),
+        "genuine getter self-reference must still report TS7023; got {diags:?}"
+    );
+}
+
+#[test]
+fn class_method_explicit_this_void_absent_member_reports_on_void() {
+    // Adjacent: class method with explicit `this:` was already correct and must
+    // stay correct (single TS2339 on `void`, no TS7023).
+    assert_single_ts2339_on_receiver(
+        r#"
+class C {
+  x = 1;
+  bad(this: void) { return this.x; }
+}
+"#,
+        "'void'",
+    );
+}
+
+#[test]
+fn standalone_function_explicit_this_void_absent_member_reports_on_void() {
+    assert_single_ts2339_on_receiver("function bad(this: void) { return this.x; }\n", "'void'");
+}
+
+#[test]
+fn object_literal_function_property_explicit_this_no_spurious_circular_return() {
+    // The same rule applies to a `function`-expression property (not just method
+    // shorthand): an explicit `this:` parameter governs `this`, so an absent
+    // member reports a single TS2339 against the declared type with no TS7023.
+    assert_single_ts2339_on_receiver(
+        r#"
+interface Ctx { kind: string; }
+const obj = {
+  x: 1,
+  bad: function (this: Ctx) { return this.x; }
+};
+"#,
+        "'Ctx'",
+    );
+}
+
+#[test]
+fn object_literal_function_property_explicit_this_member_present_is_clean() {
+    let diags = check_source_strict_messages(
+        r#"
+interface Ctx { x: number; }
+const obj = { x: 1, bad: function (this: Ctx) { return this.x; } };
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "function-expression property with member present on `this:` must be clean; got {diags:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -7,9 +7,7 @@ use super::super::object_literal_context::ContextualPropertyPresence;
 use super::accessor_element::{ObjectLiteralAccessorContext, ObjectLiteralAccessorState};
 use crate::context::speculation::DiagnosticSpeculationSnapshot;
 use crate::context::{PartialObjectLiteralInitializer, TypingRequest};
-use crate::query_boundaries::common::{
-    ContextualTypeContext, get_application_base, is_conditional_type, is_mapped_type,
-};
+use crate::query_boundaries::common::ContextualTypeContext;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
@@ -31,14 +29,6 @@ struct ObjectLiteralRequestFacts {
 }
 
 impl<'a> CheckerState<'a> {
-    fn contextual_type_requires_authoritative_evaluation(&mut self, type_id: TypeId) -> bool {
-        let Some(base) = get_application_base(self.ctx.types, type_id) else {
-            return false;
-        };
-        let base_body = self.resolve_lazy_type(base);
-        is_conditional_type(self.ctx.types, base_body) || is_mapped_type(self.ctx.types, base_body)
-    }
-
     fn collect_object_literal_request_facts(
         &mut self,
         idx: NodeIndex,
@@ -559,22 +549,16 @@ impl<'a> CheckerState<'a> {
                                 .remove(&prop.initializer);
                             self.invalidate_initializer_for_context_change(prop.initializer);
                         }
-                        // For function expression property initializers (not arrow functions),
-                        // push a synthetic `this` type so that `this` inside the function body
-                        // resolves to the object literal's type rather than `any`.
-                        // Arrow functions inherit `this` from the enclosing scope, so they
-                        // must NOT get a synthetic `this` push. Likewise a function
-                        // expression with an explicit `this:` parameter binds `this`
-                        // to that declared type (tsc's `getThisTypeOfSignature`), so
-                        // the object-literal synthetic `this` must not override it
-                        // (see issue #14843).
-                        let prop_fn_has_explicit_this = initializer_is_function_expression
-                            && self.function_like_has_explicit_this_parameter(prop.initializer);
+                        // Function-expression property initializers (not arrow functions)
+                        // get a synthetic `this` of the object literal's type. Arrow
+                        // functions inherit `this`, and an explicit `this:` parameter binds
+                        // `this` to its declared type (tsc `getThisTypeOfSignature`, #14843),
+                        // so neither gets the synthetic push.
                         let mut pushed_prop_fn_this = false;
                         if initializer_is_function_expression
                             && marker_this_type.is_none()
                             && self.current_this_type().is_none()
-                            && !prop_fn_has_explicit_this
+                            && !self.function_like_has_explicit_this_parameter(prop.initializer)
                         {
                             if let Some(receiver_this_type) = contextual_receiver_this_type {
                                 self.ctx.this_type_stack.push(receiver_this_type);
@@ -1456,24 +1440,16 @@ impl<'a> CheckerState<'a> {
                         ),
                     );
                     // If no explicit ThisType marker exists, use the object literal's
-                    // contextual type as `this` inside method bodies.
+                    // contextual type as `this` inside method bodies. An explicit `this:`
+                    // parameter instead binds `this` to its declared type (tsc
+                    // `getThisTypeOfSignature`), independent of the object literal; pushing
+                    // the synthetic `this` would mis-print TS2339 receivers and trip
+                    // `method_return_this_circularity` into a spurious TS7023 (#14843).
                     let mut pushed_contextual_this = false;
                     let mut pushed_synthetic_this = false;
-                    // An explicit `this:` parameter binds `this` to exactly that
-                    // type (tsc's `getThisTypeOfSignature`), independent of the
-                    // enclosing object literal. Pushing the synthetic
-                    // object-literal `this` here would (1) print the wrong
-                    // receiver for a genuine TS2339 on `this.<absentMember>` and
-                    // (2) trip `method_return_this_circularity` below — which is
-                    // gated on `pushed_synthetic_this` — into a spurious TS7023.
-                    // The body-check pass (`implicit_function_this_type`) already
-                    // establishes the explicit `this:` type, so leaving the stack
-                    // untouched here is sufficient. See issue #14843.
-                    let method_has_explicit_this =
-                        self.function_like_has_explicit_this_parameter(elem_idx);
                     if marker_this_type.is_none()
                         && self.current_this_type().is_none()
-                        && !method_has_explicit_this
+                        && !self.function_like_has_explicit_this_parameter(elem_idx)
                     {
                         // Prefer the method's contextual `this` type (e.g., from an
                         // interface declaration `(this: { options: T }) => R`) over the

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -563,11 +563,18 @@ impl<'a> CheckerState<'a> {
                         // push a synthetic `this` type so that `this` inside the function body
                         // resolves to the object literal's type rather than `any`.
                         // Arrow functions inherit `this` from the enclosing scope, so they
-                        // must NOT get a synthetic `this` push.
+                        // must NOT get a synthetic `this` push. Likewise a function
+                        // expression with an explicit `this:` parameter binds `this`
+                        // to that declared type (tsc's `getThisTypeOfSignature`), so
+                        // the object-literal synthetic `this` must not override it
+                        // (see issue #14843).
+                        let prop_fn_has_explicit_this = initializer_is_function_expression
+                            && self.function_like_has_explicit_this_parameter(prop.initializer);
                         let mut pushed_prop_fn_this = false;
                         if initializer_is_function_expression
                             && marker_this_type.is_none()
                             && self.current_this_type().is_none()
+                            && !prop_fn_has_explicit_this
                         {
                             if let Some(receiver_this_type) = contextual_receiver_this_type {
                                 self.ctx.this_type_stack.push(receiver_this_type);
@@ -1452,7 +1459,22 @@ impl<'a> CheckerState<'a> {
                     // contextual type as `this` inside method bodies.
                     let mut pushed_contextual_this = false;
                     let mut pushed_synthetic_this = false;
-                    if marker_this_type.is_none() && self.current_this_type().is_none() {
+                    // An explicit `this:` parameter binds `this` to exactly that
+                    // type (tsc's `getThisTypeOfSignature`), independent of the
+                    // enclosing object literal. Pushing the synthetic
+                    // object-literal `this` here would (1) print the wrong
+                    // receiver for a genuine TS2339 on `this.<absentMember>` and
+                    // (2) trip `method_return_this_circularity` below — which is
+                    // gated on `pushed_synthetic_this` — into a spurious TS7023.
+                    // The body-check pass (`implicit_function_this_type`) already
+                    // establishes the explicit `this:` type, so leaving the stack
+                    // untouched here is sufficient. See issue #14843.
+                    let method_has_explicit_this =
+                        self.function_like_has_explicit_this_parameter(elem_idx);
+                    if marker_this_type.is_none()
+                        && self.current_this_type().is_none()
+                        && !method_has_explicit_this
+                    {
                         // Prefer the method's contextual `this` type (e.g., from an
                         // interface declaration `(this: { options: T }) => R`) over the
                         // outer object's contextual type. This ensures that in Round 2 of

--- a/crates/tsz-checker/src/types/computation/object_literal/computation_support.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation_support.rs
@@ -1,5 +1,6 @@
 //! Support helpers for object literal type computation.
 
+use crate::query_boundaries::common::{get_application_base, is_conditional_type, is_mapped_type};
 use crate::state::CheckerState;
 use crate::symbols_domain::name_text::{
     is_zero_arg_call_like_expr_in_arena, simple_computed_name_expr_text_in_arena,
@@ -11,6 +12,19 @@ use tsz_solver::{PropertyInfo, TypeId};
 
 pub(super) const SPREAD_DISPLAY_ORDER_OFFSET: u32 = 1_000_000;
 pub(super) const SPREAD_DISPLAY_ORDER_STRIDE: u32 = 10_000;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn contextual_type_requires_authoritative_evaluation(
+        &mut self,
+        type_id: TypeId,
+    ) -> bool {
+        let Some(base) = get_application_base(self.ctx.types, type_id) else {
+            return false;
+        };
+        let base_body = self.resolve_lazy_type(base);
+        is_conditional_type(self.ctx.types, base_body) || is_mapped_type(self.ctx.types, base_body)
+    }
+}
 
 pub(super) fn rebase_spread_display_property_order(
     props: &[PropertyInfo],

--- a/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
@@ -40,6 +40,28 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|init_node| init_node.kind == syntax_kind_ext::FUNCTION_EXPRESSION)
     }
 
+    /// Whether a function-like node (method shorthand, `function`-expression
+    /// property initializer, or accessor) declares an explicit `this:`
+    /// parameter. tsc's `getThisTypeOfSignature` makes such a `this` bind to
+    /// exactly that declared type, so the enclosing object literal's synthetic
+    /// `this` must not be pushed for the member body. Centralizing the check
+    /// keeps every object-literal callable-member path in sync (see #14843).
+    pub(super) fn function_like_has_explicit_this_parameter(&self, node_idx: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+        let params: &[NodeIndex] = if let Some(method) = self.ctx.arena.get_method_decl(node) {
+            &method.parameters.nodes
+        } else if let Some(func) = self.ctx.arena.get_function(node) {
+            &func.parameters.nodes
+        } else if let Some(accessor) = self.ctx.arena.get_accessor(node) {
+            &accessor.parameters.nodes
+        } else {
+            return false;
+        };
+        self.get_explicit_this_type_annotation(params).is_some()
+    }
+
     /// Best-effort `PropertyInfo` entries for the object literal's non-method
     /// members (data properties, shorthands, and accessors) declared *after* the
     /// first `this`-capturing callable member.


### PR DESCRIPTION
Fixes #14843.

When an object-literal **method shorthand** or **`function`-expression property** declares an explicit `this:` parameter and has no return-type annotation, tsz pushed the *synthetic object-literal* `this` type for the member body. tsc's `getThisTypeOfSignature` binds `this` to exactly the declared parameter type, independent of the enclosing object literal. The mismatch surfaced when the body accessed a member **absent** on the declared receiver (`this.x` where `x` is not on the `this:` type):

- a spurious **TS7023** (`'bad' implicitly has return type 'any' ... referenced directly or indirectly`), because the `method_return_this_circularity` heuristic is gated on `pushed_synthetic_this`; and
- a **TS2339** whose printed receiver was the whole object-literal type (`{ x: number; bad(this: Ctx): any; }`) instead of the explicit `this:` type (`Ctx` / `void`).

Structural rule: when an object-literal callable member declares an explicit `this:` parameter, tsc resolves `this` against that declared type; tsz must do the same and must not push the synthetic object-literal `this`. Owner layer: checker object-literal computation (`crates/tsz-checker/src/types/computation/object_literal/`). The body-check pass (`implicit_function_this_type` in `function_type.rs`) already establishes the explicit `this:` type, so simply leaving the `this`-type stack untouched for these members is sufficient.

Both callable-member paths (method shorthand and function-expression property) now consult a single shared helper `function_like_has_explicit_this_parameter`, so the two sites cannot drift.

Adjacent matrix (all verified against tsc 5.9.3):
- method `bad(this: Ctx)` / `bad(this: void)` with absent member → one TS2339 on `Ctx`/`void`, no TS7023.
- function-expression property `bad: function (this: Ctx)` → same.
- member present on the `this:` type (`interface Ctx { x: number }`) → clean (both tools).
- inline `this: { y: string }` accessing `this.y` → clean.
- class method / standalone function with explicit `this:` → unchanged (already correct).
- negative: getter `get x() { return this.x + 1; }` with no explicit `this:` → still TS7023.

## Goal
Goal: green

## Verification
- `cargo test -p tsz-checker --lib -- this_context_self_type` (15 pass, incl. 9 new #14843 cases covering both member paths, both witnesses, the present-member controls, and the genuine-circularity negative)
- `cargo test -p tsz-checker --lib -- object_literal` and `-- circular self_referential function_declaration class_member`: no new failures (2 unrelated failures — `const_assertion_preserves_later_data_literal`, `mapped_type_generic_indexed_access_class_member` — confirmed pre-existing on the base commit via `git stash`)
- Broad lib/conformance suites owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_016QzvCH63GrWijbpxm18hiV)_