### PR TITLE
fix(checker): recover cross-file unresolved-alias residue in the guard narrowing path (#14756)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -48,6 +48,21 @@ impl<'a> FlowAnalyzer<'a> {
         guard: &TypeGuard,
         is_true_branch: bool,
     ) -> TypeId {
+        // Recover cross-file `Application(UnresolvedTypeName, args)` residue before
+        // applying any guard (`typeof` / `instanceof` / `in` / predicate) so the
+        // solver can read the union members. This is the central chokepoint for
+        // the "solver-first" guard path, which equality/discriminant narrowing in
+        // `narrow_by_binary_expr` does not reach. The `in`-operator guard in
+        // particular targets the whole object (`'right' in a`); when `a` is a
+        // cross-file discriminated-union element obtained through indexed access
+        // (`as[0]`), its members stay `Application(UnresolvedTypeName, ..)` that
+        // the solver-side `NarrowingContext` resolver (a `TypeEnvironment`) cannot
+        // resolve, so member-presence filtering keeps the whole union and a later
+        // `.right` access surfaces a false `TS2339`/`TS2322`. The `CheckerContext`
+        // resolver walks the merged binder graph to recover the members. Gated
+        // structurally on the residue (cached per `TypeId`), so resolved flow
+        // types are untouched (#14756).
+        let type_id = self.recover_unresolved_application_for_narrowing(type_id);
         flow_query::narrow_with_guard_in_context(narrowing, type_id, guard, is_true_branch)
     }
 
