### PR TITLE
fix(solver): resolve query re-reduce through store (#14351)

### DIFF
--- a/crates/tsz-solver/src/caches/instantiation_cache_test.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache_test.rs
@@ -21,6 +21,8 @@
 //! / subtype-checker paths thread `self.query_db`.
 
 use crate::caches::query_cache::QueryCache;
+use crate::def::{DefId, DefinitionStore};
+use crate::instantiation::instantiate::flags::InstResolverRereduceFlagGuard;
 use crate::instantiation::instantiate::{
     MAX_INSTANTIATION_DEPTH, ProjectInstCacheDisabledGuard, TypeSubstitution,
     instantiate_generic_cached, instantiate_type, instantiate_type_cached,
@@ -1221,5 +1223,48 @@ fn query_database_evaluate_entry_points_preserve_results() {
         QueryDatabase::evaluate_mapped(&qc, &mapped),
         crate::evaluation::evaluate::evaluate_mapped(&interner, &mapped),
         "evaluate_mapped override must match the uncached result",
+    );
+}
+
+#[test]
+fn query_database_store_backed_rereduce_resolves_published_lazy_body() {
+    use crate::caches::db::QueryDatabase;
+
+    let interner = TypeInterner::new();
+    let store = DefinitionStore::new();
+    let def_id = DefId(43_451);
+    let body = object_with(&interner, TypeId::STRING);
+    let lazy = interner.lazy(def_id);
+    let key_a = interner.literal_string("a");
+    store.set_body(def_id, body);
+
+    let qc = QueryCache::new(&interner).with_definition_store(&store);
+    let deferred_index = interner.index_access(lazy, key_a);
+    let deferred_keyof = interner.keyof(lazy);
+
+    {
+        let _flag = InstResolverRereduceFlagGuard::new(false);
+        assert_eq!(
+            QueryDatabase::evaluate_index_access(&qc, lazy, key_a),
+            deferred_index,
+            "flag-off QueryCache evaluation must keep the historical resolver-less deferred index",
+        );
+        assert_eq!(
+            QueryDatabase::evaluate_keyof(&qc, lazy),
+            deferred_keyof,
+            "flag-off QueryCache evaluation must keep the historical resolver-less deferred keyof",
+        );
+    }
+
+    let _flag = InstResolverRereduceFlagGuard::new(true);
+    assert_eq!(
+        QueryDatabase::evaluate_index_access(&qc, lazy, key_a),
+        TypeId::STRING,
+        "flag-on store-backed QueryCache evaluation must resolve the published Lazy body",
+    );
+    assert_eq!(
+        QueryDatabase::evaluate_keyof(&qc, lazy),
+        key_a,
+        "flag-on store-backed QueryCache evaluation must compute keys from the published body",
     );
 }

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -42,6 +42,8 @@ use std::sync::Arc;
 use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
 
+mod resolver;
+
 // Element access (indexed access) of an optional property includes `undefined`
 // under both `exactOptionalPropertyTypes` settings (matching tsc), so the result
 // does not depend on that option and it is intentionally not part of this key.
@@ -361,6 +363,10 @@ impl<'a> QueryCache<'a> {
     pub const fn with_definition_store(mut self, store: &'a crate::def::DefinitionStore) -> Self {
         self.definition_store = Some(store);
         self
+    }
+
+    pub(crate) const fn has_definition_store(&self) -> bool {
+        self.definition_store.is_some()
     }
 
     pub fn clear(&self) {
@@ -1286,100 +1292,6 @@ impl TypeDatabase for QueryCache<'_> {
     }
 }
 
-/// Implement `TypeResolver` for `QueryCache` with noop resolution.
-///
-/// `QueryCache` doesn't have access to the Binder or type environment,
-/// so it cannot resolve symbol references or `DefIds`. Only `resolve_ref`
-/// (required) is explicitly implemented; all other resolution methods
-/// inherit the trait's default `None`/`false` behavior. The three boxed/array
-/// methods delegate to the underlying interner.
-impl TypeResolver for QueryCache<'_> {
-    fn resolve_ref(&self, _symbol: SymbolRef, _interner: &dyn TypeDatabase) -> Option<TypeId> {
-        None
-    }
-
-    fn get_boxed_type(&self, kind: IntrinsicKind) -> Option<TypeId> {
-        self.interner.get_boxed_type(kind)
-    }
-
-    fn get_array_base_type(&self) -> Option<TypeId> {
-        self.interner.get_array_base_type()
-    }
-
-    fn get_array_base_type_params(&self) -> &[TypeParamInfo] {
-        self.interner.get_array_base_type_params()
-    }
-
-    fn get_readonly_array_base_type(&self) -> Option<TypeId> {
-        self.interner.get_readonly_array_base_type()
-    }
-
-    /// Resolve `DefId` identity/metadata through the attached `DefinitionStore`.
-    ///
-    /// The `QueryCache` is the `&dyn QueryDatabase` resolver used by generic-call
-    /// inference. Historically it had NO `DefinitionStore`, so these `DefId`-keyed
-    /// resolver methods silently returned trait defaults in inference: the
-    /// `shared_application_base_def_id` cross-arena base unification (via
-    /// `defs_are_equivalent` declaration-site/`SymbolId` equality) and the
-    /// variance-computation paths that depend on them were dead, leaving
-    /// cross-arena generic-call inference unable to pair type-args (issue #14344;
-    /// the fp-ts `unknown`-widening FP family). Wiring the store re-enables them.
-    ///
-    /// Gated behind `TSZ_XARENA_BASE_DECL` (default-OFF) so flag-OFF stays
-    /// byte-parity with the historical store-less behavior until the change is
-    /// proven on full conformance.
-    fn def_to_symbol_id(&self, def_id: DefId) -> Option<SymbolId> {
-        if !crate::inference::xarena_base::xarena_base_decl_enabled() {
-            return None;
-        }
-        self.definition_store?.get_symbol_id(def_id).map(SymbolId)
-    }
-
-    fn get_def_kind(&self, def_id: DefId) -> Option<crate::def::DefKind> {
-        if !crate::inference::xarena_base::xarena_base_decl_enabled() {
-            return None;
-        }
-        self.definition_store?.get_kind(def_id)
-    }
-
-    fn get_def_name(&self, def_id: DefId) -> Option<tsz_common::interner::Atom> {
-        if !crate::inference::xarena_base::xarena_base_decl_enabled() {
-            return None;
-        }
-        self.definition_store?.get(def_id).map(|info| info.name)
-    }
-
-    fn canonical_def_id(&self, def_id: DefId) -> DefId {
-        if !crate::inference::xarena_base::xarena_base_decl_enabled() {
-            return def_id;
-        }
-        self.definition_store
-            .map_or(def_id, |store| store.canonical_def_id(def_id))
-    }
-
-    fn defs_are_equivalent(&self, a: DefId, b: DefId) -> bool {
-        if a == b {
-            return true;
-        }
-        if !crate::inference::xarena_base::xarena_base_decl_enabled() {
-            return false;
-        }
-        let Some(store) = self.definition_store else {
-            return false;
-        };
-        store.defs_have_same_decl_site(a, b)
-            || store
-                .get_symbol_id(a)
-                .zip(store.get_symbol_id(b))
-                .is_some_and(|(sa, sb)| sa == sb)
-    }
-
-    fn canonical_decl_site_def_for_symbol(&self, symbol: SymbolRef) -> Option<DefId> {
-        self.definition_store?
-            .canonical_decl_site_def_for_symbol(symbol.0)
-    }
-}
-
 impl CollectPropertiesResultCache for QueryCache<'_> {
     fn collect_properties_result_cached(
         &self,
@@ -1583,6 +1495,9 @@ impl QueryDatabase for QueryCache<'_> {
     /// Cache-aware override of the `QueryDatabase` default, which would build a
     /// `query_db = None` evaluator and bypass the cross-call instantiation cache.
     fn evaluate_conditional(&self, cond: &ConditionalType) -> TypeId {
+        if let Some(mut evaluator) = self.store_backed_rereduce_evaluator() {
+            return evaluator.evaluate_conditional(cond);
+        }
         self.query_backed_evaluator().evaluate_conditional(cond)
     }
 
@@ -1592,16 +1507,26 @@ impl QueryDatabase for QueryCache<'_> {
         index_type: TypeId,
         no_unchecked_indexed_access: bool,
     ) -> TypeId {
+        if let Some(mut evaluator) = self.store_backed_rereduce_evaluator() {
+            evaluator.set_no_unchecked_indexed_access(no_unchecked_indexed_access);
+            return evaluator.evaluate_index_access(object_type, index_type);
+        }
         let mut evaluator = self.query_backed_evaluator();
         evaluator.set_no_unchecked_indexed_access(no_unchecked_indexed_access);
         evaluator.evaluate_index_access(object_type, index_type)
     }
 
     fn evaluate_keyof(&self, operand: TypeId) -> TypeId {
+        if let Some(mut evaluator) = self.store_backed_rereduce_evaluator() {
+            return evaluator.evaluate_keyof(operand);
+        }
         self.query_backed_evaluator().evaluate_keyof(operand)
     }
 
     fn evaluate_mapped(&self, mapped: &MappedType) -> TypeId {
+        if let Some(mut evaluator) = self.store_backed_rereduce_evaluator() {
+            return evaluator.evaluate_mapped(mapped);
+        }
         self.query_backed_evaluator().evaluate_mapped(mapped)
     }
 

