### PR TITLE
fix(solver): resolve judge eval helpers through env (#14351)

### DIFF
--- a/crates/tsz-solver/src/relations/judge.rs
+++ b/crates/tsz-solver/src/relations/judge.rs
@@ -307,6 +307,12 @@ impl<'a> DefaultJudge<'a> {
 }
 
 impl<'a> DefaultJudge<'a> {
+    fn configured_evaluator(&self) -> TypeEvaluator<'a, TypeEnvironment> {
+        let mut evaluator = TypeEvaluator::with_resolver(self.db, self.env);
+        evaluator.set_no_unchecked_indexed_access(self.config.no_unchecked_indexed_access);
+        evaluator
+    }
+
     /// Check if `source` is a subtype of `target`.
     pub fn is_subtype(&self, source: TypeId, target: TypeId) -> bool {
         // Fast path: identity
@@ -934,12 +940,8 @@ impl<'a> DefaultJudge<'a> {
 
     /// Get the result of indexing: `T[K]`.
     pub fn get_index_type(&self, object: TypeId, key: TypeId) -> TypeId {
-        crate::evaluation::evaluate::evaluate_index_access_with_options(
-            self.db,
-            object,
-            key,
-            self.config.no_unchecked_indexed_access,
-        )
+        self.configured_evaluator()
+            .evaluate_index_access(object, key)
     }
 
     /// Get index signature type (string or number indexer).
@@ -967,7 +969,7 @@ impl<'a> DefaultJudge<'a> {
 
     /// Get `keyof T`.
     pub fn get_keyof(&self, type_id: TypeId) -> TypeId {
-        crate::evaluation::evaluate::evaluate_keyof(self.db, type_id)
+        self.configured_evaluator().evaluate_keyof(type_id)
     }
 
     /// Get the current configuration.

--- a/crates/tsz-solver/tests/judge_tests.rs
+++ b/crates/tsz-solver/tests/judge_tests.rs
@@ -198,6 +198,42 @@ fn test_get_property_object() {
 }
 
 #[test]
+fn test_get_index_type_resolves_lazy_object_body() {
+    let mut setup = JudgeSetup::new();
+
+    let alpha = setup.interner.intern_string("alpha");
+    let object = setup
+        .interner
+        .object(vec![PropertyInfo::new(alpha, TypeId::NUMBER)]);
+    let def_id = DefId(40_001);
+    setup.env.insert_def(def_id, object);
+
+    let lazy_object = setup.interner.lazy(def_id);
+    let alpha_key = setup.interner.literal_string("alpha");
+    let judge = setup.judge();
+
+    assert_eq!(judge.get_index_type(lazy_object, alpha_key), TypeId::NUMBER);
+}
+
+#[test]
+fn test_get_keyof_resolves_lazy_object_body() {
+    let mut setup = JudgeSetup::new();
+
+    let beta = setup.interner.intern_string("beta");
+    let object = setup
+        .interner
+        .object(vec![PropertyInfo::new(beta, TypeId::STRING)]);
+    let def_id = DefId(40_002);
+    setup.env.insert_def(def_id, object);
+
+    let lazy_object = setup.interner.lazy(def_id);
+    let beta_key = setup.interner.literal_string("beta");
+    let judge = setup.judge();
+
+    assert_eq!(judge.get_keyof(lazy_object), beta_key);
+}
+
+#[test]
 fn test_get_property_special_types() {
     let setup = JudgeSetup::new();
     let interner = &setup.interner;


### PR DESCRIPTION
Goal: green

## Summary
- Route `DefaultJudge::get_index_type` and `DefaultJudge::get_keyof` through a resolver-backed `TypeEvaluator` built from the judge's `TypeEnvironment`.
- Preserve `JudgeConfig::no_unchecked_indexed_access` on those helper evaluations.
- Add focused solver regressions for `Lazy(DefId)` object bodies in indexed access and `keyof` queries.

## Structural Rule
When a judge helper evaluates a `Lazy(DefId)` operand whose body is available in the judge's `TypeEnvironment`, tsc evaluates the resolved structural body. tsz should do that through the solver-owned `DefaultJudge` evaluator/resolver boundary, rather than the resolver-less convenience wrappers.

## Owner Layer
Owner: `tsz-solver` judge/evaluation boundary. `DefaultJudge` already owns the `TypeEnvironment`; this PR keeps the helper methods inside that solver-owned resolver path and does not add checker type-shape logic.

## Adjacent Case Matrix
- `Lazy` object body plus literal property key: `get_index_type` reduces to the property read type.
- `Lazy` object body under `keyof`: `get_keyof` reduces to the concrete literal key space.
- `noUncheckedIndexedAccess`: the judge config is still applied to index-access helper evaluation.
- Unresolved `Lazy` body or unsupported shape: evaluator fallback remains deferred/error-preserving as before.
- Existing judge classification, relation, member, and property tests remain unchanged.

## Fallback
If the `TypeEnvironment` cannot resolve the `DefId`, the resolver-backed evaluator keeps the same deferred `IndexAccess` / `KeyOf` behavior used by the existing evaluation rules.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver test_get_index_type_resolves_lazy_object_body test_get_keyof_resolves_lazy_object_body`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver relations::judge::tests`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `wc -l crates/tsz-solver/src/relations/judge.rs crates/tsz-solver/tests/judge_tests.rs`

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high