### PR TITLE
fix(solver): skip property cache for unresolved lazy fallbacks

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache_property.rs
+++ b/crates/tsz-solver/src/caches/query_cache_property.rs
@@ -34,7 +34,9 @@ impl QueryCache<'_> {
         evaluator.set_no_unchecked_indexed_access(no_unchecked_indexed_access);
         evaluator.set_exact_optional_property_types(exact_optional_property_types);
         let result = evaluator.resolve_property_access_atom(object_type, prop_atom);
-        self.insert_property_cache(key, result);
+        if evaluator.property_result_cacheable() {
+            self.insert_property_cache(key, result);
+        }
         result
     }
 }

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -219,6 +219,10 @@ pub struct PropertyAccessEvaluator<'a> {
     /// fields. Ordinary string/index lookups keep this false so ES-private
     /// fields do not leak through dynamic property access.
     allow_private_identifier_properties: Cell<bool>,
+    /// Set when this access observes a deferred `Lazy(DefId)` whose body cannot
+    /// be resolved by the current resolver. Such results depend on publication
+    /// timing, so callers must not publish them into resolver-independent caches.
+    unresolved_lazy_property_seen: Cell<bool>,
     /// Per-access memo for deferred (`Application`/`Lazy`) property resolution.
     ///
     /// `resolve_application_property` and the deferred-`Lazy` walk re-instantiate
@@ -258,6 +262,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
             )),
             skip_this_binding: Cell::new(false),
             allow_private_identifier_properties: Cell::new(false),
+            unresolved_lazy_property_seen: Cell::new(false),
             deferred_property_memo: RefCell::new(FxHashMap::default()),
         }
     }
@@ -294,6 +299,14 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
     pub(crate) const fn allow_private_identifier_properties(&self) -> bool {
         self.allow_private_identifier_properties.get()
+    }
+
+    pub(crate) fn mark_unresolved_lazy_property_seen(&self) {
+        self.unresolved_lazy_property_seen.set(true);
+    }
+
+    pub const fn property_result_cacheable(&self) -> bool {
+        !self.unresolved_lazy_property_seen.get()
     }
 
     /// Helper to access the underlying `TypeDatabase`
