### PR TITLE
feat(solver): publish augmented registry bodies (#14345)

### DIFF
--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -68,6 +68,17 @@ impl<'a> CheckerContext<'a> {
             .unwrap_or(false)
     }
 
+    fn module_augmented_body_or_current(
+        &self,
+        def_id: DefId,
+        body: TypeId,
+        interner: &dyn TypeDatabase,
+    ) -> TypeId {
+        self.definition_store
+            .module_augmented_body_for(def_id, body, interner)
+            .unwrap_or(body)
+    }
+
     /// On a `resolve_lazy` miss for a force-eligible simple lib interface,
     /// recover its already-flattened body from the by-name lib-type cache and
     /// register it into the type environments, so a structurally-consuming
@@ -803,7 +814,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
     fn resolve_lazy_lookup_only(
         &self,
         def_id: DefId,
-        _interner: &dyn TypeDatabase,
+        interner: &dyn TypeDatabase,
     ) -> Option<TypeId> {
         use tsz_binder::symbol_flags;
 
@@ -884,7 +895,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                 && let Some(real_def_id) = self.get_existing_def_id(sym_id)
                 && real_def_id != def_id
             {
-                return self.resolve_lazy(real_def_id, _interner);
+                return self.resolve_lazy(real_def_id, interner);
             }
 
             // For classes/interfaces/type aliases, check if we should return
@@ -917,7 +928,11 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                         // fall through to the type environment or
                         // DefinitionStore body for transparent aliases.
                         if !type_alias_self_wrapper {
-                            return Some(instance_type);
+                            return Some(self.module_augmented_body_or_current(
+                                def_id,
+                                instance_type,
+                                interner,
+                            ));
                         }
                     }
                 } else {
@@ -932,7 +947,11 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                                 | symbol_flags::TYPE_ALIAS,
                         )
                     {
-                        return Some(instance_type);
+                        return Some(self.module_augmented_body_or_current(
+                            def_id,
+                            instance_type,
+                            interner,
+                        ));
                     }
                 }
             }
@@ -1004,7 +1023,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                             .map_or("?", |s| s.escaped_name.as_str()),
                         "resolve_lazy: found in symbol_types cache"
                     );
-                    return Some(ty);
+                    return Some(self.module_augmented_body_or_current(def_id, ty, interner));
                 }
             }
         }
@@ -1031,7 +1050,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                 type_id = body.0,
                 "resolve_lazy: found in type_env"
             );
-            return Some(body);
+            return Some(self.module_augmented_body_or_current(def_id, body, interner));
         }
 
         if let Some(sym_id) = self.def_to_symbol_id_with_fallback(def_id)
@@ -1095,7 +1114,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                 type_id = resolved.0,
                 "resolve_lazy: found in SYMBOL_TYPE bucket"
             );
-            return Some(resolved);
+            return Some(self.module_augmented_body_or_current(def_id, resolved, interner));
         }
 
         // Final fallback: consult the shared `DefinitionStore` for a body
@@ -1112,7 +1131,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                 type_id = body.0,
                 "resolve_lazy: found in DefinitionStore body"
             );
-            return Some(body);
+            return Some(self.module_augmented_body_or_current(def_id, body, interner));
         }
         tracing::trace!(def_id = def_id.0, "resolve_lazy: NOT FOUND");
         None

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -7,7 +7,7 @@
 //! - Updating cached symbol types for self-referential augmentations
 
 use crate::state::CheckerState;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use tsz_binder::{ModuleAugmentation, symbol_flags};
@@ -261,56 +261,44 @@ impl<'a> CheckerState<'a> {
                 })
             });
 
