### PR TITLE
fix(solver): recognize declaration-site def identity

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1311,7 +1311,7 @@ impl TypeResolver for QueryCache<'_> {
     /// inference. Historically it had NO `DefinitionStore`, so these `DefId`-keyed
     /// resolver methods silently returned trait defaults in inference: the
     /// `shared_application_base_def_id` cross-arena base unification (via
-    /// `defs_are_equivalent` -> `def_to_symbol_id` `SymbolId` equality) and the
+    /// `defs_are_equivalent` declaration-site/`SymbolId` equality) and the
     /// variance-computation paths that depend on them were dead, leaving
     /// cross-arena generic-call inference unable to pair type-args (issue #14344;
     /// the fp-ts `unknown`-widening FP family). Wiring the store re-enables them.
@@ -1346,6 +1346,23 @@ impl TypeResolver for QueryCache<'_> {
         }
         self.definition_store
             .map_or(def_id, |store| store.canonical_def_id(def_id))
+    }
+
+    fn defs_are_equivalent(&self, a: DefId, b: DefId) -> bool {
+        if a == b {
+            return true;
+        }
+        if !crate::inference::xarena_base::xarena_base_decl_enabled() {
+            return false;
+        }
+        let Some(store) = self.definition_store else {
+            return false;
+        };
+        store.defs_have_same_decl_site(a, b)
+            || store
+                .get_symbol_id(a)
+                .zip(store.get_symbol_id(b))
+                .is_some_and(|(sa, sb)| sa == sb)
     }
 }
 

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -730,6 +730,37 @@ impl DefinitionStore {
         self.definitions.get(&id).and_then(|info| info.symbol_id)
     }
 
+    fn decl_site_key(&self, id: DefId) -> Option<(DefKind, Atom, usize, u32, u32)> {
+        let info = self.definitions.get(&id)?;
+        let file_id = info.file_id?;
+        if file_id == Self::NON_PROGRAM_FILE_SENTINEL {
+            return None;
+        }
+        let (span_start, _) = info.span?;
+        Some((
+            info.kind,
+            info.name,
+            info.type_params.len(),
+            file_id,
+            span_start,
+        ))
+    }
+
+    /// Whether two `DefId`s came from the same binder declaration site.
+    ///
+    /// This is deliberately narrower than [`Self::canonical_def_id`]: it does
+    /// not chase aliases or pick a representative. It only recognizes the same
+    /// `(file, declaration-node)` entry re-created in different arenas, with
+    /// kind/name/arity guards to avoid treating unrelated declarations as one.
+    pub fn defs_have_same_decl_site(&self, a: DefId, b: DefId) -> bool {
+        if a == b {
+            return true;
+        }
+        self.decl_site_key(a)
+            .zip(self.decl_site_key(b))
+            .is_some_and(|(a_key, b_key)| a_key == b_key)
+    }
+
     /// Check if a `DefId` exists.
     pub fn contains(&self, id: DefId) -> bool {
         self.definitions.contains_key(&id)

--- a/crates/tsz-solver/src/inference/xarena_base.rs
+++ b/crates/tsz-solver/src/inference/xarena_base.rs
@@ -13,10 +13,11 @@
 //! `Magma`/`Eq`/`Semigroup`/`Kind`) is lowered into DISTINCT per-arena `DefId`s
 //! with DISTINCT binder-local `SymbolId`s. When inference compares two
 //! `Application` bases that are this same interface from different arenas,
-//! `shared_application_base_def_id` calls `defs_are_equivalent`, which falls
-//! back to `SymbolId` equality — but with no store the `SymbolId`s were never
-//! resolvable, so the bases were treated as unrelated, per-argument inference
-//! was SKIPPED, and the callee's type parameter resolved to `unknown`
+//! `shared_application_base_def_id` calls `defs_are_equivalent`; without the
+//! shared store, the resolver cannot observe either `(file, declaration-node)`
+//! identity or store-owned `SymbolId`s, so the bases are treated as unrelated,
+//! per-argument inference is SKIPPED, and the callee's type parameter resolves
+//! to `unknown`
 //! (`infer_resolve.rs`), surfacing as a false `TS2322`/`TS2345`
 //! (`HKT<F, unknown>` vs `HKT<F, readonly [K, A]>`).
 //!
@@ -25,7 +26,9 @@
 //! Thread the shared `DefinitionStore` into the inference `QueryCache` (see the
 //! CLI driver and `tsz-core` checking paths) so the `DefId`-keyed resolver
 //! methods resolve, re-enabling the intended `defs_are_equivalent` cross-arena
-//! base unification. Those `QueryCache` resolver methods are gated behind
+//! base unification. The equivalence is deliberately declaration-site based;
+//! it does not rewrite `DefId`s or chase broad alias canonicalization. Those
+//! `QueryCache` resolver methods are gated behind
 //! [`xarena_base_decl_enabled`] (`TSZ_XARENA_BASE_DECL`, default-OFF) so flag-OFF
 //! stays byte-parity with the historical store-less behavior until the change is
 //! proven on full conformance.

--- a/crates/tsz-solver/tests/def_tests.rs
+++ b/crates/tsz-solver/tests/def_tests.rs
@@ -102,6 +102,65 @@ fn test_definition_store_semantic_def_overlays_override_base_without_losing_base
 }
 
 #[test]
