### PR TITLE
refactor(solver): name type-query traversal states (#14346)

### DIFF
--- a/crates/tsz-solver/src/intern/mod.rs
+++ b/crates/tsz-solver/src/intern/mod.rs
@@ -56,6 +56,13 @@ use crate::def::DefId;
 use crate::types::*;
 
 #[cfg(test)]
+impl TypeInterner {
+    pub(crate) fn readonly_type_fresh_for_test(&self, inner: TypeId) -> TypeId {
+        self.intern_fresh(TypeData::ReadonlyType(inner))
+    }
+}
+
+#[cfg(test)]
 #[path = "../../tests/intern_tests.rs"]
 mod tests;
 

--- a/crates/tsz-solver/src/type_queries/data/accessors.rs
+++ b/crates/tsz-solver/src/type_queries/data/accessors.rs
@@ -15,6 +15,22 @@ use rustc_hash::FxHashSet;
 use std::sync::Arc;
 use tsz_common::Atom;
 
+const MAX_READONLY_UNWRAP_DEPTH: usize = 100;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReadonlyUnwrapDepthState {
+    Continue,
+    LimitExceeded,
+}
+
+const fn readonly_unwrap_depth_state(next_depth: usize) -> ReadonlyUnwrapDepthState {
+    if next_depth > MAX_READONLY_UNWRAP_DEPTH {
+        ReadonlyUnwrapDepthState::LimitExceeded
+    } else {
+        ReadonlyUnwrapDepthState::Continue
+    }
+}
+
 /// Decompose a substitution type into its `(base_type, constraint)` pair.
 ///
 /// Returns `None` when `type_id` is not a `TypeData::Substitution`.
@@ -1591,14 +1607,73 @@ pub fn unwrap_readonly_deep(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
     }
     let mut current = type_id;
     let mut depth = 0;
-    const MAX_DEPTH: usize = 100;
 
     while let Some(TypeData::ReadonlyType(inner)) = db.lookup(current) {
-        depth += 1;
-        if depth > MAX_DEPTH {
-            break;
+        let next_depth = depth + 1;
+        match readonly_unwrap_depth_state(next_depth) {
+            ReadonlyUnwrapDepthState::Continue => {
+                depth = next_depth;
+                current = inner;
+            }
+            ReadonlyUnwrapDepthState::LimitExceeded => break,
         }
-        current = inner;
     }
     current
+}
+
+#[cfg(test)]
+mod readonly_unwrap_depth_state_tests {
+    use super::{
+        MAX_READONLY_UNWRAP_DEPTH, ReadonlyUnwrapDepthState, readonly_unwrap_depth_state,
+        unwrap_readonly_deep,
+    };
+    use crate::construction::TypeInterner;
+    use crate::types::{TypeData, TypeId};
+
+    #[test]
+    fn readonly_unwrap_depth_allows_exact_cap() {
+        assert_eq!(
+            readonly_unwrap_depth_state(MAX_READONLY_UNWRAP_DEPTH),
+            ReadonlyUnwrapDepthState::Continue
+        );
+    }
+
+    #[test]
+    fn readonly_unwrap_depth_limits_past_cap() {
+        assert_eq!(
+            readonly_unwrap_depth_state(MAX_READONLY_UNWRAP_DEPTH + 1),
+            ReadonlyUnwrapDepthState::LimitExceeded
+        );
+    }
+
+    #[test]
+    fn unwrap_readonly_deep_unwraps_exact_cap() {
+        let interner = TypeInterner::new();
+        let nested = raw_readonly_chain(&interner, TypeId::STRING, MAX_READONLY_UNWRAP_DEPTH);
+
+        assert_eq!(unwrap_readonly_deep(&interner, nested), TypeId::STRING);
+    }
+
+    #[test]
+    fn unwrap_readonly_deep_preserves_wrapper_past_cap() {
+        let interner = TypeInterner::new();
+        let nested = raw_readonly_chain(&interner, TypeId::STRING, MAX_READONLY_UNWRAP_DEPTH + 1);
+        let unwrapped = unwrap_readonly_deep(&interner, nested);
+
+        assert!(
+            matches!(
+                interner.lookup(unwrapped),
+                Some(TypeData::ReadonlyType(inner)) if inner == TypeId::STRING
+            ),
+            "past the cap, the previous opaque wrapper is preserved"
+        );
+    }
+
+    fn raw_readonly_chain(interner: &TypeInterner, inner: TypeId, depth: usize) -> TypeId {
+        let mut current = inner;
+        for _ in 0..depth {
+            current = interner.readonly_type_fresh_for_test(current);
+        }
+        current
+    }
 }

--- a/crates/tsz-solver/src/type_queries/mapped_declaration_surface.rs
+++ b/crates/tsz-solver/src/type_queries/mapped_declaration_surface.rs
@@ -6,6 +6,22 @@ use crate::types::{
 };
 use tsz_common::Atom;
 
+const MAX_MAPPED_SURFACE_OPTIONAL_DEPTH: u8 = 8;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MappedSurfaceOptionalDepthState {
+    Continue,
+    LimitExceeded,
+}
+
+const fn mapped_surface_optional_depth_state(depth: u8) -> MappedSurfaceOptionalDepthState {
+    if depth >= MAX_MAPPED_SURFACE_OPTIONAL_DEPTH {
+        MappedSurfaceOptionalDepthState::LimitExceeded
+    } else {
+        MappedSurfaceOptionalDepthState::Continue
+    }
+}
+
 /// Return the public declaration surface for an inferred mapped type whose
 /// source is a constrained type parameter.
 ///
@@ -86,9 +102,10 @@ fn mapped_surface_with_optional_undefined_inner(
     surface: TypeId,
     depth: u8,
 ) -> TypeId {
-    if depth >= 8 {
-        return surface;
-    };
+    match mapped_surface_optional_depth_state(depth) {
+        MappedSurfaceOptionalDepthState::Continue => {}
+        MappedSurfaceOptionalDepthState::LimitExceeded => return surface,
+    }
 
     let Some(type_data) = db.lookup(surface) else {
         return surface;
@@ -352,4 +369,69 @@ fn number_wrapper_rank(db: &dyn TypeDatabase, name: Atom) -> Option<usize> {
     ])
     .iter()
     .position(|candidate| db.resolve_atom_ref(name).as_ref() == *candidate)
+}
+
+#[cfg(test)]
+mod mapped_surface_optional_depth_state_tests {
+    use super::{
+        MAX_MAPPED_SURFACE_OPTIONAL_DEPTH, MappedSurfaceOptionalDepthState,
+        mapped_surface_optional_depth_state, mapped_surface_with_optional_undefined_inner,
+    };
+    use crate::construction::TypeInterner;
+    use crate::types::{PropertyInfo, TypeData, TypeId};
+
+    #[test]
+    fn optional_surface_depth_allows_below_cap() {
+        assert_eq!(
+            mapped_surface_optional_depth_state(MAX_MAPPED_SURFACE_OPTIONAL_DEPTH - 1),
+            MappedSurfaceOptionalDepthState::Continue
+        );
+    }
+
+    #[test]
+    fn optional_surface_depth_limits_at_cap() {
+        assert_eq!(
+            mapped_surface_optional_depth_state(MAX_MAPPED_SURFACE_OPTIONAL_DEPTH),
+            MappedSurfaceOptionalDepthState::LimitExceeded
+        );
+    }
+
+    #[test]
+    fn optional_surface_depth_cap_preserves_surface() {
+        let db = TypeInterner::new();
+        let prop = db.intern_string("value");
+        let surface = db.object(vec![PropertyInfo::opt(prop, TypeId::NUMBER)]);
+
+        let limited = mapped_surface_with_optional_undefined_inner(
+            &db,
+            surface,
+            MAX_MAPPED_SURFACE_OPTIONAL_DEPTH,
+        );
+
+        assert_eq!(limited, surface);
+    }
+
+    #[test]
+    fn optional_surface_below_depth_cap_adds_undefined() {
+        let db = TypeInterner::new();
+        let prop = db.intern_string("value");
+        let surface = db.object(vec![PropertyInfo::opt(prop, TypeId::NUMBER)]);
+
+        let mapped = mapped_surface_with_optional_undefined_inner(
+            &db,
+            surface,
+            MAX_MAPPED_SURFACE_OPTIONAL_DEPTH - 1,
+        );
+
+        let Some(TypeData::Object(shape_id)) = db.lookup(mapped) else {
+            panic!("expected mapped object surface");
+        };
+        let shape = db.object_shape(shape_id);
+        let value = shape
+            .properties
+            .iter()
+            .find(|property| property.name == prop)
+            .expect("optional property must survive");
+        assert!(super::super::type_includes_undefined(&db, value.type_id));
+    }
 }

--- a/crates/tsz-solver/src/visitors/visitor_extract.rs
+++ b/crates/tsz-solver/src/visitors/visitor_extract.rs
@@ -26,6 +26,22 @@ thread_local! {
     static EXTRACT_VISITED_POOL: RefCell<Option<FxHashSet<TypeId>>> = const { RefCell::new(None) };
 }
 
+const MAX_ERROR_APPLICATION_BASE_DEPTH: u8 = 16;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ApplicationBaseErrorWalkState {
+    Continue,
+    LimitExceeded,
+}
+
+const fn application_base_error_walk_state(depth: u8) -> ApplicationBaseErrorWalkState {
+    if depth >= MAX_ERROR_APPLICATION_BASE_DEPTH {
+        ApplicationBaseErrorWalkState::LimitExceeded
+    } else {
+        ApplicationBaseErrorWalkState::Continue
+    }
+}
+
 #[inline]
 fn with_extract_visited<R>(f: impl FnOnce(&mut FxHashSet<TypeId>) -> R) -> R {
     let mut visited = EXTRACT_VISITED_POOL
@@ -895,8 +911,13 @@ fn error_type_through_application_bases(
     treat_unresolved_as_error: bool,
 ) -> bool {
     let mut current = type_id;
+    let mut depth = 0;
 
-    for _ in 0..16 {
+    loop {
+        match application_base_error_walk_state(depth) {
+            ApplicationBaseErrorWalkState::Continue => {}
+            ApplicationBaseErrorWalkState::LimitExceeded => return false,
+        }
         if current == TypeId::ERROR {
             return true;
         }
@@ -906,12 +927,11 @@ fn error_type_through_application_bases(
             Some(TypeData::UnresolvedTypeName(_)) => return treat_unresolved_as_error,
             Some(TypeData::Application(app_id)) => {
                 current = types.type_application(app_id).base;
+                depth += 1;
             }
             _ => return false,
         }
     }
-
-    false
 }
 
 /// Extract the function shape id if this is a function type.
@@ -923,6 +943,64 @@ pub fn function_shape_id(types: &dyn TypeDatabase, type_id: TypeId) -> Option<Fu
         TypeData::Function(shape_id) => Some(*shape_id),
         _ => None,
     })
+}
+
+#[cfg(test)]
+mod application_base_error_walk_state_tests {
+    use super::{
+        ApplicationBaseErrorWalkState, MAX_ERROR_APPLICATION_BASE_DEPTH,
+        application_base_error_walk_state, is_error_type,
+    };
+    use crate::construction::TypeInterner;
+    use crate::types::TypeId;
+
+    #[test]
+    fn application_base_error_walk_allows_below_cap() {
+        assert_eq!(
+            application_base_error_walk_state(MAX_ERROR_APPLICATION_BASE_DEPTH - 1),
+            ApplicationBaseErrorWalkState::Continue
+        );
+    }
+
+    #[test]
+    fn application_base_error_walk_limits_at_cap() {
+        assert_eq!(
+            application_base_error_walk_state(MAX_ERROR_APPLICATION_BASE_DEPTH),
+            ApplicationBaseErrorWalkState::LimitExceeded
+        );
+    }
+
+    #[test]
+    fn error_base_before_cap_is_detected() {
+        let interner = TypeInterner::new();
+        let ty = application_base_chain(
+            &interner,
+            TypeId::ERROR,
+            usize::from(MAX_ERROR_APPLICATION_BASE_DEPTH - 1),
+        );
+
+        assert!(is_error_type(&interner, ty));
+    }
+
+    #[test]
+    fn error_base_at_cap_preserves_false_fallback() {
+        let interner = TypeInterner::new();
+        let ty = application_base_chain(
+            &interner,
+            TypeId::ERROR,
+            usize::from(MAX_ERROR_APPLICATION_BASE_DEPTH),
+        );
+
+        assert!(!is_error_type(&interner, ty));
+    }
+
+    fn application_base_chain(interner: &TypeInterner, base: TypeId, depth: usize) -> TypeId {
+        let mut current = base;
+        for _ in 0..depth {
+            current = interner.application(current, Vec::new());
+        }
+        current
+    }
 }
 
 /// Extract the callable shape id if this is a callable type.


