### PR TITLE
refactor(solver): consume eval memo stability (#14346)

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1501,8 +1501,8 @@ impl QueryDatabase for QueryCache<'_> {
 
         let union_too_complex_before = self.interner.is_union_too_complex();
         let mut evaluator = self.query_backed_evaluator();
-        let evaluation_result = evaluator.evaluate_request_result(request);
-        let result = evaluation_result.into_type_id();
+        let evaluation_memo_result = evaluator.evaluate_request_memo_result(request);
+        let result = evaluation_memo_result.into_type_id();
 
         // PERF: Persist intermediate evaluation results from this session into
         // the long-lived eval_cache. During recursive mapped type expansion
@@ -1524,19 +1524,20 @@ impl QueryDatabase for QueryCache<'_> {
         // recursive-utility fixtures flip with surrounding code.
         //
         // The discrimination is per-entry (issue #13241, extending the
-        // PR #12902 application-eval epoch split): the top-level result first
-        // consults the typed `EvaluationResult` verdict (#14346), then keeps the
-        // run-sticky `recursion_limit_hit` guard for taint classes that are not
-        // solely modeled by the typed verdict yet. Its subtree IS the whole
-        // run, while drained intermediates are filtered through the evaluator's
-        // per-node `tainted` set, so the clean intermediates of a run whose
-        // *unrelated sibling* subtree bailed are still persisted instead of
-        // being recomputed from scratch on every later query.
+        // PR #12902 application-eval epoch split): the top-level result uses
+        // the named `EvaluationMemoResult` stability verdict (#14346), which
+        // combines the typed `EvaluationResult` verdict with the legacy
+        // run-sticky `recursion_limit_hit` guard for taint classes not solely
+        // modeled by the typed channel yet. Its subtree IS the whole run, while
+        // drained intermediates are filtered through the evaluator's per-node
+        // `tainted` set, so the clean intermediates of a run whose *unrelated
+        // sibling* subtree bailed are still persisted instead of being
+        // recomputed from scratch on every later query.
         // A union-complexity overflow is not routed through the evaluator's
         // limit epoch, so it conservatively suppresses all writes, as before.
         let newly_union_too_complex =
             self.interner.is_union_too_complex() && !union_too_complex_before;
-        let top_level_clean = evaluation_result.is_complete() && !evaluator.recursion_limit_hit();
+        let top_level_clean = evaluation_memo_result.is_stable_for_depth_agnostic_cache();
         if !newly_union_too_complex
             && (top_level_clean || crate::limits::limit_result_cache_enabled())
         {

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -240,8 +240,11 @@ fn evaluation_engine_keeps_request_stage_boundary() {
         query_cache_rs
             .contains("use crate::evaluation::request::{EvaluationCacheKey, EvaluationRequest};")
             && query_cache_rs.contains("request.cache_key()")
-            && query_cache_rs.contains("evaluate_request_result(request).into_type_id()"),
-        "query cache evaluation entries must derive option-sensitive keys from EvaluationRequest and unwrap EvaluationResult only at the cache compatibility edge"
+            && query_cache_rs.contains("evaluate_request_memo_result(request)")
+            && query_cache_rs.contains("is_stable_for_depth_agnostic_cache()")
+            && !query_cache_rs
+                .contains("evaluation_result.is_complete() && !evaluator.recursion_limit_hit()"),
+        "query cache evaluation entries must derive option-sensitive keys from EvaluationRequest and consume EvaluationMemoResult stability instead of rebuilding termination predicates"
     );
 }
 


### PR DESCRIPTION
Goal: hold

## Summary
- Route the query-backed top-level evaluation cache through `EvaluationMemoResult` from `evaluate_request_memo_result`.
- Use the named stability verdict for top-level depth-agnostic eval-cache writes instead of rebuilding `EvaluationResult + recursion_limit_hit` locally.
- Ratchet the solver architecture guard so query-cache consumers keep using the typed memo-result boundary.

Structural rule: when a top-level query-backed evaluation decides whether to publish into a depth-agnostic cache, tsz consumes the solver-owned `EvaluationMemoResult` stability verdict; cache sites do not reconstruct termination semantics from loose evaluator flags. Owner layer: `tsz-solver` evaluation/result plus query-cache boundary.

Coordination: this is the #14346 termination-consumer lane. It is rebased after #15040 landed, and it does not touch Claude's #14345 `application.rs` opaque/fixpoint work.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(evaluation_engine_keeps_request_stage_boundary)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(clean_evaluation_after_unrelated_bail_is_not_tainted) or test(drain_stable_cache_filters_tainted_entries) or test(test_non_stable_evaluation_result_is_not_cached)'`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high