### PR TITLE
feat(solver): resolve self-looping typeof URI to its value literal (#14345)

### DIFF
--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -27,19 +27,40 @@ pub use observability::StoreStatistics;
 use state_flags::DefStateFlags;
 
 use super::publication_census;
+use crate::construction::TypeDatabase;
 #[cfg(test)]
 use crate::types::ObjectFlags;
-use crate::types::{ObjectShape, TypeId, TypeParamInfo};
+use crate::types::{ObjectShape, SymbolRef, TypeData, TypeId, TypeParamInfo};
 use crate::utils::MutexExt;
 use dashmap::{DashMap, DashSet};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use tracing::trace;
 use tsz_common::define_id;
 use tsz_common::interner::Atom;
+
+/// `TSZ_TYPEOF_URI_SELFLOOP=1` activates the program-wide value-space literal
+/// substitution for a self-looping `typeof X` query in
+/// `TypeEnvironment::resolve_type_query` (issue #14345). Default-OFF, so
+/// flag-OFF is byte-parity with the historical per-arena-only behavior (the
+/// self-looping `TypeQuery(symbol)` is returned unchanged and stays deferred).
+///
+/// When ON, a `typeof X` whose `SymbolRef`/`DefId` body resolves back to a
+/// self-referential `TypeQuery(symbol)` (the fp-ts `const URI = "Array"; type
+/// URI = typeof URI` higher-kinded-type tag idiom) is resolved to the concrete
+/// value literal published in `DefinitionStore::typeof_value_to_literal`, when
+/// one exists. Substitution is gated on a registered concrete literal, so an
+/// abstract URI / literal-less `typeof` still self-loops/defers (sound). Both
+/// the write-through (`register_typeof_value_literal_if_enabled`) and the read
+/// (`typeof_self_loop_literal`) are gated on this flag.
+pub(crate) fn typeof_uri_selfloop_enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("TSZ_TYPEOF_URI_SELFLOOP").is_ok_and(|v| v == "1"))
+}
 
 /// Global counter for assigning unique instance IDs to `DefinitionStore` instances.
 /// Used for debugging `DefId` collision issues.
