### PR TITLE
fix(checker): lower source augmentation map members (#14345)

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -150,6 +150,7 @@ impl<'a> CheckerState<'a> {
                         &delegatable_member_indices,
                         decl_arena,
                         None,
+                        false,
                     )
                 };
 
@@ -579,6 +580,7 @@ impl<'a> CheckerState<'a> {
                         &delegatable_member_indices,
                         iface_arena,
                         Some(&substitution_args),
+                        false,
                     )
                 };
 

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -1671,6 +1671,7 @@ impl CheckerState<'_> {
             std::slice::from_ref(&member_idx),
             interface_arena,
             type_args,
+            false,
         )
         .and_then(|mut results| results.remove(&member_idx))
     }
@@ -1687,6 +1688,7 @@ impl CheckerState<'_> {
         member_indices: &[NodeIndex],
         interface_arena: &tsz_parser::NodeArena,
         type_args: Option<&[TypeId]>,
+        allow_source_file_arena: bool,
     ) -> Option<rustc_hash::FxHashMap<NodeIndex, TypeId>> {
         if std::ptr::eq(interface_arena, self.ctx.arena) {
             return None;
@@ -1732,7 +1734,7 @@ impl CheckerState<'_> {
             interface_arena,
             delegate_binder,
             type_args,
-            false,
+            allow_source_file_arena,
         ) {
             if type_args.is_none()
                 && let Some(file_idx) = delegate_file_idx

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/interface_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/interface_methods.rs
@@ -161,11 +161,19 @@ impl<'a> CheckerState<'a> {
                 allow_source_file_arena && is_direct_lowering_source_file_arena(interface_arena);
             let name_resolver = |type_name: &str| -> Option<tsz_solver::def::DefId> {
                 if direct_source_file_arena {
-                    return self.source_file_local_name_def_id_for_lowering(
-                        delegate_binder,
-                        interface_arena,
-                        type_name,
-                    );
+                    return self
+                        .source_file_local_name_def_id_for_lowering(
+                            delegate_binder,
+                            interface_arena,
+                            type_name,
+                        )
+                        .or_else(|| {
+                            self.source_file_global_name_def_id_for_lowering(
+                                delegate_binder,
+                                interface_arena,
+                                type_name,
+                            )
+                        });
                 }
                 (!self.ctx.file_local_type_shadow_for_lib_name(type_name))
                     .then(|| self.resolve_actual_lib_name_to_def_id_for_lowering(type_name))

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/source_shape_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/source_shape_methods.rs
@@ -441,6 +441,28 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    pub(in crate::state_domain::type_analysis) fn source_file_global_name_def_id_for_lowering(
+        &self,
+        delegate_binder: &BinderState,
+        symbol_arena: &NodeArena,
+        type_name: &str,
+    ) -> Option<tsz_solver::def::DefId> {
+        if !self.source_file_global_type_is_direct_lowerable(delegate_binder, type_name) {
+            return None;
+        }
+        if let Some(sym_id) = delegate_binder.file_locals.get(type_name)
+            && !Self::source_file_local_symbol_can_fall_back_to_global_type(
+                symbol_arena,
+                delegate_binder,
+                sym_id,
+            )
+        {
+            return None;
+        }
+        self.resolve_actual_lib_name_to_def_id_for_lowering(type_name)
+            .or_else(|| self.resolve_entity_name_text_to_def_id_for_lowering(type_name))
+    }
+
     pub(in crate::state_domain::type_analysis) fn source_file_type_node_is_generic_scope_independent(
         arena: &NodeArena,
         node_idx: NodeIndex,

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
@@ -1288,7 +1288,7 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn source_file_local_symbol_can_fall_back_to_global_type(
+    pub(super) fn source_file_local_symbol_can_fall_back_to_global_type(
         arena: &NodeArena,
         binder: &BinderState,
         sym_id: SymbolId,

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_source_option_bag_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_source_option_bag_tests.rs
@@ -17,9 +17,10 @@
 //! remains the safety gate, so heritage/computed/complex shapes still fall back
 //! to the child-checker path.
 
-use crate::context::{CheckerContext, CheckerOptions};
+use crate::context::{CheckerContext, CheckerOptions, LibContext};
 use crate::query_boundaries::common::TypeInterner;
 use crate::state::CheckerState;
+use crate::test_utils::load_lib_files;
 use std::sync::Arc;
 use tsz_binder::{BinderState, ModuleAugmentation};
 use tsz_common::perf_counters::{DirectCrossFileInterfaceLoweringOutcome, PerfCounters};
@@ -361,6 +362,182 @@ fn delegate_cross_arena_source_option_bag_resolves_in_program_with_module_augmen
         )
         .is_some(),
         "BuildOptions should retain 'minify' property even with program-level augmentations present",
+    );
+}
+
+#[test]
+fn delegate_cross_arena_source_module_augmentation_member_substitutes_generic_interface_ref() {
+    let (registry_arena, registry_binder, types) = parse_bound_source_with_name(
+        "HKT.ts",
+        r#"
+                export interface URItoKind2<E, A> {}
+            "#,
+    );
+    let (augmentation_arena, augmentation_binder, _) = parse_bound_source_with_name(
+        "io-either.ts",
+        r#"
+                import { URItoKind2 } from "./HKT";
+                declare module "./HKT" {
+                    interface URItoKind2<E, A> {
+                        readonly IOEither: IOEither<E, A>;
+                    }
+                }
+                export interface IOEither<E, A> { readonly value: E | A; }
+            "#,
+    );
+    let mut ctx = CheckerContext::new_with_shared_def_store(
+        registry_arena.as_ref(),
+        registry_binder.as_ref(),
+        &types,
+        "HKT.ts".to_string(),
+        CheckerOptions::default(),
+        Arc::new(DefinitionStore::new()),
+    );
+    ctx.set_all_arenas(Arc::new(vec![
+        Arc::clone(&registry_arena),
+        Arc::clone(&augmentation_arena),
+    ]));
+    ctx.set_all_binders(Arc::new(vec![
+        Arc::clone(&registry_binder),
+        Arc::clone(&augmentation_binder),
+    ]));
+    ctx.set_current_file_idx(0);
+    let mut state = CheckerState { ctx };
+
+    let augmentation = augmentation_binder
+        .module_augmentations
+        .get("./HKT")
+        .and_then(|augmentations| {
+            augmentations
+                .iter()
+                .find(|augmentation| augmentation.name == "URItoKind2")
+        })
+        .expect("URItoKind2 module augmentation");
+    let registry_decl = augmentation.node;
+    let registry_interface = augmentation_arena
+        .get(registry_decl)
+        .and_then(|node| augmentation_arena.get_interface(node))
+        .expect("URItoKind2 augmentation interface");
+    let io_member = registry_interface.members.nodes[0];
+    let type_args = [TypeId::STRING, TypeId::NUMBER];
+
+    let member_types = state
+        .delegate_cross_arena_interface_member_simple_types(
+            registry_decl,
+            &[io_member],
+            augmentation_arena.as_ref(),
+            Some(&type_args),
+            true,
+        )
+        .expect("source-file module augmentation member should lower directly");
+    let member_type = member_types
+        .get(&io_member)
+        .copied()
+        .expect("IOEither member type");
+
+    assert_ne!(
+        member_type,
+        TypeId::ANY,
+        "source-file module augmentation member must not fall back to ANY"
+    );
+    assert_ne!(member_type, TypeId::UNKNOWN);
+    assert_ne!(member_type, TypeId::ERROR);
+}
+
+#[test]
+fn delegate_cross_arena_source_module_augmentation_member_lowers_global_map_ref() {
+    let (registry_arena, registry_binder, types) = parse_bound_source_with_name(
+        "HKT.ts",
+        r#"
+                export interface URItoKind2<E, A> {}
+            "#,
+    );
+    let (augmentation_arena, augmentation_binder, _) = parse_bound_source_with_name(
+        "table.ts",
+        r#"
+                import { URItoKind2 } from "./HKT";
+                declare module "./HKT" {
+                    interface URItoKind2<E, A> {
+                        readonly Table: ReadonlyMap<E, A>;
+                    }
+                }
+            "#,
+    );
+    let lib_files = load_lib_files(&["es5.d.ts", "es2015.collection.d.ts"]);
+    let mut ctx = CheckerContext::new_with_shared_def_store(
+        registry_arena.as_ref(),
+        registry_binder.as_ref(),
+        &types,
+        "HKT.ts".to_string(),
+        CheckerOptions::default(),
+        Arc::new(DefinitionStore::new()),
+    );
+    ctx.set_all_arenas(Arc::new(vec![
+        Arc::clone(&registry_arena),
+        Arc::clone(&augmentation_arena),
+    ]));
+    ctx.set_all_binders(Arc::new(vec![
+        Arc::clone(&registry_binder),
+        Arc::clone(&augmentation_binder),
+    ]));
+    ctx.set_current_file_idx(0);
+    ctx.set_lib_contexts(
+        lib_files
+            .iter()
+            .map(|lib| LibContext {
+                arena: Arc::clone(&lib.arena),
+                binder: Arc::clone(&lib.binder),
+            })
+            .collect(),
+    );
+    ctx.set_actual_lib_file_count(lib_files.len());
+    let mut state = CheckerState { ctx };
+
+    let augmentation = augmentation_binder
+        .module_augmentations
+        .get("./HKT")
+        .and_then(|augmentations| {
+            augmentations
+                .iter()
+                .find(|augmentation| augmentation.name == "URItoKind2")
+        })
+        .expect("URItoKind2 module augmentation");
+    let registry_decl = augmentation.node;
+    let registry_interface = augmentation_arena
+        .get(registry_decl)
+        .and_then(|node| augmentation_arena.get_interface(node))
+        .expect("URItoKind2 augmentation interface");
+    let table_member = registry_interface.members.nodes[0];
+    let type_args = [TypeId::STRING, TypeId::NUMBER];
+
+    let member_types = state
+        .delegate_cross_arena_interface_member_simple_types(
+            registry_decl,
+            &[table_member],
+            augmentation_arena.as_ref(),
+            Some(&type_args),
+            true,
+        )
+        .expect("source-file module augmentation member with global map ref should lower directly");
+    let member_type = member_types
+        .get(&table_member)
+        .copied()
+        .expect("Table member type");
+
+    assert_ne!(
+        member_type,
+        TypeId::ANY,
+        "global `ReadonlyMap` member must not fall back to ANY"
+    );
+    assert_ne!(member_type, TypeId::UNKNOWN);
+    assert_ne!(member_type, TypeId::ERROR);
+    assert!(
+        crate::query_boundaries::common::application_info(
+            state.ctx.types.as_type_database(),
+            member_type,
+        )
+        .is_some(),
+        "global `ReadonlyMap<E, A>` should lower as an application"
     );
 }
 

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -707,6 +707,7 @@ impl<'a> CheckerState<'a> {
                         &delegatable_member_indices,
                         arena,
                         type_args,
+                        true,
                     )
                 };
 


### PR DESCRIPTION
Goal: green

## Summary
- Allows module-augmentation registry member delegation to opt into direct source-file member lowering for augmentation arenas.
- Resolves unshadowed direct-lowerable globals such as `ReadonlyMap` from source-file augmentation member annotations while preserving local shadow checks.
- Keeps ordinary class/interface member delegation and full source-file interface lowering on their existing source-local behavior.

## Structural Rule
When a source-file `declare module` augmentation contributes a generic registry member whose annotation references a delegate-local type or an unshadowed lowerable global such as `ReadonlyMap<E, A>`, `tsc` materializes that member structurally with the registry type arguments. `tsz` now does that through the checker-owned cross-arena module-augmentation member delegation path and direct member type lowering; the solver/application substitution lane remains untouched.

## Owner Layer
Checker cross-file direct member lowering plus module-augmentation registry construction.

## Adjacent Matrix
- Delegate-local generic interface member: `IOEither<E, A>` lowers and substitutes `[string, number]` instead of falling back to `ANY`/`UNKNOWN`/`ERROR`.
- Global generic map member: `ReadonlyMap<E, A>` lowers as an application instead of falling back to `ANY`.
- Existing source option-bag delegation positives still pass.
- Class and normal interface member delegation call sites keep `allow_source_file_arena = false`.

## Fallback/Risk
- Source global fallback is only used in the direct member-simple path with caller opt-in from module-augmentation construction.
- Local source-file shadows still block global fallback unless the local symbol is allowed to fall back to the builtin/global.
- Calibration: `scripts/safe-run.sh cargo nextest run -p tsz-checker --test hkt_typeof_uri_instance_assignability_13930_repro` still has the two pre-existing high-level HKT failures (`Kind2<any, E, A>` / `Pick2<any, E, A>`), consistent with the latest #14345 c1 substitution/application split.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(delegate_cross_arena_source_option_bag_lowers_directly_via_cross_file_index) or test(delegate_cross_arena_source_option_bag_with_sibling_alias_lowers_directly_via_cross_file_index) or test(delegate_cross_arena_source_option_bag_resolves_in_program_with_module_augmentations) or test(delegate_cross_arena_source_module_augmentation_member_substitutes_generic_interface_ref) or test(delegate_cross_arena_source_module_augmentation_member_lowers_global_map_ref)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib 'state_domain::type_analysis::cross_file_direct::source_heritage_tests'`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
