### PR TITLE
refactor(solver): name conditional branch cache verdict (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -46,6 +46,42 @@ impl ConditionalBranchCacheStability {
     }
 }
 
+/// Verdict for publishing a conditional-branch relation to the depth-agnostic
+/// cross-evaluator cache.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ConditionalBranchCacheVerdict {
+    /// Publish that the true branch is assignable.
+    PublishTrueBranch,
+    /// Publish that the false branch is assignable.
+    PublishFalseBranch,
+    /// Do not publish a cross-evaluator verdict for this probe.
+    DoNotPublish,
+}
+
+impl ConditionalBranchCacheVerdict {
+    const fn from_probe(
+        relation: BranchRelation,
+        cache_stability: ConditionalBranchCacheStability,
+    ) -> Self {
+        if !cache_stability.is_depth_agnostic() {
+            return Self::DoNotPublish;
+        }
+        match relation {
+            BranchRelation::Holds => Self::PublishTrueBranch,
+            BranchRelation::Fails => Self::PublishFalseBranch,
+            BranchRelation::Undetermined => Self::DoNotPublish,
+        }
+    }
+
+    const fn as_bool(self) -> Option<bool> {
+        match self {
+            Self::PublishTrueBranch => Some(true),
+            Self::PublishFalseBranch => Some(false),
+            Self::DoNotPublish => None,
+        }
+    }
+}
+
 /// Conditional-branch relation result plus its publication verdict.
 ///
 /// The per-evaluator cache can remember any definitive branch relation. The
@@ -80,12 +116,8 @@ impl ConditionalBranchProbeResult {
         }
     }
 
-    const fn depth_agnostic_cache_verdict(self) -> Option<bool> {
-        if self.cache_stability.is_depth_agnostic() {
-            self.definitive_verdict()
-        } else {
-            None
-        }
+    const fn depth_agnostic_cache_verdict(self) -> ConditionalBranchCacheVerdict {
+        ConditionalBranchCacheVerdict::from_probe(self.relation, self.cache_stability)
     }
 }
 
@@ -779,7 +811,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             //    body, and neither operand is tainted — the same whole-run
             //    gates `closed_eval` uses before persisting.
             if conditional_branch_verdict_cache_enabled()
-                && let Some(verdict) = probe.depth_agnostic_cache_verdict()
+                && let Some(verdict) = probe.depth_agnostic_cache_verdict().as_bool()
                 && self.request_state_is_depth_agnostic_cache_stable()
                 && !self.unresolved_def_seen()
                 && !self.is_tainted(check_type)
@@ -999,7 +1031,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
 #[cfg(test)]
 mod conditional_branch_probe_result_tests {
-    use super::{BranchRelation, ConditionalBranchCacheStability, ConditionalBranchProbeResult};
+    use super::{
+        BranchRelation, ConditionalBranchCacheStability, ConditionalBranchCacheVerdict,
+        ConditionalBranchProbeResult,
+    };
 
     #[test]
     fn budget_bounded_probe_keeps_definitive_verdict_but_blocks_depth_cache() {
@@ -1010,7 +1045,11 @@ mod conditional_branch_probe_result_tests {
 
         assert_eq!(probe.relation(), BranchRelation::Fails);
         assert_eq!(probe.definitive_verdict(), Some(false));
-        assert_eq!(probe.depth_agnostic_cache_verdict(), None);
+        assert_eq!(
+            probe.depth_agnostic_cache_verdict(),
+            ConditionalBranchCacheVerdict::DoNotPublish
+        );
+        assert_eq!(probe.depth_agnostic_cache_verdict().as_bool(), None);
     }
 
     #[test]
@@ -1022,7 +1061,11 @@ mod conditional_branch_probe_result_tests {
 
         assert_eq!(probe.relation(), BranchRelation::Undetermined);
         assert_eq!(probe.definitive_verdict(), None);
-        assert_eq!(probe.depth_agnostic_cache_verdict(), None);
+        assert_eq!(
+            probe.depth_agnostic_cache_verdict(),
+            ConditionalBranchCacheVerdict::DoNotPublish
+        );
+        assert_eq!(probe.depth_agnostic_cache_verdict().as_bool(), None);
     }
 
     #[test]
@@ -1034,7 +1077,11 @@ mod conditional_branch_probe_result_tests {
 
         assert_eq!(probe.relation(), BranchRelation::Holds);
         assert_eq!(probe.definitive_verdict(), Some(true));
-        assert_eq!(probe.depth_agnostic_cache_verdict(), Some(true));
+        assert_eq!(
+            probe.depth_agnostic_cache_verdict(),
+            ConditionalBranchCacheVerdict::PublishTrueBranch
+        );
+        assert_eq!(probe.depth_agnostic_cache_verdict().as_bool(), Some(true));
     }
 }
 


### PR DESCRIPTION
Goal: green

## Summary
- Add `ConditionalBranchCacheVerdict` so the conditional branch probe carries cross-evaluator cache publication as a named verdict instead of `Option<bool>`.
- Keep local branch selection and cross-evaluator cache insert behavior unchanged; the named verdict is converted to the existing bool only at the cache API edge.
- Scope stays in the #14346 typed termination/result lane; no #14344 reference-mint identity work, no #14345 materialize-once/publication work, no `evaluate/application.rs` edits, and no queued #15098 files.

## Structural Rule
When a conditional subtype probe returns a branch relation, tsz keeps the local definitive relation separate from the solver-owned verdict about whether that relation may be published to the depth-agnostic cross-evaluator cache. Owner layer: `tsz-solver` conditional evaluation/cache boundary.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver conditional_branch_probe_result_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver evaluation::evaluate_rules::conditional::tests`
- `scripts/safe-run.sh cargo check -p tsz-solver`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high