--- a/crates/tsz-solver/src/caches/query_cache/resolver.rs
+++ b/crates/tsz-solver/src/caches/query_cache/resolver.rs
@@ -1,0 +1,132 @@
+//! `TypeResolver` implementation for `QueryCache`.
+
+use super::QueryCache;
+use crate::caches::db::TypeDatabase;
+use crate::def::DefId;
+use crate::instantiation::instantiate::flags::inst_resolver_rereduce_enabled;
+use crate::relations::subtype::TypeResolver;
+use crate::types::{IntrinsicKind, SymbolRef, TypeId, TypeParamInfo};
+use tsz_binder::SymbolId;
+
+/// Symbol references remain unresolved here: the cache has no binder/type-env
+/// symbol scope. When a shared `DefinitionStore` is attached, DefId-backed
+/// lazy bodies and type parameters can be read through the store so the staged
+/// instantiation re-reduce path can reduce already-published declarations.
+/// Default evaluator construction still uses `NoopResolver`; these methods are
+/// only consulted by the explicit store-backed evaluator.
+impl TypeResolver for QueryCache<'_> {
+    fn resolver_generation(&self) -> u64 {
+        if !inst_resolver_rereduce_enabled() {
+            return 0;
+        }
+        self.definition_store
+            .map_or(0, crate::DefinitionStore::generation)
+    }
+
+    fn resolve_ref(&self, _symbol: SymbolRef, _interner: &dyn TypeDatabase) -> Option<TypeId> {
+        None
+    }
+
+    fn resolve_lazy(&self, def_id: DefId, _interner: &dyn TypeDatabase) -> Option<TypeId> {
+        if !inst_resolver_rereduce_enabled() {
+            return None;
+        }
+        self.definition_store?.get_body(def_id)
+    }
+
+    fn resolve_lazy_lookup_only(
+        &self,
+        def_id: DefId,
+        interner: &dyn TypeDatabase,
+    ) -> Option<TypeId> {
+        self.resolve_lazy(def_id, interner)
+    }
+
+    fn get_lazy_type_params(&self, def_id: DefId) -> Option<Vec<TypeParamInfo>> {
+        if !inst_resolver_rereduce_enabled() {
+            return None;
+        }
+        self.definition_store?.get_type_params(def_id)
+    }
+
+    fn get_boxed_type(&self, kind: IntrinsicKind) -> Option<TypeId> {
+        self.interner.get_boxed_type(kind)
+    }
+
+    fn get_array_base_type(&self) -> Option<TypeId> {
+        self.interner.get_array_base_type()
+    }
+
+    fn get_array_base_type_params(&self) -> &[TypeParamInfo] {
+        self.interner.get_array_base_type_params()
+    }
+
+    fn get_readonly_array_base_type(&self) -> Option<TypeId> {
+        self.interner.get_readonly_array_base_type()
+    }
+
+    /// Resolve `DefId` identity/metadata through the attached `DefinitionStore`.
+    ///
+    /// The `QueryCache` is the `&dyn QueryDatabase` resolver used by generic-call
+    /// inference. Historically it had NO `DefinitionStore`, so these `DefId`-keyed
+    /// resolver methods silently returned trait defaults in inference: the
+    /// `shared_application_base_def_id` cross-arena base unification (via
+    /// `defs_are_equivalent` declaration-site/`SymbolId` equality) and the
+    /// variance-computation paths that depend on them were dead, leaving
+    /// cross-arena generic-call inference unable to pair type-args (issue #14344;
+    /// the fp-ts `unknown`-widening FP family). Wiring the store re-enables them.
+    ///
+    /// Gated behind `TSZ_XARENA_BASE_DECL` (default-OFF) so flag-OFF stays
+    /// byte-parity with the historical store-less behavior until the change is
+    /// proven on full conformance.
+    fn def_to_symbol_id(&self, def_id: DefId) -> Option<SymbolId> {
+        if !crate::inference::xarena_base::xarena_base_decl_enabled() {
+            return None;
+        }
+        self.definition_store?.get_symbol_id(def_id).map(SymbolId)
+    }
+
+    fn get_def_kind(&self, def_id: DefId) -> Option<crate::def::DefKind> {
+        if !crate::inference::xarena_base::xarena_base_decl_enabled() {
+            return None;
+        }
+        self.definition_store?.get_kind(def_id)
+    }
+
+    fn get_def_name(&self, def_id: DefId) -> Option<tsz_common::interner::Atom> {
+        if !crate::inference::xarena_base::xarena_base_decl_enabled() {
+            return None;
+        }
+        self.definition_store?.get(def_id).map(|info| info.name)
+    }
+
+    fn canonical_def_id(&self, def_id: DefId) -> DefId {
+        if !crate::inference::xarena_base::xarena_base_decl_enabled() {
+            return def_id;
+        }
+        self.definition_store
+            .map_or(def_id, |store| store.canonical_def_id(def_id))
+    }
+
+    fn defs_are_equivalent(&self, a: DefId, b: DefId) -> bool {
+        if a == b {
+            return true;
+        }
+        if !crate::inference::xarena_base::xarena_base_decl_enabled() {
+            return false;
+        }
+        let Some(store) = self.definition_store else {
+            return false;
+        };
+        store.defs_have_same_decl_site(a, b)
+            || store
+                .get_symbol_id(a)
+                .zip(store.get_symbol_id(b))
+                .is_some_and(|(sa, sb)| sa == sb)
+    }
+
+    fn canonical_decl_site_def_for_symbol(&self, symbol: SymbolRef) -> Option<DefId> {
+        self.definition_store?
+            .canonical_decl_site_def_for_symbol(symbol.0)
+    }
+}

