### PR TITLE
fix(checker): replay type analysis env merges (#14348)

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping_env_writes.rs
+++ b/crates/tsz-checker/src/context/def_mapping_env_writes.rs
@@ -71,4 +71,36 @@ impl CheckerContext<'_> {
     ) {
         self.register_in_envs(DeferredFlowEnvWrite::InsertSymbolType { symbol, ty, params });
     }
+
+    /// Merge a child environment's `DefId -> TypeId` body into both parent
+    /// environments when the parent lacks the body, deferring on borrow races.
+    pub(crate) fn merge_def_if_missing_in_envs(&self, def_id: DefId, body: TypeId) {
+        self.register_in_envs(DeferredFlowEnvWrite::InsertDefIfMissing { def_id, body });
+    }
+
+    /// Merge a child environment's class instance metadata into both parent
+    /// environments when the parent lacks it, deferring on borrow races.
+    pub(crate) fn merge_class_instance_if_missing_in_envs(
+        &self,
+        def_id: DefId,
+        instance_type: TypeId,
+    ) {
+        self.register_in_envs(DeferredFlowEnvWrite::InsertClassInstanceIfMissing {
+            def_id,
+            instance_type,
+        });
+    }
+
+    /// Merge a child environment's class `extends` metadata into both parent
+    /// environments when the parent lacks it, deferring on borrow races.
+    pub(crate) fn merge_class_extends_if_missing_in_envs(
+        &self,
+        def_id: DefId,
+        parent_def_id: DefId,
+    ) {
+        self.register_in_envs(DeferredFlowEnvWrite::RegisterClassExtendsIfMissing {
+            def_id,
+            parent_def_id,
+        });
+    }
 }

--- a/crates/tsz-checker/src/context/def_mapping_tests.rs
+++ b/crates/tsz-checker/src/context/def_mapping_tests.rs
@@ -520,6 +520,96 @@ fn enum_metadata_defer_then_replay_under_simultaneous_borrow() {
     );
 }
 
+/// Child checker snapshots are parent-wins vacancy fills, not body rewrites.
+/// They still must use the same deferred dual-env write discipline as ordinary
+/// registrations: a borrow conflict queues the merge for replay, and replay
+/// inserts only when the parent env has not already published the entry.
+#[test]
+fn child_snapshot_merge_defer_then_replay_preserves_parent_entries() {
+    use tsz_solver::TypeId;
+    use tsz_solver::def::DefId;
+
+    let (arena, binder, types) = minimal_checker_ctx();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    let def_id = DefId(21);
+    let class_def = DefId(22);
+    let child_def = DefId(23);
+    let parent_def = DefId(24);
+
+    {
+        let held_eval = ctx.type_env.borrow();
+        let held_flow = ctx.type_environment.borrow();
+        ctx.merge_def_if_missing_in_envs(def_id, TypeId::NUMBER);
+        ctx.merge_class_instance_if_missing_in_envs(class_def, TypeId::STRING);
+        ctx.merge_class_extends_if_missing_in_envs(child_def, parent_def);
+
+        assert_eq!(held_eval.get_def(def_id), None);
+        assert_eq!(held_flow.get_def(def_id), None);
+        assert_eq!(held_eval.get_class_instance_type(class_def), None);
+        assert_eq!(held_flow.get_class_instance_type(class_def), None);
+        assert_eq!(held_eval.get_class_extends_def(child_def), None);
+        assert_eq!(held_flow.get_class_extends_def(child_def), None);
+        assert_eq!(ctx.deferred_eval_env_write_count(), 3);
+        assert_eq!(ctx.deferred_flow_env_write_count(), 3);
+    }
+
+    ctx.flush_deferred_eval_env_writes();
+    ctx.flush_deferred_flow_env_writes();
+    assert_eq!(ctx.type_env.borrow().get_def(def_id), Some(TypeId::NUMBER));
+    assert_eq!(
+        ctx.type_environment.borrow().get_def(def_id),
+        Some(TypeId::NUMBER)
+    );
+    assert_eq!(
+        ctx.type_env.borrow().get_class_instance_type(class_def),
+        Some(TypeId::STRING)
+    );
+    assert_eq!(
+        ctx.type_environment
+            .borrow()
+            .get_class_instance_type(class_def),
+        Some(TypeId::STRING)
+    );
+    assert_eq!(
+        ctx.type_env.borrow().get_class_extends_def(child_def),
+        Some(parent_def)
+    );
+    assert_eq!(
+        ctx.type_environment
+            .borrow()
+            .get_class_extends_def(child_def),
+        Some(parent_def)
+    );
+
+    let other_parent = DefId(25);
+    ctx.merge_def_if_missing_in_envs(def_id, TypeId::STRING);
+    ctx.merge_class_instance_if_missing_in_envs(class_def, TypeId::BOOLEAN);
+    ctx.merge_class_extends_if_missing_in_envs(child_def, other_parent);
+
+    assert_eq!(
+        ctx.type_env.borrow().get_def(def_id),
+        Some(TypeId::NUMBER),
+        "merge-if-missing must not overwrite an existing parent body"
+    );
+    assert_eq!(
+        ctx.type_env.borrow().get_class_instance_type(class_def),
+        Some(TypeId::STRING),
+        "merge-if-missing must not overwrite an existing parent instance"
+    );
+    assert_eq!(
+        ctx.type_env.borrow().get_class_extends_def(child_def),
+        Some(parent_def),
+        "merge-if-missing must not overwrite an existing parent extends edge"
+    );
+}
+
 /// Pins the body-registration construction rule shared by
 /// `register_resolved_def_in_envs` and `mirror_def_in_type_environment`:
 /// empty params build the non-generic `InsertDef` variant, non-empty params