@@ -1258,7 +1273,9 @@ impl<'a> FlowAnalyzer<'a> {
         // resolver walks the merged binder graph and recovers the members, so
         // discriminant filtering then works (benefits any cross-file discriminated
         // union). Gated structurally on the residue, so resolved flow types are
-        // untouched.
+        // untouched. The `in`/`instanceof`/`typeof`/predicate guard forms take the
+        // solver-first guard path and recover at
+        // `narrow_with_guard_via_flow_boundary` instead (#14756).
         let mut type_id = self.recover_unresolved_application_for_narrowing(type_id);
 
         // Optional-chain equality transport:

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -850,6 +850,9 @@ mod cross_file_class_merge_tests;
 #[path = "tests/cross_file_generic_alias_union_implements_tests.rs"]
 mod cross_file_generic_alias_union_implements_tests;
 #[cfg(test)]
+#[path = "tests/cross_file_in_operator_indexed_element_narrowing_tests.rs"]
+mod cross_file_in_operator_indexed_element_narrowing_tests;
+#[cfg(test)]
 #[path = "../tests/cross_file_interface_merge_ts2717_tests.rs"]
 mod cross_file_interface_merge_ts2717_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/cross_file_in_operator_indexed_element_narrowing_tests.rs
+++ b/crates/tsz-checker/src/tests/cross_file_in_operator_indexed_element_narrowing_tests.rs
@@ -1,0 +1,258 @@
+//! `in`-operator narrowing of a cross-file discriminated-union element reached
+//! through an indexed access (`xs[0]`, `m[k]`, `t[1]`).
+//!
+//! When a file checker lowers an imported alias body
+//! (`type Either<E, A> = Left<E> | Right<A>`), the inner `Left`/`Right`
+//! references stay interned as `Application(UnresolvedTypeName(..), args)` until
+//! a later resolver pass. The solver-side `NarrowingContext` resolver is a
+//! `TypeEnvironment` that only resolves names it was explicitly seeded with, so
+//! when those still-unresolved members reach `narrow_by_property_presence` it
+//! cannot read their property tables. `'right' in a` then fails to filter the
+//! union, keeps every member, and a later `a.right` access surfaces a false
+//! `TS2339` (or, in a typed return position, a `TS2322` `'unknown'`-vs-`A`).
+//!
+//! The equality/discriminant path (`a._tag === 'Right'`) already recovers this
+//! residue through the `CheckerContext` resolver (#14992), but the `in` operator
+//! (and the other `typeof`/`instanceof`/predicate guards) take the "solver-first"
+//! guard path, which did not. The fix recovers the residue at the shared guard
+//! application chokepoint (`narrow_with_guard_via_flow_boundary`) so every guard
+//! form reads the resolved members (#14756).
+//!
+//! The cross-file cases vary binder names and cover
+//! `Array`/`ReadonlyArray`/`Record`/tuple index receivers plus a 3-way
+//! discriminant. Same-file negative controls (which do not need cross-file
+//! recovery) assert that the narrowing logic itself is unchanged: a wrong-branch
+//! access and a genuinely-absent property must still report `TS2339`, proving the
+//! `in` check narrows to the correct single member rather than silencing the
+//! union.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::{check_multi_file_with_libs_stamped, load_lib_files};
+use tsz_common::common::ModuleKind;
+
+const PROPERTY_DOES_NOT_EXIST: u32 = 2339;
+const TYPE_NOT_ASSIGNABLE: u32 = 2322;
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file_with_libs_stamped(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &load_lib_files(&["es5.d.ts"]),
+    )
+}
+
+fn narrowing_false_positives(diagnostics: &[Diagnostic]) -> Vec<(u32, String)> {
+    diagnostics
+        .iter()
+        .filter(|d| d.code == PROPERTY_DOES_NOT_EXIST || d.code == TYPE_NOT_ASSIGNABLE)
+        .map(|d| (d.code, d.message_text.to_string()))
+        .collect()
+}
+
+/// Assert the cross-file `in` narrowing produces no false-positive `TS2339`/
+/// `TS2322` (`./either.ts` carries the discriminated union, `./main.ts` the
+/// narrowing site). `msg` describes the receiver shape under test.
+fn assert_in_narrowing_clean(main: &str, msg: &str) {
+    let diags = check(
+        &[("./either.ts", EITHER_SRC), ("./main.ts", main)],
+        "./main.ts",
+    );
+    let errors = narrowing_false_positives(&diags);
+    assert!(errors.is_empty(), "{msg}, got: {errors:?}");
+}
+
+const EITHER_SRC: &str = r#"
+export interface Left<E> { readonly _tag: 'Left'; readonly left: E }
+export interface Right<A> { readonly _tag: 'Right'; readonly right: A }
+export type Either<E, A> = Left<E> | Right<A>
+export interface Both<E, A> { readonly _tag: 'Both'; readonly left: E; readonly right: A }
+export type These<E, A> = Left<E> | Right<A> | Both<E, A>
+"#;
+
+#[test]
+fn in_operator_narrows_array_indexed_cross_file_union() {
+    let main = r#"
+import { type Either } from './either'
+export const f = <X, A>(xs: Array<Either<X, A>>): A | undefined => {
+    const a = xs[0]
+    if ('right' in a) { return a.right }
+    return undefined
+}
+"#;
+    assert_in_narrowing_clean(
+        main,
+        "expected `'right' in a` to narrow the indexed cross-file element to `Right<A>`",
+    );
+}
+
+#[test]
+fn in_operator_narrows_left_branch_indexed() {
+    let main = r#"
+import { type Either } from './either'
+export const lhs = <X, A>(xs: Array<Either<X, A>>): X | undefined => {
+    const a = xs[0]
+    if ('left' in a) { return a.left }
+    return undefined
+}
+"#;
+    assert_in_narrowing_clean(
+        main,
+        "expected the positive `'left' in a` branch to narrow to `Left<X>`",
+    );
+}
+
+#[test]
+fn in_operator_narrows_readonly_array_indexed() {
+    let main = r#"
+import { type Either } from './either'
+export const ro = <X, A>(xs: ReadonlyArray<Either<X, A>>): A | undefined => {
+    const a = xs[0]
+    if ('right' in a) { return a.right }
+    return undefined
+}
+"#;
+    assert_in_narrowing_clean(
+        main,
+        "expected ReadonlyArray indexed `in` narrowing to stay clean",
+    );
+}
+
+#[test]
+fn in_operator_narrows_record_value_indexed() {
+    let main = r#"
+import { type Either } from './either'
+export const rec = <X, A>(m: Record<string, Either<X, A>>, k: string): A | undefined => {
+    const a = m[k]
+    if ('right' in a) { return a.right }
+    return undefined
+}
+"#;
+    assert_in_narrowing_clean(
+        main,
+        "expected Record value indexed `in` narrowing to stay clean",
+    );
+}
+
+#[test]
+fn in_operator_narrows_tuple_indexed() {
+    let main = r#"
+import { type Either } from './either'
+export const tup = <X, A>(t: [Either<X, A>, Either<X, A>]): A | undefined => {
+    const a = t[1]
+    if ('right' in a) { return a.right }
+    return undefined
+}
+"#;
+    assert_in_narrowing_clean(main, "expected tuple indexed `in` narrowing to stay clean");
+}
+
+#[test]
+fn in_operator_narrows_three_way_indexed() {
+    let main = r#"
+import { type These } from './either'
+export const three = <X, A>(xs: Array<These<X, A>>): A | undefined => {
+    const a = xs[0]
+    if ('right' in a) { return a.right }
+    return undefined
+}
+"#;
+    assert_in_narrowing_clean(
+        main,
+        "expected 3-way discriminant indexed `in` narrowing to stay clean",
+    );
+}
+
+#[test]
+fn in_operator_concrete_array_index_narrows() {
+    // No use-site generics: still a cross-file generic alias, so the same residue
+    // path applies (per the issue's concrete-array witness).
+    let main = r#"
+import { type Either } from './either'
+export const f = (xs: Array<Either<string, number>>): number | undefined => {
+    const a = xs[0]
+    if ('right' in a) { return a.right }
+    return undefined
+}
+"#;
+    assert_in_narrowing_clean(
+        main,
+        "expected the concrete `Array<Either<string, number>>` index `in` narrowing to be clean",
+    );
+}
+
+#[test]
+fn renamed_binders_in_operator_indexed_narrowing_stays_clean() {
+    // Same shape with entirely different binder names, so the recovery cannot key
+    // on `Either`/`Left`/`Right`/`_tag`/`right`.
+    let shapes = r#"
+export interface Ok<V> { readonly variant: 'ok'; readonly payload: V }
+export interface Fail<E> { readonly variant: 'fail'; readonly reason: E }
+export type Result<V, E> = Ok<V> | Fail<E>
+"#;
+    let main = r#"
+import { type Result } from './shapes'
+export const f = <V, E>(rs: Array<Result<V, E>>): V | undefined => {
+    const r = rs[0]
+    if ('payload' in r) { return r.payload }
+    return undefined
+}
+"#;
+    let diags = check(&[("./shapes.ts", shapes), ("./main.ts", main)], "./main.ts");
+    let errors = narrowing_false_positives(&diags);
+    assert!(
+        errors.is_empty(),
+        "expected renamed-binder indexed `in` narrowing to stay clean, got: {errors:?}",
+    );
+}
+
+/// Same-file source so no cross-file residue recovery is involved: this exercises
+/// the unchanged member-presence narrowing logic. In the `'l' in a` true branch
+/// the element narrows to `L<X>`, so `.r` (only on `R<A>`) must still report
+/// TS2339 — the fix must not silence genuine mismatches.
+const SAME_FILE_DU: &str = r#"
+interface L<E> { readonly _tag: 'L'; readonly l: E }
+interface R<A> { readonly _tag: 'R'; readonly r: A }
+type Ei<E, A> = L<E> | R<A>
+"#;
+
+#[test]
+fn in_operator_wrong_branch_access_still_reports_ts2339() {
+    let main = format!(
+        "{SAME_FILE_DU}\nexport const f = <X, A>(xs: Array<Ei<X, A>>): A | undefined => {{\n    const a = xs[0]\n    if ('l' in a) {{ return a.r }}\n    return undefined\n}}\n"
+    );
+    let diags = check(&[("./main.ts", &main)], "./main.ts");
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.code == PROPERTY_DOES_NOT_EXIST && d.message_text.contains('r')),
+        "expected TS2339 for `.r` on the narrowed `L<X>` branch, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.to_string()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn in_operator_genuinely_absent_property_still_reports_ts2339() {
+    let main = format!(
+        "{SAME_FILE_DU}\nexport const f = <X, A>(xs: Array<Ei<X, A>>): A | undefined => {{\n    const a = xs[0]\n    if ('r' in a) {{ return a.missing }}\n    return undefined\n}}\n"
+    );
+    let diags = check(&[("./main.ts", &main)], "./main.ts");
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.code == PROPERTY_DOES_NOT_EXIST && d.message_text.contains("missing")),
+        "expected TS2339 for the genuinely-absent `missing` property, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.to_string()))
+            .collect::<Vec<_>>(),
+    );
+}

