### PR TITLE
refactor(solver): name eval cache limit state (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/cache_stability.rs
+++ b/crates/tsz-solver/src/evaluation/cache_stability.rs
@@ -7,6 +7,19 @@ pub(crate) struct EvaluationCacheLimitSnapshot {
     union_too_complex: bool,
 }
 
+/// Solver-owned verdict for cache writes gated by ambient evaluation limits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum EvaluationCacheLimitState {
+    Stable,
+    UnionComplexityNewlyExceeded,
+}
+
+impl EvaluationCacheLimitState {
+    pub(crate) const fn allows_cache_writes(self) -> bool {
+        matches!(self, Self::Stable)
+    }
+}
+
 impl EvaluationCacheLimitSnapshot {
     pub(crate) fn capture(interner: &dyn TypeDatabase) -> Self {
         Self {
@@ -14,14 +27,22 @@ impl EvaluationCacheLimitSnapshot {
         }
     }
 
+    pub(crate) fn state_after(self, interner: &dyn TypeDatabase) -> EvaluationCacheLimitState {
+        if interner.is_union_too_complex() && !self.union_too_complex {
+            EvaluationCacheLimitState::UnionComplexityNewlyExceeded
+        } else {
+            EvaluationCacheLimitState::Stable
+        }
+    }
+
     pub(crate) fn union_complexity_stayed_stable_after(self, interner: &dyn TypeDatabase) -> bool {
-        !interner.is_union_too_complex() || self.union_too_complex
+        self.state_after(interner).allows_cache_writes()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::EvaluationCacheLimitSnapshot;
+    use super::{EvaluationCacheLimitSnapshot, EvaluationCacheLimitState};
     use crate::intern::TypeInterner;
 
     #[test]
@@ -29,12 +50,24 @@ mod tests {
         let interner = TypeInterner::new();
 
         let clean_snapshot = EvaluationCacheLimitSnapshot::capture(&interner);
+        assert_eq!(
+            clean_snapshot.state_after(&interner),
+            EvaluationCacheLimitState::Stable
+        );
         assert!(clean_snapshot.union_complexity_stayed_stable_after(&interner));
 
         interner.set_union_too_complex();
+        assert_eq!(
+            clean_snapshot.state_after(&interner),
+            EvaluationCacheLimitState::UnionComplexityNewlyExceeded
+        );
         assert!(!clean_snapshot.union_complexity_stayed_stable_after(&interner));
 
         let pre_existing_snapshot = EvaluationCacheLimitSnapshot::capture(&interner);
+        assert_eq!(
+            pre_existing_snapshot.state_after(&interner),
+            EvaluationCacheLimitState::Stable
+        );
         assert!(pre_existing_snapshot.union_complexity_stayed_stable_after(&interner));
     }
 }


### PR DESCRIPTION
Goal: green

## Summary
- Names the evaluation cache-limit snapshot verdict as `EvaluationCacheLimitState`.
- Keeps the existing `union_complexity_stayed_stable_after` cache-gate question unchanged by delegating it through the named verdict.
- Updates the focused cache-stability test to assert stable, newly-exceeded, and pre-existing limit states.

## Structural Rule
When an evaluation cache write compares ambient union-complexity limit state after a captured snapshot, tsz records whether the write remains stable or a new union-complexity limit was observed as a solver-owned `EvaluationCacheLimitState`. Existing cache writers keep the same boolean publish/no-publish behavior.

## Owner Layer
`tsz-solver` evaluation cache-stability boundary.

## Adjacent Matrix
- Stable: no union-complexity limit after the snapshot, or the limit was already present at snapshot capture, remains cache-write eligible.
- Newly exceeded: union complexity becomes too complex after a clean snapshot, remains cache-write ineligible.
- Fallback/non-overlap: no #14344 reference-mint/canonical declaration identity work, no #14345 solver def publication/materialize-once work, no `evaluate/application.rs` edits, and no files touched by open #15103/#15105/#15106.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver evaluation::cache_stability`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high