### PR TITLE
refactor(solver): name template context depth state (#14346)

### DIFF
--- a/crates/tsz-solver/src/operations/expression_ops.rs
+++ b/crates/tsz-solver/src/operations/expression_ops.rs
@@ -712,9 +712,26 @@ fn template_substitution_type(db: &dyn TypeDatabase, part: TypeId) -> TypeId {
     }
 }
 
+const MAX_TEMPLATE_CONTEXT_DEPTH: u32 = 10;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TemplateContextDepthState {
+    Continue,
+    LimitExceeded,
+}
+
+const fn template_context_depth_state(depth: u32) -> TemplateContextDepthState {
+    if depth > MAX_TEMPLATE_CONTEXT_DEPTH {
+        TemplateContextDepthState::LimitExceeded
+    } else {
+        TemplateContextDepthState::Continue
+    }
+}
+
 fn template_substitution_type_is_valid(db: &dyn TypeDatabase, part: TypeId, depth: u32) -> bool {
-    if depth > 10 {
-        return false;
+    match template_context_depth_state(depth) {
+        TemplateContextDepthState::Continue => {}
+        TemplateContextDepthState::LimitExceeded => return false,
     }
     if matches!(
         part,
@@ -770,7 +787,11 @@ fn template_substitution_constraint_is_dependent(
     type_id: TypeId,
     depth: u32,
 ) -> bool {
-    if depth > 10 || type_id.is_intrinsic() {
+    match template_context_depth_state(depth) {
+        TemplateContextDepthState::Continue => {}
+        TemplateContextDepthState::LimitExceeded => return false,
+    }
+    if type_id.is_intrinsic() {
         return false;
     }
 
@@ -807,8 +828,9 @@ fn is_template_literal_contextual_type_inner(
     type_id: TypeId,
     depth: u32,
 ) -> bool {
-    if depth > 10 {
-        return false;
+    match template_context_depth_state(depth) {
+        TemplateContextDepthState::Continue => {}
+        TemplateContextDepthState::LimitExceeded => return false,
     }
     if type_id.is_intrinsic() {
         return false;

--- a/crates/tsz-solver/tests/expression_ops_tests.rs
+++ b/crates/tsz-solver/tests/expression_ops_tests.rs
@@ -1050,6 +1050,48 @@ fn test_template_expression_contextual_error_still_propagates() {
     assert_eq!(result, TypeId::ERROR);
 }
 
+fn nested_no_infer(interner: &TypeInterner, mut type_id: TypeId, depth: u32) -> TypeId {
+    for _ in 0..depth {
+        type_id = interner.no_infer(type_id);
+    }
+    type_id
+}
+
+#[test]
+fn template_context_depth_state_continues_at_cap() {
+    assert_eq!(
+        template_context_depth_state(MAX_TEMPLATE_CONTEXT_DEPTH),
+        TemplateContextDepthState::Continue
+    );
+}
+
+#[test]
+fn template_context_depth_state_limits_past_cap() {
+    assert_eq!(
+        template_context_depth_state(MAX_TEMPLATE_CONTEXT_DEPTH + 1),
+        TemplateContextDepthState::LimitExceeded
+    );
+}
+
+#[test]
+fn template_substitution_depth_state_preserves_exact_cap() {
+    let interner = TypeInterner::new();
+    let capped = nested_no_infer(&interner, TypeId::STRING, MAX_TEMPLATE_CONTEXT_DEPTH);
+
+    assert_eq!(template_substitution_type(&interner, capped), capped);
+}
+
+#[test]
+fn template_substitution_depth_state_falls_back_past_cap() {
+    let interner = TypeInterner::new();
+    let over_cap = nested_no_infer(&interner, TypeId::STRING, MAX_TEMPLATE_CONTEXT_DEPTH + 1);
+
+    assert_eq!(
+        template_substitution_type(&interner, over_cap),
+        TypeId::STRING
+    );
+}
+
 #[test]
 fn test_is_template_literal_contextual_type_basic() {
     let interner = TypeInterner::new();


### PR DESCRIPTION
Goal: green

## Summary
- Add `TemplateContextDepthState` around the shared template-context recursion cap.
- Route template-substitution validity, dependent-constraint detection, and template-contextual-type detection through the named state.
- Preserve the existing fallback: depths past `MAX_TEMPLATE_CONTEXT_DEPTH` still return `false`, causing template substitutions to widen to `string` where they already did.

## Structural Rule
When contextual-template helper walks recurse at or below `MAX_TEMPLATE_CONTEXT_DEPTH`, tsz records `TemplateContextDepthState::Continue` and keeps walking. When they recurse past that cap, tsz records `TemplateContextDepthState::LimitExceeded` and preserves the existing conservative `false` fallback. Owner layer: `tsz-solver` expression operation/template-context classification.

## Adjacent Matrix
- Exact cap: nested `NoInfer` string substitutions still stay valid.
- Past cap: nested `NoInfer` substitutions still fall back to `string`.
- Contextual template detection and dependent-constraint detection use the same state boundary and fallback.
- No checker, emitter, #14344 identity, #14345 materialize-once, #14347 cache-taint, or active relation-cache files are touched.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-solver expression_ops`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `wc -l crates/tsz-solver/src/operations/expression_ops.rs crates/tsz-solver/tests/expression_ops_tests.rs`

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high