--- a/crates/tsz-checker/src/tests/cross_file_in_operator_indexed_element_narrowing_tests.rs
+++ b/crates/tsz-checker/src/tests/cross_file_in_operator_indexed_element_narrowing_tests.rs
@@ -51,7 +51,7 @@ fn narrowing_false_positives(diagnostics: &[Diagnostic]) -> Vec<(u32, String)> {
     diagnostics
         .iter()
         .filter(|d| d.code == PROPERTY_DOES_NOT_EXIST || d.code == TYPE_NOT_ASSIGNABLE)
-        .map(|d| (d.code, d.message_text.to_string()))
+        .map(|d| (d.code, d.message_text.clone()))
         .collect()
 }
 
@@ -234,7 +234,7 @@ fn in_operator_wrong_branch_access_still_reports_ts2339() {
         "expected TS2339 for `.r` on the narrowed `L<X>` branch, got: {:?}",
         diags
             .iter()
-            .map(|d| (d.code, d.message_text.to_string()))
+            .map(|d| (d.code, d.message_text.clone()))
             .collect::<Vec<_>>(),
     );
 }
@@ -252,7 +252,7 @@ fn in_operator_genuinely_absent_property_still_reports_ts2339() {
         "expected TS2339 for the genuinely-absent `missing` property, got: {:?}",
         diags
             .iter()
-            .map(|d| (d.code, d.message_text.to_string()))
+            .map(|d| (d.code, d.message_text.clone()))
             .collect::<Vec<_>>(),
     );
 }


