### PR TITLE
refactor(solver): name inference cycle guard states (#14351)

### DIFF
--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -10,6 +10,7 @@
 //! - Best common type calculation
 //! - Efficient unification with path compression
 
+use super::infer_guard_state as guard_state;
 use crate::construction::{QueryDatabase, TypeDatabase};
 #[cfg(test)]
 use crate::types::*;
@@ -788,8 +789,9 @@ impl<'a> InferenceContext<'a> {
         if ty.is_intrinsic() {
             return;
         }
-        if !visited.insert(ty) {
-            return;
+        match guard_state::type_graph_visit_state(visited.insert(ty)) {
+            guard_state::TypeGraphVisitState::Entered => {}
+            guard_state::TypeGraphVisitState::AlreadyVisited => return,
         }
         let Some(key) = self.interner.lookup(ty) else {
             return;
@@ -942,11 +944,12 @@ impl<'a> InferenceContext<'a> {
         targets: &[Atom],
         visited: &mut FxHashSet<Atom>,
     ) -> bool {
-        if targets.contains(&name) {
-            return true;
-        }
-        if !visited.insert(name) {
-            return false;
+        let is_target = targets.contains(&name);
+        let inserted_visit = !is_target && visited.insert(name);
+        match guard_state::param_dependency_state(is_target, inserted_visit) {
+            guard_state::ParamDependencyState::TargetReached => return true,
+            guard_state::ParamDependencyState::Entered => {}
+            guard_state::ParamDependencyState::AlreadyVisited => return false,
         }
         let Some(var) = self.find_type_param(name) else {
             return false;
@@ -981,8 +984,9 @@ impl<'a> InferenceContext<'a> {
         if ty.is_intrinsic() {
             return false;
         }
-        if !visited.insert(ty) {
-            return false;
+        match guard_state::type_graph_visit_state(visited.insert(ty)) {
+            guard_state::TypeGraphVisitState::Entered => {}
+            guard_state::TypeGraphVisitState::AlreadyVisited => return false,
         }
 
         let key = match self.interner.lookup(ty) {

--- a/crates/tsz-solver/src/inference/infer_guard_state.rs
+++ b/crates/tsz-solver/src/inference/infer_guard_state.rs
@@ -1,0 +1,67 @@
+//! Named guard states for inference constraint walks.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TypeGraphVisitState {
+    Entered,
+    AlreadyVisited,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ParamDependencyState {
+    TargetReached,
+    Entered,
+    AlreadyVisited,
+}
+
+pub(crate) const fn type_graph_visit_state(inserted_visit: bool) -> TypeGraphVisitState {
+    if inserted_visit {
+        TypeGraphVisitState::Entered
+    } else {
+        TypeGraphVisitState::AlreadyVisited
+    }
+}
+
+pub(crate) const fn param_dependency_state(
+    is_target: bool,
+    inserted_visit: bool,
+) -> ParamDependencyState {
+    if is_target {
+        ParamDependencyState::TargetReached
+    } else if inserted_visit {
+        ParamDependencyState::Entered
+    } else {
+        ParamDependencyState::AlreadyVisited
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ParamDependencyState, TypeGraphVisitState, param_dependency_state, type_graph_visit_state,
+    };
+
+    #[test]
+    fn type_graph_visit_state_names_revisit_cutoff() {
+        assert_eq!(type_graph_visit_state(true), TypeGraphVisitState::Entered);
+        assert_eq!(
+            type_graph_visit_state(false),
+            TypeGraphVisitState::AlreadyVisited
+        );
+    }
+
+    #[test]
+    fn param_dependency_state_prioritizes_target_before_revisit() {
+        assert_eq!(
+            param_dependency_state(true, false),
+            ParamDependencyState::TargetReached
+        );
+        assert_eq!(
+            param_dependency_state(false, true),
+            ParamDependencyState::Entered
+        );
+        assert_eq!(
+            param_dependency_state(false, false),
+            ParamDependencyState::AlreadyVisited
+        );
+    }
+}

--- a/crates/tsz-solver/src/inference/mod.rs
+++ b/crates/tsz-solver/src/inference/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod infer;
 pub(crate) mod infer_bct;
 mod infer_bct_guard_state;
 pub(crate) mod infer_candidate_kinds;
+mod infer_guard_state;
 pub(crate) mod infer_matching;
 mod infer_matching_guard_state;
 mod infer_matching_helpers;

--- a/crates/tsz-solver/tests/infer_tests/bounds_core.rs
+++ b/crates/tsz-solver/tests/infer_tests/bounds_core.rs
@@ -506,6 +506,42 @@ fn test_resolve_mutual_circular_upper_bounds_with_concrete() {
 }
 
 #[test]
+fn test_resolve_mutual_circular_upper_bounds_renamed_binders_with_concrete() {
+    let interner = TypeInterner::new();
+    let mut ctx = InferenceContext::new(&interner);
+    let left_name = interner.intern_string("LeftParam");
+    let right_name = interner.intern_string("RightParam");
+
+    let var_left = ctx.fresh_type_param(left_name, false);
+    let var_right = ctx.fresh_type_param(right_name, false);
+
+    let left_type = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: left_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    }));
+    let right_type = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: right_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    }));
+
+    ctx.add_upper_bound(var_left, right_type);
+    ctx.add_upper_bound(var_right, left_type);
+    ctx.add_upper_bound(var_left, TypeId::STRING);
+
+    let result_left = ctx.resolve_with_constraints(var_left).unwrap();
+    let result_right = ctx.resolve_with_constraints(var_right).unwrap();
+
+    assert_eq!(result_left, TypeId::STRING);
+    assert_eq!(result_right, TypeId::STRING);
+}
+
+#[test]
 fn test_resolve_self_recursive_object_bounds_two_params_unknown() {
     let interner = TypeInterner::new();
     let mut ctx = InferenceContext::new(&interner);


### PR DESCRIPTION
Goal: green

## Summary
- Add solver-owned named guard states for inference type-graph revisits and parameter-dependency target/revisit decisions.
- Route `collect_type_params`, `type_contains_param`, and `param_depends_on_targets` through those guard verdicts without moving traversal or fallback policy out of `infer.rs`.
- Add a renamed-binder mutual upper-bound regression case so circular dependency handling stays structural.

## Structural Rule
When inference upper-bound resolution walks a type/parameter dependency graph and reaches a target parameter, `tsz` treats that as a cyclic upper-bound signal; when the walk revisits an already-seen type graph node or parameter, it cuts off with the existing fallback. This PR keeps that behavior in solver inference while naming the guard decisions through `infer_guard_state`.

## Adjacent Matrix
- Occurs-check: direct and function-this-type occurs checks still pass.
- Circular upper bound: self and mutual cycles still resolve to the existing unknown/bounds-violation outcomes.
- Concrete fallback: mutual circular upper bounds still recover a concrete string bound.
- Renamed binders: the same mutual-cycle concrete recovery works for non-`T`/`U` names.
- Circular extends: existing circular extends/bound-order cases still pass.

## Verification
- `cargo fmt --all && cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver infer_guard_state test_resolve_circular_upper_bound_defaults_unknown test_resolve_mutual_circular_upper_bounds_unknown test_resolve_mutual_circular_upper_bounds_with_concrete test_resolve_mutual_circular_upper_bounds_renamed_binders_with_concrete`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(test_inference_occurs_check) or test(test_inference_occurs_check_function_this_type) or test(test_resolve_circular_upper_bound_defaults_unknown) or test(test_resolve_self_upper_bound_with_concrete) or test(test_resolve_mutual_circular_upper_bounds_unknown) or test(test_resolve_mutual_circular_upper_bounds_with_concrete) or test(test_resolve_mutual_circular_upper_bounds_renamed_binders_with_concrete) or test(test_resolve_self_recursive_object_bounds_two_params_unknown) or test(test_resolve_mutual_recursive_object_bounds_unknown) or test(test_resolve_circular_extends_with_concrete_bound) or test(test_resolve_circular_extends_bound_order) or test(test_resolve_usage_based_inference_from_bound_param)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(test_resolve_all_with_circular_extends_unknown) or test(test_circular_extends_multiple_lower_bounds_same_param)'`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy -p tsz-solver --all-targets -- -D warnings`
- `python3 scripts/arch/arch_guard.py --json`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
