### PR TITLE
refactor(solver): name visitor predicate guard states (#14346)

### DIFF
--- a/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
@@ -179,8 +179,10 @@ fn worklist_contains_matching(
     with_predicate_buffers(|visited, stack| {
         stack.push(root);
         while let Some(current) = stack.pop() {
-            if current.is_intrinsic() || !visited.insert(current) {
-                continue;
+            match PredicateWorklistVisitState::enter(current, visited) {
+                PredicateWorklistVisitState::Entered => {}
+                PredicateWorklistVisitState::IgnoredIntrinsic
+                | PredicateWorklistVisitState::AlreadyVisited => continue,
             }
             let data = types.lookup(current);
             if node_matches(current, data.as_ref()) {
@@ -197,6 +199,25 @@ fn worklist_contains_matching(
         }
         false
     })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PredicateWorklistVisitState {
+    Entered,
+    AlreadyVisited,
+    IgnoredIntrinsic,
+}
+
+impl PredicateWorklistVisitState {
+    fn enter(current: TypeId, visited: &mut FxHashSet<TypeId>) -> Self {
+        if current.is_intrinsic() {
+            Self::IgnoredIntrinsic
+        } else if visited.insert(current) {
+            Self::Entered
+        } else {
+            Self::AlreadyVisited
+        }
+    }
 }
 
 fn type_parameter_identity_matches(
@@ -358,8 +379,10 @@ fn resolution_path_contains_matching(
     with_predicate_buffers(|visited, stack| {
         stack.push(root);
         while let Some(current) = stack.pop() {
-            if current.is_intrinsic() || !visited.insert(current) {
-                continue;
+            match PredicateWorklistVisitState::enter(current, visited) {
+                PredicateWorklistVisitState::Entered => {}
+                PredicateWorklistVisitState::IgnoredIntrinsic
+                | PredicateWorklistVisitState::AlreadyVisited => continue,
             }
             let data = types.lookup(current);
             if node_matches(current, data.as_ref()) {
@@ -397,8 +420,9 @@ pub fn contains_type_by_id(types: &dyn TypeDatabase, root: TypeId, target: TypeI
         if current == target {
             return true;
         }
-        if !visited.insert(current) {
-            continue;
+        match ContainsTypeByIdVisitState::enter(current, &mut visited) {
+            ContainsTypeByIdVisitState::Entered => {}
+            ContainsTypeByIdVisitState::AlreadyVisited => continue,
         }
         crate::visitors::visitor::for_each_child_by_id(types, current, |child| {
             if !visited.contains(&child) {
@@ -407,6 +431,22 @@ pub fn contains_type_by_id(types: &dyn TypeDatabase, root: TypeId, target: TypeI
         });
     }
     false
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContainsTypeByIdVisitState {
+    Entered,
+    AlreadyVisited,
+}
+
+impl ContainsTypeByIdVisitState {
+    fn enter(current: TypeId, visited: &mut FxHashSet<TypeId>) -> Self {
+        if visited.insert(current) {
+            Self::Entered
+        } else {
+            Self::AlreadyVisited
+        }
+    }
 }
 
 /// The single deep boolean-containment driver behind every `contains_*`
@@ -684,7 +724,54 @@ pub fn contains_free_type_parameters_except_name(
 mod tests {
     use super::*;
     use crate::intern::TypeInterner;
-    use crate::types::TypeParamInfo;
+    use crate::types::{TupleElement, TypeParamInfo};
+
+    #[test]
+    fn predicate_worklist_visit_state_names_intrinsic_entered_and_revisit() {
+        let interner = TypeInterner::new();
+        let type_id = interner.object(vec![]);
+        let mut visited = FxHashSet::default();
+
+        assert_eq!(
+            PredicateWorklistVisitState::enter(TypeId::ANY, &mut visited),
+            PredicateWorklistVisitState::IgnoredIntrinsic
+        );
+        assert!(visited.is_empty());
+        assert_eq!(
+            PredicateWorklistVisitState::enter(type_id, &mut visited),
+            PredicateWorklistVisitState::Entered
+        );
+        assert_eq!(
+            PredicateWorklistVisitState::enter(type_id, &mut visited),
+            PredicateWorklistVisitState::AlreadyVisited
+        );
+    }
+
+    #[test]
+    fn contains_type_by_id_visit_state_names_entered_and_revisit() {
+        let interner = TypeInterner::new();
+        let type_id = interner.object(vec![]);
+        let mut visited = FxHashSet::default();
+
+        assert_eq!(
+            ContainsTypeByIdVisitState::enter(type_id, &mut visited),
+            ContainsTypeByIdVisitState::Entered
+        );
+        assert_eq!(
+            ContainsTypeByIdVisitState::enter(type_id, &mut visited),
+            ContainsTypeByIdVisitState::AlreadyVisited
+        );
+    }
+
+    #[test]
+    fn contains_type_by_id_handles_shared_child_once() {
+        let interner = TypeInterner::new();
+        let child = interner.object(vec![]);
+        let root = interner.tuple(vec![TupleElement::fixed(child), TupleElement::fixed(child)]);
+
+        assert!(contains_type_by_id(&interner, root, child));
+        assert!(!contains_type_by_id(&interner, root, TypeId::STRING));
+    }
 
     #[test]
     fn predicate_checker_memo_entry_counts_are_observable() {

--- a/crates/tsz-solver/src/visitors/visitor_predicates/identity_comparable.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates/identity_comparable.rs
@@ -11,10 +11,27 @@ pub fn is_identity_comparable_type(types: &dyn TypeDatabase, type_id: TypeId) ->
 
 const MAX_IDENTITY_COMPARABLE_DEPTH: u32 = 10;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IdentityComparableDepthState {
+    Continue,
+    LimitExceeded,
+}
+
+impl IdentityComparableDepthState {
+    const fn for_depth(depth: u32) -> Self {
+        if depth > MAX_IDENTITY_COMPARABLE_DEPTH {
+            Self::LimitExceeded
+        } else {
+            Self::Continue
+        }
+    }
+}
+
 fn is_identity_comparable_type_impl(types: &dyn TypeDatabase, type_id: TypeId, depth: u32) -> bool {
     // Prevent stack overflow on pathological types
-    if depth > MAX_IDENTITY_COMPARABLE_DEPTH {
-        return false;
+    match IdentityComparableDepthState::for_depth(depth) {
+        IdentityComparableDepthState::Continue => {}
+        IdentityComparableDepthState::LimitExceeded => return false,
     }
 
     // Check well-known singleton types first.
@@ -42,5 +59,35 @@ fn is_identity_comparable_type_impl(types: &dyn TypeDatabase, type_id: TypeId, d
 
         // Everything else is not identity-comparable.
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::intern::TypeInterner;
+
+    #[test]
+    fn identity_comparable_depth_state_names_exact_cap_and_limit() {
+        assert_eq!(
+            IdentityComparableDepthState::for_depth(MAX_IDENTITY_COMPARABLE_DEPTH),
+            IdentityComparableDepthState::Continue
+        );
+        assert_eq!(
+            IdentityComparableDepthState::for_depth(MAX_IDENTITY_COMPARABLE_DEPTH + 1),
+            IdentityComparableDepthState::LimitExceeded
+        );
+    }
+
+    #[test]
+    fn identity_comparable_depth_limit_preserves_false_fallback() {
+        let interner = TypeInterner::new();
+
+        assert!(is_identity_comparable_type(&interner, TypeId::BOOLEAN_TRUE));
+        assert!(!is_identity_comparable_type_impl(
+            &interner,
+            TypeId::BOOLEAN_TRUE,
+            MAX_IDENTITY_COMPARABLE_DEPTH + 1
+        ));
     }
 }


### PR DESCRIPTION
Goal: green

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high

## Summary
Names existing solver visitor-predicate guard decisions without changing behavior:
- `PredicateWorklistVisitState::{Entered, AlreadyVisited, IgnoredIntrinsic}` for pooled worklist predicate walks and constraint-resolution path walks.
- `ContainsTypeByIdVisitState::{Entered, AlreadyVisited}` for transitive `TypeId` containment walks.
- `IdentityComparableDepthState::{Continue, LimitExceeded}` for the identity-comparable depth cap.

## Structural Rule
When a solver visitor-predicate worklist sees an intrinsic `TypeId`, tsz preserves the existing intrinsic skip; when it sees a duplicate non-intrinsic node, tsz records a revisit and skips that node. `contains_type_by_id` still checks the target before recording a revisit. For identity-comparable probes, depths at or below `MAX_IDENTITY_COMPARABLE_DEPTH` continue and depths past the cap preserve the existing `false` fallback.

## Owner Layer
Solver visitor predicates only. No checker, emitter, relation policy, constraint walker, inference, type-query traversal, generic-call, or cache-purity logic is changed.

## Adjacent Matrix
Added focused tests for intrinsic/entered/revisit states, shared-child containment, and exact-cap/past-cap identity-comparable depth behavior. This avoids the active M4 inference/cache files, #15147 type-query depth-state files, #15160 constraint-walker files, #15161 traversal files, checker env/indexed-access files, generic-call/call-args, and relation-cache/function files.

## Fallback
Behavior is unchanged: intrinsic predicate-walk nodes are skipped, revisits are skipped, shared children are visited once for containment, and identity-comparable depth overflow returns `false`.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver predicate_worklist_visit_state contains_type_by_id_visit_state contains_type_by_id_handles_shared_child_once identity_comparable_depth_state identity_comparable_depth_limit`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `wc -l crates/tsz-solver/src/visitors/visitor_predicates/content.rs crates/tsz-solver/src/visitors/visitor_predicates/identity_comparable.rs`

Additional local probe: `scripts/safe-run.sh cargo nextest run -p tsz-solver free_infer_policy_skips_generic_signature_bodies` fails the same way on clean `origin/main` with this diff stashed, so it is not used as verification for this behavior-preserving slice.
