### PR TITLE
feat(solver): dormant resolver-aware re-reduce of instantiation-time deferred index/conditional (#14345)

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -104,12 +104,22 @@ impl<'a> TypeInstantiator<'a> {
         self.shadowed.contains(&name)
     }
 
-    pub(crate) const fn with_query_db(mut self, _query_db: Option<&'a dyn QueryDatabase>) -> Self {
+    pub(crate) fn with_query_db(mut self, query_db: Option<&'a dyn QueryDatabase>) -> Self {
         // Keep the resolver-aware `QueryDatabase` at the outer cache boundary.
         // Nested instantiation evaluation must stay resolver-less: routing
         // `evaluate_*` through query-backed semantic helpers is not cache-only
         // and can change inference/conformance behavior.
-        self.query_db = None;
+        //
+        // #14345 dormant re-reduce: when `TSZ_INST_RESOLVER_REREDUCE=1`,
+        // thread the resolver-aware db through so the gated re-reduce sites in
+        // `instantiate_index_access`/`instantiate_conditional` can resolve the
+        // cross-arena `Lazy` base instead of re-deferring resolver-less. The OFF
+        // path is byte-identical to the prior unconditional `None`.
+        if inst_resolver_rereduce_enabled() {
+            self.query_db = query_db;
+        } else {
+            self.query_db = None;
+        }
         self
     }
 

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -1782,6 +1782,33 @@ fn defer_lazy_default_conditional_enabled() -> bool {
     })
 }
 
+/// #14345 dormant resolver-aware re-reduce of instantiation-time deferred
+/// index-access / conditional leaks (default OFF; byte-parity when OFF).
+///
+/// When `TSZ_INST_RESOLVER_REREDUCE=1`, the instantiator keeps the
+/// resolver-aware `QueryDatabase` it was handed (instead of nulling it in
+/// `with_query_db`) and, at the two deferred-leak sites
+/// (`instantiate_index_access` and `instantiate_conditional`), re-runs the
+/// reduction through that resolver once the base/check became concrete (no
+/// type parameters remain). This resolves the cross-arena `Lazy(DefId)` base
+/// of an `URItoKind[URI]` index — e.g. fp-ts `Kind<TypeLambda, ...>` — to its
+/// alias instead of returning a structurally-detached deferred form.
+///
+/// The flag is OFF by default and the OFF path is the literal pre-existing
+/// code, so default-pipeline behavior is byte-identical. It is dormant
+/// infrastructure: with the flag ON it correctly clears the `TypeLambda` leak
+/// family but also exposes the #14344 unknown-drop family (the resolver
+/// returns alias bodies whose type-arg positions still carry the default
+/// `unknown` because the alias body was not materialized with the call's
+/// inferred arguments). Turning the flag into a default-on win requires the
+/// materialize-once stage (#14345 XL) to supply fully-substituted alias
+/// bodies before this re-reduce runs.
+pub(super) fn inst_resolver_rereduce_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("TSZ_INST_RESOLVER_REREDUCE").is_ok_and(|v| v == "1"))
+}
+
 pub(super) fn maybe_evaluate_concrete_conditional(
     interner: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-solver/src/instantiation/instantiate/conditional.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/conditional.rs
@@ -133,6 +133,21 @@ impl<'a> TypeInstantiator<'a> {
         if instantiated == cond {
             return type_id;
         }
-        self.interner.conditional(instantiated)
+        let rebuilt = self.interner.conditional(instantiated);
+        // #14345 dormant re-reduce (default OFF, byte-parity): the general path
+        // interns a fresh deferred `ConditionalType` and never re-runs the
+        // `extends` test. With the flag on, a resolver-aware db threaded in, and
+        // both check/extends now concrete (no type parameters), route the
+        // re-reduce through the resolver so a cross-arena `Lazy` ref in the
+        // condition resolves and the branch is picked. OFF returns the deferred
+        // form (the literal pre-existing behavior).
+        if super::inst_resolver_rereduce_enabled()
+            && self.query_db.is_some()
+            && !crate::visitor::contains_type_parameters(self.interner, instantiated.check_type)
+            && !crate::visitor::contains_type_parameters(self.interner, instantiated.extends_type)
+        {
+            return self.evaluate_type(rebuilt);
+        }
+        rebuilt
     }
 }

