### PR TITLE
fix(solver): require all union members to supply an index signature (#14804)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -430,6 +430,9 @@ mod nuia_any_index_emits_ts2322_tests;
 #[path = "tests/noUIA_write_index_signature_emits_ts2322_tests.rs"]
 mod nuia_write_index_signature_emits_ts2322_tests;
 #[cfg(test)]
+#[path = "tests/nullish_union_indexed_access_missing_property_tests.rs"]
+mod nullish_union_indexed_access_missing_property_tests;
+#[cfg(test)]
 #[path = "../tests/optional_param_display_tests.rs"]
 mod optional_param_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/nullish_union_indexed_access_missing_property_tests.rs
+++ b/crates/tsz-checker/src/tests/nullish_union_indexed_access_missing_property_tests.rs
@@ -1,0 +1,185 @@
+//! Regression coverage for type-level indexed access over a union with a
+//! nullish member (`null` / `undefined` / `void`).
+//!
+//! `tsc` computes `(T)[K]` over a union by requiring *every* constituent to
+//! resolve the key — `getPropertyTypeForIndexType` consults `getPropertyOfType`
+//! (present only when all members have it) and `getApplicableIndexInfo`
+//! (`getUnionIndexInfos`, present only when all members supply it). A nullish
+//! constituent has no members and no index signatures, so it can never resolve a
+//! key, and the whole access reports TS2339.
+//!
+//! tsz previously exposed a union's index signature whenever *any* member had
+//! one (`get_index_signatures` collected from "any member"), so a union like
+//! `null | { [k: string]: number }` wrongly looked string-indexed: the
+//! type-level indexed-access checker accepted the key and dropped TS2339, and
+//! the access silently evaluated to the member value type (#14804). The fix
+//! requires every constituent to supply the index signature, voiding it when a
+//! nullish (or otherwise index-less) member is present.
+//!
+//! Binder-name invariance: witnesses vary the alias / key names so the rule is
+//! structural, not keyed off any spelling.
+
+use crate::test_utils::{
+    check_source_with_libs, diagnostic_codes, load_default_lib_files, strict_checker_options,
+};
+
+fn codes(source: &str) -> Vec<u32> {
+    diagnostic_codes(&check_source_with_libs(
+        source,
+        "test.ts",
+        strict_checker_options(),
+        &load_default_lib_files(),
+    ))
+}
+
+fn assert_has_2339(source: &str) {
+    let found = codes(source);
+    assert!(
+        found.contains(&2339),
+        "expected TS2339 (property does not exist) for source:\n{source}\ngot: {found:?}"
+    );
+    // The missing-key family is TS2339, never the generic TS2536
+    // ("cannot be used to index type"), which `tsc` reserves for
+    // generic/type-parameter object receivers.
+    assert!(
+        !found.contains(&2536),
+        "must not emit TS2536 for a concrete nullish-union receiver:\n{source}\ngot: {found:?}"
+    );
+}
+
+fn assert_clean(source: &str) {
+    let found = codes(source);
+    assert!(
+        found.is_empty(),
+        "expected no diagnostics, got {found:?} for source:\n{source}"
+    );
+}
+
+/// The reported witness: a string-index member plus a `null` member. The union
+/// has no applicable string index (null supplies none), so every key is missing.
+#[test]
+fn null_with_string_index_member_reports_missing() {
+    assert_has_2339(
+        r#"
+type T = null | { [k: string]: number };
+type Bad = T["nope"];
+"#,
+    );
+}
+
+/// `undefined` constituent behaves identically to `null`.
+#[test]
+fn undefined_with_string_index_member_reports_missing() {
+    assert_has_2339(
+        r#"
+type T = undefined | { [k: string]: number };
+type Bad = T["nope"];
+"#,
+    );
+}
+
+/// `void` is also a nullish-like member with no apparent members.
+#[test]
+fn void_with_string_index_member_reports_missing() {
+    assert_has_2339(
+        r#"
+type T = void | { [k: string]: number };
+type Bad = T["nope"];
+"#,
+    );
+}
+
+/// Named-property member plus a nullish member: the named member resolves the
+/// key, but `null` does not, so the union access is still TS2339.
+#[test]
+fn null_with_named_property_member_reports_missing() {
+    assert_has_2339(
+        r#"
+type T = null | { a: number };
+type Bad = T["a"];
+"#,
+    );
+}
+
+/// Number-index member plus a nullish member, indexed numerically.
+#[test]
+fn null_with_number_index_member_reports_missing() {
+    assert_has_2339(
+        r#"
+type T = null | { [k: number]: string };
+type Bad = T[0];
+"#,
+    );
+}
+
+/// Multiple index-signature members plus a nullish member: still missing,
+/// because the nullish member breaks the all-members requirement.
+#[test]
+fn null_with_multiple_index_members_reports_missing() {
+    assert_has_2339(
+        r#"
+type T = null | { [k: string]: number } | { [k: string]: boolean };
+type Bad = T["x"];
+"#,
+    );
+}
+
+/// Binder-name invariance: the rule must not key off the alias or key spelling.
+#[test]
+fn nullish_union_missing_property_is_binder_name_invariant() {
+    assert_has_2339(
+        r#"
+type Receiver = undefined | { [property: string]: boolean };
+type Result = Receiver["anything"];
+"#,
+    );
+}
+
+/// Control — `NonNullable` strips the nullish member, leaving a genuinely
+/// string-indexed object whose key space accepts every string key.
+#[test]
+fn non_nullable_strips_nullish_member_and_is_clean() {
+    assert_clean(
+        r#"
+type T = NonNullable<null | { [k: string]: number }>;
+type Ok = T["nope"];
+"#,
+    );
+}
+
+/// Control — when every constituent supplies the string index signature, the
+/// union exposes it and the access is valid (the value type is the union of the
+/// per-member value types).
+#[test]
+fn union_where_all_members_have_string_index_is_clean() {
+    assert_clean(
+        r#"
+type T = { [k: string]: number } | { [k: string]: boolean };
+type Ok = T["x"];
+"#,
+    );
+}
+
+/// Control — a key resolvable on every member (named on one, via the string
+/// index on the other) is valid even though the members differ in shape.
+#[test]
+fn union_key_resolvable_on_all_members_is_clean() {
+    assert_clean(
+        r#"
+type T = { a: number } | { [k: string]: number };
+type Ok = T["a"];
+"#,
+    );
+}
+
+/// Control — a single string-indexed object (no nullish member) accepts any
+/// string key, unchanged by the fix.
+#[test]
+fn plain_string_indexed_object_is_clean() {
+    assert_clean(
+        r#"
+type T = { [k: string]: number };
+type Ok = T["nope"];
+"#,
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -1887,22 +1887,20 @@ impl<'a> CheckerState<'a> {
     }
 
     pub(super) fn type_node_refers_to_type_parameter(&self, node_idx: NodeIndex) -> bool {
-        use tsz_binder::symbol_flags;
-
-        let Some(name) = self.simple_type_reference_name(node_idx) else {
-            return false;
-        };
-        self.ctx
-            .binder
-            .get_symbols()
-            .find_all_by_name(&name)
-            .iter()
-            .any(|&sym_id| {
-                self.ctx
-                    .binder
-                    .get_symbol(sym_id)
-                    .is_some_and(|symbol| symbol.has_any_flags(symbol_flags::TYPE_PARAMETER))
-            })
+        // Resolve the name in its lexical scope rather than matching *any* symbol
+        // with the same spelling. A global `find_all_by_name` match also catches
+        // unrelated type parameters declared by lib/global generics — e.g. a user
+        // alias named `T` collides with `Array<T>`'s parameter `T` — and would
+        // mis-classify the concrete alias receiver as a type parameter, routing a
+        // missing literal key to TS2536 instead of TS2339 (#14804). The in-scope
+        // resolution keys off the actual binding (type-parameter scope or the
+        // identifier's resolved symbol), so it is independent of the chosen name.
+        crate::query_boundaries::type_checking_utilities::ast_index_node_is_in_scope_type_parameter(
+            self.ctx.arena,
+            self.ctx.binder,
+            &self.ctx.type_parameter_scope,
+            node_idx,
+        )
     }
 
     /// Structural rule: when the object has a plain string index signature and the index

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -2159,49 +2159,46 @@ impl QueryDatabase for TypeInterner {
                 }
             }
             Some(TypeData::Union(members_id)) => {
-                // For unions, collect index signatures from all members
+                // tsc's `getUnionIndexInfos`: an index signature is applicable to a
+                // union only when EVERY constituent supplies a matching one; the
+                // value type is then the union of the per-constituent value types.
+                // A constituent that lacks the signature voids it for the whole
+                // union — in particular a nullish (`null`/`undefined`/`void`)
+                // member, which has no members at all. Collecting from "any member"
+                // instead would expose an index signature the union does not have,
+                // making e.g. `(null | { [k: string]: number })["nope"]` silently
+                // resolve to `number` and drop tsc's TS2339 (#14804).
                 let members = self.type_list(members_id);
                 let mut string_indices = Vec::with_capacity(members.len());
                 let mut number_indices = Vec::with_capacity(members.len());
+                let mut all_have_string = !members.is_empty();
+                let mut all_have_number = !members.is_empty();
 
                 for &member in members.iter() {
                     let info = self.get_index_signatures(member);
-                    if let Some(sig) = info.string_index {
-                        string_indices.push(sig);
+                    match info.string_index {
+                        Some(sig) => string_indices.push(sig),
+                        None => all_have_string = false,
                     }
-                    if let Some(sig) = info.number_index {
-                        number_indices.push(sig);
+                    match info.number_index {
+                        Some(sig) => number_indices.push(sig),
+                        None => all_have_number = false,
                     }
                 }
 
-                // Union of the value types
-                let string_index = if string_indices.is_empty() {
-                    None
-                } else {
-                    Some(crate::types::IndexSignature {
-                        key_type: TypeId::STRING,
-                        value_type: self
-                            .union(string_indices.iter().map(|s| s.value_type).collect()),
-                        readonly: string_indices.iter().all(|s| s.readonly),
-                        param_name: None,
-                    })
-                };
-
-                let number_index = if number_indices.is_empty() {
-                    None
-                } else {
-                    Some(crate::types::IndexSignature {
-                        key_type: TypeId::NUMBER,
-                        value_type: self
-                            .union(number_indices.iter().map(|s| s.value_type).collect()),
-                        readonly: number_indices.iter().all(|s| s.readonly),
+                // Union of the value types, kept only when every member contributed.
+                let merge = |all: bool, sigs: &[crate::types::IndexSignature], key_type: TypeId| {
+                    all.then(|| crate::types::IndexSignature {
+                        key_type,
+                        value_type: self.union(sigs.iter().map(|s| s.value_type).collect()),
+                        readonly: sigs.iter().all(|s| s.readonly),
                         param_name: None,
                     })
                 };
 
                 IndexInfo {
-                    string_index,
-                    number_index,
+                    string_index: merge(all_have_string, &string_indices, TypeId::STRING),
+                    number_index: merge(all_have_number, &number_indices, TypeId::NUMBER),
                 }
             }
             Some(TypeData::Intersection(members_id)) => {


### PR DESCRIPTION
Fixes #14804.

A type-level indexed access over a union with a nullish member silently dropped tsc's TS2339.

**Structural rule:** when the receiver of `T[K]` is a union, `tsc` requires *every* constituent to resolve the key — `getPropertyOfType` (present only when all members have it) plus `getApplicableIndexInfo`/`getUnionIndexInfos` (present only when all members supply it). A nullish (`null`/`undefined`/`void`) constituent has no members and no index signatures, so it never resolves a key and the access reports TS2339. tsz exposed a union's index signature whenever *any* member had one, so `null | { [k: string]: number }` looked string-indexed: the indexed-access checker accepted the key and the access silently evaluated to the member value type. Now the solver's `get_index_signatures` exposes a union index signature only when **all** members supply one (value type = union of per-member value types), through the solver `TypeData::Union` arm.

This surfaced a second, name-dependent defect. `type_node_refers_to_type_parameter` matched *any* symbol with the receiver alias's spelling, so a user alias named `T` collided with a lib generic's parameter `T` (e.g. `Array<T>`) and the missing-key access was misrouted to TS2536 instead of TS2339 under the default lib (the issue repro used a single-letter alias). It now resolves the name in its lexical scope via the existing `ast_index_node_is_in_scope_type_parameter` query boundary, so the decision is independent of the chosen name (anti-hardcoding).

Owner layers: solver `get_index_signatures` (union index info); checker indexed-access validation gateway.

**Adjacent matrix** (all verified against `tsc` 5.9.3, `--strict --target es2022 --lib es2022`):
- `null` / `undefined` / `void` member with a string-index member → TS2339
- nullish member with a named-property member → TS2339
- nullish member with a number-index member (numeric key) → TS2339
- multiple index-signature members plus a nullish member → TS2339
- binder-name invariance (varied alias / key spellings) → TS2339
- Negatives (stay clean): `NonNullable<...>` strips the nullish member; every member shares the string index; the key resolves on all members (named on one, index on another); a plain string-indexed object with no nullish member.

## Goal
Goal: hold

## Verification
- New regression suite `nullish_union_indexed_access_missing_property_tests` (11 cases) — `cargo test -p tsz-checker --lib nullish_union_indexed_access` → 11 passed.
- No regressions vs. clean main on the families this change touches (identical pass/fail counts to baseline): checker `index` (568 passed incl. 11 new, 8 pre-existing failures unchanged), `ts2536` (32/0), `keyof` (121/1), `mapped_type` (73/5), `architecture_contract` (137/8); full `tsz-solver` lib (6993 passed, 5 pre-existing failures unchanged).
- Full repro matrix diffed against `tsc` 5.9.3 — codes and locations match.
- Note (out of scope, follow-up): the parallel `StringIndexResolver`/`NumberIndexResolver::visit_union` resolvers in `objects/index_signatures.rs` still use first-member (`find_map`) union semantics; unifying them with this all-members rule is a latent-consistency follow-up not required by this fix.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01DRF8RpN9jUEYB2uuyP7rKJ)_