### PR TITLE
refactor(solver): name tuple spread depth state (#14346)

### DIFF
--- a/crates/tsz-solver/src/operations/sequence_property.rs
+++ b/crates/tsz-solver/src/operations/sequence_property.rs
@@ -33,6 +33,22 @@ const MAX_TUPLE_SPREAD_DEPTH: usize = 64;
 /// Upper bound on the fixed length we will count out of a tuple.
 const MAX_FIXED_LENGTH: usize = 1000;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TupleSpreadDepthState {
+    Continue,
+    LimitExceeded,
+}
+
+impl TupleSpreadDepthState {
+    const fn from_depth(depth: usize) -> Self {
+        if depth > MAX_TUPLE_SPREAD_DEPTH {
+            Self::LimitExceeded
+        } else {
+            Self::Continue
+        }
+    }
+}
+
 /// Widen an element type to include `undefined`, matching the reading of an
 /// optional tuple slot.
 pub(crate) fn element_type_with_undefined(db: &dyn TypeDatabase, element_type: TypeId) -> TypeId {
@@ -94,8 +110,9 @@ fn tuple_fixed_slot_inner(
     index: usize,
     depth: usize,
 ) -> Option<(TypeId, bool)> {
-    if depth > MAX_TUPLE_SPREAD_DEPTH {
-        return None;
+    match TupleSpreadDepthState::from_depth(depth) {
+        TupleSpreadDepthState::Continue => {}
+        TupleSpreadDepthState::LimitExceeded => return None,
     }
 
     let mut position = 0usize;
@@ -182,4 +199,25 @@ pub(crate) fn compute_tuple_fixed_length(db: &dyn TypeDatabase, type_id: TypeId)
     }
 
     Some(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tuple_spread_depth_state_continues_at_limit() {
+        assert_eq!(
+            TupleSpreadDepthState::from_depth(MAX_TUPLE_SPREAD_DEPTH),
+            TupleSpreadDepthState::Continue
+        );
+    }
+
+    #[test]
+    fn tuple_spread_depth_state_limits_past_limit() {
+        assert_eq!(
+            TupleSpreadDepthState::from_depth(MAX_TUPLE_SPREAD_DEPTH + 1),
+            TupleSpreadDepthState::LimitExceeded
+        );
+    }
 }


### PR DESCRIPTION
Goal: green

## Summary
- Name the tuple-spread recursion depth decision used by fixed tuple slot recovery.
- Preserve the existing `None` fallback when the spread walk exceeds `MAX_TUPLE_SPREAD_DEPTH`.
- Add boundary tests for the exact cap and past-cap behavior.

## Structural Rule
When tuple fixed-slot recovery descends through nested rest-spread tuples at or below `MAX_TUPLE_SPREAD_DEPTH`, tsz records `TupleSpreadDepthState::Continue` and keeps walking. When the walk exceeds that cap, tsz records `TupleSpreadDepthState::LimitExceeded` and preserves the existing `None` fallback for that slot recovery attempt.

## Owner Layer
`tsz-solver` tuple/array sequence-property resolution. This is a #14346 typed-termination cleanup slice; it does not change checker, emitter, relation, generic-call, module augmentation, or #14344/#14345 identity/publication logic.

## Adjacent Case Matrix
- Exact cap (`depth == MAX_TUPLE_SPREAD_DEPTH`) remains a continuing walk.
- Past cap (`depth == MAX_TUPLE_SPREAD_DEPTH + 1`) remains the no-slot `None` fallback.
- Existing callers still receive `Option<(TypeId, bool)>` from `tuple_fixed_slot` unchanged.

## Fallback
`LimitExceeded` collapses to the previous early `return None`; no diagnostic, cache, or evaluation policy changes.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver tuple_spread_depth_state`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `wc -l crates/tsz-solver/src/operations/sequence_property.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
