### PR TITLE
refactor(solver): move conditional subtype depth into session (#14351)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -138,8 +138,8 @@ impl ConditionalBranchProbeResult {
 }
 
 /// Run a structural relation probe that chooses a conditional branch and
-/// classify its result, following the thread-local unresolved-`Lazy` sentinel
-/// so a `false` that depended on an unregistered `Lazy` body is reported as
+/// classify its result, following the unresolved-`Lazy` sentinel so a `false`
+/// that depended on an unregistered `Lazy` body is reported as
 /// [`BranchRelation::Undetermined`] instead of [`BranchRelation::Fails`].
 ///
 /// This mirrors the subtype cache's own poison-sentinel discipline (it never
@@ -174,74 +174,6 @@ pub(super) struct ConditionalOperands {
     pub(super) extends_type: TypeId,
     pub(super) extends_has_infer: bool,
     pub(super) extends_has_type_params: bool,
-}
-
-thread_local! {
-    /// Re-entrant conditional-subtype recursion depth on this thread.
-    ///
-    /// The counter is consulted by [`ConditionalSubtypeDepthGuard`] to cap the
-    /// `Evaluator -> SubtypeChecker -> Evaluator -> ...` chain at depth 50.
-    /// It MUST be zero between compilations: a leaked positive depth would make
-    /// later conditional-subtype checks on a reused batch/merge-group worker
-    /// conservatively take the false branch, so the same code would select
-    /// different conditional branches run-to-run (#13368). The guard restores
-    /// the depth on every exit including a panic-unwind a caller swallows, so
-    /// no manual post-call decrement (which the unwind skips) is needed.
-    static CONDITIONAL_SUBTYPE_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
-}
-
-/// RAII recursion-depth guard for [`check_conditional_subtype`].
-///
-/// [`enter`](Self::enter) increments [`CONDITIONAL_SUBTYPE_DEPTH`] and returns a
-/// [`ConditionalSubtypeDepthEntry`] containing the depth observed *before* the
-/// increment plus the guard; `Drop` decrements it, so the counter is restored on
-/// the normal return path and when the guarded subtype walk unwinds via a caught
-/// panic. The counter is
-/// function-private state that the batch boundary reset cannot reach, so this
-/// self-cleaning guard is the only correct cross-compilation isolation for it.
-#[must_use]
-struct ConditionalSubtypeDepthGuard;
-
-#[must_use]
-struct ConditionalSubtypeDepthEntry {
-    prior_depth: u32,
-    guard: ConditionalSubtypeDepthGuard,
-}
-
-impl ConditionalSubtypeDepthGuard {
-    /// Cap above which the conditional-subtype relation conservatively returns
-    /// `false`, matching tsc returning the deferred conditional once the
-    /// instantiation depth is exceeded.
-    const LIMIT: u32 = 50;
-
-    fn enter() -> ConditionalSubtypeDepthEntry {
-        let prior_depth = CONDITIONAL_SUBTYPE_DEPTH.with(|d| {
-            let c = d.get();
-            d.set(c + 1);
-            c
-        });
-        ConditionalSubtypeDepthEntry {
-            prior_depth,
-            guard: Self,
-        }
-    }
-}
-
-impl ConditionalSubtypeDepthEntry {
-    const fn prior_depth(&self) -> u32 {
-        self.prior_depth
-    }
-
-    fn exit(self) {
-        let Self { guard, .. } = self;
-        drop(guard);
-    }
-}
-
-impl Drop for ConditionalSubtypeDepthGuard {
-    fn drop(&mut self) {
-        CONDITIONAL_SUBTYPE_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
-    }
 }
 
 /// Result from tail-call dispatch in conditional evaluation.
@@ -704,7 +636,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     }
 
     /// Structural subtype probe that decides a conditional branch, with cache
-    /// lookup, a thread-local depth guard, and unresolved-`Lazy` classification.
+    /// lookup, a session-owned depth guard, and unresolved-`Lazy` classification.
     ///
     /// Returns [`BranchRelation::Holds`] when
     /// `check_type <: extends_type`,
