### PR TITLE
fix(emit): async-generator ES5 return value is awaited and yield-await re-marks resumed value (#14765)

### DIFF
--- a/crates/tsz-emitter/src/transforms/async_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir.rs
@@ -475,7 +475,12 @@ impl<'a> AsyncES5Transformer<'a> {
             self.collect_binding_name(param.name, &mut param_binding_names);
         }
 
-        let has_yield = self.body_contains_await(body_idx);
+        // An async generator's return value is awaited, so every explicit
+        // `return` becomes a `yield __await(...)` suspension. Force the
+        // `__generator` state machine when the body has any explicit return,
+        // even with no source-level `await`/`yield`.
+        let has_yield =
+            self.body_contains_await(body_idx) || self.contains_explicit_return_recursive(body_idx);
         self.state.has_await = has_yield;
         self.state.captures_arguments =
             tsz_parser::syntax::transform_utils::contains_arguments_reference(self.arena, body_idx);

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_discovery.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_discovery.rs
@@ -68,6 +68,36 @@ impl AsyncES5Transformer<'_> {
             .any(|child| self.contains_for_await_recursive(child))
     }
 
+    /// True when the sub-tree at `idx` contains an explicit `return` statement
+    /// in the current function scope (not inside a nested function/class). In
+    /// an async generator every explicit `return` lowers to a
+    /// `yield __await(...)` suspension, so its presence forces the
+    /// `__generator` state machine even when the body has no `await`/`yield`.
+    /// The implicit end-of-body completion does not count — tsc emits those
+    /// async generators linearly.
+    pub(super) fn contains_explicit_return_recursive(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+
+        if node.kind == syntax_kind_ext::FUNCTION_DECLARATION
+            || node.is_function_expression_or_arrow()
+            || node.kind == syntax_kind_ext::CLASS_DECLARATION
+            || node.kind == syntax_kind_ext::CLASS_EXPRESSION
+        {
+            return false;
+        }
+
+        if node.kind == syntax_kind_ext::RETURN_STATEMENT {
+            return true;
+        }
+
+        self.arena
+            .get_children(idx)
+            .into_iter()
+            .any(|child| self.contains_explicit_return_recursive(child))
+    }
+
     pub(super) fn contains_array_spread_recursive(&self, idx: NodeIndex) -> bool {
         let Some(node) = self.arena.get(idx) else {
             return false;

--- a/crates/tsz-emitter/src/transforms/async_es5_ir_statements.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5_ir_statements.rs
@@ -114,96 +114,47 @@ impl<'a> AsyncES5Transformer<'a> {
 
             k if k == syntax_kind_ext::RETURN_STATEMENT => {
                 if let Some(ret) = self.arena.get_return_statement(node) {
-                    if ret.expression.is_none() {
-                        current_statements.push(IRNode::ReturnStatement(Some(Box::new(
-                            IRNode::GeneratorOp {
-                                opcode: opcodes::RETURN,
-                                value: None,
-                                comment: Some("return".to_string().into()),
-                            },
-                        ))));
-                    } else if self.is_suspension_expression(ret.expression) {
-                        // return await/yield expr; -> yield, then return _a.sent()
-                        self.process_await_expression(
+                    let has_expr = ret.expression.is_some();
+                    // Lower the operand (emitting any inner suspensions as their
+                    // own cases). A bare `return;` carries the implicit
+                    // `undefined` with no suspension.
+                    let (value, had_suspension) = if has_expr {
+                        self.lower_return_value(
                             ret.expression,
+                            cases,
+                            current_statements,
+                            current_label,
+                        )
+                    } else {
+                        (IRNode::Undefined, false)
+                    };
+
+                    if self.async_generator_mode {
+                        // An async generator awaits its return value before
+                        // resolving the iterator result — even the implicit
+                        // `undefined` of a bare `return;`. Re-mark the value as
+                        // an await (the `.apply` form when it depends on a
+                        // resumed `_a.sent()`), yield it, then return the
+                        // resolved value.
+                        let awaited = if had_suspension {
+                            self.wrap_await_apply(value)
+                        } else {
+                            self.wrap_await_value(value)
+                        };
+                        self.push_generator_yield(
+                            opcodes::YIELD,
+                            awaited,
+                            "yield",
                             cases,
                             current_statements,
                             current_label,
                         );
-
-                        // After the yield resumes, return the sent value
-                        current_statements.push(IRNode::ReturnStatement(Some(Box::new(
-                            IRNode::GeneratorOp {
-                                opcode: opcodes::RETURN,
-                                value: Some(Box::new(IRNode::GeneratorSent)),
-                                comment: Some("return".to_string().into()),
-                            },
-                        ))));
-                    } else if self.contains_await_recursive(ret.expression) {
-                        let value = if let Some(lowered_comma) = self
-                            .lower_return_comma_before_suspension(
-                                ret.expression,
-                                cases,
-                                current_statements,
-                                current_label,
-                            ) {
-                            lowered_comma
-                        } else if let Some(lowered_object) = self
-                            .lower_object_literal_before_suspension(
-                                ret.expression,
-                                cases,
-                                current_statements,
-                                current_label,
-                            )
-                        {
-                            lowered_object
-                        } else if let Some(lowered_call) = self.lower_call_callee_before_suspension(
-                            ret.expression,
-                            cases,
-                            current_statements,
-                            current_label,
-                        ) {
-                            lowered_call
-                        } else if let Some(lowered_array) = self
-                            .lower_array_literal_before_suspension(
-                                ret.expression,
-                                cases,
-                                current_statements,
-                                current_label,
-                            )
-                        {
-                            lowered_array
-                        } else if let Some(lowered_access) = self
-                            .lower_element_access_object_before_suspension(
-                                ret.expression,
-                                cases,
-                                current_statements,
-                                current_label,
-                            )
-                        {
-                            lowered_access
-                        } else {
-                            self.emit_nested_suspension(
-                                ret.expression,
-                                cases,
-                                current_statements,
-                                current_label,
-                            );
-                            self.expression_to_ir(ret.expression)
-                        };
-                        current_statements.push(IRNode::ReturnStatement(Some(Box::new(
-                            IRNode::GeneratorOp {
-                                opcode: opcodes::RETURN,
-                                value: Some(Box::new(value)),
-                                comment: Some("return".to_string().into()),
-                            },
-                        ))));
+                        self.push_generator_return_sent(current_statements);
                     } else {
-                        let value = self.expression_to_ir(ret.expression);
                         current_statements.push(IRNode::ReturnStatement(Some(Box::new(
                             IRNode::GeneratorOp {
                                 opcode: opcodes::RETURN,
-                                value: Some(Box::new(value)),
+                                value: has_expr.then(|| Box::new(value)),
                                 comment: Some("return".to_string().into()),
                             },
                         ))));
@@ -1051,19 +1002,9 @@ impl<'a> AsyncES5Transformer<'a> {
                 current_label,
             );
 
-            let awaited_delegated_value = IRNode::CallExpr {
-                callee: Box::new(IRNode::PropertyAccess {
-                    object: Box::new(IRNode::RuntimeHelper("__await".into())),
-                    property: "apply".into(),
-                }),
-                arguments: vec![
-                    IRNode::Undefined,
-                    IRNode::ArrayLiteral(vec![IRNode::GeneratorSent]),
-                ],
-            };
             self.push_generator_yield(
                 opcodes::YIELD,
-                awaited_delegated_value,
+                self.wrap_async_generator_await_sent(),
                 "yield",
                 cases,
                 current_statements,
@@ -1092,7 +1033,11 @@ impl<'a> AsyncES5Transformer<'a> {
                 current_statements,
                 current_label,
             );
-            IRNode::GeneratorSent
+            // Re-mark the awaited result as an await before re-yielding it, so
+            // the `__asyncGenerator` runtime can tell an await-resolution apart
+            // from a yielded value. Mirrors the `yield*` branch above; a bare
+            // `GeneratorSent` here corrupts the async-iterator protocol.
+            self.wrap_async_generator_await_sent()
         } else {
             self.wrap_async_generator_await(yield_expr.expression)
         };
@@ -1138,14 +1083,120 @@ impl<'a> AsyncES5Transformer<'a> {
         *current_label = self.state.next_label();
     }
 
+    /// Pushes `return [2 /*return*/, _a.sent()]`: returns the value resolved at
+    /// the immediately preceding suspension. Used by the async-generator
+    /// return-await lowering after the `yield __await(...)` it pairs with.
+    pub(in crate::transforms) fn push_generator_return_sent(
+        &self,
+        current_statements: &mut Vec<IRNode>,
+    ) {
+        current_statements.push(IRNode::ReturnStatement(Some(Box::new(
+            IRNode::GeneratorOp {
+                opcode: opcodes::RETURN,
+                value: Some(Box::new(IRNode::GeneratorSent)),
+                comment: Some("return".to_string().into()),
+            },
+        ))));
+    }
+
+    /// Lowers a `return <expr>` operand into an IR value, emitting any inner
+    /// suspensions as their own cases first. Returns the value plus whether a
+    /// suspension was emitted while computing it (so the async-generator
+    /// return-await path can pick the `__await.apply` vs `__await` wrapper).
+    pub(in crate::transforms) fn lower_return_value(
+        &mut self,
+        expression: NodeIndex,
+        cases: &mut Vec<IRGeneratorCase>,
+        current_statements: &mut Vec<IRNode>,
+        current_label: &mut u32,
+    ) -> (IRNode, bool) {
+        if self.is_suspension_expression(expression) {
+            // return await/yield expr; -> yield, then the resumed sent value.
+            self.process_await_expression(expression, cases, current_statements, current_label);
+            (IRNode::GeneratorSent, true)
+        } else if self.contains_await_recursive(expression) {
+            let value = if let Some(lowered_comma) = self.lower_return_comma_before_suspension(
+                expression,
+                cases,
+                current_statements,
+                current_label,
+            ) {
+                lowered_comma
+            } else if let Some(lowered_object) = self.lower_object_literal_before_suspension(
+                expression,
+                cases,
+                current_statements,
+                current_label,
+            ) {
+                lowered_object
+            } else if let Some(lowered_call) = self.lower_call_callee_before_suspension(
+                expression,
+                cases,
+                current_statements,
+                current_label,
+            ) {
+                lowered_call
+            } else if let Some(lowered_array) = self.lower_array_literal_before_suspension(
+                expression,
+                cases,
+                current_statements,
+                current_label,
+            ) {
+                lowered_array
+            } else if let Some(lowered_access) = self.lower_element_access_object_before_suspension(
+                expression,
+                cases,
+                current_statements,
+                current_label,
+            ) {
+                lowered_access
+            } else {
+                self.emit_nested_suspension(expression, cases, current_statements, current_label);
+                self.expression_to_ir(expression)
+            };
+            (value, true)
+        } else {
+            (self.expression_to_ir(expression), false)
+        }
+    }
+
     pub(in crate::transforms) fn wrap_async_generator_await(
         &self,
         expression: NodeIndex,
     ) -> IRNode {
+        self.wrap_await_value(self.expression_to_ir(expression))
+    }
+
+    /// Builds `__await(value)`: marks an expression evaluated at the start of a
+    /// case as an await for the `__asyncGenerator` runtime.
+    pub(in crate::transforms) fn wrap_await_value(&self, value: IRNode) -> IRNode {
         IRNode::CallExpr {
             callee: Box::new(IRNode::RuntimeHelper("__await".into())),
-            arguments: vec![self.expression_to_ir(expression)],
+            arguments: vec![value],
         }
+    }
+
+    /// Builds `__await.apply(void 0, [value])`: re-marks a value that was
+    /// computed *after* a suspension resumed (so it embeds `_a.sent()`) as an
+    /// await. tsc uses the `.apply` form — rather than a direct `__await(value)`
+    /// call — whenever the awaited operand depends on a resumed sent value, so
+    /// the `__asyncGenerator` runtime keeps await/yield framing.
+    pub(in crate::transforms) fn wrap_await_apply(&self, value: IRNode) -> IRNode {
+        IRNode::CallExpr {
+            callee: Box::new(IRNode::PropertyAccess {
+                object: Box::new(IRNode::RuntimeHelper("__await".into())),
+                property: "apply".into(),
+            }),
+            arguments: vec![IRNode::Undefined, IRNode::ArrayLiteral(vec![value])],
+        }
+    }
+
+    /// `__await.apply(void 0, [_a.sent()])` — the common re-await of the value
+    /// resumed at the immediately preceding suspension point (the `yield*`
+    /// delegate result and the inner `yield await x` result both flow through
+    /// this).
+    pub(in crate::transforms) fn wrap_async_generator_await_sent(&self) -> IRNode {
+        self.wrap_await_apply(IRNode::GeneratorSent)
     }
 
     pub(in crate::transforms) fn process_variable_declaration(

--- a/crates/tsz-emitter/tests/async_es5_ir_parts/part_02.rs
+++ b/crates/tsz-emitter/tests/async_es5_ir_parts/part_02.rs
@@ -194,3 +194,90 @@ fn async_es5_catch_clause_nested_pattern() {
         "a nested catch pattern chains access through the caught-value temp.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn async_generator_yield_await_re_marks_awaited_value() {
+    // Issue #14765: `yield await p` in an async generator lowered to the ES5
+    // `__generator` state machine must re-mark the awaited result as an await
+    // (`__await.apply(void 0, [_a.sent()])`) before re-yielding it. A bare
+    // `_a.sent()` at the middle label corrupts the async-iterator protocol.
+    let output = transform_async_generator_inner_and_print(
+        "async function* ag(p: Promise<number>) { yield await p; }",
+    );
+
+    assert!(
+        output.contains("return [4 /*yield*/, __await(p)];"),
+        "The inner await must still yield `__await(p)`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return [4 /*yield*/, __await.apply(void 0, [_a.sent()])];"),
+        "`yield await p` must re-mark the awaited value with `__await.apply(void 0, [_a.sent()])`, not bare `_a.sent()`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_generator_return_value_is_awaited() {
+    // An async generator awaits its return value: `return expr` lowers to
+    // `yield __await(expr)` then `return _a.sent()`. tsz previously dropped the
+    // wrapper and emitted a bare `return [2, expr]`.
+    let output = transform_async_generator_inner_and_print(
+        "async function* ag(x: number) { return x; }",
+    );
+    assert!(
+        output.contains("return [4 /*yield*/, __await(x)];"),
+        "An async generator must await its return value via `yield __await(x)`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return [2 /*return*/, _a.sent()];"),
+        "The awaited return value must resolve to the resumed `_a.sent()`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return [2 /*return*/, x];"),
+        "The bare un-awaited return must not survive.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_generator_bare_return_awaits_void() {
+    // Even a bare `return;` awaits the implicit `undefined`.
+    let output = transform_async_generator_inner_and_print(
+        "async function* ag() { foo(); return; }",
+    );
+    assert!(
+        output.contains("return [4 /*yield*/, __await(void 0)];")
+            && output.contains("return [2 /*return*/, _a.sent()];"),
+        "A bare `return;` in an async generator awaits `void 0`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_generator_implicit_completion_stays_linear() {
+    // No explicit return and no await/yield: tsc emits the body linearly with
+    // a plain `return [2 /*return*/]`, no state machine and no await wrap.
+    let output = transform_async_generator_inner_and_print(
+        "async function* ag() { foo(); }",
+    );
+    assert!(
+        !output.contains("switch (_a.label)") && output.contains("return [2 /*return*/];"),
+        "An async generator with no explicit return stays linear.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_generator_yield_await_then_return_keeps_protocol_labels() {
+    // The adjacent case from #14765: `const r = yield await p; return r;` shows
+    // the same dropped wrapper, and the shifted labels collapse the
+    // return-await. Both must be present once the wrapper is restored.
+    let output = transform_async_generator_inner_and_print(
+        "async function* ag(p: Promise<number>) { const r = yield await p; return r; }",
+    );
+
+    assert!(
+        output.contains("return [4 /*yield*/, __await.apply(void 0, [_a.sent()])];"),
+        "The `yield await` result must be re-awaited before re-yielding.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("return [4 /*yield*/, _a.sent()];\n            case 1: return [4 /*yield*/, _a.sent()];"),
+        "The middle label must not collapse to a bare sent value.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
Structural rule: when an async generator is downleveled to the ES5 `__generator` state machine, tsc awaits the result of `yield await x` and the value of every `return <expr>` before resolving the iterator — emitting `yield __await(value)` then `return [2, _a.sent()]`. tsz dropped those wrappers; the fix restores them through the emitter's async-generator lowering (`crates/tsz-emitter/src/transforms/async_es5_ir_statements.rs`).

This fixes the reported bug (#14765, the `yield await x` wrapper) and the broader return-await family it pointed at.

## What changed
- **`yield await x`** (reported): the non-asterisk yield-of-await path emitted a bare `_a.sent()` at the middle label instead of `__await.apply(void 0, [_a.sent()])`, corrupting the async-iterator protocol and shifting later case labels. It now mirrors the `yield*` branch via the shared `wrap_async_generator_await_sent` helper.
- **`return <expr>` / `return;`** (broadened): every async-generator return is awaited by tsc. tsz emitted a bare `return [2, value]`. The value is now re-marked as an await — the `.apply(void 0, [value])` form when it depends on a resumed `_a.sent()`, the direct `__await(value)` form otherwise — yielded, then `return [2, _a.sent()]`.
- Because an explicit return now introduces a suspension, the state machine must engage even when the body has no source-level `await`/`yield`; `has_yield` is forced true when the body contains an explicit return (`contains_explicit_return_recursive`). The implicit end-of-body completion is excluded — tsc emits those linearly.
- Regular (non-async) generators and async functions are unaffected: the return-await is gated on `async_generator_mode`.
- Cleanup: extracted `lower_return_value` and the `wrap_await_value`/`wrap_await_apply`/`wrap_async_generator_await_sent`/`push_generator_return_sent` helpers, deduplicating the previously inlined `__await.apply` builder and the return-op literals.

## Goal
Goal: hold

## Verification
- New unit tests in `crates/tsz-emitter/tests/async_es5_ir_parts/part_02.rs`: `async_generator_yield_await_re_marks_awaited_value`, `async_generator_yield_await_then_return_keeps_protocol_labels`, `async_generator_return_value_is_awaited`, `async_generator_bare_return_awaits_void`, `async_generator_implicit_completion_stays_linear`.
- `cargo test -p tsz-emitter --lib async_es5_ir` → 137 passed, 0 failed.
- Full `tsz-emitter` suite: 44 test binaries pass; the sole failure (`generator_object_literal_prefix_before_yield_omits_source_trailing_comma`) is pre-existing on a clean checkout and unrelated.
- End-to-end emit verified byte-for-byte against `tsc 5.9.3` (`--target es5`) across a return-form matrix: literal, identifier, call, `await`, embedded-await (`f(await p)`, `(await p)+1`), bare `return;`, `return` after a yield, async-generator implicit completion (stays linear), and regular `function*` (unchanged).
- `cargo fmt -p tsz-emitter --check` and `cargo clippy -p tsz-emitter` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4HFtKwN5ABEbTtABnU2hX)_