### PR TITLE
refactor(solver): name subtype explain guard states (#14351)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -8,6 +8,7 @@ use crate::def::resolver::TypeResolver;
 use crate::diagnostics::SubtypeFailureReason;
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::relations::subtype::SubtypeChecker;
+use crate::relations::subtype::explain_guard::{ExplainFuelState, ExplainRecursionEntryState};
 use crate::type_queries::data::get_object_symbol;
 use crate::types::{
     IntrinsicKind, LiteralValue, ObjectShape, ObjectShapeId, PropertyInfo, TupleElement,
@@ -287,23 +288,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // pathological traversals that would otherwise not terminate. On
         // terminating workloads the budget is never reached, so this is inert
         // and rendered output is byte-identical.
-        if self.explain_eval_fuel == Some(0) {
-            return Some(SubtypeFailureReason::TypeMismatch {
-                source_type: source,
-                target_type: target,
-            });
+        if let Some(reason) =
+            ExplainFuelState::from_fuel(self.explain_eval_fuel).fallback_reason(source, target)
+        {
+            return Some(reason);
         }
         let pair = (source, target);
-        match self.guard.enter(pair) {
-            crate::recursion::RecursionResult::Entered => {}
-            crate::recursion::RecursionResult::Cycle
-            | crate::recursion::RecursionResult::DepthExceeded
-            | crate::recursion::RecursionResult::IterationExceeded => {
-                return Some(SubtypeFailureReason::TypeMismatch {
-                    source_type: source,
-                    target_type: target,
-                });
-            }
+        let entry_state = ExplainRecursionEntryState::from_recursion_result(self.guard.enter(pair));
+        if let Some(reason) = entry_state.fallback_reason(source, target) {
+            return Some(reason);
         }
         let result = self.explain_failure_body(source, target);
         self.guard.leave(pair);

--- a/crates/tsz-solver/src/relations/subtype/explain_guard.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain_guard.rs
@@ -1,0 +1,140 @@
+use crate::diagnostics::SubtypeFailureReason;
+use crate::recursion::RecursionResult;
+use crate::types::TypeId;
+
+/// Work-budget verdict for one subtype explanation entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ExplainFuelState {
+    /// Explanation may continue.
+    Ready,
+    /// Explanation has consumed its per-failure elaboration budget.
+    Exhausted,
+}
+
+impl ExplainFuelState {
+    pub(super) const fn from_fuel(fuel: Option<u32>) -> Self {
+        if matches!(fuel, Some(0)) {
+            Self::Exhausted
+        } else {
+            Self::Ready
+        }
+    }
+
+    pub(super) const fn fallback_reason(
+        self,
+        source: TypeId,
+        target: TypeId,
+    ) -> Option<SubtypeFailureReason> {
+        match self {
+            Self::Ready => None,
+            Self::Exhausted => Some(SubtypeFailureReason::TypeMismatch {
+                source_type: source,
+                target_type: target,
+            }),
+        }
+    }
+}
+
+/// Recursion-entry verdict for subtype explanation elaboration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ExplainRecursionEntryState {
+    /// The relation pair entered the explanation recursion guard.
+    Entered,
+    /// The pair hit a cycle/depth/iteration guard and should use the coarse
+    /// mismatch fallback.
+    Fallback,
+}
+
+impl ExplainRecursionEntryState {
+    pub(super) const fn from_recursion_result(result: RecursionResult) -> Self {
+        match result {
+            RecursionResult::Entered => Self::Entered,
+            RecursionResult::Cycle
+            | RecursionResult::DepthExceeded
+            | RecursionResult::IterationExceeded => Self::Fallback,
+        }
+    }
+
+    pub(super) const fn fallback_reason(
+        self,
+        source: TypeId,
+        target: TypeId,
+    ) -> Option<SubtypeFailureReason> {
+        match self {
+            Self::Entered => None,
+            Self::Fallback => Some(SubtypeFailureReason::TypeMismatch {
+                source_type: source,
+                target_type: target,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::recursion::RecursionResult;
+    use crate::types::TypeId;
+
+    use super::{ExplainFuelState, ExplainRecursionEntryState};
+
+    #[test]
+    fn fuel_state_reports_exhausted_only_at_zero() {
+        assert_eq!(ExplainFuelState::from_fuel(None), ExplainFuelState::Ready);
+        assert_eq!(
+            ExplainFuelState::from_fuel(Some(1)),
+            ExplainFuelState::Ready
+        );
+        assert_eq!(
+            ExplainFuelState::from_fuel(Some(0)),
+            ExplainFuelState::Exhausted
+        );
+    }
+
+    #[test]
+    fn exhausted_fuel_builds_type_mismatch_fallback() {
+        assert!(
+            ExplainFuelState::Ready
+                .fallback_reason(TypeId::STRING, TypeId::NUMBER)
+                .is_none()
+        );
+        let reason = ExplainFuelState::Exhausted
+            .fallback_reason(TypeId::STRING, TypeId::NUMBER)
+            .expect("exhausted fuel should produce a coarse fallback");
+
+        assert!(matches!(
+            reason,
+            crate::diagnostics::SubtypeFailureReason::TypeMismatch {
+                source_type: TypeId::STRING,
+                target_type: TypeId::NUMBER,
+            }
+        ));
+    }
+
+    #[test]
+    fn recursion_entry_state_preserves_entered_vs_fallback() {
+        assert_eq!(
+            ExplainRecursionEntryState::from_recursion_result(RecursionResult::Entered),
+            ExplainRecursionEntryState::Entered
+        );
+        for denied in [
+            RecursionResult::Cycle,
+            RecursionResult::DepthExceeded,
+            RecursionResult::IterationExceeded,
+        ] {
+            assert_eq!(
+                ExplainRecursionEntryState::from_recursion_result(denied),
+                ExplainRecursionEntryState::Fallback
+            );
+        }
+    }
+
+    #[test]
+    fn explain_funnel_uses_named_guard_states() {
+        let explain_rs = include_str!("explain.rs");
+
+        assert!(explain_rs.contains("ExplainFuelState::from_fuel"));
+        assert!(explain_rs.contains("ExplainRecursionEntryState::from_recursion_result"));
+        assert!(!explain_rs.contains("explain_eval_fuel == Some(0)"));
+        assert!(!explain_rs.contains("RecursionResult::Cycle"));
+    }
+}

--- a/crates/tsz-solver/src/relations/subtype/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod cache;
 pub(crate) mod core;
 pub(crate) mod explain;
 pub(crate) mod explain_function;
+pub(crate) mod explain_guard;
 pub(crate) mod explain_tuple;
 pub(crate) mod helpers;
 pub(crate) mod overlap;

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -673,6 +673,11 @@ FILE_LINE_LIMIT_CHECKS = [
         2018,
     ),
     (
+        "Solver boundary: diagnostics/format/mod.rs size ratchet",
+        ROOT / "crates/tsz-solver/src/diagnostics/format/mod.rs",
+        2012,
+    ),
+    (
         "Emitter boundary: declaration_emitter/helpers/type_inference_return_normalization.rs size ratchet",
         ROOT
         / "crates"


### PR DESCRIPTION
Goal: green

## Summary
- Add a subtype-explain guard owner module for the explanation work-budget and recursion-entry verdicts.
- Route `explain_failure_guarded` through named fuel and recursion states instead of raw `Option<u32>` / `RecursionResult` branching.
- Keep the existing coarse `TypeMismatch` fallback and move `explain.rs` below the source-shard ceiling.

## Structural Rule
When subtype failure elaboration recursively explains nested member, branch, tuple, or function relations, tsc eventually stops drilling and reports the coarser relation line. `tsz` now does that through solver subtype-explain guard states: fuel exhaustion and recursion denial both map to the existing coarse `TypeMismatch` fallback at the explanation owner boundary.

Owner layer: solver `relations::subtype::explain_guard`; subtype explanation consumes the named verdicts while relation semantics and diagnostic rendering remain unchanged.

Adjacent matrix:
- Positive: available fuel keeps explanation eligible to continue.
- Budget fallback: zero explain fuel returns the same coarse type mismatch.
- Recursion positive: `RecursionResult::Entered` remains the only path that enters the explain body.
- Recursion fallback: cycle, depth, and iteration denial all preserve the previous coarse mismatch fallback.

Performance: no new traversal or cache key; this is a branch-shape extraction around existing constant-time guard checks.

Part of #14351.

## Verification
- `cargo fmt --all --check`
- `scripts/safe-run.sh cargo check -p tsz-solver -p tsz-checker`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver relations::subtype::explain_guard explain_intersection_source_collect_memo_tests explain_failure`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`
- `python3 scripts/arch/arch_guard.py`
- `python3 scripts/arch/test_arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/check-clippy-warn-ratchet.py`
- `git diff --check`
- `wc -l crates/tsz-solver/src/relations/subtype/explain.rs crates/tsz-solver/src/relations/subtype/explain_guard.rs`

## Provenance
Machine: m4
Assistant: codex
Model: GPT-5
Effort: high
