### PR TITLE
fix(checker): namespace import of export= module is the value, not a { default } wrapper

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "namespace_import_export_equals_passthrough_tests"
+path = "tests/namespace_import_export_equals_passthrough_tests.rs"
+[[test]]
 name = "union_overloaded_member_call_signatures_tests"
 path = "tests/union_overloaded_member_call_signatures_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -1504,8 +1504,31 @@ impl<'a> CheckerState<'a> {
                                         self.ctx.types,
                                         export_equals_type,
                                     );
-                                if namespace_default_belongs_to_namespace_shape
-                                    && (is_object_like || is_callable_like)
+                                // Non-node CJS interop (`esModuleInterop` /
+                                // `allowSyntheticDefaultImports`) namespace import of an
+                                // `export = X` whose target symbol IS a module/variable
+                                // (so it does not take the TS2497 path) and whose value
+                                // is callable/constructable: tsc wraps the namespace as
+                                // `{ default: X }` via `getTypeWithSyntheticDefault`,
+                                // gated on the export= type having call/construct
+                                // signatures. A function/class-only `export =` (the
+                                // TS2497 path, `export_equals_target_is_not_module_or_variable`)
+                                // stays the value so `ns(...)` / `new ns()` work; a plain
+                                // non-callable object `export =` (no signatures) also
+                                // stays the value so `ns.a` resolves (issue #14810). This
+                                // is the `esModuleInteropPrettyErrorRelatedInformation`
+                                // case (`declare function foo(); declare namespace foo {};
+                                // export = foo;`): the merged namespace makes the symbol a
+                                // module, so `import * as foo` is `{ default: () => void }`.
+                                let export_equals_target_is_module_or_variable = !self
+                                    .export_equals_target_is_not_module_or_variable(&exports_table);
+                                let export_equals_interop_callable_default =
+                                    export_equals_synthetic_default
+                                        && export_equals_target_is_module_or_variable
+                                        && is_callable_like;
+                                if (namespace_default_belongs_to_namespace_shape
+                                    && (is_object_like || is_callable_like))
+                                    || export_equals_interop_callable_default
                                 {
                                     return (namespace_type, Vec::new());
                                 }

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -1365,16 +1365,39 @@ impl<'a> CheckerState<'a> {
                                 node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
                             });
 
-                        let allow_namespace_default = self
-                            .source_file_import_uses_system_default_namespace_fallback(module_name)
-                            || (!self.ctx.compiler_options.module.is_node_module()
-                                && self.ctx.allow_synthetic_default_imports()
-                                && !is_import_equals_alias
-                                && export_equals_type.is_some())
-                            || (self.ctx.compiler_options.module.is_node_module()
+                        // The synthetic `default` member is a real part of the
+                        // *namespace* shape only for CJS-interop namespace imports
+                        // (an ESM file importing a CJS module under node resolution)
+                        // and the `System`-module default fallback. For a plain
+                        // `export = X` module imported with `import * as ns` under
+                        // `allowSyntheticDefaultImports` in a non-node module, tsc
+                        // binds `ns` to `X` directly: `ns.a`/`ns(...)` work and
+                        // `ns.default` does NOT exist. That synthetic `default`
+                        // belongs only to the *default-import* resolution path, not
+                        // the namespace type, so it must not turn the namespace into a
+                        // `{ default: X }` wrapper.
+                        let system_default_namespace_fallback = self
+                            .source_file_import_uses_system_default_namespace_fallback(module_name);
+                        let node_esm_imports_cjs_synthetic_default =
+                            self.ctx.compiler_options.module.is_node_module()
                                 && self.ctx.file_is_esm == Some(true)
                                 && !self.module_is_esm(module_name)
-                                && self.module_can_use_synthetic_default_import(module_name));
+                                && self.module_can_use_synthetic_default_import(module_name);
+                        let export_equals_synthetic_default =
+                            !self.ctx.compiler_options.module.is_node_module()
+                                && self.ctx.allow_synthetic_default_imports()
+                                && !is_import_equals_alias
+                                && export_equals_type.is_some();
+                        // True only when the synthetic `default` is part of the
+                        // namespace shape itself (CJS-interop / `System`), as opposed
+                        // to the non-node `export =` synthetic-default that belongs to
+                        // default-import resolution.
+                        let namespace_default_belongs_to_namespace_shape =
+                            system_default_namespace_fallback
+                                || node_esm_imports_cjs_synthetic_default;
+                        let allow_namespace_default = system_default_namespace_fallback
+                            || export_equals_synthetic_default
+                            || node_esm_imports_cjs_synthetic_default;
 
                         // Namespace imports in CJS-fallback mode need a synthetic
                         // required `default` that points to the module object surface.
