### PR TITLE
fix(checker): resolve indexed-access keyof through env (#14351)

### DIFF
--- a/crates/tsz-checker/src/tests/ts2536_deferred_conditional_indexed_access_tests.rs
+++ b/crates/tsz-checker/src/tests/ts2536_deferred_conditional_indexed_access_tests.rs
@@ -51,6 +51,25 @@ type First<U extends ReadonlyArray<unknown>> = Cond<U>["head"][0];
     );
 }
 
+/// Named branch aliases still contribute their tuple members to the apparent
+/// key space; raw resolverless `keyof` used to see the `Lazy(DefId)` branches as
+/// unresolved and reject the outer `length` key.
+#[test]
+fn nested_aliased_branch_deferred_conditional_length_index_does_not_emit_ts2536() {
+    let codes = check_source_codes(
+        r#"
+type PresentPart = { bucket: [1, 2] };
+type FallbackPart = { bucket: [3] };
+type Branches<Item> = Item extends string ? PresentPart : FallbackPart;
+type Len<Item> = Branches<Item>["bucket"]["length"];
+"#,
+    );
+    assert!(
+        !codes.contains(&2536),
+        "TS2536 should not fire for aliased branch tuple `length`: {codes:?}"
+    );
+}
+
 /// Inline deferred conditional (no alias indirection) — same acceptance for an
 /// array method key.
 #[test]

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/deferred_conditional_index.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/deferred_conditional_index.rs
@@ -66,7 +66,7 @@ impl<'a> CheckerState<'a> {
         {
             return false;
         }
-        let keyof_constraint = self.ctx.types.evaluate_keyof(base_constraint);
+        let keyof_constraint = self.indexed_access_keyof_with_env(base_constraint);
         // The key space itself must be concrete (not a deferred `keyof T`) for a
         // concrete-literal index validation to be meaningful.
         if crate::query_boundaries::common::is_keyof_type(self.ctx.types, keyof_constraint) {
@@ -181,7 +181,7 @@ impl<'a> CheckerState<'a> {
         else {
             return false;
         };
-        let keyof_apparent = self.ctx.types.evaluate_keyof(apparent);
+        let keyof_apparent = self.indexed_access_keyof_with_env(apparent);
         if crate::query_boundaries::common::is_keyof_type(self.ctx.types, keyof_apparent) {
             return false;
         }

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/error_contagion.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/error_contagion.rs
@@ -60,7 +60,7 @@ impl CheckerState<'_> {
         if evaluated_constraint == TypeId::ERROR || evaluated_constraint == TypeId::ANY {
             return false;
         }
-        let keyof = self.ctx.types.evaluate_keyof(evaluated_constraint);
+        let keyof = self.indexed_access_keyof_with_env(evaluated_constraint);
         if !self.indexed_access_key_space_is_resolved(keyof) {
             return false;
         }
@@ -280,10 +280,11 @@ impl CheckerState<'_> {
             // Every branch is error-typed -> universal key space -> any key valid.
             return Some(true);
         }
-        // `evaluate_keyof` over the union of the concrete branches already computes
-        // their key-space intersection.
+        // `keyof` over the union of the concrete branches already computes their
+        // key-space intersection; use the checker resolver so named branches
+        // contribute their resolved members.
         let concrete_union = self.ctx.types.union(concrete);
-        let keyof_concrete = self.ctx.types.evaluate_keyof(concrete_union);
+        let keyof_concrete = self.indexed_access_keyof_with_env(concrete_union);
         if !self.indexed_access_key_space_is_resolved(keyof_concrete) {
             return None;
         }

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -176,13 +176,25 @@ impl<'a> CheckerState<'a> {
 
     /// Whether a `keyof` result is a concrete key space rather than a still-deferred
     /// `keyof`. Used to decide whether a deferred conditional's apparent constraint
-    /// has a usable key space for indexed-access validation. `evaluate_keyof` only
-    /// leaves a deferred operator (its `Conditional` arm re-wraps as `KeyOf`, never
-    /// a bare conditional/application), so guarding `ERROR`/`ANY`/`KeyOf` suffices.
+    /// has a usable key space for indexed-access validation. Key-space callers
+    /// should compute the result through [`Self::indexed_access_keyof_with_env`]
+    /// so `Lazy(DefId)` operands are resolved before `keyof` is classified.
     pub(super) fn indexed_access_key_space_is_resolved(&self, keyof_result: TypeId) -> bool {
         !(keyof_result == TypeId::ERROR
             || keyof_result == TypeId::ANY
             || crate::query_boundaries::common::is_keyof_type(self.ctx.types, keyof_result))
+    }
+
+    /// Compute `keyof operand` through the checker's resolver-backed evaluator.
+    ///
+    /// Raw `ctx.types.evaluate_keyof` uses a resolverless evaluator; for indexed
+    /// access validation that can make `Lazy(DefId)` object members inside
+    /// deferred/apparent constraints look empty. Routing through
+    /// `evaluate_type_with_env` keeps the solver-owned `keyof` semantics while
+    /// giving the evaluator the checker resolver environment.
+    pub(super) fn indexed_access_keyof_with_env(&mut self, operand: TypeId) -> TypeId {
+        let keyof = self.ctx.types.factory().keyof(operand);
+        self.evaluate_type_with_env(keyof)
     }
 
     /// TS4105: Emit "Private or protected member '{name}' cannot be accessed on
@@ -1206,7 +1218,7 @@ impl<'a> CheckerState<'a> {
         let Some(value_union) = self.generic_tuple_chain_value_type(object_type_node_idx) else {
             return false;
         };
-        let value_keyof = self.ctx.types.evaluate_keyof(value_union);
+        let value_keyof = self.indexed_access_keyof_with_env(value_union);
 
         let mut outer_index_constraint = crate::query_boundaries::common::type_parameter_constraint(
             self.ctx.types,
@@ -1427,7 +1439,7 @@ impl<'a> CheckerState<'a> {
             {
                 let extends_type = self.get_type_from_type_node(cond.extends_type);
                 let extends_type = self.evaluate_type_with_env(extends_type);
-                let keyof_extends = self.ctx.types.evaluate_keyof(extends_type);
+                let keyof_extends = self.indexed_access_keyof_with_env(extends_type);
                 if self
                     .indexed_access_key_space_relation_outcome(index_type_for_check, keyof_extends)
                     .related
@@ -1477,7 +1489,7 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::mapped_type_id(self.ctx.types, base_type)
         {
             let mapped = self.ctx.types.mapped_type(mapped_id);
-            let template_keyof = self.ctx.types.evaluate_keyof(mapped.template);
+            let template_keyof = self.indexed_access_keyof_with_env(mapped.template);
             return self
                 .indexed_access_key_space_relation_outcome(index_type, template_keyof)
                 .related;
@@ -1493,13 +1505,13 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let key_space = self.ctx.types.evaluate_keyof(constraint);
+        let key_space = self.indexed_access_keyof_with_env(constraint);
         let values = self
             .evaluate_type_with_env(self.ctx.types.factory().index_access(constraint, key_space));
         if matches!(values, TypeId::ERROR | TypeId::UNDEFINED) {
             return false;
         }
-        let values_keyof = self.ctx.types.evaluate_keyof(values);
+        let values_keyof = self.indexed_access_keyof_with_env(values);
         self.indexed_access_key_space_relation_outcome(index_type, values_keyof)
             .related
     }
@@ -1743,7 +1755,7 @@ impl<'a> CheckerState<'a> {
 
         let current_base = self.get_type_from_type_node(current_object.object_type);
         let current_index = self.get_type_from_type_node(current_object.index_type);
-        let current_base_keyof = self.ctx.types.evaluate_keyof(current_base);
+        let current_base_keyof = self.indexed_access_keyof_with_env(current_base);
         let current_index_for_check = self.evaluate_type_with_env(current_index);
         !self
             .indexed_access_key_space_relation_outcome(current_index_for_check, current_base_keyof)

--- a/crates/tsz-checker/tests/deferred_conditional_indexed_access_tests.rs
+++ b/crates/tsz-checker/tests/deferred_conditional_indexed_access_tests.rs
@@ -60,6 +60,18 @@ fn renamed_binders_index_into_deferred_conditional_is_valid() {
 }
 
 #[test]
+fn aliased_branch_index_into_deferred_conditional_is_valid() {
+    // The branch results are named aliases, so the conditional branch-union key
+    // space contains `Lazy(DefId)` members. `keyof` must resolve those aliases
+    // before validating the index key.
+    let src = "type LeftChoice = { shared: 1; leftOnly: 1 };\n\
+               type RightChoice = { shared: 2; rightOnly: 2 };\n\
+               type Choice<Input> = Input extends string ? LeftChoice : RightChoice;\n\
+               type Shared<Subject> = Choice<Subject>['shared'];";
+    assert_eq!(count(src, 2536), 0, "no TS2536 expected: {:?}", codes(src));
+}
+
+#[test]
 fn non_distributive_conditional_index_is_valid() {
     // `[T] extends [string]` is non-distributive; the branch-union rule still
     // applies.
@@ -122,6 +134,15 @@ fn key_in_only_one_branch_still_reports_ts2536() {
     // member keys) excludes it, matching tsc.
     let src = "type C<T> = T extends string ? { x: 1; y: 2 } : { x: 3 };\n\
                type Partial1<T> = C<T>['y'];";
+    assert_eq!(count(src, 2536), 1, "TS2536 expected: {:?}", codes(src));
+}
+
+#[test]
+fn aliased_branch_key_in_only_one_branch_still_reports_ts2536() {
+    let src = "type WithExtra = { shared: 1; extra: 1 };\n\
+               type WithoutExtra = { shared: 2 };\n\
+               type PickBranch<Source> = Source extends string ? WithExtra : WithoutExtra;\n\
+               type Bad<Other> = PickBranch<Other>['extra'];";
     assert_eq!(count(src, 2536), 1, "TS2536 expected: {:?}", codes(src));
 }
 


### PR DESCRIPTION
Goal: green

## Summary
- route checker indexed-access key-space `keyof` computations through the resolver-backed checker evaluation boundary
- apply the resolver-backed path to deferred conditional branch-union/apparent constraints and error-contagion concrete branch key spaces
- add named alias branch regressions for first-level and nested deferred conditional indexed access

## Structural Rule
When checker validates `T[K]` key space after resolving deferred conditional/apparent/constraint shapes, `tsc` computes keys from the resolved structural members. tsz now computes `keyof` through the checker resolver environment via `indexed_access_keyof_with_env`, not raw resolverless `ctx.types.evaluate_keyof`, so `Lazy(DefId)` branch members contribute their keys.

Owner layer: checker indexed-access orchestration owns the routing. Key-space semantics remain solver-owned through the existing resolver-backed evaluator boundary. No solver cache, module augmentation, or emitter work is touched.

## Adjacent Matrix
- Named alias branch shared key: accepted, no TS2536.
- Named alias key present in only one branch: still TS2536.
- Nested `Cond<T>["part"]["length"]` with aliased tuple branches: accepted.
- Existing deferred conditional and string-index/keyof suites remain green.

## Verification
- cargo fmt --all
- cargo fmt --all --check
- git diff --check
- scripts/safe-run.sh cargo nextest run -p tsz-checker --test deferred_conditional_indexed_access_tests
- scripts/safe-run.sh cargo nextest run -p tsz-checker --lib ts2536_deferred_conditional_indexed_access_tests
- scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts2536_keyof_string_index_signature_tests
- scripts/safe-run.sh cargo check -p tsz-checker
- python3 scripts/arch/arch_guard.py --json
- scripts/arch/check-checker-boundaries.sh
- wc -l crates/tsz-checker/src/types/type_checking/indexed_access/deferred_conditional_index.rs crates/tsz-checker/src/types/type_checking/indexed_access/error_contagion.rs crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs crates/tsz-checker/tests/deferred_conditional_indexed_access_tests.rs crates/tsz-checker/src/tests/ts2536_deferred_conditional_indexed_access_tests.rs

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high
