### PR TITLE
hold(bench): matrix-free republish lever + published-data freshness monitor

### DIFF
--- a/.github/workflows/bench-republish.yml
+++ b/.github/workflows/bench-republish.yml
@@ -1,0 +1,174 @@
+name: Bench Republish
+
+# Quick, matrix-free republish of an ALREADY-COMPLETED bench run's data to the
+# public benchmark site. The perf matrix takes ~2.5h and queues for hours on the
+# contended self-hosted pool; when latest.json freezes (a failed publish gate,
+# runner starvation, or a gate-policy fix that only applies to newer commits),
+# this lever re-publishes the newest complete run WITHOUT re-running the matrix.
+#
+# It is deliberately the lowest-risk shape: a single self-hosted job that reuses
+# the bench-publish auth (ambient GCS creds on tsz-cloud-run), the SAME readiness
+# gate, and the SAME monotonic generated_at guard — it never publishes
+# gate-failing or older data. Unlike re-running an old Bench run's bench-publish
+# (which checks out that run's pinned, possibly pre-fix commit and re-runs its
+# OLD gate code), this workflow checks out CURRENT main, so the gate that runs is
+# always the current-main policy.
+#
+# Why a separate workflow rather than a job inside bench.yml: adding a republish
+# job to bench.yml would require gating ~8 existing jobs (and the publish job's
+# `needs:`) to stay skipped for this lane — large and risky. A standalone
+# workflow reuses the publish/guard snippet verbatim with zero blast radius on
+# the perf pipeline.
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Bench run id whose bench-results-merged artifact to republish (e.g. 28322724209)"
+        required: true
+        type: string
+      redeploy_site:
+        description: "Trigger the gh-pages site rebuild after publishing"
+        required: false
+        default: true
+        type: boolean
+
+# Never let two republish operations race the single latest.json object.
+concurrency:
+  group: bench-republish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write
+  issues: read
+
+env:
+  _TSZ_CI_CACHE_BUCKET: gs://thirdface-ai-oauth_cloudbuild/tsz-ci-cache
+
+jobs:
+  republish:
+    name: bench-republish
+    runs-on: [self-hosted, tsz-cloud-run]
+    timeout-minutes: 20
+    steps:
+      # Plain checkout: for workflow_dispatch this is the selected ref (main by
+      # default), so the readiness gate below is CURRENT-main policy, not the
+      # republished run's (possibly pre-fix) pinned commit.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Download bench-results-merged from the target run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bench-results-merged
+          path: bench-merged
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Stage merged artifact + siblings
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The bench-results-merged artifact already contains the merged
+          # bench-results.json and every sibling the publish step copies to GCS
+          # (winners + missing-attribution), so there is nothing to re-merge.
+          for required in \
+            bench-results.json \
+            bench-results-tsgo-winners.json \
+            bench-results-missing-attribution.md; do
+            if [[ ! -f "bench-merged/${required}" ]]; then
+              echo "::error::bench-results-merged artifact from run ${{ inputs.run_id }} is missing ${required}; cannot republish."
+              find bench-merged -maxdepth 2 -type f -print || true
+              exit 1
+            fi
+            cp "bench-merged/${required}" "$GITHUB_WORKSPACE/${required}"
+          done
+          echo "Staged bench-results.json + siblings from run ${{ inputs.run_id }}."
+
+      - name: Re-gate against current main readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+          # SAME gate as bench-publish, but executed from the CURRENT-main
+          # checkout. A republish must never push gate-failing data to the site.
+          if ! node scripts/bench/check-artifact-readiness.mjs \
+            --json \
+            --require-application-compat \
+            --require-green-project-timing-pairs \
+            --require-project-timing-pairs=1 \
+            "$GITHUB_WORKSPACE/bench-results.json" \
+            > "$GITHUB_WORKSPACE/bench-results-readiness.json"; then
+            echo "::error::Run ${{ inputs.run_id }} bench-results.json does not pass the current-main readiness gate; refusing to republish."
+            cat "$GITHUB_WORKSPACE/bench-results-readiness.json" || true
+            exit 1
+          fi
+          echo "Readiness gate passed for run ${{ inputs.run_id }}."
+
+      - name: Publish to GCS latest.json (monotonic guard preserved)
+        id: publish
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+
+          # Always keep a timestamped history copy regardless of the guard below.
+          gsutil -q cp "$GITHUB_WORKSPACE/bench-results.json" \
+            "${_TSZ_CI_CACHE_BUCKET}/bench-runs/${TIMESTAMP}.json"
+          echo "Published: ${_TSZ_CI_CACHE_BUCKET}/bench-runs/${TIMESTAMP}.json"
+          gsutil -q cp "$GITHUB_WORKSPACE/bench-results-tsgo-winners.json" \
+            "${_TSZ_CI_CACHE_BUCKET}/bench-runs/${TIMESTAMP}.tsgo-winners.json"
+          gsutil -q cp "$GITHUB_WORKSPACE/bench-results-missing-attribution.md" \
+            "${_TSZ_CI_CACHE_BUCKET}/bench-runs/${TIMESTAMP}.missing-attribution.md"
+
+          # Monotonic latest.json guard — identical policy to bench.yml: refuse to
+          # overwrite latest.* when the already-published latest.json carries a
+          # newer-or-equal generated_at than the run being republished. Only
+          # refuses when BOTH timestamps parse and this run is not strictly newer,
+          # so it never reduces publishing on first publish or unparseable data.
+          existing_latest="$GITHUB_WORKSPACE/bench-results-existing-latest.json"
+          if ! gsutil -q cp "${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.json" "$existing_latest" 2>/dev/null; then
+            rm -f "$existing_latest"
+          fi
+          latest_decision="$(node -e '
+            const fs = require("node:fs");
+            const gen = (p) => { try { return Date.parse(JSON.parse(fs.readFileSync(p, "utf8")).generated_at) || 0; } catch { return 0; } };
+            const incoming = gen(process.argv[1]);
+            const existing = gen(process.argv[2]);
+            process.stdout.write(incoming > 0 && existing > 0 && incoming <= existing ? "skip" : "publish");
+          ' "$GITHUB_WORKSPACE/bench-results.json" "$existing_latest")"
+          rm -f "$existing_latest"
+
+          if [[ "$latest_decision" == "skip" ]]; then
+            echo "latest.json guard: existing latest.json is newer-or-equal than run ${{ inputs.run_id }}; keeping it and skipping the latest.* overwrite (timestamped ${TIMESTAMP}.json was still published)."
+            echo "should_redeploy=false" >> "$GITHUB_OUTPUT"
+          else
+            gsutil -q cp "$GITHUB_WORKSPACE/bench-results.json" \
+              "${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.json"
+            echo "Published: ${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.json"
+            gsutil -q cp "$GITHUB_WORKSPACE/bench-results-tsgo-winners.json" \
+              "${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.tsgo-winners.json"
+            gsutil -q cp "$GITHUB_WORKSPACE/bench-results-missing-attribution.md" \
+              "${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.missing-attribution.md"
+            echo "should_redeploy=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger website redeploy
+        if: steps.publish.outputs.should_redeploy == 'true' && inputs.redeploy_site
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # GCS latest.json alone does NOT update tsz.dev — the public file is a
+          # static asset baked by the gh-pages "Deploy Website" build. Dispatch it
+          # (idempotent, retried) so the site rebakes the freshly published data.
+          if ! curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 15 \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/gh-pages.yml/dispatches" \
+            -d '{"ref":"main"}'; then
+            echo "::warning::Website redeploy dispatch failed after retries; benchmark data is published to GCS. Re-run gh-pages.yml manually to rebake the site."
+          fi

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -520,3 +520,34 @@ jobs:
             echo "::warning::bench artifact absent or could not be parsed — bench did not complete for latest main"
           fi
           exit 0
