### PR TITLE
ci(hold): score canary compatibility rows against the tsc oracle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -759,6 +759,24 @@ jobs:
           path: .
       - name: Unpack dist-fast binaries
         run: mkdir -p .target/dist-fast && tar -C .target/dist-fast -xf dist-fast-binaries.tar
+      - name: Provision tsc oracle for canary scoring
+        # The per-row tsc oracle (scripts/ci/lib/project-tsc-oracle.sh) subtracts
+        # tsc's own diagnostics from tsz's, so a canary row where tsz reproduces
+        # tsc's errors exactly (e.g. ts-belt TS2305, tiny-invariant TS2591) scores
+        # green (parity) instead of being counted as a tsz-only regression. The
+        # guard resolves the oracle command ONCE at startup, so the pinned
+        # TypeScript must already be installed when it runs; without it every
+        # canary row records diagnostic_counts.tsc=0 / oracle_classification=unknown
+        # and tsz==tsc parity rows over-report (yellow/red). This installs the same
+        # pinned TypeScript the type-challenges oracle already uses
+        # (scripts/package.json -> scripts/node_modules/.bin/tsc, the second entry
+        # in tsz_project_oracle_tsc_command's resolution order). Best-effort: a
+        # registry hiccup leaves the oracle unavailable and the guard falls back to
+        # its pre-oracle behaviour (no regression); the job is continue-on-error.
+        # The oracle only runs for rows where tsz exits with diagnostics (not
+        # green/crash/timeout/oom rows), so this adds at most one skipLibCheck tsc
+        # run per failing row, capped by TSZ_PROJECT_COMPILE_TIMEOUT.
+        run: (cd scripts && npm install --silent --no-audit --no-fund --include=dev) || echo "::warning::tsc oracle provisioning failed; canary rows will score without the tsc oracle (pre-oracle fallback)"
       - name: Run compile canaries
         run: scripts/ci/project-compile-guard.sh
       - name: Upload compile canary logs

