### PR TITLE
refactor(solver): name instantiation cache stability (#14346)

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -1084,6 +1084,7 @@ impl<'a> TypeInstantiator<'a> {
 }
 
 mod api;
+mod cache_stability;
 mod conditional;
 mod display_properties;
 mod homomorphic;

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::caches::db::QueryDatabase;
 use crate::caches::instantiation_cache::{CanonicalSubst, InstantiationCacheKey};
+use crate::instantiation::instantiate::cache_stability::ProjectInstantiationCacheLimitSnapshot;
 use crate::instantiation::request::{InstantiationOptions, InstantiationRequest};
-use crate::instantiation::result::InstantiationResult;
+use crate::instantiation::result::{InstantiationMemoResult, InstantiationResult};
 use crate::types::{ConditionalType, FunctionShape, PropertyInfo};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
@@ -864,43 +865,16 @@ pub(crate) fn instantiate_with_request_cached(
         // #13889-class trap one layer down). Snapshot the sticky flags BEFORE so
         // a newly-tripped flag is attributed to THIS instantiation, not an
         // earlier sibling that already set it.
-        let union_too_complex_before = interner.is_union_too_complex();
-        let tuple_too_large_before = interner.is_tuple_too_large();
-        let frame_bail_before = crate::recursion::solver_frame_bail_count();
+        let limit_snapshot = ProjectInstantiationCacheLimitSnapshot::capture(interner);
         let result =
             instantiate_with_request_cached_inner(interner, query_db, allow_alpha_cache, request);
-        // Limit signals, each a reason a result is bounded/degraded:
-        //  - depth_exceeded: per-instance depth cap OR the shared solver-frame
-        //    budget tripping on the instantiator's OWN entry — the
-        //    recursion-limit analog of closed_eval's `recursion_limit_hit`
-        //    (already carried on the result).
-        //  - union_too_complex (TS2590) / tuple_too_large (TS2799): sticky flags
-        //    a nested `evaluate_*` (mapped/conditional body) can trip; gate on
-        //    NEWLY-tripped so a pre-existing sibling flag does not block an
-        //    unrelated result.
-        //  - evaluation fuel exhausted: the global fuel budget; an exhausted run
-        //    yields a bounded result.
-        //  - poisoned: the interner type-count budget degraded new construction
-        //    to `TypeId::ERROR`.
-        //  - solver-frame curtailment: a NESTED `evaluate_*` (instantiate.rs
-        //    evaluate_type/index_access/keyof) curtailed by the shared frame
-        //    budget returns an under-evaluated form WITHOUT flipping the
-        //    instantiator's own `depth_exceeded` (the instantiator's frame is
-        //    already on the stack). This is closed_eval's per-node `tainted`
-        //    exclusion at the instantiation layer: a budget-rich walk would
-        //    otherwise cache an under-evaluated result a budget-poor walk should
-        //    re-derive. The monotonic counter changing across the walk detects it.
-        let newly_too_complex = interner.is_union_too_complex() && !union_too_complex_before;
-        let newly_tuple_too_large = interner.is_tuple_too_large() && !tuple_too_large_before;
-        let frame_curtailed = crate::recursion::solver_frame_bail_count() != frame_bail_before;
-        let limit_tripped = result.depth_exceeded()
-            || newly_too_complex
-            || newly_tuple_too_large
-            || frame_curtailed
-            || interner.is_evaluation_fuel_exhausted()
-            || interner.is_poisoned();
-        if !limit_tripped {
-            interner.insert_proto_instantiation_cache(proto_key, result.type_id());
+        let memo_result = InstantiationMemoResult::for_project_cache(
+            result,
+            limit_snapshot.request_state_is_stable_after(interner),
+        );
+        if memo_result.is_stable_for_project_cache() {
+            interner
+                .insert_proto_instantiation_cache(proto_key, memo_result.into_result().type_id());
         }
         return result;
     }

--- a/crates/tsz-solver/src/instantiation/instantiate/cache_stability.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/cache_stability.rs
@@ -1,0 +1,37 @@
+use crate::construction::TypeDatabase;
+
+#[derive(Clone, Copy)]
+pub(super) struct ProjectInstantiationCacheLimitSnapshot {
+    union_too_complex: bool,
+    tuple_too_large: bool,
+    solver_frame_bail_count: u32,
+}
+
+impl ProjectInstantiationCacheLimitSnapshot {
+    pub(super) fn capture(interner: &dyn TypeDatabase) -> Self {
+        Self {
+            union_too_complex: interner.is_union_too_complex(),
+            tuple_too_large: interner.is_tuple_too_large(),
+            solver_frame_bail_count: crate::recursion::solver_frame_bail_count(),
+        }
+    }
+
+    pub(super) fn request_state_is_stable_after(self, interner: &dyn TypeDatabase) -> bool {
+        // Limit signals, each a reason a result is bounded/degraded:
+        //  - union_too_complex (TS2590) / tuple_too_large (TS2799): sticky flags
+        //    a nested `evaluate_*` can trip; gate on newly-tripped so a
+        //    pre-existing sibling flag does not block an unrelated result.
+        //  - solver-frame curtailment: a nested `evaluate_*` can return an
+        //    under-evaluated form without flipping the instantiator's own
+        //    `depth_exceeded`; the monotonic counter changing detects it.
+        let newly_too_complex = interner.is_union_too_complex() && !self.union_too_complex;
+        let newly_tuple_too_large = interner.is_tuple_too_large() && !self.tuple_too_large;
+        let frame_curtailed =
+            crate::recursion::solver_frame_bail_count() != self.solver_frame_bail_count;
+        !newly_too_complex
+            && !newly_tuple_too_large
+            && !frame_curtailed
+            && !interner.is_evaluation_fuel_exhausted()
+            && !interner.is_poisoned()
+    }
+}

--- a/crates/tsz-solver/src/instantiation/result.rs
+++ b/crates/tsz-solver/src/instantiation/result.rs
@@ -19,6 +19,18 @@ pub struct InstantiationResult {
     overflowed: bool,
 }
 
+/// Instantiation result plus the verdict for project-wide cache publication.
+///
+/// #14346 is moving cache eligibility away from loose local booleans and into
+/// typed result boundaries. The project-wide instantiation cache needs the
+/// walk's [`InstantiationResult`] and whether surrounding sticky state stayed
+/// clean for this request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct InstantiationMemoResult {
+    result: InstantiationResult,
+    stable_for_project_cache: bool,
+}
+
 impl InstantiationResult {
     /// Construct a successful result.
     pub const fn ok(type_id: TypeId) -> Self {
@@ -85,9 +97,35 @@ impl InstantiationResult {
     }
 }
 
+impl InstantiationMemoResult {
+    /// Construct a memo result from a typed instantiation result and the
+    /// request-state stability verdict.
+    pub(crate) const fn for_project_cache(
+        result: InstantiationResult,
+        request_state_stable: bool,
+    ) -> Self {
+        Self {
+            result,
+            stable_for_project_cache: !result.depth_exceeded() && request_state_stable,
+        }
+    }
+
+    /// Whether this result can be stored in the project-wide instantiation
+    /// cache, whose key does not capture ambient recursion/fuel state.
+    pub(crate) const fn is_stable_for_project_cache(self) -> bool {
+        self.stable_for_project_cache
+    }
+
+    /// Collapse to the request's instantiation result while preserving today's
+    /// behavior for callers that are not yet cache-verdict-aware.
+    pub(crate) const fn into_result(self) -> InstantiationResult {
+        self.result
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::InstantiationResult;
+    use super::{InstantiationMemoResult, InstantiationResult};
     use crate::types::TypeId;
 
     #[test]
@@ -128,5 +166,32 @@ mod tests {
         let bad = InstantiationResult::from_walk(TypeId::STRING, true);
         assert!(bad.depth_exceeded());
         assert_eq!(bad.into_type_id(), TypeId::STRING);
+    }
+
+    #[test]
+    fn memo_result_requires_clean_instantiation_and_request_state() {
+        let stable = InstantiationMemoResult::for_project_cache(
+            InstantiationResult::ok(TypeId::STRING),
+            true,
+        );
+        assert!(stable.is_stable_for_project_cache());
+        assert_eq!(stable.into_result().type_id(), TypeId::STRING);
+
+        let request_state_tainted = InstantiationMemoResult::for_project_cache(
+            InstantiationResult::ok(TypeId::NUMBER),
+            false,
+        );
+        assert!(!request_state_tainted.is_stable_for_project_cache());
+        assert_eq!(
+            request_state_tainted.into_result().type_id(),
+            TypeId::NUMBER
+        );
+
+        let overflowed = InstantiationMemoResult::for_project_cache(
+            InstantiationResult::overflow_with(TypeId::BOOLEAN),
+            true,
+        );
+        assert!(!overflowed.is_stable_for_project_cache());
+        assert_eq!(overflowed.into_result().type_id(), TypeId::BOOLEAN);
     }
 }

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -209,6 +209,8 @@ fn evaluation_engine_keeps_request_stage_boundary() {
     let evaluate_api_rs = read_solver_source("evaluation/evaluate/api.rs");
     let cross_eval_guard_rs = read_solver_source("evaluation/cross_eval_guard.rs");
     let infer_pattern_rs = read_solver_source("evaluation/evaluate_rules/infer_pattern.rs");
+    let instantiation_result_rs = read_solver_source("instantiation/result.rs");
+    let instantiation_api_rs = read_solver_source("instantiation/instantiate/api.rs");
     let query_cache_rs = read_solver_source("caches/query_cache.rs");
     let iteration_incomplete_tests =
         read_solver_test("evaluate_tests_parts/iteration_exceeded_incomplete.rs");
@@ -272,6 +274,16 @@ fn evaluation_engine_keeps_request_stage_boundary() {
                 .contains("EvaluationMemoResult::new(EvaluationResult::complete")
             && !infer_pattern_rs.contains("EvaluationMemoResult::new(EvaluationResult::complete"),
         "unstable complete memo results must use the named EvaluationMemoResult boundary instead of rebuilding the stability bit by hand"
+    );
+    assert!(
+        instantiation_result_rs.contains("pub(crate) struct InstantiationMemoResult")
+            && instantiation_result_rs.contains("fn for_project_cache(")
+            && instantiation_result_rs.contains("fn is_stable_for_project_cache(self) -> bool")
+            && instantiation_api_rs.contains("ProjectInstantiationCacheLimitSnapshot::capture")
+            && instantiation_api_rs.contains("InstantiationMemoResult::for_project_cache")
+            && instantiation_api_rs.contains("is_stable_for_project_cache()")
+            && !instantiation_api_rs.contains("let limit_tripped ="),
+        "project instantiation cache writes must consume InstantiationMemoResult stability instead of rebuilding a raw limit_tripped predicate"
     );
 }
 


### PR DESCRIPTION
Goal: green

## Structural Rule
When the project-wide instantiation cache decides whether to publish, tsz asks a named instantiation-result/cache-stability boundary. The cache write site should not reconstruct termination or ambient-limit semantics from loose local booleans.

Owner layer: `tsz-solver` instantiation result plus the project-instantiation cache boundary.

## Scope
- Adds `InstantiationMemoResult` as the typed result plus project-cache stability verdict.
- Moves the ambient limit snapshot into `ProjectInstantiationCacheLimitSnapshot`.
- Routes the project-wide instantiation cache write through `InstantiationMemoResult::for_project_cache`.
- Ratchets the architecture guard so the cache site consumes the named boundary instead of rebuilding `let limit_tripped =`.
- No #14344 reference-mint edits, no #14345 materialize-once/substitution edits, and no behavior-policy changes.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(memo_result_requires_clean_instantiation_and_request_state)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(clean_instantiation_is_cached_project_wide) or test(depth_exceeded_instantiation_not_cached_project_wide) or test(pre_existing_limit_flag_does_not_block_clean_instantiation)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(evaluation_engine_keeps_request_stage_boundary)'`
- `wc -l crates/tsz-solver/src/instantiation/instantiate/api.rs crates/tsz-solver/src/instantiation/instantiate/cache_stability.rs crates/tsz-solver/src/instantiation/instantiate.rs crates/tsz-solver/src/instantiation/result.rs crates/tsz-solver/tests/architecture_guards.rs`
- `rg -n "let limit_tripped =" crates/tsz-solver/src/instantiation/instantiate/api.rs` (no matches)

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high