### PR TITLE
refactor(solver): name comparability depth state (#14346)

### DIFF
--- a/crates/tsz-solver/src/type_queries/flow/comparability.rs
+++ b/crates/tsz-solver/src/type_queries/flow/comparability.rs
@@ -4,6 +4,34 @@ use crate::type_queries::{get_array_element_type, get_callable_shape_for_type, g
 use crate::types::{CallSignature, ParamInfo, TypeData, TypeId};
 use tsz_common::Atom;
 
+const MAX_COMPARABILITY_DEPTH: u32 = 5;
+
+/// Named recursion-depth state for comparability walks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ComparabilityDepthState {
+    /// The current recursion depth is still inside the existing walk budget.
+    WithinLimit,
+    /// The current recursion depth exceeded the existing walk budget.
+    LimitExceeded,
+}
+
+impl ComparabilityDepthState {
+    const fn from_depth(depth: u32) -> Self {
+        if depth > MAX_COMPARABILITY_DEPTH {
+            Self::LimitExceeded
+        } else {
+            Self::WithinLimit
+        }
+    }
+
+    const fn fallback_result(self) -> Option<bool> {
+        match self {
+            Self::WithinLimit => None,
+            Self::LimitExceeded => Some(false),
+        }
+    }
+}
+
 /// Check if two types are "comparable" for TS2352 type assertion overlap check.
 ///
 /// TSC uses `isTypeComparableTo` which is more relaxed than assignability.
@@ -51,9 +79,8 @@ pub(in crate::type_queries) fn types_are_comparable_for_assertion_inner(
     depth: u32,
     nested: bool,
 ) -> bool {
-    // Prevent infinite recursion
-    if depth > 5 {
-        return false;
+    if let Some(result) = ComparabilityDepthState::from_depth(depth).fallback_result() {
+        return result;
     }
 
     // Same type is always comparable
@@ -623,9 +650,8 @@ fn types_are_comparable_inner(
     target: TypeId,
     depth: u32,
 ) -> bool {
-    // Prevent infinite recursion
-    if depth > 5 {
-        return false;
+    if let Some(result) = ComparabilityDepthState::from_depth(depth).fallback_result() {
+        return result;
     }
 
     // Same type is always comparable
@@ -1092,4 +1118,58 @@ fn types_have_common_properties(
         }
     }
     found_common
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::construction::TypeInterner;
+
+    #[test]
+    fn comparability_depth_state_names_cap_boundary() {
+        assert_eq!(
+            ComparabilityDepthState::from_depth(MAX_COMPARABILITY_DEPTH),
+            ComparabilityDepthState::WithinLimit
+        );
+        assert_eq!(
+            ComparabilityDepthState::from_depth(MAX_COMPARABILITY_DEPTH + 1),
+            ComparabilityDepthState::LimitExceeded
+        );
+        assert_eq!(
+            ComparabilityDepthState::LimitExceeded.fallback_result(),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn comparability_depth_state_preserves_strict_and_assertion_fallback() {
+        let interner = TypeInterner::new();
+
+        assert!(types_are_comparable_inner(
+            &interner,
+            TypeId::STRING,
+            TypeId::STRING,
+            MAX_COMPARABILITY_DEPTH
+        ));
+        assert!(!types_are_comparable_inner(
+            &interner,
+            TypeId::STRING,
+            TypeId::STRING,
+            MAX_COMPARABILITY_DEPTH + 1
+        ));
+        assert!(types_are_comparable_for_assertion_inner(
+            &interner,
+            TypeId::STRING,
+            TypeId::STRING,
+            MAX_COMPARABILITY_DEPTH,
+            false
+        ));
+        assert!(!types_are_comparable_for_assertion_inner(
+            &interner,
+            TypeId::STRING,
+            TypeId::STRING,
+            MAX_COMPARABILITY_DEPTH + 1,
+            false
+        ));
+    }
 }


### PR DESCRIPTION
Goal: green

## Summary
- Replace the raw comparability recursion cap with `MAX_COMPARABILITY_DEPTH` and `ComparabilityDepthState`.
- Route both strict comparability and TS2352 assertion comparability through the same named depth fallback.
- Add solver unit coverage for the cap boundary and the pre-existing over-cap `false` result.

## Structural Rule
When comparability recursion depth is at or below the solver's existing cap, `tsz` continues the comparability walk. When the depth exceeds that cap, `tsz` records `ComparabilityDepthState::LimitExceeded` and preserves the existing solver-owned fallback result of `false` before identity or shape checks.

## Owner Layer
Solver: `crates/tsz-solver/src/type_queries/flow/comparability.rs` owns the recursion-depth state and fallback for comparability walks.

## Adjacent Case Matrix
- Strict comparability: identical primitives at the cap remain comparable; identical primitives over the cap keep the old `false` fallback.
- Assertion comparability: identical primitives at the cap remain comparable; identical primitives over the cap keep the old `false` fallback.
- Checker TS2352 nested literal overlap smoke continues to pass through the assertion-comparability path.

## Fallback
No semantic fallback changed. This PR names and tests the old `depth > 5 => false` behavior. While smoke-testing adjacent checker coverage, `contravariant_app_constrained_type_param_target_tests::same_base_mapped_record_alias_keeps_tsc_variance_quirk` failed; rerunning the same test with this patch reversed reproduced the failure on plain `origin/main` content, so it is not a branch regression.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver comparability_depth_state_names_cap_boundary comparability_depth_state_preserves_strict_and_assertion_fallback`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts2352_nested_literal_overlap_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test contravariant_app_constrained_type_param_target_tests same_base_mapped_record_alias_keeps_tsc_variance_quirk` reproduced an existing `origin/main` failure before and after the patch.
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: high
