### PR TITLE
refactor(solver): bundle relation query overflow result (#14346)

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -332,6 +332,32 @@ impl RelationResult {
     }
 }
 
+const fn relation_result_from_compat_checker<R: TypeResolver>(
+    kind: RelationKind,
+    related: bool,
+    checker: &CompatChecker<'_, R>,
+) -> RelationResult {
+    RelationResult {
+        kind,
+        related,
+        depth_exceeded: checker.depth_exceeded(),
+        iteration_exceeded: checker.iteration_exceeded(),
+    }
+}
+
+const fn relation_result_from_subtype_checker<R: TypeResolver>(
+    kind: RelationKind,
+    related: bool,
+    checker: &SubtypeChecker<'_, R>,
+) -> RelationResult {
+    RelationResult {
+        kind,
+        related,
+        depth_exceeded: checker.depth_exceeded(),
+        iteration_exceeded: checker.iteration_exceeded(),
+    }
+}
+
 /// Structured failure details for assignability diagnostics.
 #[derive(Debug, Clone)]
 pub struct AssignabilityFailureAnalysis {
@@ -565,68 +591,43 @@ pub fn query_relation_with_overrides<
     )
     .entered();
 
-    let (related, depth_exceeded, iteration_exceeded) = match kind {
+    let result = match kind {
         RelationKind::Assignable => {
             let mut checker = configured_compat_checker(interner, resolver, policy, context);
             let related = checker.is_assignable_with_overrides(source, target, overrides);
-            (
-                related,
-                checker.depth_exceeded(),
-                checker.iteration_exceeded(),
-            )
+            relation_result_from_compat_checker(kind, related, &checker)
         }
         RelationKind::AssignableBivariantCallbacks => {
             let mut checker = configured_compat_checker(interner, resolver, policy, context);
             let _ = overrides;
             let related = checker.is_assignable_to_bivariant_callback(source, target);
-            (
-                related,
-                checker.depth_exceeded(),
-                checker.iteration_exceeded(),
-            )
+            relation_result_from_compat_checker(kind, related, &checker)
         }
         RelationKind::Subtype => {
             let mut checker = configured_subtype_checker(interner, resolver, policy, context);
             let related = checker.is_subtype_of(source, target);
-            (
-                related,
-                checker.depth_exceeded(),
-                checker.iteration_exceeded(),
-            )
+            relation_result_from_subtype_checker(kind, related, &checker)
         }
         RelationKind::Overlap => {
             let mut checker = configured_subtype_checker(interner, resolver, policy, context);
             let related = checker.are_types_overlapping(source, target);
-            (
-                related,
-                checker.depth_exceeded(),
-                checker.iteration_exceeded(),
-            )
+            relation_result_from_subtype_checker(kind, related, &checker)
         }
         RelationKind::RedeclarationIdentical => {
             let mut checker = configured_compat_checker(interner, resolver, policy, context);
             let related = checker.are_types_identical_for_redeclaration(source, target);
-            (
-                related,
-                checker.depth_exceeded(),
-                checker.iteration_exceeded(),
-            )
+            relation_result_from_compat_checker(kind, related, &checker)
         }
     };
 
     tracing::debug!(
-        related,
-        depth_exceeded,
-        iteration_exceeded,
+        related = result.related,
+        depth_exceeded = result.depth_exceeded,
+        iteration_exceeded = result.iteration_exceeded,
         "query_relation result"
     );
 
-    RelationResult {
-        kind,
-        related,
-        depth_exceeded,
-        iteration_exceeded,
-    }
+    result
 }
 
 /// Query the overload implementation fallback that compares erased parameter

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -328,6 +328,26 @@ fn narrowing_engine_keeps_request_stage_boundary() {
     );
 }
 
+#[test]
+fn relation_queries_keep_overflow_flags_on_relation_result() {
+    let relation_queries_rs = read_solver_source("relations/relation_queries.rs");
+
+    assert!(
+        relation_queries_rs.contains("pub struct RelationResult")
+            && relation_queries_rs.contains("fn relation_result_from_compat_checker")
+            && relation_queries_rs.contains("fn relation_result_from_subtype_checker")
+            && relation_queries_rs.contains("let result = match kind")
+            && relation_queries_rs
+                .contains("relation_result_from_compat_checker(kind, related, &checker)")
+            && relation_queries_rs
+                .contains("relation_result_from_subtype_checker(kind, related, &checker)")
+            && !relation_queries_rs
+                .contains("let (related, depth_exceeded, iteration_exceeded) = match kind"),
+        "relation query dispatch must keep related/depth/iteration verdicts bundled \
+         as RelationResult instead of passing around anonymous overflow tuples"
+    );
+}
+
 // =============================================================================
 // Identity bridge guard — DefId-as-SymbolId raw-symbol fallback budget (#14344)
 // =============================================================================


### PR DESCRIPTION
Goal: green

## Summary
Structural rule: when a relation query engine produces a related verdict plus depth/iteration overflow metadata, tsz carries those fields as the solver-owned `RelationResult`; the relation dispatcher no longer passes around an anonymous `(related, depth_exceeded, iteration_exceeded)` tuple before rebuilding the result.

Owner layer: `tsz-solver` relation query boundary.

Scope:
- Adds private `RelationResult` constructors for compat and subtype checker engines.
- Makes `query_relation_with_overrides` return a `RelationResult` from each engine branch directly.
- Updates tracing to read the bundled result fields.
- Adds a solver architecture guard to keep relation query overflow verdicts bundled.

Non-overlap:
- no #14344 reference-mint identity edits
- no #14345 materialize-once/publication edits
- no `evaluate/application.rs` edits
- no cache key or cache eligibility policy change

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(relation_queries_keep_overflow_flags_on_relation_result)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(relation_queries)'`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh scripts/ci/github-suite.sh lint`
- `wc -l crates/tsz-solver/src/relations/relation_queries.rs crates/tsz-solver/tests/architecture_guards.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high