### PR TITLE
fix(solver): bind polymorphic this to receiver in infer-pattern member match (#14785)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2287,3 +2287,7 @@ path = "tests/let_var_initializer_assignment_reduced_type_tests.rs"
 [[test]]
 name = "noinfer_object_property_literal_widening_tests"
 path = "tests/noinfer_object_property_literal_widening_tests.rs"
+
+[[test]]
+name = "conditional_infer_this_member_14785_tests"
+path = "tests/conditional_infer_this_member_14785_tests.rs"

--- a/crates/tsz-checker/tests/conditional_infer_this_member_14785_tests.rs
+++ b/crates/tsz-checker/tests/conditional_infer_this_member_14785_tests.rs
@@ -1,0 +1,123 @@
+//! `infer` extraction from a polymorphic-`this`-returning member.
+//!
+//! Regression coverage for issue #14785: `T extends { m(): infer S } ? S : F`
+//! instantiated with a class/interface whose `m()` returns the polymorphic
+//! `this` type. tsc binds `this` to the matched receiver
+//! (`getTypeWithThisArgument`) and infers `S = receiver`, taking the true
+//! branch. tsz collected no candidate for `S` (the member return stayed an
+//! unsubstituted `ThisType`), so the conditional fell to the false branch and
+//! a spurious `TS2322` was raised when the (correct) value was assigned.
+//!
+//! Structural rule: when an `infer` pattern matches a source member whose
+//! declared type references the polymorphic `this`, the member type must be
+//! read through its receiver (the matched source object) before candidate
+//! collection. Owner: solver conditional-`infer` evaluation
+//! (`evaluate_rules/infer_pattern_object_match.rs`).
+
+/// Minimal lib surface so `class`/conditional/`infer` resolve without pulling
+/// the real standard library into the test.
+fn check(source: &str) -> Vec<(u32, String)> {
+    tsz_checker::test_utils::check_source_code_messages(&format!(
+        r#"
+interface Array<T> {{}}
+interface Boolean {{}}
+interface CallableFunction {{}}
+interface Function {{}}
+interface IArguments {{}}
+interface NewableFunction {{}}
+interface Number {{}}
+interface Object {{}}
+interface RegExp {{}}
+interface String {{}}
+
+{source}
+"#
+    ))
+}
+
+fn assignability_codes(diagnostics: &[(u32, String)]) -> Vec<&(u32, String)> {
+    diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2322 || *code == 2345)
+        .collect()
+}
+
+/// Canonical witness (class receiver): the conditional must take the true
+/// branch and infer `S = Node`, so assigning a `Node` to the result is sound.
+#[test]
+fn infer_this_returning_method_class_takes_true_branch() {
+    let diagnostics = check(
+        r#"
+class Node { self(): this { return this; } }
+type GetSelf<T> = T extends { self(): infer S } ? S : never;
+type GN = GetSelf<Node>;
+const g: GN = new Node();
+"#,
+    );
+    let errs = assignability_codes(&diagnostics);
+    assert!(
+        errs.is_empty(),
+        "infer S against a `this`-returning method must infer S = receiver (true branch); assigning the receiver must be clean.\nGot: {errs:#?}\nAll: {diagnostics:#?}"
+    );
+}
+
+/// Same shape, varied binder/alias/property names (anti-hardcoding): the fix
+/// must be structural, not keyed on any identifier.
+#[test]
+fn infer_this_returning_method_renamed_binders_takes_true_branch() {
+    let diagnostics = check(
+        r#"
+class Gadget { fluent(): this { return this; } }
+type Pull<Recv> = Recv extends { fluent(): infer Out } ? Out : never;
+type PG = Pull<Gadget>;
+const value: PG = new Gadget();
+"#,
+    );
+    let errs = assignability_codes(&diagnostics);
+    assert!(
+        errs.is_empty(),
+        "renamed-binder variant must also take the true branch.\nGot: {errs:#?}\nAll: {diagnostics:#?}"
+    );
+}
+
+/// False-branch witness with a non-`never` false branch: if the true branch is
+/// taken (correct), `S = Widget`, so assigning the result to the false-branch
+/// literal `"FAIL"` must error `TS2322`. A *silent* result would prove the bug
+/// (false branch, `S = "FAIL"`). The presence of TS2322 confirms parity.
+#[test]
+fn infer_this_returning_method_interface_does_not_take_false_branch() {
+    let diagnostics = check(
+        r#"
+interface Widget { build(): this; }
+type Extract1<T> = T extends { build(): infer S } ? S : "FAIL";
+type R1 = Extract1<Widget>;
+declare const w: R1;
+const bad: "FAIL" = w;
+"#,
+    );
+    let errs = assignability_codes(&diagnostics);
+    assert!(
+        !errs.is_empty(),
+        "true branch makes R1 = Widget, which is not assignable to the false-branch literal \"FAIL\" -> expected TS2322. Silence proves the false-branch bug.\nGot: {errs:#?}\nAll: {diagnostics:#?}"
+    );
+}
+
+/// Control: a concrete (non-`this`) return was already sound and must stay so —
+/// `S = Payload`, true branch, clean assignment.
+#[test]
+fn infer_concrete_returning_method_control_stays_sound() {
+    let diagnostics = check(
+        r#"
+class Payload {}
+class Source { take(): Payload { return new Payload(); } }
+type Taken<T> = T extends { take(): infer S } ? S : never;
+type TS = Taken<Source>;
+const p: TS = new Payload();
+"#,
+    );
+    let errs = assignability_codes(&diagnostics);
+    assert!(
+        errs.is_empty(),
+        "concrete-return control must remain sound.\nGot: {errs:#?}\nAll: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
@@ -120,6 +120,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         source_props: &[PropertyInfo],
         pattern_props: &[PropertyInfo],
         pattern: TypeId,
+        this_arg: TypeId,
         bindings: &mut FxHashMap<Atom, TypeId>,
         visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
@@ -133,11 +134,21 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 .find(|prop| prop.name == pattern_prop.name);
             let source_type = match source_prop {
                 Some(source_prop) => {
-                    if self.type_contains_infer(pattern_prop.type_id) {
+                    let raw = if self.type_contains_infer(pattern_prop.type_id) {
                         source_prop.type_id
                     } else {
                         self.optional_property_type(source_prop)
-                    }
+                    };
+                    // A member whose declared type references the polymorphic
+                    // `this` (e.g. `self(): this`) must be read through its
+                    // receiver before `infer` matching: tsc's
+                    // `getTypeWithThisArgument` binds `this` to the matched
+                    // source object so `T extends { self(): infer S } ? S : F`
+                    // infers `S = receiver` (true branch) instead of leaving an
+                    // unbound `ThisType` that collects no candidate and falls to
+                    // the false branch. The quick `contains_this_type` guard
+                    // keeps the common (no-`this`) path allocation-free.
+                    self.bind_member_this(raw, this_arg)
                 }
                 None => {
                     if !pattern_prop.optional {
@@ -169,6 +180,27 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         true
     }
 
+    /// Bind the polymorphic `this` in a member's declared type to the receiver
+    /// it is read from (`this_arg`), mirroring tsc's `getTypeWithThisArgument`.
+    ///
+    /// Used on the `infer`-extraction path so a `this`-returning member
+    /// (`self(): this`) contributes its concrete receiver as the `infer`
+    /// candidate. The quick `contains_this_type` probe keeps the common
+    /// (no-`this`) member read free of substitution work.
+    fn bind_member_this(&self, member_type: TypeId, this_arg: TypeId) -> TypeId {
+        if member_type.is_intrinsic()
+            || this_arg.is_intrinsic()
+            || !crate::contains_this_type(self.interner(), member_type)
+        {
+            return member_type;
+        }
+        crate::instantiation::instantiate::substitute_this_type(
+            self.interner(),
+            member_type,
+            this_arg,
+        )
+    }
+
     /// Helper for matching object type patterns.
     pub(crate) fn match_infer_object_pattern(
         &self,
@@ -190,6 +222,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     &source_shape.properties,
                     &pattern_shape.properties,
                     pattern,
+                    source,
                     bindings,
                     visited,
                     checker,
@@ -468,6 +501,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     &source_shape.properties,
                     &pattern_shape.properties,
                     pattern,
+                    source,
                     bindings,
                     visited,
                     checker,


### PR DESCRIPTION
Closes #14785.

## Summary
`infer` extraction from a member whose declared return type is the polymorphic
`this` type produced a false-positive `TS2322`. For
`T extends { m(): infer S } ? S : F` instantiated with a class/interface whose
`m()` returns `this`, tsc binds `this` to the matched receiver
(`getTypeWithThisArgument`) and infers `S = receiver`. tsz left the member
return as an unsubstituted `ThisType`, so `S` bound to a bare `this` and
assigning the (correct) receiver value to the conditional result raised a
spurious `TS2322`.

Goal: green

## Structural rule
When an `infer` pattern matches a source member whose declared type references
the polymorphic `this`, tsc reads that member through its receiver (the matched
source object) before collecting `infer` candidates; tsz must too, via the
solver conditional-`infer` evaluator
(`crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs`).
The matched source object is threaded as the `this`-argument into
`match_infer_object_properties` and substituted with the existing
`substitute_this_type` helper, guarded by `contains_this_type` so the common
(no-`this`) member path stays allocation-free.

## Adjacent-case matrix
| Case | Receiver | Return | Expected (tsc) | Result |
| --- | --- | --- | --- | --- |
| `T extends { self(): infer S } ? S : never`, assign receiver | class | `this` | clean | pass (flips) |
| renamed binders/props variant | class | `this` | clean | pass (flips) |
| non-`never` false branch (`"FAIL"`), assign result to `"FAIL"` | interface | `this` | `TS2322` (true branch, `S=I`) | pass |
| concrete (non-`this`) return control | class | `Payload` | clean | pass |

## Verification
- New regression binary
  `crates/tsz-checker/tests/conditional_infer_this_member_14785_tests.rs`:
  `cargo nextest run -p tsz-checker -E 'binary(conditional_infer_this_member_14785_tests)'`
  -> 4 passed. Flip confirmed: the two `this`-returning true-branch cases FAIL
  on `origin/main` (`Type 'Gadget' is not assignable to type 'this'`) and PASS
  with the fix.
- Adjacent guard (no regressions):
  `cargo nextest run -p tsz-checker -E 'binary(instance_type_this_member_class_tests) | binary(this_type_tests) | binary(this_typed_value_into_this_field_tests) | binary(tuple_infer_mapped_recursive_tests) | binary(conditional_infer_this_member_14785_tests)'`
  -> 52 passed.
- `cargo check -p tsz-solver` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
