### PR TITLE
fix(checker): route semantic def body reads through augmentation bodies (#14345)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_eval.rs
+++ b/crates/tsz-checker/src/assignability/assignability_eval.rs
@@ -15,7 +15,7 @@ impl<'a> CheckerState<'a> {
         {
             return None;
         }
-        let body = self.ctx.definition_store.get_body(def_id)?;
+        let body = self.ctx.get_semantic_def_body(def_id)?;
         if body == TypeId::ERROR || body == TypeId::ANY || body == type_id {
             return None;
         }

--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -86,9 +86,14 @@ impl<'a> CheckerContext<'a> {
     /// Keep those direct reads aligned with the module-augmentation body publication
     /// channel instead of reintroducing raw `DefinitionStore::get_body` bypasses.
     pub(crate) fn get_semantic_def_body(&self, def_id: DefId) -> Option<TypeId> {
-        self.definition_store
-            .get_body(def_id)
-            .map(|body| self.module_augmented_body_or_current(def_id, body, self.types))
+        let body = self.definition_store.get_body(def_id)?;
+        if !self
+            .definition_store
+            .module_augmented_body_publication_enabled()
+        {
+            return Some(body);
+        }
+        Some(self.module_augmented_body_or_current(def_id, body, self.types))
     }
 
     /// On a `resolve_lazy` miss for a force-eligible simple lib interface,

--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -68,7 +68,7 @@ impl<'a> CheckerContext<'a> {
             .unwrap_or(false)
     }
 
-    fn module_augmented_body_or_current(
+    pub(crate) fn module_augmented_body_or_current(
         &self,
         def_id: DefId,
         body: TypeId,
@@ -77,6 +77,18 @@ impl<'a> CheckerContext<'a> {
         self.definition_store
             .module_augmented_body_for(def_id, body, interner)
             .unwrap_or(body)
+    }
+
+    /// Read a `DefId` body for checker-side semantic decisions.
+    ///
+    /// Most `Lazy(DefId)` resolution flows through [`TypeResolver::resolve_lazy`],
+    /// but a few diagnostic and indexed-access paths need the stored body directly.
+    /// Keep those direct reads aligned with the module-augmentation body publication
+    /// channel instead of reintroducing raw `DefinitionStore::get_body` bypasses.
+    pub(crate) fn get_semantic_def_body(&self, def_id: DefId) -> Option<TypeId> {
+        self.definition_store
+            .get_body(def_id)
+            .map(|body| self.module_augmented_body_or_current(def_id, body, self.types))
     }
 
     /// On a `resolve_lazy` miss for a force-eligible simple lib interface,

--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -68,6 +68,17 @@ impl<'a> CheckerContext<'a> {
             .unwrap_or(false)
     }
 
+    fn module_augmented_body_or_current(
+        &self,
+        def_id: DefId,
+        body: TypeId,
+        interner: &dyn TypeDatabase,
+    ) -> TypeId {
+        self.definition_store
+            .module_augmented_body_for(def_id, body, interner)
+            .unwrap_or(body)
+    }
+
     /// On a `resolve_lazy` miss for a force-eligible simple lib interface,
     /// recover its already-flattened body from the by-name lib-type cache and
     /// register it into the type environments, so a structurally-consuming
@@ -803,7 +814,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
     fn resolve_lazy_lookup_only(
         &self,
         def_id: DefId,
-        _interner: &dyn TypeDatabase,
+        interner: &dyn TypeDatabase,
     ) -> Option<TypeId> {
         use tsz_binder::symbol_flags;
 
@@ -884,7 +895,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                 && let Some(real_def_id) = self.get_existing_def_id(sym_id)
                 && real_def_id != def_id
             {
-                return self.resolve_lazy(real_def_id, _interner);
+                return self.resolve_lazy(real_def_id, interner);
             }
 
             // For classes/interfaces/type aliases, check if we should return
@@ -917,7 +928,11 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                         // fall through to the type environment or
                         // DefinitionStore body for transparent aliases.
                         if !type_alias_self_wrapper {
-                            return Some(instance_type);
+                            return Some(self.module_augmented_body_or_current(
+                                def_id,
+                                instance_type,
+                                interner,
+                            ));
                         }
                     }
                 } else {
@@ -932,7 +947,11 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                                 | symbol_flags::TYPE_ALIAS,
                         )
                     {
-                        return Some(instance_type);
+                        return Some(self.module_augmented_body_or_current(
+                            def_id,
+                            instance_type,
+                            interner,
+                        ));
                     }
                 }
             }
@@ -1004,7 +1023,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                             .map_or("?", |s| s.escaped_name.as_str()),
                         "resolve_lazy: found in symbol_types cache"
                     );
-                    return Some(ty);
+                    return Some(self.module_augmented_body_or_current(def_id, ty, interner));
                 }
             }
         }
@@ -1031,7 +1050,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                 type_id = body.0,
                 "resolve_lazy: found in type_env"
             );
-            return Some(body);
+            return Some(self.module_augmented_body_or_current(def_id, body, interner));
         }
 
         if let Some(sym_id) = self.def_to_symbol_id_with_fallback(def_id)
