### PR TITLE
fix(checker): recover generator iteration types for materialized call-result iterables

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1313,6 +1313,9 @@ path = "tests/homomorphic_mapped_empty_keyspace_tests.rs"
 name = "homomorphic_mapped_symbol_iterator_tests"
 path = "tests/homomorphic_mapped_symbol_iterator_tests.rs"
 [[test]]
+name = "iterator_next_send_type_call_result_tests"
+path = "tests/iterator_next_send_type_call_result_tests.rs"
+[[test]]
 name = "homomorphic_mapped_never_source_tests"
 path = "tests/homomorphic_mapped_never_source_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/mod.rs
+++ b/crates/tsz-checker/src/checkers/mod.rs
@@ -12,6 +12,7 @@ pub mod iterable_checker;
 pub mod jsx;
 pub mod parameter_checker;
 pub mod promise_checker;
+mod promise_checker_generator;
 mod promise_checker_object_normalization;
 pub mod property_checker;
 pub mod signature_builder;

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -1476,63 +1476,6 @@ impl<'a> CheckerState<'a> {
         self.recover_generator_arg_from_iterator_factory(type_id, arg_index)
     }
 
-    /// Recover a generator-like type argument for a call-result iterable whose
-    /// `Generator`/`AsyncGenerator` return type was eagerly materialized into a
-    /// structural object, losing the `Generator<Y, R, N>` Application form the
-    /// direct extractor reads.
-    ///
-    /// tsc reads the iteration types (`TYield`/`TReturn`/`TNext`) from this
-    /// declared Application — not from the materialized
-    /// `next(...[v]: [] | [TNext])` rest-tuple, whose optionality would
-    /// otherwise suppress the `TS2763`-`TS2766` send-type diagnostics. The
-    /// materialized object still exposes `[Symbol.iterator]()` /
-    /// `[Symbol.asyncIterator]()` returning the surviving Application, so we
-    /// reach it through the iterator factory's return type and re-extract the
-    /// argument. A non-generator iterable (`Set`, `Map`, a user interface that
-    /// merely declares `next`) resolves to an iterator that is not a
-    /// generator-like Application, so extraction yields `None` and nothing is
-    /// forced — matching tsc.
-    fn recover_generator_arg_from_iterator_factory(
-        &mut self,
-        type_id: TypeId,
-        arg_index: usize,
-    ) -> Option<TypeId> {
-        use crate::query_boundaries::common::PropertyAccessResult;
-        for symbol_name in ["[Symbol.iterator]", "[Symbol.asyncIterator]"] {
-            let PropertyAccessResult::Success {
-                type_id: factory_type,
-                ..
-            } = self.resolve_property_access_with_env(type_id, symbol_name)
-            else {
-                continue;
-            };
-            let iterator_type = self.iterator_factory_return_type(factory_type);
-            // Guard against looping back on the same object when the factory
-            // returns `this`.
-            if iterator_type != type_id
-                && let Some(arg) = self.get_generator_arg_direct(iterator_type, arg_index)
-            {
-                return Some(arg);
-            }
-        }
-        None
-    }
-
-    /// Return type of an iterator factory (`[Symbol.iterator]` /
-    /// `[Symbol.asyncIterator]`), or `any` when it is not callable.
-    fn iterator_factory_return_type(&self, factory_type: TypeId) -> TypeId {
-        if factory_type == TypeId::ANY {
-            return TypeId::ANY;
-        }
-        if let Some(shape) = query::function_shape_for_type(self.ctx.types, factory_type) {
-            return shape.return_type;
-        }
-        if let Some(sigs) = query::call_signatures_for_type(self.ctx.types, factory_type) {
-            return sigs.first().map_or(TypeId::ANY, |sig| sig.return_type);
-        }
-        TypeId::ANY
-    }
-
     /// Expand a type alias application by one level: substitute type args into the body
     /// without recursively evaluating the result. This preserves Application types like
     /// `Generator<Y,R,N>` in their wrapper form rather than expanding them to structural objects.
