### PR TITLE
emit(dts): widen enum-member array elements to their parent enum

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_enum_access.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_enum_access.rs
@@ -45,13 +45,20 @@ impl<'a> DeclarationEmitter<'a> {
 
         if let Some(binder) = self.binder
             && let Some(symbol_id) = binder.get_node_symbol(access.expression)
-            && let Some(symbol) = binder.symbols.get(symbol_id)
-            && symbol.flags & tsz_binder::symbol_flags::ENUM != 0
-            && symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER == 0
         {
-            return Some(expr_idx);
+            // The binder resolved the base, so trust it and skip the source-file
+            // scan below: only an enum *object* symbol names enum members, and
+            // any other resolution (including a local that shadows a same-named
+            // top-level enum) means this is not an enum access.
+            let is_enum = binder.symbols.get(symbol_id).is_some_and(|symbol| {
+                symbol.flags & tsz_binder::symbol_flags::ENUM != 0
+                    && symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER == 0
+            });
+            return is_enum.then_some(expr_idx);
         }
 
+        // The binder attached no symbol to the base: fall back to a source-file
+        // scan for a same-named enum declaration.
         let source_file_idx = self.current_source_file_idx?;
         let source_file_node = self.arena.get(source_file_idx)?;
         let source_file = self.arena.get_source_file(source_file_node)?;
@@ -146,10 +153,7 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
 
-        let binder = self.binder?;
-        let sym_id = self.access_reference_symbol(expr_idx)?;
-        let symbol = binder.symbols.get(sym_id)?;
-        if symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER == 0 {
+        if !self.access_resolves_to_enum_member(expr_idx) {
             return None;
         }
 
@@ -157,6 +161,27 @@ impl<'a> DeclarationEmitter<'a> {
         // slice: this normalizes `E["B"]` to `E.B` and prevents parenthesis /
         // non-null punctuation from leaking into the declaration output.
         self.enum_member_access_canonical_text(expr_idx)
+    }
+
+    /// Whether `expr_idx` is a member-access that resolves (via the binder) to a
+    /// genuine enum-*member* symbol — as opposed to a reverse mapping (`E[0]`),
+    /// the enum object itself, or a non-enum access. Shared by the enum-member
+    /// initializer path and the enum-member widening fallback so the binder
+    /// resolution + `ENUM_MEMBER` flag check lives in one place.
+    pub(in crate::declaration_emitter) fn access_resolves_to_enum_member(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> bool {
+        let Some(binder) = self.binder else {
+            return false;
+        };
+        let Some(sym_id) = self.access_reference_symbol(expr_idx) else {
+            return false;
+        };
+        binder
+            .symbols
+            .get(sym_id)
+            .is_some_and(|symbol| symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER != 0)
     }
 
     /// Resolve a value reference or namespace-qualified property-access chain
@@ -328,37 +353,48 @@ impl<'a> DeclarationEmitter<'a> {
         self.get_source_slice(base_node.pos, base_node.end)
     }
 
-    /// Widen a single returned enum-member access (`return E.A`, `() => E.A`) to
-    /// its parent enum name (`E`) for an inferred declaration return type.
+    /// Widen a single enum-member access expression (`E.A`, `E["A"]`) to its
+    /// parent enum name (`E`) for an inferred declaration type. Shared by the
+    /// return-position paths (`return E.A`, `() => E.A`) and the array-element
+    /// path (`[E.A, E.B]` -> `E[]`).
     ///
-    /// tsc's `getReturnTypeFromBody` runs the aggregated return type through
-    /// `getWidenedType`, which widens a fresh enum-member literal to its parent
-    /// enum exactly as a fresh primitive literal widens to its base. The checker
-    /// already does this at the type level; this is the declaration-emit analog
-    /// for the AST-text return paths (class methods, arrow expression bodies,
-    /// returned local callables) that render the returned expression directly
-    /// rather than printing the solver return type.
+    /// tsc widens a fresh enum-member literal to its parent enum exactly as a
+    /// fresh primitive literal widens to its base — `getReturnTypeFromBody`
+    /// applies `getWidenedType` to the aggregated return type, and an
+    /// (un-asserted) array literal widens each fresh element type the same way.
+    /// The checker already does this at the type level; this is the
+    /// declaration-emit analog for the AST-text paths that render the access
+    /// expression directly rather than printing the solver type.
     ///
-    /// The gate is the returned expression's solver type being a *literal* enum
-    /// member (`is_literal_enum_member`), so a reverse mapping (`E[0]`, type
-    /// `string`) is excluded and only a genuine member literal widens. Returns
-    /// `None` when the expression is not a widenable enum member, so const
-    /// initializers and explicit annotations (handled by their own paths) are
-    /// never reached here.
-    pub(in crate::declaration_emitter) fn returned_enum_member_widened_base_text(
+    /// The gate confirms the access names a genuine enum *member*, so a reverse
+    /// mapping (`E[0]`, type `string`) is excluded and only a real member widens.
+    /// When the checker populated a solver type it is preferred
+    /// (`is_literal_enum_member`); otherwise the binder symbol's `ENUM_MEMBER`
+    /// flag is used, so the widening is deterministic even in declaration-only
+    /// contexts that carry no solver types. Returns `None` when the expression is
+    /// not a widenable enum member, so callers fall back to general inference.
+    pub(in crate::declaration_emitter) fn enum_member_access_widened_base_text(
         &self,
-        return_expr: NodeIndex,
+        expr_idx: NodeIndex,
     ) -> Option<String> {
         // Cheap syntactic gate first: only an `Enum.Member` / `Enum["Member"]`
         // access can widen. `simple_enum_access_base_name_text` rejects every
-        // other return shape (literals, calls, objects) before the solver type
-        // lookup below runs, so the common non-enum return pays no type query.
-        let base_name = self.simple_enum_access_base_name_text(return_expr)?;
-        let interner = self.type_interner?;
-        let type_id = self.get_node_type_or_names(&[return_expr])?;
-        // Confirm a *literal* member, so a reverse mapping (`E[0]`, type `string`)
-        // is excluded and only a genuine member literal widens to its parent enum.
-        tsz_solver::type_queries::is_literal_enum_member(interner, type_id).then_some(base_name)
+        // other shape (literals, calls, objects) before the gates below run, so
+        // the common non-enum expression pays no symbol/type lookup.
+        let base_name = self.simple_enum_access_base_name_text(expr_idx)?;
+        if let Some(interner) = self.type_interner
+            && let Some(type_id) = self.get_node_type_or_names(&[expr_idx])
+        {
+            // A *literal* member widens; a reverse mapping (`E[0]`, type
+            // `string`) does not.
+            return tsz_solver::type_queries::is_literal_enum_member(interner, type_id)
+                .then_some(base_name);
+        }
+        // No solver type available: fall back to the binder symbol — the access
+        // must resolve to a genuine enum-member symbol (not a reverse mapping or
+        // the enum object itself).
+        self.access_resolves_to_enum_member(expr_idx)
+            .then_some(base_name)
     }
 
     /// Inferred return-type text for a single returned expression, widening a
@@ -371,7 +407,7 @@ impl<'a> DeclarationEmitter<'a> {
         return_expr: NodeIndex,
         depth: u32,
     ) -> Option<String> {
-        self.returned_enum_member_widened_base_text(return_expr)
+        self.enum_member_access_widened_base_text(return_expr)
             .or_else(|| self.declaration_summary_primitive_expression_type_text(return_expr, depth))
             .or_else(|| self.infer_fallback_type_text_at(return_expr, depth))
     }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -131,7 +131,11 @@ impl<'a> DeclarationEmitter<'a> {
                 }
             }
             let elem_type = self
-                .preferred_expression_type_text(elem_idx)
+                // Widen a fresh enum-member element to its parent enum first
+                // (`[E.A, E.B]` -> `E[]`, mixed enums -> `(A | B)[]`), matching
+                // tsc's per-element literal widening, before general inference.
+                .enum_member_access_widened_base_text(elem_idx)
+                .or_else(|| self.preferred_expression_type_text(elem_idx))
                 .or_else(|| {
                     self.get_node_type_or_names(&[elem_idx])
                         .map(|type_id| self.print_type_id(type_id))

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -22,7 +22,7 @@ impl DeclarationEmitter<'_> {
         // type-level widening. Done before the member-qualified text paths below
         // so methods/functions emit `E`, not `E.A`.
         if let Some(return_expr) = self.function_body_single_return_expression(body_idx)
-            && let Some(type_text) = self.returned_enum_member_widened_base_text(return_expr)
+            && let Some(type_text) = self.enum_member_access_widened_base_text(return_expr)
         {
             return Some(type_text);
         }
@@ -1122,8 +1122,7 @@ impl DeclarationEmitter<'_> {
                     // return is equivalent to `return undefined` with
                     // widening to `void`. Matches declFileTypeAnnotationBuiltInType.
                     "void".to_string()
-                } else if let Some(text) =
-                    self.returned_enum_member_widened_base_text(ret.expression)
+                } else if let Some(text) = self.enum_member_access_widened_base_text(ret.expression)
                 {
                     // A returned enum-member literal widens to its parent enum,
                     // so multiple `return E.A` branches collapse to `E` (matching

--- a/crates/tsz-emitter/src/declaration_emitter/tests/type_info.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/type_info.rs
@@ -1724,6 +1724,81 @@ var d = {
 }
 
 #[test]
+fn test_const_array_of_enum_members_widens_element_to_enum_type() {
+    // tsc widens each fresh enum-member element of an un-asserted array literal
+    // to its parent enum, so a single-enum array infers `E[]` (not a union of
+    // member literals `(E.A | E.B)[]` or a single-member `E.A[]`).
+    let output = emit_dts_with_binding(
+        r#"
+enum Dir { Up, Down }
+export const all = [Dir.Up, Dir.Down];
+export const some = [Dir.Up];
+export const one = Dir.Up;
+"#,
+    );
+
+    assert!(
+        output.contains("const all: Dir[];"),
+        "Expected multi-member array to widen to enum type: {output}"
+    );
+    assert!(
+        output.contains("const some: Dir[];"),
+        "Expected single-member array to widen to enum type: {output}"
+    );
+    // A non-array single member must stay a member literal (unchanged).
+    assert!(
+        output.contains("const one = Dir.Up;"),
+        "Expected non-array single member to keep its literal value: {output}"
+    );
+    assert!(
+        !output.contains("Dir.Up |") && !output.contains("Dir.Up[]"),
+        "Did not expect member-literal element types to leak: {output}"
+    );
+}
+
+#[test]
+fn test_const_array_of_enum_members_inside_merged_namespace_keeps_enum_reference() {
+    // Inside a namespace merged with the same enum, the element must render as
+    // the enum type `Dir` — never the bare member name (`(Up | Down)[]`), which
+    // is not a standalone type and would emit an invalid `.d.ts`.
+    let output = emit_dts_with_binding(
+        r#"
+enum Dir { Up, Down }
+namespace Dir {
+  export const all = [Dir.Up, Dir.Down];
+}
+"#,
+    );
+
+    assert!(
+        output.contains("const all: Dir[];"),
+        "Expected namespace-merged array to widen to enum type: {output}"
+    );
+    assert!(
+        !output.contains("(Up | Down)") && !output.contains("Up |"),
+        "Did not expect bare member names in namespace-merged array element: {output}"
+    );
+}
+
+#[test]
+fn test_const_array_of_mixed_enum_members_unions_enum_types() {
+    // Members of two different enums widen independently, yielding a union of
+    // the enum types `(A | B)[]` (not a union of member literals).
+    let output = emit_dts_with_binding(
+        r#"
+enum A2 { X }
+enum B2 { Y }
+export const mixed = [A2.X, B2.Y];
+"#,
+    );
+
+    assert!(
+        output.contains("const mixed: (A2 | B2)[];"),
+        "Expected mixed-enum array to union the parent enum types: {output}"
+    );
+}
+
+#[test]
 fn test_nested_namespace_enum_value_typeof_uses_relative_reference() {
     let output = emit_dts_with_binding(
         r#"


### PR DESCRIPTION
Fixes #14774.

When a declaration-emit array literal infers its element type from fresh enum-member elements, `tsc` widens each element to its parent enum (`getWidenedType`), so a single-enum array infers `E[]` and a mixed-enum array `(A | B)[]`; tsz instead kept the per-element member literals, rendering `(Dir.Up | Dir.Down)[]` (or `Dir.Up[]` for a single member). Inside a namespace merged with the same enum, the member-name rendering additionally dropped the `Dir.` qualifier and emitted the **invalid** `(Up | Down)[]` (the bare member names are not standalone types).

tsz now widens each fresh enum-member element to its parent enum in the array-element type-text path (owner: `tsz-emitter` `declaration_emitter`), before the existing dedup/sort. Rendering the enum type instead of the member literal also removes the invalid bare-member output in the merged namespace.

The return-position widening helper is generalized (`returned_enum_member_widened_base_text` → `enum_member_access_widened_base_text`) and shared by both the return and array-element paths. It prefers the solver `is_literal_enum_member` gate and falls back to a binder `ENUM_MEMBER` symbol check, so widening is deterministic in declaration-only contexts that carry no solver types. The shared binder check is extracted into `access_resolves_to_enum_member`, and `semantic_simple_enum_access` now short-circuits on a binder-resolved non-enum base instead of scanning the source file's statements per array element (also fixing a shadowed-enum mis-detection).

### Adjacent-case matrix (all match `tsc` 5.9.3)
| Input | tsz before | tsz after / tsc |
|---|---|---|
| `[Dir.Up, Dir.Down]` | `(Dir.Up \| Dir.Down)[]` | `Dir[]` |
| `[Dir.Up]` | `Dir.Up[]` | `Dir[]` |
| `namespace Dir { const all = [Dir.Up, Dir.Down] }` | `(Up \| Down)[]` (invalid) | `Dir[]` |
| string enum `[Col.R, Col.G]` | `(Col.R \| Col.G)[]` | `Col[]` |
| const enum `[CE.A, CE.B]` | `(CE.A \| CE.B)[]` | `CE[]` |
| mixed enums `[A2.X, B2.Y]` | `(A2.X \| B2.Y)[]` | `(A2 \| B2)[]` |
| non-array `= Dir.Up` | `Dir.Up` | `Dir.Up` (unchanged) |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --lib` — 3884 passed, 0 failed (includes 3 new regression tests: top-level, namespace-merged, mixed-enum).
- `cargo clippy -p tsz-emitter` and `cargo fmt -p tsz-emitter -- --check` — clean.
- Manual `tsz --declaration --emitDeclarationOnly --target ES2020` over the issue repro + adjacent matrix above — output matches `tsc` for every row.
- Ready-review CI owns the broad conformance/emit suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01R5gRvvmnY1UkWUazxGYHwW)_