### PR TITLE
fix(emit): fold enum `/` as ECMAScript float division, not integer truncation

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
@@ -1593,3 +1593,26 @@ fn test_const_enum_element_access_string_member_normalizes() {
         "const enum CE[\"Y\"] must normalize to CE.Y: {output}"
     );
 }
+
+#[test]
+fn test_enum_division_dts_is_float_value() {
+    // ECMAScript `/` is float division; `.d.ts` member values must carry the
+    // true fractional constant (regression: 10/4 -> 2 instead of 2.5).
+    let result = emit_dts("export enum RE {\n    A = 10 / 4,\n    B = 7 / 2,\n    C = 8 / 4,\n}\n");
+    assert!(
+        result.contains("A = 2.5") && result.contains("B = 3.5") && result.contains("C = 2"),
+        "enum division .d.ts values must be float quotients: {result}"
+    );
+}
+
+#[test]
+fn test_const_enum_division_dts_is_float_value() {
+    let result =
+        emit_dts("export const enum CE {\n    A = 10 / 4,\n    D = 1 / 3,\n    F = 100 / 8,\n}\n");
+    assert!(
+        result.contains("A = 2.5")
+            && result.contains("D = 0.3333333333333333")
+            && result.contains("F = 12.5"),
+        "const enum division .d.ts values must be float quotients: {result}"
+    );
+}

--- a/crates/tsz-emitter/src/enums/evaluator.rs
+++ b/crates/tsz-emitter/src/enums/evaluator.rs
@@ -558,6 +558,19 @@ impl<'a> EnumEvaluator<'a> {
         EnumValue::Computed
     }
 
