### PR TITLE
refactor(solver): name round1 reach visit state (#14346)

### DIFF
--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers_reach.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers_reach.rs
@@ -10,6 +10,26 @@ use crate::operations::{AssignabilityChecker, CallEvaluator};
 use crate::types::{TypeData, TypeId};
 use rustc_hash::{FxHashMap, FxHashSet};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Round1ReachVisitState {
+    Entered,
+    AlreadyVisited,
+}
+
+impl Round1ReachVisitState {
+    fn record(
+        arg_type: TypeId,
+        target_type: TypeId,
+        visited: &mut FxHashSet<(TypeId, TypeId)>,
+    ) -> Self {
+        if visited.insert((arg_type, target_type)) {
+            Self::Entered
+        } else {
+            Self::AlreadyVisited
+        }
+    }
+}
+
 impl<C: AssignabilityChecker> CallEvaluator<'_, C> {
     /// Collect the inference placeholder vars that round-1 *direct argument*
     /// inference will actually constrain for `arg_type` against `target_type`.
@@ -37,8 +57,9 @@ impl<C: AssignabilityChecker> CallEvaluator<'_, C> {
         if var_map.is_empty() {
             return;
         }
-        if !visited.insert((arg_type, target_type)) {
-            return;
+        match Round1ReachVisitState::record(arg_type, target_type, visited) {
+            Round1ReachVisitState::Entered => {}
+            Round1ReachVisitState::AlreadyVisited => return,
         }
 
         // The target is itself a placeholder: the argument constrains it directly.
@@ -213,5 +234,50 @@ impl<C: AssignabilityChecker> CallEvaluator<'_, C> {
             &mut FxHashMap::default(),
             &mut FxHashSet::default(),
         ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Round1ReachVisitState;
+    use crate::types::TypeId;
+    use rustc_hash::FxHashSet;
+
+    #[test]
+    fn round1_reach_visit_state_enters_new_pair() {
+        let mut visited = FxHashSet::default();
+
+        let state = Round1ReachVisitState::record(TypeId::STRING, TypeId::NUMBER, &mut visited);
+
+        assert_eq!(state, Round1ReachVisitState::Entered);
+        assert!(visited.contains(&(TypeId::STRING, TypeId::NUMBER)));
+    }
+
+    #[test]
+    fn round1_reach_visit_state_detects_reentry() {
+        let mut visited = FxHashSet::default();
+
+        assert_eq!(
+            Round1ReachVisitState::record(TypeId::STRING, TypeId::NUMBER, &mut visited),
+            Round1ReachVisitState::Entered
+        );
+        assert_eq!(
+            Round1ReachVisitState::record(TypeId::STRING, TypeId::NUMBER, &mut visited),
+            Round1ReachVisitState::AlreadyVisited
+        );
+    }
+
+    #[test]
+    fn round1_reach_visit_state_distinguishes_target_pairs() {
+        let mut visited = FxHashSet::default();
+
+        assert_eq!(
+            Round1ReachVisitState::record(TypeId::STRING, TypeId::NUMBER, &mut visited),
+            Round1ReachVisitState::Entered
+        );
+        assert_eq!(
+            Round1ReachVisitState::record(TypeId::STRING, TypeId::BOOLEAN, &mut visited),
+            Round1ReachVisitState::Entered
+        );
     }
 }


### PR DESCRIPTION
Goal: green

## Summary
- Add `Round1ReachVisitState` around the round-1 generic-call reachability DFS visited-set gate.
- Preserve the existing already-visited early return while making the termination state explicit and testable.
- Add focused unit tests for first entry, exact-pair reentry, and distinct target-pair traversal.

## Structural Rule
When generic-call round-1 reachability sees an `(argument TypeId, target TypeId)` pair already active in the current DFS walk, tsz records the solver-owned `Round1ReachVisitState::AlreadyVisited` and preserves the existing no-op fallback for that branch. Otherwise `Round1ReachVisitState::Entered` allows the structural reachability walk to continue.

## Owner Layer
`tsz-solver` generic-call inference reachability helper. This is a behavior-preserving #14346 typed-termination slice and does not touch #14344 declaration identity, #14345 materialize-once publication, checker, emitter, or relation logic.

## Adjacent Case Matrix
- New `(arg_type, target_type)` pair: records `Entered` and keeps walking.
- Repeated exact pair: records `AlreadyVisited` and returns through the existing cycle break.
- Same argument with a different target: records `Entered`, so distinct target traversal remains allowed.

## Fallback
Compiler behavior is unchanged. `AlreadyVisited` collapses to the same early `return` that the raw `visited.insert` boolean previously used, and all other paths continue through the existing reachability logic.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver round1_reach_visit_state`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `wc -l crates/tsz-solver/src/operations/generic_call/inference_helpers_reach.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
