### PR TITLE
refactor(solver): name eval request cache stability (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -27,6 +27,7 @@ use crate::diagnostics::display_provenance::{
 use crate::evaluation::cache_stability::EvaluationCacheLimitSnapshot;
 use crate::evaluation::request::EvaluationRequest;
 use crate::evaluation::result::EvaluationMemoResult;
+use crate::evaluation::result::EvaluationRequestStability;
 use crate::evaluation::result::EvaluationResult;
 use crate::evaluation::result::TerminationKind;
 #[cfg(test)]
@@ -616,10 +617,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         request: EvaluationRequest,
     ) -> EvaluationMemoResult {
         let result = self.evaluate_request_result(request);
-        EvaluationMemoResult::for_depth_agnostic_memo(
-            result,
-            self.request_state_is_depth_agnostic_cache_stable(),
-        )
+        EvaluationMemoResult::for_depth_agnostic_memo(result, self.request_state_cache_stability())
     }
 
     /// Whether the current request state is stable enough for depth-agnostic
@@ -632,8 +630,17 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// backstop remains until every recursion-taint class is owned by the typed
     /// termination channel.
     #[inline]
+    pub(crate) const fn request_state_cache_stability(&self) -> EvaluationRequestStability {
+        EvaluationRequestStability::from_request_state(
+            self.has_incomplete_request_verdict(),
+            self.recursion_limit_hit(),
+        )
+    }
+
+    #[inline]
     pub(crate) const fn request_state_is_depth_agnostic_cache_stable(&self) -> bool {
-        !self.has_incomplete_request_verdict() && !self.recursion_limit_hit()
+        self.request_state_cache_stability()
+            .is_stable_for_depth_agnostic_cache()
     }
 
     // =========================================================================

--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -158,6 +158,33 @@ pub(crate) struct EvaluationMemoResult {
     cache_stability: EvaluationMemoStability,
 }
 
+/// Whether the evaluator request state is safe for depth-agnostic memo writes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EvaluationRequestStability {
+    Stable,
+    IncompleteVerdict,
+    RecursionLimit,
+}
+
+impl EvaluationRequestStability {
+    pub(crate) const fn from_request_state(
+        has_incomplete_request_verdict: bool,
+        recursion_limit_hit: bool,
+    ) -> Self {
+        if has_incomplete_request_verdict {
+            Self::IncompleteVerdict
+        } else if recursion_limit_hit {
+            Self::RecursionLimit
+        } else {
+            Self::Stable
+        }
+    }
+
+    pub(crate) const fn is_stable_for_depth_agnostic_cache(self) -> bool {
+        matches!(self, Self::Stable)
+    }
+}
+
 /// Whether an evaluated memo result is safe to publish into caches whose key
 /// does not encode ambient recursion/fuel state.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -167,8 +194,11 @@ pub(crate) enum EvaluationMemoStability {
 }
 
 impl EvaluationMemoStability {
-    const fn from_result(result: EvaluationResult, request_state_stable: bool) -> Self {
-        if result.is_complete() && request_state_stable {
+    const fn from_result(
+        result: EvaluationResult,
+        request_stability: EvaluationRequestStability,
+    ) -> Self {
+        if result.is_complete() && request_stability.is_stable_for_depth_agnostic_cache() {
             Self::Stable
         } else {
             Self::Unstable
@@ -185,11 +215,11 @@ impl EvaluationMemoResult {
     /// request-state stability verdict.
     pub(crate) const fn for_depth_agnostic_memo(
         result: EvaluationResult,
-        request_state_stable: bool,
+        request_stability: EvaluationRequestStability,
     ) -> Self {
         Self {
             result,
-            cache_stability: EvaluationMemoStability::from_result(result, request_state_stable),
+            cache_stability: EvaluationMemoStability::from_result(result, request_stability),
         }
     }
 
@@ -236,8 +266,8 @@ impl EvaluationMemoResult {
 #[cfg(test)]
 mod tests {
     use super::{
-        EvaluationMemoResult, EvaluationMemoStability, EvaluationResult, Termination,
-        TerminationKind,
+        EvaluationMemoResult, EvaluationMemoStability, EvaluationRequestStability,
+        EvaluationResult, Termination, TerminationKind,
     };
     use crate::types::TypeId;
 
@@ -278,7 +308,10 @@ mod tests {
     #[test]
     fn memo_result_stability_requires_complete_result_and_clean_request_state() {
         let complete = EvaluationResult::complete(TypeId::STRING);
-        let stable = EvaluationMemoResult::for_depth_agnostic_memo(complete, true);
+        let stable = EvaluationMemoResult::for_depth_agnostic_memo(
+            complete,
+            EvaluationRequestStability::Stable,
+        );
 
         assert_eq!(stable.evaluation_result(), complete);
         assert_eq!(stable.type_id(), TypeId::STRING);
@@ -286,7 +319,10 @@ mod tests {
         assert_eq!(stable.cache_stability, EvaluationMemoStability::Stable);
         assert!(stable.is_stable_for_depth_agnostic_cache());
 
-        let request_state_tainted = EvaluationMemoResult::for_depth_agnostic_memo(complete, false);
+        let request_state_tainted = EvaluationMemoResult::for_depth_agnostic_memo(
+            complete,
+            EvaluationRequestStability::RecursionLimit,
+        );
         assert_eq!(
             request_state_tainted.cache_stability,
             EvaluationMemoStability::Unstable
@@ -295,13 +331,42 @@ mod tests {
 
         let incomplete =
             EvaluationResult::incomplete(TypeId::NUMBER, TerminationKind::DepthExceeded);
-        let typed_tainted = EvaluationMemoResult::for_depth_agnostic_memo(incomplete, true);
+        let typed_tainted = EvaluationMemoResult::for_depth_agnostic_memo(
+            incomplete,
+            EvaluationRequestStability::Stable,
+        );
         assert_eq!(typed_tainted.into_type_id(), TypeId::NUMBER);
         assert_eq!(
             typed_tainted.cache_stability,
             EvaluationMemoStability::Unstable
         );
         assert!(!typed_tainted.is_stable_for_depth_agnostic_cache());
+    }
+
+    #[test]
+    fn request_stability_names_request_state_reason() {
+        assert_eq!(
+            EvaluationRequestStability::from_request_state(false, false),
+            EvaluationRequestStability::Stable
+        );
+        assert_eq!(
+            EvaluationRequestStability::from_request_state(true, false),
+            EvaluationRequestStability::IncompleteVerdict
+        );
+        assert_eq!(
+            EvaluationRequestStability::from_request_state(false, true),
+            EvaluationRequestStability::RecursionLimit
+        );
+        assert_eq!(
+            EvaluationRequestStability::from_request_state(true, true),
+            EvaluationRequestStability::IncompleteVerdict,
+            "typed incomplete verdict should stay the primary request-state reason"
+        );
+        assert!(EvaluationRequestStability::Stable.is_stable_for_depth_agnostic_cache());
+        assert!(
+            !EvaluationRequestStability::IncompleteVerdict.is_stable_for_depth_agnostic_cache()
+        );
+        assert!(!EvaluationRequestStability::RecursionLimit.is_stable_for_depth_agnostic_cache());
     }
 
     #[test]

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -213,7 +213,9 @@ impl RelationEvaluationResult {
 #[cfg(test)]
 mod relation_evaluation_result_tests {
     use super::{RelationEvaluationResult, RelationEvaluationStability};
-    use crate::evaluation::result::{EvaluationMemoResult, EvaluationResult, TerminationKind};
+    use crate::evaluation::result::{
+        EvaluationMemoResult, EvaluationRequestStability, EvaluationResult, TerminationKind,
+    };
     use crate::types::TypeId;
 
     #[test]
@@ -238,7 +240,7 @@ mod relation_evaluation_result_tests {
     fn relation_evaluation_result_imports_memo_stability() {
         let complete_memo = EvaluationMemoResult::for_depth_agnostic_memo(
             EvaluationResult::complete(TypeId::NUMBER),
-            true,
+            EvaluationRequestStability::Stable,
         );
         let complete = RelationEvaluationResult::from_depth_agnostic_memo(complete_memo);
         assert_eq!(complete.type_id(), TypeId::NUMBER);
@@ -249,7 +251,7 @@ mod relation_evaluation_result_tests {
 
         let incomplete_memo = EvaluationMemoResult::for_depth_agnostic_memo(
             EvaluationResult::incomplete(TypeId::UNKNOWN, TerminationKind::DepthExceeded),
-            true,
+            EvaluationRequestStability::Stable,
         );
         let incomplete = RelationEvaluationResult::from_depth_agnostic_memo(incomplete_memo);
         assert_eq!(incomplete.type_id(), TypeId::UNKNOWN);

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -271,6 +271,11 @@ fn evaluation_engine_keeps_request_stage_boundary() {
     );
     assert!(
         result_rs.contains("fn unstable_complete(type_id: TypeId) -> Self")
+            && result_rs.contains("enum EvaluationRequestStability")
+            && result_rs.contains("request_stability: EvaluationRequestStability")
+            && !result_rs.contains("request_state_stable: bool")
+            && evaluate_rs
+                .contains("request_state_cache_stability(&self) -> EvaluationRequestStability")
             && result_rs.contains("enum EvaluationMemoStability")
             && result_rs.contains("cache_stability: EvaluationMemoStability")
             && !result_rs.contains("stable_for_depth_agnostic_cache: bool")


### PR DESCRIPTION
Goal: green

## Summary
- Add `EvaluationRequestStability` for the evaluator request-state side of depth-agnostic memo publication.
- Preserve current behavior by collapsing the named verdict through `request_state_is_depth_agnostic_cache_stable`.
- Update memo-boundary tests and the architecture guard so callers pass a typed request-stability verdict instead of a loose boolean.

## Structural Rule
When an evaluation request finishes, tsz preserves the typed evaluation result separately from the solver-owned verdict about whether request state makes the result safe for depth-agnostic memo publication. Owner layer: `tsz-solver` evaluation result/cache-stability boundary.

Scope avoids #14344 reference-mint/canonical declaration identity work, #14345 solver def publication/materialize-once work, `evaluate/application.rs`, and files touched by open #15103/#15105/#15106/#15107.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver evaluation::result`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver relation_evaluation_result_imports_memo_stability`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards evaluation_engine_keeps_request_stage_boundary`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high