@@ -1095,7 +1114,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                 type_id = resolved.0,
                 "resolve_lazy: found in SYMBOL_TYPE bucket"
             );
-            return Some(resolved);
+            return Some(self.module_augmented_body_or_current(def_id, resolved, interner));
         }
 
         // Final fallback: consult the shared `DefinitionStore` for a body
@@ -1112,7 +1131,7 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                 type_id = body.0,
                 "resolve_lazy: found in DefinitionStore body"
             );
-            return Some(body);
+            return Some(self.module_augmented_body_or_current(def_id, body, interner));
         }
         tracing::trace!(def_id = def_id.0, "resolve_lazy: NOT FOUND");
         None

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1486,6 +1486,9 @@ mod self_referential_arrow_property_soundness_tests;
 #[path = "tests/self_referential_conditional_infer_soundness_tests.rs"]
 mod self_referential_conditional_infer_soundness_tests;
 #[cfg(test)]
+#[path = "tests/semantic_def_body_read_arch_tests.rs"]
+mod semantic_def_body_read_arch_tests;
+#[cfg(test)]
 #[path = "tests/shadowed_type_param_identity_tests.rs"]
 mod shadowed_type_param_identity_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
@@ -24,7 +24,7 @@ impl<'a> CheckerState<'a> {
         if def.kind != tsz_solver::def::DefKind::TypeAlias || !def.type_params.is_empty() {
             return resolved_target;
         }
-        let Some(body) = def.body else {
+        let Some(body) = self.ctx.get_semantic_def_body(def_id).or(def.body) else {
             return resolved_target;
         };
         if query::union_members(self.ctx.types, body).is_some() {
@@ -50,7 +50,7 @@ impl<'a> CheckerState<'a> {
         if outer_members.contains(&lazy_candidate) {
             return true;
         }
-        let body = self.ctx.definition_store.get_body(def_id);
+        let body = self.ctx.get_semantic_def_body(def_id);
         outer_members.iter().any(|&m| {
             body == Some(m)
                 || self.ctx.definition_store.find_def_for_type(m) == Some(def_id)
@@ -164,7 +164,7 @@ impl<'a> CheckerState<'a> {
             return Some(target);
         }
         if let Some(def_id) = crate::query_boundaries::common::lazy_def_id(self.ctx.types, target)
-            && let Some(body) = self.ctx.definition_store.get_body(def_id)
+            && let Some(body) = self.ctx.get_semantic_def_body(def_id)
             && is_intersection(body)
         {
             return Some(body);
@@ -198,7 +198,7 @@ impl<'a> CheckerState<'a> {
             return nested_target;
         };
 
-        let Some(body) = self.ctx.definition_store.get_body(def_id) else {
+        let Some(body) = self.ctx.get_semantic_def_body(def_id) else {
             return nested_target;
         };
 

--- a/crates/tsz-checker/src/state/type_environment/application.rs
+++ b/crates/tsz-checker/src/state/type_environment/application.rs
@@ -276,6 +276,9 @@ impl<'a> CheckerState<'a> {
                     .ok()
                     .and_then(|env| env.get_def(def_id))
             })?;
+            let body = self
+                .ctx
+                .module_augmented_body_or_current(def_id, body, self.ctx.types);
             let params = self.ctx.get_def_type_params(def_id).unwrap_or_default();
             Some((def_id, body, params))
         });

--- a/crates/tsz-checker/src/state/type_resolution/reference_type_params.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_type_params.rs
@@ -68,7 +68,7 @@ impl CheckerState<'_> {
             .try_borrow()
             .ok()
             .and_then(|env| env.get_def(def_id))
-            .or_else(|| self.ctx.definition_store.get_body(def_id))
+            .or_else(|| self.ctx.get_semantic_def_body(def_id))
         else {
             return false;
         };

--- a/crates/tsz-checker/src/tests/semantic_def_body_read_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/semantic_def_body_read_arch_tests.rs
@@ -1,0 +1,21 @@
+use std::fs;
+
+#[test]
+fn semantic_def_body_consumers_use_resolver_adapter() {
+    for path in [
+        "src/assignability/assignability_eval.rs",
+        "src/state/state_checking/property/excess_property_tail.rs",
+        "src/state/type_resolution/reference_type_params.rs",
+    ] {
+        let source = fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("failed to read {path} for architecture guard: {err}"));
+        assert!(
+            !source.contains("definition_store.get_body"),
+            "{path} should use CheckerContext::get_semantic_def_body for semantic body reads"
+        );
+        assert!(
+            source.contains("get_semantic_def_body("),
+            "{path} should route semantic DefId body reads through the resolver adapter"
+        );
+    }
+}

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -7,7 +7,7 @@
 //! - Updating cached symbol types for self-referential augmentations
 
 use crate::state::CheckerState;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use tsz_binder::{ModuleAugmentation, symbol_flags};
@@ -261,56 +261,44 @@ impl<'a> CheckerState<'a> {
                 })
             });
 
+        let mut seen = FxHashSet::default();
+        let mut push_aug = |file_idx: usize, mut aug: ModuleAugmentation| {
+            if aug.name != interface_name || !seen.insert((file_idx, aug.node)) {
+                return;
+            }
+            if aug.arena.is_none()
+                && let Some(arenas) = self.ctx.all_arenas.as_ref()
+                && let Some(arena) = arenas.get(file_idx)
+            {
+                aug.arena = Some(Arc::clone(arena));
+            }
+            result.push(aug);
+        };
+
         for candidate in &candidates {
             if let Some(augmentations) = self.ctx.binder.module_augmentations.get(candidate) {
-                result.extend(
-                    augmentations
-                        .iter()
-                        .filter(|aug| aug.name == interface_name)
-                        .cloned(),
-                );
+                for aug in augmentations.iter().cloned() {
+                    push_aug(self.ctx.current_file_idx, aug);
+                }
             }
         }
 
-        // Use global module augmentations index for O(1) lookup instead of O(N) binder scan.
-        // Cross-file augmentations need their arena populated so the node index is
-        // interpreted in the correct AST arena (not the current file's arena).
-        if result.is_empty() {
-            if let Some(aug_index) = self.ctx.global_module_augmentations_index.as_ref() {
-                for candidate in &candidates {
-                    if let Some(entries) = aug_index.get(candidate) {
-                        for (file_idx, aug) in entries.iter() {
-                            if aug.name != interface_name {
-                                continue;
-                            }
-                            let mut cloned = aug.clone();
-                            if cloned.arena.is_none()
-                                && let Some(arenas) = self.ctx.all_arenas.as_ref()
-                                && let Some(arena) = arenas.get(*file_idx)
-                            {
-                                cloned.arena = Some(Arc::clone(arena));
-                            }
-                            result.push(cloned);
-                        }
+        // Use the global module augmentations index in addition to local binder
+        // hits: the current file can augment the same interface as siblings.
+        if let Some(aug_index) = self.ctx.global_module_augmentations_index.as_ref() {
+            for candidate in &candidates {
+                if let Some(entries) = aug_index.get(candidate) {
+                    for (file_idx, aug) in entries.iter() {
+                        push_aug(*file_idx, aug.clone());
                     }
                 }
-            } else if let Some(all_binders) = self.ctx.all_binders.as_ref() {
-                for (file_idx, binder) in all_binders.iter().enumerate() {
-                    for candidate in &candidates {
-                        if let Some(augmentations) = binder.module_augmentations.get(candidate) {
-                            for aug in augmentations.iter() {
-                                if aug.name != interface_name {
-                                    continue;
-                                }
-                                let mut cloned = aug.clone();
-                                if cloned.arena.is_none()
-                                    && let Some(arenas) = self.ctx.all_arenas.as_ref()
-                                    && let Some(arena) = arenas.get(file_idx)
-                                {
-                                    cloned.arena = Some(Arc::clone(arena));
-                                }
-                                result.push(cloned);
-                            }
+            }
+        } else if let Some(all_binders) = self.ctx.all_binders.as_ref() {
+            for (file_idx, binder) in all_binders.iter().enumerate() {
+                for candidate in &candidates {
+                    if let Some(augmentations) = binder.module_augmentations.get(candidate) {
+                        for aug in augmentations.iter().cloned() {
+                            push_aug(file_idx, aug);
                         }
                     }
                 }
@@ -473,6 +461,35 @@ impl<'a> CheckerState<'a> {
         }
 
         result
+    }
+
+    fn module_augmentation_source_files(&self, module_spec: &str) -> Vec<u32> {
+        let candidates = self.module_augmentation_key_candidates(module_spec);
+        let mut files = FxHashSet::default();
+
+        for candidate in &candidates {
+            if self.ctx.binder.module_augmentations.contains_key(candidate) {
+                files.insert(self.ctx.current_file_idx as u32);
+            }
+        }
+        if let Some(aug_index) = self.ctx.global_module_augmentations_index.as_ref() {
+            for candidate in &candidates {
+                if let Some(entries) = aug_index.get(candidate) {
+                    files.extend(entries.iter().map(|(file_idx, _)| *file_idx as u32));
+                }
+            }
+        } else if let Some(all_binders) = self.ctx.all_binders.as_ref() {
+            for (file_idx, binder) in all_binders.iter().enumerate() {
+                if candidates
+                    .iter()
+                    .any(|candidate| binder.module_augmentations.contains_key(candidate))
+                {
+                    files.insert(file_idx as u32);
+                }
+            }
+        }
+
+        files.into_iter().collect()
     }
 
     pub(crate) fn module_augmentation_value_type(
@@ -1247,11 +1264,27 @@ impl<'a> CheckerState<'a> {
                 // object-level flags so the augmented type keeps its canonical
                 // declaration name (e.g. `Tool` rather than an expanded
                 // `{ ... }` literal) and stays a single interned identity.
-                factory.object_with_flags_and_symbol(
+                let augmented = factory.object_with_flags_and_symbol(
                     merged_properties,
                     base_shape.flags,
                     base_shape.symbol,
-                )
+                );
+                if let Some(def_id) = base_def_id
+                    && base_shape.symbol.is_some()
+                    && self
+                        .ctx
+                        .definition_store
+                        .register_module_augmented_body_if_enabled(
+                            def_id,
+                            resolved_base,
+                            augmented,
+                            self.ctx.types,
+                            &self.module_augmentation_source_files(module_spec),
+                        )
+                {
+                    self.ctx.clear_type_evaluation_caches_for_def(def_id);
+                }
+                augmented
             }
             AugmentationTargetKind::ObjectWithIndex(shape_id) => {
                 let base_shape = self.ctx.types.object_shape(shape_id);

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -1637,7 +1637,7 @@ impl<'a> CheckerState<'a> {
                     // returned by `get_type_from_type_node`), so comparing it against
                     // `current_object` detects this case without any structural comparison.
                     if let Some(def_id) = constraint_def
-                        && let Some(body_type) = self.ctx.definition_store.get_body(def_id)
+                        && let Some(body_type) = self.ctx.get_semantic_def_body(def_id)
                         && body_type == current_object
                     {
                         return false;

--- a/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
@@ -194,7 +194,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                             self.ctx.types,
                             object_type,
                         )
-                        .and_then(|def_id| self.ctx.definition_store.get_body(def_id))
+                        .and_then(|def_id| self.ctx.get_semantic_def_body(def_id))
                         .is_some_and(|body| {
                             crate::query_boundaries::common::is_conditional_type(
                                 self.ctx.types,
@@ -345,7 +345,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
 
                 let alias_body_is_deferred =
                     crate::query_boundaries::common::lazy_def_id(self.ctx.types, object_type)
-                        .and_then(|def_id| self.ctx.definition_store.get_body(def_id))
+                        .and_then(|def_id| self.ctx.get_semantic_def_body(def_id))
                         .is_some_and(|body| {
                             crate::query_boundaries::common::is_conditional_type(
                                 self.ctx.types,
@@ -622,7 +622,11 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     env.get_class_instance_type(def_id)
                         .or_else(|| env.get_def(def_id))
                 })
-                .or_else(|| self.ctx.definition_store.get_body(def_id))
+                .map(|body| {
+                    self.ctx
+                        .module_augmented_body_or_current(def_id, body, self.ctx.types)
+                })
+                .or_else(|| self.ctx.get_semantic_def_body(def_id))
                 .unwrap_or(unwrapped);
             crate::query_boundaries::common::unwrap_readonly(self.ctx.types, resolved)
         } else {

--- a/crates/tsz-checker/tests/hkt_cross_file_augmentation_13653_repro.rs
+++ b/crates/tsz-checker/tests/hkt_cross_file_augmentation_13653_repro.rs
@@ -153,6 +153,84 @@ export type MyArr = Kind<"MyArray", number>;
     );
 }
 
+/// Direct literal indexed access bypasses the normal `resolve_lazy` call chain
+/// in a few syntax/diagnostic paths. With body publication enabled, those reads
+/// must still observe the augmented registry body instead of the empty base.
+#[test]
+#[ignore = "requires TSZ_MODULE_AUG_BODY_PUBLISH=1"]
+fn direct_literal_indexed_access_observes_augmented_registry_body() {
+    let diags = diagnostics(&[
+        (
+            "HKT.ts",
+            r#"
+export interface URItoKind<A> {}
+"#,
+        ),
+        (
+            "Array.ts",
+            r#"
+import { URItoKind } from "./HKT";
+declare module "./HKT" {
+    interface URItoKind<A> {
+        readonly MyArray: ReadonlyArray<A>;
+    }
+}
+export const wrong: URItoKind<number>["MyArray"] = ["x"];
+"#,
+        ),
+    ]);
+
+    assert_eq!(
+        count_code(&diags, 2339) + count_code(&diags, 2536),
+        0,
+        "direct indexed access should see the augmented key; got {diags:#?}"
+    );
+    assert_eq!(
+        count_code(&diags, 2322),
+        1,
+        "augmented body should preserve the ReadonlyArray<number> element type; got {diags:#?}"
+    );
+}
+
+/// Same direct-read path, but with the registry hidden behind an alias. This
+/// guards alias-body probes that inspect a `Lazy(DefId)` body directly.
+#[test]
+#[ignore = "requires TSZ_MODULE_AUG_BODY_PUBLISH=1"]
+fn alias_wrapped_indexed_access_observes_augmented_registry_body() {
+    let diags = diagnostics(&[
+        (
+            "registry.ts",
+            r#"
+export interface Slots<T> {}
+export type Registry<T> = Slots<T>;
+"#,
+        ),
+        (
+            "widget.ts",
+            r#"
+import { Registry, Slots } from "./registry";
+declare module "./registry" {
+    interface Slots<T> {
+        readonly Widget: ReadonlyArray<T>;
+    }
+}
+export const wrong: Registry<number>["Widget"] = ["x"];
+"#,
+        ),
+    ]);
+
+    assert_eq!(
+        count_code(&diags, 2339) + count_code(&diags, 2536),
+        0,
+        "alias-wrapped indexed access should see the augmented key; got {diags:#?}"
+    );
+    assert_eq!(
+        count_code(&diags, 2322),
+        1,
+        "alias-wrapped augmented body should preserve the element type; got {diags:#?}"
+    );
+}
+
 /// Structural assignability: the cross-file augmented member is REQUIRED, so an
 /// empty object literal assigned to the interface is TS2741 (missing member).
 /// tsz previously accepted this (the augmented member was absent from the

--- a/crates/tsz-checker/tests/hkt_cross_file_augmentation_13653_repro.rs
+++ b/crates/tsz-checker/tests/hkt_cross_file_augmentation_13653_repro.rs
@@ -231,6 +231,41 @@ export const wrong: Registry<number>["Widget"] = ["x"];
     );
 }
 
+/// Assignability alias probes can inspect a `Lazy(DefId)` body directly before
+/// relation fallback. With body publication enabled, that probe must see the
+/// augmented registry body so the missing augmented member is still required.
+#[test]
+#[ignore = "requires TSZ_MODULE_AUG_BODY_PUBLISH=1"]
+fn alias_assignability_observes_augmented_registry_body() {
+    let diags = diagnostics(&[
+        (
+            "registry.ts",
+            r#"
+export interface Slots<T> {}
+export type Registry<T> = Slots<T>;
+"#,
+        ),
+        (
+            "widget.ts",
+            r#"
+import { Registry, Slots } from "./registry";
+declare module "./registry" {
+    interface Slots<T> {
+        readonly Widget: ReadonlyArray<T>;
+    }
+}
+export const r: Registry<number> = {};
+"#,
+        ),
+    ]);
+
+    assert_eq!(
+        count_code(&diags, 2741),
+        1,
+        "alias assignability should require the augmented member; got {diags:#?}"
+    );
+}
+
 /// Structural assignability: the cross-file augmented member is REQUIRED, so an
 /// empty object literal assigned to the interface is TS2741 (missing member).
 /// tsz previously accepted this (the augmented member was absent from the

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -508,6 +508,8 @@ pub struct DefinitionStore {
     /// rejects unknown/error/any), so an abstract URI / literal-less `typeof`
     /// stays deferred.
     typeof_value_to_literal: DefDashMap<u32, TypeId>,
+    /// Empty registry `DefId` -> merged module-augmentation body and source files.
+    module_augmented_bodies: DefDashMap<DefId, (TypeId, Vec<u32>)>,
 
     /// Reverse index: `Atom` (name) -> `Vec<DefId>` for name-based lookups.
     ///
@@ -590,6 +592,7 @@ impl DefinitionStore {
                 Default::default(),
             ),
             typeof_value_to_literal: DefDashMap::default(),
+            module_augmented_bodies: DefDashMap::default(),
             enum_member_to_parent: DefDashMap::default(),
             name_to_defs: DefDashMap::with_capacity_and_hasher(id_capacity, Default::default()),
             cross_file_cache: CrossFileQueryCache::default(),
@@ -1300,6 +1303,7 @@ impl DefinitionStore {
         self.class_to_constructor.clear();
         self.class_to_instance.clear();
         self.typeof_value_to_literal.clear();
+        self.module_augmented_bodies.clear();
         self.enum_member_to_parent.clear();
         self.name_to_defs.clear();
         self.next_id.store(DefId::FIRST_VALID, Ordering::SeqCst);
@@ -1871,6 +1875,7 @@ impl DefinitionStore {
     ///
     /// Returns the number of definitions invalidated.
     pub fn invalidate_file(&self, file_id: u32) -> usize {
+        self.invalidate_module_augmented_bodies_for_file(file_id);
         let def_ids = match self.file_to_defs.remove(&file_id) {
             Some((_, ids)) => ids,
             None => return 0,
@@ -1895,6 +1900,8 @@ impl DefinitionStore {
                         self.invalidate_symbol_mappings_log();
                     }
                 }
+
+                self.module_augmented_bodies.remove(def_id);
 
                 // Clean up type_to_def (reverse scan is expensive, but invalidation
                 // is rare and bounded by per-file definition count).

--- a/crates/tsz-solver/src/def/core/augmentation_symbols.rs
+++ b/crates/tsz-solver/src/def/core/augmentation_symbols.rs
@@ -1,19 +1,35 @@
-//! Symbol-edge publication for module-augmented empty object registries.
+//! Symbol/body publication for module-augmented empty object registries.
 //!
 //! This is a narrow bridge for the higher-kinded registry pattern where an
 //! empty interface body is interned before cross-file augmentation merges its
-//! members. The checker publishes the base shape's symbol to the home `DefId`;
-//! indexed-access evaluation uses that edge only when it later sees an empty
-//! symbolic object shape.
+//! members. The checker publishes the base shape's symbol to the home `DefId`
+//! and, behind a separate flag, the merged body for an empty registry. Consumers
+//! use those channels only when they later see an empty symbolic object/body.
 
 use std::sync::OnceLock;
 
 use super::{DefId, DefinitionStore};
+use crate::construction::TypeDatabase;
+use crate::types::{TypeData, TypeId};
+use dashmap::mapref::entry::Entry;
 
 /// Whether module-augmentation symbol-edge publication and consumption is active.
 pub(crate) fn module_augmentation_symbol_edge_enabled() -> bool {
     static ON: OnceLock<bool> = OnceLock::new();
     *ON.get_or_init(|| std::env::var("TSZ_MODULE_AUG_SYMBOL_EDGE").is_ok_and(|v| v == "1"))
+}
+
+/// Whether merged body publication for empty module-augmented registries is active.
+pub(crate) fn module_augmentation_body_publish_enabled() -> bool {
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("TSZ_MODULE_AUG_BODY_PUBLISH").is_ok_and(|v| v == "1"))
+}
+
+fn plain_object_property_count(db: &dyn TypeDatabase, ty: TypeId) -> Option<usize> {
+    match db.lookup(ty)? {
+        TypeData::Object(shape_id) => Some(db.object_shape(shape_id).properties.len()),
+        _ => None,
+    }
 }
 
 impl DefinitionStore {
@@ -36,11 +52,117 @@ impl DefinitionStore {
             self.register_module_augmentation_symbol_def(symbol_id, def_id);
         }
     }
+
+    /// Register the merged body for an empty module-augmented registry.
+    pub fn register_module_augmented_body(
+        &self,
+        def_id: DefId,
+        body: TypeId,
+        source_files: &[u32],
+    ) -> bool {
+        match self.module_augmented_bodies.entry(def_id) {
+            Entry::Vacant(entry) => {
+                entry.insert((body, source_files.to_vec()));
+                self.bump_generation();
+                true
+            }
+            Entry::Occupied(mut entry) => {
+                if entry.get().0 == body {
+                    merge_source_files(&mut entry.get_mut().1, source_files);
+                }
+                false
+            }
+        }
+    }
+
+    /// Flag-gated body publication for a plain empty object receiving members.
+    pub fn register_module_augmented_body_if_enabled(
+        &self,
+        def_id: DefId,
+        base_body: TypeId,
+        augmented_body: TypeId,
+        db: &dyn TypeDatabase,
+        source_files: &[u32],
+    ) -> bool {
+        if !module_augmentation_body_publish_enabled() {
+            return false;
+        }
+        if plain_object_property_count(db, base_body) != Some(0) {
+            return false;
+        }
+        if plain_object_property_count(db, augmented_body).is_none_or(|count| count == 0) {
+            return false;
+        }
+        self.register_module_augmented_body(def_id, augmented_body, source_files)
+    }
+
+    fn module_augmented_body_for_registered(
+        &self,
+        def_id: DefId,
+        current_body: TypeId,
+        db: &dyn TypeDatabase,
+    ) -> Option<TypeId> {
+        if plain_object_property_count(db, current_body) != Some(0) {
+            return None;
+        }
+        let body = self.module_augmented_bodies.get(&def_id)?.0;
+        plain_object_property_count(db, body)
+            .is_some_and(|count| count > 0)
+            .then_some(body)
+    }
+
+    /// Resolve an empty registry body to its merged module-augmented body.
+    pub fn module_augmented_body_for(
+        &self,
+        def_id: DefId,
+        current_body: TypeId,
+        db: &dyn TypeDatabase,
+    ) -> Option<TypeId> {
+        module_augmentation_body_publish_enabled()
+            .then(|| self.module_augmented_body_for_registered(def_id, current_body, db))
+            .flatten()
+    }
+
+    /// Return the merged module-augmented body when `current_body` is the empty base.
+    pub fn module_augmented_body_or_current(
+        &self,
+        def_id: DefId,
+        current_body: TypeId,
+        db: &dyn TypeDatabase,
+    ) -> TypeId {
+        self.module_augmented_body_for(def_id, current_body, db)
+            .unwrap_or(current_body)
+    }
+
+    pub(crate) fn invalidate_module_augmented_bodies_for_file(&self, file_id: u32) {
+        let affected: Vec<_> = self
+            .module_augmented_bodies
+            .iter()
+            .filter_map(|entry| entry.value().1.contains(&file_id).then_some(*entry.key()))
+            .collect();
+        if affected.is_empty() {
+            return;
+        }
+        for def_id in affected {
+            self.module_augmented_bodies.remove(&def_id);
+        }
+        self.bump_generation();
+    }
+}
+
+fn merge_source_files(existing: &mut Vec<u32>, source_files: &[u32]) {
+    for &file_id in source_files {
+        if !existing.contains(&file_id) {
+            existing.push(file_id);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::construction::TypeInterner;
+    use crate::types::PropertyInfo;
 
     #[test]
     fn module_augmentation_symbol_def_registers_missing_edge() {
@@ -62,5 +184,94 @@ mod tests {
         store.register_module_augmentation_symbol_def(100, second);
 
         assert_eq!(store.find_def_by_symbol(100), Some(first));
+    }
+
+    #[test]
+    fn module_augmented_body_redirects_empty_plain_object() {
+        let store = DefinitionStore::new();
+        let types = TypeInterner::new();
+        let def_id = DefId(42);
+        let empty = types.object(Vec::new());
+        let augmented = types.object(vec![PropertyInfo::new(
+            types.intern_string("member"),
+            TypeId::STRING,
+        )]);
+
+        assert!(store.register_module_augmented_body(def_id, augmented, &[]));
+
+        assert_eq!(
+            store.module_augmented_body_for_registered(def_id, empty, &types),
+            Some(augmented)
+        );
+    }
+
+    #[test]
+    fn module_augmented_body_keeps_non_empty_current_body() {
+        let store = DefinitionStore::new();
+        let types = TypeInterner::new();
+        let def_id = DefId(42);
+        let current = types.object(vec![PropertyInfo::new(
+            types.intern_string("current"),
+            TypeId::NUMBER,
+        )]);
+        let augmented = types.object(vec![PropertyInfo::new(
+            types.intern_string("member"),
+            TypeId::STRING,
+        )]);
+
+        assert!(store.register_module_augmented_body(def_id, augmented, &[]));
+
+        assert_eq!(
+            store.module_augmented_body_for_registered(def_id, current, &types),
+            None
+        );
+    }
+
+    #[test]
+    fn module_augmented_body_keeps_first_publication() {
+        let store = DefinitionStore::new();
+        let types = TypeInterner::new();
+        let def_id = DefId(42);
+        let first = types.object(vec![PropertyInfo::new(
+            types.intern_string("first"),
+            TypeId::STRING,
+        )]);
+        let second = types.object(vec![PropertyInfo::new(
+            types.intern_string("second"),
+            TypeId::STRING,
+        )]);
+
+        assert!(store.register_module_augmented_body(def_id, first, &[]));
+        assert!(!store.register_module_augmented_body(def_id, second, &[]));
+
+        assert_eq!(
+            store.module_augmented_body_for_registered(def_id, types.object(Vec::new()), &types),
+            Some(first)
+        );
+    }
+
+    #[test]
+    fn module_augmented_body_invalidates_when_augmentation_file_changes() {
+        let store = DefinitionStore::new();
+        let types = TypeInterner::new();
+        let def_id = DefId(42);
+        let empty = types.object(Vec::new());
+        let augmented = types.object(vec![PropertyInfo::new(
+            types.intern_string("member"),
+            TypeId::STRING,
+        )]);
+
+        assert!(store.register_module_augmented_body(def_id, augmented, &[7]));
+        assert_eq!(
+            store.module_augmented_body_for_registered(def_id, empty, &types),
+            Some(augmented)
+        );
+
+        assert_eq!(store.invalidate_file(7), 0);
+
+        assert_eq!(
+            store.module_augmented_body_for_registered(def_id, empty, &types),
+            None
+        );
     }
 }

--- a/crates/tsz-solver/src/def/core/augmentation_symbols.rs
+++ b/crates/tsz-solver/src/def/core/augmentation_symbols.rs
@@ -33,6 +33,12 @@ fn plain_object_property_count(db: &dyn TypeDatabase, ty: TypeId) -> Option<usiz
 }
 
 impl DefinitionStore {
+    /// Whether merged body publication/consumption for empty module-augmented
+    /// registries is active.
+    pub fn module_augmented_body_publication_enabled(&self) -> bool {
+        module_augmentation_body_publish_enabled()
+    }
+
     /// Register a first-wins module-augmentation edge from `symbol_id` to `def_id`.
     pub fn register_module_augmentation_symbol_def(&self, symbol_id: u32, def_id: DefId) {
         if self.find_def_by_symbol(symbol_id).is_some() {
@@ -202,6 +208,29 @@ mod tests {
         assert_eq!(
             store.module_augmented_body_for_registered(def_id, empty, &types),
             Some(augmented)
+        );
+    }
+
+    #[test]
+    fn module_augmented_body_public_lookup_is_raw_when_publication_flag_off() {
+        let store = DefinitionStore::new();
+        if store.module_augmented_body_publication_enabled() {
+            return;
+        }
+        let types = TypeInterner::new();
+        let def_id = DefId(42);
+        let empty = types.object(Vec::new());
+        let augmented = types.object(vec![PropertyInfo::new(
+            types.intern_string("member"),
+            TypeId::STRING,
+        )]);
+
+        assert!(store.register_module_augmented_body(def_id, augmented, &[]));
+
+        assert_eq!(store.module_augmented_body_for(def_id, empty, &types), None);
+        assert_eq!(
+            store.module_augmented_body_or_current(def_id, empty, &types),
+            empty
         );
     }
 

--- a/crates/tsz-solver/src/def/core/observability.rs
+++ b/crates/tsz-solver/src/def/core/observability.rs
@@ -253,6 +253,12 @@ impl DefinitionStore {
                 + std::mem::size_of::<TypeId>()
                 + DASHMAP_ENTRY_OVERHEAD);
 
+        // module_augmented_bodies: DefId -> TypeId
+        size += self.module_augmented_bodies.len()
+            * (std::mem::size_of::<DefId>()
+                + std::mem::size_of::<TypeId>()
+                + DASHMAP_ENTRY_OVERHEAD);
+
         // file_to_defs: u32 -> Vec<DefId>
         for entry in &self.file_to_defs {
             size += std::mem::size_of::<u32>() + DASHMAP_ENTRY_OVERHEAD;

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -1064,12 +1064,7 @@ impl TypeEnvironment {
         self.bump_generation();
     }
 
-    /// Get a `DefId`'s resolved type.
-    ///
-    /// First checks the local `def_types` cache, then falls back to the shared
-    /// `DefinitionStore.get_body()` if available. The fallback enables cross-file
-    /// delegation results to be visible without explicit merge-back: the child
-    /// checker writes to `DefinitionStore` and the parent reads via this fallback.
+    /// Get a `DefId`'s resolved type from the local cache or shared store fallback.
     pub fn get_def(&self, def_id: DefId) -> Option<TypeId> {
         self.def_types.get(&def_id.0).copied().or_else(|| {
             let body = self.definition_store.as_ref()?.get_body(def_id)?;
@@ -1613,20 +1608,22 @@ impl TypeResolver for TypeEnvironment {
             .or(candidate)
     }
 
-    fn resolve_lazy(&self, def_id: DefId, _interner: &dyn TypeDatabase) -> Option<TypeId> {
+    fn resolve_lazy(&self, def_id: DefId, interner: &dyn TypeDatabase) -> Option<TypeId> {
+        let augment = |def_id, ty| {
+            self.definition_store.as_ref().map_or(ty, |store| {
+                store.module_augmented_body_or_current(def_id, ty, interner)
+            })
+        };
         // For classes, return the instance type (type position) instead of the constructor type
         if let Some(&instance_type) = self.class_instance_types.get(&def_id.0) {
             return Some(instance_type);
         }
         if let Some(ty) = self.get_def(def_id) {
-            return Some(ty);
+            return Some(augment(def_id, ty));
         }
 
-        // Fallback: `interner.reference(SymbolRef(N))` creates a zombie
-        // `Lazy(DefId(N))` whose numeric value is a raw `SymbolId`; redirect to
-        // the real `DefId`. `raw_symbol_fallback_def` returns `None` for a
-        // registered `DefId` so its value is never mis-read as a colliding
-        // `SymbolId` (#13862).
+        // Fallback: a zombie `Lazy(DefId(N))` may carry raw `SymbolId(N)`.
+        // Registered `DefId`s never redirect through this path (#13862).
         let real_def = self.raw_symbol_fallback_def(def_id)?;
         tsz_common::perf_counters::record_type_environment_raw_symbol_lazy_fallback();
         tracing::trace!(
@@ -1638,7 +1635,7 @@ impl TypeResolver for TypeEnvironment {
         if let Some(&instance_type) = self.class_instance_types.get(&real_def.0) {
             return Some(instance_type);
         }
-        self.get_def(real_def)
+        self.get_def(real_def).map(|ty| augment(real_def, ty))
     }
 
     fn resolve_this_type(&self, _interner: &dyn TypeDatabase) -> Option<TypeId> {


### PR DESCRIPTION
Goal: green

## Summary
- Add a checker context helper for semantic `DefId` body reads that preserves the module-augmentation body publication channel from #15125.
- Route indexed-access diagnostic probes, foreign-keyof key-space comparison, and application base-body materialization through the helper instead of raw `DefinitionStore::get_body` bypasses.
- Keep direct semantic body reads exactly raw when `TSZ_MODULE_AUG_BODY_PUBLISH` is off, and add a solver guard for the default/off publication path.
- Add flag-on HKT indexed-access witnesses for direct literal registry indexing and alias-wrapped registry indexing.

## Structural Rule
When a checker-side semantic read inspects the body of an exported empty registry interface that has a merged module-augmentation body and augmentation-body publication is enabled, tsc observes the augmented structural body. tsz should do that through the checker `TypeResolver` adapter and solver-owned `DefinitionStore::module_augmented_body_for` publication channel, not by reading the raw empty body from `DefinitionStore::get_body`.

## Owner Layer
Owner: checker resolver adapter plus solver definition-store body publication. The checker helper is only an adapter for direct body-read sites; the structural predicate and augmented-body substitution remain owned by `tsz-solver::def::DefinitionStore`.

## Adjacent Case Matrix
- Direct `URItoKind<number>["MyArray"]` reads the augmented body when `TSZ_MODULE_AUG_BODY_PUBLISH=1`.
- Alias-wrapped `Registry<number>["Widget"]` reads the augmented body through the same helper.
- Default/off publication mode returns the original `DefinitionStore::get_body` result without consulting augmented bodies.
- Default test mode skips the flag-only witnesses and keeps existing HKT cross-file coverage green.
- Class instance body priority in tuple/index checks is preserved before applying the augmented-body substitution.
- Existence-only `get_body` checks and raw canonicalizer callbacks stay raw; this PR changes only semantic body consumers.

## Fallback
If body publication is disabled, no augmented body is published, or the current body is not the empty plain object base, the helper returns the original stored body. Unsupported and unresolved direct reads keep their existing fallback behavior.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver module_augmented_body_public_lookup_is_raw_when_publication_flag_off`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test hkt_cross_file_augmentation_13653_repro`
- `TSZ_MODULE_AUG_BODY_PUBLISH=1 TSZ_MODULE_AUG_SYMBOL_EDGE=1 scripts/safe-run.sh cargo nextest run -p tsz-checker --test hkt_cross_file_augmentation_13653_repro --run-ignored ignored-only -E 'test(direct_literal_indexed_access_observes_augmented_registry_body) or test(alias_wrapped_indexed_access_observes_augmented_registry_body)'`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter 'compiler/inferentialTypingWithFunctionTypeZip.ts' --verbose --workers 1`
- `wc -l crates/tsz-checker/src/context/resolver.rs crates/tsz-solver/src/def/core/augmentation_symbols.rs`

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high
