### PR TITLE
feat(solver): reroute cached index instantiation rereduce (#14345)

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -115,7 +115,7 @@ impl<'a> TypeInstantiator<'a> {
         // `instantiate_index_access`/`instantiate_conditional` can resolve the
         // cross-arena `Lazy` base instead of re-deferring resolver-less. The OFF
         // path is byte-identical to the prior unconditional `None`.
-        if inst_resolver_rereduce_enabled() {
+        if flags::inst_resolver_rereduce_enabled() {
             self.query_db = query_db;
         } else {
             self.query_db = None;
@@ -1087,6 +1087,7 @@ mod api;
 mod cache_stability;
 mod conditional;
 mod display_properties;
+mod flags;
 mod homomorphic;
 mod indexed;
 mod mapped;

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -1071,6 +1071,15 @@ pub fn instantiate_type_cached(
         if new_obj == obj && new_idx == idx {
             return type_id;
         }
+        if let Some(db) = query_db
+            && super::flags::inst_resolver_rereduce_enabled()
+            && !crate::visitor::contains_type_parameters(interner, new_obj)
+            && !crate::visitor::contains_type_parameters(interner, new_idx)
+            && (index_access_operand_needs_resolver(interner, new_obj)
+                || index_access_operand_needs_resolver(interner, new_idx))
+        {
+            return db.evaluate_index_access(new_obj, new_idx);
+        }
         return interner.index_access(new_obj, new_idx);
     }
     // Concrete identity short-circuit — no cache key construction needed. This
@@ -1759,33 +1768,6 @@ fn defer_lazy_default_conditional_enabled() -> bool {
     *ON.get_or_init(|| {
         !std::env::var("TSZ_DISABLE_DEFER_LAZY_DEFAULT_CONDITIONAL").is_ok_and(|v| v == "1")
     })
-}
-
-/// #14345 dormant resolver-aware re-reduce of instantiation-time deferred
-/// index-access / conditional leaks (default OFF; byte-parity when OFF).
-///
-/// When `TSZ_INST_RESOLVER_REREDUCE=1`, the instantiator keeps the
-/// resolver-aware `QueryDatabase` it was handed (instead of nulling it in
-/// `with_query_db`) and, at the two deferred-leak sites
-/// (`instantiate_index_access` and `instantiate_conditional`), re-runs the
-/// reduction through that resolver once the base/check became concrete (no
-/// type parameters remain). This resolves the cross-arena `Lazy(DefId)` base
-/// of an `URItoKind[URI]` index — e.g. fp-ts `Kind<TypeLambda, ...>` — to its
-/// alias instead of returning a structurally-detached deferred form.
-///
-/// The flag is OFF by default and the OFF path is the literal pre-existing
-/// code, so default-pipeline behavior is byte-identical. It is dormant
-/// infrastructure: with the flag ON it correctly clears the `TypeLambda` leak
-/// family but also exposes the #14344 unknown-drop family (the resolver
-/// returns alias bodies whose type-arg positions still carry the default
-/// `unknown` because the alias body was not materialized with the call's
-/// inferred arguments). Turning the flag into a default-on win requires the
-/// materialize-once stage (#14345 XL) to supply fully-substituted alias
-/// bodies before this re-reduce runs.
-pub(super) fn inst_resolver_rereduce_enabled() -> bool {
-    use std::sync::OnceLock;
-    static ON: OnceLock<bool> = OnceLock::new();
-    *ON.get_or_init(|| std::env::var("TSZ_INST_RESOLVER_REREDUCE").is_ok_and(|v| v == "1"))
 }
 
 pub(super) fn maybe_evaluate_concrete_conditional(

--- a/crates/tsz-solver/src/instantiation/instantiate/conditional.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/conditional.rs
@@ -141,7 +141,7 @@ impl<'a> TypeInstantiator<'a> {
         // re-reduce through the resolver so a cross-arena `Lazy` ref in the
         // condition resolves and the branch is picked. OFF returns the deferred
         // form (the literal pre-existing behavior).
-        if super::inst_resolver_rereduce_enabled()
+        if super::flags::inst_resolver_rereduce_enabled()
             && self.query_db.is_some()
             && !crate::visitor::contains_type_parameters(self.interner, instantiated.check_type)
             && !crate::visitor::contains_type_parameters(self.interner, instantiated.extends_type)

--- a/crates/tsz-solver/src/instantiation/instantiate/flags.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/flags.rs
@@ -1,0 +1,55 @@
+//! Env and test gates for instantiation policy.
+
+use std::sync::OnceLock;
+
+static INST_RESOLVER_REREDUCE_ENV: OnceLock<bool> = OnceLock::new();
+
+#[cfg(test)]
+thread_local! {
+    static INST_RESOLVER_REREDUCE_TEST_OVERRIDE: std::cell::Cell<Option<bool>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// Test guard for forcing the resolver-aware re-reduce flag on one thread.
+#[cfg(test)]
+pub(crate) struct InstResolverRereduceFlagGuard {
+    previous: Option<bool>,
+}
+
+#[cfg(test)]
+impl InstResolverRereduceFlagGuard {
+    pub(crate) fn new(enabled: bool) -> Self {
+        let previous = INST_RESOLVER_REREDUCE_TEST_OVERRIDE.with(|slot| {
+            let previous = slot.get();
+            slot.set(Some(enabled));
+            previous
+        });
+        Self { previous }
+    }
+}
+
+#[cfg(test)]
+impl Drop for InstResolverRereduceFlagGuard {
+    fn drop(&mut self) {
+        INST_RESOLVER_REREDUCE_TEST_OVERRIDE.with(|slot| slot.set(self.previous));
+    }
+}
+
+/// #14345 dormant resolver-aware re-reduce of instantiation-time deferred
+/// index-access / conditional leaks (default OFF; byte-parity when OFF).
+///
+/// When `TSZ_INST_RESOLVER_REREDUCE=1`, the instantiator keeps the
+/// resolver-aware [`QueryDatabase`](crate::caches::db::QueryDatabase) it was
+/// handed and, at the deferred-leak
+/// sites, re-runs reduction through that resolver once the base/check became
+/// concrete. The flag stays OFF until the materialize-once stages provide the
+/// fully published bodies those reductions need.
+pub(super) fn inst_resolver_rereduce_enabled() -> bool {
+    #[cfg(test)]
+    if let Some(enabled) = INST_RESOLVER_REREDUCE_TEST_OVERRIDE.with(std::cell::Cell::get) {
+        return enabled;
+    }
+
+    *INST_RESOLVER_REREDUCE_ENV
+        .get_or_init(|| std::env::var("TSZ_INST_RESOLVER_REREDUCE").is_ok_and(|v| v == "1"))
+}

--- a/crates/tsz-solver/src/instantiation/instantiate/indexed.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/indexed.rs
@@ -37,7 +37,7 @@ impl<'a> TypeInstantiator<'a> {
             // route the re-reduce through it (resolving the cross-arena `Lazy`
             // base) instead of returning the deferred `IndexAccess`. The OFF
             // path below is the literal pre-existing deferred return.
-            if super::inst_resolver_rereduce_enabled() && self.query_db.is_some() {
+            if super::flags::inst_resolver_rereduce_enabled() && self.query_db.is_some() {
                 return self.evaluate_index_access(inst_obj, inst_idx);
             }
             return self.interner.index_access(inst_obj, inst_idx);

--- a/crates/tsz-solver/tests/instantiate_tests.rs
+++ b/crates/tsz-solver/tests/instantiate_tests.rs
@@ -9,3 +9,4 @@ use crate::types::TypeData;
 
 include!("instantiate_tests_parts/part_00.rs");
 include!("instantiate_tests_parts/part_01.rs");
+include!("instantiate_tests_parts/part_02.rs");

--- a/crates/tsz-solver/tests/instantiate_tests_parts/part_02.rs
+++ b/crates/tsz-solver/tests/instantiate_tests_parts/part_02.rs
@@ -1,0 +1,41 @@
+#[test]
+fn cached_index_access_fast_path_uses_resolver_rereduce_when_flagged() {
+    let interner = TypeInterner::new();
+    let query_cache = crate::caches::query_cache::QueryCache::new(&interner);
+
+    let object_param_name = interner.intern_string("Obj");
+    let object_param = interner.type_param(TypeParamInfo {
+        name: object_param_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    });
+
+    let a_name = interner.intern_string("a");
+    let k_name = interner.intern_string("k");
+    let object = interner.object(vec![PropertyInfo::new(a_name, TypeId::STRING)]);
+    let key_source = interner.object(vec![PropertyInfo::new(k_name, interner.literal_string("a"))]);
+    let nested_key = interner.index_access(key_source, interner.literal_string("k"));
+    let indexed = interner.index_access(object_param, nested_key);
+
+    let mut subst = TypeSubstitution::new();
+    subst.insert(object_param_name, object);
+
+    {
+        let _flag = super::flags::InstResolverRereduceFlagGuard::new(false);
+        let deferred = instantiate_type_cached(&interner, Some(&query_cache), indexed, &subst);
+        assert!(
+            matches!(interner.lookup(deferred), Some(TypeData::IndexAccess(_, _))),
+            "flag-off fast path should preserve the historical deferred index access"
+        );
+    }
+
+    let _flag = super::flags::InstResolverRereduceFlagGuard::new(true);
+    let reduced = instantiate_type_cached(&interner, Some(&query_cache), indexed, &subst);
+    assert_eq!(
+        reduced,
+        TypeId::STRING,
+        "flag-on fast path must enter the resolver-aware index re-reduce seam"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
- Route `instantiate_type_cached`'s top-level `IndexAccess` fast path through the existing #15055 resolver-aware re-reduce seam when `TSZ_INST_RESOLVER_REREDUCE=1`, a `QueryDatabase` is present, both operands are concrete, and either operand still needs resolver-backed reduction.
- Move the env-gated re-reduce flag into a small `instantiate/flags.rs` module with a thread-local test override, keeping `api.rs` below the shard ceiling.
- Add a focused regression test proving flag-OFF keeps the historical deferred fast-path result while flag-ON enters `QueryDatabase::evaluate_index_access` and reduces the nested key.

## Structural Rule
When instantiation substitutes `T[K]` into a concrete indexed access whose object or key still contains resolver-owned meta types (`Lazy`, `Application`, `TypeQuery`, nested `IndexAccess`, `Conditional`, `KeyOf`, or `Mapped`), tsz should use the caller's resolver-aware re-reduce policy instead of returning a resolver-less deferred artifact from the allocation-free cached fast path. This matches the #15055 rule already owned by `TypeInstantiator::instantiate_index_access`; this PR applies the same rule to the public cached `IndexAccess` shortcut.

## Owner Layer
Solver instantiation owns the change. No checker/module-augmentation publication, `DefinitionStore`, `index_access.rs`, relation, diagnostic, emit, or #15116/#15119 files are touched.

## Adjacent Case Matrix
- Flag OFF: the `IndexAccess` fast path still returns the rebuilt deferred `IndexAccess`, preserving default byte behavior.
- Flag ON with no `QueryDatabase`: the fast path remains deferred, matching the existing resolver-less behavior.
- Flag ON with type parameters still present: the fast path remains deferred, preserving generic `T[K]` semantics.
- Flag ON with concrete operands that do not need resolver-backed reduction: the allocation-free fast path remains allocation-light and deferred as before.
- Flag ON with concrete resolver-needing operands: the fast path calls `db.evaluate_index_access`, matching the full instantiator's #15055 re-reduce seam.

## Fallback
If any structural precondition is missing, evaluation falls through to the historical `interner.index_access(new_obj, new_idx)` result. The new path bypasses the cross-call instantiation cache for this fast-path leaf, so it does not add a resolver/flag dimension to `InstantiationCacheKey`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver cached_index_access_fast_path_uses_resolver_rereduce_when_flagged`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver query_database_evaluate_entry_points_preserve_results`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `wc -l crates/tsz-solver/src/instantiation/instantiate/api.rs crates/tsz-solver/src/instantiation/instantiate/flags.rs crates/tsz-solver/src/instantiation/instantiate.rs crates/tsz-solver/tests/instantiate_tests_parts/part_00.rs crates/tsz-solver/tests/instantiate_tests_parts/part_01.rs crates/tsz-solver/tests/instantiate_tests_parts/part_02.rs`

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high