--- a/scripts/ci/project-compatibility.mjs
+++ b/scripts/ci/project-compatibility.mjs
@@ -124,8 +124,16 @@ function codesFromLines(lines, limit) {
 // Single-sided failures classify as *-fails-only so dashboards can route
 // oracle-side failures away from tsz-divergence triage.
 function oracleClassificationFrom({ tscExitCodes, tszExitCodes, tscDiagnosticCodes, tszDiagnosticCodes }) {
+  // A side counts as "failed" when it emitted any diagnostic codes OR exited
+  // nonzero. Diagnostic codes are the authoritative per-compiler signal: the
+  // parity path in scripts/ci/project-compile-guard.sh normalizes tsz's exit
+  // code to 0 once the tsc oracle cancels the tsz-only delta, yet tsz DID
+  // report the same diagnostics tsc did. Keying only on the exit code there
+  // would misread that side as "passed" and mislabel a tsz==tsc parity row as
+  // tsc-fails-only instead of both-fail-same. Empty codes + nonzero exit
+  // (crash/timeout/oom) still classifies as failed via the exit-code branch.
   const failed = (exitCodes, diagnosticCodes) => (
-    exitCodes.length > 0 ? exitCodes.some((code) => code !== 0) : diagnosticCodes.length > 0
+    diagnosticCodes.length > 0 || exitCodes.some((code) => code !== 0)
   );
   const tscSignaled = tscExitCodes.length > 0 || tscDiagnosticCodes.length > 0;
   const tszSignaled = tszExitCodes.length > 0 || tszDiagnosticCodes.length > 0;

--- a/scripts/ci/test-project-compatibility.mjs
+++ b/scripts/ci/test-project-compatibility.mjs
@@ -243,6 +243,82 @@ withTempDir((dir) => {
   }
 });
 
+// Canary tsc-oracle scoring: pin the exact rows the bash guard records once a
+// tsc oracle is available for the canary set (scripts/ci/project-compile-guard.sh
+// check_project). These reproduce the guard's record_project_compatibility calls
+// verbatim — only the UNIFIED COMPAT_DIAGNOSTIC_DELTA is set (the `tsc:`/`tsz:`
+// label-partitioned body the oracle deltas emit), with NO explicit per-source
+// env overrides, so the test exercises the same aggregator path the guard does.
+//
+// Before the oracle was provisioned for the canary CI job, every canary row was
+// recorded with an empty tsc side (diagnostic_counts.tsc=0, no tsc exit code),
+// so a row where tsz reproduces tsc's diagnostics exactly was scored as a
+// tsz-only failure (yellow/red, oracle_classification=unknown). The two cases
+// below are the witnesses from the original report (ts-belt TS2305, tiny-invariant
+// TS2591): parity must cancel to green, and a genuine tsz-only delta must stay red.
+withTempDir((dir) => {
+  const jsonl = path.join(dir, "compat.jsonl");
+
+  // (1) Parity: tsz reproduces tsc's diagnostic exactly. The guard cancels the
+  // tsz-only delta, normalizes tsz's exit to 0, sets exit_class "exit success"
+  // / status "none", and records both sides via tsc_and_tsz_oracle_delta. tsc
+  // itself still exited nonzero (it flagged the same error), so its exit code is
+  // carried through. This must score GREEN with oracle_classification both-fail-same.
+  const parity = runProjectCompatibility(["record"], {
+    COMPAT_JSONL_FILE: jsonl,
+    COMPAT_NAME: "ts-belt-project",
+    COMPAT_EXIT_CLASS: "exit success",
+    COMPAT_PHASE: "check",
+    COMPAT_DIAGNOSTIC_STATUS: "none",
+    COMPAT_DIAGNOSTIC_DELTA: [
+      "tsc: src/Dict/Dict.ts(2,17): error TS2305: Module '\"../types\"' has no exported member 'NonNullable'.",
+      "tsz: src/Dict/Dict.ts(2,17): error TS2305: Module '\"../types\"' has no exported member 'NonNullable'.",
+    ].join("\n"),
+    COMPAT_TSZ_EXIT_CODES: "0",
+    COMPAT_TSC_EXIT_CODES: "2",
+  });
+  assert.equal(parity.status, 0, parity.stderr);
+
+  // (2) Genuine tsz-only failure: tsc is clean (exit 0, no diagnostics) but tsz
+  // reports an error tsc does not. The guard records exit_class "nonzero exit"
+  // / "diagnostic mismatch" with only the tsz line (tsz_only_and_tsc_context_delta).
+  // This must stay a tsz-fails-only failure (not green), so genuine regressions
+  // are not hidden by the oracle.
+  const tszOnly = runProjectCompatibility(["record"], {
+    COMPAT_JSONL_FILE: jsonl,
+    COMPAT_NAME: "tiny-invariant-project",
+    COMPAT_EXIT_CLASS: "nonzero exit",
+    COMPAT_PHASE: "check",
+    COMPAT_DIAGNOSTIC_STATUS: "diagnostic mismatch or compiler error",
+    COMPAT_DIAGNOSTIC_DELTA:
+      "tsz: src/tiny-invariant.ts(1,31): error TS2591: Cannot find name 'process'.",
+    COMPAT_TSZ_EXIT_CODES: "2",
+    COMPAT_TSC_EXIT_CODES: "0",
+  });
+  assert.equal(tszOnly.status, 0, tszOnly.stderr);
+
+  const [parityRow, tszOnlyRow] = fs
+    .readFileSync(jsonl, "utf8")
+    .trim()
+    .split(/\r?\n/)
+    .map(JSON.parse);
+
+  assert.equal(parityRow.name, "ts-belt-project");
+  assert.equal(parityRow.state, "green", "parity row must score green");
+  assert.equal(parityRow.oracle_classification, "both-fail-same", "parity row classification");
+  assert.deepEqual(parityRow.diagnostic_counts, { tsc: 1, tsz: 1, tsgo: 0 });
+  assert.deepEqual(parityRow.tsc_diagnostic_codes, ["TS2305"]);
+  assert.deepEqual(parityRow.tsz_diagnostic_codes, ["TS2305"]);
+  assert.deepEqual(parityRow.exit_codes, { tsc: [2], tsz: [0], tsgo: [] });
+
+  assert.equal(tszOnlyRow.name, "tiny-invariant-project");
+  assert.notEqual(tszOnlyRow.state, "green", "genuine tsz-only delta must not score green");
+  assert.equal(tszOnlyRow.oracle_classification, "tsz-fails-only", "tsz-only row classification");
+  assert.deepEqual(tszOnlyRow.diagnostic_counts, { tsc: 0, tsz: 1, tsgo: 0 });
+  assert.deepEqual(tszOnlyRow.tsc_diagnostic_codes, []);
+  assert.deepEqual(tszOnlyRow.tsz_diagnostic_codes, ["TS2591"]);
+});
+
 // Residency: oom/timeout/crash rows must carry both measurements AND
 // structured reasons (when absent). A bare null without a reason is a schema
 // violation downstream; the runner is expected to pass a reason via env, but


### PR DESCRIPTION
Goal: hold

## Summary

The compatibility page (tsz.dev/compatibility) over-reports the canary set:
canary rows are scored **without** the tsc oracle, so a row where tsz emits the
same diagnostics tsc emits is recorded as a tsz-only failure (yellow/red)
instead of canceling to green. Witnesses: `ts-belt` (TS2305 on `Dict.ts`) and
`tiny-invariant` (TS2591 on `process`) show non-green though tsz is in exact
parity with tsc.

## Structural rule

When tsz emits a diagnostic that tsc **also** emits at the same
(basename, line, column, code), `tsc` and tsz are in parity and the row must
score green (parity cancels). The cancellation is owned by the per-row tsc
oracle in `scripts/ci/lib/project-tsc-oracle.sh`, driven by `check_project` in
`scripts/ci/project-compile-guard.sh`. That guard resolves the oracle command
**once at startup** (`TSC_ORACLE_CMD`); if no tsc binary is resolvable it skips
the oracle and falls back to counting every tsz diagnostic as a tsz-only
failure.

The `project-compile-canary` CI job (`.github/workflows/ci.yml`) never makes a
tsc available, so `TSC_ORACLE_CMD` is empty for every canary shard. Confirmed
from CI run 28353547198 (`project-compile-canary-logs`): all 58 canary rows have
`oracle_classification=unknown` and `exit_codes.tsc=[]` (oracle never ran); 25
rows have `diagnostic_counts.tsc=0` with tsz diagnostics, i.e. the over-report
set (ts-belt, tiny-invariant, zod, kysely, ...). The required set scores
correctly only because its 8 fixtures are tsc-clean (the oracle is a no-op
there) and the one row that needs a real oracle, `type-challenges-solutions`,
carries its own bespoke static oracle.

## Fix (lowest-cost correct)

- **`.github/workflows/ci.yml`** — add a `Provision tsc oracle for canary
  scoring` step to the `project-compile-canary` matrix job that installs the
  **same pinned TypeScript the type-challenges oracle already uses**
  (`scripts/package.json` -> `scripts/node_modules/.bin/tsc`, the 2nd entry in
  `tsz_project_oracle_tsc_command`'s resolution order) before the guard runs.
  The guard then subtracts tsc's diagnostics per row, so tsz==tsc cancels to
  green and genuine tsz-only deltas stay red. Best-effort (`|| ::warning`): a
  registry hiccup degrades to the pre-oracle fallback (no regression), and the
  job is `continue-on-error`.
- **`scripts/ci/project-compatibility.mjs`** — `oracleClassificationFrom` now
  treats a side with diagnostic codes as failed even when its exit code is 0.
  The parity path normalizes tsz's exit to 0 after the oracle cancels the
  tsz-only delta, yet tsz did report the same diagnostics tsc did; keying only
  on the exit code mislabeled a tsz==tsc parity row as `tsc-fails-only` instead
  of `both-fail-same`. (The green **state** was already correct via the bash
  `exit success`/`none` record; this fixes the classification label.)

### Cache vs recompile / CI-cost note

No cross-run tsc cache exists for the canary corpus (the committed
`tsc-cache-full.json` covers the conformance corpus, not these cloned-repo
fixtures; the fixtures themselves are re-cloned each run). The oracle only runs
for rows where tsz **exits with diagnostics** — green/crash/timeout/oom rows are
skipped — so this adds at most one `skipLibCheck` tsc run per failing row
(~25 rows across 3 shards in run 28353547198), each capped by
`TSZ_PROJECT_COMPILE_TIMEOUT` (90s). The npm install is small and uses the
job's existing `npm_config_cache`. This is the designed mechanism (the oracle
header documents preferring a real tsc); a committed per-project tsc baseline
would avoid the runs but adds a heavy artifact + maintenance burden, so the
live-oracle path is the lowest-cost correct option. The required-set job and
the bench PGO canary step are untouched (no tsc provisioned there), so neither
pays the cost nor changes scoring.

## Verification

- `node scripts/ci/test-project-compatibility.mjs` — extended with two cases
  reproducing the guard's exact `record` calls (unified `tsc:`/`tsz:` delta, no
  explicit per-source env): a parity row (`ts-belt`, tsz_exit normalized to 0,
  tsc_exit=2, TS2305 on both sides) scores **green / both-fail-same**; a genuine
  tsz-only row (`tiny-invariant`, tsc clean, TS2591) stays **tsz-fails-only**
  (not green). Passes.
- `node scripts/ci/test-project-tsc-oracle.mjs` — passes (bash oracle helpers).
- `node scripts/ci/test-project-compat-ratchet.mjs` — passes (9/9).
- `node scripts/ci/test-project-compile-guard-{fingerprint,readiness-artifacts,rss-sentinel}.mjs` — pass.
- The full existing oracle-classification matrix in
  `test-project-compatibility.mjs` (both-pass, tsc-fails-only, tsz-fails-only,
  both-fail-same, both-fail-same-no-codes, both-fail-different, three
  no-tsc-signal cases) is unchanged and passes under the new `failed()`.
- `python3 -c yaml.safe_load` on `ci.yml`: valid. `bash -n` on the guard +
  oracle + aggregate scripts: clean.
- End-to-end capture (the canary CI job actually resolving tsc and the over-
  reported rows flipping to green) will be confirmed by the next canary CI run.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
