### PR TITLE
refactor(solver): record depth guard verdicts (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -791,6 +791,18 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.note_limit_event();
     }
 
+    /// Mark a depth-style guard bail and surface the typed request verdict.
+    ///
+    /// Use this for producers whose own bailout reason is
+    /// [`TerminationKind::DepthExceeded`]. Producers with a more specific typed
+    /// verdict, such as fuel exhaustion, should keep using
+    /// [`Self::mark_depth_exceeded`] and then record their specific kind.
+    #[inline]
+    pub(crate) fn mark_depth_exceeded_for_request(&mut self) {
+        self.mark_depth_exceeded();
+        self.note_request_termination(TerminationKind::DepthExceeded);
+    }
+
     /// Record that a recursion/depth/iteration/divergence limit just fired.
     ///
     /// Bumping the monotonic `limit_epoch` is how a later
@@ -1174,8 +1186,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // catch because cycle detection fires first. Flag depth_exceeded so
                 // the checker can emit TS2589.
                 if self.flag_depth_on_app_cycle && matches!(key, Some(TypeData::Application(_))) {
-                    self.guard.mark_exceeded();
-                    self.note_limit_event();
+                    self.mark_depth_exceeded_for_request();
                     return TypeId::ERROR;
                 }
                 return type_id;
@@ -1183,6 +1194,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             RecursionResult::DepthExceeded => {
                 // Depth-bounded run (see `deep_recursion_seen`).
                 self.mark_deep_recursion_seen();
+                self.note_request_termination(TerminationKind::DepthExceeded);
                 // The per-`TypeId` guard's depth limit is structural — it caps the
                 // type-tree walk to protect the stack, not the instantiation chain.
                 // tsc's `instantiationDepth` (the source of TS2589) is mirrored by

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -3,6 +3,7 @@
 //! Handles TypeScript's conditional types: `T extends U ? X : Y`
 //! Including distributive conditional types over union types.
 
+mod application_infer;
 mod application_reduction;
 mod array_infer;
 mod object_infer;
@@ -321,7 +322,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // Flag TS2589 and return ERROR to prevent stack overflow.
             // This matches tsc's tail recursion limit of 1000 (instantiationCount).
             if tail_recursion_count >= Self::MAX_TAIL_RECURSION_DEPTH {
-                self.mark_depth_exceeded();
+                self.mark_depth_exceeded_for_request();
                 return TypeId::ERROR;
             }
 
@@ -336,7 +337,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     cond.false_type,
                 ))
             {
-                self.mark_depth_exceeded();
+                self.mark_depth_exceeded_for_request();
                 return TypeId::ERROR;
             }
 
