### PR TITLE
fix(parser): emit TS1028 for duplicate accessibility modifier on class properties

### DIFF
--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -385,6 +385,7 @@ const fn is_parser_grammar_code(code: u32) -> bool {
         | 1017 // An index signature cannot have a rest parameter
         | 1019 // An index signature parameter cannot have a question mark
         | 1021 // An index signature must have a type annotation
+        | 1028 // Accessibility modifier already seen
         | 1029 // '{0}' modifier must precede '{1}' modifier
         | 1030 // '{0}' modifier already seen
         | 1031 // '{0}' modifier cannot appear on class elements of this kind

--- a/crates/tsz-cli/src/driver/check_utils/tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/tests.rs
@@ -1229,6 +1229,64 @@ fn filtered_parse_diagnostics_keeps_await_ts1359_when_alone() {
 }
 
 #[test]
+fn filtered_parse_diagnostics_suppresses_ts1028_when_real_parse_error_present() {
+    use tsz::parser::ParseDiagnostic;
+
+    // multipleClassPropertyModifiersErrors.ts: `public public p1;` would emit
+    // TS1028, but the file also contains `static static p3;` which yields a real
+    // parse error (TS1434). tsc emits TS1028 via grammarErrorOnNode, which is
+    // suppressed by hasParseDiagnostics(sourceFile) when any real parse error
+    // exists, so only TS1434 survives.
+    let diagnostics = vec![
+        ParseDiagnostic {
+            start: 18,
+            length: 6,
+            message: "Accessibility modifier already seen.".to_string(),
+            code: 1028,
+        },
+        ParseDiagnostic {
+            start: 50,
+            length: 6,
+            message: "Unexpected keyword or identifier.".to_string(),
+            code: 1434,
+        },
+    ];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&1028),
+        "TS1028 should be suppressed when a real parse error (TS1434) is present, got: {codes:?}"
+    );
+    assert!(
+        codes.contains(&1434),
+        "TS1434 (real parse error) should survive, got: {codes:?}"
+    );
+}
+
+#[test]
+fn filtered_parse_diagnostics_keeps_ts1028_when_alone() {
+    use tsz::parser::ParseDiagnostic;
+
+    // parserMemberVariableDeclaration1.ts: `public public Foo;` with no other
+    // parse error. hasParseDiagnostics is false in tsc, so the grammar error is
+    // reported. tsz must keep its parser-emitted TS1028 in this case.
+    let diagnostics = vec![ParseDiagnostic {
+        start: 18,
+        length: 6,
+        message: "Accessibility modifier already seen.".to_string(),
+        code: 1028,
+    }];
+
+    let filtered = filtered_parse_diagnostics(&diagnostics, false);
+    let codes: Vec<u32> = filtered.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&1028),
+        "TS1028 should be kept when it is the only diagnostic, got: {codes:?}"
+    );
+}
+
+#[test]
 fn js_parse_allowlist_keeps_plain_js_binder_strict_codes() {
     for code in [1214, 18012] {
         assert!(

--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -46,6 +46,10 @@ impl ParserState {
 
         // State tracking for TS1028 (duplicates) and TS1029 (ordering)
         let mut seen_accessibility = false;
+        // Matches tsc's `checkGrammarModifiers`, which reports TS1028 only once
+        // per modifier list (it `return`s after the first duplicate). A third
+        // accessibility keyword must not produce a second TS1028.
+        let mut reported_accessibility_duplicate = false;
         let mut seen_static = false;
         let mut seen_abstract = false;
         let mut seen_readonly = false;
@@ -69,42 +73,19 @@ impl ParserState {
                     | SyntaxKind::PrivateKeyword
                     | SyntaxKind::ProtectedKeyword
             ) {
-                if seen_accessibility {
-                    // tsc silently accepts duplicate/mixed accessibility on property
-                    // declarations (e.g., `public public p1;`) — no TS1028 emitted.
-                    // But for methods/constructors (e.g., `public public Foo()`,
-                    // `public public constructor()`), tsc emits TS1028.
-                    //
-                    // Detect method/constructor context with two-token lookahead:
-                    // if the token after the duplicate keyword is `constructor`, or
-                    // an identifier/keyword followed by `(` or `<`, this is a method.
-                    let snapshot = self.scanner.save_state();
-                    let saved_token = self.current_token;
-                    self.next_token(); // skip duplicate accessibility keyword
-                    let token_after = self.current_token;
-                    let is_method_context = if token_after == SyntaxKind::ConstructorKeyword {
-                        true
-                    } else {
-                        // Look one more ahead to check for `(` or `<`
-                        self.next_token();
-                        let token_after_name = self.current_token;
-                        matches!(
-                            token_after_name,
-                            SyntaxKind::OpenParenToken | SyntaxKind::LessThanToken
-                        )
-                    };
-                    self.scanner.restore_state(snapshot);
-                    self.current_token = saved_token;
-
-                    if is_method_context {
-                        // Method/constructor context — emit TS1028
-                        use tsz_common::diagnostics::diagnostic_codes;
-                        self.parse_error_at_current_token(
-                            "Accessibility modifier already seen.",
-                            diagnostic_codes::ACCESSIBILITY_MODIFIER_ALREADY_SEEN,
-                        );
-                    }
-                    // For property context, silently accept the duplicate modifier
+                if seen_accessibility && !reported_accessibility_duplicate {
+                    // tsc emits TS1028 for a second accessibility modifier on ANY
+                    // class member — property, method, accessor, or constructor —
+                    // via `checkGrammarModifiers`, which records each modifier and
+                    // reports the duplicate without inspecting the member kind.
+                    // Emit it unconditionally at the duplicate keyword; the
+                    // member-kind lookahead the old path used was based on a false
+                    // premise (that tsc silently accepts duplicates on properties).
+                    self.parse_error_at_current_token(
+                        "Accessibility modifier already seen.",
+                        diagnostic_codes::ACCESSIBILITY_MODIFIER_ALREADY_SEEN,
+                    );
+                    reported_accessibility_duplicate = true;
                 }
                 // TS1029: accessibility must come after certain modifiers
                 if seen_static

--- a/crates/tsz-parser/tests/modifier_ordering_tests.rs
+++ b/crates/tsz-parser/tests/modifier_ordering_tests.rs
@@ -422,3 +422,87 @@ fn accessor_property_keys_off_token_kind_not_member_name() {
         );
     }
 }
+
+// =========================================================================
+// TS1028: Duplicate accessibility modifier — properties AND methods
+//
+// tsc emits TS1028 for a second accessibility modifier on ANY class member
+// (checkGrammarModifiers records each modifier and reports the duplicate
+// without inspecting the member kind). tsz previously suppressed it on
+// property declarations via a method-context lookahead heuristic.
+// =========================================================================
+
+#[test]
+fn duplicate_accessibility_on_property_ts1028() {
+    // Every property form — with/without initializer or type annotation, each
+    // accessibility keyword, and a mixed pair — must emit exactly one TS1028.
+    // This is the path the old method-context lookahead heuristic wrongly
+    // suppressed.
+    for member in [
+        "public public x = 1",
+        "public public x",
+        "public public x: number",
+        "private private y = 1",
+        "protected protected z = 1",
+        "public private mixed = 1",
+    ] {
+        let source = format!("class C {{ {member}; }}");
+        assert_eq!(
+            count_error(&source, 1028),
+            1,
+            "`{member}` should emit exactly one TS1028"
+        );
+    }
+}
+
+#[test]
+fn duplicate_accessibility_on_method_still_ts1028() {
+    // Control: the method/constructor path already fired TS1028 and must not
+    // regress when the lookahead heuristic is removed.
+    assert_eq!(count_error("class C { public public m() {} }", 1028), 1);
+    assert_eq!(
+        count_error("class C { protected protected m() {} }", 1028),
+        1
+    );
+    assert_eq!(
+        count_error("class C { public public constructor() {} }", 1028),
+        1
+    );
+}
+
+#[test]
+fn triple_accessibility_emits_single_ts1028() {
+    // tsc's checkGrammarModifiers `return`s after the first duplicate, so a
+    // third accessibility keyword does not produce a second TS1028.
+    let source = "class C { public public public x = 1; }";
+    assert_eq!(count_error(source, 1028), 1);
+}
+
+#[test]
+fn single_accessibility_no_ts1028() {
+    // No false positive on a lone accessibility modifier.
+    assert!(!has_error("class C { public x = 1; }", 1028));
+    assert!(!has_error("class C { private m() {} }", 1028));
+    assert!(!has_error("class C { protected p: number; }", 1028));
+}
+
+#[test]
+fn duplicate_accessibility_keys_off_token_kind_not_member_name() {
+    // The diagnostic must fire regardless of the property/method identifier,
+    // confirming the parser keys off token kind rather than the binder name.
+    for name in ["a", "myProp", "_x", "$field"] {
+        let prop_src = format!("class C {{ public public {name} = 1; }}");
+        assert_eq!(
+            count_error(&prop_src, 1028),
+            1,
+            "duplicate accessibility on property `{name}` should emit one TS1028"
+        );
+
+        let method_src = format!("class C {{ private private {name}() {{}} }}");
+        assert_eq!(
+            count_error(&method_src, 1028),
+            1,
+            "duplicate accessibility on method `{name}()` should emit one TS1028"
+        );
+    }
+}


### PR DESCRIPTION
Closes #14837.

When a class member's modifier list contains a second `public`/`private`/`protected`, tsc emits **TS1028 `Accessibility modifier already seen`** at the duplicate modifier regardless of member kind — its `checkGrammarModifiers` records each modifier and reports the duplicate without inspecting whether the member is a property, method, accessor, or constructor. tsz only emitted TS1028 when a two-token lookahead classified the member as a method/constructor, and **silently dropped it for property declarations** on the false premise that tsc accepts the duplicate there. So `class C { public public x = 1; }` produced no diagnostic in tsz vs `TS1028` in tsc 5.9.3 and `next`.

**Structural rule:** When a class member's modifier list contains a second accessibility modifier, tsc emits TS1028 at the duplicate keyword; tsz now does the same through the parser's class-member modifier grammar check (`parse_class_member_modifiers`), for property members too — not only methods/constructors.

### Change
- `crates/tsz-parser/src/parser/state_statements_class_members.rs`: removed the member-kind `scanner.save_state()` / `next_token()` / `restore_state()` lookahead and emit TS1028 unconditionally at the second accessibility keyword. A `reported_accessibility_duplicate` once-flag suppresses a second TS1028 on a third keyword, matching tsc's single-report `return` and mirroring the sibling `parse_parameter_modifiers` path that already handled parameter properties this way.
- TS1028 is a grammar check, not a "real" syntax error (`is_real_syntax_error` excludes it), so checker diagnostics like TS2564 / TS7008 still fire alongside it — matching tsc's combined output on the adjacent cases.

### Goal
Goal: hold

### Verification
- `cargo test -p tsz-parser --lib modifier_ordering_tests` — 35 passed, 0 failed. New cases cover every property form (with/without initializer or type annotation, each accessibility keyword, mixed pair), the method/constructor controls (must not regress), the triple-keyword single-report case, the lone-modifier no-false-positive case, and a binder-name-varied case (anti-hardcoding gate).
- `cargo test -p tsz-parser --lib` — full parser lib suite 1489 passed, 0 failed.
- `cargo fmt -p tsz-parser --check` and `cargo clippy -p tsz-parser --tests` — clean.

### Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_013Luu1kpYAt1kEPq3gfr1v2)_