### PR TITLE
fix(parser): recover statement-leading misplaced declaration modifiers

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -230,6 +230,10 @@ mod decorator_tests;
 mod modifier_ordering_tests;
 
 #[cfg(test)]
+#[path = "../../tests/statement_leading_modifier_recovery_tests.rs"]
+mod statement_leading_modifier_recovery_tests;
+
+#[cfg(test)]
 #[path = "../../tests/parse_diagnostic_order_tests.rs"]
 mod parse_diagnostic_order_tests;
 

--- a/crates/tsz-parser/src/parser/parse_rules/mod.rs
+++ b/crates/tsz-parser/src/parser/parse_rules/mod.rs
@@ -20,5 +20,5 @@ pub use utils::{
     is_identifier_or_contextual_keyword, is_identifier_or_keyword, look_ahead_is,
     look_ahead_is_abstract_declaration, look_ahead_is_async_declaration, look_ahead_is_const_enum,
     look_ahead_is_import_call, look_ahead_is_import_equals, look_ahead_is_module_declaration,
-    look_ahead_is_type_alias_declaration,
+    look_ahead_is_on_same_line, look_ahead_is_type_alias_declaration,
 };

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -1562,6 +1562,18 @@ impl ParserState {
         let mut all_modifiers = prefix_modifiers;
         all_modifiers.push(declare_modifier);
 
+        // Consume any redundant `declare` modifiers (`declare declare const x`).
+        // tsc reports TS1030 ("'declare' modifier already seen") at each extra
+        // `declare` keyword and parses the trailing ambient declaration as usual.
+        while self.is_token(SyntaxKind::DeclareKeyword) {
+            let dup_modifier = self.consume_modifier_with_error(
+                SyntaxKind::DeclareKeyword,
+                "'declare' modifier already seen.",
+                tsz_common::diagnostics::diagnostic_codes::MODIFIER_ALREADY_SEEN,
+            );
+            all_modifiers.push(dup_modifier);
+        }
+
         // Parse the inner declaration based on what follows 'declare'
         let saved_flags = self.context_flags;
         self.context_flags |= crate::parser::state::CONTEXT_FLAG_AMBIENT;

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -51,6 +51,22 @@ impl ParserState {
                 }
                 _ => self.parse_expression_statement(),
             }
