### PR TITLE
perf(solver): bound narrowing generation memos (#14347)

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property_access.rs
+++ b/crates/tsz-checker/src/state/state_checking/property_access.rs
@@ -832,11 +832,8 @@ impl<'a> CheckerState<'a> {
         let mapped = self.ctx.types.mapped_type(mapped_id);
 
         let prop_atom = self.ctx.types.intern_string(prop_name);
-        let cache_key = (
-            mapped_type,
-            TypeResolver::resolver_generation(&self.ctx),
-            prop_atom,
-        );
+        let resolver_generation = TypeResolver::resolver_generation(&self.ctx);
+        let cache_key = (mapped_type, prop_atom);
 
         if let Some(cached) = self
             .ctx
@@ -844,8 +841,7 @@ impl<'a> CheckerState<'a> {
             .narrowing_cache
             .property_cache
             .borrow()
-            .get(&cache_key)
-            .copied()
+            .get(&cache_key, resolver_generation)
         {
             return Some(match cached {
                 Some(entry) => tsz_solver::operations::property::PropertyAccessResult::Success {
@@ -924,6 +920,7 @@ impl<'a> CheckerState<'a> {
                 .borrow_mut()
                 .insert(
                     cache_key,
+                    resolver_generation,
                     Some(tsz_solver::narrowing::CachedPropertyType::explicit(
                         property_type,
                     )),
@@ -955,7 +952,7 @@ impl<'a> CheckerState<'a> {
                     .narrowing_cache
                     .property_cache
                     .borrow_mut()
-                    .insert(cache_key, None);
+                    .insert(cache_key, resolver_generation, None);
             }
             if !names.contains(&prop_atom) {
                 return Some(
@@ -986,7 +983,7 @@ impl<'a> CheckerState<'a> {
                     .narrowing_cache
                     .property_cache
                     .borrow_mut()
-                    .insert(cache_key, None);
+                    .insert(cache_key, resolver_generation, None);
                 return Some(
                     tsz_solver::operations::property::PropertyAccessResult::PropertyNotFound {
                         type_id: mapped_type,
@@ -1010,7 +1007,7 @@ impl<'a> CheckerState<'a> {
                             .narrowing_cache
                             .property_cache
                             .borrow_mut()
-                            .insert(cache_key, None);
+                            .insert(cache_key, resolver_generation, None);
                         return Some(
                             tsz_solver::operations::property::PropertyAccessResult::PropertyNotFound {
                                 type_id: mapped_type,
@@ -1024,7 +1021,7 @@ impl<'a> CheckerState<'a> {
                         .narrowing_cache
                         .property_cache
                         .borrow_mut()
-                        .insert(cache_key, None);
+                        .insert(cache_key, resolver_generation, None);
                     return Some(
                         tsz_solver::operations::property::PropertyAccessResult::PropertyNotFound {
                             type_id: mapped_type,
@@ -1071,6 +1068,7 @@ impl<'a> CheckerState<'a> {
             .borrow_mut()
             .insert(
                 cache_key,
+                resolver_generation,
                 Some(tsz_solver::narrowing::CachedPropertyType::explicit(
                     property_type,
                 )),

--- a/crates/tsz-checker/src/types/property_access_type/optional_fast_path.rs
+++ b/crates/tsz-checker/src/types/property_access_type/optional_fast_path.rs
@@ -100,7 +100,7 @@ impl<'a> CheckerState<'a> {
             self.resolve_property_access_base_materialized(non_nullish_base)
         };
         let resolver_generation = TypeResolver::resolver_generation(&self.ctx);
-        let cache_key = |base, name| (base, resolver_generation, name);
+        let cache_key = |base, name| (base, name);
         let effective_write_result = |type_id: TypeId, write_type: Option<TypeId>| -> TypeId {
             if skip_flow_narrowing {
                 if write_presence_only {
@@ -119,8 +119,7 @@ impl<'a> CheckerState<'a> {
             .narrowing_cache
             .property_cache
             .borrow()
-            .get(&cache_key(resolved_base, prop_atom))
-            .copied();
+            .get(&cache_key(resolved_base, prop_atom), resolver_generation);
         if let Some(Some(entry)) = cached_property_type {
             let mut result_type = self.refine_expando_property_read_type(
                 idx,
@@ -205,6 +204,7 @@ impl<'a> CheckerState<'a> {
                     .borrow_mut()
                     .insert(
                         cache_key(resolved_base, prop_atom),
+                        resolver_generation,
                         Some(CachedPropertyType::new(
                             refined_type_id,
                             from_index_signature,
@@ -248,6 +248,7 @@ impl<'a> CheckerState<'a> {
                     .borrow_mut()
                     .insert(
                         cache_key(resolved_base, prop_atom),
+                        resolver_generation,
                         property_type.map(CachedPropertyType::explicit),
                     );
                 let mut result_type = property_type.unwrap_or(TypeId::ERROR);
@@ -270,7 +271,11 @@ impl<'a> CheckerState<'a> {
                     .narrowing_cache
                     .property_cache
                     .borrow_mut()
-                    .insert(cache_key(resolved_base, prop_atom), None);
+                    .insert(
+                        cache_key(resolved_base, prop_atom),
+                        resolver_generation,
+                        None,
+                    );
                 None
             }
             PropertyAccessResult::IsUnknown => None,

--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -1,7 +1,10 @@
 use crate::caches::db::TypeCompilerOptions;
 use crate::construction::{QueryDatabase, TypeDatabase};
 use crate::def::DefId;
-use crate::narrowing::request::{NarrowTypeCacheKey, NarrowingOptions, NarrowingRequest};
+use crate::narrowing::generation_memo::GenerationMemo;
+#[cfg(test)]
+use crate::narrowing::generation_memo::MAX_GENERATIONS_PER_NARROWING_KEY;
+use crate::narrowing::request::{NarrowTypeStableCacheKey, NarrowingOptions, NarrowingRequest};
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
 use crate::type_queries::{UnionMembersKind, classify_for_union_members};
 use crate::types::{FunctionShape, LiteralValue, ParamInfo, TypeData, TypeId};
@@ -295,7 +298,7 @@ pub struct DiscriminantInfo {
 
 type DiscriminantMembers = FxHashMap<TypeId, Vec<TypeId>>;
 type DiscriminantIndex = FxHashMap<(TypeId, Atom), Arc<DiscriminantMembers>>;
-type PropertyCacheKey = (TypeId, u64, Atom);
+type PropertyCacheKey = (TypeId, Atom);
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CachedPropertyType {
     pub type_id: TypeId,
@@ -325,8 +328,8 @@ impl CachedPropertyType {
     }
 }
 
-type NarrowedPropertyCache = FxHashMap<PropertyCacheKey, Option<CachedPropertyType>>;
-type RequiredPropertyCache = FxHashMap<PropertyCacheKey, bool>;
+type NarrowedPropertyCache = GenerationMemo<PropertyCacheKey, Option<CachedPropertyType>>;
+type RequiredPropertyCache = GenerationMemo<PropertyCacheKey, bool>;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct NarrowingCacheStatistics {
@@ -417,7 +420,7 @@ pub struct NarrowingCache {
     /// stale predicate results. Other guard kinds keep their existing dynamic
     /// paths because their results depend on structural lookups that are already
     /// cached at narrower query boundaries.
-    pub(crate) narrow_type_cache: RefCell<FxHashMap<NarrowTypeCacheKey, TypeId>>,
+    pub(crate) narrow_type_cache: RefCell<GenerationMemo<NarrowTypeStableCacheKey, TypeId>>,
     /// Memo for [`NarrowingContext::narrow_excluding_type`] keyed by
     /// `(source, excluded, resolver_generation)`.
     ///
@@ -429,7 +432,7 @@ pub struct NarrowingCache {
     /// Memoizing collapses that re-expansion to linear; combined with
     /// `narrow_excluding_visiting` it is the structural fix for the
     /// non-terminating typebox row (issue #13242 / #13250).
-    pub(crate) narrow_excluding_cache: RefCell<FxHashMap<NarrowExcludingKey, TypeId>>,
+    pub(crate) narrow_excluding_cache: RefCell<GenerationMemo<NarrowExcludingStableKey, TypeId>>,
     /// In-progress `(source, excluded, resolver_generation)` set for
     /// `narrow_excluding_type`. A recursive-alias member whose resolution
     /// re-enters the same `(source, excluded)` pair is a cycle; returning the
@@ -448,7 +451,7 @@ pub struct NarrowingCache {
     /// pair recurs across the many `IsXxx(s)` guards a typebox/ts-morph file runs
     /// over one recursive `TSchema`, so memoizing the boolean collapses the
     /// repeated deep materialization (issue #13242 / #13250).
-    pub(crate) narrow_assignable_cache: RefCell<FxHashMap<NarrowExcludingKey, bool>>,
+    pub(crate) narrow_assignable_cache: RefCell<GenerationMemo<NarrowExcludingStableKey, bool>>,
     /// Memo for the narrowing-boundary subtype check
     /// ([`NarrowingContext::is_subtype_for_narrowing`]) keyed by
     /// `(source, target, resolver_generation)`.
@@ -458,7 +461,7 @@ pub struct NarrowingCache {
     /// `is_assignable_to` funnel here, so it is the deepest point at which the
     /// recursive-schema `collect_properties_cached` walk can be cached once per
     /// `(source, target)` pair (issue #13242 / #13250).
-    pub(crate) narrow_subtype_cache: RefCell<FxHashMap<NarrowExcludingKey, bool>>,
+    pub(crate) narrow_subtype_cache: RefCell<GenerationMemo<NarrowExcludingStableKey, bool>>,
     /// Re-entrancy depth of the exclusion-narrowing families
     /// (`narrow_excluding_type` / `narrow_excluding_function` /
     /// `narrow_excluding_typeof_object`).
@@ -531,16 +534,19 @@ pub(crate) struct NarrowExcludingKey {
     resolver_generation: u64,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]
+pub(crate) struct NarrowExcludingStableKey {
+    source: TypeId,
+    excluded: TypeId,
+}
+
 impl NarrowingCache {
     pub fn new() -> Self {
         Self {
             resolve_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(1024, FxBuildHasher)),
             resolve_visiting: RefCell::new(FxHashSet::default()),
-            property_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(512, FxBuildHasher)),
-            required_property_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
-                256,
-                FxBuildHasher,
-            )),
+            property_cache: RefCell::new(GenerationMemo::default()),
+            required_property_cache: RefCell::new(GenerationMemo::default()),
             split_nullish_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
                 512,
                 FxBuildHasher,
@@ -562,23 +568,11 @@ impl NarrowingCache {
                 FxBuildHasher,
             )),
             discriminant_index: RefCell::new(FxHashMap::default()),
-            narrow_type_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
-                1024,
-                FxBuildHasher,
-            )),
-            narrow_excluding_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
-                256,
-                FxBuildHasher,
-            )),
+            narrow_type_cache: RefCell::new(GenerationMemo::default()),
+            narrow_excluding_cache: RefCell::new(GenerationMemo::default()),
             narrow_excluding_visiting: RefCell::new(FxHashSet::default()),
-            narrow_assignable_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
-                512,
-                FxBuildHasher,
-            )),
-            narrow_subtype_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
-                512,
-                FxBuildHasher,
-            )),
+            narrow_assignable_cache: RefCell::new(GenerationMemo::default()),
+            narrow_subtype_cache: RefCell::new(GenerationMemo::default()),
             narrow_excluding_depth: Cell::new(0),
             narrow_excluding_fuel: Cell::new(0),
             narrow_excluding_budget: Cell::new(0),
@@ -627,17 +621,11 @@ impl NarrowingCache {
         }
         {
             let map = self.property_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<PropertyCacheKey>()
-                    + std::mem::size_of::<Option<CachedPropertyType>>());
+            size += map.estimated_size_bytes(BUCKET_OVERHEAD);
         }
         {
             let map = self.required_property_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<PropertyCacheKey>()
-                    + std::mem::size_of::<bool>());
+            size += map.estimated_size_bytes(BUCKET_OVERHEAD);
         }
         {
             let map = self.split_nullish_cache.borrow();
@@ -691,17 +679,11 @@ impl NarrowingCache {
         }
         {
             let map = self.narrow_type_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<NarrowTypeCacheKey>()
-                    + std::mem::size_of::<TypeId>());
+            size += map.estimated_size_bytes(BUCKET_OVERHEAD);
         }
         {
             let map = self.narrow_excluding_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<NarrowExcludingKey>()
-                    + std::mem::size_of::<TypeId>());
+            size += map.estimated_size_bytes(BUCKET_OVERHEAD);
         }
         {
             let set = self.narrow_excluding_visiting.borrow();
@@ -709,17 +691,11 @@ impl NarrowingCache {
         }
         {
             let map = self.narrow_assignable_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<NarrowExcludingKey>()
-                    + std::mem::size_of::<bool>());
+            size += map.estimated_size_bytes(BUCKET_OVERHEAD);
         }
         {
             let map = self.narrow_subtype_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<NarrowExcludingKey>()
-                    + std::mem::size_of::<bool>());
+            size += map.estimated_size_bytes(BUCKET_OVERHEAD);
         }
 
         size
@@ -1720,12 +1696,22 @@ impl<'a> NarrowingContext<'a> {
     /// Memoized, budget-charged body of [`Self::narrow_excluding_type`]. Always
     /// reached with the per-request fuel primed by the outermost frame.
     fn narrow_excluding_type_budgeted(&self, source_type: TypeId, excluded_type: TypeId) -> TypeId {
+        let resolver_generation = self.resolver_generation();
+        let stable_key = NarrowExcludingStableKey {
+            source: source_type,
+            excluded: excluded_type,
+        };
         let key = NarrowExcludingKey {
             source: source_type,
             excluded: excluded_type,
-            resolver_generation: self.resolver_generation(),
+            resolver_generation,
         };
-        if let Some(&cached) = self.cache.narrow_excluding_cache.borrow().get(&key) {
+        if let Some(cached) = self
+            .cache
+            .narrow_excluding_cache
+            .borrow()
+            .get(&stable_key, resolver_generation)
+        {
             return cached;
         }
         // Charge one unit of the per-request budget for each fresh exclusion
@@ -1757,10 +1743,11 @@ impl<'a> NarrowingContext<'a> {
         // would poison a later, fully-budgeted request with the conservative
         // answer.
         if self.exclusion_within_budget() {
-            self.cache
-                .narrow_excluding_cache
-                .borrow_mut()
-                .insert(key, result);
+            self.cache.narrow_excluding_cache.borrow_mut().insert(
+                stable_key,
+                resolver_generation,
+                result,
+            );
         }
         result
     }
@@ -2089,8 +2076,9 @@ impl<'a> NarrowingContext<'a> {
     }
 
     fn narrow_predicate_cached(&self, request: &NarrowingRequest) -> TypeId {
-        let key = request.cache_key(self.narrowing_options(), self.resolver_generation());
-        if let Some(cached) = self.cache.narrow_type_cache.borrow().get(&key).copied() {
+        let generation = self.resolver_generation();
+        let key = request.stable_cache_key(self.narrowing_options());
+        if let Some(cached) = self.cache.narrow_type_cache.borrow().get(&key, generation) {
             return cached;
         }
         let narrowed =
@@ -2098,7 +2086,7 @@ impl<'a> NarrowingContext<'a> {
         self.cache
             .narrow_type_cache
             .borrow_mut()
-            .insert(key, narrowed);
+            .insert(key, generation, narrowed);
         narrowed
     }
 
@@ -2575,81 +2563,5 @@ impl<'a> NarrowingContext<'a> {
 }
 
 #[cfg(test)]
-mod cache_visibility_tests {
-    use super::*;
-    use crate::intern::TypeInterner;
-
-    #[test]
-    fn narrowing_cache_statistics_report_entries_and_size() {
-        let db = TypeInterner::new();
-        let prop = db.intern_string("prop");
-        let key = (TypeId::STRING, 7, prop);
-        let chain_key = OptionalPropertyChainKey {
-            root_type: TypeId::STRING,
-            properties: vec![prop],
-            optional_mask: 1,
-            no_unchecked_indexed_access: true,
-        };
-        let cache = NarrowingCache::new();
-        let empty = cache.cache_statistics();
-
-        assert_eq!(empty.total_entries(), 0);
-        assert!(empty.estimated_size_bytes > 0);
-
-        cache
-            .resolve_cache
-            .borrow_mut()
-            .insert(TypeId::STRING, TypeId::NUMBER);
-        cache
-            .property_cache
-            .borrow_mut()
-            .insert(key, Some(CachedPropertyType::explicit(TypeId::BOOLEAN)));
-        cache.required_property_cache.borrow_mut().insert(key, true);
-        cache
-            .split_nullish_cache
-            .borrow_mut()
-            .insert(TypeId::STRING, (Some(TypeId::STRING), Some(TypeId::NULL)));
-        cache
-            .contains_type_parameters_cache
-            .borrow_mut()
-            .insert(TypeId::STRING, false);
-        cache
-            .optional_chain_cache
-            .borrow_mut()
-            .insert((TypeId::STRING, prop), TypeId::BOOLEAN);
-        cache
-            .optional_property_chain_cache
-            .borrow_mut()
-            .insert(chain_key, TypeId::BOOLEAN);
-        cache
-            .contextual_resolve_cache
-            .borrow_mut()
-            .insert(TypeId::STRING, TypeId::BOOLEAN);
-        let mut discriminants = FxHashMap::default();
-        discriminants.insert(TypeId::STRING, vec![TypeId::BOOLEAN]);
-        cache
-            .discriminant_index
-            .borrow_mut()
-            .insert((TypeId::STRING, prop), Arc::new(discriminants));
-        cache.narrow_type_cache.borrow_mut().insert(
-            NarrowingRequest::new(TypeId::STRING, TypeGuard::Truthy, GuardSense::Positive)
-                .cache_key(NarrowingOptions::new(), 0),
-            TypeId::STRING,
-        );
-
-        let stats = cache.cache_statistics();
-        assert_eq!(stats.resolve_cache_entries, 1);
-        assert_eq!(stats.narrowed_property_cache_entries, 1);
-        assert_eq!(stats.required_property_cache_entries, 1);
-        assert_eq!(stats.split_nullish_cache_entries, 1);
-        assert_eq!(stats.contains_type_parameters_cache_entries, 1);
-        assert_eq!(stats.optional_chain_cache_entries, 1);
-        assert_eq!(stats.optional_property_chain_cache_entries, 1);
-        assert_eq!(stats.contextual_resolve_cache_entries, 1);
-        assert_eq!(stats.discriminant_index_entries, 1);
-        assert_eq!(stats.narrow_type_cache_entries, 1);
-        assert_eq!(stats.total_entries(), 10);
-        assert!(stats.estimated_size_bytes > empty.estimated_size_bytes);
-        assert!(cache.estimated_size_bytes() >= stats.estimated_size_bytes);
-    }
-}
+#[path = "core/cache_visibility_tests.rs"]
+mod cache_visibility_tests;

--- a/crates/tsz-solver/src/narrowing/core/cache_visibility_tests.rs
+++ b/crates/tsz-solver/src/narrowing/core/cache_visibility_tests.rs
@@ -1,0 +1,162 @@
+use super::*;
+use crate::intern::TypeInterner;
+
+#[test]
+fn narrowing_cache_statistics_report_entries_and_size() {
+    let db = TypeInterner::new();
+    let prop = db.intern_string("prop");
+    let key = (TypeId::STRING, prop);
+    let chain_key = OptionalPropertyChainKey {
+        root_type: TypeId::STRING,
+        properties: vec![prop],
+        optional_mask: 1,
+        no_unchecked_indexed_access: true,
+    };
+    let cache = NarrowingCache::new();
+    let empty = cache.cache_statistics();
+
+    assert_eq!(empty.total_entries(), 0);
+    assert!(empty.estimated_size_bytes > 0);
+
+    cache
+        .resolve_cache
+        .borrow_mut()
+        .insert(TypeId::STRING, TypeId::NUMBER);
+    cache.property_cache.borrow_mut().insert(
+        key,
+        7,
+        Some(CachedPropertyType::explicit(TypeId::BOOLEAN)),
+    );
+    cache
+        .required_property_cache
+        .borrow_mut()
+        .insert(key, 7, true);
+    cache
+        .split_nullish_cache
+        .borrow_mut()
+        .insert(TypeId::STRING, (Some(TypeId::STRING), Some(TypeId::NULL)));
+    cache
+        .contains_type_parameters_cache
+        .borrow_mut()
+        .insert(TypeId::STRING, false);
+    cache
+        .optional_chain_cache
+        .borrow_mut()
+        .insert((TypeId::STRING, prop), TypeId::BOOLEAN);
+    cache
+        .optional_property_chain_cache
+        .borrow_mut()
+        .insert(chain_key, TypeId::BOOLEAN);
+    cache
+        .contextual_resolve_cache
+        .borrow_mut()
+        .insert(TypeId::STRING, TypeId::BOOLEAN);
+    let mut discriminants = FxHashMap::default();
+    discriminants.insert(TypeId::STRING, vec![TypeId::BOOLEAN]);
+    cache
+        .discriminant_index
+        .borrow_mut()
+        .insert((TypeId::STRING, prop), Arc::new(discriminants));
+    cache.narrow_type_cache.borrow_mut().insert(
+        NarrowingRequest::new(TypeId::STRING, TypeGuard::Truthy, GuardSense::Positive)
+            .stable_cache_key(NarrowingOptions::new()),
+        0,
+        TypeId::STRING,
+    );
+
+    let stats = cache.cache_statistics();
+    assert_eq!(stats.resolve_cache_entries, 1);
+    assert_eq!(stats.narrowed_property_cache_entries, 1);
+    assert_eq!(stats.required_property_cache_entries, 1);
+    assert_eq!(stats.split_nullish_cache_entries, 1);
+    assert_eq!(stats.contains_type_parameters_cache_entries, 1);
+    assert_eq!(stats.optional_chain_cache_entries, 1);
+    assert_eq!(stats.optional_property_chain_cache_entries, 1);
+    assert_eq!(stats.contextual_resolve_cache_entries, 1);
+    assert_eq!(stats.discriminant_index_entries, 1);
+    assert_eq!(stats.narrow_type_cache_entries, 1);
+    assert_eq!(stats.total_entries(), 10);
+    assert!(stats.estimated_size_bytes > empty.estimated_size_bytes);
+    assert!(cache.estimated_size_bytes() >= stats.estimated_size_bytes);
+}
+
+#[test]
+fn generation_stamped_narrowing_caches_bound_retained_generations() {
+    let db = TypeInterner::new();
+    let prop = db.intern_string("prop");
+    let cache = NarrowingCache::new();
+    let property_key = (TypeId::STRING, prop);
+    let request_key =
+        NarrowingRequest::new(TypeId::STRING, TypeGuard::Truthy, GuardSense::Positive)
+            .stable_cache_key(NarrowingOptions::new());
+    let relation_key = NarrowExcludingStableKey {
+        source: TypeId::STRING,
+        excluded: TypeId::NUMBER,
+    };
+
+    for generation in 1..=(MAX_GENERATIONS_PER_NARROWING_KEY as u64 + 3) {
+        cache.property_cache.borrow_mut().insert(
+            property_key,
+            generation,
+            Some(CachedPropertyType::explicit(TypeId::BOOLEAN)),
+        );
+        cache
+            .required_property_cache
+            .borrow_mut()
+            .insert(property_key, generation, true);
+        cache.narrow_type_cache.borrow_mut().insert(
+            request_key.clone(),
+            generation,
+            TypeId::STRING,
+        );
+        cache
+            .narrow_excluding_cache
+            .borrow_mut()
+            .insert(relation_key, generation, TypeId::BOOLEAN);
+        cache
+            .narrow_assignable_cache
+            .borrow_mut()
+            .insert(relation_key, generation, true);
+        cache
+            .narrow_subtype_cache
+            .borrow_mut()
+            .insert(relation_key, generation, true);
+    }
+
+    let stats = cache.cache_statistics();
+    assert_eq!(
+        stats.narrowed_property_cache_entries,
+        MAX_GENERATIONS_PER_NARROWING_KEY
+    );
+    assert_eq!(
+        stats.required_property_cache_entries,
+        MAX_GENERATIONS_PER_NARROWING_KEY
+    );
+    assert_eq!(
+        stats.narrow_type_cache_entries,
+        MAX_GENERATIONS_PER_NARROWING_KEY
+    );
+    assert_eq!(
+        stats.narrow_excluding_cache_entries,
+        MAX_GENERATIONS_PER_NARROWING_KEY
+    );
+    assert_eq!(
+        stats.narrow_assignable_cache_entries,
+        MAX_GENERATIONS_PER_NARROWING_KEY
+    );
+    assert_eq!(
+        stats.narrow_subtype_cache_entries,
+        MAX_GENERATIONS_PER_NARROWING_KEY
+    );
+
+    assert_eq!(cache.property_cache.borrow().get(&property_key, 1), None);
+    assert_eq!(
+        cache.property_cache.borrow().get(&property_key, 7),
+        Some(Some(CachedPropertyType::explicit(TypeId::BOOLEAN)))
+    );
+    assert_eq!(cache.narrow_type_cache.borrow().get(&request_key, 1), None);
+    assert_eq!(
+        cache.narrow_type_cache.borrow().get(&request_key, 7),
+        Some(TypeId::STRING)
+    );
+}

--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -827,19 +827,24 @@ impl<'a> NarrowingContext<'a> {
             return self.is_assignable_to_uncached(source, target);
         }
 
-        let key = NarrowExcludingKey {
+        let generation = self.resolver_generation();
+        let key = NarrowExcludingStableKey {
             source,
             excluded: target,
-            resolver_generation: self.resolver_generation(),
         };
-        if let Some(&cached) = self.cache.narrow_assignable_cache.borrow().get(&key) {
+        if let Some(cached) = self
+            .cache
+            .narrow_assignable_cache
+            .borrow()
+            .get(&key, generation)
+        {
             return cached;
         }
         let result = self.is_assignable_to_uncached(source, target);
         self.cache
             .narrow_assignable_cache
             .borrow_mut()
-            .insert(key, result);
+            .insert(key, generation, result);
         result
     }
 
@@ -969,12 +974,17 @@ impl<'a> NarrowingContext<'a> {
         if source == target {
             return true;
         }
-        let key = NarrowExcludingKey {
+        let generation = self.resolver_generation();
+        let key = NarrowExcludingStableKey {
             source,
             excluded: target,
-            resolver_generation: self.resolver_generation(),
         };
-        if let Some(&cached) = self.cache.narrow_subtype_cache.borrow().get(&key) {
+        if let Some(cached) = self
+            .cache
+            .narrow_subtype_cache
+            .borrow()
+            .get(&key, generation)
+        {
             return cached;
         }
         let result = if let Some(resolver) = self.resolver {
@@ -987,7 +997,7 @@ impl<'a> NarrowingContext<'a> {
         self.cache
             .narrow_subtype_cache
             .borrow_mut()
-            .insert(key, result);
+            .insert(key, generation, result);
         result
     }
 

--- a/crates/tsz-solver/src/narrowing/discriminants.rs
+++ b/crates/tsz-solver/src/narrowing/discriminants.rs
@@ -328,8 +328,9 @@ impl<'a> NarrowingContext<'a> {
             return None;
         }
 
-        let key = (type_id, self.resolver_generation(), property);
-        if let Some(&cached) = self.cache.property_cache.borrow().get(&key) {
+        let generation = self.resolver_generation();
+        let key = (type_id, property);
+        if let Some(cached) = self.cache.property_cache.borrow().get(&key, generation) {
             // Don't trust a cached Lazy type — re-resolve in case the TypeEnvironment
             // has been populated since the cache entry was created.
             if let Some(entry) = cached {
@@ -350,10 +351,11 @@ impl<'a> NarrowingContext<'a> {
                         type_id: re_resolved,
                         from_index_signature: entry.from_index_signature,
                     };
-                    self.cache
-                        .property_cache
-                        .borrow_mut()
-                        .insert(key, Some(re_resolved_entry));
+                    self.cache.property_cache.borrow_mut().insert(
+                        key,
+                        generation,
+                        Some(re_resolved_entry),
+                    );
                     return Some(re_resolved);
                 }
                 return Some(prop_type);
@@ -378,10 +380,11 @@ impl<'a> NarrowingContext<'a> {
             None => true,
         };
         if should_cache {
-            self.cache
-                .property_cache
-                .borrow_mut()
-                .insert(key, result.map(CachedPropertyType::explicit));
+            self.cache.property_cache.borrow_mut().insert(
+                key,
+                generation,
+                result.map(CachedPropertyType::explicit),
+            );
         }
         result
     }

--- a/crates/tsz-solver/src/narrowing/generation_memo.rs
+++ b/crates/tsz-solver/src/narrowing/generation_memo.rs
@@ -1,0 +1,137 @@
+use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
+use std::hash::Hash;
+
+pub(super) const MAX_GENERATIONS_PER_NARROWING_KEY: usize = 4;
+
+type GenerationSlots<V> = SmallVec<[(u64, V); 1]>;
+
+#[derive(Clone, Debug)]
+pub struct GenerationMemo<K, V> {
+    entries: FxHashMap<K, GenerationSlots<V>>,
+}
+
+impl<K, V> Default for GenerationMemo<K, V> {
+    fn default() -> Self {
+        Self {
+            entries: FxHashMap::default(),
+        }
+    }
+}
+
+impl<K, V> GenerationMemo<K, V>
+where
+    K: Eq + Hash,
+    V: Copy,
+{
+    pub fn get(&self, key: &K, generation: u64) -> Option<V> {
+        self.entries
+            .get(key)?
+            .iter()
+            .find(|(slot_generation, _)| *slot_generation == generation)
+            .map(|(_, value)| *value)
+    }
+
+    pub fn insert(&mut self, key: K, generation: u64, value: V) {
+        let slots = self.entries.entry(key).or_default();
+
+        if let Some((_, slot_value)) = slots
+            .iter_mut()
+            .find(|(slot_generation, _)| *slot_generation == generation)
+        {
+            *slot_value = value;
+            return;
+        }
+
+        if slots.len() >= MAX_GENERATIONS_PER_NARROWING_KEY
+            && let Some(oldest) = slots
+                .iter()
+                .enumerate()
+                .min_by_key(|(_, (slot_generation, _))| *slot_generation)
+                .map(|(index, _)| index)
+        {
+            slots.swap_remove(oldest);
+        }
+
+        slots.push((generation, value));
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.values().map(SmallVec::len).sum()
+    }
+
+    pub fn estimated_size_bytes(&self, bucket_overhead: usize) -> usize {
+        let mut size = self.entries.capacity()
+            * (bucket_overhead
+                + std::mem::size_of::<K>()
+                + std::mem::size_of::<GenerationSlots<V>>());
+        for slots in self.entries.values() {
+            if slots.spilled() {
+                size += slots.capacity() * std::mem::size_of::<(u64, V)>();
+            }
+        }
+        size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::TypeId;
+
+    #[test]
+    fn serves_only_the_matching_generation() {
+        let mut memo = GenerationMemo::<TypeId, TypeId>::default();
+
+        memo.insert(TypeId::STRING, 7, TypeId::NUMBER);
+
+        assert_eq!(memo.get(&TypeId::STRING, 7), Some(TypeId::NUMBER));
+        assert_eq!(memo.get(&TypeId::STRING, 8), None);
+        assert_eq!(memo.get(&TypeId::BOOLEAN, 7), None);
+    }
+
+    #[test]
+    fn reinsert_at_same_generation_updates_in_place() {
+        let mut memo = GenerationMemo::<TypeId, TypeId>::default();
+
+        memo.insert(TypeId::STRING, 3, TypeId::NUMBER);
+        memo.insert(TypeId::STRING, 3, TypeId::BOOLEAN);
+
+        assert_eq!(memo.len(), 1);
+        assert_eq!(memo.get(&TypeId::STRING, 3), Some(TypeId::BOOLEAN));
+    }
+
+    #[test]
+    fn bounds_retained_generations_per_key_and_evicts_oldest() {
+        let mut memo = GenerationMemo::<TypeId, TypeId>::default();
+
+        for generation in 1..=(MAX_GENERATIONS_PER_NARROWING_KEY as u64 + 3) {
+            memo.insert(TypeId::STRING, generation, TypeId::NUMBER);
+        }
+
+        assert_eq!(memo.len(), MAX_GENERATIONS_PER_NARROWING_KEY);
+
+        for generation in 1..=3 {
+            assert_eq!(memo.get(&TypeId::STRING, generation), None);
+        }
+        for generation in 4..=7 {
+            assert_eq!(memo.get(&TypeId::STRING, generation), Some(TypeId::NUMBER));
+        }
+    }
+
+    #[test]
+    fn bounds_each_key_independently() {
+        let mut memo = GenerationMemo::<TypeId, TypeId>::default();
+
+        for generation in 1..=6 {
+            memo.insert(TypeId::STRING, generation, TypeId::NUMBER);
+            memo.insert(TypeId::BOOLEAN, generation, TypeId::STRING);
+        }
+
+        assert_eq!(memo.len(), MAX_GENERATIONS_PER_NARROWING_KEY * 2);
+        assert_eq!(memo.get(&TypeId::STRING, 6), Some(TypeId::NUMBER));
+        assert_eq!(memo.get(&TypeId::BOOLEAN, 6), Some(TypeId::STRING));
+        assert_eq!(memo.get(&TypeId::STRING, 1), None);
+        assert_eq!(memo.get(&TypeId::BOOLEAN, 1), None);
+    }
+}

--- a/crates/tsz-solver/src/narrowing/mod.rs
+++ b/crates/tsz-solver/src/narrowing/mod.rs
@@ -30,6 +30,7 @@
 mod compound;
 mod core;
 mod discriminants;
+mod generation_memo;
 mod instanceof;
 mod property;
 pub mod request;

--- a/crates/tsz-solver/src/narrowing/property.rs
+++ b/crates/tsz-solver/src/narrowing/property.rs
@@ -414,8 +414,14 @@ impl<'a> NarrowingContext<'a> {
             return false;
         }
 
-        let key = (resolved_type, self.resolver_generation(), property_name);
-        if let Some(&cached) = self.cache.required_property_cache.borrow().get(&key) {
+        let generation = self.resolver_generation();
+        let key = (resolved_type, property_name);
+        if let Some(cached) = self
+            .cache
+            .required_property_cache
+            .borrow()
+            .get(&key, generation)
+        {
             return cached;
         }
 
@@ -423,7 +429,7 @@ impl<'a> NarrowingContext<'a> {
         self.cache
             .required_property_cache
             .borrow_mut()
-            .insert(key, required);
+            .insert(key, generation, required);
         required
     }
 
@@ -537,9 +543,10 @@ impl<'a> NarrowingContext<'a> {
         property_name: Atom,
     ) -> Option<CachedPropertyType> {
         let resolved_type = self.resolve_type(type_id);
-        let key = (resolved_type, self.resolver_generation(), property_name);
+        let generation = self.resolver_generation();
+        let key = (resolved_type, property_name);
 
-        if let Some(&cached) = self.cache.property_cache.borrow().get(&key) {
+        if let Some(cached) = self.cache.property_cache.borrow().get(&key, generation) {
             if let Some(cached_entry) = cached {
                 let cached_prop_type = cached_entry.type_id;
                 if cached_prop_type != TypeId::ERROR
@@ -556,10 +563,11 @@ impl<'a> NarrowingContext<'a> {
                         type_id: resolved_cached,
                         from_index_signature: cached_entry.from_index_signature,
                     };
-                    self.cache
-                        .property_cache
-                        .borrow_mut()
-                        .insert(key, Some(resolved_entry));
+                    self.cache.property_cache.borrow_mut().insert(
+                        key,
+                        generation,
+                        Some(resolved_entry),
+                    );
                     return Some(resolved_entry);
                 }
                 return Some(cached_entry);
@@ -590,7 +598,10 @@ impl<'a> NarrowingContext<'a> {
             None => true,
         };
         if should_cache {
-            self.cache.property_cache.borrow_mut().insert(key, result);
+            self.cache
+                .property_cache
+                .borrow_mut()
+                .insert(key, generation, result);
         }
         result
     }

--- a/crates/tsz-solver/src/narrowing/request.rs
+++ b/crates/tsz-solver/src/narrowing/request.rs
@@ -55,26 +55,25 @@ impl NarrowingOptions {
     }
 }
 
-/// Cache key for option-sensitive predicate-guard narrowing.
+/// Generation-independent key for option-sensitive predicate-guard narrowing.
 ///
-/// Extracted from `narrowing/core.rs` so all cache-key inputs are visible in
-/// one canonical location. The `options` field replaces the former packed `u8`
-/// `compiler_flags`, making each option explicit.
+/// Narrowing cache entries are valid only for the resolver generation at which
+/// they were computed, but old generations are dead once the resolver advances.
+/// Keeping the generation as a separate memo stamp lets the cache retain only
+/// recent generations per stable predicate key.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct NarrowTypeCacheKey {
+pub(crate) struct NarrowTypeStableCacheKey {
     source_type: TypeId,
     guard: TypeGuard,
     sense: GuardSense,
     options: NarrowingOptions,
-    resolver_generation: u64,
 }
 
 /// A normalized request to narrow one type by a guard under caller-supplied
 /// inputs.
 ///
 /// Groups `source_type`, `guard`, and `sense` so they travel together and the
-/// cache key can be built canonically via `cache_key()` rather than at each
-/// call site.
+/// stable cache key can be built canonically rather than at each call site.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NarrowingRequest {
     source_type: TypeId,
@@ -103,19 +102,12 @@ impl NarrowingRequest {
         self.sense
     }
 
-    /// Build the option-sensitive cache key, binding in context-derived
-    /// options and resolver generation from the calling `NarrowingContext`.
-    pub(crate) fn cache_key(
-        &self,
-        options: NarrowingOptions,
-        resolver_generation: u64,
-    ) -> NarrowTypeCacheKey {
-        NarrowTypeCacheKey {
+    pub(crate) fn stable_cache_key(&self, options: NarrowingOptions) -> NarrowTypeStableCacheKey {
+        NarrowTypeStableCacheKey {
             source_type: self.source_type,
             guard: self.guard.clone(),
             sense: self.sense,
             options,
-            resolver_generation,
         }
     }
 }
@@ -168,16 +160,13 @@ mod tests {
     }
 
     #[test]
-    fn narrowing_request_cache_key_binds_resolver_generation() {
+    fn narrowing_request_stable_cache_key_omits_resolver_generation() {
         let guard = TypeGuard::Typeof(TypeofKind::String);
         let req = NarrowingRequest::new(TypeId::NUMBER, guard, GuardSense::Positive);
         let opts = NarrowingOptions::new();
-        let key0 = req.cache_key(opts, 0);
-        let key1 = req.cache_key(opts, 1);
-        assert_ne!(
-            key0, key1,
-            "different resolver generations must produce different cache keys"
-        );
+        let key0 = req.stable_cache_key(opts);
+        let key1 = req.stable_cache_key(opts);
+        assert_eq!(key0, key1, "resolver generation is a memo stamp now");
     }
 
     #[test]
@@ -186,8 +175,8 @@ mod tests {
         let req = NarrowingRequest::new(TypeId::ANY, guard, GuardSense::Negative);
         let opts_default = NarrowingOptions::new();
         let opts_unchecked = NarrowingOptions::new().with_no_unchecked_indexed_access(true);
-        let key_default = req.cache_key(opts_default, 0);
-        let key_unchecked = req.cache_key(opts_unchecked, 0);
+        let key_default = req.stable_cache_key(opts_default);
+        let key_unchecked = req.stable_cache_key(opts_unchecked);
         assert_ne!(
             key_default, key_unchecked,
             "different options must produce different cache keys"
@@ -199,8 +188,8 @@ mod tests {
         let make_req =
             || NarrowingRequest::new(TypeId::STRING, TypeGuard::Truthy, GuardSense::Positive);
         let opts = NarrowingOptions::new();
-        let k1 = make_req().cache_key(opts, 7);
-        let k2 = make_req().cache_key(opts, 7);
+        let k1 = make_req().stable_cache_key(opts);
+        let k2 = make_req().stable_cache_key(opts);
         assert_eq!(k1, k2, "equal inputs must produce equal cache keys");
     }
 }

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -333,7 +333,7 @@ fn narrowing_engine_keeps_request_stage_boundary() {
     assert!(
         request_rs.contains("pub struct NarrowingOptions")
             && request_rs.contains("pub struct NarrowingRequest")
-            && request_rs.contains("pub(crate) struct NarrowTypeCacheKey"),
+            && request_rs.contains("pub(crate) struct NarrowTypeStableCacheKey"),
         "narrowing/request.rs must own the typed options, request, and cache-key stage"
     );
     assert!(

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs
@@ -248,7 +248,6 @@ fn test_in_property_narrowing_reuses_property_cache() {
     assert_eq!(cache.property_cache.borrow().len(), 2);
 
     let resolver_generation = ctx.resolver_generation();
-
     let ctx_false = NarrowingContext::with_cache(&interner, &cache);
     let narrowed_false = ctx_false.narrow_type(union, &guard, GuardSense::Negative);
     let expected = TypeId::NUMBER;
@@ -257,12 +256,12 @@ fn test_in_property_narrowing_reuses_property_cache() {
 
     // Ensure the property cache includes the resolved object-shape lookup path
     // and can be reused across guard sense changes.
-    let kind_key = (obj, resolver_generation, kind_name);
+    let kind_key = (obj, kind_name);
     let cached_kind = cache
         .property_cache
         .borrow()
-        .get(&kind_key)
-        .and_then(|entry| *entry)
+        .get(&kind_key, resolver_generation)
+        .flatten()
         .expect("expected cached explicit property lookup");
     assert_eq!(cached_kind.type_id, TypeId::STRING);
     assert!(!cached_kind.from_index_signature);
@@ -294,12 +293,13 @@ fn test_in_property_narrowing_preserves_index_signature_cache_origin() {
     let narrowed = ctx.narrow_type(union, &guard, GuardSense::Positive);
     assert_eq!(narrowed, record_type);
 
-    let key = (record_type, ctx.resolver_generation(), key_name);
+    let resolver_generation = ctx.resolver_generation();
+    let key = (record_type, key_name);
     let cached_entry = cache
         .property_cache
         .borrow()
-        .get(&key)
-        .and_then(|entry| *entry)
+        .get(&key, resolver_generation)
+        .flatten()
         .expect("expected cached index-signature property lookup");
     assert_eq!(cached_entry.type_id, TypeId::STRING);
     assert!(cached_entry.from_index_signature);
@@ -361,22 +361,18 @@ fn test_negative_in_property_narrowing_reuses_required_property_cache() {
     assert_eq!(narrowed, expected);
 
     assert_eq!(cache.required_property_cache.borrow().len(), 3);
-    let required_cached =
-        cache
-            .required_property_cache
-            .borrow()
-            .iter()
-            .any(|((type_id, _, prop), is_required)| {
-                *type_id == required_obj && *prop == kind_name && *is_required
-            });
+    let resolver_generation = ctx.resolver_generation();
+    let required_cached = cache
+        .required_property_cache
+        .borrow()
+        .get(&(required_obj, kind_name), resolver_generation)
+        .is_some_and(|is_required| is_required);
     assert!(required_cached);
-
     let optional_cached = cache
         .required_property_cache
         .borrow()
-        .iter()
-        .filter(|((type_id, _, prop), _)| *type_id == optional_obj && *prop == kind_name)
-        .all(|(_, is_required)| !*is_required);
+        .get(&(optional_obj, kind_name), resolver_generation)
+        .is_some_and(|is_required| !is_required);
     assert!(optional_cached);
 
     let narrowed_again = ctx.narrow_type(union, &guard, GuardSense::Negative);


### PR DESCRIPTION
Goal: fast

## Summary
- Add a generation-bounded narrowing memo that keeps exact-generation hits but evicts superseded resolver-generation slots per stable key.
- Route narrowing property, required-property, predicate, exclusion, assignability, and subtype memo entries through stable structural keys plus generation stamps.
- Move narrowing cache visibility tests out of the oversized core shard while adding coverage for the per-key generation bound.

## Structural Rule
When a narrowing memo result is valid only for the current monotonic resolver generation, tsz must serve only an exact generation match and evict superseded generations per stable narrowing key through the solver narrowing cache layer. Dropping an old generation can only force recomputation; it must never serve a stale answer.

## Adjacent Matrix
- Property lookup caches: explicit property hits, index-signature hits, missing properties.
- Required-property caches: required, optional, and absent property checks.
- Predicate/exclusion/relation caches: stable request or source-target key with generation as memo stamp.
- Fallback: cache miss recomputes through the existing narrowing path; no checker semantics or identifier/file-name predicates are added.

## Verification
- cargo fmt --all --check
- git diff --check
- scripts/safe-run.sh cargo nextest run -p tsz-solver generation_memo generation_stamped_narrowing_caches_bound_retained_generations narrowing_request_stable_cache_key_omits_resolver_generation narrowing_request_cache_key_reflects_options narrowing_engine_keeps_request_stage_boundary test_in_property_narrowing_preserves_index_signature_cache_origin test_negative_in_property_narrowing_reuses_required_property_cache test_narrow_type_cache_keys_predicate_payload_flags_and_resolver_generation
- scripts/safe-run.sh cargo check -p tsz-solver
- scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings

Note: I also sampled scripts/safe-run.sh cargo nextest run -p tsz-solver narrowing; it reaches unrelated untouched readonly Array.isArray negative-branch tests whose assertions conflict with the current #14782-era implementation comments, so I did not use that broad filter as this PR's gate.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high