### PR TITLE
refactor(checker): centralize SymbolRef identity bridge (#14351)

### DIFF
--- a/crates/tsz-checker/src/checkers/call_context.rs
+++ b/crates/tsz-checker/src/checkers/call_context.rs
@@ -11,6 +11,7 @@ use crate::computation::complex::is_contextually_sensitive;
 use crate::context::TypingRequest;
 use crate::query_boundaries::checkers::call as call_checker;
 use crate::query_boundaries::common;
+use crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id;
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
 use tsz_common::interner::Atom;
@@ -1141,8 +1142,7 @@ impl<'a> CheckerState<'a> {
                     .and_then(|def_id| self.ctx.def_to_symbol_id(def_id))
             })
             .or_else(|| {
-                common::type_query_symbol(self.ctx.types, base)
-                    .map(|symbol_ref| tsz_binder::SymbolId(symbol_ref.0))
+                common::type_query_symbol(self.ctx.types, base).map(symbol_ref_to_symbol_id)
             })
             .and_then(|symbol_id| {
                 self.ctx

--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -2,6 +2,7 @@
 
 use crate::query_boundaries::checkers::promise as query;
 use crate::query_boundaries::common::is_definitely_nullish;
+use crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id;
 use crate::state::CheckerState;
 use crate::symbol_resolver::TypeSymbolResolution;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -150,7 +151,7 @@ impl<'a> CheckerState<'a> {
             query::PromiseTypeKind::Lazy(def_id) => self.def_is_lib_promise_or_promise_like(def_id),
             query::PromiseTypeKind::TypeQuery(sym_ref) => self
                 .ctx
-                .sym_id_is_lib_promise_or_promise_like(SymbolId(sym_ref.0)),
+                .sym_id_is_lib_promise_or_promise_like(symbol_ref_to_symbol_id(sym_ref)),
             _ => false,
         };
         is_builtin.then(|| args.first().copied().unwrap_or(TypeId::UNKNOWN))
@@ -167,7 +168,7 @@ impl<'a> CheckerState<'a> {
         };
         let sym_id = match query::classify_promise_type(self.ctx.types, base) {
             query::PromiseTypeKind::Lazy(def_id) => self.ctx.def_to_symbol_id(def_id)?,
-            query::PromiseTypeKind::TypeQuery(sym_ref) => SymbolId(sym_ref.0),
+            query::PromiseTypeKind::TypeQuery(sym_ref) => symbol_ref_to_symbol_id(sym_ref),
             _ => return None,
         };
         let (symbol, decl_file_idx) = self.promise_symbol_and_decl_file(sym_id)?;
@@ -323,9 +324,9 @@ impl<'a> CheckerState<'a> {
                         }
                         false
                     }
-                    query::PromiseTypeKind::TypeQuery(sym_ref) => {
-                        self.ctx.sym_id_is_lib_promise(SymbolId(sym_ref.0))
-                    }
+                    query::PromiseTypeKind::TypeQuery(sym_ref) => self
+                        .ctx
+                        .sym_id_is_lib_promise(symbol_ref_to_symbol_id(sym_ref)),
                     query::PromiseTypeKind::Application {
                         base: inner_base, ..
                     } => self.is_global_promise_type(inner_base),
@@ -333,9 +334,9 @@ impl<'a> CheckerState<'a> {
                 }
             }
             query::PromiseTypeKind::Lazy(def_id) => self.def_is_lib_promise(def_id),
-            query::PromiseTypeKind::TypeQuery(sym_ref) => {
-                self.ctx.sym_id_is_lib_promise(SymbolId(sym_ref.0))
-            }
+            query::PromiseTypeKind::TypeQuery(sym_ref) => self
+                .ctx
+                .sym_id_is_lib_promise(symbol_ref_to_symbol_id(sym_ref)),
             query::PromiseTypeKind::Object(_)
             | query::PromiseTypeKind::Union(_)
             | query::PromiseTypeKind::NotPromise => false,
