### PR TITLE
refactor(solver): gate conditional branch verdict cache on typed verdict (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -765,6 +765,15 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.guard.is_exceeded() || self.silent_depth_bailed || self.deep_recursion_seen
     }
 
+    /// Whether the current top-level request has already recorded a typed
+    /// `Termination::Incomplete` verdict. Cache writers that publish outside
+    /// this evaluator must treat such results as partial even when the legacy
+    /// recursion-limit backstop has not fired (for example query-budget bails).
+    #[inline]
+    pub(crate) const fn has_incomplete_request_verdict(&self) -> bool {
+        self.request_termination_kind.is_some()
+    }
+
     /// Mark the guard as exceeded, causing subsequent evaluations to bail out.
     ///
     /// Used when an external condition (e.g. mapped key count or distribution
@@ -868,6 +877,18 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     #[cfg(test)]
     pub(crate) const fn simulate_unrelated_recursion_bail_for_test(&mut self) {
         self.mark_deep_recursion_seen();
+    }
+
+    /// Test hook: simulate a request that has already produced a typed
+    /// incomplete verdict without also setting the legacy recursion-limit flags.
+    /// This lets cache-boundary tests prove they consult the typed channel
+    /// directly rather than passing only because `recursion_limit_hit` is true.
+    #[cfg(test)]
+    pub(crate) const fn simulate_incomplete_request_verdict_for_test(
+        &mut self,
+        kind: TerminationKind,
+    ) {
+        self.request_termination_kind = Some(kind);
     }
 
     /// Global thread-local depth counter for cross-evaluator stack overflow

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -690,12 +690,15 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             //    this arm, so no registration-window artifact is published;
             //  - not budget-bounded — neither the depth bail nor a limit-tripped
             //    structural walk produced it;
-            //  - the enclosing evaluation window saw no recursion limit and no
-            //    unresolved application body (`recursion_limit_hit` /
-            //    `unresolved_def_seen`), and neither operand is tainted — the
-            //    same whole-run gates `closed_eval` uses before persisting.
+            //  - the enclosing evaluation request saw no typed incomplete
+            //    verdict, legacy recursion limit, or unresolved application
+            //    body (`has_incomplete_request_verdict` /
+            //    `recursion_limit_hit` / `unresolved_def_seen`), and neither
+            //    operand is tainted — the same whole-run gates `closed_eval`
+            //    uses before persisting.
             if conditional_branch_verdict_cache_enabled()
                 && !verdict_is_budget_bounded
+                && !self.has_incomplete_request_verdict()
                 && !self.recursion_limit_hit()
                 && !self.unresolved_def_seen()
                 && !self.is_tainted(check_type)

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/tests.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::caches::db::TypeApplicationEvalCache;
+use crate::caches::query_cache::QueryCache;
+use crate::evaluation::result::TerminationKind;
 use crate::intern::TypeInterner;
 use crate::types::TypeId;
 
@@ -262,5 +265,32 @@ fn opaque_application_check_type_defers_instead_of_taking_true_branch() {
         ),
         "opaque-application check type must keep the conditional deferred, got {:?}",
         interner.lookup(result)
+    );
+}
+
+#[test]
+fn incomplete_request_verdict_blocks_conditional_branch_persistent_write() {
+    let interner = TypeInterner::new();
+    let cache = QueryCache::new(&interner);
+
+    let mut complete = TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&cache);
+    assert_eq!(
+        complete.conditional_subtype_relation(TypeId::STRING, TypeId::UNKNOWN),
+        BranchRelation::Holds
+    );
+    assert_eq!(
+        cache.lookup_conditional_branch_verdict(TypeId::STRING, TypeId::UNKNOWN, false),
+        Some(true)
+    );
+
+    let mut incomplete = TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&cache);
+    incomplete.simulate_incomplete_request_verdict_for_test(TerminationKind::QueryOpBudget);
+    assert_eq!(
+        incomplete.conditional_subtype_relation(TypeId::NUMBER, TypeId::UNKNOWN),
+        BranchRelation::Holds
+    );
+    assert_eq!(
+        cache.lookup_conditional_branch_verdict(TypeId::NUMBER, TypeId::UNKNOWN, false),
+        None
     );
 }


### PR DESCRIPTION
Goal: green

## Summary
- Adds `TypeEvaluator::has_incomplete_request_verdict` so cache writers can see #14346 typed incomplete request state without inspecting private fields.
- Gates the conditional-branch persistent verdict cache on that typed channel alongside legacy recursion, unresolved-def, and taint gates.
- Adds a focused solver test proving complete branch probes publish while typed-incomplete probes return the branch relation without publishing.

## Structural Rule
When a conditional branch subtype probe is definitive but its owning evaluation request has recorded `Termination::Incomplete`, `tsc` has not produced a reusable complete semantic answer; tsz owns that through the solver evaluation cache boundary and must not publish the verdict into the cross-evaluator conditional-branch cache.

## Adjacent Matrix
- Complete request: persistent conditional branch verdict is inserted.
- Typed-incomplete request without `recursion_limit_hit`: relation result is returned, but no persistent verdict is inserted.
- Existing fallback gates remain: budget-bounded relation, unresolved defs, recursion-limit backstop, tainted operands.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-solver incomplete_request_verdict_blocks_conditional_branch_persistent_write`
- `cargo nextest run -p tsz-solver evaluation::evaluate_rules::conditional::tests`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high