### PR TITLE
hold(bench): a flaky canary perf-timing pair must not freeze latest.json

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -103,7 +103,7 @@ jobs:
               .application_compatibility.missing == 0 and
               .application_compatibility.incomplete == 0 and
               .application_compatibility.duplicates == 0 and
-              .green_project_timing_pair_gaps == 0 and
+              .blocking_project_timing_pair_gaps == 0 and
               .successful_project_timing_pairs >= .required_project_timing_pairs
             ' "${tmpdir}/artifact/bench-results-readiness.json" >/dev/null; then
               rm -rf "${tmpdir}"
@@ -259,7 +259,7 @@ jobs:
               .application_compatibility.missing == 0 and
               .application_compatibility.incomplete == 0 and
               .application_compatibility.duplicates == 0 and
-              .green_project_timing_pair_gaps == 0 and
+              .blocking_project_timing_pair_gaps == 0 and
               .successful_project_timing_pairs >= .required_project_timing_pairs
             ' "${tmpdir}/artifact/bench-results-readiness.json" >/dev/null; then
               rm -rf "${tmpdir}"

--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -56,9 +56,25 @@ const REQUIRED_MEASURED_ROWS = REQUIRED_PROJECT_ROWS.filter(
     !BENCH_RUNNER_EXCLUDED_ROWS.has(name) &&
     PROJECT_ROWS_BY_NAME[name]?.category !== "application",
 );
+const REQUIRED_MEASURED_ROW_SET = new Set(REQUIRED_MEASURED_ROWS);
 const APPLICATION_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS
   .filter((row) => row.category === "application")
   .map((row) => row.name);
+
+// A green perf-timed row missing its tsz/tsgo timing pair only blocks the public
+// publish when the row is part of the required publish completeness set. Every
+// `perf_timed` row today is a canary/advisory shard (external libraries and
+// application canaries) that is intentionally outside that gate (see the
+// REQUIRED_MEASURED_ROWS note above and the optional-shard contract in
+// project-rows.mjs). A canary perf benchmark legitimately errors or is skipped
+// from time to time; treating that as publish-blocking froze the whole
+// benchmark site for ~half a day when one green canary application row
+// (infisical) produced no timing pair. #15004 demoted that single row to
+// perf_timed:false; this guard generalizes the rule so any flaky canary timing
+// pair is advisory, while a future required perf-timed row still blocks.
+function isBlockingTimedRow(name) {
+  return REQUIRED_MEASURED_ROW_SET.has(name);
+}
 
 const args = process.argv.slice(2);
 
@@ -359,6 +375,12 @@ function analyzeArtifact(artifact, expectedCommit) {
         hasGreenCompatibilityEvidence(sourceRow) &&
         !hasSuccessfulTimingPair(sourceRow);
     });
+  const blockingTimedRowsMissingTimingPairs = greenTimedRowsMissingTimingPairs.filter(
+    (row) => isBlockingTimedRow(row.name),
+  );
+  const advisoryTimedRowsMissingTimingPairs = greenTimedRowsMissingTimingPairs.filter(
+    (row) => !isBlockingTimedRow(row.name),
+  );
 
   return {
     measurementProfile: measurementProfileStatus(artifact),
@@ -374,6 +396,8 @@ function analyzeArtifact(artifact, expectedCommit) {
     )),
     applicationDuplicates: applicationRows.filter((r) => r.duplicate_count > 1),
     greenTimedRowsMissingTimingPairs,
