### PR TITLE
fix(checker): render resolved JSX props object, not raw LibraryManagedAttributes conditional (#14817)

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/jsx/diagnostics.rs
@@ -352,10 +352,63 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Render the resolved props object for a JSX component-prop diagnostic
+    /// target whose semantic type is (or aliases to) an *unevaluated*
+    /// `LibraryManagedAttributes` conditional.
+    ///
+    /// `LibraryManagedAttributes<C, P>` whose body is a conditional (React's
+    /// `… extends MemoExoticComponent<…> ? … : ReactManagedAttributes<…>`, or a
+    /// minimal `C extends (props: infer Q) => any ? Q : P`) is preserved by the
+    /// solver in its unevaluated form for contextual inference, while its
+    /// *apparent* type is the concrete props object the relation actually
+    /// compares against. `tsc` always prints that resolved props object, never
+    /// the raw conditional. Two shapes reach the display layer:
+    ///
+    /// * the props already materialized to an object, but the object carries the
+    ///   inline conditional as its `display_alias` (the explicit-attrs / TS2741
+    ///   path), and
+    /// * the props is still the bare inline conditional whose apparent type is an
+    ///   object (the whole-object / spread assignability path).
+    ///
+    /// In both cases render the structural object, skipping the inline-conditional
+    /// alias. The gate is structural — it fires only for an inline `Conditional`
+    /// (`TypeData::Conditional`). Named aliases (`Lazy(DefId)` references to
+    /// interfaces / type aliases) and `LibraryManagedAttributes<…>` application
+    /// surfaces are not inline conditionals, so they keep their existing display
+    /// paths and legitimate alias names are preserved.
+    pub(in crate::checkers_domain::jsx) fn jsx_managed_conditional_props_display(
+        &mut self,
+        props_type: TypeId,
+    ) -> Option<String> {
+        use crate::query_boundaries::common::{get_conditional_type_id, object_shape_for_type};
+
+        // Materialized object whose display alias is an inline conditional.
+        if let Some(alias) = self.ctx.types.get_display_alias(props_type)
+            && get_conditional_type_id(self.ctx.types, alias).is_some()
+            && object_shape_for_type(self.ctx.types, props_type).is_some()
+        {
+            return Some(self.format_type_skip_object_display_alias(props_type));
+        }
+
+        // Bare inline conditional whose apparent type is a props object.
+        if get_conditional_type_id(self.ctx.types, props_type).is_some()
+            && let Some(shape) = object_shape_for_type(self.ctx.types, props_type)
+        {
+            let object = self.ctx.types.factory().object(shape.properties.clone());
+            return Some(self.format_type_skip_object_display_alias(object));
+        }
+
+        None
+    }
+
     pub(in crate::checkers_domain::jsx) fn jsx_library_managed_structural_props_display(
         &mut self,
         props_type: TypeId,
     ) -> Option<String> {
+        if let Some(display) = self.jsx_managed_conditional_props_display(props_type) {
+            return Some(display);
+        }
+
         let raw_display = self.format_type(props_type);
         if let Some(display) =
             Self::jsx_library_managed_application_simplified_display(&raw_display)

--- a/crates/tsz-checker/src/checkers/jsx/spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/spread.rs
@@ -184,7 +184,11 @@ impl<'a> CheckerState<'a> {
             Some(display) if !display.is_empty() => display.to_string(),
             _ => {
                 let props_display_type = self.strip_jsx_children_injection_for_display(props_type);
-                self.format_type(props_display_type)
+                // When the props target is (or aliases to) an unevaluated
+                // `LibraryManagedAttributes` conditional, render its resolved
+                // props object — never the raw conditional (issue #14817).
+                self.jsx_managed_conditional_props_display(props_display_type)
+                    .unwrap_or_else(|| self.format_type(props_display_type))
             }
         };
 

--- a/crates/tsz-checker/tests/jsx_component_attribute_tests/part_04.rs
+++ b/crates/tsz-checker/tests/jsx_component_attribute_tests/part_04.rs
@@ -511,3 +511,154 @@ fn jsx_intrinsic_key_ref_ts2322_target_follows_renamed_alias_structurally() {
         "ref target should follow renamed alias `DomRef<…> | undefined`, got: {diags:?}"
     );
 }
+
+// ── Issue #14817: JSX component-prop diagnostic target must render the resolved
+// props object, not the unevaluated LibraryManagedAttributes conditional ──────
+//
+// When a function-component's props flow through `JSX.LibraryManagedAttributes`
+// whose body is a conditional (the React shape, but reproducible with a minimal
+// local LMA), the solver resolves the props to a concrete object but kept the
+// raw `C extends … ? … : …` conditional as the object's *display alias*. tsc
+// resolves the conditional and prints the props object, e.g.
+// `{ name: string; count: number; }`. The fix renders the structural object,
+// skipping the inline-conditional alias, across TS2741 / TS2322 / excess.
+
+const ISSUE_14817_LMA_NAMESPACE: &str = r#"
+declare namespace JSX {
+    interface Element {}
+    interface IntrinsicElements {}
+    type LibraryManagedAttributes<C, P> =
+        C extends (props: infer Q) => any ? Q : P;
+}
+"#;
+
+#[test]
+fn issue_14817_missing_prop_ts2741_shows_resolved_props_object() {
+    let source = format!(
+        "{ISSUE_14817_LMA_NAMESPACE}\n\
+         function Comp(props: {{ name: string; count: number }}): JSX.Element {{ return null as any; }}\n\
+         const b = <Comp name=\"x\" />;\n"
+    );
+
+    let diags = jsx_diagnostics(&source);
+    let messages = messages_for_code(
+        &diags,
+        diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+    );
+    assert!(
+        messages.iter().any(|m| m.contains(
+            "Property 'count' is missing in type '{ name: string; }' but required in type '{ name: string; count: number; }'."
+        )),
+        "TS2741 target must be the resolved props object, not the LMA conditional, got: {diags:?}"
+    );
+    assert!(
+        !messages
+            .iter()
+            .any(|m| m.contains("extends") && m.contains("infer Q")),
+        "TS2741 target must not leak the unevaluated LMA conditional, got: {diags:?}"
+    );
+}
+
+#[test]
+fn issue_14817_prop_type_mismatch_ts2322_shows_resolved_props_object() {
+    let source = format!(
+        "{ISSUE_14817_LMA_NAMESPACE}\n\
+         function Comp(props: {{ name: string; count: number }}): JSX.Element {{ return null as any; }}\n\
+         const b = <Comp name=\"x\" count=\"nope\" />;\n"
+    );
+
+    let diags = jsx_diagnostics(&source);
+    assert!(
+        !diags
+            .iter()
+            .any(|(_, m)| m.contains("extends") && m.contains("infer Q")),
+        "JSX prop-mismatch diagnostics must not leak the unevaluated LMA conditional, got: {diags:?}"
+    );
+}
+
+#[test]
+fn issue_14817_named_props_interface_alias_is_not_stripped() {
+    // A named conditional-bodied alias is a `Lazy(DefId)` reference, not an
+    // inline conditional; the structural gate must leave such named aliases on
+    // their normal display path. Here `Props` is a plain interface, the common
+    // case — its name/structure must survive and TS2741 must still fire.
+    let source = format!(
+        "{ISSUE_14817_LMA_NAMESPACE}\n\
+         interface Props {{ name: string; count: number; }}\n\
+         function Comp(props: Props): JSX.Element {{ return null as any; }}\n\
+         const b = <Comp name=\"x\" />;\n"
+    );
+
+    let diags = jsx_diagnostics(&source);
+    assert!(
+        has_code(
+            &diags,
+            diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
+        ),
+        "named-interface props must still report the missing required prop, got: {diags:?}"
+    );
+    assert!(
+        !diags
+            .iter()
+            .any(|(_, m)| m.contains("extends") && m.contains("infer Q")),
+        "named-interface props target must not leak the LMA conditional, got: {diags:?}"
+    );
+}
+
+#[test]
+fn issue_14817_renamed_binders_still_resolve_props_object() {
+    // Vary the component binder name and the LMA type-parameter names to prove
+    // the fix is structural and not keyed on any identifier spelling.
+    let source = r#"
+declare namespace JSX {
+    interface Element {}
+    interface IntrinsicElements {}
+    type LibraryManagedAttributes<Component, Properties> =
+        Component extends (p: infer Inferred) => any ? Inferred : Properties;
+}
+
+function Widget(props: { title: string; size: number }): JSX.Element { return null as any; }
+
+const w = <Widget title="x" />;
+"#;
+
+    let diags = jsx_diagnostics(source);
+    let messages = messages_for_code(
+        &diags,
+        diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("but required in type '{ title: string; size: number; }'.")),
+        "renamed binders must still resolve to the structural props object, got: {diags:?}"
+    );
+}
+
+#[test]
+fn issue_14817_spread_attrs_target_shows_resolved_props_object() {
+    // The whole-object / spread assignability path renders its target through a
+    // different code path than explicit attrs; it must also resolve the LMA
+    // conditional to the props object rather than leaking the raw conditional.
+    let source = format!(
+        "{ISSUE_14817_LMA_NAMESPACE}\n\
+         function Comp(props: {{ name: string; count: number }}): JSX.Element {{ return null as any; }}\n\
+         const p = {{ name: \"x\", count: \"nope\" }};\n\
+         const b = <Comp {{...p}} />;\n"
+    );
+
+    let diags = jsx_diagnostics(&source);
+    assert!(
+        !diags
+            .iter()
+            .any(|(_, m)| m.contains("extends") && m.contains("infer Q")),
+        "spread-attrs target must not leak the unevaluated LMA conditional, got: {diags:?}"
+    );
+    assert!(
+        diags.iter().any(
+            |(code, m)| *code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+                && m.contains("type '{ name: string; count: number; }'")
+        ),
+        "spread-attrs target must be the resolved props object, got: {diags:?}"
+    );
+}


