### PR TITLE
refactor(solver): reset evaluation termination state (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -566,6 +566,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.def_depth.clear();
         self.def_eval_stack.clear();
         self.real_instantiation_depth_count = 0;
+        self.silent_depth_bailed = false;
+        self.deep_recursion_seen = false;
+        self.request_termination_kind = None;
+        self.limit_epoch = 0;
+        self.app_body_limit_epoch = 0;
+        self.unresolved_def_seen = false;
     }
 
     /// Evaluate a normalized request, applying option-sensitive configuration

--- a/crates/tsz-solver/tests/evaluate_tests_parts/iteration_exceeded_incomplete.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/iteration_exceeded_incomplete.rs
@@ -68,3 +68,28 @@ fn every_guard_bail_reports_incomplete_with_its_kind_and_partial() {
         assert!(result.is_identity_for(partial));
     }
 }
+
+#[test]
+fn reset_clears_typed_and_legacy_termination_state() {
+    let interner = TypeInterner::new();
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.simulate_unrelated_recursion_bail_for_test();
+    evaluator.simulate_incomplete_request_verdict_for_test(TerminationKind::QueryOpBudget);
+    evaluator.mark_unresolved_def_seen();
+    evaluator.app_body_limit_epoch = evaluator.limit_epoch;
+
+    assert!(evaluator.recursion_limit_hit());
+    assert!(evaluator.has_incomplete_request_verdict());
+    assert!(evaluator.unresolved_def_seen());
+    assert_ne!(evaluator.limit_epoch, 0);
+    assert_ne!(evaluator.app_body_limit_epoch, 0);
+
+    evaluator.reset();
+
+    assert!(!evaluator.recursion_limit_hit());
+    assert!(!evaluator.has_incomplete_request_verdict());
+    assert!(!evaluator.unresolved_def_seen());
+    assert_eq!(evaluator.limit_epoch, 0);
+    assert_eq!(evaluator.app_body_limit_epoch, 0);
+}


### PR DESCRIPTION
Goal: green

## Summary
- Clear `TypeEvaluator::reset()` termination state: legacy recursion-limit flags, typed request verdict, unresolved-def state, and limit epoch snapshots.
- Add a focused #14346 unit test proving reset drops both typed and legacy termination state before evaluator reuse.

## Structural Rule
When a `TypeEvaluator` is reset for another request, tsz must discard prior guard-truncation state; solver-owned termination bookkeeping is per run, not evaluator-lifetime state. Cache/stability gates after reset should observe only the next run, while existing direct `evaluate_request_result` collapse behavior remains unchanged.

## Adjacent Matrix
- Positive: legacy `recursion_limit_hit()` state, typed incomplete verdict state, unresolved-def state, and epoch snapshots all clear on reset.
- Fallback: no cache eligibility broadening, no application opaque/fixpoint edits, no #14344 reference-mint canonicalization, and no #14345 `application.rs` SCC materialize-once work.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(reset_clears_typed_and_legacy_termination_state) or test(every_guard_bail_reports_incomplete_with_its_kind_and_partial)'`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `wc -l crates/tsz-solver/src/evaluation/evaluate.rs crates/tsz-solver/tests/evaluate_tests_parts/iteration_exceeded_incomplete.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high