### PR TITLE
refactor(solver): name recursion guard limit state (#14346)

### DIFF
--- a/crates/tsz-solver/src/recursion.rs
+++ b/crates/tsz-solver/src/recursion.rs
@@ -226,6 +226,35 @@ impl RecursionResult {
     }
 }
 
+/// Sticky limit state observed by a [`RecursionGuard`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RecursionLimitState {
+    /// No depth or iteration limit has fired.
+    Clear,
+    /// A depth-like guard fired, including explicit external marking.
+    DepthExceeded,
+    /// The iteration/work budget fired.
+    IterationExceeded,
+    /// The iteration/work budget fired, but `clear_exceeded()` cleared the
+    /// legacy main exceeded signal for a controlled retry path.
+    IterationExceededCleared,
+}
+
+impl RecursionLimitState {
+    #[inline]
+    pub(crate) const fn is_exceeded(self) -> bool {
+        matches!(self, Self::DepthExceeded | Self::IterationExceeded)
+    }
+
+    #[inline]
+    pub(crate) const fn iteration_exceeded(self) -> bool {
+        matches!(
+            self,
+            Self::IterationExceeded | Self::IterationExceededCleared
+        )
+    }
+}
+
 // ---------------------------------------------------------------------------
 // RecursionGuard
 // ---------------------------------------------------------------------------
@@ -264,10 +293,8 @@ pub struct RecursionGuard<K: Hash + Eq + Copy> {
     max_depth: u32,
     max_iterations: u32,
     max_visiting: u32,
-    exceeded: bool,
-    /// Sticky flag set when the iteration (relation-count) budget is exhausted.
-    /// Distinct from `exceeded` which also covers depth overflow.
-    iteration_exceeded: bool,
+    /// Sticky verdict recording which limit class, if any, has fired.
+    limit_state: RecursionLimitState,
 }
 
 impl<K: Hash + Eq + Copy> RecursionGuard<K> {
@@ -282,8 +309,7 @@ impl<K: Hash + Eq + Copy> RecursionGuard<K> {
             max_depth,
             max_iterations,
             max_visiting: 10_000,
-            exceeded: false,
-            iteration_exceeded: false,
+            limit_state: RecursionLimitState::Clear,
         }
     }
 
