### PR TITLE
fix(solver): accept non-string literals for string-mapping intrinsics over `any` (#14788)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -265,6 +265,34 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 }
             }
         }
+
+        // A non-string primitive literal (number/boolean/bigint) is a fixed point
+        // of every case mapping, since the mapping only transforms strings. Per
+        // tsc's `isMemberOfStringMapping`, such a literal is assignable to
+        // `Mapping<T>` iff (1) mapping it yields itself — always true here — and
+        // (2) it is a member of the innermost mapped type `T`. For these literals
+        // condition (2) holds only when `T` is `any`: a non-string literal is
+        // never assignable to `string` or a template-literal pattern, so any other
+        // `T` (including `string`) rejects. Unwrapping nested mappings reaches the
+        // innermost argument, so `Uppercase<Lowercase<any>>` is handled too.
+        //
+        // This restores tsc parity for `const x: Uppercase<any> = 5` / `= true`
+        // (#14788) without weakening the #9668 string-literal case constraint, the
+        // `Uppercase<string> = 5` rejection, or the widened-`number` rejection (a
+        // widened primitive is not a literal and never reaches `visit_literal`).
+        if matches!(
+            value,
+            LiteralValue::Number(_) | LiteralValue::Boolean(_) | LiteralValue::BigInt(_)
+        ) {
+            let mut arg = self.target;
+            while let Some((_, inner)) = string_intrinsic_components(self.checker.interner, arg) {
+                arg = inner;
+            }
+            if arg != self.target && arg == TypeId::ANY {
+                return SubtypeResult::True;
+            }
+        }
+
         if let Some(t_lit) = literal_value(self.checker.interner, self.target) {
             return if value == &t_lit {
                 SubtypeResult::True

--- a/crates/tsz-solver/tests/string_intrinsic_subtype_tests.rs
+++ b/crates/tsz-solver/tests/string_intrinsic_subtype_tests.rs
@@ -735,3 +735,94 @@ fn string_primitive_is_not_member_of_string_intrinsic_over_any() {
         );
     }
 }
+
+// =============================================================================
+// Non-string literal sources vs a string-mapping target (#14788).
+//
+// `#9668` correctly kept `Uppercase<any>` deferred (so `Uppercase<any> = "x"`
+// rejects), but over-corrected by treating the `any` argument exactly like
+// `string` for every source, wrongly rejecting fresh number/boolean/bigint
+// literals that tsc accepts.
+//
+// tsc rule (`isMemberOfStringMapping`): a non-string literal is a fixed point of
+// every case mapping, so it is a member of `Mapping<T>` iff it is a member of the
+// innermost `T`. For these literals that holds only when `T` is `any` (a
+// non-string literal is never assignable to `string`), so `Mapping<any>` accepts
+// them while `Mapping<string>` rejects them — and a widened `number` is never a
+// fixed point, so it stays rejected for both.
+// =============================================================================
+
+#[test]
+fn non_string_literal_is_member_of_string_intrinsic_over_any() {
+    let interner = TypeInterner::new();
+
+    // Vary literal value/shape so the rule is exercised structurally, not for one
+    // spelling.
+    let literals = [
+        interner.literal_number(5.0),
+        interner.literal_number(-42.0),
+        interner.literal_number(0.0),
+        interner.literal_boolean(true),
+        interner.literal_boolean(false),
+        interner.literal_bigint("7"),
+    ];
+
+    for kind in [
+        StringIntrinsicKind::Uppercase,
+        StringIntrinsicKind::Lowercase,
+        StringIntrinsicKind::Capitalize,
+        StringIntrinsicKind::Uncapitalize,
+    ] {
+        let mapping_any = interner.string_intrinsic(kind, TypeId::ANY);
+        let mapping_string = interner.string_intrinsic(kind, TypeId::STRING);
+        // Nested mapping over `any` must unwrap to the innermost `any` and accept.
+        let nested_any = interner.string_intrinsic(kind, mapping_any);
+
+        let mut checker = SubtypeChecker::new(&interner);
+        for &lit in &literals {
+            // Accept over `any` (the #14788 fix flips these from rejected).
+            assert!(
+                checker.is_subtype_of(lit, mapping_any),
+                "non-string literal {lit:?} should be assignable to {kind:?}<any>"
+            );
+            // Nested `M<M<any>>` still accepts.
+            assert!(
+                checker.is_subtype_of(lit, nested_any),
+                "non-string literal {lit:?} should be assignable to {kind:?}<{kind:?}<any>>"
+            );
+            // Reject over `string` (control: the `string` arg is strict).
+            assert!(
+                !checker.is_subtype_of(lit, mapping_string),
+                "non-string literal {lit:?} should NOT be assignable to {kind:?}<string>"
+            );
+        }
+
+        // Control: a widened `number` primitive is not a fixed point of the
+        // mapping, so it stays rejected even over `any`.
+        assert!(
+            !checker.is_subtype_of(TypeId::NUMBER, mapping_any),
+            "widened number should NOT be assignable to {kind:?}<any>"
+        );
+        assert!(
+            !checker.is_subtype_of(TypeId::BOOLEAN, mapping_any),
+            "widened boolean should NOT be assignable to {kind:?}<any>"
+        );
+
+        // Control: a fixed-point string literal still accepted, a non-fixed-point
+        // string literal still rejected (the #9668 case constraint is untouched).
+        let (fixed, broken) = match kind {
+            StringIntrinsicKind::Uppercase => ("X", "x"),
+            StringIntrinsicKind::Lowercase => ("x", "X"),
+            StringIntrinsicKind::Capitalize => ("Xy", "xy"),
+            StringIntrinsicKind::Uncapitalize => ("xy", "Xy"),
+        };
+        assert!(
+            checker.is_subtype_of(interner.literal_string(fixed), mapping_any),
+            "\"{fixed}\" should be assignable to {kind:?}<any>"
+        );
+        assert!(
+            !checker.is_subtype_of(interner.literal_string(broken), mapping_any),
+            "\"{broken}\" should NOT be assignable to {kind:?}<any>"
+        );
+    }
+}


