### PR TITLE
hold(bench): make canary application-compat gaps advisory, not publish-blocking

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -100,9 +100,7 @@ jobs:
             fi
             if ! jq -e '
               .application_compatibility.required == true and
-              .application_compatibility.missing == 0 and
-              .application_compatibility.incomplete == 0 and
-              .application_compatibility.duplicates == 0 and
+              .blocking_application_compatibility_gaps == 0 and
               .blocking_project_timing_pair_gaps == 0 and
               .successful_project_timing_pairs >= .required_project_timing_pairs
             ' "${tmpdir}/artifact/bench-results-readiness.json" >/dev/null; then
@@ -256,9 +254,7 @@ jobs:
             fi
             if ! jq -e '
               .application_compatibility.required == true and
-              .application_compatibility.missing == 0 and
-              .application_compatibility.incomplete == 0 and
-              .application_compatibility.duplicates == 0 and
+              .blocking_application_compatibility_gaps == 0 and
               .blocking_project_timing_pair_gaps == 0 and
               .successful_project_timing_pairs >= .required_project_timing_pairs
             ' "${tmpdir}/artifact/bench-results-readiness.json" >/dev/null; then

--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -7,7 +7,8 @@
  *   1 — artifact present, one or more required rows are missing, the
  *       --require-green release gate found non-green required rows, the
  *       --require-clean-metadata gate found artifact metadata warnings,
- *       --require-application-compat found missing/incomplete application rows,
+ *       --require-application-compat found missing/incomplete benchmark_set:"required"
+ *       application rows (canary application gaps are advisory, never blocking),
  *       --require-green-project-timing-pairs found green perf-timed rows
  *       missing tsz/tsgo timing pairs,
  *       or the --require-source-current gate found a stale artifact source commit
@@ -74,6 +75,22 @@ const APPLICATION_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS
 // pair is advisory, while a future required perf-timed row still blocks.
 function isBlockingTimedRow(name) {
   return REQUIRED_MEASURED_ROW_SET.has(name);
+}
+
+// Application compatibility rows are real apps cloned + installed by the
+// optional, best-effort bench-applications shard (their compat lands from that
+// shard or, as a fallback, a matching-CI compat artifact). BOTH sources can
+// legitimately be absent for a given run: a flaky package-manager install, or a
+// workflow_dispatch Bench with no matching main CI push run — the exact failure
+// that froze the public site when infisical's only compat source vanished
+// (#15004 dropped infisical from the perf-timed shard, so it stopped being
+// benched, and that run's matching-CI compat was absent, leaving the row
+// entirely missing). Mirror the perf-timing split (isBlockingTimedRow): a
+// canary application row with missing/incomplete/duplicate compat is advisory
+// (reported, never publish-blocking), while a future benchmark_set:"required"
+// application row still blocks the publish.
+function isBlockingApplicationRow(name) {
+  return PROJECT_ROWS_BY_NAME[name]?.benchmark_set === "required";
 }
 
 const args = process.argv.slice(2);
@@ -382,19 +399,37 @@ function analyzeArtifact(artifact, expectedCommit) {
     (row) => !isBlockingTimedRow(row.name),
   );
 
