### PR TITLE
fix(solver): keep lib conditional-utility return type from degrading to unknown consumer-first (#14740)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -662,6 +662,9 @@ path = "tests/literal_source_widening_position_parity_tests.rs"
 name = "interface_call_signature_typeof_param_tests"
 path = "tests/interface_call_signature_typeof_param_tests.rs"
 [[test]]
+name = "lib_conditional_alias_return_consumer_first_tests"
+path = "tests/lib_conditional_alias_return_consumer_first_tests.rs"
+[[test]]
 name = "lib_merge_indexed_access_no_cascade_tests"
 path = "tests/lib_merge_indexed_access_no_cascade_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/lib_conditional_alias_return_consumer_first_tests.rs
+++ b/crates/tsz-checker/tests/lib_conditional_alias_return_consumer_first_tests.rs
@@ -1,0 +1,133 @@
+//! Regression tests for issue #14740.
+//!
+//! A function whose declared return type is a lib distributive-conditional
+//! utility alias (`Exclude<T | undefined, undefined>`) — or the `NonNullable`
+//! variant — must resolve to its reduced body when the consumer module is
+//! type-checked BEFORE (or instead of) the producer module that declares the
+//! function. Before the fix, the cross-arena `Application(Lazy(lib_alias_def),
+//! args)` lost its conditional body and degraded to `unknown`, so a member
+//! access on the call result reported a false `TS2571` (`Object is of type
+//! 'unknown'`).
+//!
+//! Binder names are deliberately varied away from the issue's `getWidget`/
+//! `Widget` so the fix cannot key on any user identifier.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_common::common::ModuleKind;
+
+fn check_consumer_first(files: &[(&str, &str)], entry_file: &str) -> Vec<(u32, String)> {
+    let libs = tsz_checker::test_utils::load_lib_files(&["es5.d.ts"]);
+    tsz_checker::test_utils::check_multi_file_with_libs(
+        files,
+        entry_file,
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            strict: true,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .filter(|diag| diag.code != 2318)
+    .map(|diag| (diag.code, diag.message_text))
+    .collect()
+}
+
+/// `Exclude<Shape | undefined, undefined>` return type, consumer checked first.
+#[test]
+fn exclude_undefined_return_member_access_consumer_first_is_clean() {
+    let producer = r#"
+export type Gadget = { ping(n: number): void };
+export function pickGadget(): Exclude<Gadget | undefined, undefined> {
+    return undefined as any;
+}
+"#;
+    let consumer = r#"
+import { pickGadget } from "../zservices/gadgets";
+export function runner() {
+    pickGadget().ping(1);
+}
+"#;
+
+    let diagnostics = check_consumer_first(
+        &[
+            ("acore/runner.ts", consumer),
+            ("zservices/gadgets.ts", producer),
+        ],
+        "acore/runner.ts",
+    );
+    let codes: Vec<u32> = diagnostics.iter().map(|(code, _)| *code).collect();
+    assert!(
+        !codes.contains(&2571),
+        "Exclude<...> return type must reduce to its conditional body cross-module \
+         (no TS2571 'Object is of type unknown'); got {diagnostics:#?}"
+    );
+    assert!(
+        !codes.contains(&2322) && !codes.contains(&7006),
+        "no downstream degradation diagnostics expected; got {diagnostics:#?}"
+    );
+}
+
+/// `NonNullable<Shape | undefined>` variant, consumer checked first.
+#[test]
+fn non_nullable_return_member_access_consumer_first_is_clean() {
+    let producer = r#"
+export type Lever = { yank(n: number): void };
+export function grabLever(): NonNullable<Lever | undefined> {
+    return undefined as any;
+}
+"#;
+    let consumer = r#"
+import { grabLever } from "../zservices/levers";
+export function operate() {
+    grabLever().yank(2);
+}
+"#;
+
+    let diagnostics = check_consumer_first(
+        &[
+            ("acore/operate.ts", consumer),
+            ("zservices/levers.ts", producer),
+        ],
+        "acore/operate.ts",
+    );
+    let codes: Vec<u32> = diagnostics.iter().map(|(code, _)| *code).collect();
+    assert!(
+        !codes.contains(&2571),
+        "NonNullable<...> return type must reduce cross-module (no TS2571); got {diagnostics:#?}"
+    );
+}
+
+/// Control: a user-defined distributive conditional with identical semantics
+/// is already order-independent and must stay clean (guards against the fix
+/// regressing the working path).
+#[test]
+fn user_conditional_return_member_access_consumer_first_is_clean() {
+    let producer = r#"
+type DropUndef<T> = T extends undefined ? never : T;
+export type Hatch = { open(n: number): void };
+export function findHatch(): DropUndef<Hatch | undefined> {
+    return undefined as any;
+}
+"#;
+    let consumer = r#"
+import { findHatch } from "../zservices/hatches";
+export function unlock() {
+    findHatch().open(3);
+}
+"#;
+
+    let diagnostics = check_consumer_first(
+        &[
+            ("acore/unlock.ts", consumer),
+            ("zservices/hatches.ts", producer),
+        ],
+        "acore/unlock.ts",
+    );
+    let codes: Vec<u32> = diagnostics.iter().map(|(code, _)| *code).collect();
+    assert!(
+        !codes.contains(&2571),
+        "user distributive conditional control must stay clean; got {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate/application.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/application.rs
@@ -383,7 +383,27 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // path cannot refine it and only widens the observable surface of
             // this special case.
             if resolved == TypeId::UNKNOWN {
+                // Reducing `Alias<Args>` to canonical `unknown` requires the
+                // base def to be a *positively confirmed* type alias in THIS
+                // evaluation's resolver context. A thin cross-arena
+                // registration — where the resolver knows the `DefId` exists but
+                // not its `DefKind` (`ctx.is_type_alias_def` is false) — is a
+                // not-yet-materialized placeholder, never proof of a genuine
+                // `type C = unknown`. Without this gate a lib
+                // distributive-conditional alias (`Exclude`, `NonNullable`, …)
+                // resolved consumer-first carries a placeholder `unknown` body
+                // AND a lost lib file-origin in the consuming arena, so
+                // `is_genuine_unknown_alias_body`'s file-origin check alone
+                // misclassifies it as genuine and collapses
+                // `Exclude<T | undefined, undefined>` to bare `unknown` (false
+                // `TS2571`, issue #14740). Keeping the application opaque lets a
+                // later pass expand the real conditional body. The narrower gate
+                // lives here (the evaluator's reduction) rather than in the
+                // shared `is_genuine_unknown_alias_body` predicate, which the
+                // relation layer also consumes for deferred `unknown`-returning
+                // members (#13212 / #14595).
                 let genuine_unknown_body = genuine_unknown_alias_reduction_enabled()
+                    && ctx.is_type_alias_def
                     && self
                         .resolver
                         .is_genuine_unknown_alias_body(def_id, self.interner);


### PR DESCRIPTION
Closes #14740.

Goal: green

## Summary
A function whose declared return type is a lib distributive-conditional utility alias — `Exclude<T | undefined, undefined>` or `NonNullable<T | undefined>` — degraded to `unknown` when the **consumer** module was type-checked **before** the **producer** module that declares the function. Member access on the call result then reported a false `TS2571` (`Object is of type 'unknown'`). In the immer canary this accounts for 5 of the 9 tsz-only false positives (`immerClass.ts(127,222,244,246)` plus the downstream `(261)` TS7006). `tsc` 5.9.3 is clean.

## Root cause (traced)
`Application(Lazy(lib_alias_def), Args)` for `Exclude` (DefId 195) is evaluated in the consuming arena. There the lib alias is only **thinly registered**: its body reads the placeholder `unknown` and the resolver cannot confirm its `DefKind` (`get_def_kind` returns `None`) nor its lib file-origin (`def_is_non_program` returns `false`). The solver's application evaluator reduces the application to canonical `unknown` whenever the resolved body is `unknown` and `is_genuine_unknown_alias_body` returns `true`. That predicate's only discriminator between a genuine `type C = unknown` and a not-yet-materialized lib placeholder is the **file-origin** check — which misfires here, so the placeholder is mistaken for a genuine `unknown` alias and the conditional collapses to bare `unknown`.

Confirmed via tracing: two evaluations of DefId 195 reach the reduction branch — one with `non_program=true` (correctly opaque) and one with `non_program=false, kind=None` (wrongly reduced to literal `unknown`); the latter result becomes the property-access receiver.

## Structural rule
When an `Application`'s base is a type-alias def whose resolved body is the placeholder `unknown`, `tsc` keeps the alias's real (conditional/mapped) body and only collapses to `unknown` for a genuine `type C = unknown`. tsz must do the same via the solver evaluator: only reduce when the base is a **positively confirmed** type alias in the current resolver context (`ctx.is_type_alias_def`). An unconfirmed thin cross-arena registration stays opaque so a later pass expands the real body.

## Fix
One-line gate (plus comment) in `crates/tsz-solver/src/evaluation/evaluate/application.rs`: require `ctx.is_type_alias_def` before the `is_genuine_unknown_alias_body` reduction. The gate is **local to the evaluator**, leaving the shared `is_genuine_unknown_alias_body` predicate untouched — the relation layer still uses it for deferred `unknown`-returning members (#13212 / #14595). No user-name / file-name / printer-string predicate; the discriminator is the structural `DefKind` confirmation.

## Adjacent-case matrix
| Case | Before | After | tsc |
| --- | --- | --- | --- |
| `Exclude<T \| undefined, undefined>` return, consumer-first | TS2571 | clean | clean |
| `NonNullable<T \| undefined>` return, consumer-first | TS2571 | clean | clean |
| `Exclude<string \| undefined, undefined>` (primitive operand) | degraded | clean | clean |
| user `type Drop<T> = T extends undefined ? never : T` (control) | clean | clean | clean |
| genuine `type C<T> = unknown`, single-file, `.foo` access | TS2571 | TS2571 | TS2571 |
| genuine `type C<T> = unknown`, cross-file consumer-first, `.foo` | TS2571 | TS2571 | TS2571 |

Binder/alias names in the regression test are varied away from the issue's identifiers.

## Verification
- `cargo nextest run -p tsz-checker --test lib_conditional_alias_return_consumer_first_tests` — 3/3 pass (new regression: Exclude, NonNullable, user-conditional control). These flip: the same repro emits TS2571 on `origin/main` and is clean after the fix (verified with the built CLI on the issue's exact repro + tsconfig).
- Related suite `test(/omit/) or test(/exclude/) or test(/non_nullable/) or test(/genuine/) or test(/unknown_alias/) or test(/cross_file_recursive_alias/) or test(/lib_type_alias/)` — all pass except `zod_..._partial_omit_preserves_imported_path_property`, which **also fails on pristine `origin/main`** (pre-existing, unrelated).
- Genuine `type C = unknown` reduction preserved (single-file and cross-file), confirming no FN regression.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