@@ -462,6 +483,26 @@ pub struct DefinitionStore {
     /// SymbolRef/body path and continue to return the constructor.
     class_to_instance: DefDashMap<DefId, TypeId>,
 
+    /// Program-wide value-space literal for a merged value+type symbol's
+    /// `typeof X` query, keyed by raw `SymbolRef.0` (issue #14345).
+    ///
+    /// The fp-ts higher-kinded-type tag idiom (`const URI = "Array"; type URI =
+    /// typeof URI`) produces a self-referential type-space alias body: resolving
+    /// `typeof URI` through the `DefId`/`SymbolRef` body re-yields
+    /// `TypeQuery(URI)` and self-loops, so `URItoKind[URI]` never reduces to
+    /// `Kind<"Array", A>`. The checker computes the genuine value-space literal
+    /// (`"Array"`) per-arena into `TypeEnvironment::typeof_value_types`, but that
+    /// registration is gated on a syntactic `typeof <symbol>` node reached while
+    /// checking THIS file; a cross-arena `Kind<URI, A>` body never registers it
+    /// in the consuming arena, so the per-arena map misses. This shared slot is
+    /// the program-wide publish of that literal: producer checkers write-through
+    /// here from `TypeEnvironment::insert_typeof_value_type`, and any arena's
+    /// `resolve_type_query` consults it as the sound substitute for the
+    /// self-loop. Only populated with a concrete value literal (the producer
+    /// rejects unknown/error/any), so an abstract URI / literal-less `typeof`
+    /// stays deferred.
+    typeof_value_to_literal: DefDashMap<u32, TypeId>,
+
     /// Reverse index: `Atom` (name) -> `Vec<DefId>` for name-based lookups.
     ///
     /// Populated during `register()` for every definition. Enables O(1) lookup
@@ -541,6 +582,7 @@ impl DefinitionStore {
                 id_capacity / 2,
                 Default::default(),
             ),
+            typeof_value_to_literal: DefDashMap::default(),
             enum_member_to_parent: DefDashMap::default(),
             name_to_defs: DefDashMap::with_capacity_and_hasher(id_capacity, Default::default()),
             cross_file_cache: CrossFileQueryCache::default(),
@@ -1271,6 +1313,7 @@ impl DefinitionStore {
         self.file_to_defs.clear();
         self.class_to_constructor.clear();
         self.class_to_instance.clear();
+        self.typeof_value_to_literal.clear();
         self.enum_member_to_parent.clear();
         self.name_to_defs.clear();
         self.next_id.store(DefId::FIRST_VALID, Ordering::SeqCst);
@@ -1418,6 +1461,73 @@ impl DefinitionStore {
     /// finished building the class yet.
     pub fn get_class_instance_type(&self, class_def: DefId) -> Option<TypeId> {
         self.class_to_instance.get(&class_def).map(|r| *r)
+    }
+
+    /// Publish a merged value+type symbol's value-space `typeof` literal into
+    /// the program-wide slot (see the `typeof_value_to_literal` field doc).
+    ///
+    /// Write-through target for `TypeEnvironment::insert_typeof_value_type`. The
+    /// producing arena's local `typeof_value_types` map only carries entries for
+    /// symbols whose `typeof` query was syntactically reached while checking that
+    /// file; this shared copy lets a consuming arena's `resolve_type_query`
+    /// resolve a cross-arena self-looping `typeof X` to the concrete literal.
+    pub fn register_typeof_value_literal(&self, symbol_id: u32, literal: TypeId) {
+        if self
+            .typeof_value_to_literal
+            .insert(symbol_id, literal)
+            .is_none_or(|prev| prev != literal)
+        {
+            self.bump_generation();
+        }
+    }
+
+    /// Look up the program-wide value-space `typeof` literal for a merged
+    /// value+type symbol, if some checker has published one.
+    pub fn get_typeof_value_literal(&self, symbol_id: u32) -> Option<TypeId> {
+        self.typeof_value_to_literal.get(&symbol_id).map(|r| *r)
+    }
+
+    /// Flag-gated write-through of a merged value+type symbol's value literal
+    /// into the program-wide slot (issue #14345). Called from
+    /// `TypeEnvironment::insert_typeof_value_type`; the producer only passes a
+    /// concrete value type (unknown/error/any are rejected upstream in the
+    /// checker), so the shared slot stays sound. Gated on
+    /// `typeof_uri_selfloop_enabled()` so flag-OFF leaves the shared store (and
+    /// its generation) untouched — fully byte-parity.
+    pub fn register_typeof_value_literal_if_enabled(&self, symbol_id: u32, literal: TypeId) {
+        if typeof_uri_selfloop_enabled() {
+            self.register_typeof_value_literal(symbol_id, literal);
+        }
+    }
+
+    /// Resolve a self-looping `typeof X` query to its program-wide value literal
+    /// (issue #14345). A merged value+type symbol whose type-space body is a
+    /// self-referential `typeof X` (the fp-ts `const URI = "..."; type URI =
+    /// typeof URI` tag idiom) self-loops in `resolve_type_query` — `candidate`
+    /// re-yields `TypeQuery(symbol)`, so `URItoKind[URI]` never reduces. When the
+    /// consuming arena never registered the value literal locally (its `typeof X`
+    /// site lives in another arena), substitute the program-wide literal
+    /// published by the producing arena. Returns `None` (leaving `candidate`
+    /// unchanged) unless the flag is on, `candidate` is exactly the self-loop
+    /// `TypeQuery(symbol)`, and a concrete literal was published — so an abstract
+    /// URI / literal-less `typeof` stays deferred. Flag-gated; OFF is byte-parity.
+    pub fn typeof_self_loop_literal(
+        &self,
+        symbol: SymbolRef,
+        candidate: Option<TypeId>,
+        interner: &dyn TypeDatabase,
+    ) -> Option<TypeId> {
+        if !typeof_uri_selfloop_enabled() {
+            return None;
+        }
+        let is_self_loop = candidate.is_some_and(
+            |ty| matches!(interner.lookup(ty), Some(TypeData::TypeQuery(s)) if s == symbol),
+        );
+        if is_self_loop {
+            self.get_typeof_value_literal(symbol.0)
+        } else {
+            None
+        }
     }
 
     /// Publish an enum member `DefId` -> parent enum `DefId` edge into the

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -937,6 +937,9 @@ impl TypeEnvironment {
     /// Register the VALUE-space type a `typeof X` query should resolve to for a
     /// merged interface+value symbol. See `typeof_value_types`.
     pub fn insert_typeof_value_type(&mut self, symbol: SymbolRef, type_id: TypeId) {
+        if let Some(ref store) = self.definition_store {
+            store.register_typeof_value_literal_if_enabled(symbol.0, type_id); // #14345
+        }
         if self.typeof_value_types.get(&symbol.0) == Some(&type_id) {
             return;
         }
@@ -1571,11 +1574,7 @@ impl TypeResolver for TypeEnvironment {
         self.lookup_well_known_symbol_name(symbol)
     }
 
-    fn resolve_type_query(
-        &self,
-        symbol: SymbolRef,
-        _interner: &dyn TypeDatabase,
-    ) -> Option<TypeId> {
+    fn resolve_type_query(&self, symbol: SymbolRef, interner: &dyn TypeDatabase) -> Option<TypeId> {
         // For TypeQuery (typeof X), we need the VALUE-space type:
         // - For classes: the constructor type (stored under DefId in the types map)
         // - For other symbols: same as resolve_ref
@@ -1590,13 +1589,14 @@ impl TypeResolver for TypeEnvironment {
         if let Some(&value_ty) = self.typeof_value_types.get(&symbol.0) {
             return Some(value_ty);
         }
-        if let Some(&def_id) = self.symbol_to_def.get(&symbol.0)
-            && let Some(ty) = self.get_def(DefId(def_id.0))
-        {
-            return Some(ty);
-        }
-        // Fallback to SymbolRef lookup for non-class symbols
-        self.get(symbol)
+        // Prefer the class `DefId` constructor type, else the `SymbolRef` lookup,
+        // then #14345-substitute the program-wide literal on a self-loop body.
+        let candidate = (self.symbol_to_def.get(&symbol.0))
+            .and_then(|&def_id| self.get_def(DefId(def_id.0)))
+            .or_else(|| self.get(symbol));
+        (self.definition_store.as_ref())
+            .and_then(|store| store.typeof_self_loop_literal(symbol, candidate, interner))
+            .or(candidate)
     }
 
     fn resolve_lazy(&self, def_id: DefId, _interner: &dyn TypeDatabase) -> Option<TypeId> {


### PR DESCRIPTION
Goal: green

## Summary

Resolve a self-looping `typeof URI` to its value-space literal at the per-arena solver resolver, so the fp-ts HKT encoding `Kind<typeof URI, A>` reduces. **Dormant** — gated behind `TSZ_TYPEOF_URI_SELFLOOP` (default OFF); flag-OFF is byte-identical to `main`.

### Root pinned (witness-driven)
fp-ts tags each module with `export const URI = "Array"; export type URI = typeof URI`. At relation/eval time the merged value+type symbol's `typeof URI` **self-loops**: `resolve_type_query` returns `TypeData::TypeQuery(symbol)` again instead of the literal `"Array"`. The literal *is* computed by the checker (`register_typeof_value_type_in_envs`) but written only into the evaluator + flow-analyzer envs — the **cross-arena per-arena resolver instance has `typeof_value_types` vacant ~99.6%** (probe: 30,408/30,525 self-loops have a registered literal that never reaches this resolver). With `typeof URI` stuck as a `TypeQuery`, the conditional deferral guard (`conditional.rs:1045`) fires and `Kind<typeof URI, A>` never reduces → false `TS2322`/`TS2345`.

### Structural rule
When `resolve_type_query` would self-loop (`get(symbol)` is `TypeQuery(symbol)`) **and** a concrete value-space literal is registered for that symbol, resolve to the literal. Plumbed via a program-wide `typeof_value_to_literal` channel on `DefinitionStore` (write-through from `insert_typeof_value_type`, mirroring `class_to_instance`), keyed by symbol identity. No identifier/file-name checks. Abstract/literal-less URIs (0.4%) correctly stay deferred — tsc-faithful.

### Effect (gated OFF by default)
fp-ts es2022 both-base-flags: **959 → 812 (net −147; 155 cleared / 8 new)**. The concrete-URI `Kind` family clears (witness `Array.ts(1438)` + the `Array.ts(1429-1493)` block). Self-loop re-entries drop 30,525 → 7,775. Of the 8 new: 4 are column re-attributions of pre-existing same-line diags; 4 are genuinely-new downstream FPs (`Tree.ts(219)`, `ReadonlyMap.ts(633)`, `ReadonlyTuple.ts(85)`) from the **separate** #14344/#14345 wrong-HKT-arity-substitution entanglement that the now-correct reduction exposes. The flag therefore stays OFF until that residual is fixed; this PR lands only the sound, byte-parity self-loop resolution it requires.

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- fp-ts es2022 both-base-flags: flag-OFF = baseline **byte-identical** to a clean `main` binary (no-flags AND both-base-flags configs both byte-identical); flag-ON = 812 (−147), gated OFF.
- typeof resolution is sound: 30,408/30,525 resolve to the genuine value literal, 117 (0.4%) correctly stay deferred; tsc 5.x oracle = 0 (all tsz diags are FPs).
- Determinism: RAYON 1/2/4 = 812/812/812, byte-identical diagnostic sets.
- `cargo nextest`: `tsz-solver def::` 106/106; **0 new failures** vs `main` (all pre-existing reproduced on stashed clean tree).
- `cargo clippy -p tsz-solver --lib`: clean. `core.rs` 1918 lines (< 2000).
