### PR TITLE
fix(solver): keep readonly arrays/tuples in the !Array.isArray negative branch

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -797,6 +797,9 @@ path = "tests/computed_property_name_type_position_no_ts2454_tests.rs"
 name = "array_isarray_mutual_subtype_narrowing_tests"
 path = "tests/array_isarray_mutual_subtype_narrowing_tests.rs"
 [[test]]
+name = "array_isarray_negative_branch_readonly_tests"
+path = "tests/array_isarray_negative_branch_readonly_tests.rs"
+[[test]]
 name = "typeof_const_member_conditional_tests"
 path = "tests/typeof_const_member_conditional_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/array_isarray_negative_branch_readonly_tests.rs
+++ b/crates/tsz-checker/tests/array_isarray_negative_branch_readonly_tests.rs
@@ -1,0 +1,205 @@
+//! Tests for the negative `!Array.isArray(x)` branch keeping `readonly`
+//! array-likes (issue #14782).
+//!
+//! Rule under test:
+//!
+//! > `Array.isArray`'s effective type predicate is `x is any[]` — a MUTABLE
+//! > array. A `readonly` array/tuple (`readonly T[]`, `readonly [..]`,
+//! > `ReadonlyArray<T>`) is NOT assignable to a mutable `any[]`, so tsc KEEPS
+//! > those members in the negative (`else`) branch of `if (Array.isArray(x))`.
+//! > Only mutable arrays/tuples are subtracted. tsz previously dropped readonly
+//! > array-likes too, narrowing a single readonly array to `never` and masking
+//! > downstream assignability/property errors (a soundness gap / false
+//! > negative).
+//!
+//! The rule is *structural*, not name-bound: each case varies the binder and
+//! element-type spelling so the behavior cannot be a fixture-name fast path.
+//! All cases use the es5 lib so `Array.isArray` resolves to its real
+//! `arg is any[]` predicate and `ReadonlyArray`/`Array` are defined.
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs_code_messages, load_lib_files};
+
+fn check_es5(source: &str) -> Vec<(u32, String)> {
+    let libs = load_lib_files(&["es5.d.ts"]);
+    check_source_with_libs_code_messages(source, "test.ts", CheckerOptions::default(), &libs)
+}
+
+// ─── readonly single member is kept (not collapsed to `never`) ───────────────
+
+/// A lone `readonly T[]` source must stay `readonly T[]` in the `else` branch,
+/// so assigning it to `never` is a TS2322. Pre-#14782 tsz narrowed it to
+/// `never` and accepted the assignment (false negative).
+#[test]
+fn negative_branch_keeps_readonly_array_single() {
+    let source = r#"
+function probe(values: readonly number[]) {
+    if (Array.isArray(values)) {
+    } else {
+        const sink: never = values;
+    }
+}
+"#;
+    let diags = check_es5(source);
+    let ts2322: Vec<_> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert!(
+        !ts2322.is_empty(),
+        "readonly number[] must be kept in the !Array.isArray branch (not narrowed to never), \
+         so `const sink: never = values` should be TS2322; got: {diags:?}"
+    );
+}
+
+/// `ReadonlyArray<T>` (the lib generic, distinct element spelling) is likewise
+/// kept in the negative branch.
+#[test]
+fn negative_branch_keeps_readonly_array_generic_single() {
+    let source = r#"
+function inspect(items: ReadonlyArray<string>) {
+    if (Array.isArray(items)) {
+    } else {
+        const out: number = items;
+    }
+}
+"#;
+    let diags = check_es5(source);
+    let ts2322: Vec<_> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert!(
+        !ts2322.is_empty(),
+        "ReadonlyArray<string> must be kept in the !Array.isArray branch, so \
+         `const out: number = items` should be TS2322; got: {diags:?}"
+    );
+}
+
+/// A `readonly` tuple (`ReadonlyType(Tuple)`) is kept too.
+#[test]
+fn negative_branch_keeps_readonly_tuple_single() {
+    let source = r#"
+function unpack(pair: readonly [number, string]) {
+    if (Array.isArray(pair)) {
+    } else {
+        const gone: never = pair;
+    }
+}
+"#;
+    let diags = check_es5(source);
+    let ts2322: Vec<_> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert!(
+        !ts2322.is_empty(),
+        "readonly [number, string] must be kept in the !Array.isArray branch; \
+         `const gone: never = pair` should be TS2322; got: {diags:?}"
+    );
+}
+
+// ─── mutable members are still subtracted (controls that discriminate) ───────
+
+/// A lone *mutable* `T[]` is still narrowed to `never` in the negative branch
+/// (it IS assignable to the mutable `any[]` predicate). Assigning to `never`
+/// must therefore be accepted — proving the fix discriminates readonly from
+/// mutable rather than blanket-keeping every array.
+#[test]
+fn negative_branch_subtracts_mutable_array_single_to_never() {
+    let source = r#"
+function probe(values: number[]) {
+    if (Array.isArray(values)) {
+    } else {
+        const sink: never = values;
+    }
+}
+"#;
+    let diags = check_es5(source);
+    let ts2322: Vec<_> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "mutable number[] must still narrow to never in the !Array.isArray branch, \
+         so `const sink: never = values` must be accepted; got: {diags:?}"
+    );
+}
+
+/// A lone *mutable* tuple is also subtracted to `never`.
+#[test]
+fn negative_branch_subtracts_mutable_tuple_single_to_never() {
+    let source = r#"
+function unpack(pair: [number, string]) {
+    if (Array.isArray(pair)) {
+    } else {
+        const gone: never = pair;
+    }
+}
+"#;
+    let diags = check_es5(source);
+    let ts2322: Vec<_> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "mutable [number, string] must still narrow to never in the !Array.isArray branch; \
+         `const gone: never = pair` must be accepted; got: {diags:?}"
+    );
+}
+
+// ─── unions: readonly kept, mutable dropped ──────────────────────────────────
+
+/// In `readonly T[] | scalar`, the `else` branch keeps both members, so the
+/// whole source is not assignable to the scalar alone (TS2322).
+#[test]
+fn negative_branch_union_keeps_readonly_member() {
+    let source = r#"
+function handle(input: readonly string[] | number) {
+    if (Array.isArray(input)) {
+    } else {
+        const n: number = input;
+    }
+}
+"#;
+    let diags = check_es5(source);
+    let ts2322: Vec<_> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert!(
+        !ts2322.is_empty(),
+        "readonly string[] must survive into the else branch alongside number, so \
+         `const n: number = input` should be TS2322; got: {diags:?}"
+    );
+}
+
+/// In `mutable T[] | scalar`, the mutable array is removed, leaving only the
+/// scalar — so assigning to the scalar is accepted (no TS2322). Discriminating
+/// control versus the readonly-union case above.
+#[test]
+fn negative_branch_union_drops_mutable_member() {
+    let source = r#"
+function handle(input: string[] | number) {
+    if (Array.isArray(input)) {
+    } else {
+        const n: number = input;
+    }
+}
+"#;
+    let diags = check_es5(source);
+    let ts2322: Vec<_> = diags.iter().filter(|(c, _)| *c == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "mutable string[] must be removed from the else branch, leaving only number, so \
+         `const n: number = input` must be accepted; got: {diags:?}"
+    );
+}
+
+// ─── downstream property access is no longer masked ──────────────────────────
+
+/// With a readonly array kept in the else branch, a property that exists only
+/// on the object member is a TS2339 (pre-#14782 the readonly member was dropped
+/// and the access silently succeeded against the object alone).
+#[test]
+fn negative_branch_readonly_union_member_unmasks_property_error() {
+    let source = r#"
+function route(value: ReadonlyArray<string> | { tag: "obj" }) {
+    if (Array.isArray(value)) {
+    } else {
+        const t: "obj" = value.tag;
+    }
+}
+"#;
+    let diags = check_es5(source);
+    let ts2339: Vec<_> = diags.iter().filter(|(c, _)| *c == 2339).collect();
+    assert!(
+        !ts2339.is_empty(),
+        "readonly string[] must remain in the else branch, so `value.tag` should be a \
+         TS2339 on the readonly-array member; got: {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/narrowing/compound.rs
+++ b/crates/tsz-solver/src/narrowing/compound.rs
@@ -825,12 +825,20 @@ impl<'a> NarrowingContext<'a> {
 
     /// Exclude array-like types from a type.
     ///
-    /// Used for `!Array.isArray(x)` in the false branch.
-    /// Removes arrays, tuples, and readonly arrays.
+    /// Used for `!Array.isArray(x)` in the false branch. `Array.isArray`'s
+    /// effective type predicate is `x is any[]` — a MUTABLE array — so only
+    /// members assignable to a mutable `any[]` are subtracted. `readonly`
+    /// arrays/tuples (`ReadonlyType`-wrapped arrays/tuples and `ReadonlyArray<T>`
+    /// applications) are NOT assignable to `any[]`, so tsc keeps them in the
+    /// negative branch; subtracting them is a soundness gap (#14782). Only
+    /// mutable arrays/tuples are removed here; the positive branch
+    /// (`narrow_to_array`) still absorbs readonly arrays into `any[]`.
     ///
     /// # Examples
     /// - `narrow_excluding_array(string[] | number)` → `number`
     /// - `narrow_excluding_array(string[])` → `NEVER`
+    /// - `narrow_excluding_array(readonly string[])` → `readonly string[]`
+    /// - `narrow_excluding_array(readonly string[] | number)` → `readonly string[] | number`
     /// - `narrow_excluding_array(unknown)` → `unknown`
     pub(crate) fn narrow_excluding_array(&self, source_type: TypeId) -> TypeId {
         // Handle ANY and UNKNOWN
@@ -843,7 +851,7 @@ impl<'a> NarrowingContext<'a> {
             return TypeId::UNKNOWN;
         }
 
-        if self.is_array_like(source_type) {
+        if self.is_mutable_array_like(source_type) {
             return TypeId::NEVER;
         }
 
@@ -889,12 +897,11 @@ impl<'a> NarrowingContext<'a> {
             }
         }
 
-        // If array-like, return NEVER (excluded)
-        if self.is_array_like(source_type) {
-            return TypeId::NEVER;
-        }
-
-        // Not array-like, keep as-is
+        // `source_type` is an immutable parameter and was already checked for
+        // mutable-array-likeness at the top of this function (returning NEVER),
+        // so any type reaching here is kept as-is. `readonly` arrays/tuples in
+        // particular survive: they are not assignable to the predicate's
+        // mutable `any[]` type (#14782).
         source_type
     }
 
@@ -914,6 +921,30 @@ impl<'a> NarrowingContext<'a> {
         }
 
         // Check if type is Array, Tuple, or ReadonlyArray (wrapped)
+        type_queries::is_array_type(self.db, type_id)
+            || type_queries::is_tuple_type(self.db, type_id)
+    }
+
+    /// Check if a type is a *mutable* array-like (a plain `Array<T>`/`T[]` or a
+    /// mutable tuple) — i.e. assignable to the mutable `any[]` type predicate
+    /// that `Array.isArray` narrows by.
+    ///
+    /// Unlike [`Self::is_array_like`], this returns `false` for `readonly`
+    /// arrays/tuples: a `ReadonlyType`-wrapped array/tuple or a `ReadonlyArray<T>`
+    /// application. Those are not assignable to a mutable `any[]`, so they must
+    /// be kept in the negative `!Array.isArray(x)` branch to match tsc (#14782).
+    fn is_mutable_array_like(&self, type_id: TypeId) -> bool {
+        use crate::type_queries;
+
+        // `readonly`-wrapped arrays/tuples and `ReadonlyArray<T>` applications
+        // are not mutable arrays, so they are not subtracted by the predicate.
+        if type_queries::is_readonly_type(self.db, type_id)
+            || self.readonly_array_application_element(type_id).is_some()
+        {
+            return false;
+        }
+
+        // A bare `Array<T>`/`T[]` or a (non-readonly) tuple is mutable.
         type_queries::is_array_type(self.db, type_id)
             || type_queries::is_tuple_type(self.db, type_id)
     }


### PR DESCRIPTION
Structural rule: `Array.isArray`'s effective type predicate is `x is any[]` — a **mutable** array. When a member of `x`'s type is a `readonly` array/tuple (`readonly T[]`, `readonly [..]`, or `ReadonlyArray<T>`), it is **not** assignable to a mutable `any[]`, so tsc **keeps** it in the negative (`else`) branch of `if (Array.isArray(x))`; tsz was subtracting it. This narrowed a lone readonly array to `never` and masked downstream assignability/property errors — a soundness gap / false negative (#14782).

The wrong operation was negative type-guard subtraction for the built-in array predicate, owned by `narrow_excluding_array` in `crates/tsz-solver/src/narrowing/compound.rs`, which used `is_array_like` (treats readonly array-likes as removable). The fix adds `is_mutable_array_like` — a plain `Array<T>`/`T[]` or a non-readonly tuple, excluding `ReadonlyType`-wrapped arrays/tuples and `ReadonlyArray<T>` applications (reusing the existing `type_queries::is_readonly_type`) — and uses it for the negative branch. The positive branch (`narrow_to_array`) is unchanged and still absorbs readonly arrays into `any[]`. A now-provably-dead second predicate check on the immutable `source_type` parameter was removed.

Adjacent matrix (all verified against tsc 6.0.2): readonly array / readonly tuple / `ReadonlyArray<T>` single members kept (TS2322 on `never`-binding); mutable array / mutable tuple still collapse to `never` (accepted); `readonly T[] | scalar` keeps both members while `mutable T[] | scalar` drops the array; property access on a kept readonly union member now reports TS2339; user-guard `x is any[]` control unchanged.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test array_isarray_negative_branch_readonly_tests` — 8 new tests (readonly kept + mutable-control discriminators), all pass.
- `cargo test -p tsz-checker --test array_isarray_mutual_subtype_narrowing_tests` — 17 existing positive-branch tests still pass (no regression).
- Differential vs `tsc` 6.0.2 on the issue repro + a 13-case adjacent matrix: tsz now matches tsc exactly.
- `cargo clippy -p tsz-solver` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LU791Fr7QPpPsAphJvMf3U)_