@@ -626,9 +639,11 @@ impl<'a> PropertyAccessEvaluator<'a> {
             .insert(key, DeferredPropertyMemo::InProgress);
         let result = resolve();
         let truncated = !exceeded_before && self.guard.borrow().is_exceeded();
-        if truncated {
+        let unresolved_lazy_seen = self.unresolved_lazy_property_seen.get();
+        if truncated || unresolved_lazy_seen {
             // Degraded by a depth/iteration limit: not a pure function of the
-            // key, so drop the in-progress marker without caching the result.
+            // key, or by an unresolved lazy body whose answer depends on the
+            // current resolver window, so drop the marker without caching.
             self.deferred_property_memo.borrow_mut().remove(&key);
         } else {
             self.deferred_property_memo
@@ -1270,6 +1285,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                             // Successfully resolved - resolve property on the concrete type
                             self.resolve_property_access_inner(resolved, prop_atom)
                         } else {
+                            self.mark_unresolved_lazy_property_seen();
                             // Can't resolve lazy type - try apparent members
                             if let Some(result) = self.resolve_object_member(prop_atom) {
                                 result

--- a/crates/tsz-solver/src/operations/property_helpers.rs
+++ b/crates/tsz-solver/src/operations/property_helpers.rs
@@ -916,6 +916,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
         };
 
         let Some(body_type) = body_type else {
+            self.mark_unresolved_lazy_property_seen();
             // Resolution failed - fall back to structural evaluation.
             let evaluated = self
                 .db

--- a/crates/tsz-solver/tests/db_tests.rs
+++ b/crates/tsz-solver/tests/db_tests.rs
@@ -1,5 +1,6 @@
 use crate::caches::db::TypeApplicationEvalCache;
 use crate::construction::{QueryCache, QueryCacheStatistics, RelationCacheProbe};
+use crate::operations::property::PropertyAccessResult;
 use crate::relations::relation_queries::RelationPolicy;
 use crate::{
     LiteralValue, ObjectFlags, PropertyInfo, QueryDatabase, RelationCacheConfig, RelationCacheKey,
@@ -84,6 +85,82 @@ fn query_cache_caches_evaluate_and_subtype() {
     assert_eq!(db.subtype_cache_len(), 1);
     assert!(db.is_subtype_of(hello, TypeId::STRING));
     assert_eq!(db.subtype_cache_len(), 1);
+}
+
+#[test]
+fn property_cache_skips_unresolved_lazy_result() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let prop = interner.intern_string("value");
+    let unresolved = interner.lazy(crate::def::DefId(9001));
+
+    let result = db.resolve_property_access_atom(unresolved, prop);
+    assert!(
+        matches!(
+            result,
+            PropertyAccessResult::Success {
+                type_id: TypeId::ANY,
+                ..
+            }
+        ),
+        "unresolved lazy fallback should still be returned, got {result:?}"
+    );
+    assert_eq!(
+        db.property_cache_len(),
+        0,
+        "unresolved lazy fallback must not publish into the property cache"
+    );
+}
+
+#[test]
+fn property_cache_skips_unresolved_application_base_result() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let prop = interner.intern_string("value");
+    let unresolved_base = interner.lazy(crate::def::DefId(9002));
+    let app = interner.application(unresolved_base, vec![TypeId::STRING]);
+
+    let result = db.resolve_property_access_atom(app, prop);
+    assert!(
+        matches!(
+            result,
+            PropertyAccessResult::Success {
+                type_id: TypeId::ANY,
+                ..
+            }
+        ),
+        "unresolved application fallback should still be returned, got {result:?}"
+    );
+    assert_eq!(
+        db.property_cache_len(),
+        0,
+        "unresolved lazy application fallback must not publish into the property cache"
+    );
+}
+
+#[test]
+fn property_cache_keeps_resolved_object_property_result() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let prop = interner.intern_string("value");
+    let obj = interner.object(vec![PropertyInfo::new(prop, TypeId::NUMBER)]);
+
+    let result = db.resolve_property_access_atom(obj, prop);
+    assert!(
+        matches!(
+            result,
+            PropertyAccessResult::Success {
+                type_id: TypeId::NUMBER,
+                ..
+            }
+        ),
+        "resolved object property should still be returned, got {result:?}"
+    );
+    assert_eq!(
+        db.property_cache_len(),
+        1,
+        "resolved object property access should still publish into the property cache"
+    );
 }
 
 /// Test cache poisoning prevention.


### PR DESCRIPTION
Goal: green

## Summary
- mark property accesses that observe unresolved `Lazy(DefId)` bodies in the current resolver window
- skip `QueryCache.property_cache` publication when the result depends on that unresolved lazy fallback
- keep ordinary resolved property results cacheable, and avoid storing single-access deferred memo `Done` values for unresolved-lazy fallbacks

## Structural Rule
When property access on `Lazy(DefId)` or `Application(Lazy(DefId), ...)` cannot resolve the lazy body in the current resolver window, tsz may return the existing apparent/`any` fallback for compatibility, but that result is publication-order dependent and must not enter resolver-independent property caches.

Owner layer: solver property access/cache (`crates/tsz-solver/src/operations/property*`, `crates/tsz-solver/src/caches/query_cache_property.rs`).

Adjacent matrix:
- bare unresolved `Lazy(DefId).value`: fallback result is returned, `property_cache` remains empty
- unresolved `Application(Lazy(DefId), [string]).value`: fallback result is returned, `property_cache` remains empty
- resolved object property access: result is returned and still publishes to `property_cache`

Fallback/performance: this is conservative within one top-level access tree: if an unresolved lazy contributes to the answer, the access skips cross-access caching and deferred memo `Done`. Resolved accesses retain the existing cache path.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver property_cache`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `python3 scripts/arch/arch_guard.py`
- `wc -l crates/tsz-solver/src/caches/query_cache_property.rs crates/tsz-solver/src/operations/property.rs crates/tsz-solver/src/operations/property_helpers.rs crates/tsz-solver/tests/db_tests.rs`

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: high