### PR TITLE
fix(solver): preserve a non-widening literal-union object property during inference-time widening (TS2322/TS2345)

### DIFF
--- a/crates/tsz-solver/src/operations/widening.rs
+++ b/crates/tsz-solver/src/operations/widening.rs
@@ -51,11 +51,25 @@ fn readonly_property_preserves_top_level_type(
     db: &dyn crate::construction::TypeDatabase,
     type_id: TypeId,
 ) -> bool {
-    matches!(
-        db.lookup(type_id),
-        Some(TypeData::Literal(_) | TypeData::UniqueSymbol(_))
-    ) || type_id == TypeId::BOOLEAN_TRUE
-        || type_id == TypeId::BOOLEAN_FALSE
+    match db.lookup(type_id) {
+        Some(TypeData::Literal(_) | TypeData::UniqueSymbol(_)) => true,
+        // A union whose members are *all* themselves preservable top-level
+        // literals/unit types (`-1 | 0 | 1`, `"a" | "b"`) is preserved as a
+        // whole: tsc's `getWidenedType` never widens a regular literal union on
+        // a `readonly`/non-widening property. This mirrors the member-by-member
+        // union distribution in the main widen path, where literal members are
+        // already kept — without it, a non-widening property carrying a literal
+        // union (e.g. `comparison: x as -1 | 0 | 1`) would widen to its base
+        // primitive (`number`) and produce false TS2322/TS2345.
+        Some(TypeData::Union(list_id)) => {
+            let members = db.type_list(list_id);
+            !members.is_empty()
+                && members
+                    .iter()
+                    .all(|&member| readonly_property_preserves_top_level_type(db, member))
+        }
+        _ => type_id == TypeId::BOOLEAN_TRUE || type_id == TypeId::BOOLEAN_FALSE,
+    }
 }
 
 /// Public API to widen a literal type to its primitive.


### PR DESCRIPTION
Generic-call argument inference widened a **non-widening** object-literal property whose type is a **literal union** down to its base primitive, producing a false `TS2322`/`TS2345`. For example `id({ comparison: 1 as -1 | 0 | 1 })` produced `{ comparison: number }` instead of `{ comparison: -1 | 0 | 1 }` (found in date-fns `formatDistance`/`formatDistanceStrict`, 25 FPs). `tsc` preserves the literal union.

## Structural rule
A `readonly` / non-widening object-literal property whose type is a **union all of whose members are themselves preservable top-level literal/unit types** must be preserved (not widened to its base primitive) during inference-time object-literal widening — matching `tsc`'s `getWidenedType`, which never widens a regular literal union on such a property.

Owner layer: solver `crates/tsz-solver/src/operations/widening.rs` — `readonly_property_preserves_top_level_type` (consumed by the inference-time object-property widener reached from `generic_call`). It previously recognized only a single top-level literal/unique-symbol; it now recurses over union members (a union is preserved iff every member is preservable), mirroring the existing member-by-member union distribution in the main widen path. The decision is structural (type-shape only) — no name/file/printer-string checks.

## Scope and controls
Scoped to the non-widening (assertion/annotation) + `readonly` subset; the declared-`const` freshness path is untouched. Verified against `tsc` 5.5.4 (all match exactly):
- `id({ comparison: 1 })` — bare fresh literal → widens to `number` (errors, like `tsc`).
- `id({ comparison: cond ? 1 : 2 })` — bare fresh literal union → widens (errors, like `tsc`).
- `id({ comparison: 1 as 1 })` — single-literal assertion → preserves `1` (already worked).
- `id({ comparison: 1 as -1 | 0 | 1 })` — literal-union assertion → now preserves `-1 | 0 | 1` (the fix).
- Plus array-element / nested-object / return-position / `true|false` / string-union / mixed-`literal|number` cases — all `tsc`-parity (mixed unions with a non-literal member still widen).

Goal: green

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Minimal repro + faithful date-fns `Object.assign({}, options, { comparison: x as -1|0|1 })` shape compile clean; all controls match `tsc` 5.5.4.
- date-fns (`pkgs/core/src`, strict/es2017; `tsc` 5.5.4 = 0 src errors): the 25-FP `formatDistance`/`formatDistanceStrict` `TS2345` cluster clears with **0 new FPs** (noise-robust: confirmed stable across 5 runs per tree, since date-fns is run-to-run non-deterministic on main too).
- `cargo nextest -p tsz-solver -p tsz-checker` (full): failure-leaf set **byte-identical** to `origin/main` (0 new failures, 23768 passed). `widening.rs` 2028→2042 lines, below the solver max (`narrowing/core.rs` 2655) and already counted as oversized, so the solver file-size ceiling test is unaffected.
