### PR TITLE
refactor(solver): name evaluation cache limit snapshot (#14346)

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -17,6 +17,7 @@ use crate::caches::shared_query_cache::ApplicationEvalCacheKey;
 pub use crate::caches::shared_query_cache::SharedQueryCache;
 use crate::caches::subtype_reduction_cache::{SubtypeReductionCache, SubtypeReductionKey};
 use crate::def::DefId;
+use crate::evaluation::cache_stability::EvaluationCacheLimitSnapshot;
 use crate::evaluation::request::{EvaluationCacheKey, EvaluationRequest};
 use crate::intern::TypeInterner;
 use crate::objects::element_access::ElementAccessResult;
@@ -1499,7 +1500,7 @@ impl QueryDatabase for QueryCache<'_> {
             query_id
         });
 
-        let union_too_complex_before = self.interner.is_union_too_complex();
+        let limit_snapshot = EvaluationCacheLimitSnapshot::capture(self.interner);
         let mut evaluator = self.query_backed_evaluator();
         let evaluation_memo_result = evaluator.evaluate_request_memo_result(request);
         let result = evaluation_memo_result.into_type_id();
@@ -1535,10 +1536,10 @@ impl QueryDatabase for QueryCache<'_> {
         // recomputed from scratch on every later query.
         // A union-complexity overflow is not routed through the evaluator's
         // limit epoch, so it conservatively suppresses all writes, as before.
-        let newly_union_too_complex =
-            self.interner.is_union_too_complex() && !union_too_complex_before;
+        let union_complexity_stable =
+            limit_snapshot.union_complexity_stayed_stable_after(self.interner);
         let top_level_clean = evaluation_memo_result.is_stable_for_depth_agnostic_cache();