--- a/crates/tsz-solver/src/caches/query_cache_evaluation.rs
+++ b/crates/tsz-solver/src/caches/query_cache_evaluation.rs
@@ -4,11 +4,17 @@ use crate::caches::db::TypeDatabase;
 use crate::caches::query_cache::QueryCache;
 use crate::def::resolver::NoopResolver;
 use crate::evaluation::evaluate::TypeEvaluator;
+use crate::instantiation::instantiate::flags::inst_resolver_rereduce_enabled;
 
 /// A `query_db`-backed evaluator: a `TypeEvaluator` with the `NoopResolver`
 /// (matching `evaluate_type_with_options`) whose cross-call caches are wired to
 /// a `QueryCache`. See [`QueryCache::query_backed_evaluator`].
 pub(crate) type QueryBackedEvaluator<'a> = TypeEvaluator<'a, NoopResolver>;
+
+/// A resolver-backed query evaluator for the dormant instantiation re-reduce
+/// path. It may read the resolver-independent application cache but must not
+/// write resolver-dependent answers into it.
+pub(crate) type StoreBackedQueryEvaluator<'eval, 'cache> = TypeEvaluator<'eval, QueryCache<'cache>>;
 
 impl<'a> QueryCache<'a> {
     /// Build a `TypeEvaluator` wired to this cache's cross-call instantiation
@@ -26,5 +32,21 @@ impl<'a> QueryCache<'a> {
     /// caching behavior changes, never the computed result.
     pub(crate) fn query_backed_evaluator(&self) -> QueryBackedEvaluator<'_> {
         TypeEvaluator::new(self as &dyn TypeDatabase).with_query_db(self)
+    }
+
+    /// Build a resolver-backed evaluator only when the staged
+    /// instantiation-time re-reduce gate is active and this cache carries a
+    /// shared `DefinitionStore`.
+    pub(crate) fn store_backed_rereduce_evaluator<'eval>(
+        &'eval self,
+    ) -> Option<StoreBackedQueryEvaluator<'eval, 'a>> {
+        if !inst_resolver_rereduce_enabled() || !self.has_definition_store() {
+            return None;
+        }
+        Some(
+            TypeEvaluator::with_resolver(self as &dyn TypeDatabase, self)
+                .with_query_db(self)
+                .with_limited_resolver(),
+        )
     }
 }

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -1087,7 +1087,7 @@ mod api;
 mod cache_stability;
 mod conditional;
 mod display_properties;
