### PR TITLE
fix(solver): reduce enum subtypes into their base primitive in unions

### DIFF
--- a/crates/tsz-checker/tests/enum_literal_comparison_overlap_tests.rs
+++ b/crates/tsz-checker/tests/enum_literal_comparison_overlap_tests.rs
@@ -276,3 +276,110 @@ switch (k) {
         "only the non-member case reports TS2678 for a mixed enum: {c:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// TS2367 operand display: enum-base widening + union subtype reduction.
+//
+// tsc renders each no-overlap operand through `getBaseTypeOfLiteralType`
+// (enum member -> parent enum, literal -> base primitive) and then reduces the
+// resulting union via `getUnionType`. A numeric enum is a subtype of `number`
+// and a string enum of `string`, so when an enum-member operand sits in a
+// union beside a literal of that base primitive the enum collapses into the
+// primitive: `E.A | 1` displays as `number`, `S.X | "lit"` as `string`. A
+// disjoint pairing (string enum beside a numeric literal) is preserved.
+//
+// Owner layer: solver union subtype-reduction (`is_subtype_shallow` now defers
+// an enum to its structural member union). Binder names are varied so the rule
+// is name-independent.
+// ---------------------------------------------------------------------------
+
+use tsz_checker::test_utils::check_source_strict_messages;
+
+fn ts2367_message(src: &str) -> String {
+    check_source_strict_messages(src)
+        .into_iter()
+        .find(|(c, _)| *c == 2367)
+        .map(|(_, m)| m)
+        .unwrap_or_else(|| panic!("expected a TS2367 diagnostic for: {src}"))
+}
+
+#[test]
+fn numeric_enum_member_union_with_literal_displays_as_number() {
+    // `Hue.Red | 1` widens to `Color | number` then reduces to `number`.
+    let msg = ts2367_message(
+        r#"
+enum Hue { Red, Green }
+declare const sample: Hue.Red | 1;
+const cmp = sample === "needle";
+"#,
+    );
+    assert!(
+        msg.contains("'number' and 'string'"),
+        "numeric enum member unioned with a number literal must display as 'number': {msg}"
+    );
+}
+
+#[test]
+fn string_enum_member_union_with_literal_displays_as_string() {
+    // `Tag.Open | "extra"` widens to `Marker | string` then reduces to `string`.
+    let msg = ts2367_message(
+        r#"
+enum Tag { Open = "open", Shut = "shut" }
+declare const sample: Tag.Open | "extra";
+const cmp = sample === 42;
+"#,
+    );
+    assert!(
+        msg.contains("'string' and 'number'"),
+        "string enum member unioned with a string literal must display as 'string': {msg}"
+    );
+}
+
+#[test]
+fn numeric_enum_member_union_with_distinct_value_still_displays_as_number() {
+    // The literal need not be a member value; the base primitive still absorbs.
+    let msg = ts2367_message(
+        r#"
+enum Level { Low = 5, High = 6 }
+declare const sample: Level.Low | 9;
+const cmp = sample === "needle";
+"#,
+    );
+    assert!(
+        msg.contains("'number' and 'string'"),
+        "numeric enum member unioned with any number literal displays as 'number': {msg}"
+    );
+}
+
+#[test]
+fn string_enum_union_with_numeric_literal_is_preserved() {
+    // A string enum is disjoint from `number`, so the union is kept (no collapse).
+    let msg = ts2367_message(
+        r#"
+enum Mode { On = "on", Off = "off" }
+declare const sample: Mode.On | 1;
+const cmp = sample === true;
+"#,
+    );
+    assert!(
+        msg.contains("'number | Mode' and 'boolean'"),
+        "string enum disjoint from number must keep the union 'number | Mode': {msg}"
+    );
+}
+
+#[test]
+fn bare_enum_member_comparison_keeps_enum_name() {
+    // A bare enum-member operand (no union) still widens to the parent enum and
+    // is displayed by name, not collapsed to a primitive.
+    let msg = ts2367_message(
+        r#"
+enum Alpha { A, B }
+enum Beta { X = "x" }
+const cmp = Alpha.A === Beta.X;
+"#,
+    );
+    assert!(
+        msg.contains("'Alpha' and 'Beta'"),
+        "bare enum member comparison must show parent enum names: {msg}"
+    );
+}

--- a/crates/tsz-checker/tests/enum_literal_comparison_overlap_tests.rs
+++ b/crates/tsz-checker/tests/enum_literal_comparison_overlap_tests.rs
@@ -299,8 +299,10 @@ fn ts2367_message(src: &str) -> String {
     check_source_strict_messages(src)
         .into_iter()
         .find(|(c, _)| *c == 2367)
-        .map(|(_, m)| m)
-        .unwrap_or_else(|| panic!("expected a TS2367 diagnostic for: {src}"))
+        .map_or_else(
+            || panic!("expected a TS2367 diagnostic for: {src}"),
+            |(_, m)| m,
+        )
 }
 
 #[test]

--- a/crates/tsz-solver/src/intern/normalize_tests.rs
+++ b/crates/tsz-solver/src/intern/normalize_tests.rs
@@ -238,6 +238,64 @@ fn literal_mask_preserves_object_vs_literal_reduction() {
     assert!(list.contains(&interner.literal_string("y")));
 }
 
+#[test]
+fn enum_absorbed_into_base_primitive_in_union_reduction() {
+    use crate::def::DefId;
+    let interner = TypeInterner::new();
+    // A nominal enum wrapping a union of `members` under `def`.
+    let mk_enum =
+        |def: u32, members: Vec<TypeId>| interner.enum_type(DefId(def), interner.union(members));
+    let num_members = || vec![interner.literal_number(0.0), interner.literal_number(1.0)];
+
+    // A numeric enum's structural member union (`0 | 1`) is a subtype of
+    // `number`, so `number | E` reduces to `number`; a string enum's
+    // (`"p" | "q"`) is a subtype of `string`, so `string | S` reduces to
+    // `string`. This mirrors tsc's `getUnionType` reduction after
+    // `getBaseTypeOfLiteralType` brands enum members as their base primitive.
+    let num_enum = mk_enum(7001, num_members());
+    assert_eq!(
+        interner.union(vec![TypeId::NUMBER, num_enum]),
+        TypeId::NUMBER,
+        "number | (numeric enum) must reduce to number"
+    );
+    // Intersection mirrors this: `E & number` keeps the nominal enum.
+    assert_eq!(
+        interner.intersection(vec![TypeId::NUMBER, num_enum]),
+        num_enum,
+        "number & (numeric enum) must reduce to the enum"
+    );
+
+    let str_enum = mk_enum(
+        7002,
+        vec![interner.literal_string("p"), interner.literal_string("q")],
+    );
+    assert_eq!(
+        interner.union(vec![TypeId::STRING, str_enum]),
+        TypeId::STRING,
+        "string | (string enum) must reduce to string"
+    );
+
+    // A string enum is disjoint from `number`, so `number | S` is preserved.
+    let mixed = interner.union(vec![TypeId::NUMBER, str_enum]);
+    let Some(TypeData::Union(list_id)) = interner.lookup(mixed) else {
+        panic!("number | (string enum) must stay a union");
+    };
+    assert_eq!(interner.type_list(list_id).len(), 2);
+
+    // Distinct enums stay nominal: neither absorbs the other even with
+    // identical structural members.
+    let other_num_enum = mk_enum(7003, num_members());
+    let two = interner.union(vec![num_enum, other_num_enum]);
+    let Some(TypeData::Union(list_id)) = interner.lookup(two) else {
+        panic!("two distinct enums must stay a union");
+    };
+    assert_eq!(
+        interner.type_list(list_id).len(),
+        2,
+        "distinct enums are nominal and irreducible"
+    );
+}
+
 fn distinct_keyof(interner: &TypeInterner, n: u32) -> TypeId {
     // `keyof <unique literal>` — a distinct, unevaluated `TypeData::KeyOf`
     // per `n`. This is the shape produced by distributing `keyof` over a

--- a/crates/tsz-solver/src/intern/shallow_subtype.rs
+++ b/crates/tsz-solver/src/intern/shallow_subtype.rs
@@ -103,6 +103,22 @@ impl TypeInterner {
             }
         }
 
+        // An enum is a subtype of a non-enum target exactly when its structural
+        // member union is: a numeric enum's members are number literals
+        // (`E <: number`), a string enum's are string literals (`S <: string`).
+        // This lets union/intersection reduction collapse `number | E` to
+        // `number` and `string | S` to `string`, matching tsc's `getUnionType`
+        // reduction (`getBaseTypeOfLiteralType` brands enum members as their base
+        // primitive). Deferring to the structural type keeps enums nominal: a
+        // bare literal is never a subtype of a nominal `Enum` *target*, so an
+        // `Enum` target still falls through to the identity check and `E1 <: E2`
+        // stays false for distinct enums.
+        if let Some(TypeData::Enum(_, structural)) = s_data
+            && !matches!(t_data, Some(TypeData::Enum(..)))
+        {
+            return self.is_subtype_shallow_depth(structural, target, depth);
+        }
+
         // Handle source as member of target union (for built-in/primitive types only).
         if self.is_builtin_type(source)
             && let Some(TypeData::Union(members)) = t_data


### PR DESCRIPTION
A numeric enum is a subtype of `number` and a string enum of `string`, so tsc
collapses them in a union: `number | E` reduces to `number` and `string | S`
to `string` (tsc's `getUnionType` reduction after `getBaseTypeOfLiteralType`
brands each enum member as its base primitive). tsz's shallow subtype engine
(`is_subtype_shallow`, used by union/intersection normalization) had no `Enum`
case, so the enum survived the reduction.

The user-visible symptom is the TS2367 "no overlap" operand display
(issue #14807). The cross-family widening cases the issue lists
(`void`/object/function/enum-member/union vs literal) already match tsc after
#15007; the remaining divergence was the enum-in-a-union facet:

```ts
enum E { A, B }
declare const sample: E.A | 1;
const cmp = sample === "x";
// tsc:  types 'number' and 'string' have no overlap.
// tsz:  types 'number | E' and 'string' have no overlap.   (before)
```

## Structural rule

When an enum operand sits in a union beside its base primitive, tsc reduces the
union by absorbing the enum into the primitive (`E.A | 1` → `E | number` →
`number`; `S.X | "lit"` → `S | string` → `string`); tsz now does the same
through the solver's `is_subtype_shallow` union/intersection reducer. A string
enum unioned with `number` (`S.X | 1`) stays `number | S` because it is
disjoint from the primitive, matching tsc.

## Owner layer

Solver — `crates/tsz-solver/src/intern/shallow_subtype.rs`. The fix defers an
`Enum` *source* to its structural member union (the `TypeData::Enum(_,
structural)` field, documented as "used for assignability to primitives"),
guarded so an `Enum` *target* still matches only by identity. This keeps enums
nominal: distinct enums (`E1` vs `E2`) never reduce into each other, and
`E.a | E.b` still merges to `E` via the existing `merge_same_enum_parts`. It
mirrors the full subtype relation (which already defers an enum source to its
structural members) rather than special-casing the TS2367 display path.

## Adjacent matrix (verified vs `tsc` 6.0.2)

- `E.A | 1 === "x"` → `'number'` / `'string'`
- `S.X | "lit" === 1` → `'string'` / `'number'`
- `E.A | 9 === "x"` (literal ≠ member value) → `'number'` / `'string'`
- `S.X | 1 === true` (string enum disjoint from number) → `'number | S'` / `'boolean'` (preserved)
- `E.A === F.X` (bare member, no union) → `'E'` / `'F'` (unchanged)
- `number | E` / `string | S` / `E & number` reduce generally, not just in TS2367
- nominal `E1` vs `E2` still incompatible (TS2322 unchanged)

## Non-goal

The union member *order* tsc shows (`(1|2) === 3` renders `'2 | 1'`) reflects
tsc's internal literal-interning order, not a semantic rule; matching it would
be a display-only hack and is intentionally not pursued. A `number | E`
annotation whose enum is still a `Lazy(DefId)` ref at normalization time is not
reduced (the shallow engine skips unresolved refs); that is a separate
resolution-timing matter.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-solver -E 'test(enum_absorbed_into_base_primitive_in_union_reduction)'`
- `cargo nextest run -p tsz-checker --test enum_literal_comparison_overlap_tests` (18 pass)
- `cargo nextest run -p tsz-checker --test ts2367_comparison_overlap_tests` (57 pass)
- `cargo nextest run -p tsz-checker --test enum_nominality_tests` (40 pass)
- Full conformance/emit/fourslash via ready-review CI.

Fixes #14807

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuicjbST4xVxtP3CvNfFky)_