### PR TITLE
refactor(solver): name traversal visit states (#14346)

### DIFF
--- a/crates/tsz-solver/src/type_queries/traversal.rs
+++ b/crates/tsz-solver/src/type_queries/traversal.rs
@@ -303,11 +303,10 @@ where
 {
     let mut stack = vec![(type_id, in_conditional_branch)];
     while let Some((current, in_branch)) = stack.pop() {
-        if current == TypeId::ERROR || current == TypeId::ANY {
-            continue;
-        }
-        if !visited.insert((current, in_branch)) {
-            continue;
+        match ConditionalBranchAliasVisitState::enter(current, in_branch, visited) {
+            ConditionalBranchAliasVisitState::Entered => {}
+            ConditionalBranchAliasVisitState::IgnoredSentinel
+            | ConditionalBranchAliasVisitState::AlreadyVisited => continue,
         }
 
         let Some(key) = db.lookup(current) else {
@@ -334,6 +333,25 @@ where
         }
     }
     false
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConditionalBranchAliasVisitState {
+    Entered,
+    AlreadyVisited,
+    IgnoredSentinel,
+}
+
+impl ConditionalBranchAliasVisitState {
+    fn enter(current: TypeId, in_branch: bool, visited: &mut FxHashSet<(TypeId, bool)>) -> Self {
+        if current == TypeId::ERROR || current == TypeId::ANY {
+            Self::IgnoredSentinel
+        } else if visited.insert((current, in_branch)) {
+            Self::Entered
+        } else {
+            Self::AlreadyVisited
+        }
+    }
 }
 
 /// Check whether a declaration type contains a cyclic structure that cannot be
@@ -653,6 +671,7 @@ mod tests {
     use super::*;
     use crate::construction::TypeInterner;
     use crate::types::SymbolRef;
+    use rustc_hash::FxHashSet;
 
     struct ExemptApplicationHost {
         exempt_def_id: DefId,
@@ -679,6 +698,41 @@ mod tests {
         fn is_application_alias_serialization_exempt(&self, base_def_id: DefId) -> bool {
             base_def_id == self.exempt_def_id
         }
+    }
+
+    #[test]
+    fn conditional_branch_alias_visit_state_names_ignored_sentinels() {
+        let mut visited = FxHashSet::default();
+
+        assert_eq!(
+            ConditionalBranchAliasVisitState::enter(TypeId::ERROR, false, &mut visited),
+            ConditionalBranchAliasVisitState::IgnoredSentinel
+        );
+        assert_eq!(
+            ConditionalBranchAliasVisitState::enter(TypeId::ANY, true, &mut visited),
+            ConditionalBranchAliasVisitState::IgnoredSentinel
+        );
+        assert!(visited.is_empty());
+    }
+
+    #[test]
+    fn conditional_branch_alias_visit_state_keys_on_branch_context() {
+        let interner = TypeInterner::new();
+        let type_id = interner.object(vec![]);
+        let mut visited = FxHashSet::default();
+
+        assert_eq!(
+            ConditionalBranchAliasVisitState::enter(type_id, false, &mut visited),
+            ConditionalBranchAliasVisitState::Entered
+        );
+        assert_eq!(
+            ConditionalBranchAliasVisitState::enter(type_id, false, &mut visited),
+            ConditionalBranchAliasVisitState::AlreadyVisited
+        );
+        assert_eq!(
+            ConditionalBranchAliasVisitState::enter(type_id, true, &mut visited),
+            ConditionalBranchAliasVisitState::Entered
+        );
     }
 
     #[test]

--- a/crates/tsz-solver/src/visitors/visitor.rs
+++ b/crates/tsz-solver/src/visitors/visitor.rs
@@ -389,6 +389,22 @@ thread_local! {
     static WALK_POOL: RefCell<Option<WalkPool>> = const { RefCell::new(None) };
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReferencedTypeWalkState {
+    Entered,
+    AlreadyVisited,
+}
+
+impl ReferencedTypeWalkState {
+    fn enter(visited: &mut FxHashSet<TypeId>, current: TypeId) -> Self {
+        if visited.insert(current) {
+            Self::Entered
+        } else {
+            Self::AlreadyVisited
+        }
+    }
+}
+
 /// The callback is invoked once per unique reachable type (including `root`).
 pub fn walk_referenced_types<F>(types: &dyn TypeDatabase, root: TypeId, mut f: F)
 where
@@ -403,8 +419,9 @@ where
     stack.push(root);
 
     while let Some(current) = stack.pop() {
-        if !visited.insert(current) {
-            continue;
+        match ReferencedTypeWalkState::enter(visited, current) {
+            ReferencedTypeWalkState::Entered => {}
+            ReferencedTypeWalkState::AlreadyVisited => continue,
         }
         f(current);
 
@@ -1304,6 +1321,46 @@ impl<'a> ConstAssertionVisitor<'a> {
             return self.db.union_from_sorted_vec(const_members);
         }
         self.apply_const_assertion(type_id)
+    }
+}
+
+#[cfg(test)]
+mod referenced_type_walk_state_tests {
+    use super::{ReferencedTypeWalkState, walk_referenced_types};
+    use crate::construction::TypeInterner;
+    use crate::types::TupleElement;
+    use rustc_hash::FxHashSet;
+
+    #[test]
+    fn referenced_type_walk_state_names_entered_and_revisit() {
+        let db = TypeInterner::new();
+        let type_id = db.object(vec![]);
+        let mut visited = FxHashSet::default();
+
+        assert_eq!(
+            ReferencedTypeWalkState::enter(&mut visited, type_id),
+            ReferencedTypeWalkState::Entered
+        );
+        assert_eq!(
+            ReferencedTypeWalkState::enter(&mut visited, type_id),
+            ReferencedTypeWalkState::AlreadyVisited
+        );
+    }
+
+    #[test]
+    fn walk_referenced_types_visits_shared_child_once() {
+        let db = TypeInterner::new();
+        let child = db.object(vec![]);
+        let root = db.tuple(vec![TupleElement::fixed(child), TupleElement::fixed(child)]);
+        let mut visits = Vec::new();
+
+        walk_referenced_types(&db, root, |type_id| visits.push(type_id));
+
+        assert_eq!(
+            visits.iter().filter(|&&type_id| type_id == child).count(),
+            1
+        );
+        assert!(visits.contains(&root));
     }
 }
 


### PR DESCRIPTION
Goal: green

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high

## Summary
Names two existing solver traversal/revisit decisions without changing behavior:
- `ReferencedTypeWalkState::{Entered, AlreadyVisited}` for the shared referenced-type walk in `visitors/visitor.rs`.
- `ConditionalBranchAliasVisitState::{Entered, AlreadyVisited, IgnoredSentinel}` for branch-sensitive recursive alias detection in `type_queries/traversal.rs`.

## Structural Rule
When solver-owned structural traversal sees a duplicate work item, tsz records a revisit and skips that node. When conditional-branch alias detection sees `ERROR`/`ANY`, tsz preserves the existing sentinel skip. The branch-sensitive traversal key remains `(TypeId, in_branch)`, so the same type may be visited once outside and once inside a conditional branch.

## Owner Layer
Solver type traversal / type-query helpers. No checker, emitter, relation policy, generic-call, constraint-walker, inference, or cache-purity logic is changed.

## Adjacent Matrix
Added focused tests for the named state transitions, shared-child single-visit behavior, sentinel skips, and the branch-context key. This avoids the active M4 inference/cache files, #15147 type-query depth-state files, #15160 constraint-walker files, checker env/indexed-access files, generic-call/call-args, and relation-cache/function files.

## Fallback
Behavior is unchanged: repeated referenced types are skipped after first visit, repeated conditional-branch alias keys are skipped, and `ERROR`/`ANY` remain ignored sentinels.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver referenced_type_walk_state conditional_branch_alias_visit_state walk_referenced_types_visits_shared_child_once`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `wc -l crates/tsz-solver/src/visitors/visitor.rs crates/tsz-solver/src/type_queries/traversal.rs`
