### PR TITLE
refactor(solver): return instantiation depth result (#14346)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -1013,15 +1013,16 @@ impl<'a> CheckerState<'a> {
             &type_params,
             &app.args,
         );
-        let (mut instantiated, depth_exceeded) =
+        let instantiation_result =
             crate::query_boundaries::common::instantiate_type_with_depth_status(
                 self.ctx.types,
                 body_type,
                 &substitution,
             );
-        if depth_exceeded {
+        if instantiation_result.depth_exceeded() {
             self.ctx.depth_exceeded.set(true);
         }
+        let mut instantiated = instantiation_result.into_type_id();
         if !crate::query_boundaries::common::contains_this_type(self.ctx.types, instantiated) {
             return None;
         }

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -618,13 +618,13 @@ pub(crate) fn keyof_inner_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option
     tsz_solver::keyof_inner_type(db, type_id)
 }
 
-/// Instantiate a type, returning the result and a flag indicating whether the
-/// depth limit was exceeded during instantiation.
+/// Instantiate a type, returning the typed result and whether the depth limit
+/// was exceeded during instantiation.
 pub(crate) fn instantiate_type_with_depth_status(
     db: &dyn TypeDatabase,
     type_id: TypeId,
     substitution: &TypeSubstitution,
-) -> (TypeId, bool) {
+) -> c::InstantiationResult {
     c::instantiate_type_with_depth_status(db, type_id, substitution)
 }
 

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -636,11 +636,12 @@ impl CheckerState<'_> {
         // Create substitution and instantiate
         let substitution =
             TypeSubstitution::from_args(self.ctx.types, &type_params, &evaluated_args);
-        let (mut instantiated, depth_exceeded) =
+        let instantiation_result =
             instantiate_type_with_depth_status(self.ctx.types, body_type, &substitution);