-mod flags;
+pub(crate) mod flags;
 mod homomorphic;
 mod indexed;
 mod mapped;

--- a/crates/tsz-solver/src/instantiation/instantiate/flags.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/flags.rs
@@ -40,11 +40,11 @@ impl Drop for InstResolverRereduceFlagGuard {
 ///
 /// When `TSZ_INST_RESOLVER_REREDUCE=1`, the instantiator keeps the
 /// resolver-aware [`QueryDatabase`](crate::caches::db::QueryDatabase) it was
-/// handed and, at the deferred-leak
-/// sites, re-runs reduction through that resolver once the base/check became
-/// concrete. The flag stays OFF until the materialize-once stages provide the
-/// fully published bodies those reductions need.
-pub(super) fn inst_resolver_rereduce_enabled() -> bool {
+/// handed and, at the deferred-leak sites, re-runs reduction through that
+/// resolver once the base/check became concrete. The flag stays OFF until the
+/// materialize-once stages provide the fully published bodies those reductions
+/// need.
+pub(crate) fn inst_resolver_rereduce_enabled() -> bool {
     #[cfg(test)]
     if let Some(enabled) = INST_RESOLVER_REREDUCE_TEST_OVERRIDE.with(std::cell::Cell::get) {
         return enabled;


### PR DESCRIPTION
Goal: green

## Summary
- Add a flag-gated, store-backed `QueryCache` evaluator for query re-reduce entry points while keeping the default `NoopResolver` query evaluator unchanged.
- Teach the `QueryCache` resolver to read published `DefinitionStore` lazy bodies/type params only when `TSZ_INST_RESOLVER_REREDUCE=1`, and keep symbol refs unresolved.
- Reuse the landed `instantiate/flags.rs` gate from #15127 so solver cache code and instantiation share the same staged flag/test override.
- Add regression coverage proving flag-OFF preserves deferred `Lazy` index/keyof results and flag-ON resolves through a published store body.

## Structural Rule
When instantiation/query-backed re-reduce is explicitly enabled and a `QueryCache` carries a shared `DefinitionStore` with a published `Lazy(DefId)` body, `tsc` reduces using the program declaration resolver. `tsz` now routes those query re-reductions through the solver-owned `QueryCache` resolver/store boundary. With the flag off, no store, or no body, `tsz` preserves the historical resolver-less deferred result.

## Owner Layer
Solver cache/evaluation/instantiation owns this change: `QueryCache`, its `TypeResolver` implementation, query-backed evaluation entry points, and the staged instantiation re-reduce flag. Checker publication, module augmentation producers, diagnostics, emit, and relation policy are unchanged.

## Adjacent Case Matrix
- Flag OFF with a store-published body: `evaluate_index_access` and `evaluate_keyof` keep the historical deferred `Lazy` results.
- Flag ON with a store-published body: query re-reduce resolves the lazy body and computes the concrete index/key result.
- Missing store/body: the store-backed evaluator is not selected, so the existing `NoopResolver` query evaluator remains the fallback.
- Resolver-dependent evaluator: marked limited, so it may read resolver-independent application cache entries but does not write resolver-dependent answers into that cache.
- Existing `TSZ_XARENA_BASE_DECL` metadata behavior stays separately gated; this only adds body/type-param reads for the staged re-reduce gate.

## Fallback
If any precondition is absent, `QueryCache` uses the original `query_backed_evaluator()` path. That path still uses `NoopResolver`, preserving cache-only behavior and keeping resolver-dependent answers out of default eval/application caches.

## Overlap
Rebased over #15127 after its `instantiate/flags.rs` split landed on `main`; the instantiation diff is now limited to crate-visible flag access, while this PR owns the `QueryCache` store-backed resolver/evaluator consumer. It avoids checker env publication/module augmentation, constraint walker, property-cache, union-normalize, widening, and queued guard-state files.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver query_database_store_backed_rereduce_resolves_published_lazy_body query_database_evaluate_entry_points_preserve_results canonical_decl_site_symbol_lookup_uses_shared_store_identity`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `wc -l crates/tsz-solver/src/caches/query_cache.rs crates/tsz-solver/src/caches/query_cache/resolver.rs crates/tsz-solver/src/caches/query_cache_evaluation.rs crates/tsz-solver/src/caches/instantiation_cache_test.rs crates/tsz-solver/src/instantiation/instantiate.rs crates/tsz-solver/src/instantiation/instantiate/flags.rs`

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high
