### PR TITLE
fix(solver): all-any index source satisfies generic homomorphic mapped target (TS2322, #14943)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -249,6 +249,9 @@ path = "tests/identity_alias_union_arm_inference_tests.rs"
 name = "recursive_array_utility_inference_tests"
 path = "tests/recursive_array_utility_inference_tests.rs"
 [[test]]
+name = "record_any_index_to_homomorphic_mapped_tests"
+path = "tests/record_any_index_to_homomorphic_mapped_tests.rs"
+[[test]]
 name = "recursive_tuple_mapped_index_tests"
 path = "tests/recursive_tuple_mapped_index_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/record_any_index_to_homomorphic_mapped_tests.rs
+++ b/crates/tsz-checker/tests/record_any_index_to_homomorphic_mapped_tests.rs
@@ -1,0 +1,154 @@
+//! Regression guard: `Record<keyof P, any>` assignable to a still-generic
+//! homomorphic mapped target `{ [K in keyof P]: P[K] }` (issue #14943).
+//!
+//! Structural rule: when relating a homomorphic mapped source whose per-key
+//! value type is `any` (e.g. `Record<keyof P, any>` ≡ `{ [K in keyof P]: any }`)
+//! to a still-generic homomorphic mapped target `{ [K in keyof P]: P[K] }` over
+//! the same generic key set `keyof P`, every source value is `any`, which is
+//! assignable to each deferred target value `P[K]`. tsc accepts (clean); tsz
+//! used to drop the `any`-propagation on the deferred mapped template leg and
+//! report a false `TS2322` at the assignment. Owner: solver relation
+//! (mapped-to-mapped template comparison).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_lib_files};
+
+fn strict_opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        no_implicit_any: true,
+        ..CheckerOptions::default()
+    }
+}
+
+/// Type-check `source` as an external module with the bundled `es5` lib loaded
+/// (so `Record` is in scope), returning only the diagnostic codes. Skips
+/// gracefully (empty) when the bundled lib asset is unavailable.
+fn check_es5_strict_codes(source: &str) -> Vec<u32> {
+    let libs = load_lib_files(&["es5.d.ts"]);
+    if libs.is_empty() {
+        return Vec::new();
+    }
+    check_source_with_libs_code_messages(source, "test.ts", strict_opts(), &libs)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+fn ts2322_count(codes: &[u32]) -> usize {
+    codes.iter().filter(|&&c| c == 2322).count()
+}
+
+/// The exact witness from #14943.
+#[test]
+fn record_keyof_any_assignable_to_homomorphic_identity_mapped() {
+    let codes = check_es5_strict_codes(
+        r#"
+function g<P extends Record<string, unknown>>(): { [K in keyof P]: P[K] } {
+  const o: Record<keyof P, any> = {} as any;
+  return o;
+}
+export {};
+"#,
+    );
+    if codes.is_empty() {
+        return; // lib asset unavailable — covered by CLI/conformance instead
+    }
+    assert_eq!(
+        ts2322_count(&codes),
+        0,
+        "Record<keyof P, any> assignable to homomorphic identity mapped: {codes:?}"
+    );
+}
+
+/// Same rule with deliberately different binder names (no name-keyed logic).
+#[test]
+fn record_keyof_any_renamed_binders_assignable() {
+    let codes = check_es5_strict_codes(
+        r#"
+function build<TRec extends Record<string, unknown>>(): { [Key in keyof TRec]: TRec[Key] } {
+  const bag: Record<keyof TRec, any> = {} as any;
+  return bag;
+}
+export {};
+"#,
+    );
+    if codes.is_empty() {
+        return;
+    }
+    assert_eq!(
+        ts2322_count(&codes),
+        0,
+        "renamed-binder form must also be assignable: {codes:?}"
+    );
+}
+
+/// Widened target value (`unknown`): `any` source value is still assignable.
+#[test]
+fn record_keyof_any_assignable_to_unknown_valued_mapped() {
+    let codes = check_es5_strict_codes(
+        r#"
+function widen<Q extends Record<string, unknown>>(): { [K in keyof Q]: unknown } {
+  const o: Record<keyof Q, any> = {} as any;
+  return o;
+}
+export {};
+"#,
+    );
+    if codes.is_empty() {
+        return;
+    }
+    assert_eq!(
+        ts2322_count(&codes),
+        0,
+        "Record<keyof Q, any> assignable to unknown-valued mapped: {codes:?}"
+    );
+}
+
+/// Alias wrapper around the `Record<keyof T, any>` source.
+#[test]
+fn record_keyof_any_through_alias_wrapper_assignable() {
+    let codes = check_es5_strict_codes(
+        r#"
+type AnyRec<T> = Record<keyof T, any>;
+function via<P extends Record<string, unknown>>(): { [K in keyof P]: P[K] } {
+  const o: AnyRec<P> = {} as any;
+  return o;
+}
+export {};
+"#,
+    );
+    if codes.is_empty() {
+        return;
+    }
+    assert_eq!(
+        ts2322_count(&codes),
+        0,
+        "alias-wrapped Record<keyof P, any> is assignable: {codes:?}"
+    );
+}
+
+/// Negative: a concrete (non-`any`) source value type that does NOT satisfy the
+/// target value type must still error. The `any`-propagation must be specific to
+/// `any`, not a blanket accept of any homomorphic mapped source.
+#[test]
+fn record_keyof_string_not_assignable_to_number_valued_mapped() {
+    let codes = check_es5_strict_codes(
+        r#"
+function bad<P extends Record<string, unknown>>(): { [K in keyof P]: number } {
+  const o: Record<keyof P, string> = {} as any;
+  return o;
+}
+export {};
+"#,
+    );
+    if codes.is_empty() {
+        return;
+    }
+    assert_eq!(
+        ts2322_count(&codes),
+        1,
+        "string values must not satisfy a number-valued mapped target: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/mapped_target.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/mapped_target.rs
@@ -290,6 +290,17 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
             }
         }
 
+        // An all-`any` index-signature source (e.g. `Record<keyof T, any>`
+        // reduced to its `{ [x: string]: any }` index shape) supplies `any` for
+        // every property a still-generic homomorphic mapped target demands.
+        // tsc's `any`-propagation accepts it regardless of whether each deferred
+        // per-key access `target[K]` resolves, so handle it before the
+        // unbounded-key veto below (which would otherwise reject the source for
+        // not mentioning `T`).
+        if self.any_valued_index_source_satisfies_homomorphic_mapped(source, mapped_id) {
+            return SubtypeResult::True;
+        }
+
         // A homomorphic mapped target `{ [K in keyof T]: ... }` over a bare,
         // unresolved type parameter `T` has an *unbounded* required key-set: a
         // concrete instantiation of `T` may carry members its constraint does not
@@ -395,6 +406,57 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
     fn source_correlated_with_type_param(&self, source: TypeId, tp_id: TypeId) -> bool {
         // Short-circuiting containment walk (no full type-set allocation).
         crate::visitor::contains_type_by_id(self.interner, source, tp_id)
+    }
+
+    /// Whether `source` yields `any` for every key it carries — it has at least
+    /// one index signature and every index-signature value type and declared
+    /// property type is exactly `any`.
+    ///
+    /// Such a source (e.g. `Record<keyof T, any>` reduced to its
+    /// `{ [x: string]: any }` index shape) supplies `any` for every property a
+    /// still-generic homomorphic mapped target `{ [K in keyof T]: ... }` demands,
+    /// so `tsc`'s `any`-propagation makes the relation hold regardless of how
+    /// each deferred per-key access `target[K]` resolves: the source no longer
+    /// mentions `T`, yet `any` is assignable to every target property value.
+    ///
+    /// Gated to exactly `any` — an `unknown`/concrete index value still fails the
+    /// ordinary structural comparison — and disabled in Sound Mode alongside the
+    /// other `any`-propagation index waivers (see
+    /// [`Self::target_string_index_any_waives_missing_index`]).
+    fn any_valued_index_source_satisfies_homomorphic_mapped(
+        &mut self,
+        source: TypeId,
+        mapped_id: MappedTypeId,
+    ) -> bool {
+        if self.disable_method_bivariance {
+            return false;
+        }
+        if self.generic_homomorphic_key_param(mapped_id).is_none() {
+            return false;
+        }
+        let source = self.evaluate_type(source);
+        let Some(shape_id) = object_with_index_shape_id(self.interner, source)
+            .or_else(|| object_shape_id(self.interner, source))
+        else {
+            return false;
+        };
+        let shape = self.interner.object_shape(shape_id);
+        // A property-only object cannot cover the unbounded key set a homomorphic
+        // mapped target over a bare type parameter demands.
+        if shape.string_index.is_none()
+            && shape.number_index.is_none()
+            && shape.symbol_index.is_none()
+        {
+            return false;
+        }
+        shape
+            .string_index
+            .iter()
+            .chain(shape.number_index.iter())
+            .chain(shape.symbol_index.iter())
+            .map(|idx| idx.value_type)
+            .chain(shape.properties.iter().map(|p| p.type_id))
+            .all(|value| value.is_any())
     }
 
     /// Check if any source type is assignable to a homomorphic mapped type.

--- a/crates/tsz-solver/src/relations/subtype/rules/mapped_target.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/mapped_target.rs
@@ -456,7 +456,7 @@ impl<R: TypeResolver> SubtypeChecker<'_, R> {
             .chain(shape.symbol_index.iter())
             .map(|idx| idx.value_type)
             .chain(shape.properties.iter().map(|p| p.type_id))
-            .all(|value| value.is_any())
+            .all(TypeId::is_any)
     }
 
     /// Check if any source type is assignable to a homomorphic mapped type.


