### PR TITLE
fix(solver): contextually type object-literal method params from a union annotation

### DIFF
--- a/crates/tsz-checker/src/types/computation/object_literal_context.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_context.rs
@@ -1508,6 +1508,33 @@ impl<'a> CheckerState<'a> {
     /// type B = { kind: "b"; onClick: (e: number) => void };
     /// const x: A | B = { kind: "a", onClick: (e) => e.length }; // e: string
     /// ```
+    /// Returns `true` when the syntactic form of `idx` can never have a unit
+    /// (literal) type, so type-checking it to look for a discriminant value is
+    /// pure overhead — and, worse, would commit context-free diagnostics for a
+    /// node that is re-checked later with its proper contextual type.
+    ///
+    /// Covers function/arrow expressions (always a function type), object/array
+    /// literals (always an object/array type), and class/JSX expressions. These
+    /// already classify as non-unit today; skipping the probe only suppresses
+    /// the premature side-effect diagnostics, leaving discriminant detection
+    /// unchanged.
+    fn initializer_is_structurally_non_unit(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(idx) else {
+            return false;
+        };
+        matches!(
+            node.kind,
+            syntax_kind_ext::ARROW_FUNCTION
+                | syntax_kind_ext::FUNCTION_EXPRESSION
+                | syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                | syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                | syntax_kind_ext::CLASS_EXPRESSION
+                | syntax_kind_ext::JSX_ELEMENT
+                | syntax_kind_ext::JSX_SELF_CLOSING_ELEMENT
+                | syntax_kind_ext::JSX_FRAGMENT
+        )
+    }
+
     pub(crate) fn narrow_contextual_union_via_object_literal_discriminants(
         &mut self,
         ctx_type: TypeId,
@@ -1545,21 +1572,20 @@ impl<'a> CheckerState<'a> {
                 };
                 present_property_names.push(name.clone());
                 // Get the literal type of the initializer without full type computation.
-                // A function-like initializer (arrow / function expression) can never be a
-                // unit/literal type, so it is irrelevant to discriminant narrowing. Computing
-                // its type bare here — before the real contextual pass over the object literal
-                // — would prematurely check the function with no contextual type and emit a
-                // spurious TS7006 for parameters that the contextual union member would have
-                // typed. Skip the bare probe for those initializers.
-                let initializer_is_function_like =
-                    self.ctx.arena.get(prop.initializer).is_some_and(|node| {
-                        node.kind == syntax_kind_ext::ARROW_FUNCTION
-                            || node.kind == syntax_kind_ext::FUNCTION_EXPRESSION
-                    });
+                // The `get_type_of_node` fallback exists only to catch *reference*
+                // initializers whose type is a unit literal (a `const` bound to a
+                // literal, an enum member, an `as const`, etc.). Initializer forms
+                // whose type is structurally never a unit type — function/arrow
+                // expressions, object/array literals, class/JSX expressions — can
+                // never be a discriminant, so the only effect of type-checking them
+                // here is to commit premature, context-free diagnostics (e.g. a
+                // spurious TS7006 on an object-literal method's parameters). Skip the
+                // probe for those forms; the real, contextually-typed check of the
+                // object-literal element still runs afterward.
                 let unit_lit = self
                     .literal_type_from_initializer(prop.initializer)
                     .or_else(|| {
-                        if initializer_is_function_like {
+                        if self.initializer_is_structurally_non_unit(prop.initializer) {
                             return None;
                         }
                         let initializer_type = self.get_type_of_node(prop.initializer);

--- a/crates/tsz-checker/tests/object_literal_union_contextual_typing_tests.rs
+++ b/crates/tsz-checker/tests/object_literal_union_contextual_typing_tests.rs
@@ -24,7 +24,7 @@
 //! This is the object-literal counterpart of
 //! `tuple_union_contextual_typing_tests.rs`.
 
-use tsz_checker::test_utils::check_source_codes;
+use tsz_checker::test_utils::{check_source_codes, check_source_strict_codes};
 
 // ---------------------------------------------------------------------------
 // Core cases - differing-arity object unions, literal arm preserved
@@ -182,4 +182,127 @@ const b: { v: string } | { v: number } = { v: 42 };
 "#,
     );
     assert!(!codes.contains(&2322), "expected no TS2322, got: {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Object-literal METHOD/property params contextually typed from a union
+// annotation (jotai `atomWithStorage` / `createJSONStorage`).
+//
+// Two roots are exercised here:
+//   1. The discriminant pre-scan of a union contextual type must not check
+//      function/object/array initializers context-free — doing so committed a
+//      premature TS7006 on the method's parameters before the real, contextually
+//      typed pass ran.
+//   2. The union contextual *parameter* extraction is signature-level: params are
+//      contextually typed iff the callable members agree at every shared position
+//      (tsc `getUnionSignatures`); if any position disagrees, every parameter is
+//      implicit-any (#5840), not just the disagreeing one.
+// ---------------------------------------------------------------------------
+
+/// Repro: union members declare `getItem` with identical parameter types and
+/// differ only in return type (`Promise<Value>` vs `Value`). tsc contextually
+/// types `key`/`initialValue`; tsz used to emit spurious TS7006.
+#[test]
+fn union_member_identical_params_method_is_contextually_typed() {
+    let codes = check_source_strict_codes(
+        r#"
+interface AsyncStorage<Value> { getItem: (key: string, initialValue: Value) => Promise<Value> }
+interface SyncStorage<Value>  { getItem: (key: string, initialValue: Value) => Value }
+function make<Value>() {
+  const storage: AsyncStorage<Value> | SyncStorage<Value> = {
+    getItem: (key, initialValue) => initialValue,
+  };
+  return storage;
+}
+"#,
+    );
+    assert!(!codes.contains(&7006), "expected no TS7006, got: {codes:?}");
+}
+
+/// Renamed binders + a second method (`setItem`) and a third union arm: the fix
+/// must not depend on any particular property/identifier name.
+#[test]
+fn union_member_identical_params_multi_method_three_arms_contextual() {
+    let codes = check_source_strict_codes(
+        r#"
+interface A<V> { read: (slot: string, seed: V) => Promise<V>; write: (slot: string, next: V) => void }
+interface B<V> { read: (slot: string, seed: V) => V; write: (slot: string, next: V) => void }
+interface C<V> { read: (slot: string, seed: V) => V | null; write: (slot: string, next: V) => void }
+function make<V>() {
+  const store: A<V> | B<V> | C<V> = {
+    read: (slot, seed) => seed,
+    write: (slot, next) => {},
+  };
+  return store;
+}
+"#,
+    );
+    assert!(!codes.contains(&7006), "expected no TS7006, got: {codes:?}");
+}
+
+/// Optional union member (`| undefined`) still contextually types the method.
+#[test]
+fn union_with_undefined_member_method_is_contextually_typed() {
+    let codes = check_source_strict_codes(
+        r#"
+interface AsyncStorage<Value> { getItem: (key: string, initialValue: Value) => Promise<Value> }
+interface SyncStorage<Value>  { getItem: (key: string, initialValue: Value) => Value }
+function make<Value>() {
+  const storage: AsyncStorage<Value> | SyncStorage<Value> | undefined = {
+    getItem: (key, initialValue) => initialValue,
+  };
+  return storage;
+}
+"#,
+    );
+    assert!(!codes.contains(&7006), "expected no TS7006, got: {codes:?}");
+}
+
+/// Negative (#5840): when the union members disagree on a parameter type, the
+/// union provides NO contextual signature, so EVERY parameter is implicit-any —
+/// not just the one that differs.
+#[test]
+fn union_member_disagreeing_params_keeps_all_implicit_any() {
+    let codes = check_source_strict_codes(
+        r#"
+interface A<V> { getItem: (key: string, v: V) => V }
+interface B<V> { getItem: (key: number, v: V) => V }
+function make<V>() {
+  const s: A<V> | B<V> = { getItem: (key, v) => v };
+  return s;
+}
+"#,
+    );
+    // Both `key` (disagrees) and `v` (agrees) must be implicit-any.
+    let ts7006 = codes.iter().filter(|&&c| c == 7006).count();
+    assert_eq!(ts7006, 2, "expected TS7006 on both params, got: {codes:?}");
+}
+
+/// Negative: first parameter agrees, second disagrees → still all implicit-any.
+#[test]
+fn union_member_later_param_disagrees_keeps_all_implicit_any() {
+    let codes = check_source_strict_codes(
+        r#"
+interface A { f: (a: string, b: string) => void }
+interface B { f: (a: string, b: number) => void }
+const o: A | B = { f: (a, b) => {} };
+"#,
+    );
+    let ts7006 = codes.iter().filter(|&&c| c == 7006).count();
+    assert_eq!(ts7006, 2, "expected TS7006 on both params, got: {codes:?}");
+}
+
+/// Arity gap is not a disagreement: the longer member's extra parameter is
+/// contextually typed from the member that declares it.
+#[test]
+fn union_member_arity_gap_still_contextually_types_extra_param() {
+    let codes = check_source_strict_codes(
+        r#"
+interface A { f: (a: string, b: number) => void }
+interface B { f: (a: string) => void }
+const o: A | B = { f: (a, b) => { a.toUpperCase(); b.toFixed(); } };
+"#,
+    );
+    assert!(!codes.contains(&7006), "expected no TS7006, got: {codes:?}");
+    assert!(!codes.contains(&2339), "expected no TS2339, got: {codes:?}");
 }

--- a/crates/tsz-solver/src/contextual/core.rs
+++ b/crates/tsz-solver/src/contextual/core.rs
@@ -183,12 +183,15 @@ impl<'a> ContextualTypeContext<'a> {
         // Handle Union explicitly - collect parameter types from callable members.
         // Per TypeScript spec: "If S is not empty and the sets of call signatures of the
         // types in S are identical ignoring return types, U has the same set of call
-        // signatures." If parameter types differ across callable members at the same
-        // index, no contextual type is provided (triggers TS7006 under noImplicitAny).
+        // signatures." (`getUnionSignatures`). The decision is **signature-level, not
+        // per-parameter**: if the callable members disagree at *any* shared parameter
+        // position, the union has no combined call signature, so *every* parameter is
+        // implicit-any — not just the position that disagrees. Members with lower arity
+        // simply do not constrain the positions they lack (`getContextualCallSignature`
+        // filters arity-smaller signatures), so a trailing parameter present in only one
+        // member is still contextually typed from that member.
         if let Some(TypeData::Union(members)) = self.interner.lookup(expected) {
             let members = self.interner.type_list(members);
-            let mut param_types: Vec<TypeId> = Vec::new();
-            let mut has_callable_member = false;
 
             // tsc excludes construct-only Function members when any callable member exists,
             // so `ComponentClass<P> | StatelessComponent<P> | string` infers only from the
@@ -208,6 +211,12 @@ impl<'a> ContextualTypeContext<'a> {
                 }
             });
 
+            // Callable members that participate in the contextual signature, plus the
+            // highest declared arity among them — the bound for the signature-
+            // compatibility scan. A rest parameter is counted by its own slot
+            // (positions beyond it are homogeneous with the rest element).
+            let mut callable_members: Vec<TypeId> = Vec::new();
+            let mut max_scan_arity = 0usize;
             for &m in members.iter() {
                 let type_data = self.interner.lookup(m);
                 let is_callable = m == TypeId::FUNCTION
@@ -218,79 +227,115 @@ impl<'a> ContextualTypeContext<'a> {
                 if !is_callable {
                     continue;
                 }
-                if has_non_constructor_callable
-                    && let Some(TypeData::Function(func_id)) = type_data
-                    && self.interner.function_shape(func_id).is_constructor
-                {
-                    continue;
-                }
-                has_callable_member = true;
-
-                let ctx = ContextualTypeContext::with_expected_and_options(
-                    self.interner,
-                    m,
-                    self.no_implicit_any,
-                );
-                match ctx.get_parameter_type(index) {
-                    // A member whose parameter type is one of that member's own
-                    // (un-instantiated) generic type parameters represents a generic
-                    // overload that tsc would instantiate before contextually typing
-                    // the callback. Its contextual contribution is the type parameter's
-                    // constraint, or `any` when unconstrained — not the bare type
-                    // parameter (which would otherwise read as a spurious "disagreement"
-                    // against a concrete sibling overload and block contextual typing,
-                    // e.g. `Array.reduce`'s `(prev: T, ...) => T | (prev: U, ...) => U`
-                    // contextual union for the `previousValue` slot when the
-                    // initializer is `any`).
-                    Some(ty) if self.is_signature_own_free_type_parameter(m, ty) => {
-                        param_types.push(
-                            crate::type_queries::get_type_parameter_constraint(self.interner, ty)
-                                .unwrap_or(TypeId::ANY),
-                        );
-                    }
-                    Some(ty) => param_types.push(ty),
-                    None => {
-                        // Callable member returned None — either:
-                        // - Multiple overloads with disagreeing param types
-                        // - No parameter at this index for any signature
-                        // In either case, the signatures are not identical
-                        // across members, so no contextual type is provided.
-                        // However, for arity differences (member has fewer params),
-                        // tsc still provides contextual types from other members.
-                        // We check: does this callable have ANY signature with a
-                        // param at this index? If yes → internal disagreement → None.
-                        // If no → arity gap → skip this member.
-                        if self.callable_has_param_at_index(m, index) {
-                            return None;
+                // Compute the member's arity from the `type_data` already looked up,
+                // skipping construct-only members when a call member exists.
+                let arity = match type_data {
+                    Some(TypeData::Function(func_id)) => {
+                        let shape = self.interner.function_shape(func_id);
+                        if has_non_constructor_callable && shape.is_constructor {
+                            continue;
                         }
-                        // Arity gap — this member simply has fewer params; skip.
+                        shape.params.len()
                     }
-                }
+                    Some(TypeData::Callable(callable_id)) => self
+                        .interner
+                        .callable_shape(callable_id)
+                        .call_signatures
+                        .iter()
+                        .map(|sig| sig.params.len())
+                        .max()
+                        .unwrap_or(0),
+                    // `TypeId::FUNCTION` intrinsic: no declared params.
+                    _ => 0,
+                };
+                max_scan_arity = max_scan_arity.max(arity);
+                callable_members.push(m);
             }
 
-            if !has_callable_member || param_types.is_empty() {
+            if callable_members.is_empty() {
                 return None;
             }
-            // When all callable union members agree on the parameter type, return it directly.
-            // When they disagree, a direct union of callable types does not provide a
-            // contextual parameter type. This matches conformance cases like
-            // `IWithCallSignatures | IWithCallSignatures3`, where the callback
-            // parameter should remain implicit-any and report TS7006.
-            let first = param_types[0];
-            if param_types.iter().all(|&t| t == first) {
-                return Some(first);
+
+            // Resolve the contextual parameter type contributed by all callable members
+            // at a single position. Returns:
+            // - `Some(Some(ty))` — the members that have a param here agree on `ty`
+            //   (or one of them is `any`, which tsc instantiates to `any`).
+            // - `Some(None)`     — no member has a param at this position (arity gap).
+            // - `None`           — the members disagree; the union has no combined
+            //                       signature at this position.
+            let resolve_position = |this: &Self, position: usize| -> Option<Option<TypeId>> {
+                let mut position_types: Vec<TypeId> = Vec::new();
+                for &m in &callable_members {
+                    let ctx = ContextualTypeContext::with_expected_and_options(
+                        this.interner,
+                        m,
+                        this.no_implicit_any,
+                    );
+                    match ctx.get_parameter_type(position) {
+                        // A member whose parameter type is one of that member's own
+                        // (un-instantiated) generic type parameters represents a generic
+                        // overload that tsc would instantiate before contextually typing
+                        // the callback. Its contextual contribution is the type
+                        // parameter's constraint, or `any` when unconstrained — not the
+                        // bare type parameter (which would otherwise read as a spurious
+                        // "disagreement" against a concrete sibling overload, e.g.
+                        // `Array.reduce`'s `(prev: T, ...) => T | (prev: U, ...) => U`).
+                        Some(ty) if this.is_signature_own_free_type_parameter(m, ty) => {
+                            position_types.push(
+                                crate::type_queries::get_type_parameter_constraint(
+                                    this.interner,
+                                    ty,
+                                )
+                                .unwrap_or(TypeId::ANY),
+                            );
+                        }
+                        Some(ty) => position_types.push(ty),
+                        None => {
+                            // `None` from a member that *does* have a parameter here is
+                            // an internal overload disagreement; a member that lacks the
+                            // position (lower arity) just abstains.
+                            if this.callable_has_param_at_index(m, position) {
+                                return None;
+                            }
+                        }
+                    }
+                }
+
+                let Some(&first) = position_types.first() else {
+                    return Some(None);
+                };
+                if position_types.iter().all(|&t| t == first) {
+                    return Some(Some(first));
+                }
+                // A member contributing `any` (from widening an un-instantiated generic
+                // overload's own type parameter) lets tsc select and instantiate that
+                // overload, contextually typing the parameter as `any` rather than
+                // treating the mix as an irreconcilable disagreement.
+                if position_types.contains(&TypeId::ANY) {
+                    return Some(Some(TypeId::ANY));
+                }
+                None
+            };
+
+            // Signature-level gate: scan every shared position. If any disagrees, the
+            // union has no combined signature, so no position is contextually typed.
+            // Capture the queried index's contribution during the scan to avoid
+            // resolving it twice.
+            let mut queried_param: Option<Option<TypeId>> = None;
+            for position in 0..max_scan_arity {
+                let resolved = resolve_position(self, position)?;
+                if position == index {
+                    queried_param = Some(resolved);
+                }
             }
-            // If a member contributed `any` (from widening an un-instantiated generic
-            // overload's own type parameter above), the contextual parameter type is
-            // `any`: tsc selects and instantiates that generic overload, contextually
-            // typing the parameter as `any` rather than treating the mix of a concrete
-            // and a generic overload as an irreconcilable disagreement. This keeps the
-            // callback parameter contextually typed (no false TS7006) without affecting
-            // unions of purely-concrete callable members, which still return `None`.
-            if param_types.contains(&TypeId::ANY) {
-                return Some(TypeId::ANY);
-            }
-            return None;
+
+            // An `index` at or beyond the scanned arity is an arity gap (or an
+            // intrinsic `Function` member with no declared params); resolve it
+            // directly. `Some(None)` (arity gap) collapses to `None` via `flatten`.
+            return match queried_param {
+                Some(resolved) => resolved,
+                None => resolve_position(self, index).flatten(),
+            };
         }
 
         // Handle Application explicitly.


### PR DESCRIPTION
Fixes #14744.

Structural rule: when an object literal is checked against a union-of-objects
contextual type whose members declare a method/property with compatible
(here identical) parameter signatures, `tsc` contextually types that method's
parameters from the union's per-member property signatures
(`getTypeOfPropertyOfContextualType` → `getUnionSignatures` →
`getContextualCallSignature`); `tsz` emitted spurious **TS7006** through two
separate owners. Mined from **jotai** (`atomWithStorage` /
`createJSONStorage`, `AsyncStorage<V> | SyncStorage<V>`).

Two independent roots, both fixed:

1. **Discriminant pre-scan side effects** — owner
   `tsz_checker` `object_literal_context::narrow_contextual_union_via_object_literal_discriminants`.
   The pre-scan probed every non-literal property initializer with
   `get_type_of_node` to detect unit-typed discriminant values. For
   function/arrow/object/array/class/JSX initializers — which can never be a
   unit type — that probe only type-checked the node **context-free** and
   committed a premature TS7006 on the method parameters *before* the real,
   contextually typed pass ran. The pre-scan now skips initializer forms that
   are structurally never unit types (`initializer_is_structurally_non_unit`).
   Discriminant detection is unchanged — those forms already classified as
   non-unit; only the premature side-effect diagnostics are removed.

2. **Per-parameter vs signature-level union extraction** — owner
   `tsz_solver` `contextual::core::get_parameter_type` (Union branch).
   The branch decided contextual typing per parameter *position*, so a union
   whose members agreed on some params but disagreed on others would type the
   agreeing ones. `tsc`'s rule is **signature-level**: if the callable members
   disagree at any shared position, the union has no combined call signature
   and *every* parameter is implicit-any (the #5840 floor), while lower-arity
   members simply do not constrain the positions they lack. The branch now
   scans all shared positions and gates the whole signature on agreement.

Adjacent matrix (all checked against `tsc@5.9.3`, `--strict --target es2022
--lib es2022 --noEmit`): identical-param union members differing only in return
type → contextually typed (clean); renamed binders + a second method + a third
arm → clean; `| undefined` member → clean; members disagreeing on a param →
TS7006 on **both** params (not just the differing one); first param agrees /
second disagrees → both implicit-any; arity-gap member → trailing param still
typed from the longer member. Negative discriminant-narrowing cases (literal
arm matched, const-ref discriminant, genuine mismatch → TS2322/TS2353)
unchanged.

Anti-hardcoding: both fixes are structural — no identifier/property/file-name
checks, no formatted-message predicates. The skip-list keys on
syntactic-expression kind (a form whose type is never a unit literal); the
union gate keys on per-position signature agreement.

## Goal
Goal: green

## Verification
- New regression tests: `cargo test -p tsz-checker --test object_literal_union_contextual_typing_tests` (17 passed; 6 new cover the repro, multi-method/3-arm, `| undefined`, the #5840 negatives, and the arity-gap case).
- `cargo test -p tsz-solver --lib contextual` (128 passed) and `--lib union` (930 passed).
- `cargo clippy -p tsz-solver -p tsz-checker` clean.
- Parity matrix vs `tsc@5.9.3` for all adjacent cases above.
- Full conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: undisclosed
Effort: high

https://claude.ai/code/session_01AtRmQKMZzMGE71TqUPSxtV

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtRmQKMZzMGE71TqUPSxtV)_