### PR TITLE
refactor(solver): name conditional branch verdict result (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -26,6 +26,69 @@ pub(super) enum BranchRelation {
     Undetermined,
 }
 
+/// Whether a conditional-branch probe can seed the depth-agnostic verdict
+/// cache.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ConditionalBranchCacheStability {
+    /// The probe did not consume a local recursion/iteration budget.
+    DepthAgnostic,
+    /// The probe returned a conservative answer after a local budget fired.
+    BudgetBounded,
+}
+
+impl ConditionalBranchCacheStability {
+    const fn mark_budget_bounded(&mut self) {
+        *self = Self::BudgetBounded;
+    }
+
+    const fn is_depth_agnostic(self) -> bool {
+        matches!(self, Self::DepthAgnostic)
+    }
+}
+
+/// Conditional-branch relation result plus its publication verdict.
+///
+/// The per-evaluator cache can remember any definitive branch relation. The
+/// cross-evaluator cache is stricter: it may only store definitive answers that
+/// are independent of the local subtype walk's recursion/iteration budgets.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct ConditionalBranchProbeResult {
+    relation: BranchRelation,
+    cache_stability: ConditionalBranchCacheStability,
+}
+
+impl ConditionalBranchProbeResult {
+    const fn new(
+        relation: BranchRelation,
+        cache_stability: ConditionalBranchCacheStability,
+    ) -> Self {
+        Self {
+            relation,
+            cache_stability,
+        }
+    }
+
+    const fn relation(self) -> BranchRelation {
+        self.relation
+    }
+
+    const fn definitive_verdict(self) -> Option<bool> {
+        match self.relation {
+            BranchRelation::Holds => Some(true),
+            BranchRelation::Fails => Some(false),
+            BranchRelation::Undetermined => None,
+        }
+    }
+
+    const fn depth_agnostic_cache_verdict(self) -> Option<bool> {
+        if self.cache_stability.is_depth_agnostic() {
+            self.definitive_verdict()
+        } else {
+            None
+        }
+    }
+}
+
 /// Run a structural relation probe that chooses a conditional branch and
 /// classify its result, following the thread-local unresolved-`Lazy` sentinel
 /// so a `false` that depended on an unregistered `Lazy` body is reported as
@@ -617,9 +680,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // itself tripped a recursion/iteration limit is a *budget-bounded*
         // conservative answer, not a stable function of the type pair: it must
         // never be published to the cross-evaluator cache (it would permanently
-        // shadow the full answer a deeper-budget run derives). Tracked here and
-        // consulted at the write site.
-        let mut verdict_is_budget_bounded = false;
+        // shadow the full answer a deeper-budget run derives). Carry that as a
+        // typed publication verdict and consult it at the write site.
+        let mut cache_stability = ConditionalBranchCacheStability::DepthAgnostic;
         // Classify against the unresolved-`Lazy` sentinel: a `false` produced
         // only because the structural walk descended into an unregistered
         // `Lazy` body is reported as `Undetermined` rather than a definitive
@@ -631,7 +694,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // (takes the false/else branch of the conditional).
                 // This matches tsc's behavior of returning the deferred
                 // conditional when instantiation depth is exceeded.
-                verdict_is_budget_bounded = true;
+                cache_stability.mark_budget_bounded();
                 false
             } else if Self::is_primitive_vs_function(self.interner(), check_type, extends_type) {
                 // Fast-path: primitive types (string, number, boolean, bigint,
@@ -666,11 +729,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // A walk that exhausted its own depth/iteration budget returned
                 // a conservative verdict; mark it un-publishable.
                 if strict_checker.depth_exceeded() || strict_checker.iteration_exceeded() {
-                    verdict_is_budget_bounded = true;
+                    cache_stability.mark_budget_bounded();
                 }
                 verdict
             }
         });
+        let probe = ConditionalBranchProbeResult::new(relation, cache_stability);
         // Restore the depth before the cache write to preserve the original
         // decrement ordering; `Drop` would otherwise run at end of scope, but
         // either way the depth is restored on a panic-unwind exit.
@@ -679,8 +743,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // cache it and do not let it take the false branch — defer so a later
         // resolved pass decides the conditional (issue #14238). Definitive
         // verdicts are cached as before.
