### PR TITLE
refactor(solver): move cross-eval state into evaluation session (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
+++ b/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
@@ -16,44 +16,17 @@
 //! per-query operation budget bails, leaving an opaque/deferred result instead
 //! of the converged one.
 //!
-//! This thread-local set records the `TypeId`s currently being expanded by a
-//! fresh evaluator anywhere on the thread. Re-entering one that is already in
-//! flight is a cross-instance cycle: the caller skips the re-expansion and
+//! The active set now lives on [`EvaluationSession`](crate::evaluation::session::EvaluationSession).
+//! This adapter keeps the existing fresh-evaluator call sites stable while
+//! routing the state through the session owner. Re-entering a `TypeId` already
+//! in flight is a cross-instance cycle: the caller skips the re-expansion and
 //! treats the type as not-yet-resolved (exactly how the per-instance guard
 //! treats a within-instance cycle), which lets the in-flight expansion — the one
 //! holding the real work — converge and breaks the churn.
 
 use crate::evaluation::result::EvaluationMemoResult;
+use crate::evaluation::session::with_current_session;
 use crate::types::TypeId;
-use rustc_hash::{FxHashMap, FxHashSet};
-use std::cell::RefCell;
-
-thread_local! {
-    static ACTIVE: RefCell<FxHashSet<TypeId>> = RefCell::new(FxHashSet::default());
-
-    /// Per-top-level-query result memo shared across *all* `TypeEvaluator`
-    /// instances on the thread (#11586).
-    ///
-    /// The two fresh-evaluator boundaries — infer-pattern expansion
-    /// (`evaluate_for_infer_match`) and the subtype checker
-    /// (`SubtypeChecker::evaluate_type`) — each construct a brand-new evaluator
-    /// with an empty result cache, so a recursive conditional/`infer` application
-    /// (`Unbox<Box<2>>`, `Awaited<Promise<2>>`, …) is re-evaluated from scratch
-    /// tens of thousands of times as the recursion fans out, exhausting the
-    /// per-query operation budget and bailing opaque instead of converging.
-    ///
-    /// This memo records each root `TypeId` those boundaries evaluate, so a
-    /// repeated evaluation of the same type within one query is served from the
-    /// memo instead of recomputed. It is **cleared at the start of every
-    /// top-level query** (see [`reset_query_memo`], called when the per-query
-    /// budget frame count transitions from zero), so a result never crosses query
-    /// or file boundaries — strictly tighter than the per-file isolation that
-    /// motivated keeping the application cache thread-local (issue #9507). Only
-    /// stable, key-determined results are stored; recursion-bailed artifacts are
-    /// not (see the call sites).
-    static QUERY_MEMO: RefCell<FxHashMap<(TypeId, bool), TypeId>> =
-        RefCell::new(FxHashMap::default());
-}
 
 /// Look up a memoized fresh-evaluator result for the current top-level query.
 ///
@@ -61,11 +34,7 @@ thread_local! {
 /// depend on it (the per-checker `eval_cache` keys on the same flag): a memo
 /// keyed on `TypeId` alone would return a result computed under the wrong mode.
 pub(crate) fn query_memo_get(type_id: TypeId, no_unchecked_indexed_access: bool) -> Option<TypeId> {
-    QUERY_MEMO.with(|memo| {
-        memo.borrow()
-            .get(&(type_id, no_unchecked_indexed_access))
-            .copied()
-    })
+    with_current_session(|session| session.query_memo_get(type_id, no_unchecked_indexed_access))
 }
 
 /// Record a stable fresh-evaluator result for the current top-level query.
@@ -74,16 +43,15 @@ pub(crate) fn query_memo_get(type_id: TypeId, no_unchecked_indexed_access: bool)
 /// (`TypeEvaluator::recursion_limit_hit`), so an opaque cycle/budget bail is
 /// never cached and reused as if it were the converged answer.
 pub(crate) fn query_memo_put(type_id: TypeId, no_unchecked_indexed_access: bool, result: TypeId) {
-    QUERY_MEMO.with(|memo| {
-        memo.borrow_mut()
-            .insert((type_id, no_unchecked_indexed_access), result);
+    with_current_session(|session| {
+        session.query_memo_put(type_id, no_unchecked_indexed_access, result);
     });
 }
 
 /// Clear the per-query memo. Invoked when a fresh top-level evaluation query
 /// begins so results never leak across queries, threads, or files.
 pub(crate) fn reset_query_memo() {
-    QUERY_MEMO.with(|memo| memo.borrow_mut().clear());
+    with_current_session(super::session::EvaluationSession::reset_query_memo);
 }
 
 /// Run a fresh sub-evaluator for `type_id` with cross-instance cycle breaking
@@ -160,21 +128,17 @@ pub(crate) enum CrossEvalExpansionState {
 
 impl CrossEvalExpansionGuard {
     pub(crate) fn enter(type_id: TypeId) -> CrossEvalExpansionState {
-        ACTIVE.with(|set| {
-            if set.borrow_mut().insert(type_id) {
-                CrossEvalExpansionState::Entered(Self(type_id))
-            } else {
-                CrossEvalExpansionState::AlreadyActive
-            }
-        })
+        if with_current_session(|session| session.enter_cross_eval_type(type_id)) {
+            CrossEvalExpansionState::Entered(Self(type_id))
+        } else {
+            CrossEvalExpansionState::AlreadyActive
+        }
     }
 }
 
 impl Drop for CrossEvalExpansionGuard {
     fn drop(&mut self) {
-        ACTIVE.with(|set| {
-            set.borrow_mut().remove(&self.0);
-        });
+        with_current_session(|session| session.leave_cross_eval_type(self.0));
     }
 }
 

--- a/crates/tsz-solver/src/evaluation/session.rs
+++ b/crates/tsz-solver/src/evaluation/session.rs
@@ -9,7 +9,9 @@
 //! via `Rc` across parent/child contexts so counters survive cross-arena
 //! delegation without implicit global state.
 
-use std::cell::Cell;
+use crate::types::TypeId;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::cell::{Cell, RefCell};
 
 /// Maximum global instantiation depth — bounds nesting of
 /// `evaluate_application_type` calls across all `CheckerContext` instances.
@@ -49,14 +51,20 @@ pub struct EvaluationSession {
     global_instantiation_depth: Cell<u32>,
     /// Cross-context instantiation fuel (total non-cached evaluations per file).
     global_instantiation_fuel: Cell<u32>,
+    /// `TypeId`s currently expanded by fresh evaluators in this session.
+    cross_eval_active: RefCell<FxHashSet<TypeId>>,
+    /// Per-top-level-query memo for stable fresh-evaluator results.
+    query_memo: RefCell<FxHashMap<(TypeId, bool), TypeId>>,
 }
 
 impl EvaluationSession {
     /// Create a new session with all counters at zero.
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             global_instantiation_depth: Cell::new(0),
             global_instantiation_fuel: Cell::new(0),
+            cross_eval_active: RefCell::new(FxHashSet::default()),
+            query_memo: RefCell::new(FxHashMap::default()),
         }
     }
 
@@ -113,6 +121,61 @@ impl EvaluationSession {
     pub const fn global_instantiation_fuel(&self) -> u32 {
         self.global_instantiation_fuel.get()
     }
+
+    /// Enter cross-evaluator expansion of `type_id`.
+    ///
+    /// Returns `false` when this session is already expanding the same type.
+    #[inline]
+    pub(crate) fn enter_cross_eval_type(&self, type_id: TypeId) -> bool {
+        self.cross_eval_active.borrow_mut().insert(type_id)
+    }
+
+    /// Leave cross-evaluator expansion of `type_id`.
+    #[inline]
+    pub(crate) fn leave_cross_eval_type(&self, type_id: TypeId) {
+        self.cross_eval_active.borrow_mut().remove(&type_id);
+    }
+
+    /// Look up a stable fresh-evaluator result for the current top-level query.
+    #[inline]
+    pub(crate) fn query_memo_get(
+        &self,
+        type_id: TypeId,
+        no_unchecked_indexed_access: bool,
+    ) -> Option<TypeId> {
+        self.query_memo
+            .borrow()
+            .get(&(type_id, no_unchecked_indexed_access))
+            .copied()
+    }
+
+    /// Record a stable fresh-evaluator result for the current top-level query.
+    #[inline]
+    pub(crate) fn query_memo_put(
+        &self,
+        type_id: TypeId,
+        no_unchecked_indexed_access: bool,
+        result: TypeId,
+    ) {
+        self.query_memo
+            .borrow_mut()
+            .insert((type_id, no_unchecked_indexed_access), result);
+    }
+
+    /// Clear the per-query fresh-evaluator memo.
+    #[inline]
+    pub(crate) fn reset_query_memo(&self) {
+        self.query_memo.borrow_mut().clear();
+    }
+}
+
+thread_local! {
+    static CURRENT_SESSION: EvaluationSession = EvaluationSession::new();
+}
+
+/// Borrow the current thread's default evaluation session.
+pub(crate) fn with_current_session<T>(f: impl FnOnce(&EvaluationSession) -> T) -> T {
+    CURRENT_SESSION.with(f)
 }
 
 #[cfg(test)]
@@ -202,5 +265,35 @@ mod tests {
             EvaluationSessionLimitState::DepthExceeded,
             "depth limit should stay the primary session limit once both limits are exceeded"
         );
+    }
+
+    #[test]
+    fn test_cross_eval_active_set_is_session_owned() {
+        let session = EvaluationSession::new();
+        let type_id = TypeId(101);
+
+        assert!(session.enter_cross_eval_type(type_id));
+        assert!(
+            !session.enter_cross_eval_type(type_id),
+            "re-entering the same type in one session should be rejected"
+        );
+        session.leave_cross_eval_type(type_id);
+        assert!(session.enter_cross_eval_type(type_id));
+    }
+
+    #[test]
+    fn test_query_memo_keys_on_no_unchecked_indexed_access() {
+        let session = EvaluationSession::new();
+        let type_id = TypeId(202);
+
+        session.query_memo_put(type_id, false, TypeId(210));
+        session.query_memo_put(type_id, true, TypeId(211));
+
+        assert_eq!(session.query_memo_get(type_id, false), Some(TypeId(210)));
+        assert_eq!(session.query_memo_get(type_id, true), Some(TypeId(211)));
+
+        session.reset_query_memo();
+        assert_eq!(session.query_memo_get(type_id, false), None);
+        assert_eq!(session.query_memo_get(type_id, true), None);
     }
 }


### PR DESCRIPTION
Goal: green

## Summary
- Move the cross-evaluator active set and per-query fresh-evaluator memo into `EvaluationSession`.
- Keep `cross_eval_guard` as a thin adapter so existing infer-pattern and subtype fresh-evaluator call sites keep their behavior.
- Add session-owned tests for active-set reentry and option-sensitive query memo state.

## Structural Rule
When fresh evaluators cooperate during one evaluation query, the active expansion set and stable-result memo are evaluation-session state. tsz should own that state in `EvaluationSession`; the cross-eval guard module should adapt call sites to the session owner rather than owning independent TLS maps.

## Owner Layer
Owner: `tsz-solver` evaluation session/cross-evaluator boundary. This PR does not change checker orchestration, relation policy, application-eval caches, module augmentation, or mapped/keyof evaluation.

## Adjacent Case Matrix
- Same `TypeId` reentry in one session: records an already-active state and preserves the existing skip-expansion behavior.
- Distinct `TypeId`s: remain independently enterable.
- Fresh-evaluator memo keys: remain option-sensitive on `noUncheckedIndexedAccess`.
- Non-stable memo results: still return to the caller without being stored.
- Top-level query reset: still clears the per-query memo through the existing query-budget entry point.

## Fallback
The adapter preserves the previous `cross_eval_guard` API and fallback behavior: a cross-instance cycle returns `None`, and callers continue returning the input type unchanged without caching that partial result.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver evaluation::session evaluation::cross_eval_guard`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards evaluation_engine_keeps_request_stage_boundary`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `wc -l crates/tsz-solver/src/evaluation/session.rs crates/tsz-solver/src/evaluation/cross_eval_guard.rs`

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high
