### PR TITLE
fix(checker): yield enum object type for value-position namespace enum member access (TS2339)

### DIFF
--- a/crates/tsz-checker/src/types/property_access_type/enum_namespace_access.rs
+++ b/crates/tsz-checker/src/types/property_access_type/enum_namespace_access.rs
@@ -260,7 +260,23 @@ impl<'a> CheckerState<'a> {
         let member_sym = self
             .get_cross_file_symbol(member_sym_id)
             .or_else(|| self.ctx.binder.get_symbol(member_sym_id));
-        let member_type = if let Some(member_sym) = member_sym
+        let member_is_enum_object = member_sym.is_some_and(|s| {
+            s.has_any_flags(symbol_flags::ENUM) && !s.has_any_flags(symbol_flags::ENUM_MEMBER)
+        });
+        let member_type = if member_is_enum_object {
+            // Value-position access of a namespace's nested enum
+            // (`Ns.SomeEnum`) must yield the enum's VALUE meaning — the
+            // `typeof SomeEnum` object carrying the static member keys — not the
+            // enum instance type (the union of member literals). `get_type_of_symbol`
+            // can return either depending on which position resolved the enum
+            // first; through a re-export hop the type-position resolves first and
+            // caches the instance type, dropping the static keys (TS2339 on
+            // `Ns.SomeEnum.Member`). Mirror the identifier value-position path and
+            // `build_namespace_object_type`, which both convert the enum member to
+            // its enum object type via `get_enum_namespace_type_for_value`.
+            let base = self.get_type_of_symbol(member_sym_id);
+            self.get_enum_namespace_type_for_value(base)
+        } else if let Some(member_sym) = member_sym
             && member_sym.has_any_flags(symbol_flags::INTERFACE)
             && member_sym.has_any_flags(symbol_flags::VARIABLE)
             && member_sym.value_declaration.is_some()


### PR DESCRIPTION
Value-position access of a namespace-nested enum member (`Ns.SomeEnum.Member`) reported a false `TS2339`. When the enum is reached through a re-export hop (`import { ns } from "./x"; export { ns }`), the enum's TYPE meaning resolves first and caches the enum *instance* type (the union of member literals, which has no static keys), so the value reference `Ns.SomeEnum` is typed as the instance type and the subsequent `.Member` fails. `tsc` accepts (it uses the enum *object* type, `typeof SomeEnum`).

## Structural rule
When a namespace member accessed in **value position** is an enum symbol (`ENUM` and not `ENUM_MEMBER`), its type is the enum **object** (`typeof SomeEnum`, the static-key object), not the enum instance type. `tsz` now produces this via `get_enum_namespace_type_for_value`, mirroring the identifier value-position path and `build_namespace_object_type` which already do so.

Owner layer: checker value-position property-access (`crates/tsz-checker/src/types/property_access_type/enum_namespace_access.rs`). The decision is keyed structurally on the member symbol's `ENUM`/`ENUM_MEMBER` flags — no name/file-string predicate. Type-position access (`: Ns.SomeEnum`) and `keyof typeof Ns.SomeEnum` are unaffected (they don't take the value-position branch).

## Adjacent matrix
Verified against `tsc` 5.5.4: nested enum reached via `export { ns } from` and via import-then-`export { ns }`, const enum, single-hop (already worked), top-level re-exported enum (already worked), type-position annotation preserved (no over-coercion), and the absent-member negative case — which now renders the receiver as `typeof E` matching `tsc` exactly (a parity improvement; previously the receiver was mis-rendered).

Goal: green

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Minimal repro (3-file: `declare namespace ts { enum ModifierFlags {...} }` re-exported, consumer does `ts.ModifierFlags.Private`) now compiles clean; 1-file (same-file) stays clean; `tsc` 5.5.4 reports 0 on both.
- ts-morph source (flags off, `tsc` accepts the cluster): total 10865 -> 10781 (-84); the 38 enum-instance `TS2339` value-access FPs (e.g. `ScopeableNode.ts` `Private`/`Protected`, `CompilerComments.ts` `NodeFlags.None`, `ModifierFlags.Ambient`) -> 0, plus their downstream cascade; precise `file(line,col)`+code diff = 0 new FPs.
- `cargo nextest -p tsz-checker -p tsz-binder` (export/reexport/namespace/enum/property filter): failure set byte-identical to clean main (0 new failures); changed file is 344 lines (< 2000); no name/file-string predicate added.
