### PR TITLE
fix(checker): seed JSDoc @this receiver type so this-property reads check uniformly (#14848)

### DIFF
--- a/crates/tsz-checker/src/dispatch/this.rs
+++ b/crates/tsz-checker/src/dispatch/this.rs
@@ -3,7 +3,6 @@
 //! Extracted from `dispatch.rs` to keep that file under the §19 hard limit of 2000 lines.
 //! All `this`-keyword diagnostic checks and type resolution live here.
 
-use crate::state::CheckerState;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
 
@@ -133,8 +132,7 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
         if self.checker.is_js_file()
             && let Some(func_idx) = self.checker.find_enclosing_non_arrow_function(idx)
             && let Some(jsdoc) = self.checker.get_jsdoc_for_function(func_idx)
-            && let Some(this_expr) = CheckerState::extract_jsdoc_tag_type_expression(&jsdoc, "this")
-            && let Some(this_type) = self.checker.resolve_jsdoc_reference(this_expr)
+            && let Some(this_type) = self.checker.resolve_jsdoc_this_type(&jsdoc)
         {
             return self.checker.apply_flow_narrowing(idx, this_type);
         }

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -1063,6 +1063,14 @@ impl<'a> CheckerState<'a> {
         self.resolve_jsdoc_type_name(type_expr)
     }
 
+    /// Extract a JSDoc `@this {T}` tag from a function's JSDoc comment and
+    /// resolve it to a `TypeId`. Returns `None` when there is no `@this` tag
+    /// or the referenced type cannot be resolved.
+    pub(crate) fn resolve_jsdoc_this_type(&mut self, jsdoc: &str) -> Option<TypeId> {
+        let this_expr = Self::extract_jsdoc_tag_type_expression(jsdoc, "this")?;
+        self.resolve_jsdoc_reference(this_expr)
+    }
+
     /// Backward-compatible alias for `resolve_jsdoc_reference`.
     ///
     /// All internal callers within the JSDoc subsystem should prefer

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -589,6 +589,27 @@ impl<'a> CheckerState<'a> {
                 _node.kind,
                 syntax_kind_ext::FUNCTION_DECLARATION | syntax_kind_ext::FUNCTION_EXPRESSION
             )
+            && let Some(jsdoc) = func_decl_jsdoc.as_ref()
+            && let Some(this_type) = self.resolve_jsdoc_this_type(jsdoc)
+        {
+            // A JSDoc `@this {T}` tag declares the receiver type of a free
+            // function (declaration or expression), mirroring tsc's
+            // `getThisTypeOfSignature`. Seeding the `this` stack makes the
+            // declared receiver authoritative for the whole body so property
+            // READS and WRITES are checked uniformly against it (TS2339).
+            // Without this seed only the `this`-keyword dispatch knew the
+            // type, so reads of an unknown member were silently typed `any`
+            // while writes errored — a read/write asymmetry.
+            self.ctx.this_type_stack.push(this_type);
+            self.ctx.function_owned_this_stack.push(func_idx);
+            pushed_this_type = true;
+        }
+        if !pushed_this_type
+            && self.is_js_file()
+            && matches!(
+                _node.kind,
+                syntax_kind_ext::FUNCTION_DECLARATION | syntax_kind_ext::FUNCTION_EXPRESSION
+            )
             && let Some(this_type) =
                 self.synthesize_js_constructor_instance_type(func_idx, TypeId::ANY, &[])
         {

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -477,7 +477,7 @@ impl<'a> CheckerState<'a> {
         let FunctionBodyCtx {
             func_idx,
             func,
-            node: _node,
+            node,
             is_closure,
             has_type_annotation,
             has_jsdoc_return_type,
@@ -586,7 +586,7 @@ impl<'a> CheckerState<'a> {
         if !pushed_this_type
             && self.is_js_file()
             && matches!(
-                _node.kind,
+                node.kind,
                 syntax_kind_ext::FUNCTION_DECLARATION | syntax_kind_ext::FUNCTION_EXPRESSION
             )
             && let Some(jsdoc) = func_decl_jsdoc.as_ref()
@@ -607,7 +607,7 @@ impl<'a> CheckerState<'a> {
         if !pushed_this_type
             && self.is_js_file()
             && matches!(
-                _node.kind,
+                node.kind,
                 syntax_kind_ext::FUNCTION_DECLARATION | syntax_kind_ext::FUNCTION_EXPRESSION
             )
             && let Some(this_type) =
@@ -622,7 +622,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let owns_untyped_this_binding = matches!(
-            _node.kind,
+            node.kind,
             syntax_kind_ext::FUNCTION_DECLARATION | syntax_kind_ext::FUNCTION_EXPRESSION
         ) && !pushed_this_type
             && !self.enclosing_function_has_contextual_this_type(func_idx)

--- a/crates/tsz-checker/src/types/function_type.rs
+++ b/crates/tsz-checker/src/types/function_type.rs
@@ -238,8 +238,7 @@ impl<'a> CheckerState<'a> {
         if self.is_js_file()
             && !is_arrow_function
             && let Some(ref jsdoc) = func_jsdoc
-            && let Some(this_expr) = Self::extract_jsdoc_tag_type_expression(jsdoc, "this")
-            && let Some(resolved_this) = self.resolve_jsdoc_reference(this_expr)
+            && let Some(resolved_this) = self.resolve_jsdoc_this_type(jsdoc)
         {
             this_type = Some(resolved_this);
         }

--- a/crates/tsz-checker/tests/js_constructor_property_more_tests.rs
+++ b/crates/tsz-checker/tests/js_constructor_property_more_tests.rs
@@ -905,6 +905,142 @@ mark.call({ ready: false });
 }
 
 #[test]
+fn test_jsdoc_this_direct_read_checks_explicit_receiver_shape() {
+    // Read/write parity: reading an unknown member of a JSDoc `@this`-typed
+    // receiver must emit TS2339 just like writing one does. Previously the
+    // read silently typed `any`.
+    let source = r#"
+/**
+ * @this {{ ready: boolean }}
+ */
+function mark() {
+  const x = this.missing;
+}
+"#;
+
+    let diagnostics = check_js(source);
+
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2339
+                && message == "Property 'missing' does not exist on type '{ ready: boolean; }'."
+        }),
+        "Expected TS2339 for reading `this.missing` against the explicit @this receiver shape, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_jsdoc_this_bare_read_expression_checks_receiver_shape() {
+    // Bare expression-statement read (no binding) must also be checked.
+    let source = r#"
+/**
+ * @this {{ ready: boolean }}
+ */
+function mark() {
+  this.missing;
+}
+"#;
+
+    let diagnostics = check_js(source);
+
+    assert_eq!(
+        count_code(&diagnostics, 2339),
+        1,
+        "Expected exactly one TS2339 for bare `this.missing` read, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_jsdoc_this_read_known_member_is_clean() {
+    // Reading a member that DOES exist on the @this receiver must not error.
+    let source = r#"
+/**
+ * @this {{ ready: boolean }}
+ */
+function mark() {
+  const x = this.ready;
+}
+"#;
+
+    let diagnostics = check_js(source);
+
+    assert_eq!(
+        count_code(&diagnostics, 2339),
+        0,
+        "Expected no TS2339 for reading the known `this.ready` member, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_jsdoc_this_read_on_function_expression_checks_receiver_shape() {
+    // The fix applies uniformly to function EXPRESSIONS, not just declarations.
+    let source = r#"
+/**
+ * @this {{ ready: boolean }}
+ */
+const mark = function () {
+  const x = this.missing;
+};
+"#;
+
+    let diagnostics = check_js(source);
+
+    assert_eq!(
+        count_code(&diagnostics, 2339),
+        1,
+        "Expected TS2339 for `this.missing` read inside a @this-typed function expression, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_jsdoc_this_read_is_structural_not_name_keyed() {
+    // Anti-hardcoding: the miss was structural. Vary both the receiver-shape
+    // member name and the accessed property name; the read must still error.
+    let source = r#"
+/**
+ * @this {{ alpha: number }}
+ */
+function configure() {
+  const v = this.omega;
+}
+"#;
+
+    let diagnostics = check_js(source);
+
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2339
+                && message == "Property 'omega' does not exist on type '{ alpha: number; }'."
+        }),
+        "Expected TS2339 for `this.omega` against `{{ alpha: number }}`, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_jsdoc_this_read_write_parity_count() {
+    // Both a read and a write of unknown members emit exactly one TS2339 each;
+    // a known-member read/write stays clean.
+    let source = r#"
+/**
+ * @this {{ ready: boolean }}
+ */
+function mark() {
+  this.ready = true;
+  const x = this.missingRead;
+  this.missingWrite = 1;
+}
+"#;
+
+    let diagnostics = check_js(source);
+
+    assert_eq!(
+        count_code(&diagnostics, 2339),
+        2,
+        "Expected exactly two TS2339 (one read, one write) for unknown members, got: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn test_js_chained_this_element_assignment_reports_ts7053() {
     let source = r#"
 this["y"] = {};


### PR DESCRIPTION
Fixes #14848.

Structural rule: when a free `function` (declaration or expression) in a checked JS file carries a JSDoc `@this {T}` tag, tsc types the `this` receiver as `T` for the whole body via `getThisTypeOfSignature`, so BOTH property reads and writes are checked against `T` (TS2339). tsz only typed `this` as `T` in the `this`-keyword dispatch, so writes and known-property reads were checked but a READ of an unknown member silently typed `any` and skipped TS2339 — a read/write asymmetry owned by the checker's function-body `this`-seeding path.

Root cause: the resolved `@this` type was never pushed onto `this_type_stack`, so `has_explicit_this_context` was false in `property_access_type/identifier_resolution.rs`; the read branch then returned `any` (the write branch had a separate `has_jsdoc_this_context` gate, which is why writes worked). Rather than special-casing the read branch, the fix seeds the `this` stack with the resolved `@this` type when checking a function declaration/expression body — a new arm alongside the existing explicit-`this`-parameter, JSDoc-callable-type, and JS-constructor-synthesis arms in `function_declaration_checks.rs`. This makes the declared receiver authoritative uniformly for every `current_this_type()` consumer, matching tsc.

Also extracts a shared `resolve_jsdoc_this_type` helper and routes the three existing `@this` extract+resolve sites (`dispatch/this.rs`, `types/function_type.rs`, the new arm) through it.

Adjacent matrix covered by new tests: direct read (`const x = this.missing`), bare-expression read (`this.missing;`), known-member read stays clean, function-expression form (not just declarations), renamed/structural variant (anti-hardcoding — varies both receiver-shape member name and accessed property name), and a read+write parity count. The pre-existing write test (`test_jsdoc_this_direct_write_checks_explicit_receiver_shape`) continues to pass.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test js_constructor_property_more_tests` — 45 passed (includes 6 new JSDoc `@this` read tests + the existing write control).
- `cargo build -p tsz-checker` — no warnings/errors.
- Ready-review CI owns the broad checker/conformance suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01GWq5WA8iwCREvPTN4SbmZj

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWq5WA8iwCREvPTN4SbmZj)_