### PR TITLE
refactor(solver): route property index signatures through resolver surface (#14351)

### DIFF
--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -376,6 +376,45 @@ impl<'a> PropertyAccessEvaluator<'a> {
         self.resolver.unwrap_or_else(|| self.db.as_type_resolver())
     }
 
+    fn with_index_signature_resolver<T>(
+        &self,
+        f: impl FnOnce(
+            &crate::objects::index_signatures::IndexSignatureResolver<'_, &dyn TypeResolver>,
+        ) -> T,
+    ) -> T {
+        let resolver = self.resolver();
+        let index_resolver =
+            crate::objects::index_signatures::IndexSignatureResolver::with_resolver(
+                self.interner(),
+                &resolver,
+            );
+        f(&index_resolver)
+    }
+
+    pub(crate) fn has_index_signature(
+        &self,
+        obj: TypeId,
+        kind: crate::objects::index_signatures::IndexKind,
+    ) -> bool {
+        self.with_index_signature_resolver(|resolver| resolver.has_index_signature(obj, kind))
+    }
+
+    pub(crate) fn resolve_string_index_signature(&self, obj: TypeId) -> Option<TypeId> {
+        self.with_index_signature_resolver(|resolver| resolver.resolve_string_index(obj))
+    }
+
+    pub(crate) fn resolve_number_index_signature(&self, obj: TypeId) -> Option<TypeId> {
+        self.with_index_signature_resolver(|resolver| resolver.resolve_number_index(obj))
+    }
+
+    pub(crate) fn get_index_info(&self, obj: TypeId) -> crate::types::IndexInfo {
+        self.with_index_signature_resolver(|resolver| resolver.get_index_info(obj))
+    }
+
+    pub(crate) fn is_numeric_index_name(&self, prop_name: &str) -> bool {
+        self.with_index_signature_resolver(|resolver| resolver.is_numeric_index_name(prop_name))
+    }
+
     pub(crate) fn bind_object_receiver_this(&self, receiver: TypeId, type_id: TypeId) -> TypeId {
         if self.skip_this_binding.get() {
             return type_id;
@@ -755,11 +794,9 @@ impl<'a> PropertyAccessEvaluator<'a> {
                         };
                     }
                 }
-                // Check numeric index signature first for numeric property names
-                use crate::objects::index_signatures::IndexSignatureResolver;
-                let resolver = IndexSignatureResolver::new(self.interner());
+                // Check numeric index signature first for numeric property names.
                 if let Some(ref idx) = shape.number_index
-                    && resolver
+                    && self
                         .is_numeric_index_name(self.interner().resolve_atom_ref(prop_atom).as_ref())
                 {
                     return PropertyAccessResult::from_index(
@@ -888,13 +925,12 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
                     // Before giving up, check if any member has an index signature
                     // For intersections, if ANY member has an index signature, the property access should succeed
-                    use crate::objects::index_signatures::{IndexKind, IndexSignatureResolver};
-                    let resolver = IndexSignatureResolver::new(self.interner());
+                    use crate::objects::index_signatures::IndexKind;
 
                     // Check string index signature on all members
                     for &member in members.iter() {
-                        if resolver.has_index_signature(member, IndexKind::String)
-                            && let Some(value_type) = resolver.resolve_string_index(member)
+                        if self.has_index_signature(member, IndexKind::String)
+                            && let Some(value_type) = self.resolve_string_index_signature(member)
                         {
                             return PropertyAccessResult::from_index(
                                 self.add_undefined_if_unchecked(value_type),
@@ -903,11 +939,11 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     }
 
                     // Check numeric index signature if property name looks numeric
-                    if resolver
+                    if self
                         .is_numeric_index_name(self.interner().resolve_atom_ref(prop_atom).as_ref())
                     {
                         for &member in members.iter() {
-                            if let Some(value_type) = resolver.resolve_number_index(member) {
+                            if let Some(value_type) = self.resolve_number_index_signature(member) {
                                 return PropertyAccessResult::from_index(
                                     self.add_undefined_if_unchecked(value_type),
                                 );

--- a/crates/tsz-solver/src/operations/property_helpers.rs
+++ b/crates/tsz-solver/src/operations/property_helpers.rs
@@ -1058,11 +1058,9 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     );
                 }
 
-                // Check numeric index signature for numeric property names
-                use crate::objects::index_signatures::IndexSignatureResolver;
-                let resolver = IndexSignatureResolver::new(self.interner());
+                // Check numeric index signature for numeric property names.
                 if let Some(ref idx) = shape.number_index
-                    && resolver
+                    && self
                         .is_numeric_index_name(self.interner().resolve_atom_ref(prop_atom).as_ref())
                 {
                     let instantiated_value = self.instantiate_application_member_type(
@@ -1213,14 +1211,12 @@ impl<'a> PropertyAccessEvaluator<'a> {
     /// signature; callers should fall back to the standard `T[any] = any`
     /// behaviour in that case.
     pub fn resolve_any_index_access(&self, obj_type: TypeId) -> Option<PropertyAccessResult> {
-        use crate::objects::index_signatures::IndexSignatureResolver;
-        let resolver = IndexSignatureResolver::new(self.interner());
         // String index signatures cover string and numeric keys (number falls
         // through to string when no number signature exists). Try string first
         // and fall back to number-only.
-        let value_type = resolver
-            .resolve_string_index(obj_type)
-            .or_else(|| resolver.resolve_number_index(obj_type))?;
+        let value_type = self
+            .resolve_string_index_signature(obj_type)
+            .or_else(|| self.resolve_number_index_signature(obj_type))?;
         Some(self.index_signature_result_with_nuia_write_type(value_type))
     }
 
@@ -1424,8 +1420,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
         }
 
-        use crate::objects::index_signatures::IndexSignatureResolver;
-        if IndexSignatureResolver::new(self.interner()).is_numeric_index_name(prop_name) {
+        if self.is_numeric_index_name(prop_name) {
             let element_or_undefined = self.element_type_with_undefined(elem);
             return PropertyAccessResult::from_index(element_or_undefined);
         }
@@ -1505,9 +1500,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
         }
 
         // Handle numeric index access (e.g., arr[0], arr["0"])
-        use crate::objects::index_signatures::IndexSignatureResolver;
-        let resolver = IndexSignatureResolver::new(self.interner());
-        if resolver.is_numeric_index_name(prop_name) {
+        if self.is_numeric_index_name(prop_name) {
             let element_or_undefined = self.element_type_with_undefined(element_type);
             return PropertyAccessResult::from_index(element_or_undefined);
         }

--- a/crates/tsz-solver/src/operations/property_visitor.rs
+++ b/crates/tsz-solver/src/operations/property_visitor.rs
@@ -118,7 +118,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
         shape_id: u32,
         prop_atom: Atom,
     ) -> Option<PropertyAccessResult> {
-        use crate::objects::index_signatures::{IndexKind, IndexSignatureResolver};
+        use crate::objects::index_signatures::IndexKind;
 
         let shape = self.interner().object_shape(ObjectShapeId(shape_id));
         let obj_type = self
@@ -160,15 +160,13 @@ impl<'a> PropertyAccessEvaluator<'a> {
         }
 
         // Check for index signatures (some Object types may have index signatures that aren't in ObjectWithIndex)
-        let resolver = IndexSignatureResolver::new(self.interner());
-
         // Try string index signature first (most common).
         // Symbol-keyed properties (internal "__unique_N" names) must NOT
         // fall through to string index signatures.
         if !prop_name.starts_with("__unique_")
-            && resolver.has_index_signature(obj_type, IndexKind::String)
-            && let Some(value_type) = resolver.resolve_string_index(obj_type)
-            && resolver
+            && self.has_index_signature(obj_type, IndexKind::String)
+            && let Some(value_type) = self.resolve_string_index_signature(obj_type)
+            && self
                 .get_index_info(obj_type)
                 .string_index
                 .as_ref()
@@ -180,8 +178,8 @@ impl<'a> PropertyAccessEvaluator<'a> {
         }
 
         // Try numeric index signature if property name looks numeric
-        if resolver.is_numeric_index_name(prop_name)
-            && let Some(value_type) = resolver.resolve_number_index(obj_type)
+        if self.is_numeric_index_name(prop_name)
+            && let Some(value_type) = self.resolve_number_index_signature(obj_type)
         {
             return Some(PropertyAccessResult::from_index(
                 self.add_undefined_if_unchecked(
@@ -201,8 +199,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
         shape_id: u32,
         prop_atom: Atom,
     ) -> Option<PropertyAccessResult> {
-        use crate::objects::index_signatures::IndexSignatureResolver;
-
         let shape = self.interner().object_shape(ObjectShapeId(shape_id));
         let obj_type = self
             .interner()
@@ -245,8 +241,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
         // Check numeric index signature FIRST if property name looks numeric.
         // Number index signatures take precedence over string index signatures
         // for numeric keys (e.g., obj["0"] or obj[0] prefers [n: number] over [s: string]).
-        let resolver = IndexSignatureResolver::new(self.interner());
-        if resolver.is_numeric_index_name(prop_name)
+        if self.is_numeric_index_name(prop_name)
             && let Some(ref idx) = shape.number_index
         {
             let bound = self.bind_object_receiver_this(obj_type, idx.value_type);
@@ -280,7 +275,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
         list_id: u32,
         prop_atom: Atom,
     ) -> Option<PropertyAccessResult> {
-        use crate::objects::index_signatures::{IndexKind, IndexSignatureResolver};
+        use crate::objects::index_signatures::IndexKind;
 
         // Re-enable `this` binding for union member resolution. When a union is
         // nested inside an intersection (e.g., `(A & B) | (C & D)`), the
@@ -500,15 +495,14 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
 
             // Before giving up, check union-level index signatures
-            let resolver = IndexSignatureResolver::new(self.interner());
             let obj_type = obj_type_for_error();
             let prop_name_arc = self.interner().resolve_atom_ref(prop_atom);
             let prop_name = prop_name_arc.as_ref();
 
             if !prop_name.starts_with("__unique_")
-                && resolver.has_index_signature(obj_type, IndexKind::String)
-                && let Some(value_type) = resolver.resolve_string_index(obj_type)
-                && resolver
+                && self.has_index_signature(obj_type, IndexKind::String)
+                && let Some(value_type) = self.resolve_string_index_signature(obj_type)
+                && self
                     .get_index_info(obj_type)
                     .string_index
                     .as_ref()
@@ -519,8 +513,8 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 ));
             }
 
-            if resolver.is_numeric_index_name(prop_name)
-                && let Some(value_type) = resolver.resolve_number_index(obj_type)
+            if self.is_numeric_index_name(prop_name)
+                && let Some(value_type) = self.resolve_number_index_signature(obj_type)
             {
                 return Some(PropertyAccessResult::from_index(
                     self.add_undefined_if_unchecked(value_type),

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -199,6 +199,40 @@ fn read_solver_test(rel: &str) -> String {
 }
 
 #[test]
+fn property_access_uses_evaluator_owned_index_signature_resolver() {
+    let files = [
+        "operations/property.rs",
+        "operations/property_helpers.rs",
+        "operations/property_visitor.rs",
+    ];
+    let mut violations = Vec::new();
+
+    for rel in files {
+        let src = read_solver_source(rel);
+        for (line_num, line) in src.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") || trimmed.starts_with("///") {
+                continue;
+            }
+            if line.contains("IndexSignatureResolver::new(") {
+                violations.push(format!(
+                    "  {rel}:{} — query through PropertyAccessEvaluator's resolver-aware index-signature helpers",
+                    line_num + 1
+                ));
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "Property access must use its evaluator-owned index-signature resolver so \
+         deferred application/lazy materialization sees the same resolver surface. \
+         Violations found:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
 fn evaluation_engine_keeps_request_stage_boundary() {
     let mod_rs = read_solver_source("evaluation/mod.rs");
     let request_rs = read_solver_source("evaluation/request.rs");


### PR DESCRIPTION
Goal: green

## Summary
- Add resolver-aware index-signature helper methods on `PropertyAccessEvaluator`.
- Route property, property-helper, and property-visitor index-signature miss paths through those helpers instead of constructing fresh `IndexSignatureResolver::new(...)` instances.
- Add a solver architecture guard so property access cannot regress to Noop-backed index-signature queries.

## Structural Rule
When property access falls through to string or numeric index-signature lookup, `tsc` observes the same materialized type surface as the surrounding property query. `tsz` now does that through the solver property-access owner: index-signature queries use the evaluator-owned resolver surface, preserving existing string/numeric/symbol fallback behavior while avoiding ad hoc Noop-backed resolver construction inside property access.

## Owner Layer
Solver: `PropertyAccessEvaluator` owns property/index-signature lookup policy and resolver visibility; `objects::index_signatures::IndexSignatureResolver` remains the standalone query primitive for direct callers and tests.

## Adjacent Matrix
- Plain object/object-with-index property misses still prefer explicit members, then string/numeric index signatures in the existing order.
- Callable and intersection fallback index-signature checks now share the evaluator resolver surface.
- `any` element access still prefers string index signatures and falls back to number index signatures.
- Array/readonly-array numeric property names still resolve through the same numeric-name predicate.
- Symbol-keyed index leakage protections remain in the property owner.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards property_access_uses_evaluator_owned_index_signature_resolver`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver property_helpers_tests objects::index_signatures::tests index_access_comprehensive_tests`
- `python3 scripts/arch/arch_guard.py --json`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy -p tsz-solver --all-targets -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high