### PR TITLE
fix(solver): scope lazy relation cache taint (#14347)

### DIFF
--- a/crates/tsz-solver/src/limits/mod.rs
+++ b/crates/tsz-solver/src/limits/mod.rs
@@ -201,10 +201,13 @@ struct LimitBudgets {
     subtype_state: Cell<u64>,
     /// Monotonic counter bumped whenever a `Lazy(DefId)` could not be
     /// resolved (its body is not yet registered — typically a re-entrant
-    /// lib-resolution window). A subtype result computed while this counter
-    /// changed depended on an undetermined type and must NOT be cached as
-    /// definitive, or it poisons every later structural check that shares
-    /// the same member type.
+    /// lib-resolution window).
+    ///
+    /// This remains a public compatibility sentinel for checker-side proof
+    /// caches and conditional branch probes that run outside the relation frame
+    /// owner. The relation cache itself uses a `SubtypeChecker`-local
+    /// unresolved-lazy counter so fresh/nested checker probes do not suppress
+    /// unrelated relation cache writes.
     lazy_resolve_failures: Cell<u64>,
     /// Monotonic counter bumped whenever a structural comparison hits the
     /// weak-type (TS2559) trigger: a non-empty, non-weak source compared
@@ -303,7 +306,7 @@ const fn unpack_fuel(state: u64) -> u32 {
 // -----------------------------------------------------------------------------
 
 /// Snapshot returned by [`enter_subtype_frame`]: the chain state *before*
-/// this frame's increment plus the cache-poisoning sentinel counters and the
+/// this frame's increment plus the weak-type cache-poisoning sentinel and the
 /// shared solver-frame depth, all read under one TLS resolution.
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct SubtypeFrameEntry {
@@ -311,8 +314,6 @@ pub(crate) struct SubtypeFrameEntry {
     pub(crate) global_depth: u32,
     /// Fuel consumed by the chain before this frame entered.
     pub(crate) fuel: u32,
-    /// [`lazy_resolve_failure_count`] at entry.
-    pub(crate) lazy_failures: u64,
     /// [`weak_type_sensitivity_count`] at entry.
     pub(crate) weak_sensitivity: u64,
     /// [`solver_stack_frame_depth`](crate::recursion::solver_stack_frame_depth)
@@ -322,7 +323,7 @@ pub(crate) struct SubtypeFrameEntry {
 
 /// Enter one non-trivial `check_subtype` frame: increments chain depth and
 /// consumes one unit of global fuel, returning the pre-increment state and
-/// sentinel snapshots. Single TLS access.
+/// weak-type sentinel snapshot. Single TLS access.
 #[inline]
 pub(crate) fn enter_subtype_frame() -> SubtypeFrameEntry {
     LIMIT_BUDGETS.with(|b| {
@@ -333,7 +334,6 @@ pub(crate) fn enter_subtype_frame() -> SubtypeFrameEntry {
         SubtypeFrameEntry {
             global_depth: depth,
             fuel,
-            lazy_failures: b.lazy_resolve_failures.get(),
             weak_sensitivity: b.weak_type_sensitivity.get(),
             solver_stack_frames: b.solver_stack_frames.get(),
         }
@@ -403,9 +403,20 @@ pub(crate) fn note_weak_type_sensitivity() {
     });
 }
 
-/// Both cache-poisoning sentinel counters under one TLS resolution:
-/// `(lazy_resolve_failures, weak_type_sensitivity)`. Used at relation-frame
-/// exits that gate cache writes/promotions on sentinel stability.
+/// Current value of the weak-type sensitivity counter; compare a snapshot taken
+/// before computing a relation result with the value after to detect whether
+/// the computation depended on weak-type enforcement state that the
+/// flag-agnostic relation cache key does not encode.
+#[inline]
+pub(crate) fn weak_type_sensitivity_count() -> u64 {
+    LIMIT_BUDGETS.with(|b| b.weak_type_sensitivity.get())
+}
+
+/// Both legacy cache-poisoning sentinel counters under one TLS resolution:
+/// `(lazy_resolve_failures, weak_type_sensitivity)`. Checker-side proof caches
+/// still snapshot both counters; relation cache writes now use a
+/// `SubtypeChecker`-local unresolved-lazy counter plus the weak-type sentinel.
+#[cfg(test)]
 #[inline]
 pub(crate) fn poison_sentinel_counts() -> (u64, u64) {
     LIMIT_BUDGETS.with(|b| (b.lazy_resolve_failures.get(), b.weak_type_sensitivity.get()))

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -27,8 +27,7 @@ use crate::visitor::{
 // module (issue #13091). The re-exports below keep this module the stable
 // import path for relation-side callers.
 pub(crate) use crate::limits::{
-    MAX_GLOBAL_SUBTYPE_FUEL, note_lazy_resolve_failure, note_weak_type_sensitivity,
-    remaining_global_subtype_fuel,
+    MAX_GLOBAL_SUBTYPE_FUEL, note_weak_type_sensitivity, remaining_global_subtype_fuel,
 };
 pub use crate::limits::{lazy_resolve_failure_count, reset_subtype_thread_local_state};
 
@@ -72,7 +71,7 @@ struct RelationFrameSnapshot {
     maybe_start: usize,
     frame_promotable: bool,
     pristine_budget_chain: bool,
-    lazy_failures_at_entry: u64,
+    unresolved_lazy_events_at_entry: u64,
     weak_sensitivity_at_entry: u64,
 }
 
@@ -477,12 +476,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // Track nesting depth and consume fuel for every non-trivial check.
         // Fuel is monotonically consumed; depth tracks when we're back at root.
         // PERF: A single consolidated TLS access (`crate::limits`) reads and
-        // updates the packed depth/fuel state AND snapshots the two
-        // cache-poisoning sentinel counters and the shared solver-frame depth:
+        // updates the packed depth/fuel state AND snapshots the weak-type
+        // cache-poisoning sentinel counter and the shared solver-frame depth:
         //
-        // - The unresolved-`Lazy` snapshot: if it changes while computing this
-        //   pair's result, the result depended on a `Lazy` whose body was not
-        //   yet registered, so a `False` is undetermined and must not be cached.
+        // - The unresolved-`Lazy` snapshot is checker-local: if it changes while
+        //   computing this pair's result, this relation depended on a `Lazy`
+        //   whose body was not yet registered, so a `False` is undetermined and
+        //   must not be cached. Unrelated fresh/nested relation checkers cannot
+        //   poison this snapshot, while subcheckers whose verdict contributes to
+        //   this result explicitly propagate their event.
         // - The weak-type-sensitivity snapshot: if it changes, the result
         //   depended on weak-type enforcement state (TS2559), which the
         //   flag-agnostic `RelationCacheKey` does not encode. Caching it would
@@ -491,7 +493,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let frame_entry = crate::limits::enter_subtype_frame();
         let global_depth = frame_entry.global_depth;
         let fuel = frame_entry.fuel;
-        let lazy_failures_at_entry = frame_entry.lazy_failures;
+        let unresolved_lazy_events_at_entry = self.unresolved_lazy_relation_event_count();
         let weak_sensitivity_at_entry = frame_entry.weak_sensitivity;
 
         // ── Limit-hit maybe-stack (tsc `maybeKeys` parity, issue #13241) ────
@@ -530,7 +532,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             maybe_start,
             frame_promotable,
             pristine_budget_chain,
-            lazy_failures_at_entry,
+            unresolved_lazy_events_at_entry,
             weak_sensitivity_at_entry,
         };
 
@@ -1067,7 +1069,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     target,
                     result,
                     can_use_shared_relation_cache,
-                    lazy_failures_at_entry,
+                    unresolved_lazy_events_at_entry,
                     weak_sensitivity_at_entry,
                 );
                 finish_frame!(result);
@@ -1131,7 +1133,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 target,
                 result,
                 can_use_shared_relation_cache,
-                lazy_failures_at_entry,
+                unresolved_lazy_events_at_entry,
                 weak_sensitivity_at_entry,
             );
             finish_frame!(result);
@@ -1157,7 +1159,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 target,
                 result,
                 can_use_shared_relation_cache,
-                lazy_failures_at_entry,
+                unresolved_lazy_events_at_entry,
                 weak_sensitivity_at_entry,
             );
             finish_frame!(result);
@@ -1252,7 +1254,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             target,
             result,
             can_use_shared_relation_cache,
-            lazy_failures_at_entry,
+            unresolved_lazy_events_at_entry,
             weak_sensitivity_at_entry,
         );
 
@@ -1284,12 +1286,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// `DepthExceeded` are budget-conditional and handled by the maybe-keys
     /// promotion path.
     ///
-    /// This mirrors the discipline of the former `cache_definitive!` macro and
-    /// is intentionally conservative: the poison-sentinel snapshots are
-    /// process-wide (thread-local), so *any* unresolved-`Lazy` event or
-    /// weak-type-sensitivity event anywhere in this top-level call's subtree —
-    /// even in a branch whose result did not feed the final answer —
-    /// suppresses the write. That only ever skips a write
+    /// This mirrors the discipline of the former `cache_definitive!` macro. The
+    /// unresolved-`Lazy` snapshot is checker-local, so only misses observed by
+    /// this relation checker suppress this frame's write; fresh/nested checker
+    /// probes only propagate when their verdict contributes to the outer
+    /// relation. The weak-type
+    /// sentinel remains thread-local because weak enforcement state is still
+    /// operation-local and absent from the cache key. Suppression only skips a write
     /// (correctness-preserving: the result is recomputed later), never
     /// produces a wrong answer. Results computed under `bypass_evaluation` are
     /// likewise never written: that mode compares raw alias/meta forms without
@@ -1302,7 +1305,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         target: TypeId,
         result: SubtypeResult,
         can_use_shared_relation_cache: bool,
-        lazy_failures_at_entry: u64,
+        unresolved_lazy_events_at_entry: u64,
         weak_sensitivity_at_entry: u64,
     ) {
         let related = match result {
@@ -1311,8 +1314,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             SubtypeResult::CycleDetected | SubtypeResult::DepthExceeded => return,
         };
         if self.bypass_evaluation
-            || crate::limits::poison_sentinel_counts()
-                != (lazy_failures_at_entry, weak_sensitivity_at_entry)
+            || self.unresolved_lazy_relation_event_count() != unresolved_lazy_events_at_entry
+            || crate::limits::weak_type_sensitivity_count() != weak_sensitivity_at_entry
         {
             return;
         }
@@ -1353,9 +1356,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ///   success — cycle entries to definitive `true` (the coinductive
     ///   assumption set is self-consistent), fuel entries to band-conditional
     ///   `LimitTrue` — or discarded on failure. Promotion is additionally
-    ///   gated on the unresolved-`Lazy` / weak-type-sensitivity counters
-    ///   having been stable across the whole outermost window, the same
-    ///   discipline `record_definitive_verdict` applies to definitive writes.
+    ///   gated on the checker-local unresolved-`Lazy` counter and thread-local
+    ///   weak-type-sensitivity counter having been stable across the whole
+    ///   outermost window, the same discipline `record_definitive_verdict`
+    ///   applies to definitive writes.
     fn finish_relation_frame(
         &mut self,
         result: SubtypeResult,
@@ -1390,11 +1394,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if self.guard.depth() == 0 && !self.maybe_keys.is_empty() {
             let entries = std::mem::take(&mut self.maybe_keys);
             if result.is_true()
-                && crate::limits::poison_sentinel_counts()
-                    == (
-                        frame.lazy_failures_at_entry,
-                        frame.weak_sensitivity_at_entry,
-                    )
+                && self.unresolved_lazy_relation_event_count()
+                    == frame.unresolved_lazy_events_at_entry
+                && crate::limits::weak_type_sensitivity_count() == frame.weak_sensitivity_at_entry
                 && let Some(db) = self.query_db
             {
                 for entry in entries {
@@ -1518,7 +1520,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 def_id = def_id.0,
                 "is_conditional_alias_base_inline: no body found"
             );
-            note_lazy_resolve_failure();
+            self.note_unresolved_lazy_relation_event();
             return false;
         };
         let body_kind = self.interner.lookup(body);
@@ -1576,7 +1578,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return false;
         }
         let Some(body) = self.resolver.resolve_lazy(def_id, self.interner) else {
-            note_lazy_resolve_failure();
+            self.note_unresolved_lazy_relation_event();
             return false;
         };
         matches!(
@@ -1589,6 +1591,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::caches::db::QueryDatabase;
+    use crate::caches::query_cache::QueryCache;
+    use crate::intern::TypeInterner;
     use tsz_binder::SymbolId;
 
     #[test]
@@ -1641,5 +1646,102 @@ mod tests {
             (SymbolId(10), SymbolId(20)),
         );
         assert_eq!(different_symbol, SymbolDefCycleState::NoCycle);
+    }
+
+    #[test]
+    fn relation_cache_write_ignores_sibling_checker_lazy_event() {
+        crate::limits::reset_subtype_thread_local_state();
+        let interner = TypeInterner::new();
+        let db = QueryCache::new(&interner);
+        let mut checker = SubtypeChecker::new(&interner).with_query_db(&db);
+        let sibling = SubtypeChecker::new(&interner);
+
+        let source = TypeId::STRING;
+        let target = TypeId::NUMBER;
+        let key = checker.make_cache_key(source, target);
+        let lazy_entry = checker.unresolved_lazy_relation_event_count();
+        let weak_entry = crate::limits::weak_type_sensitivity_count();
+
+        sibling.note_unresolved_lazy_relation_event();
+        checker.record_definitive_verdict(
+            source,
+            target,
+            SubtypeResult::False,
+            true,
+            lazy_entry,
+            weak_entry,
+        );
+
+        assert_eq!(
+            db.lookup_subtype_cache(key),
+            Some(false),
+            "sibling checker lazy misses must not poison this relation frame"
+        );
+        crate::limits::reset_subtype_thread_local_state();
+    }
+
+    #[test]
+    fn relation_cache_write_skips_same_checker_lazy_event() {
+        crate::limits::reset_subtype_thread_local_state();
+        let interner = TypeInterner::new();
+        let db = QueryCache::new(&interner);
+        let mut checker = SubtypeChecker::new(&interner).with_query_db(&db);
+
+        let source = TypeId::STRING;
+        let target = TypeId::NUMBER;
+        let key = checker.make_cache_key(source, target);
+        let lazy_entry = checker.unresolved_lazy_relation_event_count();
+        let weak_entry = crate::limits::weak_type_sensitivity_count();
+
+        checker.note_unresolved_lazy_relation_event();
+        checker.record_definitive_verdict(
+            source,
+            target,
+            SubtypeResult::False,
+            true,
+            lazy_entry,
+            weak_entry,
+        );
+
+        assert_eq!(
+            db.lookup_subtype_cache(key),
+            None,
+            "this checker's unresolved Lazy event must keep the frame non-cacheable"
+        );
+        crate::limits::reset_subtype_thread_local_state();
+    }
+
+    #[test]
+    fn relation_cache_write_skips_contributing_subchecker_lazy_event() {
+        crate::limits::reset_subtype_thread_local_state();
+        let interner = TypeInterner::new();
+        let db = QueryCache::new(&interner);
+        let mut checker = SubtypeChecker::new(&interner).with_query_db(&db);
+        let subchecker = SubtypeChecker::new(&interner);
+
+        let source = TypeId::STRING;
+        let target = TypeId::NUMBER;
+        let key = checker.make_cache_key(source, target);
+        let lazy_entry = checker.unresolved_lazy_relation_event_count();
+        let weak_entry = crate::limits::weak_type_sensitivity_count();
+        let subchecker_entry = subchecker.unresolved_lazy_relation_event_count();
+
+        subchecker.note_unresolved_lazy_relation_event();
+        checker.absorb_unresolved_lazy_relation_events_from(&subchecker, subchecker_entry);
+        checker.record_definitive_verdict(
+            source,
+            target,
+            SubtypeResult::False,
+            true,
+            lazy_entry,
+            weak_entry,
+        );
+
+        assert_eq!(
+            db.lookup_subtype_cache(key),
+            None,
+            "a contributing subchecker Lazy miss must keep the outer frame non-cacheable"
+        );
+        crate::limits::reset_subtype_thread_local_state();
     }
 }

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -9,6 +9,7 @@
 //! - Set-theoretic operations for unions and intersections
 //! - `TypeResolver` trait for lazy symbol resolution
 
+use std::cell::Cell;
 use std::sync::Arc;
 
 use crate::caches::db::QueryDatabase;
@@ -448,6 +449,17 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// parity, issue #13241). See `cache::MaybeRelationEntry` and
     /// `finish_relation_frame` in the `cache` module.
     pub(crate) maybe_keys: Vec<super::cache::MaybeRelationEntry>,
+    /// Monotonic count of unresolved `Lazy(DefId)` events seen while computing
+    /// relation answers for this checker.
+    ///
+    /// This is deliberately scoped to one [`SubtypeChecker`] instance. The
+    /// legacy thread-local lazy counter still feeds checker-side proof caches
+    /// and conditional branch selection, but relation cache writes should be
+    /// gated only by unresolved bodies observed through this relation checker
+    /// or by a subchecker whose verdict contributes to it. Fresh unrelated
+    /// checkers keep their own scoped counters without poisoning this relation
+    /// verdict.
+    pub(crate) unresolved_lazy_relation_events: Cell<u64>,
     /// Instance-local fallback memo for definitive relation verdicts that the
     /// cross-checker shared cache must skip (issue #13828).
     ///
@@ -559,6 +571,7 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             apparent_primitive_shapes: std::array::from_fn(|_| None),
             type_param_equivalences: Vec::new(),
             maybe_keys: Vec::new(),
+            unresolved_lazy_relation_events: Cell::new(0),
             local_relation_cache: FxHashMap::default(),
             explain_budget: super::explain::EXPLAIN_EVAL_BUDGET,
             explain_eval_fuel: None,
@@ -613,6 +626,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             apparent_primitive_shapes: std::array::from_fn(|_| None),
             type_param_equivalences: Vec::new(),
             maybe_keys: Vec::new(),
+            unresolved_lazy_relation_events: Cell::new(0),
             local_relation_cache: FxHashMap::default(),
             explain_budget: super::explain::EXPLAIN_EVAL_BUDGET,
             explain_eval_fuel: None,
@@ -645,6 +659,38 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     pub fn with_query_db(mut self, db: &'a dyn QueryDatabase) -> Self {
         self.query_db = Some(db);
         self
+    }
+
+    /// Record that this relation checker observed an unresolved `Lazy(DefId)`.
+    ///
+    /// The checker-local counter gates relation cache writes. The legacy
+    /// thread-local counter remains updated for checker-side proof caches and
+    /// conditional branch-selection probes that still snapshot it outside the
+    /// relation frame owner.
+    #[inline]
+    pub(crate) fn note_unresolved_lazy_relation_event(&self) {
+        self.unresolved_lazy_relation_events
+            .set(self.unresolved_lazy_relation_events.get().wrapping_add(1));
+        crate::limits::note_lazy_resolve_failure();
+    }
+
+    /// Current checker-local unresolved-lazy relation event count.
+    #[inline]
+    pub(crate) const fn unresolved_lazy_relation_event_count(&self) -> u64 {
+        self.unresolved_lazy_relation_events.get()
+    }
+
+    /// Propagate unresolved-lazy events from a subchecker whose verdict was
+    /// consumed by this checker.
+    #[inline]
+    pub(crate) fn absorb_unresolved_lazy_relation_events_from<S: TypeResolver>(
+        &self,
+        subchecker: &SubtypeChecker<'_, S>,
+        subchecker_events_at_entry: u64,
+    ) {
+        if subchecker.unresolved_lazy_relation_event_count() != subchecker_events_at_entry {
+            self.note_unresolved_lazy_relation_event();
+        }
     }
 
     /// Set whether strict null checks are enabled.
@@ -757,6 +803,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.sym_visiting.clear();
         self.eval_cache.clear();
         self.maybe_keys.clear();
+        self.unresolved_lazy_relation_events.set(0);
         self.local_relation_cache.clear();
         self.explain_eval_fuel = None;
     }
@@ -832,7 +879,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         def_id = def_id.0,
                         "resolve_lazy_type: body unregistered, recording undetermined-result event"
                     );
-                    super::cache::note_lazy_resolve_failure();
+                    self.note_unresolved_lazy_relation_event();
                     type_id
                 }
             }

--- a/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/conditionals.rs
@@ -70,8 +70,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if let Some(db) = self.query_db {
             fallback = fallback.with_query_db(db);
         }
-        fallback.check_subtype(left_eval, right_eval).is_true()
-            && fallback.check_subtype(right_eval, left_eval).is_true()
+        let fallback_events_at_entry = fallback.unresolved_lazy_relation_event_count();
+        let equivalent = fallback.check_subtype(left_eval, right_eval).is_true()
+            && fallback.check_subtype(right_eval, left_eval).is_true();
+        self.absorb_unresolved_lazy_relation_events_from(&fallback, fallback_events_at_entry);
+        equivalent
     }
 
     fn identity_fallback_property_modifiers_match(&self, left: TypeId, right: TypeId) -> bool {

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
@@ -983,10 +983,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// yet registered), or a self-referential `Lazy` wrapper — justifies the
     /// raw-form fallback.
     ///
-    /// Detecting a placeholder also records an undetermined-result event
-    /// (`note_lazy_resolve_failure`): any relation result derived from the
-    /// raw comparison is schedule-dependent and must not be memoized as
-    /// definitive in the shared relation cache.
+    /// Detecting a placeholder also records an unresolved-lazy relation event:
+    /// any relation result derived from the raw comparison is
+    /// schedule-dependent and must not be memoized as definitive in the shared
+    /// relation cache.
     fn return_type_needs_raw_fallback(&mut self, return_type: TypeId) -> bool {
         // Single interner lookup yields both the alias-shape gate and the
         // defining `DefId` (this runs for every function-pair return check).
@@ -1034,7 +1034,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             None => true,
         };
         if is_placeholder {
-            crate::relations::subtype::cache::note_lazy_resolve_failure();
+            self.note_unresolved_lazy_relation_event();
         }
         is_placeholder
     }

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -222,11 +222,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // a transiently-unresolvable ref.
         let s_resolved = self.resolver.resolve_lazy(s_def, self.interner);
         if s_resolved.is_none() {
-            crate::relations::subtype::cache::note_lazy_resolve_failure();
+            self.note_unresolved_lazy_relation_event();
         }
         let t_resolved = self.resolver.resolve_lazy(t_def, self.interner);
         if t_resolved.is_none() {
-            crate::relations::subtype::cache::note_lazy_resolve_failure();
+            self.note_unresolved_lazy_relation_event();
         }
 
         // Detect self-referencing Lazy types (namespace circular references).
