### PR TITLE
fix(solver): keep conditional-constraint union param arms across modules (#14753)

### DIFF
--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -172,6 +172,10 @@ name = "imported_infer_readonly_alias_cli_tests"
 path = "tests/imported_infer_readonly_alias_cli_tests.rs"
 
 [[test]]
+name = "cross_module_conditional_constraint_union_param_cli_tests"
+path = "tests/cross_module_conditional_constraint_union_param_cli_tests.rs"
+
+[[test]]
 name = "merged_unique_symbol_factory_cli_tests"
 path = "tests/merged_unique_symbol_factory_cli_tests.rs"
 

--- a/crates/tsz-cli/tests/cross_module_conditional_constraint_union_param_cli_tests.rs
+++ b/crates/tsz-cli/tests/cross_module_conditional_constraint_union_param_cli_tests.rs
@@ -1,0 +1,154 @@
+//! Regression: a cross-module generic function whose type parameter has a
+//! *conditional-type* constraint must not collapse a union parameter's arms.
+//!
+//! Issue #14753. When `resolve<K extends Key>(opt: undefined | Opt<K>, …)` is
+//! imported across a module boundary and `Key` is a conditional alias carrying
+//! a definitional `infer T` (`R extends { key: infer T } ? T : …`), the
+//! placeholder-union pruning in generic-call finalization walked into `K`'s
+//! conditional constraint, classified the bound `infer T` as a live inference
+//! placeholder, and dropped the `Opt<K>` arm — leaving the parameter as bare
+//! `undefined`. The relation then checked `number` (a valid `Opt<K>` arm)
+//! against `undefined`, yielding a spurious `TS2345`. `tsc` accepts.
+//!
+//! Binder names below are deliberately varied from the issue's repro (no
+//! `Register`/`Key`/`Opt`/`resolve`) so the fix cannot be a name-scoped path.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+const FLAGS: &[&str] = &[
+    "--strict",
+    "--target",
+    "es2022",
+    "--lib",
+    "es2022",
+    "--types",
+    "",
+    "--moduleResolution",
+    "bundler",
+    "--module",
+    "esnext",
+    "--noEmit",
+    "--pretty",
+    "false",
+];
+
+/// The reported false positive: a `number | fn` union arm survives the
+/// cross-module conditional-constraint instantiation, so the call type-checks
+/// exactly as `tsc` accepts it.
+#[test]
+fn cross_module_conditional_constraint_keeps_union_param_arms() {
+    let Some(tsz_bin) = find_tsz_binary() else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("temp dir");
+
+    std::fs::write(
+        dir.path().join("registry.ts"),
+        r#"
+interface Slots {}
+export type Tag = Slots extends { entry: infer Picked }
+  ? Picked extends ReadonlyArray<unknown> ? Picked : ReadonlyArray<unknown>
+  : ReadonlyArray<unknown>
+export type Choice<Slot extends Tag = Tag> = number | ((cell: Holder<Slot>) => number)
+export declare class Holder<Slot extends Tag = Tag> { stamp: Slot }
+export declare function settle<Slot extends Tag = Tag>(
+  choice: undefined | Choice<Slot>,
+  holder: Holder<Slot>,
+): number | undefined
+"#,
+    )
+    .expect("write registry.ts");
+    std::fs::write(
+        dir.path().join("consumer.ts"),
+        r#"
+import { settle } from './registry'
+import type { Holder, Choice, Tag } from './registry'
+export class Gauge<Slot extends Tag> {
+  choice!: Choice<any> | undefined
+  holder!: Holder<Slot>
+  run(): number | undefined { return settle(this.choice, this.holder) }
+}
+"#,
+    )
+    .expect("write consumer.ts");
+
+    let output = Command::new(tsz_bin)
+        .args(FLAGS)
+        .arg("registry.ts")
+        .arg("consumer.ts")
+        .current_dir(dir.path())
+        .output()
+        .expect("run tsz");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success() && !stdout.contains("TS2345"),
+        "cross-module conditional-constraint union param must keep its `number | fn` arm \
+         (no spurious TS2345).\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+/// Adjacent guard: the same conditional-constraint shape *inlined* in a single
+/// file must reject a genuinely-bad `string` argument (the alias resolves, so
+/// the parameter is `number | fn`). Pins that the pruning fix does not blanket
+/// the union into `any`.
+#[test]
+fn single_file_conditional_constraint_still_rejects_bad_arg() {
+    let Some(tsz_bin) = find_tsz_binary() else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("temp dir");
+
+    std::fs::write(
+        dir.path().join("inline.ts"),
+        r#"
+interface Slots {}
+type Tag = Slots extends { entry: infer Picked }
+  ? Picked extends ReadonlyArray<unknown> ? Picked : ReadonlyArray<unknown>
+  : ReadonlyArray<unknown>
+type Choice<Slot extends Tag = Tag> = number | ((cell: Holder<Slot>) => number)
+declare class Holder<Slot extends Tag = Tag> { stamp: Slot }
+declare function settle<Slot extends Tag = Tag>(
+  choice: undefined | Choice<Slot>,
+  holder: Holder<Slot>,
+): number | undefined
+class Gauge<Slot extends Tag> {
+  bad!: string
+  holder!: Holder<Slot>
+  run(): number | undefined { return settle(this.bad, this.holder) }
+}
+"#,
+    )
+    .expect("write inline.ts");
+
+    let output = Command::new(tsz_bin)
+        .args(FLAGS)
+        .arg("inline.ts")
+        .current_dir(dir.path())
+        .output()
+        .expect("run tsz");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("TS2345"),
+        "single-file conditional-constraint param `number | fn` must reject a `string` arg.\nstdout:\n{stdout}"
+    );
+}

