### PR TITLE
fix(solver): prune application eval dependency edges (#14347)

### DIFF
--- a/crates/tsz-solver/src/caches/application_eval_index.rs
+++ b/crates/tsz-solver/src/caches/application_eval_index.rs
@@ -13,16 +13,21 @@ pub(super) fn record_dependencies(
     interner: &TypeInterner,
     index: &ApplicationEvalDependencyIndex,
     key: &ApplicationEvalCacheKey,
+    old_result: Option<TypeId>,
     result: TypeId,
 ) {
-    let deps = collect_application_eval_entry_def_dependencies(interner, key, result);
     let mut index = index.borrow_mut();
+    if let Some(old_result) = old_result {
+        remove_dependencies(interner, &mut index, key, old_result);
+    }
+    let deps = collect_application_eval_entry_def_dependencies(interner, key, result);
     for def_id in deps {
         index.entry(def_id).or_default().insert(key.clone());
     }
 }
 
 pub(super) fn invalidate_for_def(
+    interner: &TypeInterner,
     index: &ApplicationEvalDependencyIndex,
     cache: &RefCell<FxHashMap<ApplicationEvalCacheKey, TypeId>>,
     def_id: DefId,
@@ -31,12 +36,32 @@ pub(super) fn invalidate_for_def(
         return;
     };
     let mut cache = cache.borrow_mut();
+    let mut index = index.borrow_mut();
     for key in keys {
-        cache.remove(&key);
+        if let Some(old_result) = cache.remove(&key) {
+            remove_dependencies(interner, &mut index, &key, old_result);
+        }
     }
 }
 
 #[cfg(test)]
 pub(super) fn key_count(index: &ApplicationEvalDependencyIndex, def_id: DefId) -> usize {
     index.borrow().get(&def_id).map_or(0, FxHashSet::len)
+}
+
+fn remove_dependencies(
+    interner: &TypeInterner,
+    index: &mut FxHashMap<DefId, FxHashSet<ApplicationEvalCacheKey>>,
+    key: &ApplicationEvalCacheKey,
+    result: TypeId,
+) {
+    for def_id in collect_application_eval_entry_def_dependencies(interner, key, result) {
+        let Some(keys) = index.get_mut(&def_id) else {
+            continue;
+        };
+        keys.remove(key);
+        if keys.is_empty() {
+            index.remove(&def_id);
+        }
+    }
 }

--- a/crates/tsz-solver/src/caches/query_cache_application_eval.rs
+++ b/crates/tsz-solver/src/caches/query_cache_application_eval.rs
@@ -60,6 +60,7 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
 
     fn invalidate_application_eval_cache_for_def(&self, def_id: DefId) {
         application_eval_index::invalidate_for_def(
+            self.interner,
             &self.application_eval_dependency_index,
             &self.application_eval_cache,
             def_id,
@@ -67,7 +68,7 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
         if let Some(shared) = self.shared
             && shared.shares_instantiation_family()
         {
-            shared.invalidate_application_eval_cache_for_def(def_id);
+            shared.invalidate_application_eval_cache_for_def(self.interner, def_id);
         }
     }
 

--- a/crates/tsz-solver/src/caches/query_cache_spread.rs
+++ b/crates/tsz-solver/src/caches/query_cache_spread.rs
@@ -75,6 +75,7 @@ impl QueryCache<'_> {
                     self.interner,
                     &self.application_eval_dependency_index,
                     &key,
+                    None,
                     result,
                 );
                 self.application_eval_cache_stats.record_hit();
@@ -103,13 +104,15 @@ impl QueryCache<'_> {
             self.application_eval_cache_stats.record_shared_insert();
             tsz_common::perf_counters::record_shared_application_eval_cache_insert();
         }
-        self.application_eval_cache
+        let old_result = self
+            .application_eval_cache
             .borrow_mut()
             .insert(key.clone(), result);
         application_eval_index::record_dependencies(
             self.interner,
             &self.application_eval_dependency_index,
             &key,
+            old_result,
             result,
         );
     }

--- a/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
@@ -312,6 +312,100 @@ fn application_eval_cache_invalidation_uses_recorded_def_dependencies() {
 }
 
 #[test]