@@ -1809,7 +1810,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     ) -> TypeId {
         // Limit distribution to prevent OOM with pathologically large unions.
         if members.len() > MAX_CONDITIONAL_DISTRIBUTION_SIZE {
-            self.mark_depth_exceeded();
+            self.mark_depth_exceeded_for_request();
             return TypeId::ERROR;
         }
 
@@ -1903,177 +1904,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         // Combine results into a union
         self.interner().union_from_slice(&results)
-    }
-
-    /// Try to match conditional types at the Application level before structural expansion.
-    ///
-    /// When both `check_type` and `extends_type` are Applications with the same base type
-    /// (e.g., `Promise<string>` vs `Promise<infer U>`), we can match type arguments
-    /// directly without expanding the interface structure. This is critical for complex
-    /// generic interfaces like Promise, Map, Set where structural expansion makes the
-    /// infer pattern matching fail.
-    fn try_application_infer_match(&mut self, cond: &ConditionalType) -> Option<TypeId> {
-        // Only proceed if extends_type is an Application containing infer.
-        // Keep extends_type as-is (unevaluated) so match_infer_pattern can handle
-        // it at the Application level. This is critical for complex generic interfaces
-        // like Promise, Map, Set where structural expansion loses the ability to
-        // match type arguments directly.
-        let Some(TypeData::Application(pattern_app_id)) = self.interner().lookup(cond.extends_type)
-        else {
-            return None;
-        };
-        let pattern_base = self.interner().type_application(pattern_app_id).base;
-
-        let contains_infer =
-            if let Some(contains_infer) = self.cached_contains_infer(cond.extends_type) {
-                contains_infer
-            } else {
-                let contains_infer = self.type_contains_infer(cond.extends_type);
-                self.cache_contains_infer(cond.extends_type, contains_infer);
-                contains_infer
-            };
-        if !contains_infer {
-            return None;
-        }
-
-        // Recover an Application form for `check_type` whose base matches
-        // `pattern_base`. Three shapes need recovery:
-        //   1. raw type isn't an Application (e.g. `S[K]` inside a per-key
-        //      conditional) — evaluate may yield one;
-        //   2. raw type evaluates to a structural Object/Callable — the
-        //      `display_alias` map records a back-reference to the original
-        //      Application;
-        //   3. raw type IS an Application but its base differs from the
-        //      pattern's (e.g. `Exclude<X<T> | undefined, undefined>` wraps
-        //      `X<T>`) — evaluate through the wrapper so the
-        //      Application-vs-Application match has a same-base source.
-        let mut check_type = cond.check_type;
-        if get_application_base(self.interner(), check_type) != Some(pattern_base) {
-            let evaluated = self.evaluate(check_type);
-            if get_application_base(self.interner(), evaluated) == Some(pattern_base) {
-                check_type = evaluated;
-            } else if let Some(origin) = self.try_recover_application_from_display_alias(evaluated)
-                && get_application_base(self.interner(), origin) == Some(pattern_base)
-            {
-                check_type = origin;
-            }
-        }
-
-        // Skip for special types
-        if check_type == TypeId::ANY || check_type == TypeId::NEVER {
-            return None;
-        }
-        if matches!(
-            self.interner().lookup(check_type),
-            Some(TypeData::TypeParameter(_))
-        ) {
-            return None;
-        }
-
-        // Try infer pattern matching with unevaluated types.
-        // match_infer_pattern handles Application vs Application matching
-        // by comparing base types and recursing on type arguments.
-        let mut checker = self.conditional_subtype_checker();
-        checker.allow_bivariant_rest = true;
-        let mut bindings = FxHashMap::default();
-        let mut visited = InferPatternVisited::default();
-        let matched = self.match_infer_pattern(
-            check_type,
-            cond.extends_type,
-            &mut bindings,
-            &mut visited,
-            &mut checker,
-        );
-        if matched && !bindings.is_empty() {
-            let substituted_true = self.substitute_infer(cond.true_type, &bindings);
-            return Some(self.evaluate(substituted_true));
-        }
-        if self.application_infer_bases_match(check_type, cond.extends_type, &mut checker) {
-            return Some(self.evaluate(cond.false_type));
-        }
-
-        // Last-chance recovery: reduce the source through generic-alias bodies
-        // whose alias body is a conditional that yields an Application form
-        // matching the pattern's base. Handles `Application(ReturnType, [F])
-        // extends Application(Promise, [infer T])` by simulating ReturnType's
-        // body conditional to discover its `Application(Promise, [...])`
-        // substituted true-branch, which the structural fallback cannot
-        // recover from the fully expanded structural object.
-        //
-        // Only worth attempting when the raw source is itself an `Application`
-        // (potentially reducible by alias peeling) or has a display-alias
-        // back-reference to one (recorded for parametric structural bodies).
-        // For intrinsics, type parameters, unions, and other shapes the
-        // reducer would just do one no-op lookup before returning None.
-        for candidate in [cond.check_type, check_type] {
-            if Self::is_alias_reducible_candidate(self.interner(), candidate)
-                && let Some(reduced) = self.reduce_alias_body_to_application_form(candidate)
-                && reduced != candidate
-                && reduced != check_type
-            {
-                let mut checker = self.conditional_subtype_checker();
-                checker.allow_bivariant_rest = true;
-                let mut bindings = FxHashMap::default();
-                let mut visited = InferPatternVisited::default();
-                let matched = self.match_infer_pattern(
-                    reduced,
-                    cond.extends_type,
-                    &mut bindings,
-                    &mut visited,
-                    &mut checker,
-                );
-                if matched && !bindings.is_empty() {
-                    let substituted_true = self.substitute_infer(cond.true_type, &bindings);
-                    return Some(self.evaluate(substituted_true));
-                }
-            }
-        }
-
-        if let Some(alias) = self.try_recover_application_from_display_alias(check_type)
-            && alias != check_type
-        {
-            let mut checker = self.conditional_subtype_checker();
-            checker.allow_bivariant_rest = true;
-            let mut bindings = FxHashMap::default();
-            let mut visited = InferPatternVisited::default();
-            let matched = self.match_infer_pattern(
-                alias,
-                cond.extends_type,
-                &mut bindings,
-                &mut visited,
-                &mut checker,
-            );
-            if matched && !bindings.is_empty() {
-                let substituted_true = self.substitute_infer(cond.true_type, &bindings);
-                return Some(self.evaluate(substituted_true));
-            }
-        }
-
-        None
-    }
-
-    fn application_infer_bases_match(
-        &self,
-        check_type: TypeId,
-        extends_type: TypeId,
-        checker: &mut SubtypeChecker<'_, R>,
-    ) -> bool {
-        let (
-            Some(TypeData::Application(check_app_id)),
-            Some(TypeData::Application(pattern_app_id)),
-        ) = (
-            self.interner().lookup(check_type),
-            self.interner().lookup(extends_type),
-        )
-        else {
-            return false;
-        };
-        let check_app = self.interner().type_application(check_app_id);
-        let pattern_app = self.interner().type_application(pattern_app_id);
-        check_app.args.len() == pattern_app.args.len()
-            && (check_app.base == pattern_app.base
-                || (checker.is_subtype_of(check_app.base, pattern_app.base)
-                    && checker.is_subtype_of(pattern_app.base, check_app.base)))
     }
 }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/application_infer.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/application_infer.rs
