### PR TITLE
refactor(solver): name valid key visit state (#14346)

### DIFF
--- a/crates/tsz-solver/src/operations/binary_ops.rs
+++ b/crates/tsz-solver/src/operations/binary_ops.rs
@@ -48,6 +48,24 @@ pub(crate) enum PrimitiveClass {
     Undefined,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ValidKeyTypeVisitState {
+    Entered,
+    AlreadyVisited { fallback: bool },
+}
+
+impl ValidKeyTypeVisitState {
+    fn record(type_id: TypeId, defer_unresolved: bool, seen: &mut FxHashSet<TypeId>) -> Self {
+        if seen.insert(type_id) {
+            Self::Entered
+        } else {
+            Self::AlreadyVisited {
+                fallback: defer_unresolved,
+            }
+        }
+    }
+}
+
 // =============================================================================
 // Visitor Pattern Implementations
 // =============================================================================
@@ -1254,8 +1272,9 @@ impl<'a> BinaryOpEvaluator<'a> {
         if type_id == TypeId::ANY || type_id == TypeId::NEVER || type_id == TypeId::ERROR {
             return true;
         }
-        if !seen.insert(type_id) {
-            return defer_unresolved;
+        match ValidKeyTypeVisitState::record(type_id, defer_unresolved, seen) {
+            ValidKeyTypeVisitState::Entered => {}
+            ValidKeyTypeVisitState::AlreadyVisited { fallback } => return fallback,
         }
 
         let result = match self.interner.lookup(type_id) {
@@ -1400,5 +1419,64 @@ impl<'a> BinaryOpEvaluator<'a> {
 
         // Non-nullish non-symbol object/function-like types are string-concat-compatible.
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ValidKeyTypeVisitState;
+    use crate::types::TypeId;
+    use rustc_hash::FxHashSet;
+
+    #[test]
+    fn valid_key_type_visit_state_enters_new_type() {
+        let mut seen = FxHashSet::default();
+
+        let state = ValidKeyTypeVisitState::record(TypeId::STRING, false, &mut seen);
+
+        assert_eq!(state, ValidKeyTypeVisitState::Entered);
+        assert!(seen.contains(&TypeId::STRING));
+    }
+
+    #[test]
+    fn valid_key_type_visit_state_reentry_keeps_concrete_fallback() {
+        let mut seen = FxHashSet::default();
+
+        assert_eq!(
+            ValidKeyTypeVisitState::record(TypeId::STRING, false, &mut seen),
+            ValidKeyTypeVisitState::Entered
+        );
+        assert_eq!(
+            ValidKeyTypeVisitState::record(TypeId::STRING, false, &mut seen),
+            ValidKeyTypeVisitState::AlreadyVisited { fallback: false }
+        );
+    }
+
+    #[test]
+    fn valid_key_type_visit_state_reentry_keeps_deferred_fallback() {
+        let mut seen = FxHashSet::default();
+
+        assert_eq!(
+            ValidKeyTypeVisitState::record(TypeId::STRING, true, &mut seen),
+            ValidKeyTypeVisitState::Entered
+        );
+        assert_eq!(
+            ValidKeyTypeVisitState::record(TypeId::STRING, true, &mut seen),
+            ValidKeyTypeVisitState::AlreadyVisited { fallback: true }
+        );
+    }
+
+    #[test]
+    fn valid_key_type_visit_state_distinguishes_types() {
+        let mut seen = FxHashSet::default();
+
+        assert_eq!(
+            ValidKeyTypeVisitState::record(TypeId::STRING, false, &mut seen),
+            ValidKeyTypeVisitState::Entered
+        );
+        assert_eq!(
+            ValidKeyTypeVisitState::record(TypeId::NUMBER, false, &mut seen),
+            ValidKeyTypeVisitState::Entered
+        );
     }
 }


### PR DESCRIPTION
Goal: green

## Summary
- Add `ValidKeyTypeVisitState` around the valid-key-type recursion visited-set gate in binary operation helpers.
- Preserve the existing context-sensitive already-visited fallback for concrete computed-property checks versus deferred mapped-key checks.
- Add focused unit tests for first entry, concrete reentry, deferred reentry, and distinct type traversal.

## Structural Rule
When valid key-type classification re-enters a `TypeId` already active in the current recursion walk, tsz records the solver-owned `ValidKeyTypeVisitState::AlreadyVisited { fallback }` and preserves the existing fallback: concrete computed-property validation returns `false`, while deferred mapped-key validation returns `true`. Otherwise `ValidKeyTypeVisitState::Entered` allows recursive key classification to continue.

## Owner Layer
`tsz-solver` binary operation key-type classification. This is a behavior-preserving #14346 typed-termination slice and does not touch #14344 declaration identity, #14345 materialize-once publication, checker, emitter, or relation logic.

## Adjacent Case Matrix
- New `TypeId`: records `Entered` and keeps walking.
- Repeated `TypeId` in concrete computed-property validation: records `AlreadyVisited { fallback: false }` and preserves the existing invalid-key fallback.
- Repeated `TypeId` in deferred mapped-key validation: records `AlreadyVisited { fallback: true }` and preserves the existing deferred acceptance fallback.
- Different `TypeId`: records `Entered`, so distinct recursive branches still traverse normally.

## Fallback
Compiler behavior is unchanged. `AlreadyVisited` collapses to the same `defer_unresolved` return value that the raw `seen.insert` boolean previously used, and all other paths continue through the existing key-type logic.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver valid_key_type_visit_state`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `wc -l crates/tsz-solver/src/operations/binary_ops.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
