### PR TITLE
fix(config): match tsc 6.0 default-module derivation for omitted/ES3 target

### DIFF
--- a/crates/tsz-core/src/config/parse.rs
+++ b/crates/tsz-core/src/config/parse.rs
@@ -1119,11 +1119,14 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
         // Match the defaulting chain `resolve_compiler_options` uses so the
         // pre-resolve TS5098 gate doesn't disagree with the post-resolve
         // option state. tsz's defaults are:
-        //   target unset → default ScriptTarget::ESNext
-        //   module unset → default ESNext (when target unset) else
-        //                  `default_module_kind_for_target(target, true)`
+        //   target unset → `default_module_kind_for_target` folds it to
+        //                  `LatestStandard` per tsc 6.0
+        //   module unset → `default_module_kind_for_target(target, explicit)`
+        //                  (tsc 6.0: `ES2022` when target is unset)
         //   moduleResolution unset → `default_module_resolution_for_module(module)`
-        // and `Bundler` / `Node16` / `NodeNext` all count as "modern".
+        // and `Bundler` / `Node16` / `NodeNext` all count as "modern". The
+        // unset-target module (`ES2022`) still resolves to `Bundler`, so this
+        // gate is unaffected by the exact module kind.
         // See https://github.com/tsz-org/tsz/issues/3509.
         let mr_is_modern = if let Some(serde_json::Value::String(mr_value)) =
             compiler_opts.get("moduleResolution")

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -149,30 +149,58 @@ impl ModuleResolutionKind {
 
 /// Default module kind used when `module` is omitted.
 ///
-/// The default differs depending on whether `target` was explicitly supplied,
-/// matching the existing tsc-parity behavior used by config resolution.
+/// Faithful port of tsc 6.0's `_computedOptions.module.computeValue`
+/// (`commandLineParser.ts`), which derives the module from the *effective*
+/// target rather than the raw `target` option:
+///
+/// 1. `_computedOptions.target.computeValue` first folds an omitted target —
+///    and an explicit `ES3`, which tsc 6.0 no longer treats as a distinct
+///    emit target — into `LatestStandard` (`ES2025`).
+/// 2. The module is then chosen from that effective target by descending
+///    capability tiers: `ESNext -> ESNext`, `>= ES2022 -> ES2022`,
+///    `>= ES2020 -> ES2020`, `>= ES2015 -> ES2015`, otherwise `CommonJS`.
+///
+/// This is what distinguishes tsc 6.0 from the older
+/// `target >= ES2015 ? ES2015 : CommonJS` rule. The observable consequences,
+/// both verified against the pinned tsc 6.0.2:
+/// - with no `target`/`module`, the default module is `ES2022` (not `ESNext`),
+///   so capability gates such as TS2823 (import attributes) fire by default
+///   exactly as tsc does instead of being silently suppressed; and
+/// - `--target es3` reports module `ES2022` (folded through `LatestStandard`)
+///   rather than `CommonJS`, so `--showConfig` omits the implied `module` line
+///   just as tsc does.
+///
+/// `target_explicitly_set` distinguishes an omitted `target` from one that was
+/// supplied, because callers pass an already-defaulted [`ScriptTarget`]; only
+/// the omitted case (and an explicit `ES3`) folds to `LatestStandard`.
+///
+/// The `LatestStandard` fold is intentionally *local* to module derivation and
+/// must not be hoisted into a shared "effective target": lib and checker-target
+/// resolution deliberately keep tsz's own default target (`ES2024`, set by
+/// `PrinterOptions::default`) and preserve an explicit `ES3`, so sharing the
+/// fold would change lib-file selection.
 #[must_use]
 pub const fn default_module_kind_for_target(
     target: ScriptTarget,
     target_explicitly_set: bool,
 ) -> ModuleKind {
-    if !target_explicitly_set {
-        return ModuleKind::ESNext;
-    }
+    // Step 1: resolve the effective target. An omitted target and an explicit
+    // `ES3` both collapse to `LatestStandard` (`ES2025`).
+    let effective = if !target_explicitly_set || matches!(target, ScriptTarget::ES3) {
+        ScriptTarget::ES2025
+    } else {
+        target
+    };
 
-    match target {
-        ScriptTarget::ES3 | ScriptTarget::ES5 => ModuleKind::CommonJS,
-        ScriptTarget::ES2015
-        | ScriptTarget::ES2016
-        | ScriptTarget::ES2017
-        | ScriptTarget::ES2018
-        | ScriptTarget::ES2019 => ModuleKind::ES2015,
-        ScriptTarget::ES2020 | ScriptTarget::ES2021 => ModuleKind::ES2020,
-        ScriptTarget::ES2022
-        | ScriptTarget::ES2023
-        | ScriptTarget::ES2024
-        | ScriptTarget::ES2025 => ModuleKind::ES2022,
+    // Step 2: pick the module from the effective target by capability tier,
+    // reusing the shared `ScriptTarget::supports_*` comparators. `ESNext` must
+    // be matched before the tiers because it outranks every dated target.
+    match effective {
         ScriptTarget::ESNext => ModuleKind::ESNext,
+        t if t.supports_es2022() => ModuleKind::ES2022,
+        t if t.supports_es2020() => ModuleKind::ES2020,
+        t if t.supports_es2015() => ModuleKind::ES2015,
+        _ => ModuleKind::CommonJS,
     }
 }
 

--- a/crates/tsz-core/src/config/tests/module_resolution.rs
+++ b/crates/tsz-core/src/config/tests/module_resolution.rs
@@ -147,25 +147,55 @@ fn test_ts6046_emitted_for_invalid_module_detection_and_new_line() {
 
 #[test]
 fn test_shared_module_defaults_cover_targets_and_resolution() {
+    // tsc 6.0 `_computedOptions.module.computeValue`: every dated target tier,
+    // verified against the pinned tsc 6.0.2 via `--showConfig`.
     assert_eq!(
         default_module_kind_for_target(ScriptTarget::ES5, true),
         ModuleKind::CommonJS
+    );
+    assert_eq!(
+        default_module_kind_for_target(ScriptTarget::ES2015, true),
+        ModuleKind::ES2015
     );
     assert_eq!(
         default_module_kind_for_target(ScriptTarget::ES2019, true),
         ModuleKind::ES2015
     );
     assert_eq!(
+        default_module_kind_for_target(ScriptTarget::ES2020, true),
+        ModuleKind::ES2020
+    );
+    assert_eq!(
         default_module_kind_for_target(ScriptTarget::ES2021, true),
         ModuleKind::ES2020
+    );
+    assert_eq!(
+        default_module_kind_for_target(ScriptTarget::ES2022, true),
+        ModuleKind::ES2022
     );
     assert_eq!(
         default_module_kind_for_target(ScriptTarget::ES2025, true),
         ModuleKind::ES2022
     );
     assert_eq!(
-        default_module_kind_for_target(ScriptTarget::ES2025, false),
+        default_module_kind_for_target(ScriptTarget::ESNext, true),
         ModuleKind::ESNext
+    );
+    // tsc 6.0 folds an explicit `ES3` into `LatestStandard` before deriving the
+    // module, so it lands on `ES2022` rather than the legacy `CommonJS`.
+    assert_eq!(
+        default_module_kind_for_target(ScriptTarget::ES3, true),
+        ModuleKind::ES2022
+    );
+    // An omitted `target` resolves to `LatestStandard` (`ES2025`) → `ES2022`,
+    // independent of the already-defaulted `ScriptTarget` the caller passes.
+    assert_eq!(
+        default_module_kind_for_target(ScriptTarget::ES2025, false),
+        ModuleKind::ES2022
+    );
+    assert_eq!(
+        default_module_kind_for_target(ScriptTarget::ESNext, false),
+        ModuleKind::ES2022
     );
     assert_eq!(
         default_module_resolution_for_module(ModuleKind::System),
@@ -183,6 +213,34 @@ fn test_shared_module_defaults_cover_targets_and_resolution() {
         default_module_resolution_for_module(ModuleKind::NodeNext),
         ModuleResolutionKind::NodeNext
     );
+}
+
+#[test]
+fn test_omitted_module_resolves_to_tsc6_default_es2022() {
+    // tsc 6.0 derives the default module from `LatestStandard` when `module`
+    // and `target` are both omitted, which lands on `ES2022` (not `ESNext`).
+    // Verified against the pinned tsc 6.0.2: `tsc --showConfig` omits the
+    // implied `module` line for `--target es2022`, proving the default equals
+    // the `ES2022`-derived module.
+    let resolved = resolve_compiler_options(None).unwrap();
+    assert_eq!(resolved.printer.module, ModuleKind::ES2022);
+    assert_eq!(resolved.checker.module, ModuleKind::ES2022);
+    assert!(!resolved.checker.module_explicitly_set);
+
+    // An explicit target with `module` omitted follows the same tiered table.
+    let with_target = |target: &str| {
+        let json = format!(r#"{{"compilerOptions":{{"target":"{target}"}}}}"#);
+        let config: TsConfig = serde_json::from_str(&json).unwrap();
+        resolve_compiler_options(config.compiler_options.as_ref())
+            .unwrap()
+            .printer
+            .module
+    };
+    assert_eq!(with_target("es5"), ModuleKind::CommonJS);
+    assert_eq!(with_target("es2015"), ModuleKind::ES2015);
+    assert_eq!(with_target("es2020"), ModuleKind::ES2020);
+    assert_eq!(with_target("es2022"), ModuleKind::ES2022);
+    assert_eq!(with_target("esnext"), ModuleKind::ESNext);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #14856.

## Summary

`default_module_kind_for_target` — the single shared helper that derives the
default `module` when `--module` is omitted — diverged from the pinned **tsc
6.0.2** in two cases. This rewrites it as a faithful port of tsc 6.0's
`_computedOptions.module.computeValue` plus the `target.computeValue` fold,
verified empirically against `tsc 6.0.2`.

The issue body was written against tsc **5.9.3** (`target >= ES2015 ? ES2015 :
CommonJS`), and the originally reported TS1378/TS2854/TS1343 repro is stale
under 6.0.2 — both `ESNext` and `ES2022` sit inside those gates' allowed sets,
so neither tsc nor tsz fires them on default options. But the same function had
**real** 6.0.2 divergences, which this PR fixes broadly rather than chasing the
stale symptom.

## Structural rule

When `module` is omitted, tsc 6.0 derives it from the *effective* target:
`target.computeValue` first folds an omitted `target` **and** an explicit `ES3`
into `LatestStandard` (`ES2025`); `module.computeValue` then descends capability
tiers (`ESNext→ESNext`, `>=ES2022→ES2022`, `>=ES2020→ES2020`,
`>=ES2015→ES2015`, else `CommonJS`). tsz does this through the solver-adjacent
config layer (`tsz_core::config::resolved_options::default_module_kind_for_target`).

Previously tsz returned `ESNext` for an omitted target and `CommonJS` for `ES3`.

## Behavioral consequences (verified against tsc 6.0.2)

- **No `target`/`module`** → default module is now `ES2022` (was `ESNext`).
  Confirmed via `tsc --showConfig --target es2022` omitting the implied
  `module` line, and `--target es5`/`es2015`/`esnext` showing it.
- **TS2823 (import attributes)** now fires by default exactly as tsc does
  (default module `ES2022` is outside the import-attribute-allowed set), instead
  of being silently suppressed under the old `ESNext` default. Verified:
  `tsc --noEmit imp.ts` (no flags) emits TS2823.
- **`--target es3`** → module folds to `ES2022` (not `CommonJS`), so
  `--showConfig` omits the implied `module` line just as tsc does.

The fold is kept *local* to module derivation: lib and checker-target
resolution deliberately retain tsz's own default target (`ES2024`) and a
distinct `ES3`, so the fold must not leak into lib-file selection.

## Adjacent-case matrix

Every dated tier plus the explicit/omitted and `ES3` cases are covered in
`test_shared_module_defaults_cover_targets_and_resolution`, and the end-to-end
resolution path (`resolve_compiler_options`) in
`test_omitted_module_resolves_to_tsc6_default_es2022`.

## Owner layer

`tsz-core` config resolution (the shared default-module gateway consumed by the
checker capability gates, the emitter/printer, and `--showConfig`). No
checker/emitter internals touched; the existing `ScriptTarget::supports_*`
comparators are reused for the tier checks.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo nextest run -p tsz-core` config suite — `test_shared_module_defaults_cover_targets_and_resolution`, `test_omitted_module_resolves_to_tsc6_default_es2022`, and the 229-test `config::` module all pass.
- `cargo clippy -p tsz-core --lib` clean.
- Empirically cross-checked against pinned `tsc 6.0.2` via `--showConfig` (per-target module derivation) and `--noEmit` (default-options TS2823).
- ready-review CI owns the broad conformance/emit/fourslash suites.

https://claude.ai/code/session_019yUt5pNQC4pPX62JNKsPYG

---
_Generated by [Claude Code](https://claude.ai/code/session_019yUt5pNQC4pPX62JNKsPYG)_