@@ -1,0 +1,183 @@
+use crate::relations::subtype::{SubtypeChecker, TypeResolver};
+use crate::type_queries::get_application_base;
+use crate::types::{ConditionalType, TypeData, TypeId};
+use rustc_hash::FxHashMap;
+
+use super::super::super::evaluate::TypeEvaluator;
+use super::super::infer_pattern::InferPatternVisited;
+
+impl<R: TypeResolver> TypeEvaluator<'_, R> {
+    /// Try to match conditional types at the Application level before structural expansion.
+    ///
+    /// When both `check_type` and `extends_type` are Applications with the same base type
+    /// (e.g., `Promise<string>` vs `Promise<infer U>`), we can match type arguments
+    /// directly without expanding the interface structure. This is critical for complex
+    /// generic interfaces like Promise, Map, Set where structural expansion makes the
+    /// infer pattern matching fail.
+    pub(in crate::evaluation::evaluate_rules::conditional) fn try_application_infer_match(
+        &mut self,
+        cond: &ConditionalType,
+    ) -> Option<TypeId> {
+        // Only proceed if extends_type is an Application containing infer.
+        // Keep extends_type as-is (unevaluated) so match_infer_pattern can handle
+        // it at the Application level. This is critical for complex generic interfaces
+        // like Promise, Map, Set where structural expansion loses the ability to
+        // match type arguments directly.
+        let Some(TypeData::Application(pattern_app_id)) = self.interner().lookup(cond.extends_type)
+        else {
+            return None;
+        };
+        let pattern_base = self.interner().type_application(pattern_app_id).base;
+
+        let contains_infer =
+            if let Some(contains_infer) = self.cached_contains_infer(cond.extends_type) {
+                contains_infer
+            } else {
+                let contains_infer = self.type_contains_infer(cond.extends_type);
+                self.cache_contains_infer(cond.extends_type, contains_infer);
+                contains_infer
+            };
+        if !contains_infer {
+            return None;
+        }
+
+        // Recover an Application form for `check_type` whose base matches
+        // `pattern_base`. Three shapes need recovery:
+        //   1. raw type isn't an Application (e.g. `S[K]` inside a per-key
+        //      conditional) — evaluate may yield one;
+        //   2. raw type evaluates to a structural Object/Callable — the
+        //      `display_alias` map records a back-reference to the original
+        //      Application;
+        //   3. raw type IS an Application but its base differs from the
+        //      pattern's (e.g. `Exclude<X<T> | undefined, undefined>` wraps
+        //      `X<T>`) — evaluate through the wrapper so the
+        //      Application-vs-Application match has a same-base source.
+        let mut check_type = cond.check_type;
+        if get_application_base(self.interner(), check_type) != Some(pattern_base) {
+            let evaluated = self.evaluate(check_type);
+            if get_application_base(self.interner(), evaluated) == Some(pattern_base) {
+                check_type = evaluated;
+            } else if let Some(origin) = self.try_recover_application_from_display_alias(evaluated)
+                && get_application_base(self.interner(), origin) == Some(pattern_base)
+            {
+                check_type = origin;
+            }
+        }
+
+        // Skip for special types.
+        if check_type == TypeId::ANY || check_type == TypeId::NEVER {
+            return None;
+        }
+        if matches!(
+            self.interner().lookup(check_type),
+            Some(TypeData::TypeParameter(_))
+        ) {
+            return None;
+        }
+
+        // Try infer pattern matching with unevaluated types.
+        // match_infer_pattern handles Application vs Application matching
+        // by comparing base types and recursing on type arguments.
+        let mut checker = self.conditional_subtype_checker();
+        checker.allow_bivariant_rest = true;
+        let mut bindings = FxHashMap::default();
+        let mut visited = InferPatternVisited::default();
+        let matched = self.match_infer_pattern(
+            check_type,
+            cond.extends_type,
+            &mut bindings,
+            &mut visited,
+            &mut checker,
+        );
+        if matched && !bindings.is_empty() {
+            let substituted_true = self.substitute_infer(cond.true_type, &bindings);
+            return Some(self.evaluate(substituted_true));
+        }
+        if self.application_infer_bases_match(check_type, cond.extends_type, &mut checker) {
+            return Some(self.evaluate(cond.false_type));
+        }
+
+        // Last-chance recovery: reduce the source through generic-alias bodies
+        // whose alias body is a conditional that yields an Application form
+        // matching the pattern's base. Handles `Application(ReturnType, [F])
+        // extends Application(Promise, [infer T])` by simulating ReturnType's
+        // body conditional to discover its `Application(Promise, [...])`
+        // substituted true-branch, which the structural fallback cannot
+        // recover from the fully expanded structural object.
+        //
+        // Only worth attempting when the raw source is itself an `Application`
+        // (potentially reducible by alias peeling) or has a display-alias
+        // back-reference to one (recorded for parametric structural bodies).
+        // For intrinsics, type parameters, unions, and other shapes the
+        // reducer would just do one no-op lookup before returning None.
+        for candidate in [cond.check_type, check_type] {
+            if Self::is_alias_reducible_candidate(self.interner(), candidate)
+                && let Some(reduced) = self.reduce_alias_body_to_application_form(candidate)
+                && reduced != candidate
+                && reduced != check_type
+            {
+                let mut checker = self.conditional_subtype_checker();
+                checker.allow_bivariant_rest = true;
+                let mut bindings = FxHashMap::default();
+                let mut visited = InferPatternVisited::default();
+                let matched = self.match_infer_pattern(
+                    reduced,
+                    cond.extends_type,
+                    &mut bindings,
+                    &mut visited,
+                    &mut checker,
+                );
+                if matched && !bindings.is_empty() {
+                    let substituted_true = self.substitute_infer(cond.true_type, &bindings);
+                    return Some(self.evaluate(substituted_true));
+                }
+            }
+        }
+
+        if let Some(alias) = self.try_recover_application_from_display_alias(check_type)
+            && alias != check_type
+        {
+            let mut checker = self.conditional_subtype_checker();
+            checker.allow_bivariant_rest = true;
+            let mut bindings = FxHashMap::default();
+            let mut visited = InferPatternVisited::default();
+            let matched = self.match_infer_pattern(
+                alias,
+                cond.extends_type,
+                &mut bindings,
+                &mut visited,
+                &mut checker,
+            );
+            if matched && !bindings.is_empty() {
+                let substituted_true = self.substitute_infer(cond.true_type, &bindings);
+                return Some(self.evaluate(substituted_true));
+            }
+        }
+
+        None
+    }
+
+    fn application_infer_bases_match(
+        &self,
+        check_type: TypeId,
+        extends_type: TypeId,
+        checker: &mut SubtypeChecker<'_, R>,
+    ) -> bool {
+        let (
+            Some(TypeData::Application(check_app_id)),
+            Some(TypeData::Application(pattern_app_id)),
+        ) = (
+            self.interner().lookup(check_type),
+            self.interner().lookup(extends_type),
+        )
+        else {
+            return false;
+        };
+        let check_app = self.interner().type_application(check_app_id);
+        let pattern_app = self.interner().type_application(pattern_app_id);
+        check_app.args.len() == pattern_app.args.len()
+            && (check_app.base == pattern_app.base
+                || (checker.is_subtype_of(check_app.base, pattern_app.base)
+                    && checker.is_subtype_of(pattern_app.base, check_app.base)))
+    }
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -892,7 +892,7 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
             if let Some(result) = self.try_fast_index_large_union(&members) {
                 return Some(result);
             }
