### PR TITLE
refactor(solver): name infer matching guard states

### DIFF
--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -22,6 +22,7 @@ use rustc_hash::FxHashMap;
 use tsz_common::interner::Atom;
 
 use super::infer::{InferenceContext, InferenceError, InferenceVar};
+use super::infer_matching_guard_state as guard_state;
 use super::infer_matching_helpers::constraint_is_nullable_union;
 use super::template_anchor::{find_leftmost_occurrence, find_next_anchor_alternatives};
 use super::template_segment_prefix::match_template_segment_prefix;
@@ -78,13 +79,17 @@ impl<'a> InferenceContext<'a> {
         target: TypeId,
         priority: InferencePriority,
     ) -> Result<(), InferenceError> {
-        if self.infer_depth >= Self::MAX_INFER_DEPTH {
-            return Ok(());
+        let inserted_visit =
+            self.infer_depth < Self::MAX_INFER_DEPTH && self.infer_visited.insert((source, target));
+        match guard_state::infer_match_entry_state(
+            self.infer_depth,
+            Self::MAX_INFER_DEPTH,
+            inserted_visit,
+        ) {
+            guard_state::InferMatchEntryState::Entered { depth } => self.infer_depth = depth,
+            guard_state::InferMatchEntryState::DepthExceeded
+            | guard_state::InferMatchEntryState::AlreadyVisited => return Ok(()),
         }
-        if !self.infer_visited.insert((source, target)) {
-            return Ok(());
-        }
-        self.infer_depth += 1;
         let result = self.infer_from_types_inner(source, target, priority);
         self.infer_depth -= 1;
         result
@@ -923,17 +928,10 @@ impl<'a> InferenceContext<'a> {
     /// inference to proceed. Without this, `(Object, Application)` falls through
     /// the match and inference candidates are lost.
     ///
-    /// Returns `None` if:
-    /// - No resolver is available
-    /// - The base isn't a resolvable DefId
-    /// - Type parameters or body can't be resolved
-    /// - Application expansion depth limit is exceeded (prevents infinite recursion
-    ///   for recursive type aliases)
     fn try_expand_application(&mut self, app_id: TypeApplicationId) -> Option<TypeId> {
         let resolver = self.resolver?;
         let app = self.interner.type_application(app_id);
 
-        // Extract DefId from the base type (must be Lazy(DefId))
         if app.base.is_intrinsic() {
             return None;
         }
@@ -942,13 +940,13 @@ impl<'a> InferenceContext<'a> {
             _ => return None,
         };
 
-        // Depth guard: prevent infinite recursion for recursive type aliases
-        // (e.g., type Spec<T> = { [P in keyof T]: Spec<T[P]> })
         let depth = self.app_expansion_depth;
-        if depth >= Self::MAX_APP_EXPANSION_DEPTH {
-            return None;
+        match guard_state::app_expansion_state(depth, Self::MAX_APP_EXPANSION_DEPTH) {
+            guard_state::AppExpansionState::Entered { depth } => {
+                self.app_expansion_depth = depth;
+            }
+            guard_state::AppExpansionState::DepthExceeded => return None,
         }
-        self.app_expansion_depth += 1;
 
         // Resolve the type alias body and its type parameters
         let type_params = resolver.get_lazy_type_params(def_id)?;
@@ -1642,8 +1640,9 @@ impl<'a> InferenceContext<'a> {
         if target.is_intrinsic() {
             return false;
         }
-        if !visited.insert(target) {
-            return false;
+        match guard_state::target_param_visit_state(visited.insert(target)) {
+            guard_state::TargetParamVisitState::Entered => {}
+            guard_state::TargetParamVisitState::AlreadyVisited { fallback } => return fallback,
         }
         let Some(key) = self.interner.lookup(target) else {
             return false;

--- a/crates/tsz-solver/src/inference/infer_matching_guard_state.rs
+++ b/crates/tsz-solver/src/inference/infer_matching_guard_state.rs
@@ -1,0 +1,95 @@
+//! Named guard states for structural inference matching.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum InferMatchEntryState {
+    Entered { depth: u32 },
+    DepthExceeded,
+    AlreadyVisited,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AppExpansionState {
+    Entered { depth: u32 },
+    DepthExceeded,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TargetParamVisitState {
+    Entered,
+    AlreadyVisited { fallback: bool },
+}
+
+pub(crate) const fn infer_match_entry_state(
+    depth: u32,
+    max_depth: u32,
+    inserted_visit: bool,
+) -> InferMatchEntryState {
+    if depth >= max_depth {
+        InferMatchEntryState::DepthExceeded
+    } else if !inserted_visit {
+        InferMatchEntryState::AlreadyVisited
+    } else {
+        InferMatchEntryState::Entered { depth: depth + 1 }
+    }
+}
+
+pub(crate) const fn app_expansion_state(depth: u32, max_depth: u32) -> AppExpansionState {
+    if depth >= max_depth {
+        AppExpansionState::DepthExceeded
+    } else {
+        AppExpansionState::Entered { depth: depth + 1 }
+    }
+}
+
+pub(crate) const fn target_param_visit_state(inserted_visit: bool) -> TargetParamVisitState {
+    if inserted_visit {
+        TargetParamVisitState::Entered
+    } else {
+        TargetParamVisitState::AlreadyVisited { fallback: false }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AppExpansionState, InferMatchEntryState, TargetParamVisitState, app_expansion_state,
+        infer_match_entry_state, target_param_visit_state,
+    };
+
+    #[test]
+    fn infer_match_entry_state_names_depth_and_revisit_cutoffs() {
+        assert_eq!(
+            infer_match_entry_state(20, 20, true),
+            InferMatchEntryState::DepthExceeded
+        );
+        assert_eq!(
+            infer_match_entry_state(0, 20, false),
+            InferMatchEntryState::AlreadyVisited
+        );
+        assert_eq!(
+            infer_match_entry_state(0, 20, true),
+            InferMatchEntryState::Entered { depth: 1 }
+        );
+    }
+
+    #[test]
+    fn app_expansion_state_names_depth_cutoff() {
+        assert_eq!(app_expansion_state(8, 8), AppExpansionState::DepthExceeded);
+        assert_eq!(
+            app_expansion_state(7, 8),
+            AppExpansionState::Entered { depth: 8 }
+        );
+    }
+
+    #[test]
+    fn target_param_visit_state_names_cycle_cutoff() {
+        assert_eq!(
+            target_param_visit_state(true),
+            TargetParamVisitState::Entered
+        );
+        assert_eq!(
+            target_param_visit_state(false),
+            TargetParamVisitState::AlreadyVisited { fallback: false }
+        );
+    }
+}

--- a/crates/tsz-solver/src/inference/mod.rs
+++ b/crates/tsz-solver/src/inference/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod infer;
 pub(crate) mod infer_bct;
 pub(crate) mod infer_candidate_kinds;
 pub(crate) mod infer_matching;
+mod infer_matching_guard_state;
 mod infer_matching_helpers;
 pub(crate) mod infer_matching_tuples;
 pub(crate) mod infer_resolve;


### PR DESCRIPTION
Goal: green

## Summary
- add solver-owned guard-state enums for inference matching entry, application expansion, and target-parameter cycle checks
- route existing inference matching depth/revisit/fallback exits through the named state helpers
- keep behavior unchanged while making the termination policy explicit for #14351 / #14346 follow-up work

## Structural Rule
When inference matching hits depth, revisit, or traversal-cycle cutoffs, `tsc` still relies on bounded structural exploration; tsz preserves its current fallback behavior through solver-owned inference guard states rather than burying the policy in anonymous `Ok(())`, `None`, or `false` exits.

Owner layer: solver inference (`crates/tsz-solver/src/inference`).

Adjacent matrix:
- infer match entry: entered increments depth; depth cutoff returns `Ok(())`; revisit returns `Ok(())`
- application expansion: entered increments expansion depth; depth cutoff returns `None`
- target inference-parameter traversal: first visit continues; cycle returns fallback `false`

Fallback/performance: no cache or residency behavior changes; helpers are pure state classifiers and preserve existing side-effect order around visited insertion.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib infer_matching`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `python3 scripts/arch/arch_guard.py`
- `wc -l crates/tsz-solver/src/inference/infer_matching.rs crates/tsz-solver/src/inference/infer_matching_guard_state.rs crates/tsz-solver/src/inference/mod.rs`

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: high