### PR DESCRIPTION
Goal: green

Fixes a GREEN-goal false positive surfaced by the io-ts row: `Record<keyof P, any>` returned where `{ [K in keyof P]: P[K] }` is expected raised a spurious `TS2322`; `tsc 5.9.3 --strict` accepts it.

```ts
function g<P extends Record<string, unknown>>(): { [K in keyof P]: P[K] } {
  const o: Record<keyof P, any> = {} as any;
  return o;            // tsz: TS2322; tsc: clean
}
```

## Structural rule
When relating an all-`any` index-signature source (`Record<keyof T, any>`,
reduced by evaluation to its `{ [x: string]: any }` index shape) to a
still-generic homomorphic mapped target `{ [K in keyof T]: ... }` over the same
bare type parameter `T`, tsc accepts: the source supplies `any` for every key
the target demands, and `any` is assignable to each deferred per-key value
`target[K]`. tsz dropped that any-propagation: the source no longer mentions
`T`, so the recently-added unbounded-key veto in `check_source_to_mapped_expansion`
(`constraint_expansion_can_overaccept`) rejected it.

## Owner / fix
solver relation, `crates/tsz-solver/src/relations/subtype/rules/mapped_target.rs`.
New `any_valued_index_source_satisfies_homomorphic_mapped`: when the source has
at least one index signature and every index/property value is exactly `any`,
and the target is a generic homomorphic mapped (`generic_homomorphic_key_param`
is `Some`), accept before the veto. Gated to exactly `any` so `unknown`/concrete
sources still fail the ordinary structural comparison, and disabled in Sound
Mode (`disable_method_bivariance`) alongside the existing any-propagation index
waivers (`target_string_index_any_waives_missing_index`). No checker/printer
predicate, no name/file-name literal.

