### PR TITLE
fix(checker): scope loop-widened-receiver recheck to genuine widening (#14944)

### DIFF
--- a/crates/tsz-checker/src/types/property_access_type/helpers.rs
+++ b/crates/tsz-checker/src/types/property_access_type/helpers.rs
@@ -1103,6 +1103,21 @@ impl<'a> CheckerState<'a> {
                 {
                     let analyzer = self.flow_analyzer_for_property_reads();
                     if analyzer.is_matching_reference(binary.left, access.expression) {
+                        // Only a *widening* self-recursive assignment drops the
+                        // property next iteration. When the narrowed first-pass
+                        // receiver is already a subtype of the assigned-back value
+                        // (`receiver_type <: property_type`), `union2` re-introduces
+                        // only the variable's own declared/flow union, which the
+                        // loop's per-iteration narrowing at this site (e.g. a
+                        // `switch (x._tag)` discriminant guarding a recursive
+                        // `x = x.child`) re-derives every pass — so the property
+                        // never actually goes missing (#14944). The genuine case
+                        // this heuristic targets escapes the receiver's domain
+                        // (`x = x.length` widening `string` with `number`, where
+                        // `string` is not a subtype of `number`) and still fires.
+                        if self.is_subtype_of(receiver_type, property_type) {
+                            return false;
+                        }
                         let loop_receiver_type = self
                             .ctx
                             .types

--- a/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/fp_repro_audit_2026.rs
@@ -437,3 +437,90 @@ fn issue_14216_export_alias_collides_local_class_no_ts2552_ts2749() {
          class constructor. Actual: {diagnostics:#?}"
     );
 }
+
+/// #14944 (TS2339, narrowing/loop): a discriminated-union variable narrowed by
+/// `switch (x._tag)` inside a `while (true)` loop and reassigned within a case to
+/// a value of the full union must keep the per-case narrowing; the loop back-edge
+/// join must not re-introduce the full union into the narrowed case branch.
+#[test]
+fn issue_14944_while_switch_discriminant_loop_backedge_no_ts2339() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type Node = { _tag: 'A'; left: Node } | { _tag: 'B'; value: number };
+function walk(start: Node): number {
+  let cursor = start;
+  while (true) {
+    switch (cursor._tag) {
+      case 'A': cursor = cursor.left; break;
+      case 'B': return cursor.value;
+    }
+  }
+}
+export {};
+"#,
+    );
+    assert!(
+        !has_error(&diagnostics, 2339),
+        "no TS2339 expected — `case 'A'` narrows `cursor` to the `_tag: 'A'` member, \
+         so `cursor.left` is valid; the loop back-edge must not leak the full union \
+         into the narrowed branch. Actual: {diagnostics:#?}"
+    );
+}
+
+/// #14944 (adjacent, varied binders): same defect reached through an interface
+/// union alias (`Tree = A | B`) whose recursive `left` field is the self-alias.
+/// Renaming the binders (`Tree`/`walk`/`cursor`) keeps the structural shape and
+/// guards against a name-scoped fix.
+#[test]
+fn issue_14944_interface_union_alias_recursive_field_no_ts2339() {
+    let d = compile_and_get_diagnostics(
+        r#"
+interface Leaf { _tag: 'A'; left: Tree }
+interface Done { _tag: 'B'; value: number }
+type Tree = Leaf | Done;
+function descend(root: Tree): number {
+  let node = root;
+  while (true) {
+    switch (node._tag) {
+      case 'A': node = node.left; break;
+      case 'B': return node.value;
+    }
+  }
+}
+export {};
+"#,
+    );
+    assert!(
+        !has_error(&d, 2339),
+        "no TS2339 expected — `case 'A'` narrows `node` to the recursive `_tag: 'A'` \
+         member each iteration; the loop-widened-receiver recheck must not fire when \
+         the narrowed receiver is already a subtype of `node.left`. Actual: {d:#?}"
+    );
+}
+
+/// #14944 (negative control): a genuine self-recursive *widening* assignment
+/// (`x = x.length` widens `string` with `number`) must still report TS2339 the
+/// next iteration, because `.length` is missing on the `number` arm and the
+/// first-pass receiver (`string`) is NOT a subtype of the assigned value
+/// (`number`). This pins that the fix narrows the heuristic rather than disabling
+/// it.
+#[test]
+fn issue_14944_genuine_widening_self_assignment_still_errors() {
+    let d = compile_and_get_diagnostics(
+        r#"
+function f(x: string | number) {
+  if (typeof x === "number") return;
+  while (true) {
+    x.length;
+    x = x.length;
+  }
+}
+export {};
+"#,
+    );
+    assert!(
+        has_error(&d, 2339),
+        "TS2339 expected — `x = x.length` widens `x` to `string | number`, and `.length` \
+         is missing on the `number` arm. Actual: {d:#?}"
+    );
+}


### PR DESCRIPTION
Closes #14944.

Goal: green

## Summary
The io-ts benchmark row emitted a false-positive TS2339 that `tsc 5.9.3` does
not, on a discriminated-union container walked in a `while (true)` + `switch`
loop:

```ts
type T = { _tag: 'A'; left: T } | { _tag: 'B'; value: number };
function f(e: T) {
  let focus = e;
  while (true) {
    switch (focus._tag) {
      case 'A': focus = focus.left; break;   // tsz: false TS2339 on `focus.left`
      case 'B': return focus.value;
    }
  }
}
```

## Root cause
Not the flow-graph loop join (it correctly converges to `T`). The defect is in
`report_loop_widened_receiver_property_error`
(`crates/tsz-checker/src/types/property_access_type/helpers.rs`). For a
self-recursive loop assignment `x = x.prop`, this heuristic rechecks the
property against `union2(receiver_type, property_type)` to catch a *widening*
self-assignment that drops the property next iteration (its target case is
`x = x.length`, which widens `string` to `string | number`).

For `focus = focus.left`, the case-narrowed receiver is `{_tag:'A';left:T}` and
the assigned value `focus.left` has type `T` (the recursive alias). Because the
narrowed receiver is a *subtype* of `T`, `union2` collapses to the un-narrowed
declared union `T`, whose `_tag:'B'` arm has no `left` — so the recheck fires.
tsc keeps the per-iteration switch narrowing and reports nothing.

## Structural rule
When a self-recursive loop assignment `x = x.prop` has a first-pass receiver
that is already a (resolver-aware, strict) subtype of the assigned-back value's
type (`receiver_type <: property_type`), tsc does NOT widen the receiver beyond
that value: the per-iteration narrowing at the access site (here the
`switch (x._tag)` discriminant) re-derives the narrowed receiver every pass, so
the property never goes missing. tsz must match, via the checker
property-access layer — skip the loop-widened-receiver recheck in that case.
A genuine widening (`x = x.length`, where `string` is not a subtype of
`number`) is unaffected and still reports.

## Fix
One guard in the existing heuristic: `if self.is_subtype_of(receiver_type,
property_type) { return false; }` before constructing/checking the widened
union. `is_subtype_of` is the resolver-aware strict-subtype relation (no
`any`-coercion, resolves `Lazy(DefId)` alias members), so the recursive named
union `T` is seen through. No name/file/printer-string predicates; no
single-test suppression.

## Adjacent-case matrix
| Case | Shape | Expected | Result |
| --- | --- | --- | --- |
| Original repro | `type` union, `cursor = cursor.left` in `while`+`switch` | no TS2339 | fixed |
| Renamed binders / interface alias | `interface Leaf/Done; type Tree`, `descend`/`node` | no TS2339 | fixed |
| No loop | same `switch`, no `while` | no TS2339 | already clean (control) |
| Reassign to a foreign full-union param (`cursor = other`) | recursive alias | no TS2339 | clean |
| Genuine widening (`x = x.length`) | `string` widened with `number` | TS2339 still fires | preserved (negative control) |

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo nextest run -p tsz-checker --test conformance_issues_types -E 'test(14944)'`
  - `issue_14944_while_switch_discriminant_loop_backedge_no_ts2339` — flips (failed before, passes after)
  - `issue_14944_interface_union_alias_recursive_field_no_ts2339` — passes (varied binders)
  - `issue_14944_genuine_widening_self_assignment_still_errors` — passes (heuristic still fires)
- `cargo nextest run -p tsz-checker --test conformance_issues_types` — 446 pass, 1 pre-existing failure (`nested_generic_indexed_access_missing_literal_key_still_emits_ts2536`, fails on clean `origin/main` too; unrelated).
- `cargo nextest run -p tsz-checker -E 'test(narrow) or test(loop) or test(property_access) or test(discriminant) or test(while)'` — 1062 pass, 3 failures all pre-existing on clean `origin/main` (`type_literal_split_accessor_narrower_setter_rejected`, `direct_reassign_maybe_after_join_keeps_ts18048`, `mapped_enum_discriminant_application_exposes_member_property`).
