### PR TITLE
refactor(checker): gate object flags behind boundaries (#14351)

### DIFF
--- a/crates/tsz-checker/src/declarations/namespace_checker.rs
+++ b/crates/tsz-checker/src/declarations/namespace_checker.rs
@@ -1,7 +1,7 @@
 //! Namespace type merging and re-export resolution for declaration merging.
 
 use crate::query_boundaries::class_type as query;
-use crate::query_boundaries::common::ObjectFlags;
+use crate::query_boundaries::type_construction;
 use crate::state::{CheckerState, EnumKind};
 use std::sync::Arc;
 use tsz_binder::SymbolId;
@@ -9,7 +9,7 @@ use tsz_common::interner::Atom;
 use tsz_parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
-use tsz_solver::{IndexSignature, ObjectShape, TypeId, Visibility};
+use tsz_solver::{TypeId, Visibility};
 
 /// Maximum recursion depth for namespace export merging.
 ///
@@ -402,14 +402,13 @@ impl<'a> CheckerState<'a> {
         }
         self.ctx.symbol_resolution_depth.set(depth);
         Self::normalize_namespace_export_declaration_order(&mut props);
-        // Use object_with_flags_and_symbol to preserve the namespace's SymbolId.
-        // This enables the type formatter to detect the namespace and display
-        // it as `typeof M` instead of expanding to the structural object shape.
-        let namespace_type = self.ctx.types.factory().object_with_flags_and_symbol(
-            props,
-            ObjectFlags::empty(),
-            Some(sym_id),
-        );
+        // Preserve the namespace's SymbolId so the type formatter displays the
+        // value surface as `typeof M` instead of expanding its object shape.
+        let namespace_type = self
+            .ctx
+            .types
+            .factory()
+            .object_with_symbol(props, Some(sym_id));
         self.ctx
             .symbol_instance_types
             .insert(sym_id, namespace_type);
@@ -904,23 +903,20 @@ impl<'a> CheckerState<'a> {
 
         if needs_reverse_map {
             let index_name = self.ctx.types.intern_string("index");
-            self.ctx.types.factory().object_with_index(ObjectShape {
-                flags: ObjectFlags::ENUM_NAMESPACE,
+            type_construction::enum_namespace_object_with_number_reverse_map(
+                self.ctx.types,
                 properties,
-                number_index: Some(IndexSignature {
-                    key_type: TypeId::NUMBER,
-                    value_type: TypeId::STRING,
-                    readonly: false,
-                    param_name: Some(index_name),
-                }),
-                symbol: Some(sym_id),
-                ..ObjectShape::default()
-            })
-        } else {
-            self.ctx.types.object_with_flags_and_symbol(
-                properties,
-                ObjectFlags::ENUM_NAMESPACE,
                 Some(sym_id),
+                Some(index_name),
+                false,
+                false,
+            )
+        } else {
+            type_construction::enum_namespace_object(
+                self.ctx.types,
+                properties,
+                Some(sym_id),
+                false,
             )
         }
     }

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -23,7 +23,7 @@ pub(crate) use tsz_solver::type_queries::{
     remapped_mapped_index_access_result,
 };
 pub(crate) use tsz_solver::{
-    FunctionShape, IntrinsicKind, MappedType, ObjectFlags, ParamInfo, PendingDiagnostic,
+    FunctionShape, IntrinsicKind, MappedType, ParamInfo, PendingDiagnostic,
     PendingDiagnosticBuilder, SourceLocation, SubtypeFailureReason, TypeFormatter,
     computation::{ContextualTypeContext, TypeSubstitution},
 };

--- a/crates/tsz-checker/src/query_boundaries/lib_augmentations.rs
+++ b/crates/tsz-checker/src/query_boundaries/lib_augmentations.rs
@@ -1,5 +1,5 @@
 use tsz_solver::construction::TypeDatabase;
-use tsz_solver::{DefId, TypeId};
+use tsz_solver::{DefId, ObjectFlags, TypeId};
 
 /// True when `candidate`'s named-property set is a strict subset of
 /// `current`'s named-property set.
@@ -34,6 +34,17 @@ pub(crate) fn lib_body_strictly_loses_members(
             .properties
             .iter()
             .any(|cur| cur.name == cand.name)
+    })
+}
+
+pub(crate) fn suppresses_module_augmentation_lookup(
+    db: &dyn TypeDatabase,
+    object_type: TypeId,
+) -> bool {
+    super::common::object_shape_for_type(db, object_type).is_some_and(|shape| {
+        shape
+            .flags
+            .contains(ObjectFlags::NO_MODULE_AUGMENTATION_LOOKUP)
     })
 }
 

