### PR TITLE
refactor(solver): hide eval verdict storage in tests (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -927,6 +927,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.request_termination_kind = Some(kind);
     }
 
+    /// Test hook: expose the typed request-result boundary without exposing the
+    /// raw per-request verdict slot.
+    #[cfg(test)]
+    pub(crate) const fn request_result_for_test(&self, type_id: TypeId) -> EvaluationResult {
+        request_result_verdict(type_id, self.request_termination_kind)
+    }
+
     /// Global thread-local depth counter for cross-evaluator stack overflow
     /// prevention. Each `SubtypeChecker::evaluate_type` creates a fresh
     /// `TypeEvaluator`, but the OS stack accumulates across ALL of them: deep

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -191,6 +191,13 @@ fn read_solver_source(rel: &str) -> String {
     fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
 }
 
+fn read_solver_test(rel: &str) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join(rel);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()))
+}
+
 #[test]
 fn evaluation_engine_keeps_request_stage_boundary() {
     let mod_rs = read_solver_source("evaluation/mod.rs");
@@ -201,6 +208,8 @@ fn evaluation_engine_keeps_request_stage_boundary() {
     // after the engine split; the module boundary is still owned by `evaluate`.
     let evaluate_api_rs = read_solver_source("evaluation/evaluate/api.rs");
     let query_cache_rs = read_solver_source("caches/query_cache.rs");
+    let iteration_incomplete_tests =
+        read_solver_test("evaluate_tests_parts/iteration_exceeded_incomplete.rs");
 
     assert!(
         mod_rs.contains("pub mod request;"),
@@ -245,6 +254,13 @@ fn evaluation_engine_keeps_request_stage_boundary() {
             && !query_cache_rs
                 .contains("evaluation_result.is_complete() && !evaluator.recursion_limit_hit()"),
         "query cache evaluation entries must derive option-sensitive keys from EvaluationRequest and consume EvaluationMemoResult stability instead of rebuilding termination predicates"
+    );
+    assert!(
+        evaluate_rs
+            .contains("fn request_result_for_test(&self, type_id: TypeId) -> EvaluationResult")
+            && iteration_incomplete_tests.contains("request_result_for_test(TypeId::ERROR)")
+            && !iteration_incomplete_tests.contains("evaluator.request_termination_kind"),
+        "typed request-verdict tests must consume EvaluationResult through the evaluator boundary instead of reading the raw request_termination_kind slot"
     );
 }
 

--- a/crates/tsz-solver/tests/evaluate_tests_parts/iteration_exceeded_incomplete.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/iteration_exceeded_incomplete.rs
@@ -101,11 +101,7 @@ fn depth_marker_for_request_records_depth_verdict() {
 
     evaluator.mark_depth_exceeded_for_request();
 
-    assert_eq!(
-        evaluator.request_termination_kind,
-        Some(TerminationKind::DepthExceeded)
-    );
-    let result = request_result_verdict(TypeId::ERROR, evaluator.request_termination_kind);
+    let result = evaluator.request_result_for_test(TypeId::ERROR);
     assert_eq!(
         result.termination(),
         Termination::Incomplete {
@@ -124,11 +120,7 @@ fn raw_depth_marker_allows_specific_fuel_verdict() {
     evaluator.mark_depth_exceeded();
     evaluator.note_request_termination(TerminationKind::FuelExhausted);
 
-    assert_eq!(
-        evaluator.request_termination_kind,
-        Some(TerminationKind::FuelExhausted)
-    );
-    let result = request_result_verdict(TypeId::ERROR, evaluator.request_termination_kind);
+    let result = evaluator.request_result_for_test(TypeId::ERROR);
     assert_eq!(
         result.termination(),
         Termination::Incomplete {


### PR DESCRIPTION
Goal: green

## Summary
- Add a test-only `TypeEvaluator::request_result_for_test` helper that exposes the typed `EvaluationResult` boundary without exposing the raw verdict slot.
- Update the focused #14346 guard-producer tests to assert through `EvaluationResult` instead of reading `request_termination_kind` directly.
- Ratchet the evaluation architecture guard so the test shard keeps consuming the typed boundary.

## Structural Rule
When a guard producer test needs to verify the current evaluation request verdict, tsz observes that verdict through the solver-owned `EvaluationResult` boundary; tests and cache consumers do not reconstruct semantics from raw `request_termination_kind` storage.

Owner layer: `tsz-solver` evaluation/result boundary plus the architecture guard that pins the consumer path.

## Adjacent Matrix
- Depth producer: `mark_depth_exceeded_for_request` still reports `TerminationKind::DepthExceeded` with `TypeId::ERROR` as the partial.
- Specific producer: raw depth marking followed by `FuelExhausted` still reports the specific fuel verdict with the same partial.
- Boundary guard: the architecture test now requires the test-only typed-result helper and rejects direct `evaluator.request_termination_kind` reads in the focused shard.
- Fallback: production behavior is unchanged; the new helper is `#[cfg(test)]` only.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(evaluation_engine_keeps_request_stage_boundary) or test(depth_marker_for_request_records_depth_verdict) or test(raw_depth_marker_allows_specific_fuel_verdict)'`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