+
+  bench-latest-freshness:
+    name: bench-latest-freshness
+    runs-on: ubuntu-latest
+    # Advisory by design: a monitoring job must not red the health workflow.
+    # The SIGNAL is a single deduplicated tracking issue (--file-issue), not a
+    # red run — mirroring main-red-sentinel. This closes the freeze blind spot:
+    # bench-artifact-readiness above inspects a freshly merged ARTIFACT and gates
+    # on source-commit currency, so it stays green while the PUBLISHED
+    # latest.json silently stops advancing (the 46-commit freeze went unnoticed
+    # for half a day for exactly this reason).
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Detect stale published benchmark data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Threshold is 9h, not the 6h script default: the perf cadence is 3h but
+          # runs queue for hours on the contended self-hosted pool, so 9h (~3
+          # missed cadences) avoids false alarms during normal long queueing while
+          # still catching a real freeze within a few hours. --file-issue opens /
+          # updates / closes one deduplicated tracking issue; no --strict so a
+          # transient fetch blip never reds this advisory job.
+          node scripts/bench/check-latest-freshness.mjs --file-issue --max-age-hours 9 \
+            | tee -a "${GITHUB_STEP_SUMMARY}"

--- a/scripts/bench/check-latest-freshness.mjs
+++ b/scripts/bench/check-latest-freshness.mjs
@@ -1,0 +1,432 @@
+#!/usr/bin/env node
+/**
+ * Detects a stale *published* benchmark dataset.
+ *
+ * Fetches the public benchmark JSON (default
+ * `https://tsz.dev/benchmark-data/latest.json`), parses `generated_at`, and
+ * alerts when it is older than `--max-age-hours` (default 6) — or when the
+ * payload cannot be parsed into a dated artifact at all.
+ *
+ * Why this exists: nothing else watches the *published* dataset's freshness.
+ * `check-artifact-readiness.mjs` only inspects a freshly merged GitHub Actions
+ * artifact and gates on source-commit currency, not wall-clock staleness, so the
+ * advisory readiness probe stays green while `latest.json` silently stops
+ * advancing. A 46-commit / half-day publish freeze went unnoticed precisely
+ * because no monitor compared the live `generated_at` to now. This is that
+ * monitor.
+ *
+ * Exit codes:
+ *   0 — fresh (or advisory mode, the default, regardless of status)
+ *   3 — stale or unparseable artifact AND `--strict`
+ *   4 — fetch/transport failure AND `--strict` (advisory "unknown" by default)
+ *
+ * With `--file-issue`: opens / updates / closes ONE deduplicated tracking issue
+ * keyed on a hidden marker, mirroring `scripts/ci/check-main-red.mjs`, so a
+ * standing freeze surfaces as a single tracking issue (non-spammy) instead of a
+ * red advisory workflow nobody reads.
+ *
+ * Usage:
+ *   node scripts/bench/check-latest-freshness.mjs [--url <url>] [--max-age-hours <n>]
+ *     [--fixture <file>] [--file-issue] [--strict] [--json]
+ */
+
+import fs from "node:fs";
+import https from "node:https";
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+export const DEFAULT_LATEST_URL = "https://tsz.dev/benchmark-data/latest.json";
+export const DEFAULT_MAX_AGE_HOURS = 6;
+const ISSUE_MARKER = "<!-- bench-latest-freshness-sentinel -->";
+const ISSUE_TITLE =
+  "🟡 benchmark site data is stale — latest.json generated_at not advancing";
+const MS_PER_HOUR = 3_600_000;
+
+/**
+ * Pure classifier: decide freshness from a response body + a clock.
+ *
+ * Returns `{ status, alert, reason, generatedAt, ageHours, maxAgeHours }` where
+ * `status` is one of `"ok" | "stale" | "unparseable"` and `alert` is true for
+ * anything that should raise attention.
+ *
+ * @param {string|object|null|undefined} body
+ * @param {{ now?: number, maxAgeHours?: number }} [options]
+ */
+export function classifyFreshness(body, options = {}) {
+  const now = Number.isFinite(options.now) ? options.now : Date.now();
+  const maxAgeHours = Number.isFinite(options.maxAgeHours)
+    ? options.maxAgeHours
+    : DEFAULT_MAX_AGE_HOURS;
+
+  let parsed;
+  if (body && typeof body === "object") {
+    parsed = body;
+  } else if (typeof body === "string") {
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      return {
+        status: "unparseable",
+        alert: true,
+        reason: "published benchmark payload is not valid JSON",
+        generatedAt: null,
+        ageHours: null,
+        maxAgeHours,
+      };
+    }
+  } else {
+    return {
+      status: "unparseable",
+      alert: true,
+      reason: "published benchmark payload is empty",
+      generatedAt: null,
+      ageHours: null,
+      maxAgeHours,
+    };
+  }
+
+  const generatedAt =
+    parsed && typeof parsed === "object" ? parsed.generated_at : undefined;
+  const generatedMs = generatedAt ? Date.parse(generatedAt) : Number.NaN;
+  if (!generatedAt || Number.isNaN(generatedMs)) {
+    return {
+      status: "unparseable",
+      alert: true,
+      reason: generatedAt
+        ? `generated_at ${JSON.stringify(generatedAt)} is not a parseable date`
+        : "generated_at field is missing from the published benchmark payload",
+      generatedAt: generatedAt ?? null,
+      ageHours: null,
+      maxAgeHours,
+    };
+  }
+
+  const ageHours = (now - generatedMs) / MS_PER_HOUR;
+  // A future generated_at (clock skew) is not stale; clamp the display age.
+  const displayAge = Math.max(0, ageHours);
+  if (ageHours > maxAgeHours) {
+    return {
+      status: "stale",
+      alert: true,
+      reason: `published benchmark data is ${ageHours.toFixed(
+        1,
+      )}h old (threshold ${maxAgeHours}h)`,
+      generatedAt,
+      ageHours,
+      maxAgeHours,
+    };
+  }
+  return {
+    status: "ok",
+    alert: false,
+    reason: `published benchmark data is ${displayAge.toFixed(
+      1,
+    )}h old (threshold ${maxAgeHours}h)`,
+    generatedAt,
+    ageHours,
+    maxAgeHours,
+  };
+}
+
+/**
+ * Render a short markdown report (stdout / step summary).
+ * @param {ReturnType<typeof classifyFreshness>} verdict
+ * @param {{ url: string }} ctx
+ */
+export function formatReport(verdict, ctx) {
+  const icon =
+    verdict.status === "ok" ? "✅" : verdict.status === "stale" ? "🟡" : "🔴";
+  const lines = [
+    `### ${icon} Published benchmark freshness`,
+    "",
+    `- Source: \`${ctx.url}\``,
+    `- generated_at: \`${verdict.generatedAt ?? "—"}\``,
+    `- Age: ${
+      verdict.ageHours == null ? "unknown" : `${verdict.ageHours.toFixed(1)}h`
+    } (threshold ${verdict.maxAgeHours}h)`,
+    `- Status: **${verdict.status}** — ${verdict.reason}`,
+  ];
+  return lines.join("\n");
+}
+
+/**
+ * Issue body for the dedup tracking issue. Embeds the marker (for dedup) and the
+ * tracked generated_at (so a still-stale heartbeat only comments when the
+ * generated_at actually changed, never every firing).
+ */
+export function formatIssueBody(verdict, ctx, nowIso) {
+  return [
+    ISSUE_MARKER,
+    "",
+    `**The public benchmark dataset has stopped advancing.**`,
+    "",
+    `- Source: \`${ctx.url}\``,
+    `- generated_at: \`${verdict.generatedAt ?? "—"}\``,
+    `- Age: ${
+      verdict.ageHours == null ? "unknown" : `${verdict.ageHours.toFixed(1)}h`
+    } (threshold ${verdict.maxAgeHours}h)`,
+    `- Status: \`${verdict.status}\` — ${verdict.reason}`,
+    `- Last checked: ${nowIso}`,
+    "",
+    "Likely causes: the Bench `bench-publish` job stopped publishing `latest.json`",
+    "(readiness gate, required-shard completeness, runner-signature, or",
+    "`pgo-compile-canaries` failure), or the gh-pages site stopped redeploying.",
+    "",
+    "Quick fix without a ~2.5h matrix rerun: re-publish a recent COMPLETE run's",
+    "artifact with `gh workflow run bench-republish.yml -f run_id=<run id>`",
+    "(re-gates against current main, preserves the monotonic guard).",
+    "",
+    "_Filed automatically by `scripts/bench/check-latest-freshness.mjs`",
+    "(ci-health bench-latest-freshness). Do not edit the marker line._",
+  ].join("\n");
+}
+
+// ---- gh I/O (kept behind injectable seams so main() stays testable) ----------
+
+const GH_RETRY_ATTEMPTS = 3;
+const GH_RETRY_BASE_MS = 750;
+const GH_RETRY_MAX_MS = 6000;
+const TRANSIENT_NET_CODES = new Set(["ETIMEDOUT", "ECONNRESET", "EAI_AGAIN", "ENETUNREACH"]);
+
+function sleepSync(ms) {
+  if (!(ms > 0)) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function isTransientGhResult(result) {
+  if (result.error) return TRANSIENT_NET_CODES.has(result.error.code);
+  if ((result.status ?? 0) === 0) return false;
+  const text = `${result.stdout || ""}\n${result.stderr || ""}`;
+  return /\bHTTP\s+(?:408|425|429|5\d\d)\b/i.test(text) || /secondary rate limit/i.test(text);
+}
+
+function spawnGh(args) {
+  let result;
+  for (let attempt = 1; attempt <= GH_RETRY_ATTEMPTS; attempt += 1) {
+    result = spawnSync("gh", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "pipe"] });
+    if (attempt === GH_RETRY_ATTEMPTS || !isTransientGhResult(result)) break;
+    sleepSync(Math.min(GH_RETRY_BASE_MS * 2 ** (attempt - 1), GH_RETRY_MAX_MS));
+  }
+  return result;
+}
+
+function runGhJson(args) {
+  const result = spawnGh(args);
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`gh ${args.join(" ")} failed: ${result.stderr?.trim() || result.stdout?.trim()}`);
+  }
+  return JSON.parse(result.stdout);
+}
+
+function runGh(args) {
+  const result = spawnGh(args);
+  if (result.error) return { status: 1, stdout: "", stderr: result.error.message };
+  return { status: result.status ?? 1, stdout: (result.stdout || "").trim(), stderr: (result.stderr || "").trim() };
+}
+
+const TRACKED_GENERATED_RE = /generated_at:\s*`([^`]+)`/;
+
+function findSentinelIssue(repository, fetchJson) {
+  const issues = fetchJson([
+    "api",
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${repository}/issues?state=open&per_page=100`,
+  ]);
+  if (!Array.isArray(issues)) return null;
+  return issues.find((it) => typeof it.body === "string" && it.body.includes(ISSUE_MARKER)) || null;
+}
+
+/**
+ * Open / update / close the single dedup tracking issue.
+ * @param {ReturnType<typeof classifyFreshness>} verdict
+ */
+export function reconcileIssue(verdict, ctx, nowIso, gh = {}) {
+  const { repository } = ctx;
+  const fetchJson = gh.fetchJson || runGhJson;
+  const runCommand = gh.runCommand || runGh;
+  const existing = findSentinelIssue(repository, fetchJson);
+
+  if (verdict.alert) {
+    const body = formatIssueBody(verdict, ctx, nowIso);
+    if (existing) {
+      const previous = (existing.body?.match(TRACKED_GENERATED_RE) || [])[1] || "";
+      const current = verdict.generatedAt ?? "";
+      runCommand(["issue", "edit", String(existing.number), "--repo", repository, "--body", body]);
+      // Heartbeat-comment only when the tracked generated_at changed, so a
+      // standing freeze does not comment on every 15-minute firing.
+      const changed = current !== "" && current !== previous;
+      if (changed) {
+        runCommand([
+          "issue",
+          "comment",
+          String(existing.number),
+          "--repo",
+          repository,
+          "--body",
+          `Still stale as of ${nowIso}: generated_at \`${current}\` (${verdict.reason}).`,
+        ]);
+      }
+      return { action: "updated", number: existing.number, commented: changed };
+    }
+    const created = runCommand([
+      "issue",
+      "create",
+      "--repo",
+      repository,
+      "--title",
+      ISSUE_TITLE,
+      "--body",
+      body,
+      "--label",
+      "tech-debt",
+    ]);
+    return { action: "created", detail: created.stdout || created.stderr };
+  }
+
+  if (existing) {
+    runCommand([
+      "issue",
+      "comment",
+      String(existing.number),
+      "--repo",
+      repository,
+      "--body",
+      `✅ Published benchmark data is fresh again as of ${nowIso} (${verdict.reason}). Closing.`,
+    ]);
+    runCommand(["issue", "close", String(existing.number), "--repo", repository, "--reason", "completed"]);
+    return { action: "closed", number: existing.number };
+  }
+  return { action: "noop" };
+}
+
+// ---- HTTP (node:https, redirect-following, works on every Node version) ------
+
+function httpGet(url, { maxRedirects = 4, timeoutMs = 15000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, { headers: { "User-Agent": "tsz-bench-latest-freshness" } }, (response) => {
+      const status = response.statusCode || 0;
+      if (status >= 300 && status < 400 && response.headers.location) {
+        response.resume();
+        if (maxRedirects <= 0) {
+          reject(new Error(`too many redirects fetching ${url}`));
+          return;
+        }
+        const next = new URL(response.headers.location, url).toString();
+        httpGet(next, { maxRedirects: maxRedirects - 1, timeoutMs }).then(resolve, reject);
+        return;
+      }
+      let raw = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => (raw += chunk));
+      response.on("end", () => {
+        if (status < 200 || status >= 300) {
+          reject(new Error(`GET ${url} returned ${status}`));
+          return;
+        }
+        resolve(raw);
+      });
+    });
+    request.setTimeout(timeoutMs, () => request.destroy(new Error(`GET ${url} timed out after ${timeoutMs}ms`)));
+    request.on("error", reject);
+  });
+}
+
+function parseArgs(argv) {
+  const options = {
+    url: DEFAULT_LATEST_URL,
+    maxAgeHours: DEFAULT_MAX_AGE_HOURS,
+    fixture: null,
+    fileIssue: false,
+    strict: false,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const valueOf = (inline) => (inline !== undefined ? inline : argv[++i]);
+    if (arg === "--url" || arg.startsWith("--url=")) {
+      options.url = valueOf(arg.includes("=") ? arg.split("=").slice(1).join("=") : undefined);
+    } else if (arg === "--max-age-hours" || arg.startsWith("--max-age-hours=")) {
+      options.maxAgeHours = Number(valueOf(arg.includes("=") ? arg.split("=")[1] : undefined));
+    } else if (arg === "--fixture" || arg.startsWith("--fixture=")) {
+      options.fixture = valueOf(arg.includes("=") ? arg.split("=").slice(1).join("=") : undefined);
+    } else if (arg === "--file-issue") {
+      options.fileIssue = true;
+    } else if (arg === "--strict") {
+      options.strict = true;
+    } else if (arg === "--json") {
+      options.json = true;
+    }
+  }
+  if (!Number.isFinite(options.maxAgeHours) || options.maxAgeHours <= 0) {
+    options.maxAgeHours = DEFAULT_MAX_AGE_HOURS;
+  }
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const nowIso = new Date().toISOString();
+
+  let body;
+  let fetchError = null;
+  if (options.fixture) {
+    body = fs.readFileSync(options.fixture, "utf8");
+  } else {
+    try {
+      body = await httpGet(options.url);
+    } catch (error) {
+      fetchError = error;
+    }
+  }
+
+  if (fetchError) {
+    // A transport failure is "unknown", not proof of staleness: stay advisory by
+    // default so a transient network blip never spams the tracking issue.
+    const message = `::warning::bench-latest-freshness: could not fetch ${options.url}: ${fetchError.message}`;
+    process.stderr.write(`${message}\n`);
+    if (options.json) process.stdout.write(`${JSON.stringify({ status: "fetch-error", url: options.url, error: fetchError.message })}\n`);
+    process.exit(options.strict ? 4 : 0);
+  }
+
+  const verdict = classifyFreshness(body, { maxAgeHours: options.maxAgeHours });
+  const report = formatReport(verdict, { url: options.url });
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ url: options.url, ...verdict })}\n`);
+  } else {
+    process.stdout.write(`${report}\n`);
+  }
+
+  if (verdict.alert) {
+    process.stderr.write(
+      `::warning::bench-latest-freshness: ${verdict.status} — ${verdict.reason} (${options.url})\n`,
+    );
+  }
+
+  if (options.fileIssue) {
+    const repository = process.env.REPOSITORY || process.env.GITHUB_REPOSITORY;
+    if (!repository) {
+      process.stderr.write("::warning::bench-latest-freshness: --file-issue requires REPOSITORY or GITHUB_REPOSITORY\n");
+    } else {
+      try {
+        const outcome = reconcileIssue(verdict, { url: options.url, repository }, nowIso);
+        process.stderr.write(`bench-latest-freshness issue: ${JSON.stringify(outcome)}\n`);
+      } catch (error) {
+        process.stderr.write(`::warning::bench-latest-freshness: issue reconcile failed: ${error.message}\n`);
+      }
+    }
+  }
+
+  process.exit(options.strict && verdict.alert ? 3 : 0);
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((error) => {
+    process.stderr.write(`bench-latest-freshness failed: ${error.stack || error.message}\n`);
+    process.exit(2);
+  });
+}

--- a/scripts/bench/merge-results.mjs
+++ b/scripts/bench/merge-results.mjs
@@ -36,6 +36,23 @@ const PROJECT_COMPATIBILITY_ROW_SET = new Set([
 ]);
 const BENCHMARK_RUNNER = "scripts/bench/bench-vs-tsgo.sh";
 
+// The bench-canaries and bench-applications shards are OPTIONAL: they are
+// excluded from the required-shard completeness gate in bench.yml (the same
+// `bench-results-bench-(canaries|applications).json` exclusion lives there) and
+// the readiness gate only blocks on required rows. A flaky optional shard must
+// therefore never fail the merge step either: its runner-signature defects are
+// advisory, not publish-blocking. Classify by shard.label first (authoritative
+// when present) and fall back to the shard artifact filename so a shard that is
+// SO broken it dropped its shard.label is still recognised as optional.
+const OPTIONAL_SHARD_LABELS = new Set(["bench-canaries", "bench-applications"]);
+const OPTIONAL_SHARD_FILE_PATTERN = /^bench-results-bench-(canaries|applications)\.json$/;
+
+function isOptionalShard(file, payload) {
+  const label = payload?.shard?.label;
+  if (typeof label === "string" && OPTIONAL_SHARD_LABELS.has(label)) return true;
+  return OPTIONAL_SHARD_FILE_PATTERN.test(path.basename(file));
+}
+
 function hasProjectCompatibilityRows(rows) {
   return rows.some((row) => PROJECT_COMPATIBILITY_ROW_SET.has(row?.name));
 }
@@ -269,11 +286,21 @@ function collectFixtureSourceFailures(rowName, fixtureSources) {
 }
 
 function collectRunnerSignatureFailures(payloads, runnerEnvironmentWarnings) {
-  const failures = [];
+  const blocking = [];
+  const advisory = [];
+  // Route a per-shard signature defect to advisory for the optional
+  // (canary/application) shards and blocking for the required ones.
+  const optionalFiles = new Set(
+    payloads.filter(({ file, payload }) => isOptionalShard(file, payload)).map(({ file }) => path.basename(file)),
+  );
+  const push = (basename, message) => {
+    (optionalFiles.has(basename) ? advisory : blocking).push(message);
+  };
   const seenShardLabels = new Map();
 
   for (const { file, payload } of payloads) {
     const basename = path.basename(file);
+    const failures = { push: (message) => push(basename, message) };
     const environment = payload.runner_environment;
     if (!environment || typeof environment !== "object") {
       failures.push(`${basename}: missing runner_environment`);
@@ -339,10 +366,17 @@ function collectRunnerSignatureFailures(payloads, runnerEnvironmentWarnings) {
   }
 
   for (const warning of runnerEnvironmentWarnings.filter(isFatalRunnerEnvironmentWarning)) {
-    failures.push(`${warning.file}: runner_environment mismatch (${warning.mismatched_fields.join(", ")})`);
+    // warning.file is already a basename (validateRunnerEnvironmentConsistency).
+    // A required shard diverging from the baseline runner is a measurement
+    // integrity failure (blocking); an optional shard that legitimately ran on a
+    // different runner is advisory.
+    push(
+      warning.file,
+      `${warning.file}: runner_environment mismatch (${warning.mismatched_fields.join(", ")})`,
+    );
   }
 
-  return failures;
+  return { blocking, advisory };
 }
 
 function measurementProfileSignature(profile) {
@@ -640,12 +674,21 @@ function main() {
     .filter(({ profile }) => profile && typeof profile === "object");
   const measurementProfile = measurementProfiles[0]?.profile ?? null;
   const measurementProfileWarnings = validateMeasurementProfileConsistency(measurementProfiles);
-  const runnerSignatureFailures = requireRunnerSignature
+  const { blocking: runnerSignatureBlocking, advisory: runnerSignatureAdvisory } = requireRunnerSignature
     ? collectRunnerSignatureFailures(payloads, runnerEnvironmentWarnings)
-    : [];
-  if (runnerSignatureFailures.length > 0) {
-    console.error("Benchmark runner signature validation failed:");
-    for (const failure of runnerSignatureFailures) {
+    : { blocking: [], advisory: [] };
+  if (runnerSignatureAdvisory.length > 0) {
+    // Optional canary/application shard signature defects must NOT block
+    // publishing the required benchmark timings (a flaky optional shard once
+    // froze the whole benchmark site). Surface them as annotations and continue.
+    console.warn("::warning::Benchmark runner signature validation found advisory gaps on optional shards; publishing required timing data anyway:");
+    for (const failure of runnerSignatureAdvisory) {
+      console.warn(`  - ${failure}`);
+    }
+  }
+  if (runnerSignatureBlocking.length > 0) {
+    console.error("Benchmark runner signature validation failed (blocking):");
+    for (const failure of runnerSignatureBlocking) {
       console.error(`  - ${failure}`);
     }
     process.exit(1);
@@ -662,6 +705,7 @@ function main() {
       runner_environment_warnings: runnerEnvironmentWarnings,
       measurement_profile_warnings: measurementProfileWarnings,
       project_compatibility_advisory: compatAdvisory,
+      runner_signature_advisory: runnerSignatureAdvisory,
       dropped_empty_shards: droppedEmptyShards.map(({ file, payload }) => ({
         file: path.basename(file),
         error: shardStubError(payload),

--- a/scripts/bench/test-check-latest-freshness.mjs
+++ b/scripts/bench/test-check-latest-freshness.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  classifyFreshness,
+  formatReport,
+  formatIssueBody,
+  reconcileIssue,
+  DEFAULT_MAX_AGE_HOURS,
+  DEFAULT_LATEST_URL,
+} from "./check-latest-freshness.mjs";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(SCRIPT_DIR, "check-latest-freshness.mjs");
+const NOW = Date.parse("2026-06-28T18:00:00.000Z");
+
+function at(hoursAgo) {
+  return new Date(NOW - hoursAgo * 3_600_000).toISOString();
+}
+
+// ---- fresh -> ok ------------------------------------------------------------
+{
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: at(2) }), {
+    now: NOW,
+    maxAgeHours: 6,
+  });
+  assert.equal(verdict.status, "ok", "2h-old data under a 6h threshold is fresh");
+  assert.equal(verdict.alert, false, "fresh data must not alert");
+  assert.ok(Math.abs(verdict.ageHours - 2) < 1e-6, "age is computed in hours");
+}
+
+// Exactly at the threshold is still fresh (boundary is inclusive of <=).
+{
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: at(6) }), {
+    now: NOW,
+    maxAgeHours: 6,
+  });
+  assert.equal(verdict.status, "ok", "age == threshold is not yet stale");
+  assert.equal(verdict.alert, false);
+}
+
+// A future generated_at (clock skew) is not stale.
+{
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: at(-1) }), {
+    now: NOW,
+    maxAgeHours: 6,
+  });
+  assert.equal(verdict.status, "ok", "future generated_at is not stale");
+  assert.equal(verdict.alert, false);
+}
+
+// Default threshold is applied when none is supplied.
+{
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: at(1) }), { now: NOW });
+  assert.equal(verdict.maxAgeHours, DEFAULT_MAX_AGE_HOURS, "default threshold applied");
+  assert.equal(verdict.status, "ok");
+}
+
+// ---- stale -> alert ---------------------------------------------------------
+{
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: at(9) }), {
+    now: NOW,
+    maxAgeHours: 6,
+  });
+  assert.equal(verdict.status, "stale", "9h-old data over a 6h threshold is stale");
+  assert.equal(verdict.alert, true, "stale data must alert");
+  assert.match(verdict.reason, /9\.0h old \(threshold 6h\)/);
+}
+
+// The exact 46-commit-freeze witness: 2026-06-27T19:03 frozen, ~23h later.
+{
+  const frozen = "2026-06-27T19:03:16.801Z";
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: frozen }), {
+    now: Date.parse("2026-06-28T18:00:00.000Z"),
+    maxAgeHours: 6,
+  });
+  assert.equal(verdict.status, "stale", "the real freeze witness is flagged stale");
+  assert.equal(verdict.alert, true);
+}
+
+// ---- unparseable -> alert ---------------------------------------------------
+{
+  const verdict = classifyFreshness("<html>not json</html>", { now: NOW, maxAgeHours: 6 });
+  assert.equal(verdict.status, "unparseable", "non-JSON body is unparseable");
+  assert.equal(verdict.alert, true, "unparseable payload must alert");
+}
+{
+  const verdict = classifyFreshness(JSON.stringify({ results: [] }), { now: NOW });
+  assert.equal(verdict.status, "unparseable", "missing generated_at is unparseable");
+  assert.equal(verdict.alert, true);
+}
+{
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: "not-a-date" }), { now: NOW });
+  assert.equal(verdict.status, "unparseable", "unparseable generated_at date is flagged");
+  assert.equal(verdict.alert, true);
+}
+{
+  const verdict = classifyFreshness("", { now: NOW });
+  assert.equal(verdict.status, "unparseable", "empty body is unparseable");
+  assert.equal(verdict.alert, true);
+}
+
+// ---- report + issue body include the marker / key facts ---------------------
+{
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: at(9) }), {
+    now: NOW,
+    maxAgeHours: 6,
+  });
+  const report = formatReport(verdict, { url: DEFAULT_LATEST_URL });
+  assert.match(report, /Status: \*\*stale\*\*/);
+  const body = formatIssueBody(verdict, { url: DEFAULT_LATEST_URL, repository: "tsz-org/tsz" }, NOW_ISO());
+  assert.match(body, /bench-latest-freshness-sentinel/, "issue body carries the dedup marker");
+  assert.match(body, /bench-republish\.yml/, "issue body points at the quick-fix lever");
+  assert.match(body, /generated_at: `2026-06-2/, "issue body records the tracked generated_at");
+}
+
+function NOW_ISO() {
+  return new Date(NOW).toISOString();
+}
+
+// ---- reconcileIssue: open / heartbeat / close, deduped on the marker --------
+{
+  // No existing issue + alert -> create.
+  const calls = [];
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: at(9) }), { now: NOW, maxAgeHours: 6 });
+  const outcome = reconcileIssue(
+    verdict,
+    { url: DEFAULT_LATEST_URL, repository: "tsz-org/tsz" },
+    NOW_ISO(),
+    {
+      fetchJson: () => [],
+      runCommand: (args) => {
+        calls.push(args);
+        return { status: 0, stdout: "https://github.com/tsz-org/tsz/issues/1", stderr: "" };
+      },
+    },
+  );
+  assert.equal(outcome.action, "created");
+  assert.ok(calls.some((c) => c[0] === "issue" && c[1] === "create"), "creates a tracking issue");
+}
+{
+  // Existing issue with same generated_at + still alert -> edit, NO heartbeat.
+  const calls = [];
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: "2026-06-27T19:03:16.801Z" }), {
+    now: NOW,
+    maxAgeHours: 6,
+  });
+  const existingBody = formatIssueBody(verdict, { url: DEFAULT_LATEST_URL, repository: "tsz-org/tsz" }, NOW_ISO());
+  const outcome = reconcileIssue(
+    verdict,
+    { url: DEFAULT_LATEST_URL, repository: "tsz-org/tsz" },
+    NOW_ISO(),
+    {
+      fetchJson: () => [{ number: 7, body: existingBody }],
+      runCommand: (args) => {
+        calls.push(args);
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    },
+  );
+  assert.equal(outcome.action, "updated");
+  assert.equal(outcome.commented, false, "no heartbeat comment when generated_at is unchanged");
+  assert.ok(calls.some((c) => c[1] === "edit"), "edits the existing issue body");
+  assert.ok(!calls.some((c) => c[1] === "comment"), "does not spam a comment on every firing");
+}
+{
+  // Existing issue + now fresh -> comment + close.
+  const calls = [];
+  const verdict = classifyFreshness(JSON.stringify({ generated_at: at(1) }), { now: NOW, maxAgeHours: 6 });
+  const outcome = reconcileIssue(
+    verdict,
+    { url: DEFAULT_LATEST_URL, repository: "tsz-org/tsz" },
+    NOW_ISO(),
+    {
+      fetchJson: () => [{ number: 9, body: `${"<!-- bench-latest-freshness-sentinel -->"}\nstale` }],
+      runCommand: (args) => {
+        calls.push(args);
+        return { status: 0, stdout: "", stderr: "" };
+      },
+    },
+  );
+  assert.equal(outcome.action, "closed");
+  assert.ok(calls.some((c) => c[1] === "close"), "closes the tracking issue on recovery");
+}
+
+// ---- end-to-end CLI via --fixture (offline, no network) ---------------------
+function runCli(args, fixtureValue) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-latest-freshness-"));
+  try {
+    const fixture = path.join(dir, "latest.json");
+    fs.writeFileSync(fixture, fixtureValue, "utf8");
+    return spawnSync(process.execPath, [SCRIPT, "--fixture", fixture, ...args], { encoding: "utf8" });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+{
+  // Fresh fixture: advisory exit 0, JSON status ok.
+  const result = runCli(["--json", "--max-age-hours", "100000"], JSON.stringify({ generated_at: at(1) }));
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /"status":"ok"/);
+}
+{
+  // Stale fixture in advisory mode: still exit 0, but warns.
+  const result = runCli(["--json", "--max-age-hours", "0.001"], JSON.stringify({ generated_at: at(9) }));
+  assert.equal(result.status, 0, "advisory mode never fails the job");
+  assert.match(result.stdout, /"status":"stale"/);
+  assert.match(result.stderr, /::warning::bench-latest-freshness/);
+}
+{
+  // Stale fixture with --strict: exit 3.
+  const result = runCli(["--strict", "--max-age-hours", "0.001"], JSON.stringify({ generated_at: at(9) }));
+  assert.equal(result.status, 3, "strict mode exits non-zero on staleness");
+}
+{
+  // Unparseable fixture with --strict: exit 3.
+  const result = runCli(["--strict"], "not json at all");
+  assert.equal(result.status, 3, "strict mode exits non-zero on unparseable payload");
+}
+
+console.log("check-latest-freshness tests passed");

