### PR TITLE
refactor(solver): name instantiation termination verdict (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -7,10 +7,11 @@
 //! # Termination channel (#14346 scaffold)
 //!
 //! Beyond the evaluated `TypeId`, the result now carries an explicit
-//! [`Termination`] verdict mirroring the `InstantiationResult::overflowed`
-//! precedent (`crate::instantiation::result`). The verdict names *whether* a
-//! bound (depth, fuel, solver-stack frame budget, cross-eval cycle, query-op
-//! budget) cut the walk short and, if so, which one — instead of letting an
+//! [`Termination`] verdict mirroring the instantiation result's typed
+//! termination precedent (`crate::instantiation::result`). The verdict names
+//! *whether* a bound (depth, fuel, solver-stack frame budget, cross-eval
+//! cycle, query-op budget) cut the walk short and, if so, which one — instead
+//! of letting an
 //! outer collapse silently treat a budget-truncated partial as a finished
 //! type.
 //!

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -3,7 +3,9 @@ use crate::caches::db::QueryDatabase;
 use crate::caches::instantiation_cache::{CanonicalSubst, InstantiationCacheKey};
 use crate::instantiation::instantiate::cache_stability::ProjectInstantiationCacheLimitSnapshot;
 use crate::instantiation::request::{InstantiationOptions, InstantiationRequest};
-use crate::instantiation::result::{InstantiationMemoResult, InstantiationResult};
+use crate::instantiation::result::{
+    InstantiationMemoResult, InstantiationResult, InstantiationTermination,
+};
 use crate::types::{ConditionalType, FunctionShape, PropertyInfo};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
@@ -965,7 +967,8 @@ fn run_instantiator(
     instantiator.shallow_this_only = options.shallow_this_only();
     instantiator.this_type = request.this_type();
     let result = instantiator.instantiate(request.type_id());
-    InstantiationResult::from_walk(result, instantiator.depth_exceeded)
+    let termination = InstantiationTermination::from_depth_exceeded(instantiator.depth_exceeded);
+    InstantiationResult::from_walk(result, termination)
 }
 
 /// Convenience function for instantiating a type with a substitution.
@@ -1334,7 +1337,8 @@ pub fn instantiate_type_with_depth_status(
     // Report the overflow verdict for callers that gate on it, but hand back
     // the relation-preserving bail value (never a substitution-bound free type
     // parameter) instead of the `TypeId::ERROR` sentinel (#13652).
-    InstantiationResult::from_walk(result, instantiator.depth_exceeded)
+    let termination = InstantiationTermination::from_depth_exceeded(instantiator.depth_exceeded);
+    InstantiationResult::from_walk(result, termination)
 }
 
 /// Convenience function for instantiating a type while preserving meta-type

--- a/crates/tsz-solver/src/instantiation/result.rs
+++ b/crates/tsz-solver/src/instantiation/result.rs
@@ -12,11 +12,36 @@
 
 use crate::types::TypeId;
 
+/// Whether an instantiation walk ran to completion or hit its depth guard.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InstantiationTermination {
+    /// The walk finished within the instantiation recursion-depth budget.
+    Complete,
+    /// The instantiation recursion-depth guard cut the walk short.
+    DepthExceeded,
+}
+
+impl InstantiationTermination {
+    /// Convert the raw per-walk guard bit into a named termination verdict at
+    /// the result boundary.
+    pub const fn from_depth_exceeded(depth_exceeded: bool) -> Self {
+        if depth_exceeded {
+            Self::DepthExceeded
+        } else {
+            Self::Complete
+        }
+    }
+
+    pub const fn depth_exceeded(self) -> bool {
+        matches!(self, Self::DepthExceeded)
+    }
+}
+
 /// The outcome of one instantiation walk.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct InstantiationResult {
     type_id: TypeId,
-    overflowed: bool,
+    termination: InstantiationTermination,
 }
 
 /// Instantiation result plus the verdict for project-wide cache publication.