-        if !newly_union_too_complex
+        if union_complexity_stable
             && (top_level_clean || crate::limits::limit_result_cache_enabled())
         {
             let mut cache = self.eval_cache.borrow_mut();

--- a/crates/tsz-solver/src/evaluation/cache_stability.rs
+++ b/crates/tsz-solver/src/evaluation/cache_stability.rs
@@ -1,0 +1,40 @@
+use crate::construction::TypeDatabase;
+
+/// Snapshot for evaluation cache writes whose keys do not encode ambient limit
+/// state.
+#[derive(Clone, Copy)]
+pub(crate) struct EvaluationCacheLimitSnapshot {
+    union_too_complex: bool,
+}
+
+impl EvaluationCacheLimitSnapshot {
+    pub(crate) fn capture(interner: &dyn TypeDatabase) -> Self {
+        Self {
+            union_too_complex: interner.is_union_too_complex(),
+        }
+    }
+
+    pub(crate) fn union_complexity_stayed_stable_after(self, interner: &dyn TypeDatabase) -> bool {
+        !interner.is_union_too_complex() || self.union_too_complex
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EvaluationCacheLimitSnapshot;
+    use crate::intern::TypeInterner;
+
+    #[test]
+    fn union_complexity_snapshot_only_blocks_new_limit_events() {
+        let interner = TypeInterner::new();
+
+        let clean_snapshot = EvaluationCacheLimitSnapshot::capture(&interner);
+        assert!(clean_snapshot.union_complexity_stayed_stable_after(&interner));
+
+        interner.set_union_too_complex();
+        assert!(!clean_snapshot.union_complexity_stayed_stable_after(&interner));
+
+        let pre_existing_snapshot = EvaluationCacheLimitSnapshot::capture(&interner);
+        assert!(pre_existing_snapshot.union_complexity_stayed_stable_after(&interner));
+    }
+}

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -24,6 +24,7 @@ use crate::diagnostics::display_provenance::{
     self, AliasApplicationPriority, AliasApplicationProvenance,
     FreshObjectLiteralDisplayProvenance, UnionOriginProvenance,
 };
+use crate::evaluation::cache_stability::EvaluationCacheLimitSnapshot;
 use crate::evaluation::request::EvaluationRequest;
 use crate::evaluation::result::EvaluationMemoResult;
 use crate::evaluation::result::EvaluationResult;
@@ -1050,9 +1051,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         // Top-level frame: evaluate, then commit closed-eval cache writes.
         // See the `closed_eval` module for the safety gates.
-        let union_too_complex_before = self.interner.is_union_too_complex();
+        let limit_snapshot = EvaluationCacheLimitSnapshot::capture(self.interner);
         let result = self.evaluate_guarded(type_id);
-        self.commit_closed_eval_writes(union_too_complex_before);
+        self.commit_closed_eval_writes(limit_snapshot);
         result
     }
 

--- a/crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs
@@ -42,6 +42,7 @@
 //!    derived after the real body registers.
 
 use super::TypeEvaluator;
+use crate::evaluation::cache_stability::EvaluationCacheLimitSnapshot;
 use crate::relations::subtype::TypeResolver;
 use crate::types::{TypeData, TypeId};
 
@@ -108,10 +109,9 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
     /// Commit this evaluator's per-evaluator cache entries to the project-wide
     /// `closed_eval_cache`, subject to the authoritative-write and limit gates.
     ///
-    /// `union_too_complex_before` is the `TS2590` flag snapshot taken before the
-    /// top-level evaluation began; if the run newly tripped the flag, nothing is
-    /// cached.
-    pub(super) fn commit_closed_eval_writes(&self, union_too_complex_before: bool) {
+    /// `limit_snapshot` is captured before the top-level evaluation began; if
+    /// the run newly tripped `TS2590`, nothing is cached.
+    pub(super) fn commit_closed_eval_writes(&self, limit_snapshot: EvaluationCacheLimitSnapshot) {
         // A substitution-independent node's *final* result is a pure function of
         // `(TypeId, no_unchecked, exact_optional)` and the project's single fixed
         // resolver — but only once that resolver can resolve every
@@ -123,7 +123,7 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
         if !is_top_level
             || !self.request_state_is_depth_agnostic_cache_stable()
             || self.unresolved_def_seen()
-            || (self.interner.is_union_too_complex() && !union_too_complex_before)
+            || !limit_snapshot.union_complexity_stayed_stable_after(self.interner)
         {
             return;
         }
@@ -502,7 +502,8 @@ mod tests {
             .with_query_db(&cache)
             .with_closed_eval_writes();
         complete.cache.insert(complete_node, TypeId::NUMBER);
-        complete.commit_closed_eval_writes(false);
+        let complete_snapshot = EvaluationCacheLimitSnapshot::capture(&cache);
+        complete.commit_closed_eval_writes(complete_snapshot);
         assert_eq!(
             cache.lookup_closed_eval_cache(complete_node, false),
             Some(TypeId::NUMBER)
@@ -514,7 +515,8 @@ mod tests {
             .with_closed_eval_writes();
         incomplete.cache.insert(incomplete_node, TypeId::BOOLEAN);
         incomplete.simulate_incomplete_request_verdict_for_test(TerminationKind::DepthExceeded);
-        incomplete.commit_closed_eval_writes(false);
+        let incomplete_snapshot = EvaluationCacheLimitSnapshot::capture(&cache);
+        incomplete.commit_closed_eval_writes(incomplete_snapshot);
         assert_eq!(cache.lookup_closed_eval_cache(incomplete_node, false), None);
 
         let legacy_tainted_node = interner.index_access(TypeId::STRING, TypeId::NUMBER);
@@ -525,7 +527,8 @@ mod tests {
             .cache
             .insert(legacy_tainted_node, TypeId::STRING);
         legacy_tainted.simulate_unrelated_recursion_bail_for_test();
-        legacy_tainted.commit_closed_eval_writes(false);
+        let legacy_tainted_snapshot = EvaluationCacheLimitSnapshot::capture(&cache);
+        legacy_tainted.commit_closed_eval_writes(legacy_tainted_snapshot);
         assert_eq!(
             cache.lookup_closed_eval_cache(legacy_tainted_node, false),
             None

--- a/crates/tsz-solver/src/evaluation/mod.rs
+++ b/crates/tsz-solver/src/evaluation/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod cache_stability;
 pub(crate) mod cross_eval_guard;
 pub mod eval_materialization_probe;
 pub(crate) mod evaluate;


### PR DESCRIPTION
Goal: green

## Structural Rule
When an evaluation cache whose key does not encode ambient limit state decides whether to publish, tsz asks a named evaluation cache limit snapshot for newly tripped union-complexity state. Cache write sites should not pass around raw union_too_complex_before booleans.

Owner layer: tsz-solver evaluation cache stability boundary plus the query-cache and closed-eval write gates.

## Scope
- Adds EvaluationCacheLimitSnapshot for the TS2590 union-complexity snapshot that still lives outside EvaluationMemoResult.
- Routes top-level QueryCache::evaluate_request eval-cache writes through the named snapshot.
- Routes closed-eval write commits through the same snapshot instead of a raw bool.
- Adds a focused helper test proving newly tripped union complexity blocks writes while pre-existing sticky state is not attributed to the current run.
- No #14344 reference-mint edits, no #14345 materialize-once/substitution edits, and no cache eligibility policy changes.

## Verification
- cargo fmt --all --check
- git diff --check
- git diff --check HEAD~1..HEAD
- scripts/safe-run.sh cargo nextest run -p tsz-solver -E "test(union_complexity_snapshot_only_blocks_new_limit_events) or test(request_state_stability_gate_blocks_closed_eval_write)"
- scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter inferentialTypingWithFunctionTypeZip --verbose
- exact-head PR CI pending on rebased head 1cb938d3b9d5d3d3c42ad31b2e9c7b3d6ad58e1e

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high