### PR TITLE
chore(deps): bump anyhow for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"


### PR DESCRIPTION
Goal: hold

## Summary
- Updates `anyhow` in `Cargo.lock` from `1.0.102` to `1.0.103`.
- Clears cargo-deny's new `RUSTSEC-2026-0190` advisory failure (`Error::downcast_mut()` unsoundness; fixed by `anyhow >=1.0.103`).
- Lockfile-only CI unblock; no source or compiler behavior changes.

## Failure Evidence
- #15093 cargo-deny failed on `RUSTSEC-2026-0190` for `anyhow 1.0.102`: https://github.com/tsz-org/tsz/actions/runs/28378461199/job/84074343664

## Verification
- `git diff --check`
- `cargo deny check`
- `scripts/safe-run.sh cargo check -p tsz-cli -p tsz-core -p tsz-conformance`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high