### PR TITLE
refactor(solver): name relation eval stability result (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -197,11 +197,6 @@ impl EvaluationMemoResult {
         self.result.type_id()
     }
 
-    /// Return the collapsed value and its depth-agnostic cache stability verdict.
-    pub(crate) const fn into_type_id_and_stability(self) -> (TypeId, bool) {
-        (self.into_type_id(), self.stable_for_depth_agnostic_cache)
-    }
-
     /// Whether this result can be stored in caches whose key does not capture
     /// ambient recursion depth/fuel state.
     pub(crate) const fn is_stable_for_depth_agnostic_cache(self) -> bool {

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -16,6 +16,7 @@ use crate::construction::TypeDatabase;
 use crate::def::DefId;
 #[cfg(test)]
 use crate::diagnostics::SubtypeFailureReason;
+use crate::evaluation::result::EvaluationMemoResult;
 use crate::objects::{PropertyCollectionResult, collect_properties_cached};
 use crate::operations::AssignabilityChecker;
 #[cfg(test)]
@@ -143,6 +144,48 @@ pub use crate::def::resolver::{NoopResolver, TypeEnvironment, TypeResolver};
 
 use super::rules::intrinsics::boxable_intrinsic_kind;
 use super::visitor::SubtypeVisitor;
+
+/// Result of relation-local type evaluation plus its cache-stability verdict.
+///
+/// Function-relation checking asks fresh evaluators to normalize nested types.
+/// The collapsed type and whether that collapse was depth/budget-stable travel
+/// together so callers do not pass around anonymous `(TypeId, bool)` tuples.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct RelationEvaluationResult {
+    type_id: TypeId,
+    stable_for_depth_agnostic_cache: bool,
+}
+
+impl RelationEvaluationResult {
+    pub(crate) const fn stable(type_id: TypeId) -> Self {
+        Self {
+            type_id,
+            stable_for_depth_agnostic_cache: true,
+        }
+    }
+
+    pub(crate) const fn unstable(type_id: TypeId) -> Self {
+        Self {
+            type_id,
+            stable_for_depth_agnostic_cache: false,
+        }
+    }
+
+    pub(crate) const fn from_depth_agnostic_memo(result: EvaluationMemoResult) -> Self {
+        Self {
+            type_id: result.type_id(),
+            stable_for_depth_agnostic_cache: result.is_stable_for_depth_agnostic_cache(),
+        }
+    }
+
+    pub(crate) const fn type_id(self) -> TypeId {
+        self.type_id
+    }
+
+    pub(crate) fn is_unstable_unknown(self) -> bool {
+        self.type_id == TypeId::UNKNOWN && !self.stable_for_depth_agnostic_cache
+    }
+}
 
 /// Subtype checking context.
 /// Maintains the "seen" set for cycle detection.
@@ -289,10 +332,10 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// This prevents O(n²) behavior when the same type (e.g., a large union) is
     /// evaluated multiple times across different subtype checks.
     /// Key is (`TypeId`, `no_unchecked_indexed_access`) since that flag affects evaluation.
-    /// Value is `(result, stable)` where `stable` records whether the evaluation
-    /// converged without tripping a recursion/depth/budget limit (see
+    /// Value records the collapsed result plus whether evaluation converged
+    /// without tripping a recursion/depth/budget limit (see
     /// `evaluate_type_with_stability`).
-    pub(crate) eval_cache: FxHashMap<(TypeId, bool), (TypeId, bool)>,
+    pub(crate) eval_cache: FxHashMap<(TypeId, bool), RelationEvaluationResult>,
     /// Apparent object shapes for primitive wrapper fallback.
     ///
     /// Primitive structural subtype checks can ask for the same wrapper shape

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -12,7 +12,7 @@ use crate::types::{
 };
 use crate::visitor::callable_shape_id;
 
-use super::super::super::{SubtypeChecker, SubtypeResult, TypeResolver};
+use super::super::super::{RelationEvaluationResult, SubtypeChecker, SubtypeResult, TypeResolver};
 use super::erase_type_params_to_constraints;
 
 mod context_instantiation;
@@ -2127,23 +2127,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Results are cached in `eval_cache` to avoid re-evaluating the same type across
     /// multiple subtype checks. This turns O(n²) evaluate calls into O(n).
     pub(crate) fn evaluate_type(&mut self, type_id: TypeId) -> TypeId {
-        self.evaluate_type_with_stability(type_id).0
+        self.evaluate_type_with_stability(type_id).type_id()
     }
 
     /// Like [`Self::evaluate_type`], but also reports whether the evaluation is
     /// *stable*: it converged without tripping any recursion/depth/budget limit
-    /// and without a cross-instance cycle bail.
+    /// or cross-instance cycle bail.
     ///
-    /// A stable result is the type's converged answer; an unstable one is a
-    /// recursion artifact (e.g. a self-referential application collapsed to
-    /// `unknown` by a cycle guard). Callers that special-case collapsed results
-    /// must consult the flag so a genuinely evaluated `unknown` is not treated
-    /// like a bail artifact.
-    pub(crate) fn evaluate_type_with_stability(&mut self, type_id: TypeId) -> (TypeId, bool) {
+    /// Callers that special-case collapsed `unknown` results must consult the
+    /// flag so a genuine `unknown` is not treated like a bail artifact.
+    pub(crate) fn evaluate_type_with_stability(
+        &mut self,
+        type_id: TypeId,
+    ) -> RelationEvaluationResult {
         // Fast path: intrinsic types (number, string, boolean, void, null, etc.)
         // never need evaluation. Skip cache lookup entirely.
         if type_id.is_intrinsic() {
-            return (type_id, true);
+            return RelationEvaluationResult::stable(type_id);
         }
         // Check local evaluation cache first.
         // Key includes no_unchecked_indexed_access since with that flag evaluation results can vary.
@@ -2161,7 +2161,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // `instantiate_and_finalize_application`.
         if let Some(fuel) = self.explain_eval_fuel.as_mut() {
             if *fuel == 0 {
-                return (type_id, false);
+                return RelationEvaluationResult::unstable(type_id);
             }
             *fuel -= 1;
         }
@@ -2189,9 +2189,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 evaluator.evaluate_request_memo_result(request)
             },
         ) else {
-            return (type_id, false);
+            return RelationEvaluationResult::unstable(type_id);
         };
-        let entry = memo_result.into_type_id_and_stability();
+        let entry = RelationEvaluationResult::from_depth_agnostic_memo(memo_result);
         self.eval_cache.insert(cache_key, entry);
         entry
     }

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
@@ -942,7 +942,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             matches!(
                 self.interner.lookup(ret),
                 Some(TypeData::Application(_) | TypeData::Lazy(_))
-            ) && self.evaluate_type_with_stability(ret) == (TypeId::UNKNOWN, false)
+            ) && self.evaluate_type_with_stability(ret).is_unstable_unknown()
         };
         let needs_raw_fallback = placeholder_fallback
             || unstable_unknown_collapse(source_return)

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -211,6 +211,9 @@ fn evaluation_engine_keeps_request_stage_boundary() {
     let infer_pattern_rs = read_solver_source("evaluation/evaluate_rules/infer_pattern.rs");
     let instantiation_result_rs = read_solver_source("instantiation/result.rs");
     let instantiation_api_rs = read_solver_source("instantiation/instantiate/api.rs");
+    let subtype_core_rs = read_solver_source("relations/subtype/core.rs");
+    let function_checking_rs = read_solver_source("relations/subtype/rules/functions/checking.rs");
+    let functions_mod_rs = read_solver_source("relations/subtype/rules/functions/mod.rs");
     let query_cache_rs = read_solver_source("caches/query_cache.rs");
     let iteration_incomplete_tests =
         read_solver_test("evaluate_tests_parts/iteration_exceeded_incomplete.rs");
@@ -274,6 +277,17 @@ fn evaluation_engine_keeps_request_stage_boundary() {
                 .contains("EvaluationMemoResult::new(EvaluationResult::complete")
             && !infer_pattern_rs.contains("EvaluationMemoResult::new(EvaluationResult::complete"),
         "unstable complete memo results must use the named EvaluationMemoResult boundary instead of rebuilding the stability bit by hand"
+    );
+    assert!(
+        subtype_core_rs.contains("pub(crate) struct RelationEvaluationResult")
+            && subtype_core_rs
+                .contains("eval_cache: FxHashMap<(TypeId, bool), RelationEvaluationResult>")
+            && function_checking_rs
+                .contains("RelationEvaluationResult::from_depth_agnostic_memo(memo_result)")
+            && functions_mod_rs.contains(".is_unstable_unknown()")
+            && !functions_mod_rs
+                .contains("evaluate_type_with_stability(ret) == (TypeId::UNKNOWN, false)"),
+        "function-relation evaluation caches must carry stability through RelationEvaluationResult instead of anonymous (TypeId, bool) tuples"
     );
     assert!(
         instantiation_result_rs.contains("pub(crate) struct InstantiationMemoResult")


### PR DESCRIPTION
Goal: green

## Summary
- Adds `RelationEvaluationResult` for relation-local fresh-evaluator results plus depth-agnostic cache stability.
- Makes function-relation `eval_cache` store the named result instead of an anonymous `(TypeId, bool)` tuple.
- Replaces the unstable-unknown tuple comparison with `is_unstable_unknown()` and removes the now-unused tuple helper from `EvaluationMemoResult`.
- Ratchets the architecture guard so this relation-side stability channel stays named.

## Structural Rule
When function relation checking evaluates a nested type through a fresh evaluator, tsz carries the collapsed `TypeId` and its cache-stability verdict as a solver-owned value. Function relation code consumes that named verdict instead of storing or comparing anonymous `(TypeId, bool)` tuples. Owner layer: `tsz-solver` relation/evaluation boundary. Compiler behavior: unchanged.

## Adjacent Matrix
- Stable intrinsic evaluation returns `RelationEvaluationResult::stable`.
- Explain-fuel exhaustion and cross-eval reentry return `RelationEvaluationResult::unstable`.
- Fresh evaluator results convert through `RelationEvaluationResult::from_depth_agnostic_memo`.
- Stable `unknown` remains a valid evaluated result; unstable collapsed `unknown` still triggers the raw fallback path.
- Non-goals: no #14344 reference-mint identity edits, no #14345 materialize-once/publication edits, no `evaluate/application.rs` edits, and no cache eligibility policy change.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py --json`
- `wc -l crates/tsz-solver/src/relations/subtype/core.rs crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs crates/tsz-solver/src/evaluation/result.rs crates/tsz-solver/tests/architecture_guards.rs`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(evaluation_engine_keeps_request_stage_boundary) or test(evaluate_application_genuine_unknown_body_reduces_to_canonical_unknown) or test(test_unknown_fallback_prevents_silent_acceptance)'`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high