+    /// Re-narrow an f64 arithmetic result back to an integer [`EnumValue::Number`]
+    /// when it is integral and within `i64` range, otherwise keep it as an
+    /// [`EnumValue::Float`]. This mirrors how JavaScript stores every numeric
+    /// value as an IEEE-754 double yet prints integral results without a
+    /// fractional part, so the inlined enum constant round-trips exactly.
+    fn narrow_f64(result: f64) -> EnumValue {
+        if result.fract() == 0.0 && result >= i64::MIN as f64 && result <= i64::MAX as f64 {
+            EnumValue::Number(result as i64)
+        } else {
+            EnumValue::Float(result)
+        }
+    }
+
     /// Evaluate a binary expression
     fn evaluate_binary(&self, left: NodeIndex, op: u16, right: NodeIndex) -> EnumValue {
         let left_val = self.evaluate_expression(left);
@@ -572,10 +585,15 @@ impl<'a> EnumEvaluator<'a> {
                     k if k == SyntaxKind::MinusToken as u16 => l.wrapping_sub(*r),
                     k if k == SyntaxKind::AsteriskToken as u16 => l.wrapping_mul(*r),
                     k if k == SyntaxKind::SlashToken as u16 => {
+                        // ECMAScript `/` is always IEEE-754 float division, even
+                        // for two integer operands (`10 / 4` is `2.5`, not the
+                        // Rust integer `2`). Route through f64 and re-narrow to an
+                        // integer only when the quotient is integral, exactly as
+                        // the mixed/float arm below does.
                         if *r == 0 {
                             return EnumValue::Computed;
                         }
-                        l / r
+                        return Self::narrow_f64(*l as f64 / *r as f64);
                     }
                     k if k == SyntaxKind::PercentToken as u16 => {
                         if *r == 0 {
@@ -630,11 +648,7 @@ impl<'a> EnumEvaluator<'a> {
                     k if k == SyntaxKind::AsteriskAsteriskToken as u16 => l.powf(r),
                     _ => return EnumValue::Computed,
                 };
-                if result.fract() == 0.0 && result >= i64::MIN as f64 && result <= i64::MAX as f64 {
-                    EnumValue::Number(result as i64)
-                } else {
-                    EnumValue::Float(result)
-                }
+                Self::narrow_f64(result)
             }
             // String concatenation
             (EnumValue::String(l), EnumValue::String(r)) if op == SyntaxKind::PlusToken as u16 => {

--- a/crates/tsz-emitter/src/transforms/enum_es5.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5.rs
@@ -1554,7 +1554,15 @@ impl<'a> EnumES5Transformer<'a> {
                     o if o == SyntaxKind::PlusToken as u16 => left.checked_add(right),
                     o if o == SyntaxKind::MinusToken as u16 => left.checked_sub(right),
                     o if o == SyntaxKind::AsteriskToken as u16 => left.checked_mul(right),
-                    o if o == SyntaxKind::SlashToken as u16 => (right != 0).then(|| left / right),
+                    // ECMAScript `/` is IEEE-754 float division. Only fold on
+                    // the integer fast-path when the quotient is exact; a
+                    // non-integral quotient (e.g. `10 / 4`) returns `None` so the
+                    // caller falls back to `evaluate_constant_float_expression`,
+                    // which produces the true value (`2.5`) instead of the
+                    // truncated integer.
+                    o if o == SyntaxKind::SlashToken as u16 => {
+                        (right != 0 && left % right == 0).then(|| left / right)
+                    }
                     o if o == SyntaxKind::PercentToken as u16 => (right != 0).then(|| left % right),
                     // Bitwise shifts use ECMAScript int32 semantics: the left
                     // operand is coerced to i32, the shift count is the low 5

--- a/crates/tsz-emitter/src/transforms/enum_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5_ir.rs
@@ -68,6 +68,7 @@ pub fn transform_enum_to_ir(arena: &NodeArena, enum_idx: NodeIndex) -> Option<IR
 #[derive(Clone)]
 enum ResolvedValue {
     Numeric(i64),
+    Float(f64),
     String(std::borrow::Cow<'static, str>),
 }
 
@@ -133,6 +134,9 @@ fn transform_enum_members(
                 EnumMemberValue::Auto(v) | EnumMemberValue::Numeric(v) => {
                     resolved.push((member_name.clone(), ResolvedValue::Numeric(*v)));
                 }
+                EnumMemberValue::Float(f) => {
+                    resolved.push((member_name.clone(), ResolvedValue::Float(*f)));
+                }
                 EnumMemberValue::String(s) => {
                     resolved.push((member_name.clone(), ResolvedValue::String(s.clone())));
                 }
@@ -159,6 +163,7 @@ fn resolve_member(resolved: &[(String, ResolvedValue)], name: &str) -> Option<En
         if n == name {
             return Some(match v {
                 ResolvedValue::Numeric(val) => EnumMemberValue::Numeric(*val),
+                ResolvedValue::Float(val) => EnumMemberValue::Float(*val),
                 ResolvedValue::String(s) => EnumMemberValue::String(s.clone()),
             });
         }
@@ -179,6 +184,75 @@ fn try_eval_numeric(
     }
 }
 
+/// Re-narrow an f64 enum value to an integer [`EnumMemberValue::Numeric`] when
+/// it is integral and in `i64` range, else keep it as [`EnumMemberValue::Float`]
+/// so the printer emits the exact fractional literal. Mirrors the re-narrowing
+/// in `enums/evaluator.rs` and `transforms/enum_es5.rs`.
+fn narrow_enum_float(value: f64) -> EnumMemberValue {
+    if value.fract() == 0.0 && value >= i64::MIN as f64 && value <= i64::MAX as f64 {
+        EnumMemberValue::Numeric(value as i64)
+    } else {
+        EnumMemberValue::Float(value)
+    }
+}
+
+/// Evaluate an expression as an f64 for the float fallback path. Handles the
+/// same constant forms as the integer evaluator (literals, same-enum member
+/// references, `+ - * / %`, unary `+ - ~`, parentheses) but in IEEE-754 space,
+/// so a non-integral quotient like `10 / 4` yields `2.5`.
+fn try_eval_float(
+    arena: &NodeArena,
+    idx: NodeIndex,
+    resolved: &[(String, ResolvedValue)],
+) -> Option<f64> {
+    let node = arena.get(idx)?;
+    match node.kind {
+        k if k == SyntaxKind::NumericLiteral as u16 => {
+            let lit = arena.get_literal(node)?;
+            lit.text
+                .parse::<f64>()
+                .ok()
+                .or_else(|| tsz_common::numeric::parse_numeric_literal_value(&lit.text))
+        }
+        k if k == SyntaxKind::Identifier as u16 => {
+            let name = get_identifier_text(arena, idx)?;
+            match resolve_member(resolved, &name)? {
+                EnumMemberValue::Auto(v) | EnumMemberValue::Numeric(v) => Some(v as f64),
+                EnumMemberValue::Float(f) => Some(f),
+                _ => None,
+            }
+        }
+        k if k == syntax_kind_ext::BINARY_EXPRESSION => {
+            let binary = arena.get_binary_expr(node)?;
+            let l = try_eval_float(arena, binary.left, resolved)?;
+            let r = try_eval_float(arena, binary.right, resolved)?;
+            match binary.operator_token {
+                t if t == SyntaxKind::PlusToken as u16 => Some(l + r),
+                t if t == SyntaxKind::MinusToken as u16 => Some(l - r),
+                t if t == SyntaxKind::AsteriskToken as u16 => Some(l * r),
+                t if t == SyntaxKind::SlashToken as u16 => (r != 0.0).then(|| l / r),
+                t if t == SyntaxKind::PercentToken as u16 => (r != 0.0).then(|| l % r),
+                _ => None,
+            }
+        }
+        k if k == syntax_kind_ext::PREFIX_UNARY_EXPRESSION => {
+            let unary = arena.get_unary_expr(node)?;
+            let operand = try_eval_float(arena, unary.operand, resolved)?;
+            match unary.operator {
+                t if t == SyntaxKind::PlusToken as u16 => Some(operand),
+                t if t == SyntaxKind::MinusToken as u16 => Some(-operand),
+                t if t == SyntaxKind::TildeToken as u16 => Some(!(operand as i64) as f64),
+                _ => None,
+            }
+        }
+        k if k == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
+            let paren = arena.get_parenthesized(node)?;
+            try_eval_float(arena, paren.expression, resolved)
+        }
+        _ => None,
+    }
+}
+
 /// Extract enum member value from an expression, resolving cross-references
 /// to previously computed members of the same enum.
 fn extract_enum_value_with_resolve(
@@ -193,10 +267,15 @@ fn extract_enum_value_with_resolve(
 
     match node.kind {
         k if k == SyntaxKind::NumericLiteral as u16 => {
-            if let Some(lit) = arena.get_literal(node)
-                && let Ok(val) = lit.text.parse::<i64>()
-            {
-                return EnumMemberValue::Numeric(val);
+            if let Some(lit) = arena.get_literal(node) {
+                if let Ok(val) = lit.text.parse::<i64>() {
+                    return EnumMemberValue::Numeric(val);
+                }
+                // Hex/binary/octal/separator/float literals: fold through the
+                // shared numeric parser and keep the fractional part.
+                if let Some(val) = tsz_common::numeric::parse_numeric_literal_value(&lit.text) {
+                    return narrow_enum_float(val);
+                }
             }
             EnumMemberValue::Auto(0)
         }
@@ -234,7 +313,11 @@ fn extract_enum_value_with_resolve(
                         t if t == SyntaxKind::MinusToken as u16 => Some(l - r),
                         t if t == SyntaxKind::AsteriskToken as u16 => Some(l * r),
                         t if t == SyntaxKind::SlashToken as u16 => {
-                            if r != 0 {
+                            // ECMAScript `/` is float division: only fold on the
+                            // integer fast-path when the quotient is exact; a
+                            // non-integral quotient falls through to the float
+                            // evaluator below (producing `2.5` rather than `2`).
+                            if r != 0 && l % r == 0 {
                                 Some(l / r)
                             } else {
                                 None
@@ -254,6 +337,11 @@ fn extract_enum_value_with_resolve(
                         return EnumMemberValue::Numeric(val);
                     }
                 }
+            }
+            // Integer folding failed (e.g. a non-integral `/` quotient, or a
+            // float operand): retry in f64 so the true value is emitted.
+            if let Some(f) = try_eval_float(arena, idx, resolved) {
+                return narrow_enum_float(f);
             }
             EnumMemberValue::Computed(Box::new(IRNode::ASTRef(idx)))
         }

--- a/crates/tsz-emitter/src/transforms/ir.rs
+++ b/crates/tsz-emitter/src/transforms/ir.rs
@@ -724,6 +724,10 @@ pub enum EnumMemberValue {
     Auto(i64),
     /// Explicit numeric value
     Numeric(i64),
+    /// Explicit non-integral numeric value (e.g. `10 / 4` -> `2.5`). Kept
+    /// distinct from `Numeric` so the emitter prints the true IEEE-754 quotient
+    /// instead of a truncated integer.
+    Float(f64),
     /// String value
     String(Cow<'static, str>),
     /// Computed expression (not a simple literal)
@@ -929,9 +933,10 @@ impl EnumMember {
     fn contains_identifier(&self, name: &str) -> bool {
         match &self.value {
             EnumMemberValue::Computed(expr) => expr.contains_identifier(name),
-            EnumMemberValue::Auto(_) | EnumMemberValue::Numeric(_) | EnumMemberValue::String(_) => {
-                false
-            }
+            EnumMemberValue::Auto(_)
+            | EnumMemberValue::Numeric(_)
+            | EnumMemberValue::Float(_)
+            | EnumMemberValue::String(_) => false,
         }
     }
 }

--- a/crates/tsz-emitter/src/transforms/ir_printer_namespace.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_namespace.rs
@@ -90,14 +90,21 @@ impl<'a> IRPrinter<'a> {
         self.write(enum_name);
 
         match &member.value {
-            EnumMemberValue::Auto(value) | EnumMemberValue::Numeric(value) => {
+            EnumMemberValue::Auto(_) | EnumMemberValue::Numeric(_) | EnumMemberValue::Float(_) => {
                 // Numeric enum with reverse mapping: E[E["A"] = 0] = "A";
+                // Non-integral members (`Float`) print the exact IEEE-754
+                // quotient: E[E["A"] = 2.5] = "A";
+                let value_text = match &member.value {
+                    EnumMemberValue::Auto(v) | EnumMemberValue::Numeric(v) => v.to_string(),
+                    EnumMemberValue::Float(v) => crate::text_utils::format_js_number(*v),
+                    _ => unreachable!(),
+                };
                 self.write("[");
                 self.write(enum_name);
                 self.write("[\"");
                 self.write(&member.name);
                 self.write("\"] = ");
-                self.write(&value.to_string());
+                self.write(&value_text);
                 self.write("] = \"");
                 self.write(&member.name);
                 self.write("\";");

--- a/crates/tsz-emitter/tests/enum_constant_value_emit_tests.rs
+++ b/crates/tsz-emitter/tests/enum_constant_value_emit_tests.rs
@@ -92,3 +92,79 @@ enum StrExt {
         "Folded string enum members must not receive numeric reverse mappings.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn const_enum_division_inlines_float_quotient() {
+    // ECMAScript `/` is float division; const-enum inlining must emit the
+    // exact fractional constant, not the truncated integer (regression: 10/4
+    // inlined as 2 instead of 2.5). See issue: enum constant folding `/`.
+    let output = emit_esnext(
+        r#"
+const enum CE { A = 10 / 4, B = 3.14, C = 7 / 2, D = 1 / 3, E = 0.5, F = 100 / 8 }
+let v = [CE.A, CE.B, CE.C, CE.D, CE.E, CE.F];
+"#,
+    );
+    assert!(
+        output.contains(
+            r#"[2.5 /* CE.A */, 3.14 /* CE.B */, 3.5 /* CE.C */, 0.3333333333333333 /* CE.D */, 0.5 /* CE.E */, 12.5 /* CE.F */]"#
+        ),
+        "const-enum division must inline true float quotients byte-for-byte with tsc.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn regular_enum_division_object_member_is_float() {
+    // The shared evaluator feeds the regular-enum object emit too, so the
+    // member assignment must carry the float value.
+    let output = emit_esnext(
+        r#"
+enum RE { A = 10 / 4, B = 7 / 2 }
+"#,
+    );
+    assert!(
+        output.contains(r#"RE[RE["A"] = 2.5] = "A";"#),
+        "regular enum division member A must be 2.5.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(r#"RE[RE["B"] = 3.5] = "B";"#),
+        "regular enum division member B must be 3.5.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn enum_division_with_integral_quotient_stays_integer() {
+    // Quotients that are integral re-narrow to integers, matching tsc (no
+    // spurious `.0`).
+    let output = emit_esnext(
+        r#"
+enum RE { A = 8 / 4, B = 9 / 3 }
+"#,
+    );
+    assert!(
+        output.contains(r#"RE[RE["A"] = 2] = "A";"#)
+            && output.contains(r#"RE[RE["B"] = 3] = "B";"#),
+        "integral quotients must emit as integers.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn namespace_enum_division_is_float_at_es5_and_esnext() {
+    // The namespace-nested enum IR path (`enum_es5_ir.rs`) must also honor
+    // ECMAScript float division, at both ES5 (its own IR emitter) and ES2015+.
+    let source = "namespace N { export enum E { A = 10 / 4, B = 7 / 2, C = 8 / 4 } }\n";
+    for target in [ScriptTarget::ES5, ScriptTarget::ESNext] {
+        let output = parse_lower_emit(
+            source,
+            PrinterOptions {
+                target,
+                ..Default::default()
+            },
+        );
+        assert!(
+            output.contains(r#"E[E["A"] = 2.5] = "A";"#)
+                && output.contains(r#"E[E["B"] = 3.5] = "B";"#)
+                && output.contains(r#"E[E["C"] = 2] = "C";"#),
+            "namespace enum division must emit float quotients at {target:?}.\nOutput:\n{output}"
+        );
+    }
+}

--- a/crates/tsz-emitter/tests/evaluator.rs
+++ b/crates/tsz-emitter/tests/evaluator.rs
@@ -180,3 +180,55 @@ const enum E {
     );
     assert_eq!(values.get("A"), Some(&EnumValue::Number(0)));
 }
+
+#[test]
+fn test_integer_division_is_float_division() {
+    // ECMAScript `/` is always IEEE-754 float division, even for two integer
+    // literals. Regression for the integer-truncation defect (10/4 -> 2, not
+    // 2.5). The structural rule is operator-keyed, not value-keyed: only
+    // non-integral quotients become Float; integral ones re-narrow to Number.
+    let values = evaluate_enum(
+        "const enum E { A = 10 / 4, B = 7 / 2, C = 1 / 3, D = 100 / 8, E = 8 / 4, F = 9 / 3 }",
+    );
+    assert_eq!(values.get("A"), Some(&EnumValue::Float(2.5)));
+    assert_eq!(values.get("B"), Some(&EnumValue::Float(3.5)));
+    assert_eq!(values.get("C"), Some(&EnumValue::Float(1.0 / 3.0)));
+    assert_eq!(values.get("D"), Some(&EnumValue::Float(12.5)));
+    // Integral quotients stay integers (re-narrowed), matching tsc's emit.
+    assert_eq!(values.get("E"), Some(&EnumValue::Number(2)));
+    assert_eq!(values.get("F"), Some(&EnumValue::Number(3)));
+}
+
+#[test]
+fn test_negative_integer_division_keeps_fraction() {
+    // `-7 / 2` must be -3.5 (true division), not -3 (round-toward-zero).
+    let values = evaluate_enum("const enum E { A = -7 / 2, B = 7 / -2, C = -8 / 2 }");
+    assert_eq!(values.get("A"), Some(&EnumValue::Float(-3.5)));
+    assert_eq!(values.get("B"), Some(&EnumValue::Float(-3.5)));
+    assert_eq!(values.get("C"), Some(&EnumValue::Number(-4)));
+}
+
+#[test]
+fn test_division_by_zero_is_computed() {
+    // Division by an integer zero remains non-foldable (Computed), unchanged.
+    let values = evaluate_enum("const enum E { A = 1 / 0 }");
+    assert_eq!(values.get("A"), Some(&EnumValue::Computed));
+}
+
+#[test]
+fn test_integer_modulo_unchanged() {
+    // `%` over two integers already matches JS (integral remainder); the fix
+    // must not perturb it.
+    let values = evaluate_enum("const enum E { A = 10 % 4, B = 10 % 3, C = -7 % 2 }");
+    assert_eq!(values.get("A"), Some(&EnumValue::Number(2)));
+    assert_eq!(values.get("B"), Some(&EnumValue::Number(1)));
+    assert_eq!(values.get("C"), Some(&EnumValue::Number(-1)));
+}
+
+#[test]
+fn test_division_in_larger_constant_expression() {
+    // Division composes with the rest of the integer fast-path operators.
+    let values = evaluate_enum("const enum E { A = 1 + 10 / 4, B = (10 / 4) * 2 }");
+    assert_eq!(values.get("A"), Some(&EnumValue::Float(3.5)));
+    assert_eq!(values.get("B"), Some(&EnumValue::Number(5)));
+}


### PR DESCRIPTION
Enum constant folding truncated `/` of two integer literals with Rust integer division (`10 / 4` inlined as `2`). JavaScript `/` is always IEEE‑754 float division, so const‑enum inlining, regular‑enum object emit, namespace‑nested enum emit, and `.d.ts` member values all emitted a **runtime‑wrong** inlined constant. Negative operands rounded toward zero too (`-7 / 2` → `-3` instead of `-3.5`).

**Structural rule:** when an enum member initializer divides two integer constants, `tsc` evaluates `/` in IEEE‑754 and re‑narrows to an integer only when the quotient is integral; tsz now does the same through the enum value evaluators in the emitter layer. `%` and the bitwise/shift operators keep their integer fast path (their integer‑operand results already match JS).

The defect lived in **three** independent enum value evaluators that all share the integer‑division shortcut; this fixes all of them so the repro's const enum, regular enum, namespace enum, and `.d.ts` outputs all match `tsc` 5.9.3 byte‑for‑byte:

- `crates/tsz-emitter/src/enums/evaluator.rs` (const‑enum inlining) — factor the existing f64 re‑narrow into `narrow_f64` and route the integer `/` arm through it.
- `crates/tsz-emitter/src/transforms/enum_es5.rs` (top‑level enum object + `.d.ts`) — fold the integer `/` only when exact, so a non‑integral quotient falls through to the existing `evaluate_constant_float_expression`.
- `crates/tsz-emitter/src/transforms/enum_es5_ir.rs` (namespace‑nested enum IR) — add a `Float` variant to `EnumMemberValue` plus a float‑fallback evaluator (`try_eval_float`/`narrow_enum_float`) so the namespace IIFE printer emits the exact fractional literal instead of a truncated integer.

Closes #14768.

## Goal
Goal: hold

## Verification
Verified each emit path against `tsc` 5.9.3 ground truth (`10/4 → 2.5`, `7/2 → 3.5`, `1/3 → 0.3333333333333333`, `100/8 → 12.5`, `-7/2 → -3.5`; exact quotients like `8/4` stay `2`):

- `cargo test -p tsz-emitter --lib enums::evaluator::tests` — evaluator unit tests incl. division, negative division, integral re‑narrow, modulo unchanged, division‑in‑larger‑expression.
- `cargo test -p tsz-emitter --test enum_constant_value_emit_tests` — JS emit parity for const‑enum inlining, regular‑enum object members, and namespace enums at ES5 + ESNext.
- `cargo test -p tsz-emitter --lib declaration_emitter::tests::enum_template_and_advanced` — `.d.ts` parity for const and regular enums.
- `cargo build --workspace` and `cargo clippy -p tsz-emitter` clean.

The one pre‑existing unrelated failure (`generator_object_literal_prefix_before_yield_omits_source_trailing_comma`) fails identically on the clean base and is not touched by this change.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01VU34sAGvXAkxhafndKkU9S)_