### PR TITLE
fix(checker): share namespace suggestion cap (#14351)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/name_resolution.rs
+++ b/crates/tsz-checker/src/error_reporter/name_resolution.rs
@@ -1621,6 +1621,30 @@ impl<'a> CheckerState<'a> {
         name: &str,
         idx: NodeIndex,
     ) {
+        self.error_cannot_find_namespace_with_suggestion_and_eligibility(name, idx, None);
+    }
+
+    /// Report TS2503/TS2833 after the name-resolution boundary has already
+    /// charged the spelling-suggestion cap for this namespace lookup.
+    pub(crate) fn error_cannot_find_namespace_with_precomputed_eligibility(
+        &mut self,
+        name: &str,
+        idx: NodeIndex,
+        suggestions_eligible: bool,
+    ) {
+        self.error_cannot_find_namespace_with_suggestion_and_eligibility(
+            name,
+            idx,
+            Some(suggestions_eligible),
+        );
+    }
+
+    fn error_cannot_find_namespace_with_suggestion_and_eligibility(
+        &mut self,
+        name: &str,
+        idx: NodeIndex,
+        suggestions_eligible: Option<bool>,
+    ) {
         use crate::diagnostics::diagnostic_codes;
         use tsz_binder::symbol_flags;
 
@@ -1637,14 +1661,40 @@ impl<'a> CheckerState<'a> {
         // Route through the shared memoized scan gateway (keyed by node +
         // `NAMESPACE` meaning) so a missing namespace re-resolved during
         // demand-driven evaluation does not re-run the full-symbol-universe
-        // walk on every revisit (issue #14349). An empty result means no
-        // close-enough namespace candidate, so we fall through to plain TS2503 —
-        // identical to the previous `Option`-returning direct call.
-        if !self.has_syntax_parse_errors()
-            && let Some(suggestion) = self
-                .scan_similar_identifiers_for_meaning(name, idx, symbol_flags::NAMESPACE)
-                .first()
-        {
+        // walk on every revisit (issue #14349). Namespace diagnostics also
+        // share the same spelling-suggestion cap as ordinary missing names; a
+        // capped site records an empty scan result so revisits stay capped.
+        let suggestion_meaning = symbol_flags::NAMESPACE;
+        let cache_key = (idx, suggestion_meaning);
+        let cached_suggestions = self
+            .ctx
+            .name_resolution_diagnostics
+            .suggestion_scan_cache
+            .borrow()
+            .get(&cache_key)
+            .cloned();
+        let suggestions = if let Some(suggestions) = cached_suggestions {
+            suggestions
+        } else {
+            let eligible =
+                suggestions_eligible.unwrap_or_else(|| self.suggestion_scan_eligible(name, idx));
+            if eligible {
+                self.scan_similar_identifiers_for_meaning(name, idx, suggestion_meaning)
+            } else {
+                self.ctx
+                    .name_resolution_diagnostics
+                    .suggestion_scan_cache
+                    .borrow_mut()
+                    .insert(cache_key, Vec::new());
+                Vec::new()
+            }
+        };
+        self.ctx
+            .name_resolution_diagnostics
+            .reported_nodes
+            .insert(idx);
+
+        if let Some(suggestion) = suggestions.first() {
             self.error_at_node_msg(
                 idx,
                 diagnostic_codes::CANNOT_FIND_NAMESPACE_DID_YOU_MEAN,

--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -326,11 +326,12 @@ impl<'a> CheckerState<'a> {
                                 qn.left,
                             );
                             match self.resolve_name_structured(&req) {
-                                Err(_failure) => {
+                                Err(failure) => {
                                     // Emit TS2503 (cannot find namespace) with suggestions
-                                    self.error_cannot_find_namespace_with_suggestion(
+                                    self.error_cannot_find_namespace_with_precomputed_eligibility(
                                         left_name.as_str(),
                                         qn.left,
+                                        failure.suggestions_eligible,
                                     );
                                 }
                                 Ok(_) => {

--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -327,12 +327,26 @@ impl<'a> CheckerState<'a> {
                             );
                             match self.resolve_name_structured(&req) {
                                 Err(failure) => {
-                                    // Emit TS2503 (cannot find namespace) with suggestions
-                                    self.error_cannot_find_namespace_with_precomputed_eligibility(
-                                        left_name.as_str(),
-                                        qn.left,
-                                        failure.suggestions_eligible,
-                                    );
+                                    // The boundary precomputes suggestion eligibility for true
+                                    // not-found failures. Wrong-meaning namespace anchors (for
+                                    // example a value-only `m` near namespace `M`) still need the
+                                    // namespace diagnostic owner to apply the suggestion cap at
+                                    // emission time.
+                                    if matches!(
+                                        &failure.kind,
+                                        crate::query_boundaries::name_resolution::ResolutionFailureKind::NotFound
+                                    ) {
+                                        self.error_cannot_find_namespace_with_precomputed_eligibility(
+                                            left_name.as_str(),
+                                            qn.left,
+                                            failure.suggestions_eligible,
+                                        );
+                                    } else {
+                                        self.error_cannot_find_namespace_with_suggestion(
+                                            left_name.as_str(),
+                                            qn.left,
+                                        );
+                                    }
                                 }
                                 Ok(_) => {
                                     // Shouldn't happen since resolve_qualified_symbol_in_type_position

--- a/crates/tsz-checker/src/tests/spurious_suggestion_suppression_tests.rs
+++ b/crates/tsz-checker/src/tests/spurious_suggestion_suppression_tests.rs
@@ -83,6 +83,39 @@ type C = Foobaz.X;
 }
 
 #[test]
+fn namespace_suggestion_respects_spelling_cap() {
+    // tsc's spelling-suggestion cap is shared by namespace "did you mean?"
+    // diagnostics. Once distinct missing namespace sites consume the cap, a
+    // later near-match should stay plain TS2503 rather than escaping as TS2833.
+    let codes = check_strict(
+        r#"
+namespace Foobar { export type X = number; }
+type T0 = Foobaz.X;
+type T1 = Foobaz.X;
+type T2 = Foobaz.X;
+type T3 = Foobaz.X;
+type T4 = Foobaz.X;
+type T5 = Foobaz.X;
+type T6 = Foobaz.X;
+type T7 = Foobaz.X;
+type T8 = Foobaz.X;
+type T9 = Foobaz.X;
+type T10 = Foobaz.X;
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS2833),
+        10,
+        "only the first ten namespace sites should get suggestions: {codes:?}"
+    );
+    assert_eq!(
+        count(&codes, TS2503),
+        1,
+        "the capped namespace failure should fall back to plain TS2503: {codes:?}"
+    );
+}
+
+#[test]
 fn rest_only_indexer_method_does_not_get_call_hint() {
     // `o[sym]` where `get` takes only a rest param (min-arg-count 0) — tsc emits
     // plain TS7053, not the "Did you mean to call 'o.get'?" TS7052 hint.

--- a/crates/tsz-checker/src/tests/spurious_suggestion_suppression_tests.rs
+++ b/crates/tsz-checker/src/tests/spurious_suggestion_suppression_tests.rs
@@ -83,6 +83,25 @@ type C = Foobaz.X;
 }
 
 #[test]
+fn value_only_qualified_name_anchor_still_gets_namespace_suggestion() {
+    // `m` resolves as a value, not a namespace, but tsc still offers the nearby
+    // namespace `M` for the qualified type-name anchor.
+    let codes = check_strict(
+        r#"
+namespace M { export interface Point { x: number; y: number } }
+var m = M;
+var p: m.Point;
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS2833),
+        1,
+        "wrong-meaning namespace anchors still get suggestions: {codes:?}"
+    );
+    assert_eq!(count(&codes, TS2503), 0, "{codes:?}");
+}
+
+#[test]
 fn namespace_suggestion_respects_spelling_cap() {
     // tsc's spelling-suggestion cap is shared by namespace "did you mean?"
     // diagnostics. Once distinct missing namespace sites consume the cap, a

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -28,3 +28,5 @@ mod common_boundary_export_ratchets;
 mod construction_boundary_signature_scans;
 #[path = "arch_source_scans/relation_routing_residual_arch_tests.rs"]
 mod relation_routing_residual_arch_tests;
+#[path = "arch_source_scans/spelling_suggestion_gateway_scans.rs"]
+mod spelling_suggestion_gateway_scans;

--- a/crates/tsz-checker/tests/arch_source_scans/spelling_suggestion_gateway_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/spelling_suggestion_gateway_scans.rs
@@ -1,0 +1,71 @@
+//! Spelling-suggestion gateway scans.
+//!
+//! `find_similar_identifiers` walks the visible symbol universe and performs
+//! spelling-distance work. Namespace diagnostics used to call it directly,
+//! bypassing the memoized `(node, meaning)` gateway and the shared cap. Keep
+//! production checker call sites routed through
+//! `error_reporter::name_resolution::scan_similar_identifiers_for_meaning`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn checker_src_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn collect_rust_sources(dir: &Path, sources: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("failed to read source directory") {
+        let path = entry.expect("failed to read source entry").path();
+        if path.is_dir() {
+            if path.file_name().and_then(|name| name.to_str()) != Some("tests") {
+                collect_rust_sources(&path, sources);
+            }
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+            sources.push(path);
+        }
+    }
+}
+
+fn rust_sources_under(dir: &Path) -> Vec<PathBuf> {
+    let mut sources = Vec::new();
+    collect_rust_sources(dir, &mut sources);
+    sources.sort();
+    sources
+}
+
+#[test]
+fn production_spelling_suggestions_use_memoized_gateway() {
+    let src_root = checker_src_root();
+    let mut violations = Vec::new();
+
+    for path in rust_sources_under(&src_root) {
+        let relative_path = format!(
+            "src/{}",
+            path.strip_prefix(&src_root)
+                .expect("scanned path is under the src root")
+                .to_string_lossy()
+                .replace('\\', "/")
+        );
+        let source = fs::read_to_string(&path).expect("failed to read Rust source");
+        for (line_index, line) in source.lines().enumerate() {
+            if !line.contains(".find_similar_identifiers(") {
+                continue;
+            }
+            if relative_path == "src/error_reporter/name_resolution.rs" {
+                continue;
+            }
+            violations.push(format!(
+                "{}:{} calls find_similar_identifiers directly",
+                relative_path,
+                line_index + 1
+            ));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "checker production code should route spelling scans through \
+         scan_similar_identifiers_for_meaning so memoization and cap gating stay shared:\n{}",
+        violations.join("\n")
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
- Route missing-namespace `TS2833` suggestions through the shared name-resolution spelling cap and memoized `(node, NAMESPACE)` scan result.
- Preserve already-computed boundary eligibility for true not-found qualified-name namespace failures, while wrong-meaning namespace anchors compute suggestion eligibility at diagnostic emission time.
- Add a checker source-scan ratchet preventing future direct `.find_similar_identifiers(` call sites outside the name-resolution gateway.

## Structural Rule
When distinct missing namespace references exceed TypeScript's per-file spelling-suggestion cap, `tsc` emits `TS2833` for the first ten near-matches and falls back to plain `TS2503` afterward. When a qualified-name anchor resolves with the wrong meaning, such as value-only `m` near namespace `M`, `tsc` still offers the namespace suggestion. `tsz` now does both through the checker name-resolution diagnostic owner: true not-found boundary failures reuse precomputed cap eligibility, wrong-meaning namespace anchors charge eligibility at emission time, and namespace candidate scans stay behind `scan_similar_identifiers_for_meaning`.

## Adjacent Matrix
- Pure type near-match: still emits plain `TS2503`, never suggesting a type as a namespace.
- Real namespace near-match before the cap: still emits `TS2833`.
- Repeated namespace sites: still use the memoized namespace scan without stale empty results.
- Cap boundary: 10 namespace `TS2833` diagnostics, then 1 `TS2503`, matching `tsc 5.9.3`.
- Qualified-name not-found path: reuses precomputed `suggestions_eligible` so cap accounting is once per site.
- Qualified-name wrong-meaning path: value-only `m` near namespace `M` still emits `TS2833`, matching the conformance witnesses.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib type_is_not_offered_as_namespace_suggestion real_namespace_is_still_suggested namespace_suggestion_stable_across_repeated_references value_only_qualified_name_anchor_still_gets_namespace_suggestion namespace_suggestion_respects_spelling_cap`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "primaryExpressionMods.ts" --verbose`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "invalidInstantiatedModule.ts" --verbose`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test arch_source_scans production_spelling_suggestions_use_memoized_gateway`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy -p tsz-checker --lib --test arch_source_scans -- -D warnings`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`
- `npx -y -p typescript@5.9.3 tsc --noEmit --strict --pretty false --skipLibCheck <namespace-cap witness>` produced 10 `TS2833` diagnostics and 1 `TS2503` diagnostic.

Note: the previous exact-head CI run failed `conformance-aggregate` on `primaryExpressionMods.ts` and `invalidInstantiatedModule.ts`; both now pass with the focused filters above.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high