### PR TITLE
fix(checker): keep interface `this`-return polymorphic on a generic-param receiver

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "interface_this_return_generic_param_14797_tests"
+path = "tests/interface_this_return_generic_param_14797_tests.rs"
+[[test]]
 name = "union_overloaded_member_call_signatures_tests"
 path = "tests/union_overloaded_member_call_signatures_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
+++ b/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
@@ -898,6 +898,75 @@ impl<'a> CheckerState<'a> {
                     }
                 }
 
+                // #14797: a generic-parameter receiver `T extends I` whose
+                // interface constraint `I` has a *callable* member returning
+                // polymorphic `this` (`clone(): this`, or a `self: () => this`
+                // property). The solver materializes the `Lazy(DefId)` interface
+                // constraint with `this` already bound to the interface type — so
+                // unlike the class-instance constraint (which keeps `this`
+                // polymorphic), `prop_type`'s return collapsed to `I`, drawing a
+                // false `TS2322` on `return n.clone()`. Re-materialize the
+                // constraint *suppressing* `this` binding so the member keeps its
+                // polymorphic `this`, then rebind it to the receiver type
+                // parameter. Gated on a callable member that lost its `this` so
+                // ordinary type-parameter property reads do no extra work.
+                if (crate::query_boundaries::common::get_call_signatures(self.ctx.types, prop_type)
+                    .is_some_and(|sigs| !sigs.is_empty())
+                    || crate::query_boundaries::property_access::is_function_type(
+                        self.ctx.types,
+                        prop_type,
+                    ))
+                    && !crate::query_boundaries::common::contains_this_type(
+                        self.ctx.types,
+                        prop_type,
+                    )
+                    && crate::query_boundaries::state::checking::is_type_parameter_like(
+                        self.ctx.types,
+                        object_type_for_access,
+                    )
+                    && let Some(constraint) =
+                        crate::query_boundaries::property_access::type_parameter_constraint(
+                            self.ctx.types,
+                            object_type_for_access,
+                        )
+                {
+                    let suppressed = {
+                        let env = self.ctx.type_env.borrow();
+                        crate::query_boundaries::state::type_environment::evaluate_type_suppressing_this(
+                            self.ctx.types,
+                            &*env,
+                            constraint,
+                        )
+                    };
+                    if suppressed != constraint {
+                        let raw =
+                            crate::query_boundaries::property_access::resolve_property_access_raw_this(
+                                self.ctx.types,
+                                suppressed,
+                                self.ctx.types.intern_string(property_name),
+                            );
+                        if let PropertyAccessResult::Success {
+                            type_id: raw_type, ..
+                        } = raw
+                            && crate::query_boundaries::common::contains_this_type(
+                                self.ctx.types,
+                                raw_type,
+                            )
+                        {
+                            // Rebind to the *receiver type parameter* itself
+                            // (`object_type_for_access`), not the generic
+                            // `this_substitution_target`: this recovery only runs
+                            // for a type-parameter receiver, whose polymorphic
+                            // `this` is exactly that type parameter.
+                            prop_type = crate::query_boundaries::common::substitute_this_type(
+                                self.ctx.types,
+                                raw_type,
+                                object_type_for_access,
+                            );
+                        }
+                    }
+                }
+
                 if skip_flow_narrowing
                     && from_index_signature
                     && crate::query_boundaries::state::checking::is_type_parameter_like(

--- a/crates/tsz-checker/tests/interface_this_return_generic_param_14797_tests.rs
+++ b/crates/tsz-checker/tests/interface_this_return_generic_param_14797_tests.rs
@@ -1,0 +1,135 @@
+//! Regression coverage for #14797: an interface method (or function-valued
+//! property) that returns polymorphic `this`, called on a value typed as a
+//! generic type parameter `T extends I`, must resolve to `this`/`T` — not to the
+//! interface constraint `I`.
+//!
+//! Structural rule: when a member is resolved through a *type parameter*
+//! receiver, the member's polymorphic `this` must stay `this` so the checker can
+//! rebind it to the type parameter. The solver's bare-`TypeParameter` property
+//! path already skips `this` binding for concrete-object constraints (the class
+//! case), but an *interface* constraint is a `Lazy(DefId)` semantic ref, so the
+//! first-pass noop-resolver lookup is degenerate and the checker's env-eval
+//! retry previously re-resolved the member on the evaluated interface object
+//! *with* `this` binding, collapsing `clone(): this` to `(): INode`. That drew a
+//! false `TS2322` on `return n.clone();`. `tsc` keeps the result `T`.
+//!
+//! The fix is name-agnostic (it keys on the structural `Lazy` constraint, not on
+//! identifiers), so every case below varies its binders.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn strict_options() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn ts2322(source: &str) -> usize {
+    check_source(source, "test.ts", strict_options())
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .count()
+}
+
+/// The exact repro from #14797: `n.clone(): this` for `n: T extends INode`.
+#[test]
+fn interface_this_return_through_generic_param_is_clean() {
+    let source = r#"
+interface INode { clone(): this; }
+function cloneI<T extends INode>(n: T): T { return n.clone(); }
+"#;
+    assert_eq!(
+        ts2322(source),
+        0,
+        "`n.clone()` for `n: T extends INode` must return `T`, not `INode`"
+    );
+}
+
+/// Same rule, fully renamed binders — the fix is structural, not name-keyed.
+#[test]
+fn interface_this_return_renamed_binders() {
+    let source = r#"
+interface Shape { duplicate(): this; }
+function copy<Element extends Shape>(item: Element): Element {
+    return item.duplicate();
+}
+"#;
+    assert_eq!(ts2322(source), 0, "renamed binders must behave identically");
+}
+
+/// Chained interface `this`-returning calls keep `this` bound to the param.
+#[test]
+fn interface_this_return_chained_calls() {
+    let source = r#"
+interface Cursor { next(): this; prev(): this; }
+function step<C extends Cursor>(c: C): C {
+    return c.next().prev();
+}
+"#;
+    assert_eq!(ts2322(source), 0, "chained `this`-returns must stay `C`");
+}
+
+/// An interface function-valued *property* returning `this` behaves the same.
+#[test]
+fn interface_this_property_through_generic_param_is_clean() {
+    let source = r#"
+interface Linked { self: () => this; }
+function identity<L extends Linked>(node: L): L {
+    return node.self();
+}
+"#;
+    assert_eq!(
+        ts2322(source),
+        0,
+        "`node.self()` for a `() => this` property must return `L`"
+    );
+}
+
+/// Class control (parity target): the class path already preserves `T`.
+#[test]
+fn class_this_return_through_generic_param_is_clean() {
+    let source = r#"
+class CNode { clone(): this { return this; } }
+function cloneC<T extends CNode>(n: T): T { return n.clone(); }
+"#;
+    assert_eq!(
+        ts2322(source),
+        0,
+        "class `this`-return must stay `T` (control)"
+    );
+}
+
+/// Direct (non-generic) interface receiver: `clone()` on an `INode` value is
+/// `INode`, and returning it as `INode` must stay clean.
+#[test]
+fn direct_interface_receiver_this_return_is_interface() {
+    let source = r#"
+interface INode { clone(): this; }
+function dup(n: INode): INode { return n.clone(); }
+"#;
+    assert_eq!(
+        ts2322(source),
+        0,
+        "direct `INode` receiver `clone()` is assignable to `INode`"
+    );
+}
+
+/// Negative control: returning an unrelated interface value as `T` must still
+/// error — the fix must not blanket-silence TS2322 on generic-param returns.
+#[test]
+fn unrelated_interface_value_returned_as_param_still_errors() {
+    let source = r#"
+interface INode { clone(): this; tag: string; }
+function bad<T extends INode>(n: T, other: INode): T {
+    return other;
+}
+"#;
+    assert_eq!(
+        ts2322(source),
+        1,
+        "a bare `INode` (not `this`/`T`) returned as `T` must still draw TS2322"
+    );
+}