### PR DESCRIPTION
Fixes #14817.

When a function component's props flow through `JSX.LibraryManagedAttributes` whose body is a conditional (React's `… extends MemoExoticComponent<…> ? … : ReactManagedAttributes<…>`, or a minimal `C extends (props: infer Q) => any ? Q : P`), the solver keeps the LMA body unevaluated for contextual inference. Its *apparent* type is the concrete props object the relation compares against, but the materialized object carried the inline conditional as its `display_alias` (and the whole-object/spread path received the bare conditional). Component-prop diagnostics then printed the giant `… extends … ? … : …` expression where tsc prints the resolved props object.

**Structural rule:** when a JSX component-prop diagnostic target is (or aliases to) an inline `Conditional` whose apparent type is a props object, `tsc` renders the resolved props object; tsz now renders the structural object through the checker JSX display boundary (`jsx_managed_conditional_props_display`), skipping the inline-conditional alias. The gate is structural (`TypeData::Conditional` + object shape) — named aliases (`Lazy(DefId)` references to interfaces/type aliases) and `LibraryManagedAttributes<…>` application surfaces are not inline conditionals, so legitimate alias names are preserved. No relation, inference, or semantic-type change.

Owner layer: checker JSX presentation policy, routed through the shared `jsx_library_managed_structural_props_display` helper (explicit-attrs TS2741/TS2322) and the JSX spread whole-object display.