+        } else if self.look_ahead_is_abstract_before_var_or_function() {
+            use tsz_common::diagnostics::diagnostic_codes;
+            // `abstract` before a variable or function declaration
+            // (`abstract const x = 1;`, `abstract function f() {}`): tsc parses
+            // `abstract` as a modifier and reports TS1242 at the keyword, then
+            // parses the trailing declaration with the (invalid) modifier — it
+            // does NOT degrade to an identifier expression (which would give a
+            // spurious TS2304). Route through the shared modifier-prefixed
+            // statement parser so the declaration is still produced.
+            let abstract_start = self.token_pos();
+            let abstract_modifier = self.consume_modifier_with_error(
+                SyntaxKind::AbstractKeyword,
+                "'abstract' modifier can only appear on a class, method, or property declaration.",
+                diagnostic_codes::ABSTRACT_MODIFIER_CAN_ONLY_APPEAR_ON_A_CLASS_METHOD_OR_PROPERTY_DECLARATION,
+            );
+            self.parse_accessor_modified_statement(abstract_start, vec![abstract_modifier])
         } else {
             // When 'abstract' at statement level is followed by '@' on the same line,
             // tsc emits TS1434 "Unexpected keyword or identifier." at the 'abstract' position,
@@ -411,6 +427,15 @@ impl ParserState {
         let snapshot = self.scanner.save_state();
         let current = self.current_token;
         self.next_token(); // skip `declare`
+        // A statement may begin with a run of redundant `declare` keywords
+        // (`declare declare const x`). tsc treats each extra `declare` as a
+        // modifier (TS1030) and still parses the trailing ambient declaration,
+        // so skip the run here and classify by what ultimately follows. ASI
+        // still applies between consecutive `declare` keywords.
+        while self.is_token(SyntaxKind::DeclareKeyword) && !self.scanner.has_preceding_line_break()
+        {
+            self.next_token();
+        }
         let is_decl = if self.scanner.has_preceding_line_break() {
             false
         } else if self.is_token(SyntaxKind::ImportKeyword) {
@@ -543,6 +568,40 @@ impl ParserState {
     /// Look ahead to see if "abstract" is followed by another declaration keyword.
     pub(crate) fn look_ahead_is_abstract_declaration(&mut self) -> bool {
         look_ahead_is_abstract_declaration(&mut self.scanner, self.current_token)
+    }
+
+    /// Emit a grammar diagnostic for a misplaced or duplicated modifier keyword
+    /// at the current token, consume it, and return the modifier token node.
+    /// Shared by the statement-leading recovery paths (a duplicated `declare`,
+    /// a stray `abstract` before a variable/function declaration).
+    pub(crate) fn consume_modifier_with_error(
+        &mut self,
+        kind: SyntaxKind,
+        message: &str,
+        code: u32,
+    ) -> NodeIndex {
+        let start = self.token_pos();
+        let end = self.token_end();
+        self.parse_error_at(start, end - start, message, code);
+        self.next_token();
+        self.arena.add_token(kind as u16, start, end)
+    }
+
+    /// Look ahead to see if `abstract` is followed by a variable or function
+    /// declaration keyword (`var`/`let`/`const`/`function`) on the same line.
+    /// These are reserved words, so the following construct is unambiguously a
+    /// declaration where `abstract` is a misplaced modifier (TS1242), not an
+    /// expression that happens to start with the identifier `abstract`.
+    pub(crate) fn look_ahead_is_abstract_before_var_or_function(&mut self) -> bool {
+        look_ahead_is_on_same_line(&mut self.scanner, self.current_token, |token| {
+            matches!(
+                token,
+                SyntaxKind::VarKeyword
+                    | SyntaxKind::LetKeyword
+                    | SyntaxKind::ConstKeyword
+                    | SyntaxKind::FunctionKeyword
+            )
+        })
     }
 
     /// Look ahead to see if "accessor" is followed by a declaration keyword.

--- a/crates/tsz-parser/tests/statement_leading_modifier_recovery_tests.rs
+++ b/crates/tsz-parser/tests/statement_leading_modifier_recovery_tests.rs
@@ -1,0 +1,171 @@
+//! Tests for statement-leading misplaced/duplicated declaration modifiers.
+//!
+//! A statement that begins with a run of declaration modifiers (a duplicated
+//! `declare`, a stray `abstract`) before a `var`/`let`/`const`/`function`
+//! declaration must be parsed as a modifier-prefixed declaration so the proper
+//! grammar diagnostic fires (TS1030 for a duplicate `declare`, TS1242 for a
+//! misplaced `abstract`). Previously tsz degraded these to an expression
+//! statement, producing a spurious TS2304 "Cannot find name" instead.
+
+use crate::parser::test_fixture::parse_source;
+
+fn diagnostics(source: &str) -> Vec<(u32, u32, String)> {
+    let (parser, _root) = parse_source(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|d| (d.code, d.start, d.message.clone()))
+        .collect()
+}
+
+fn codes(source: &str) -> Vec<u32> {
+    diagnostics(source).iter().map(|(c, _, _)| *c).collect()
+}
+
+fn count(source: &str, code: u32) -> usize {
+    codes(source).iter().filter(|c| **c == code).count()
+}
+
+// =========================================================================
+// Duplicate `declare` modifier -> TS1030 (not TS2304)
+// =========================================================================
+
+#[test]
+fn duplicate_declare_const_emits_ts1030_not_ts2304() {
+    let source = "declare declare const x = 1;";
+    let diags = diagnostics(source);
+    assert!(
+        diags.iter().any(|(c, _, _)| *c == 1030),
+        "duplicate `declare` should emit TS1030, got {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|(c, _, _)| *c == 2304),
+        "duplicate `declare` must NOT degrade to TS2304, got {diags:?}"
+    );
+}
+
+#[test]
+fn duplicate_declare_ts1030_anchored_at_second_declare() {
+    // `declare declare const x = 1;`
+    //  ^col1   ^col9 (offset 8)
+    let source = "declare declare const x = 1;";
+    let ts1030 = diagnostics(source)
+        .into_iter()
+        .find(|(c, _, _)| *c == 1030)
+        .expect("expected TS1030");
+    assert_eq!(ts1030.1, 8, "TS1030 should anchor at the second `declare`");
+}
+
+#[test]
+fn triple_declare_emits_two_ts1030() {
+    let source = "declare declare declare const x = 1;";
+    assert_eq!(
+        count(source, 1030),
+        2,
+        "two redundant `declare` keywords should each emit TS1030"
+    );
+}
+
+#[test]
+fn duplicate_declare_class_still_parses_and_emits_ts1030() {
+    let source = "declare declare class C {}";
+    assert_eq!(count(source, 1030), 1);
+    assert_eq!(count(source, 2304), 0);
+}
+
+// =========================================================================
+// Misplaced `abstract` before var/function declarations -> TS1242 (not TS2304)
+// =========================================================================
+
+#[test]
+fn abstract_const_emits_ts1242_not_ts2304() {
+    let source = "abstract const x = 1;";
+    let diags = diagnostics(source);
+    assert!(
+        diags.iter().any(|(c, _, _)| *c == 1242),
+        "`abstract const` should emit TS1242, got {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|(c, _, _)| *c == 2304),
+        "`abstract const` must NOT degrade to TS2304, got {diags:?}"
+    );
+}
+
+#[test]
+fn abstract_ts1242_anchored_at_abstract_keyword() {
+    let source = "abstract const x = 1;";
+    let ts1242 = diagnostics(source)
+        .into_iter()
+        .find(|(c, _, _)| *c == 1242)
+        .expect("expected TS1242");
+    assert_eq!(
+        ts1242.1, 0,
+        "TS1242 should anchor at the `abstract` keyword"
+    );
+}
+
+#[test]
+fn abstract_let_var_function_emit_ts1242() {
+    for source in [
+        "abstract let y = 2;",
+        "abstract var z = 3;",
+        "abstract function f() {}",
+    ] {
+        assert_eq!(
+            count(source, 1242),
+            1,
+            "{source:?} should emit exactly one TS1242"
+        );
+        assert_eq!(count(source, 2304), 0, "{source:?} should not emit TS2304");
+    }
+}
+
+// =========================================================================
+// Genuine identifier uses and valid forms must be unchanged
+// =========================================================================
+
+#[test]
+fn declare_as_identifier_unchanged() {
+    // `declare;`/`abstract;` are genuine identifier-expression uses. The parser
+    // must not synthesize a grammar diagnostic for them; they parse as an
+    // expression statement (the checker later reports TS2304 "Cannot find name").
+    for source in ["declare;", "abstract;"] {
+        assert_eq!(count(source, 1030), 0, "{source:?} should not emit TS1030");
+        assert_eq!(count(source, 1242), 0, "{source:?} should not emit TS1242");
+    }
+}
+
+#[test]
+fn valid_declare_const_no_grammar_error() {
+    let source = "declare const x = 1;";
+    assert_eq!(count(source, 1030), 0);
+    assert_eq!(count(source, 2304), 0);
+    assert_eq!(count(source, 1242), 0);
+}
+
+#[test]
+fn valid_abstract_class_no_ts1242() {
+    let source = "abstract class C {}";
+    assert_eq!(count(source, 1242), 0);
+    assert_eq!(count(source, 2304), 0);
+}
+
+#[test]
+fn valid_declare_abstract_class_no_grammar_error() {
+    let source = "declare abstract class C {}";
+    assert_eq!(count(source, 1030), 0);
+    assert_eq!(count(source, 1242), 0);
+    assert_eq!(count(source, 2304), 0);
+}
+
+#[test]
+fn declare_with_line_break_is_asi_expression() {
+    // ASI: `declare` then a newline is a standalone expression statement, so the
+    // following `declare const` is its own (valid) ambient declaration.
+    let source = "declare\ndeclare const x = 1;";
+    assert_eq!(
+        count(source, 1030),
+        0,
+        "ASI must prevent treating the two `declare`s as one modifier run"
+    );
+}


### PR DESCRIPTION
Fixes #14841.

When a statement begins with a run of declaration modifiers — a duplicated `declare`, or a stray `abstract` before a `var`/`let`/`const`/`function` declaration — tsc parses the modifier prefix and reports the proper grammar diagnostic. tsz mis-recovered these as an identifier expression, producing a spurious `TS2304` "Cannot find name".

Structural rule: when a statement begins with a sequence of declaration modifiers (a duplicate `declare`, or a misplaced `abstract`) followed by a variable/function declaration, tsc parses them as modifiers and reports TS1030 (duplicate `declare`) / TS1242 (misplaced `abstract`); tsz now parses the modifier prefix through the parser's statement-leading modifier paths instead of degrading the first keyword to an identifier expression. Owner layer: `tsz-parser` statement dispatch / ambient-declaration parser.

The fix generalizes beyond the two reported witnesses to the whole family (runs of `declare`, all of var/let/const/function after `abstract`):

- `look_ahead_is_declare_before_declaration` skips a run of redundant `declare` keywords (ASI-aware) before classifying, so `declare declare const x` routes to the ambient-declaration parser.
- `parse_ambient_declaration_with_modifiers` consumes the redundant `declare` keywords, emitting TS1030 at each one (`declare declare declare const` → two TS1030).
- `parse_statement_abstract_keyword` handles `abstract` before a var/let/const/function declaration, emitting TS1242 at the keyword and parsing the declaration with the (invalid) modifier via the shared `parse_accessor_modified_statement` path.
- Extracted `consume_modifier_with_error`, shared by both recovery paths.

Genuine identifier uses (`declare;`, `abstract;`) and valid forms (`declare const x = 1;`, `abstract class C {}`, `declare abstract class C {}`) are unchanged.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-parser --lib` — 1479 existing + 12 new tests pass (`statement_leading_modifier_recovery_tests`).
- `cargo fmt -p tsz-parser --check` and `cargo clippy -p tsz-parser --lib` clean.
- Full-pipeline CLI parity (`tsz --strict --target es2022 --lib es2022 --noEmit`):
  - `declare declare const x = 1;` → `(1,9) TS1030` (was TS2304)
  - `abstract const x = 1;` / `abstract function f() {}` → `(1,1) TS1242` (was TS2304)
  - `declare const x = 1;`, `abstract class C {}`, `declare abstract class C {}` → unchanged (clean)

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_018pZ9uKoE26yznRw5aPnSQ1)_