-            self.evaluator.mark_depth_exceeded();
+            self.evaluator.mark_depth_exceeded_for_request();
             return Some(TypeId::ERROR);
         }
         let mut results = Vec::new();

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_union_distribution.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_union_distribution.rs
@@ -15,7 +15,7 @@ pub(super) fn evaluate_index_union_distribution<R: TypeResolver>(
 ) -> TypeId {
     // Limit to prevent OOM with large unions.
     if members.len() > MAX_UNION_INDEX_SIZE {
-        evaluator.mark_depth_exceeded();
+        evaluator.mark_depth_exceeded_for_request();
         return TypeId::ERROR;
     }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -325,7 +325,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // real-world code (large SDKs, generated API types often have 150-250 keys).
         // 250 covers ~99% of real-world use cases while remaining safe for WASM.
         if key_set.keys.len() + key_set.symbol_keys.len() > self.max_mapped_keys() {
-            self.mark_depth_exceeded();
+            self.mark_depth_exceeded_for_request();
             return TypeId::ERROR;
         }
 

--- a/crates/tsz-solver/src/evaluation/recursive_growth.rs
+++ b/crates/tsz-solver/src/evaluation/recursive_growth.rs
@@ -148,7 +148,7 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
         // Bail with TS2589 when the recursive argument is diverging rather than
         // building an ever-larger type.
         if self.detect_recursive_growth(def_id, &expanded_args) {
-            self.mark_depth_exceeded();
+            self.mark_depth_exceeded_for_request();
             return Some(TypeId::ERROR);
         }
 

--- a/crates/tsz-solver/tests/evaluate_tests_parts/iteration_exceeded_incomplete.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/iteration_exceeded_incomplete.rs
@@ -93,3 +93,48 @@ fn reset_clears_typed_and_legacy_termination_state() {
     assert_eq!(evaluator.limit_epoch, 0);
     assert_eq!(evaluator.app_body_limit_epoch, 0);
 }
+
+#[test]
+fn depth_marker_for_request_records_depth_verdict() {
+    let interner = TypeInterner::new();
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.mark_depth_exceeded_for_request();
+
+    assert_eq!(
+        evaluator.request_termination_kind,
+        Some(TerminationKind::DepthExceeded)
+    );
+    let result = request_result_verdict(TypeId::ERROR, evaluator.request_termination_kind);
+    assert_eq!(
+        result.termination(),
+        Termination::Incomplete {
+            kind: TerminationKind::DepthExceeded,
+            partial: TypeId::ERROR,
+        }
+    );
+    assert_eq!(result.into_type_id(), TypeId::ERROR);
+}
+
+#[test]
+fn raw_depth_marker_allows_specific_fuel_verdict() {
+    let interner = TypeInterner::new();
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    evaluator.mark_depth_exceeded();
+    evaluator.note_request_termination(TerminationKind::FuelExhausted);
+
+    assert_eq!(
+        evaluator.request_termination_kind,
+        Some(TerminationKind::FuelExhausted)
+    );
+    let result = request_result_verdict(TypeId::ERROR, evaluator.request_termination_kind);
+    assert_eq!(
+        result.termination(),
+        Termination::Incomplete {
+            kind: TerminationKind::FuelExhausted,
+            partial: TypeId::ERROR,
+        }
+    );
+    assert_eq!(result.into_type_id(), TypeId::ERROR);
+}


### PR DESCRIPTION
Goal: hold

## Summary
- Add `TypeEvaluator::mark_depth_exceeded_for_request` so depth-style evaluator guard bails record the typed `DepthExceeded` request verdict while preserving the existing legacy guard taint.
- Route depth-style producers in conditional tail recursion, conditional distribution, mapped-key expansion, index-union distribution, recursive-growth detection, and application-cycle TS2589 through the helper.
- Keep fuel exhaustion on the raw depth marker plus its explicit `FuelExhausted` verdict, so the generic depth marker does not overwrite the more specific kind.
- Move the conditional Application-infer helper into `conditional/application_infer.rs` as a mechanical split so touched shards stay under the 2000-line cap.

## Structural Rule
When a depth-style solver evaluation guard bails out, tsc reports the same collapsed partial result to the current walk while treating the request as incomplete; tsz now preserves the same `TypeId` collapse but records `TerminationKind::DepthExceeded` through the solver-owned evaluation request channel. Producers with a more specific typed reason, such as fuel exhaustion, continue to record that specific kind after the raw legacy depth marker.

## Adjacent Matrix
- Tail-recursion depth limit and tail-cycle guards record `DepthExceeded` while returning the same `TypeId::ERROR` partial.
- Conditional distribution, index-union distribution, mapped-key expansion, recursive-growth detection, and application-cycle TS2589 bails record `DepthExceeded` at their existing bailout points.
- Fuel exhaustion still records `FuelExhausted`, proving the helper is only used for producers whose own reason is depth-style truncation.
- Conditional Application-infer behavior is unchanged; it was moved only to keep `conditional.rs` under the shard-size cap. The moved impl now elides its lifetime so it does not raise the clippy warn ratchet.
- No #14344 reference-mint edits, no #14345 reduction or `application.rs` opaque/fixpoint edits, and no relation-policy changes.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(depth_marker_for_request_records_depth_verdict) or test(raw_depth_marker_allows_specific_fuel_verdict) or test(every_guard_bail_reports_incomplete_with_its_kind_and_partial) or test(reset_clears_typed_and_legacy_termination_state)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(strip)'`
- `scripts/safe-run.sh scripts/ci/github-suite.sh lint`
- `wc -l crates/tsz-solver/src/evaluation/evaluate.rs crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs crates/tsz-solver/src/evaluation/evaluate_rules/conditional/application_infer.rs crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs crates/tsz-solver/src/evaluation/evaluate_rules/index_access_union_distribution.rs crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs crates/tsz-solver/src/evaluation/recursive_growth.rs crates/tsz-solver/tests/evaluate_tests_parts/iteration_exceeded_incomplete.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