+  const applicationMissing = applicationRows.filter((r) => r.state === "missing");
+  const applicationIncomplete = applicationRows.filter((r) => (
+    r.state !== "missing" &&
+    r.duplicate_count <= 1 &&
+    r.metadata_complete !== true
+  ));
+  const applicationDuplicates = applicationRows.filter((r) => r.duplicate_count > 1);
+  // Every application-compat gap, tagged with the kind of gap, then split into
+  // publish-blocking (benchmark_set:"required") and advisory (canary) buckets so
+  // a flaky canary app install can never freeze the public benchmark site while
+  // a required application row still gates the publish.
+  const applicationGaps = [
+    ...applicationMissing.map((r) => ({ ...r, gap_kind: "missing" })),
+    ...applicationIncomplete.map((r) => ({ ...r, gap_kind: "incomplete" })),
+    ...applicationDuplicates.map((r) => ({ ...r, gap_kind: "duplicate" })),
+  ];
+  const blockingApplicationGaps = applicationGaps.filter((r) => isBlockingApplicationRow(r.name));
+  const advisoryApplicationGaps = applicationGaps.filter((r) => !isBlockingApplicationRow(r.name));
+
   return {
     measurementProfile: measurementProfileStatus(artifact),
     validationWarnings: analyzeValidationWarnings(artifact),
     sourceFreshness: analyzeSourceFreshness(artifact, expectedCommit),
     rows,
     applicationRows,
-    applicationMissing: applicationRows.filter((r) => r.state === "missing"),
-    applicationIncomplete: applicationRows.filter((r) => (
-      r.state !== "missing" &&
-      r.duplicate_count <= 1 &&
-      r.metadata_complete !== true
-    )),
-    applicationDuplicates: applicationRows.filter((r) => r.duplicate_count > 1),
+    applicationMissing,
+    applicationIncomplete,
+    applicationDuplicates,
+    applicationGaps,
+    blockingApplicationGaps,
+    advisoryApplicationGaps,
     greenTimedRowsMissingTimingPairs,
     blockingTimedRowsMissingTimingPairs,
     advisoryTimedRowsMissingTimingPairs,
@@ -432,6 +467,8 @@ function buildJson({
   applicationMissing,
   applicationIncomplete,
   applicationDuplicates,
+  blockingApplicationGaps,
+  advisoryApplicationGaps,
   greenTimedRowsMissingTimingPairs,
   blockingTimedRowsMissingTimingPairs,
   advisoryTimedRowsMissingTimingPairs,
@@ -498,6 +535,11 @@ function buildJson({
       tsgo_ms: r.tsgo_ms,
     })) ?? [],
     advisory_project_timing_pair_gaps: advisoryTimedRowsMissingTimingPairs?.length ?? 0,
+    // Only benchmark_set:"required" application rows missing/incomplete compat
+    // block the publish; canary application gaps are reported but never freeze
+    // latest.json. gh-pages.yml gates on blocking_application_compatibility_gaps.
+    blocking_application_compatibility_gaps: blockingApplicationGaps?.length ?? 0,
+    advisory_application_compatibility_gaps: advisoryApplicationGaps?.length ?? 0,
     application_compatibility: applicationRows
       ? {
           required: requireApplicationCompat,
@@ -507,9 +549,13 @@ function buildJson({
           missing: applicationMissing?.length ?? 0,
           incomplete: applicationIncomplete?.length ?? 0,
           duplicates: applicationDuplicates?.length ?? 0,
+          blocking_gaps: blockingApplicationGaps?.length ?? 0,
+          advisory_gaps: advisoryApplicationGaps?.length ?? 0,
           missing_rows: applicationMissing?.map((r) => r.name) ?? [],
           incomplete_rows: applicationIncomplete?.map((r) => ({ name: r.name, state: r.state })) ?? [],
           duplicate_rows: applicationDuplicates?.map((r) => ({ name: r.name, count: r.duplicate_count })) ?? [],
+          blocking_gap_rows: blockingApplicationGaps?.map((r) => ({ name: r.name, state: r.state, gap_kind: r.gap_kind })) ?? [],
+          advisory_gap_rows: advisoryApplicationGaps?.map((r) => ({ name: r.name, state: r.state, gap_kind: r.gap_kind })) ?? [],
         }
       : null,
     green: green?.length ?? 0,
@@ -630,6 +676,8 @@ function buildReport({
   applicationMissing,
   applicationIncomplete,
   applicationDuplicates,
+  blockingApplicationGaps,
+  advisoryApplicationGaps,
   greenTimedRowsMissingTimingPairs,
   blockingTimedRowsMissingTimingPairs,
   advisoryTimedRowsMissingTimingPairs,
@@ -695,14 +743,24 @@ function buildReport({
     lines.push("");
   }
 
-  if (applicationMissing.length > 0 || applicationIncomplete.length > 0 || applicationDuplicates.length > 0) {
-    lines.push(
-      `### Application compatibility gaps (${applicationMissing.length + applicationIncomplete.length + applicationDuplicates.length})`,
-      "",
-    );
-    for (const r of applicationMissing) lines.push(`- \`${r.name}\`: missing compatibility row`);
-    for (const r of applicationIncomplete) lines.push(`- \`${r.name}\`: incomplete compatibility metadata`);
-    for (const r of applicationDuplicates) lines.push(`- \`${r.name}\`: duplicate compatibility row (${r.duplicate_count})`);
+  const blockingAppGaps = blockingApplicationGaps ?? [];
+  const advisoryAppGaps = advisoryApplicationGaps ?? [];
+  const gapText = (r) =>
+    r.gap_kind === "missing"
+      ? "missing compatibility row"
+      : r.gap_kind === "duplicate"
+        ? `duplicate compatibility row (${r.duplicate_count})`
+        : "incomplete compatibility metadata";
+  if (blockingAppGaps.length > 0) {
+    lines.push(`### 🚫 Required application compatibility gaps (${blockingAppGaps.length})`, "");
+    for (const r of blockingAppGaps) lines.push(`- \`${r.name}\`: ${gapText(r)} (blocks publish)`);
+    lines.push("");
+  }
+  if (advisoryAppGaps.length > 0) {
+    lines.push(`### Canary application compatibility gaps (advisory, ${advisoryAppGaps.length})`, "");
+    for (const r of advisoryAppGaps) {
+      lines.push(`- \`${r.name}\`: ${gapText(r)}; reported only, never blocks publish`);
+    }
     lines.push("");
   }
 
@@ -800,6 +858,8 @@ if (artifactAbsent || parseError) {
         applicationMissing: null,
         applicationIncomplete: null,
         applicationDuplicates: null,
+        blockingApplicationGaps: null,
+        advisoryApplicationGaps: null,
         greenTimedRowsMissingTimingPairs: null,
         blockingTimedRowsMissingTimingPairs: null,
         advisoryTimedRowsMissingTimingPairs: null,
@@ -826,6 +886,8 @@ const {
   applicationMissing,
   applicationIncomplete,
   applicationDuplicates,
+  blockingApplicationGaps,
+  advisoryApplicationGaps,
   greenTimedRowsMissingTimingPairs,
   blockingTimedRowsMissingTimingPairs,
   advisoryTimedRowsMissingTimingPairs,
@@ -854,6 +916,8 @@ if (jsonOutput) {
       applicationMissing,
       applicationIncomplete,
       applicationDuplicates,
+      blockingApplicationGaps,
+      advisoryApplicationGaps,
       greenTimedRowsMissingTimingPairs,
       blockingTimedRowsMissingTimingPairs,
       advisoryTimedRowsMissingTimingPairs,
@@ -884,19 +948,25 @@ if (missing.length > 0 || duplicates.length > 0) {
   process.exit(1);
 }
 
-if (requireApplicationCompat && (
-  applicationMissing.length > 0 ||
-  applicationIncomplete.length > 0 ||
-  applicationDuplicates.length > 0
-)) {
-  const gaps = [
-    ...applicationMissing.map((r) => `${r.name} (missing)`),
-    ...applicationIncomplete.map((r) => `${r.name} (incomplete)`),
-    ...applicationDuplicates.map((r) => `${r.name} (${r.duplicate_count} duplicates)`),
-  ];
+if (requireApplicationCompat && advisoryApplicationGaps.length > 0) {
+  // Canary application rows (every category:"application" row today) are real
+  // apps installed by the optional best-effort bench-applications shard; a
+  // flaky install or an absent matching-CI compat artifact legitimately leaves
+  // one missing/incomplete. Surface it but never block the publish — exactly as
+  // a missing canary perf-timing pair is advisory. A single such gap (infisical)
+  // froze the public benchmark site; this keeps latest.json flowing.
   process.stderr.write(
-    `bench-artifact-readiness: application compatibility incomplete for ${gaps.length} row(s): ` +
-      gaps.join(", ") + "\n",
+    `::warning::bench-artifact-readiness: ${advisoryApplicationGaps.length} canary application ` +
+      `compatibility gap(s) (advisory, not blocking publish): ` +
+      advisoryApplicationGaps.map((r) => `${r.name} (${r.gap_kind})`).join(", ") + "\n",
+  );
+}
+
+if (requireApplicationCompat && blockingApplicationGaps.length > 0) {
+  process.stderr.write(
+    `bench-artifact-readiness: application compatibility incomplete for ` +
+      `${blockingApplicationGaps.length} required row(s): ` +
+      blockingApplicationGaps.map((r) => `${r.name} (${r.gap_kind})`).join(", ") + "\n",
   );
   process.exit(1);
 }

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -33,6 +33,16 @@ const PERF_TIMED_APPLICATION_ROWS = PROJECT_ROW_DEFINITIONS
 const NON_PERF_TIMED_APPLICATION_ROWS = PROJECT_ROW_DEFINITIONS
   .filter((row) => row.category === "application" && row.perf_timed !== true)
   .map((row) => row.name);
+// --require-application-compat only HARD-BLOCKS on benchmark_set:"required"
+// application rows. Canary application rows (every category:"application" row
+// today) are real apps installed by the optional best-effort bench-applications
+// shard, so a missing/incomplete one is advisory, never publish-blocking.
+const CANARY_APPLICATION_ROWS = PROJECT_ROW_DEFINITIONS
+  .filter((row) => row.category === "application" && row.benchmark_set === "canary")
+  .map((row) => row.name);
+const REQUIRED_APPLICATION_ROWS = PROJECT_ROW_DEFINITIONS
+  .filter((row) => row.category === "application" && row.benchmark_set === "required")
+  .map((row) => row.name);
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
@@ -465,24 +475,40 @@ withTempDir((dir) => {
 console.log("✅ --require-project-timing-pairs fails all-crashed project artifacts");
 
 // ---------------------------------------------------------------------------
-// Test: --require-application-compat fails the public publish gate when the
-// benchmark artifact has timing rows but no application compatibility rows.
+// Test: --require-application-compat surfaces absent application compatibility
+// rows but, because every application row today is benchmark_set:"canary", does
+// NOT block the publish — they are advisory. The compat for these real apps
+// comes from the optional best-effort bench-applications shard / matching-CI
+// artifact, either of which can legitimately be absent. (When a future
+// benchmark_set:"required" application row is added, its gap WOULD block; see
+// blocking_application_compatibility_gaps below.)
 // ---------------------------------------------------------------------------
 withTempDir((dir) => {
   const file = path.join(dir, "bench.json");
   const rows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
   writeJson(file, makeArtifact(rows));
   const result = run(file, ["--json", "--require-application-compat"]);
-  assert.equal(result.status, 1, "publish gate should fail when application compat rows are absent");
+  const expectBlocking = REQUIRED_APPLICATION_ROWS.length > 0;
+  assert.equal(
+    result.status,
+    expectBlocking ? 1 : 0,
+    `all-canary application rows absent must be advisory (exit 0), not blocking:\n${result.stderr}`,
+  );
   const parsed = JSON.parse(result.stdout.trim());
   assert.equal(parsed.application_compatibility.required, true);
   assert.equal(parsed.application_compatibility.row_count, APPLICATION_PROJECT_ROWS.length);
   assert.equal(parsed.application_compatibility.present, 0);
   assert.equal(parsed.application_compatibility.missing, APPLICATION_PROJECT_ROWS.length);
-  assert.match(result.stderr, /application compatibility incomplete/);
-  assert.match(result.stderr, new RegExp(`${APPLICATION_PROJECT_ROWS[0]} \\(missing\\)`));
+  assert.equal(parsed.application_compatibility.advisory_gaps, CANARY_APPLICATION_ROWS.length);
+  assert.equal(parsed.application_compatibility.blocking_gaps, REQUIRED_APPLICATION_ROWS.length);
+  assert.equal(parsed.advisory_application_compatibility_gaps, CANARY_APPLICATION_ROWS.length);
+  assert.equal(parsed.blocking_application_compatibility_gaps, REQUIRED_APPLICATION_ROWS.length);
+  assert.match(
+    result.stderr,
+    /canary application compatibility gap\(s\) \(advisory, not blocking publish\)/,
+  );
 });
-console.log("✅ --require-application-compat fails missing application rows");
+console.log("✅ --require-application-compat treats absent canary application rows as advisory");
 
 // ---------------------------------------------------------------------------
 // Test: compile-only application rows with complete compatibility metadata pass
@@ -672,7 +698,60 @@ withTempDir((dir) => {
 console.log("✅ --require-application-compat accepts complete gray app rows");
 
 // ---------------------------------------------------------------------------
-// Test: a gray application row with partial metadata is still incomplete.
+// Regression (#15004 follow-up): a SINGLE canary application row missing its
+// compatibility entirely — exactly infisical in Bench run 28322724209, where
+// the bench-applications shard no longer benched it and that run had no matching
+// main-CI compat — must be advisory, not publish-blocking. The other 19/20 app
+// rows are present + complete; the lone missing canary must not freeze the site.
+// ---------------------------------------------------------------------------
+if (CANARY_APPLICATION_ROWS.length > 1) {
+  withTempDir((dir) => {
+    const file = path.join(dir, "bench.json");
+    const missingName = CANARY_APPLICATION_ROWS.includes("infisical-project")
+      ? "infisical-project"
+      : CANARY_APPLICATION_ROWS[0];
+    const requiredRows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+    const applicationRows = APPLICATION_PROJECT_ROWS
+      .filter((name) => name !== missingName)
+      .map((name) =>
+        makeRow(name, "green", {
+          errorStatus: "compile canary tracked in CI; not timed by vs-tsgo benchmarks",
+          tsz_ms: null,
+          tsgo_ms: null,
+          winner: "error",
+        }),
+      );
+    writeJson(file, makeArtifact([...requiredRows, ...applicationRows]));
+    const result = run(file, ["--json", "--require-application-compat", "--require-green-project-timing-pairs"]);
+    assert.equal(
+      result.status,
+      0,
+      `one missing canary application row must not block the publish:\n${result.stderr}`,
+    );
+    const parsed = JSON.parse(result.stdout.trim());
+    assert.equal(parsed.application_compatibility.missing, 1);
+    assert.equal(parsed.application_compatibility.present, APPLICATION_PROJECT_ROWS.length - 1);
+    assert.equal(parsed.blocking_application_compatibility_gaps, 0);
+    assert.equal(parsed.advisory_application_compatibility_gaps, 1);
+    assert.deepEqual(parsed.application_compatibility.advisory_gap_rows, [
+      { name: missingName, state: "missing", gap_kind: "missing" },
+    ]);
+    assert.deepEqual(parsed.application_compatibility.blocking_gap_rows, []);
+    assert.match(
+      result.stderr,
+      new RegExp(`${missingName} \\(missing\\)`),
+    );
+    assert.doesNotMatch(
+      result.stderr,
+      /application compatibility incomplete for \d+ required row/,
+    );
+  });
+  console.log("✅ --require-application-compat keeps a single missing canary app row advisory");
+}
+
+// ---------------------------------------------------------------------------
+// Test: a gray application row with partial metadata is incomplete, but because
+// it is a canary row the gap is advisory (reported, not publish-blocking).
 // ---------------------------------------------------------------------------
 withTempDir((dir) => {
   const file = path.join(dir, "bench.json");
@@ -688,16 +767,29 @@ withTempDir((dir) => {
   delete applicationRows[0].compatibility.phase;
   writeJson(file, makeArtifact([...requiredRows, ...applicationRows]));
   const result = run(file, ["--json", "--require-application-compat"]);
-  assert.equal(result.status, 1, "partial application compatibility should fail readiness");
+  const incompleteName = APPLICATION_PROJECT_ROWS[0];
+  const expectBlocking = REQUIRED_APPLICATION_ROWS.includes(incompleteName);
+  assert.equal(
+    result.status,
+    expectBlocking ? 1 : 0,
+    `partial canary application compatibility must be advisory, not blocking:\n${result.stderr}`,
+  );
   const parsed = JSON.parse(result.stdout.trim());
   assert.equal(parsed.application_compatibility.present, APPLICATION_PROJECT_ROWS.length);
   assert.equal(parsed.application_compatibility.complete, APPLICATION_PROJECT_ROWS.length - 1);
   assert.equal(parsed.application_compatibility.incomplete, 1);
   assert.deepEqual(parsed.application_compatibility.incomplete_rows, [
-    { name: APPLICATION_PROJECT_ROWS[0], state: "gray" },
+    { name: incompleteName, state: "gray" },
   ]);
+  if (!expectBlocking) {
+    assert.equal(parsed.blocking_application_compatibility_gaps, 0);
+    assert.equal(parsed.advisory_application_compatibility_gaps, 1);
+    assert.deepEqual(parsed.application_compatibility.advisory_gap_rows, [
+      { name: incompleteName, state: "gray", gap_kind: "incomplete" },
+    ]);
+  }
 });
-console.log("✅ --require-application-compat rejects partial app rows");
+console.log("✅ --require-application-compat keeps a partial canary app row advisory");
 
 // ---------------------------------------------------------------------------
 // Test: --require-green fails when any present required row is red.

--- a/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
+++ b/scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs
@@ -43,8 +43,8 @@ assert.match(
 
 assert.match(
   workflow,
-  /artifact_ready_for_pages\(\)[\s\S]+application_compatibility\.required == true[\s\S]+application_compatibility\.missing == 0[\s\S]+application_compatibility\.incomplete == 0[\s\S]+application_compatibility\.duplicates == 0[\s\S]+blocking_project_timing_pair_gaps == 0[\s\S]+successful_project_timing_pairs >= \.required_project_timing_pairs/,
-  "Pages deploy should require benchmark readiness JSON with complete application compatibility and no blocking (required) project timing-pair gaps before using merged artifacts",
+  /artifact_ready_for_pages\(\)[\s\S]+application_compatibility\.required == true[\s\S]+blocking_application_compatibility_gaps == 0[\s\S]+blocking_project_timing_pair_gaps == 0[\s\S]+successful_project_timing_pairs >= \.required_project_timing_pairs/,
+  "Pages deploy should require benchmark readiness JSON with no blocking (required) application-compat or project timing-pair gaps before using merged artifacts; canary application gaps are advisory",
 );
 
 assert.match(


### PR DESCRIPTION
Goal: hold

## Summary
The tsz.dev benchmark site was frozen at `generated_at=2026-06-27T19:03:16Z`. After #15004 (infisical `perf_timed:false`) and #15019 (canary perf-timing gaps advisory) closed the perf-timing-gap failure, a *different* readiness check hard-blocked the publish (Bench run 28322724209, bench-publish log):

```
bench-artifact-readiness: application compatibility incomplete for 1 row(s): infisical-project (missing)
```

This decouples the application-compatibility *requirement* from the inherently-best-effort source that produces it.

## Structural rule
When a `category:"application"` benchmark row is `benchmark_set:"canary"` (every application row today) and its compatibility is missing/incomplete/duplicated in the merged bench artifact, `--require-application-compat` now **reports** it (`::warning::`) but does **not** block the publish. A future `benchmark_set:"required"` application row still blocks. Owner layer: bench-delivery infra (`scripts/bench/check-artifact-readiness.mjs` gate + `.github/workflows/gh-pages.yml` deploy gate). This mirrors exactly the `blocking_*`/`advisory_*` split #15019 applied to canary perf-timing gaps.

## Root cause
Application compat lands from the optional, best-effort **bench-applications shard** (`run_project_benchmark` writes a `compatibility` object per app row), or, as a fallback, a **matching-CI compat artifact**. In run 28322724209:
- #15004 set infisical `perf_timed:false`, so the bench-applications shard (gated on `perf_timed===true` in `lib/application-benchmarks.sh`) no longer benched it → no compat row from the shard.
- The run was `workflow_dispatch` and found **no matching main-CI push run** for the target SHA → the fallback matching-CI compat was absent for the whole run.

Result: 19/20 application rows were present + complete (their perf-timed shard wrote compat); infisical alone was entirely missing, and `--require-application-compat` hard-blocked the entire publish. The gate coupled a per-row compat *requirement* onto a row whose data is best-effort by design.

## Chosen fix: (b), not (a)
Fix (a) (bench ALL application rows in the bench-applications shard for compat) requires lifting the `perf_timed===true` gate in `scripts/bench/lib/application-benchmarks.sh` / re-adding infisical to the perf runner's `run_isolated` list so the shell actually compiles it for compat. That behavior is **unverifiable under the node-only / no-cargo constraint** (it needs the real `tsz` binary + cloning/installing infisical) and re-introduces infisical's erroring vs-tsgo timing run. Fix (b) is fully node-verifiable, surgically mirrors merged #15019, and addresses the whole *class* of "one flaky best-effort app row freezes the site," not just infisical.

## Changes
- `scripts/bench/check-artifact-readiness.mjs`: add `isBlockingApplicationRow` (`benchmark_set === "required"`); split application gaps into blocking/advisory; the gate exits 1 only on blocking gaps and emits a `::warning::` for advisory gaps. New JSON: top-level `blocking_application_compatibility_gaps` / `advisory_application_compatibility_gaps`, and `application_compatibility.{blocking_gaps,advisory_gaps,blocking_gap_rows,advisory_gap_rows}` (existing `missing`/`incomplete`/`duplicates` fields preserved).
- `.github/workflows/gh-pages.yml`: both `artifact_ready_for_pages()` gates now require `.blocking_application_compatibility_gaps == 0` instead of `application_compatibility.{missing,incomplete,duplicates} == 0` — consistent with the existing `.blocking_project_timing_pair_gaps == 0` line from #15019.
- Tests: pinned the fixed behavior.

Note: `.github/workflows/bench.yml` is intentionally unchanged — the `--require-application-compat` flag stays; only the gate's blocking criterion changes.

## Verification
Node-only (no cargo):
- `node scripts/bench/test-check-artifact-readiness.mjs` — pass (incl. 3 new/updated advisory tests).
- `node scripts/bench/test-bench-workflow-micro-coverage.mjs` — pass.
- `node scripts/bench/test-project-rows.mjs` — pass.
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs` — pass.
- Full `scripts/bench/test-*.mjs` suite — 22/23 pass; the only failure is `test-measure-tsz.mjs` (exit 125), pre-existing and environmental: it shells out to `measure-tsz.sh` which needs a built binary, and has zero references to any file changed here.
- End-to-end smoke reproducing run 28322724209 (all required rows green + 19/20 app rows present + infisical missing) against the exact bench.yml gate command (`--require-application-compat --require-green-project-timing-pairs --require-project-timing-pairs=1`): **exit 0 (publish proceeds)**, `blocking_application_compatibility_gaps=0`, `advisory_application_compatibility_gaps=1`, advisory `::warning::` naming `infisical-project (missing)`.

Once this lands, a fresh perf-cadence Bench run will publish latest.json.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high