### PR TITLE
refactor(solver): expose typed evaluation result API (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -40,8 +40,8 @@ use crate::types::{
 use crate::visitors::visitor_predicates::contains_type_matching;
 pub use api::{
     evaluate_conditional, evaluate_index_access, evaluate_index_access_with_options,
-    evaluate_keyof, evaluate_mapped, evaluate_type, evaluate_type_with_request,
-    evaluate_type_with_resolver,
+    evaluate_keyof, evaluate_mapped, evaluate_type, evaluate_type_result_with_request,
+    evaluate_type_with_request, evaluate_type_with_resolver,
 };
 use application_types::{ApplicationEvalContext, ApplicationEvalOutcome, HomomorphicMappedArg};
 pub(crate) use array_methods::{

--- a/crates/tsz-solver/src/evaluation/evaluate/api.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/api.rs
@@ -2,6 +2,7 @@
 
 use crate::construction::TypeDatabase;
 use crate::evaluation::request::EvaluationRequest;
+use crate::evaluation::result::EvaluationResult;
 use crate::relations::subtype::TypeResolver;
 use crate::types::{ConditionalType, MappedType, TypeId};
 
@@ -55,8 +56,17 @@ pub fn evaluate_type_with_request(
     interner: &dyn TypeDatabase,
     request: EvaluationRequest,
 ) -> TypeId {
+    evaluate_type_result_with_request(interner, request).into_type_id()
+}
+
+/// Convenience function for full type evaluation with explicit request options,
+/// preserving the typed termination verdict.
+pub fn evaluate_type_result_with_request(
+    interner: &dyn TypeDatabase,
+    request: EvaluationRequest,
+) -> EvaluationResult {
     let mut evaluator = TypeEvaluator::new(interner);
-    evaluator.evaluate_request_result(request).into_type_id()
+    evaluator.evaluate_request_result(request)
 }
 
 /// Convenience function for evaluating mapped types.

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -160,8 +160,9 @@ pub mod computation {
     pub use crate::evaluation::evaluate::{
         TypeEvaluator, evaluate_conditional, evaluate_index_access,
         evaluate_index_access_with_options, evaluate_keyof, evaluate_mapped, evaluate_type,
-        evaluate_type_with_request,
+        evaluate_type_result_with_request, evaluate_type_with_request,
     };
+    pub use crate::evaluation::result::{EvaluationResult, Termination, TerminationKind};
 
     // Instantiation
     pub use crate::instantiation::application::ApplicationEvaluator;
@@ -310,7 +311,8 @@ pub use diagnostics::{SubtypeFailureReason, TupleArity};
 #[allow(unused_imports)]
 pub(crate) use evaluation::evaluate::{
     TypeEvaluator, evaluate_conditional, evaluate_index_access, evaluate_index_access_with_options,
-    evaluate_keyof, evaluate_mapped, evaluate_type, evaluate_type_with_request,
+    evaluate_keyof, evaluate_mapped, evaluate_type, evaluate_type_result_with_request,
+    evaluate_type_with_request,
 };
 #[cfg(test)]
 pub(crate) use operations::compound_assignment::{

--- a/crates/tsz-solver/tests/public_api_tests.rs
+++ b/crates/tsz-solver/tests/public_api_tests.rs
@@ -1,9 +1,11 @@
 use tsz_solver::TypeId;
 use tsz_solver::computation::{
-    InstantiationOptions, InstantiationRequest, InstantiationResult, TypeSubstitution,
+    EvaluationResult, InstantiationOptions, InstantiationRequest, InstantiationResult, Termination,
+    TypeSubstitution, evaluate_type_result_with_request, evaluate_type_with_request,
     instantiate_type_with_request,
 };
 use tsz_solver::construction::TypeInterner;
+use tsz_solver::evaluation::request::EvaluationRequest;
 
 #[test]
 fn computation_exports_staged_instantiation_api() {
@@ -16,4 +18,21 @@ fn computation_exports_staged_instantiation_api() {
 
     assert!(!result.depth_exceeded());
     assert_eq!(result.into_type_id(), TypeId::STRING);
+}
+
+#[test]
+fn computation_exports_staged_evaluation_api() {
+    let interner = TypeInterner::new();
+    let request = EvaluationRequest::new(TypeId::STRING);
+
+    let result: EvaluationResult = evaluate_type_result_with_request(&interner, request);
+
+    assert_eq!(result.type_id(), TypeId::STRING);
+    assert_eq!(result.termination(), Termination::Complete);
+    assert_eq!(result.into_type_id(), TypeId::STRING);
+    assert_eq!(
+        evaluate_type_with_request(&interner, request),
+        TypeId::STRING,
+        "the legacy TypeId-returning helper must keep the same collapsed value"
+    );
 }


### PR DESCRIPTION
Goal: green

## Summary
- Expose `EvaluationResult`, `Termination`, and `TerminationKind` through `tsz_solver::computation`.
- Add `evaluate_type_result_with_request` so callers can preserve the typed termination verdict instead of immediately collapsing to `TypeId`.
- Keep `evaluate_type_with_request` behavior-identical by routing it through `into_type_id`, and pin the public API contract in `public_api_tests`.

Structural rule: when an evaluation request is guard-truncated, tsz should preserve the solver-owned `Termination` verdict for verdict-aware consumers; legacy `TypeId` consumers keep the same collapsed partial value.
Owner layer: solver evaluation API only. No checker recursion, no relation policy change, no `application.rs` opaque-bail edits, and no #14344 canonical identity index changes.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test public_api_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(strip)'`
- `git diff --check origin/main...HEAD`

## Coordination
- Rebases on `origin/main` after #15007 merged at `0298f0ac88`.
- Avoids Claude's claimed #14344 `green/scc-materialize-once-s1` canonical-index stage and the #14345 `application.rs` fixpoint lane.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
