### PR TITLE
fix(emit): tighten empty JSX fragment props to {} in automatic runtime

### DIFF
--- a/crates/tsz-emitter/Cargo.toml
+++ b/crates/tsz-emitter/Cargo.toml
@@ -123,6 +123,10 @@ name = "jsx_spread_tests"
 path = "tests/jsx_spread_tests.rs"
 
 [[test]]
+name = "jsx_fragment_empty_props_tests"
+path = "tests/jsx_fragment_empty_props_tests.rs"
+
+[[test]]
 name = "jsx_auto_import_order_tests"
 path = "tests/jsx_auto_import_order_tests.rs"
 

--- a/crates/tsz-emitter/src/emitter/jsx/emit.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/emit.rs
@@ -895,16 +895,19 @@ impl<'a> Printer<'a> {
             self.write("_Fragment");
         }
 
-        // Props with children
-        self.write(", { ");
-        if !filtered_children.is_empty() {
-            self.write("children: ");
-            self.emit_jsx_children_value(&children, &filtered_children, is_jsxs);
-            self.write(" ");
-        } else {
+        // Props object (with children embedded). Mirror the element automatic
+        // path (`emit_jsx_automatic_call`): emit a tight `{}` when there are no
+        // children rather than leaving a stray space (`{ }`), matching tsc
+        // byte-for-byte across the ESM, dev, and CJS automatic runtimes.
+        self.write(", ");
+        if filtered_children.is_empty() {
             self.skip_empty_jsx_children_comments(&children);
+            self.write("{}");
+        } else {
+            self.write("{ children: ");
+            self.emit_jsx_children_value(&children, &filtered_children, is_jsxs);
+            self.write(" }");
         }
-        self.write("}");
 
         if is_dev {
             // jsxDEV extra args: key, isStaticChildren, source, self

--- a/crates/tsz-emitter/tests/jsx_fragment_empty_props_tests.rs
+++ b/crates/tsz-emitter/tests/jsx_fragment_empty_props_tests.rs
@@ -1,0 +1,130 @@
+//! Empty JSX fragments lowered through the automatic runtime must emit a tight
+//! `{}` props object, matching tsc byte-for-byte. Issue #14781: the fragment
+//! path previously opened the props object unconditionally with `, { ` and
+//! closed with `}`, leaving a stray space (`{ }`) when there were no children.
+//! The element automatic path always emitted `{}` for the empty case; the
+//! fragment path now mirrors it across the ESM, dev, and CommonJS runtimes.
+
+use tsz_common::common::{ModuleKind, ScriptTarget};
+use tsz_emitter::emitter::JsxEmit;
+use tsz_emitter::output::printer::PrintOptions;
+
+#[path = "test_support.rs"]
+mod test_support;
+
+use test_support::{parse_and_lower_print_named_with_opts, parse_and_print_named_with_opts};
+
+fn emit_jsx(source: &str, jsx: JsxEmit, target: ScriptTarget) -> String {
+    let opts = PrintOptions {
+        jsx,
+        target,
+        ..Default::default()
+    };
+    parse_and_print_named_with_opts("test.tsx", source, opts)
+}
+
+fn emit_jsx_cjs(source: &str, jsx: JsxEmit) -> String {
+    let opts = PrintOptions {
+        jsx,
+        module: ModuleKind::CommonJS,
+        target: ScriptTarget::ES2017,
+        ..Default::default()
+    };
+    parse_and_lower_print_named_with_opts("test.tsx", source, opts)
+}
+
+#[test]
+fn empty_fragment_esm_emits_tight_empty_props() {
+    let output = emit_jsx(
+        "const b = <></>;\n",
+        JsxEmit::ReactJsx,
+        ScriptTarget::ES2017,
+    );
+    assert!(
+        output.contains("_jsx(_Fragment, {})"),
+        "Empty fragment must emit a tight `{{}}` props object.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("{ }"),
+        "Empty fragment must not leave a stray space inside the props object.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn empty_fragment_dev_emits_tight_empty_props() {
+    let output = emit_jsx(
+        "const b = <></>;\n",
+        JsxEmit::ReactJsxDev,
+        ScriptTarget::ES2017,
+    );
+    assert!(
+        output.contains("_jsxDEV(_Fragment, {},"),
+        "Empty fragment under react-jsxdev must emit a tight `{{}}` props object.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("{ }"),
+        "Empty fragment (dev) must not leave a stray space.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn empty_fragment_cjs_emits_tight_empty_props() {
+    let output = emit_jsx_cjs("const b = <></>;\n", JsxEmit::ReactJsx);
+    assert!(
+        output.contains(".Fragment, {})"),
+        "Empty fragment under the CommonJS automatic runtime must emit `{{}}`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("{ }"),
+        "Empty fragment (CJS) must not leave a stray space.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn empty_element_and_self_closing_still_emit_tight_props() {
+    // Regression guard: the element automatic path was already correct and must
+    // stay byte-identical alongside the fragment fix.
+    let output = emit_jsx(
+        "const a = <div></div>;\nconst c = <span/>;\n",
+        JsxEmit::ReactJsx,
+        ScriptTarget::ES2017,
+    );
+    assert!(
+        output.contains("_jsx(\"div\", {})"),
+        "Empty element must keep emitting a tight `{{}}`.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("_jsx(\"span\", {})"),
+        "Self-closing element must keep emitting a tight `{{}}`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn non_empty_fragment_still_emits_children_props() {
+    // Fragments with content keep the spaced `{ children: ... }` shape that tsc
+    // emits; the fix only tightened the empty case.
+    let output = emit_jsx(
+        "const b = <>hello</>;\n",
+        JsxEmit::ReactJsx,
+        ScriptTarget::ES2017,
+    );
+    assert!(
+        output.contains("_jsx(_Fragment, { children: \"hello\" })"),
+        "Non-empty fragment must keep the spaced `{{ children: ... }}` props object.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn nested_empty_fragment_children_emit_tight_props() {
+    // A fragment that only contains another empty fragment: the inner empty
+    // fragment must still tighten while the outer carries it as a child.
+    let output = emit_jsx(
+        "const b = <><></></>;\n",
+        JsxEmit::ReactJsx,
+        ScriptTarget::ES2017,
+    );
+    assert!(
+        output.contains("_jsx(_Fragment, { children: _jsx(_Fragment, {}) })"),
+        "Nested empty fragment must tighten to `{{}}` inside the outer children.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/tests/test_support.rs
+++ b/crates/tsz-emitter/tests/test_support.rs
@@ -76,6 +76,18 @@ pub fn parse_and_lower_print(source: &str, opts: PrintOptions) -> String {
     lower_and_print(&parser.arena, root, opts).code
 }
 
+/// Like `parse_and_lower_print` but uses a caller-supplied file name. Required
+/// for `.tsx` integration tests that exercise lowering transforms whose output
+/// depends on the module kind (e.g. the CommonJS automatic JSX runtime).
+pub fn parse_and_lower_print_named_with_opts(
+    file_name: &str,
+    source: &str,
+    opts: PrintOptions,
+) -> String {
+    let (parser, root) = parse_source_named(file_name, source);
+    lower_and_print(&parser.arena, root, opts).code
+}
+
 /// Like `parse_and_print_with_opts` but uses a caller-supplied file name.
 /// Required for `.tsx` integration tests where the file name drives JSX
 /// parsing.


### PR DESCRIPTION
Fixes #14781.

Structural rule: when an empty JSX fragment (`<></>`) is lowered through the automatic runtime and has no children, tsc emits a tight props object `_jsx(_Fragment, {})`; tsz emitted `_jsx(_Fragment, { })` with a stray interior space. `emit_jsx_fragment_automatic` (owner: emitter / `crates/tsz-emitter/src/emitter/jsx/emit.rs`) opened the props object unconditionally with `, { ` and closed with `}`, leaving the space when there were no children. The sibling element automatic path (`emit_jsx_automatic_call`) already emitted a tight `{}` for the empty case.

The fix mirrors the element path in the fragment path: emit `{}` when there are no children, otherwise `{ children: ... }`. One change covers the whole family — a single function services the ESM, dev (`react-jsxdev`), and CommonJS automatic runtimes, so all three are corrected at once. Non-empty fragments keep the spaced `{ children: ... }` shape tsc emits; only the empty case is tightened.

Adjacent-case matrix (all covered by new emit tests):
- empty fragment, ESM `react-jsx` → `_jsx(_Fragment, {})`
- empty fragment, dev `react-jsxdev` → `_jsxDEV(_Fragment, {}, ...)`
- empty fragment, CommonJS automatic runtime → `(0, jsx_runtime_1.jsx)(jsx_runtime_1.Fragment, {})`
- non-empty fragment (regression) → `_jsx(_Fragment, { children: "hello" })`
- empty element / self-closing element (regression) → already `{}`, stays `{}`
- nested empty fragment → inner tightens to `{}` inside the outer `{ children: ... }`

No anti-hardcoding concerns: the change is a structural branch on whether the fragment has children, with no identifier/file-name/printer-output checks. The CommonJS lowering boilerplate in the test was centralized into a new `parse_and_lower_print_named_with_opts` test-support helper rather than hand-rolled.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-emitter --test jsx_fragment_empty_props_tests` (6 tests, all pass)
- `cargo test -p tsz-emitter --test jsx_spread_tests --test jsx_cjs_runtime_collision_tests --test jsx_auto_import_order_tests` (no regressions)
- `cargo clippy -p tsz-emitter --tests` (clean)
- Ready-review CI owns broad emit/conformance suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: medium

https://claude.ai/code/session_01CNSQSiMALFLzAkmx5gFVDi

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNSQSiMALFLzAkmx5gFVDi)_