### PR TITLE
refactor(solver): name bct inference guard states

### DIFF
--- a/crates/tsz-solver/src/inference/infer_bct.rs
+++ b/crates/tsz-solver/src/inference/infer_bct.rs
@@ -21,6 +21,7 @@ use rustc_hash::FxHashSet;
 use tsz_common::interner::Atom;
 
 use super::InferenceContext;
+use super::infer_bct_guard_state as guard_state;
 
 impl<'a> InferenceContext<'a> {
     // =========================================================================
@@ -498,8 +499,9 @@ impl<'a> InferenceContext<'a> {
         // Walk up the extends chain from source
         let mut current = source;
         let mut depth = 0;
-        while depth < 20 {
-            // guard against infinite loops
+        while let guard_state::ExtendsWalkState::Continue =
+            guard_state::extends_walk_state(depth, 20)
+        {
             if let Some(base) = self.get_extends_clause(current) {
                 if base == target {
                     return true;
@@ -531,9 +533,9 @@ impl<'a> InferenceContext<'a> {
 
     /// Recursively collect the class hierarchy for a type.
     fn collect_class_hierarchy(&self, ty: TypeId, hierarchy: &mut Vec<TypeId>) {
-        // Prevent infinite recursion
-        if hierarchy.contains(&ty) {
-            return;
+        match guard_state::class_hierarchy_visit_state(!hierarchy.contains(&ty)) {
+            guard_state::ClassHierarchyVisitState::Entered => {}
+            guard_state::ClassHierarchyVisitState::AlreadyVisited => return,
         }
 
         // Add current type to hierarchy
@@ -612,11 +614,15 @@ impl<'a> InferenceContext<'a> {
         // cached result exists. Treat those in-progress cycles as tentatively
         // true, matching the solver's recursive-type handling and avoiding
         // stack overflows on deeply nested signature comparisons.
-        {
+        let active_pair_state = {
             let active = self.active_subtype_checks.borrow();
-            if active.contains(&key) || active.contains(&(target, source)) {
-                return true;
-            }
+            guard_state::active_subtype_pair_state(
+                active.contains(&key) || active.contains(&(target, source)),
+            )
+        };
+        match active_pair_state {
+            guard_state::ActiveSubtypePairState::Entered => {}
+            guard_state::ActiveSubtypePairState::AlreadyActive { fallback } => return fallback,
         }
 
         self.active_subtype_checks.borrow_mut().insert(key);

--- a/crates/tsz-solver/src/inference/infer_bct_guard_state.rs
+++ b/crates/tsz-solver/src/inference/infer_bct_guard_state.rs
@@ -1,0 +1,81 @@
+//! Named guard states for best-common-type inference.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ExtendsWalkState {
+    Continue,
+    DepthExceeded,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ClassHierarchyVisitState {
+    Entered,
+    AlreadyVisited,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ActiveSubtypePairState {
+    Entered,
+    AlreadyActive { fallback: bool },
+}
+
+pub(crate) const fn extends_walk_state(depth: u32, max_depth: u32) -> ExtendsWalkState {
+    if depth >= max_depth {
+        ExtendsWalkState::DepthExceeded
+    } else {
+        ExtendsWalkState::Continue
+    }
+}
+
+pub(crate) const fn class_hierarchy_visit_state(inserted_visit: bool) -> ClassHierarchyVisitState {
+    if inserted_visit {
+        ClassHierarchyVisitState::Entered
+    } else {
+        ClassHierarchyVisitState::AlreadyVisited
+    }
+}
+
+pub(crate) const fn active_subtype_pair_state(already_active: bool) -> ActiveSubtypePairState {
+    if already_active {
+        ActiveSubtypePairState::AlreadyActive { fallback: true }
+    } else {
+        ActiveSubtypePairState::Entered
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ActiveSubtypePairState, ClassHierarchyVisitState, ExtendsWalkState,
+        active_subtype_pair_state, class_hierarchy_visit_state, extends_walk_state,
+    };
+
+    #[test]
+    fn extends_walk_state_names_continue_and_depth_cutoff() {
+        assert_eq!(extends_walk_state(0, 20), ExtendsWalkState::Continue);
+        assert_eq!(extends_walk_state(20, 20), ExtendsWalkState::DepthExceeded);
+    }
+
+    #[test]
+    fn class_hierarchy_visit_state_names_revisit_cutoff() {
+        assert_eq!(
+            class_hierarchy_visit_state(true),
+            ClassHierarchyVisitState::Entered
+        );
+        assert_eq!(
+            class_hierarchy_visit_state(false),
+            ClassHierarchyVisitState::AlreadyVisited
+        );
+    }
+
+    #[test]
+    fn active_subtype_pair_state_names_coinductive_fallback() {
+        assert_eq!(
+            active_subtype_pair_state(false),
+            ActiveSubtypePairState::Entered
+        );
+        assert_eq!(
+            active_subtype_pair_state(true),
+            ActiveSubtypePairState::AlreadyActive { fallback: true }
+        );
+    }
+}

--- a/crates/tsz-solver/src/inference/mod.rs
+++ b/crates/tsz-solver/src/inference/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod infer;
 pub(crate) mod infer_bct;
+mod infer_bct_guard_state;
 pub(crate) mod infer_candidate_kinds;
 pub(crate) mod infer_matching;
 mod infer_matching_helpers;


### PR DESCRIPTION
Goal: green

## Summary
- add solver-owned guard-state enums for BCT extends walking, hierarchy revisits, and active subtype-pair recursion
- route the existing BCT inference guard exits through those named state helpers
- preserve current fallback behavior while making #14346 termination policy explicit

## Structural Rule
When best-common-type inference hits class-chain depth, hierarchy revisit, or recursive subtype-pair cutoffs, `tsc` still relies on bounded structural exploration; tsz preserves today’s solver-owned fallback behavior through explicit BCT guard states instead of anonymous loop, `return`, or `true` exits.

Owner layer: solver inference (`crates/tsz-solver/src/inference`).

Adjacent matrix:
- extends walk: continue below depth cap; stop at depth cap and keep existing `false` fallback unless zero-depth non-lazy fallback delegates to `is_subtype`
- class hierarchy collection: first visit pushes the type; revisit returns without adding duplicate hierarchy entries
- BCT subtype recursion: inactive pair enters normally; active pair returns the existing coinductive `true` fallback without writing a cache entry

Fallback/performance: no cache or residency behavior changes; helpers are pure state classifiers and preserve existing mutation order for hierarchy vectors and active subtype tracking.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver bct`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `python3 scripts/arch/arch_guard.py`
- `wc -l crates/tsz-solver/src/inference/infer_bct.rs crates/tsz-solver/src/inference/infer_bct_guard_state.rs crates/tsz-solver/src/inference/mod.rs`

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: high