+fn application_eval_cache_overwrite_replaces_recorded_result_dependencies() {
+    // Structural rule: the dependency index describes the cache entry that is
+    // currently stored for a key. Re-inserting the same application-eval key
+    // with a new result must detach the key from the old result's `DefId`
+    // bucket, or an invalidation of the old body would evict a live result.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let base_def = DefId(50);
+    let stale_result_def = DefId(60);
+    let current_result_def = DefId(70);
+    let stale_result = interner.lazy(stale_result_def);
+    let current_result = interner.lazy(current_result_def);
+
+    db.insert_application_eval_cache(base_def, &[TypeId::STRING], false, stale_result);
+    db.insert_application_eval_cache(base_def, &[TypeId::STRING], false, current_result);
+
+    assert_eq!(db.application_eval_dependency_key_count(base_def), 1);
+    assert_eq!(
+        db.application_eval_dependency_key_count(stale_result_def),
+        0,
+        "overwriting a key must remove dependency edges for the old result"
+    );
+    assert_eq!(
+        db.application_eval_dependency_key_count(current_result_def),
+        1
+    );
+
+    db.invalidate_application_eval_cache_for_def(stale_result_def);
+    assert_eq!(
+        db.lookup_application_eval_cache(base_def, &[TypeId::STRING], false),
+        Some(current_result),
+        "invalidating a stale result dependency must not evict the replacement"
+    );
+
+    db.invalidate_application_eval_cache_for_def(current_result_def);
+    assert_eq!(
+        db.lookup_application_eval_cache(base_def, &[TypeId::STRING], false),
+        None,
+        "invalidating the current result dependency must evict the entry"
+    );
+    assert_eq!(
+        db.application_eval_dependency_key_count(base_def),
+        0,
+        "eviction by result dependency must remove the base-def reverse edge"
+    );
+}
+
+#[test]
+fn shared_application_eval_cache_overwrite_replaces_recorded_result_dependencies() {
+    // Structural rule: the opt-in shared application-eval cache has the same
+    // exact-dependency invariant as the file-local cache. A stale dependency
+    // edge in the shared index can otherwise evict the current value for fresh
+    // sibling file checkers.
+    let interner = TypeInterner::new();
+    let shared = SharedQueryCache::new_for_instantiation_family_test(true);
+
+    let base_def = DefId(80);
+    let stale_result_def = DefId(90);
+    let current_result_def = DefId(100);
+    let stale_result = interner.lazy(stale_result_def);
+    let current_result = interner.lazy(current_result_def);
+
+    {
+        let db_a = QueryCache::new_with_shared(&interner, &shared);
+        db_a.insert_application_eval_cache(base_def, &[TypeId::NUMBER], false, stale_result);
+        db_a.insert_application_eval_cache(base_def, &[TypeId::NUMBER], false, current_result);
+        db_a.invalidate_application_eval_cache_for_def(stale_result_def);
+    }
+
+    {
+        let db_b = QueryCache::new_with_shared(&interner, &shared);
+        assert_eq!(
+            db_b.lookup_application_eval_cache(base_def, &[TypeId::NUMBER], false),
+            Some(current_result),
+            "invalidating a stale shared dependency must not evict the replacement"
+        );
+    }
+
+    {
+        let db_c = QueryCache::new_with_shared(&interner, &shared);
+        db_c.invalidate_application_eval_cache_for_def(current_result_def);
+    }
+    {
+        let db_d = QueryCache::new_with_shared(&interner, &shared);
+        assert_eq!(
+            db_d.lookup_application_eval_cache(base_def, &[TypeId::NUMBER], false),
+            None,
+            "invalidating the current shared dependency must evict the entry"
+        );
+    }
+}
+
+#[test]
 fn instantiation_cache_is_per_file_isolated() {
     // Structural rule: `instantiation_cache` is intentionally NOT shared
     // cross-file. The same class of ordering-sensitivity that affects

--- a/crates/tsz-solver/src/caches/shared_query_cache.rs
+++ b/crates/tsz-solver/src/caches/shared_query_cache.rs
@@ -101,7 +101,10 @@ impl SharedQueryCache {
         key: ApplicationEvalCacheKey,
         result: TypeId,
     ) {
-        self.application_eval_cache.insert(key.clone(), result);
+        let old_result = self.application_eval_cache.insert(key.clone(), result);
+        if let Some(old_result) = old_result {
+            self.remove_application_eval_dependencies(interner, &key, old_result);
+        }
         for def_id in collect_application_eval_entry_def_dependencies(interner, &key, result) {
             self.application_eval_dependency_index
                 .entry(def_id)
@@ -110,12 +113,37 @@ impl SharedQueryCache {
         }
     }
 
-    pub(super) fn invalidate_application_eval_cache_for_def(&self, def_id: DefId) {
+    pub(super) fn invalidate_application_eval_cache_for_def(
+        &self,
+        interner: &TypeInterner,
+        def_id: DefId,
+    ) {
         let Some((_, keys)) = self.application_eval_dependency_index.remove(&def_id) else {
             return;
         };
         for key in keys {
-            self.application_eval_cache.remove(&key);
+            if let Some((_, old_result)) = self.application_eval_cache.remove(&key) {
+                self.remove_application_eval_dependencies(interner, &key, old_result);
+            }
+        }
+    }
+
+    fn remove_application_eval_dependencies(
+        &self,
+        interner: &TypeInterner,
+        key: &ApplicationEvalCacheKey,
+        result: TypeId,
+    ) {
+        for def_id in collect_application_eval_entry_def_dependencies(interner, key, result) {
+            let Some(mut keys) = self.application_eval_dependency_index.get_mut(&def_id) else {
+                continue;
+            };
+            keys.remove(key);
+            let empty = keys.is_empty();
+            drop(keys);
+            if empty {
+                self.application_eval_dependency_index.remove(&def_id);
+            }
         }
     }
 


### PR DESCRIPTION
Goal: fast

## Summary
- Keep the file-local application-eval dependency index exact when a cache key is overwritten or invalidated.
- Apply the same exact-edge maintenance to the opt-in shared application-eval cache so stale dependency buckets cannot evict a live replacement for sibling file checkers.
- Add regression coverage for stale-result dependency invalidation and current-result invalidation on both local and shared paths.

## Structural Rule
When an application-eval cache key is inserted, overwritten, or invalidated, the dependency index must describe only the currently stored key/value. `tsc` does not retain historical dependency edges after a generic application answer changes; tsz preserves that invariant through the solver cache layer by removing the old `(key, result)` dependency set before recording the replacement and by pruning all reverse edges when invalidation evicts an entry.

## Owner Layer
Solver cache infrastructure owns this change: `QueryCache` application-eval dependency indexing and the opt-in `SharedQueryCache` application-eval index. No checker diagnostics, relation semantics, module augmentation producers, definition-store identity, narrowing caches, or instantiation re-reduce paths are changed.

## Adjacent Case Matrix
- Local overwrite: replacing a key whose old result mentioned `Lazy(old_def)` removes the old result bucket and preserves the replacement when `old_def` is invalidated.
- Local current invalidation: invalidating the replacement's current result `DefId` evicts the entry and removes its base-def reverse edge.
- Shared overwrite: the opt-in shared application-eval cache preserves a replacement for fresh sibling `QueryCache`s when only a stale result dependency is invalidated.
- Shared current invalidation: invalidating the current shared dependency evicts the entry for subsequent sibling `QueryCache`s.
- Existing base/argument/result dependency invalidation behavior stays covered by the existing `application_eval_cache_invalidation_uses_recorded_def_dependencies` test.

## Fallback
If an invalidated dependency bucket is absent, behavior remains a no-op. If a stale bucket points at a key that no longer exists in the cache, no result is served or synthesized; cleanup simply skips that missing entry. Dropping stale reverse edges can only prevent over-eviction or leaked index residency, not make a stale value cacheable.

## Verification
- `cargo fmt --all --check`
- `git diff --check HEAD~1..HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver application_eval_cache_overwrite_replaces_recorded_result_dependencies shared_application_eval_cache_overwrite_replaces_recorded_result_dependencies application_eval_cache_invalidation_uses_recorded_def_dependencies opt_in_shared_application_eval_cache_reuses_across_file_caches`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: high