@@ -714,7 +646,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// in which case the spurious false is neither cached nor used to take the
     /// false branch and the conditional defers (issue #14238). The result cache
     /// consults `conditional_subtype_cache` first; the structural fallback is
-    /// guarded by a thread-local recursion counter that caps at depth 50.
+    /// guarded by a session recursion counter that caps at depth 50.
     pub(super) fn conditional_subtype_relation(
         &mut self,
         check_type: TypeId,
@@ -757,76 +689,78 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // Depth guard: evaluating conditional types can trigger subtype checks
         // that evaluate MORE conditional types, creating an
         // Evaluator -> SubtypeChecker -> Evaluator -> ... chain where each
-        // instance has fresh cycle-detection state. Without this global depth
+        // instance has fresh cycle-detection state. Without this session depth
         // limit, recursive generic types like `Vector<T> implements Seq<T>`
         // with `Exclude<T, U>` in overloads cause stack overflow. The guard is
-        // RAII (see `ConditionalSubtypeDepthGuard`) so the depth is restored on
-        // every exit including a caught panic-unwind, keeping the relation
-        // schedule-independent across batch-worker reuse (#13368).
-        let depth_entry = ConditionalSubtypeDepthGuard::enter();
+        // RAII, so the depth is restored on every exit including a caught
+        // panic-unwind, keeping the relation schedule-independent across
+        // batch-worker reuse (#13368).
         // A verdict produced by the depth bail or by a structural walk that
         // itself tripped a recursion/iteration limit is a *budget-bounded*
         // conservative answer, not a stable function of the type pair: it must
         // never be published to the cross-evaluator cache (it would permanently
         // shadow the full answer a deeper-budget run derives). Carry that as a
         // typed publication verdict and consult it at the write site.
-        let mut cache_stability = ConditionalBranchCacheStability::DepthAgnostic;
-        // Classify against the unresolved-`Lazy` sentinel: a `false` produced
-        // only because the structural walk descended into an unregistered
-        // `Lazy` body is reported as `Undetermined` rather than a definitive
-        // false (issue #14238). Shared with the array fast path via
-        // `classify_branch_relation`.
-        let relation = classify_branch_relation(|| {
-            if depth_entry.prior_depth() >= ConditionalSubtypeDepthGuard::LIMIT {
-                // At excessive depth, conservatively assume not a subtype
-                // (takes the false/else branch of the conditional).
-                // This matches tsc's behavior of returning the deferred
-                // conditional when instantiation depth is exceeded.
-                cache_stability.mark_budget_bounded();
-                false
-            } else if Self::is_primitive_vs_function(self.interner(), check_type, extends_type) {
-                // Fast-path: primitive types (string, number, boolean, bigint,
-                // symbol) are never subtypes of Function. The structural subtype
-                // checker may incorrectly autobox the primitive to its wrapper
-                // type (String, Number, etc.) and find structural compatibility
-                // with the evaluated Function interface. This fast-path prevents
-                // `string extends Function` from incorrectly taking the true
-                // branch, matching tsc's behavior where primitives never extend
-                // Function.
-                false
-            } else if Self::function_intrinsic_extends_callable_target(
-                self.interner(),
-                check_type,
-                extends_type,
-            ) {
-                // In conditional types, tsc treats the global `Function`
-                // intrinsic as satisfying callable targets. Ordinary
-                // assignment intentionally remains stricter.
-                true
-            } else if self
-                .object_literals_have_conflicting_required_property(check_type, extends_type)
-            {
-                // `Extract<Union, { kind: "x" }>` and similar discriminant filters
-                // distribute over every union member. If both sides expose the same
-                // required property with distinct literal values, the relation is
-                // definitively false, so avoid the full structural subtype walk.
-                false
-            } else {
-                let mut strict_checker = self.conditional_subtype_checker();
-                let verdict = strict_checker.is_subtype_of(check_type, extends_type);
-                // A walk that exhausted its own depth/iteration budget returned
-                // a conservative verdict; mark it un-publishable.
-                if strict_checker.depth_exceeded() || strict_checker.iteration_exceeded() {
+        let probe = crate::evaluation::session::with_current_session(|session| {
+            let depth_entry = session.enter_conditional_subtype_depth();
+            let mut cache_stability = ConditionalBranchCacheStability::DepthAgnostic;
+            // Classify against the unresolved-`Lazy` sentinel: a `false` produced
+            // only because the structural walk descended into an unregistered
+            // `Lazy` body is reported as `Undetermined` rather than a definitive
+            // false (issue #14238). Shared with the array fast path via
+            // `classify_branch_relation`.
+            let relation = classify_branch_relation(|| {
+                if depth_entry.prior_depth()
+                    >= crate::evaluation::session::ConditionalSubtypeDepthEntry::limit()
+                {
+                    // At excessive depth, conservatively assume not a subtype
+                    // (takes the false/else branch of the conditional).
+                    // This matches tsc's behavior of returning the deferred
+                    // conditional when instantiation depth is exceeded.
                     cache_stability.mark_budget_bounded();
+                    false
+                } else if Self::is_primitive_vs_function(self.interner(), check_type, extends_type)
+                {
+                    // Fast-path: primitive types (string, number, boolean,
+                    // bigint, symbol) are never subtypes of Function. The
+                    // structural subtype checker may incorrectly autobox the
+                    // primitive to its wrapper type (String, Number, etc.) and
+                    // find structural compatibility with the evaluated Function
+                    // interface. This fast-path prevents `string extends Function`
+                    // from incorrectly taking the true branch, matching tsc's
+                    // behavior where primitives never extend Function.
+                    false
+                } else if Self::function_intrinsic_extends_callable_target(
+                    self.interner(),
+                    check_type,
+                    extends_type,
+                ) {
+                    // In conditional types, tsc treats the global `Function`
+                    // intrinsic as satisfying callable targets. Ordinary
+                    // assignment intentionally remains stricter.
+                    true
+                } else if self
+                    .object_literals_have_conflicting_required_property(check_type, extends_type)
+                {
+                    // `Extract<Union, { kind: "x" }>` and similar discriminant
+                    // filters distribute over every union member. If both sides
+                    // expose the same required property with distinct literal
+                    // values, the relation is definitively false, so avoid the
+                    // full structural subtype walk.
+                    false
+                } else {
+                    let mut strict_checker = self.conditional_subtype_checker();
+                    let verdict = strict_checker.is_subtype_of(check_type, extends_type);
+                    // A walk that exhausted its own depth/iteration budget returned
+                    // a conservative verdict; mark it un-publishable.
+                    if strict_checker.depth_exceeded() || strict_checker.iteration_exceeded() {
+                        cache_stability.mark_budget_bounded();
+                    }
+                    verdict
                 }
-                verdict
-            }
+            });
+            ConditionalBranchProbeResult::new(relation, cache_stability)
         });
-        let probe = ConditionalBranchProbeResult::new(relation, cache_stability);
-        // Restore the depth before the cache write to preserve the original
-        // decrement ordering; `Drop` would otherwise run at end of scope, but
-        // either way the depth is restored on a panic-unwind exit.
-        depth_entry.exit();
         // An `Undetermined` false consumed an unregistered `Lazy` body: do not
         // cache it and do not let it take the false branch — defer so a later
         // resolved pass decides the conditional (issue #14238). Definitive
@@ -1170,30 +1104,39 @@ mod conditional_branch_probe_result_tests {
 
 #[cfg(test)]
 mod conditional_subtype_depth_guard_tests {
-    use super::{CONDITIONAL_SUBTYPE_DEPTH, ConditionalSubtypeDepthGuard};
-
-    fn current_depth() -> u32 {
-        CONDITIONAL_SUBTYPE_DEPTH.with(std::cell::Cell::get)
-    }
+    use crate::evaluation::session::EvaluationSession;
 
     #[test]
     fn enter_reports_prior_depth_and_drop_restores() {
-        assert_eq!(current_depth(), 0, "counter starts clean");
-        let entry0 = ConditionalSubtypeDepthGuard::enter();
+        let session = EvaluationSession::new();
+        assert_eq!(
+            session.conditional_subtype_depth(),
+            0,
+            "counter starts clean"
+        );
+        let entry0 = session.enter_conditional_subtype_depth();
         assert_eq!(entry0.prior_depth(), 0, "first entry observes depth 0");
-        assert_eq!(current_depth(), 1);
+        assert_eq!(session.conditional_subtype_depth(), 1);
         {
-            let entry1 = ConditionalSubtypeDepthGuard::enter();
+            let entry1 = session.enter_conditional_subtype_depth();
             assert_eq!(
                 entry1.prior_depth(),
                 1,
                 "nested entry observes the outer depth"
             );
-            assert_eq!(current_depth(), 2);
+            assert_eq!(session.conditional_subtype_depth(), 2);
         }
-        assert_eq!(current_depth(), 1, "nested drop restores one level");
+        assert_eq!(
+            session.conditional_subtype_depth(),
+            1,
+            "nested drop restores one level"
+        );
         drop(entry0);
-        assert_eq!(current_depth(), 0, "outer drop restores the clean slate");
+        assert_eq!(
+            session.conditional_subtype_depth(),
+            0,
+            "outer drop restores the clean slate"
+        );
     }
 
     /// #13368: the guard must restore the depth even when the guarded subtype
@@ -1203,15 +1146,20 @@ mod conditional_subtype_depth_guard_tests {
     /// conditional-subtype checks onto the conservative false branch).
     #[test]
     fn depth_is_restored_on_unwind() {
-        assert_eq!(current_depth(), 0, "counter starts clean");
-        let result = std::panic::catch_unwind(|| {
-            let _entry = ConditionalSubtypeDepthGuard::enter();
-            assert_eq!(current_depth(), 1);
+        let session = EvaluationSession::new();
+        assert_eq!(
+            session.conditional_subtype_depth(),
+            0,
+            "counter starts clean"
+        );
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _entry = session.enter_conditional_subtype_depth();
+            assert_eq!(session.conditional_subtype_depth(), 1);
             panic!("simulated mid-subtype-walk panic");
-        });
+        }));
         assert!(result.is_err(), "the closure panicked");
         assert_eq!(
-            current_depth(),
+            session.conditional_subtype_depth(),
             0,
             "guard Drop must restore the depth during unwind"
         );

--- a/crates/tsz-solver/src/evaluation/session.rs
+++ b/crates/tsz-solver/src/evaluation/session.rs
@@ -24,6 +24,9 @@ const MAX_GLOBAL_INSTANTIATION_DEPTH: u32 = crate::limits::MAX_GLOBAL_INSTANTIAT
 /// Canonical definition in [`crate::limits`].
 const MAX_GLOBAL_INSTANTIATION_FUEL: u32 = crate::limits::MAX_GLOBAL_INSTANTIATION_FUEL;
 
+/// Maximum re-entrant conditional-subtype relation depth.
+const MAX_CONDITIONAL_SUBTYPE_DEPTH: u32 = crate::limits::MAX_CONDITIONAL_SUBTYPE_DEPTH;
+
 /// Whether the shared evaluation session can enter another instantiation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum EvaluationSessionLimitState {
@@ -51,10 +54,42 @@ pub struct EvaluationSession {
     global_instantiation_depth: Cell<u32>,
     /// Cross-context instantiation fuel (total non-cached evaluations per file).
     global_instantiation_fuel: Cell<u32>,
+    /// Re-entrant conditional-subtype depth for
+    /// `Evaluator -> SubtypeChecker -> Evaluator -> ...` chains.
+    conditional_subtype_depth: Cell<u32>,
     /// `TypeId`s currently expanded by fresh evaluators in this session.
     cross_eval_active: RefCell<FxHashSet<TypeId>>,
     /// Per-top-level-query memo for stable fresh-evaluator results.
     query_memo: RefCell<FxHashMap<(TypeId, bool), TypeId>>,
+}
+
+/// RAII entry for one conditional-subtype relation probe in an
+/// [`EvaluationSession`].
+#[must_use]
+pub(crate) struct ConditionalSubtypeDepthEntry<'a> {
+    session: &'a EvaluationSession,
+    prior_depth: u32,
+}
+
+impl ConditionalSubtypeDepthEntry<'_> {
+    pub(crate) const fn prior_depth(&self) -> u32 {
+        self.prior_depth
+    }
+
+    pub(crate) const fn limit() -> u32 {
+        MAX_CONDITIONAL_SUBTYPE_DEPTH
+    }
+}
+
+impl Drop for ConditionalSubtypeDepthEntry<'_> {
+    fn drop(&mut self) {
+        self.session.conditional_subtype_depth.set(
+            self.session
+                .conditional_subtype_depth
+                .get()
+                .saturating_sub(1),
+        );
+    }
 }
 
 impl EvaluationSession {
@@ -63,6 +98,7 @@ impl EvaluationSession {
         Self {
             global_instantiation_depth: Cell::new(0),
             global_instantiation_fuel: Cell::new(0),
+            conditional_subtype_depth: Cell::new(0),
             cross_eval_active: RefCell::new(FxHashSet::default()),
             query_memo: RefCell::new(FxHashMap::default()),
         }
@@ -120,6 +156,24 @@ impl EvaluationSession {
     #[inline]
     pub const fn global_instantiation_fuel(&self) -> u32 {
         self.global_instantiation_fuel.get()
+    }
+
+    /// Enter a conditional-subtype probe and return the observed prior depth.
+    #[inline]
+    pub(crate) fn enter_conditional_subtype_depth(&self) -> ConditionalSubtypeDepthEntry<'_> {
+        let prior_depth = self.conditional_subtype_depth.get();
+        self.conditional_subtype_depth.set(prior_depth + 1);
+        ConditionalSubtypeDepthEntry {
+            session: self,
+            prior_depth,
+        }
+    }
+
+    /// Current re-entrant conditional-subtype depth.
+    #[cfg(test)]
+    #[inline]
+    pub(crate) const fn conditional_subtype_depth(&self) -> u32 {
+        self.conditional_subtype_depth.get()
     }
 
     /// Enter cross-evaluator expansion of `type_id`.
@@ -295,5 +349,19 @@ mod tests {
         session.reset_query_memo();
         assert_eq!(session.query_memo_get(type_id, false), None);
         assert_eq!(session.query_memo_get(type_id, true), None);
+    }
+
+    #[test]
+    fn conditional_subtype_depth_entry_restores_on_drop() {
+        let session = EvaluationSession::new();
+        assert_eq!(session.conditional_subtype_depth(), 0);
+
+        {
+            let entry = session.enter_conditional_subtype_depth();
+            assert_eq!(entry.prior_depth(), 0);
+            assert_eq!(session.conditional_subtype_depth(), 1);
+        }
+
+        assert_eq!(session.conditional_subtype_depth(), 0);
     }
 }

--- a/crates/tsz-solver/src/limits/mod.rs
+++ b/crates/tsz-solver/src/limits/mod.rs
@@ -39,6 +39,7 @@
 //! | `TypeEvaluator.def_depth` per-`DefId` map (`evaluation/evaluate.rs`) | [`MAX_DEF_DEPTH`] = 100, escalation floor [`REAL_INSTANTIATION_BAILOUT_THRESHOLD`] = 40 | `instantiationDepth` (100) → TS2589 | hard bail, memoized `ERROR` when real | TS2589 conformance, `TrimRight` aliases |
 //! | Conditional tail-recursion loop (`evaluation/evaluate_rules/conditional.rs`) | [`MAX_TAIL_RECURSION_DEPTH`] = 1000 | `getConditionalType` `tailCount` 1000 (exact parity) | `TS2589` + `ERROR` | tail-recursive conditional tests |
 //! | Cross-evaluator stack depth, thread-local (this module) | [`MAX_GLOBAL_EVAL_DEPTH`] = 200 live frames | none (fresh-instance artifact) | silent opaque bail (`mark_silent_depth_bailed`) | deep `implements` chains |
+//! | Conditional subtype relation depth, `EvaluationSession` (`evaluation/session.rs`) | [`MAX_CONDITIONAL_SUBTYPE_DEPTH`] = 50 re-entrant branch probes | `instantiationDepth` adjacent | conservative false, not published to branch cache | recursive conditional subtype probes |
 //! | Per-query eval op budget, thread-local (this module) | [`DEFAULT_MAX_EVAL_OPS_PER_QUERY`] = 2M ops per top-level query (`TSZ_MAX_EVAL_OPS` override) | `instantiationCount` (5M) per checked element | silent opaque bail | `Unbox`/`Awaited` runaway tests (`query_budget`) |
 //! | Per-file evaluation fuel, thread-local (this module) | [`MAX_EVALUATION_FUEL`] = 2M, sampled every [`EVAL_FUEL_CHECK_INTERVAL`] = 128 guard iterations | `instantiationCount` (5M; tsz lower because eager expansion is heavier) | `TS2589`-style `ERROR` bail | ts-toolbelt corpus, #13172/#13181 |
 //! | `TypeInstantiator.depth` per-instance (`instantiation/instantiate.rs`) | [`MAX_TYPE_SUBSTITUTION_DEPTH`] = 50 | `instantiateType` recursion (tsc `instantiationDepth` = 100; see note below) | sticky `depth_exceeded`, returns input type opaque | recursive generic instantiation tests |
@@ -158,6 +159,11 @@ pub(crate) const EVAL_FUEL_CHECK_INTERVAL: u32 = 128;
 /// Maximum live `evaluate` stack frames summed across every `TypeEvaluator`
 /// instance on the thread (cross-evaluator stack overflow prevention).
 pub(crate) const MAX_GLOBAL_EVAL_DEPTH: u32 = 200;
+
+/// Maximum re-entrant conditional-subtype branch probes in one evaluation
+/// session. Exhaustion conservatively treats the relation as false and marks
+/// the result budget-bounded so it is not published to the branch cache.
+pub(crate) const MAX_CONDITIONAL_SUBTYPE_DEPTH: u32 = 50;
 
 /// Total `evaluate` operations permitted for a single top-level evaluation
 /// query (the outermost `evaluate` call on the thread, before it returns).

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -209,6 +209,8 @@ fn evaluation_engine_keeps_request_stage_boundary() {
     let evaluate_api_rs = read_solver_source("evaluation/evaluate/api.rs");
     let cross_eval_guard_rs = read_solver_source("evaluation/cross_eval_guard.rs");
     let infer_pattern_rs = read_solver_source("evaluation/evaluate_rules/infer_pattern.rs");
+    let infer_match_expansion_rs =
+        read_solver_source("evaluation/evaluate_rules/infer_match_expansion.rs");
     let instantiation_result_rs = read_solver_source("instantiation/result.rs");
     let instantiation_api_rs = read_solver_source("instantiation/instantiate/api.rs");
     let subtype_core_rs = read_solver_source("relations/subtype/core.rs");
@@ -280,10 +282,13 @@ fn evaluation_engine_keeps_request_stage_boundary() {
             && result_rs.contains("cache_stability: EvaluationMemoStability")
             && !result_rs.contains("stable_for_depth_agnostic_cache: bool")
             && cross_eval_guard_rs.contains("EvaluationMemoResult::unstable_complete(TypeId(80))")
-            && infer_pattern_rs.contains("EvaluationMemoResult::unstable_complete(type_id)")
+            && infer_match_expansion_rs
+                .contains("EvaluationMemoResult::unstable_complete(type_id)")
             && !cross_eval_guard_rs
                 .contains("EvaluationMemoResult::new(EvaluationResult::complete")
-            && !infer_pattern_rs.contains("EvaluationMemoResult::new(EvaluationResult::complete"),
+            && !infer_pattern_rs.contains("EvaluationMemoResult::new(EvaluationResult::complete")
+            && !infer_match_expansion_rs
+                .contains("EvaluationMemoResult::new(EvaluationResult::complete"),
         "unstable complete memo results must use the named EvaluationMemoResult boundary instead of rebuilding the stability bit by hand"
     );
     assert!(
@@ -368,17 +373,20 @@ fn relation_queries_keep_overflow_flags_on_relation_result() {
 
     let conditional_phases_rs =
         read_solver_source("evaluation/evaluate_rules/conditional/phases.rs");
+    let evaluation_session_rs = read_solver_source("evaluation/session.rs");
     assert!(
-        conditional_phases_rs.contains("struct ConditionalSubtypeDepthEntry")
-            && conditional_phases_rs.contains("fn enter() -> ConditionalSubtypeDepthEntry")
-            && conditional_phases_rs
-                .contains("let depth_entry = ConditionalSubtypeDepthGuard::enter()")
+        evaluation_session_rs.contains("pub(crate) struct ConditionalSubtypeDepthEntry")
+            && evaluation_session_rs.contains(
+                "pub(crate) fn enter_conditional_subtype_depth(&self) -> ConditionalSubtypeDepthEntry<'_>"
+            )
+            && evaluation_session_rs.contains("MAX_CONDITIONAL_SUBTYPE_DEPTH")
+            && conditional_phases_rs.contains("session.enter_conditional_subtype_depth()")
             && conditional_phases_rs.contains("depth_entry.prior_depth()")
-            && conditional_phases_rs.contains("depth_entry.exit()")
-            && !conditional_phases_rs
-                .contains("let (prev_depth, depth_guard) = ConditionalSubtypeDepthGuard::enter()"),
-        "conditional subtype depth probes must carry prior-depth plus RAII guard \
-         as a named entry object instead of an anonymous tuple"
+            && !conditional_phases_rs.contains("CONDITIONAL_SUBTYPE_DEPTH")
+            && !conditional_phases_rs.contains("ConditionalSubtypeDepthGuard"),
+        "conditional subtype depth probes must be owned by EvaluationSession and \
+         entered through its named RAII entry, not a private conditional-phase \
+         thread-local guard"
     );
 }
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -673,6 +673,11 @@ FILE_LINE_LIMIT_CHECKS = [
         2018,
     ),
     (
+        "Solver boundary: diagnostics/format/mod.rs size ratchet",
+        ROOT / "crates/tsz-solver/src/diagnostics/format/mod.rs",
+        2012,
+    ),
+    (
         "Emitter boundary: declaration_emitter/helpers/type_inference_return_normalization.rs size ratchet",
         ROOT
         / "crates"


### PR DESCRIPTION
Goal: green

## Summary
- Move the conditional subtype relation depth counter out of conditional phases and into `EvaluationSession`.
- Keep the existing RAII restore behavior, budget-bounded false fallback, and branch-cache publication suppression.
- Update architecture guards for the new owner plus current main guard drift.

## Structural Rule
When conditional subtype relation probes recursively enter `Evaluator -> SubtypeChecker -> Evaluator` chains, `tsc` eventually treats the relation as depth-bounded/deferred. `tsz` now does that through a solver `EvaluationSession` RAII entry, so the depth cap is session-owned evaluation state instead of private conditional-phase TLS.

Owner layer: solver evaluation session owns the counter and limit; conditional evaluation consumes the session boundary while relation/cache publication behavior stays in the existing conditional branch probe.

Adjacent matrix:
- Positive: entering the session depth guard reports prior depth and increments the active depth.
- Nested: dropping an inner entry restores one level while the outer entry remains active.
- Unwind: dropping during caught panic restores the clean slate.
- Fallback: depth-bounded false still marks the branch probe budget-bounded and avoids persistent branch-cache publication.

Performance: one `Cell<u32>` remains the hot-path state; this changes ownership, not relation traversal complexity or cache keys.

Part of #14351.

## Verification
- `cargo fmt --all --check`
- `scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver evaluation::session conditional_subtype_depth_guard_tests incomplete_request_verdict_blocks_conditional_branch_persistent_write`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `python3 scripts/arch/arch_guard.py`
- `python3 scripts/arch/test_arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/check-clippy-warn-ratchet.py`

## Provenance
Machine: m4
Assistant: codex
Model: GPT-5
Effort: high
