### PR TITLE
fix(checker): emit duplicate-member implicit-any once per symbol (TS7008, #14842)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2302,3 +2302,7 @@ path = "tests/let_var_initializer_assignment_reduced_type_tests.rs"
 [[test]]
 name = "noinfer_object_property_literal_widening_tests"
 path = "tests/noinfer_object_property_literal_widening_tests.rs"
+
+[[test]]
+name = "class_duplicate_member_implicit_any_tests"
+path = "tests/class_duplicate_member_implicit_any_tests.rs"

--- a/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/ambient_signature_checks.rs
@@ -16,6 +16,42 @@ impl<'a> CheckerState<'a> {
         self.check_property_declaration_with_request(member_idx, &TypingRequest::NONE);
     }
 
+    /// Whether `member_idx` is a *redeclaration* of an earlier same-named
+    /// property (with the same static-ness) in the enclosing class.
+    ///
+    /// `tsc` computes a member's implicit-`any` (`TS7008`) once per member
+    /// *symbol*, anchored at the symbol's first declaration. A later
+    /// declaration that shares the name only receives the duplicate-identifier
+    /// (`TS2300`) and initialization/subsequent-type (`TS2564`/`TS2717`)
+    /// diagnostics, never a second `TS7008` — even when that later declaration
+    /// itself lacks a type annotation and initializer. Static and instance
+    /// members occupy separate namespaces, so a `static x` does not shadow an
+    /// instance `x` (each keeps its own `TS7008`).
+    fn member_redeclares_earlier_property(&self, member_idx: NodeIndex, is_static: bool) -> bool {
+        let Some(class_info) = self.ctx.enclosing_class.as_ref() else {
+            return false;
+        };
+        let Some(pos) = class_info
+            .member_nodes
+            .iter()
+            .position(|&idx| idx == member_idx)
+        else {
+            return false;
+        };
+        let earlier_members: Vec<NodeIndex> = class_info.member_nodes[..pos].to_vec();
+        let Some(name) = self.get_member_name(member_idx) else {
+            return false;
+        };
+        earlier_members.iter().any(|&earlier| {
+            self.ctx
+                .arena
+                .get(earlier)
+                .is_some_and(|n| n.kind == syntax_kind_ext::PROPERTY_DECLARATION)
+                && self.is_static_property(earlier) == is_static
+                && self.get_member_name(earlier).as_deref() == Some(name.as_str())
+        })
+    }
+
     pub(crate) fn check_property_declaration_with_request(
         &mut self,
         member_idx: NodeIndex,
@@ -506,6 +542,11 @@ impl<'a> CheckerState<'a> {
             // static blocks (e.g., `static { this.x = 1; }`)
             && !(is_static
                 && self.property_assigned_in_enclosing_class_static_block(prop.name))
+            // A redeclaration of an earlier same-named member is not the
+            // symbol's primary declaration; tsc emits the implicit-any member
+            // error once, on the first declaration (the redeclaration still
+            // gets TS2300/TS2564/TS2717).
+            && !self.member_redeclares_earlier_property(member_idx, is_static)
             && let Some(member_name) = self.get_member_name_display_text(prop.name)
         {
             use crate::diagnostics::diagnostic_codes;

--- a/crates/tsz-checker/tests/class_duplicate_member_implicit_any_tests.rs
+++ b/crates/tsz-checker/tests/class_duplicate_member_implicit_any_tests.rs
@@ -1,0 +1,118 @@
+//! Implicit-`any` (`TS7008`) reporting for duplicate, un-annotated class members.
+//!
+//! Structural rule: `tsc` computes a member's implicit-`any` error once per
+//! member *symbol*, anchored at the symbol's first declaration. When a class
+//! declares the same member name twice without a type annotation or
+//! initializer, `tsc` emits `TS7008` once (on the first declaration) plus
+//! `TS2300` (duplicate identifier) on the redeclaration — never a second
+//! `TS7008`. tsz previously ran the per-declaration implicit-any check on every
+//! declaration node sharing the name, emitting an extra `TS7008` on the
+//! redeclaration. Owner: `state_checking_members/ambient_signature_checks.rs`
+//! (`check_property_declaration_with_request`), gated by
+//! `member_redeclares_earlier_property`.
+//!
+//! Static and instance members live in separate namespaces, so `static x` and
+//! instance `x` are not duplicates and each keeps its own `TS7008`. These tests
+//! vary the class/member binder names to confirm no identifier string drives
+//! the logic.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+const TS7008: u32 = 7008; // Member implicitly has an 'any' type.
+const TS2300: u32 = 2300; // Duplicate identifier.
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+#[test]
+fn duplicate_private_untyped_member_emits_ts7008_once() {
+    // Witness from #14842: `#x; #x;` — one TS7008 on the first decl, one TS2300
+    // on the redeclaration (no second TS7008).
+    let codes = check_source_strict_codes("class C { #x; #x; }");
+    assert_eq!(
+        count(&codes, TS7008),
+        1,
+        "TS7008 once per symbol: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, TS2300),
+        1,
+        "duplicate still flagged: {codes:?}"
+    );
+}
+
+#[test]
+fn duplicate_public_untyped_member_emits_ts7008_once_renamed() {
+    // Same shape, public field, different binder names: still one TS7008.
+    let codes = check_source_strict_codes("class Widget { handle; handle; }");
+    assert_eq!(count(&codes, TS7008), 1, "{codes:?}");
+    assert_eq!(count(&codes, TS2300), 1, "{codes:?}");
+}
+
+#[test]
+fn triple_untyped_member_emits_ts7008_once() {
+    // Three declarations: TS7008 once, TS2300 on each redeclaration.
+    let codes = check_source_strict_codes("class Box { slot; slot; slot; }");
+    assert_eq!(count(&codes, TS7008), 1, "{codes:?}");
+    assert_eq!(count(&codes, TS2300), 2, "{codes:?}");
+}
+
+#[test]
+fn interleaved_distinct_names_each_get_one_ts7008() {
+    // `p; q; p;`: distinct first declarations of `p` and `q` each emit TS7008;
+    // the second `p` is the redeclaration (TS2300 only).
+    let codes = check_source_strict_codes("class Grid { row; col; row; }");
+    assert_eq!(count(&codes, TS7008), 2, "{codes:?}");
+    assert_eq!(count(&codes, TS2300), 1, "{codes:?}");
+}
+
+#[test]
+fn static_and_instance_same_name_are_not_duplicates() {
+    // `static x; x;` are separate symbols: TS7008 on both, no TS2300.
+    let codes = check_source_strict_codes("class Reg { static entry; entry; }");
+    assert_eq!(count(&codes, TS7008), 2, "{codes:?}");
+    assert_eq!(count(&codes, TS2300), 0, "{codes:?}");
+}
+
+#[test]
+fn duplicate_static_untyped_member_emits_ts7008_once() {
+    // `static t; static t;` is a duplicate static symbol: TS7008 once + TS2300.
+    let codes = check_source_strict_codes("class Pool { static node; static node; }");
+    assert_eq!(count(&codes, TS7008), 1, "{codes:?}");
+    assert_eq!(count(&codes, TS2300), 1, "{codes:?}");
+}
+
+#[test]
+fn redeclaration_after_initialized_member_has_no_ts7008() {
+    // First decl has an initializer (typed `number`), so the symbol is not
+    // implicit-any; the un-annotated redeclaration must not get TS7008.
+    let codes = check_source_strict_codes("class Acc { total = 1; total; }");
+    assert_eq!(count(&codes, TS7008), 0, "{codes:?}");
+    assert_eq!(count(&codes, TS2300), 1, "{codes:?}");
+}
+
+#[test]
+fn redeclaration_after_typed_member_has_no_ts7008() {
+    // First decl is typed; the un-annotated redeclaration must not get TS7008.
+    let codes = check_source_strict_codes("class Pt { value: number; value; }");
+    assert_eq!(count(&codes, TS7008), 0, "{codes:?}");
+    assert_eq!(count(&codes, TS2300), 1, "{codes:?}");
+}
+
+#[test]
+fn single_untyped_member_still_emits_ts7008() {
+    // Fallback: a non-duplicate un-annotated field still gets exactly one
+    // TS7008 (the suppression must not over-fire).
+    let codes = check_source_strict_codes("class One { lone; }");
+    assert_eq!(count(&codes, TS7008), 1, "{codes:?}");
+    assert_eq!(count(&codes, TS2300), 0, "{codes:?}");
+}
+
+#[test]
+fn distinct_untyped_members_each_emit_ts7008() {
+    // Two distinct un-annotated fields each get their own TS7008, no TS2300.
+    let codes = check_source_strict_codes("class Two { first; second; }");
+    assert_eq!(count(&codes, TS7008), 2, "{codes:?}");
+    assert_eq!(count(&codes, TS2300), 0, "{codes:?}");
+}


### PR DESCRIPTION
## Summary
A class that declares the same untyped member name twice emitted an extra `TS7008` ("Member implicitly has an 'any' type") on the *redeclaration*. `tsc` emits `TS7008` once (on the first declaration) plus `TS2300` on the duplicate; tsz produced one more diagnostic than `tsc`. Affects both private (`#x; #x;`) and public (`x; x;`) untyped members.

Goal: green

## Root cause
`TS7008` for a class field is emitted per *declaration node* in `check_property_declaration_with_request` (`state_checking_members/ambient_signature_checks.rs`). For a duplicate-named member, two declaration nodes share one symbol, so the per-node check fires on both. `tsc` computes a member's implicit-any once per *symbol*, anchored at the symbol's first declaration; the redeclaration only receives `TS2300`/`TS2564`/`TS2717`.

## Structural rule
When two or more class members share a name (same static-ness) and lack a type annotation and initializer, `tsc` emits `TS7008` once for the member symbol (first declaration) plus `TS2300` on each redeclaration; tsz must suppress `TS7008` on the non-primary declaration. Owner layer: checker member-declaration check, gated by a new `member_redeclares_earlier_property` query over `enclosing_class.member_nodes` (binder/symbol-ordering, not printer output, not name/file literals). Static and instance members are separate namespaces, so `static x` and instance `x` each keep their own `TS7008`.

Verified against `tsc` 6.0.0-dev (= 5.9 behavior) that `TS2564` is reported *per declaration* (twice for `x: number; x: number;`) — so the fix is scoped to `TS7008` only and leaves the typed-duplicate `TS2564` path untouched.

## Adjacent-case matrix (verified against tsc, renamed binders)
| input | tsc / tsz after fix |
| --- | --- |
| `class C { #x; #x; }` | TS7008 x1 + TS2300 x1 |
| `class Widget { handle; handle; }` | TS7008 x1 + TS2300 x1 |
| `class Box { slot; slot; slot; }` | TS7008 x1 + TS2300 x2 |
| `class Grid { row; col; row; }` (interleaved) | TS7008 x2 + TS2300 x1 |
| `class Reg { static entry; entry; }` (static vs instance) | TS7008 x2, no TS2300 |
| `class Pool { static node; static node; }` | TS7008 x1 + TS2300 x1 |
| `class Acc { total = 1; total; }` (first initialized) | TS7008 x0 + TS2300 x1 |
| `class Pt { value: number; value; }` (first typed) | TS7008 x0 + TS2300 x1 |
| `class One { lone; }` (fallback, single) | TS7008 x1 |
| `class Two { first; second; }` (distinct) | TS7008 x2 |

## Verification
- New witness suite `crates/tsz-checker/tests/class_duplicate_member_implicit_any_tests.rs` (10 tests, varied binder names) — all green:
  `cargo nextest run -p tsz-checker -E 'binary(class_duplicate_member_implicit_any_tests)'`
- Reproduced pre-fix double `TS7008` via the CLI and confirmed parity with `tsc` 6.0.0-dev for the full matrix above.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Closes #14842