### PR TITLE
fix(checker,emit): widen inferred enum-member return types to the parent enum (#14763)

### DIFF
--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -499,7 +499,11 @@ impl<'a> CheckerState<'a> {
         return_context: Option<TypeId>,
     ) -> TypeId {
         if self.return_contribution_is_widenable(expr_idx, type_id, return_context) {
-            return self.widen_return_contribution_preserving_const(expr_idx, type_id);
+            let widened = self.widen_return_contribution_preserving_const(expr_idx, type_id);
+            // The primitive-literal widener skips `TypeData::Enum`, so a fresh
+            // enum-member return (`() => E.A`) must additionally widen to its
+            // parent enum. No-op for the already-widened primitive/object result.
+            return self.widen_enum_member_type(widened);
         }
         type_id
     }
@@ -539,7 +543,15 @@ impl<'a> CheckerState<'a> {
         }) {
             return false;
         }
-        self.is_fresh_literal_expression(expr_idx)
+        // An enum-member access (`return E.A`) is a fresh enum literal in tsc:
+        // `getReturnTypeFromBody` widens it to the parent enum (`E`), exactly as
+        // a fresh primitive literal widens to its base (`return "x"` → `string`).
+        // The carve-outs above (a pinning contextual return, `preserve_literal_types`,
+        // an `as const` assertion, a conditional deferred to union collapse) already
+        // returned, so enum members observe the same preservation rules. The widen
+        // itself runs through `widen_enum_member_type` at each widenable site,
+        // since the primitive literal widener leaves `TypeData::Enum` untouched.
+        self.is_fresh_literal_expression(expr_idx) || self.is_enum_member_type_for_widening(type_id)
     }
 
     /// Widen a fresh return-expression contribution while preserving literal
@@ -1480,13 +1492,18 @@ impl<'a> CheckerState<'a> {
                                 self.ctx.types,
                                 return_type,
                             ) {
-                            (
+                            // A widenable non-literal contribution is widened here
+                            // (fresh object/array structure via `widen_const_initializer`)
+                            // and its enum-member leaf is folded to the parent enum —
+                            // an enum member is `TypeData::Enum`, not a literal, so it
+                            // takes this branch rather than the deferred single-literal
+                            // collapse below.
+                            let widened =
                                 crate::query_boundaries::widening::widen_const_initializer(
                                     self.ctx.types,
                                     return_type,
-                                ),
-                                None,
-                            )
+                                );
+                            (self.widen_enum_member_type(widened), None)
                         } else {
                             (return_type, widenable.then_some(return_data.expression))
                         };

--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -128,6 +128,10 @@ name = "inferred_function_value_apparent_member_return_dts_emit_tests"
 path = "tests/inferred_function_value_apparent_member_return_dts_emit_tests.rs"
 
 [[test]]
+name = "inferred_enum_member_return_dts_emit_tests"
+path = "tests/inferred_enum_member_return_dts_emit_tests.rs"
+
+[[test]]
 name = "overload_call_node_type_cache_dts_emit_tests"
 path = "tests/overload_call_node_type_cache_dts_emit_tests.rs"
 

