### PR TITLE
fix(checker): elaborate the failing type argument for same-base generic TS2322 (#15072)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -619,9 +619,25 @@ impl<'a> CheckerState<'a> {
                         return true;
                     }
                 } else {
-                    self.error_type_not_assignable_at_with_raw_display_types(
-                        source, target, diag_idx,
-                    );
+                    // The public-variance prepass determined these two
+                    // instantiations of the same generic base are not
+                    // assignable. tsc elaborates the failing type argument
+                    // (`TypeArgumentMismatch`) under the top-line TS2322 — e.g.
+                    //   Type 'Box<string>' is not assignable to type 'Box<number>'.
+                    //     Type 'string' is not assignable to type 'number'.
+                    // Route through the reason-bearing emitter so the nested
+                    // relation reason is rendered, matching the return/argument
+                    // (TS2345) paths instead of dropping it. If that path
+                    // suppresses (the full structural relation disagrees with the
+                    // variance prepass), preserve the prepass decision with the
+                    // bare top-line diagnostic.
+                    let diags_before = self.ctx.diagnostics.len();
+                    self.error_type_not_assignable_with_reason_at(source, target, diag_idx);
+                    if self.ctx.diagnostics.len() == diags_before {
+                        self.error_type_not_assignable_at_with_raw_display_types(
+                            source, target, diag_idx,
+                        );
+                    }
                     return false;
                 }
             }

--- a/crates/tsz-checker/src/assignability/assignment_checker_generic_display_tests.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker_generic_display_tests.rs
@@ -129,3 +129,99 @@ function f<U>(value: Branch<U>): Target<U> {
         "named conditional alias source must not collapse to its branch union, got: {diag:?}"
     );
 }
+
+/// Helper: find the TS2322 and return its `(top message, related messages)`.
+fn ts2322_with_related(diagnostics: &[crate::diagnostics::Diagnostic]) -> (String, Vec<String>) {
+    let diag = diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .expect("expected TS2322");
+    (
+        diag.message_text.clone(),
+        diag.related_information
+            .iter()
+            .map(|r| r.message_text.clone())
+            .collect(),
+    )
+}
+
+/// Assigning one instantiation of a generic to another (same base, differing
+/// type argument) in a **variable declaration** must elaborate the failing
+/// type-argument relation under the top-line TS2322, matching tsc:
+///
+/// ```text
+/// Type 'Container<string>' is not assignable to type 'Container<number>'.
+///   Type 'string' is not assignable to type 'number'.
+/// ```
+///
+/// Regression: the public-variance prepass used to emit a bare top-line and
+/// drop the nested `TypeArgumentMismatch` reason for the var-decl /
+/// assignment-expression path, while the return-statement and argument
+/// (TS2345) paths kept it. Binder names are deliberately non-canonical so the
+/// assertion checks structure, not spellings.
+#[test]
+fn same_base_generic_var_decl_elaborates_failing_type_argument() {
+    let diagnostics = diagnostics_for(
+        r#"
+interface Container<Payload> { item: Payload; }
+declare const source: Container<string>;
+const sink: Container<number> = source;
+"#,
+    );
+    let (top, related) = ts2322_with_related(&diagnostics);
+    assert!(
+        top.contains("Container<string>") && top.contains("Container<number>"),
+        "top line should name both same-base instantiations, got: {top:?}"
+    );
+    assert!(
+        related
+            .iter()
+            .any(|m| m.contains("'string' is not assignable to type 'number'")),
+        "must elaborate the failing type argument under the top-line, got related: {related:?}"
+    );
+}
+
+/// Same divergence through an **assignment expression** (`x = y`) rather than a
+/// declaration: the elaboration must still carry the type-argument reason.
+#[test]
+fn same_base_generic_assignment_expr_elaborates_failing_type_argument() {
+    let diagnostics = diagnostics_for(
+        r#"
+interface Cell<Slot> { slot: Slot; }
+declare let target: Cell<number>;
+declare const origin: Cell<string>;
+target = origin;
+"#,
+    );
+    let (_, related) = ts2322_with_related(&diagnostics);
+    assert!(
+        related
+            .iter()
+            .any(|m| m.contains("'string' is not assignable to type 'number'")),
+        "assignment-expression path must elaborate the failing type argument, got: {related:?}"
+    );
+}
+
+/// Two type parameters where only the **second** argument differs: the
+/// elaboration must point at the offending argument's relation, not be dropped.
+#[test]
+fn same_base_two_type_param_application_elaborates_second_argument() {
+    let diagnostics = diagnostics_for(
+        r#"
+interface Couple<First, Second> { left: First; right: Second; }
+declare const made: Couple<number, string>;
+const want: Couple<number, number> = made;
+"#,
+    );
+    let (top, related) = ts2322_with_related(&diagnostics);
+    assert!(
+        top.contains("Couple<number, string>") && top.contains("Couple<number, number>"),
+        "top line should name both instantiations, got: {top:?}"
+    );
+    assert!(
+        related
+            .iter()
+            .any(|m| m.contains("'string' is not assignable to type 'number'")),
+        "the differing (second) type argument must be elaborated, got: {related:?}"
+    );
+}


