### PR TITLE
refactor(solver): name unstable eval memo results (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
+++ b/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
@@ -180,13 +180,11 @@ mod tests {
 
     #[test]
     fn non_stable_fresh_result_is_returned_but_not_memoized() {
-        use crate::evaluation::result::EvaluationResult;
-
         reset_query_memo();
         let t = TypeId(8);
 
         let first = memoized_eval(t, false, || {
-            EvaluationMemoResult::new(EvaluationResult::complete(TypeId(80)), false)
+            EvaluationMemoResult::unstable_complete(TypeId(80))
         });
 
         assert_eq!(first, Some(TypeId(80)));

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -12,7 +12,7 @@
 //! - `bind_infer`: Bind a type to an infer parameter
 
 use crate::def::DefId;
-use crate::evaluation::result::{EvaluationMemoResult, EvaluationResult};
+use crate::evaluation::result::EvaluationMemoResult;
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
 use crate::types::{
     LiteralValue, ParamInfo, TemplateSpan, TupleElement, TypeApplication, TypeData, TypeId,
@@ -1737,7 +1737,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // in-flight ancestor expansion converges.
         crate::evaluation::cross_eval_guard::memoized_eval(type_id, nuia, || {
             let Some(_guard) = InferMatchExpansionGuard::enter() else {
-                return EvaluationMemoResult::new(EvaluationResult::complete(type_id), false);
+                return EvaluationMemoResult::unstable_complete(type_id);
             };
             let mut evaluator = TypeEvaluator::with_resolver(self.interner(), self.resolver());
             if let Some(query_db) = self.query_db() {

--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -170,23 +170,21 @@ impl EvaluationMemoResult {
         }
     }
 
-    /// Construct a memo result with an explicit stability verdict.
-    pub(crate) const fn new(
-        result: EvaluationResult,
-        stable_for_depth_agnostic_cache: bool,
-    ) -> Self {
-        Self {
-            result,
-            stable_for_depth_agnostic_cache,
-        }
-    }
-
     /// Construct a completed memo result read from a cache that stores only
     /// stable entries.
     pub(crate) const fn cached(type_id: TypeId) -> Self {
         Self {
             result: EvaluationResult::complete(type_id),
             stable_for_depth_agnostic_cache: true,
+        }
+    }
+
+    /// Construct a completed result that must not be stored in a
+    /// depth-agnostic memo.
+    pub(crate) const fn unstable_complete(type_id: TypeId) -> Self {
+        Self {
+            result: EvaluationResult::complete(type_id),
+            stable_for_depth_agnostic_cache: false,
         }
     }
 
@@ -286,5 +284,14 @@ mod tests {
             cached.evaluation_result().termination(),
             Termination::Complete
         );
+    }
+
+    #[test]
+    fn unstable_complete_memo_result_collapses_without_becoming_cacheable() {
+        let result = EvaluationMemoResult::unstable_complete(TypeId::STRING);
+
+        assert_eq!(result.type_id(), TypeId::STRING);
+        assert_eq!(result.into_type_id(), TypeId::STRING);
+        assert!(!result.is_stable_for_depth_agnostic_cache());
     }
 }

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -207,6 +207,8 @@ fn evaluation_engine_keeps_request_stage_boundary() {
     // The public staged entry points live in the `evaluate/api.rs` submodule
     // after the engine split; the module boundary is still owned by `evaluate`.
     let evaluate_api_rs = read_solver_source("evaluation/evaluate/api.rs");
+    let cross_eval_guard_rs = read_solver_source("evaluation/cross_eval_guard.rs");
+    let infer_pattern_rs = read_solver_source("evaluation/evaluate_rules/infer_pattern.rs");
     let query_cache_rs = read_solver_source("caches/query_cache.rs");
     let iteration_incomplete_tests =
         read_solver_test("evaluate_tests_parts/iteration_exceeded_incomplete.rs");
@@ -261,6 +263,15 @@ fn evaluation_engine_keeps_request_stage_boundary() {
             && iteration_incomplete_tests.contains("request_result_for_test(TypeId::ERROR)")
             && !iteration_incomplete_tests.contains("evaluator.request_termination_kind"),
         "typed request-verdict tests must consume EvaluationResult through the evaluator boundary instead of reading the raw request_termination_kind slot"
+    );
+    assert!(
+        result_rs.contains("fn unstable_complete(type_id: TypeId) -> Self")
+            && cross_eval_guard_rs.contains("EvaluationMemoResult::unstable_complete(TypeId(80))")
+            && infer_pattern_rs.contains("EvaluationMemoResult::unstable_complete(type_id)")
+            && !cross_eval_guard_rs
+                .contains("EvaluationMemoResult::new(EvaluationResult::complete")
+            && !infer_pattern_rs.contains("EvaluationMemoResult::new(EvaluationResult::complete"),
+        "unstable complete memo results must use the named EvaluationMemoResult boundary instead of rebuilding the stability bit by hand"
     );
 }
 

--- a/crates/tsz-solver/tests/judge_tests.rs
+++ b/crates/tsz-solver/tests/judge_tests.rs
@@ -294,10 +294,7 @@ fn test_non_stable_evaluation_result_is_not_cached() {
     assert_eq!(
         judge.record_evaluation_result(
             no_infer_string,
-            crate::evaluation::result::EvaluationMemoResult::new(
-                crate::evaluation::result::EvaluationResult::complete(TypeId::ERROR),
-                false,
-            ),
+            crate::evaluation::result::EvaluationMemoResult::unstable_complete(TypeId::ERROR),
         ),
         TypeId::ERROR
     );


### PR DESCRIPTION
Goal: green

## Summary
- Add `EvaluationMemoResult::unstable_complete` for complete fallback values that must not be stored in depth-agnostic memos.
- Route the infer-match expansion guard and cross-eval memo test through the named boundary; remove the generic explicit-stability constructor.
- Ratchet the architecture guard against rebuilding `EvaluationMemoResult::new(EvaluationResult::complete(...), false)` by hand.

## Structural Rule
When an evaluation path returns a complete fallback value but the request is not safe to persist in a depth-agnostic cache, tsz records that through the solver-owned `EvaluationMemoResult` constructor; call sites do not rebuild the typed result plus raw stability bit by hand. Owner layer: `tsz-solver` evaluation/result plus cross-evaluator memo boundary.

## Adjacent Matrix
- Positive: stable cached memo remains `EvaluationMemoResult::cached`.
- Negative/fallback: infer-match expansion-budget fallback returns the same `TypeId` through `unstable_complete`.
- Test consumer: judge non-stable result still collapses to `TypeId` but does not populate eval cache.
- Guard: architecture guard rejects source-side `EvaluationMemoResult::new(EvaluationResult::complete(...), false)` reconstruction.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `rg -n "EvaluationMemoResult::new" crates/tsz-solver/src crates/tsz-solver/tests --glob '!architecture_guards.rs'` (no matches)
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(evaluation_engine_keeps_request_stage_boundary) or test(non_stable_fresh_result_is_returned_but_not_memoized) or test(unstable_complete_memo_result_collapses_without_becoming_cacheable) or test(test_non_stable_evaluation_result_is_not_cached)'`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high