### PR TITLE
refactor(solver): name display reduce visit states (#14346)

### DIFF
--- a/crates/tsz-solver/src/diagnostics/reduce.rs
+++ b/crates/tsz-solver/src/diagnostics/reduce.rs
@@ -32,6 +32,25 @@ thread_local! {
     static REDUCE_VISITED_POOL: RefCell<Option<FxHashSet<TypeId>>> = const { RefCell::new(None) };
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeepReduceVisitState {
+    Intrinsic,
+    Entered,
+    AlreadyVisited,
+}
+
+impl DeepReduceVisitState {
+    fn enter(type_id: TypeId, visited: &mut FxHashSet<TypeId>) -> Self {
+        if type_id.is_intrinsic() {
+            Self::Intrinsic
+        } else if visited.insert(type_id) {
+            Self::Entered
+        } else {
+            Self::AlreadyVisited
+        }
+    }
+}
+
 #[inline]
 fn with_reduce_visited<R>(f: impl FnOnce(&mut FxHashSet<TypeId>) -> R) -> R {
     let mut visited = REDUCE_VISITED_POOL
@@ -78,11 +97,11 @@ fn reduce_inner<R: TypeResolver>(
     type_id: TypeId,
     visited: &mut FxHashSet<TypeId>,
 ) -> TypeId {
-    if type_id.is_intrinsic() {
-        return type_id;
-    }
-    if !visited.insert(type_id) {
-        return type_id;
+    match DeepReduceVisitState::enter(type_id, visited) {
+        DeepReduceVisitState::Intrinsic | DeepReduceVisitState::AlreadyVisited => {
+            return type_id;
+        }
+        DeepReduceVisitState::Entered => {}
     }
 
     let key = db.lookup(type_id);

--- a/crates/tsz-solver/src/evaluation/evaluate/display_alias.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/display_alias.rs
@@ -8,6 +8,25 @@ use crate::relations::subtype::TypeResolver;
 use crate::types::{TypeData, TypeId};
 use rustc_hash::FxHashSet;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AliasDefReachVisitState {
+    Intrinsic,
+    Entered,
+    AlreadyVisited,
+}
+
+impl AliasDefReachVisitState {
+    fn enter(type_id: TypeId, visited: &mut FxHashSet<TypeId>) -> Self {
+        if type_id.is_intrinsic() {
+            Self::Intrinsic
+        } else if visited.insert(type_id) {
+            Self::Entered
+        } else {
+            Self::AlreadyVisited
+        }
+    }
+}
+
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     pub(in crate::evaluation) fn should_record_application_alias(
         &self,
@@ -89,8 +108,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         target_def_id: DefId,
         visited: &mut FxHashSet<TypeId>,
     ) -> bool {
-        if type_id.is_intrinsic() || !visited.insert(type_id) {
-            return false;
+        match AliasDefReachVisitState::enter(type_id, visited) {
+            AliasDefReachVisitState::Intrinsic | AliasDefReachVisitState::AlreadyVisited => {
+                return false;
+            }
+            AliasDefReachVisitState::Entered => {}
         }
         match self.interner.lookup(type_id) {
             Some(TypeData::Lazy(def_id))
@@ -231,3 +253,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         )
     }
 }
+
+#[cfg(test)]
+#[path = "../../../tests/display_alias_visit_state_tests.rs"]
+mod display_alias_visit_state_tests;

--- a/crates/tsz-solver/tests/deep_reduce_tests.rs
+++ b/crates/tsz-solver/tests/deep_reduce_tests.rs
@@ -461,6 +461,33 @@ fn deep_reduce_handles_self_referential_union_via_visited_guard() {
     assert_eq!(reduced, outer_i);
 }
 
+#[test]
+fn deep_reduce_visit_state_names_intrinsic_skip() {
+    let mut visited = rustc_hash::FxHashSet::default();
+
+    assert_eq!(
+        DeepReduceVisitState::enter(TypeId::STRING, &mut visited),
+        DeepReduceVisitState::Intrinsic
+    );
+    assert!(visited.is_empty());
+}
+
+#[test]
+fn deep_reduce_visit_state_names_entered_and_revisit() {
+    let interner = TypeInterner::new();
+    let type_id = interner.object(vec![]);
+    let mut visited = rustc_hash::FxHashSet::default();
+
+    assert_eq!(
+        DeepReduceVisitState::enter(type_id, &mut visited),
+        DeepReduceVisitState::Entered
+    );
+    assert_eq!(
+        DeepReduceVisitState::enter(type_id, &mut visited),
+        DeepReduceVisitState::AlreadyVisited
+    );
+}
+
 // =============================================================================
 // Application with reducible inner — current contract: Application leaves
 // are NOT recursed into, only `evaluate(...)` is asked. Lock that.

--- a/crates/tsz-solver/tests/display_alias_visit_state_tests.rs
+++ b/crates/tsz-solver/tests/display_alias_visit_state_tests.rs
@@ -1,0 +1,31 @@
+use super::*;
+use crate::construction::TypeInterner;
+use crate::types::TypeId;
+use rustc_hash::FxHashSet;
+
+#[test]
+fn alias_def_reach_visit_state_names_intrinsic_skip() {
+    let mut visited = FxHashSet::default();
+
+    assert_eq!(
+        AliasDefReachVisitState::enter(TypeId::STRING, &mut visited),
+        AliasDefReachVisitState::Intrinsic
+    );
+    assert!(visited.is_empty());
+}
+
+#[test]
+fn alias_def_reach_visit_state_names_entered_and_revisit() {
+    let interner = TypeInterner::new();
+    let type_id = interner.object(vec![]);
+    let mut visited = FxHashSet::default();
+
+    assert_eq!(
+        AliasDefReachVisitState::enter(type_id, &mut visited),
+        AliasDefReachVisitState::Entered
+    );
+    assert_eq!(
+        AliasDefReachVisitState::enter(type_id, &mut visited),
+        AliasDefReachVisitState::AlreadyVisited
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
- names the deep display-reduction DFS guard as `DeepReduceVisitState`
- names recursive alias-definition reachability guard as `AliasDefReachVisitState`
- preserves the existing intrinsic/revisit fallbacks and adds focused state tests

## Structural Rule
When diagnostic/display-only solver walkers revisit a type or see an intrinsic leaf, `tsz` must stop that traversal without changing the rendered semantic surface. `tsz-solver` owns both decisions: deep display reduction returns the original `TypeId`, and alias-definition reachability returns `false` for intrinsic or already-visited nodes.

## Owner Layer
Solver diagnostic/evaluation display helpers only. No checker, emitter, relation-cache, generic-call, instantiation, or M4 cache/inference files are touched. `diagnostics/format/mod.rs` is intentionally untouched because it is already above the 2000-line shard ceiling.

## Adjacent Matrix
- deep-reduce intrinsic input preserves the original `TypeId`
- deep-reduce first visit records `Entered`; second visit records `AlreadyVisited`
- alias-def reachability intrinsic input preserves the existing false fallback
- alias-def first visit records `Entered`; second visit records `AlreadyVisited`
- existing deep-reduce behavior suite remains green

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver deep_reduce_visit_state alias_def_reach_visit_state`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver deep_reduce`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `wc -l crates/tsz-solver/src/diagnostics/reduce.rs crates/tsz-solver/src/evaluation/evaluate/display_alias.rs crates/tsz-solver/tests/deep_reduce_tests.rs crates/tsz-solver/tests/display_alias_visit_state_tests.rs`

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high
