### PR TITLE
refactor(solver): expose stable eval cache drain (#14346)

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1540,7 +1540,6 @@ impl QueryDatabase for QueryCache<'_> {
         if !newly_union_too_complex
             && (top_level_clean || crate::limits::limit_result_cache_enabled())
         {
-            let tainted = evaluator.take_tainted();
             let mut cache = self.eval_cache.borrow_mut();
             if top_level_clean {
                 cache.insert(key, result);
@@ -1549,11 +1548,8 @@ impl QueryDatabase for QueryCache<'_> {
                     shared.eval_cache.insert(key, result);
                 }
             }
-            for (intermediate_id, intermediate_result) in evaluator.drain_cache() {
-                if intermediate_id != intermediate_result
-                    && !intermediate_id.is_intrinsic()
-                    && !tainted.contains(&intermediate_id)
-                {
+            for (intermediate_id, intermediate_result) in evaluator.drain_stable_cache() {
+                if intermediate_id != intermediate_result && !intermediate_id.is_intrinsic() {
                     let ikey = request.with_type_id(intermediate_id).cache_key();
                     cache.entry(ikey).or_insert(intermediate_result);
                     if let Some(shared) = self.shared {

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -511,21 +511,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     }
 
     /// Drain the evaluator's internal cache, returning all intermediate results.
-    /// This allows callers to persist intermediate evaluation results
-    /// (e.g., from recursive mapped type expansion) into a longer-lived cache.
-    ///
-    /// Callers persisting these into a cache whose key does not capture the
-    /// ambient stack depth must filter out limit-truncated entries via
-    /// [`take_tainted`](Self::take_tainted).
+    /// This is for callers that inspect or discard entries. Callers persisting
+    /// results into a cache whose key does not capture the ambient stack depth
+    /// should use [`drain_stable_cache`](Self::drain_stable_cache).
     pub fn drain_cache(&mut self) -> impl Iterator<Item = (TypeId, TypeId)> + '_ {
         self.cache.drain()
     }
 
-    /// Take the set of cache entries whose values are limit-truncated
-    /// stack-context artifacts (see the `tainted` field). Pair with
-    /// [`drain_cache`](Self::drain_cache) to persist only stable entries.
-    pub(crate) fn take_tainted(&mut self) -> FxHashSet<TypeId> {
-        std::mem::take(&mut self.tainted)
+    /// Drain only cache entries whose values are stable functions of their
+    /// input `TypeId`.
+    ///
+    /// This filters out entries whose values are limit-truncated stack-context
+    /// artifacts, which must not be persisted into evaluator caches keyed only
+    /// by `TypeId`.
+    pub fn drain_stable_cache(&mut self) -> impl Iterator<Item = (TypeId, TypeId)> + '_ {
+        let tainted = std::mem::take(&mut self.tainted);
+        self.cache
+            .drain()
+            .filter(move |(type_id, _)| !tainted.contains(type_id))
     }
 
     /// Whether `type_id`'s memoized value is a limit-truncated artifact.

--- a/crates/tsz-solver/tests/limit_relation_cache_tests.rs
+++ b/crates/tsz-solver/tests/limit_relation_cache_tests.rs
@@ -390,10 +390,12 @@ fn clean_evaluation_after_unrelated_bail_is_not_tainted() {
         !evaluator.is_tainted(keyof_obj),
         "a clean sibling evaluation must not be marked as a truncated artifact"
     );
-    let tainted = evaluator.take_tainted();
+    let stable_entries = evaluator.drain_stable_cache().collect::<Vec<_>>();
     assert!(
-        tainted.is_empty(),
-        "no node in this run was truncated; tainted set must be empty"
+        stable_entries
+            .iter()
+            .any(|(key, value)| *key == keyof_obj && *value == result),
+        "a clean sibling evaluation must remain available from the stable drain"
     );
 }
 
@@ -484,6 +486,60 @@ fn reading_a_tainted_memo_entry_taints_the_consumer() {
     assert!(
         evaluator.is_tainted(consumer),
         "artifact-dependence must propagate through memo reads"
+    );
+}
+
+#[test]
+fn drain_stable_cache_filters_tainted_entries() {
+    let interner = TypeInterner::new();
+
+    let def = DefId(80);
+    let lazy_m = interner.lazy(def);
+    let mapped_ty = interner.mapped(MappedType {
+        type_param: TypeParamInfo {
+            name: interner.intern_string("S"),
+            constraint: None,
+            default: None,
+            is_const: false,
+            origin: crate::types::TypeParamOrigin::User,
+        },
+        constraint: interner.keyof(lazy_m),
+        name_type: None,
+        template: TypeId::NUMBER,
+        optional_modifier: None,
+        readonly_modifier: None,
+    });
+    let resolver = RecursiveDefResolver {
+        defs: vec![(def, mapped_ty)],
+    };
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &resolver);
+    let _ = evaluator.evaluate(mapped_ty);
+    assert!(
+        evaluator.is_tainted(mapped_ty),
+        "the recursive mapped type cache entry must be tainted"
+    );
+
+    let key = interner.intern_string("stable");
+    let object = interner.object(vec![PropertyInfo::new(key, TypeId::STRING)]);
+    let keyof_object = interner.keyof(object);
+    let stable_result = evaluator.evaluate(keyof_object);
+    assert_ne!(stable_result, keyof_object);
+    assert!(
+        !evaluator.is_tainted(keyof_object),
+        "an unrelated clean evaluation in the same run must stay stable"
+    );
+
+    let stable_entries = evaluator.drain_stable_cache().collect::<Vec<_>>();
+    assert!(
+        !stable_entries.iter().any(|(key, _)| *key == mapped_ty),
+        "stable drain must filter limit-truncated artifacts"
+    );
+    assert!(
+        stable_entries
+            .iter()
+            .any(|(key, value)| *key == keyof_object && *value == stable_result),
+        "stable drain must keep clean intermediates from the same limit-hit run"
     );
 }
 


### PR DESCRIPTION
Goal: hold

## Summary
- Add `TypeEvaluator::drain_stable_cache` so solver-owned taint filtering is available as the persistence boundary for intermediate eval cache entries.
- Route the solver top-level eval-cache intermediate persistence through the stable drain instead of re-exposing raw per-run evaluator entries there.
- Keep checker env-eval cache-entry collection on its existing raw side channel; the merge-queue repro showed dropping those entries changes JSX contextual-typing parity.

## Structural Rule
When a solver evaluator run contains limit-tainted intermediate cache entries, tsz returns the same collapsed top-level `TypeId` and side flags to the current caller, but must not persist tainted intermediates into the depth-agnostic solver eval cache. Owner layer: solver evaluation/cache boundary. Checker env-eval persistence is not changed in this slice because its speed-only replay behavior is a separate checker boundary and filtering it regressed `contextuallyTypedJsxAttribute2.tsx`.

## Adjacent Matrix
- Clean intermediates from a limit-hit run remain persistable in solver eval-cache drains.
- Limit-truncated recursive mapped/cycle artifacts are filtered before solver eval-cache persistence.
- `drain_cache` remains available for inspect/discard and checker env-eval callers whose replay semantics are not owned by this solver-cache slice.
- Rebased on fresh `origin/main` after #15030/#15032; focused conformance repro for `contextuallyTypedJsxAttribute2.tsx` passes on the repaired head.
- No #14344 reference-mint edits, no #14345 `application.rs` opaque/fixpoint edits, and no relation-policy changes.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(clean_evaluation_after_unrelated_bail_is_not_tainted) or test(drain_stable_cache_filters_tainted_entries)'`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "contextuallyTypedJsxAttribute2" --verbose`
- `wc -l crates/tsz-solver/src/evaluation/evaluate.rs crates/tsz-solver/src/caches/query_cache.rs crates/tsz-solver/tests/limit_relation_cache_tests.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