--- a/crates/tsz-cli/tests/inferred_enum_member_return_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/inferred_enum_member_return_dts_emit_tests.rs
@@ -1,0 +1,210 @@
+//! DTS emit: an inferred function/arrow/method return type whose body returns a
+//! single enum member widens the member to its parent enum (issue #14763).
+//!
+//! tsc's `getReturnTypeFromBody` runs the aggregated return type through
+//! `getWidenedType`, which widens a fresh enum-member literal (`return E.A`) to
+//! the parent enum (`E`), exactly as a fresh primitive literal widens to its
+//! base (`return "x"` → `string`). Const initializers (`const v = E.A`) and
+//! explicit return annotations (`(): E.A`) are NOT widened by tsc, and a reverse
+//! mapping (`E[0]`, type `string`) and a non-fresh enum-typed parameter
+//! passthrough must be preserved as-is.
+//!
+//! Binder names are varied across cases so the widening cannot be keyed on any
+//! particular enum/member identifier (anti-hardcoding gate).
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_inferred_enum_return_dts_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+/// Compile `source` with declaration emit and return the generated `.d.ts` text.
+/// Returns `None` when the tsz binary is unavailable (lets the test self-skip).
+fn emit_dts(name: &str, source: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let src_path = temp.path.join("repro.ts");
+    std::fs::write(&src_path, source).expect("write repro file");
+
+    let output = Command::new(tsz_bin)
+        .args([
+            "repro.ts",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--pretty",
+            "false",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz declaration emit");
+
+    let dts = std::fs::read_to_string(temp.path.join("repro.d.ts")).unwrap_or_else(|_| {
+        panic!(
+            "expected repro.d.ts to be emitted.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    Some(dts)
+}
+
+fn assert_line(dts: &str, needle: &str) {
+    assert!(
+        dts.lines().any(|line| line.trim() == needle),
+        "expected a line `{needle}` in declaration output:\n{dts}"
+    );
+}
+
+fn assert_no_line(dts: &str, needle: &str) {
+    assert!(
+        dts.lines().all(|line| line.trim() != needle),
+        "did not expect a line `{needle}` in declaration output:\n{dts}"
+    );
+}
+
+/// Function declaration, arrow initializer, method, and getter all widen a
+/// single returned enum member to the parent enum. Const enum behaves the same.
+#[test]
+fn single_enum_member_return_widens_to_parent_enum() {
+    let Some(dts) = emit_dts(
+        "single_member",
+        r#"
+enum Color { Red, Green }
+const enum Mode { On, Off }
+export function f() { return Color.Red; }
+export const g = () => Color.Green;
+export function cf() { return Mode.On; }
+export const ca = () => Mode.Off;
+export class K {
+    m() { return Color.Green; }
+    get accessor() { return Color.Red; }
+}
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    // Inferred returns widen the member to the parent enum.
+    assert_line(&dts, "export declare function f(): Color;");
+    assert_line(&dts, "export declare const g: () => Color;");
+    assert_line(&dts, "export declare function cf(): Mode;");
+    assert_line(&dts, "export declare const ca: () => Mode;");
+    assert_line(&dts, "m(): Color;");
+    assert_line(&dts, "get accessor(): Color;");
+
+    // The narrow member-qualified type must not survive on any inferred return.
+    assert_no_line(&dts, "export declare function f(): Color.Red;");
+    assert_no_line(&dts, "export declare const g: () => Color.Green;");
+    assert_no_line(&dts, "export declare function cf(): Mode.On;");
+    assert_no_line(&dts, "m(): Color.Green;");
+}
+
+/// Const initializers and explicit return annotations keep the exact member
+/// type; widening is scoped to *inferred* function-like returns.
+#[test]
+fn const_initializer_and_explicit_annotation_keep_member_type() {
+    let Some(dts) = emit_dts(
+        "preserved",
+        r#"
+enum Suit { Hearts, Spades }
+export const v = Suit.Hearts;
+export function h(): Suit.Hearts { return Suit.Hearts; }
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_line(&dts, "export declare const v = Suit.Hearts;");
+    assert_line(&dts, "export declare function h(): Suit.Hearts;");
+}
+
+/// A multi-member union of the same enum already collapses to the enum, and must
+/// stay that way; an enum-typed parameter passthrough is non-fresh and is never
+/// widened; a reverse mapping (`E[0]`, type `string`) stays `string`.
+#[test]
+fn union_passthrough_and_reverse_mapping_are_unchanged() {
+    let Some(dts) = emit_dts(
+        "edges",
+        r#"
+enum Dir { Up = "UP", Down = "DOWN" }
+export function both(b: boolean) { return b ? Dir.Up : Dir.Down; }
+export function passthrough(x: Dir.Up) { return x; }
+enum Num { A, B }
+export function rev() { return Num[0]; }
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    // Same-enum union — widened in both tsc and tsz.
+    assert_line(&dts, "export declare function both(b: boolean): Dir;");
+    // Non-fresh parameter passthrough keeps the exact member type.
+    assert_line(
+        &dts,
+        "export declare function passthrough(x: Dir.Up): Dir.Up;",
+    );
+    // Reverse mapping is a `string`, never the parent enum.
+    assert_line(&dts, "export declare function rev(): string;");
+    assert_no_line(&dts, "export declare function rev(): Num;");
+}
+
+/// Multiple `return E.A` branches that dedup to a single member still widen to
+/// the parent enum (the union collapses to one member, then widens).
+#[test]
+fn multiple_same_member_returns_widen() {
+    let Some(dts) = emit_dts(
+        "multi_return",
+        r#"
+enum Phase { Start, End }
+export class Runner {
+    run(b: boolean) {
+        if (b) return Phase.Start;
+        return Phase.Start;
+    }
+}
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_line(&dts, "run(b: boolean): Phase;");
+    assert_no_line(&dts, "run(b: boolean): Phase.Start;");
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_enum_access.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_enum_access.rs
@@ -328,6 +328,54 @@ impl<'a> DeclarationEmitter<'a> {
         self.get_source_slice(base_node.pos, base_node.end)
     }
 
+    /// Widen a single returned enum-member access (`return E.A`, `() => E.A`) to
+    /// its parent enum name (`E`) for an inferred declaration return type.
+    ///
+    /// tsc's `getReturnTypeFromBody` runs the aggregated return type through
+    /// `getWidenedType`, which widens a fresh enum-member literal to its parent
+    /// enum exactly as a fresh primitive literal widens to its base. The checker
+    /// already does this at the type level; this is the declaration-emit analog
+    /// for the AST-text return paths (class methods, arrow expression bodies,
+    /// returned local callables) that render the returned expression directly
+    /// rather than printing the solver return type.
+    ///
+    /// The gate is the returned expression's solver type being a *literal* enum
+    /// member (`is_literal_enum_member`), so a reverse mapping (`E[0]`, type
+    /// `string`) is excluded and only a genuine member literal widens. Returns
+    /// `None` when the expression is not a widenable enum member, so const
+    /// initializers and explicit annotations (handled by their own paths) are
+    /// never reached here.
+    pub(in crate::declaration_emitter) fn returned_enum_member_widened_base_text(
+        &self,
+        return_expr: NodeIndex,
+    ) -> Option<String> {
+        // Cheap syntactic gate first: only an `Enum.Member` / `Enum["Member"]`
+        // access can widen. `simple_enum_access_base_name_text` rejects every
+        // other return shape (literals, calls, objects) before the solver type
+        // lookup below runs, so the common non-enum return pays no type query.
+        let base_name = self.simple_enum_access_base_name_text(return_expr)?;
+        let interner = self.type_interner?;
+        let type_id = self.get_node_type_or_names(&[return_expr])?;
+        // Confirm a *literal* member, so a reverse mapping (`E[0]`, type `string`)
+        // is excluded and only a genuine member literal widens to its parent enum.
+        tsz_solver::type_queries::is_literal_enum_member(interner, type_id).then_some(base_name)
+    }
+
+    /// Inferred return-type text for a single returned expression, widening a
+    /// returned enum-member literal to its parent enum before the general
+    /// declaration-summary / fallback inference. Shared by the block-body,
+    /// arrow-body, and returned-local-callable return paths so the widen-then-
+    /// fallback order stays in one place.
+    pub(in crate::declaration_emitter) fn return_expression_type_text_with_enum_widening(
+        &self,
+        return_expr: NodeIndex,
+        depth: u32,
+    ) -> Option<String> {
+        self.returned_enum_member_widened_base_text(return_expr)
+            .or_else(|| self.declaration_summary_primitive_expression_type_text(return_expr, depth))
+            .or_else(|| self.infer_fallback_type_text_at(return_expr, depth))
+    }
+
     pub(crate) fn const_asserted_enum_access_member_text(
         &self,
         expr_idx: NodeIndex,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -691,16 +691,17 @@ impl<'a> DeclarationEmitter<'a> {
         }
         let body_node = self.arena.get(func.body)?;
         if body_node.kind == syntax_kind_ext::BLOCK {
+            // A returned enum-member literal widens to its parent enum, matching
+            // the checker's inferred-return widening.
             return self
                 .function_body_single_return_expression(func.body)
                 .and_then(|return_expr| {
-                    self.declaration_summary_primitive_expression_type_text(return_expr, depth + 1)
-                        .or_else(|| self.infer_fallback_type_text_at(return_expr, depth + 1))
+                    self.return_expression_type_text_with_enum_widening(return_expr, depth + 1)
                 })
                 .or_else(|| self.function_body_preferred_return_type_text(func.body));
         }
-        self.declaration_summary_primitive_expression_type_text(func.body, depth + 1)
-            .or_else(|| self.infer_fallback_type_text_at(func.body, depth + 1))
+        // Expression-bodied arrow (`() => E.A`): same widen-then-fallback path.
+        self.return_expression_type_text_with_enum_widening(func.body, depth + 1)
     }
 
     fn well_known_method_call_return_type_text(&self, expr_idx: NodeIndex) -> Option<String> {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -17,6 +17,15 @@ impl DeclarationEmitter<'_> {
     ) -> Option<String> {
         let body_node = self.arena.get(body_idx)?;
         let block = self.arena.get_block(body_node)?;
+        // A single returned enum-member literal (`return E.A`) widens to its
+        // parent enum (`E`) in an inferred return type, mirroring the checker's
+        // type-level widening. Done before the member-qualified text paths below
+        // so methods/functions emit `E`, not `E.A`.
+        if let Some(return_expr) = self.function_body_single_return_expression(body_idx)
+            && let Some(type_text) = self.returned_enum_member_widened_base_text(return_expr)
+        {
+            return Some(type_text);
+        }
         if let Some(type_text) =
             self.function_body_numeric_literal_return_union_type_text(&block.statements)
         {
@@ -1113,6 +1122,14 @@ impl DeclarationEmitter<'_> {
                     // return is equivalent to `return undefined` with
                     // widening to `void`. Matches declFileTypeAnnotationBuiltInType.
                     "void".to_string()
+                } else if let Some(text) =
+                    self.returned_enum_member_widened_base_text(ret.expression)
+                {
+                    // A returned enum-member literal widens to its parent enum,
+                    // so multiple `return E.A` branches collapse to `E` (matching
+                    // the checker's inferred-return widening) instead of unifying
+                    // as the member-qualified `E.A`.
+                    text
                 } else if self
                     .arena
                     .get(ret.expression)

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -943,8 +943,7 @@ impl<'a> DeclarationEmitter<'a> {
             }
             if let Some(return_expr) = self.single_return_expression(func.body)
                 && let Some(type_text) = self
-                    .declaration_summary_primitive_expression_type_text(return_expr, 0)
-                    .or_else(|| self.infer_fallback_type_text_at(return_expr, 0))
+                    .return_expression_type_text_with_enum_widening(return_expr, 0)
                     .filter(|text| !text.is_empty() && text != "any")
             {
                 return Some(type_text);


### PR DESCRIPTION
Closes #14763.

When a function/arrow/method has no return annotation and returns a single enum member (`return Color.Red`), tsc's `getReturnTypeFromBody` runs the aggregated return type through `getWidenedType`, folding a fresh enum-member literal to its parent enum (`Color`) exactly as a fresh primitive literal widens to its base (`return "x"` → `string`). tsz kept the narrow member-qualified type — at the **type level** (a real false-negative: `const x: Color.Red = f()` wrongly type-checked) and on the **`.d.ts` emit** surface (`(): Color.Red` instead of `(): Color`).

**Structural rule:** when an inferred function-like return is a fresh enum-member literal and no carve-out applies (a pinning contextual return, `preserve_literal_types`, an `as const` assertion, or a conditional deferred to union collapse), `tsc` widens it to the parent enum; tsz now does the same through the checker's return-type inference (owner: solver-backed widening) and mirrors it on the declaration-emit AST-text paths.

### Changes
- **Checker** (`types/utilities/return_type.rs`): a fresh enum-member contribution is now widenable; both the expression-body widen and the block-collect widen route the result through the existing `widen_enum_member_type`, which the primitive-literal widener leaves untouched. This fixes the inferred return **type** itself, so checking and every emit path benefit uniformly.
- **Emit** (`declaration_emitter`): the AST-text return paths that render the returned expression directly (class methods, arrow expression bodies, returned local callables, multi-return collapse) — which bypass the now-correct solver return type — widen a returned enum-member literal via the new `returned_enum_member_widened_base_text` gate, shared through `return_expression_type_text_with_enum_widening`. The gate confirms the solver type is a *literal* enum member, so reverse mappings (`E[0]`, type `string`) and non-fresh parameter passthroughs are left unchanged.

### Adjacent matrix (binder names varied to avoid name-keyed logic)
Function declaration, arrow, function expression, method, getter; numeric and string enum; `const enum`; single-member return (widens) vs multi-member union (already collapses to the enum, must stay); const initializer (`const v = E.A`) and explicit annotation (`(): E.A`) preserved; reverse mapping (`E[0]`) and enum-typed parameter passthrough preserved.

## Goal
Goal: hold

## Verification
- New full-pipeline test: `cargo test -p tsz-cli --test inferred_enum_member_return_dts_emit_tests` (4 cases: single-member widen across function/arrow/method/getter + const enum; const-init/explicit-annotation preserved; union/passthrough/reverse-mapping unchanged; multi-return collapse).
- `cargo test -p tsz-emitter --lib` (3876 passed); existing dts-emit CLI suites green; `cargo clippy -p tsz-emitter -p tsz-checker` clean.
- Checker `widen` / `return_type` / `enum` lib filters: no new failures vs. clean tree (the same 7 lib-fixture-dependent tests fail before and after this change).
- Ready-review CI owns broad conformance/emit/fourslash.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_013kT4yeLWhm1kBHa4kBD4iC)_