+    blockingTimedRowsMissingTimingPairs,
+    advisoryTimedRowsMissingTimingPairs,
     successfulProjectTimingPairs: rows.filter((row) => (
       row.state === "green" &&
       hasSuccessfulTimingPair(row)
@@ -409,6 +433,8 @@ function buildJson({
   applicationIncomplete,
   applicationDuplicates,
   greenTimedRowsMissingTimingPairs,
+  blockingTimedRowsMissingTimingPairs,
+  advisoryTimedRowsMissingTimingPairs,
   successfulProjectTimingPairs,
   missing,
   red,
@@ -459,7 +485,19 @@ function buildJson({
       state: r.state,
       tsz_ms: r.tsz_ms,
       tsgo_ms: r.tsgo_ms,
+      blocking: isBlockingTimedRow(r.name),
     })) ?? [],
+    // Only required perf-timed rows missing a timing pair block the publish;
+    // canary/advisory perf-timed rows are reported but never freeze latest.json.
+    blocking_project_timing_pair_gaps: blockingTimedRowsMissingTimingPairs?.length ?? 0,
+    blocking_project_timing_pair_gap_rows: blockingTimedRowsMissingTimingPairs?.map((r) => ({
+      name: r.name,
+      label: r.label,
+      state: r.state,
+      tsz_ms: r.tsz_ms,
+      tsgo_ms: r.tsgo_ms,
+    })) ?? [],
+    advisory_project_timing_pair_gaps: advisoryTimedRowsMissingTimingPairs?.length ?? 0,
     application_compatibility: applicationRows
       ? {
           required: requireApplicationCompat,
@@ -593,6 +631,8 @@ function buildReport({
   applicationIncomplete,
   applicationDuplicates,
   greenTimedRowsMissingTimingPairs,
+  blockingTimedRowsMissingTimingPairs,
+  advisoryTimedRowsMissingTimingPairs,
   successfulProjectTimingPairs,
   missing,
   red,
@@ -666,10 +706,19 @@ function buildReport({
     lines.push("");
   }
 
-  if (greenTimedRowsMissingTimingPairs.length > 0) {
-    lines.push(`### Green perf-timed rows missing timing (${greenTimedRowsMissingTimingPairs.length})`, "");
-    for (const r of greenTimedRowsMissingTimingPairs) {
-      lines.push(`- \`${r.name}\`: compatibility is green but no tsz/tsgo timing pair was recorded`);
+  const blockingGaps = blockingTimedRowsMissingTimingPairs ?? [];
+  const advisoryGaps = advisoryTimedRowsMissingTimingPairs ?? [];
+  if (blockingGaps.length > 0) {
+    lines.push(`### 🚫 Required perf-timed rows missing timing (${blockingGaps.length})`, "");
+    for (const r of blockingGaps) {
+      lines.push(`- \`${r.name}\`: required row is green but no tsz/tsgo timing pair was recorded (blocks publish)`);
+    }
+    lines.push("");
+  }
+  if (advisoryGaps.length > 0) {
+    lines.push(`### Canary perf-timed rows missing timing (advisory, ${advisoryGaps.length})`, "");
+    for (const r of advisoryGaps) {
+      lines.push(`- \`${r.name}\`: green compat but no tsz/tsgo timing pair; charted only when timed, never blocks publish`);
     }
     lines.push("");
   }
@@ -752,6 +801,8 @@ if (artifactAbsent || parseError) {
         applicationIncomplete: null,
         applicationDuplicates: null,
         greenTimedRowsMissingTimingPairs: null,
+        blockingTimedRowsMissingTimingPairs: null,
+        advisoryTimedRowsMissingTimingPairs: null,
         missing: null,
         red: null,
         yellow: null,
@@ -776,6 +827,8 @@ const {
   applicationIncomplete,
   applicationDuplicates,
   greenTimedRowsMissingTimingPairs,
+  blockingTimedRowsMissingTimingPairs,
+  advisoryTimedRowsMissingTimingPairs,
   successfulProjectTimingPairs,
   missing,
   red,
@@ -802,6 +855,8 @@ if (jsonOutput) {
       applicationIncomplete,
       applicationDuplicates,
       greenTimedRowsMissingTimingPairs,
+      blockingTimedRowsMissingTimingPairs,
+      advisoryTimedRowsMissingTimingPairs,
       successfulProjectTimingPairs,
       missing,
       red,
@@ -881,10 +936,23 @@ if (successfulProjectTimingPairs.length < requiredProjectTimingPairs) {
   process.exit(1);
 }
 
-if (requireGreenProjectTimingPairs && greenTimedRowsMissingTimingPairs.length > 0) {
+if (requireGreenProjectTimingPairs && advisoryTimedRowsMissingTimingPairs.length > 0) {
+  // Canary/advisory perf-timed rows missing a timing pair are surfaced but never
+  // block the publish: the website only charts a perf-timed row once it is both
+  // green and timed, so a missing canary pair simply omits that row from the
+  // chart. A single such gap previously froze the whole benchmark site for half
+  // a day; this keeps the latest.json publish flowing.
   process.stderr.write(
-    `bench-artifact-readiness: ${greenTimedRowsMissingTimingPairs.length} green perf-timed project row(s) ` +
-      `missing tsz/tsgo timing pairs: ${greenTimedRowsMissingTimingPairs.map((r) => r.name).join(", ")}\n`,
+    `::warning::bench-artifact-readiness: ${advisoryTimedRowsMissingTimingPairs.length} canary perf-timed project row(s) ` +
+      `missing tsz/tsgo timing pairs (advisory, not blocking publish): ` +
+      `${advisoryTimedRowsMissingTimingPairs.map((r) => r.name).join(", ")}\n`,
+  );
+}
+
+if (requireGreenProjectTimingPairs && blockingTimedRowsMissingTimingPairs.length > 0) {
+  process.stderr.write(
+    `bench-artifact-readiness: ${blockingTimedRowsMissingTimingPairs.length} required perf-timed project row(s) ` +
+      `missing tsz/tsgo timing pairs: ${blockingTimedRowsMissingTimingPairs.map((r) => r.name).join(", ")}\n`,
   );
   process.exit(1);
 }

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -511,9 +511,14 @@ withTempDir((dir) => {
 console.log("✅ --require-application-compat accepts complete compile-only app rows");
 
 // ---------------------------------------------------------------------------
-// Test: --require-green-project-timing-pairs rejects green perf-timed rows that
-// only have compile compatibility. They would otherwise appear green in the
-// compatibility table while being absent from the vs-tsgo chart.
+// Test: --require-green-project-timing-pairs surfaces green perf-timed rows that
+// only have compile compatibility, but treats them as ADVISORY (non-blocking)
+// because every perf_timed row today is a canary/advisory shard. A green-compat
+// canary whose vs-tsgo perf benchmark errors must not freeze the publish — it is
+// simply omitted from the chart. Regression guard for the half-day benchmark
+// site freeze where one such canary (infisical) hard-blocked ~70% of Bench
+// publishes until it was demoted to perf_timed:false (#15004); this generalizes
+// the rule so any flaky canary timing pair is advisory.
 // ---------------------------------------------------------------------------
 withTempDir((dir) => {
   const file = path.join(dir, "bench.json");
@@ -532,12 +537,19 @@ withTempDir((dir) => {
     "--require-application-compat",
     "--require-green-project-timing-pairs",
   ]);
-  assert.equal(result.status, 1, "green compile-only perf-timed rows should fail the chart timing gate");
+  assert.equal(
+    result.status,
+    0,
+    `canary perf-timed rows missing a chart timing pair must not block publish:\n${result.stderr}`,
+  );
   const parsed = JSON.parse(result.stdout.trim());
   assert.equal(parsed.require_green_project_timing_pairs, true);
-  // Only perf_timed application rows are required to have a chart; non-perf-timed
-  // canary apps (whose perf benchmark errors) are tracked for compat only.
+  // The full advisory set still surfaces the missing canary charts...
   assert.equal(parsed.green_project_timing_pair_gaps, PERF_TIMED_APPLICATION_ROWS.length);
+  assert.equal(parsed.advisory_project_timing_pair_gaps, PERF_TIMED_APPLICATION_ROWS.length);
+  // ...but none of them is publish-blocking (no required row opts into perf timing).
+  assert.equal(parsed.blocking_project_timing_pair_gaps, 0);
+  assert.deepEqual(parsed.blocking_project_timing_pair_gap_rows, []);
   const gapRowNames = parsed.green_project_timing_pair_gap_rows.map((r) => r.name);
   for (const name of NON_PERF_TIMED_APPLICATION_ROWS) {
     assert.ok(
@@ -545,10 +557,20 @@ withTempDir((dir) => {
       `non-perf-timed canary app ${name} must not be flagged as a missing timing-pair gap`,
     );
   }
-  assert.match(result.stderr, /green perf-timed project row\(s\) missing tsz\/tsgo timing pairs/);
-  assert.match(result.stderr, new RegExp(PERF_TIMED_APPLICATION_ROWS[0]));
+  for (const row of parsed.green_project_timing_pair_gap_rows) {
+    assert.equal(row.blocking, false, `canary timing gap ${row.name} must be marked non-blocking`);
+  }
+  // Advisory warning is surfaced, but not as a publish-blocking failure line.
+  assert.match(
+    result.stderr,
+    /canary perf-timed project row\(s\) missing tsz\/tsgo timing pairs \(advisory/,
+  );
+  assert.doesNotMatch(
+    result.stderr,
+    /required perf-timed project row\(s\) missing tsz\/tsgo timing pairs/,
+  );
 });
-console.log("✅ --require-green-project-timing-pairs rejects green perf-timed app rows without charts");
+console.log("✅ --require-green-project-timing-pairs treats canary perf-timed gaps as advisory, not blocking");
 
 // ---------------------------------------------------------------------------
 // Test: --require-green-project-timing-pairs accepts green perf-timed rows once

--- a/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
+++ b/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
@@ -43,8 +43,8 @@ assert.match(
 
 assert.match(
   workflow,
-  /artifact_ready_for_pages\(\)[\s\S]+application_compatibility\.required == true[\s\S]+application_compatibility\.missing == 0[\s\S]+application_compatibility\.incomplete == 0[\s\S]+application_compatibility\.duplicates == 0[\s\S]+green_project_timing_pair_gaps == 0[\s\S]+successful_project_timing_pairs >= \.required_project_timing_pairs/,
-  "Pages deploy should require benchmark readiness JSON with complete application compatibility and green project timing pairs before using merged artifacts",
+  /artifact_ready_for_pages\(\)[\s\S]+application_compatibility\.required == true[\s\S]+application_compatibility\.missing == 0[\s\S]+application_compatibility\.incomplete == 0[\s\S]+application_compatibility\.duplicates == 0[\s\S]+blocking_project_timing_pair_gaps == 0[\s\S]+successful_project_timing_pairs >= \.required_project_timing_pairs/,
+  "Pages deploy should require benchmark readiness JSON with complete application compatibility and no blocking (required) project timing-pair gaps before using merged artifacts",
 );
 
 assert.match(

--- a/scripts/bench/test-merge-results.mjs
+++ b/scripts/bench/test-merge-results.mjs
@@ -1201,3 +1201,42 @@ withTempDir((dir) => {
   assert.ok(!row.status, "a perf-timed canary must not be stamped 'not timed' (would drop it off the chart)");
   assert.equal(row.compatibility.state, "green");
 });
+
+// The merged artifact's `generated_at` must be a FRESH wall-clock stamp at merge
+// time, never inherited from a shard payload. The publish path's monotonic
+// latest.json guard refuses to overwrite latest.json when the incoming
+// generated_at is <= the published one; if the merge inherited a frozen/stale
+// shard timestamp, every fresh run would look "older-or-equal" and the public
+// site would stop advancing. Pin that a stale shard generated_at does not leak
+// into the merged metadata.
+withTempDir((dir) => {
+  const staleGeneratedAt = "2020-01-01T00:00:00.000Z";
+  const inputs = REQUIRED_PROJECT_ROWS.map((name, index) =>
+    writeInput(dir, `bench-results-${index}.json`, [projectRow(name)], {
+      generated_at: staleGeneratedAt,
+      source_commit: "abcdef1234567890abcd",
+    }),
+  );
+  const before = Date.now();
+  const result = runMergeInputs(dir, inputs);
+  const after = Date.now();
+  assert.equal(result.status, 0, result.stderr);
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.notEqual(
+    merged.generated_at,
+    staleGeneratedAt,
+    "merged generated_at must not inherit a shard's frozen timestamp",
+  );
+  const mergedMs = Date.parse(merged.generated_at);
+  assert.ok(Number.isFinite(mergedMs), "merged generated_at must be a valid ISO 8601 timestamp");
+  // Wall-clock stamp at merge time: within the [before, after] window (allowing
+  // a small clock skew). Critically it is strictly newer than the stale shards.
+  assert.ok(
+    mergedMs >= before - 1000 && mergedMs <= after + 1000,
+    `merged generated_at (${merged.generated_at}) should reflect merge time, not a stale/inherited value`,
+  );
+  assert.ok(
+    mergedMs > Date.parse(staleGeneratedAt),
+    "merged generated_at must advance past stale shard timestamps so the monotonic publish guard can publish",
+  );
+});


### PR DESCRIPTION
Goal: hold

## Problem

`https://tsz.dev/benchmark-data/latest.json` froze at `generated_at=2026-06-27T19:03:16.801Z` (run `28295318779`, commit `0887beee`) and stopped advancing for ~46 commits.

### Root cause (verified)

Every perf-cadence (`30 */3 * * *`) `Bench` run after `28295318779` **failed at `bench-publish`**, not at the monotonic guard. The failing step is the readiness gate:

```
bench-artifact-readiness: 1 green perf-timed project row(s) missing tsz/tsgo timing pairs: infisical-project
##[error]Process completed with exit code 1.
Benchmark artifact readiness check did not pass; refusing to publish it as latest.
```

`check-artifact-readiness.mjs --require-green-project-timing-pairs` iterated **all** `perf_timed` project rows (today: 56 rows, every one `benchmark_set: "canary"`, **zero** `required`) and hard-blocked the whole publish when **any** green-compat canary row produced no tsz/tsgo timing pair. One green canary application row (`infisical`) whose vs-tsgo perf benchmark errors was enough to freeze the entire public site. The same `green_project_timing_pair_gaps == 0` condition gates the gh-pages deploy, so the website redeploy was blocked too.

The 06-28 runs that reported `success` (`28316408243` `0 5` schedule, `28321205720` `workflow_dispatch publish_latest_pgo`) are **release-only lanes** that skip the benchmark matrix by design (`bench`, `pgo-compile-canaries`, `bench-publish` all `skipped`), so they never refresh `latest.json`. There is **no `generated_at` freeze**: `merge-results.mjs` always stamps `new Date().toISOString()` at merge time (confirmed; run `28321205720` produced no `bench-results-merged` artifact at all because `bench-publish` was skipped).

`#15004` patched the single `infisical` row (`perf_timed: false`). This PR fixes the structural fragility (55 remaining canary perf-timed rows + the gh-pages-side gate).

## Structural rule

When a green-compat project row that opted into vs-tsgo perf timing produces no tsz/tsgo timing pair, the public publish and gh-pages deploy are **blocked only when the row is in the required publish completeness set**. Every `perf_timed` row today is a canary/advisory shard intentionally outside that gate, so a missing canary timing pair is advisory (reported + `::warning::`) and never freezes `latest.json`. A future required perf-timed row still hard-blocks. The website already charts a perf-timed row only once it is both green and timed, so an advisory canary gap simply omits that row from the chart — no integrity loss.

Owner layer: bench-delivery readiness gate (`scripts/bench/check-artifact-readiness.mjs`) and the gh-pages deploy gate (`.github/workflows/gh-pages.yml`). No compiler/solver/emit behavior changes.

## Changes

- `check-artifact-readiness.mjs`: split green-perf-timed-missing-timing into a blocking (required) set and an advisory (canary) set; only the blocking set exits 1. New JSON: `blocking_project_timing_pair_gaps`, `blocking_project_timing_pair_gap_rows`, `advisory_project_timing_pair_gaps`, and a per-row `blocking` flag. `green_project_timing_pair_gaps` keeps its full advisory+blocking count for visibility.
- `gh-pages.yml`: deploy gate reads `blocking_project_timing_pair_gaps == 0` (both publish paths).
- Tests: flip the readiness test so canary perf-timed gaps are advisory (status 0, not 1); update the gh-pages gate test; add a `merge-results` regression pinning that the merged `generated_at` is a fresh merge-time stamp, never inherited from a stale shard (the value the monotonic publish guard relies on).

## Adjacent matrix

- canary perf-timed row, green compat, no timing pair -> advisory, exit 0 (flipped).
- canary perf-timed row, green compat, timed -> not a gap, exit 0 (unchanged).
- non-perf-timed canary app row, errored perf -> not flagged (unchanged, #15004 regression kept).
- required perf-timed row missing timing -> still exit 1 (future-proof blocking branch).
- merge with stale shard `generated_at` -> merged `generated_at` is fresh wall-clock (new guard).

## Verification

Node-only (no cargo build):

- `node scripts/bench/test-check-artifact-readiness.mjs` (flipped canary-advisory case + blocking/advisory/JSON-shape assertions)
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs` (gate now keys on `blocking_project_timing_pair_gaps`)
- `node scripts/bench/test-merge-results.mjs` (new `generated_at` freshness regression)
- `node scripts/bench/test-benchmark-artifact-selection.mjs`, `node scripts/bench/test-bench-readiness-banner.mjs`, `node scripts/bench/test-ci-health-benchmark-readiness.mjs`, `node scripts/bench/test-project-winner-regression-report.mjs`

All pass.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high