### PR TITLE
refactor(solver): name infer pattern guard state (#14351)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -20,7 +20,10 @@ use smallvec::SmallVec;
 use tsz_common::interner::Atom;
 
 use super::super::evaluate::TypeEvaluator;
+use super::infer_pattern_guard_state::InferPatternVisitDecision;
 use super::infer_substitutor::InferSubstitutor;
+
+pub(crate) use super::infer_pattern_guard_state::InferPatternGuardState as InferPatternVisited;
 
 /// Selects how co-located `infer T` candidates are merged when the same name
 /// gets distinct bindings from multiple structurally adjacent positions.
@@ -42,55 +45,6 @@ enum CoLocatedMerge {
 struct InferContainsWalk {
     visited: FxHashMap<TypeId, bool>,
     tainted: bool,
-}
-
-/// Logged visited set for one infer-pattern match operation.
-///
-/// The match algorithm needs branch-local rollback for speculative alias
-/// recovery, but cloning the full visited set on every branch is a hot-path
-/// multiplier for recursive conditional utilities. Logging only successful
-/// inserts lets a branch checkpoint and roll back the entries it added while
-/// preserving the parent walk's cycle guard.
-#[derive(Default)]
-pub(crate) struct InferPatternVisited {
-    entries: FxHashSet<(TypeId, TypeId)>,
-    insert_log: Vec<(TypeId, TypeId)>,
-}
-
-impl InferPatternVisited {
-    #[inline]
-    fn insert(&mut self, pair: (TypeId, TypeId)) -> bool {
-        if self.entries.insert(pair) {
-            self.insert_log.push(pair);
-            true
-        } else {
-            false
-        }
-    }
-
-    #[inline]
-    pub(super) fn contains(&self, pair: &(TypeId, TypeId)) -> bool {
-        self.entries.contains(pair)
-    }
-
-    #[inline]
-    pub(super) const fn checkpoint(&self) -> usize {
-        self.insert_log.len()
-    }
-
-    pub(super) fn rollback_to(&mut self, checkpoint: usize) {
-        while self.insert_log.len() > checkpoint {
-            if let Some(pair) = self.insert_log.pop() {
-                self.entries.remove(&pair);
-            }
-        }
-    }
-
-    #[inline]
-    pub(crate) fn clear(&mut self) {
-        self.entries.clear();
-        self.insert_log.clear();
-    }
 }
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
@@ -1587,8 +1541,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // Cheap cycle guard first: re-entering the same `(source, pattern)` pair
         // is a converged cycle and returns before any further work or stack
         // growth.
-        if !visited.insert((source, pattern)) {
-            return true;
+        match visited.enter_pair(source, pattern) {
+            InferPatternVisitDecision::Entered => {}
+            InferPatternVisitDecision::RevisitedConverged => return true,
         }
         // Defensive stack growth for the structural infer-match recursion in
         // `match_infer_pattern_inner`. That recursion is already logically

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_guard_state.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_guard_state.rs
@@ -1,0 +1,142 @@
+//! Guard state for recursive infer-pattern matching.
+//!
+//! The matcher intentionally treats a repeated `(source, pattern)` pair as a
+//! converged recursive path: it stops descending and reports a successful local
+//! match. Branches also need speculative rollback when alias recovery fails, so
+//! this module owns both the visited set and its checkpoint log.
+
+use crate::types::TypeId;
+use rustc_hash::FxHashSet;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum InferPatternVisitDecision {
+    Entered,
+    RevisitedConverged,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct InferPatternCheckpoint(usize);
+
+/// Logged visited set for one infer-pattern match operation.
+///
+/// The match algorithm needs branch-local rollback for speculative alias
+/// recovery, but cloning the full visited set on every branch is a hot-path
+/// multiplier for recursive conditional utilities. Logging only successful
+/// inserts lets a branch checkpoint and roll back the entries it added while
+/// preserving the parent walk's cycle guard.
+#[derive(Default)]
+pub(crate) struct InferPatternGuardState {
+    entries: FxHashSet<(TypeId, TypeId)>,
+    insert_log: Vec<(TypeId, TypeId)>,
+}
+
+impl InferPatternGuardState {
+    #[inline]
+    pub(crate) fn enter_pair(
+        &mut self,
+        source: TypeId,
+        pattern: TypeId,
+    ) -> InferPatternVisitDecision {
+        let pair = (source, pattern);
+        if self.entries.insert(pair) {
+            self.insert_log.push(pair);
+            InferPatternVisitDecision::Entered
+        } else {
+            InferPatternVisitDecision::RevisitedConverged
+        }
+    }
+
+    #[inline]
+    pub(crate) fn contains(&self, pair: &(TypeId, TypeId)) -> bool {
+        self.entries.contains(pair)
+    }
+
+    #[inline]
+    pub(crate) const fn checkpoint(&self) -> InferPatternCheckpoint {
+        InferPatternCheckpoint(self.insert_log.len())
+    }
+
+    pub(crate) fn rollback_to(&mut self, checkpoint: InferPatternCheckpoint) {
+        while self.insert_log.len() > checkpoint.0 {
+            if let Some(pair) = self.insert_log.pop() {
+                self.entries.remove(&pair);
+            }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn clear(&mut self) {
+        self.entries.clear();
+        self.insert_log.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InferPatternGuardState, InferPatternVisitDecision};
+    use crate::types::TypeId;
+
+    #[test]
+    fn entering_same_pair_reports_converged_revisit() {
+        let mut guard = InferPatternGuardState::default();
+
+        assert_eq!(
+            guard.enter_pair(TypeId::STRING, TypeId::UNKNOWN),
+            InferPatternVisitDecision::Entered
+        );
+        assert_eq!(
+            guard.enter_pair(TypeId::STRING, TypeId::UNKNOWN),
+            InferPatternVisitDecision::RevisitedConverged
+        );
+    }
+
+    #[test]
+    fn checkpoint_rollback_preserves_parent_entries() {
+        let mut guard = InferPatternGuardState::default();
+        let parent = (TypeId::STRING, TypeId::UNKNOWN);
+        let branch = (TypeId::NUMBER, TypeId::ANY);
+        let sibling = (TypeId::BOOLEAN, TypeId::VOID);
+
+        assert_eq!(
+            guard.enter_pair(parent.0, parent.1),
+            InferPatternVisitDecision::Entered
+        );
+        let checkpoint = guard.checkpoint();
+        assert_eq!(
+            guard.enter_pair(branch.0, branch.1),
+            InferPatternVisitDecision::Entered
+        );
+        assert_eq!(
+            guard.enter_pair(sibling.0, sibling.1),
+            InferPatternVisitDecision::Entered
+        );
+
+        guard.rollback_to(checkpoint);
+
+        assert!(guard.contains(&parent));
+        assert!(!guard.contains(&branch));
+        assert!(!guard.contains(&sibling));
+        assert_eq!(
+            guard.enter_pair(branch.0, branch.1),
+            InferPatternVisitDecision::Entered
+        );
+    }
+
+    #[test]
+    fn clear_resets_entries_and_log() {
+        let mut guard = InferPatternGuardState::default();
+        let pair = (TypeId::STRING, TypeId::UNKNOWN);
+
+        assert_eq!(
+            guard.enter_pair(pair.0, pair.1),
+            InferPatternVisitDecision::Entered
+        );
+        guard.clear();
+
+        assert!(!guard.contains(&pair));
+        assert_eq!(
+            guard.enter_pair(pair.0, pair.1),
+            InferPatternVisitDecision::Entered
+        );
+    }
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
@@ -26,6 +26,7 @@ mod index_access_tuple_literal;
 mod index_access_union_distribution;
 mod infer_match_expansion;
 pub mod infer_pattern;
+mod infer_pattern_guard_state;
 mod infer_pattern_helpers;
 mod infer_pattern_object_match;
 mod infer_pattern_template_match;


### PR DESCRIPTION
Goal: green

## Summary
- Move infer-pattern `(source, pattern)` revisit tracking and branch checkpoint rollback into `InferPatternGuardState`.
- Replace the raw visited-set insert boolean with typed `Entered` / `RevisitedConverged` decisions.
- Keep the existing recursive revisit fallback and reduce `infer_pattern.rs` below its previous line pressure.

## Structural Rule
When infer-pattern matching re-enters the same `(source, pattern)` pair, `tsc` effective conditional-infer behavior treats that recursive branch as locally converged rather than expanding forever. `tsz` now names that through solver-owned `InferPatternGuardState`, preserving the existing successful local fallback and keeping branch rollback/checkpoint ownership with the guard state.

## Owner Layer
Solver: infer-pattern recursion, revisit decisions, branch checkpoints, rollback, and clear/reset all stay inside `evaluation::evaluate_rules`.

## Adjacent Matrix
- First visit to a `(source, pattern)` pair still enters the structural match.
- Revisit of the same pair still returns the existing `true` converged fallback.
- Alias-recovery branch rollback still removes only branch-local entries.
- Parent match entries survive rollback and clear still resets the whole match state.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver infer_pattern_guard_state infer_pattern`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `python3 scripts/arch/arch_guard.py --json`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy -p tsz-solver --all-targets -- -D warnings`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high