### PR TITLE
refactor(solver): name object-spread visit state (#14346)

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache_spread.rs
+++ b/crates/tsz-solver/src/caches/query_cache_spread.rs
@@ -8,6 +8,23 @@
 use super::*;
 use crate::types::Visibility;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ObjectSpreadVisitState {
+    Entered,
+    AlreadyVisited,
+}
+
+fn object_spread_visit_state(
+    visited: &mut FxHashSet<TypeId>,
+    normalized: TypeId,
+) -> ObjectSpreadVisitState {
+    if visited.insert(normalized) {
+        ObjectSpreadVisitState::Entered
+    } else {
+        ObjectSpreadVisitState::AlreadyVisited
+    }
+}
+
 impl QueryCache<'_> {
     pub(super) fn check_property_cache(
         &self,
@@ -147,8 +164,9 @@ impl QueryCache<'_> {
         let normalized =
             self.evaluate_type_with_options(spread_type, self.no_unchecked_indexed_access());
 
-        if !visited.insert(normalized) {
-            return Vec::new();
+        match object_spread_visit_state(visited, normalized) {
+            ObjectSpreadVisitState::Entered => {}
+            ObjectSpreadVisitState::AlreadyVisited => return Vec::new(),
         }
 
         if normalized != spread_type {
@@ -273,5 +291,35 @@ impl QueryCache<'_> {
                 p
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn object_spread_visit_state_records_first_entry() {
+        let mut visited = FxHashSet::default();
+
+        let state = object_spread_visit_state(&mut visited, TypeId::STRING);
+
+        assert_eq!(state, ObjectSpreadVisitState::Entered);
+        assert!(visited.contains(&TypeId::STRING));
+    }
+
+    #[test]
+    fn object_spread_visit_state_records_reentry() {
+        let mut visited = FxHashSet::default();
+
+        assert_eq!(
+            object_spread_visit_state(&mut visited, TypeId::STRING),
+            ObjectSpreadVisitState::Entered
+        );
+        assert_eq!(
+            object_spread_visit_state(&mut visited, TypeId::STRING),
+            ObjectSpreadVisitState::AlreadyVisited
+        );
+        assert_eq!(visited.len(), 1);
     }
 }


### PR DESCRIPTION
Goal: green

## Summary
- Add `ObjectSpreadVisitState::{Entered, AlreadyVisited}` around object-spread normalized `TypeId` visit tracking.
- Preserve the existing empty-property cycle break when a spread walk re-enters the same normalized `TypeId`.
- Add focused unit tests for first entry and reentry.

## Structural Rule
When object-spread property collection normalizes a spread operand to a `TypeId` already active in the current spread walk, tsz must treat that recursive contribution as no spread properties; tsz owns that as `ObjectSpreadVisitState::AlreadyVisited` in solver query-cache spread collection. Otherwise `ObjectSpreadVisitState::Entered` allows the existing recursive property collection.

## Owner Layer
`tsz-solver` cache / object-spread property collection (`crates/tsz-solver/src/caches/query_cache_spread.rs`).

## Adjacent Cases
- Binder names are not consulted.
- Normalized reentry preserves today's `Vec::new()` fallback.
- Distinct first entries keep normal recursive collection.
- Existing cache shape and publish behavior are unchanged.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver object_spread_visit_state`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