--- a/scripts/bench/test-merge-results.mjs
+++ b/scripts/bench/test-merge-results.mjs
@@ -927,6 +927,94 @@ withTempDir((dir) => {
   );
 });
 
+// Optional canary/application shard signature defects are ADVISORY: a broken
+// optional shard must never fail the merge step (and freeze latest.json) when
+// the required shards are clean. Classify by shard.label.
+withTempDir((dir) => {
+  const required = writeInput(
+    dir,
+    "bench-results-projects.json",
+    [projectRow("required-row")],
+    {
+      ...SAMPLE_RUN_METADATA,
+      runner_environment: SAMPLE_RUNNER_ENVIRONMENT,
+      shard: { label: "projects", filter: "projects" },
+      filter: "projects",
+    },
+  );
+  // Optional canary shard missing its entire runner_environment — would block
+  // pre-fix; advisory now.
+  const canary = writeInput(
+    dir,
+    "bench-results-bench-canaries.json",
+    [projectRow("valibot-project")],
+    {
+      ...SAMPLE_RUN_METADATA,
+      shard: { label: "bench-canaries", filter: "valibot-project" },
+      filter: "bench-canaries",
+    },
+  );
+  const result = runMergeInputs(dir, [required, canary], ["--require-runner-signature"]);
+  assert.equal(result.status, 0, `optional canary signature defect must not block publish:\n${result.stderr}`);
+  assert.match(result.stderr, /advisory gaps on optional shards/);
+  assert.match(result.stderr, /bench-results-bench-canaries\.json: missing runner_environment/);
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.ok(
+    merged.validation.runner_signature_advisory.some((m) => /bench-results-bench-canaries\.json/.test(m)),
+    "advisory signature gaps are recorded in the merged validation block",
+  );
+});
+
+// The same defect on a REQUIRED shard still blocks (the advisory split must not
+// leak to required rows).
+withTempDir((dir) => {
+  const required = writeInput(
+    dir,
+    "bench-results-projects.json",
+    [projectRow("required-row")],
+    {
+      ...SAMPLE_RUN_METADATA,
+      shard: { label: "projects", filter: "projects" },
+      filter: "projects",
+    },
+  );
+  const result = runMergeInputs(dir, [required], ["--require-runner-signature"]);
+  assert.equal(result.status, 1, "a required shard missing runner_environment still blocks");
+  assert.match(result.stderr, /validation failed \(blocking\)/);
+  assert.match(result.stderr, /bench-results-projects\.json: missing runner_environment/);
+});
+
+// Filename fallback: an optional shard so broken it dropped shard.label is still
+// recognised as optional by its `bench-results-bench-applications.json` name.
+withTempDir((dir) => {
+  const required = writeInput(
+    dir,
+    "bench-results-projects.json",
+    [projectRow("required-row")],
+    {
+      ...SAMPLE_RUN_METADATA,
+      runner_environment: SAMPLE_RUNNER_ENVIRONMENT,
+      shard: { label: "projects", filter: "projects" },
+      filter: "projects",
+    },
+  );
+  const application = writeInput(
+    dir,
+    "bench-results-bench-applications.json",
+    [projectRow("umami-project")],
+    {
+      ...SAMPLE_RUN_METADATA,
+      runner_environment: SAMPLE_RUNNER_ENVIRONMENT,
+      // shard omitted entirely -> missing shard.label/shard.filter, but the
+      // filename identifies it as the optional applications shard.
+      filter: "bench-applications",
+    },
+  );
+  const result = runMergeInputs(dir, [required, application], ["--require-runner-signature"]);
+  assert.equal(result.status, 0, `optional applications shard defect must not block:\n${result.stderr}`);
+  assert.match(result.stderr, /bench-results-bench-applications\.json: missing shard\.label/);
+});
+
 withTempDir((dir) => {
   const result = runMerge(
     dir,


### PR DESCRIPTION
Goal: hold

Sustainable fix for the `latest.json` publish-freeze class that froze
`tsz.dev/benchmark-data/latest.json` for ~46 commits. Two operator levers plus
the one latent gate blocker the publish-chain audit surfaced.

## What this adds

### 1. Matrix-free republish lever — `.github/workflows/bench-republish.yml`
`workflow_dispatch` with a `run_id` input. A single `[self-hosted, tsz-cloud-run]`
job downloads that run's already-built `bench-results-merged` artifact (which
already contains the merged `bench-results.json` + winners + missing-attribution
siblings), re-runs the **current-main** `check-artifact-readiness.mjs` gate
against it, and — only on pass and only when the **monotonic `generated_at`
guard** allows — `gsutil`-cp's `latest.json` + siblings using the SAME ambient
GCS auth and publish/guard snippet as `bench-publish`, then dispatches
`gh-pages.yml` so `tsz.dev` rebakes. No ~2.5h matrix rerun.

Structural rule: *When a COMPLETE bench run already produced a readiness-clean
`bench-results-merged` but its `bench-publish` did not publish (failed gate on an
old pinned commit, runner starvation, or a gate-policy fix that only lives at
newer SHAs), an operator can re-publish it through current-main policy via
`bench-republish.yml`, owned entirely by a standalone workflow.* This is why it
checks out current main (not the run's pinned, possibly pre-fix commit) — the
gate that runs is always current policy. A standalone workflow (rather than a job
inside `bench.yml`) keeps **zero blast radius** on the perf pipeline: a
`bench.yml` job would need ~8 existing jobs and the publish `needs:` re-gated to
stay skipped for this lane.

### 2. Published-data freshness monitor — `scripts/bench/check-latest-freshness.mjs` + `ci-health.yml`
New advisory `bench-latest-freshness` job on the existing `*/15` ci-health cron
(GitHub-hosted) fetches the public `latest.json`, parses `generated_at`, and
opens / updates / closes **one deduplicated tracking issue** (marker-keyed,
mirroring `main-red-sentinel`) when it stops advancing. Closes the blind spot
that let the freeze go unnoticed: `bench-artifact-readiness` inspects a freshly
merged *artifact* and gates on source-commit currency, so it stays green while
the *published* file is stale. Threshold 9h in CI (perf cadence is 3h but runs
queue for hours; script default is 6h, configurable via `--max-age-hours`).

### 3. Latent gate blocker (advisory/blocking split, à la #15019/#15032) — `scripts/bench/merge-results.mjs`
`--require-runner-signature` validated ALL shards including the optional
`bench-canaries` / `bench-applications` shards, so a flaky optional shard with an
incomplete `runner_environment`, missing `shard.label`, wrong `benchmark_runner`,
or a cross-shard env mismatch failed the merge step and froze publishing —
contradicting "canary shards never block publish". Now split into **blocking**
(required shards) vs **advisory** (optional shards, classified by `shard.label`
with a `bench-results-bench-(canaries|applications).json` filename fallback), the
same pattern as the project-compatibility and #15019/#15032 gates. Advisory gaps
are annotated and recorded in `validation.runner_signature_advisory`.

## Verification
Node-only (no cargo), all green:
- `node scripts/bench/test-check-latest-freshness.mjs` (new; pins fresh→ok,
  stale→alert, unparseable→alert, plus dedup-issue open/heartbeat/close and CLI
  exit codes)
- `node scripts/bench/test-merge-results.mjs` (new optional-shard advisory cases
  + required-shard-still-blocks + filename-fallback)
- `node scripts/bench/test-check-artifact-readiness.mjs`,
  `test-bench-workflow-micro-coverage.mjs`, `test-project-rows.mjs`,
  `test-ci-health-benchmark-readiness.mjs`
- full `scripts/bench/test-*.mjs` suite: 24/24 pass
- `python3 -c 'import yaml; yaml.safe_load(open(f))'` on `bench-republish.yml`,
  `ci-health.yml`, `bench.yml`

Quick-fix once merged (republish the stuck 12:47 complete run):
`gh workflow run bench-republish.yml --repo tsz-org/tsz -f run_id=28322724209`

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
