### PR TITLE
fix(solver): lower mapped `as string`/`as number` remap to an index signature (#14791)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2137,6 +2137,9 @@ path = "tests/same_generic_application_assign_outcome_tests.rs"
 [[test]]
 name = "import_meta_module_support_diagnostics_tests"
 path = "tests/import_meta_module_support_diagnostics_tests.rs"
+[[test]]
+name = "mapped_as_primitive_index_tests"
+path = "tests/mapped_as_primitive_index_tests.rs"
 
 [lints]
 workspace = true

--- a/crates/tsz-checker/tests/mapped_as_primitive_index_tests.rs
+++ b/crates/tsz-checker/tests/mapped_as_primitive_index_tests.rs
@@ -1,0 +1,183 @@
+//! Regression tests for #14791: a mapped type whose key-remapping `as` clause
+//! collapses every literal source key to the *bare* `string`/`number` primitive
+//! must lower to a string/number index signature, not to named properties with
+//! a degenerate value type.
+//!
+//! Structural rule: when `{ [K in keyof S as string]: S[K] }` (or `as number`)
+//! produces a bare-primitive remapped key, tsc synthesizes an index signature
+//! `{ [x: string]: V }` whose value `V` unions every contributing source key's
+//! value type. tsz now does the same in the solver mapped-type evaluator, so
+//! object-literal assignment routes through index-signature assignability
+//! (no spurious `TS2322`) and excess-property checking is suppressed
+//! (no spurious `TS2353`).
+//!
+//! Binder names are varied across cases so the fix cannot depend on any
+//! identifier, alias, or property literal.
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn check(source: &str) -> Vec<u32> {
+    check_source_codes(source)
+}
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+/// `as string` over named-key source: object literal with arbitrary keys must
+/// be accepted through the synthesized string index signature.
+#[test]
+fn as_string_remap_synthesizes_string_index_no_false_positive() {
+    let codes = check(
+        r#"
+type ToStringIndex<S> = { [K in keyof S as string]: S[K] };
+type R = ToStringIndex<{ a: number; b: string }>;
+const r: R = { x: 1, y: "hello" };
+export {};
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2322),
+        0,
+        "no TS2322: value assigns through the string index signature: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2353),
+        0,
+        "no TS2353: an index-signature target suppresses excess-property checks: {codes:?}"
+    );
+}
+
+/// `as number` over a renamed binder/source: produces a numeric index signature.
+#[test]
+fn as_number_remap_synthesizes_number_index_no_false_positive() {
+    let codes = check(
+        r#"
+type ToNumIndex<Src> = { [Prop in keyof Src as number]: Src[Prop] };
+type Out = ToNumIndex<{ first: number; second: number }>;
+const out: Out = { 0: 1, 7: 42 };
+export {};
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2322),
+        0,
+        "no TS2322 for numeric index: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2353),
+        0,
+        "no TS2353 for numeric index: {codes:?}"
+    );
+}
+
+/// The synthesized string index value type is the union of source value types,
+/// so a wrongly-typed entry still errors (the fix must not become a blanket
+/// `any` index). `boolean` is not assignable to `number | string`.
+#[test]
+fn as_string_remap_index_value_is_union_and_still_rejects_bad_value() {
+    let codes = check(
+        r#"
+type StrIndex<T> = { [P in keyof T as string]: T[P] };
+type Rec = StrIndex<{ a: number; b: string }>;
+const bad: Rec = { whatever: true };
+export {};
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2322),
+        1,
+        "exactly one TS2322: `true` is not in the index value `number | string`: {codes:?}"
+    );
+}
+
+/// Mixed remap: some keys stay literal (conditionally remapped to themselves),
+/// some collapse to `string`. The literal property keeps precise typing while
+/// the collapsed keys feed the index signature.
+#[test]
+fn mixed_literal_and_primitive_remap() {
+    let codes = check(
+        r#"
+type Mix<S> = { [K in keyof S as K extends "keep" ? K : string]: S[K] };
+type M = Mix<{ keep: number; drop: string }>;
+const m: M = { keep: 5, anything: "x" };
+export {};
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2322),
+        0,
+        "mixed remap assigns cleanly: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2353),
+        0,
+        "mixed remap suppresses excess: {codes:?}"
+    );
+}
+
+/// Conditional `as` that always widens to `string` is still a bare-primitive
+/// remap and must synthesize the string index signature.
+#[test]
+fn conditional_as_widening_to_string() {
+    let codes = check(
+        r#"
+type Widen<Source> = { [Key in keyof Source as Key extends never ? never : string]: Source[Key] };
+type W = Widen<{ alpha: number }>;
+const w: W = { anyName: 1 };
+export {};
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2322),
+        0,
+        "conditional widen assigns: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, 2353),
+        0,
+        "conditional widen no excess: {codes:?}"
+    );
+}
+
+/// `keyof` of the remapped result must include the index key space
+/// (`string | number` for a string index), so it is NOT assignable to `string`.
+/// This guards the opposite-direction unsoundness called out in #14791.
+#[test]
+fn keyof_remapped_string_index_is_not_assignable_to_string() {
+    let codes = check(
+        r#"
+type ToIdx<S> = { [K in keyof S as string]: S[K] };
+type Keys = keyof ToIdx<{ a: number }>;
+declare const k: Keys;
+const s: string = k;
+export {};
+"#,
+    );
+    assert_eq!(
+        count(&codes, 2322),
+        1,
+        "keyof is `string | number`, not assignable to `string`: {codes:?}"
+    );
+}
+
+/// Scoping control: `as symbol` is a non-property-name primitive, NOT a
+/// string/number index. The fix must stay scoped to `string`/`number` and must
+/// not synthesize a permissive string index from a `symbol` remap. If it did,
+/// an arbitrary string-keyed object literal would be wrongly accepted; instead
+/// it must still be rejected (proving the symbol path is untouched).
+#[test]
+fn as_symbol_remap_not_lowered_to_string_index() {
+    let codes = check(
+        r#"
+type ToSym<S> = { [K in keyof S as symbol]: S[K] };
+type Sy = ToSym<{ a: number }>;
+const sy: Sy = { arbitrary: 1 };
+export {};
+"#,
+    );
+    assert!(
+        count(&codes, 2322) + count(&codes, 2353) >= 1,
+        "`as symbol` must NOT synthesize a string index that accepts arbitrary keys: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -607,6 +607,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // cross-product expansion caps. The sticky `union_too_complex` flag then
         // drives TS2590 in the checker.
         let mut cumulative_value_members: usize = 0;
+        // Index-signature values synthesized from literal source keys whose `as`
+        // clause collapses to a *bare primitive* key (`as string` / `as number`).
+        // tsc lowers `{ [K in keyof S as string]: S[K] }` to `{ [x: string]: V }`
+        // where `V` unions each contributing source key's value type, rather than
+        // materializing named properties. Accumulate that union here and promote
+        // it to a string/number index signature after the key loop.
+        let mut string_index_from_remap: Option<TypeId> = None;
+        let mut number_index_from_remap: Option<TypeId> = None;
         // Snapshot the flag so the cascade short-circuit reacts only to
         // complexity that arose *inside* this evaluation (a nested key's
         // sub-evaluation), never to a flag a sibling type left set before this
@@ -633,25 +641,40 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 Ok(None) => continue,
                 Err(()) => return self.interner().mapped(*mapped),
             };
+            // When the `as` clause collapses a literal source key to the *bare*
+            // `string`/`number` primitive (not a literal, not a usable property
+            // name), tsc folds it into a string/number index signature instead of
+            // a named property. Mark which index this key feeds; the value type is
+            // accumulated once `property_type` is computed below. `as symbol` and
+            // other non-property-name primitives stay on the deferral path.
+            let remapped_primitive_index =
+                if remapped == TypeId::STRING || remapped == TypeId::NUMBER {
+                    Some(remapped)
+                } else {
+                    None
+                };
             // Property key(s) from the remapped key. Each `MappedKey` carries the
             // naming key literal (string- vs number-named; see `is_string_named`).
-            let remapped_keys: smallvec::SmallVec<[MappedKey; 1]> = if remapped == key_literal {
-                smallvec::smallvec![mapped_key]
-            } else if let Some(entry) = self.mapped_key_from_literal(remapped) {
-                smallvec::smallvec![entry]
-            } else if let Some(TypeData::Union(list_id)) = self.interner().lookup(remapped) {
-                let members = self.interner().type_list(list_id);
-                let keys: smallvec::SmallVec<[MappedKey; 1]> = members
-                    .iter()
-                    .filter_map(|&m| self.mapped_key_from_literal(m))
-                    .collect();
-                if keys.is_empty() {
+            let remapped_keys: smallvec::SmallVec<[MappedKey; 1]> =
+                if remapped_primitive_index.is_some() {
+                    smallvec::smallvec![]
+                } else if remapped == key_literal {
+                    smallvec::smallvec![mapped_key]
+                } else if let Some(entry) = self.mapped_key_from_literal(remapped) {
+                    smallvec::smallvec![entry]
+                } else if let Some(TypeData::Union(list_id)) = self.interner().lookup(remapped) {
+                    let members = self.interner().type_list(list_id);
+                    let keys: smallvec::SmallVec<[MappedKey; 1]> = members
+                        .iter()
+                        .filter_map(|&m| self.mapped_key_from_literal(m))
+                        .collect();
+                    if keys.is_empty() {
+                        return self.interner().mapped(*mapped);
+                    }
+                    keys
+                } else {
                     return self.interner().mapped(*mapped);
-                }
-                keys
-            } else {
-                return self.interner().mapped(*mapped);
-            };
+                };
 
             // Get modifiers for this specific key (preserves homomorphic behavior)
             // Use memoized source property info for O(1) lookup.
@@ -714,6 +737,30 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 property_type,
                 homomorphic_removes_optional && source_optional,
             );