### PR DESCRIPTION
Closes #14797.

## Summary
Calling an interface member that returns polymorphic `this` (`clone(): this`, or a `self: () => this` property) on a value typed as a generic type parameter `T extends I` resolved to the interface `I` instead of `this`/`T`, producing a false `TS2322` on `return n.clone();`. The structurally identical class-receiver path already yields `T`. This makes the interface path match `tsc`.

```ts
interface INode { clone(): this; }
function cloneI<T extends INode>(n: T): T { return n.clone(); } // was: false TS2322; now: OK (matches tsc)
class CNode { clone(): this { return this; } }
function cloneC<T extends CNode>(n: T): T { return n.clone(); } // both OK (control, unchanged)
```

Goal: green

## Structural rule
When a callable member that returns polymorphic `this` is read through a **type-parameter receiver** `T extends I`, `tsc` keeps the result `this` and rebinds it to the receiver type parameter (yielding `T`). tsz must too.

Owner layer: checker property-access type computation (`crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs`).

Root cause: an interface constraint is a `Lazy(DefId)` semantic ref, so the solver's bare-`TypeParameter` property path falls into its constraint-evaluation retry, which materializes the interface through the cached evaluator with `this` **already bound to the interface type** before the checker can rebind it. A concrete class-instance constraint keeps `this` polymorphic (the member stores `() => this`), so only interface constraints regressed.