@@ -317,19 +343,18 @@ impl<K: Hash + Eq + Copy> RecursionGuard<K> {
         self.iterations = self.iterations.saturating_add(1);
 
         if self.iterations > self.max_iterations {
-            self.exceeded = true;
-            self.iteration_exceeded = true;
+            self.limit_state = RecursionLimitState::IterationExceeded;
             return RecursionResult::IterationExceeded;
         }
         if self.depth >= self.max_depth {
-            self.exceeded = true;
+            self.mark_exceeded();
             return RecursionResult::DepthExceeded;
         }
         if self.visiting.contains(&key) {
             return RecursionResult::Cycle;
         }
         if self.visiting.len() as u32 >= self.max_visiting {
-            self.exceeded = true;
+            self.mark_exceeded();
             return RecursionResult::DepthExceeded;
         }
 
@@ -459,7 +484,7 @@ impl<K: Hash + Eq + Copy> RecursionGuard<K> {
     /// subsequent calls (e.g. TS2589 "excessively deep" diagnostics).
     #[inline]
     pub const fn is_exceeded(&self) -> bool {
-        self.exceeded
+        self.limit_state.is_exceeded()
     }
 
     /// Whether the iteration (relation-count) budget was exhausted.
@@ -468,7 +493,14 @@ impl<K: Hash + Eq + Copy> RecursionGuard<K> {
     /// [`reset()`](Self::reset) is called.
     #[inline]
     pub const fn iteration_exceeded(&self) -> bool {
-        self.iteration_exceeded
+        self.limit_state.iteration_exceeded()
+    }
+
+    /// Named sticky limit state for callers/tests that need the owning verdict.
+    #[inline]
+    #[cfg(test)]
+    pub(crate) const fn limit_state(&self) -> RecursionLimitState {
+        self.limit_state
     }
 
     /// Manually mark the guard as exceeded.
@@ -477,7 +509,15 @@ impl<K: Hash + Eq + Copy> RecursionGuard<K> {
     /// further recursion should be blocked.
     #[inline]
     pub const fn mark_exceeded(&mut self) {
-        self.exceeded = true;
+        self.limit_state = match self.limit_state {
+            RecursionLimitState::IterationExceeded
+            | RecursionLimitState::IterationExceededCleared => {
+                RecursionLimitState::IterationExceeded
+            }
+            RecursionLimitState::Clear | RecursionLimitState::DepthExceeded => {
+                RecursionLimitState::DepthExceeded
+            }
+        };
     }
 
     /// Clear the depth-`exceeded` flag while preserving `visiting` / `depth` /
@@ -492,7 +532,13 @@ impl<K: Hash + Eq + Copy> RecursionGuard<K> {
     /// always fatal and must not be silently suppressed.
     #[inline]
     pub(crate) const fn clear_exceeded(&mut self) {
-        self.exceeded = false;
+        self.limit_state = match self.limit_state {
+            RecursionLimitState::IterationExceeded => RecursionLimitState::IterationExceededCleared,
+            RecursionLimitState::DepthExceeded => RecursionLimitState::Clear,
+            RecursionLimitState::Clear | RecursionLimitState::IterationExceededCleared => {
+                self.limit_state
+            }
+        };
     }
 
     // -----------------------------------------------------------------------
@@ -506,8 +552,7 @@ impl<K: Hash + Eq + Copy> RecursionGuard<K> {
         self.visiting.clear();
         self.depth = 0;
         self.iterations = 0;
-        self.exceeded = false;
-        self.iteration_exceeded = false;
+        self.limit_state = RecursionLimitState::Clear;
     }
 }
 

--- a/crates/tsz-solver/tests/recursion_tests.rs
+++ b/crates/tsz-solver/tests/recursion_tests.rs
@@ -182,6 +182,7 @@ fn depth_exceeded_at_max() {
     // depth = 2, max = 2, next enter should fail
     assert_eq!(guard.enter(3u32), RecursionResult::DepthExceeded);
     assert!(guard.is_exceeded());
+    assert_eq!(guard.limit_state(), RecursionLimitState::DepthExceeded);
 
     guard.leave(2);
     guard.leave(1);
@@ -231,6 +232,7 @@ fn iteration_exceeded() {
     // 4th attempt exceeds iteration limit
     assert_eq!(guard.enter(4u32), RecursionResult::IterationExceeded);
     assert!(guard.is_exceeded());
+    assert_eq!(guard.limit_state(), RecursionLimitState::IterationExceeded);
 }
 
 #[test]
@@ -307,8 +309,10 @@ fn max_visiting_zero_blocks_all() {
 fn mark_exceeded_manually() {
     let mut guard = RecursionGuard::<u32>::new(10, 100);
     assert!(!guard.is_exceeded());
+    assert_eq!(guard.limit_state(), RecursionLimitState::Clear);
     guard.mark_exceeded();
     assert!(guard.is_exceeded());
+    assert_eq!(guard.limit_state(), RecursionLimitState::DepthExceeded);
 }
 
 #[test]
@@ -318,6 +322,7 @@ fn exceeded_cleared_by_reset() {
     assert!(guard.is_exceeded());
     guard.reset();
     assert!(!guard.is_exceeded());
+    assert_eq!(guard.limit_state(), RecursionLimitState::Clear);
 }
 
 // ===================================================================
@@ -1162,6 +1167,10 @@ fn clear_exceeded_does_not_clear_iteration_exceeded_flag() {
         guard.iteration_exceeded(),
         "clear_exceeded must NOT clear iteration_exceeded"
     );
+    assert_eq!(
+        guard.limit_state(),
+        RecursionLimitState::IterationExceededCleared
+    );
 }
 
 #[test]
@@ -1183,6 +1192,7 @@ fn clear_exceeded_clears_depth_exceeded_when_iteration_is_not_set() {
         !guard.iteration_exceeded(),
         "iteration_exceeded remains false"
     );
+    assert_eq!(guard.limit_state(), RecursionLimitState::Clear);
     guard.leave(1);
 }
 
@@ -1200,6 +1210,7 @@ fn reset_clears_iteration_exceeded_flag() {
         !guard.iteration_exceeded(),
         "reset must clear iteration_exceeded"
     );
+    assert_eq!(guard.limit_state(), RecursionLimitState::Clear);
     // Guard is usable again.
     assert_eq!(guard.enter(1u32), RecursionResult::Entered);
     guard.leave(1);


### PR DESCRIPTION
Goal: green

## Summary
- Replace `RecursionGuard`'s anonymous sticky overflow booleans with a named `RecursionLimitState` verdict.
- Preserve existing `is_exceeded()` and `iteration_exceeded()` behavior, including the legacy `clear_exceeded()` split where the main exceeded flag is cleared while iteration exhaustion remains sticky.
- Add focused recursion tests for depth, iteration, manual marking, clearing, and reset state transitions.

## Structural Rule
When a recursion guard denies entry due to depth/max-visiting/iteration limits, or is manually marked exceeded by an owning solver path, tsz records that state as a solver-owned `RecursionLimitState` verdict. Existing callers keep the same observable questions through `is_exceeded()` and `iteration_exceeded()`.

Owner layer: `tsz-solver` recursion guard boundary.

## Scope
- #14346 typed termination/result lane only.
- No #14344 reference-mint/canonical declaration identity work.
- No #14345 solver def publication, resolver, or application materialization work.
- No `evaluate/application.rs` edits and no files touched by open #15098/#15100/#15101/#15102/#15103/#15104.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver recursion`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
