### PR TITLE
refactor(solver): centralize eval cache stability gate (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -615,7 +615,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         request: EvaluationRequest,
     ) -> EvaluationMemoResult {
         let result = self.evaluate_request_result(request);
-        EvaluationMemoResult::for_depth_agnostic_memo(result, self.recursion_limit_hit())
+        EvaluationMemoResult::for_depth_agnostic_memo(
+            result,
+            self.request_state_is_depth_agnostic_cache_stable(),
+        )
+    }
+
+    /// Whether the current request state is stable enough for depth-agnostic
+    /// cache publication.
+    ///
+    /// This centralizes the #14346 transition from loose evaluator flags to the
+    /// typed request verdict. A typed incomplete verdict catches guard bails
+    /// that the legacy sticky flags did not fully model (for example
+    /// fuel/query-budget bails). The legacy [`Self::recursion_limit_hit`]
+    /// backstop remains until every recursion-taint class is owned by the typed
+    /// termination channel.
+    #[inline]
+    pub(crate) const fn request_state_is_depth_agnostic_cache_stable(&self) -> bool {
+        !self.has_incomplete_request_verdict() && !self.recursion_limit_hit()
     }
 
     // =========================================================================

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -690,16 +690,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             //    this arm, so no registration-window artifact is published;
             //  - not budget-bounded — neither the depth bail nor a limit-tripped
             //    structural walk produced it;
-            //  - the enclosing evaluation request saw no typed incomplete
-            //    verdict, legacy recursion limit, or unresolved application
-            //    body (`has_incomplete_request_verdict` /
-            //    `recursion_limit_hit` / `unresolved_def_seen`), and neither
-            //    operand is tainted — the same whole-run gates `closed_eval`
-            //    uses before persisting.
+            //  - the enclosing evaluation request is stable enough for
+            //    depth-agnostic publication, saw no unresolved application
+            //    body, and neither operand is tainted — the same whole-run
+            //    gates `closed_eval` uses before persisting.
             if conditional_branch_verdict_cache_enabled()
                 && !verdict_is_budget_bounded
-                && !self.has_incomplete_request_verdict()
-                && !self.recursion_limit_hit()
+                && self.request_state_is_depth_agnostic_cache_stable()
                 && !self.unresolved_def_seen()
                 && !self.is_tainted(check_type)
                 && !self.is_tainted(extends_type)

--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -149,8 +149,8 @@ impl EvaluationResult {
 ///
 /// #14346 is moving cache eligibility from loose evaluator flags into typed
 /// result boundaries. A fresh-evaluator memo has two pieces of information:
-/// the request's [`EvaluationResult`] and whether legacy stack-context taint
-/// still makes the collapsed value unsafe to store in a depth-agnostic cache.
+/// the request's [`EvaluationResult`] and whether the request state still makes
+/// the collapsed value safe to store in a depth-agnostic cache.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct EvaluationMemoResult {
     result: EvaluationResult,
@@ -158,15 +158,15 @@ pub(crate) struct EvaluationMemoResult {
 }
 
 impl EvaluationMemoResult {
-    /// Construct a memo result from a typed evaluation result and the legacy
-    /// recursion-limit backstop.
+    /// Construct a memo result from a typed evaluation result and the
+    /// request-state stability verdict.
     pub(crate) const fn for_depth_agnostic_memo(
         result: EvaluationResult,
-        legacy_recursion_limit_hit: bool,
+        request_state_stable: bool,
     ) -> Self {
         Self {
             result,
-            stable_for_depth_agnostic_cache: result.is_complete() && !legacy_recursion_limit_hit,
+            stable_for_depth_agnostic_cache: result.is_complete() && request_state_stable,
         }
     }
 
@@ -257,21 +257,21 @@ mod tests {
     }
 
     #[test]
-    fn memo_result_stability_requires_complete_result_and_clean_legacy_backstop() {
+    fn memo_result_stability_requires_complete_result_and_clean_request_state() {
         let complete = EvaluationResult::complete(TypeId::STRING);
-        let stable = EvaluationMemoResult::for_depth_agnostic_memo(complete, false);
+        let stable = EvaluationMemoResult::for_depth_agnostic_memo(complete, true);
 
         assert_eq!(stable.evaluation_result(), complete);
         assert_eq!(stable.type_id(), TypeId::STRING);
         assert_eq!(stable.into_type_id(), TypeId::STRING);
         assert!(stable.is_stable_for_depth_agnostic_cache());
 
-        let legacy_tainted = EvaluationMemoResult::for_depth_agnostic_memo(complete, true);
-        assert!(!legacy_tainted.is_stable_for_depth_agnostic_cache());
+        let request_state_tainted = EvaluationMemoResult::for_depth_agnostic_memo(complete, false);
+        assert!(!request_state_tainted.is_stable_for_depth_agnostic_cache());
 
         let incomplete =
             EvaluationResult::incomplete(TypeId::NUMBER, TerminationKind::DepthExceeded);
-        let typed_tainted = EvaluationMemoResult::for_depth_agnostic_memo(incomplete, false);
+        let typed_tainted = EvaluationMemoResult::for_depth_agnostic_memo(incomplete, true);
         assert_eq!(typed_tainted.into_type_id(), TypeId::NUMBER);
         assert!(!typed_tainted.is_stable_for_depth_agnostic_cache());
     }


### PR DESCRIPTION
Goal: green

## Summary
- centralize the evaluator request-state predicate for depth-agnostic cache publication
- route the conditional-branch persistent verdict cache through that predicate instead of spelling out typed-verdict plus legacy recursion flags locally
- keep `EvaluationMemoResult` construction tied to the same request-state stability verdict

## Structural Rule
When an evaluation-side cache decides whether a result can be published without a depth/fuel-aware key, tsz asks the solver-owned evaluation/result boundary whether the current request state is stable; individual cache sites do not reconstruct termination semantics from loose evaluator flags.

Owner layer: `tsz-solver` evaluation/result and conditional-branch cache boundary.
Adjacent matrix: complete request state remains publishable; typed incomplete request verdict blocks the conditional persistent cache; incomplete evaluation result remains unpublishable even with a clean request-state predicate; legacy recursion taint remains in the centralized helper until #14346 retires it.
Fallback: unstable request state skips the cross-evaluator cache write and recomputes, preserving current behavior.
Performance: behavior-preserving refactor; no row/perf measurement expected.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(incomplete_request_verdict_blocks_conditional_branch_persistent_write) or test(memo_result_stability_requires_complete_result_and_clean_request_state)'`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high