### PR TITLE
feat(solver): publish module augmentation symbol edges (#14344)

### DIFF
--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -1210,8 +1210,8 @@ impl<'a> CheckerState<'a> {
         // Resolve Lazy(DefId) types to their structural representation before classifying.
         // Interface types from other files arrive as Lazy(DefId) — we need the concrete
         // Object/ObjectWithIndex/Callable shape to merge properties directly.
-        let resolved_base = if let Some(def_id) = query::get_lazy_def_id(self.ctx.types, base_type)
-        {
+        let base_def_id = query::get_lazy_def_id(self.ctx.types, base_type);
+        let resolved_base = if let Some(def_id) = base_def_id {
             // Look up DefId in the type environment
             if let Some(env_type) = self.ctx.type_env.borrow().get_def(def_id) {
                 env_type
@@ -1238,6 +1238,11 @@ impl<'a> CheckerState<'a> {
                     &base_shape.properties,
                     crate::interface_type::InterfaceMergeMode::Declaration,
                 );
+                if let (Some(symbol), Some(def_id)) = (base_shape.symbol, base_def_id) {
+                    self.ctx
+                        .definition_store
+                        .register_module_augmentation_symbol_def_if_enabled(symbol.0, def_id);
+                }
                 // Preserve the base interface's nominal identity (symbol) and
                 // object-level flags so the augmented type keeps its canonical
                 // declaration name (e.g. `Tool` rather than an expanded
@@ -1255,6 +1260,11 @@ impl<'a> CheckerState<'a> {
                     &base_shape.properties,
                     crate::interface_type::InterfaceMergeMode::Declaration,
                 );
+                if let (Some(symbol), Some(def_id)) = (base_shape.symbol, base_def_id) {
+                    self.ctx
+                        .definition_store
+                        .register_module_augmentation_symbol_def_if_enabled(symbol.0, def_id);
+                }
                 factory.object_with_index(ObjectShape {
                     flags: base_shape.flags,
                     properties: merged_properties,

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -13,6 +13,7 @@
 //! |------|----------|----------|
 //! | CLI  | Sequential allocation | Fresh start each compilation |
 //! | LSP  | Content-addressed hash | Stable IDs across edits |
+mod augmentation_symbols;
 mod content_addressed;
 mod cross_file_cache;
 mod definition_info;
@@ -21,6 +22,7 @@ mod semantic_construction;
 mod state_flags;
 mod symbol_registration;
 
+pub(crate) use augmentation_symbols::module_augmentation_symbol_edge_enabled;
 pub use content_addressed::ContentAddressedDefIds;
 use cross_file_cache::CrossFileQueryCache;
 pub use observability::StoreStatistics;

--- a/crates/tsz-solver/src/def/core/augmentation_symbols.rs
+++ b/crates/tsz-solver/src/def/core/augmentation_symbols.rs
@@ -1,12 +1,23 @@
-use super::{DefId, DefinitionStore};
+//! Symbol-edge publication for module-augmented empty object registries.
+//!
+//! This is a narrow bridge for the higher-kinded registry pattern where an
+//! empty interface body is interned before cross-file augmentation merges its
+//! members. The checker publishes the base shape's symbol to the home `DefId`;
+//! indexed-access evaluation uses that edge only when it later sees an empty
+//! symbolic object shape.
+
 use std::sync::OnceLock;
 
+use super::{DefId, DefinitionStore};
+
+/// Whether module-augmentation symbol-edge publication and consumption is active.
 pub(crate) fn module_augmentation_symbol_edge_enabled() -> bool {
     static ON: OnceLock<bool> = OnceLock::new();
     *ON.get_or_init(|| std::env::var("TSZ_MODULE_AUG_SYMBOL_EDGE").is_ok_and(|v| v == "1"))
 }
 
 impl DefinitionStore {
+    /// Register a first-wins module-augmentation edge from `symbol_id` to `def_id`.
     pub fn register_module_augmentation_symbol_def(&self, symbol_id: u32, def_id: DefId) {
         if self.find_def_by_symbol(symbol_id).is_some() {
             return;
@@ -15,6 +26,7 @@ impl DefinitionStore {
         self.bump_generation();
     }
 
+    /// Flag-gated wrapper for module-augmentation edge publication.
     pub fn register_module_augmentation_symbol_def_if_enabled(
         &self,
         symbol_id: u32,

--- a/crates/tsz-solver/src/def/core/augmentation_symbols.rs
+++ b/crates/tsz-solver/src/def/core/augmentation_symbols.rs
@@ -1,0 +1,54 @@
+use super::{DefId, DefinitionStore};
+use std::sync::OnceLock;
+
+pub(crate) fn module_augmentation_symbol_edge_enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("TSZ_MODULE_AUG_SYMBOL_EDGE").is_ok_and(|v| v == "1"))
+}
+
+impl DefinitionStore {
+    pub fn register_module_augmentation_symbol_def(&self, symbol_id: u32, def_id: DefId) {
+        if self.find_def_by_symbol(symbol_id).is_some() {
+            return;
+        }
+        self.insert_symbol_only_mapping(symbol_id, def_id);
+        self.bump_generation();
+    }
+
+    pub fn register_module_augmentation_symbol_def_if_enabled(
+        &self,
+        symbol_id: u32,
+        def_id: DefId,
+    ) {
+        if module_augmentation_symbol_edge_enabled() {
+            self.register_module_augmentation_symbol_def(symbol_id, def_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_augmentation_symbol_def_registers_missing_edge() {
+        let store = DefinitionStore::new();
+        let def_id = DefId(42);
+
+        store.register_module_augmentation_symbol_def(100, def_id);
+
+        assert_eq!(store.find_def_by_symbol(100), Some(def_id));
+    }
+
+    #[test]
+    fn module_augmentation_symbol_def_keeps_first_edge() {
+        let store = DefinitionStore::new();
+        let first = DefId(42);
+        let second = DefId(43);
+
+        store.register_module_augmentation_symbol_def(100, first);
+        store.register_module_augmentation_symbol_def(100, second);
+
+        assert_eq!(store.find_def_by_symbol(100), Some(first));
+    }
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -46,37 +46,32 @@ impl<'a, 'b, R: TypeResolver> IndexAccessVisitor<'a, 'b, R> {
         )
     }
 
-    fn evaluate_module_augmented_empty_symbol_object(
-        &mut self,
-        shape: &ObjectShape,
-    ) -> Option<TypeId> {
+    fn eval_augmented_empty_symbol_object(&mut self, shape: &ObjectShape) -> Option<TypeId> {
         if !crate::def::module_augmentation_symbol_edge_enabled() || !shape.properties.is_empty() {
             return None;
         }
-        let symbol = shape.symbol?;
         let def_id = self
             .evaluator
             .resolver()
-            .symbol_to_def_id(SymbolRef(symbol.0))?;
+            .symbol_to_def_id(SymbolRef(shape.symbol?.0))?;
         let body = self
             .evaluator
             .resolver()
             .resolve_lazy(def_id, self.evaluator.interner())?;
-        let redirected_shape = match self.evaluator.interner().lookup(body)? {
-            TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
-                self.evaluator.interner().object_shape(shape_id)
-            }
+        let shape_id = match self.evaluator.interner().lookup(body)? {
+            TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => shape_id,
             _ => return None,
         };
-        if redirected_shape.properties.is_empty() {
+        let properties = &self.evaluator.interner().object_shape(shape_id).properties;
+        if properties.is_empty() {
             return None;
         }
         let result = self
             .evaluator
-            .evaluate_object_index_from_constraint(&redirected_shape.properties, self.index_type)
+            .evaluate_object_index_from_constraint(properties, self.index_type)
             .unwrap_or_else(|| {
                 self.evaluator
-                    .evaluate_object_index(&redirected_shape.properties, self.index_type)
+                    .evaluate_object_index(properties, self.index_type)
             });
         (result != TypeId::UNDEFINED).then_some(result)
     }
@@ -852,7 +847,7 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
             return None;
         }
 
-        if let Some(result) = self.evaluate_module_augmented_empty_symbol_object(&shape) {
+        if let Some(result) = self.eval_augmented_empty_symbol_object(&shape) {
             return Some(self.bind_property_this(result));
         }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -46,6 +46,41 @@ impl<'a, 'b, R: TypeResolver> IndexAccessVisitor<'a, 'b, R> {
         )
     }
 
+    fn evaluate_module_augmented_empty_symbol_object(
+        &mut self,
+        shape: &ObjectShape,
+    ) -> Option<TypeId> {
+        if !crate::def::module_augmentation_symbol_edge_enabled() || !shape.properties.is_empty() {
+            return None;
+        }
+        let symbol = shape.symbol?;
+        let def_id = self
+            .evaluator
+            .resolver()
+            .symbol_to_def_id(SymbolRef(symbol.0))?;
+        let body = self
+            .evaluator
+            .resolver()
+            .resolve_lazy(def_id, self.evaluator.interner())?;
+        let redirected_shape = match self.evaluator.interner().lookup(body)? {
+            TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
+                self.evaluator.interner().object_shape(shape_id)
+            }
+            _ => return None,
+        };
+        if redirected_shape.properties.is_empty() {
+            return None;
+        }
+        let result = self
+            .evaluator
+            .evaluate_object_index_from_constraint(&redirected_shape.properties, self.index_type)
+            .unwrap_or_else(|| {
+                self.evaluator
+                    .evaluate_object_index(&redirected_shape.properties, self.index_type)
+            });
+        (result != TypeId::UNDEFINED).then_some(result)
+    }
+
     fn instantiate_mapped_template_with_constraint_param(
         &mut self,
         mapped: &crate::types::MappedType,
@@ -815,6 +850,10 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
         // (e.g. `JSX.IntrinsicElements`) independent of property count.
         if self.keyof_constraint_distribution_is_lossy(&shape.properties) {
             return None;
+        }
+
+        if let Some(result) = self.evaluate_module_augmented_empty_symbol_object(&shape) {
+            return Some(self.bind_property_this(result));
         }
 
         let result = self


### PR DESCRIPTION
Goal: green

## Summary
- Add a default-OFF `TSZ_MODULE_AUG_SYMBOL_EDGE` channel for module-augmentation object merges to publish `base_shape.symbol -> home DefId` into the shared store's first-wins symbol edge.
- When the flag is enabled, let index access on an empty symbolic object shape resolve that symbol edge, read the home def body, and re-index the populated merged properties.
- Keep the implementation off `evaluate/application.rs` and avoid a new `TypeResolver` method while `resolver.rs` is over the line ceiling on fresh main.
- Add focused store tests for missing-edge publication and first-edge stability.
- Keep the index-access shard within the current architecture size ratchet after the CI lint failure.

## Structural Rule
When module augmentation merges members into an object or object-with-index whose base type is `Lazy(home DefId)` and whose base shape carries a symbol, tsz may publish that structural edge from the shape symbol to the home definition. When an index access later sees an empty object shape with that symbol, and the flag is enabled, tsz resolves the home definition body and evaluates the indexed access against the populated merged properties instead of committing the empty-shape `UNDEFINED` result. The redirect is gated by symbol-edge availability and empty-shape structure, not by user-chosen names.

## Owner Layer
Producer: `tsz-checker` module-augmentation merge path. Store/channel and consumer: `tsz-solver` `DefinitionStore` plus index-access evaluation. This PR does not touch #14345 `evaluate/application.rs`, declaration emit, checker diagnostics, or relation logic.

## Adjacent Case Matrix
- Flag OFF: producer does not publish the edge and consumer redirect is disabled; byte behavior remains the existing empty-shape path.
- Missing symbol edge with flag ON: first publication records `symbol -> home DefId` and bumps store generation.
- Existing symbol edge with flag ON: first-wins behavior is preserved; no overwrite of an existing mapping.
- Empty symbolic object with resolvable populated home body: index access reuses the populated body properties.
- Empty symbolic object with no edge, unresolved body, non-object body, or still-empty body: falls back to the existing object-index path.

## Fallback
If any structural prerequisite is missing, evaluation falls through to the pre-existing object index logic. A redirected lookup that still produces `UNDEFINED` also falls through, preserving the generic-index deferral logic already in `visit_object`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver module_augmentation_symbol_def`
- `TSZ_MODULE_AUG_SYMBOL_EDGE=1 scripts/safe-run.sh cargo nextest run -p tsz-checker --test hkt_cross_file_augmentation_13653_repro cross_file_augmentation`
- `scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver -p tsz-checker --all-targets -- -D warnings`
- `wc -l crates/tsz-checker/src/types/module_augmentation.rs crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs crates/tsz-solver/src/def/core.rs crates/tsz-solver/src/def/core/augmentation_symbols.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