### PR DESCRIPTION
Closes #14756 (the residual `in`-operator facet of the cross-file discriminated-union false positive).

Structural rule: when a member-reading narrowing **guard** (`in` / `typeof` / `instanceof` / predicate) observes a flow type that still carries cross-file `Application(UnresolvedTypeName, args)` residue, `tsc` reads the resolved union members; `tsz` must recover that residue through the `CheckerContext` resolver (the merged binder graph) before the solver filters members — owner layer: checker flow-narrowing boundary (`narrow_with_guard_via_flow_boundary`), delegating resolution to the existing `recover_unresolved_application_for_narrowing` helper.

#### Background
An imported `type Either<E, A> = Left<E> | Right<A>` lowers its alias body before the merged binder exists, so the inner `Left`/`Right` refs stay interned as `Application(UnresolvedTypeName, ..)`. The solver-side `NarrowingContext` resolver is a `TypeEnvironment` that only resolves names it was explicitly seeded with, so those members are unreadable. The equality/discriminant path already recovered this in #14992, but `in`/`typeof`/`instanceof`/predicate guards take the separate "solver-first" guard path and never reached that recovery.

Concretely, for a discriminated-union element obtained through an indexed access (`as[0]`, `m[k]`, `t[1]`) of a cross-module generic alias, `'right' in a` member-presence filtering kept the whole union, so a later `a.right` access surfaced a false `TS2339` (or `TS2322` `'unknown'`-vs-`A` in a typed return position). The discriminant form (`a._tag === 'Right'`) was already clean; only the guard forms regressed.

#### Fix
Recover the residue once at the shared guard chokepoint (`narrow_with_guard_via_flow_boundary`), so every guard form reads the resolved members. The change is gated structurally on the residue (`contains_unresolved_application`, cached per `TypeId`) — no name/file-string predicate, and resolved flow types pass through untouched. The equality-path recovery keeps its original position with a cross-reference comment.

#### Adjacent matrix (verified via CLI, `--strict --target es2022 --lib es2022 --moduleResolution bundler`)
- `Array` / `ReadonlyArray` / `Record`-value / tuple indexed `in` narrowing → clean
- 3-way (`Left | Right | Both`) discriminant via indexed `in` → clean
- concrete (`Array<Either<string, number>>`, no use-site generics) → clean
- renamed binders (`Ok`/`Fail`/`Result`/`payload`) → clean (anti-hardcoding)
- negative controls: wrong-branch access and genuinely-absent property still report `TS2339` (narrowing selects a single member, never silences the union)

## Goal
Goal: green

## Verification
- New module `crates/tsz-checker/src/tests/cross_file_in_operator_indexed_element_narrowing_tests.rs` (10 tests) — `cargo test -p tsz-checker --lib cross_file_in_operator_indexed_element_narrowing_tests` → 10 passed.
- Regression: `cargo test -p tsz-checker --lib -- in_narrow flow_guard_boundary cross_file_unresolved_alias` → green (the only subset failures are pre-existing test-isolation cases that also fail on `origin/main` with the same `Got: []` pattern).
- Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01QY9qymQM9orJGYp7pt2rwk)_