@@ -1144,7 +1144,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // structural fallback that can produce a cacheable False —
                 // record the undetermined-result event so the enclosing
                 // `check_subtype` call skips caching for this pair.
-                crate::relations::subtype::cache::note_lazy_resolve_failure();
+                self.note_unresolved_lazy_relation_event();
                 return None;
             }
         };
@@ -1498,7 +1498,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // structural fallback that can produce a cacheable False —
                 // record the undetermined-result event so the enclosing
                 // `check_subtype` call skips caching for this pair.
-                crate::relations::subtype::cache::note_lazy_resolve_failure();
+                self.note_unresolved_lazy_relation_event();
                 return None;
             }
         };

--- a/crates/tsz-solver/src/relations/subtype/rules/generics_application_helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics_application_helpers.rs
@@ -416,7 +416,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return false;
         }
         let Some(body) = self.resolver.resolve_lazy(alias_def, self.interner) else {
-            crate::relations::subtype::cache::note_lazy_resolve_failure();
+            self.note_unresolved_lazy_relation_event();
             return false;
         };
         let Some(body_app_id) = application_id(self.interner, body) else {

--- a/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
@@ -262,6 +262,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             if let Some(resolved) = resolved {
                 return self.check_subtype(resolved, TypeId::OBJECT).is_true();
             }
+            self.note_unresolved_lazy_relation_event();
         }
 
         false