--- a/crates/tsz-checker/src/query_boundaries/type_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_construction.rs
@@ -5,10 +5,14 @@
 //! over direct `TypeInterner` access. Test code may use the re-exported
 //! `TypeInterner` type for scaffolding.
 
+use tsz_binder::SymbolId;
+use tsz_common::Atom;
 use tsz_solver::construction::TypeDatabase;
 #[cfg(test)]
 pub(crate) use tsz_solver::construction::TypeInterner;
-use tsz_solver::{IndexSignature, ObjectShape, StringIntrinsicKind, TypeId};
+use tsz_solver::{
+    IndexSignature, ObjectFlags, ObjectShape, PropertyInfo, StringIntrinsicKind, TypeId,
+};
 
 /// Intern an object type carrying only a string index signature
 /// (`{ [key: string]: V }`).
@@ -24,6 +28,49 @@ pub(crate) fn object_with_string_index_value(
             readonly,
             param_name: None,
         }),
+        ..ObjectShape::default()
+    })
+}
+
+fn enum_namespace_flags(is_const_enum: bool) -> ObjectFlags {
+    let mut flags = ObjectFlags::ENUM_NAMESPACE;
+    if is_const_enum {
+        flags |= ObjectFlags::CONST_ENUM;
+    }
+    flags
+}
+
+/// Intern a `typeof Enum` namespace object without exposing raw solver flags to
+/// checker call sites.
+pub(crate) fn enum_namespace_object(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    symbol: Option<SymbolId>,
+    is_const_enum: bool,
+) -> TypeId {
+    db.object_with_flags_and_symbol(properties, enum_namespace_flags(is_const_enum), symbol)
+}
+
+/// Intern a numeric/mixed enum namespace object with the implicit reverse-map
+/// number index used by value-side element access.
+pub(crate) fn enum_namespace_object_with_number_reverse_map(
+    db: &dyn TypeDatabase,
+    properties: Vec<PropertyInfo>,
+    symbol: Option<SymbolId>,
+    index_param_name: Option<Atom>,
+    index_readonly: bool,
+    is_const_enum: bool,
+) -> TypeId {
+    db.object_with_index(ObjectShape {
+        flags: enum_namespace_flags(is_const_enum),
+        properties,
+        number_index: Some(IndexSignature {
+            key_type: TypeId::NUMBER,
+            value_type: TypeId::STRING,
+            readonly: index_readonly,
+            param_name: index_param_name,
+        }),
+        symbol,
         ..ObjectShape::default()
     })
 }

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -28,7 +28,7 @@ impl CheckerState<'_> {
     // Note: enum_symbol_from_type and enum_symbol_from_value_type are defined in type_checking.rs
 
     pub(crate) fn enum_object_type(&mut self, sym_id: SymbolId) -> Option<TypeId> {
-        use tsz_solver::{IndexSignature, ObjectShape, PropertyInfo};
+        use tsz_solver::PropertyInfo;
 
         let factory = self.ctx.types.factory();
         let symbol = self
@@ -132,30 +132,32 @@ impl CheckerState<'_> {
         // of the member names only (`"A" | "B" | ...`), never `number`, even
         // though `E[someNumber]` reverse-mapping element access still resolves to
         // `string`. Without the flag the numeric index leaked into `keyof`.
-        let mut flags = tsz_solver::ObjectFlags::ENUM_NAMESPACE;
-        if is_const_enum {
-            flags |= tsz_solver::ObjectFlags::CONST_ENUM;
-        }
         if matches!(
             self.enum_kind(sym_id),
             Some(EnumKind::Numeric) | Some(EnumKind::Mixed)
         ) {
-            let number_index = Some(IndexSignature {
-                key_type: TypeId::NUMBER,
-                value_type: TypeId::STRING,
-                readonly: true,
-                param_name: None,
-            });
-            return Some(factory.object_with_index(ObjectShape {
-                flags,
-                properties,
-                number_index,
-                ..ObjectShape::default()
-            }));
+            return Some(
+                crate::query_boundaries::type_construction::enum_namespace_object_with_number_reverse_map(
+                    self.ctx.types,
+                    properties,
+                    None,
+                    None,
+                    true,
+                    is_const_enum,
+                ),
+            );
         }
 
-        Some(factory.object_with_flags_and_symbol(properties, flags, None))
+        Some(
+            crate::query_boundaries::type_construction::enum_namespace_object(
+                self.ctx.types,
+                properties,
+                None,
+                is_const_enum,
+            ),
+        )
     }
