### PR TITLE
refactor(solver): name template source depth state (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/key_extraction.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/key_extraction.rs
@@ -16,6 +16,22 @@ use crate::types::{IntrinsicKind, LiteralValue, MappedType, PropertyInfo, TypeDa
 use crate::visitor::keyof_inner_type;
 use tsz_common::interner::Atom;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TemplateSourceDepthState {
+    Continue,
+    LimitExceeded,
+}
+
+impl TemplateSourceDepthState {
+    const fn from_depth(depth: usize, max_depth: usize) -> Self {
+        if depth > max_depth {
+            Self::LimitExceeded
+        } else {
+            Self::Continue
+        }
+    }
+}
+
 impl<R: TypeResolver> TypeEvaluator<'_, R> {
     /// Classify a source object's non-numeric index slot into
     /// `(contributes_string, contributes_symbol)`. A symbol-only signature
@@ -692,8 +708,9 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
         depth: usize,
     ) -> Option<TypeId> {
         const MAX_TEMPLATE_SOURCE_DEPTH: usize = 16;
-        if depth > MAX_TEMPLATE_SOURCE_DEPTH {
-            return None;
+        match TemplateSourceDepthState::from_depth(depth, MAX_TEMPLATE_SOURCE_DEPTH) {
+            TemplateSourceDepthState::Continue => {}
+            TemplateSourceDepthState::LimitExceeded => return None,
         }
         match self.interner().lookup(template) {
             Some(TypeData::IndexAccess(obj, idx)) => match self.interner().lookup(idx) {
@@ -760,5 +777,26 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
             }
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TemplateSourceDepthState;
+
+    #[test]
+    fn template_source_depth_state_continues_at_limit() {
+        assert_eq!(
+            TemplateSourceDepthState::from_depth(16, 16),
+            TemplateSourceDepthState::Continue
+        );
+    }
+
+    #[test]
+    fn template_source_depth_state_stops_past_limit() {
+        assert_eq!(
+            TemplateSourceDepthState::from_depth(17, 16),
+            TemplateSourceDepthState::LimitExceeded
+        );
     }
 }


### PR DESCRIPTION
Goal: green

## Summary
- Add `TemplateSourceDepthState` around the mapped-template source recovery depth cap.
- Preserve the existing `depth > 16` bailout while making the termination state explicit and testable.
- Add focused unit tests for continuing at the limit and stopping past the limit.

## Structural Rule
When mapped-template source recovery recurses at or below the configured maximum depth, tsz records `TemplateSourceDepthState::Continue` and keeps searching for the homomorphic `source[K]`. When recursion exceeds that maximum, tsz records `TemplateSourceDepthState::LimitExceeded` and preserves the existing `None` fallback for that recovery attempt.

## Owner Layer
`tsz-solver` mapped-type key/source extraction. This is a behavior-preserving #14346 typed-termination slice and does not touch #14344 declaration/symbol identity, #14345 materialize-once publication, checker, emitter, or relation logic.

## Adjacent Case Matrix
- Depth exactly at the cap: records `Continue`, preserving the old `depth > max` boundary.
- Depth past the cap: records `LimitExceeded` and returns `None`.
- All recursive shape cases continue to call the same bounded helper with `depth + 1`.

## Fallback
Compiler behavior is unchanged. `LimitExceeded` collapses to the same `None` result that the raw depth comparison previously returned.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver template_source_depth_state`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `wc -l crates/tsz-solver/src/evaluation/evaluate_rules/mapped/key_extraction.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
