### PR TITLE
refactor(solver): name index access union size state (#14346)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -19,9 +19,8 @@ use crate::visitor::{
 };
 
 use super::super::evaluate::TypeEvaluator;
+use super::index_access_union_distribution::UnionIndexSizeState;
 use crate::objects::apparent::literal_value_intrinsic_kind;
-
-const MAX_UNION_INDEX_SIZE: usize = 500;
 
 struct IndexAccessVisitor<'a, 'b, R: TypeResolver> {
     evaluator: &'b mut TypeEvaluator<'a, R>,
@@ -922,7 +921,7 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
 
     fn visit_union(&mut self, list_id: u32) -> Self::Output {
         let members = self.evaluator.interner().type_list(TypeListId(list_id));
-        if members.len() > MAX_UNION_INDEX_SIZE {
+        if UnionIndexSizeState::for_member_count(members.len()).is_limit_exceeded() {
             if let Some(result) = self.try_fast_index_large_union(&members) {
                 return Some(result);
             }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_union_distribution.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_union_distribution.rs
@@ -6,7 +6,27 @@ use crate::types::{TypeData, TypeId};
 
 use super::super::evaluate::TypeEvaluator;
 
-const MAX_UNION_INDEX_SIZE: usize = 500;
+pub(super) const MAX_UNION_INDEX_SIZE: usize = 500;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum UnionIndexSizeState {
+    Continue,
+    LimitExceeded,
+}
+
+impl UnionIndexSizeState {
+    pub(super) const fn for_member_count(member_count: usize) -> Self {
+        if member_count > MAX_UNION_INDEX_SIZE {
+            Self::LimitExceeded
+        } else {
+            Self::Continue
+        }
+    }
+
+    pub(super) const fn is_limit_exceeded(self) -> bool {
+        matches!(self, Self::LimitExceeded)
+    }
+}
 
 pub(super) fn evaluate_index_union_distribution<R: TypeResolver>(
     evaluator: &mut TypeEvaluator<'_, R>,
@@ -14,9 +34,12 @@ pub(super) fn evaluate_index_union_distribution<R: TypeResolver>(
     members: &[TypeId],
 ) -> TypeId {
     // Limit to prevent OOM with large unions.
-    if members.len() > MAX_UNION_INDEX_SIZE {
-        evaluator.mark_depth_exceeded_for_request();
-        return TypeId::ERROR;
+    match UnionIndexSizeState::for_member_count(members.len()) {
+        UnionIndexSizeState::Continue => {}
+        UnionIndexSizeState::LimitExceeded => {
+            evaluator.mark_depth_exceeded_for_request();
+            return TypeId::ERROR;
+        }
     }
 
     // TS2590 union-complexity bail (parity with tsc's `getUnionType`, which
@@ -86,4 +109,21 @@ fn index_result_is_string_like<R: TypeResolver>(
             .all(|&member| index_result_is_string_like(evaluator, member));
     }
     crate::type_queries::is_string_like_type(evaluator.interner(), ty)
+}
+
+#[cfg(test)]
+mod union_index_size_state_tests {
+    use super::*;
+
+    #[test]
+    fn union_index_size_state_names_exact_cap_and_overflow() {
+        assert_eq!(
+            UnionIndexSizeState::for_member_count(MAX_UNION_INDEX_SIZE),
+            UnionIndexSizeState::Continue
+        );
+        assert_eq!(
+            UnionIndexSizeState::for_member_count(MAX_UNION_INDEX_SIZE + 1),
+            UnionIndexSizeState::LimitExceeded
+        );
+    }
 }


### PR DESCRIPTION
Goal: green

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high

## Summary
Names the existing indexed-access union-size guard without changing behavior:
- Adds `UnionIndexSizeState::{Continue, LimitExceeded}` beside `MAX_UNION_INDEX_SIZE` in `index_access_union_distribution.rs`.
- Reuses that state from the main `index_access.rs` union visitor, preserving the fast large-union literal-property path before the depth-exceeded fallback.

## Structural Rule
When an indexed-access union has at most `MAX_UNION_INDEX_SIZE` members, tsz continues the existing distribution/evaluation path. When the union exceeds that cap, `index_access.rs` still first tries `try_fast_index_large_union`; if no fast result exists, both indexed-access paths mark the request depth-exceeded and return `ERROR` as before.

## Owner Layer
Solver indexed-access evaluation only. No checker, emitter, relation policy, constraint walker, inference, type-query traversal, visitor predicates, generic-call, or cache-purity logic is changed.

## Adjacent Matrix
Added focused exact-cap/overflow state coverage and reran the existing `index_access` filter. The `index_access.rs` call site was kept under its 1794-line arch ratchet (`1793` after formatting). This avoids #15142 checker indexed-access files and #15139 instantiation/query-cache files.

## Fallback
Behavior is unchanged: oversized index unions keep the existing fast-path attempt where available, then mark depth exceeded and return `ERROR`; exact-cap cases continue.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver union_index_size_state`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver index_access`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `scripts/safe-run.sh python3 scripts/arch/check-clippy-warn-ratchet.py --profile ci-lint`
- `wc -l crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs crates/tsz-solver/src/evaluation/evaluate_rules/index_access_union_distribution.rs`