@@ -1568,7 +1511,11 @@ impl<'a> CheckerState<'a> {
     /// Direct extraction of a type argument at `arg_index` from a generator-like Application type.
     /// Also handles union types (e.g., `Generator<Y,R,N> | AsyncGenerator<Y,R,N>`) by extracting
     /// the arg from each union member and combining them into a union.
-    fn get_generator_arg_direct(&mut self, type_id: TypeId, arg_index: usize) -> Option<TypeId> {
+    pub(super) fn get_generator_arg_direct(
+        &mut self,
+        type_id: TypeId,
+        arg_index: usize,
+    ) -> Option<TypeId> {
         // Try direct extraction first (non-union case)
         if let Some(app) = query::type_application(self.ctx.types, type_id) {
             if !app.args.is_empty() && self.is_generator_like_base_type(app.base) {

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -1463,11 +1463,74 @@ impl<'a> CheckerState<'a> {
         // instantiate the alias body with args but don't recursively evaluate
         // Generator/AsyncGenerator into structural forms. This preserves the
         // Application wrappers we need to extract type args from.
-        if let Some(expanded) = self.shallow_expand_type_alias(type_id) {
-            return self.get_generator_arg_direct(expanded, arg_index);
+        if let Some(expanded) = self.shallow_expand_type_alias(type_id)
+            && let Some(result) = self.get_generator_arg_direct(expanded, arg_index)
+        {
+            return Some(result);
         }
 
+        // Fallback: a call-result `Generator`/`AsyncGenerator` whose Application
+        // wrapper was eagerly materialized into a structural object still
+        // exposes its iterator factory; reach the surviving Application through
+        // the factory's return type.
+        self.recover_generator_arg_from_iterator_factory(type_id, arg_index)
+    }
+
+    /// Recover a generator-like type argument for a call-result iterable whose
+    /// `Generator`/`AsyncGenerator` return type was eagerly materialized into a
+    /// structural object, losing the `Generator<Y, R, N>` Application form the
+    /// direct extractor reads.
+    ///
+    /// tsc reads the iteration types (`TYield`/`TReturn`/`TNext`) from this
+    /// declared Application — not from the materialized
+    /// `next(...[v]: [] | [TNext])` rest-tuple, whose optionality would
+    /// otherwise suppress the `TS2763`-`TS2766` send-type diagnostics. The
+    /// materialized object still exposes `[Symbol.iterator]()` /
+    /// `[Symbol.asyncIterator]()` returning the surviving Application, so we
+    /// reach it through the iterator factory's return type and re-extract the
+    /// argument. A non-generator iterable (`Set`, `Map`, a user interface that
+    /// merely declares `next`) resolves to an iterator that is not a
+    /// generator-like Application, so extraction yields `None` and nothing is
+    /// forced — matching tsc.
+    fn recover_generator_arg_from_iterator_factory(
+        &mut self,
+        type_id: TypeId,
+        arg_index: usize,
+    ) -> Option<TypeId> {
+        use crate::query_boundaries::common::PropertyAccessResult;
+        for symbol_name in ["[Symbol.iterator]", "[Symbol.asyncIterator]"] {
+            let PropertyAccessResult::Success {
+                type_id: factory_type,
+                ..
+            } = self.resolve_property_access_with_env(type_id, symbol_name)
+            else {
+                continue;
+            };
+            let iterator_type = self.iterator_factory_return_type(factory_type);
+            // Guard against looping back on the same object when the factory
+            // returns `this`.
+            if iterator_type != type_id
+                && let Some(arg) = self.get_generator_arg_direct(iterator_type, arg_index)
+            {
+                return Some(arg);
+            }
+        }
         None
+    }
+
+    /// Return type of an iterator factory (`[Symbol.iterator]` /
+    /// `[Symbol.asyncIterator]`), or `any` when it is not callable.
+    fn iterator_factory_return_type(&self, factory_type: TypeId) -> TypeId {
+        if factory_type == TypeId::ANY {
+            return TypeId::ANY;
+        }
+        if let Some(shape) = query::function_shape_for_type(self.ctx.types, factory_type) {
+            return shape.return_type;
+        }
+        if let Some(sigs) = query::call_signatures_for_type(self.ctx.types, factory_type) {
+            return sigs.first().map_or(TypeId::ANY, |sig| sig.return_type);
+        }
+        TypeId::ANY
     }
 
     /// Expand a type alias application by one level: substitute type args into the body

--- a/crates/tsz-checker/src/checkers/promise_checker_generator.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker_generator.rs
@@ -6,7 +6,7 @@ use crate::query_boundaries::common::PropertyAccessResult;
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
-impl<'a> CheckerState<'a> {
+impl CheckerState<'_> {
     /// Recover a generator-like type argument for a call-result iterable whose
     /// `Generator`/`AsyncGenerator` return type was eagerly materialized into a
     /// structural object, losing the `Generator<Y, R, N>` Application form the

--- a/crates/tsz-checker/src/checkers/promise_checker_generator.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker_generator.rs
@@ -1,0 +1,65 @@
+//! Generator-iteration helpers split from `promise_checker.rs` to keep that
+//! checker shard under the 2000-line size guard. Behavior is unchanged.
+
+use crate::query_boundaries::checkers::promise as query;
+use crate::query_boundaries::common::PropertyAccessResult;
+use crate::state::CheckerState;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Recover a generator-like type argument for a call-result iterable whose
+    /// `Generator`/`AsyncGenerator` return type was eagerly materialized into a
+    /// structural object, losing the `Generator<Y, R, N>` Application form the
+    /// direct extractor reads.
+    ///
+    /// tsc reads the iteration types (`TYield`/`TReturn`/`TNext`) from this
+    /// declared Application, not from the materialized
+    /// `next(...[v]: [] | [TNext])` rest-tuple, whose optionality would
+    /// otherwise suppress the `TS2763`-`TS2766` send-type diagnostics. The
+    /// materialized object still exposes `[Symbol.iterator]()` /
+    /// `[Symbol.asyncIterator]()` returning the surviving Application, so we
+    /// reach it through the iterator factory's return type and re-extract the
+    /// argument. A non-generator iterable (`Set`, `Map`, a user interface that
+    /// merely declares `next`) resolves to an iterator that is not a
+    /// generator-like Application, so extraction yields `None` and nothing is
+    /// forced, matching tsc.
+    pub(super) fn recover_generator_arg_from_iterator_factory(
+        &mut self,
+        type_id: TypeId,
+        arg_index: usize,
+    ) -> Option<TypeId> {
+        for symbol_name in ["[Symbol.iterator]", "[Symbol.asyncIterator]"] {
+            let PropertyAccessResult::Success {
+                type_id: factory_type,
+                ..
+            } = self.resolve_property_access_with_env(type_id, symbol_name)
+            else {
+                continue;
+            };
+            let iterator_type = self.iterator_factory_return_type(factory_type);
+            // Guard against looping back on the same object when the factory
+            // returns `this`.
+            if iterator_type != type_id
+                && let Some(arg) = self.get_generator_arg_direct(iterator_type, arg_index)
+            {
+                return Some(arg);
+            }
+        }
+        None
+    }
+
+    /// Return type of an iterator factory (`[Symbol.iterator]` /
+    /// `[Symbol.asyncIterator]`), or `any` when it is not callable.
+    fn iterator_factory_return_type(&self, factory_type: TypeId) -> TypeId {
+        if factory_type == TypeId::ANY {
+            return TypeId::ANY;
+        }
+        if let Some(shape) = query::function_shape_for_type(self.ctx.types, factory_type) {
+            return shape.return_type;
+        }
+        if let Some(sigs) = query::call_signatures_for_type(self.ctx.types, factory_type) {
+            return sigs.first().map_or(TypeId::ANY, |sig| sig.return_type);
+        }
+        TypeId::ANY
+    }
+}

--- a/crates/tsz-checker/tests/iterator_next_send_type_call_result_tests.rs
+++ b/crates/tsz-checker/tests/iterator_next_send_type_call_result_tests.rs
@@ -17,7 +17,7 @@
 //! all recovered (`yield*` `TReturn` resolution benefits too), and:
 //!   - Generator/AsyncGenerator call results report exactly as their
 //!     `declare const` form does, and
-//!   - non-generator iterables (`Set`, `Map`, IterableIterator, a user
+//!   - non-generator iterables (`Set`, `Map`, `IterableIterator`, a user
 //!     interface whose iterator factory returns a non-generator) report
 //!     nothing, matching tsc.
 //!

--- a/crates/tsz-checker/tests/iterator_next_send_type_call_result_tests.rs
+++ b/crates/tsz-checker/tests/iterator_next_send_type_call_result_tests.rs
@@ -1,0 +1,237 @@
+//! Iterator next-send-type diagnostics (TS2763/TS2764/TS2765/TS2766) on
+//! function-call-result iterables — regression for #14814.
+//!
+//! When the iterable is the result of a function call, tsz materializes the
+//! call-result `Generator`/`AsyncGenerator` return type into a structural
+//! object, which loses the `Generator<Y, R, N>` Application form that the
+//! send-type check reads directly. Before the fix the four diagnostics were
+//! silently dropped for call results while still firing for `declare const` /
+//! explicitly-annotated iterables.
+//!
+//! tsc derives the send-type from the iterator's declared `TNext` type
+//! argument, not from the materialized `next(...[v]: [] | [TNext])` rest-tuple
+//! (whose optionality would otherwise suppress the diagnostic). The fix adds a
+//! final fallback to the shared generator-argument extraction chain that
+//! recovers the surviving Application through the `[Symbol.iterator]()` /
+//! `[Symbol.asyncIterator]()` return type — so `TYield`/`TReturn`/`TNext` are
+//! all recovered (`yield*` `TReturn` resolution benefits too), and:
+//!   - Generator/AsyncGenerator call results report exactly as their
+//!     `declare const` form does, and
+//!   - non-generator iterables (`Set`, `Map`, IterableIterator, a user
+//!     interface whose iterator factory returns a non-generator) report
+//!     nothing, matching tsc.
+//!
+//! Verified verbatim (codes, spans, message text) against tsc 6.0.2.
+
+use std::sync::Arc;
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::context::CheckerOptions;
+
+fn strict_options() -> CheckerOptions {
+    CheckerOptions {
+        strict_null_checks: true,
+        no_implicit_any: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn libs() -> Vec<Arc<LibFile>> {
+    tsz_checker::test_utils::load_default_lib_files()
+}
+
+fn codes(source: &str, lib_files: &[Arc<LibFile>]) -> Vec<u32> {
+    let diagnostics = tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        strict_options(),
+        lib_files,
+    );
+    diagnostics
+        .iter()
+        .filter(|d| d.category == tsz_checker::diagnostics::DiagnosticCategory::Error)
+        .map(|d| d.code)
+        .collect()
+}
+
+/// A call-result `Generator<_, _, TNext>` whose `TNext` rejects `undefined`
+/// must report the send-type mismatch at every iteration site, exactly as the
+/// `declare const` form does. The producer function name is varied to prove the
+/// rule is structural and not keyed to a particular binder.
+#[test]
+fn call_result_generator_reports_send_mismatch_at_every_site() {
+    let libs = libs();
+    let source = r#"
+declare function buildSeq(): Generator<string, void, number>;
+function consume() { for (const x of buildSeq()) { x; } }
+const spread = [...buildSeq()];
+const [first] = buildSeq();
+"#;
+    let got = codes(source, &libs);
+    for code in [2763u32, 2764, 2765] {
+        assert!(
+            got.contains(&code),
+            "expected TS{code} for a call-result Generator with TNext=number; got {got:?}"
+        );
+    }
+}
+
+/// `yield* call()` delegating to a generator whose `TNext` rejects the
+/// containing generator's send type (`undefined`) reports TS2766.
+#[test]
+fn call_result_yield_star_reports_ts2766() {
+    let libs = libs();
+    let source = r#"
+declare function makeInner(): Generator<string, void, number>;
+function* outer(): Generator<string, void, undefined> { yield* makeInner(); }
+"#;
+    let got = codes(source, &libs);
+    assert!(
+        got.contains(&2766),
+        "expected TS2766 for yield* of a call-result Generator; got {got:?}"
+    );
+}
+
+/// The async family: for-await over a call-result `AsyncGenerator` reports
+/// TS2763, and async `yield*` reports TS2766.
+#[test]
+fn call_result_async_generator_reports_send_mismatch() {
+    let libs = libs();
+    let source = r#"
+declare function makeAsync(): AsyncGenerator<string, void, number>;
+async function consume() { for await (const x of makeAsync()) { x; } }
+async function* outer(): AsyncGenerator<string, void, undefined> { yield* makeAsync(); }
+"#;
+    let got = codes(source, &libs);
+    assert!(
+        got.contains(&2763),
+        "expected TS2763 for for-await of a call-result AsyncGenerator; got {got:?}"
+    );
+    assert!(
+        got.contains(&2766),
+        "expected TS2766 for async yield* of a call-result AsyncGenerator; got {got:?}"
+    );
+}
+
+/// Control: a call-result `Generator` whose `TNext` accepts `undefined`
+/// (`undefined` itself, `unknown`, or a union containing `undefined`) must
+/// stay clean — recovery must not over-report.
+#[test]
+fn call_result_generator_accepting_undefined_is_clean() {
+    let libs = libs();
+    let source = r#"
+declare function gUndef(): Generator<string, void, undefined>;
+declare function gUnknown(): Generator<string, void, unknown>;
+declare function gOptional(): Generator<string, void, number | undefined>;
+function a() { for (const x of gUndef()) { x; } }
+function b() { for (const x of gUnknown()) { x; } }
+function c() { for (const x of gOptional()) { x; } }
+const s = [...gUnknown()];
+"#;
+    let got = codes(source, &libs);
+    for code in [2763u32, 2764, 2765, 2766] {
+        assert!(
+            !got.contains(&code),
+            "TS{code} must not fire when TNext accepts undefined; got {got:?}"
+        );
+    }
+}
+
+/// Control: non-generator call-result iterables (`Set`, `Map`,
+/// `IterableIterator`) send `undefined` to a `TNext` of `unknown`, so no
+/// send-type diagnostic is forced — the recovery only fires for generator-like
+/// Applications.
+#[test]
+fn call_result_non_generator_iterables_are_clean() {
+    let libs = libs();
+    let source = r#"
+declare function makeSet(): Set<number>;
+declare function makeMap(): Map<string, number>;
+declare function makeII(): IterableIterator<string>;
+function a() { for (const x of makeSet()) { x; } }
+function b() { for (const x of makeMap()) { x; } }
+function c() { for (const x of makeII()) { x; } }
+const s = [...makeSet()];
+const [m] = makeMap();
+const i = [...makeII()];
+"#;
+    let got = codes(source, &libs);
+    for code in [2763u32, 2764, 2765, 2766] {
+        assert!(
+            !got.contains(&code),
+            "TS{code} must not fire for non-generator call-result iterables; got {got:?}"
+        );
+    }
+}
+
+/// Control: a user iterable whose iterator factory returns a non-generator with
+/// an optional `next(...args: [] | [N])` accepts a no-argument `next()`, so tsc
+/// (and tsz) report nothing. The recovery must not synthesize a `TNext` from
+/// the optional rest-tuple.
+#[test]
+fn call_result_optional_rest_next_interface_is_clean() {
+    let libs = libs();
+    let source = r#"
+interface OptIter {
+    [Symbol.iterator](): OptIter;
+    next(...args: [] | [boolean]): IteratorResult<number, void>;
+}
+declare function makeOpt(): OptIter;
+function a() { for (const x of makeOpt()) { x; } }
+const s = [...makeOpt()];
+"#;
+    let got = codes(source, &libs);
+    for code in [2763u32, 2764, 2765, 2766] {
+        assert!(
+            !got.contains(&code),
+            "TS{code} must not fire for an optional-rest next() iterable; got {got:?}"
+        );
+    }
+}
+
+/// The recovery is wired into the shared generator-argument fallback chain, so
+/// it also restores `TReturn` extraction for `yield*` of a call result: the
+/// result of `yield* makeG()` is the delegated generator's `TReturn`. tsc
+/// resolves it from the call result, so a downstream type mismatch must report
+/// TS2322 just as it does for an annotated generator.
+#[test]
+fn call_result_yield_star_return_type_is_recovered() {
+    let libs = libs();
+    let source = r#"
+declare function makeG(): Generator<string, number, undefined>;
+function* g() {
+    const r = yield* makeG();
+    const bad: string = r;
+}
+"#;
+    assert!(
+        codes(source, &libs).contains(&2322),
+        "yield* of a call-result Generator must resolve its TReturn (number) so the \
+         string annotation reports TS2322"
+    );
+}
+
+/// The `declare const` / annotated forms already reported correctly; keep them
+/// as a parity anchor so the call-result fix is not confused with a change to
+/// the direct-Application path.
+#[test]
+fn declared_and_annotated_forms_still_report() {
+    let libs = libs();
+    let declared = r#"
+declare const g: Generator<string, void, number>;
+function consume() { for (const x of g) { x; } }
+"#;
+    assert!(
+        codes(declared, &libs).contains(&2763),
+        "declared-const Generator must still report TS2763"
+    );
+
+    let annotated = r#"
+declare function build(): Generator<string, void, number>;
+const it: Generator<string, void, number> = build();
+function consume() { for (const x of it) { x; } }
+"#;
+    assert!(
+        codes(annotated, &libs).contains(&2763),
+        "explicitly-annotated Generator must still report TS2763"
+    );
+}


### PR DESCRIPTION
When the iterable is the result of a function call, tsz eagerly materializes the call-result `Generator`/`AsyncGenerator` return type into a structural object, which loses the `Generator<Y, R, N>` Application form that the generator-argument extractors read directly. This silently dropped the iterator send-type diagnostics on call results while they still fired for `declare const` / explicitly-annotated iterables.

**Structural rule:** When an iterable's declared iteration type (`TYield`/`TReturn`/`TNext`) must be read but the value is a *materialized* call-result `Generator`/`AsyncGenerator` (no surviving Application wrapper), tsc reads the iteration types from the Application returned by `[Symbol.iterator]()`/`[Symbol.asyncIterator]()` — not from the materialized `next(...[v]: [] | [TNext])` rest-tuple. tsz now does the same through the solver-backed property-access boundary in the checker's shared generator-argument fallback chain (`get_generator_arg_with_eval`, owner: checker → `promise_checker`).

The recovery is added as a final fallback after direct/heritage/alias extraction, so all three iteration types are restored uniformly:
- TS2763 (for-of), TS2764 (array spread), TS2765 (array destructuring), TS2766 (`yield*` delegation) now fire on call-result generators exactly as on annotated ones.
- `yield*` `TReturn` resolution from a call result is fixed as a bonus of the shared placement.

Non-generator iterables (`Set`/`Map`/`IterableIterator`, and user interfaces whose iterator factory returns a non-generator with an optional-rest `next`) resolve to an iterator that is not a generator-like Application, so extraction yields `None` and nothing is forced — matching tsc and avoiding over-reporting on the optional-rest form.

Closes #14814.

## Goal
Goal: hold

## Verification
- New regression suite (8 cases, real default libs, binder names varied): `cargo test -p tsz-checker --test iterator_next_send_type_call_result_tests` — covers for-of/spread/destructuring/`yield*`, sync + async, the `yield*` TReturn recovery, and the `Set`/`Map`/`IterableIterator`/optional-rest/undefined-`TNext` controls.
- Verified verbatim (codes, spans, message text) against `tsc 6.0.2` for every positive and control case.
- No new regressions across `cargo test -p tsz-checker --lib -- iterable iterator generator yield for_of spread destructur` (the only failures are pre-existing on the base commit and unrelated to this change — full-lib environment).
- ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMxcw1JJAvMH91yHUd4qiF)_