### PR DESCRIPTION
Goal: green

## Summary
Names three bounded type-query traversal decisions without changing fallbacks:
- `MappedSurfaceOptionalDepthState::{Continue, LimitExceeded}` for declaration mapped-surface optional/undefined recursion;
- `ApplicationBaseErrorWalkState::{Continue, LimitExceeded}` for bounded `Application` base walks in error-type predicates;
- `ReadonlyUnwrapDepthState::{Continue, LimitExceeded}` for deep readonly wrapper unwrapping.

The repaired head also moves the readonly-depth fixture's fresh wrapper construction behind a test-only `TypeInterner` helper, keeping `TypeData` construction inside the interner owner for the arch guard.

## Structural Rule
When solver type-query helpers traverse nested declaration surfaces, application bases, or readonly wrappers below their caps, tsz continues the structural walk. When the cap is reached, tsz preserves the existing conservative fallback: mapped-surface recursion returns the current surface, application-base error probing returns `false`, and readonly unwrapping preserves the remaining wrapper.

Owner layer: `tsz-solver` type-query and visitor helpers, with a test-only interner fixture helper. No checker, emitter, relation policy, module-augmentation, query-cache, instantiation, infer-pattern, collect-properties, or reverse-mapped files are touched.

## Adjacent Matrix
- Mapped optional-surface depth below cap still adds `undefined` to optional property reads; at cap it preserves the input surface.
- Application-base error walk detects an error base before the cap; at cap it preserves the previous `false` fallback.
- Readonly unwrap peels exactly the cap count; past cap it preserves the remaining readonly wrapper.
- The readonly fixture now uses an interner-owned fresh wrapper helper instead of direct `TypeData` construction in the accessor test shard.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver mapped_surface_optional_depth_state application_base_error_walk_state readonly_unwrap_depth_state`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `wc -l crates/tsz-solver/src/intern/mod.rs crates/tsz-solver/src/type_queries/mapped_declaration_surface.rs crates/tsz-solver/src/visitors/visitor_extract.rs crates/tsz-solver/src/type_queries/data/accessors.rs` (79 / 437 / 1340 / 1679 lines)

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high