## Adjacent-case matrix
- witness `Record<keyof P, any>` -> `{ [K in keyof P]: P[K] }`: clean (positive).
- renamed binders (`TRec`/`Key`): clean — rule is structural, not name-keyed.
- widened target value `{ [K in keyof Q]: unknown }`: clean (`any` <: `unknown`).
- alias wrapper `type AnyRec<T> = Record<keyof T, any>`: clean.
- negative `Record<keyof P, string>` -> `{ [K in keyof P]: number }`: still `TS2322`
  (non-`any` value fails structural comparison).
- negative `Record<keyof P, unknown>` -> `{ [K in keyof P]: P[K] }`: still `TS2322`
  (any-specific, matches tsc).

## Verification
- New test binary `crates/tsz-checker/tests/record_any_index_to_homomorphic_mapped_tests.rs`
  (5 cases) — 5 passed with the fix; the 4 positive cases failed on `origin/main`.
  `cargo nextest run -p tsz-checker --test record_any_index_to_homomorphic_mapped_tests`
- CLI: `tsz --strict --noEmit` on the witness is clean; both negatives still emit `TS2322`.
- No regressions in adjacent binaries:
  `homomorphic_mapped_keyof_modifier_tests`, `mapped_strip_optional_template_undefined_tests`,
  `any_propagation_tests` (38 passed), and the superstruct Pick/Omit family in
  `generic_mapped_to_index_signature_tests` (6 passed).
- `cargo clippy -p tsz-solver` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Closes #14943