### PR TITLE
refactor(solver): name eval session limit state (#14346)

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -289,8 +289,9 @@ impl CheckerState<'_> {
         // Check BOTH per-context and session-level instantiation depth/fuel.
         // Per-context counters reset to 0 on cross-arena delegation (with_parent_cache),
         // but the session is shared via Rc so its counters survive delegation.
+        let session_limit_state = self.ctx.eval_session.instantiation_limit_state();
         if self.ctx.instantiation_depth.get() >= MAX_INSTANTIATION_DEPTH
-            || self.ctx.eval_session.instantiation_limits_exceeded()
+            || session_limit_state.is_exceeded()
         {
             self.ctx.depth_exceeded.set(true);
             self.ctx.application_eval_set.remove(&type_id);

--- a/crates/tsz-solver/src/evaluation/session.rs
+++ b/crates/tsz-solver/src/evaluation/session.rs
@@ -22,6 +22,20 @@ const MAX_GLOBAL_INSTANTIATION_DEPTH: u32 = crate::limits::MAX_GLOBAL_INSTANTIAT
 /// Canonical definition in [`crate::limits`].
 const MAX_GLOBAL_INSTANTIATION_FUEL: u32 = crate::limits::MAX_GLOBAL_INSTANTIATION_FUEL;
 
+/// Whether the shared evaluation session can enter another instantiation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EvaluationSessionLimitState {
+    WithinLimits,
+    DepthExceeded,
+    FuelExhausted,
+}
+
+impl EvaluationSessionLimitState {
+    pub const fn is_exceeded(self) -> bool {
+        !matches!(self, Self::WithinLimits)
+    }
+}
+
 /// Explicit evaluation session state.
 ///
 /// Holds depth and fuel counters that must survive across `CheckerContext`
@@ -46,11 +60,22 @@ impl EvaluationSession {
         }
     }
 
+    /// Check which global instantiation limit, if any, is exceeded.
+    #[inline]
+    pub const fn instantiation_limit_state(&self) -> EvaluationSessionLimitState {
+        if self.global_instantiation_depth.get() >= MAX_GLOBAL_INSTANTIATION_DEPTH {
+            EvaluationSessionLimitState::DepthExceeded
+        } else if self.global_instantiation_fuel.get() >= MAX_GLOBAL_INSTANTIATION_FUEL {
+            EvaluationSessionLimitState::FuelExhausted
+        } else {
+            EvaluationSessionLimitState::WithinLimits
+        }
+    }
+
     /// Check if global instantiation limits are exceeded.
     #[inline]
     pub const fn instantiation_limits_exceeded(&self) -> bool {
-        self.global_instantiation_depth.get() >= MAX_GLOBAL_INSTANTIATION_DEPTH
-            || self.global_instantiation_fuel.get() >= MAX_GLOBAL_INSTANTIATION_FUEL
+        self.instantiation_limit_state().is_exceeded()
     }
 
     /// Increment both instantiation depth and fuel before an evaluation.
@@ -99,6 +124,10 @@ mod tests {
         let session = EvaluationSession::new();
         assert_eq!(session.global_instantiation_depth(), 0);
         assert_eq!(session.global_instantiation_fuel(), 0);
+        assert_eq!(
+            session.instantiation_limit_state(),
+            EvaluationSessionLimitState::WithinLimits
+        );
         assert!(!session.instantiation_limits_exceeded());
     }
 
@@ -122,6 +151,10 @@ mod tests {
         for _ in 0..MAX_GLOBAL_INSTANTIATION_DEPTH {
             session.enter_instantiation();
         }
+        assert_eq!(
+            session.instantiation_limit_state(),
+            EvaluationSessionLimitState::DepthExceeded
+        );
         assert!(session.instantiation_limits_exceeded());
     }
 
@@ -133,6 +166,10 @@ mod tests {
             session.enter_instantiation();
             session.leave_instantiation();
         }
+        assert_eq!(
+            session.instantiation_limit_state(),
+            EvaluationSessionLimitState::FuelExhausted
+        );
         assert!(session.instantiation_limits_exceeded());
     }
 
@@ -146,6 +183,24 @@ mod tests {
         assert_eq!(session.global_instantiation_fuel(), 10);
         session.reset_instantiation_fuel();
         assert_eq!(session.global_instantiation_fuel(), 0);
+        assert_eq!(
+            session.instantiation_limit_state(),
+            EvaluationSessionLimitState::WithinLimits
+        );
         assert!(!session.instantiation_limits_exceeded());
+    }
+
+    #[test]
+    fn test_depth_limit_is_primary_when_both_limits_exceeded() {
+        let session = EvaluationSession::new();
+        for _ in 0..MAX_GLOBAL_INSTANTIATION_FUEL {
+            session.enter_instantiation();
+        }
+
+        assert_eq!(
+            session.instantiation_limit_state(),
+            EvaluationSessionLimitState::DepthExceeded,
+            "depth limit should stay the primary session limit once both limits are exceeded"
+        );
     }
 }


### PR DESCRIPTION
Goal: green

## Summary
- Add `EvaluationSessionLimitState` so shared evaluation-session instantiation limits name depth-vs-fuel instead of returning only a loose boolean.
- Preserve current behavior by keeping `instantiation_limits_exceeded()` as the compatibility collapse.
- Update the checker application-evaluation guard to consume the named session verdict before collapsing it to the existing opaque bailout.

## Structural Rule
When the shared evaluation session reaches its cross-context instantiation depth or fuel bound, tsz records which solver-owned session limit fired. The checker keeps the same observable bailout behavior by collapsing that verdict to the existing `depth_exceeded` path. Owner layer: `tsz-solver` evaluation session boundary, consumed by checker type-environment orchestration.

Scope avoids #14344 reference-mint/canonical declaration identity work, #14345 solver def publication/materialize-once work, `evaluate/application.rs`, and files touched by open #15103/#15105/#15106/#15107/#15108.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver evaluation::session`
- `scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver -p tsz-checker --all-targets -- -D warnings`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high