### PR TITLE
fix(checker): TS2717/TS2394 for class+interface declaration merges

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "class_interface_merge_member_type_tests"
+path = "tests/class_interface_merge_member_type_tests.rs"
+[[test]]
 name = "namespace_import_export_equals_passthrough_tests"
 path = "tests/namespace_import_export_equals_passthrough_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_merge.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_merge.rs
@@ -256,16 +256,15 @@ impl<'a> CheckerState<'a> {
             for &member_idx in &dm.members {
                 // Phase 1: read the member shape and position under the
                 // immutable arena borrow only.
-                let mut pos = u32::MAX;
-                let shape = {
+                let (pos, shape) = {
                     let Some(member_node) = self.ctx.arena.get(member_idx) else {
                         continue;
                     };
-                    pos = member_node.pos;
+                    let pos = member_node.pos;
                     let instance = |modifiers: &Option<tsz_parser::parser::NodeList>| {
                         !self.has_static_modifier(modifiers)
                     };
-                    match member_node.kind {
+                    let shape = match member_node.kind {
                         syntax_kind_ext::PROPERTY_DECLARATION if dm.is_class => self
                             .ctx
                             .arena
@@ -318,7 +317,8 @@ impl<'a> CheckerState<'a> {
                             })
                             .unwrap_or(Shape::Skip),
                         _ => Shape::Skip,
-                    }
+                    };
+                    (pos, shape)
                 };
 
                 // Phase 2: resolve the comparison type with `&mut self`.

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_merge.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_merge.rs
@@ -270,52 +270,47 @@ impl<'a> CheckerState<'a> {
                             .arena
                             .get_property_decl(member_node)
                             .filter(|prop| instance(&prop.modifiers))
-                            .map(|prop| Shape::Property {
+                            .map_or(Shape::Skip, |prop| Shape::Property {
                                 name_idx: prop.name,
                                 type_annotation: prop.type_annotation,
                                 initializer: prop.initializer,
-                            })
-                            .unwrap_or(Shape::Skip),
+                            }),
                         syntax_kind_ext::GET_ACCESSOR if dm.is_class => self
                             .ctx
                             .arena
                             .get_accessor(member_node)
                             .filter(|acc| instance(&acc.modifiers))
-                            .map(|acc| Shape::Property {
+                            .map_or(Shape::Skip, |acc| Shape::Property {
                                 name_idx: acc.name,
                                 type_annotation: NodeIndex::NONE,
                                 initializer: NodeIndex::NONE,
-                            })
-                            .unwrap_or(Shape::Skip),
+                            }),
                         syntax_kind_ext::METHOD_DECLARATION if dm.is_class => self
                             .ctx
                             .arena
                             .get_method_decl(member_node)
                             .filter(|method| instance(&method.modifiers))
-                            .map(|method| Shape::Method {
+                            .map_or(Shape::Skip, |method| Shape::Method {
                                 name_idx: method.name,
                                 has_body: method.body.is_some(),
-                            })
-                            .unwrap_or(Shape::Skip),
+                            }),
                         syntax_kind_ext::PROPERTY_SIGNATURE if !dm.is_class => self
                             .ctx
                             .arena
                             .get_signature(member_node)
-                            .map(|sig| Shape::Property {
+                            .map_or(Shape::Skip, |sig| Shape::Property {
                                 name_idx: sig.name,
                                 type_annotation: sig.type_annotation,
                                 initializer: NodeIndex::NONE,
-                            })
-                            .unwrap_or(Shape::Skip),
+                            }),
                         syntax_kind_ext::METHOD_SIGNATURE if !dm.is_class => self
                             .ctx
                             .arena
                             .get_signature(member_node)
-                            .map(|sig| Shape::Method {
+                            .map_or(Shape::Skip, |sig| Shape::Method {
                                 name_idx: sig.name,
                                 has_body: false,
-                            })
-                            .unwrap_or(Shape::Skip),
+                            }),
                         _ => Shape::Skip,
                     };
                     (pos, shape)

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_merge.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_merge.rs
@@ -2,12 +2,29 @@ use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::Visibility;
+use tsz_solver::{TypeId, Visibility};
+
+/// A resolved instance member contributed by one declaration of a merged
+/// class+interface symbol. Carries the comparison type and enough provenance to
+/// anchor a diagnostic on the right declaration in source order.
+struct MergedMemberType {
+    /// Property name node — diagnostics anchor here (TSC points at the name).
+    name_node: NodeIndex,
+    /// Source position of the owning member, used to order the two conflicting
+    /// declarations (the earlier one supplies the canonical type).
+    pos: u32,
+    /// Resolved comparison type: the property type, or the function type for a
+    /// method.
+    ty: TypeId,
+}
 
 impl<'a> CheckerState<'a> {
     /// Check diagnostics specific to merged class+interface declarations.
     ///
     /// - TS2687: All declarations of a merged member must have identical modifiers.
+    /// - TS2717: A property declared on both halves with differing types.
+    /// - TS2394: An interface method signature incompatible with the class
+    ///   method implementation it merges with (overload-vs-implementation).
     pub(crate) fn check_merged_class_interface_declaration_diagnostics(
         &mut self,
         declarations: &[NodeIndex],
@@ -143,6 +160,293 @@ impl<'a> CheckerState<'a> {
                 &message,
                 diagnostic_codes::ALL_DECLARATIONS_OF_MUST_HAVE_IDENTICAL_MODIFIERS,
             );
+        }
+
+        self.check_merged_class_interface_member_type_conflicts(&declarations_by_position);
+    }
+
+    /// Compare the resolved member *types* across a merged class+interface
+    /// symbol, the gap that left tsz silent where tsc reports TS2717/TS2394.
+    ///
+    /// Structural rule: when a class and a merging interface (any declaration
+    /// order) both declare an instance member of the same name, tsc folds them
+    /// into one symbol and enforces type agreement.
+    /// - Two property-like members whose widened types differ -> TS2717,
+    ///   anchored on the *later* declaration, naming the earlier (canonical)
+    ///   type. This mirrors `checkVariableLikeDeclaration`, where the symbol's
+    ///   `valueDeclaration` is the first-bound declaration and every subsequent
+    ///   one must match it.
+    /// - An interface method signature is an *overload* of the class method
+    ///   *implementation*; an overload incompatible with the implementation ->
+    ///   TS2394, anchored on the interface signature. This reuses the same
+    ///   `isImplementationCompatibleWithOverload` relation the intra-class
+    ///   overload path uses.
+    ///
+    /// Only instance members participate: `static` class members live on the
+    /// constructor side and never merge with the interface. Interface+interface
+    /// conflicts are owned by `check_merged_interface_declaration_diagnostics`,
+    /// so this path compares strictly across the class/interface boundary.
+    fn check_merged_class_interface_member_type_conflicts(
+        &mut self,
+        declarations_sorted: &[NodeIndex],
+    ) {
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+
+        // Snapshot the member lists (owned) so the arena borrow is released
+        // before `&mut self` type resolution runs below.
+        struct DeclMembers {
+            is_class: bool,
+            type_params: Option<tsz_parser::parser::NodeList>,
+            members: Vec<NodeIndex>,
+        }
+        let mut decl_members: Vec<DeclMembers> = Vec::new();
+        for &decl_idx in declarations_sorted {
+            let Some(node) = self.ctx.arena.get(decl_idx) else {
+                continue;
+            };
+            match node.kind {
+                k if k == syntax_kind_ext::CLASS_DECLARATION => {
+                    if let Some(class) = self.ctx.arena.get_class(node) {
+                        decl_members.push(DeclMembers {
+                            is_class: true,
+                            type_params: class.type_parameters.clone(),
+                            members: class.members.nodes.clone(),
+                        });
+                    }
+                }
+                k if k == syntax_kind_ext::INTERFACE_DECLARATION => {
+                    if let Some(iface) = self.ctx.arena.get_interface(node) {
+                        decl_members.push(DeclMembers {
+                            is_class: false,
+                            type_params: iface.type_parameters.clone(),
+                            members: iface.members.nodes.clone(),
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Earliest-by-position property/method per name on each side. Methods
+        // are kept as a list because an interface may contribute several
+        // overload signatures for one name.
+        let mut interface_props: FxHashMap<String, MergedMemberType> = FxHashMap::default();
+        let mut interface_methods: FxHashMap<String, Vec<MergedMemberType>> = FxHashMap::default();
+        let mut class_props: FxHashMap<String, MergedMemberType> = FxHashMap::default();
+        let mut class_method_impls: FxHashMap<String, MergedMemberType> = FxHashMap::default();
+
+        // The annotated type node is `NONE` for class fields inferred from an
+        // initializer and for accessors; both route through the member helper.
+        enum Shape {
+            Property {
+                name_idx: NodeIndex,
+                type_annotation: NodeIndex,
+                initializer: NodeIndex,
+            },
+            Method {
+                name_idx: NodeIndex,
+                has_body: bool,
+            },
+            Skip,
+        }
+
+        for dm in &decl_members {
+            let (_, updates) = self.push_type_parameters(&dm.type_params);
+
+            for &member_idx in &dm.members {
+                // Phase 1: read the member shape and position under the
+                // immutable arena borrow only.
+                let mut pos = u32::MAX;
+                let shape = {
+                    let Some(member_node) = self.ctx.arena.get(member_idx) else {
+                        continue;
+                    };
+                    pos = member_node.pos;
+                    let instance = |modifiers: &Option<tsz_parser::parser::NodeList>| {
+                        !self.has_static_modifier(modifiers)
+                    };
+                    match member_node.kind {
+                        syntax_kind_ext::PROPERTY_DECLARATION if dm.is_class => self
+                            .ctx
+                            .arena
+                            .get_property_decl(member_node)
+                            .filter(|prop| instance(&prop.modifiers))
+                            .map(|prop| Shape::Property {
+                                name_idx: prop.name,
+                                type_annotation: prop.type_annotation,
+                                initializer: prop.initializer,
+                            })
+                            .unwrap_or(Shape::Skip),
+                        syntax_kind_ext::GET_ACCESSOR if dm.is_class => self
+                            .ctx
+                            .arena
+                            .get_accessor(member_node)
+                            .filter(|acc| instance(&acc.modifiers))
+                            .map(|acc| Shape::Property {
+                                name_idx: acc.name,
+                                type_annotation: NodeIndex::NONE,
+                                initializer: NodeIndex::NONE,
+                            })
+                            .unwrap_or(Shape::Skip),
+                        syntax_kind_ext::METHOD_DECLARATION if dm.is_class => self
+                            .ctx
+                            .arena
+                            .get_method_decl(member_node)
+                            .filter(|method| instance(&method.modifiers))
+                            .map(|method| Shape::Method {
+                                name_idx: method.name,
+                                has_body: method.body.is_some(),
+                            })
+                            .unwrap_or(Shape::Skip),
+                        syntax_kind_ext::PROPERTY_SIGNATURE if !dm.is_class => self
+                            .ctx
+                            .arena
+                            .get_signature(member_node)
+                            .map(|sig| Shape::Property {
+                                name_idx: sig.name,
+                                type_annotation: sig.type_annotation,
+                                initializer: NodeIndex::NONE,
+                            })
+                            .unwrap_or(Shape::Skip),
+                        syntax_kind_ext::METHOD_SIGNATURE if !dm.is_class => self
+                            .ctx
+                            .arena
+                            .get_signature(member_node)
+                            .map(|sig| Shape::Method {
+                                name_idx: sig.name,
+                                has_body: false,
+                            })
+                            .unwrap_or(Shape::Skip),
+                        _ => Shape::Skip,
+                    }
+                };
+
+                // Phase 2: resolve the comparison type with `&mut self`.
+                match shape {
+                    Shape::Skip => {}
+                    Shape::Property {
+                        name_idx,
+                        type_annotation,
+                        initializer,
+                    } => {
+                        let Some(name) = self.get_property_name(name_idx) else {
+                            continue;
+                        };
+                        let ty = if type_annotation.is_some() {
+                            self.get_type_from_type_node(type_annotation)
+                        } else if dm.is_class {
+                            // Class field/accessor with no annotation: the type
+                            // comes from the initializer, widened the way
+                            // `getWidenedTypeForVariableLikeDeclaration` widens
+                            // it (`p = "x"` -> `string`, not `"x"`). Accessors
+                            // (no initializer) route through the member helper.
+                            if initializer.is_some() {
+                                let init = self.get_type_of_node(initializer);
+                                self.widen_literal_type(init)
+                            } else {
+                                self.get_type_of_class_member(member_idx)
+                            }
+                        } else {
+                            TypeId::ANY
+                        };
+                        let entry = MergedMemberType {
+                            name_node: name_idx,
+                            pos,
+                            ty,
+                        };
+                        if dm.is_class {
+                            class_props.entry(name).or_insert(entry);
+                        } else {
+                            interface_props.entry(name).or_insert(entry);
+                        }
+                    }
+                    Shape::Method { name_idx, has_body } => {
+                        let Some(name) = self.get_property_name(name_idx) else {
+                            continue;
+                        };
+                        let ty = if dm.is_class {
+                            self.get_type_of_class_member(member_idx)
+                        } else {
+                            self.get_type_of_interface_member_simple(member_idx)
+                        };
+                        let entry = MergedMemberType {
+                            name_node: name_idx,
+                            pos,
+                            ty,
+                        };
+                        if dm.is_class {
+                            // Only the implementation (the one with a body) is a
+                            // valid target for the overload-compatibility check.
+                            if has_body {
+                                class_method_impls.entry(name).or_insert(entry);
+                            }
+                        } else {
+                            interface_methods.entry(name).or_default().push(entry);
+                        }
+                    }
+                }
+            }
+
+            self.pop_type_parameters(updates);
+        }
+
+        // TS2717: a property declared on both halves with differing widened
+        // types. Final diagnostics are position-sorted downstream, so emit
+        // directly. The earlier declaration is the symbol's value declaration
+        // in tsc; it supplies the canonical "must be of type" target, and the
+        // error anchors on the later one.
+        for (name, class_member) in &class_props {
+            let Some(iface_member) = interface_props.get(name) else {
+                continue;
+            };
+            if self.type_contains_error(class_member.ty)
+                || self.type_contains_error(iface_member.ty)
+            {
+                continue;
+            }
+            let (first, second) = if iface_member.pos <= class_member.pos {
+                (iface_member, class_member)
+            } else {
+                (class_member, iface_member)
+            };
+            if !self.duplicate_decl_types_match(first.ty, second.ty) {
+                let expected = self.format_type(first.ty);
+                let actual = self.format_type(second.ty);
+                self.error_at_node_msg(
+                    second.name_node,
+                    diagnostic_codes::SUBSEQUENT_PROPERTY_DECLARATIONS_MUST_HAVE_THE_SAME_TYPE_PROPERTY_MUST_BE_OF_TYP,
+                    &[name, &expected, &actual],
+                );
+            }
+        }
+
+        // TS2394: an interface method signature incompatible with the class
+        // method implementation it merges into.
+        for (name, overloads) in &interface_methods {
+            let Some(class_impl) = class_method_impls.get(name) else {
+                continue;
+            };
+            if self.type_contains_error(class_impl.ty) {
+                continue;
+            }
+            for overload in overloads {
+                if self.type_contains_error(overload.ty) {
+                    continue;
+                }
+                if !self.is_implementation_compatible_with_overload_inner(
+                    class_impl.ty,
+                    overload.ty,
+                    /* bivariant_params */ true,
+                ) {
+                    self.error_at_node(
+                        overload.name_node,
+                        diagnostic_messages::THIS_OVERLOAD_SIGNATURE_IS_NOT_COMPATIBLE_WITH_ITS_IMPLEMENTATION_SIGNATURE,
+                        diagnostic_codes::THIS_OVERLOAD_SIGNATURE_IS_NOT_COMPATIBLE_WITH_ITS_IMPLEMENTATION_SIGNATURE,
+                    );
+                    // tsc reports only the first incompatible overload.
+                    break;
+                }
+            }
         }
     }
 }

--- a/crates/tsz-checker/tests/class_interface_merge_member_type_tests.rs
+++ b/crates/tsz-checker/tests/class_interface_merge_member_type_tests.rs
@@ -1,0 +1,214 @@
+//! Class+interface declaration-merge member type/signature compatibility.
+//!
+//! When a class and an interface of the same name merge and declare a
+//! same-named instance member with conflicting types, tsc reports TS2717
+//! (property type conflict) or TS2394 (interface method signature incompatible
+//! with the class method implementation). These tests pin that parity, which
+//! was previously a silent false-negative (issue #14798).
+
+use tsz_checker::test_utils::check_source_code_messages as get_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    get_diagnostics(source).iter().map(|d| d.0).collect()
+}
+
+fn has_code(source: &str, code: u32) -> bool {
+    codes(source).contains(&code)
+}
+
+fn message_for(source: &str, code: u32) -> Option<String> {
+    get_diagnostics(source)
+        .into_iter()
+        .find(|d| d.0 == code)
+        .map(|d| d.1)
+}
+
+// --- TS2394: interface method vs class method implementation ----------------
+
+#[test]
+fn method_return_conflict_reports_ts2394_interface_first() {
+    let source = r#"
+interface B { m(): number; }
+class B { m(): string { return ""; } }
+"#;
+    assert!(
+        has_code(source, 2394),
+        "expected TS2394, got {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn method_return_conflict_reports_ts2394_class_first() {
+    let source = r#"
+class B { m(): string { return ""; } }
+interface B { m(): number; }
+"#;
+    assert!(
+        has_code(source, 2394),
+        "expected TS2394, got {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn method_return_compatible_is_clean() {
+    let source = r#"
+interface C { m(): number; }
+class C { m(): number { return 0; } }
+"#;
+    assert!(
+        !has_code(source, 2394),
+        "unexpected TS2394: {:?}",
+        codes(source)
+    );
+    assert!(
+        !has_code(source, 2717),
+        "unexpected TS2717: {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn method_param_conflict_reports_ts2394() {
+    // The implementation accepts a narrower param than the interface overload
+    // requires, so the overload is not satisfiable by the implementation.
+    let source = r#"
+interface B { m(x: number): void; }
+class B { m(x: string): void {} }
+"#;
+    assert!(
+        has_code(source, 2394),
+        "expected TS2394, got {:?}",
+        codes(source)
+    );
+}
+
+// --- TS2717: interface property vs class field ------------------------------
+
+#[test]
+fn property_type_conflict_reports_ts2717_interface_first() {
+    let source = r#"
+interface D { p: number; }
+class D { p = "x"; }
+"#;
+    assert!(
+        has_code(source, 2717),
+        "expected TS2717, got {:?}",
+        codes(source)
+    );
+    let msg = message_for(source, 2717).unwrap_or_default();
+    assert!(
+        msg.contains("Property 'p'")
+            && msg.contains("must be of type 'number'")
+            && msg.contains("here has type 'string'"),
+        "unexpected TS2717 message: {msg}"
+    );
+}
+
+#[test]
+fn property_type_conflict_reports_ts2717_class_first() {
+    let source = r#"
+class D { p = "x"; }
+interface D { p: number; }
+"#;
+    assert!(
+        has_code(source, 2717),
+        "expected TS2717, got {:?}",
+        codes(source)
+    );
+    // Now the class field is the canonical (first) declaration: it must be
+    // `string`, and the interface property is the one that disagrees.
+    let msg = message_for(source, 2717).unwrap_or_default();
+    assert!(
+        msg.contains("must be of type 'string'") && msg.contains("here has type 'number'"),
+        "unexpected TS2717 message: {msg}"
+    );
+}
+
+#[test]
+fn property_annotation_conflict_reports_ts2717() {
+    let source = r#"
+interface D { p: number; }
+class D { p: string = "x"; }
+"#;
+    assert!(
+        has_code(source, 2717),
+        "expected TS2717, got {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn property_type_compatible_is_clean() {
+    let source = r#"
+interface E { p: number; }
+class E { p = 1; }
+"#;
+    assert!(
+        !has_code(source, 2717),
+        "unexpected TS2717: {:?}",
+        codes(source)
+    );
+}
+
+// --- Scope guards: static + binder-name independence ------------------------
+
+#[test]
+fn static_class_member_does_not_merge_with_interface() {
+    // A static class member lives on the constructor side and never merges
+    // with the interface instance member, so no conflict is reported.
+    let source = r#"
+interface F { p: number; }
+class F { static p = "x"; p = 1; }
+"#;
+    assert!(
+        !has_code(source, 2717),
+        "unexpected TS2717: {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn conflict_is_structural_not_name_keyed() {
+    // Renaming the merged binder must not change the outcome: the rule is
+    // structural, not keyed off any particular identifier.
+    let source = r#"
+interface Widget { compute(): number; value: number; }
+class Widget {
+    compute(): string { return ""; }
+    value = "x";
+}
+"#;
+    assert!(
+        has_code(source, 2394),
+        "expected TS2394, got {:?}",
+        codes(source)
+    );
+    assert!(
+        has_code(source, 2717),
+        "expected TS2717, got {:?}",
+        codes(source)
+    );
+}
+
+#[test]
+fn fully_compatible_merge_is_clean() {
+    let source = r#"
+interface G { compute(): number; value: number; }
+class G {
+    compute(): number { return 0; }
+    value = 1;
+}
+"#;
+    assert!(
+        !has_code(source, 2394),
+        "unexpected TS2394: {:?}",
+        codes(source)
+    );
+    assert!(
+        !has_code(source, 2717),
+        "unexpected TS2717: {:?}",
+        codes(source)
+    );
+}


### PR DESCRIPTION
Fixes #14798.

When an interface and a class of the same name merge and declare a same-named
instance member with conflicting types, tsz emitted nothing. tsc reports TS2717
(property type conflict) or TS2394 (interface method signature incompatible with
the class method implementation). Interface+interface merges already fire TS2717;
the gap was specifically the class+interface declaration-merge path.

Structural rule: when a class and a merging interface (in any declaration order)
both declare an instance member of the same name, tsc folds them into one symbol
and enforces type agreement; tsz now does the same through the checker
duplicate-identifier merge path (`check_merged_class_interface_member_type_conflicts`).
- Two property-like members whose widened types differ → TS2717, anchored on the
  later declaration, naming the earlier (canonical) type. This mirrors tsc's
  `checkVariableLikeDeclaration`, where the symbol's value declaration is the
  first-bound declaration and every subsequent one must match it.
- An interface method signature is an overload of the class method
  implementation; an overload incompatible with the implementation → TS2394,
  anchored on the interface signature. This reuses the existing
  `is_implementation_compatible_with_overload_inner` relation (tsc's
  `isImplementationCompatibleWithOverload`) that the intra-class overload path
  already uses.

Owner layer: `tsz_checker`, in `duplicate_identifiers_merge.rs`. Only instance
members participate — `static` class members live on the constructor side and
never merge with the interface, so they are excluded. Interface+interface
conflicts remain owned by `check_merged_interface_declaration_diagnostics`, so
this path compares strictly across the class/interface boundary. No anti-hardcoding
concerns: decisions are structural (member kind, widened type, overload relation),
never keyed on identifier/file-name strings or rendered diagnostic text.

Adjacent-case matrix (all covered by the new test file):
- interface method `m(): number` + class `m(): string {}` → TS2394 (both orders).
- interface method param mismatch incompatible with the impl → TS2394.
- interface property `p: number` + class field `p = "x"` → TS2717 (both orders,
  canonical/anchored type swaps with order), plus the annotated-field form.
- compatible method merge and compatible property merge → stay clean.
- `static` class member of the same name → no conflict.
- renamed binders → identical outcome (structural, not name-keyed).

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test class_interface_merge_member_type_tests` (11 new tests, all pass)
- Regression sweep, all green: `overload_modifier_tests`, `abstract_method_overload_ts2416_tests`, `class_implements_overloaded_method_ts2416_tests`, `class_member_modifier_ts2687_tests`, `class_interface_namespace_merge_tests`, `class_interface_self_merge_implements_tests`, `class_duplicate_member_implicit_any_tests`, `duplicate_property_modifier_ts2687_tests`
- `cargo clippy -p tsz-checker --tests` clean
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBAZDgv18TkXYKDwAErk52)_