### PR TITLE
fix(checker): keep source nullish in TS2322 instead of spurious TS2719 (#14824)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_generic.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_generic.rs
@@ -287,6 +287,18 @@ impl<'a> CheckerState<'a> {
             }
             tgt_str =
                 self.canonicalize_assignment_numeric_literal_union_display(target, source, tgt_str);
+            // A source union whose top-level `null`/`undefined` was stripped by
+            // the target-only display policy can collapse to the target's
+            // display (e.g. `string[] | undefined` rendered as `string[]`).
+            // `tsc` keeps the source nullish; restore it so the duplicate-name
+            // TS2719 gate below does not misfire where `tsc` reports a plain
+            // TS2322.
+            if let Some(restored) = self.source_display_preserving_nullish_if_collapsed_to_target(
+                source, target, &src_str, &tgt_str,
+            ) {
+                src_str = restored;
+            }
+
             // TS2719: when both types display identically but are different,
             // emit "Two different types with this name exist" instead of TS2322.
             let authoritative_src = self.authoritative_assignability_def_name(source);

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -1273,6 +1273,45 @@ impl<'a> CheckerState<'a> {
                 .is_some()
     }
 
+    /// `tsc` never strips a *source* union's top-level `null`/`undefined`
+    /// members from an assignability message. The shared assignment-source
+    /// display policy, however, strips them when the target is non-nullable —
+    /// correct only for the *target* side ("show the non-nullable part of the
+    /// target"). Applied to the source it drops members `tsc` keeps, collapsing
+    /// e.g. `string[] | undefined` to `string[]`. When that stripped source
+    /// display then equals the target display, the duplicate-name TS2719 gate
+    /// ("two different types with this name exist") misfires where `tsc` reports
+    /// a plain TS2322 (`Type 'string[] | undefined' is not assignable to type
+    /// 'string[]'`).
+    ///
+    /// When the rendered `source_str` has collapsed to equal `target_str` and
+    /// the source structurally carries top-level `null`/`undefined` the target
+    /// lacks, return a source display that preserves those members so the
+    /// diagnostic stays TS2322. This is purely a display correction: the
+    /// relation verdict and the failing union member are unchanged. Returns
+    /// `None` (leaving the existing display, and thus the existing TS2719 path,
+    /// intact) for genuinely distinct same-named nominal types, which carry no
+    /// such nullish difference.
+    pub(crate) fn source_display_preserving_nullish_if_collapsed_to_target(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        source_str: &str,
+        target_str: &str,
+    ) -> Option<String> {
+        if source_str != target_str {
+            return None;
+        }
+        // Structural witness that the source carries top-level `null`/`undefined`
+        // the target does not: `strip_nullish_for_assignability_display` yields
+        // the stripped form in exactly that case. Use it only as the predicate;
+        // the display itself is recomputed with the nullish-preserving formatter.
+        self.strip_nullish_for_assignability_display(source, target)?;
+        let preserved =
+            self.format_assignability_type_for_message_preserving_nullish(source, target);
+        (preserved != target_str).then_some(preserved)
+    }
+
     pub(super) fn format_enum_member_name_for_message(&mut self, ty: TypeId) -> Option<String> {
         let def_id = crate::query_boundaries::common::enum_def_id(self.ctx.types, ty)?;
         let sym_id = self.ctx.def_to_symbol_id_with_fallback(def_id)?;

--- a/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/type_mismatch.rs
@@ -472,6 +472,22 @@ impl<'a> CheckerState<'a> {
             target_str = self
                 .canonicalize_assignment_numeric_literal_union_display(target, source, target_str);
         }
+        // A source union whose top-level `null`/`undefined` was stripped by the
+        // target-only display policy can collapse to the target's display (e.g.
+        // `string[] | undefined` rendered as `string[]`). `tsc` keeps the source
+        // nullish, so restore it before building the assignability message:
+        // otherwise the collapse both misfires the TS2719 duplicate-name gate
+        // below and (on the TS2322 fallthrough) drops the `| undefined`/`| null`
+        // that `tsc` shows (`Type 'string[] | undefined' is not assignable to
+        // type 'string[]'`).
+        if let Some(restored) = self.source_display_preserving_nullish_if_collapsed_to_target(
+            source,
+            target,
+            &source_str,
+            &target_str,
+        ) {
+            source_str = restored;
+        }
         let base = format_message(
             diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             &[&source_str, &target_str],

--- a/crates/tsz-checker/tests/conformance_issues/features/elaboration.rs
+++ b/crates/tsz-checker/tests/conformance_issues/features/elaboration.rs
@@ -855,6 +855,175 @@ function check<U>(y: Bar<U>, n: number) {
     );
 }
 
+/// A `T[] | undefined` source assigned/returned against a non-nullable `T[]`
+/// target must report TS2322 with the full `T[] | undefined` source — not a
+/// spurious TS2719 ("two different types with this name exist"). The shared
+/// assignment display policy strips a *target* union's nullish; applied to the
+/// source it collapsed `string[] | undefined` to `string[]`, which collided
+/// with the target display and misfired the duplicate-name gate. Repro family
+/// from class-transformer `MetadataStorage.ts` (`Map<string, X[]>.get(...)`),
+/// reproduced here lib-free via an optional property whose value is `string[]`.
+#[test]
+fn test_no_ts2719_for_nullable_array_source_returned() {
+    let code = r#"
+function pull(store: { items?: string[] }): string[] {
+  return store.items;
+}
+"#;
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        code,
+        CheckerOptions {
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+    );
+    assert!(
+        !has_error(&diagnostics, 2719),
+        "Should NOT emit TS2719 for `string[] | undefined` -> `string[]`, got: {diagnostics:?}"
+    );
+    assert!(
+        has_error(&diagnostics, 2322),
+        "Expected TS2322 for nullable array source, got: {diagnostics:?}"
+    );
+    let msg = diagnostics
+        .iter()
+        .find(|(c, _)| *c == 2322)
+        .map(|(_, m)| m.clone())
+        .unwrap_or_default();
+    assert!(
+        msg.contains("string[] | undefined") && msg.contains("type 'string[]'"),
+        "TS2322 must preserve the source nullish like tsc \
+         (`Type 'string[] | undefined' is not assignable to type 'string[]'`), got: {msg}"
+    );
+}
+
+/// Same structural rule with renamed binders, a `number[]` element type, and a
+/// `const`-initializer assignment position instead of a `return`. Confirms the
+/// gate is not keyed on any identifier, element type, or assignment shape.
+#[test]
+fn test_no_ts2719_for_nullable_array_source_renamed_number_const() {
+    let code = r#"
+function grab(bucket: { payload?: number[] }): void {
+  const out: number[] = bucket.payload;
+}
+"#;
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        code,
+        CheckerOptions {
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+    );
+    assert!(
+        !has_error(&diagnostics, 2719),
+        "Should NOT emit TS2719 for `number[] | undefined` -> `number[]`, got: {diagnostics:?}"
+    );
+    assert!(
+        has_error(&diagnostics, 2322),
+        "Expected TS2322 for nullable array source, got: {diagnostics:?}"
+    );
+    let msg = diagnostics
+        .iter()
+        .find(|(c, _)| *c == 2322)
+        .map(|(_, m)| m.clone())
+        .unwrap_or_default();
+    assert!(
+        msg.contains("number[] | undefined") && msg.contains("type 'number[]'"),
+        "TS2322 must preserve the source nullish, got: {msg}"
+    );
+}
+
+/// The `| null` flavor of the same collapse (`string[] | null` -> `string[]`)
+/// must likewise report TS2322 with the nullish preserved, never TS2719.
+#[test]
+fn test_no_ts2719_for_null_array_source() {
+    let code = r#"
+declare const maybe: string[] | null;
+function take(): string[] {
+  return maybe;
+}
+"#;
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        code,
+        CheckerOptions {
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+    );
+    assert!(
+        !has_error(&diagnostics, 2719),
+        "Should NOT emit TS2719 for `string[] | null` -> `string[]`, got: {diagnostics:?}"
+    );
+    assert!(
+        has_error(&diagnostics, 2322),
+        "Expected TS2322 for nullable array source, got: {diagnostics:?}"
+    );
+    let msg = diagnostics
+        .iter()
+        .find(|(c, _)| *c == 2322)
+        .map(|(_, m)| m.clone())
+        .unwrap_or_default();
+    assert!(
+        msg.contains("string[] | null") && msg.contains("type 'string[]'"),
+        "TS2322 must preserve the source nullish, got: {msg}"
+    );
+}
+
+/// An `as`-cast that yields `string[] | undefined` is the same source shape and
+/// must also fall through to TS2322 rather than TS2719.
+#[test]
+fn test_no_ts2719_for_nullable_array_source_via_as_cast() {
+    let code = r#"
+function coerce(value: unknown): string[] {
+  return value as string[] | undefined;
+}
+"#;
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        code,
+        CheckerOptions {
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+    );
+    assert!(
+        !has_error(&diagnostics, 2719),
+        "Should NOT emit TS2719 for an `as string[] | undefined` source, got: {diagnostics:?}"
+    );
+    assert!(
+        has_error(&diagnostics, 2322),
+        "Expected TS2322 for nullable array source, got: {diagnostics:?}"
+    );
+}
+
+/// Negative / fallback: a genuine pair of distinct same-named types with no
+/// nullish difference (a type parameter `T` shadowing an interface `T`) must
+/// still emit TS2719 — the nullish-restore guard returns `None` here, leaving
+/// the duplicate-name path intact.
+#[test]
+fn test_ts2719_still_fires_for_distinct_same_named_types_without_nullish() {
+    let code = r#"
+interface T { }
+declare const a: T;
+class Box<T> {
+    x: T;
+    fn() {
+        this.x = a;
+    }
+}
+"#;
+    let diagnostics = compile_and_get_diagnostics_with_options(
+        code,
+        CheckerOptions {
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+    );
+    assert!(
+        has_error(&diagnostics, 2719),
+        "Genuine distinct same-named types must still emit TS2719, got: {diagnostics:?}"
+    );
+}
+
 /// CJS modules whose `module.exports = <callable>` produce a merged
 /// callable+properties apparent type. tsc renders the structural form
 /// (`{ (): void; blah: any; }`) for TS2339 receivers, not the


### PR DESCRIPTION
Goal: green

Fixes #14824: a spurious `TS2719` ("Two different types with this name exist, but they are unrelated") was emitted instead of `TS2322` when a source union whose only non-nullish member shares the target's display name (e.g. `string[] | undefined`) is assigned/returned against a non-nullable `string[]`.

Witness (class-transformer `MetadataStorage.ts`):
```ts
function d1(m: Map<string, string[]>): string[] {
  return m.get("a"); // m.get -> string[] | undefined
}
```
- tsz before: `TS2719: Type 'string[]' is not assignable to type 'string[]'. Two different types with this name exist, but they are unrelated.`
- tsc 5.9.3 / tsz after: `TS2322: Type 'string[] | undefined' is not assignable to type 'string[]'.`

## Root cause / structural rule

The wrong operation is **diagnostic display**, not the relation. The solver already produced the correct `UnionSourceMismatch` reason with the failing member `undefined` (the nested child line `Type 'undefined' is not assignable to type 'string[]'` was always correct).

`strip_nullish_for_assignability_display` is a **target-only** display behavior ("show the non-nullable part of the target"). It was also reaching the **source** display path, stripping `string[] | undefined` down to `string[]`. The stripped source then equaled the target display, which misfired the existing `source_str == target_str` TS2719 duplicate-name gate.

Structural rule: **When a diagnostic source is a union carrying top-level `null`/`undefined` the target lacks, and the source display has collapsed to equal the target display, tsc keeps the source nullish (TS2322) — tsz now restores it through the checker error-reporter** instead of stripping and misfiring TS2719. Confirmed structurally: with a nullable target (`string[] | null`) the strip helper already no-ops and tsz was correct; the bug only surfaced for non-nullable targets.

Owner layer: checker `error_reporter` (diagnostic display). A new shared helper `source_display_preserving_nullish_if_collapsed_to_target` recomputes the source with the existing nullish-preserving formatter only when (a) the rendered source equals the target and (b) the source structurally has top-level nullish absent from the target. It is applied at both TS2719 emission sites (`render_failure/type_mismatch.rs`, `assignability_generic.rs`), before the assignability message is built, so the TS2322 fallthrough also shows the full `… | undefined` source. No relation/inference change; no printer-output predicate driving a type decision (the gate reuses the same display comparison the existing TS2719 logic already performs, then defers to a structural nullish check).

## Adjacent-case matrix

- Witness `Map<string,string[]>.get` return + inferred-`const` + `Array<string>` generic spelling: now TS2322 with `string[] | undefined`.
- Renamed binders + `number[]` element type + `const`-initializer position (not just `return`): TS2322 with `number[] | undefined` — gate is not name/element/position keyed.
- `| null` flavor (`string[] | null` -> `string[]`): TS2322 with `string[] | null`.
- `as`-cast source (`value as string[] | undefined`): TS2322.
- Property-access source (`o.a` where `a?: string[]`): TS2322.
- Negative / fallback: genuine distinct same-named types with no nullish difference (type parameter `T` shadowing interface `T`) still emit TS2719 — the restore helper returns `None`.
- Nullable target (`string[] | null`) was already correct and stays TS2322.

## Verification

- `cargo nextest run -p tsz-checker -E 'test(no_ts2719_for_nullable_array) + test(ts2719_still_fires_for_distinct) + test(no_ts2719_for_null_array)'` — 5/5 new tests pass.
- Broad display-path regression filter `test(ts2719)+test(2719)+test(in_operator_non_null)+test(private_brand)+test(elaboration)+test(nullable_array)`: 257 passed, 18 failed; the 18 failures are pre-existing on `origin/main` (verified by stashing the fix and re-running the identical filter — same 18 fail without the change). No new regressions.
- CLI end-to-end (`tsz --noEmit --strict`) over the witness family: every prior `TS2719` is now `TS2322` with the tsc-matching `T[] | undefined` / `T[] | null` source text.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Closes #14824
