### PR TITLE
refactor(solver): gate judge eval memo on typed verdict (#14346)

### DIFF
--- a/crates/tsz-solver/src/relations/judge.rs
+++ b/crates/tsz-solver/src/relations/judge.rs
@@ -50,6 +50,7 @@
 
 use crate::construction::TypeDatabase;
 use crate::evaluation::evaluate::TypeEvaluator;
+use crate::evaluation::request::EvaluationRequest;
 use crate::objects::index_signatures::IndexKind;
 use crate::relations::subtype::{SubtypeChecker, TypeEnvironment};
 use crate::types::{
@@ -290,6 +291,13 @@ impl<'a> DefaultJudge<'a> {
         }
     }
 
+    fn record_evaluation_result(&self, input: TypeId, result: TypeId, stable: bool) -> TypeId {
+        if stable {
+            self.eval_cache.borrow_mut().insert(input, result);
+        }
+        result
+    }
+
     /// Get the underlying database.
     pub fn db(&self) -> &'a dyn TypeDatabase {
         self.db
@@ -344,12 +352,10 @@ impl<'a> DefaultJudge<'a> {
 
         // Create evaluator and evaluate
         let mut evaluator = TypeEvaluator::with_resolver(self.db, self.env);
-        let result = evaluator.evaluate(type_id);
+        let request = EvaluationRequest::new(type_id);
+        let (result, stable) = evaluator.evaluate_request_memo_result(request);
 
-        // Cache the result
-        self.eval_cache.borrow_mut().insert(type_id, result);
-
-        result
+        self.record_evaluation_result(type_id, result, stable)
     }
 
     /// Instantiate a generic type with type arguments.

--- a/crates/tsz-solver/tests/judge_tests.rs
+++ b/crates/tsz-solver/tests/judge_tests.rs
@@ -262,6 +262,49 @@ fn test_caching() {
     assert_eq!(judge.cache_statistics().subtype_entries, 1);
 }
 
+#[test]
+fn test_evaluate_caches_stable_result() {
+    let setup = JudgeSetup::new();
+    let interner = &setup.interner;
+    let judge = setup.judge();
+
+    let no_infer_number = interner.no_infer(TypeId::NUMBER);
+
+    assert_eq!(judge.cache_statistics().eval_entries, 0);
+    assert_eq!(judge.evaluate(no_infer_number), TypeId::NUMBER);
+
+    let populated = judge.cache_statistics();
+    assert_eq!(populated.eval_entries, 1);
+
+    assert_eq!(judge.evaluate(no_infer_number), TypeId::NUMBER);
+    assert_eq!(
+        judge.cache_statistics().eval_entries,
+        populated.eval_entries
+    );
+}
+
+#[test]
+fn test_non_stable_evaluation_result_is_not_cached() {
+    let setup = JudgeSetup::new();
+    let interner = &setup.interner;
+    let judge = setup.judge();
+
+    let no_infer_string = interner.no_infer(TypeId::STRING);
+
+    assert_eq!(
+        judge.record_evaluation_result(no_infer_string, TypeId::ERROR, false),
+        TypeId::ERROR
+    );
+    assert_eq!(judge.cache_statistics().eval_entries, 0);
+
+    assert_eq!(
+        judge.record_evaluation_result(no_infer_string, TypeId::STRING, true),
+        TypeId::STRING
+    );
+    assert_eq!(judge.cache_statistics().eval_entries, 1);
+    assert_eq!(judge.evaluate(no_infer_string), TypeId::STRING);
+}
+
 // =============================================================================
 // Primitive Subtyping Tests
 // =============================================================================


### PR DESCRIPTION
Goal: green

## Summary
- Route `DefaultJudge::evaluate` through `EvaluationRequest` and the typed memo-stability result from `TypeEvaluator`.
- Keep returning the same collapsed `TypeId` while only writing the Judge-local eval memo when the evaluator reports the request as stable.
- Add focused Judge cache tests for stable writes and non-stable write suppression.

## Structural Rule
When a Judge-owned evaluation request records `Termination::Incomplete`, tsz returns the same collapsed partial `TypeId` to the current caller but must not persist that partial as a complete Judge eval-memo result. Owner layer: solver relation/evaluation boundary.

## Adjacent Matrix
- Complete `NoInfer<T>` evaluation still memoizes and repeated reads use the existing Judge eval cache.
- Non-stable evaluation results are returned unchanged and do not populate the Judge eval cache.
- Legacy evaluator options remain unchanged for this slice; this PR only changes memo eligibility.
- No #14344 reference-mint edits, no #14345 `application.rs` opaque-bail/fixpoint edits, and no checker recursion changes.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E "test(test_evaluate_caches_stable_result) or test(test_non_stable_evaluation_result_is_not_cached)"`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E "test(relations::judge::tests::)"`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E "test(strip)"`
- `git diff --check`
- `wc -l crates/tsz-solver/src/relations/judge.rs crates/tsz-solver/tests/judge_tests.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high