### PR TITLE
fix(checker): resolve Lazy alias args in the TS2589 convergence metric

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -428,6 +428,9 @@ path = "tests/reverse_mapped_inference_tests.rs"
 name = "recursive_alias_resolution_tests"
 path = "tests/recursive_alias_resolution_tests.rs"
 [[test]]
+name = "recursive_alias_named_tuple_arg_ts2589_tests"
+path = "tests/recursive_alias_named_tuple_arg_ts2589_tests.rs"
+[[test]]
 name = "recursive_intersection_assignability_tests"
 path = "tests/recursive_intersection_assignability_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/type_environment.rs
@@ -28,12 +28,13 @@ pub(crate) fn collect_concrete_applications_with_def(
 /// `def_id`, or `None` if `type_id` is not such an application. The shared
 /// recursion-growth metric used to decide whether a residual self-application
 /// is converging (shrinking) or diverging.
-pub(crate) fn self_application_arg_weight(
+pub(crate) fn self_application_arg_weight<R: tsz_solver::relations::subtype::TypeResolver>(
     db: &dyn TypeDatabase,
+    resolver: &R,
     type_id: TypeId,
     def_id: tsz_solver::def::DefId,
 ) -> Option<u64> {
-    tsz_solver::visitor::self_application_arg_weight(db, type_id, def_id)
+    tsz_solver::visitor::self_application_arg_weight(db, resolver, type_id, def_id)
 }
 
 /// Thin wrapper around `tsz_solver::computation::TypeEvaluator`.

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -764,6 +764,7 @@ impl CheckerState<'_> {
             );
             match crate::query_boundaries::state::type_environment::self_application_arg_weight(
                 db,
+                &*env,
                 type_id,
                 alias_def_id,
             ) {
@@ -772,6 +773,7 @@ impl CheckerState<'_> {
                     let diverges = residuals.iter().any(|&residual| {
                         crate::query_boundaries::state::type_environment::self_application_arg_weight(
                             db,
+                            &*env,
                             residual,
                             alias_def_id,
                         )

--- a/crates/tsz-checker/tests/recursive_alias_named_tuple_arg_ts2589_tests.rs
+++ b/crates/tsz-checker/tests/recursive_alias_named_tuple_arg_ts2589_tests.rs
@@ -1,0 +1,130 @@
+//! Regression tests: a terminating recursive conditional alias driven by a
+//! *named* tuple-type-alias argument must not trip a spurious TS2589.
+//!
+//! Root cause (use-site TS2589 convergence check): the residual-growth metric
+//! compared the input application's argument weight against the residual
+//! self-applications left in the evaluated body. A named tuple alias argument
+//! (`type TN = [0, 0]`, a `Lazy(DefId)` reference) was scored as a single opaque
+//! unit on the *input* side, while the evaluator left the *resolved* inline
+//! tuple in the residual — so a recursion that is actually shrinking
+//! (`Nest<T, TN>` -> `Nest<T, [...shorter]>`) was misread as growing and flagged
+//! infinite. The fix resolves `Lazy(DefId)` alias arguments before weighing, so
+//! a named alias and its inline expansion weigh identically.
+//!
+//! `tsc` accepts every "must be clean" case below and still reports TS2589 for
+//! the genuinely diverging one.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn diagnostic_codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|diag| diag.code)
+        .collect()
+}
+
+#[test]
+fn shrinking_recursion_with_named_tuple_alias_arg_is_not_ts2589() {
+    let codes = diagnostic_codes(
+        r#"
+type Nest<T, N extends readonly any[]> =
+  N extends readonly [any, ...infer R] ? { child: Nest<T, R> } : T;
+type TN = [0, 0];
+declare const d: Nest<{ leaf: string }, TN>;
+"#,
+    );
+    assert!(
+        !codes.contains(&2589),
+        "terminating recursion through a named tuple alias arg must not be TS2589: {codes:?}"
+    );
+}
+
+#[test]
+fn shrinking_recursion_with_named_tuple_alias_arg_renamed_binders_is_not_ts2589() {
+    // Same structure as above with every user-chosen identifier renamed, so the
+    // fix is proven structural rather than keyed on any particular binder name.
+    let codes = diagnostic_codes(
+        r#"
+type Wrap<Payload, Steps extends readonly any[]> =
+  Steps extends readonly [any, ...infer Rest] ? { next: Wrap<Payload, Rest> } : Payload;
+type Counter = [unknown, unknown, unknown];
+declare const value: Wrap<{ tag: number }, Counter>;
+"#,
+    );
+    assert!(
+        !codes.contains(&2589),
+        "renamed-binder variant must also avoid spurious TS2589: {codes:?}"
+    );
+}
+
+#[test]
+fn shrinking_recursion_named_alias_first_arg_position_is_not_ts2589() {
+    // The named alias sits in the carried (non-driving) argument position; the
+    // driving tuple is inline. The fix must not depend on argument order.
+    let codes = diagnostic_codes(
+        r#"
+type Nest<T, N extends readonly any[]> =
+  N extends readonly [any, ...infer R] ? { child: Nest<T, R> } : T;
+type Carried = [0, 0];
+declare const d: Nest<Carried, [0, 0]>;
+"#,
+    );
+    assert!(
+        !codes.contains(&2589),
+        "named alias in the carried argument must not be TS2589: {codes:?}"
+    );
+}
+
+#[test]
+fn inline_tuple_arg_control_is_not_ts2589() {
+    // Control: the inline-tuple form always worked; it must keep working.
+    let codes = diagnostic_codes(
+        r#"
+type Nest<T, N extends readonly any[]> =
+  N extends readonly [any, ...infer R] ? { child: Nest<T, R> } : T;
+declare const d: Nest<{ leaf: string }, [0, 0]>;
+"#,
+    );
+    assert!(
+        !codes.contains(&2589),
+        "inline-tuple control must not be TS2589: {codes:?}"
+    );
+}
+
+#[test]
+fn deep_terminating_recursion_with_named_tuple_alias_arg_is_not_ts2589() {
+    // A longer (but still finite) seed exercises more recursion steps; tsc is
+    // clean here too.
+    let codes = diagnostic_codes(
+        r#"
+type Nest<T, N extends readonly any[]> =
+  N extends readonly [any, ...infer R] ? { child: Nest<T, R> } : T;
+type TN = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
+declare const d: Nest<{ leaf: string }, TN>;
+"#,
+    );
+    assert!(
+        !codes.contains(&2589),
+        "deep terminating recursion through a named tuple alias arg must not be TS2589: {codes:?}"
+    );
+}
+
+#[test]
+fn growing_recursion_with_named_tuple_alias_arg_still_emits_ts2589() {
+    // True-positive guard: the same named-alias shape but with a *growing*
+    // driving tuple (`[any, ...N]`) never reaches a base case. tsc reports
+    // TS2589; the fix must keep detecting genuine divergence rather than
+    // blanket-suppressing it once a named alias is involved.
+    let codes = diagnostic_codes(
+        r#"
+type Grow<T, N extends readonly any[]> =
+  N extends readonly [any, ...infer R] ? Grow<T, [any, ...N]> : T;
+type TN = [0, 0];
+declare const d: Grow<{ leaf: string }, TN>;
+"#,
+    );
+    assert!(
+        codes.contains(&2589),
+        "genuinely diverging recursion must still emit TS2589: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/visitors/visitor.rs
+++ b/crates/tsz-solver/src/visitors/visitor.rs
@@ -40,6 +40,7 @@
 
 use crate::construction::TypeDatabase;
 use crate::def::DefId;
+use crate::relations::subtype::TypeResolver;
 use crate::types::{IntrinsicKind, StringIntrinsicKind, TupleElement, TypeParamInfo};
 use crate::{LiteralValue, SymbolRef, TypeData, TypeId};
 use rustc_hash::FxHashSet;
@@ -629,6 +630,37 @@ fn unbounded_growth_weight(types: &dyn TypeDatabase, type_id: TypeId) -> u64 {
     }
 }
 
+/// Follow a `Lazy(DefId)` reference (bounded) to the underlying type so the
+/// growth metric measures the *resolved* shape rather than treating the
+/// reference as a single opaque unit.
+///
+/// A named alias argument such as `type TN = [0, 0]` must weigh the same as the
+/// inline `[0, 0]` it stands for. Without this, the use-site convergence check
+/// (see [`self_application_arg_weight`]) compares an unresolved `Lazy` arg on the
+/// *input* side (scored as a single unit) against the resolved tuple / string /
+/// template that the evaluator left in a *residual* self-application, so a
+/// recursion that is actually shrinking (`Nest<T, TN>` -> `Nest<T, [...]>` with a
+/// shorter tail) is misread as growing and trips a spurious TS2589. The bounded
+/// hop count mirrors the alias-resolution cap in
+/// `evaluate_rules::keyof::resolve_index_signature_key_alias`.
+fn resolve_lazy_for_growth_weight<R: TypeResolver>(
+    types: &dyn TypeDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> TypeId {
+    let mut current = type_id;
+    for _ in 0..8 {
+        let Some(TypeData::Lazy(def_id)) = types.lookup(current) else {
+            return current;
+        };
+        match resolver.resolve_lazy(def_id, types) {
+            Some(next) if next != current => current = next,
+            _ => return current,
+        }
+    }
+    current
+}
+
 /// Total structural weight of the arguments of a concrete `Application` of
 /// `target_def_id`, or `None` if `type_id` is not such an application.
 ///
@@ -637,8 +669,15 @@ fn unbounded_growth_weight(types: &dyn TypeDatabase, type_id: TypeId) -> u64 {
 /// argument weight is strictly smaller is making progress toward the base case
 /// (e.g. a variadic tuple tail that loses an element each step) and is not, on
 /// its own, evidence of an infinite instantiation.
-pub fn self_application_arg_weight(
+///
+/// Each argument is first resolved through any `Lazy(DefId)` alias indirection
+/// (see [`resolve_lazy_for_growth_weight`]) so that a named-alias argument and
+/// its inline expansion weigh identically — the input and residual sides of the
+/// comparison must measure the same shape regardless of whether the argument was
+/// written as an alias reference or spelled out inline.
+pub fn self_application_arg_weight<R: TypeResolver>(
     types: &dyn TypeDatabase,
+    resolver: &R,
     type_id: TypeId,
     target_def_id: DefId,
 ) -> Option<u64> {
@@ -650,7 +689,10 @@ pub fn self_application_arg_weight(
             return Some(
                 app.args
                     .iter()
-                    .map(|&a| unbounded_growth_weight(types, a))
+                    .map(|&a| {
+                        let resolved = resolve_lazy_for_growth_weight(types, resolver, a);
+                        unbounded_growth_weight(types, resolved)
+                    })
                     .sum(),
             );
         }


### PR DESCRIPTION
A terminating recursive conditional type alias driven by a **named** tuple-type-alias argument trips a spurious TS2589 ("Type instantiation is excessively deep and possibly infinite"):

```ts
type Nest<T, N extends readonly any[]> =
  N extends readonly [any, ...infer R] ? { child: Nest<T, R> } : T;
type TN = [0, 0];
declare const d: Nest<{ leaf: string }, TN>;   // tsc: ok; tsz: TS2589
```

The same recursion written with an **inline** tuple (`Nest<{leaf}, [0, 0]>`) is accepted — only the named-alias form fails — so the divergence is purely an artifact of how the alias argument is weighed, not real infinite recursion (it terminates at depth 2).

**Structural rule:** when the use-site TS2589 convergence check compares a recursive alias's input application against the residual self-applications left in its evaluated body, the per-argument growth weight must measure the same shape on both sides; tsc accepts the terminating recursion, and tsz must too through the solver growth metric. `self_application_arg_weight` scored a `Lazy(DefId)` alias argument (the named tuple `TN`) as a single opaque unit on the *input* side, while the evaluator left the *resolved* inline tuple in the residual. A recursion that is actually shrinking (`Nest<T, TN>` → `Nest<T, [...shorter]>`) therefore looked like growth (`residual_weight > input_weight`) and was flagged divergent.

**Fix (owner: solver growth metric).** `self_application_arg_weight` now resolves `Lazy(DefId)` alias arguments through bounded indirection before weighing, so a named alias and its inline expansion weigh identically. Both the input and residual sides route through this function, keeping the comparison symmetric. The bounded hop count mirrors the existing alias-resolution cap in `evaluate_rules::keyof::resolve_index_signature_key_alias`. Genuine divergence is unaffected: a recursion whose driving tuple grows (`Grow<T, [any, ...N]>`) still has a residual strictly larger than the resolved input and still emits TS2589.

This was found while investigating the recursive-alias evaluation lane of #14337 (it is a distinct, adjacent TS2589 false-positive, not the constraint-degradation root tracked there).

## Goal
Goal: hold

## Verification
- New regression suite (all pass): `cargo test -p tsz-checker --test recursive_alias_named_tuple_arg_ts2589_tests` — covers the named-alias shrinking case, a renamed-binder variant, named alias in the carried argument position, the inline-tuple control, a deeper (N=30) terminating case, and a true-positive guard asserting a genuinely growing recursion still emits TS2589.
- Manual `tsz` vs `tsc` parity confirmed on all of the above plus the original witness.
- Targeted `cargo test -p tsz-checker --lib 2589` shows no new failures introduced by this change.
- `cargo clippy -p tsz-solver -p tsz-checker` clean; `cargo fmt` applied.
- Broad conformance/emit/integration suites: deferred to ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAf1B5jDCDHEoTN5dQcLth)_