+
+            // The `as` clause collapsed this key to a bare `string`/`number`
+            // primitive: fold its value into the corresponding index signature
+            // (unioned across every source key that maps to that primitive)
+            // instead of emitting a named property, mirroring tsc's
+            // `resolveMappedTypeMembers` index-info accumulation.
+            if let Some(primitive) = remapped_primitive_index {
+                let slot = if primitive == TypeId::NUMBER {
+                    &mut number_index_from_remap
+                } else {
+                    &mut string_index_from_remap
+                };
+                *slot = Some(match *slot {
+                    Some(existing) => self.interner().union2(existing, property_type),
+                    None => property_type,
+                });
+                cumulative_value_members = cumulative_value_members
+                    .saturating_add(self.count_union_members(property_type));
+                if cumulative_value_members >= TEMPLATE_LITERAL_EXPANSION_LIMIT {
+                    self.interner().mark_union_too_complex();
+                    break;
+                }
+                continue;
+            }
 
             // Naming flags an identity key inherits from its homomorphic source.
             let (src_string_named, src_symbol_named, src_single_quoted) =
@@ -971,6 +1018,61 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             Some(sig)
         } else {
             string_index
+        };
+
+        // Promote literal source keys that the `as` clause collapsed to a bare
+        // `string`/`number` primitive into the matching index signature. The
+        // value is the union accumulated across those keys; modifiers come from
+        // the mapped type itself (`get_mapped_modifiers`), and an optional
+        // modifier widens the value with `undefined`, exactly as for the
+        // template-instantiated index path above. Only fills an index slot the
+        // source did not already provide, so source string/number index
+        // signatures keep priority.
+        let string_index = match (string_index, string_index_from_remap) {
+            (None, Some(value)) => {
+                let (idx_optional, idx_readonly) = self.get_mapped_modifiers(
+                    mapped,
+                    is_identity_homomorphic || is_homomorphic,
+                    source_object,
+                    TypeId::STRING,
+                );
+                let value_type = if idx_optional {
+                    self.interner().union2(value, TypeId::UNDEFINED)
+                } else {
+                    value
+                };
+                string_index_optional = idx_optional;
+                Some(IndexSignature {
+                    key_type: TypeId::STRING,
+                    value_type,
+                    readonly: idx_readonly,
+                    param_name: None,
+                })
+            }
+            (existing, _) => existing,
+        };
+        let number_index = match (number_index, number_index_from_remap) {
+            (None, Some(value)) => {
+                let (idx_optional, idx_readonly) = self.get_mapped_modifiers(
+                    mapped,
+                    is_identity_homomorphic || is_homomorphic,
+                    source_object,
+                    TypeId::NUMBER,
+                );
+                let value_type = if idx_optional {
+                    self.interner().union2(value, TypeId::UNDEFINED)
+                } else {
+                    value
+                };
+                number_index_optional = idx_optional;
+                Some(IndexSignature {
+                    key_type: TypeId::NUMBER,
+                    value_type,
+                    readonly: idx_readonly,
+                    param_name: None,
+                })
+            }
+            (existing, _) => existing,
         };
 
         if string_index.is_some() || number_index.is_some() || symbol_index.is_some() {


### PR DESCRIPTION
Closes #14791.

Goal: green

## Summary
A mapped type whose key-remapping `as` clause collapses a literal source key to
the **bare** `string`/`number` primitive must lower to an index signature, just
like `tsc`: `{ [K in keyof S as string]: S[K] }` becomes `{ [x: string]: V }`
(and `as number` -> `{ [n: number]: V }`), where `V` unions every contributing
source key's value type.

Before this change the per-literal-key remap loop in
`crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs` bailed when the
remapped key was a bare primitive (`else => return self.interner().mapped(...)`),
so the result materialized named keys with a degenerate value type and no index
signature. Any object-literal assignment then produced spurious `TS2322`
("not assignable to type 'undefined'") and `TS2353` (excess property), and
`keyof` of the result was too narrow (the opposite-direction unsoundness: it
was wrongly assignable to `string`).

## Structural rule
When a mapped type's `as` clause evaluates a literal source key to the bare
`string`/`number` primitive (not a literal, not a usable property name, not a
union of literals), `tsc` folds that key into the corresponding string/number
**index signature** whose value is the union of the contributing keys' value
types, instead of emitting a named property. tsz must do the same, in the
solver mapped-type evaluator (`evaluate_mapped_object`), so that
(a) object-literal assignment routes through index-signature assignability,
(b) excess-property checking is suppressed for the index target, and
(c) `keyof` yields `string | number` (string index) / `number` (number index).

## Owner layer
Solver — `evaluation/evaluate_rules/mapped.rs::evaluate_mapped_object`. The
per-key loop now routes a bare-primitive remap into a string/number value
accumulator (unioned across keys); after the loop the accumulated value is
promoted to an `IndexSignature` via the existing modifier helper
(`get_mapped_modifiers`), filling only an index slot the source did not already
provide. Symbol and other non-property-name primitives keep the existing
deferral behavior (no change).

## Adjacent-case matrix
- `as string` over named-key source -> string index signature (no TS2322/TS2353). PASS
- `as number` over named-key source (renamed binders) -> number index. PASS
- Index value is the **union** of source value types and still rejects a
  non-member value (`true` vs `number | string`) -> exactly one TS2322. PASS
- Mixed remap: some keys stay literal, some collapse to `string` -> literal
  property keeps precise typing, collapsed keys feed the index. PASS
- Conditional `as` that widens to `string` -> string index. PASS
- `keyof` of the remapped result includes the index key space, so it is NOT
  assignable to `string` (guards the opposite-direction unsoundness). PASS
- Scoping control: `as symbol` is NOT lowered to a string/number index (the
  symbol path is untouched; arbitrary string keys still rejected). PASS

Binder/alias and source-property names are varied across every test so the fix
cannot depend on any identifier, alias, or property-name literal.

## Verification
- `cargo nextest run -p tsz-checker --test mapped_as_primitive_index_tests`
  -> 7 tests, all pass (new regression suite; the `as string`/`as number`
  cases fail before this change with the reported TS2322/TS2353 and pass after).
- `cargo check -p tsz-solver` -> clean.
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