+fn definition_store_decl_site_equivalence_matches_same_file_node() {
+    let interner = create_test_interner();
+    let store = DefinitionStore::new();
+    let name = interner.intern_string("Box");
+
+    let mut first = DefinitionInfo::interface(name, Vec::new(), Vec::new());
+    first.file_id = Some(7);
+    first.span = Some((42, 42));
+    first.symbol_id = Some(100);
+    let first = store.register(first);
+
+    let mut second = DefinitionInfo::interface(name, Vec::new(), Vec::new());
+    second.file_id = Some(7);
+    second.span = Some((42, 42));
+    second.symbol_id = Some(200);
+    let second = store.register(second);
+
+    assert!(
+        store.defs_have_same_decl_site(first, second),
+        "same (file,node) declaration must converge despite arena-local symbols"
+    );
+}
+
+#[test]
+fn definition_store_decl_site_equivalence_keeps_distinct_decls_apart() {
+    let interner = create_test_interner();
+    let store = DefinitionStore::new();
+    let name = interner.intern_string("Box");
+
+    let mut base = DefinitionInfo::interface(name, Vec::new(), Vec::new());
+    base.file_id = Some(7);
+    base.span = Some((42, 42));
+    let base = store.register(base);
+
+    let mut different_node = DefinitionInfo::interface(name, Vec::new(), Vec::new());
+    different_node.file_id = Some(7);
+    different_node.span = Some((43, 43));
+    let different_node = store.register(different_node);
+    assert!(!store.defs_have_same_decl_site(base, different_node));
+
+    let mut different_name =
+        DefinitionInfo::interface(interner.intern_string("OtherBox"), Vec::new(), Vec::new());
+    different_name.file_id = Some(7);
+    different_name.span = Some((42, 42));
+    let different_name = store.register(different_name);
+    assert!(!store.defs_have_same_decl_site(base, different_name));
+
+    let mut non_program_a = DefinitionInfo::interface(name, Vec::new(), Vec::new());
+    non_program_a.file_id = Some(DefinitionStore::NON_PROGRAM_FILE_SENTINEL);
+    non_program_a.span = Some((42, 42));
+    let non_program_a = store.register(non_program_a);
+    let mut non_program_b = DefinitionInfo::interface(name, Vec::new(), Vec::new());
+    non_program_b.file_id = Some(DefinitionStore::NON_PROGRAM_FILE_SENTINEL);
+    non_program_b.span = Some((42, 42));
+    let non_program_b = store.register(non_program_b);
+    assert!(!store.defs_have_same_decl_site(non_program_a, non_program_b));
+}
+
+#[test]
 fn test_definition_store_interface() {
     let interner = create_test_interner();
     let store = DefinitionStore::new();


### PR DESCRIPTION
Goal: green

## Summary
- add a `DefinitionStore` declaration-site equivalence predicate for same program `(kind, name, arity, file, span_start)` definitions recreated in different arenas
- wire `QueryCache::defs_are_equivalent` to use that predicate behind `TSZ_XARENA_BASE_DECL`, preserving flag-OFF historical behavior and the existing store-owned `SymbolId` equality path
- document the #14344 cross-arena generic-call inference rule and add adjacent tests for same-node convergence plus distinct-node/name/non-program fallbacks

## Structural Rule
When two per-arena `DefId`s describe the same source declaration site in the shared `DefinitionStore`, `tsc` treats the generic `Application` bases as the same declaration for type-argument pairing. TSZ answers this in the solver through `DefinitionStore` and the inference `QueryCache` resolver boundary; it does not rewrite `DefId`s, chase broad alias canonicalization, add raw-symbol fallback, or touch the #14345 `application.rs` opaque-bail lane.

## Adjacent Matrix
- same file/span/name/kind/arity with different arena-local symbols: equivalent
- different span: distinct
- different name: distinct
- non-program sentinel file: distinct
- flag-OFF: distinct `DefId`s keep the historical false result unless they are exactly equal

Refs #14344
Refs #14351

## Verification
Re-run after rebasing onto `origin/main` at `d90be7671c`:
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(definition_store_decl_site_equivalence)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(strip)'`
- `CARGO_BUILD_JOBS=1 scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz`
- fp-ts gauge via `TSZ_PROJECT_COMPILE_FILTER=fp-ts-project TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 TSZ_PROJECT_COMPILE_TIMEOUT=180 scripts/safe-run.sh scripts/ci/project-compile-guard.sh`: current main `1322` tsz-only diagnostics, PR head `1322` tsz-only diagnostics
- fp-ts both-flags gauge via `TSZ_XARENA_BASE_DECL=1 TSZ_TYPEPARAM_DECL_IDENTITY=1 ... project-compile-guard.sh` with separate result caches: current main `937` tsz-only diagnostics, PR head `937` tsz-only diagnostics

Earlier local broad checks before the rebase:
- `scripts/safe-run.sh cargo nextest run -p tsz-solver` reported 7010 run / 7006 passed / 4 failed in unrelated mainline areas: `test_conditional_infer_optional_property_present_distributive`, `literal_mask_preserves_object_vs_literal_reduction`, `test_solver_oversized_file_size_ceilings` (`src/types.rs` 2166 vs baseline 2146), and `free_infer_policy_skips_generic_signature_bodies`.
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -p tsz-checker` could not complete locally because checker test-binary linking filled disk with `ld: write() failed, errno=28`; the lower-impact checker compile above passed.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
