### PR TITLE
perf(solver): type unresolved eval cache stability (#14347)

### DIFF
--- a/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
+++ b/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
@@ -129,7 +129,7 @@ pub(crate) fn memoized_eval_with_stability(
         CrossEvalExpansionState::AlreadyActive => return None,
     };
     let memo_result = compute();
-    if memo_result.is_stable_for_depth_agnostic_cache() {
+    if memo_result.is_stable_for_per_query_memo() {
         query_memo_put(type_id, no_unchecked_indexed_access, memo_result.type_id());
     }
     Some(memo_result)
@@ -181,6 +181,7 @@ impl Drop for CrossEvalExpansionGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::evaluation::result::{EvaluationRequestStability, EvaluationResult};
 
     #[test]
     fn memo_keys_on_no_unchecked_indexed_access() {
@@ -210,6 +211,34 @@ mod tests {
 
         assert_eq!(second, Some(TypeId(81)));
         assert_eq!(query_memo_get(t, false), Some(TypeId(81)));
+        reset_query_memo();
+    }
+
+    #[test]
+    fn unresolved_def_fresh_result_is_returned_and_memoized_within_query() {
+        reset_query_memo();
+        let t = TypeId(9);
+        let mut calls = 0;
+
+        let first = memoized_eval(t, false, || {
+            calls += 1;
+            EvaluationMemoResult::for_depth_agnostic_memo(
+                EvaluationResult::complete(TypeId(90)),
+                EvaluationRequestStability::UnresolvedDef,
+            )
+        });
+
+        assert_eq!(first, Some(TypeId(90)));
+        assert_eq!(query_memo_get(t, false), Some(TypeId(90)));
+
+        let second = memoized_eval(t, false, || {
+            calls += 1;
+            EvaluationMemoResult::cached(TypeId(91))
+        });
+
+        assert_eq!(second, Some(TypeId(90)));
+        assert_eq!(calls, 1);
+        assert_eq!(query_memo_get(t, false), Some(TypeId(90)));
         reset_query_memo();
     }
 

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -153,6 +153,12 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// every `evaluate_request_result` entry so the verdict is scoped to one
     /// request and never leaks across reused-evaluator requests.
     request_termination_kind: Option<TerminationKind>,
+    /// Request-local counterpart of [`Self::unresolved_def_seen`]. The sticky
+    /// flag blocks run-wide closed-eval writes, while this flag lets memo-result
+    /// verdicts name whether the specific request observed an unresolved body.
+    /// Cleared with `request_termination_kind` on every `evaluate_request_result`
+    /// entry.
+    request_unresolved_def_seen: bool,
     /// Monotonic counter of *limit events* (cycle / depth / iteration / divergence
     /// bails) seen so far in this run. Unlike the sticky `deep_recursion_seen` /
     /// `silent_depth_bailed` booleans — which, once set by the first bail anywhere,
@@ -308,6 +314,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             detection_growth_runs: FxHashMap::default(),
             deep_recursion_seen: false,
             request_termination_kind: None,
+            request_unresolved_def_seen: false,
             limit_epoch: 0,
             app_body_limit_epoch: 0,
             unresolved_def_seen: false,
@@ -575,6 +582,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.silent_depth_bailed = false;
         self.deep_recursion_seen = false;
         self.request_termination_kind = None;
+        self.request_unresolved_def_seen = false;
         self.limit_epoch = 0;
         self.app_body_limit_epoch = 0;
         self.unresolved_def_seen = false;
@@ -601,6 +609,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     pub fn evaluate_request_result(&mut self, request: EvaluationRequest) -> EvaluationResult {
         self.set_no_unchecked_indexed_access(request.no_unchecked_indexed_access());
         self.request_termination_kind = None;
+        self.request_unresolved_def_seen = false;
         let type_id = self.evaluate(request.type_id());
         request_result_verdict(type_id, self.request_termination_kind)
     }
@@ -628,12 +637,26 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// that the legacy sticky flags did not fully model (for example
     /// fuel/query-budget bails). The legacy [`Self::recursion_limit_hit`]
     /// backstop remains until every recursion-taint class is owned by the typed
-    /// termination channel.
+    /// termination channel. The unresolved-def bit is the registration-window
+    /// artifact gate: a result observed before a `DefId` body registers must
+    /// not be published into a key-only cache.
     #[inline]
     pub(crate) const fn request_state_cache_stability(&self) -> EvaluationRequestStability {
         EvaluationRequestStability::from_request_state(
             self.has_incomplete_request_verdict(),
             self.recursion_limit_hit(),
+            self.request_unresolved_def_seen,
+        )
+    }
+
+    /// Whether the current top-level evaluation run is stable enough for
+    /// run-wide cache publication.
+    #[inline]
+    pub(crate) const fn run_state_cache_stability(&self) -> EvaluationRequestStability {
+        EvaluationRequestStability::from_request_state(
+            self.has_incomplete_request_verdict(),
+            self.recursion_limit_hit(),
+            self.unresolved_def_seen(),
         )
     }
 
@@ -902,6 +925,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     #[inline]
     pub(super) const fn mark_unresolved_def_seen(&mut self) {
         self.unresolved_def_seen = true;
+        self.request_unresolved_def_seen = true;
         self.note_limit_event();
     }
 

--- a/crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs
@@ -121,8 +121,9 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
         // answer a sibling read would observe.
         let is_top_level = closed_eval_cache_enabled() && self.guard.depth() == 0;
         if !is_top_level
-            || !self.request_state_is_depth_agnostic_cache_stable()
-            || self.unresolved_def_seen()
+            || !self
+                .run_state_cache_stability()
+                .is_stable_for_depth_agnostic_cache()
             || !limit_snapshot.union_complexity_stayed_stable_after(self.interner)
         {
             return;
@@ -447,7 +448,7 @@ mod tests {
     use crate::caches::query_cache::QueryCache;
     use crate::construction::TypeInterner;
     use crate::def::DefId;
-    use crate::evaluation::result::TerminationKind;
+    use crate::evaluation::result::{EvaluationRequestStability, TerminationKind};
 
     fn evaluator(interner: &TypeInterner) -> TypeEvaluator<'_> {
         TypeEvaluator::new(interner)
@@ -532,6 +533,69 @@ mod tests {
         assert_eq!(
             cache.lookup_closed_eval_cache(legacy_tainted_node, false),
             None
+        );
+
+        let unresolved_node = interner.index_access(TypeId::BOOLEAN, TypeId::STRING);
+        let mut unresolved = TypeEvaluator::new(&cache)
+            .with_query_db(&cache)
+            .with_closed_eval_writes();
+        unresolved.cache.insert(unresolved_node, TypeId::BOOLEAN);
+        unresolved.mark_unresolved_def_seen();
+        let unresolved_snapshot = EvaluationCacheLimitSnapshot::capture(&cache);
+        unresolved.commit_closed_eval_writes(unresolved_snapshot);
+        assert_eq!(cache.lookup_closed_eval_cache(unresolved_node, false), None);
+    }
+
+    /// An unresolved semantic body is a registration-window artifact, so the
+    /// shared request-state stability verdict should name it before closed-eval
+    /// decides whether to publish any cache entries.
+    #[test]
+    fn unresolved_def_seen_is_reported_by_request_state_stability_gate() {
+        let interner = TypeInterner::new();
+        let mut evaluator = TypeEvaluator::new(&interner);
+
+        assert_eq!(
+            evaluator.request_state_cache_stability(),
+            EvaluationRequestStability::Stable
+        );
+
+        evaluator.mark_unresolved_def_seen();
+
+        assert_eq!(
+            evaluator.request_state_cache_stability(),
+            EvaluationRequestStability::UnresolvedDef
+        );
+        assert!(!evaluator.request_state_is_depth_agnostic_cache_stable());
+    }
+
+    /// A run-wide unresolved-def hit blocks closed-eval writes for the whole
+    /// top-level evaluation, but it must not poison later independent request
+    /// memos. Otherwise a clean indexed-access request after an unrelated
+    /// registration-window artifact can lose its stable cross-evaluator memo and
+    /// re-resolve to a different method shape.
+    #[test]
+    fn request_stability_does_not_inherit_prior_unresolved_def_hit() {
+        let interner = TypeInterner::new();
+        let mut evaluator = TypeEvaluator::new(&interner);
+
+        evaluator.mark_unresolved_def_seen();
+        assert_eq!(
+            evaluator.run_state_cache_stability(),
+            EvaluationRequestStability::UnresolvedDef
+        );
+
+        let result = evaluator.evaluate_request_result(
+            crate::evaluation::request::EvaluationRequest::new(TypeId::STRING),
+        );
+
+        assert_eq!(result.into_type_id(), TypeId::STRING);
+        assert_eq!(
+            evaluator.request_state_cache_stability(),
+            EvaluationRequestStability::Stable
+        );
+        assert_eq!(
+            evaluator.run_state_cache_stability(),
+            EvaluationRequestStability::UnresolvedDef
         );
     }
 

--- a/crates/tsz-solver/src/evaluation/result.rs
+++ b/crates/tsz-solver/src/evaluation/result.rs
@@ -155,6 +155,7 @@ impl EvaluationResult {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct EvaluationMemoResult {
     result: EvaluationResult,
+    request_stability: EvaluationRequestStability,
     cache_stability: EvaluationMemoStability,
 }
 
@@ -162,19 +163,28 @@ pub(crate) struct EvaluationMemoResult {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum EvaluationRequestStability {
     Stable,
+    /// A typed request result says a guard returned a partial answer.
     IncompleteVerdict,
+    /// A legacy recursion/depth/iteration taint fired before the typed channel
+    /// fully owns that family.
     RecursionLimit,
+    /// A `DefId` body was unresolved, so the result is a registration-window
+    /// artifact rather than a stable function of the request key.
+    UnresolvedDef,
 }
 
 impl EvaluationRequestStability {
     pub(crate) const fn from_request_state(
         has_incomplete_request_verdict: bool,
         recursion_limit_hit: bool,
+        unresolved_def_seen: bool,
     ) -> Self {
         if has_incomplete_request_verdict {
             Self::IncompleteVerdict
         } else if recursion_limit_hit {
             Self::RecursionLimit
+        } else if unresolved_def_seen {
+            Self::UnresolvedDef
         } else {
             Self::Stable
         }
@@ -182,6 +192,18 @@ impl EvaluationRequestStability {
 
     pub(crate) const fn is_stable_for_depth_agnostic_cache(self) -> bool {
         matches!(self, Self::Stable)
+    }
+
+    /// Whether a complete result with this request-state verdict should remain
+    /// cacheable by ordinary eval memo consumers. `UnresolvedDef` is allowed
+    /// here to preserve pre-existing complete-result behavior; run-wide cache
+    /// publishers such as closed-eval inspect the request state directly.
+    pub(crate) const fn allows_complete_memo_result(self) -> bool {
+        matches!(self, Self::Stable | Self::UnresolvedDef)
+    }
+
+    pub(crate) const fn is_stable_for_per_query_memo(self) -> bool {
+        matches!(self, Self::Stable | Self::UnresolvedDef)
     }
 }
 
@@ -198,7 +220,7 @@ impl EvaluationMemoStability {
         result: EvaluationResult,
         request_stability: EvaluationRequestStability,
     ) -> Self {
-        if result.is_complete() && request_stability.is_stable_for_depth_agnostic_cache() {
+        if result.is_complete() && request_stability.allows_complete_memo_result() {
             Self::Stable
         } else {
             Self::Unstable
@@ -219,6 +241,7 @@ impl EvaluationMemoResult {
     ) -> Self {
         Self {
             result,
+            request_stability,
             cache_stability: EvaluationMemoStability::from_result(result, request_stability),
         }
     }
@@ -228,6 +251,7 @@ impl EvaluationMemoResult {
     pub(crate) const fn cached(type_id: TypeId) -> Self {
         Self {
             result: EvaluationResult::complete(type_id),
+            request_stability: EvaluationRequestStability::Stable,
             cache_stability: EvaluationMemoStability::Stable,
         }
     }
@@ -237,6 +261,7 @@ impl EvaluationMemoResult {
     pub(crate) const fn unstable_complete(type_id: TypeId) -> Self {
         Self {
             result: EvaluationResult::complete(type_id),
+            request_stability: EvaluationRequestStability::IncompleteVerdict,
             cache_stability: EvaluationMemoStability::Unstable,
         }
     }
@@ -254,6 +279,15 @@ impl EvaluationMemoResult {
     /// ambient recursion depth/fuel state.
     pub(crate) const fn is_stable_for_depth_agnostic_cache(self) -> bool {
         self.cache_stability.is_stable_for_depth_agnostic_cache()
+    }
+
+    /// Whether this result can be stored in the thread-local per-query memo.
+    ///
+    /// `UnresolvedDef` remains visible to run-state gates such as closed-eval
+    /// publication, but a complete memo result is reusable within the same
+    /// coherent analysis window.
+    pub(crate) const fn is_stable_for_per_query_memo(self) -> bool {
+        self.result.is_complete() && self.request_stability.is_stable_for_per_query_memo()
     }
 
     /// Collapse to the request's `TypeId` while preserving today's behavior for
@@ -329,6 +363,17 @@ mod tests {
         );
         assert!(!request_state_tainted.is_stable_for_depth_agnostic_cache());
 
+        let unresolved_def_named = EvaluationMemoResult::for_depth_agnostic_memo(
+            complete,
+            EvaluationRequestStability::UnresolvedDef,
+        );
+        assert_eq!(
+            unresolved_def_named.cache_stability,
+            EvaluationMemoStability::Stable
+        );
+        assert!(unresolved_def_named.is_stable_for_depth_agnostic_cache());
+        assert!(unresolved_def_named.is_stable_for_per_query_memo());
+
         let incomplete =
             EvaluationResult::incomplete(TypeId::NUMBER, TerminationKind::DepthExceeded);
         let typed_tainted = EvaluationMemoResult::for_depth_agnostic_memo(
@@ -346,27 +391,38 @@ mod tests {
     #[test]
     fn request_stability_names_request_state_reason() {
         assert_eq!(
-            EvaluationRequestStability::from_request_state(false, false),
+            EvaluationRequestStability::from_request_state(false, false, false),
             EvaluationRequestStability::Stable
         );
         assert_eq!(
-            EvaluationRequestStability::from_request_state(true, false),
+            EvaluationRequestStability::from_request_state(true, false, false),
             EvaluationRequestStability::IncompleteVerdict
         );
         assert_eq!(
-            EvaluationRequestStability::from_request_state(false, true),
+            EvaluationRequestStability::from_request_state(false, true, false),
             EvaluationRequestStability::RecursionLimit
         );
         assert_eq!(
-            EvaluationRequestStability::from_request_state(true, true),
+            EvaluationRequestStability::from_request_state(false, false, true),
+            EvaluationRequestStability::UnresolvedDef
+        );
+        assert_eq!(
+            EvaluationRequestStability::from_request_state(true, true, true),
             EvaluationRequestStability::IncompleteVerdict,
             "typed incomplete verdict should stay the primary request-state reason"
+        );
+        assert_eq!(
+            EvaluationRequestStability::from_request_state(false, true, true),
+            EvaluationRequestStability::RecursionLimit,
+            "recursion-limit taint should stay primary when both legacy taints are set"
         );
         assert!(EvaluationRequestStability::Stable.is_stable_for_depth_agnostic_cache());
         assert!(
             !EvaluationRequestStability::IncompleteVerdict.is_stable_for_depth_agnostic_cache()
         );
         assert!(!EvaluationRequestStability::RecursionLimit.is_stable_for_depth_agnostic_cache());
+        assert!(!EvaluationRequestStability::UnresolvedDef.is_stable_for_depth_agnostic_cache());
+        assert!(EvaluationRequestStability::UnresolvedDef.is_stable_for_per_query_memo());
     }
 
     #[test]
@@ -388,5 +444,6 @@ mod tests {
         assert_eq!(result.type_id(), TypeId::STRING);
         assert_eq!(result.into_type_id(), TypeId::STRING);
         assert!(!result.is_stable_for_depth_agnostic_cache());
+        assert!(!result.is_stable_for_per_query_memo());
     }
 }


### PR DESCRIPTION
Goal: fast

## Summary
- add `EvaluationRequestStability::UnresolvedDef` so unresolved semantic bodies are represented in the typed request-state verdict
- split request-local unresolved-def observations from the run-wide sticky unresolved-def flag
- keep complete unresolved-def memo results reusable within the same query while using the run-wide verdict to block closed-eval publication
- cover request-local/run-wide stability separation and the per-query memo behavior that protects indexed-access narrowing

## Structural Rule
When evaluation observes a semantic `DefId` before its body is registered or resolvable, `tsc` does not let that registration-window artifact escape into later authoritative evaluation. `tsz` preserves that by keeping the solver-owned run-state verdict unstable for closed-eval publication, while complete memo results remain reusable inside the current top-level query so one coherent narrowing/evaluation pass sees the same collapsed `TypeId`.

Owner layer: `tsz-solver` evaluation/result cache-stability plumbing. No checker policy, fixture names, rendered type strings, or source-text checks are involved.

## Adjacent Matrix
- Complete, clean result: remains stable and publishable.
- Typed incomplete verdict: remains unstable and skipped.
- Legacy recursion/depth taint: remains unstable and skipped.
- Unresolved `DefId` body: named as `EvaluationRequestStability::UnresolvedDef`; blocks run-wide closed-eval writes, but complete memo results remain cacheable for ordinary eval/per-query memo consumers within the same analysis window.
- Request after earlier unresolved sibling: request-local verdict returns to `Stable`; run-wide verdict remains `UnresolvedDef` for closed-eval publication.
- Fallback behavior: `EvaluationResult::into_type_id()` still returns the same `TypeId`; this PR changes cache eligibility metadata only.

Regression fixed after first CI run: `quickinfoTypeAtReturnPositionsInaccurate.ts` gained an extra narrowed-call diagnostic when `UnresolvedDef` was treated as a blanket complete-result memo blocker. The final rule keeps the run-wide closed-eval guard while preserving intra-query memo coherence.

## Verification
- cargo fmt --all --check
- git diff --check
- scripts/safe-run.sh cargo nextest run -p tsz-solver unresolved_def_fresh_result_is_returned_and_memoized_within_query non_stable_fresh_result_is_returned_but_not_memoized unresolved_def_seen_is_reported_by_request_state_stability_gate request_stability_does_not_inherit_prior_unresolved_def_hit request_stability_names_request_state_reason request_state_stability_gate_blocks_closed_eval_write memo_result_stability_requires_complete_result_and_clean_request_state
- scripts/safe-run.sh cargo check -p tsz-solver
- scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings
- ./scripts/conformance/conformance.sh run --filter "quickinfoTypeAtReturnPositionsInaccurate" --verbose

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: high