### PR TITLE
fix(checker): exempt scalar `any`/`error` spread values from TS2556

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1181,6 +1181,9 @@ path = "tests/overload_inference_literal_preservation_tests.rs"
 name = "overload_spread_into_rest_ts2556_tests"
 path = "tests/overload_spread_into_rest_ts2556_tests.rs"
 [[test]]
+name = "spread_any_value_ts2556_tests"
+path = "tests/spread_any_value_ts2556_tests.rs"
+[[test]]
 name = "overload_nontuple_spread_rest_fallback_tests"
 path = "tests/overload_nontuple_spread_rest_fallback_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/candidate_collection.rs
@@ -500,6 +500,20 @@ impl<'a> CheckerState<'a> {
                     // Check if spread argument is iterable, emit TS2488 if not
                     self.check_spread_iterability(spread_type, spread_expression);
 
+                    // A scalar `any`/`error` spread contributes an unknown number
+                    // of `any` arguments that tsc accepts against any parameter
+                    // list, so neither TS2556 nor an arity diagnostic fires.
+                    // Contribute a single `any` argument and stop: it is assignable
+                    // to whatever parameter sits at this slot, and the spread
+                    // element already relaxes the minimum-arity check. (An `any[]`
+                    // spread is different: its array-ness still overflows a non-rest
+                    // parameter, so TS2556 is correct there.) See #14746.
+                    if spread_type == TypeId::ANY || spread_type == TypeId::ERROR {
+                        arg_types.push(spread_type);
+                        effective_index += 1;
+                        continue;
+                    }
+
                     if let Some((elements, const_asserted)) =
                         self.const_asserted_array_literal_spread_elements(spread_expression)
                     {

--- a/crates/tsz-checker/src/checkers/call_checker/non_tuple_spread_signature.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/non_tuple_spread_signature.rs
@@ -49,6 +49,17 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
             let spread_type = self.normalized_spread_argument_type(spread_data.expression);
+            // A scalar `any`/`error` spread is assignable to any rest or fixed
+            // parameter and can never overflow the parameter list, so it is
+            // never a rejectable non-tuple spread. This mirrors the collector
+            // early-out in `collect_call_argument_types_with_context`; keeping
+            // the exemption in this shared overload predicate ensures the
+            // single-signature and overload-resolution paths agree (the value
+            // occupies one positional slot here).
+            if spread_type == TypeId::ANY || spread_type == TypeId::ERROR {
+                effective_index += 1;
+                continue;
+            }
             // A variadic-tuple type-parameter spread stays a single unit (see argument
             // collection and the type-parameter spread branch below); do not
             // advance by its constraint's tuple element count.

--- a/crates/tsz-checker/tests/spread_any_value_ts2556_tests.rs
+++ b/crates/tsz-checker/tests/spread_any_value_ts2556_tests.rs
@@ -1,0 +1,230 @@
+//! TS2556 must not fire for a spread whose argument *value* is typed `any`.
+//!
+//! Structural rule: spreading a value whose type is exactly `any` (or the error
+//! type) contributes an unknown number of `any` arguments. `any` is assignable
+//! both to a rest parameter and to a tuple of whatever arity the callee needs,
+//! so `tsc` accepts `f(...anyValue)` against *any* parameter list — no TS2556
+//! ("A spread argument must either have a tuple type or be passed to a rest
+//! parameter") and no arity diagnostic. This is distinct from an `any[]` (or any
+//! other opaque, non-tuple array) spread, whose definite array-ness gives it an
+//! indeterminate length that still overflows a non-rest parameter, where TS2556
+//! is correct.
+//!
+//! Owner layer: the spread-argument collector
+//! (`call_checker::candidate_collection`) short-circuits a scalar-`any`/`error`
+//! spread before the array/iterable landing-position checks that emit TS2556.
+//!
+//! Witness: jotai `freezeAtom` (#14746). A callback contextually typed by a
+//! cross-module generic `Setter` degrades to an `any`-typed rest parameter when
+//! the `Function.prototype.call` instantiation crosses the module boundary;
+//! spreading it into `set(...)` then wrongly tripped TS2556. The structural rule
+//! (scalar-`any` spread) is exercised directly below with binder names varied so
+//! nothing keys on `any`, the identifier `set`, or a file name.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{
+    check_multi_file_with_libs, check_source_diagnostics, diagnostic_count, load_default_lib_files,
+};
+use tsz_common::diagnostics::Diagnostic;
+
+const TS2556: u32 = 2556;
+// Arity diagnostics that must also stay silent: a scalar-`any` spread satisfies
+// any arity, so neither "expected N arguments" (TS2554) nor "expected at least
+// N" (TS2555) may appear.
+const TS2554: u32 = 2554;
+const TS2555: u32 = 2555;
+
+fn spread_codes(diags: &[Diagnostic]) -> Vec<u32> {
+    diags
+        .iter()
+        .map(|d| d.code)
+        .filter(|c| *c == TS2556 || *c == TS2554 || *c == TS2555)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Positive: spreading a scalar `any` value is clean against any callee shape.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scalar_any_spread_into_fixed_arity_function_is_clean() {
+    // The callee has two required, non-rest parameters and *fewer* are visibly
+    // provided; the `any` spread must satisfy both arity and TS2556.
+    let src = r#"
+        declare const payload: any;
+        function consume(first: number, second: string): void {}
+        consume(...payload);
+    "#;
+    let diags = check_source_diagnostics(src);
+    assert!(
+        spread_codes(&diags).is_empty(),
+        "scalar `any` spread into a fixed-arity callee must be clean: {diags:?}"
+    );
+}
+
+#[test]
+fn scalar_any_spread_into_many_required_params_is_clean() {
+    // Even when the callee declares many required parameters, an `any` spread is
+    // treated as supplying an unknown count — no TS2554.
+    let src = r#"
+        declare const blob: any;
+        function widen(a: number, b: number, c: number, d: number): void {}
+        widen(...blob);
+    "#;
+    let diags = check_source_diagnostics(src);
+    assert!(
+        spread_codes(&diags).is_empty(),
+        "scalar `any` spread into a many-required-param callee must be clean: {diags:?}"
+    );
+}
+
+#[test]
+fn scalar_any_spread_with_leading_fixed_arg_is_clean() {
+    let src = r#"
+        declare const rest: any;
+        function lead(head: number, tail: string): void {}
+        lead(1, ...rest);
+    "#;
+    let diags = check_source_diagnostics(src);
+    assert!(
+        spread_codes(&diags).is_empty(),
+        "leading fixed arg then scalar `any` spread must be clean: {diags:?}"
+    );
+}
+
+#[test]
+fn scalar_any_spread_into_constructor_is_clean() {
+    let src = r#"
+        declare const args: any;
+        class Widget {
+            constructor(x: number, y: string) {}
+        }
+        new Widget(...args);
+    "#;
+    let diags = check_source_diagnostics(src);
+    assert!(
+        spread_codes(&diags).is_empty(),
+        "scalar `any` spread into a constructor must be clean: {diags:?}"
+    );
+}
+
+#[test]
+fn scalar_any_spread_into_method_is_clean() {
+    let src = r#"
+        declare const data: any;
+        declare const sink: { absorb(only: number): void };
+        sink.absorb(...data);
+    "#;
+    let diags = check_source_diagnostics(src);
+    assert!(
+        spread_codes(&diags).is_empty(),
+        "scalar `any` spread into a method call must be clean: {diags:?}"
+    );
+}
+
+#[test]
+fn scalar_any_spread_into_overload_set_without_rest_is_clean() {
+    // No overload has a rest parameter; the spread still must not trip TS2556,
+    // because the `any` value can satisfy either fixed-arity overload.
+    let src = r#"
+        declare const params: any;
+        function pick(a: number): void;
+        function pick(a: number, b: number): void;
+        function pick(a: number, b?: number): void {}
+        pick(...params);
+    "#;
+    let diags = check_source_diagnostics(src);
+    assert!(
+        spread_codes(&diags).is_empty(),
+        "scalar `any` spread into a no-rest overload set must be clean: {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: the exemption is specific to a *scalar* `any`/`error`
+// value. An opaque (non-tuple) array spread into a non-rest parameter still has
+// an indeterminate length and must keep TS2556 — including an `any[]` spread, so
+// the rule is not "anything involving `any` is exempt".
+// ---------------------------------------------------------------------------
+
+#[test]
+fn any_array_spread_into_non_rest_still_emits_ts2556() {
+    let src = r#"
+        declare const items: any[];
+        function take(first: number, second: string): void {}
+        take(...items);
+    "#;
+    let diags = check_source_diagnostics(src);
+    assert_eq!(
+        diagnostic_count(&diags, TS2556),
+        1,
+        "opaque `any[]` spread into a non-rest callee must still emit TS2556: {diags:?}"
+    );
+}
+
+#[test]
+fn typed_array_spread_into_non_rest_still_emits_ts2556() {
+    // The same with a concretely typed array (binder names varied) so the
+    // negative control is not keyed on `any`.
+    let src = r#"
+        declare const values: string[];
+        function gather(alpha: number): void {}
+        gather(...values);
+    "#;
+    let diags = check_source_diagnostics(src);
+    assert_eq!(
+        diagnostic_count(&diags, TS2556),
+        1,
+        "opaque `string[]` spread into a non-rest callee must still emit TS2556: {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cross-module witness (#14746): the jotai `freezeAtom` shape, where the
+// callback contextually typed by an imported generic `Setter` degrades its rest
+// parameter to `any` across the module boundary. The whole project must be clean
+// exactly as `tsc` reports.
+// ---------------------------------------------------------------------------
+
+fn check_project(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    let libs = load_default_lib_files();
+    check_multi_file_with_libs(files, entry, CheckerOptions::default(), &libs)
+}
+
+#[test]
+fn cross_module_generic_rest_setter_spread_is_clean() {
+    let atom = r#"
+        type Getter = <Value>(atom: Atom<Value>) => Value
+        export type Setter = <Value, Args extends unknown[], Result>(
+            atom: WritableAtom<Value, Args, Result>, ...args: Args) => Result
+        type Write<Args extends unknown[], Result> =
+            (get: Getter, set: Setter, ...args: Args) => Result
+        export interface Atom<Value> { read: (get: Getter) => Value }
+        export interface WritableAtom<Value, Args extends unknown[], Result>
+            extends Atom<Value> {
+            write: Write<Args, Result>
+        }
+    "#;
+    let freeze = r#"
+        import type { WritableAtom } from './atom.ts'
+        declare const deepFreeze: <T>(v: T) => T
+        export function freezeAtom<Value, Args extends unknown[], Result>(
+            anAtom: WritableAtom<Value, Args, Result>,
+        ) {
+            const origWrite = anAtom.write
+            anAtom.write = function (get, set, ...args) {
+                return origWrite.call(this, get,
+                    (...setArgs) => {
+                        if (setArgs[0] === anAtom) { setArgs[1] = deepFreeze(setArgs[1]) }
+                        return set(...setArgs)
+                    }, ...args)
+            }
+        }
+    "#;
+    let diags = check_project(&[("atom.ts", atom), ("freeze.ts", freeze)], "freeze.ts");
+    assert_eq!(
+        diagnostic_count(&diags, TS2556),
+        0,
+        "cross-module generic-rest `Setter` spread (jotai #14746) must be clean: {diags:?}"
+    );
+}


### PR DESCRIPTION
Spreading a value whose type is exactly `any` (or the error type) was falsely rejected with TS2556 ("A spread argument must either have a tuple type or be passed to a rest parameter"). `tsc` accepts `f(...anyValue)` against any parameter list, so the diagnostic is a false positive.

**Structural rule:** When a spread argument's value type is `any`/`error`, tsc treats it as contributing an unknown number of `any` arguments that satisfy every parameter position (and any arity) — `any` is assignable both to a rest parameter and to a tuple of whatever arity the callee needs. tsz now does the same through the call-argument collector. This is distinct from an `any[]` (or other opaque, non-tuple array) spread, whose definite array-ness still overflows a non-rest parameter — TS2556 stays correct there.

**Owner layer:** `tsz_checker::checkers::call_checker::candidate_collection::collect_call_argument_types_with_context` short-circuits a scalar `any`/`error` spread before the tuple/array/iterable landing-position checks that emit TS2556, contributing a single `any` argument (the spread element already relaxes the minimum-arity check, so no TS2554/TS2555 fires). The same exemption is mirrored in the shared overload predicate `first_non_tuple_spread_rejected_by_signature` so the single-signature and overload-resolution paths cannot diverge.

**Witness:** jotai `freezeAtom` (#14746). A callback contextually typed by a cross-module generic `Setter` degrades to an `any`-typed rest parameter when the `Function.prototype.call` instantiation crosses the module boundary; spreading it into `set(...)` then tripped TS2556. The fix is general (any scalar `any` spread), not specific to the cross-module path.

**Adjacent matrix** (new tests, binder names varied per the anti-hardcoding gate): fixed-arity / many-required-param / leading-fixed-arg / constructor / method / no-rest-overload positives; `any[]` and `string[]` negative controls that keep TS2556; the cross-module jotai witness.

Closes #14746

## Goal
Goal: green

## Verification
- `cargo test -p tsz-checker --test spread_any_value_ts2556_tests` — 9/9 pass (6 positives that fail on baseline, 2 TS2556 negative controls, 1 cross-module witness).
- `cargo test -p tsz-checker --test overload_spread_into_rest_ts2556_tests --test variadic_tuple_spread_arity_ts2556_tests --test spread_rest_diagnostics_tests --test overload_nontuple_spread_rest_fallback_tests` — all pass (no spread-TS2556 regressions).
- CLI repro of the two-file jotai witness (`freeze.ts`/`atom.ts`) is now clean (was `freeze.ts(9,20): error TS2556`).
- ready-review CI owns the full conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_014DCQ6EKBc22PqEqbTiBwxR)_