+        let mut seen = FxHashSet::default();
+        let mut push_aug = |file_idx: usize, mut aug: ModuleAugmentation| {
+            if aug.name != interface_name || !seen.insert((file_idx, aug.node)) {
+                return;
+            }
+            if aug.arena.is_none()
+                && let Some(arenas) = self.ctx.all_arenas.as_ref()
+                && let Some(arena) = arenas.get(file_idx)
+            {
+                aug.arena = Some(Arc::clone(arena));
+            }
+            result.push(aug);
+        };
+
         for candidate in &candidates {
             if let Some(augmentations) = self.ctx.binder.module_augmentations.get(candidate) {
-                result.extend(
-                    augmentations
-                        .iter()
-                        .filter(|aug| aug.name == interface_name)
-                        .cloned(),
-                );
+                for aug in augmentations.iter().cloned() {
+                    push_aug(self.ctx.current_file_idx, aug);
+                }
             }
         }
 
-        // Use global module augmentations index for O(1) lookup instead of O(N) binder scan.
-        // Cross-file augmentations need their arena populated so the node index is
-        // interpreted in the correct AST arena (not the current file's arena).
-        if result.is_empty() {
-            if let Some(aug_index) = self.ctx.global_module_augmentations_index.as_ref() {
-                for candidate in &candidates {
-                    if let Some(entries) = aug_index.get(candidate) {
-                        for (file_idx, aug) in entries.iter() {
-                            if aug.name != interface_name {
-                                continue;
-                            }
-                            let mut cloned = aug.clone();
-                            if cloned.arena.is_none()
-                                && let Some(arenas) = self.ctx.all_arenas.as_ref()
-                                && let Some(arena) = arenas.get(*file_idx)
-                            {
-                                cloned.arena = Some(Arc::clone(arena));
-                            }
-                            result.push(cloned);
-                        }
+        // Use the global module augmentations index in addition to local binder
+        // hits: the current file can augment the same interface as siblings.
+        if let Some(aug_index) = self.ctx.global_module_augmentations_index.as_ref() {
+            for candidate in &candidates {
+                if let Some(entries) = aug_index.get(candidate) {
+                    for (file_idx, aug) in entries.iter() {
+                        push_aug(*file_idx, aug.clone());
                     }
                 }
-            } else if let Some(all_binders) = self.ctx.all_binders.as_ref() {
-                for (file_idx, binder) in all_binders.iter().enumerate() {
-                    for candidate in &candidates {
-                        if let Some(augmentations) = binder.module_augmentations.get(candidate) {
-                            for aug in augmentations.iter() {
-                                if aug.name != interface_name {
-                                    continue;
-                                }
-                                let mut cloned = aug.clone();
-                                if cloned.arena.is_none()
-                                    && let Some(arenas) = self.ctx.all_arenas.as_ref()
-                                    && let Some(arena) = arenas.get(file_idx)
-                                {
-                                    cloned.arena = Some(Arc::clone(arena));
-                                }
-                                result.push(cloned);
-                            }
+            }
+        } else if let Some(all_binders) = self.ctx.all_binders.as_ref() {
+            for (file_idx, binder) in all_binders.iter().enumerate() {
+                for candidate in &candidates {
+                    if let Some(augmentations) = binder.module_augmentations.get(candidate) {
+                        for aug in augmentations.iter().cloned() {
+                            push_aug(file_idx, aug);
                         }
                     }
                 }
@@ -473,6 +461,35 @@ impl<'a> CheckerState<'a> {
         }
 
         result
+    }
+
+    fn module_augmentation_source_files(&self, module_spec: &str) -> Vec<u32> {
+        let candidates = self.module_augmentation_key_candidates(module_spec);
+        let mut files = FxHashSet::default();
+
+        for candidate in &candidates {
+            if self.ctx.binder.module_augmentations.contains_key(candidate) {
+                files.insert(self.ctx.current_file_idx as u32);
+            }
+        }
+        if let Some(aug_index) = self.ctx.global_module_augmentations_index.as_ref() {
+            for candidate in &candidates {
+                if let Some(entries) = aug_index.get(candidate) {
+                    files.extend(entries.iter().map(|(file_idx, _)| *file_idx as u32));
+                }
+            }
+        } else if let Some(all_binders) = self.ctx.all_binders.as_ref() {
+            for (file_idx, binder) in all_binders.iter().enumerate() {
+                if candidates
+                    .iter()
+                    .any(|candidate| binder.module_augmentations.contains_key(candidate))
+                {
+                    files.insert(file_idx as u32);
+                }
+            }
+        }
+
+        files.into_iter().collect()
     }
 
     pub(crate) fn module_augmentation_value_type(
@@ -1247,11 +1264,27 @@ impl<'a> CheckerState<'a> {
                 // object-level flags so the augmented type keeps its canonical
                 // declaration name (e.g. `Tool` rather than an expanded
                 // `{ ... }` literal) and stays a single interned identity.
-                factory.object_with_flags_and_symbol(
+                let augmented = factory.object_with_flags_and_symbol(
                     merged_properties,
                     base_shape.flags,
                     base_shape.symbol,
-                )
+                );
+                if let Some(def_id) = base_def_id
+                    && base_shape.symbol.is_some()
+                    && self
+                        .ctx
+                        .definition_store
+                        .register_module_augmented_body_if_enabled(
+                            def_id,
+                            resolved_base,
+                            augmented,
+                            self.ctx.types,
+                            &self.module_augmentation_source_files(module_spec),
+                        )
+                {
+                    self.ctx.clear_type_evaluation_caches_for_def(def_id);
+                }
+                augmented
             }
             AugmentationTargetKind::ObjectWithIndex(shape_id) => {
                 let base_shape = self.ctx.types.object_shape(shape_id);

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -504,6 +504,8 @@ pub struct DefinitionStore {
     /// rejects unknown/error/any), so an abstract URI / literal-less `typeof`
     /// stays deferred.
     typeof_value_to_literal: DefDashMap<u32, TypeId>,
+    /// Empty registry `DefId` -> merged module-augmentation body and source files.
+    module_augmented_bodies: DefDashMap<DefId, (TypeId, Vec<u32>)>,
 
     /// Reverse index: `Atom` (name) -> `Vec<DefId>` for name-based lookups.
     ///
@@ -585,6 +587,7 @@ impl DefinitionStore {
                 Default::default(),
             ),
             typeof_value_to_literal: DefDashMap::default(),
+            module_augmented_bodies: DefDashMap::default(),
             enum_member_to_parent: DefDashMap::default(),
             name_to_defs: DefDashMap::with_capacity_and_hasher(id_capacity, Default::default()),
             cross_file_cache: CrossFileQueryCache::default(),
@@ -1316,6 +1319,7 @@ impl DefinitionStore {
         self.class_to_constructor.clear();
         self.class_to_instance.clear();
         self.typeof_value_to_literal.clear();
+        self.module_augmented_bodies.clear();
         self.enum_member_to_parent.clear();
         self.name_to_defs.clear();
         self.next_id.store(DefId::FIRST_VALID, Ordering::SeqCst);
@@ -1887,6 +1891,7 @@ impl DefinitionStore {
     ///
     /// Returns the number of definitions invalidated.
     pub fn invalidate_file(&self, file_id: u32) -> usize {
+        self.invalidate_module_augmented_bodies_for_file(file_id);
         let def_ids = match self.file_to_defs.remove(&file_id) {
             Some((_, ids)) => ids,
             None => return 0,
@@ -1910,6 +1915,8 @@ impl DefinitionStore {
                         self.invalidate_symbol_mappings_log();
                     }
                 }
+
+                self.module_augmented_bodies.remove(def_id);
 
                 // Clean up type_to_def (reverse scan is expensive, but invalidation
                 // is rare and bounded by per-file definition count).

--- a/crates/tsz-solver/src/def/core/augmentation_symbols.rs
+++ b/crates/tsz-solver/src/def/core/augmentation_symbols.rs
@@ -1,19 +1,35 @@
-//! Symbol-edge publication for module-augmented empty object registries.
+//! Symbol/body publication for module-augmented empty object registries.
 //!
 //! This is a narrow bridge for the higher-kinded registry pattern where an
 //! empty interface body is interned before cross-file augmentation merges its
-//! members. The checker publishes the base shape's symbol to the home `DefId`;
-//! indexed-access evaluation uses that edge only when it later sees an empty
-//! symbolic object shape.
+//! members. The checker publishes the base shape's symbol to the home `DefId`
+//! and, behind a separate flag, the merged body for an empty registry. Consumers
+//! use those channels only when they later see an empty symbolic object/body.
 
 use std::sync::OnceLock;
 
 use super::{DefId, DefinitionStore};
+use crate::construction::TypeDatabase;
+use crate::types::{TypeData, TypeId};
+use dashmap::mapref::entry::Entry;
 
 /// Whether module-augmentation symbol-edge publication and consumption is active.
 pub(crate) fn module_augmentation_symbol_edge_enabled() -> bool {
     static ON: OnceLock<bool> = OnceLock::new();
     *ON.get_or_init(|| std::env::var("TSZ_MODULE_AUG_SYMBOL_EDGE").is_ok_and(|v| v == "1"))
+}
+
+/// Whether merged body publication for empty module-augmented registries is active.
+pub(crate) fn module_augmentation_body_publish_enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("TSZ_MODULE_AUG_BODY_PUBLISH").is_ok_and(|v| v == "1"))
+}
+
+fn plain_object_property_count(db: &dyn TypeDatabase, ty: TypeId) -> Option<usize> {
+    match db.lookup(ty)? {
+        TypeData::Object(shape_id) => Some(db.object_shape(shape_id).properties.len()),
+        _ => None,
+    }
 }
 
 impl DefinitionStore {
@@ -36,11 +52,117 @@ impl DefinitionStore {
             self.register_module_augmentation_symbol_def(symbol_id, def_id);
         }
     }
+
+    /// Register the merged body for an empty module-augmented registry.
+    pub fn register_module_augmented_body(
+        &self,
+        def_id: DefId,
+        body: TypeId,
+        source_files: &[u32],
+    ) -> bool {
+        match self.module_augmented_bodies.entry(def_id) {
+            Entry::Vacant(entry) => {
+                entry.insert((body, source_files.to_vec()));
+                self.bump_generation();
+                true
+            }
+            Entry::Occupied(mut entry) => {
+                if entry.get().0 == body {
+                    merge_source_files(&mut entry.get_mut().1, source_files);
+                }
+                false
+            }
+        }
+    }
+
+    /// Flag-gated body publication for a plain empty object receiving members.
+    pub fn register_module_augmented_body_if_enabled(
+        &self,
+        def_id: DefId,
+        base_body: TypeId,
+        augmented_body: TypeId,
+        db: &dyn TypeDatabase,
+        source_files: &[u32],
+    ) -> bool {
+        if !module_augmentation_body_publish_enabled() {
+            return false;
+        }
+        if plain_object_property_count(db, base_body) != Some(0) {
+            return false;
+        }
+        if plain_object_property_count(db, augmented_body).is_none_or(|count| count == 0) {
+            return false;
+        }
+        self.register_module_augmented_body(def_id, augmented_body, source_files)
+    }
+
+    fn module_augmented_body_for_registered(
+        &self,
+        def_id: DefId,
+        current_body: TypeId,
+        db: &dyn TypeDatabase,
+    ) -> Option<TypeId> {
+        if plain_object_property_count(db, current_body) != Some(0) {
+            return None;
+        }
+        let body = self.module_augmented_bodies.get(&def_id)?.0;
+        plain_object_property_count(db, body)
+            .is_some_and(|count| count > 0)
+            .then_some(body)
+    }
+
+    /// Resolve an empty registry body to its merged module-augmented body.
+    pub fn module_augmented_body_for(
+        &self,
+        def_id: DefId,
+        current_body: TypeId,
+        db: &dyn TypeDatabase,
+    ) -> Option<TypeId> {
+        module_augmentation_body_publish_enabled()
+            .then(|| self.module_augmented_body_for_registered(def_id, current_body, db))
+            .flatten()
+    }
+
+    /// Return the merged module-augmented body when `current_body` is the empty base.
+    pub fn module_augmented_body_or_current(
+        &self,
+        def_id: DefId,
+        current_body: TypeId,
+        db: &dyn TypeDatabase,
+    ) -> TypeId {
+        self.module_augmented_body_for(def_id, current_body, db)
+            .unwrap_or(current_body)
+    }
+
+    pub(crate) fn invalidate_module_augmented_bodies_for_file(&self, file_id: u32) {
+        let affected: Vec<_> = self
+            .module_augmented_bodies
+            .iter()
+            .filter_map(|entry| entry.value().1.contains(&file_id).then_some(*entry.key()))
+            .collect();
+        if affected.is_empty() {
+            return;
+        }
+        for def_id in affected {
+            self.module_augmented_bodies.remove(&def_id);
+        }
+        self.bump_generation();
+    }
+}
+
+fn merge_source_files(existing: &mut Vec<u32>, source_files: &[u32]) {
+    for &file_id in source_files {
+        if !existing.contains(&file_id) {
+            existing.push(file_id);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::construction::TypeInterner;
+    use crate::types::PropertyInfo;
 
     #[test]
     fn module_augmentation_symbol_def_registers_missing_edge() {
@@ -62,5 +184,94 @@ mod tests {
         store.register_module_augmentation_symbol_def(100, second);
 
         assert_eq!(store.find_def_by_symbol(100), Some(first));
+    }
+
+    #[test]
+    fn module_augmented_body_redirects_empty_plain_object() {
+        let store = DefinitionStore::new();
+        let types = TypeInterner::new();
+        let def_id = DefId(42);
+        let empty = types.object(Vec::new());
+        let augmented = types.object(vec![PropertyInfo::new(
+            types.intern_string("member"),
+            TypeId::STRING,
+        )]);
+
+        assert!(store.register_module_augmented_body(def_id, augmented, &[]));
+
+        assert_eq!(
+            store.module_augmented_body_for_registered(def_id, empty, &types),
+            Some(augmented)
+        );
+    }
+
+    #[test]
+    fn module_augmented_body_keeps_non_empty_current_body() {
+        let store = DefinitionStore::new();
+        let types = TypeInterner::new();
+        let def_id = DefId(42);
+        let current = types.object(vec![PropertyInfo::new(
+            types.intern_string("current"),
+            TypeId::NUMBER,
+        )]);
+        let augmented = types.object(vec![PropertyInfo::new(
+            types.intern_string("member"),
+            TypeId::STRING,
+        )]);
+
+        assert!(store.register_module_augmented_body(def_id, augmented, &[]));
+
+        assert_eq!(
+            store.module_augmented_body_for_registered(def_id, current, &types),
+            None
+        );
+    }
+
+    #[test]
+    fn module_augmented_body_keeps_first_publication() {
+        let store = DefinitionStore::new();
+        let types = TypeInterner::new();
+        let def_id = DefId(42);
+        let first = types.object(vec![PropertyInfo::new(
+            types.intern_string("first"),
+            TypeId::STRING,
+        )]);
+        let second = types.object(vec![PropertyInfo::new(
+            types.intern_string("second"),
+            TypeId::STRING,
+        )]);
+
+        assert!(store.register_module_augmented_body(def_id, first, &[]));
+        assert!(!store.register_module_augmented_body(def_id, second, &[]));
+
+        assert_eq!(
+            store.module_augmented_body_for_registered(def_id, types.object(Vec::new()), &types),
+            Some(first)
+        );
+    }
+
+    #[test]
+    fn module_augmented_body_invalidates_when_augmentation_file_changes() {
+        let store = DefinitionStore::new();
+        let types = TypeInterner::new();
+        let def_id = DefId(42);
+        let empty = types.object(Vec::new());
+        let augmented = types.object(vec![PropertyInfo::new(
+            types.intern_string("member"),
+            TypeId::STRING,
+        )]);
+
+        assert!(store.register_module_augmented_body(def_id, augmented, &[7]));
+        assert_eq!(
+            store.module_augmented_body_for_registered(def_id, empty, &types),
+            Some(augmented)
+        );
+
+        assert_eq!(store.invalidate_file(7), 0);
+
+        assert_eq!(
+            store.module_augmented_body_for_registered(def_id, empty, &types),
+            None
+        );
     }
 }

--- a/crates/tsz-solver/src/def/core/observability.rs
+++ b/crates/tsz-solver/src/def/core/observability.rs
@@ -246,6 +246,12 @@ impl DefinitionStore {
                 + std::mem::size_of::<TypeId>()
                 + DASHMAP_ENTRY_OVERHEAD);
 
+        // module_augmented_bodies: DefId -> TypeId
+        size += self.module_augmented_bodies.len()
+            * (std::mem::size_of::<DefId>()
+                + std::mem::size_of::<TypeId>()
+                + DASHMAP_ENTRY_OVERHEAD);
+
         // file_to_defs: u32 -> Vec<DefId>
         for entry in &self.file_to_defs {
             size += std::mem::size_of::<u32>() + DASHMAP_ENTRY_OVERHEAD;

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -1050,12 +1050,7 @@ impl TypeEnvironment {
         self.bump_generation();
     }
 
-    /// Get a `DefId`'s resolved type.
-    ///
-    /// First checks the local `def_types` cache, then falls back to the shared
-    /// `DefinitionStore.get_body()` if available. The fallback enables cross-file
-    /// delegation results to be visible without explicit merge-back: the child
-    /// checker writes to `DefinitionStore` and the parent reads via this fallback.
+    /// Get a `DefId`'s resolved type from the local cache or shared store fallback.
     pub fn get_def(&self, def_id: DefId) -> Option<TypeId> {
         self.def_types.get(&def_id.0).copied().or_else(|| {
             let body = self.definition_store.as_ref()?.get_body(def_id)?;
@@ -1599,20 +1594,22 @@ impl TypeResolver for TypeEnvironment {
             .or(candidate)
     }
 
-    fn resolve_lazy(&self, def_id: DefId, _interner: &dyn TypeDatabase) -> Option<TypeId> {
+    fn resolve_lazy(&self, def_id: DefId, interner: &dyn TypeDatabase) -> Option<TypeId> {
+        let augment = |def_id, ty| {
+            self.definition_store.as_ref().map_or(ty, |store| {
+                store.module_augmented_body_or_current(def_id, ty, interner)
+            })
+        };
         // For classes, return the instance type (type position) instead of the constructor type
         if let Some(&instance_type) = self.class_instance_types.get(&def_id.0) {
             return Some(instance_type);
         }
         if let Some(ty) = self.get_def(def_id) {
-            return Some(ty);
+            return Some(augment(def_id, ty));
         }
 
-        // Fallback: `interner.reference(SymbolRef(N))` creates a zombie
-        // `Lazy(DefId(N))` whose numeric value is a raw `SymbolId`; redirect to
-        // the real `DefId`. `raw_symbol_fallback_def` returns `None` for a
-        // registered `DefId` so its value is never mis-read as a colliding
-        // `SymbolId` (#13862).
+        // Fallback: a zombie `Lazy(DefId(N))` may carry raw `SymbolId(N)`.
+        // Registered `DefId`s never redirect through this path (#13862).
         let real_def = self.raw_symbol_fallback_def(def_id)?;
         tsz_common::perf_counters::record_type_environment_raw_symbol_lazy_fallback();
         tracing::trace!(
@@ -1624,7 +1621,7 @@ impl TypeResolver for TypeEnvironment {
         if let Some(&instance_type) = self.class_instance_types.get(&real_def.0) {
             return Some(instance_type);
         }
-        self.get_def(real_def)
+        self.get_def(real_def).map(|ty| augment(real_def, ty))
     }
 
     fn resolve_this_type(&self, _interner: &dyn TypeDatabase) -> Option<TypeId> {


### PR DESCRIPTION
Goal: green

## Summary
- Stack on #15119 and add a default-OFF `TSZ_MODULE_AUG_BODY_PUBLISH` channel for module-augmented empty registry interfaces.
- Publish the merged plain-object body under the home `DefId` when module augmentation turns an empty symbolic registry body into a non-empty body.
- Make augmentation collection cumulative across the current binder plus global/cross-file index so a publisher does not freeze a partial body from one augmenting file.
- Let solver and checker lazy resolvers substitute the published body only when the body they already resolved is still a plain empty object.
- Track contributing augmentation source files and drop the published body when any contributing augmentation file is invalidated.
- Add focused store tests for empty-body redirect, non-empty fallback, first-publication stability, and augmentation-file invalidation.

## Structural Rule
When an exported empty HKT registry interface is augmented from another file, tsc indexes the cumulative merged registry body. With `TSZ_MODULE_AUG_BODY_PUBLISH=1`, tsz publishes that merged plain-object body through the solver-owned `DefinitionStore` keyed by the home `DefId`; resolver consumers replace only a current plain empty object body with a published plain non-empty object body. The rule is structural and does not inspect user-chosen interface, property, alias, or file names.

## Owner Layer
Producer: `tsz-checker` module-augmentation merge path after it builds the cumulative merged object. Store and resolver consumers: `tsz-solver` `DefinitionStore`, solver `TypeEnvironment`, and the checker's `TypeResolver` adapter. The checker adapter uses solver-owned APIs and canonical handles; it does not pattern-match raw solver type internals.

## Adjacent Case Matrix
- Flag OFF: no body publication or resolver substitution; existing behavior is preserved.
- Empty symbolic plain object base plus non-empty cumulative merged plain object: publish the augmented body, bump store generation, and clear def-keyed evaluation caches.
- Current file plus sibling augmentation files: merge all matching declarations before publication, deduped by `(file, node)`.
- Non-empty current body: keep the current body and do not replace it.
- `ObjectWithIndex`, callable, intrinsic, intersection, anonymous empty object, and unresolved bodies: no body-channel publication.
- Duplicate publication for the same `DefId`: first body wins, while same-body re-visits may add source-file invalidation metadata without resolver churn.
- Target file invalidation: per-file `DefId` invalidation removes the published body.
- Augmentation file invalidation: the source-file metadata removes the published body even when the target registry `DefId` belongs to another file.

## Fallback
If any structural prerequisite is absent, resolver consumers return the body they already had. This keeps the existing index-access, relation, and deferred-evaluation fallback paths intact.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver module_augmented_body`
- `TSZ_MODULE_AUG_BODY_PUBLISH=1 TSZ_MODULE_AUG_SYMBOL_EDGE=1 scripts/safe-run.sh cargo nextest run -p tsz-checker --test hkt_cross_file_augmentation_13653_repro cross_file_augmentation`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test hkt_cross_file_augmentation_13653_repro cross_file_augmentation`
- `scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver -p tsz-checker --all-targets -- -D warnings`
- `wc -l crates/tsz-solver/src/def/core.rs crates/tsz-solver/src/def/core/augmentation_symbols.rs crates/tsz-solver/src/def/resolver.rs crates/tsz-checker/src/context/resolver.rs crates/tsz-checker/src/types/module_augmentation.rs`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high