### PR TITLE
perf(solver): bound union normalize cache residency

### DIFF
--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -826,26 +826,6 @@ impl TypeInterner {
         }
     }
 
-    /// Upper input length for the `normalize_union` result memo.
-    ///
-    /// `reduce_union_subtypes` sets the sticky TS2590 `union_too_complex` flag
-    /// only when its pairwise budget (`UNION_SUBTYPE_PAIRWISE_LIMIT`) is hit;
-    /// the member list never grows inside `normalize_union_uncached`, so
-    /// inputs at or below this bound can never set the flag and their results
-    /// are pure functions of the input list. Larger inputs skip the memo so a
-    /// cache hit can never swallow the flag. The compile-time assertion below
-    /// keeps this bound the largest length whose pairwise count stays under
-    /// the budget, so editing either constant alone fails the build instead
-    /// of silently muting TS2590 on memo hits.
-    const UNION_NORMALIZE_CACHE_MAX_LEN: usize = {
-        let max_len = 1000_usize;
-        assert!(
-            (max_len as u64) * (max_len as u64 - 1) < Self::UNION_SUBTYPE_PAIRWISE_LIMIT
-                && (max_len as u64 + 1) * (max_len as u64) >= Self::UNION_SUBTYPE_PAIRWISE_LIMIT
-        );
-        max_len
-    };
-
     /// Memoized union normalization.
     ///
     /// The full pipeline (callable-order probe, semantic sort, dedup, literal
@@ -864,7 +844,7 @@ impl TypeInterner {
         }
         let key: Box<[TypeId]> = flat.as_slice().into();
         let result = self.normalize_union_uncached(flat);
-        self.union_normalize_cache.insert(key, result);
+        self.insert_union_normalize_cache(key, result);
         result
     }
 