--- a/crates/tsz-checker/src/context/deferred_flow_env_write.rs
+++ b/crates/tsz-checker/src/context/deferred_flow_env_write.rs
@@ -28,6 +28,9 @@ pub enum DeferredFlowEnvWrite {
     SetDefinitionStore(Arc<tsz_solver::def::DefinitionStore>),
     /// `insert_def` — register a non-generic definition body.
     InsertDef { def_id: DefId, body: TypeId },
+    /// `insert_def` when absent — merge a child env snapshot without
+    /// overwriting an already-published parent body.
+    InsertDefIfMissing { def_id: DefId, body: TypeId },
     /// `insert_def_with_params` (+ optional declared variances) — register a
     /// generic definition body.
     InsertDefWithParams {
@@ -41,8 +44,17 @@ pub enum DeferredFlowEnvWrite {
         def_id: DefId,
         instance_type: TypeId,
     },
+    /// `insert_class_instance_type` when absent — merge a child env snapshot
+    /// without overwriting parent metadata.
+    InsertClassInstanceIfMissing {
+        def_id: DefId,
+        instance_type: TypeId,
+    },
     /// `register_class_extends` — register a class `extends` parent.
     RegisterClassExtends { def_id: DefId, parent_def_id: DefId },
+    /// `register_class_extends` when absent — merge a child env snapshot
+    /// without overwriting a parent edge.
+    RegisterClassExtendsIfMissing { def_id: DefId, parent_def_id: DefId },
     /// `register_def_symbol_mapping` — register the `DefId` <-> `SymbolId` bridge.
     RegisterDefSymbolMapping { def_id: DefId, sym_id: SymbolId },
     /// `register_augmented_def` — re-apply an augmentation merge.
@@ -123,6 +135,11 @@ impl DeferredFlowEnvWrite {
         match self {
             Self::SetDefinitionStore(store) => env.set_definition_store(Arc::clone(store)),
             Self::InsertDef { def_id, body } => env.insert_def(*def_id, *body),
+            Self::InsertDefIfMissing { def_id, body } => {
+                if env.get_def(*def_id).is_none() {
+                    env.insert_def(*def_id, *body);
+                }
+            }
             Self::InsertDefWithParams {
                 def_id,
                 body,
@@ -138,10 +155,26 @@ impl DeferredFlowEnvWrite {
                 def_id,
                 instance_type,
             } => env.insert_class_instance_type(*def_id, *instance_type),
+            Self::InsertClassInstanceIfMissing {
+                def_id,
+                instance_type,
+            } => {
+                if env.get_class_instance_type(*def_id).is_none() {
+                    env.insert_class_instance_type(*def_id, *instance_type);
+                }
+            }
             Self::RegisterClassExtends {
                 def_id,
                 parent_def_id,
             } => env.register_class_extends(*def_id, *parent_def_id),
+            Self::RegisterClassExtendsIfMissing {
+                def_id,
+                parent_def_id,
+            } => {
+                if env.get_class_extends_def(*def_id).is_none() {
+                    env.register_class_extends(*def_id, *parent_def_id);
+                }
+            }
             Self::RegisterDefSymbolMapping { def_id, sym_id } => {
                 env.register_def_symbol_mapping(*def_id, *sym_id);
             }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1600,6 +1600,9 @@ mod type_alias_computed_display_tests;
 #[path = "tests/type_alias_primitive_display_tests.rs"]
 mod type_alias_primitive_display_tests;
 #[cfg(test)]
+#[path = "tests/type_analysis_env_merge_arch_tests.rs"]
+mod type_analysis_env_merge_arch_tests;
+#[cfg(test)]
 #[path = "tests/type_param_default_relation_routing_arch_tests.rs"]
 mod type_param_default_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -102,9 +102,9 @@ impl CheckerState<'_> {
         // evaluator env directly and mirror into the flow-analyzer env; a mirror
         // that loses the `RefCell` borrow race during recursive resolution is
         // deferred rather than dropped (issue #8269), so first replay the
-        // deferred queue. A few registrations are evaluator-env-only by design
-        // (e.g. symbol-keyed bodies, enum-parent / numeric-enum metadata); fill
-        // those into the flow-analyzer env with a vacancy-only overlay. Unlike
+        // deferred queue. A few local fields can still arrive via evaluator-env
+        // setup or shared-store/scalar wiring; fill those into the flow-analyzer
+        // env with a vacancy-only overlay. Unlike
         // the previous unconditional full `clone()`, this neither reallocates
         // already-mirrored maps nor discards flow-analyzer-env-only entries.
         self.ctx.flush_deferred_flow_env_writes();

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
@@ -849,9 +849,8 @@ impl<'a> CheckerState<'a> {
         if let Some(symbol) = self.ctx.binder.get_symbol(sym_id) {
             let parent_sym_id = symbol.parent;
             let parent_def_id = self.ctx.get_or_create_def_id(parent_sym_id);
-            if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
-                env.register_enum_parent(member_def_id, parent_def_id);
-            }
+            self.ctx
+                .register_enum_parent_in_envs(member_def_id, parent_def_id);
         }
 
         let literal_type = self.enum_member_type_from_decl(value_decl);

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_env_merge.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_env_merge.rs
@@ -1,111 +1,30 @@
 use crate::query_boundaries::common::TypeEnvironment;
 use crate::state::CheckerState;
-use tsz_solver::TypeId;
 use tsz_solver::def::DefId;
 
 impl<'a> CheckerState<'a> {
     pub(super) fn merge_child_type_env_snapshots(
         &self,
         child_env: &TypeEnvironment,
-        context: &'static str,
+        _context: &'static str,
     ) {
         let child_defs = child_env.snapshot_def_types();
         let child_class_instances = child_env.snapshot_class_instance_types();
         let child_class_extends = child_env.snapshot_class_extends();
 
-        if !child_defs.is_empty() {
-            if let Ok(mut parent_env) = self.ctx.type_env.try_borrow_mut() {
-                for (def_id_raw, type_id) in child_defs {
-                    let def_id = DefId(def_id_raw);
-                    if parent_env.get_def(def_id).is_none() {
-                        parent_env.insert_def(def_id, type_id);
-                    }
-                }
-            } else {
-                tracing::warn!("{context}: could not borrow parent type_env for def merge");
-            }
+        for (def_id_raw, type_id) in child_defs {
+            self.ctx
+                .merge_def_if_missing_in_envs(DefId(def_id_raw), type_id);
         }
 
-        if !child_class_instances.is_empty() {
-            self.merge_class_instances_into_type_env(&child_class_instances, context);
-            self.merge_class_instances_into_type_environment(&child_class_instances, context);
+        for (def_id_raw, instance_type) in child_class_instances {
+            self.ctx
+                .merge_class_instance_if_missing_in_envs(DefId(def_id_raw), instance_type);
         }
 
-        if !child_class_extends.is_empty() {
-            self.merge_class_extends_into_type_env(&child_class_extends, context);
-            self.merge_class_extends_into_type_environment(&child_class_extends, context);
-        }
-    }
-
-    fn merge_class_instances_into_type_env(
-        &self,
-        child_class_instances: &rustc_hash::FxHashMap<u32, TypeId>,
-        context: &'static str,
-    ) {
-        if let Ok(mut parent_env) = self.ctx.type_env.try_borrow_mut() {
-            for (&def_id_raw, &instance_type) in child_class_instances {
-                let def_id = DefId(def_id_raw);
-                if parent_env.get_class_instance_type(def_id).is_none() {
-                    parent_env.insert_class_instance_type(def_id, instance_type);
-                }
-            }
-        } else {
-            tracing::warn!("{context}: could not borrow parent type_env for class-instance merge");
-        }
-    }
-
-    fn merge_class_instances_into_type_environment(
-        &self,
-        child_class_instances: &rustc_hash::FxHashMap<u32, TypeId>,
-        context: &'static str,
-    ) {
-        if let Ok(mut parent_env) = self.ctx.type_environment.try_borrow_mut() {
-            for (&def_id_raw, &instance_type) in child_class_instances {
-                let def_id = DefId(def_id_raw);
-                if parent_env.get_class_instance_type(def_id).is_none() {
-                    parent_env.insert_class_instance_type(def_id, instance_type);
-                }
-            }
-        } else {
-            tracing::warn!(
-                "{context}: could not borrow parent type_environment for class-instance merge"
-            );
-        }
-    }
-
-    fn merge_class_extends_into_type_env(
-        &self,
-        child_class_extends: &rustc_hash::FxHashMap<u32, DefId>,
-        context: &'static str,
-    ) {
-        if let Ok(mut parent_env) = self.ctx.type_env.try_borrow_mut() {
-            for (&def_id_raw, &parent_def_id) in child_class_extends {
-                let def_id = DefId(def_id_raw);
-                if parent_env.get_class_extends_def(def_id).is_none() {
-                    parent_env.register_class_extends(def_id, parent_def_id);
-                }
-            }
-        } else {
-            tracing::warn!("{context}: could not borrow parent type_env for class-extends merge");
-        }
-    }
-
-    fn merge_class_extends_into_type_environment(
-        &self,
-        child_class_extends: &rustc_hash::FxHashMap<u32, DefId>,
-        context: &'static str,
-    ) {
-        if let Ok(mut parent_env) = self.ctx.type_environment.try_borrow_mut() {
-            for (&def_id_raw, &parent_def_id) in child_class_extends {
-                let def_id = DefId(def_id_raw);
-                if parent_env.get_class_extends_def(def_id).is_none() {
-                    parent_env.register_class_extends(def_id, parent_def_id);
-                }
-            }
-        } else {
-            tracing::warn!(
-                "{context}: could not borrow parent type_environment for class-extends merge"
-            );
+        for (def_id_raw, parent_def_id) in child_class_extends {
+            self.ctx
+                .merge_class_extends_if_missing_in_envs(DefId(def_id_raw), parent_def_id);
         }
     }
 }

--- a/crates/tsz-checker/src/tests/type_analysis_env_merge_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/type_analysis_env_merge_arch_tests.rs
@@ -1,0 +1,45 @@
+use std::fs;
+
+#[test]
+fn type_analysis_env_merges_use_deferred_helpers() {
+    let cross_file = fs::read_to_string("src/state/type_analysis/cross_file_env_merge.rs")
+        .expect("failed to read cross_file_env_merge.rs");
+    let enum_member = fs::read_to_string("src/state/type_analysis/computed_helpers_binding.rs")
+        .expect("failed to read computed_helpers_binding.rs");
+
+    for forbidden in [
+        "type_env.try_borrow_mut",
+        "type_environment.try_borrow_mut",
+        "could not borrow parent",
+        "insert_class_instance_type(",
+        "register_class_extends(",
+        "insert_def(",
+    ] {
+        assert!(
+            !cross_file.contains(forbidden),
+            "cross-file env snapshot merge must not use raw env write path `{forbidden}`"
+        );
+    }
+
+    for required in [
+        "merge_def_if_missing_in_envs(",
+        "merge_class_instance_if_missing_in_envs(",
+        "merge_class_extends_if_missing_in_envs(",
+    ] {
+        assert!(
+            cross_file.contains(required),
+            "cross-file env snapshot merge should route through {required}"
+        );
+    }
+
+    for forbidden in ["type_env.try_borrow_mut", "env.register_enum_parent("] {
+        assert!(
+            !enum_member.contains(forbidden),
+            "enum member env publication must not use raw env write path `{forbidden}`"
+        );
+    }
+    assert!(
+        enum_member.contains("register_enum_parent_in_envs("),
+        "enum member parent publication should route through register_enum_parent_in_envs"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
- add parent-wins deferred env-write variants for child `TypeEnvironment` snapshot merge-back
- route cross-file child def/class-instance/class-extends metadata merges through those replayable helpers instead of raw parent env borrows
- publish enum-member parent metadata through the shared dual-env helper and update the file-prep comment now that enum metadata is no longer evaluator-only
- add helper-level replay coverage plus source guards for the remaining type-analysis merge paths
- rebase onto `main` after #15148 merged as `e0ab393dcc`; current exact head is `82ae9e1f43d8fb11047ad2fc92f9a1dfdc33afcd`

## Structural Rule
When cross-file type-analysis delegates return child `TypeEnvironment` metadata, the parent checker must eventually see child def bodies, class instance metadata, and class `extends` edges unless the parent already published an entry. `tsz` now applies those parent-wins merges through the checker deferred env-write boundary, so a `RefCell` borrow conflict queues and replays the merge instead of logging and dropping it.

#15148's dependency-first scheduling and defaulted-lib-receiver repairs are now present on `main` before this branch's parent-wins merge-back runs.

## Owner Layer
Checker owns cross-file snapshot merge-back in `state/type_analysis`; the dual-env replay mechanics stay inside `CheckerContext` env-write helpers in `context`. Solver `TypeEnvironment` semantics remain unchanged: these are parent-wins vacancy fills, not body rewrites. The inherited project-ordering/defaulted-receiver repairs are owned by #15148 and already merged into `main`.

## Adjacent Matrix
- child `DefId -> TypeId` body snapshot: `merge_def_if_missing_in_envs`
- child class instance snapshot: `merge_class_instance_if_missing_in_envs`
- child class `extends` snapshot: `merge_class_extends_if_missing_in_envs`
- enum member parent publication: `register_enum_parent_in_envs`
- fallback: if the parent already has an entry, replay preserves the parent value
- inherited #15148 witnesses: `main` includes the project-ordering, TS2344 display, and defaulted DOM/lib receiver repairs from #15148
- disk note from earlier work: one package-wide accidental checker test discovery run failed during linking with `ld: write() failed, errno=28`; per `tsz-disk-cache-hygiene`, Level 1/2 cleanup was insufficient, so only that worktree's `.target` cache was deleted before exact lib filters were retried

## Verification
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`
- `git diff --name-only --diff-filter=ACMR origin/main..HEAD | xargs wc -l` (largest touched file: 1962 lines)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib child_snapshot_merge_defer_then_replay_preserves_parent_entries type_analysis_env_merges_use_deferred_helpers def_mapping cross_file_class_instance_publication` (21/21 passed)
- exact-head `CI Summary` for `82ae9e1f43d8fb11047ad2fc92f9a1dfdc33afcd` is running before queueing

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
