### PR TITLE
refactor(solver): route application bails through evaluation result (#14351)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate/application.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/application.rs
@@ -86,7 +86,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // recursive expansions are allowed before bailing to `TypeId::ERROR`,
         // matching tsc's TS2589 behavior.
         if !self.increment_def_depth(def_id) {
-            self.guard.mark_exceeded();
+            self.mark_depth_exceeded_for_request();
             return TypeId::ERROR;
         }
 
@@ -98,8 +98,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             && self.detect_recursive_growth(def_id, &app.args)
         {
             self.decrement_def_depth(def_id);
-            self.guard.mark_exceeded();
-            self.note_limit_event();
+            self.mark_depth_exceeded_for_request();
             return TypeId::ERROR;
         }
 

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -241,6 +241,7 @@ fn evaluation_engine_keeps_request_stage_boundary() {
     // The public staged entry points live in the `evaluate/api.rs` submodule
     // after the engine split; the module boundary is still owned by `evaluate`.
     let evaluate_api_rs = read_solver_source("evaluation/evaluate/api.rs");
+    let evaluate_application_rs = read_solver_source("evaluation/evaluate/application.rs");
     let cross_eval_guard_rs = read_solver_source("evaluation/cross_eval_guard.rs");
     let infer_pattern_rs = read_solver_source("evaluation/evaluate_rules/infer_pattern.rs");
     let infer_match_expansion_rs =
@@ -304,6 +305,14 @@ fn evaluation_engine_keeps_request_stage_boundary() {
             && iteration_incomplete_tests.contains("request_result_for_test(TypeId::ERROR)")
             && !iteration_incomplete_tests.contains("evaluator.request_termination_kind"),
         "typed request-verdict tests must consume EvaluationResult through the evaluator boundary instead of reading the raw request_termination_kind slot"
+    );
+    assert!(
+        !evaluate_application_rs.contains("guard.mark_exceeded()")
+            && evaluate_application_rs
+                .matches("mark_depth_exceeded_for_request()")
+                .count()
+                >= 2,
+        "application evaluation depth/divergence bails must route through the typed request termination producer"
     );
     assert!(
         result_rs.contains("fn unstable_complete(type_id: TypeId) -> Self")

--- a/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
@@ -11,6 +11,8 @@ use super::*;
 use crate::construction::TypeInterner;
 use crate::def::{DefId, DefKind};
 use crate::evaluation::evaluate::TypeEvaluator;
+use crate::evaluation::request::EvaluationRequest;
+use crate::evaluation::result::{Termination, TerminationKind};
 use crate::relations::subtype::TypeEnvironment;
 
 fn unconstrained_param(interner: &TypeInterner, name: &str) -> TypeParamInfo {
@@ -621,6 +623,40 @@ fn evaluate_application_divergent_alias_does_not_poison_cache() {
              caching it would poison every sibling use of the alias"
         );
     }
+}
+
+#[test]
+fn evaluate_application_divergent_alias_reports_incomplete_request_result() {
+    let interner = TypeInterner::new();
+    let def_id = DefId(1081);
+    let t_param = unconstrained_param(&interner, "Item");
+    let t_type = interner.intern(TypeData::TypeParameter(t_param));
+    let grown_arg = interner.array(t_type);
+    let body = interner.application(interner.lazy(def_id), vec![grown_arg]);
+
+    let mut env = TypeEnvironment::new();
+    let app = alias_application(
+        &interner,
+        &mut env,
+        def_id,
+        DefKind::TypeAlias,
+        body,
+        vec![t_param],
+        vec![TypeId::STRING],
+    );
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    let result = evaluator.evaluate_request_result(EvaluationRequest::new(app));
+
+    assert_eq!(result.into_type_id(), TypeId::ERROR);
+    assert_eq!(
+        result.termination(),
+        Termination::Incomplete {
+            kind: TerminationKind::DepthExceeded,
+            partial: TypeId::ERROR,
+        },
+        "application depth/divergence bails must surface through the typed request result"
+    );
 }
 
 /// Phase 5 — an earlier, unrelated recursion bail must not disable caching for a

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -837,6 +837,17 @@ FILE_LINE_LIMIT_CHECKS = [
         458,
     ),
     (
+        "Solver boundary: diagnostics/format/mod.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-solver"
+        / "src"
+        / "diagnostics"
+        / "format"
+        / "mod.rs",
+        2012,
+    ),
+    (
         "Checker boundary: assignability/assignability_diagnostics.rs size ratchet",
         ROOT
         / "crates"


### PR DESCRIPTION
Goal: green

## Summary
- Route application def-depth and divergent-growth bails through `mark_depth_exceeded_for_request()` instead of direct `guard.mark_exceeded()` calls.
- Extend the solver architecture guard so application evaluation cannot bypass the typed `EvaluationResult` termination producer again.
- Add a focused application request-result test for divergent alias bails.
- Add the fresh-main `diagnostics/format/mod.rs` file-size ratchet needed for `test_arch_guard.py`.

## Structural Rule
When evaluating a generic application is cut short by the application def-depth or divergent-growth bound, `tsc` treats the result as a bounded/incomplete instantiation. `tsz` should surface that through solver-owned `EvaluationResult::Incomplete { kind: DepthExceeded, partial }`, not through direct guard mutation hidden from the request-result producer.

## Owner Layer
Solver evaluation owns this termination metadata. Checker consumers still collapse through `into_type_id`; no checker policy or diagnostic formatting changes.

## Adjacent Matrix
- Def-depth bails now record the typed request termination verdict and still return `TypeId::ERROR`.
- Divergent-growth bails now record the same typed verdict and still decrement the def-depth stack before returning `TypeId::ERROR`.
- Existing fuel, recursion-depth, query-budget, cross-eval, and iteration verdict tests remain unchanged.
- Application eval cache tests still prove divergent aliases do not poison cache writes and clean aliases can cache after unrelated bails.

## Fallback / Performance
No fallback behavior changes. `mark_depth_exceeded_for_request()` preserves the existing epoch bump and guard-exceeded state while adding the request-scoped verdict. Runtime cost is one existing helper call at bail sites only.

## Verification
- Red before production change, then pass: `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards evaluation_engine_keeps_request_stage_boundary`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver evaluation::evaluate::orchestrator_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver iteration_exceeded_request_reports_incomplete_with_partial`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver depth_marker_for_request_records_depth_verdict`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver raw_depth_marker_allows_specific_fuel_verdict`
- `cargo fmt --all --check`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards`
- `python3 scripts/arch/arch_guard.py`
- `python3 scripts/arch/test_arch_guard.py`
- `git diff --check`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`

## Provenance
Machine: m4
Assistant: codex
Model: GPT-5
Effort: high