### PR TITLE
refactor(solver): name instantiation cache state verdict (#14346)

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -870,9 +870,10 @@ pub(crate) fn instantiate_with_request_cached(
         let limit_snapshot = ProjectInstantiationCacheLimitSnapshot::capture(interner);
         let result =
             instantiate_with_request_cached_inner(interner, query_db, allow_alpha_cache, request);
+        let request_state_stability = limit_snapshot.request_state_stability_after(interner);
         let memo_result = InstantiationMemoResult::for_project_cache(
             result,
-            limit_snapshot.request_state_is_stable_after(interner),
+            request_state_stability.is_stable_for_project_cache(),
         );
         if memo_result.is_stable_for_project_cache() {
             interner

--- a/crates/tsz-solver/src/instantiation/instantiate/cache_stability.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/cache_stability.rs
@@ -26,26 +26,15 @@ pub(super) enum ProjectInstantiationCacheTaint {
 }
 
 impl ProjectInstantiationCacheStability {
-    const fn from_taint_flags(
-        newly_too_complex: bool,
-        newly_tuple_too_large: bool,
-        frame_curtailed: bool,
-        evaluation_fuel_exhausted: bool,
-        poisoned: bool,
+    fn from_ordered_taints<const N: usize>(
+        taints: [(bool, ProjectInstantiationCacheTaint); N],
     ) -> Self {
-        if newly_too_complex {
-            Self::Unstable(ProjectInstantiationCacheTaint::UnionTooComplex)
-        } else if newly_tuple_too_large {
-            Self::Unstable(ProjectInstantiationCacheTaint::TupleTooLarge)
-        } else if frame_curtailed {
-            Self::Unstable(ProjectInstantiationCacheTaint::SolverFrameCurtailment)
-        } else if evaluation_fuel_exhausted {
-            Self::Unstable(ProjectInstantiationCacheTaint::EvaluationFuelExhausted)
-        } else if poisoned {
-            Self::Unstable(ProjectInstantiationCacheTaint::Poisoned)
-        } else {
-            Self::Stable
+        for (is_tainted, taint) in taints {
+            if is_tainted {
+                return Self::Unstable(taint);
+            }
         }
+        Self::Stable
     }
 
     pub(super) const fn is_stable_for_project_cache(self) -> bool {
@@ -77,13 +66,28 @@ impl ProjectInstantiationCacheLimitSnapshot {
         let newly_tuple_too_large = interner.is_tuple_too_large() && !self.tuple_too_large;
         let frame_curtailed =
             crate::recursion::solver_frame_bail_count() != self.solver_frame_bail_count;
-        ProjectInstantiationCacheStability::from_taint_flags(
-            newly_too_complex,
-            newly_tuple_too_large,
-            frame_curtailed,
-            interner.is_evaluation_fuel_exhausted(),
-            interner.is_poisoned(),
-        )
+        ProjectInstantiationCacheStability::from_ordered_taints([
+            (
+                newly_too_complex,
+                ProjectInstantiationCacheTaint::UnionTooComplex,
+            ),
+            (
+                newly_tuple_too_large,
+                ProjectInstantiationCacheTaint::TupleTooLarge,
+            ),
+            (
+                frame_curtailed,
+                ProjectInstantiationCacheTaint::SolverFrameCurtailment,
+            ),
+            (
+                interner.is_evaluation_fuel_exhausted(),
+                ProjectInstantiationCacheTaint::EvaluationFuelExhausted,
+            ),
+            (
+                interner.is_poisoned(),
+                ProjectInstantiationCacheTaint::Poisoned,
+            ),
+        ])
     }
 }
 
@@ -93,8 +97,19 @@ mod tests {
 
     #[test]
     fn stable_request_state_allows_project_cache_publication() {
-        let stability =
-            ProjectInstantiationCacheStability::from_taint_flags(false, false, false, false, false);
+        let stability = ProjectInstantiationCacheStability::from_ordered_taints([
+            (false, ProjectInstantiationCacheTaint::UnionTooComplex),
+            (false, ProjectInstantiationCacheTaint::TupleTooLarge),
+            (
+                false,
+                ProjectInstantiationCacheTaint::SolverFrameCurtailment,
+            ),
+            (
+                false,
+                ProjectInstantiationCacheTaint::EvaluationFuelExhausted,
+            ),
+            (false, ProjectInstantiationCacheTaint::Poisoned),
+        ]);
 
         assert_eq!(stability, ProjectInstantiationCacheStability::Stable);
         assert!(stability.is_stable_for_project_cache());
@@ -102,8 +117,10 @@ mod tests {
 
     #[test]
     fn unstable_request_state_names_limit_reason() {
-        let stability =
-            ProjectInstantiationCacheStability::from_taint_flags(false, false, true, false, false);
+        let stability = ProjectInstantiationCacheStability::from_ordered_taints([(
+            true,
+            ProjectInstantiationCacheTaint::SolverFrameCurtailment,
+        )]);
 
         assert_eq!(
             stability,
@@ -116,8 +133,16 @@ mod tests {
 
     #[test]
     fn unstable_request_state_keeps_existing_priority_order() {
-        let stability =
-            ProjectInstantiationCacheStability::from_taint_flags(true, true, true, true, true);
+        let stability = ProjectInstantiationCacheStability::from_ordered_taints([
+            (true, ProjectInstantiationCacheTaint::UnionTooComplex),
+            (true, ProjectInstantiationCacheTaint::TupleTooLarge),
+            (true, ProjectInstantiationCacheTaint::SolverFrameCurtailment),
+            (
+                true,
+                ProjectInstantiationCacheTaint::EvaluationFuelExhausted,
+            ),
+            (true, ProjectInstantiationCacheTaint::Poisoned),
+        ]);
 
         assert_eq!(
             stability,

--- a/crates/tsz-solver/src/instantiation/instantiate/cache_stability.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/cache_stability.rs
@@ -7,6 +7,52 @@ pub(super) struct ProjectInstantiationCacheLimitSnapshot {
     solver_frame_bail_count: u32,
 }
 
+/// Whether the surrounding request state permits publishing an instantiation
+/// result to the project-wide cache.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ProjectInstantiationCacheStability {
+    Stable,
+    Unstable(ProjectInstantiationCacheTaint),
+}
+
+/// Which ambient limit signal made the instantiation result unsafe to cache.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ProjectInstantiationCacheTaint {
+    UnionTooComplex,
+    TupleTooLarge,
+    SolverFrameCurtailment,
+    EvaluationFuelExhausted,
+    Poisoned,
+}
+
+impl ProjectInstantiationCacheStability {
+    const fn from_taint_flags(
+        newly_too_complex: bool,
+        newly_tuple_too_large: bool,
+        frame_curtailed: bool,
+        evaluation_fuel_exhausted: bool,
+        poisoned: bool,
+    ) -> Self {
+        if newly_too_complex {
+            Self::Unstable(ProjectInstantiationCacheTaint::UnionTooComplex)
+        } else if newly_tuple_too_large {
+            Self::Unstable(ProjectInstantiationCacheTaint::TupleTooLarge)
+        } else if frame_curtailed {
+            Self::Unstable(ProjectInstantiationCacheTaint::SolverFrameCurtailment)
+        } else if evaluation_fuel_exhausted {
+            Self::Unstable(ProjectInstantiationCacheTaint::EvaluationFuelExhausted)
+        } else if poisoned {
+            Self::Unstable(ProjectInstantiationCacheTaint::Poisoned)
+        } else {
+            Self::Stable
+        }
+    }
+
+    pub(super) const fn is_stable_for_project_cache(self) -> bool {
+        matches!(self, Self::Stable)
+    }
+}
+
 impl ProjectInstantiationCacheLimitSnapshot {
     pub(super) fn capture(interner: &dyn TypeDatabase) -> Self {
         Self {
@@ -16,7 +62,10 @@ impl ProjectInstantiationCacheLimitSnapshot {
         }
     }
 
-    pub(super) fn request_state_is_stable_after(self, interner: &dyn TypeDatabase) -> bool {
+    pub(super) fn request_state_stability_after(
+        self,
+        interner: &dyn TypeDatabase,
+    ) -> ProjectInstantiationCacheStability {
         // Limit signals, each a reason a result is bounded/degraded:
         //  - union_too_complex (TS2590) / tuple_too_large (TS2799): sticky flags
         //    a nested `evaluate_*` can trip; gate on newly-tripped so a
@@ -28,10 +77,53 @@ impl ProjectInstantiationCacheLimitSnapshot {
         let newly_tuple_too_large = interner.is_tuple_too_large() && !self.tuple_too_large;
         let frame_curtailed =
             crate::recursion::solver_frame_bail_count() != self.solver_frame_bail_count;
-        !newly_too_complex
-            && !newly_tuple_too_large
-            && !frame_curtailed
-            && !interner.is_evaluation_fuel_exhausted()
-            && !interner.is_poisoned()
+        ProjectInstantiationCacheStability::from_taint_flags(
+            newly_too_complex,
+            newly_tuple_too_large,
+            frame_curtailed,
+            interner.is_evaluation_fuel_exhausted(),
+            interner.is_poisoned(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ProjectInstantiationCacheStability, ProjectInstantiationCacheTaint};
+
+    #[test]
+    fn stable_request_state_allows_project_cache_publication() {
+        let stability =
+            ProjectInstantiationCacheStability::from_taint_flags(false, false, false, false, false);
+
+        assert_eq!(stability, ProjectInstantiationCacheStability::Stable);
+        assert!(stability.is_stable_for_project_cache());
+    }
+
+    #[test]
+    fn unstable_request_state_names_limit_reason() {
+        let stability =
+            ProjectInstantiationCacheStability::from_taint_flags(false, false, true, false, false);
+
+        assert_eq!(
+            stability,
+            ProjectInstantiationCacheStability::Unstable(
+                ProjectInstantiationCacheTaint::SolverFrameCurtailment
+            )
+        );
+        assert!(!stability.is_stable_for_project_cache());
+    }
+
+    #[test]
+    fn unstable_request_state_keeps_existing_priority_order() {
+        let stability =
+            ProjectInstantiationCacheStability::from_taint_flags(true, true, true, true, true);
+
+        assert_eq!(
+            stability,
+            ProjectInstantiationCacheStability::Unstable(
+                ProjectInstantiationCacheTaint::UnionTooComplex
+            )
+        );
     }
 }


### PR DESCRIPTION
Goal: green

## Summary
- Add `ProjectInstantiationCacheStability` for the project-wide instantiation cache request-state verdict.
- Preserve current behavior by collapsing the named verdict to the existing boolean at the `InstantiationMemoResult::for_project_cache` boundary.
- Add focused tests for stable state, unstable reason naming, and the existing first-match priority order.
- Repair the CI lint ratchet by avoiding a new excessive-bool helper signature on the cache-stability verdict path.

## Structural Rule
When an instantiation request finishes, tsz preserves the typed instantiation result separately from the solver-owned verdict about whether ambient limit state makes the result safe for project-wide cache publication. Owner layer: `tsz-solver` instantiation cache-state boundary.

Scope avoids #14344 reference-mint/canonical declaration identity work, #14345 solver def publication/materialize-once work, `evaluate/application.rs`, and the open #15098/#15100/#15101/#15102 touched files.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver instantiation::instantiate::cache_stability`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `scripts/safe-run.sh cargo check -p tsz-solver`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