@@ -350,7 +351,7 @@ impl<'a> CheckerState<'a> {
         match query::classify_promise_type(self.ctx.types, type_id) {
             query::PromiseTypeKind::Lazy(def_id) => self.def_is_lib_promise_or_promise_like(def_id),
             query::PromiseTypeKind::TypeQuery(sym_ref) => {
-                let sym_id = SymbolId(sym_ref.0);
+                let sym_id = symbol_ref_to_symbol_id(sym_ref);
                 self.ctx.sym_id_is_lib_promise_or_promise_like(sym_id)
             }
             query::PromiseTypeKind::Application { base, .. } => self.type_ref_is_promise_like(base),
@@ -377,7 +378,7 @@ impl<'a> CheckerState<'a> {
                         self.def_is_lib_promise_or_promise_like(def_id)
                     }
                     query::PromiseTypeKind::TypeQuery(sym_ref) => {
-                        let sym_id = SymbolId(sym_ref.0);
+                        let sym_id = symbol_ref_to_symbol_id(sym_ref);
                         self.ctx.sym_id_is_lib_promise_or_promise_like(sym_id)
                     }
                     query::PromiseTypeKind::Application {
@@ -388,7 +389,7 @@ impl<'a> CheckerState<'a> {
             }
             query::PromiseTypeKind::Lazy(def_id) => self.def_is_lib_promise_or_promise_like(def_id),
             query::PromiseTypeKind::TypeQuery(sym_ref) => {
-                let sym_id = SymbolId(sym_ref.0);
+                let sym_id = symbol_ref_to_symbol_id(sym_ref);
                 self.ctx.sym_id_is_lib_promise_or_promise_like(sym_id)
             }
             query::PromiseTypeKind::Object(_)
@@ -517,7 +518,7 @@ impl<'a> CheckerState<'a> {
             if let query::PromiseTypeKind::TypeQuery(sym_ref) =
                 query::classify_promise_type(self.ctx.types, base)
             {
-                let sym_id = SymbolId(sym_ref.0);
+                let sym_id = symbol_ref_to_symbol_id(sym_ref);
                 if self.ctx.sym_id_is_lib_promise_or_promise_like(sym_id) {
                     return Some(first_arg.unwrap_or(TypeId::UNKNOWN));
                 }
@@ -766,7 +767,7 @@ impl<'a> CheckerState<'a> {
             query::PromiseTypeKind::Lazy(def_id) => self.def_is_lib_promise_or_promise_like(def_id),
             query::PromiseTypeKind::TypeQuery(sym_ref) => self
                 .ctx
-                .sym_id_is_lib_promise_or_promise_like(SymbolId(sym_ref.0)),
+                .sym_id_is_lib_promise_or_promise_like(symbol_ref_to_symbol_id(sym_ref)),
             _ => false,
         };
         // Handle Lazy variant properly
@@ -775,7 +776,7 @@ impl<'a> CheckerState<'a> {
                 // Use DefId -> SymbolId bridge
                 self.ctx.def_to_symbol_id(def_id)?
             }
-            query::PromiseTypeKind::TypeQuery(sym_ref) => SymbolId(sym_ref.0),
+            query::PromiseTypeKind::TypeQuery(sym_ref) => symbol_ref_to_symbol_id(sym_ref),
             _ => return None,
         };
 

--- a/crates/tsz-checker/src/query_boundaries/definition_identity.rs
+++ b/crates/tsz-checker/src/query_boundaries/definition_identity.rs
@@ -1,10 +1,24 @@
 //! Boundary aliases for stable solver definition identity.
 
+use tsz_binder::SymbolId;
+use tsz_solver::SymbolRef;
 use tsz_solver::TypeId;
 use tsz_solver::construction::TypeDatabase;
 
 pub(crate) use super::common::lazy_def_id;
 pub(crate) type DefId = tsz_solver::def::DefId;
+
+/// Convert a solver `SymbolRef` that explicitly represents a binder symbol
+/// reference, such as `typeof X`/`TypeQuery`, through the checker-owned identity
+/// boundary.
+///
+/// Keep raw ordinal reinterpretation centralized here while the checker still
+/// carries legacy `SymbolRef` surfaces. New code should prefer `DefId`-backed
+/// identity where available, then use this bridge only for true symbol-ref
+/// query surfaces.
+pub(crate) const fn symbol_ref_to_symbol_id(symbol: SymbolRef) -> SymbolId {
+    SymbolId(symbol.0)
+}
 
 pub(crate) fn is_lazy_def_identity(db: &dyn TypeDatabase, type_id: TypeId, def_id: DefId) -> bool {
     tsz_solver::type_queries::get_lazy_def_id(db, type_id) == Some(def_id)

--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_06.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_06.rs
@@ -3,6 +3,60 @@
 
 use super::*;
 
+/// Guard: solver `SymbolRef` to binder `SymbolId` reinterpretation should stay
+/// behind `query_boundaries::definition_identity::symbol_ref_to_symbol_id`.
+///
+/// Existing legacy callsites are a migration budget, not a pattern for new
+/// code. Lower this budget whenever a PR moves another callsite behind the
+/// bridge.
+#[test]
+fn test_symbol_ref_to_symbol_id_cast_budget() {
+    const RAW_SYMBOL_REF_CAST_BUDGET: usize = 35;
+    const BRIDGE_PATH: &str = "src/query_boundaries/definition_identity.rs";
+
+    fn is_raw_symbol_ref_cast(line: &str) -> bool {
+        let trimmed = line.trim_start();
+        !trimmed.starts_with("//")
+            && (line.contains("SymbolId(sym_ref.0)")
+                || line.contains("SymbolId(symbol_ref.0)")
+                || line.contains("SymbolId(symbol.0)"))
+    }
+
+    let mut files = Vec::new();
+    collect_checker_rs_files_recursive(Path::new("src"), &mut files);
+
+    let mut hits = Vec::new();
+    for path in files {
+        if path
+            .components()
+            .any(|component| component.as_os_str() == "tests")
+        {
+            continue;
+        }
+        let rel_path = path.display().to_string();
+        if rel_path == BRIDGE_PATH {
+            continue;
+        }
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|_| panic!("failed to read {}", path.display()));
+        for (line_idx, line) in source.lines().enumerate() {
+            if is_raw_symbol_ref_cast(line) {
+                hits.push(format!("{}:{}: {}", rel_path, line_idx + 1, line.trim()));
+            }
+        }
+    }
+
+    assert!(
+        hits.len() <= RAW_SYMBOL_REF_CAST_BUDGET,
+        "raw SymbolRef -> SymbolId casts must go through \
+         query_boundaries::definition_identity::symbol_ref_to_symbol_id; \
+         found {} casts, budget {}:\n{}",
+        hits.len(),
+        RAW_SYMBOL_REF_CAST_BUDGET,
+        hits.join("\n")
+    );
+}
+
 #[test]
 fn test_env_eval_cache_def_invalidation_is_targeted() {
     let arena = NodeArena::new();

--- a/crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use crate::query_boundaries::common::TypeSubstitution;
+use crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id;
 
 struct ReturnContextSubstitutionRequest<'a> {
     source: TypeId,
@@ -101,7 +102,7 @@ impl<'a> CheckerState<'a> {
                 .and_then(|def_id| self.ctx.def_to_symbol_id(def_id))
                 .or_else(|| {
                     crate::query_boundaries::common::type_query_symbol(self.ctx.types, base)
-                        .map(|symbol_ref| SymbolId(symbol_ref.0))
+                        .map(symbol_ref_to_symbol_id)
                 })
         };
 

--- a/crates/tsz-checker/src/types/computation/complex_contextual_application.rs
+++ b/crates/tsz-checker/src/types/computation/complex_contextual_application.rs
@@ -1,3 +1,4 @@
+use crate::query_boundaries::definition_identity::symbol_ref_to_symbol_id;
 use crate::query_boundaries::type_computation::complex as query;
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
@@ -40,7 +41,7 @@ impl<'a> CheckerState<'a> {
         if let Some(sym_ref) =
             crate::query_boundaries::common::type_query_symbol(self.ctx.types, base)
         {
-            return Some(tsz_binder::SymbolId(sym_ref.0));
+            return Some(symbol_ref_to_symbol_id(sym_ref));
         }
 
         if !visited.insert(base) {


### PR DESCRIPTION
Goal: green

## Summary
- Add a checker query-boundary bridge for solver `SymbolRef` values that explicitly represent binder symbols.
- Move promise and contextual-call TypeQuery identity lookups through the bridge instead of scattered raw `SymbolId(sym_ref.0)` casts.
- Add an architecture contract test that budgets remaining raw `SymbolRef` -> `SymbolId` casts so this migration can only ratchet down.

## Structural Rule
When solver `SymbolRef`/TypeQuery identity crosses into checker/binder space, `tsz` should route through a checker-owned identity bridge rather than scattered ordinal reinterpretation. The checker query-boundary owns the bridge; binder still owns local `SymbolId`, and solver still owns semantic refs. `DefId` remains preferred where available.

## Adjacent Case Matrix
- `DefId`-backed promise/contextual paths still use `def_to_symbol_id` first.
- TypeQuery promise identity still compares the same binder symbol, now via `symbol_ref_to_symbol_id`.
- Contextual-call return/base identity still recognizes the same TypeQuery base symbols.
- Remaining legacy raw casts are left under a finite budget and can be migrated by future PRs.
- The fallback is unchanged: if no `DefId` or TypeQuery symbol exists, existing lookup paths return `None`/continue as before.

## Overlap Notes
This avoids active narrowing/cache files from #15165, constraint-walker files from #15160, query-cache solver files from #15139/#15166, checker env-publication/module-augmentation work from #15148/#15152/#15131, and guard-state slices under #14346.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib test_symbol_ref_to_symbol_id_cast_budget`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`
- `wc -l crates/tsz-checker/src/checkers/call_context.rs crates/tsz-checker/src/checkers/promise_checker.rs crates/tsz-checker/src/query_boundaries/definition_identity.rs crates/tsz-checker/src/tests/architecture_contract_tests/part_06.rs crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs crates/tsz-checker/src/types/computation/complex_contextual_application.rs`

## Provenance
Machine: m1
Assistant: codex
Model: gpt-5
Effort: high
