### PR TITLE
refactor(checker): name lazy resolution guard states (#14346)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -701,6 +701,9 @@ impl<'a> CheckerState<'a> {
             global_resolution_fuel_exhausted, increment_global_resolution_fuel,
             increment_refs_resolution_fuel, refs_resolution_fuel_exhausted,
         };
+        use crate::state_domain::type_environment::lazy_guard_state::{
+            RefsResolutionWorkState, refs_resolution_work_state,
+        };
 
         if self.ctx.refs_resolved.contains(&type_id) {
             return;
@@ -717,8 +720,10 @@ impl<'a> CheckerState<'a> {
         let mut worklist = vec![type_id];
 
         while let Some(current) = worklist.pop() {
-            if refs_resolution_fuel_exhausted() {
-                break;
+            match refs_resolution_work_state(refs_resolution_fuel_exhausted(), false) {
+                RefsResolutionWorkState::Continue => {}
+                RefsResolutionWorkState::RefsFuelExhausted
+                | RefsResolutionWorkState::GlobalFuelExhausted => break,
             }
 
             if !visited_types.insert(current) {
@@ -745,8 +750,10 @@ impl<'a> CheckerState<'a> {
             }
 
             for &def_id in self.ctx.collect_lazy_def_ids_cached(current).iter() {
-                if refs_resolution_fuel_exhausted() {
-                    break;
+                match refs_resolution_work_state(refs_resolution_fuel_exhausted(), false) {
+                    RefsResolutionWorkState::Continue => {}
+                    RefsResolutionWorkState::RefsFuelExhausted
+                    | RefsResolutionWorkState::GlobalFuelExhausted => break,
                 }
                 if !visited_def_ids.insert(def_id) {
                     continue;
@@ -785,7 +792,11 @@ impl<'a> CheckerState<'a> {
                     worklist.push(result);
                 }
                 if at_fuel_limit {
-                    break;
+                    match refs_resolution_work_state(false, at_fuel_limit) {
+                        RefsResolutionWorkState::GlobalFuelExhausted
+                        | RefsResolutionWorkState::RefsFuelExhausted => break,
+                        RefsResolutionWorkState::Continue => {}
+                    }
                 }
             }
         }

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -10,6 +10,11 @@ use crate::state::CheckerState;
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_solver::TypeId;
 
+use super::lazy_guard_state::{
+    ApplicationResolutionEntryState, ApplicationResolutionWorkState, EvalEnvEntryState,
+    application_resolution_entry_state, application_resolution_local_fuel_state,
+    application_resolution_post_consume_state, eval_env_entry_state,
+};
 use super::property_access_visited::PropertyAccessVisited;
 use crate::query_boundaries::state::type_environment::{
     CacheEntryCollection, EvaluateTypeWithCacheOptions, for_each_direct_referenced_type,
@@ -55,6 +60,8 @@ const MAX_APP_SYMBOL_RESOLUTION_FUEL: u32 = 200;
 // Maximum total `DefId` resolutions across recursive `ensure_refs_resolved`
 // invocations within one top-level call.
 const MAX_REFS_RESOLUTION_FUEL: u32 = 2000;
+
+const MAX_EVAL_ENV_DEPTH: u32 = 5;
 
 /// Check if refs resolution fuel is exhausted.
 pub(crate) fn refs_resolution_fuel_exhausted() -> bool {
@@ -122,10 +129,10 @@ impl CheckerState<'_> {
         // (e.g., react + create-emotion-styled). Uses thread-local counter
         // because cross-arena delegation resets per-context counters.
         let eval_depth = EVAL_ENV_DEPTH.get();
-        if eval_depth >= 5 {
-            return type_id;
+        match eval_env_entry_state(eval_depth, MAX_EVAL_ENV_DEPTH) {
+            EvalEnvEntryState::DepthExceeded => return type_id,
+            EvalEnvEntryState::Entered { depth } => EVAL_ENV_DEPTH.set(depth),
         }
-        EVAL_ENV_DEPTH.set(eval_depth + 1);
 
         // Set this_type on the TypeEnvironment so the evaluator can resolve `keyof this`
         // and similar constructs that depend on the enclosing class type.
@@ -1368,30 +1375,31 @@ impl CheckerState<'_> {
     pub(crate) fn ensure_application_symbols_resolved(&mut self, type_id: TypeId) {
         use rustc_hash::FxHashSet;
 
-        if self.ctx.application_symbols_resolved.contains(&type_id) {
-            return;
-        }
-        if !self.ctx.application_symbols_resolution_set.insert(type_id) {
-            return;
-        }
-
-        // Check global fuel first - if exhausted from a previous call, bail immediately.
-        let fuel = APP_SYMBOL_RESOLUTION_FUEL.get();
-        if fuel >= MAX_APP_SYMBOL_RESOLUTION_FUEL {
-            self.ctx.application_symbols_resolution_set.remove(&type_id);
-            return;
-        }
-
-        // Bail out when nested too deeply. Uses thread-local counter because
-        // cross-arena delegation creates child CheckerContexts that would reset
-        // a per-context counter to 0.
+        let already_resolved = self.ctx.application_symbols_resolved.contains(&type_id);
+        let inserted_active_visit = if already_resolved {
+            true
+        } else {
+            self.ctx.application_symbols_resolution_set.insert(type_id)
+        };
         let depth = APP_SYMBOL_RESOLUTION_DEPTH.get();
-        if depth >= MAX_APP_SYMBOL_RESOLUTION_DEPTH {
-            self.ctx.application_symbols_resolution_set.remove(&type_id);
-            return;
-        }
-
-        let is_outermost = depth == 0;
+        let entry_state = application_resolution_entry_state(
+            already_resolved,
+            inserted_active_visit,
+            APP_SYMBOL_RESOLUTION_FUEL.get(),
+            MAX_APP_SYMBOL_RESOLUTION_FUEL,
+            depth,
+            MAX_APP_SYMBOL_RESOLUTION_DEPTH,
+        );
+        let is_outermost = match entry_state {
+            ApplicationResolutionEntryState::Entered { outermost } => outermost,
+            ApplicationResolutionEntryState::AlreadyResolved
+            | ApplicationResolutionEntryState::AlreadyVisiting => return,
+            ApplicationResolutionEntryState::FuelExhausted
+            | ApplicationResolutionEntryState::DepthExceeded => {
+                self.ctx.application_symbols_resolution_set.remove(&type_id);
+                return;
+            }
+        };
         if is_outermost {
             // Reset fuel for each top-level resolution
             APP_SYMBOL_RESOLUTION_FUEL.set(0);
@@ -1631,9 +1639,16 @@ impl CheckerState<'_> {
         while let Some(current) = worklist.pop() {
             // Check global fuel - bail if exhausted (prevents unbounded work
             // on deeply-nested generic type graphs like react16.d.ts).
-            if APP_SYMBOL_RESOLUTION_FUEL.get() >= MAX_APP_SYMBOL_RESOLUTION_FUEL {
-                fully_resolved = false;
-                break;
+            match application_resolution_local_fuel_state(
+                APP_SYMBOL_RESOLUTION_FUEL.get(),
+                MAX_APP_SYMBOL_RESOLUTION_FUEL,
+            ) {
+                ApplicationResolutionWorkState::Continue => {}
+                ApplicationResolutionWorkState::LocalFuelExhausted
+                | ApplicationResolutionWorkState::GlobalFuelExhausted => {
+                    fully_resolved = false;
+                    break;
+                }
             }
 
             if !seen_types.insert(current) {
@@ -1663,9 +1678,14 @@ impl CheckerState<'_> {
                 // Consume fuel for each DefId resolution (the expensive part)
                 APP_SYMBOL_RESOLUTION_FUEL.set(APP_SYMBOL_RESOLUTION_FUEL.get() + 1);
                 increment_global_resolution_fuel();
-                if global_resolution_fuel_exhausted() {
-                    fully_resolved = false;
-                    break;
+                match application_resolution_post_consume_state(global_resolution_fuel_exhausted())
+                {
+                    ApplicationResolutionWorkState::Continue => {}
+                    ApplicationResolutionWorkState::GlobalFuelExhausted
+                    | ApplicationResolutionWorkState::LocalFuelExhausted => {
+                        fully_resolved = false;
+                        break;
+                    }
                 }
 
                 match self.resolve_lazy_def_for_type_env(def_id) {
@@ -1703,9 +1723,14 @@ impl CheckerState<'_> {
                 // Consume fuel for enum resolution too
                 APP_SYMBOL_RESOLUTION_FUEL.set(APP_SYMBOL_RESOLUTION_FUEL.get() + 1);
                 increment_global_resolution_fuel();
-                if global_resolution_fuel_exhausted() {
-                    fully_resolved = false;
-                    break;
+                match application_resolution_post_consume_state(global_resolution_fuel_exhausted())
+                {
+                    ApplicationResolutionWorkState::Continue => {}
+                    ApplicationResolutionWorkState::GlobalFuelExhausted
+                    | ApplicationResolutionWorkState::LocalFuelExhausted => {
+                        fully_resolved = false;
+                        break;
+                    }
                 }
 
                 match self.resolve_enum_def_for_type_env(def_id) {
@@ -1746,9 +1771,14 @@ impl CheckerState<'_> {
                 // Consume fuel for type query resolution
                 APP_SYMBOL_RESOLUTION_FUEL.set(APP_SYMBOL_RESOLUTION_FUEL.get() + 1);
                 increment_global_resolution_fuel();
-                if global_resolution_fuel_exhausted() {
-                    fully_resolved = false;
-                    break;
+                match application_resolution_post_consume_state(global_resolution_fuel_exhausted())
+                {
+                    ApplicationResolutionWorkState::Continue => {}
+                    ApplicationResolutionWorkState::GlobalFuelExhausted
+                    | ApplicationResolutionWorkState::LocalFuelExhausted => {
+                        fully_resolved = false;
+                        break;
+                    }
                 }
 
                 let resolved = if symbol.as_ref().is_some_and(|s| {

--- a/crates/tsz-checker/src/state/type_environment/lazy_guard_state.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy_guard_state.rs
@@ -1,0 +1,180 @@
+//! Named checker-side lazy-resolution guard states.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ApplicationResolutionEntryState {
+    AlreadyResolved,
+    AlreadyVisiting,
+    FuelExhausted,
+    DepthExceeded,
+    Entered { outermost: bool },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ApplicationResolutionWorkState {
+    Continue,
+    LocalFuelExhausted,
+    GlobalFuelExhausted,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RefsResolutionWorkState {
+    Continue,
+    RefsFuelExhausted,
+    GlobalFuelExhausted,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EvalEnvEntryState {
+    Entered { depth: u32 },
+    DepthExceeded,
+}
+
+pub(crate) const fn application_resolution_entry_state(
+    already_resolved: bool,
+    inserted_active_visit: bool,
+    fuel: u32,
+    max_fuel: u32,
+    depth: u32,
+    max_depth: u32,
+) -> ApplicationResolutionEntryState {
+    if already_resolved {
+        return ApplicationResolutionEntryState::AlreadyResolved;
+    }
+    if !inserted_active_visit {
+        return ApplicationResolutionEntryState::AlreadyVisiting;
+    }
+    if fuel >= max_fuel {
+        return ApplicationResolutionEntryState::FuelExhausted;
+    }
+    if depth >= max_depth {
+        return ApplicationResolutionEntryState::DepthExceeded;
+    }
+    ApplicationResolutionEntryState::Entered {
+        outermost: depth == 0,
+    }
+}
+
+pub(crate) const fn application_resolution_local_fuel_state(
+    fuel: u32,
+    max_fuel: u32,
+) -> ApplicationResolutionWorkState {
+    if fuel >= max_fuel {
+        ApplicationResolutionWorkState::LocalFuelExhausted
+    } else {
+        ApplicationResolutionWorkState::Continue
+    }
+}
+
+pub(crate) const fn application_resolution_post_consume_state(
+    global_fuel_exhausted: bool,
+) -> ApplicationResolutionWorkState {
+    if global_fuel_exhausted {
+        ApplicationResolutionWorkState::GlobalFuelExhausted
+    } else {
+        ApplicationResolutionWorkState::Continue
+    }
+}
+
+pub(crate) const fn refs_resolution_work_state(
+    refs_fuel_exhausted: bool,
+    global_fuel_exhausted: bool,
+) -> RefsResolutionWorkState {
+    if refs_fuel_exhausted {
+        RefsResolutionWorkState::RefsFuelExhausted
+    } else if global_fuel_exhausted {
+        RefsResolutionWorkState::GlobalFuelExhausted
+    } else {
+        RefsResolutionWorkState::Continue
+    }
+}
+
+pub(crate) const fn eval_env_entry_state(depth: u32, max_depth: u32) -> EvalEnvEntryState {
+    if depth >= max_depth {
+        EvalEnvEntryState::DepthExceeded
+    } else {
+        EvalEnvEntryState::Entered { depth: depth + 1 }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ApplicationResolutionEntryState, ApplicationResolutionWorkState, EvalEnvEntryState,
+        RefsResolutionWorkState, application_resolution_entry_state,
+        application_resolution_local_fuel_state, application_resolution_post_consume_state,
+        eval_env_entry_state, refs_resolution_work_state,
+    };
+
+    #[test]
+    fn application_entry_state_names_every_top_level_cutoff() {
+        assert_eq!(
+            application_resolution_entry_state(true, true, 0, 5, 0, 1),
+            ApplicationResolutionEntryState::AlreadyResolved
+        );
+        assert_eq!(
+            application_resolution_entry_state(false, false, 0, 5, 0, 1),
+            ApplicationResolutionEntryState::AlreadyVisiting
+        );
+        assert_eq!(
+            application_resolution_entry_state(false, true, 5, 5, 0, 1),
+            ApplicationResolutionEntryState::FuelExhausted
+        );
+        assert_eq!(
+            application_resolution_entry_state(false, true, 0, 5, 1, 1),
+            ApplicationResolutionEntryState::DepthExceeded
+        );
+        assert_eq!(
+            application_resolution_entry_state(false, true, 0, 5, 0, 1),
+            ApplicationResolutionEntryState::Entered { outermost: true }
+        );
+        assert_eq!(
+            application_resolution_entry_state(false, true, 0, 5, 1, 2),
+            ApplicationResolutionEntryState::Entered { outermost: false }
+        );
+    }
+
+    #[test]
+    fn application_work_state_names_local_and_global_fuel_cutoffs() {
+        assert_eq!(
+            application_resolution_local_fuel_state(4, 5),
+            ApplicationResolutionWorkState::Continue
+        );
+        assert_eq!(
+            application_resolution_local_fuel_state(5, 5),
+            ApplicationResolutionWorkState::LocalFuelExhausted
+        );
+        assert_eq!(
+            application_resolution_post_consume_state(false),
+            ApplicationResolutionWorkState::Continue
+        );
+        assert_eq!(
+            application_resolution_post_consume_state(true),
+            ApplicationResolutionWorkState::GlobalFuelExhausted
+        );
+    }
+
+    #[test]
+    fn refs_work_state_names_prewalk_cutoffs() {
+        assert_eq!(
+            refs_resolution_work_state(false, false),
+            RefsResolutionWorkState::Continue
+        );
+        assert_eq!(
+            refs_resolution_work_state(true, false),
+            RefsResolutionWorkState::RefsFuelExhausted
+        );
+        assert_eq!(
+            refs_resolution_work_state(false, true),
+            RefsResolutionWorkState::GlobalFuelExhausted
+        );
+    }
+
+    #[test]
+    fn eval_env_entry_state_names_depth_cutoff() {
+        assert_eq!(
+            eval_env_entry_state(4, 5),
+            EvalEnvEntryState::Entered { depth: 5 }
+        );
+        assert_eq!(eval_env_entry_state(5, 5), EvalEnvEntryState::DepthExceeded);
+    }
+}

--- a/crates/tsz-checker/src/state/type_environment/mod.rs
+++ b/crates/tsz-checker/src/state/type_environment/mod.rs
@@ -8,6 +8,7 @@ mod formatting;
 pub(crate) mod lazy;
 mod lazy_flow_mirror;
 mod lazy_fuel;
+pub(crate) mod lazy_guard_state;
 mod lazy_impossible_pruning;
 mod property_access_visited;
 mod source_location;


### PR DESCRIPTION
Goal: green

## Summary
- Add checker-owned `lazy_guard_state` verdicts for lazy-resolution depth, visit, local fuel, refs fuel, and global fuel cutoffs.
- Route `evaluate_type_with_env_impl`, `ensure_application_symbols_resolved`, `ensure_application_symbols_resolved_inner`, and `ensure_refs_resolved` through those named states.
- Keep existing fallback behavior unchanged while making #14346 cutoff ownership testable and explicit.

## Structural Rule
When checker-side lazy resolution reaches a depth, fuel, or active-visit cutoff, `tsc` still proceeds from the best available structural information without turning the cutoff into a semantic predicate. `tsz` now represents those checker-owned resolution cutoffs through `lazy_guard_state` verdicts, while preserving the existing fallback results: opaque root type for eval-depth cutoff, no completed application-symbol memo for incomplete app resolution, and bounded refs prewalk for refs/global-fuel cutoff.

Owner layer: checker lazy-resolution orchestration. This PR does not add checker type-shape semantics, solver internals matching, diagnostic string predicates, user-name/file-name checks, or output surgery.

Adjacent-case matrix:
- Eval env depth guard: `EVAL_ENV_DEPTH >= MAX_EVAL_ENV_DEPTH` is `EvalEnvEntryState::DepthExceeded`; otherwise the entered depth is explicit.
- Application-symbol entry guard: already-resolved, active revisit, local fuel exhausted, depth exceeded, and entered/outermost states are named before side effects proceed.
- Application-symbol worklist guard: local app-symbol fuel and global lazy-resolution fuel produce distinct incomplete-work states.
- Refs prewalk guard: refs-local fuel and global lazy-resolution fuel produce distinct bounded-work states.

Fallback: all call sites retain their previous behavior for each guard: return the input type, skip/clear the active application set, mark app resolution incomplete, or stop the refs worklist. No new cache key, no fixture/name hardcoding, and no relation or diagnostic behavior changes are intended.

Performance: the verdict helpers are `const fn` boolean/counter classification. Runtime cost is the same guard checks expressed through named states; no hot path gains allocation, hashing, or solver calls.

Refs #14346
Refs #14351

## Verification
- Red check: `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib lazy_guard_state` failed before implementation with unresolved `lazy_guard_state` API imports.
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib lazy_guard_state`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib lazy_lib_fuel_determinism_tests dom_fuel_exhaustion_ts2322_tests assignability_eval_memo_tests`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: high
