### PR TITLE
refactor(solver): gate cross-eval memo on typed verdict (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
+++ b/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
@@ -178,6 +178,23 @@ mod tests {
     }
 
     #[test]
+    fn non_stable_fresh_result_is_returned_but_not_memoized() {
+        reset_query_memo();
+        let t = TypeId(8);
+
+        let first = memoized_eval(t, false, || (TypeId(80), false));
+
+        assert_eq!(first, Some(TypeId(80)));
+        assert_eq!(query_memo_get(t, false), None);
+
+        let second = memoized_eval(t, false, || (TypeId(81), true));
+
+        assert_eq!(second, Some(TypeId(81)));
+        assert_eq!(query_memo_get(t, false), Some(TypeId(81)));
+        reset_query_memo();
+    }
+
+    #[test]
     fn reentry_of_active_type_is_rejected() {
         let t = TypeId(4242);
         let outer = CrossEvalExpansionGuard::enter(t).expect("first entry succeeds");

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -593,6 +593,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         request_result_verdict(type_id, self.request_termination_kind)
     }
 
+    /// Evaluate a request for a depth-agnostic memo and report whether the
+    /// collapsed `TypeId` is stable enough to store.
+    ///
+    /// A typed incomplete verdict catches guard bails that the legacy sticky
+    /// flags did not fully model (for example fuel/query-budget bails). The
+    /// legacy [`Self::recursion_limit_hit`] backstop remains until #14346 makes
+    /// the typed verdict the sole owner for every recursion taint class.
+    pub(crate) fn evaluate_request_memo_result(
+        &mut self,
+        request: EvaluationRequest,
+    ) -> (TypeId, bool) {
+        let result = self.evaluate_request_result(request);
+        (
+            result.into_type_id(),
+            !result.is_incomplete() && !self.recursion_limit_hit(),
+        )
+    }
+
     // =========================================================================
     // Accessor methods for evaluate_rules modules
     // =========================================================================

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -1705,14 +1705,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 return (type_id, false);
             };
             let mut evaluator = TypeEvaluator::with_resolver(self.interner(), self.resolver());
-            evaluator.set_no_unchecked_indexed_access(nuia);
             if let Some(query_db) = self.query_db() {
                 evaluator = evaluator.with_query_db(query_db);
             }
-            let result = evaluator.evaluate(type_id);
-            // Memoize only stable results — a recursion/budget bail is a
-            // stack-context artifact that must not be reused as the answer.
-            (result, !evaluator.recursion_limit_hit())
+            let request = crate::evaluation::request::EvaluationRequest::new(type_id)
+                .with_no_unchecked_indexed_access(nuia);
+            evaluator.evaluate_request_memo_result(request)
         })
         .unwrap_or(type_id)
     }

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -2179,15 +2179,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             self.no_unchecked_indexed_access,
             || {
                 let mut evaluator = TypeEvaluator::with_resolver(self.interner, self.resolver);
-                evaluator.set_no_unchecked_indexed_access(self.no_unchecked_indexed_access);
                 // Pass query_db to share the application evaluation cache across
                 // evaluations, so the same generic type produces the same
                 // ObjectShapeId and structural subtype checks stay stable.
                 if let Some(db) = self.query_db {
                     evaluator = evaluator.with_query_db(db);
                 }
-                let result = evaluator.evaluate(type_id);
-                (result, !evaluator.recursion_limit_hit())
+                let request = crate::evaluation::request::EvaluationRequest::new(type_id)
+                    .with_no_unchecked_indexed_access(self.no_unchecked_indexed_access);
+                evaluator.evaluate_request_memo_result(request)
             },
         ) else {
             return (type_id, false);


### PR DESCRIPTION
Goal: green

## Summary
- Add `TypeEvaluator::evaluate_request_memo_result` as the shared typed-verdict gate for depth-agnostic memo writes.
- Route the two fresh-evaluator cross-eval memo sites through `EvaluationRequest` and the typed `EvaluationResult` verdict before collapsing to `TypeId`.
- Keep the legacy `recursion_limit_hit` backstop while #14346 continues migrating remaining taint classes into the typed channel.
- Add a focused `cross_eval_guard` test proving non-stable fresh results are returned to the caller but not memoized.

Structural rule: when a fresh sub-evaluator returns an incomplete termination verdict, tsz must not treat that partial as a stable per-query memo result. The solver evaluation/cross-eval boundary owns this; legacy callers still receive the same collapsed `TypeId`.

Owner layer: solver evaluation and cross-evaluator memo boundaries only. No checker recursion changes, no relation policy change, no #14344 reference-mint identity edits, and no #14345 `application.rs` opaque-bail edits.

## Verification
- `cargo fmt`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(non_stable_fresh_result_is_returned_but_not_memoized) or test(memo_keys_on_no_unchecked_indexed_access) or test(reentry_of_active_type_is_rejected)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(strip)'`
- `git diff --check origin/main...HEAD`
- `wc -l crates/tsz-solver/src/evaluation/evaluate.rs crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs crates/tsz-solver/src/evaluation/cross_eval_guard.rs`

## Coordination
- Follows #15010 typed evaluation API and complements #15014, which gates the top-level eval cache on the typed verdict.
- Avoids the Claude Code #14344 reference-mint canonicalization lane and the #14345 `application.rs` fixpoint lane.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high