### PR TITLE
refactor(checker): name type guard walk states (#14351)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/mod.rs
+++ b/crates/tsz-checker/src/flow/control_flow/mod.rs
@@ -34,6 +34,7 @@ mod optional_chain;
 mod predicate_resolution;
 pub(crate) mod references;
 mod switch_distinct_literals;
+mod type_guard_walk;
 pub(crate) mod type_guards;
 mod typeof_exclusions;
 pub(crate) mod var_utils;

--- a/crates/tsz-checker/src/flow/control_flow/type_guard_walk.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guard_walk.rs
@@ -1,0 +1,44 @@
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeArena;
+
+use crate::state::MAX_TREE_WALK_ITERATIONS;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TypeGuardWalkState<T> {
+    Continue(T),
+    Finished,
+    Exhausted,
+}
+
+pub(super) struct TypeGuardWalk {
+    remaining: usize,
+}
+
+impl TypeGuardWalk {
+    pub(super) const fn new() -> Self {
+        Self {
+            remaining: MAX_TREE_WALK_ITERATIONS as usize,
+        }
+    }
+
+    pub(super) fn next<T>(&mut self, next: impl FnOnce() -> Option<T>) -> TypeGuardWalkState<T> {
+        if self.remaining == 0 {
+            return TypeGuardWalkState::Exhausted;
+        }
+
+        self.remaining -= 1;
+        next().map_or(TypeGuardWalkState::Finished, TypeGuardWalkState::Continue)
+    }
+
+    pub(super) fn next_parent(
+        &mut self,
+        arena: &NodeArena,
+        current: NodeIndex,
+    ) -> TypeGuardWalkState<NodeIndex> {
+        self.next(|| {
+            let ext = arena.get_extended(current)?;
+            let parent = ext.parent;
+            parent.is_some().then_some(parent)
+        })
+    }
+}

--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -8,9 +8,8 @@ use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{ParamInfo, SymbolRef, TypeId, TypePredicate, TypePredicateTarget};
 
-use crate::state::MAX_TREE_WALK_ITERATIONS;
-
 use super::FlowAnalyzer;
+use super::type_guard_walk::{TypeGuardWalk, TypeGuardWalkState};
 use crate::query_boundaries::flow_analysis::{self as flow_query, TypeResolver};
 use crate::types_domain::property_access_type::known_globals;
 
@@ -37,13 +36,12 @@ fn enclosing_class_property_initializer(
     reference: NodeIndex,
 ) -> Option<NodeIndex> {
     let mut current = reference;
-    for _ in 0..crate::state::MAX_TREE_WALK_ITERATIONS {
-        let ext = arena.get_extended(current)?;
-        let parent = ext.parent;
-        if parent.is_none() {
-            return None;
-        }
-
+    let mut walk = TypeGuardWalk::new();
+    loop {
+        let parent = match walk.next_parent(arena, current) {
+            TypeGuardWalkState::Continue(parent) => parent,
+            TypeGuardWalkState::Finished | TypeGuardWalkState::Exhausted => return None,
+        };
         let parent_node = arena.get(parent)?;
         if parent_node.kind == syntax_kind_ext::PROPERTY_DECLARATION {
             return arena
@@ -54,27 +52,20 @@ fn enclosing_class_property_initializer(
 
         current = parent;
     }
-
-    None
 }
 
 fn node_is_within(arena: &NodeArena, node: NodeIndex, ancestor: NodeIndex) -> bool {
     let mut current = node;
-    for _ in 0..crate::state::MAX_TREE_WALK_ITERATIONS {
+    let mut walk = TypeGuardWalk::new();
+    loop {
         if current == ancestor {
             return true;
         }
-        let Some(ext) = arena.get_extended(current) else {
-            return false;
+        current = match walk.next_parent(arena, current) {
+            TypeGuardWalkState::Continue(parent) => parent,
+            TypeGuardWalkState::Finished | TypeGuardWalkState::Exhausted => return false,
         };
-        let parent = ext.parent;
-        if parent.is_none() {
-            return false;
-        }
-        current = parent;
     }
-
-    false
 }
 
 impl<'a> FlowAnalyzer<'a> {
@@ -172,11 +163,14 @@ impl<'a> FlowAnalyzer<'a> {
                 let decl_scope_id = self.binder.find_enclosing_scope(self.arena, decl_id);
                 let mut is_in_function_scope = false;
                 if let Some(mut scope_id) = decl_scope_id {
-                    for _ in 0..crate::state::MAX_TREE_WALK_ITERATIONS {
-                        let Some(scope) = self.binder.scopes.get(scope_id.0 as usize) else {
-                            break;
-                        };
-                        match scope.kind {
+                    let mut walk = TypeGuardWalk::new();
+                    while let TypeGuardWalkState::Continue((kind, parent)) = walk.next(|| {
+                        self.binder
+                            .scopes
+                            .get(scope_id.0 as usize)
+                            .map(|scope| (scope.kind, scope.parent))
+                    }) {
+                        match kind {
                             ContainerKind::Function => {
                                 is_in_function_scope = true;
                                 break;
@@ -189,7 +183,6 @@ impl<'a> FlowAnalyzer<'a> {
                                 // Keep walking up
                             }
                         }
-                        let parent = scope.parent;
                         if parent.is_none() {
                             break;
                         }
@@ -439,14 +432,14 @@ impl<'a> FlowAnalyzer<'a> {
     /// Returns `NodeIndex::NONE` if the node is at module/global scope.
     fn find_enclosing_function_node(&self, node_idx: NodeIndex) -> NodeIndex {
         let mut current = node_idx;
-        for _ in 0..crate::state::MAX_TREE_WALK_ITERATIONS {
-            let Some(ext) = self.arena.get_extended(current) else {
-                return NodeIndex::NONE;
+        let mut walk = TypeGuardWalk::new();
+        loop {
+            let parent = match walk.next_parent(self.arena, current) {
+                TypeGuardWalkState::Continue(parent) => parent,
+                TypeGuardWalkState::Finished | TypeGuardWalkState::Exhausted => {
+                    return NodeIndex::NONE;
+                }
             };
-            let parent = ext.parent;
-            if parent.is_none() {
-                return NodeIndex::NONE;
-            }
             let Some(parent_node) = self.arena.get(parent) else {
                 return NodeIndex::NONE;
             };
@@ -455,7 +448,6 @@ impl<'a> FlowAnalyzer<'a> {
             }
             current = parent;
         }
-        NodeIndex::NONE
     }
 
     pub(crate) fn reference_is_in_class_property_initializer(&self, reference: NodeIndex) -> bool {
@@ -491,8 +483,6 @@ impl<'a> FlowAnalyzer<'a> {
     /// - Variables declared INSIDE the closure should narrow normally
     /// - Variables captured from OUTER scope reset narrowing (for let/var)
     pub(crate) fn is_captured_variable(&self, reference: NodeIndex) -> bool {
-        use tsz_binder::ScopeId;
-
         // Resolve the identifier reference to its symbol
         let Some(symbol_id) = self.binder.resolve_identifier(self.arena, reference) else {
             return false;
@@ -537,19 +527,21 @@ impl<'a> FlowAnalyzer<'a> {
 
         // Check if declaration scope is an ancestor of usage scope
         let mut scope_id = usage_scope_id;
-        let mut iterations = 0;
-        while scope_id.is_some() && iterations < MAX_TREE_WALK_ITERATIONS {
+        let mut walk = TypeGuardWalk::new();
+        while scope_id.is_some() {
             if scope_id == decl_scope_id {
                 return true;
             }
 
-            scope_id = self
-                .binder
-                .scopes
-                .get(scope_id.0 as usize)
-                .map_or(ScopeId::NONE, |scope| scope.parent);
-
-            iterations += 1;
+            scope_id = match walk.next(|| {
+                self.binder
+                    .scopes
+                    .get(scope_id.0 as usize)
+                    .map(|scope| scope.parent)
+            }) {
+                TypeGuardWalkState::Continue(parent) => parent,
+                TypeGuardWalkState::Finished | TypeGuardWalkState::Exhausted => break,
+            };
         }
 
         false

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -32,3 +32,5 @@ mod object_flags_boundary_scans;
 mod relation_routing_residual_arch_tests;
 #[path = "arch_source_scans/spelling_suggestion_gateway_scans.rs"]
 mod spelling_suggestion_gateway_scans;
+#[path = "arch_source_scans/type_guard_walk_state.rs"]
+mod type_guard_walk_state;

--- a/crates/tsz-checker/tests/arch_source_scans/type_guard_walk_state.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/type_guard_walk_state.rs
@@ -1,0 +1,22 @@
+#[test]
+fn type_guard_tree_walks_use_named_state() {
+    let type_guards = include_str!("../../src/flow/control_flow/type_guards.rs");
+    let walk_state = include_str!("../../src/flow/control_flow/type_guard_walk.rs");
+
+    assert!(
+        !type_guards.contains("MAX_TREE_WALK_ITERATIONS"),
+        "type guard walks should route through named walk state instead of raw limits"
+    );
+    assert!(
+        type_guards.contains("TypeGuardWalk"),
+        "type guard extraction should use the named walk helper"
+    );
+    assert!(
+        walk_state.contains("TypeGuardWalkState::Exhausted"),
+        "the helper should name exhausted walks explicitly"
+    );
+    assert!(
+        walk_state.contains("TypeGuardWalkState::Finished"),
+        "the helper should distinguish normal termination from exhaustion"
+    );
+}

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -283,6 +283,17 @@ FILE_LINE_LIMIT_CHECKS = [
         2098,
     ),
     (
+        "Solver diagnostics boundary: format/mod.rs must not grow",
+        ROOT
+        / "crates"
+        / "tsz-solver"
+        / "src"
+        / "diagnostics"
+        / "format"
+        / "mod.rs",
+        2012,
+    ),
+    (
         "Solver evaluation boundary: conditional.rs must not grow",
         ROOT
         / "crates"


### PR DESCRIPTION
Goal: green

## Summary
- Add a checker-local `TypeGuardWalk` helper that names type-guard parent/scope walk outcomes as `Continue`, `Finished`, or `Exhausted`.
- Route the type-guard parent-chain and scope-chain cutoffs through that named helper instead of raw `MAX_TREE_WALK_ITERATIONS` loops.
- Add an `arch_source_scans` source guard that keeps type-guard walks behind the named state helper.
- Carry the temporary `diagnostics/format/mod.rs` size ratchet required by fresh `origin/main` until the queued cleanup reaches main.

## Structural Rule
When checker flow extracts syntactic type-guard context through bounded parent/scope walks, `tsc` terminates traversal without changing the semantic narrowing rule; tsz now owns that cutoff in checker flow through `TypeGuardWalk`, while solver/query-boundary code remains responsible for type semantics.

## Owner Layer
Checker flow/control-flow only. The PR does not add solver type-shape matching, checker `TypeKey` construction, or new diagnostic policy.

## Adjacent Matrix
- Class property initializer parent walks: unchanged behavior, named `Finished`/`Exhausted` fallback to no initializer match.
- Declaration-within-ancestor parent walks: unchanged behavior, named fallback to false.
- Enclosing function parent walks: unchanged behavior, named fallback to `NodeIndex::NONE`.
- Local-let and captured-variable scope walks: unchanged behavior, named fallback to not captured / not local-function-scoped.
- Source guard: prevents reintroducing raw type-guard tree-walk limits in `type_guards.rs`.

## Verification
- Red first: `scripts/safe-run.sh cargo nextest run -p tsz-checker --test arch_source_scans type_guard_tree_walks_use_named_state` failed before the helper existed.
- `cargo fmt --all --check`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test arch_source_scans type_guard_tree_walks_use_named_state`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test control_flow_type_guard_tests --test flow_captured_let_memoization_tests --test type_guard_mutable_field_probe_tests`
- `python3 scripts/arch/arch_guard.py`
- `python3 scripts/arch/test_arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `git diff --check origin/main..HEAD`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`

## Provenance
Machine: m4
Assistant: codex
Model: GPT-5
Effort: high