@@ -1926,101 +1906,5 @@ impl TypeInterner {
 impl Default for TypeInterner {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-#[cfg(test)]
-mod union_preserve_members_tests {
-    use crate::TypeInterner;
-    use crate::types::TypeId;
-
-    /// `union_preserve_members` skips structural subtype reduction but must still
-    /// apply the universal top/bottom sentinel absorptions (`error` > `any` >
-    /// `unknown`), since `unknown | T` is `unknown`, `any | T` is `any`, and
-    /// `error | T` is `error` for every `T`. The flow-narrowing logical-condition
-    /// combiner relied on this: the false branch of
-    /// `typeof x === "object" && x !== null` over an `unknown` produced a stray
-    /// `unknown | null`, which then mis-narrowed under a later `typeof` guard.
-    #[test]
-    fn union_preserve_members_absorbs_top_and_bottom_sentinels() {
-        let interner = TypeInterner::new();
-
-        assert_eq!(
-            interner.union_preserve_members(vec![TypeId::UNKNOWN, TypeId::NULL]),
-            TypeId::UNKNOWN,
-            "unknown | null must absorb to unknown"
-        );
-        assert_eq!(
-            interner.union_preserve_members(vec![TypeId::STRING, TypeId::UNKNOWN, TypeId::NUMBER]),
-            TypeId::UNKNOWN,
-            "any member set containing unknown collapses to unknown"
-        );
-
-        // `any | T` is `any`; `any` outranks `unknown`.
-        assert_eq!(
-            interner.union_preserve_members(vec![TypeId::ANY, TypeId::STRING]),
-            TypeId::ANY,
-            "any | string must absorb to any"
-        );
-        assert_eq!(
-            interner.union_preserve_members(vec![TypeId::UNKNOWN, TypeId::ANY]),
-            TypeId::ANY,
-            "any outranks unknown"
-        );
-
-        // `error | T` is `error`; `error` outranks everything.
-        assert_eq!(
-            interner.union_preserve_members(vec![TypeId::ERROR, TypeId::ANY]),
-            TypeId::ERROR,
-            "error outranks any"
-        );
-
-        // A sentinel nested inside a member union is also caught (members are
-        // flattened before the scan).
-        let nested = interner.union_preserve_members(vec![TypeId::STRING, TypeId::UNKNOWN]);
-        assert_eq!(
-            interner.union_preserve_members(vec![TypeId::NUMBER, nested]),
-            TypeId::UNKNOWN,
-            "unknown nested inside a member union still absorbs"
-        );
-
-        // Non-sentinel members keep their structure (no subtype reduction).
-        assert_eq!(
-            interner.union_preserve_members(vec![TypeId::STRING, TypeId::NUMBER]),
-            interner.union(vec![TypeId::STRING, TypeId::NUMBER]),
-            "ordinary members are unaffected"
-        );
-    }
-
-    /// `union(Vec)` and `union_from_slice(&[..])` both delegate to the same
-    /// `union_from_iter` normalizer, so they must return a byte-identical
-    /// `TypeId` for the same member sequence. The hot evaluation/instantiation/
-    /// inference/widening/narrowing paths rely on this equivalence to construct
-    /// unions from a borrowed slice (`union_from_slice`) instead of cloning the
-    /// member vector into `union` — a pure allocation cut with no result change.
-    /// This pins the contract so a future divergence in either constructor is
-    /// caught here rather than as a silent diagnostic drift downstream.
-    #[test]
-    fn union_from_slice_matches_owned_union() {
-        let interner = TypeInterner::new();
-        let cases: &[Vec<TypeId>] = &[
-            vec![TypeId::STRING, TypeId::NUMBER],
-            // Order that requires sorting/normalization.
-            vec![TypeId::NUMBER, TypeId::STRING, TypeId::BOOLEAN],
-            // Duplicates that must dedup identically.
-            vec![TypeId::STRING, TypeId::STRING, TypeId::NUMBER],
-            // Sentinel absorption (`any | T` == `any`).
-            vec![TypeId::ANY, TypeId::STRING],
-            // Single-member and empty edge cases.
-            vec![TypeId::STRING],
-            vec![],
-        ];
-        for members in cases {
-            assert_eq!(
-                interner.union(members.clone()),
-                interner.union_from_slice(members),
-                "union(Vec) and union_from_slice(&[..]) must agree for {members:?}",
-            );
-        }
     }
 }

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -25,7 +25,7 @@ use smallvec::SmallVec;
 use std::hash::{Hash, Hasher};
 use std::sync::{
     Arc, OnceLock,
-    atomic::{AtomicBool, AtomicU32, Ordering},
+    atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering},
 };
 use tsz_common::interner::{Atom, ShardedInterner};
 
@@ -343,6 +343,8 @@ pub struct TypeInterner {
     /// `UNION_NORMALIZE_CACHE_MAX_LEN` bypass this memo so the sticky
     /// TS2590 `union_too_complex` flag is never swallowed by a hit.
     pub(crate) union_normalize_cache: DashMap<Box<[TypeId]>, TypeId, FxBuildHasher>,
+    /// Retained member slots across all `union_normalize_cache` keys.
+    pub(super) union_normalize_cache_member_slots: AtomicUsize,
     /// The global Array base type (e.g., Array<T> from lib.d.ts).
     /// Uses `AtomicU32` (with `u32::MAX` as sentinel for `None`) instead of
     /// `RwLock` so file checkers can overwrite the prime checker's value without
@@ -510,6 +512,8 @@ pub struct TypePredicateCacheStatistics {
     pub identity_comparable_cache_entries: usize,
     /// Number of memoized union-normalization results.
     pub union_normalize_cache_entries: usize,
+    /// Number of `TypeId` member slots retained by union-normalization keys.
+    pub union_normalize_cache_member_slots: usize,
     /// Number of memoized `ThisType` containment predicate results.
     pub contains_this_cache_entries: usize,
     /// Number of memoized `infer` containment predicate results.
@@ -549,12 +553,37 @@ impl std::fmt::Debug for TypeInterner {
 }
 
 impl TypeInterner {
+    /// Upper input length for the `normalize_union` result memo.
+    ///
+    /// `reduce_union_subtypes` sets the sticky TS2590 `union_too_complex` flag
+    /// only when its pairwise budget (`UNION_SUBTYPE_PAIRWISE_LIMIT`) is hit;
+    /// the member list never grows inside `normalize_union_uncached`, so
+    /// inputs at or below this bound can never set the flag and their results
+    /// are pure functions of the input list. Larger inputs skip the memo so a
+    /// cache hit can never swallow the flag. The compile-time assertion below
+    /// keeps this bound the largest length whose pairwise count stays under
+    /// the budget, so editing either constant alone fails the build instead
+    /// of silently muting TS2590 on memo hits.
+    pub(super) const UNION_NORMALIZE_CACHE_MAX_LEN: usize = {
+        let max_len = 1000_usize;
+        assert!(
+            (max_len as u64) * (max_len as u64 - 1) < Self::UNION_SUBTYPE_PAIRWISE_LIMIT
+                && (max_len as u64 + 1) * (max_len as u64) >= Self::UNION_SUBTYPE_PAIRWISE_LIMIT
+        );
+        max_len
+    };
+    /// Maximum exact-key entries retained by the union-normalization memo.
+    pub(super) const UNION_NORMALIZE_CACHE_MAX_ENTRIES: usize = 4096;
+    /// Maximum total `TypeId` slots retained by union-normalization memo keys.
+    pub(super) const UNION_NORMALIZE_CACHE_MAX_MEMBER_SLOTS: usize = 262_144;
+
     /// Capture retained predicate-cache entry counts for perf attribution.
     #[must_use]
     pub fn type_predicate_cache_statistics(&self) -> TypePredicateCacheStatistics {
         TypePredicateCacheStatistics {
             identity_comparable_cache_entries: self.identity_comparable_cache.len(),
             union_normalize_cache_entries: self.union_normalize_cache.len(),
+            union_normalize_cache_member_slots: self.union_normalize_cache_member_slots(),
             contains_this_cache_entries: self
                 .predicate_cache_entries_for(PredicateCacheKind::ContainsThis),
             contains_infer_cache_entries: self
@@ -619,6 +648,71 @@ impl TypeInterner {
             .count()
     }
 
+    pub(super) fn insert_union_normalize_cache(&self, key: Box<[TypeId]>, result: TypeId) {
+        self.insert_union_normalize_cache_with_limits(
+            key,
+            result,
+            Self::UNION_NORMALIZE_CACHE_MAX_ENTRIES,
+            Self::UNION_NORMALIZE_CACHE_MAX_MEMBER_SLOTS,
+        );
+    }
+
+    pub(super) fn insert_union_normalize_cache_with_limits(
+        &self,
+        key: Box<[TypeId]>,
+        result: TypeId,
+        max_entries: usize,
+        max_member_slots: usize,
+    ) {
+        let key_len = key.len();
+        if max_entries == 0 || key_len > max_member_slots {
+            return;
+        }
+
+        if let Some((removed_key, _)) = self.union_normalize_cache.remove(key.as_ref()) {
+            self.decrement_union_normalize_cache_member_slots(removed_key.len());
+        }
+        while self.union_normalize_cache.len() >= max_entries
+            || self
+                .union_normalize_cache_member_slots
+                .load(Ordering::Relaxed)
+                .saturating_add(key_len)
+                > max_member_slots
+        {
+            let Some(eviction_key) = self
+                .union_normalize_cache
+                .iter()
+                .next()
+                .map(|entry| entry.key().clone())
+            else {
+                break;
+            };
+            if let Some((removed_key, _)) = self.union_normalize_cache.remove(eviction_key.as_ref())
+            {
+                self.decrement_union_normalize_cache_member_slots(removed_key.len());
+            }
+        }
+
+        let inserted_new_key = self.union_normalize_cache.insert(key, result).is_none();
+        if inserted_new_key {
+            self.union_normalize_cache_member_slots
+                .fetch_add(key_len, Ordering::Relaxed);
+        }
+    }
+
+    fn union_normalize_cache_member_slots(&self) -> usize {
+        self.union_normalize_cache_member_slots
+            .load(Ordering::Relaxed)
+    }
+
+    fn decrement_union_normalize_cache_member_slots(&self, slots: usize) {
+        let _ = self.union_normalize_cache_member_slots.fetch_update(
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+            |current| Some(current.saturating_sub(slots)),
+        );
+    }
+
     /// Create a new type interner with pre-registered intrinsics.
     ///
     /// Uses lazy initialization for all `DashMap` structures to minimize
@@ -649,6 +743,7 @@ impl TypeInterner {
             proto_instantiation_cache: DashMap::with_hasher(FxBuildHasher),
             contravariant_infer_names_cache: DashMap::with_hasher(FxBuildHasher),
             union_normalize_cache: DashMap::with_hasher(FxBuildHasher),
+            union_normalize_cache_member_slots: AtomicUsize::new(0),
             array_base_type: AtomicU32::new(u32::MAX),
             array_display_base_type: AtomicU32::new(u32::MAX),
             array_base_type_params: OnceLock::new(),

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -88,6 +88,138 @@ fn type_predicate_cache_statistics_reports_union_normalize_entries() {
         stats.union_normalize_cache_entries > 0,
         "union normalization memo entries must be visible to cache residency reports"
     );
+    assert!(
+        stats.union_normalize_cache_member_slots >= 2,
+        "union normalization memo member slots must be visible to cache residency reports"
+    );
+}
+
+#[test]
+fn union_normalize_cache_bounded_insert_evicts_entries_and_member_slots() {
+    let interner = TypeInterner::new();
+
+    interner.insert_union_normalize_cache_with_limits(
+        Box::from([TypeId(100), TypeId(101)]),
+        TypeId::STRING,
+        2,
+        4,
+    );
+    interner.insert_union_normalize_cache_with_limits(
+        Box::from([TypeId(102), TypeId(103)]),
+        TypeId::NUMBER,
+        2,
+        4,
+    );
+    interner.insert_union_normalize_cache_with_limits(
+        Box::from([TypeId(104), TypeId(105)]),
+        TypeId::BOOLEAN,
+        2,
+        4,
+    );
+
+    let stats = interner.type_predicate_cache_statistics();
+    assert!(
+        stats.union_normalize_cache_entries <= 2,
+        "union normalization memo must evict instead of retaining unbounded exact keys"
+    );
+    assert!(
+        stats.union_normalize_cache_member_slots <= 4,
+        "union normalization memo must evict by retained member slots, not only entry count"
+    );
+}
+
+mod union_preserve_members_tests {
+    use super::*;
+
+    /// `union_preserve_members` skips structural subtype reduction but must still
+    /// apply the universal top/bottom sentinel absorptions (`error` > `any` >
+    /// `unknown`), since `unknown | T` is `unknown`, `any | T` is `any`, and
+    /// `error | T` is `error` for every `T`. The flow-narrowing logical-condition
+    /// combiner relied on this: the false branch of
+    /// `typeof x === "object" && x !== null` over an `unknown` produced a stray
+    /// `unknown | null`, which then mis-narrowed under a later `typeof` guard.
+    #[test]
+    fn union_preserve_members_absorbs_top_and_bottom_sentinels() {
+        let interner = TypeInterner::new();
+
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::UNKNOWN, TypeId::NULL]),
+            TypeId::UNKNOWN,
+            "unknown | null must absorb to unknown"
+        );
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::STRING, TypeId::UNKNOWN, TypeId::NUMBER]),
+            TypeId::UNKNOWN,
+            "any member set containing unknown collapses to unknown"
+        );
+
+        // `any | T` is `any`; `any` outranks `unknown`.
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::ANY, TypeId::STRING]),
+            TypeId::ANY,
+            "any | string must absorb to any"
+        );
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::UNKNOWN, TypeId::ANY]),
+            TypeId::ANY,
+            "any outranks unknown"
+        );
+
+        // `error | T` is `error`; `error` outranks everything.
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::ERROR, TypeId::ANY]),
+            TypeId::ERROR,
+            "error outranks any"
+        );
+
+        // A sentinel nested inside a member union is also caught (members are
+        // flattened before the scan).
+        let nested = interner.union_preserve_members(vec![TypeId::STRING, TypeId::UNKNOWN]);
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::NUMBER, nested]),
+            TypeId::UNKNOWN,
+            "unknown nested inside a member union still absorbs"
+        );
+
+        // Non-sentinel members keep their structure (no subtype reduction).
+        assert_eq!(
+            interner.union_preserve_members(vec![TypeId::STRING, TypeId::NUMBER]),
+            interner.union(vec![TypeId::STRING, TypeId::NUMBER]),
+            "ordinary members are unaffected"
+        );
+    }
+
+    /// `union(Vec)` and `union_from_slice(&[..])` both delegate to the same
+    /// `union_from_iter` normalizer, so they must return a byte-identical
+    /// `TypeId` for the same member sequence. The hot evaluation/instantiation/
+    /// inference/widening/narrowing paths rely on this equivalence to construct
+    /// unions from a borrowed slice (`union_from_slice`) instead of cloning the
+    /// member vector into `union` — a pure allocation cut with no result change.
+    /// This pins the contract so a future divergence in either constructor is
+    /// caught here rather than as a silent diagnostic drift downstream.
+    #[test]
+    fn union_from_slice_matches_owned_union() {
+        let interner = TypeInterner::new();
+        let cases: &[Vec<TypeId>] = &[
+            vec![TypeId::STRING, TypeId::NUMBER],
+            // Order that requires sorting/normalization.
+            vec![TypeId::NUMBER, TypeId::STRING, TypeId::BOOLEAN],
+            // Duplicates that must dedup identically.
+            vec![TypeId::STRING, TypeId::STRING, TypeId::NUMBER],
+            // Sentinel absorption (`any | T` == `any`).
+            vec![TypeId::ANY, TypeId::STRING],
+            // Single-member and empty edge cases.
+            vec![TypeId::STRING],
+            vec![],
+        ];
+        for members in cases {
+            assert_eq!(
+                interner.union(members.clone()),
+                interner.union_from_slice(members),
+                "union(Vec) and union_from_slice(&[..]) must agree for {members:?}",
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
Goal: fast

## Structural Rule
When union normalization receives a flattened member list whose length is within the existing pairwise subtype-reduction budget, the normalized result is a pure function of that exact `TypeId` sequence over immutable interned types, so `tsz` may memoize and reuse it through the solver `TypeInterner`. When the input exceeds that bound, normalization remains uncached so a memo hit cannot hide the sticky `union_too_complex` / TS2590 signal. Cache residency is bounded and reported without changing union ordering, deduplication, sentinel absorption, enum/intersection absorption, or subtype reduction.

Owner layer: solver interner union construction and residency accounting in `crates/tsz-solver/src/intern/core`.

## Adjacent Matrix
- Repeated exact pre-normalization member list: returns the cached normalized `TypeId`.
- Same semantic members in a different input order: still normalizes through the existing sort/dedup path; cache key policy does not change semantics.
- Input above `UNION_NORMALIZE_CACHE_MAX_LEN`: bypasses the memo and preserves TS2590 flag behavior.
- Cache residency/statistics: union-normalize entries and retained member slots stay visible to `type_predicate_cache_statistics`; `estimated_size_bytes` still accounts retained key payloads.
- Fallback: if an entry is evicted, absent, or ineligible, normalization falls through to `normalize_union_uncached` with existing behavior.

## Changes
- Adds entry and retained-member-slot bounds for the solver `TypeInterner` union-normalization memo.
- Tracks retained union-normalize member slots with an atomic counter and exposes it in cache statistics.
- Moves union constructor tests from `constructors.rs` to `interner_tests.rs`, dropping `constructors.rs` below the 2000-line cap.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver union_normalize_cache_bounded_insert_evicts_entries_and_member_slots type_predicate_cache_statistics_reports_union_normalize_entries union_preserve_members_absorbs_top_and_bottom_sentinels union_from_slice_matches_owned_union`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `python3 scripts/arch/arch_guard.py`
- `python3 scripts/perf/cache-visibility-report.py --json`
- `wc -l crates/tsz-solver/src/intern/core/constructors.rs crates/tsz-solver/src/intern/core/interner.rs crates/tsz-solver/src/intern/core/interner_tests.rs`

## Provenance
Machine: m4
Assistant: codex
Model: gpt-5
Effort: high
