### PR TITLE
fix(checker): route relation probes through resolver env (#14351)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -932,25 +932,19 @@ pub(crate) fn are_types_mutually_subtype(
         || tsz_solver::relations::subtype::is_subtype_of(db, right, left)
 }
 
-pub(crate) fn is_assignable(db: &dyn TypeDatabase, source: TypeId, target: TypeId) -> bool {
-    let _span = tracing::trace_span!("flow_assignable", src = source.0, tgt = target.0,).entered();
-
-    tsz_solver::relations::relation_queries::query_relation(
-        db,
-        source,
-        target,
-        tsz_solver::relations::relation_queries::RelationKind::Assignable,
-        tsz_solver::relations::relation_queries::RelationPolicy::default(),
-        tsz_solver::relations::relation_queries::RelationContext::default(),
-    )
-    .is_related()
-}
-
-pub(crate) fn is_assignable_strict_null(
+fn flow_relation_related(
     db: &dyn TypeDatabase,
+    env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
     source: TypeId,
     target: TypeId,
+    strict_null_checks: bool,
 ) -> bool {
+    let _span = tracing::trace_span!("flow_assignable", src = source.0, tgt = target.0,).entered();
+
+    if let Some(env) = env {
+        return is_assignable_with_env(db, env, source, target, strict_null_checks);
+    }
+
     tsz_solver::relations::relation_queries::query_relation(
         db,
         source,
@@ -969,13 +963,7 @@ fn flow_relation_outcome(
     target: TypeId,
     strict_null_checks: bool,
 ) -> RelationOutcome {
-    let related = if let Some(env) = env {
-        is_assignable_with_env(db, env, source, target, strict_null_checks)
-    } else if strict_null_checks {
-        is_assignable_strict_null(db, source, target)
-    } else {
-        is_assignable(db, source, target)
-    };
+    let related = flow_relation_related(db, env, source, target, strict_null_checks);
 
     RelationOutcome {
         related,

--- a/crates/tsz-checker/src/query_boundaries/type_checking_utilities.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_checking_utilities.rs
@@ -44,11 +44,13 @@ pub(crate) fn classify_array_like(db: &dyn TypeDatabase, type_id: TypeId) -> Arr
 /// [`RelationOutcome`]: super::assignability::RelationOutcome
 pub(crate) fn rest_element_array_like_relation_outcome(
     db: &dyn QueryDatabase,
+    resolver: &impl tsz_solver::relations::subtype::TypeResolver,
     source: TypeId,
     target: TypeId,
 ) -> super::assignability::RelationOutcome {
-    let result = tsz_solver::relations::relation_queries::query_relation(
+    let result = tsz_solver::relations::relation_queries::query_relation_with_resolver(
         db.as_type_database(),
+        resolver,
         source,
         target,
         tsz_solver::relations::relation_queries::RelationKind::Assignable,

--- a/crates/tsz-checker/src/tests/flow_assignment_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_assignment_relation_routing_arch_tests.rs
@@ -62,12 +62,14 @@ fn flow_assignment_and_predicate_exclusion_use_relation_outcome_boundary() {
     );
     assert!(
         compact_boundary.contains("fnflow_relation_outcome(")
+            && compact_boundary.contains("fnflow_relation_related(")
+            && compact_boundary.contains("query_relation_with_resolver(")
             && compact_boundary
                 .contains("flow_relation_outcome(db,env,source,member,true).related")
             && compact_boundary.contains(
                 "flow_relation_outcome(db,None,assigned_resolved,resolved_initial,false).related"
             ),
-        "flow assignment reduction should consume outcome-shaped relation truth"
+        "flow assignment reduction should consume outcome-shaped resolver-aware relation truth"
     );
     assert!(
         compact_core.contains("fnflow_assignability_related(")

--- a/crates/tsz-checker/src/tests/rest_parameter_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/rest_parameter_relation_routing_arch_tests.rs
@@ -73,10 +73,11 @@ fn rest_tuple_element_array_like_probe_uses_relation_outcome_boundary() {
         .collect();
 
     assert!(
-        compact_helper.contains(
-            "rest_element_array_like_relation_outcome(self.ctx.types,t,readonly_any_array).related"
-        ),
-        "TS2574 rest tuple element array-like probes should consume an outcome-shaped boundary"
+        compact_helper.contains("letenv=self.ctx.type_environment.borrow();")
+            && compact_helper.contains(
+                "rest_element_array_like_relation_outcome(self.ctx.types,&*env,t,readonly_any_array,).related"
+            ),
+        "TS2574 rest tuple element array-like probes should consume an env-backed outcome boundary"
     );
     assert!(
         !compact_helper.contains("self.ctx.types.is_assignable_to(t,readonly_any_array)"),
@@ -84,7 +85,7 @@ fn rest_tuple_element_array_like_probe_uses_relation_outcome_boundary() {
     );
     assert!(
         boundary_source.contains("fn rest_element_array_like_relation_outcome(")
-            && boundary_source.contains("relation_queries::query_relation("),
-        "type-node rest element relation truth should live behind a query boundary"
+            && boundary_source.contains("relation_queries::query_relation_with_resolver("),
+        "type-node rest element relation truth should live behind a resolver-aware query boundary"
     );
 }

--- a/crates/tsz-checker/src/types/type_node_helpers.rs
+++ b/crates/tsz-checker/src/types/type_node_helpers.rs
@@ -822,8 +822,14 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             let factory = self.ctx.types.factory();
             factory.readonly_type(factory.array(TypeId::ANY))
         };
-        !type_utils::rest_element_array_like_relation_outcome(self.ctx.types, t, readonly_any_array)
-            .related
+        let env = self.ctx.type_environment.borrow();
+        !type_utils::rest_element_array_like_relation_outcome(
+            self.ctx.types,
+            &*env,
+            t,
+            readonly_any_array,
+        )
+        .related
     }
 
     /// Resolve a rest-element type to its inspectable shape for the TS2574


### PR DESCRIPTION
Goal: green

## Structural Rule
When checker flow/type-node relation probes compare resolver-owned shapes like `Lazy(DefId)`, deferred indexed applications, or array-like object shapes, `tsc` relates the resolved structural body. `tsz` now threads the checker-owned `TypeEnvironment` resolver through the relevant query-boundary relation probes, while preserving the old resolverless fallback where the checker has no environment.

Owner layer: checker `query_boundaries` adapters call the solver relation query with the checker resolver; solver still owns relation semantics.

## Scope
- Routes TS2574 rest-element array-like probes through `rest_element_array_like_relation_outcome(..., resolver, ...)` and `query_relation_with_resolver`.
- Collapses flow relation truth through a private `flow_relation_related` helper so env-present flow probes use `is_assignable_with_env` consistently.
- Updates the focused architecture tests to assert resolver-aware boundaries for flow assignment and rest tuple element probes.

## Adjacent Matrix
- Positive: TS2574 array/tuple, alias, utility, deferred conditional indexed tuple, and renamed-binder cases remain accepted.
- Negative/fallback: non-array deferred rest branches still emit TS2574; no-env flow relation probes preserve the previous resolverless query path.
- Routing: no checker call sites outside `query_boundaries` gain raw relation access; line-count guard stays below the 2000-line ceiling.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib rest_tuple_element_array_like_probe_uses_relation_outcome_boundary flow_assignment_and_predicate_exclusion_use_relation_outcome_boundary ts2574_rest_tuple_element_type_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test deferred_conditional_indexed_access_tests`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high
