### PR TITLE
hold(bench): stop infisical canary perf-timing from blocking publish

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1042,7 +1042,7 @@ jobs:
           # flakiness never blocks required benchmark publishing.
           - label: bench-applications
             timeout: 135
-            filter: 'umami-project|excalidraw-project|dub-project|formbricks-project|typebot-project|lobe-chat-project|supabase-studio-project|infisical-project|payload-project|medusa-project|outline-project|trigger-dev-project|joplin-project|directus-project|n8n-project|cal-com-project|documenso-project|affine-project|immich-server-project|rocketchat-project'
+            filter: 'umami-project|excalidraw-project|dub-project|formbricks-project|typebot-project|lobe-chat-project|supabase-studio-project|payload-project|medusa-project|outline-project|trigger-dev-project|joplin-project|directus-project|n8n-project|cal-com-project|documenso-project|affine-project|immich-server-project|rocketchat-project'
           - label: large-ts-repo
             timeout: 135
             filter: '^large-ts-repo$'

--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -1796,7 +1796,9 @@ main() {
     run_isolated "typebot-project"                   run_application_project_benchmarks "typebot-project"
     run_isolated "lobe-chat-project"                 run_application_project_benchmarks "lobe-chat-project"
     run_isolated "supabase-studio-project"           run_application_project_benchmarks "supabase-studio-project"
-    run_isolated "infisical-project"                 run_application_project_benchmarks "infisical-project"
+    # infisical-project is perf_timed:false (its vs-tsgo perf benchmark errors).
+    # Compatibility is still tracked via the compile-canary (run_application_row),
+    # so it is intentionally absent from the perf runner. See project-rows.mjs.
     run_isolated "payload-project"                   run_application_project_benchmarks "payload-project"
     run_isolated "medusa-project"                    run_application_project_benchmarks "medusa-project"
     run_isolated "outline-project"                   run_application_project_benchmarks "outline-project"

--- a/scripts/bench/project-rows.mjs
+++ b/scripts/bench/project-rows.mjs
@@ -982,7 +982,15 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref: "704c8cf7e76f1ce49301a5f943e51303c0db0058",
     guard_set: "canary",
     benchmark_set: "canary",
-    perf_timed: true,
+    // Not perf-timed: this canary app compiles green for compatibility, but its
+    // vs-tsgo perf benchmark errors (the merged row is `winner: "error"` with no
+    // tsz/tsgo timing pair). #14478 demoted it required -> canary/advisory but
+    // left perf_timed:true, so the publish gate's --require-green-project-timing-pairs
+    // kept demanding a timing pair the row cannot produce, blocking ~70% of Bench
+    // publishes ("1 green perf-timed project row(s) missing tsz/tsgo timing pairs:
+    // infisical-project"). Compat (green/red) is still tracked via the application
+    // compat gate; only the unprovable perf-timing requirement is removed.
+    perf_timed: false,
     category: "application",
   },
   {

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -23,6 +23,16 @@ const REQUIRED_PROJECT_ROWS = ALL_REQUIRED_PROJECT_ROWS.filter(
 const APPLICATION_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS
   .filter((row) => row.category === "application")
   .map((row) => row.name);
+// The --require-green-project-timing-pairs gate only flags rows that are
+// perf_timed. A green-compat application row that is *not* perf_timed (its
+// vs-tsgo perf benchmark legitimately errors, e.g. infisical) must not be
+// counted as a missing timing-pair gap.
+const PERF_TIMED_APPLICATION_ROWS = PROJECT_ROW_DEFINITIONS
+  .filter((row) => row.category === "application" && row.perf_timed === true)
+  .map((row) => row.name);
+const NON_PERF_TIMED_APPLICATION_ROWS = PROJECT_ROW_DEFINITIONS
+  .filter((row) => row.category === "application" && row.perf_timed !== true)
+  .map((row) => row.name);
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
@@ -525,11 +535,20 @@ withTempDir((dir) => {
   assert.equal(result.status, 1, "green compile-only perf-timed rows should fail the chart timing gate");
   const parsed = JSON.parse(result.stdout.trim());
   assert.equal(parsed.require_green_project_timing_pairs, true);
-  assert.equal(parsed.green_project_timing_pair_gaps, APPLICATION_PROJECT_ROWS.length);
+  // Only perf_timed application rows are required to have a chart; non-perf-timed
+  // canary apps (whose perf benchmark errors) are tracked for compat only.
+  assert.equal(parsed.green_project_timing_pair_gaps, PERF_TIMED_APPLICATION_ROWS.length);
+  const gapRowNames = parsed.green_project_timing_pair_gap_rows.map((r) => r.name);
+  for (const name of NON_PERF_TIMED_APPLICATION_ROWS) {
+    assert.ok(
+      !gapRowNames.includes(name),
+      `non-perf-timed canary app ${name} must not be flagged as a missing timing-pair gap`,
+    );
+  }
   assert.match(result.stderr, /green perf-timed project row\(s\) missing tsz\/tsgo timing pairs/);
-  assert.match(result.stderr, new RegExp(APPLICATION_PROJECT_ROWS[0]));
+  assert.match(result.stderr, new RegExp(PERF_TIMED_APPLICATION_ROWS[0]));
 });
-console.log("✅ --require-green-project-timing-pairs rejects green app rows without charts");
+console.log("✅ --require-green-project-timing-pairs rejects green perf-timed app rows without charts");
 
 // ---------------------------------------------------------------------------
 // Test: --require-green-project-timing-pairs accepts green perf-timed rows once
@@ -550,6 +569,52 @@ withTempDir((dir) => {
   assert.equal(parsed.green_project_timing_pair_gaps, 0);
 });
 console.log("✅ --require-green-project-timing-pairs accepts green timed app rows");
+
+// ---------------------------------------------------------------------------
+// Regression: a green-compat canary application row that is NOT perf_timed
+// (its vs-tsgo perf benchmark errors, e.g. infisical) must not block
+// --require-green-project-timing-pairs. The compat row is still authoritative;
+// only perf-timed rows owe a tsz/tsgo timing pair. This pins the fix for the
+// Bench publish gate failing ~70% of runs on "1 green perf-timed project
+// row(s) missing tsz/tsgo timing pairs: infisical-project".
+// ---------------------------------------------------------------------------
+if (NON_PERF_TIMED_APPLICATION_ROWS.length > 0) {
+  withTempDir((dir) => {
+    const file = path.join(dir, "bench.json");
+    const requiredRows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+    const perfTimedAppRows = PERF_TIMED_APPLICATION_ROWS.map((name) => makeRow(name, "green"));
+    // Green compatibility, but the perf benchmark errored: no tsz/tsgo timing.
+    const nonPerfTimedAppRows = NON_PERF_TIMED_APPLICATION_ROWS.map((name) =>
+      makeRow(name, "green", {
+        errorStatus: "compile canary tracked in CI; perf benchmark errored",
+        tsz_ms: null,
+        tsgo_ms: null,
+        winner: "error",
+      }),
+    );
+    writeJson(file, makeArtifact([...requiredRows, ...perfTimedAppRows, ...nonPerfTimedAppRows]));
+    const result = run(file, [
+      "--json",
+      "--require-application-compat",
+      "--require-green-project-timing-pairs",
+    ]);
+    assert.equal(
+      result.status,
+      0,
+      `green non-perf-timed canary app rows must not block the timing gate:\n${result.stderr}`,
+    );
+    const parsed = JSON.parse(result.stdout.trim());
+    assert.equal(parsed.green_project_timing_pair_gaps, 0);
+    const gapRowNames = parsed.green_project_timing_pair_gap_rows.map((r) => r.name);
+    for (const name of NON_PERF_TIMED_APPLICATION_ROWS) {
+      assert.ok(
+        !gapRowNames.includes(name),
+        `non-perf-timed canary app ${name} must not be a timing-pair gap`,
+      );
+    }
+  });
+  console.log("✅ --require-green-project-timing-pairs ignores green non-perf-timed canary app rows");
+}
 
 // ---------------------------------------------------------------------------
 // Test: complete gray application compatibility is still authoritative data.


### PR DESCRIPTION
## Summary

The "Bench" workflow fails ~70% of runs at `bench-publish` -> "Fail non-published partial benchmark artifact". The merged artifact is a complete 9/9 shard set, but the readiness gate (`scripts/bench/check-artifact-readiness.mjs --require-green-project-timing-pairs`) refuses to publish with the sole blocker:

```
bench-artifact-readiness: 1 green perf-timed project row(s) missing tsz/tsgo timing pairs: infisical-project
```

`infisical-project` compiles green for compatibility, but its vs-tsgo perf benchmark errors (the merged row is `{"name":"infisical-project","winner":"error"}` with no tsz/tsgo timing pair). PR #14478 repointed its tsconfig and demoted it from required -> canary/advisory, but left `perf_timed:true`. The publish gate flags any `perf_timed` row that is green-compat yet lacks a successful timing pair, so it kept demanding a chart this row cannot produce.

Verified `infisical-project` is the sole green application row in `scripts/ci/project-compat-baseline.json` (payload/medusa are not green-compat, so they never trip the gate).

## Fix

- `scripts/bench/project-rows.mjs`: set `perf_timed: false` for `infisical-project`.
- `scripts/bench/bench-vs-tsgo.sh`: drop it from the perf runner (untimed app rows are compile-canaries only; the metadata helper already guards on `perf_timed`).
- `.github/workflows/bench.yml`: drop it from the `bench-applications` shard filter (kept in sync with `PERF_TIMED_APPLICATION_PROJECT_ROWS`).
- Compatibility (green/red) is still tracked: `infisical-project` remains a compile-canary via `run_application_row` in `scripts/ci/project-compile-guard.sh`, so the `--require-application-compat` gate stays satisfied.
- Added a regression test pinning that a green-compat canary application row that is NOT `perf_timed` (perf benchmark errors) does not block `--require-green-project-timing-pairs`, and updated the existing rejection test to count perf-timed application rows.

The gate's real intent is preserved: green **perf-timed** rows without charts (zod/vite and any still-timed canary app) are still rejected. Only the requirement for a row we explicitly do not time was removed.

## Structural rule

When an application/canary project row's vs-tsgo perf benchmark errors and the row is marked `perf_timed:false`, the publish gate must not require a tsz/tsgo timing pair for it. Compatibility is still tracked through the compile-canary + application-compat gate; only perf-timed rows owe a timing pair.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
All node-based (no cargo build; shared disk):
- `node scripts/bench/test-check-artifact-readiness.mjs` -> all tests passed (incl. updated rejection test + new regression test).
- `node scripts/bench/test-project-rows.mjs` -> passed (untimed app row correctly excluded from perf runner).
- `node scripts/bench/test-bench-workflow-micro-coverage.mjs` -> passed (shard filter matches `PERF_TIMED_APPLICATION_PROJECT_ROWS`).
- `node scripts/bench/test-merge-results.mjs` -> passed.
- Full `scripts/bench/test-*.mjs` suite (23 files) -> all passed.
- `bash -n scripts/bench/bench-vs-tsgo.sh` -> OK.