-        if relation != BranchRelation::Undetermined {
-            let verdict = relation == BranchRelation::Holds;
+        if let Some(verdict) = probe.definitive_verdict() {
             self.cache_conditional_subtype(check_type, extends_type, verdict);
 
             // Publish to the cross-evaluator verdict cache only when the answer
@@ -695,7 +758,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             //    body, and neither operand is tainted — the same whole-run
             //    gates `closed_eval` uses before persisting.
             if conditional_branch_verdict_cache_enabled()
-                && !verdict_is_budget_bounded
+                && let Some(verdict) = probe.depth_agnostic_cache_verdict()
                 && self.request_state_is_depth_agnostic_cache_stable()
                 && !self.unresolved_def_seen()
                 && !self.is_tainted(check_type)
@@ -710,7 +773,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 tsz_common::perf_counters::record_eval_conditional_verdict_persist_insert();
             }
         }
-        relation
+        probe.relation()
     }
 
     fn object_literals_have_conflicting_required_property(
@@ -910,6 +973,47 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             }
             _ => TailCallStep::NoTailCall,
         }
+    }
+}
+
+#[cfg(test)]
+mod conditional_branch_probe_result_tests {
+    use super::{BranchRelation, ConditionalBranchCacheStability, ConditionalBranchProbeResult};
+
+    #[test]
+    fn budget_bounded_probe_keeps_definitive_verdict_but_blocks_depth_cache() {
+        let probe = ConditionalBranchProbeResult::new(
+            BranchRelation::Fails,
+            ConditionalBranchCacheStability::BudgetBounded,
+        );
+
+        assert_eq!(probe.relation(), BranchRelation::Fails);
+        assert_eq!(probe.definitive_verdict(), Some(false));
+        assert_eq!(probe.depth_agnostic_cache_verdict(), None);
+    }
+
+    #[test]
+    fn undetermined_probe_has_no_cacheable_verdict() {
+        let probe = ConditionalBranchProbeResult::new(
+            BranchRelation::Undetermined,
+            ConditionalBranchCacheStability::DepthAgnostic,
+        );
+
+        assert_eq!(probe.relation(), BranchRelation::Undetermined);
+        assert_eq!(probe.definitive_verdict(), None);
+        assert_eq!(probe.depth_agnostic_cache_verdict(), None);
+    }
+
+    #[test]
+    fn depth_agnostic_probe_exports_definitive_cache_verdict() {
+        let probe = ConditionalBranchProbeResult::new(
+            BranchRelation::Holds,
+            ConditionalBranchCacheStability::DepthAgnostic,
+        );
+
+        assert_eq!(probe.relation(), BranchRelation::Holds);
+        assert_eq!(probe.definitive_verdict(), Some(true));
+        assert_eq!(probe.depth_agnostic_cache_verdict(), Some(true));
     }
 }
 


### PR DESCRIPTION
Goal: green

## Summary
Structural rule: when a conditional branch subtype probe produces a branch relation and a depth/cache publication verdict, tsz carries that as a solver-owned `ConditionalBranchProbeResult`; the conditional evaluator no longer publishes from a loose budget-bounded boolean.

Owner layer: `tsz-solver` conditional evaluation and cross-evaluator branch verdict cache gate.

Scope:
- Adds `ConditionalBranchCacheStability` and `ConditionalBranchProbeResult` beside `BranchRelation`.
- Keeps local conditional-subtype caching for definitive `Holds`/`Fails` results.
- Restricts cross-evaluator branch verdict publication through `depth_agnostic_cache_verdict()`.
- Adds private unit coverage for stable, budget-bounded, and undetermined probe results.

Non-overlap:
- no #14344 reference-mint identity edits
- no #14345 materialize-once/publication edits
- no `evaluate/application.rs` edits
- no cache key or cache eligibility policy change

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(budget_bounded_probe_keeps_definitive_verdict_but_blocks_depth_cache) or test(undetermined_probe_has_no_cacheable_verdict) or test(depth_agnostic_probe_exports_definitive_cache_verdict) or test(incomplete_request_verdict_blocks_conditional_branch_persistent_write)'`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh scripts/ci/github-suite.sh lint`
- `python3 scripts/arch/arch_guard.py --json`
- `wc -l crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high