### PR TITLE
refactor(solver): name relation query termination (#14346)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -50,8 +50,8 @@ impl<'a> CheckerState<'a> {
         let result = relation_result.is_related();
 
         self.propagate_overflow_flags(
-            relation_result.depth_exceeded,
-            relation_result.iteration_exceeded,
+            relation_result.depth_exceeded(),
+            relation_result.iteration_exceeded(),
         );
 
         trace!(source = source.0, target = target.0, result, "{label}");
@@ -1893,8 +1893,8 @@ impl<'a> CheckerState<'a> {
             self.ctx.sound_mode(),
         );
         self.propagate_overflow_flags(
-            relation_result.depth_exceeded,
-            relation_result.iteration_exceeded,
+            relation_result.depth_exceeded(),
+            relation_result.iteration_exceeded(),
         );
         let result = relation_result.is_related();
 

--- a/crates/tsz-checker/src/assignability/overload_subtype_pass.rs
+++ b/crates/tsz-checker/src/assignability/overload_subtype_pass.rs
@@ -44,8 +44,8 @@ impl<'a> CheckerState<'a> {
         let result = relation_result.is_related();
 
         self.propagate_overflow_flags(
-            relation_result.depth_exceeded,
-            relation_result.iteration_exceeded,
+            relation_result.depth_exceeded(),
+            relation_result.iteration_exceeded(),
         );
 
         trace!(source = source.0, target = target.0, result, "{label}");

--- a/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
+++ b/crates/tsz-checker/src/assignability/subtype_identity_checker.rs
@@ -76,7 +76,7 @@ impl<'a> CheckerState<'a> {
             )
         };
 
-        if relation_result.iteration_exceeded || relation_result.depth_exceeded {
+        if relation_result.iteration_exceeded() || relation_result.depth_exceeded() {
             let source_name = self.format_type_diagnostic(source);
             let target_name = self.format_type_diagnostic(target);
             self.error_at_current_node(

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -890,12 +890,10 @@ pub(crate) fn cached_assignability_with_overrides<
     if is_cacheable {
         let cache_key = assignability_cache_key(inputs.source, inputs.target, inputs.flags);
         if let Some(cached) = inputs.db.lookup_assignability_cache(cache_key) {
-            return tsz_solver::relations::relation_queries::RelationResult {
-                kind: tsz_solver::relations::relation_queries::RelationKind::Assignable,
-                related: cached,
-                depth_exceeded: false,
-                iteration_exceeded: false,
-            };
+            return tsz_solver::relations::relation_queries::RelationResult::complete(
+                tsz_solver::relations::relation_queries::RelationKind::Assignable,
+                cached,
+            );
         }
     }
 
@@ -1037,8 +1035,8 @@ pub(crate) fn check_assignable_gate_with_overrides<
     let related = outcome.result.is_related();
     let capture = CachedAssignabilityAnalysis {
         related,
-        depth_exceeded: outcome.result.depth_exceeded,
-        iteration_exceeded: outcome.result.iteration_exceeded,
+        depth_exceeded: outcome.result.depth_exceeded(),
+        iteration_exceeded: outcome.result.iteration_exceeded(),
         weak_union_violation: outcome
             .analysis
             .as_ref()
@@ -1194,8 +1192,8 @@ pub(crate) fn execute_relation<R: tsz_solver::relations::subtype::TypeResolver>(
                 query_assignability_with_failure_analysis(inputs)
             };
             let related = solver_outcome.result.is_related();
-            let depth_exceeded = solver_outcome.result.depth_exceeded;
-            let iteration_exceeded = solver_outcome.result.iteration_exceeded;
+            let depth_exceeded = solver_outcome.result.depth_exceeded();
+            let iteration_exceeded = solver_outcome.result.iteration_exceeded();
             let capture = (!request.decision_only).then(|| CachedAssignabilityAnalysis {
                 related,
                 depth_exceeded,

--- a/crates/tsz-checker/src/query_boundaries/assignability/final_relation.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/final_relation.rs
@@ -102,8 +102,8 @@ pub(crate) fn cached_final_assignability(
     };
     let raw_related = relation_result.is_related();
     checker.propagate_overflow_flags(
-        relation_result.depth_exceeded,
-        relation_result.iteration_exceeded,
+        relation_result.depth_exceeded(),
+        relation_result.iteration_exceeded(),
     );
 
     if is_cacheable {

--- a/crates/tsz-checker/src/query_boundaries/assignability/overload_subtype_pass.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/overload_subtype_pass.rs
@@ -36,12 +36,10 @@ pub(crate) fn cached_overload_subtype_pass_assignability<
     let cache_key =
         RelationCacheKey::for_assignability(inputs.source, inputs.target, policy.cache_config());
     if is_cacheable && let Some(cached) = inputs.db.lookup_assignability_cache(cache_key) {
-        return tsz_solver::relations::relation_queries::RelationResult {
-            kind: tsz_solver::relations::relation_queries::RelationKind::Assignable,
-            related: cached,
-            depth_exceeded: false,
-            iteration_exceeded: false,
-        };
+        return tsz_solver::relations::relation_queries::RelationResult::complete(
+            tsz_solver::relations::relation_queries::RelationKind::Assignable,
+            cached,
+        );
     }
 
     let context = tsz_solver::relations::relation_queries::RelationContext {

--- a/crates/tsz-checker/src/query_boundaries/assignability/relation_kind_variants.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/relation_kind_variants.rs
@@ -56,12 +56,10 @@ pub(crate) fn cached_bivariant_assignability_with_resolver<
     if is_cacheable {
         let cache_key = assignability_cache_key(source, target, flags);
         if let Some(cached) = db.lookup_assignability_cache(cache_key) {
-            return tsz_solver::relations::relation_queries::RelationResult {
-                kind: tsz_solver::relations::relation_queries::RelationKind::AssignableBivariantCallbacks,
-                related: cached,
-                depth_exceeded: false,
-                iteration_exceeded: false,
-            };
+            return tsz_solver::relations::relation_queries::RelationResult::complete(
+                tsz_solver::relations::relation_queries::RelationKind::AssignableBivariantCallbacks,
+                cached,
+            );
         }
     }
 

--- a/crates/tsz-checker/src/query_boundaries/type_checking_utilities.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_checking_utilities.rs
@@ -58,8 +58,8 @@ pub(crate) fn rest_element_array_like_relation_outcome(
 
     super::assignability::RelationOutcome {
         related: result.related,
-        depth_exceeded: result.depth_exceeded,
-        iteration_exceeded: result.iteration_exceeded,
+        depth_exceeded: result.depth_exceeded(),
+        iteration_exceeded: result.iteration_exceeded(),
         failure: None,
         weak_union_violation: false,
         property_classification: None,

--- a/crates/tsz-checker/src/query_boundaries/type_predicates.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_predicates.rs
@@ -186,8 +186,8 @@ fn type_predicate_relation_outcome<R: TypeResolver>(
 
     super::assignability::RelationOutcome {
         related: result.related,
-        depth_exceeded: result.depth_exceeded,
-        iteration_exceeded: result.iteration_exceeded,
+        depth_exceeded: result.depth_exceeded(),
+        iteration_exceeded: result.iteration_exceeded(),
         failure: None,
         weak_union_violation: false,
         property_classification: None,

--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_02.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_02.rs
@@ -506,14 +506,13 @@ fn test_bivariant_relation_boundary_preserves_overflow_flags() {
         "bivariant relation helper must return the full solver RelationResult \
          for the AssignableBivariantCallbacks kind"
     );
-    // Bivariant overflow flags must reach the boundary outcome. Accept either
-    // the legacy tuple destructure (`(r.is_related(), r.depth_exceeded, r.iteration_exceeded)`)
-    // or any direct propagation via field reads.
+    // Bivariant overflow verdicts must reach the boundary outcome through the
+    // solver-owned `RelationResult` methods.
     let bivariant_overflow_path = boundary_source
-        .contains("(r.is_related(), r.depth_exceeded, r.iteration_exceeded)")
+        .contains("(r.is_related(), r.depth_exceeded(), r.iteration_exceeded())")
         || (boundary_source.contains(".is_related()")
-            && boundary_source.contains(".depth_exceeded")
-            && boundary_source.contains(".iteration_exceeded"));
+            && boundary_source.contains(".depth_exceeded()")
+            && boundary_source.contains(".iteration_exceeded()"));
     assert!(
         bivariant_overflow_path,
         "execute_relation must forward bivariant callback depth/iteration overflow flags"
@@ -524,8 +523,8 @@ fn test_bivariant_relation_boundary_preserves_overflow_flags() {
     );
     assert!(
         checker_source.contains("self.propagate_overflow_flags(")
-            && checker_source.contains("relation_result.depth_exceeded")
-            && checker_source.contains("relation_result.iteration_exceeded")
+            && checker_source.contains("relation_result.depth_exceeded()")
+            && checker_source.contains("relation_result.iteration_exceeded()")
             && checker_source.contains("let result = relation_result.is_related();"),
         "legacy bivariant boolean wrapper must merge overflow flags before returning/caching the bool"
     );

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -319,16 +319,86 @@ pub struct RelationContext<'a> {
 pub struct RelationResult {
     pub kind: RelationKind,
     pub related: bool,
-    /// Stack-depth limit (nesting) was exceeded → TS2321 "Excessive stack depth".
-    pub depth_exceeded: bool,
-    /// Iteration-count budget was exhausted → TS2859 "Excessive complexity".
-    pub iteration_exceeded: bool,
+    termination: RelationTermination,
+}
+
+/// Whether a relation query completed or stopped at a relation budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelationTermination {
+    /// The relation completed within the stack-depth and iteration budgets.
+    Complete,
+    /// The relation stack-depth budget was exceeded → TS2321.
+    DepthExceeded,
+    /// The relation iteration-count budget was exceeded → TS2859.
+    IterationExceeded,
+}
+
+impl RelationTermination {
+    pub const fn from_flags(depth_exceeded: bool, iteration_exceeded: bool) -> Self {
+        if iteration_exceeded {
+            Self::IterationExceeded
+        } else if depth_exceeded {
+            Self::DepthExceeded
+        } else {
+            Self::Complete
+        }
+    }
+
+    /// Whether the relation stopped at any relation budget.
+    ///
+    /// This preserves the legacy broad `depth_exceeded` signal: iteration
+    /// complexity overflow also counts as exceeded for existing propagation
+    /// paths. Use [`Self::iteration_exceeded`] to distinguish TS2859-style
+    /// complexity overflow from stack-depth overflow.
+    pub const fn depth_exceeded(self) -> bool {
+        !matches!(self, Self::Complete)
+    }
+
+    pub const fn iteration_exceeded(self) -> bool {
+        matches!(self, Self::IterationExceeded)
+    }
 }
 
 impl RelationResult {
+    pub const fn complete(kind: RelationKind, related: bool) -> Self {
+        Self {
+            kind,
+            related,
+            termination: RelationTermination::Complete,
+        }
+    }
+
+    const fn new(
+        kind: RelationKind,
+        related: bool,
+        depth_exceeded: bool,
+        iteration_exceeded: bool,
+    ) -> Self {
+        Self {
+            kind,
+            related,
+            termination: RelationTermination::from_flags(depth_exceeded, iteration_exceeded),
+        }
+    }
+
     #[inline]
     pub const fn is_related(self) -> bool {
         self.related
+    }
+
+    #[inline]
+    pub const fn termination(self) -> RelationTermination {
+        self.termination
+    }
+
+    #[inline]
+    pub const fn depth_exceeded(self) -> bool {
+        self.termination.depth_exceeded()
+    }
+
+    #[inline]
+    pub const fn iteration_exceeded(self) -> bool {
+        self.termination.iteration_exceeded()
     }
 }
 
@@ -337,12 +407,12 @@ const fn relation_result_from_compat_checker<R: TypeResolver>(
     related: bool,
     checker: &CompatChecker<'_, R>,
 ) -> RelationResult {
-    RelationResult {
+    RelationResult::new(
         kind,
         related,
-        depth_exceeded: checker.depth_exceeded(),
-        iteration_exceeded: checker.iteration_exceeded(),
-    }
+        checker.depth_exceeded(),
+        checker.iteration_exceeded(),
+    )
 }
 
 const fn relation_result_from_subtype_checker<R: TypeResolver>(
@@ -350,12 +420,12 @@ const fn relation_result_from_subtype_checker<R: TypeResolver>(
     related: bool,
     checker: &SubtypeChecker<'_, R>,
 ) -> RelationResult {
-    RelationResult {
+    RelationResult::new(
         kind,
         related,
-        depth_exceeded: checker.depth_exceeded(),
-        iteration_exceeded: checker.iteration_exceeded(),
-    }
+        checker.depth_exceeded(),
+        checker.iteration_exceeded(),
+    )
 }
 
 /// Structured failure details for assignability diagnostics.
@@ -482,12 +552,12 @@ where
         }
     };
 
-    let result = RelationResult {
+    let result = RelationResult::new(
         kind,
         related,
-        depth_exceeded: checker.depth_exceeded(),
-        iteration_exceeded: checker.iteration_exceeded(),
-    };
+        checker.depth_exceeded(),
+        checker.iteration_exceeded(),
+    );
 
     // The failure analysis runs on the same `checker`, so its relation cache is
     // already warm with the decision's sub-results: the structural reason walk
@@ -622,8 +692,8 @@ pub fn query_relation_with_overrides<
 
     tracing::debug!(
         related = result.related,
-        depth_exceeded = result.depth_exceeded,
-        iteration_exceeded = result.iteration_exceeded,
+        depth_exceeded = result.depth_exceeded(),
+        iteration_exceeded = result.iteration_exceeded(),
         "query_relation result"
     );
 
@@ -644,12 +714,12 @@ pub fn query_erased_overload_params_with_matching_return_base<'a, R: TypeResolve
     let related = checker
         .check_erased_function_type_params_with_matching_return_base(source, target)
         .is_true();
-    RelationResult {
-        kind: RelationKind::Subtype,
+    RelationResult::new(
+        RelationKind::Subtype,
         related,
-        depth_exceeded: checker.depth_exceeded(),
-        iteration_exceeded: checker.iteration_exceeded(),
-    }
+        checker.depth_exceeded(),
+        checker.iteration_exceeded(),
+    )
 }
 
 /// Bundled inputs for relation queries.

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/cache_agreement.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/cache_agreement.rs
@@ -467,11 +467,11 @@ fn assignability_cache_assume_related_on_cycle_matches_uncached_depth_policy() {
     );
 
     assert!(
-        assume_uncached.depth_exceeded,
+        assume_uncached.depth_exceeded(),
         "deep nested array comparison should exceed the relation depth budget",
     );
     assert!(
-        reject_uncached.depth_exceeded,
+        reject_uncached.depth_exceeded(),
         "the non-assuming policy should see the same depth overflow",
     );
     assert!(


### PR DESCRIPTION
Goal: green

## Summary

Name the relation-query termination verdict at the solver result boundary.

- Add `RelationTermination::{Complete, DepthExceeded, IterationExceeded}` to `RelationResult`.
- Convert relation-query construction and cached clean hits to named constructors/verdict conversion.
- Update checker/query-boundary callers and focused tests to ask `depth_exceeded()` / `iteration_exceeded()` instead of reading anonymous result booleans.

## Structural Rule

When a relation query finishes, hits stack-depth, or hits iteration complexity, tsz records that state as a solver-owned `RelationTermination` on `RelationResult`. Checker/query-boundary callers keep the same observable questions through named methods; the owning result boundary no longer stores anonymous overflow booleans.

Owner layer: `tsz-solver` relation query result boundary.

## Refactor Contract

Behavior unchanged: `depth_exceeded()` preserves the legacy broad overflow signal, including iteration overflow, and `iteration_exceeded()` still distinguishes TS2859-style complexity. Existing checker `RelationOutcome` booleans remain the diagnostic plumbing surface.

Adjacent coverage: cached assignable and bivariant clean hits now construct `RelationResult::complete`; the relation policy cache-agreement tests cover depth overflow under both assume/reject policies; the checker architecture contract covers bivariant overflow propagation through the boundary.

Scope: #14346 typed termination/result lane only. No #14344 reference-mint/canonical declaration identity work, no #14345 solver def publication/materialize-once work, no `crates/tsz-solver/src/evaluation/evaluate/application.rs` edits, and no queued #15098 files.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver relation_policy_cache_agreement`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards relation_queries_keep_overflow_flags_on_relation_result`
- `CARGO_BUILD_JOBS=1 scripts/safe-run.sh cargo nextest run -p tsz-checker --lib test_bivariant_relation_boundary_preserves_overflow_flags`

## Provenance

Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high