--- a/crates/tsz-solver/src/operations/generic_call/normalization.rs
+++ b/crates/tsz-solver/src/operations/generic_call/normalization.rs
@@ -502,11 +502,23 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         };
 
         let members = self.interner.type_list(member_list_id);
+        // Prune only members carrying a *free* (live, transient) inference
+        // placeholder. A bare `TypeData::Infer` reachable only through a type
+        // parameter's conditional-alias constraint (e.g. `K extends Key` where
+        // `type Key = R extends { key: infer T } ? T : …`) is definitional —
+        // bound by that conditional, already resolved at the definition site —
+        // not a leaked inference variable, so it must not drop the member.
+        // `contains_infer_types_db` walked into those constraint chains and
+        // collapsed `undefined | Opt<K>` to bare `undefined` for a cross-module
+        // generic fn whose type parameter has a conditional-type constraint
+        // (spurious TS2345, issue #14753). `contains_free_infer_types` treats
+        // constraint/default and deferred-operation operands as bound, matching
+        // tsc, while still pruning genuinely free leaked placeholders.
         let retained: Vec<_> = members
             .iter()
             .copied()
             .filter(|member| {
-                !crate::type_queries::contains_infer_types_db(
+                !crate::visitor::contains_free_infer_types(
                     self.interner.as_type_database(),
                     *member,
                 )


### PR DESCRIPTION
Closes #14753.

Goal: green

## Summary
A cross-module generic function whose type parameter has a **conditional-type
constraint** (`K extends Key`, where `Key` is a conditional alias carrying a
definitional `infer T`) collapsed a union parameter's arms during generic-call
finalization, producing a spurious `TS2345` that `tsc` does not emit. In the
TanStack Query canary this is the single largest false-positive cluster (every
`resolveStaleTime`/`resolveQueryBoolean` call site, ~13 of 62 query-core FPs).

## Structural rule
When a generic call instantiates a union parameter `undefined | Opt<K>` whose
type parameter `K extends Key` has a **conditional-alias constraint**, `tsc`
keeps every union arm: the bound `infer T` inside `Key`'s conditional is
definitional (already resolved at the definition site), not a live inference
variable, so it must not drop the arm. `tsz` must do the same, via the solver
generic-call finalization layer (`prune_placeholder_union_members`).

## Root cause (wrong op + owner)
Wrong operation: union-member pruning in
`crates/tsz-solver/src/operations/generic_call/normalization.rs`
(`prune_placeholder_union_members`, reached from
`normalize_inferred_placeholder_type`). It filtered members with
`contains_infer_types_db`, whose `CONTENT_PREDICATE` child policy walks **into a
type parameter's constraint chain**. For `undefined | Opt<K>` the `Opt<K>` arm
reaches `K`'s constraint `Key = R extends { key: infer T } ? T : …`, the bound
`infer T` is matched as a placeholder, and the arm is pruned — leaving the
parameter as bare `undefined`. The relation then checks `number` (a valid
`Opt<K>` arm) against `undefined` => spurious `TS2345`. Cross-module + conditional
constraint are jointly required: single-file and non-conditional `Key` resolve
`Key` to a concrete `infer`-free type before pruning.

## Fix
Prune only members carrying a **free** (live, transient) inference placeholder,
using `contains_free_infer_types` (the `FREE_INFER` child policy:
`type_param_constraint: false`, `type_param_default: false`,
`deferred_operations: false`). This treats constraint/default and deferred-
operation operands as bound — exactly the documented purpose of that predicate
(issue #14784) — while still pruning genuinely leaked root/structural `Infer`
nodes. One-line predicate swap; no hardcoding (no name/file/printer-string
predicate).

## Adjacent-case matrix
| Variant | tsc | tsz before | tsz after |
|---|---|---|---|
| Cross-module, conditional `Key`, `number` arg (the FP) | clean | **TS2345** | clean |
| Same content inlined in one file | clean | clean | clean |
| Cross-module, non-conditional `Key = ReadonlyArray<unknown>` | clean | clean | clean |
| Single-file, conditional `Key`, `string` arg (genuine mismatch) | TS2345 | TS2345 | TS2345 |
| Cross-module, non-conditional `Key`, `string` arg | TS2345 | TS2345 | TS2345 |

Binder names in the regression test are varied from the issue repro
(`Slots`/`Tag`/`Choice`/`Holder`/`settle`/`Gauge`, not
`Register`/`Key`/`Opt`/`resolve`).

## Verification
- New: `crates/tsz-cli/tests/cross_module_conditional_constraint_union_param_cli_tests.rs`
  - `cross_module_conditional_constraint_keeps_union_param_arms` — flips: TS2345 before, clean after.
  - `single_file_conditional_constraint_still_rejects_bad_arg` — pins the negative still errors.
  - `cargo nextest run -p tsz-cli -E 'test(cross_module_conditional_constraint) + test(single_file_conditional_constraint)'` => 2 passed.
- `cargo nextest run -p tsz-solver -E 'test(infer) + test(placeholder) + test(conditional_constraint) + test(generic_call) + test(prune)'` => 1119/1121 (the 2 failures — `free_infer_policy_skips_generic_signature_bodies`, `test_conditional_infer_optional_property_present_distributive` — also fail on `origin/main` with the change stashed; local lib-snapshot deltas, not introduced here).
- Cross-module CLI sweep (`test(cross_module) + test(interface_extends_cross) + test(imported_infer) + test(cross_binder)`): only pre-existing `compile_cross_module_nested_interface_method_allows_optional_argument_currently` fails on clean `origin/main` too.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