Fix: when a callable member read through a type-parameter receiver has lost its `this`, re-materialize the constraint with `this` binding suppressed (`evaluate_type_suppressing_this`), re-resolve the member raw (`resolve_property_access_raw_this`), and rebind the recovered polymorphic `this` to the receiver type parameter (`object_type_for_access`). Gated on a callable member that lost its `this`, so ordinary type-parameter property reads do no extra work. No solver change; no anti-hardcoding predicates (keys on the structural `Lazy` constraint + callable shape, not on identifiers/printer output).

## Adjacent-case matrix
| Case | Before | After / `tsc` |
| --- | --- | --- |
| Interface method `n.clone(): this`, `n: T extends INode` | false TS2322 | OK (`T`) |
| Same, fully renamed binders (`Shape`/`Element`) | false TS2322 | OK |
| Chained `c.next().prev()` | false TS2322 | OK |
| Interface function-valued property `self: () => this` | false TS2322 | OK |
| Class `this`-return through generic param (control) | OK | OK (unchanged) |
| Direct non-generic interface receiver `(n: INode) => INode` | OK | OK (unchanged) |
| Negative: bare `INode` returned as `T` | TS2322 | TS2322 (preserved) |

## Verification
- New regression suite (flips: fails before, passes after), binders varied: `crates/tsz-checker/tests/interface_this_return_generic_param_14797_tests.rs` (7 cases incl. controls + negative).
  - `cargo nextest run -p tsz-checker --test interface_this_return_generic_param_14797_tests` → 7 passed.
- `this`-regression suites: `cargo nextest run -p tsz-checker --test this_array_field_method_call_tests --test this_type_tests --test this_typed_value_into_this_field_tests --test this_array_field_method_param_14512_tests --test instance_type_this_member_class_tests --test ts4105_this_type_indexed_access_tests --test ts2430_tests` → 126 passed, 0 failed.
- Generic/constraint suites checked for regressions; the only failures (`cross_file_generic_interface_mapped_filter_tests`, `contravariant_app_constrained_type_param_target_tests`, `kysely_callback_context_tests`) are **pre-existing on `origin/main`** (identical set with the change stashed — known cross-file/Mac platform deltas), not introduced here.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high