### PR DESCRIPTION
Closes #14788.

Fixes a `green`-goal false positive: the four string-mapping intrinsics over an
`any` argument (`Uppercase<any>` / `Lowercase<any>` / `Capitalize<any>` /
`Uncapitalize<any>`) wrongly rejected non-string primitive *literal* sources
(number/boolean/bigint) that `tsc` accepts. This was the FP-direction
over-correction of #9668 (which fixed the opposite FN: `Uppercase<any> = "x"`
must reject).

Goal: green

## Structural rule
When the argument of a string-mapping intrinsic is `any`, `tsc`
(`isMemberOfStringMapping`) accepts a non-string primitive literal source
(number/boolean/bigint) because such a literal is already a fixed point of the
case mapping (`getStringMappingType(kind, lit) === lit`) **and** a member of the
innermost argument (`any` ⇒ trivially true). tsz must too — owned by the solver
subtype relation `visit_literal`
(`crates/tsz-solver/src/relations/subtype/visitor.rs`). The rule preserves:
- the #9668 string-literal case constraint (a non-fixed-point string literal like
  `"x"` for `Uppercase<any>` still rejects);
- `Uppercase<string> = 5/true` rejection (over a `string` argument the second
  conjunct becomes `isTypeAssignableTo(lit, string)`, false for non-string
  literals — so only the `any` argument flips);
- the widened-`number` rejection (a widened primitive is never a fixed point and
  never reaches `visit_literal`).

The fix unwraps nested mappings to the innermost argument, so
`Uppercase<Lowercase<any>> = 5` is handled too.

## Owner layer
Solver relation layer only: `visit_literal` in
`crates/tsz-solver/src/relations/subtype/visitor.rs`. No checker/evaluation
changes; #9668's deferred-evaluation of `Mapping<any>` is untouched.

## Adjacent-case matrix (vs tsc 6.0.0-dev, verified verbatim)
For each intrinsic M ∈ {Uppercase, Lowercase, Capitalize, Uncapitalize}:

| source                         | `M<any>` | `M<string>` |
|--------------------------------|----------|-------------|
| fresh number literal `5`       | OK (was FP TS2322) | TS2322 |
| fresh boolean literal `true`   | OK (was FP TS2322) | TS2322 |
| fresh bigint literal `5n`      | OK (was FP TS2322) | TS2322 |
| fixed-point string lit (`"X"`) | OK        | OK         |
| broken string lit (`"x"`)      | TS2322    | TS2322     |
| non-fresh `number` var         | TS2322    | TS2322     |

(Non-fresh literal type `5` — e.g. `declare const k: 5` — behaves like the fresh
literal and is accepted over `M<any>`; freshness is not the discriminator, the
literal *kind* is.)

## Verification
Targeted solver tests (no full conformance):
- `cargo nextest run -p tsz-solver -E 'test(string_intrinsic) | test(non_string_literal_is_member)'`
- New flipping test
  `non_string_literal_is_member_of_string_intrinsic_over_any` in
  `crates/tsz-solver/tests/string_intrinsic_subtype_tests.rs` (fails before the
  fix — number/boolean/bigint literals rejected over `M<any>`; passes after),
  covering all four intrinsics × {number, boolean, bigint literal} × {any, string}
  plus nested `M<M<any>>`, widened-primitive controls, and the #9668
  string-literal fixed/broken controls.
- Oracle confirmed against installed `tsc` (`--noEmit --strict --target es2022
  --lib es2022`).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
