### PR TITLE
refactor(solver): name mro visit state (#14346)

### DIFF
--- a/crates/tsz-solver/src/classes/inheritance.rs
+++ b/crates/tsz-solver/src/classes/inheritance.rs
@@ -32,6 +32,22 @@ pub struct InheritanceGraph {
     max_symbol_id: Cell<usize>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MroVisitState {
+    Entered,
+    AlreadyVisited,
+}
+
+impl MroVisitState {
+    fn enter(visited: &mut FxHashSet<SymbolId>, symbol: SymbolId) -> Self {
+        if visited.insert(symbol) {
+            Self::Entered
+        } else {
+            Self::AlreadyVisited
+        }
+    }
+}
+
 impl InheritanceGraph {
     pub fn new() -> Self {
         Self {
@@ -226,8 +242,9 @@ impl InheritanceGraph {
         queue.push_back(symbol_id);
 
         while let Some(current) = queue.pop_front() {
-            if !visited.insert(current) {
-                continue;
+            match MroVisitState::enter(&mut visited, current) {
+                MroVisitState::Entered => {}
+                MroVisitState::AlreadyVisited => continue,
             }
 
             mro.push(current);

--- a/crates/tsz-solver/tests/inheritance_tests.rs
+++ b/crates/tsz-solver/tests/inheritance_tests.rs
@@ -86,6 +86,33 @@ fn test_multiple_inheritance() {
 }
 
 #[test]
+fn mro_visit_state_enters_first_symbol() {
+    let mut visited = FxHashSet::default();
+    let symbol = SymbolId(1);
+
+    assert_eq!(
+        MroVisitState::enter(&mut visited, symbol),
+        MroVisitState::Entered
+    );
+    assert!(visited.contains(&symbol));
+}
+
+#[test]
+fn mro_visit_state_skips_revisited_symbol() {
+    let mut visited = FxHashSet::default();
+    let symbol = SymbolId(1);
+
+    assert_eq!(
+        MroVisitState::enter(&mut visited, symbol),
+        MroVisitState::Entered
+    );
+    assert_eq!(
+        MroVisitState::enter(&mut visited, symbol),
+        MroVisitState::AlreadyVisited
+    );
+}
+
+#[test]
 fn test_common_ancestor() {
     let graph = InheritanceGraph::new();
     let a = SymbolId(1);


### PR DESCRIPTION
Goal: green

## Summary
- Name the method-resolution-order visited-set decision in the solver inheritance graph.
- Preserve the existing duplicate-symbol skip in MRO traversal.
- Add focused tests for first visit and revisit behavior.

## Structural Rule
When method-resolution-order traversal first sees a `SymbolId`, tsz records `MroVisitState::Entered` and appends it to the MRO walk. When traversal sees a `SymbolId` already visited in the same MRO queue, tsz records `MroVisitState::AlreadyVisited` and preserves the existing duplicate-skip fallback.

## Owner Layer
`tsz-solver` nominal inheritance graph / MRO traversal. This is a #14346 typed-termination cleanup slice; it does not change checker, emitter, relation, generic-call, narrowing, module augmentation, or #14344/#14345 identity/publication logic.

## Adjacent Case Matrix
- First visit records `Entered` and inserts the symbol into the visited set.
- Revisit records `AlreadyVisited` and keeps the traversal skip behavior.
- Existing inheritance/MRO tests still cover simple, transitive, diamond, cycle, multiple-inheritance, and common-ancestor behavior.

## Fallback
`AlreadyVisited` collapses to the previous `continue`; no diagnostics, cache policy, or relation semantics change.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver mro_visit_state inheritance`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `wc -l crates/tsz-solver/src/classes/inheritance.rs crates/tsz-solver/tests/inheritance_tests.rs`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