### PR DESCRIPTION
When a variable declaration or assignment expression fails `TS2322` because two
instantiations of the **same generic base** differ in a type argument (e.g.
`Box<string>` vs `Box<number>`), tsz dropped the nested type-argument relation
reason that `tsc` renders. The decision, code, span, and top-line all matched
`tsc`; only the indented elaboration tail was missing.

**Structural rule:** when two instantiations of the same generic base are not
assignable, `tsc` elaborates the failing type argument under the top-line
TS2322; tsz now does the same through the checker's assignability reporting
gateway (`error_type_not_assignable_with_reason_at` →
`diagnose_assignment_failure_with_anchor` →
`render_failure_reason(TypeArgumentMismatch)`).

The public-variance prepass in `check_assignable_or_report_at_with_options`
short-circuited the plain same-base case to a bare top-line emitter
(`error_type_not_assignable_at_with_raw_display_types`), which never computes the
`TypeArgumentMismatch` reason. The return-statement and argument (TS2345) paths
already rendered the tail. The fix routes the plain same-base `else` branch
through the reason-bearing emitter, falling back to the bare emitter only if it
suppresses (the structural relation disagrees with the variance prepass) so the
prepass "emit an error" decision is preserved.

Before:
```
d4.ts(3,7): error TS2322: Type 'Box<string>' is not assignable to type 'Box<number>'.
```
After (matches `tsc`):
```
d4.ts(3,7): error TS2322: Type 'Box<string>' is not assignable to type 'Box<number>'.
  Type 'string' is not assignable to type 'number'.
```

**Owner layer:** checker assignability reporting
(`crates/tsz-checker/src/assignability/assignability_diagnostics.rs`).

**Scope / adjacent matrix:** fixes var-decl and assignment-expression contexts
for covariant single- and multi-type-param generics (`Box`, `Pair`, `Promise`,
`Map`, nested `Holder`); the return-statement, argument (TS2345), and
`Array<T>` paths were already correct and stay correct. Deliberately **not**
broadened: the mapped/conditional-alias sub-branches and the
variadic-tuple / destructuring callers of the bare emitter intentionally render
a top-line only (verified by the altitude review and existing arch tests). The
deeper case where `tsc` uses variance elaboration for generics with methods /
contravariant params (tsz emits a structural `PropertyTypeMismatch`) is a
separate solver-reason issue tracked in #15072 as out of scope.

Resolves the var-decl/assignment portion of #15072.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib generic_display_tests` — 7 passed (3 new regression tests: var-decl, assignment-expression, two-type-param, with non-canonical binder names)
- `tsz --noEmit` vs `tsc 6.0.2` on the repro + boundary matrix (`Box`/`Pair`/`Promise`/`Map`/`Holder`, return/argument/Array controls): 10/10 match
- No new failures in the `assignment_checker` / `variance` unit modules (identical pre-existing failure set with and without the change)

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01JsrVijAZzuUK6S2sjtket9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsrVijAZzuUK6S2sjtket9)_