### PR TITLE
fix(emit/js): gate dynamic import() __importStar on esModuleInterop (#14780)

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
@@ -184,6 +184,7 @@ impl<'a> Printer<'a> {
                 es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
                 es5_emitter.set_printer_options(self.ctx.options.clone());
                 es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+                es5_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
                 if let Some(text) = self.source_text_for_map() {
                     if self.writer.has_source_map() {
                         es5_emitter
@@ -388,6 +389,7 @@ impl<'a> Printer<'a> {
             es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
             es5_emitter.set_printer_options(self.ctx.options.clone());
             es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+            es5_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
             if let Some(text) = self.source_text_for_map() {
                 if self.writer.has_source_map() {
                     es5_emitter.set_source_map_context(text, self.writer.current_source_index());
@@ -540,6 +542,7 @@ impl<'a> Printer<'a> {
         es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
         es5_emitter.set_printer_options(self.ctx.options.clone());
         es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+        es5_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
         if let Some(text) = self.source_text_for_map() {
             es5_emitter.set_source_text(text);
         }

--- a/crates/tsz-emitter/src/emitter/declarations/namespace.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/namespace.rs
@@ -83,6 +83,7 @@ impl<'a> Printer<'a> {
             let system_export_fold = self.pending_system_namespace_export_fold.take();
             let mut es5_emitter = NamespaceES5Emitter::with_commonjs(self.arena, use_cjs);
             es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+            es5_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
             es5_emitter.set_target_es5(self.ctx.target_es5);
             es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
             es5_emitter

--- a/crates/tsz-emitter/src/emitter/es5/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers.rs
@@ -1009,6 +1009,7 @@ impl<'a> Printer<'a> {
         let mut async_emitter = crate::transforms::async_es5::AsyncES5Emitter::new(self.arena);
         async_emitter.set_system_import_meta(self.in_system_execute_body);
         async_emitter.set_module_kind(self.ctx.outer_module_kind());
+        async_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
         async_emitter.set_target_es5(self.ctx.target_es5);
         async_emitter.set_dynamic_import_promise_counter(self.next_dynamic_import_promise_id);
         async_emitter

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -220,6 +220,7 @@ impl<'a> Printer<'a> {
             let mut async_emitter = crate::transforms::async_es5::AsyncES5Emitter::new(self.arena);
             async_emitter.set_system_import_meta(self.in_system_execute_body);
             async_emitter.set_module_kind(self.ctx.outer_module_kind());
+            async_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
             async_emitter.set_target_es5(self.ctx.target_es5);
             async_emitter.set_dynamic_import_promise_counter(self.next_dynamic_import_promise_id);
             async_emitter
@@ -624,6 +625,7 @@ impl<'a> Printer<'a> {
             transformer.set_source_text(text);
         }
         transformer.set_module_kind(self.ctx.outer_module_kind());
+        transformer.set_es_module_interop(self.ctx.options.es_module_interop);
         transformer.set_target_es5(self.ctx.target_es5);
         transformer.set_downlevel_iteration(self.ctx.options.downlevel_iteration);
         let blocked_disposable_names = self.blocked_disposable_names_for_transform();
@@ -996,6 +998,7 @@ impl<'a> Printer<'a> {
         es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
         es5_emitter.set_printer_options(self.ctx.options.clone());
         es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+        es5_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
         if let Some(text) = self.source_text_for_map() {
             if self.writer.has_source_map() {
                 es5_emitter.set_source_map_context(text, self.writer.current_source_index());

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async_generator.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async_generator.rs
@@ -34,6 +34,7 @@ impl<'a> Printer<'a> {
             transformer.set_source_text(text);
         }
         transformer.set_module_kind(self.ctx.outer_module_kind());
+        transformer.set_es_module_interop(self.ctx.options.es_module_interop);
         transformer.set_target_es5(self.ctx.target_es5);
         let blocked_disposable_names = self.blocked_disposable_names_for_transform();
         transformer

--- a/crates/tsz-emitter/src/emitter/expressions/call.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/call.rs
@@ -946,6 +946,24 @@ impl<'a> Printer<'a> {
         tighter_than_conditional || is_sequence
     }
 
+    /// Opens the `__importStar` wrapper for a dynamic-import require when
+    /// `esModuleInterop` is on; a no-op otherwise. Goes through `write_helper`
+    /// (which schedules the prologue), so it cannot reuse the string-form
+    /// `emit_utils::import_star_wrap`. Paired with `write_dynamic_import_star_close`.
+    fn write_dynamic_import_star_open(&mut self) {
+        if self.ctx.options.es_module_interop {
+            self.write_helper("__importStar");
+            self.write("(");
+        }
+    }
+
+    /// Closes the wrapper opened by `write_dynamic_import_star_open`.
+    fn write_dynamic_import_star_close(&mut self) {
+        if self.ctx.options.es_module_interop {
+            self.write(")");
+        }
+    }
+
     /// Emit the CommonJS branch of a downlevel dynamic import as a Promise.
     ///
     /// Cases by specifier shape, matching tsc:
@@ -972,9 +990,14 @@ impl<'a> Printer<'a> {
         } else {
             self.emit_dynamic_import_template_specifier(first);
         }
+        // tsc only wraps the dynamic `require` in `__importStar` when
+        // `esModuleInterop` is enabled; with interop off it emits a bare
+        // `require(...)` (see `createImportCallExpressionCommonJS`).
         self.write("}`).then(s => ");
-        self.write_helper("__importStar");
-        self.write("(require(s)))");
+        self.write_dynamic_import_star_open();
+        self.write("require(s)");
+        self.write_dynamic_import_star_close();
+        self.write(")");
     }
 
     fn first_dynamic_import_argument(
@@ -1006,19 +1029,20 @@ impl<'a> Printer<'a> {
         first_arg: Option<NodeIndex>,
         temp: Option<&str>,
     ) {
-        if self.ctx.target_es5 {
-            self.write("Promise.resolve().then(function () { return ");
-            self.write_helper("__importStar");
-            self.write("(require(");
-            self.emit_dynamic_import_require_specifier(first_arg, temp);
-            self.write(")); })");
+        // `__importStar` only wraps the `require` when `esModuleInterop` is on;
+        // otherwise tsc emits a bare `require(...)` in the CJS dynamic-import form.
+        let es5 = self.ctx.target_es5;
+        self.write(if es5 {
+            "Promise.resolve().then(function () { return "
         } else {
-            self.write("Promise.resolve().then(() => ");
-            self.write_helper("__importStar");
-            self.write("(require(");
-            self.emit_dynamic_import_require_specifier(first_arg, temp);
-            self.write(")))");
-        }
+            "Promise.resolve().then(() => "
+        });
+        self.write_dynamic_import_star_open();
+        self.write("require(");
+        self.emit_dynamic_import_require_specifier(first_arg, temp);
+        self.write(")");
+        self.write_dynamic_import_star_close();
+        self.write(if es5 { "; })" } else { ")" });
     }
 
     fn emit_dynamic_import_amd_branch(&mut self, first_arg: Option<NodeIndex>, temp: Option<&str>) {
@@ -1045,9 +1069,16 @@ impl<'a> Printer<'a> {
         self.write(&resolve);
         self.write(", ");
         self.write(&reject);
-        self.write("); }).then(");
-        self.write_helper("__importStar");
-        self.write(")");
+        // tsc appends `.then(__importStar)` to the AMD dynamic-import promise
+        // only when `esModuleInterop` is on (`createImportCallExpressionAMD`);
+        // with interop off it returns the bare `new Promise(...)`.
+        if self.ctx.options.es_module_interop {
+            self.write("); }).then(");
+            self.write_helper("__importStar");
+            self.write(")");
+        } else {
+            self.write("); })");
+        }
     }
 
     fn emit_dynamic_import_require_specifier(

--- a/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
@@ -451,6 +451,7 @@ impl<'a> Printer<'a> {
         es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
         es5_emitter.set_printer_options(self.ctx.options.clone());
         es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+        es5_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
         if let Some(text) = self.source_text_for_map() {
             if self.writer.has_source_map() {
                 es5_emitter.set_source_map_context(text, self.writer.current_source_index());
@@ -629,6 +630,7 @@ impl<'a> Printer<'a> {
                         es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
                         es5_emitter.set_printer_options(self.ctx.options.clone());
                         es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+                        es5_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
                         if let Some(text) = self.source_text_for_map() {
                             if self.writer.has_source_map() {
                                 es5_emitter.set_source_map_context(

--- a/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_module_exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/tests/cjs_module_exports.rs
@@ -1781,3 +1781,138 @@ fn anonymous_default_export_function_hoists_export_assignment() {
         "Should emit the anonymous default function export assignment once.\nOutput:\n{output}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Dynamic `import()` lowering must gate the `__importStar` interop wrapper on
+// `esModuleInterop`, matching tsc. With interop off, a bare `require(...)` is
+// emitted and none of the `__importStar`/`__createBinding`/`__setModuleDefault`
+// helper prologue may leak into the output (issue: dynamic import wrapped
+// `require` in `__importStar` ignoring `esModuleInterop=false`).
+// ---------------------------------------------------------------------------
+
+fn emit_module_with_interop(
+    source: &str,
+    module: ModuleKind,
+    target: ScriptTarget,
+    es_module_interop: bool,
+) -> String {
+    let (parser, root) = parse_test_source(source);
+    let options = PrinterOptions {
+        module,
+        target,
+        es_module_interop,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer = Printer::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+fn assert_no_import_star_helper(output: &str) {
+    for helper in [
+        "var __importStar",
+        "var __createBinding",
+        "var __setModuleDefault",
+    ] {
+        assert!(
+            !output.contains(helper),
+            "interop-off dynamic import must not emit the `{helper}` helper prologue.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn commonjs_dynamic_import_string_literal_bare_require_without_interop() {
+    let source = "const m = import(\"./dep\");\n";
+    let output =
+        emit_module_with_interop(source, ModuleKind::CommonJS, ScriptTarget::ES2020, false);
+    assert!(
+        output.contains("const m = Promise.resolve().then(() => require(\"./dep\"));"),
+        "interop-off CJS dynamic import should emit a bare require.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("__importStar"),
+        "interop-off CJS dynamic import must not wrap require in __importStar.\nOutput:\n{output}"
+    );
+    assert_no_import_star_helper(&output);
+}
+
+#[test]
+fn commonjs_dynamic_import_string_literal_import_star_with_interop() {
+    let source = "const m = import(\"./dep\");\n";
+    let output = emit_module_with_interop(source, ModuleKind::CommonJS, ScriptTarget::ES2020, true);
+    assert!(
+        output
+            .contains("const m = Promise.resolve().then(() => __importStar(require(\"./dep\")));"),
+        "interop-on CJS dynamic import should wrap require in __importStar.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var __importStar"),
+        "interop-on CJS dynamic import should emit the __importStar helper.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn commonjs_dynamic_import_expression_specifier_bare_require_without_interop() {
+    let source = "const f = (p: string) => import(p);\n";
+    let output =
+        emit_module_with_interop(source, ModuleKind::CommonJS, ScriptTarget::ES2020, false);
+    assert!(
+        output.contains("Promise.resolve(`${p}`).then(s => require(s))"),
+        "interop-off expression-specifier dynamic import should emit a bare require.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("__importStar"),
+        "interop-off expression-specifier dynamic import must not use __importStar.\nOutput:\n{output}"
+    );
+    assert_no_import_star_helper(&output);
+}
+
+#[test]
+fn commonjs_dynamic_import_es5_bare_require_without_interop() {
+    let source = "const m = import(\"./dep\");\n";
+    let output = emit_module_with_interop(source, ModuleKind::CommonJS, ScriptTarget::ES5, false);
+    assert!(
+        output.contains("Promise.resolve().then(function () { return require(\"./dep\"); })"),
+        "interop-off ES5 CJS dynamic import should emit a bare require.\nOutput:\n{output}"
+    );
+    assert_no_import_star_helper(&output);
+}
+
+#[test]
+fn amd_dynamic_import_drops_then_import_star_without_interop() {
+    let source = "const m = import(\"./dep\");\n";
+    let output = emit_module_with_interop(source, ModuleKind::AMD, ScriptTarget::ES2020, false);
+    assert!(
+        output.contains(
+            "new Promise((resolve_1, reject_1) => { require([\"./dep\"], resolve_1, reject_1); })"
+        ),
+        "interop-off AMD dynamic import should emit the bare Promise form.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains(".then(__importStar)"),
+        "interop-off AMD dynamic import must not append .then(__importStar).\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn commonjs_async_nested_dynamic_import_es5_bare_require_without_interop() {
+    // The dynamic import lives inside an ES5-downleveled async function, so it
+    // flows through the async generator IR transform path rather than the direct
+    // call emitter. The interop gate must hold there too, otherwise the helper
+    // prologue would be suppressed while the body still referenced __importStar.
+    let source = "export async function f() { await import(\"./dep\"); }\n";
+    let output = emit_module_with_interop(source, ModuleKind::CommonJS, ScriptTarget::ES5, false);
+    assert!(
+        output.contains("Promise.resolve().then(function () { return require(\"./dep\"); })"),
+        "interop-off async-nested ES5 dynamic import should emit a bare require.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("__importStar"),
+        "interop-off async-nested ES5 dynamic import must not reference __importStar.\nOutput:\n{output}"
+    );
+    assert_no_import_star_helper(&output);
+}

--- a/crates/tsz-emitter/src/emitter/module_emission/exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/exports.rs
@@ -946,6 +946,8 @@ impl<'a> Printer<'a> {
                                 es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
                                 es5_emitter.set_printer_options(self.ctx.options.clone());
                                 es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+                                es5_emitter
+                                    .set_es_module_interop(self.ctx.options.es_module_interop);
                                 if let Some(text) = self.source_text_for_map() {
                                     if self.writer.has_source_map() {
                                         es5_emitter.set_source_map_context(

--- a/crates/tsz-emitter/src/emitter/module_wrapper/system_emit_using.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/system_emit_using.rs
@@ -464,6 +464,7 @@ impl<'a> Printer<'a> {
         es5_emitter.set_use_define_for_class_fields(self.ctx.options.use_define_for_class_fields);
         es5_emitter.set_printer_options(self.ctx.options.clone());
         es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+        es5_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
         if let Some(text) = self.source_text_for_map() {
             es5_emitter.set_source_text(text);
         }

--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_emit.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_emit.rs
@@ -29,6 +29,10 @@ fn lower_emit_module(source: &str, module: ModuleKind, target: ScriptTarget) -> 
     let options = PrinterOptions {
         module,
         target,
+        // Dynamic-import wrapper-kind tests assert the `__importStar`-wrapped
+        // form, which tsc emits only under `esModuleInterop`. The interop-off
+        // (bare `require`) form is covered by dedicated tests.
+        es_module_interop: true,
         ..Default::default()
     };
     let ctx = EmitContext::with_options(options.clone());

--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_emit_parts/part_00.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests/system_emit_parts/part_00.rs
@@ -253,6 +253,7 @@ fn umd_dynamic_import_only_file_gets_wrapper_and_loader_branch() {
     let options = PrinterOptions {
         module: ModuleKind::UMD,
         target: ScriptTarget::ES2015,
+        es_module_interop: true,
         ..Default::default()
     };
     let ctx = EmitContext::with_options(options.clone());
@@ -294,6 +295,7 @@ fn umd_es5_class_method_dynamic_import_uses_loader_branch() {
     let options = PrinterOptions {
         module: ModuleKind::UMD,
         target: ScriptTarget::ES5,
+        es_module_interop: true,
         ..Default::default()
     };
     let ctx = EmitContext::with_options(options.clone());
@@ -378,6 +380,7 @@ import(path);
         PrinterOptions {
             module: ModuleKind::AMD,
             target: ScriptTarget::ES2015,
+            es_module_interop: true,
             ..Default::default()
         },
     );

--- a/crates/tsz-emitter/src/emitter/module_wrapper/tests/wrapped_helpers.rs
+++ b/crates/tsz-emitter/src/emitter/module_wrapper/tests/wrapped_helpers.rs
@@ -10,6 +10,10 @@ fn emit_wrapped(source: &str, module: ModuleKind, target: ScriptTarget) -> Strin
     let options = PrinterOptions {
         module,
         target,
+        // These tests assert the `__importStar`-wrapped dynamic-import form,
+        // which tsc emits only under `esModuleInterop`. Exercise interop-on here;
+        // the interop-off (bare `require`) form is covered by dedicated tests.
+        es_module_interop: true,
         ..Default::default()
     };
     let ctx = EmitContext::with_options(options.clone());

--- a/crates/tsz-emitter/src/emitter/source_file/top_level_using_parts/class_assignment.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/top_level_using_parts/class_assignment.rs
@@ -556,6 +556,7 @@ impl<'a> Printer<'a> {
             es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
             es5_emitter.set_printer_options(self.ctx.options.clone());
             es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+            es5_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
             if let Some(text) = self.source_text_for_map() {
                 es5_emitter.set_source_text(text);
             }
@@ -772,6 +773,7 @@ impl<'a> Printer<'a> {
             es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
             es5_emitter.set_printer_options(self.ctx.options.clone());
             es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+            es5_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
             if let Some(text) = self.source_text_for_map() {
                 es5_emitter.set_source_text(text);
             }
@@ -836,6 +838,7 @@ impl<'a> Printer<'a> {
             es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
             es5_emitter.set_printer_options(self.ctx.options.clone());
             es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+            es5_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
             if let Some(text) = self.source_text_for_map() {
                 es5_emitter.set_source_text(text);
             }
@@ -876,6 +879,7 @@ impl<'a> Printer<'a> {
             es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
             es5_emitter.set_printer_options(self.ctx.options.clone());
             es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+            es5_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
             if let Some(text) = self.source_text_for_map() {
                 es5_emitter.set_source_text(text);
             }

--- a/crates/tsz-emitter/src/emitter/transform_dispatch.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch.rs
@@ -185,6 +185,7 @@ impl<'a> Printer<'a> {
                 let system_export_fold = self.pending_system_namespace_export_fold.take();
                 let mut ns_emitter = NamespaceES5Emitter::with_commonjs(self.arena, true);
                 ns_emitter.set_module_kind(self.ctx.outer_module_kind());
+                ns_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
                 ns_emitter.set_const_enum_facts(
                     self.const_enum_values.clone(),
                     self.const_enum_import_aliases.clone(),
@@ -281,6 +282,7 @@ impl<'a> Printer<'a> {
                                 !merges_with_default_func,
                             );
                             ns_emitter.set_module_kind(self.ctx.outer_module_kind());
+                            ns_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
                             ns_emitter.set_const_enum_facts(
                                 self.const_enum_values.clone(),
                                 self.const_enum_import_aliases.clone(),
@@ -1641,6 +1643,7 @@ impl<'a> Printer<'a> {
                 let mut ns_emitter =
                     NamespaceES5Emitter::with_commonjs(self.arena, self.ctx.is_commonjs());
                 ns_emitter.set_module_kind(self.ctx.outer_module_kind());
+                ns_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
                 ns_emitter.set_const_enum_facts(
                     self.const_enum_values.clone(),
                     self.const_enum_import_aliases.clone(),

--- a/crates/tsz-emitter/src/emitter/transform_dispatch_chain.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch_chain.rs
@@ -97,6 +97,7 @@ impl<'a> Printer<'a> {
                 let mut ns_emitter =
                     NamespaceES5Emitter::with_commonjs(self.arena, self.ctx.is_commonjs());
                 ns_emitter.set_module_kind(self.ctx.outer_module_kind());
+                ns_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
                 ns_emitter.set_const_enum_facts(
                     self.const_enum_values.clone(),
                     self.const_enum_import_aliases.clone(),
@@ -148,6 +149,7 @@ impl<'a> Printer<'a> {
                     let cjs_export_names = self.commonjs_export_name_strings(names.as_ref());
                     let mut ns_emitter = NamespaceES5Emitter::with_commonjs(self.arena, true);
                     ns_emitter.set_module_kind(self.ctx.outer_module_kind());
+                    ns_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
                     ns_emitter.set_const_enum_facts(
                         self.const_enum_values.clone(),
                         self.const_enum_import_aliases.clone(),

--- a/crates/tsz-emitter/src/emitter/transform_dispatch_es5_class.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch_es5_class.rs
@@ -43,6 +43,7 @@ impl<'a> Printer<'a> {
         }
         es5_emitter.set_printer_options(self.ctx.options.clone());
         es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+        es5_emitter.set_es_module_interop(self.ctx.options.es_module_interop);
         if let Some(text) = self.source_text_for_map() {
             if self.writer.has_source_map() {
                 es5_emitter.set_source_map_context(text, self.writer.current_source_index());

--- a/crates/tsz-emitter/src/lowering/core.rs
+++ b/crates/tsz-emitter/src/lowering/core.rs
@@ -1518,12 +1518,20 @@ impl<'a> LoweringPass<'a> {
             );
         }
 
-        // CJS-like dynamic import: import("mod") needs __importStar helper.
+        // CJS-like dynamic import: import("mod") lowers to
+        // `Promise.resolve().then(() => require(...))`. The `require` is wrapped
+        // in `__importStar` (which pulls in `__createBinding`/`__setModuleDefault`)
+        // ONLY when `esModuleInterop` is enabled, matching tsc's
+        // `createImportCallExpressionCommonJS`/`AMD`. With interop off, the bare
+        // `require(...)` form is emitted and these helpers are dead code, so they
+        // must not be requested here (otherwise ~33 lines of unused helper
+        // prologue leak into the output).
         // `--module none --outFile` uses the same lowering below native
         // dynamic import support without promoting the script to CJS.
-        // This applies regardless of esModuleInterop setting.
         // Skip for node module CJS files where native import() is supported.
-        if (self.commonjs_mode || (self.ctx.module_none_out_file && self.ctx.needs_es2020_lowering))
+        if self.ctx.options.es_module_interop
+            && (self.commonjs_mode
+                || (self.ctx.module_none_out_file && self.ctx.needs_es2020_lowering))
             && !self.ctx.options.resolved_node_module_to_cjs
             && !is_super_call
             && let Some(expr_node) = self.arena.get(call.expression)

--- a/crates/tsz-emitter/src/output/printer.rs
+++ b/crates/tsz-emitter/src/output/printer.rs
@@ -66,6 +66,10 @@ pub struct PrintOptions {
     /// Emit class fields using `Object.defineProperty` semantics when
     /// downleveling (mirrors `--useDefineForClassFields`).
     pub use_define_for_class_fields: bool,
+    /// Enable CommonJS/ESM interop helpers (mirrors `--esModuleInterop`).
+    /// Controls, among other things, whether downlevel dynamic `import()`
+    /// wraps `require(...)` in the `__importStar` helper.
+    pub es_module_interop: bool,
 }
 
 impl PrintOptions {
@@ -112,6 +116,7 @@ impl PrintOptions {
             downlevel_iteration: self.downlevel_iteration,
             jsx: self.jsx,
             use_define_for_class_fields: self.use_define_for_class_fields,
+            es_module_interop: self.es_module_interop,
             ..Default::default()
         }
     }

--- a/crates/tsz-emitter/src/transforms/async_es5.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5.rs
@@ -154,6 +154,10 @@ impl<'a> AsyncES5Emitter<'a> {
         self.transformer.set_module_kind(kind);
     }
 
+    pub const fn set_es_module_interop(&mut self, es_module_interop: bool) {
+        self.transformer.set_es_module_interop(es_module_interop);
+    }
+
     pub const fn set_target_es5(&mut self, es5: bool) {
         self.transformer.set_target_es5(es5);
     }

--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -163,6 +163,9 @@ pub struct AsyncES5Transformer<'a> {
     pub(super) class_super_is_static: bool,
     /// Module kind for dynamic `import()` lowering inside generator bodies.
     pub(super) module_kind: ModuleKind,
+    /// Whether `esModuleInterop` is enabled. Controls whether dynamic `import()`
+    /// lowering inside generator bodies wraps `require(...)` in `__importStar`.
+    pub(super) es_module_interop: bool,
     /// Whether the emit target is ES5. Controls arrow-vs-`function` form in
     /// dynamic-import lowering inside async generator bodies.
     pub(super) target_es5: bool,
@@ -211,6 +214,7 @@ impl<'a> AsyncES5Transformer<'a> {
             class_super_name: "_super".to_string(),
             class_super_is_static: false,
             module_kind: ModuleKind::None,
+            es_module_interop: false,
             target_es5: false,
             dynamic_import_promise_counter: Cell::new(1),
             labeled_continue_targets: Vec::new(),

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_convert.rs
@@ -883,6 +883,7 @@ impl<'a> AsyncES5Transformer<'a> {
             transformer.set_temp_var_counter(self.temp_var_counter());
             transformer.downlevel_iteration = self.downlevel_iteration;
             transformer.set_module_kind(self.module_kind);
+            transformer.set_es_module_interop(self.es_module_interop);
             transformer.set_target_es5(self.target_es5);
             transformer
                 .dynamic_import_promise_counter
@@ -1252,26 +1253,21 @@ impl<'a> AsyncES5Transformer<'a> {
     }
 
     fn dynamic_import_cjs_branch(&self, specifier: &str) -> String {
-        if self.target_es5 {
-            format!(
-                "Promise.resolve().then(function () {{ return __importStar(require({specifier})); }})"
-            )
-        } else {
-            format!("Promise.resolve().then(() => __importStar(require({specifier})))")
-        }
+        crate::transforms::emit_utils::dynamic_import_cjs_form(
+            specifier,
+            self.target_es5,
+            self.es_module_interop,
+        )
     }
 
     fn dynamic_import_amd_branch(&self, specifier: &str) -> String {
         let id = self.dynamic_import_promise_counter.get();
         self.dynamic_import_promise_counter.set(id + 1);
-        if self.target_es5 {
-            format!(
-                "new Promise(function (resolve_{id}, reject_{id}) {{ require([{specifier}], resolve_{id}, reject_{id}); }}).then(__importStar)"
-            )
-        } else {
-            format!(
-                "new Promise((resolve_{id}, reject_{id}) => {{ require([{specifier}], resolve_{id}, reject_{id}); }}).then(__importStar)"
-            )
-        }
+        crate::transforms::emit_utils::dynamic_import_amd_form(
+            specifier,
+            id,
+            self.target_es5,
+            self.es_module_interop,
+        )
     }
 }

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_names.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_names.rs
@@ -56,6 +56,13 @@ impl<'a> AsyncES5Transformer<'a> {
         self.module_kind = kind;
     }
 
+    /// Set whether `esModuleInterop` is enabled so dynamic `import()` lowering
+    /// inside the generator body wraps `require(...)` in `__importStar` (on) or
+    /// emits a bare `require(...)` (off), matching tsc.
+    pub const fn set_es_module_interop(&mut self, es_module_interop: bool) {
+        self.es_module_interop = es_module_interop;
+    }
+
     /// Set whether the emit target is ES5. When `false` (ES2015+), dynamic
     /// `import()` branches inside the generator body use arrow functions
     /// instead of `function` expressions.

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_objects.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_objects.rs
@@ -608,6 +608,7 @@ impl AsyncES5Transformer<'_> {
                 nested.set_source_text(source_text);
             }
             nested.set_module_kind(self.module_kind);
+            nested.set_es_module_interop(self.es_module_interop);
             nested.set_target_es5(self.target_es5);
             let has_await = nested.body_contains_await(method.body);
             let mut generator_body = nested.transform_generator_body(method.body, has_await);

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_statements.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_statements.rs
@@ -1343,6 +1343,7 @@ impl<'a> AsyncES5Transformer<'a> {
     ) -> bool {
         let mut class_transformer = ES5ClassTransformer::new(self.arena);
         class_transformer.set_module_kind(self.module_kind);
+        class_transformer.set_es_module_interop(self.es_module_interop);
         class_transformer.set_target_es5(self.target_es5);
         if let Some(source_text) = self.source_text {
             class_transformer.set_source_text(source_text);
@@ -1423,6 +1424,7 @@ impl<'a> AsyncES5Transformer<'a> {
     ) -> Option<ES5ClassFactoryParts> {
         let mut class_transformer = ES5ClassTransformer::new(self.arena);
         class_transformer.set_module_kind(self.module_kind);
+        class_transformer.set_es_module_interop(self.es_module_interop);
         class_transformer.set_target_es5(self.target_es5);
         let class_ir =
             class_transformer.transform_class_to_ir_with_name(class_idx, Some(class_name))?;

--- a/crates/tsz-emitter/src/transforms/class_es5.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5.rs
@@ -190,6 +190,10 @@ impl<'a> ClassES5Emitter<'a> {
         self.transformer.set_module_kind(module_kind);
     }
 
+    pub const fn set_es_module_interop(&mut self, es_module_interop: bool) {
+        self.transformer.set_es_module_interop(es_module_interop);
+    }
+
     pub fn set_async_generator_inner_name_counts(
         &mut self,
         counts: rustc_hash::FxHashMap<String, u32>,

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir.rs
@@ -89,6 +89,9 @@ pub struct AstToIr<'a> {
     dynamic_import_promise_counter: Cell<u32>,
     /// Original module kind when this converter runs inside a module wrapper.
     module_kind: ModuleKind,
+    /// Whether `esModuleInterop` is enabled. Controls whether dynamic `import()`
+    /// lowering wraps `require(...)` in the `__importStar` helper.
+    es_module_interop: bool,
     target_es5: bool,
     /// Static block recovery mode where bare `await` identifiers are emitted
     /// as recovered `yield` tokens, matching `tsc` downlevel emit.
@@ -140,6 +143,7 @@ impl<'a> AstToIr<'a> {
             hoisted_temps: RefCell::new(Vec::new()),
             dynamic_import_promise_counter: Cell::new(1),
             module_kind: ModuleKind::None,
+            es_module_interop: false,
             target_es5: false,
             emit_await_as_yield: false,
             trailing_comment_limit: Cell::new(None),
@@ -200,6 +204,11 @@ impl<'a> AstToIr<'a> {
 
     pub const fn with_module_kind(mut self, module_kind: ModuleKind) -> Self {
         self.module_kind = module_kind;
+        self
+    }
+
+    pub const fn with_es_module_interop(mut self, es_module_interop: bool) -> Self {
+        self.es_module_interop = es_module_interop;
         self
     }
 
@@ -803,6 +812,7 @@ impl<'a> AstToIr<'a> {
             let mut transformer = AsyncES5Transformer::new(self.arena);
             transformer.set_temp_var_counter(self.temp_var_counter.get());
             transformer.set_module_kind(self.module_kind);
+            transformer.set_es_module_interop(self.es_module_interop);
             transformer.set_target_es5(self.target_es5);
             transformer
                 .dynamic_import_promise_counter
@@ -1632,6 +1642,7 @@ impl<'a> AstToIr<'a> {
         let mut transformer = AsyncES5Transformer::new(self.arena);
         transformer.set_temp_var_counter(self.temp_var_counter.get());
         transformer.set_module_kind(self.module_kind);
+        transformer.set_es_module_interop(self.es_module_interop);
         transformer.set_target_es5(self.target_es5);
         transformer
             .dynamic_import_promise_counter

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_classes.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_classes.rs
@@ -6,6 +6,7 @@ impl<'a> AstToIr<'a> {
     pub(super) fn convert_class_declaration(&self, idx: NodeIndex) -> IRNode {
         let mut transformer = ES5ClassTransformer::new(self.arena);
         transformer.set_module_kind(self.module_kind);
+        transformer.set_es_module_interop(self.es_module_interop);
         transformer.set_target_es5(self.target_es5);
         transformer.set_dynamic_import_promise_counter(self.dynamic_import_promise_counter.get());
         transformer.set_indent_base(self.class_transformer_indent_base);

--- a/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ast_to_ir_expressions.rs
@@ -271,14 +271,23 @@ impl<'a> AstToIr<'a> {
     }
 
     fn dynamic_import_commonjs_branch(&self, specifier: &str) -> String {
-        crate::transforms::emit_utils::dynamic_import_cjs_form(specifier)
+        // This converter lowers ES5 class bodies, so the callback is the
+        // `function` form (target_es5 is true here).
+        crate::transforms::emit_utils::dynamic_import_cjs_form(
+            specifier,
+            self.target_es5,
+            self.es_module_interop,
+        )
     }
 
     fn dynamic_import_amd_branch(&self, specifier: &str) -> String {
         let id = self.dynamic_import_promise_counter.get();
         self.dynamic_import_promise_counter.set(id + 1);
-        format!(
-            "new Promise(function (resolve_{id}, reject_{id}) {{ require([{specifier}], resolve_{id}, reject_{id}); }}).then(__importStar)"
+        crate::transforms::emit_utils::dynamic_import_amd_form(
+            specifier,
+            id,
+            self.target_es5,
+            self.es_module_interop,
         )
     }
 

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -200,6 +200,10 @@ pub struct ES5ClassTransformer<'a> {
     tslib_helpers: TslibHelperNaming,
     commonjs_import_substitutions: FxHashMap<String, String>,
     module_kind: ModuleKind,
+    /// Whether `esModuleInterop` is enabled, threaded into nested converters
+    /// (`AstToIr`, async transformer) so dynamic `import()` lowering wraps
+    /// `require(...)` in `__importStar` only when interop is on.
+    es_module_interop: bool,
     target_es5: bool,
     downlevel_iteration: bool,
     dynamic_import_promise_counter: Cell<u32>,
@@ -264,6 +268,7 @@ impl<'a> ES5ClassTransformer<'a> {
             tslib_helpers: TslibHelperNaming::default(),
             commonjs_import_substitutions: FxHashMap::default(),
             module_kind: ModuleKind::None,
+            es_module_interop: false,
             target_es5: false,
             downlevel_iteration: false,
             dynamic_import_promise_counter: Cell::new(1),
@@ -335,6 +340,10 @@ impl<'a> ES5ClassTransformer<'a> {
 
     pub const fn set_module_kind(&mut self, module_kind: ModuleKind) {
         self.module_kind = module_kind;
+    }
+
+    pub const fn set_es_module_interop(&mut self, es_module_interop: bool) {
+        self.es_module_interop = es_module_interop;
     }
 
     pub const fn set_target_es5(&mut self, es5: bool) {
@@ -686,6 +695,7 @@ impl<'a> ES5ClassTransformer<'a> {
             .with_class_transformer_indent_base(self.indent_base + 2)
             .with_downlevel_iteration(self.downlevel_iteration)
             .with_module_kind(self.module_kind)
+            .with_es_module_interop(self.es_module_interop)
             .with_target_es5(self.target_es5)
             .with_private_member_maps(
                 &self.private_fields,

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_auto_accessor.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_auto_accessor.rs
@@ -369,6 +369,7 @@ impl<'a> ES5ClassTransformer<'a> {
             async_transformer.set_source_text(source_text);
         }
         async_transformer.set_module_kind(self.module_kind);
+        async_transformer.set_es_module_interop(self.es_module_interop);
         async_transformer.set_target_es5(self.target_es5);
         async_transformer
             .dynamic_import_promise_counter

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
@@ -150,6 +150,7 @@ impl<'a> ES5ClassTransformer<'a> {
             transformer.set_source_text(source_text);
         }
         transformer.set_module_kind(self.module_kind);
+        transformer.set_es_module_interop(self.es_module_interop);
         transformer.set_target_es5(self.target_es5);
         self.configure_async_disposable_context(&mut transformer);
         let inner = transformer.transform_async_generator_inner_function(
@@ -179,6 +180,7 @@ impl<'a> ES5ClassTransformer<'a> {
             transformer.set_source_text(source_text);
         }
         transformer.set_module_kind(self.module_kind);
+        transformer.set_es_module_interop(self.es_module_interop);
         transformer.set_target_es5(self.target_es5);
         self.configure_async_disposable_context(&mut transformer);
         transformer.generator_mode = true;
@@ -617,6 +619,7 @@ impl<'a> ES5ClassTransformer<'a> {
                 async_transformer.set_source_text(source_text);
             }
             async_transformer.set_module_kind(self.module_kind);
+            async_transformer.set_es_module_interop(self.es_module_interop);
             async_transformer.set_target_es5(self.target_es5);
             async_transformer
                 .dynamic_import_promise_counter
@@ -825,6 +828,7 @@ impl<'a> ES5ClassTransformer<'a> {
                             async_transformer.set_source_text(source_text);
                         }
                         async_transformer.set_module_kind(self.module_kind);
+                        async_transformer.set_es_module_interop(self.es_module_interop);
                         async_transformer.set_target_es5(self.target_es5);
                         async_transformer
                             .dynamic_import_promise_counter
@@ -979,6 +983,7 @@ impl<'a> ES5ClassTransformer<'a> {
                             async_transformer.set_source_text(source_text);
                         }
                         async_transformer.set_module_kind(self.module_kind);
+                        async_transformer.set_es_module_interop(self.es_module_interop);
                         async_transformer.set_target_es5(self.target_es5);
                         async_transformer
                             .dynamic_import_promise_counter

--- a/crates/tsz-emitter/src/transforms/emit_utils.rs
+++ b/crates/tsz-emitter/src/transforms/emit_utils.rs
@@ -1524,9 +1524,59 @@ pub(crate) fn call_argument_should_emit(arena: &NodeArena, idx: NodeIndex) -> bo
         .is_none_or(|ident| !ident.escaped_text.is_empty())
 }
 
-/// Emit a dynamic `import(specifier)` as the CommonJS `Promise.resolve().then(...)` form.
-pub(crate) fn dynamic_import_cjs_form(specifier: &str) -> String {
-    format!("Promise.resolve().then(function () {{ return __importStar(require({specifier})); }})")
+/// Wrap a dynamic-import `require(...)` expression in the `__importStar` helper
+/// when `esModuleInterop` is enabled, mirroring tsc; otherwise return it bare.
+fn import_star_wrap(require_expr: String, es_module_interop: bool) -> String {
+    if es_module_interop {
+        format!("__importStar({require_expr})")
+    } else {
+        require_expr
+    }
+}
+
+/// Emit a dynamic `import(specifier)` as the CommonJS `Promise.resolve().then(...)`
+/// form. The callback is a `function` expression at ES5 and an arrow at ES2015+.
+/// The `require` is wrapped in `__importStar` only when `esModuleInterop` is
+/// enabled (matching tsc's `createImportCallExpressionCommonJS`); otherwise a
+/// bare `require(...)` is emitted.
+pub(crate) fn dynamic_import_cjs_form(
+    specifier: &str,
+    target_es5: bool,
+    es_module_interop: bool,
+) -> String {
+    let body = import_star_wrap(format!("require({specifier})"), es_module_interop);
+    if target_es5 {
+        format!("Promise.resolve().then(function () {{ return {body}; }})")
+    } else {
+        format!("Promise.resolve().then(() => {body})")
+    }
+}
+
+/// Emit a dynamic `import(specifier)` as the AMD/UMD async-`require` form:
+/// `new Promise((resolve_N, reject_N) => {{ require([spec], resolve_N, reject_N); }})`.
+/// The callback is a `function` expression at ES5 and an arrow at ES2015+. The
+/// `.then(__importStar)` suffix is appended only when `esModuleInterop` is
+/// enabled (matching tsc's `createImportCallExpressionAMD`).
+pub(crate) fn dynamic_import_amd_form(
+    specifier: &str,
+    id: u32,
+    target_es5: bool,
+    es_module_interop: bool,
+) -> String {
+    let then = if es_module_interop {
+        ".then(__importStar)"
+    } else {
+        ""
+    };
+    if target_es5 {
+        format!(
+            "new Promise(function (resolve_{id}, reject_{id}) {{ require([{specifier}], resolve_{id}, reject_{id}); }}){then}"
+        )
+    } else {
+        format!(
+            "new Promise((resolve_{id}, reject_{id}) => {{ require([{specifier}], resolve_{id}, reject_{id}); }}){then}"
+        )
+    }
 }
 
 #[cfg(test)]

--- a/crates/tsz-emitter/src/transforms/namespace_es5.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5.rs
@@ -267,6 +267,10 @@ impl<'a> NamespaceES5Emitter<'a> {
         self.transformer.set_module_kind(kind);
     }
 
+    pub const fn set_es_module_interop(&mut self, es_module_interop: bool) {
+        self.transformer.set_es_module_interop(es_module_interop);
+    }
+
     pub(crate) fn set_const_enum_facts(
         &mut self,
         values: FxHashMap<String, Vec<ScopedConstEnum>>,

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
@@ -123,6 +123,10 @@ pub struct NamespaceES5Transformer<'a> {
     arena: &'a NodeArena,
     is_commonjs: bool,
     module_kind: ModuleKind,
+    /// Whether `esModuleInterop` is enabled, threaded into nested async/class
+    /// converters so dynamic `import()` lowering wraps `require(...)` in
+    /// `__importStar` only when interop is on.
+    es_module_interop: bool,
     target_es5: bool,
     source_text: Option<&'a str>,
     comment_ranges: Vec<tsz_common::comments::CommentRange>,
@@ -171,6 +175,7 @@ impl<'a> NamespaceES5Transformer<'a> {
             arena,
             is_commonjs: false,
             module_kind: ModuleKind::None,
+            es_module_interop: false,
             target_es5: false,
             source_text: None,
             comment_ranges: Vec::new(),
@@ -197,6 +202,7 @@ impl<'a> NamespaceES5Transformer<'a> {
             arena,
             is_commonjs,
             module_kind: ModuleKind::None,
+            es_module_interop: false,
             source_text: None,
             comment_ranges: Vec::new(),
             prior_exported_vars: std::collections::HashSet::new(),
@@ -259,6 +265,10 @@ impl<'a> NamespaceES5Transformer<'a> {
     /// Set `CommonJS` mode
     pub const fn set_commonjs(&mut self, is_commonjs: bool) {
         self.is_commonjs = is_commonjs;
+    }
+
+    pub const fn set_es_module_interop(&mut self, es_module_interop: bool) {
+        self.es_module_interop = es_module_interop;
     }
 
     pub const fn set_module_kind(&mut self, kind: ModuleKind) {
@@ -1430,6 +1440,7 @@ impl<'a> NamespaceES5Transformer<'a> {
         let func_decl = if func_data.is_async && !func_data.asterisk_token {
             let mut async_transformer = AsyncES5Transformer::new(self.arena);
             async_transformer.set_module_kind(self.module_kind);
+            async_transformer.set_es_module_interop(self.es_module_interop);
             async_transformer.set_target_es5(self.target_es5);
             if let Some(src) = self.source_text {
                 async_transformer.set_source_text(src);
@@ -1494,6 +1505,7 @@ impl<'a> NamespaceES5Transformer<'a> {
         // Transform the class to ES5 using the class transformer
         let mut class_transformer = ES5ClassTransformer::new(self.arena);
         class_transformer.set_module_kind(self.module_kind);
+        class_transformer.set_es_module_interop(self.es_module_interop);
         class_transformer.set_target_es5(self.target_es5);
         // Classes in namespace are nested one level deeper than top-level
         class_transformer.set_indent_base(1);

--- a/crates/tsz-emitter/tests/dynamic_import_amd_umd_parity_tests.rs
+++ b/crates/tsz-emitter/tests/dynamic_import_amd_umd_parity_tests.rs
@@ -21,6 +21,12 @@
 //! - **UMD conditional** parenthesization follows parent-expression binding, not a
 //!   fixed rule — verified against `tsc` 6.x.
 //!
+//! - **`esModuleInterop` gate**: the `__importStar` wrapper (CJS/UMD-CJS) and the
+//!   `.then(__importStar)` callback (AMD/UMD-AMD) are emitted ONLY under
+//!   `esModuleInterop`. With interop off, tsc emits a bare `require(...)` /
+//!   `new Promise(...)`. The shape tests below run with interop on; the
+//!   interop-off forms are asserted in the dedicated section at the end.
+//!
 //! Owner layer: emitter (`crates/tsz-emitter/src/emitter/expressions/call.rs`).
 
 use tsz_common::common::{ModuleKind, ScriptTarget};
@@ -31,12 +37,17 @@ mod test_support;
 
 use test_support::parse_and_lower_print as emit;
 
+// The `__importStar`-wrapped forms asserted below match tsc's output under
+// `esModuleInterop` (with interop off tsc emits a bare `require(...)`; that
+// gate is covered separately by the interop-off tests at the end of this file
+// and in `cjs_module_exports.rs`). These helpers therefore enable interop.
 fn cjs(source: &str) -> String {
     emit(
         source,
         PrintOptions {
             target: ScriptTarget::ES2022,
             module: ModuleKind::CommonJS,
+            es_module_interop: true,
             ..Default::default()
         },
     )
@@ -48,6 +59,7 @@ fn umd(source: &str) -> String {
         PrintOptions {
             target: ScriptTarget::ES2017,
             module: ModuleKind::UMD,
+            es_module_interop: true,
             ..Default::default()
         },
     )
@@ -59,6 +71,7 @@ fn umd_target(source: &str, target: ScriptTarget) -> String {
         PrintOptions {
             target,
             module: ModuleKind::UMD,
+            es_module_interop: true,
             ..Default::default()
         },
     )
@@ -70,6 +83,7 @@ fn amd(source: &str) -> String {
         PrintOptions {
             target: ScriptTarget::ES2017,
             module: ModuleKind::AMD,
+            es_module_interop: true,
             ..Default::default()
         },
     )
@@ -81,6 +95,21 @@ fn system(source: &str) -> String {
         PrintOptions {
             target: ScriptTarget::ES2017,
             module: ModuleKind::System,
+            es_module_interop: true,
+            ..Default::default()
+        },
+    )
+}
+
+/// Emit with `esModuleInterop` off (tsc's default), used by the interop-gate
+/// tests at the end of this file.
+fn emit_no_interop(source: &str, module: ModuleKind, target: ScriptTarget) -> String {
+    emit(
+        source,
+        PrintOptions {
+            target,
+            module,
+            es_module_interop: false,
             ..Default::default()
         },
     )
@@ -488,6 +517,7 @@ fn async_lowered_cjs_es5_uses_function_form() {
         PrintOptions {
             target: ScriptTarget::ES5,
             module: ModuleKind::CommonJS,
+            es_module_interop: true,
             ..Default::default()
         },
     );
@@ -511,6 +541,7 @@ fn async_lowered_amd_es5_uses_function_form() {
         PrintOptions {
             target: ScriptTarget::ES5,
             module: ModuleKind::AMD,
+            es_module_interop: true,
             ..Default::default()
         },
     );
@@ -533,6 +564,7 @@ fn async_lowered_amd_es2015_uses_arrow_form() {
         PrintOptions {
             target: ScriptTarget::ES2015,
             module: ModuleKind::AMD,
+            es_module_interop: true,
             ..Default::default()
         },
     );
@@ -554,6 +586,7 @@ fn async_lowered_umd_es5_uses_function_form_in_both_branches() {
         PrintOptions {
             target: ScriptTarget::ES5,
             module: ModuleKind::UMD,
+            es_module_interop: true,
             ..Default::default()
         },
     );
@@ -577,6 +610,7 @@ fn async_lowered_umd_es2015_uses_arrow_form_in_both_branches() {
         PrintOptions {
             target: ScriptTarget::ES2015,
             module: ModuleKind::UMD,
+            es_module_interop: true,
             ..Default::default()
         },
     );
@@ -598,6 +632,7 @@ fn async_lowered_amd_es2016_uses_arrow_form() {
         PrintOptions {
             target: ScriptTarget::ES2016,
             module: ModuleKind::AMD,
+            es_module_interop: true,
             ..Default::default()
         },
     );
@@ -615,6 +650,7 @@ fn async_lowered_arrow_form_rule_is_structural_not_name_sensitive() {
         PrintOptions {
             target: ScriptTarget::ES2015,
             module: ModuleKind::AMD,
+            es_module_interop: true,
             ..Default::default()
         },
     );
@@ -641,6 +677,7 @@ fn nested_class_async_method_amd_es5_uses_function_form() {
         PrintOptions {
             target: ScriptTarget::ES5,
             module: ModuleKind::AMD,
+            es_module_interop: true,
             ..Default::default()
         },
     );
@@ -662,6 +699,7 @@ fn nested_class_async_method_amd_es2015_uses_arrow_form() {
         PrintOptions {
             target: ScriptTarget::ES2015,
             module: ModuleKind::AMD,
+            es_module_interop: true,
             ..Default::default()
         },
     );
@@ -684,6 +722,7 @@ fn namespace_class_async_method_amd_es5_uses_function_form() {
         PrintOptions {
             target: ScriptTarget::ES5,
             module: ModuleKind::AMD,
+            es_module_interop: true,
             ..Default::default()
         },
     );
@@ -705,6 +744,7 @@ fn namespace_class_async_method_amd_es2015_uses_arrow_form() {
         PrintOptions {
             target: ScriptTarget::ES2015,
             module: ModuleKind::AMD,
+            es_module_interop: true,
             ..Default::default()
         },
     );
@@ -716,4 +756,112 @@ fn namespace_class_async_method_amd_es2015_uses_arrow_form() {
         !out.contains("new Promise(function (resolve_"),
         "Namespace class async method at ES2015 must not emit function() form.\nOutput:\n{out}"
     );
+}
+
+// --- esModuleInterop gate: interop OFF emits bare require / Promise ----------
+// tsc default (`--esModuleInterop false`) does not wrap the dynamic `require`
+// in `__importStar`, and AMD/UMD drop the trailing `.then(__importStar)`.
+
+#[test]
+fn cjs_string_literal_no_interop_emits_bare_require() {
+    let out = emit_no_interop(
+        "const m = import(\"./dep\");",
+        ModuleKind::CommonJS,
+        ScriptTarget::ES2022,
+    );
+    assert!(
+        out.contains("Promise.resolve().then(() => require(\"./dep\"))"),
+        "interop-off CJS string-literal import should be a bare require.\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains("__importStar"),
+        "no __importStar wrapper.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn cjs_identifier_no_interop_emits_bare_require() {
+    let out = emit_no_interop(
+        "declare const p: string; const m = import(p);",
+        ModuleKind::CommonJS,
+        ScriptTarget::ES2022,
+    );
+    assert!(
+        out.contains("Promise.resolve(`${p}`).then(s => require(s))"),
+        "interop-off CJS identifier import should coerce then bare require.\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains("__importStar"),
+        "no __importStar wrapper.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn cjs_es5_no_interop_emits_bare_require_function_form() {
+    let out = emit_no_interop(
+        "const m = import(\"./dep\");",
+        ModuleKind::CommonJS,
+        ScriptTarget::ES5,
+    );
+    assert!(
+        out.contains("Promise.resolve().then(function () { return require(\"./dep\"); })"),
+        "interop-off ES5 CJS import should be a bare require function form.\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains("__importStar"),
+        "no __importStar wrapper.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn amd_no_interop_drops_then_import_star() {
+    let out = emit_no_interop(
+        "const m = import(\"./dep\");",
+        ModuleKind::AMD,
+        ScriptTarget::ES2017,
+    );
+    assert!(
+        out.contains(
+            "new Promise((resolve_1, reject_1) => { require([\"./dep\"], resolve_1, reject_1); })"
+        ),
+        "interop-off AMD import should emit the bare Promise form.\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains(".then(__importStar)"),
+        "interop-off AMD import must not append .then(__importStar).\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn umd_no_interop_drops_import_star_in_both_branches() {
+    let out = emit_no_interop(
+        "const m = import(\"./dep\");",
+        ModuleKind::UMD,
+        ScriptTarget::ES2017,
+    );
+    assert!(
+        out.contains("__syncRequire ? Promise.resolve().then(() => require(\"./dep\")) : new Promise((resolve_1, reject_1) => { require([\"./dep\"], resolve_1, reject_1); })"),
+        "interop-off UMD import should drop __importStar in both branches.\nOutput:\n{out}"
+    );
+    assert!(
+        !out.contains("__importStar"),
+        "no __importStar anywhere.\nOutput:\n{out}"
+    );
+}
+
+#[test]
+fn interop_off_rule_is_independent_of_specifier_name() {
+    // The gate is structural (esModuleInterop), not keyed on the specifier name.
+    let a = emit_no_interop(
+        "const m = import(\"./alpha\");",
+        ModuleKind::CommonJS,
+        ScriptTarget::ES2022,
+    );
+    let b = emit_no_interop(
+        "const m = import(\"./zeta\");",
+        ModuleKind::CommonJS,
+        ScriptTarget::ES2022,
+    );
+    assert!(a.contains("require(\"./alpha\")") && !a.contains("__importStar"));
+    assert!(b.contains("require(\"./zeta\")") && !b.contains("__importStar"));
 }


### PR DESCRIPTION
Fixes #14780.

When `--module commonjs` (and AMD/UMD) lowers a dynamic `import()` to `Promise.resolve().then(() => require(...))`, tsz unconditionally wrapped the `require` in the `__importStar` interop helper and injected the `__createBinding`/`__setModuleDefault`/`__importStar` helper prologue (~33 lines of dead code). tsc only applies `__importStar` under `esModuleInterop`; with interop off it emits a bare `require(...)`.

**Structural rule:** when a dynamic `import()` is lowered to `require`, tsc emits the `__importStar` wrapper (CJS / UMD-CJS branch) and the `.then(__importStar)` callback (AMD / UMD-AMD branch) **only** when `esModuleInterop` is enabled (`createImportCallExpressionCommonJS` / `createImportCallExpressionAMD`); with interop off it emits a bare `require(...)` / `new Promise(...)`. tsz now does the same through the emitter, gated on `self.ctx.options.es_module_interop`.

This is a broad fix across every dynamic-import lowering path, not only the reported repro:
- **Direct emitter path** (`expressions/call.rs`): string-literal, expression-specifier, ES5 `function` form, and AMD/UMD branches — gated via a shared `write_dynamic_import_star_open`/`_close` helper pair.
- **ES5 / async downlevel IR paths** (`async_es5_ir_convert`, `class_es5_ast_to_ir_expressions`): consolidated into the single-owner `emit_utils::dynamic_import_cjs_form` / `dynamic_import_amd_form` builders, which now take `target_es5` + `es_module_interop`.
- **Helper-need detection** (`lowering/core.rs`): the `__importStar`/`__createBinding`/`__setModuleDefault` prologue is requested under the same gate, so it is no longer emitted as dead code when interop is off.

`es_module_interop` is threaded through the ES5/async/class/namespace transformers alongside the existing `module_kind` (it is a global option, with no shared context object reaching the async transformer), and surfaced on the public `PrintOptions`.

Anti-hardcoding: the gate keys on the structural `esModuleInterop` option only — no specifier/file-name string checks (covered by `interop_off_rule_is_independent_of_specifier_name`).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib` — 3876 passed.
- `cargo test -p tsz-emitter --test dynamic_import_amd_umd_parity_tests` — 45 passed (interop-on shape parity + new interop-off coverage for CJS string-literal/identifier/ES5, AMD, UMD).
- New interop-on/off regression tests in `cjs_module_exports.rs` covering string-literal, expression-specifier, ES5, AMD, and the async-nested ES5 IR path (ensures the body-emission gate stays consistent with the helper-prologue gate).
- `cargo clippy -p tsz-emitter --all-targets` clean; `cargo fmt --check -p tsz-emitter` clean; `cargo build --workspace` clean.
- Pre-existing unrelated failure `generator_object_literal_prefix_before_yield_omits_source_trailing_comma` fails identically on the branch HEAD without this change (out of scope).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_0168k2FRZT8TsLdTqKkAyP9a)_