@@ -685,6 +686,7 @@ pub(crate) const fn boxable_intrinsic_kind(kind: IntrinsicKind) -> Option<Intrin
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::def::DefId;
     use crate::intern::TypeInterner;
 
     #[test]
@@ -713,5 +715,22 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn unresolved_lazy_object_keyword_probe_records_relation_event() {
+        crate::limits::reset_subtype_thread_local_state();
+        let interner = TypeInterner::new();
+        let mut checker = SubtypeChecker::new(&interner);
+        let unresolved = interner.lazy(DefId(9001));
+        let before = checker.unresolved_lazy_relation_event_count();
+
+        assert!(!checker.is_object_keyword_type(unresolved));
+        assert_ne!(
+            checker.unresolved_lazy_relation_event_count(),
+            before,
+            "Lazy <: object miss must keep the relation result non-cacheable"
+        );
+        crate::limits::reset_subtype_thread_local_state();
     }
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Replace relation-cache use of the broad thread-local lazy-resolve poison snapshot with a scoped `SubtypeChecker` unresolved-lazy event counter.
- Propagate scoped taint from contributing relation subprobes while leaving unrelated sibling checkers free to publish cacheable verdicts.
- Keep weak-type sensitivity on the existing operation-local sentinel, and cover unresolved `Lazy <: object` misses so schedule-dependent false results stay non-cacheable.

