### PR TITLE
fix(solver): infer return-only defaulted intersection type param from contextual target (#14750)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -240,6 +240,9 @@ path = "tests/generic_generator_member_substitution_tests.rs"
 name = "array_element_naked_inference_tests"
 path = "tests/array_element_naked_inference_tests.rs"
 [[test]]
+name = "return_only_defaulted_intersection_contextual_inference_tests"
+path = "tests/return_only_defaulted_intersection_contextual_inference_tests.rs"
+[[test]]
 name = "identity_alias_union_arm_inference_tests"
 path = "tests/identity_alias_union_arm_inference_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/return_only_defaulted_intersection_contextual_inference_tests.rs
+++ b/crates/tsz-checker/tests/return_only_defaulted_intersection_contextual_inference_tests.rs
@@ -1,0 +1,154 @@
+//! Regression tests for issue #14750.
+//!
+//! When a generic function has a type parameter that appears *only* in return
+//! position and carries a default equal to its constraint
+//! (`<D extends C = C>(...): R & D`), tsc infers `D` from the contextual
+//! assignment target (`inferToMultipleTypes`, single naked type-variable
+//! conjunct of an intersection target). tsz previously recorded only an upper
+//! bound for `D`, so resolution treated "default + upper-bounds-only" as "no
+//! inference happened" and fell back to the default — yielding a wrong result
+//! type and a false `TS2322`/`TS2741`. The `mobx` canary row hit this across the
+//! whole `createDecoratorAnnotation` surface.
+//!
+//! Binder names (type-parameter, property, and alias spellings) deliberately
+//! vary between cases so the fix cannot be a name- or text-scoped fast path.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+fn assignment_error_count(source: &str) -> usize {
+    check_source_strict_codes(source)
+        .into_iter()
+        // TS2322 (not assignable) / TS2741 (missing property) are the
+        // false-positive families this issue produces.
+        .filter(|code| *code == 2322 || *code == 2741)
+        .count()
+}
+
+#[test]
+fn minimal_object_constraint_inferred_from_variable_annotation() {
+    // Reported minimal repro (with a renamed binder + properties).
+    let source = r#"
+declare function build<Slot extends { marker: string } = { marker: string }>(): { payload: number } & Slot
+interface Target { payload: number; marker: "a"; extra: boolean }
+const value: Target = build()
+"#;
+    assert_eq!(
+        assignment_error_count(source),
+        0,
+        "return-only defaulted `Slot` must be inferred from the contextual `Target`, not its default"
+    );
+}
+
+#[test]
+fn mobx_faithful_decorator_union_constraint() {
+    // mobx `createDecoratorAnnotation` shape: a return-only `Deco` whose default
+    // equals a union constraint, assigned to an intersection target.
+    let source = r#"
+interface MethodCtx<This, Value> { kind_: "method" }
+interface FieldCtx<This, Value> { kind_: "field" }
+type MethodDeco<This = any, Value extends (...p: any[]) => any = any> = (value: Value, context: MethodCtx<This, Value>) => Value | void
+type FieldDeco<This = any, Value extends (...p: any[]) => any = any> = (value: Value, context: FieldCtx<This, Value>) => Value | void
+type AnyDeco = MethodDeco | FieldDeco
+interface Marker { annotationType_: string }
+type PropDeco = (target: object, key: PropertyKey) => void
+declare function makeAnnotation<Deco extends AnyDeco = AnyDeco>(a: Marker): PropDeco & Marker & Deco
+declare const marker: Marker
+const bound: Marker & PropDeco & MethodDeco & FieldDeco = makeAnnotation(marker)
+"#;
+    assert_eq!(
+        assignment_error_count(source),
+        0,
+        "return-only defaulted `Deco` (union constraint) must be inferred from the contextual intersection target"
+    );
+}
+
+#[test]
+fn inferred_from_satisfies_target() {
+    let source = r#"
+declare function assemble<Piece extends { tag: string } = { tag: string }>(): { count: number } & Piece
+const out = assemble() satisfies { count: number; tag: "x"; flag: boolean }
+"#;
+    assert_eq!(
+        assignment_error_count(source),
+        0,
+        "a `satisfies` target must seed the contextual return candidate the same way a variable annotation does"
+    );
+}
+
+#[test]
+fn inferred_from_function_return_context() {
+    let source = r#"
+declare function spawn<Cell extends { id: string } = { id: string }>(): { seq: number } & Cell
+interface Result { seq: number; id: "z"; live: boolean }
+function produce(): Result {
+  return spawn()
+}
+"#;
+    assert_eq!(
+        assignment_error_count(source),
+        0,
+        "a contextual return statement must seed the contextual return candidate"
+    );
+}
+
+#[test]
+fn default_still_applies_without_contextual_type() {
+    // Negative/fallback control: with NO contextual type at the call site, `Slot`
+    // must fall back to its default `{ marker: string }`. Assigning that defaulted
+    // result to a wider target must still report the missing-property error — both
+    // tsc and tsz reject this.
+    let source = r#"
+declare function build<Slot extends { marker: string } = { marker: string }>(): { payload: number } & Slot
+const loose = build()
+const widened: { payload: number; marker: string; extra: boolean } = loose
+"#;
+    assert_eq!(
+        assignment_error_count(source),
+        1,
+        "with no contextual type the default must still apply, leaving `extra` missing"
+    );
+}
+
+#[test]
+fn non_generic_intersection_source_still_rejected() {
+    // Control: writing the source non-generically (no inference at all) keeps the
+    // union-in-intersection rejection that both tsc and tsz produce. The fix lives
+    // entirely on the generic-call inference path, so it must not silence this
+    // genuine mismatch. Plain, structurally distinct object brands avoid the
+    // `any`-bivariance of function decorators so the mismatch is unambiguous.
+    let source = r#"
+interface MethodDeco { __method: true }
+interface FieldDeco { __field: true }
+type AnyDeco = MethodDeco | FieldDeco
+interface Marker { annotationType_: string }
+interface PropDeco { __prop: true }
+declare const src: PropDeco & Marker & AnyDeco
+const bound: Marker & PropDeco & MethodDeco & FieldDeco = src
+"#;
+    assert!(
+        assignment_error_count(source) >= 1,
+        "non-generic union-in-intersection source must remain rejected (parity with tsc)"
+    );
+}
+
+#[test]
+fn plain_object_decorator_brands_generic_path_clean() {
+    // Positive flip mirroring the mobx shape with plain, structurally distinct
+    // object brands (no function/`any` bivariance): the generic return-only
+    // `Deco` must be inferred from the contextual intersection target.
+    let source = r#"
+interface MethodDeco { __method: true }
+interface FieldDeco { __field: true }
+type AnyDeco = MethodDeco | FieldDeco
+interface Marker { annotationType_: string }
+interface PropDeco { __prop: true }
+declare function makeAnnotation<Deco extends AnyDeco = AnyDeco>(a: Marker): PropDeco & Marker & Deco
+declare const marker: Marker
+const bound: Marker & PropDeco & MethodDeco & FieldDeco = makeAnnotation(marker)
+"#;
+    assert_eq!(
+        assignment_error_count(source),
+        0,
+        "the generic return-only `Deco` must be inferred from the contextual target even with plain object brands"
+    );
+}

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -849,6 +849,62 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     );
                 }
 