+
     /// Evaluate complex type constructs for assignability checking.
     ///
     /// This function pre-processes types before assignability checking to ensure

--- a/crates/tsz-checker/src/types/property_access_augmentation.rs
+++ b/crates/tsz-checker/src/types/property_access_augmentation.rs
@@ -690,13 +690,10 @@ impl<'a> CheckerState<'a> {
     ) -> Option<TypeId> {
         let base_type =
             crate::query_boundaries::property_access::unwrap_readonly(self.ctx.types, object_type);
-        if crate::query_boundaries::common::object_shape_for_type(self.ctx.types, base_type)
-            .is_some_and(|shape| {
-                shape
-                    .flags
-                    .contains(tsz_solver::ObjectFlags::NO_MODULE_AUGMENTATION_LOOKUP)
-            })
-        {
+        if crate::query_boundaries::lib_augmentations::suppresses_module_augmentation_lookup(
+            self.ctx.types,
+            base_type,
+        ) {
             return None;
         }
 

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -26,5 +26,7 @@
 mod common_boundary_export_ratchets;
 #[path = "arch_source_scans/construction_boundary_signature_scans.rs"]
 mod construction_boundary_signature_scans;
+#[path = "arch_source_scans/object_flags_boundary_scans.rs"]
+mod object_flags_boundary_scans;
 #[path = "arch_source_scans/relation_routing_residual_arch_tests.rs"]
 mod relation_routing_residual_arch_tests;

--- a/crates/tsz-checker/tests/arch_source_scans/object_flags_boundary_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/object_flags_boundary_scans.rs
@@ -1,0 +1,94 @@
+//! Object flag boundary scans (issue #14351).
+//!
+//! Checker code may construct solver object surfaces, but semantic flag policy
+//! should stay behind named construction/query helpers. Raw `ObjectFlags`
+//! traffic outside the named construction/augmentation boundaries turns enum
+//! namespace, const-enum, and augmentation-opt-out decisions back into ad hoc
+//! checker branches.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const OBJECT_FLAG_BOUNDARIES: &[&str] = &[
+    "src/query_boundaries/type_construction.rs",
+    "src/query_boundaries/lib_augmentations.rs",
+];
+
+const RAW_OBJECT_FLAG_PATTERNS: &[&str] = &[
+    "ObjectFlags::",
+    "tsz_solver::ObjectFlags",
+    "common::ObjectFlags",
+    "query_boundaries::common::ObjectFlags",
+];
+
+fn checker_src_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn rust_sources_under(dir: &Path) -> Vec<PathBuf> {
+    let mut sources = Vec::new();
+    collect_rust_sources(dir, &mut sources);
+    sources.sort();
+    sources
+}
+
+fn collect_rust_sources(dir: &Path, sources: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("failed to read source directory") {
+        let path = entry.expect("failed to read source entry").path();
+        if path.is_dir() {
+            if path.file_name().and_then(|name| name.to_str()) != Some("tests") {
+                collect_rust_sources(&path, sources);
+            }
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+            sources.push(path);
+        }
+    }
+}
+
+fn is_comment_or_doc_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("//") || trimmed.starts_with("///") || trimmed.starts_with("//!")
+}
+
+#[test]
+fn production_object_flags_use_type_construction_boundary() {
+    let src_root = checker_src_root();
+    let mut violations = Vec::new();
+
+    for path in rust_sources_under(&src_root) {
+        let relative_path = format!(
+            "src/{}",
+            path.strip_prefix(&src_root)
+                .expect("scanned path is under the src root")
+                .to_string_lossy()
+                .replace('\\', "/")
+        );
+        if OBJECT_FLAG_BOUNDARIES.contains(&relative_path.as_str()) {
+            continue;
+        }
+
+        let source = fs::read_to_string(&path).expect("failed to read Rust source");
+        for (line_index, line) in source.lines().enumerate() {
+            if is_comment_or_doc_line(line) {
+                continue;
+            }
+            for pattern in RAW_OBJECT_FLAG_PATTERNS {
+                if line.contains(pattern) {
+                    violations.push(format!(
+                        "{}:{} contains raw object-flag traffic `{}`",
+                        relative_path,
+                        line_index + 1,
+                        pattern
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "checker production code should route object flag decisions through \
+         named query-boundary helpers:\n{}",
+        violations.join("\n")
+    );
+}

--- a/scripts/arch/arch_guard_policy.toml
+++ b/scripts/arch/arch_guard_policy.toml
@@ -111,19 +111,13 @@ ignore_comment_lines = true
 # is verified in the PR.
 
 [[pattern_checks]]
-name = "Checker boundary: ObjectFlags must not be imported (use ObjectShape builder methods)"
+name = "Checker boundary: ObjectFlags stay behind query boundaries"
 base = "crates/tsz-checker/src"
 pattern = '\buse\s+tsz_solver::.*ObjectFlags\b|\bObjectFlags::'
 exclude_dirs = ["tests"]
 exclude_files = [
-  # Pre-existing: type_environment uses ObjectFlags for const enum checks
-  "crates/tsz-checker/src/state/type_environment/core.rs",
-  # Pre-existing: namespace_checker creates enum namespace objects with ENUM_NAMESPACE flag
-  "crates/tsz-checker/src/declarations/namespace_checker.rs",
-  # Pre-existing baseline debt
-  "crates/tsz-checker/src/query_boundaries/common.rs",
-  "crates/tsz-checker/src/types/property_access_augmentation.rs",
-  "crates/tsz-checker/src/types/class_type/core.rs",
+  "crates/tsz-checker/src/query_boundaries/lib_augmentations.rs",
+  "crates/tsz-checker/src/query_boundaries/type_construction.rs",
 ]
 ignore_comment_lines = true
 


### PR DESCRIPTION
Goal: green

## Summary
- Move enum namespace and const-enum object-surface construction behind checker `query_boundaries::type_construction` helpers.
- Move the module-augmentation opt-out flag read behind `query_boundaries::lib_augmentations`.
- Remove `ObjectFlags` from the `common` re-export and ratchet production checker `ObjectFlags` usage to the named query boundaries.

## Structural Rule
When checker constructs or classifies special solver object surfaces, `tsc` treats that as semantic object metadata; tsz now sets and reads those bits through named checker query-boundary helpers while the solver-owned raw `ObjectFlags` representation stays out of ordinary checker call sites.

Owner layer: checker query boundaries own the checker-facing construction/query API; solver continues to own the raw object flag representation.

Adjacent matrix:
- Enum namespace objects: numeric and mixed reverse-map plus plain enum namespace construction still create the same flagged object surfaces.
- Const enum namespace objects: constness is preserved by the boundary helper.
- Module augmentation lookup: opt-out shapes still short-circuit name-based augmentation fallback.
- Fallback: object-shape pass-through copies that preserve already-interned metadata are left unchanged.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test arch_source_scans production_object_flags_use_type_construction_boundary`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test enum_keyof_excludes_number_tests --test enum_merge_tests --test ts2403_enum_object_redeclaration_tests --test module_augmentation_isolation_tests --test self_module_augmentation_isolation_tests --test hkt_self_augmentation_keyof_repro`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy -p tsz-checker --lib --test arch_source_scans -- -D warnings`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`

Known local baseline note: `scripts/safe-run.sh cargo nextest run -p tsz-checker --test module_augmentation_declaration_identity_tests` fails the same 3 interface/indexed-interface assertions on clean `origin/main` at `454eb3e163`, so it is not used as branch regression evidence here.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high