### PR TITLE
refactor(solver): gate eval cache on evaluation verdict (#14346)

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1501,7 +1501,8 @@ impl QueryDatabase for QueryCache<'_> {
 
         let union_too_complex_before = self.interner.is_union_too_complex();
         let mut evaluator = self.query_backed_evaluator();
-        let result = evaluator.evaluate_request_result(request).into_type_id();
+        let evaluation_result = evaluator.evaluate_request_result(request);
+        let result = evaluation_result.into_type_id();
 
         // PERF: Persist intermediate evaluation results from this session into
         // the long-lived eval_cache. During recursive mapped type expansion
@@ -1523,17 +1524,19 @@ impl QueryDatabase for QueryCache<'_> {
         // recursive-utility fixtures flip with surrounding code.
         //
         // The discrimination is per-entry (issue #13241, extending the
-        // PR #12902 application-eval epoch split): the top-level result is
-        // gated on the run-sticky `recursion_limit_hit` (its subtree IS the
-        // whole run), while drained intermediates are filtered through the
-        // evaluator's per-node `tainted` set, so the clean intermediates of a
-        // run whose *unrelated sibling* subtree bailed are still persisted
-        // instead of being recomputed from scratch on every later query.
+        // PR #12902 application-eval epoch split): the top-level result first
+        // consults the typed `EvaluationResult` verdict (#14346), then keeps the
+        // run-sticky `recursion_limit_hit` guard for taint classes that are not
+        // solely modeled by the typed verdict yet. Its subtree IS the whole
+        // run, while drained intermediates are filtered through the evaluator's
+        // per-node `tainted` set, so the clean intermediates of a run whose
+        // *unrelated sibling* subtree bailed are still persisted instead of
+        // being recomputed from scratch on every later query.
         // A union-complexity overflow is not routed through the evaluator's
         // limit epoch, so it conservatively suppresses all writes, as before.
         let newly_union_too_complex =
             self.interner.is_union_too_complex() && !union_too_complex_before;
-        let top_level_clean = !evaluator.recursion_limit_hit();
+        let top_level_clean = evaluation_result.is_complete() && !evaluator.recursion_limit_hit();
         if !newly_union_too_complex
             && (top_level_clean || crate::limits::limit_result_cache_enabled())
         {

--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -122,6 +122,11 @@ impl EvaluationResult {
         self.termination
     }
 
+    /// Whether this walk completed without a guard-truncated verdict.
+    pub const fn is_complete(self) -> bool {
+        matches!(self.termination, Termination::Complete)
+    }
+
     /// Whether a guard cut this walk short.
     pub const fn is_incomplete(self) -> bool {
         matches!(self.termination, Termination::Incomplete { .. })
@@ -152,6 +157,7 @@ mod tests {
         assert_eq!(result.type_id(), TypeId::STRING);
         assert_eq!(result.into_type_id(), TypeId::STRING);
         assert_eq!(result.termination(), Termination::Complete);
+        assert!(result.is_complete());
         assert!(!result.is_incomplete());
         assert!(result.is_identity_for(TypeId::STRING));
         assert!(!result.is_identity_for(TypeId::NUMBER));
@@ -164,6 +170,7 @@ mod tests {
         // identical for every kind.
         let result = EvaluationResult::incomplete(TypeId::NUMBER, TerminationKind::DepthExceeded);
 
+        assert!(!result.is_complete());
         assert!(result.is_incomplete());
         // `into_type_id` returns the relation-preserving partial regardless of
         // the verdict — the same collapse every consumer performs today.


### PR DESCRIPTION
Goal: green

## Summary
- Add `EvaluationResult::is_complete` as the positive typed counterpart to the existing incomplete verdict query.
- Keep `evaluate_request_result` as the single evaluation call in the top-level eval-cache path, preserving the collapsed `TypeId` value while retaining the typed verdict for cache-write policy.
- Gate top-level eval-cache writes on the typed `EvaluationResult` completion verdict plus the existing `recursion_limit_hit` guard, leaving drained intermediate filtering unchanged.

Structural rule: when evaluation returns an explicit incomplete termination verdict, tsz must not persist that top-level partial as a complete eval-cache result. The solver cache/evaluation boundary owns this; legacy `TypeId` consumers still receive the same partial value through `into_type_id`.

Owner layer: solver evaluation/cache boundary only. No checker recursion, no relation policy change, no `application.rs` opaque-bail edits, and no #14344 canonical identity index changes.

## Verification
- `cargo fmt`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(complete_result_wraps_evaluated_type_id) or test(incomplete_result_carries_partial_and_kind)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(strip)'`
- `git diff --check origin/main...HEAD`
- `wc -l crates/tsz-solver/src/caches/query_cache.rs crates/tsz-solver/src/evaluation/result.rs`

## Coordination
- Follows #15010's typed evaluation-result API direction but is an internal verdict-aware consumer slice, so it can land independently if needed.
- Avoids Claude's claimed #14344 canonical identity index stage and the #14345 `application.rs` fixpoint lane.
- The old `recursion_limit_hit` taint guard intentionally remains for limit classes not solely modeled by the typed verdict yet.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high