### PR TITLE
refactor(solver): name spread validity depth state (#14346)

### DIFF
--- a/crates/tsz-solver/src/tests/type_queries_spread_tests.rs
+++ b/crates/tsz-solver/src/tests/type_queries_spread_tests.rs
@@ -59,6 +59,30 @@ fn spread_object_type_is_valid() {
     assert!(is_valid_spread_type(&db, obj));
 }
 
+fn nested_readonly_type(db: &TypeInterner, depth: u32, leaf: TypeId) -> TypeId {
+    let mut current = leaf;
+    for _ in 0..depth {
+        current = db.intern(TypeData::ReadonlyType(current));
+    }
+    current
+}
+
+#[test]
+fn spread_depth_limit_evaluates_exact_limit() {
+    let db = TypeInterner::new();
+    let nested = nested_readonly_type(&db, 20, TypeId::STRING);
+
+    assert!(!is_valid_spread_type(&db, nested));
+}
+
+#[test]
+fn spread_depth_limit_uses_conservative_valid_fallback_past_limit() {
+    let db = TypeInterner::new();
+    let nested = nested_readonly_type(&db, 21, TypeId::STRING);
+
+    assert!(is_valid_spread_type(&db, nested));
+}
+
 // =============================================================================
 // Union with falsy members (the core fix)
 // =============================================================================

--- a/crates/tsz-solver/src/type_queries/core.rs
+++ b/crates/tsz-solver/src/type_queries/core.rs
@@ -1157,9 +1157,28 @@ pub fn substitute_reference_base_constraints(db: &dyn TypeDatabase, type_id: Typ
     }
 }
 
+const MAX_VALID_SPREAD_DEPTH: u32 = 20;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ValidSpreadDepthState {
+    Continue,
+    LimitExceeded,
+}
+
+impl ValidSpreadDepthState {
+    const fn from_depth(depth: u32) -> Self {
+        if depth > MAX_VALID_SPREAD_DEPTH {
+            Self::LimitExceeded
+        } else {
+            Self::Continue
+        }
+    }
+}
+
 fn is_valid_spread_type_impl(db: &dyn TypeDatabase, type_id: TypeId, depth: u32) -> bool {
-    if depth > 20 {
-        return true;
+    match ValidSpreadDepthState::from_depth(depth) {
+        ValidSpreadDepthState::Continue => {}
+        ValidSpreadDepthState::LimitExceeded => return true,
     }
 
     // Step 1: Resolve type parameter to its base constraint (like tsc's getBaseConstraintOrType)
@@ -1249,6 +1268,27 @@ fn is_valid_spread_type_impl(db: &dyn TypeDatabase, type_id: TypeId, depth: u32)
         // callables, mapped types, type parameters (unconstrained ones reach here
         // and are valid per tsc's InstantiableNonPrimitive), lazy refs, applications, etc.
         _ => true,
+    }
+}
+
+#[cfg(test)]
+mod valid_spread_depth_state_tests {
+    use super::*;
+
+    #[test]
+    fn valid_spread_depth_state_continues_at_limit() {
+        assert_eq!(
+            ValidSpreadDepthState::from_depth(MAX_VALID_SPREAD_DEPTH),
+            ValidSpreadDepthState::Continue
+        );
+    }
+
+    #[test]
+    fn valid_spread_depth_state_limits_past_limit() {
+        assert_eq!(
+            ValidSpreadDepthState::from_depth(MAX_VALID_SPREAD_DEPTH + 1),
+            ValidSpreadDepthState::LimitExceeded
+        );
     }
 }
 


### PR DESCRIPTION
Goal: green

## Summary
- Name the object-spread validity recursion cap as `ValidSpreadDepthState` in the solver type-query owner.
- Preserve the existing boundary behavior: depth 20 continues evaluation, while depth 21 uses the conservative valid fallback.
- Add spread-query tests that pin exact-limit and past-limit behavior through nested readonly wrappers.

## Structural Rule
When object-spread validity traverses recursive union, intersection, readonly, or index-access surfaces at or below the spread-validity depth cap, `tsc` continues checking the resolved member surface; `tsz` does this through `tsz-solver` type queries. When traversal exceeds the cap, `tsz` preserves its existing conservative `true` fallback rather than rejecting an over-deep potentially object-like type.

## Owner Layer
- Solver: `crates/tsz-solver/src/type_queries/core.rs`
- Tests: `crates/tsz-solver/src/tests/type_queries_spread_tests.rs`

## Adjacent Matrix
- Exact cap: nested readonly primitive still reaches the primitive and is invalid.
- Past cap: nested readonly primitive uses the existing conservative valid fallback.
- Existing spread union/index-access/readonly test module remains green.

## Fallback And Performance
- Fallback remains the pre-existing conservative `true` result past the cap.
- No new cache keys, allocations, or traversal breadth changes; this only names the depth verdict.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-solver valid_spread_depth_state spread_depth_limit`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver type_queries_spread_tests`
- after refreshing `origin/main` to `388787fa65`: `scripts/safe-run.sh cargo nextest run -p tsz-solver valid_spread_depth_state spread_depth_limit type_queries_spread_tests`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `wc -l crates/tsz-solver/src/type_queries/core.rs crates/tsz-solver/src/tests/type_queries_spread_tests.rs`

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high