### PR TITLE
fix(checker): route semantic body consumers through resolver (#14351)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_eval.rs
+++ b/crates/tsz-checker/src/assignability/assignability_eval.rs
@@ -15,7 +15,7 @@ impl<'a> CheckerState<'a> {
         {
             return None;
         }
-        let body = self.ctx.definition_store.get_body(def_id)?;
+        let body = self.ctx.get_semantic_def_body(def_id)?;
         if body == TypeId::ERROR || body == TypeId::ANY || body == type_id {
             return None;
         }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1480,6 +1480,9 @@ mod self_referential_arrow_property_soundness_tests;
 #[path = "tests/self_referential_conditional_infer_soundness_tests.rs"]
 mod self_referential_conditional_infer_soundness_tests;
 #[cfg(test)]
+#[path = "tests/semantic_def_body_read_arch_tests.rs"]
+mod semantic_def_body_read_arch_tests;
+#[cfg(test)]
 #[path = "tests/shadowed_type_param_identity_tests.rs"]
 mod shadowed_type_param_identity_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
@@ -24,7 +24,7 @@ impl<'a> CheckerState<'a> {
         if def.kind != tsz_solver::def::DefKind::TypeAlias || !def.type_params.is_empty() {
             return resolved_target;
         }
-        let Some(body) = def.body else {
+        let Some(body) = self.ctx.get_semantic_def_body(def_id).or(def.body) else {
             return resolved_target;
         };
         if query::union_members(self.ctx.types, body).is_some() {
@@ -50,7 +50,7 @@ impl<'a> CheckerState<'a> {
         if outer_members.contains(&lazy_candidate) {
             return true;
         }
-        let body = self.ctx.definition_store.get_body(def_id);
+        let body = self.ctx.get_semantic_def_body(def_id);
         outer_members.iter().any(|&m| {
             body == Some(m)
                 || self.ctx.definition_store.find_def_for_type(m) == Some(def_id)
@@ -164,7 +164,7 @@ impl<'a> CheckerState<'a> {
             return Some(target);
         }
         if let Some(def_id) = crate::query_boundaries::common::lazy_def_id(self.ctx.types, target)
-            && let Some(body) = self.ctx.definition_store.get_body(def_id)
+            && let Some(body) = self.ctx.get_semantic_def_body(def_id)
             && is_intersection(body)
         {
             return Some(body);
@@ -198,7 +198,7 @@ impl<'a> CheckerState<'a> {
             return nested_target;
         };
 
-        let Some(body) = self.ctx.definition_store.get_body(def_id) else {
+        let Some(body) = self.ctx.get_semantic_def_body(def_id) else {
             return nested_target;
         };
 

--- a/crates/tsz-checker/src/state/type_resolution/reference_type_params.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_type_params.rs
@@ -68,7 +68,7 @@ impl CheckerState<'_> {
             .try_borrow()
             .ok()
             .and_then(|env| env.get_def(def_id))
-            .or_else(|| self.ctx.definition_store.get_body(def_id))
+            .or_else(|| self.ctx.get_semantic_def_body(def_id))
         else {
             return false;
         };

--- a/crates/tsz-checker/src/tests/semantic_def_body_read_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/semantic_def_body_read_arch_tests.rs
@@ -1,0 +1,21 @@
+use std::fs;
+
+#[test]
+fn semantic_def_body_consumers_use_resolver_adapter() {
+    for path in [
+        "src/assignability/assignability_eval.rs",
+        "src/state/state_checking/property/excess_property_tail.rs",
+        "src/state/type_resolution/reference_type_params.rs",
+    ] {
+        let source = fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("failed to read {path} for architecture guard: {err}"));
+        assert!(
+            !source.contains("definition_store.get_body"),
+            "{path} should use CheckerContext::get_semantic_def_body for semantic body reads"
+        );
+        assert!(
+            source.contains("get_semantic_def_body("),
+            "{path} should route semantic DefId body reads through the resolver adapter"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/hkt_cross_file_augmentation_13653_repro.rs
+++ b/crates/tsz-checker/tests/hkt_cross_file_augmentation_13653_repro.rs
@@ -231,6 +231,41 @@ export const wrong: Registry<number>["Widget"] = ["x"];
     );
 }
 
+/// Assignability alias probes can inspect a `Lazy(DefId)` body directly before
+/// relation fallback. With body publication enabled, that probe must see the
+/// augmented registry body so the missing augmented member is still required.
+#[test]
+#[ignore = "requires TSZ_MODULE_AUG_BODY_PUBLISH=1"]
+fn alias_assignability_observes_augmented_registry_body() {
+    let diags = diagnostics(&[
+        (
+            "registry.ts",
+            r#"
+export interface Slots<T> {}
+export type Registry<T> = Slots<T>;
+"#,
+        ),
+        (
+            "widget.ts",
+            r#"
+import { Registry, Slots } from "./registry";
+declare module "./registry" {
+    interface Slots<T> {
+        readonly Widget: ReadonlyArray<T>;
+    }
+}
+export const r: Registry<number> = {};
+"#,
+        ),
+    ]);
+
+    assert_eq!(
+        count_code(&diags, 2741),
+        1,
+        "alias assignability should require the augmented member; got {diags:#?}"
+    );
+}
+
 /// Structural assignability: the cross-file augmented member is REQUIRED, so an
 /// empty object literal assigned to the interface is TS2741 (missing member).
 /// tsz previously accepted this (the augmented member was absent from the


### PR DESCRIPTION
Goal: green

## Summary
- Route checker semantic `DefId` body consumers in assignability, excess-property recursive target recovery, and ambient-depth reference-param checks through `CheckerContext::get_semantic_def_body`.
- Keep metadata/existence checks raw; this PR only changes places that structurally consume the body `TypeId`.
- Add a source guard preventing these audited consumers from drifting back to raw `DefinitionStore::get_body` reads.
- Add an alias-assignability HKT witness for the flag-on module-augmentation body publication path.

## Structural Rule
When checker semantic consumers inspect a `Lazy(DefId)` body for assignability, excess-property target recovery, recursive-member detection, or reference-param ambient-depth ownership, tsc observes the body that the semantic resolver would expose at that program point. tsz should read that body through the checker resolver adapter and solver-owned `DefinitionStore` publication boundary, not by directly consuming the raw stored body.

## Owner Layer
Owner: checker resolver adapter plus solver definition-store body publication. The checker sites remain orchestration and diagnostic helpers; the augmented-body predicate and default/off fallback remain owned by `DefinitionStore` and `CheckerContext::get_semantic_def_body` from #15131.

## Adjacent Case Matrix
- Alias assignability against an augmented registry requires the published augmented member when `TSZ_MODULE_AUG_BODY_PUBLISH=1`.
- Direct and alias-wrapped indexed access witnesses from #15131 still observe the augmented body.
- Default HKT augmentation coverage remains green with the flag-only witnesses skipped.
- Excess-property recursive target helpers and ambient-depth checks are source-guarded to consume semantic bodies through the resolver adapter.
- Metadata/existence-only definition-store reads outside this audited set stay raw.

## Fallback
If body publication is disabled, no augmented body exists, or a `DefId` has no body, `get_semantic_def_body` preserves the raw/default fallback from #15131. Existing assignability and excess-property fallback behavior remains unchanged for unresolved/error/any bodies.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker semantic_def_body_consumers_use_resolver_adapter`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test hkt_cross_file_augmentation_13653_repro`
- `TSZ_MODULE_AUG_BODY_PUBLISH=1 TSZ_MODULE_AUG_SYMBOL_EDGE=1 scripts/safe-run.sh cargo nextest run -p tsz-checker --test hkt_cross_file_augmentation_13653_repro --run-ignored ignored-only -E 'test(direct_literal_indexed_access_observes_augmented_registry_body) or test(alias_wrapped_indexed_access_observes_augmented_registry_body) or test(alias_assignability_observes_augmented_registry_body)'`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter 'compiler/inferentialTypingWithFunctionTypeZip.ts' --verbose --workers 1`
- `wc -l crates/tsz-checker/src/assignability/assignability_eval.rs crates/tsz-checker/src/lib.rs crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs crates/tsz-checker/src/state/type_resolution/reference_type_params.rs crates/tsz-checker/src/tests/semantic_def_body_read_arch_tests.rs crates/tsz-checker/tests/hkt_cross_file_augmentation_13653_repro.rs`

## Provenance
Machine: studio
Assistant: codex
Model: gpt-5
Effort: high