-        if depth_exceeded {
+        if instantiation_result.depth_exceeded() {
             self.ctx.depth_exceeded.set(true);
         }
+        let mut instantiated = instantiation_result.into_type_id();
         if query::contains_this_type(self.ctx.types, instantiated) {
             instantiated = query::substitute_this_type(self.ctx.types, instantiated, type_id);
         }

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -1318,23 +1318,23 @@ pub fn instantiate_type_with_depth_status(
     interner: &dyn TypeDatabase,
     type_id: TypeId,
     substitution: &TypeSubstitution,
-) -> (TypeId, bool) {
+) -> InstantiationResult {
     // Fast path: intrinsic types never need instantiation (no type-parameter
     // occurrences, no recursion). Skip the substitution probe AND the
     // `TypeInstantiator` construction. Mirrors the leaf fast path in
     // `instantiate_type_cached` / `instantiate_type_preserving_cached`.
     if type_id.is_intrinsic() {
-        return (type_id, false);
+        return InstantiationResult::ok(type_id);
     }
     if substitution.is_empty() {
-        return (type_id, false);
+        return InstantiationResult::ok(type_id);
     }
     let mut instantiator = TypeInstantiator::new(interner, substitution);
     let result = instantiator.instantiate(type_id);
-    // Report the overflow bool for callers that gate on it, but hand back the
-    // relation-preserving bail value (never a substitution-bound free type
+    // Report the overflow verdict for callers that gate on it, but hand back
+    // the relation-preserving bail value (never a substitution-bound free type
     // parameter) instead of the `TypeId::ERROR` sentinel (#13652).
-    (result, instantiator.depth_exceeded)
+    InstantiationResult::from_walk(result, instantiator.depth_exceeded)
 }
 
 /// Convenience function for instantiating a type while preserving meta-type
@@ -1927,7 +1927,8 @@ pub fn instantiate_function_with_type_args(
         .params
         .iter()
         .map(|p| {
-            let (new_ty, _) = instantiate_type_with_depth_status(interner, p.type_id, &subst);
+            let new_ty =
+                instantiate_type_with_depth_status(interner, p.type_id, &subst).into_type_id();
             ParamInfo {
                 name: p.name,
                 type_id: new_ty,
@@ -1937,16 +1938,17 @@ pub fn instantiate_function_with_type_args(
         })
         .collect();
 
-    let (new_return, _) = instantiate_type_with_depth_status(interner, shape.return_type, &subst);
+    let new_return =
+        instantiate_type_with_depth_status(interner, shape.return_type, &subst).into_type_id();
 
     let new_this = shape
         .this_type
-        .map(|t| instantiate_type_with_depth_status(interner, t, &subst).0);
+        .map(|t| instantiate_type_with_depth_status(interner, t, &subst).into_type_id());
 
     let new_predicate = shape.type_predicate.map(|tp| TypePredicate {
         type_id: tp
             .type_id
-            .map(|t| instantiate_type_with_depth_status(interner, t, &subst).0),
+            .map(|t| instantiate_type_with_depth_status(interner, t, &subst).into_type_id()),
         ..tp
     });
 

--- a/crates/tsz-solver/tests/public_api_tests.rs
+++ b/crates/tsz-solver/tests/public_api_tests.rs
@@ -2,7 +2,7 @@ use tsz_solver::TypeId;
 use tsz_solver::computation::{
     EvaluationResult, InstantiationOptions, InstantiationRequest, InstantiationResult, Termination,
     TypeSubstitution, evaluate_type_result_with_request, evaluate_type_with_request,
-    instantiate_type_with_request,
+    instantiate_type_with_depth_status, instantiate_type_with_request,
 };
 use tsz_solver::construction::TypeInterner;
 use tsz_solver::evaluation::request::EvaluationRequest;
@@ -15,6 +15,18 @@ fn computation_exports_staged_instantiation_api() {
     let request = InstantiationRequest::new(TypeId::STRING, &substitution).with_options(options);
 
     let result: InstantiationResult = instantiate_type_with_request(&interner, request);
+
+    assert!(!result.depth_exceeded());
+    assert_eq!(result.into_type_id(), TypeId::STRING);
+}
+
+#[test]
+fn computation_exports_depth_status_as_instantiation_result() {
+    let interner = TypeInterner::new();
+    let substitution = TypeSubstitution::new();
+
+    let result: InstantiationResult =
+        instantiate_type_with_depth_status(&interner, TypeId::STRING, &substitution);
 
     assert!(!result.depth_exceeded());
     assert_eq!(result.into_type_id(), TypeId::STRING);


### PR DESCRIPTION
Goal: green

## Summary
- Return `InstantiationResult` directly from `instantiate_type_with_depth_status` instead of an anonymous `(TypeId, bool)` pair.
- Thread the typed result through the checker `query_boundaries::common` wrapper and its two consumers before collapsing to `TypeId`.
- Add a public API test that type-checks the depth-status helper as `InstantiationResult`.

## Structural Rule
When an instantiation walk returns a relation-preserving partial type plus a depth-overflow verdict, tsz carries that as the solver-owned `InstantiationResult`; checker/query-boundary callers inspect `depth_exceeded()` and collapse through `into_type_id()` rather than rebuilding termination state from a tuple.

Owner layer: `tsz-solver` instantiation result boundary, with checker call sites consuming the typed query result.

Adjacent matrix:
- intrinsic and empty-substitution fast paths return `InstantiationResult::ok`.
- overflow-capable walks still use `InstantiationResult::from_walk`, preserving the partial bail value from #13652.
- checker consumers still set `ctx.depth_exceeded` before using the collapsed type.
- consumers that do not need the verdict collapse explicitly through `into_type_id()`.

## Non-Overlap
No #14344 reference-mint identity edits, no #14345 materialize-once/publication edits, no `evaluate/application.rs` edits, and no cache eligibility policy change. This is a narrow #14346 typed-termination boundary cleanup from fresh `origin/main`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(computation_exports_depth_status_as_instantiation_result) or test(computation_exports_staged_instantiation_api)'`
- `scripts/safe-run.sh cargo check -p tsz-checker -p tsz-solver`
- line-count check for touched files; all remain below 2000 physical lines

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