@@ -36,7 +61,7 @@ impl InstantiationResult {
     pub const fn ok(type_id: TypeId) -> Self {
         Self {
             type_id,
-            overflowed: false,
+            termination: InstantiationTermination::Complete,
         }
     }
 
@@ -57,20 +82,19 @@ impl InstantiationResult {
     /// of collapsing to `TypeId::ERROR` so a downstream consumer (e.g.
     /// iterator-element resolution on a fully-concrete `Map<K, V>`) does not
     /// fall back to the original un-instantiated declaration and resurface a
-    /// free `T` into a concrete context (#13652). The `overflowed` flag is
+    /// free `T` into a concrete context (#13652). The termination verdict is
     /// still set so the cross-call cache refuses to memoize a budget-limited
     /// result.
     pub const fn overflow_with(type_id: TypeId) -> Self {
         Self {
             type_id,
-            overflowed: true,
+            termination: InstantiationTermination::DepthExceeded,
         }
     }
 
-    /// Construct from a `(type_id, depth_exceeded)` pair as produced by the
-    /// raw instantiator walk.
-    pub const fn from_walk(type_id: TypeId, depth_exceeded: bool) -> Self {
-        if depth_exceeded {
+    /// Construct from the walk's partial type and named termination verdict.
+    pub const fn from_walk(type_id: TypeId, termination: InstantiationTermination) -> Self {
+        if termination.depth_exceeded() {
             Self::overflow_with(type_id)
         } else {
             Self::ok(type_id)
@@ -82,7 +106,11 @@ impl InstantiationResult {
     }
 
     pub const fn depth_exceeded(self) -> bool {
-        self.overflowed
+        self.termination.depth_exceeded()
+    }
+
+    pub const fn termination(self) -> InstantiationTermination {
+        self.termination
     }
 
     /// Collapse the result to a single `TypeId`.
@@ -125,7 +153,7 @@ impl InstantiationMemoResult {
 
 #[cfg(test)]
 mod tests {
-    use super::{InstantiationMemoResult, InstantiationResult};
+    use super::{InstantiationMemoResult, InstantiationResult, InstantiationTermination};
     use crate::types::TypeId;
 
     #[test]
@@ -133,6 +161,7 @@ mod tests {
         let r = InstantiationResult::ok(TypeId::NUMBER);
         assert_eq!(r.type_id(), TypeId::NUMBER);
         assert!(!r.depth_exceeded());
+        assert_eq!(r.termination(), InstantiationTermination::Complete);
         assert_eq!(r.into_type_id(), TypeId::NUMBER);
     }
 
@@ -140,6 +169,7 @@ mod tests {
     fn overflow_result_reports_sentinel_when_no_partial() {
         let r = InstantiationResult::overflow();
         assert!(r.depth_exceeded());
+        assert_eq!(r.termination(), InstantiationTermination::DepthExceeded);
         // `overflow()` (no partial) still surfaces the `ERROR` sentinel.
         assert_eq!(r.into_type_id(), TypeId::ERROR);
     }
@@ -152,20 +182,36 @@ mod tests {
         // original and resurface a free `T` (#13652).
         let r = InstantiationResult::overflow_with(TypeId::STRING);
         assert!(r.depth_exceeded());
+        assert_eq!(r.termination(), InstantiationTermination::DepthExceeded);
         assert_eq!(r.into_type_id(), TypeId::STRING);
     }
 
     #[test]
     fn from_walk_routes_depth_flag() {
-        let ok = InstantiationResult::from_walk(TypeId::STRING, false);
+        let ok = InstantiationResult::from_walk(TypeId::STRING, InstantiationTermination::Complete);
         assert_eq!(ok.into_type_id(), TypeId::STRING);
+        assert_eq!(ok.termination(), InstantiationTermination::Complete);
 
         // A depth-exceeded walk keeps the partial type the instantiator
         // produced (the relation-preserving bail value) while still flagging
         // the overflow so the cross-call cache refuses to memoize it.
-        let bad = InstantiationResult::from_walk(TypeId::STRING, true);
+        let bad =
+            InstantiationResult::from_walk(TypeId::STRING, InstantiationTermination::DepthExceeded);
         assert!(bad.depth_exceeded());
+        assert_eq!(bad.termination(), InstantiationTermination::DepthExceeded);
         assert_eq!(bad.into_type_id(), TypeId::STRING);
+    }
+
+    #[test]
+    fn termination_names_depth_guard_bit() {
+        assert_eq!(
+            InstantiationTermination::from_depth_exceeded(false),
+            InstantiationTermination::Complete
+        );
+        assert_eq!(
+            InstantiationTermination::from_depth_exceeded(true),
+            InstantiationTermination::DepthExceeded
+        );
     }
 
     #[test]

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -183,7 +183,7 @@ pub mod computation {
         substitute_this_type, substitute_this_type_at_return_position, substitute_this_type_cached,
     };
     pub use crate::instantiation::request::{InstantiationOptions, InstantiationRequest};
-    pub use crate::instantiation::result::InstantiationResult;
+    pub use crate::instantiation::result::{InstantiationResult, InstantiationTermination};
 
     // Contextual typing
     pub use crate::contextual::{

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -291,11 +291,19 @@ fn evaluation_engine_keeps_request_stage_boundary() {
     );
     assert!(
         instantiation_result_rs.contains("pub(crate) struct InstantiationMemoResult")
+            && instantiation_result_rs.contains("pub enum InstantiationTermination")
+            && instantiation_result_rs.contains("termination: InstantiationTermination")
+            && instantiation_result_rs
+                .contains("fn from_walk(type_id: TypeId, termination: InstantiationTermination)")
             && instantiation_result_rs.contains("fn for_project_cache(")
             && instantiation_result_rs.contains("fn is_stable_for_project_cache(self) -> bool")
             && instantiation_api_rs.contains("ProjectInstantiationCacheLimitSnapshot::capture")
             && instantiation_api_rs.contains("InstantiationMemoResult::for_project_cache")
+            && instantiation_api_rs.contains("InstantiationTermination::from_depth_exceeded")
             && instantiation_api_rs.contains("is_stable_for_project_cache()")
+            && !instantiation_result_rs.contains("overflowed: bool")
+            && !instantiation_result_rs
+                .contains("fn from_walk(type_id: TypeId, depth_exceeded: bool)")
             && !instantiation_api_rs.contains("let limit_tripped ="),
         "project instantiation cache writes must consume InstantiationMemoResult stability instead of rebuilding a raw limit_tripped predicate"
     );

--- a/crates/tsz-solver/tests/public_api_tests.rs
+++ b/crates/tsz-solver/tests/public_api_tests.rs
@@ -1,8 +1,8 @@
 use tsz_solver::TypeId;
 use tsz_solver::computation::{
-    EvaluationResult, InstantiationOptions, InstantiationRequest, InstantiationResult, Termination,
-    TypeSubstitution, evaluate_type_result_with_request, evaluate_type_with_request,
-    instantiate_type_with_depth_status, instantiate_type_with_request,
+    EvaluationResult, InstantiationOptions, InstantiationRequest, InstantiationResult,
+    InstantiationTermination, Termination, TypeSubstitution, evaluate_type_result_with_request,
+    evaluate_type_with_request, instantiate_type_with_depth_status, instantiate_type_with_request,
 };
 use tsz_solver::construction::TypeInterner;
 use tsz_solver::evaluation::request::EvaluationRequest;
@@ -17,6 +17,7 @@ fn computation_exports_staged_instantiation_api() {
     let result: InstantiationResult = instantiate_type_with_request(&interner, request);
 
     assert!(!result.depth_exceeded());
+    assert_eq!(result.termination(), InstantiationTermination::Complete);
     assert_eq!(result.into_type_id(), TypeId::STRING);
 }
 
@@ -29,6 +30,7 @@ fn computation_exports_depth_status_as_instantiation_result() {
         instantiate_type_with_depth_status(&interner, TypeId::STRING, &substitution);
 
     assert!(!result.depth_exceeded());
+    assert_eq!(result.termination(), InstantiationTermination::Complete);
     assert_eq!(result.into_type_id(), TypeId::STRING);
 }
 


### PR DESCRIPTION
Goal: green

## Summary
- Names instantiation walk termination as `InstantiationTermination::{Complete, DepthExceeded}` inside `InstantiationResult`.
- Converts `TypeInstantiator.depth_exceeded` at the result boundary in the cached runner and depth-status entry point; `depth_exceeded()` and `into_type_id()` behavior stay unchanged.
- Re-exports the verdict through the staged computation API and extends the architecture guard against reintroducing `overflowed: bool` or a `(type_id, depth_exceeded)` constructor.

## Structural Rule
When an instantiation walk hits its recursion-depth guard, tsz must keep the same relation-preserving partial type while carrying a budget-limited verdict so cache publication can reject it. tsz now owns that through `tsz-solver`'s `InstantiationTermination` at the instantiation result boundary.

## Scope / Coordination
- #14346 typed termination/result lane only.
- No #14344 reference-mint/canonical decl identity edits.
- No #14345 materialize-once/publication edits.
- No `crates/tsz-solver/src/evaluation/evaluate/application.rs` edits.
- Adjacent matrix: complete result, sentinel overflow, partial overflow, raw guard-bit conversion, public staged API export, and architecture fallback guard.
- Fallback behavior: collapsed `TypeId` and `depth_exceeded()` stay unchanged; `InstantiationMemoResult` still rejects depth-exceeded results from project cache.
- Performance: metadata-only enum replacement; no new traversals, cache keys, or cache lookups.
- CI note: rebased onto #15094's `anyhow` advisory fix so `cargo-deny` can pass on the exact head.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver instantiation::result`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test public_api_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards evaluation_engine_keeps_request_stage_boundary`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- post-rebase: `git diff --check main...HEAD`
- post-rebase: `cargo fmt --all --check`
- post-rebase: `cargo deny check`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high