### Before / after (minimal repro, no React needed)
```tsx
type LibraryManagedAttributes<C, P> = C extends (props: infer Q) => any ? Q : P;
function Comp(props: { name: string; count: number }): JSX.Element { return null as any; }
const b = <Comp name="x" />;
```
- before: `… required in type '(props: { name: string; count: number; }) => Element extends (props: infer Q) => any ? Q : { name: string; count: number; }'.`
- after / tsc: `… required in type '{ name: string; count: number; }'.`

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test jsx_component_attribute_tests issue_14817` — 5 new regression tests (TS2741 missing prop, TS2322 prop mismatch, spread whole-object mismatch, renamed binders/type-param names, named-interface alias not stripped).
- `cargo test -p tsz-checker --test jsx_component_attribute_tests` — no new failures (2 remaining failures require compiled default-lib files absent in the sandbox and are pre-existing on the base commit).
- `cargo test -p tsz-checker` JSX spread/display targets: `jsx_excess_attr_with_spread_source_display_tests`, `jsx_generic_spread_deferred_conditional_tests`, `jsx_spread_assignability_suppresses_ts2741`, `ts2322_jsx_spread_strip_children_injection_tests`, `jsx_union_callback_context_tests`, `jsx_multi_construct_overload_tests`, `jsx_overload_anchor_literal_attr_tests` — all green.
- `cargo clippy -p tsz-checker --lib` — clean.
- Ready-review CI owns conformance/emit/fourslash.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01KrePjXeojwiPJ4MDuBSrYa

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrePjXeojwiPJ4MDuBSrYa)_