### PR TITLE
refactor(solver): name mapped keyof depth state (#14346)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/rules/mapped_expansion.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/mapped_expansion.rs
@@ -10,6 +10,24 @@ use crate::visitor::{
     object_shape_id, object_with_index_shape_id, type_param_info, union_list_id,
 };
 
+const KEYOF_KEYS_MAX_DEPTH: u32 = 5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeyofKeysDepthState {
+    Continue,
+    LimitExceeded,
+}
+
+impl KeyofKeysDepthState {
+    const fn for_depth(depth: u32) -> Self {
+        if depth > KEYOF_KEYS_MAX_DEPTH {
+            Self::LimitExceeded
+        } else {
+            Self::Continue
+        }
+    }
+}
+
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// If `target` is a deferred `Mapped` node that expands to a concrete object
     /// or pure-index shape (e.g. `Record<any, V>`'s `{ [P in any]: V }` reducing
@@ -307,8 +325,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         operand: TypeId,
         depth: u32,
     ) -> Option<Vec<tsz_common::interner::Atom>> {
-        if depth > 5 {
-            return None;
+        match KeyofKeysDepthState::for_depth(depth) {
+            KeyofKeysDepthState::Continue => {}
+            KeyofKeysDepthState::LimitExceeded => return None,
         }
         let shape_id = object_shape_id(self.interner, operand)
             .or_else(|| object_with_index_shape_id(self.interner, operand));
@@ -417,3 +436,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         )
     }
 }
+
+#[cfg(test)]
+#[path = "../../../../tests/mapped_expansion_keyof_depth_state_tests.rs"]
+mod mapped_expansion_keyof_depth_state_tests;

--- a/crates/tsz-solver/tests/mapped_expansion_keyof_depth_state_tests.rs
+++ b/crates/tsz-solver/tests/mapped_expansion_keyof_depth_state_tests.rs
@@ -1,0 +1,67 @@
+use super::*;
+use crate::construction::TypeInterner;
+use crate::def::DefId;
+use crate::def::resolver::TypeEnvironment;
+use crate::types::{PropertyInfo, TypeId};
+
+fn atom_names(interner: &TypeInterner, atoms: &[tsz_common::interner::Atom]) -> Vec<String> {
+    let mut names: Vec<String> = atoms
+        .iter()
+        .map(|atom| interner.resolve_atom(*atom))
+        .collect();
+    names.sort();
+    names
+}
+
+fn lazy_chain_to(
+    interner: &TypeInterner,
+    env: &mut TypeEnvironment,
+    first_def: u32,
+    len: u32,
+    leaf: TypeId,
+) -> TypeId {
+    debug_assert!(len > 0);
+    for offset in 0..len {
+        let def_id = DefId(first_def + offset);
+        let body = if offset + 1 == len {
+            leaf
+        } else {
+            interner.lazy(DefId(first_def + offset + 1))
+        };
+        env.insert_def(def_id, body);
+    }
+    interner.lazy(DefId(first_def))
+}
+
+#[test]
+fn mapped_keyof_keys_depth_state_continues_at_exact_limit() {
+    let interner = TypeInterner::new();
+    let prop = interner.intern_string("value");
+    let leaf = interner.object(vec![PropertyInfo::new(prop, TypeId::STRING)]);
+
+    let mut env = TypeEnvironment::new();
+    let operand = lazy_chain_to(&interner, &mut env, 100, KEYOF_KEYS_MAX_DEPTH, leaf);
+    let mut checker = SubtypeChecker::with_resolver(&interner, &env);
+
+    let keys = checker
+        .try_get_keyof_keys(operand)
+        .expect("exact depth cap should still inspect the leaf object");
+
+    assert_eq!(atom_names(&interner, &keys), vec!["value"]);
+}
+
+#[test]
+fn mapped_keyof_keys_depth_state_preserves_unexpandable_past_limit() {
+    let interner = TypeInterner::new();
+    let prop = interner.intern_string("value");
+    let leaf = interner.object(vec![PropertyInfo::new(prop, TypeId::STRING)]);
+
+    let mut env = TypeEnvironment::new();
+    let operand = lazy_chain_to(&interner, &mut env, 200, KEYOF_KEYS_MAX_DEPTH + 1, leaf);
+    let mut checker = SubtypeChecker::with_resolver(&interner, &env);
+
+    assert!(
+        checker.try_get_keyof_keys(operand).is_none(),
+        "past the cap, the existing fallback keeps mapped expansion unresolvable"
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
- names the mapped-expansion `keyof` key recovery recursion cap as `KeyofKeysDepthState`
- preserves the existing exact-cap continuation and past-cap unexpandable fallback
- adds lazy-chain boundary tests in a separate under-cap test shard

## Structural Rule
When mapped expansion recovers concrete keys through nested lazy/type-parameter/`this` wrappers, `tsc` only treats the mapped key space as concrete while the structural walk can resolve it. `tsz` owns that bounded walk in `tsz-solver` mapped expansion: depths at or below `KEYOF_KEYS_MAX_DEPTH` continue, and `LimitExceeded` preserves the existing `None` fallback so the mapped type remains unexpanded.

## Owner Layer
Solver relation mapped-expansion helper only. No checker, emitter, instantiation, generic-call, cache-residency, or M4 inference/cache files are touched.

## Adjacent Matrix
- exact depth cap: lazy chain resolves to the object leaf and returns its key
- past depth cap: lazy chain preserves the existing unexpandable fallback
- existing direct object/index and lazy-reference key recovery tests remain green

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver mapped_keyof_keys_depth_state`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver try_get_keyof_keys`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `wc -l crates/tsz-solver/src/relations/subtype/rules/mapped_expansion.rs crates/tsz-solver/tests/mapped_expansion_keyof_depth_state_tests.rs crates/tsz-solver/tests/generics_rules_tests.rs`

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high