@@ -1461,12 +1484,16 @@ impl<'a> CheckerState<'a> {
                             }
                             if module_is_non_module_entity || namespace_has_no_runtime_props {
                                 // For namespace imports of `export =` non-module values:
-                                // - Callable/constructable types (functions, classes): wrap
-                                //   with `{ default: value }` under allowSyntheticDefaultImports
-                                //   so that `ns.default()` works (tsc behavior).
-                                // - Non-callable primitives (`number | undefined`, etc.):
-                                //   return the export= type directly so narrowing works
-                                //   (e.g., `if (b0) x = b0` narrows `number | undefined`).
+                                // - CJS-interop / `System` namespace imports
+                                //   (callable/constructable or object-like targets): wrap
+                                //   with `{ default: value }` so that `ns.default(...)`
+                                //   works (tsc's node ESM-imports-CJS / `System` shape).
+                                // - Plain non-node `export = X` under
+                                //   allowSyntheticDefaultImports, and non-callable
+                                //   primitives: return the export= type directly. tsc
+                                //   binds `import * as ns` to `X` itself (`ns.a`/`ns(...)`
+                                //   work, `ns.default` does not exist), and narrowing on a
+                                //   `number | undefined` export= stays intact.
                                 let is_object_like =
                                     crate::query_boundaries::dispatch::is_object_like_type(
                                         self.ctx.types,
@@ -1477,7 +1504,9 @@ impl<'a> CheckerState<'a> {
                                         self.ctx.types,
                                         export_equals_type,
                                     );
-                                if allow_namespace_default && (is_object_like || is_callable_like) {
+                                if namespace_default_belongs_to_namespace_shape
+                                    && (is_object_like || is_callable_like)
+                                {
                                     return (namespace_type, Vec::new());
                                 }
                                 return (export_equals_type, Vec::new());

--- a/crates/tsz-checker/tests/namespace_import_export_equals_passthrough_tests.rs
+++ b/crates/tsz-checker/tests/namespace_import_export_equals_passthrough_tests.rs
@@ -1,0 +1,133 @@
+//! Regression tests for issue #14810: a namespace import (`import * as ns`) of
+//! a module that uses `export = <value>` must bind `ns` to the `export =` value
+//! directly, NOT to a synthetic `{ default: <value> }` wrapper.
+//!
+//! Structural rule: when `import * as ns from "M"` resolves to a non-node module
+//! whose only export is `export = X`, tsc types `ns` as `X` itself
+//! (`ns.a` / `ns(...)` / `new ns()` work; `ns.default` does not exist). The
+//! synthetic `default` produced under `allowSyntheticDefaultImports` belongs only
+//! to the *default-import* path, never to the namespace shape. Previously tsz
+//! returned the `{ default: X }` wrapper here, producing spurious TS2339 (object/
+//! class targets) and TS2349 (function targets).
+//!
+//! These cases all run with `--module commonjs --esModuleInterop` (the exact
+//! configuration that triggered the false positive) and vary the binder/alias
+//! identifiers so the fix is proven structural, not keyed on any name.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file;
+use tsz_common::common::{ModuleKind, ScriptTarget};
+
+fn codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            target: ScriptTarget::ES2022,
+            module: ModuleKind::CommonJS,
+            strict: true,
+            es_module_interop: true,
+            no_lib: true,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+#[test]
+fn namespace_import_of_export_equals_object_exposes_properties() {
+    // `export = <object>`: `ns.a` must resolve (no TS2339).
+    let dep = r#"
+declare const obj: { a: number; b: string };
+export = obj;
+"#;
+    let main = r#"
+import * as ns from "./dep";
+const a: number = ns.a;
+const b: string = ns.b;
+"#;
+    let codes = codes(
+        &[("/proj/dep.d.ts", dep), ("/proj/main.ts", main)],
+        "/proj/main.ts",
+    );
+    assert!(
+        !codes.contains(&2339),
+        "namespace import of `export = <object>` must expose properties directly (no TS2339); got {codes:?}"
+    );
+}
+
+#[test]
+fn namespace_import_of_export_equals_object_is_the_value_not_a_default_wrapper() {
+    // Reveal probe (issue #14810): `ns` must BE the `export =` object, not a
+    // `{ default: <object> }` wrapper. Assigning `ns` to the bare object shape
+    // must succeed; if tsz still wrapped it as `{ default: { value: number } }`
+    // this assignment would raise TS2322. Using assignability (instead of a
+    // `.default` property probe) keeps the check independent of lib-type
+    // resolution under `no_lib`.
+    let dep = r#"
+declare const payload: { value: number };
+export = payload;
+"#;
+    let main = r#"
+import * as bag from "./dep";
+const direct: { value: number } = bag;
+"#;
+    let codes = codes(
+        &[("/proj/dep.d.ts", dep), ("/proj/main.ts", main)],
+        "/proj/main.ts",
+    );
+    assert!(
+        !codes.contains(&2322),
+        "namespace import of `export = <object>` must be the object itself, not a `{{ default }}` wrapper (no TS2322 on direct assignment); got {codes:?}"
+    );
+}
+
+#[test]
+fn namespace_import_of_export_equals_function_is_callable() {
+    // `export = <function>`: `ns(...)` must be callable (no TS2349). Distinct
+    // alias and parameter names to keep the rule structural.
+    let dep = r#"
+declare function transform(input: number): string;
+export = transform;
+"#;
+    let main = r#"
+import * as helper from "./dep";
+const out: string = helper(5);
+"#;
+    let codes = codes(
+        &[("/proj/dep.d.ts", dep), ("/proj/main.ts", main)],
+        "/proj/main.ts",
+    );
+    assert!(
+        !codes.contains(&2349),
+        "namespace import of `export = <function>` must be callable (no TS2349); got {codes:?}"
+    );
+}
+
+#[test]
+fn namespace_import_of_export_equals_class_is_constructable() {
+    // `export = <class>`: `new ns()` must construct (no TS2351/TS2349), and the
+    // instance member must be visible.
+    let dep = r#"
+declare class Widget {
+    constructor(size: number);
+    size: number;
+}
+export = Widget;
+"#;
+    let main = r#"
+import * as Boxed from "./dep";
+const w = new Boxed(3);
+const s: number = w.size;
+"#;
+    let codes = codes(
+        &[("/proj/dep.d.ts", dep), ("/proj/main.ts", main)],
+        "/proj/main.ts",
+    );
+    assert!(
+        !codes.contains(&2351) && !codes.contains(&2349),
+        "namespace import of `export = <class>` must be constructable (no TS2351/TS2349); got {codes:?}"
+    );
+}


### PR DESCRIPTION
Closes #14810.

Goal: green

## Summary
A namespace import (`import * as ns from "M"`) of a non-node module whose only
export is `export = X` was typed as a synthetic `{ default: X }` wrapper. Every
property access, call, or construction on `ns` then failed: TS2339 for
object/class targets, TS2349 for function targets. tsc binds `ns` to `X`
itself — `ns.a` / `ns(...)` / `new ns()` work and `ns.default` does not exist —
so this is a false positive on the common CJS `export =` interop pattern.

## Structural rule
When `import * as ns from "M"` resolves to a non-node module whose only export
is `export = X`, tsc types `ns` as `X` (the namespace IS the value;
`ns.default` does not exist). tsz must too, via the checker namespace-import
type construction owner
(`type_alias_variable_alias.rs`). The synthetic `default` produced under
`allowSyntheticDefaultImports` belongs only to the *default-import* resolution
path, never to the namespace shape.

## Owner layer and fix
`crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs`,
namespace-import (`import * as`) `export =` branch.

The `{ default }` namespace shape is correct only for namespace imports where
the synthetic default is genuinely part of the surface: an ESM file importing a
CJS module under node resolution, and the `System`-module default fallback.
The fix splits the previous `allow_namespace_default` predicate into named
branches and returns the `{ default }` wrapper only for those
namespace-shape cases (`namespace_default_belongs_to_namespace_shape`). For the
non-node `export =` synthetic-default branch, it returns the `export =` value
directly. No name/file-string predicates; the decision is purely structural
(module kind, ESM-ness, `export =` presence, object/callable shape).

## Adjacent-case matrix
| Case | Module/flags | Before | After (tsc parity) |
|------|--------------|--------|--------------------|
| `export = <object>`, `ns.a` | commonjs + esModuleInterop | TS2339 | no error; `ns.a` resolves |
| `export = <object>` reveal probe | commonjs + esModuleInterop | `{ default: {...} }` | object itself (no TS2322 on direct assign) |
| `export = <function>`, `ns(5)` | commonjs + esModuleInterop | TS2349 | callable; no TS2349 |
| `export = <class>`, `new ns()` | commonjs + esModuleInterop | TS2351/TS2349 risk | constructable |
| default import `import ns from M` of `export = fn` (node ESM-imports-CJS) | nodenext | callable | unchanged (control) |
| `import * as ns` of CJS `.cts` exposing `ns.default` | nodenext ESM | `ns.default` valid | unchanged (control) |
| `module: preserve` default import of `export =` | preserve | no TS1192 | unchanged (control) |

## Verification
Targeted `cargo nextest run -p tsz-checker` (no full conformance):

- New regression suite `namespace_import_export_equals_passthrough_tests` (4
  tests, binder/alias names varied per the anti-hardcoding gate): all pass with
  the fix and exercise object / function / class `export =` targets plus the
  reveal probe. These flip the reported false positives.
- Controls all green: `node_esm_default_import_export_equals_callable_tests`
  (function/class callable+constructable), `node_esm_default_import_from_cts_is_namespace_shaped`,
  `module_preserve_default_import_from_explicit_esm_export_equals_no_ts1192`.
- Related families (`export_equals*`, `ts1259`, `ts2498`, `self_namespace`,
  `json_namespace`, `ts1362`, `commonjs_module_export`) byte-identical
  before/after the change (78 passed / 1 pre-existing Mac-local failure both at
  baseline and with the fix), confirming the fix is behavior-neutral outside
  the targeted case.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