+                // When the return type is an intersection (`{ ... } & D`) whose
+                // only inference placeholder is a bare, return-only conjunct `D`,
+                // the original-direction `constrain_types` above records only an
+                // upper bound `D <: ctx`. If `D` carries a `D extends C = C`
+                // default, resolution then treats "default + upper-bounds-only" as
+                // "no inference happened" and falls back to the default, dropping
+                // the contextual target (false TS2322/TS2741). tsc instead infers a
+                // single naked type-variable conjunct of an intersection target
+                // from the whole contextual source (`inferToMultipleTypes`,
+                // `typeVariableCount === 1`). Seed the contextual type as a
+                // `ReturnType` candidate (a lower bound) so the default applies
+                // only when no contextual type exists. Restricted to exactly one
+                // return-only naked conjunct with no other placeholder-bearing
+                // conjunct, matching tsc's single-type-variable intersection rule.
+                if let Some(TypeData::Intersection(members_id)) =
+                    self.interner.lookup(return_type_with_placeholders)
+                {
+                    let members = self.interner.type_list(members_id);
+                    let mut naked_return_only_var: Option<InferenceVar> = None;
+                    let mut blocked = false;
+                    for &member in members.iter() {
+                        if let Some(&var) = var_map.get(&member) {
+                            // A bare naked type-variable conjunct. Skip seeding when
+                            // a direct argument already owns it, or when more than
+                            // one naked conjunct exists (ambiguous, not tsc's
+                            // single-type-variable case).
+                            if round1_direct_seed_vars.contains(&var)
+                                || naked_return_only_var.is_some()
+                            {
+                                blocked = true;
+                                break;
+                            }
+                            naked_return_only_var = Some(var);
+                        } else {
+                            placeholder_visited.clear();
+                            if self.type_contains_placeholder(
+                                member,
+                                &var_map,
+                                &mut placeholder_visited,
+                            ) {
+                                // Another conjunct nests a placeholder; structural
+                                // inference owns it, so leave the original direction.
+                                blocked = true;
+                                break;
+                            }
+                        }
+                    }
+                    if !blocked && let Some(var) = naked_return_only_var {
+                        infer_ctx.add_candidate(
+                            var,
+                            ctx_type,
+                            crate::types::InferencePriority::ReturnType,
+                        );
+                    }
+                }
+
                 // When the return type is a union containing a single placeholder
                 // (e.g., `E | null`), the structural constrain_types adds the
                 // contextual type as an upper bound for E. But for contextual return


