### PR TITLE
refactor(solver): hide closed eval verdict storage (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs
@@ -121,7 +121,7 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
         // answer a sibling read would observe.
         let is_top_level = closed_eval_cache_enabled() && self.guard.depth() == 0;
         if !is_top_level
-            || self.request_termination_kind.is_some()
+            || self.has_incomplete_request_verdict()
             || self.recursion_limit_hit()
             || self.unresolved_def_seen()
             || (self.interner.is_union_too_complex() && !union_too_complex_before)
@@ -515,7 +515,7 @@ mod tests {
             .with_query_db(&cache)
             .with_closed_eval_writes();
         incomplete.cache.insert(incomplete_node, TypeId::BOOLEAN);
-        incomplete.request_termination_kind = Some(TerminationKind::DepthExceeded);
+        incomplete.simulate_incomplete_request_verdict_for_test(TerminationKind::DepthExceeded);
         incomplete.commit_closed_eval_writes(false);
         assert_eq!(cache.lookup_closed_eval_cache(incomplete_node, false), None);
     }


### PR DESCRIPTION
Goal: hold

## Summary
- Route the closed-eval write gate through `TypeEvaluator::has_incomplete_request_verdict()`.
- Update the focused closed-eval unit test to use the existing typed-verdict test hook instead of writing the raw request-verdict field.

Structural rule: when closed-eval decides whether a substitution-independent evaluation result can publish into the project-wide cache, tsz asks the solver-owned request-verdict boundary whether the current request is incomplete; closed-eval does not inspect the raw verdict storage slot. Owner layer: `tsz-solver` evaluation/result plus closed-eval cache boundary.

Coordination: #14346 termination-consumer ratchet on top of #15040. Does not touch #15044's query-cache consumer files or Claude's #14345 `application.rs` path.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(incomplete_request_verdict_blocks_closed_eval_write)'`
- `rg -n "request_termination_kind" crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs crates/tsz-solver/src/evaluation/evaluate.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high