### PR TITLE
refactor(solver): name evaluation memo result (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
+++ b/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
@@ -23,6 +23,7 @@
 //! treats a within-instance cycle), which lets the in-flight expansion — the one
 //! holding the real work — converge and breaks the churn.
 
+use crate::evaluation::result::EvaluationMemoResult;
 use crate::types::TypeId;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
@@ -102,10 +103,10 @@ pub(crate) fn reset_query_memo() {
 pub(crate) fn memoized_eval(
     type_id: TypeId,
     no_unchecked_indexed_access: bool,
-    compute: impl FnOnce() -> (TypeId, bool),
+    compute: impl FnOnce() -> EvaluationMemoResult,
 ) -> Option<TypeId> {
     memoized_eval_with_stability(type_id, no_unchecked_indexed_access, compute)
-        .map(|(result, _)| result)
+        .map(EvaluationMemoResult::into_type_id)
 }
 
 /// Like [`memoized_eval`], but also reports whether the result is *stable*:
@@ -118,17 +119,17 @@ pub(crate) fn memoized_eval(
 pub(crate) fn memoized_eval_with_stability(
     type_id: TypeId,
     no_unchecked_indexed_access: bool,
-    compute: impl FnOnce() -> (TypeId, bool),
-) -> Option<(TypeId, bool)> {
+    compute: impl FnOnce() -> EvaluationMemoResult,
+) -> Option<EvaluationMemoResult> {
     if let Some(cached) = query_memo_get(type_id, no_unchecked_indexed_access) {
-        return Some((cached, true));
+        return Some(EvaluationMemoResult::cached(cached));
     }
     let _cross = CrossEvalExpansionGuard::enter(type_id)?;
-    let (result, memoizable) = compute();
-    if memoizable {
-        query_memo_put(type_id, no_unchecked_indexed_access, result);
+    let memo_result = compute();
+    if memo_result.is_stable_for_depth_agnostic_cache() {
+        query_memo_put(type_id, no_unchecked_indexed_access, memo_result.type_id());
     }
-    Some((result, memoizable))
+    Some(memo_result)
 }
 
 /// RAII membership guard for cross-evaluator expansion of a `TypeId`.
@@ -179,15 +180,19 @@ mod tests {
 
     #[test]
     fn non_stable_fresh_result_is_returned_but_not_memoized() {
+        use crate::evaluation::result::EvaluationResult;
+
         reset_query_memo();
         let t = TypeId(8);
 
-        let first = memoized_eval(t, false, || (TypeId(80), false));
+        let first = memoized_eval(t, false, || {
+            EvaluationMemoResult::new(EvaluationResult::complete(TypeId(80)), false)
+        });
 
         assert_eq!(first, Some(TypeId(80)));
         assert_eq!(query_memo_get(t, false), None);
 
-        let second = memoized_eval(t, false, || (TypeId(81), true));
+        let second = memoized_eval(t, false, || EvaluationMemoResult::cached(TypeId(81)));
 
         assert_eq!(second, Some(TypeId(81)));
         assert_eq!(query_memo_get(t, false), Some(TypeId(81)));

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -25,6 +25,7 @@ use crate::diagnostics::display_provenance::{
     FreshObjectLiteralDisplayProvenance, UnionOriginProvenance,
 };
 use crate::evaluation::request::EvaluationRequest;
+use crate::evaluation::result::EvaluationMemoResult;
 use crate::evaluation::result::EvaluationResult;
 use crate::evaluation::result::TerminationKind;
 #[cfg(test)]
@@ -603,12 +604,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     pub(crate) fn evaluate_request_memo_result(
         &mut self,
         request: EvaluationRequest,
-    ) -> (TypeId, bool) {
+    ) -> EvaluationMemoResult {
         let result = self.evaluate_request_result(request);
-        (
-            result.into_type_id(),
-            !result.is_incomplete() && !self.recursion_limit_hit(),
-        )
+        EvaluationMemoResult::for_depth_agnostic_memo(result, self.recursion_limit_hit())
     }
 
     // =========================================================================

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -12,6 +12,7 @@
 //! - `bind_infer`: Bind a type to an infer parameter
 
 use crate::def::DefId;
+use crate::evaluation::result::{EvaluationMemoResult, EvaluationResult};
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
 use crate::types::{
     LiteralValue, ParamInfo, TemplateSpan, TupleElement, TypeApplication, TypeData, TypeId,
@@ -1702,7 +1703,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // in-flight ancestor expansion converges.
         crate::evaluation::cross_eval_guard::memoized_eval(type_id, nuia, || {
             let Some(_guard) = InferMatchExpansionGuard::enter() else {
-                return (type_id, false);
+                return EvaluationMemoResult::new(EvaluationResult::complete(type_id), false);
             };
             let mut evaluator = TypeEvaluator::with_resolver(self.interner(), self.resolver());
             if let Some(query_db) = self.query_db() {

--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -145,9 +145,76 @@ impl EvaluationResult {
     }
 }
 
+/// Evaluation result plus the verdict for depth-agnostic memo publication.
+///
+/// #14346 is moving cache eligibility from loose evaluator flags into typed
+/// result boundaries. A fresh-evaluator memo has two pieces of information:
+/// the request's [`EvaluationResult`] and whether legacy stack-context taint
+/// still makes the collapsed value unsafe to store in a depth-agnostic cache.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct EvaluationMemoResult {
+    result: EvaluationResult,
+    stable_for_depth_agnostic_cache: bool,
+}
+
+impl EvaluationMemoResult {
+    /// Construct a memo result from a typed evaluation result and the legacy
+    /// recursion-limit backstop.
+    pub(crate) const fn for_depth_agnostic_memo(
+        result: EvaluationResult,
+        legacy_recursion_limit_hit: bool,
+    ) -> Self {
+        Self {
+            result,
+            stable_for_depth_agnostic_cache: result.is_complete() && !legacy_recursion_limit_hit,
+        }
+    }
+
+    /// Construct a memo result with an explicit stability verdict.
+    pub(crate) const fn new(
+        result: EvaluationResult,
+        stable_for_depth_agnostic_cache: bool,
+    ) -> Self {
+        Self {
+            result,
+            stable_for_depth_agnostic_cache,
+        }
+    }
+
+    /// Construct a completed memo result read from a cache that stores only
+    /// stable entries.
+    pub(crate) const fn cached(type_id: TypeId) -> Self {
+        Self {
+            result: EvaluationResult::complete(type_id),
+            stable_for_depth_agnostic_cache: true,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn evaluation_result(self) -> EvaluationResult {
+        self.result
+    }
+
+    pub(crate) const fn type_id(self) -> TypeId {
+        self.result.type_id()
+    }
+
+    /// Whether this result can be stored in caches whose key does not capture
+    /// ambient recursion depth/fuel state.
+    pub(crate) const fn is_stable_for_depth_agnostic_cache(self) -> bool {
+        self.stable_for_depth_agnostic_cache
+    }
+
+    /// Collapse to the request's `TypeId` while preserving today's behavior for
+    /// callers that are not yet verdict-aware.
+    pub(crate) const fn into_type_id(self) -> TypeId {
+        self.result.into_type_id()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{EvaluationResult, Termination, TerminationKind};
+    use super::{EvaluationMemoResult, EvaluationResult, Termination, TerminationKind};
     use crate::types::TypeId;
 
     #[test]
@@ -181,6 +248,38 @@ mod tests {
                 kind: TerminationKind::DepthExceeded,
                 partial: TypeId::NUMBER,
             }
+        );
+    }
+
+    #[test]
+    fn memo_result_stability_requires_complete_result_and_clean_legacy_backstop() {
+        let complete = EvaluationResult::complete(TypeId::STRING);
+        let stable = EvaluationMemoResult::for_depth_agnostic_memo(complete, false);
+
+        assert_eq!(stable.evaluation_result(), complete);
+        assert_eq!(stable.type_id(), TypeId::STRING);
+        assert_eq!(stable.into_type_id(), TypeId::STRING);
+        assert!(stable.is_stable_for_depth_agnostic_cache());
+
+        let legacy_tainted = EvaluationMemoResult::for_depth_agnostic_memo(complete, true);
+        assert!(!legacy_tainted.is_stable_for_depth_agnostic_cache());
+
+        let incomplete =
+            EvaluationResult::incomplete(TypeId::NUMBER, TerminationKind::DepthExceeded);
+        let typed_tainted = EvaluationMemoResult::for_depth_agnostic_memo(incomplete, false);
+        assert_eq!(typed_tainted.into_type_id(), TypeId::NUMBER);
+        assert!(!typed_tainted.is_stable_for_depth_agnostic_cache());
+    }
+
+    #[test]
+    fn cached_memo_result_is_stable_and_complete() {
+        let cached = EvaluationMemoResult::cached(TypeId::BOOLEAN);
+
+        assert_eq!(cached.type_id(), TypeId::BOOLEAN);
+        assert!(cached.is_stable_for_depth_agnostic_cache());
+        assert_eq!(
+            cached.evaluation_result().termination(),
+            Termination::Complete
         );
     }
 }

--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -199,6 +199,11 @@ impl EvaluationMemoResult {
         self.result.type_id()
     }
 
+    /// Return the collapsed value and its depth-agnostic cache stability verdict.
+    pub(crate) const fn into_type_id_and_stability(self) -> (TypeId, bool) {
+        (self.into_type_id(), self.stable_for_depth_agnostic_cache)
+    }
+
     /// Whether this result can be stored in caches whose key does not capture
     /// ambient recursion depth/fuel state.
     pub(crate) const fn is_stable_for_depth_agnostic_cache(self) -> bool {

--- a/crates/tsz-solver/src/operations/core/union_signatures.rs
+++ b/crates/tsz-solver/src/operations/core/union_signatures.rs
@@ -216,10 +216,8 @@ impl<C: AssignabilityChecker> CallEvaluator<'_, C> {
                 self.find_matching_signature_for_union(list, signature, false, true)
                     .or_else(|| self.find_matching_signature_for_union(list, signature, true, true))
             };
-            match matched {
-                Some(sig) => append_if_unique(&mut result, sig),
-                None => return None,
-            }
+            let sig = matched?;
+            append_if_unique(&mut result, sig);
         }
         Some(result)
     }

--- a/crates/tsz-solver/src/relations/judge.rs
+++ b/crates/tsz-solver/src/relations/judge.rs
@@ -51,6 +51,7 @@
 use crate::construction::TypeDatabase;
 use crate::evaluation::evaluate::TypeEvaluator;
 use crate::evaluation::request::EvaluationRequest;
+use crate::evaluation::result::EvaluationMemoResult;
 use crate::objects::index_signatures::IndexKind;
 use crate::relations::subtype::{SubtypeChecker, TypeEnvironment};
 use crate::types::{
@@ -291,11 +292,12 @@ impl<'a> DefaultJudge<'a> {
         }
     }
 
-    fn record_evaluation_result(&self, input: TypeId, result: TypeId, stable: bool) -> TypeId {
-        if stable {
-            self.eval_cache.borrow_mut().insert(input, result);
+    fn record_evaluation_result(&self, input: TypeId, result: EvaluationMemoResult) -> TypeId {
+        let type_id = result.into_type_id();
+        if result.is_stable_for_depth_agnostic_cache() {
+            self.eval_cache.borrow_mut().insert(input, type_id);
         }
-        result
+        type_id
     }
 
     /// Get the underlying database.
@@ -353,9 +355,9 @@ impl<'a> DefaultJudge<'a> {
         // Create evaluator and evaluate
         let mut evaluator = TypeEvaluator::with_resolver(self.db, self.env);
         let request = EvaluationRequest::new(type_id);
-        let (result, stable) = evaluator.evaluate_request_memo_result(request);
+        let result = evaluator.evaluate_request_memo_result(request);
 
-        self.record_evaluation_result(type_id, result, stable)
+        self.record_evaluation_result(type_id, result)
     }
 
     /// Instantiate a generic type with type arguments.

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -2174,7 +2174,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // evaluator, re-entering the same `TypeId` without any guard firing. On a
         // cross-instance cycle (`None`) leave the type unevaluated and, crucially,
         // do not record it in `eval_cache` — the in-flight ancestor owns the result.
-        let Some((result, stable)) = cross_eval_guard::memoized_eval_with_stability(
+        let Some(memo_result) = cross_eval_guard::memoized_eval_with_stability(
             type_id,
             self.no_unchecked_indexed_access,
             || {
@@ -2192,6 +2192,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         ) else {
             return (type_id, false);
         };
+        let result = memo_result.into_type_id();
+        let stable = memo_result.is_stable_for_depth_agnostic_cache();
         self.eval_cache.insert(cache_key, (result, stable));
         (result, stable)
     }

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -2180,8 +2180,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             || {
                 let mut evaluator = TypeEvaluator::with_resolver(self.interner, self.resolver);
                 // Pass query_db to share the application evaluation cache across
-                // evaluations, so the same generic type produces the same
-                // ObjectShapeId and structural subtype checks stay stable.
+                // evaluations, keeping structural subtype checks stable.
                 if let Some(db) = self.query_db {
                     evaluator = evaluator.with_query_db(db);
                 }
@@ -2192,9 +2191,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         ) else {
             return (type_id, false);
         };
-        let result = memo_result.into_type_id();
-        let stable = memo_result.is_stable_for_depth_agnostic_cache();
-        self.eval_cache.insert(cache_key, (result, stable));
-        (result, stable)
+        let entry = memo_result.into_type_id_and_stability();
+        self.eval_cache.insert(cache_key, entry);
+        entry
     }
 }

--- a/crates/tsz-solver/tests/judge_tests.rs
+++ b/crates/tsz-solver/tests/judge_tests.rs
@@ -292,13 +292,22 @@ fn test_non_stable_evaluation_result_is_not_cached() {
     let no_infer_string = interner.no_infer(TypeId::STRING);
 
     assert_eq!(
-        judge.record_evaluation_result(no_infer_string, TypeId::ERROR, false),
+        judge.record_evaluation_result(
+            no_infer_string,
+            crate::evaluation::result::EvaluationMemoResult::new(
+                crate::evaluation::result::EvaluationResult::complete(TypeId::ERROR),
+                false,
+            ),
+        ),
         TypeId::ERROR
     );
     assert_eq!(judge.cache_statistics().eval_entries, 0);
 
     assert_eq!(
-        judge.record_evaluation_result(no_infer_string, TypeId::STRING, true),
+        judge.record_evaluation_result(
+            no_infer_string,
+            crate::evaluation::result::EvaluationMemoResult::cached(TypeId::STRING),
+        ),
         TypeId::STRING
     );
     assert_eq!(judge.cache_statistics().eval_entries, 1);


### PR DESCRIPTION
Goal: hold

## Summary
- Add crate-local `EvaluationMemoResult` beside `EvaluationResult` to carry a collapsed evaluation result with its depth-agnostic memo stability verdict.
- Route `TypeEvaluator::evaluate_request_memo_result`, `cross_eval_guard`, infer-pattern fresh evaluation, subtype fresh evaluation, and Judge eval memo writes through the named result.
- Preserve existing behavior: legacy callers still receive the same collapsed `TypeId`, and unstable/incomplete results are returned but not memoized.
- Carry a mechanical CI-profile Clippy repair in union signature matching; the rewrite only expresses the existing `None` propagation with `?`.
- Keep the subtype function-checker size ratchet at its current limit by moving memo-result cache-entry unpacking onto `EvaluationMemoResult`.

## Structural Rule
When a fresh-evaluator request produces a collapsed `TypeId` plus a cache-stability verdict, tsz should carry that verdict as a solver-owned result object. Stable entries may publish to depth-agnostic memo caches; typed-incomplete or legacy-tainted entries return the same partial value to the caller but must not be stored as converged cache results.

Owner layer: solver evaluation/result boundary plus solver fresh-evaluator memo boundaries.

## Adjacent Matrix
- Complete result, no legacy taint: stable and memoizable.
- Complete result, legacy recursion-limit taint: returned to caller, not memoized.
- Typed incomplete result: returns the same collapsed partial, not memoized.
- Memo hit: represented as a complete stable cached memo result.

Fallback: the legacy `recursion_limit_hit` backstop remains part of `EvaluationMemoResult::for_depth_agnostic_memo` until the typed termination channel owns every remaining taint class.

## Non-Overlap
- No #14344 reference-mint canonicalization or identity-index edits.
- No #14345 `application.rs` opaque-bail/fixpoint edits.
- No checker lazy guard or `EvaluationSession` migration changes.
- Based on fresh `origin/main` after #15023; independent of the still-running #15025/#15028 queue work.

## Verification
- `cargo fmt --check`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `git diff --check`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(memo_result_stability_requires_complete_result_and_clean_legacy_backstop) or test(cached_memo_result_is_stable_and_complete) or test(memo_keys_on_no_unchecked_indexed_access) or test(non_stable_fresh_result_is_returned_but_not_memoized) or test(test_evaluate_caches_stable_result) or test(test_non_stable_evaluation_result_is_not_cached)'`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `wc -l crates/tsz-solver/src/evaluation/result.rs crates/tsz-solver/src/evaluation/evaluate.rs crates/tsz-solver/src/evaluation/cross_eval_guard.rs crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs crates/tsz-solver/src/relations/judge.rs crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs crates/tsz-solver/tests/judge_tests.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