## Structural Rule
When a relation result observes an unresolved `Lazy(DefId)`, tsc does not commit that unstable answer as a definitive reusable relation verdict. tsz now enforces that through the solver relation owner: cache writes and maybe-key promotions are gated by the current relation checker plus any subchecker whose verdict contributes to the result. Fresh unrelated relation checkers no longer suppress sibling cache writes. Weak-type sensitivity remains thread-local because weak enforcement state is still operation-local and absent from `RelationCacheKey`.

## Owner Layer
Solver relation/cache owns this change: `SubtypeChecker`, relation frame cache gates, relation lazy-resolution fallback sites, and intrinsic object probing. Checker diagnostics, assignability gateways, definition-store publication, module augmentation producers, emit, and project-row metadata are unchanged.

## Adjacent Case Matrix
- Same relation checker observes an unresolved lazy body: definitive relation cache write is skipped.
- Fresh unrelated sibling checker observes an unresolved lazy body: this relation can still publish its stable verdict.
- Contributing subchecker observes an unresolved lazy body during conditional extends fallback: the outer relation absorbs the event and skips the cache write.
- `Lazy(DefId) <: object` miss through intrinsic object probing records an unresolved-lazy relation event before returning false.
- Weak-type-sensitive relation results continue to be excluded from the flag-agnostic shared relation cache through the existing weak-type sentinel.

## Fallback
If no unresolved lazy body is observed by the relation checker or a contributing subchecker, cache behavior is unchanged. If an unresolved body is observed, tsz only skips a shared/local relation cache write or maybe-key promotion; it recomputes later rather than synthesizing or widening a type. The legacy lazy-resolve counter is still updated for checker-side proof caches and conditional branch-selection probes.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(limit_relation_cache_tests::) or test(subtype_cache_tests::) or test(relations::subtype::cache::) or test(relations::subtype::rules::intrinsics::tests::unresolved_lazy_object_keyword_probe_records_relation_event) or test(limits::tests::)'`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `scripts/safe-run.sh python3 scripts/arch/arch_guard.py --json`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high