### PR TITLE
fix(checker): suppress false TS7006 for object-method params from compatible union annotation (#14744)

### DIFF
--- a/crates/tsz-checker/src/tests/dispatch_tests/part_00.rs
+++ b/crates/tsz-checker/src/tests/dispatch_tests/part_00.rs
@@ -1820,3 +1820,66 @@ b(1);
         "Expected instantiated callback typedef to stay callable, got: {codes:?}"
     );
 }
+
+#[test]
+fn ts7006_no_false_positive_object_method_param_from_compatible_union_annotation() {
+    // Regression for #14744 (jotai `createJSONStorage`).
+    // When a variable annotation is a UNION of object types whose members declare
+    // the same method with IDENTICAL parameter types (differing only in return
+    // type), tsc contextually types the object-literal method's parameters from
+    // the union. tsz previously emitted spurious TS7006 because discriminant
+    // narrowing over the union computed the arrow initializer's type with no
+    // contextual type before the real contextual pass ran. Binder names are
+    // deliberately varied from the upstream witness to avoid name-coupling.
+    let diags = check_source_diagnostics(
+        r#"
+interface Remote<Payload> { fetchEntry: (slot: string, seed: Payload) => Promise<Payload> }
+interface Local<Payload>  { fetchEntry: (slot: string, seed: Payload) => Payload }
+
+function build<Payload>() {
+    const backend: Remote<Payload> | Local<Payload> = {
+        fetchEntry: (slot, seed) => {
+            return seed;
+        },
+    };
+    return backend;
+}
+"#,
+    );
+    let ts7006 = diagnostics_with_code(&diags, 7006);
+    assert_eq!(
+        ts7006.len(),
+        0,
+        "Expected no TS7006 for object-method params contextually typed by a compatible union, got: {:?}",
+        diagnostic_messages(&ts7006)
+    );
+}
+
+#[test]
+fn ts7006_still_emitted_for_object_method_param_from_incompatible_union_annotation() {
+    // Adjacent negative for #14744 / #5840: when the union members disagree on a
+    // parameter position's type, that position has no agreed contextual type, so
+    // tsc (and tsz) keep the implicit-any TS7006 there. The fix for #14744 must
+    // not silence this case.
+    let diags = check_source_diagnostics(
+        r#"
+interface ByName<Payload>  { lookup: (handle: string, seed: Payload) => Promise<Payload> }
+interface ByIndex<Payload> { lookup: (handle: number, seed: Payload) => Payload }
+
+function build<Payload>() {
+    const provider: ByName<Payload> | ByIndex<Payload> = {
+        lookup: (handle, seed) => {
+            return seed;
+        },
+    };
+    return provider;
+}
+"#,
+    );
+    let ts7006 = diagnostics_with_code(&diags, 7006);
+    assert!(
+        ts7006.iter().any(|d| d.message_text.contains("handle")),
+        "Expected TS7006 on the disagreeing param `handle` for an incompatible union, got: {:?}",
+        diagnostic_messages(&ts7006)
+    );
+}

--- a/crates/tsz-checker/src/types/computation/object_literal_context.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_context.rs
@@ -1545,9 +1545,23 @@ impl<'a> CheckerState<'a> {
                 };
                 present_property_names.push(name.clone());
                 // Get the literal type of the initializer without full type computation.
+                // A function-like initializer (arrow / function expression) can never be a
+                // unit/literal type, so it is irrelevant to discriminant narrowing. Computing
+                // its type bare here — before the real contextual pass over the object literal
+                // — would prematurely check the function with no contextual type and emit a
+                // spurious TS7006 for parameters that the contextual union member would have
+                // typed. Skip the bare probe for those initializers.
+                let initializer_is_function_like =
+                    self.ctx.arena.get(prop.initializer).is_some_and(|node| {
+                        node.kind == syntax_kind_ext::ARROW_FUNCTION
+                            || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
+                    });
                 let unit_lit = self
                     .literal_type_from_initializer(prop.initializer)
                     .or_else(|| {
+                        if initializer_is_function_like {
+                            return None;
+                        }
                         let initializer_type = self.get_type_of_node(prop.initializer);
                         common::is_unit_type(self.ctx.types, initializer_type)
                             .then_some(initializer_type)


### PR DESCRIPTION
Fixes #14744.

## Summary
Under a union variable annotation whose members declare a method/function-property with **identical** parameter types (differing only in return type, e.g. jotai's `AsyncStorage<Value> | SyncStorage<Value>`), tsc contextually types the object-literal method's parameters. tsz emitted spurious **TS7006** implicit-any on those params.

Goal: green

## Structural rule
When the contextual type for an object literal is a union and tsz narrows it via object-literal discriminants, the discriminant pre-scan (`narrow_contextual_union_via_object_literal_discriminants`) computed the type of each present property's initializer **bare** (no contextual type) solely to test whether it is a unit/literal discriminant value. A function-like initializer (arrow / function expression) can **never** be a unit type, so the probe's result is always discarded by the `is_unit_type` filter — but the bare computation runs the implicit-any check first and fires TS7006 before the real contextual pass types the parameters. tsc never re-checks object-literal members for implicit-any during discriminant selection.

Fix (owner layer: checker, `crates/tsz-checker/src/types/computation/object_literal_context.rs`): skip the bare type probe for arrow/function-expression initializers in the discriminant pre-scan. Discriminant **selection** is unchanged (functions were never valid discriminants); only the premature, diagnostic-emitting computation is avoided. The contextual pass then types the params correctly. The root cause was a checker ordering/side-effect issue, not the solver contextual extractor — the solver's `get_parameter_type` union branch already returns the agreed per-position contextual type (verified by tracing: it returned `string` / `Value`).

No name/printer-string predicates; the guard keys only on AST node kind (`ARROW_FUNCTION` / `FUNCTION_EXPRESSION`).

## Adjacent-case matrix
| Case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| Union members, identical method params, differ only in return type (the repro) | clean | TS7006 | clean |
| Single (non-union) annotation `Local<V>` (control) | clean | clean | clean |
| Union members disagree on a param position's type (#5840) | TS7006 on that param | TS7006 | TS7006 (preserved) |
| Discriminated union with a real `kind: "..."` literal discriminant + a callback property | narrows + types callback | narrows | narrows + types callback (unchanged) |
| Varied binder names (Remote/Local/Payload vs upstream Async/Sync/Value) | clean | TS7006 | clean |

Tests vary binder names from the upstream witness to avoid name-coupling.

## Verification
Targeted (no full conformance run):
- `cargo nextest run -p tsz-checker -E 'test(object_method_param_from_compatible_union) or test(object_method_param_from_incompatible_union)'` → 2 passed (the new regressions; the compatible case fails before the fix, passes after).
- `cargo nextest run -p tsz-checker -E 'test(object_literal_relation_architecture) or test(contextual_typing) or test(implicit_any) or test(union_method)'` → 291 passed.
- `cargo nextest run -p tsz-checker -E 'test(ts7006) or test(discriminant)'` → all green except `mapped_enum_discriminant_application_exposes_member_property`, which **fails identically on clean `origin/main`** (pre-existing, unrelated).
- CLI repro (`tsz --strict --target es2022 --lib es2022 --noEmit`): the issue's minimal repro is now clean; the single-annotation control stays clean; the incompatible-union variant still reports TS7006.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
