### PR TITLE
refactor(checker): name object annotation walk state (#14351)

### DIFF
--- a/crates/tsz-checker/src/types/computation/object_literal/conditional_mapped_annotation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/conditional_mapped_annotation.rs
@@ -1,13 +1,33 @@
 //! Object-literal annotation predicates for conditional mapped types.
 
 use crate::state::CheckerState;
+use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::Node;
 use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
-type TypeNodeVisitSet = rustc_hash::FxHashSet<(usize, NodeIndex)>;
+type AnnotationTypeNodeSet = rustc_hash::FxHashSet<(usize, NodeIndex)>;
+
+#[derive(Default)]
+struct ObjectLiteralAnnotationWalkState {
+    type_nodes: AnnotationTypeNodeSet,
+    aliases: rustc_hash::FxHashSet<SymbolId>,
+}
+
+impl ObjectLiteralAnnotationWalkState {
+    fn enter_type_node(&mut self, arena: &NodeArena, type_node_idx: NodeIndex) -> bool {
+        !type_node_idx.is_none()
+            && self
+                .type_nodes
+                .insert((arena as *const NodeArena as usize, type_node_idx))
+    }
+
+    fn enter_alias(&mut self, sym_id: SymbolId) -> bool {
+        self.aliases.insert(sym_id)
+    }
+}
 
 impl<'a> CheckerState<'a> {
     pub(crate) fn object_literal_property_has_conditional_mapped_annotation(
@@ -17,13 +37,11 @@ impl<'a> CheckerState<'a> {
         self.object_literal_property_annotation_satisfies(
             property_elem_idx,
             |checker, type_node| {
-                let mut visited_type_nodes = rustc_hash::FxHashSet::default();
-                let mut visited_symbols = rustc_hash::FxHashSet::default();
+                let mut walk_state = ObjectLiteralAnnotationWalkState::default();
                 checker.type_node_contains_conditional_mapped_value_template(
                     checker.ctx.arena,
                     type_node,
-                    &mut visited_type_nodes,
-                    &mut visited_symbols,
+                    &mut walk_state,
                 )
             },
         )
@@ -36,13 +54,11 @@ impl<'a> CheckerState<'a> {
         self.object_literal_property_annotation_satisfies(
             property_elem_idx,
             |checker, type_node| {
-                let mut visited_type_nodes = rustc_hash::FxHashSet::default();
-                let mut visited_symbols = rustc_hash::FxHashSet::default();
+                let mut walk_state = ObjectLiteralAnnotationWalkState::default();
                 checker.type_node_contains_conditional(
                     checker.ctx.arena,
                     type_node,
-                    &mut visited_type_nodes,
-                    &mut visited_symbols,
+                    &mut walk_state,
                 )
             },
         )
@@ -55,13 +71,11 @@ impl<'a> CheckerState<'a> {
         self.object_literal_property_annotation_satisfies(
             property_elem_idx,
             |checker, type_node| {
-                let mut visited_type_nodes = rustc_hash::FxHashSet::default();
-                let mut visited_symbols = rustc_hash::FxHashSet::default();
+                let mut walk_state = ObjectLiteralAnnotationWalkState::default();
                 checker.type_node_contains_mapped_value_template(
                     checker.ctx.arena,
                     type_node,
-                    &mut visited_type_nodes,
-                    &mut visited_symbols,
+                    &mut walk_state,
                 )
             },
         )
@@ -98,12 +112,9 @@ impl<'a> CheckerState<'a> {
         &self,
         arena: &NodeArena,
         type_node_idx: NodeIndex,
-        visited_type_nodes: &mut TypeNodeVisitSet,
-        visited_symbols: &mut rustc_hash::FxHashSet<tsz_binder::SymbolId>,
+        walk_state: &mut ObjectLiteralAnnotationWalkState,
     ) -> bool {
-        if type_node_idx.is_none()
-            || !visited_type_nodes.insert((arena as *const NodeArena as usize, type_node_idx))
-        {
+        if !walk_state.enter_type_node(arena, type_node_idx) {
             return false;
         }
         let Some(type_node) = arena.get(type_node_idx) else {
@@ -112,12 +123,7 @@ impl<'a> CheckerState<'a> {
 
         if let Some(mapped) = arena.get_mapped_type(type_node)
             && mapped.type_node.is_some()
-            && self.type_node_contains_conditional(
-                arena,
-                mapped.type_node,
-                visited_type_nodes,
-                visited_symbols,
-            )
+            && self.type_node_contains_conditional(arena, mapped.type_node, walk_state)
         {
             return true;
         }
@@ -126,18 +132,14 @@ impl<'a> CheckerState<'a> {
             if self.type_reference_alias_body_contains_conditional_mapped_value_template(
                 arena,
                 type_ref.type_name,
-                visited_type_nodes,
-                visited_symbols,
+                walk_state,
             ) {
                 return true;
             }
             if let Some(args) = &type_ref.type_arguments
                 && args.nodes.iter().copied().any(|arg| {
                     self.type_node_contains_conditional_mapped_value_template(
-                        arena,
-                        arg,
-                        visited_type_nodes,
-                        visited_symbols,
+                        arena, arg, walk_state,
                     )
                 })
             {
@@ -147,10 +149,7 @@ impl<'a> CheckerState<'a> {
         }
 
         self.type_node_children_contain_conditional_mapped_value_template(
-            arena,
-            type_node,
-            visited_type_nodes,
-            visited_symbols,
+            arena, type_node, walk_state,
         )
     }
 
@@ -158,12 +157,9 @@ impl<'a> CheckerState<'a> {
         &self,
         arena: &NodeArena,
         type_node_idx: NodeIndex,
-        visited_type_nodes: &mut TypeNodeVisitSet,
-        visited_symbols: &mut rustc_hash::FxHashSet<tsz_binder::SymbolId>,
+        walk_state: &mut ObjectLiteralAnnotationWalkState,
     ) -> bool {
-        if type_node_idx.is_none()
-            || !visited_type_nodes.insert((arena as *const NodeArena as usize, type_node_idx))
-        {
+        if !walk_state.enter_type_node(arena, type_node_idx) {
             return false;
         }
         let Some(type_node) = arena.get(type_node_idx) else {
@@ -178,32 +174,25 @@ impl<'a> CheckerState<'a> {
             && self.type_reference_alias_body_contains_conditional(
                 arena,
                 type_ref.type_name,
-                visited_type_nodes,
-                visited_symbols,
+                walk_state,
             )
         {
             return true;
         }
 
-        self.type_node_children_contain_conditional(
-            arena,
-            type_node,
-            visited_type_nodes,
-            visited_symbols,
-        )
+        self.type_node_children_contain_conditional(arena, type_node, walk_state)
     }
 
     fn type_reference_alias_body_contains_conditional_mapped_value_template(
         &self,
         arena: &NodeArena,
         type_name: NodeIndex,
-        visited_type_nodes: &mut TypeNodeVisitSet,
-        visited_symbols: &mut rustc_hash::FxHashSet<tsz_binder::SymbolId>,
+        walk_state: &mut ObjectLiteralAnnotationWalkState,
     ) -> bool {
         let Some(sym_id) = self.type_reference_alias_symbol(arena, type_name) else {
             return false;
         };
-        if !visited_symbols.insert(sym_id) {
+        if !walk_state.enter_alias(sym_id) {
             return false;
         }
 
@@ -211,8 +200,7 @@ impl<'a> CheckerState<'a> {
             self.type_node_contains_conditional_mapped_value_template(
                 decl_arena,
                 alias_type_node,
-                visited_type_nodes,
-                visited_symbols,
+                walk_state,
             )
         })
     }
@@ -221,16 +209,10 @@ impl<'a> CheckerState<'a> {
         &self,
         arena: &NodeArena,
         type_node: &Node,
-        visited_type_nodes: &mut TypeNodeVisitSet,
-        visited_symbols: &mut rustc_hash::FxHashSet<tsz_binder::SymbolId>,
+        walk_state: &mut ObjectLiteralAnnotationWalkState,
     ) -> bool {
         let mut visit = |child| {
-            self.type_node_contains_conditional_mapped_value_template(
-                arena,
-                child,
-                visited_type_nodes,
-                visited_symbols,
-            )
+            self.type_node_contains_conditional_mapped_value_template(arena, child, walk_state)
         };
 
         if let Some(composite) = arena.get_composite_type(type_node) {
@@ -262,12 +244,9 @@ impl<'a> CheckerState<'a> {
         &self,
         arena: &NodeArena,
         type_node_idx: NodeIndex,
-        visited_type_nodes: &mut TypeNodeVisitSet,
-        visited_symbols: &mut rustc_hash::FxHashSet<tsz_binder::SymbolId>,
+        walk_state: &mut ObjectLiteralAnnotationWalkState,
     ) -> bool {
-        if type_node_idx.is_none()
-            || !visited_type_nodes.insert((arena as *const NodeArena as usize, type_node_idx))
-        {
+        if !walk_state.enter_type_node(arena, type_node_idx) {
             return false;
         }
         let Some(type_node) = arena.get(type_node_idx) else {
@@ -285,19 +264,13 @@ impl<'a> CheckerState<'a> {
             if self.type_reference_alias_body_contains_mapped_value_template(
                 arena,
                 type_ref.type_name,
-                visited_type_nodes,
-                visited_symbols,
+                walk_state,
             ) {
                 return true;
             }
             if let Some(args) = &type_ref.type_arguments
                 && args.nodes.iter().copied().any(|arg| {
-                    self.type_node_contains_mapped_value_template(
-                        arena,
-                        arg,
-                        visited_type_nodes,
-                        visited_symbols,
-                    )
+                    self.type_node_contains_mapped_value_template(arena, arg, walk_state)
                 })
             {
                 return true;
@@ -305,35 +278,24 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        self.type_node_children_contain_mapped_value_template(
-            arena,
-            type_node,
-            visited_type_nodes,
-            visited_symbols,
-        )
+        self.type_node_children_contain_mapped_value_template(arena, type_node, walk_state)
     }
 
     fn type_reference_alias_body_contains_mapped_value_template(
         &self,
         arena: &NodeArena,
         type_name: NodeIndex,
-        visited_type_nodes: &mut TypeNodeVisitSet,
-        visited_symbols: &mut rustc_hash::FxHashSet<tsz_binder::SymbolId>,
+        walk_state: &mut ObjectLiteralAnnotationWalkState,
     ) -> bool {
         let Some(sym_id) = self.type_reference_alias_symbol(arena, type_name) else {
             return false;
         };
-        if !visited_symbols.insert(sym_id) {
+        if !walk_state.enter_alias(sym_id) {
             return false;
         }
 
         self.any_type_alias_declaration_body(sym_id, |decl_arena, alias_type_node| {
-            self.type_node_contains_mapped_value_template(
-                decl_arena,
-                alias_type_node,
-                visited_type_nodes,
-                visited_symbols,
-            )
+            self.type_node_contains_mapped_value_template(decl_arena, alias_type_node, walk_state)
         })
     }
 
@@ -341,17 +303,10 @@ impl<'a> CheckerState<'a> {
         &self,
         arena: &NodeArena,
         type_node: &Node,
-        visited_type_nodes: &mut TypeNodeVisitSet,
-        visited_symbols: &mut rustc_hash::FxHashSet<tsz_binder::SymbolId>,
+        walk_state: &mut ObjectLiteralAnnotationWalkState,
     ) -> bool {
-        let mut visit = |child| {
-            self.type_node_contains_mapped_value_template(
-                arena,
-                child,
-                visited_type_nodes,
-                visited_symbols,
-            )
-        };
+        let mut visit =
+            |child| self.type_node_contains_mapped_value_template(arena, child, walk_state);
 
         if let Some(composite) = arena.get_composite_type(type_node) {
             return composite.types.nodes.iter().copied().any(visit);
@@ -382,23 +337,17 @@ impl<'a> CheckerState<'a> {
         &self,
         arena: &NodeArena,
         type_name: NodeIndex,
-        visited_type_nodes: &mut TypeNodeVisitSet,
-        visited_symbols: &mut rustc_hash::FxHashSet<tsz_binder::SymbolId>,
+        walk_state: &mut ObjectLiteralAnnotationWalkState,
     ) -> bool {
         let Some(sym_id) = self.type_reference_alias_symbol(arena, type_name) else {
             return false;
         };
-        if !visited_symbols.insert(sym_id) {
+        if !walk_state.enter_alias(sym_id) {
             return false;
         }
 
         self.any_type_alias_declaration_body(sym_id, |decl_arena, alias_type_node| {
-            self.type_node_contains_conditional(
-                decl_arena,
-                alias_type_node,
-                visited_type_nodes,
-                visited_symbols,
-            )
+            self.type_node_contains_conditional(decl_arena, alias_type_node, walk_state)
         })
     }
 
@@ -406,12 +355,9 @@ impl<'a> CheckerState<'a> {
         &self,
         arena: &NodeArena,
         type_node: &Node,
-        visited_type_nodes: &mut TypeNodeVisitSet,
-        visited_symbols: &mut rustc_hash::FxHashSet<tsz_binder::SymbolId>,
+        walk_state: &mut ObjectLiteralAnnotationWalkState,
     ) -> bool {
-        let mut visit = |child| {
-            self.type_node_contains_conditional(arena, child, visited_type_nodes, visited_symbols)
-        };
+        let mut visit = |child| self.type_node_contains_conditional(arena, child, walk_state);
 
         if let Some(type_ref) = arena.get_type_ref(type_node)
             && let Some(args) = &type_ref.type_arguments

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -28,6 +28,8 @@ mod common_boundary_export_ratchets;
 mod construction_boundary_signature_scans;
 #[path = "arch_source_scans/object_flags_boundary_scans.rs"]
 mod object_flags_boundary_scans;
+#[path = "arch_source_scans/object_literal_annotation_walker_scans.rs"]
+mod object_literal_annotation_walker_scans;
 #[path = "arch_source_scans/relation_routing_residual_arch_tests.rs"]
 mod relation_routing_residual_arch_tests;
 #[path = "arch_source_scans/spelling_suggestion_gateway_scans.rs"]

--- a/crates/tsz-checker/tests/arch_source_scans/object_literal_annotation_walker_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/object_literal_annotation_walker_scans.rs
@@ -1,0 +1,26 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn object_literal_annotation_walk_uses_named_visit_state() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/types/computation/object_literal/conditional_mapped_annotation.rs");
+    let source =
+        fs::read_to_string(&source_path).expect("read object literal annotation walker source");
+
+    assert!(
+        source.contains("struct ObjectLiteralAnnotationWalkState"),
+        "object literal annotation predicates should own visit state in a named walker state"
+    );
+    assert!(
+        source.contains("fn enter_type_node(") && source.contains("fn enter_alias("),
+        "walker state should name both type-node and alias-cycle entry operations"
+    );
+    assert!(
+        !source.contains("let mut visited_type_nodes")
+            && !source.contains("let mut visited_symbols")
+            && !source.contains("visited_type_nodes: &mut")
+            && !source.contains("visited_symbols: &mut"),
+        "annotation walker helpers should not thread raw visit sets through every helper"
+    );
+}

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -837,6 +837,17 @@ FILE_LINE_LIMIT_CHECKS = [
         458,
     ),
     (
+        "Solver boundary: diagnostics/format/mod.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-solver"
+        / "src"
+        / "diagnostics"
+        / "format"
+        / "mod.rs",
+        2012,
+    ),
+    (
         "Checker boundary: assignability/assignability_diagnostics.rs size ratchet",
         ROOT
         / "crates"


### PR DESCRIPTION
Goal: green

## Summary
- Introduce `ObjectLiteralAnnotationWalkState` for the object-literal conditional/mapped annotation walker.
- Route type-node and alias-cycle entry through named `enter_type_node` / `enter_alias` operations instead of threading raw visit sets through every helper.
- Add a source-scan ratchet so this walker stays state-owned.
- Add the fresh-main `diagnostics/format/mod.rs` file-size ratchet needed for `test_arch_guard.py`.

## Structural Rule
When an object literal property is checked against a variable annotation that reaches conditional or mapped type syntax through wrappers, type arguments, or aliases, `tsc` treats that as annotation-shape discovery. `tsz` should perform the discovery in checker-local syntax orchestration through a named walk-state owner; raw `(arena, node)` and alias symbol visit sets should not leak through every recursive helper.

## Owner Layer
Checker orchestration owns this syntax annotation walk. It does not compute type semantics, construct solver types, or change relation behavior.

## Adjacent Matrix
- Conditional mapped value-template annotations still recurse through mapped value templates and conditional children.
- Conditional-only annotations still follow alias bodies and type arguments.
- Mapped-only annotations still detect mapped value templates through wrappers and aliases.
- Alias cycles and repeated type nodes still bail through the same visited-state rules, now owned by `ObjectLiteralAnnotationWalkState`.
- Existing conditional/mapped object-literal behavior tests cover renamed binders, recursive aliases, positive and negative mismatch cases.

## Fallback / Performance
No behavioral fallback changes. Complexity remains bounded by the same visited type-node and alias sets; the refactor reduces parameter fan-out and names the termination state for #14351 follow-up work.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test arch_source_scans object_literal_annotation_walker_scans::object_literal_annotation_walk_uses_named_visit_state` (red before production change, then pass)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test deeply_nested_conditional_mapped_recursion_tests --test excess_property_check_recursive_intersection_tests --test keyof_mapped_as_clause_tests`
- `cargo fmt --all --check`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py`
- `python3 scripts/arch/test_arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `git diff --check`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`

Known unrelated local red:
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test arch_source_scans` still reports existing fresh-main source-scan failures outside this diff: common boundary allowlist drift, relation-routing residual markers/calls, and signature-construction scans in `assignability_checker.rs`.

## Provenance
Machine: m4
Assistant: codex
Model: GPT-5
Effort: high