--- a/crates/tsz-solver/src/instantiation/instantiate/indexed.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/indexed.rs
@@ -30,6 +30,16 @@ impl<'a> TypeInstantiator<'a> {
             || index_access_operand_needs_resolver(self.interner, inst_obj)
             || index_access_operand_needs_resolver(self.interner, inst_idx)
         {
+            // #14345 dormant re-reduce (default OFF, byte-parity): the
+            // base/index are concrete (no type parameters reached this point)
+            // but still hold a resolver-only meta-type (`Application`/`Lazy`/
+            // etc.). With the flag on and a resolver-aware db threaded in,
+            // route the re-reduce through it (resolving the cross-arena `Lazy`
+            // base) instead of returning the deferred `IndexAccess`. The OFF
+            // path below is the literal pre-existing deferred return.
+            if super::inst_resolver_rereduce_enabled() && self.query_db.is_some() {
+                return self.evaluate_index_access(inst_obj, inst_idx);
+            }
             return self.interner.index_access(inst_obj, inst_idx);
         }
         // Evaluate immediately to achieve O(1) equality


### PR DESCRIPTION
Goal: green

## Summary

Stage-1 of the #14345 materialize-once composition: thread the resolver-aware `QueryDatabase` through instantiation so a now-concrete deferred `IndexAccess`/`Conditional` can re-reduce instead of re-deferring. **Dormant** — gated behind `TSZ_INST_RESOLVER_REREDUCE` (default OFF); flag-OFF is byte-identical to current `main`.

### Root pinned
`crates/tsz-solver/src/instantiation/instantiate.rs` `with_query_db` unconditionally set `self.query_db = None`, so all instantiation-time reduction was **resolver-blind**: a deferred index/conditional whose base became concrete via substitution re-defers at `index_access.rs:1662`. The leak is *reduced-without-a-resolver*, not *un-reduced-after-substitution*.

### Structural rule
When type-parameter substitution makes the base of a deferred `IndexAccess` (or the check of a deferred `Conditional`) concrete (no type parameters remain) and a resolver-aware `query_db` is in scope, tsc's `instantiateType` re-invokes `getIndexedAccessType`/`getConditionalType` to retry reduction. tsz did not, because the resolver was dropped at the instantiation boundary. This change re-routes that retry through `db.evaluate_index_access` / `evaluate_type`, owned by the solver instantiation layer.

### What flag-ON does (not yet flippable — kept OFF)
On the fp-ts es2022 both-flags corpus it clears the entire **TypeLambda** leak family (their `URItoKindN[key]` registry body is a populated single-arena alias that now resolves) with a 2-FP shatter (`ReaderTask.ts` unknown-drop, where the alias body's type-params still default to `unknown`). The **156 concrete `Kind<"Array",A>`** diags do not clear: their cross-arena `Lazy(DefId)` body is unpopulated, so the resolver follows the ref but cannot reduce an unpopulated recursive-alias body (71%/95% still-deferred). The flag stays OFF until the next stage materializes that body with the inferred args; this PR lands only the sound resolver-threading seam that stage requires. See #14345 (comment 4827605991) for the full characterization.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- fp-ts es2022 both-flags corpus: flag-OFF = 925 errors, **byte-identical (file,line,col)+code keyset** to the unmodified-`main` binary (diff empty). flag-ON = 922 (5 cleared / 2 new), gated OFF.
- Determinism: RAYON 1/2/4 = 925/925/925 (OFF), 922/922/922 (ON).
- `cargo nextest` targeted filters over `tsz-solver` (`index_access|instantiat|conditional|reduction|substitution|mapped|intersection|this_type`) and `tsz-checker` (`index|conditional|instantiat|mapped|hkt|kind`): **0 new failures** vs `main` (pre-existing failures reproduce identically with changes stashed).
- `cargo clippy`: 0 warnings; no `eprintln!`/`unsafe`.
