### PR TITLE
refactor(solver): name abstract constructor anchor visit state (#14346)

### DIFF
--- a/crates/tsz-solver/src/type_queries/extended_constructors.rs
+++ b/crates/tsz-solver/src/type_queries/extended_constructors.rs
@@ -37,6 +37,23 @@ fn with_extended_constructors_visited<R>(f: impl FnOnce(&mut FxHashSet<TypeId>) 
     r
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AbstractConstructorAnchorVisitState {
+    Entered,
+    AlreadyVisited,
+}
+
+fn abstract_constructor_anchor_visit_state(
+    visited: &mut FxHashSet<TypeId>,
+    type_id: TypeId,
+) -> AbstractConstructorAnchorVisitState {
+    if visited.insert(type_id) {
+        AbstractConstructorAnchorVisitState::Entered
+    } else {
+        AbstractConstructorAnchorVisitState::AlreadyVisited
+    }
+}
+
 // =============================================================================
 // Abstract Class Type Classification
 // =============================================================================
@@ -352,7 +369,9 @@ pub fn resolve_abstract_constructor_anchor(
 ) -> AbstractConstructorAnchor {
     with_extended_constructors_visited(|visited| {
         let mut current = type_id;
-        while visited.insert(current) {
+        while let AbstractConstructorAnchorVisitState::Entered =
+            abstract_constructor_anchor_visit_state(visited, current)
+        {
             match classify_for_abstract_constructor(db, current) {
                 AbstractConstructorKind::TypeQuery(sym_ref) => {
                     return AbstractConstructorAnchor::TypeQuery(sym_ref);

--- a/crates/tsz-solver/tests/extended_constructors_tests.rs
+++ b/crates/tsz-solver/tests/extended_constructors_tests.rs
@@ -735,6 +735,30 @@ fn base_instance_merge_function_callable_intrinsic_are_other() {
 // =============================================================================
 
 #[test]
+fn abstract_constructor_anchor_visit_state_enters_new_type() {
+    let mut visited = rustc_hash::FxHashSet::default();
+
+    assert_eq!(
+        abstract_constructor_anchor_visit_state(&mut visited, TypeId::STRING),
+        AbstractConstructorAnchorVisitState::Entered,
+    );
+}
+
+#[test]
+fn abstract_constructor_anchor_visit_state_reports_repeated_type() {
+    let mut visited = rustc_hash::FxHashSet::default();
+
+    assert_eq!(
+        abstract_constructor_anchor_visit_state(&mut visited, TypeId::STRING),
+        AbstractConstructorAnchorVisitState::Entered,
+    );
+    assert_eq!(
+        abstract_constructor_anchor_visit_state(&mut visited, TypeId::STRING),
+        AbstractConstructorAnchorVisitState::AlreadyVisited,
+    );
+}
+
+#[test]
 fn anchor_type_query_returns_type_query_anchor() {
     let interner = TypeInterner::new();
     let tq = interner.type_query(SymbolRef(13));
@@ -763,6 +787,19 @@ fn anchor_application_unwraps_to_base_callable() {
     let app = interner.application(callable, vec![TypeId::NUMBER]);
     assert_eq!(
         resolve_abstract_constructor_anchor(&interner, app),
+        AbstractConstructorAnchor::CallableType(callable),
+    );
+}
+
+#[test]
+fn anchor_nested_application_unwraps_to_base_callable() {
+    let interner = TypeInterner::new();
+    let callable = interner.callable(CallableShape::default());
+    let app = interner.application(callable, vec![TypeId::NUMBER]);
+    let outer = interner.application(app, vec![TypeId::STRING]);
+
+    assert_eq!(
+        resolve_abstract_constructor_anchor(&interner, outer),
         AbstractConstructorAnchor::CallableType(callable),
     );
 }


### PR DESCRIPTION
Goal: green

## Summary
- Name the visited-set verdict in `resolve_abstract_constructor_anchor` as `AbstractConstructorAnchorVisitState::{Entered, AlreadyVisited}`.
- Preserve the existing behavior: application peeling continues for newly visited anchors, and revisiting an anchor falls back to `AbstractConstructorAnchor::NotAbstract`.
- Add constructor-anchor tests for first/repeated visits and nested application peeling to a callable anchor.

## Structural Rule
When abstract-constructor anchor resolution traverses an `Application` chain and reaches a newly visited type, tsz continues peeling through the solver-owned type-query helper. When the traversal reaches an already visited type, tsz preserves the existing cycle fallback by stopping the walk and returning `NotAbstract`; checker code still only consumes the resolved anchor and owns source-context rules.

## Owner Layer
- Solver type-query owner: `crates/tsz-solver/src/type_queries/extended_constructors.rs`
- Tests: `crates/tsz-solver/tests/extended_constructors_tests.rs`
- No checker, emitter, relation, query-cache, inference, property-cache, or diagnostic files are touched.

## Adjacent Matrix
- New type: visit state is `Entered`.
- Repeated type: visit state is `AlreadyVisited`.
- Nested application: `Application(Application(Callable, ...), ...)` still peels to the callable anchor.
- Existing constructor/classification rows remain green through the full `extended_constructors` test filter.

## Fallback And Performance
- Fallback remains the pre-existing `NotAbstract` result after the visited-set loop stops.
- No new allocations or cache keys; this only names the existing `FxHashSet::insert` verdict while continuing to use the pooled visited set.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver abstract_constructor_anchor extended_constructors`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `wc -l crates/tsz-solver/src/type_queries/extended_constructors.rs crates/tsz-solver/tests/extended_constructors_tests.rs` (443 / 860 lines)

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high