### PR TITLE
refactor(solver): name cross-eval expansion state (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
+++ b/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
@@ -124,7 +124,10 @@ pub(crate) fn memoized_eval_with_stability(
     if let Some(cached) = query_memo_get(type_id, no_unchecked_indexed_access) {
         return Some(EvaluationMemoResult::cached(cached));
     }
-    let _cross = CrossEvalExpansionGuard::enter(type_id)?;
+    let _cross = match CrossEvalExpansionGuard::enter(type_id) {
+        CrossEvalExpansionState::Entered(guard) => guard,
+        CrossEvalExpansionState::AlreadyActive => return None,
+    };
     let memo_result = compute();
     if memo_result.is_stable_for_depth_agnostic_cache() {
         query_memo_put(type_id, no_unchecked_indexed_access, memo_result.type_id());
@@ -140,15 +143,28 @@ pub(crate) fn memoized_eval_with_stability(
 /// unchanged. Otherwise it records membership and clears it on drop, so the set
 /// is restored even if evaluation unwinds via panic.
 #[must_use]
+#[derive(Debug)]
 pub(crate) struct CrossEvalExpansionGuard(TypeId);
 
+/// Result of entering the cross-evaluator expansion active set.
+///
+/// `Entered` owns the RAII membership guard for this expansion. `AlreadyActive`
+/// names the cross-instance cycle case that callers collapse to the existing
+/// "skip expansion and return the input unchanged" behavior.
+#[must_use]
+#[derive(Debug)]
+pub(crate) enum CrossEvalExpansionState {
+    Entered(CrossEvalExpansionGuard),
+    AlreadyActive,
+}
+
 impl CrossEvalExpansionGuard {
-    pub(crate) fn enter(type_id: TypeId) -> Option<Self> {
+    pub(crate) fn enter(type_id: TypeId) -> CrossEvalExpansionState {
         ACTIVE.with(|set| {
             if set.borrow_mut().insert(type_id) {
-                Some(Self(type_id))
+                CrossEvalExpansionState::Entered(Self(type_id))
             } else {
-                None
+                CrossEvalExpansionState::AlreadyActive
             }
         })
     }
@@ -200,22 +216,34 @@ mod tests {
     #[test]
     fn reentry_of_active_type_is_rejected() {
         let t = TypeId(4242);
-        let outer = CrossEvalExpansionGuard::enter(t).expect("first entry succeeds");
+        let CrossEvalExpansionState::Entered(outer) = CrossEvalExpansionGuard::enter(t) else {
+            panic!("first entry succeeds");
+        };
         assert!(
-            CrossEvalExpansionGuard::enter(t).is_none(),
+            matches!(
+                CrossEvalExpansionGuard::enter(t),
+                CrossEvalExpansionState::AlreadyActive
+            ),
             "re-entering an in-flight TypeId must be rejected"
         );
         drop(outer);
         assert!(
-            CrossEvalExpansionGuard::enter(t).is_some(),
+            matches!(
+                CrossEvalExpansionGuard::enter(t),
+                CrossEvalExpansionState::Entered(_)
+            ),
             "once the in-flight guard drops, the TypeId is enterable again"
         );
     }
 
     #[test]
     fn distinct_types_are_independent() {
-        let a = CrossEvalExpansionGuard::enter(TypeId(1)).expect("a enters");
-        let b = CrossEvalExpansionGuard::enter(TypeId(2)).expect("b enters independently");
+        let CrossEvalExpansionState::Entered(a) = CrossEvalExpansionGuard::enter(TypeId(1)) else {
+            panic!("a enters");
+        };
+        let CrossEvalExpansionState::Entered(b) = CrossEvalExpansionGuard::enter(TypeId(2)) else {
+            panic!("b enters independently");
+        };
         drop(a);
         drop(b);
     }


### PR DESCRIPTION
Goal: green

## Summary
- Add `CrossEvalExpansionState` so the cross-evaluator active-set gate names entered-vs-already-active state instead of returning a raw `Option`.
- Preserve current behavior by collapsing `AlreadyActive` to the existing `None` result from `memoized_eval_with_stability`.
- Update focused guard tests to assert the named states.

## Structural Rule
When a fresh evaluator tries to expand a `TypeId` already active in an ancestor fresh evaluator, tsz records the solver-owned `CrossEvalExpansionState::AlreadyActive` cycle state and still skips expansion through the existing `None` collapse. Otherwise `CrossEvalExpansionState::Entered` owns the RAII membership guard until drop. Owner layer: `tsz-solver` cross-evaluator expansion guard.

Scope avoids #14344 reference-mint/canonical declaration identity work, #14345 solver def publication/materialize-once work, `evaluate/application.rs`, and files touched by open #15100/#15101/#15102/#15103/#15104/#15105/#15106/#15107/#15108/#15109.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver evaluation::cross_eval_guard`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high