### PR DESCRIPTION
Closes #14750.

Goal: green

## Summary
A generic signature whose type parameter appears **only** in an intersection
return type with a default equal to its constraint
(`<D extends C = C>(...): R & D`) was resolved to its **default** instead of
being inferred from the **contextual assignment target**. tsz emitted a false
`TS2322`/`TS2741` that `tsc` 5.9.3 does not. This hit the **mobx** canary row
across the whole `createDecoratorAnnotation` decorator-annotation surface.

## Structural rule
When a call's result is contextually typed and a type parameter `D` occurs only
as a single naked conjunct of an **intersection** return type (`{ ... } & D`),
`tsc` infers `D` from the whole contextual source — `inferToMultipleTypes` with
an intersection target and `typeVariableCount === 1`. tsz must do the same,
through the **solver** generic-call inference path (`tsz-solver`
`operations/generic_call/resolve.rs`), seeding the contextual type as a
`ReturnType` candidate **before** the `= constraint` default is applied.

## Root cause
For an intersection return type the contextual-return seeding used the
"original direction" `constrain_types(return, ctx)`, which only records an
**upper bound** `D <: ctx` for the naked conjunct. During resolution
(`resolve/finalize.rs`) a type parameter that has a default and only declared
upper bounds (`has_only_declared_upper_bounds`) is treated as "no inference
happened" and falls back to its default — dropping the contextual target. The
union case already had a candidate-seeding path; the intersection case did not.

## Fix
After the existing return-context constrain, when `return_type_with_placeholders`
is an `Intersection` with exactly one bare, return-only naked type-variable
conjunct (no direct-argument coverage, no other placeholder-bearing conjunct),
add the contextual type as a `ReturnType` candidate (a lower bound) for that
variable. A lower bound makes `has_only_declared_upper_bounds` false, so the
default is used only when no contextual type exists. The change is purely
additive and gated on the intersection shape; it touches no relation logic.

## Adjacent-case matrix
| Case | Before | After | tsc |
| --- | --- | --- | --- |
| Return-only `D` (object constraint) inferred from variable annotation | TS2741 | clean | clean |
| mobx-faithful decorator (`Deco extends MethodDeco \| FieldDeco = ...`) | clean* | clean | clean |
| Return-only `D` inferred from `satisfies` target | clean* | clean | clean |
| Return-only `D` inferred from contextual `return` statement | TS2741 | clean | clean |
| Plain-object decorator brands, generic path | TS2741 | clean | clean |
| **No** contextual type → default applies (fallback) | error | error | error |
| Non-generic union-in-intersection source still rejected | error | error | error |

\* already passed pre-fix via the structural function/`satisfies` path; kept as
robustness coverage. The three `TS2741` rows are the flips that fail before and
pass after.

Binder names (type-parameter, property, and alias spellings) vary between every
test case so the fix cannot be a name- or text-scoped fast path.

## Verification
- `cargo test -p tsz-checker --test return_only_defaulted_intersection_contextual_inference_tests`
  → 7 passed (4 positive flips + default-fallback control + non-generic
  rejection control + plain-object generic flip).
- Flip confirmed: reverting only `resolve.rs` makes the minimal repro,
  contextual-return, and plain-object-generic tests fail; restoring it passes.
- Adjacent suites unchanged: `contextual_return_callback_param_only_inference_tests`,
  `generic_return_fingerprint_tests`, `intersection_infer_last_member_tests`,
  `new_generic_callback_contextual_infer_tests`,
  `return_context_identity_wrapper_literal_tests`,
  `variance_skip_type_param_default_tests` all green. The single failure in
  `nonnull_contextual_type_arg_inference_tests`
  (`contextual_return_can_refine_transparent_wrapper_inference`, a `Readonly<T>`
  mapped-return case) reproduces on `origin/main` without this change and is
  unrelated (not an intersection return type).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
