### PR TITLE
refactor(checker): name heritage symbol walk state (#14351)

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/recursive_heritage_constraint.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/recursive_heritage_constraint.rs
@@ -6,6 +6,7 @@
 
 use crate::query_boundaries::checkers::generic as query;
 use crate::state::CheckerState;
+use crate::types_domain::utilities::heritage_walk_state::HeritageSymbolWalkState;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
@@ -77,23 +78,23 @@ impl<'a> CheckerState<'a> {
         interface_sym_id: tsz_binder::SymbolId,
         target_sym_id: tsz_binder::SymbolId,
     ) -> bool {
-        self.interface_extends_symbol_inner(interface_sym_id, target_sym_id, &mut Vec::new(), None)
+        let mut walk_state = HeritageSymbolWalkState::new();
+        self.interface_extends_symbol_inner(interface_sym_id, target_sym_id, &mut walk_state, None)
     }
 
     fn interface_extends_symbol_inner(
         &self,
         interface_sym_id: tsz_binder::SymbolId,
         target_sym_id: tsz_binder::SymbolId,
-        seen: &mut Vec<tsz_binder::SymbolId>,
+        walk_state: &mut HeritageSymbolWalkState,
         preferred_binder: Option<&tsz_binder::BinderState>,
     ) -> bool {
         if interface_sym_id == target_sym_id {
             return true;
         }
-        if seen.contains(&interface_sym_id) {
+        if !walk_state.mark_seen(interface_sym_id) {
             return false;
         }
-        seen.push(interface_sym_id);
 
         let Some((owner_binder, symbol)) = preferred_binder
             .and_then(|binder| {
@@ -151,7 +152,7 @@ impl<'a> CheckerState<'a> {
                             || self.interface_extends_symbol_inner(
                                 base_sym,
                                 target_sym_id,
-                                seen,
+                                walk_state,
                                 Some(owner_binder),
                             ))
                     {

--- a/crates/tsz-checker/src/tests/heritage_constraint_structural_name_lookup_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/heritage_constraint_structural_name_lookup_arch_tests.rs
@@ -64,3 +64,35 @@ fn recursive_heritage_property_conflicts_use_relation_outcome_boundary() {
         "recursive heritage property conflicts must not regress to raw checker assignability"
     );
 }
+
+#[test]
+fn heritage_symbol_walks_use_named_visit_state() {
+    let recursive_heritage =
+        include_str!("../checkers/generic_checker/recursive_heritage_constraint.rs");
+    let type_utilities = include_str!("../types/utilities/core.rs");
+    let walk_state = include_str!("../types/utilities/heritage_walk_state.rs");
+
+    assert!(
+        recursive_heritage.contains("HeritageSymbolWalkState::new()")
+            && recursive_heritage.contains("walk_state.mark_seen(interface_sym_id)")
+            && type_utilities.contains("HeritageSymbolWalkState::new()")
+            && type_utilities.contains("walk_state.enter_path(sym_id)")
+            && type_utilities.contains("walk_state.leave_path(sym_id)"),
+        "checker heritage symbol walks should route visit ownership through `HeritageSymbolWalkState`"
+    );
+    assert!(
+        !recursive_heritage.contains("&mut Vec<tsz_binder::SymbolId>")
+            && !recursive_heritage.contains("seen.contains(&interface_sym_id)")
+            && !type_utilities.contains("let mut visited = Vec::new()")
+            && !type_utilities.contains("visited: &mut Vec<SymbolId>")
+            && !type_utilities.contains("visited.contains(&sym_id)"),
+        "heritage walks should not thread raw symbol vectors through recursion"
+    );
+    assert!(
+        walk_state.contains("pub(crate) struct HeritageSymbolWalkState")
+            && walk_state.contains("pub(crate) fn mark_seen")
+            && walk_state.contains("pub(crate) fn enter_path")
+            && walk_state.contains("pub(crate) fn leave_path"),
+        "`HeritageSymbolWalkState` must own both seen-set and path-stack visit semantics"
+    );
+}

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -1,6 +1,7 @@
 //! Parameter type utilities, type construction, and type resolution methods
 //! for `CheckerState`.
 
+use super::heritage_walk_state::HeritageSymbolWalkState;
 use crate::query_boundaries::type_checking_utilities as query;
 use crate::state::{CheckerState, EnumKind};
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -1284,28 +1285,27 @@ impl<'a> CheckerState<'a> {
         let Some(sym_id) = sym_id else {
             return false;
         };
-        let mut visited = Vec::new();
-        self.symbol_has_array_like_heritage(sym_id, &mut visited)
+        let mut walk_state = HeritageSymbolWalkState::new();
+        self.symbol_has_array_like_heritage(sym_id, &mut walk_state)
     }
 
     fn symbol_has_array_like_heritage(
         &self,
         sym_id: SymbolId,
-        visited: &mut Vec<SymbolId>,
+        walk_state: &mut HeritageSymbolWalkState,
     ) -> bool {
-        if visited.contains(&sym_id) {
+        if !walk_state.enter_path(sym_id) {
             return false;
         }
-        visited.push(sym_id);
 
         let lib_binders = self.get_lib_binders();
         let Some(symbol) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders) else {
-            visited.pop();
+            walk_state.leave_path(sym_id);
             return false;
         };
 
         if Self::is_builtin_array_like_name(symbol.escaped_name.as_str()) {
-            visited.pop();
+            walk_state.leave_path(sym_id);
             return true;
         }
 
@@ -1364,21 +1364,21 @@ impl<'a> CheckerState<'a> {
                     if let Some(base_name) = self.heritage_name_text(expr_idx)
                         && Self::is_builtin_array_like_name(base_name.as_str())
                     {
-                        visited.pop();
+                        walk_state.leave_path(sym_id);
                         return true;
                     }
 
                     if let Some(base_sym_id) = self.resolve_heritage_symbol(expr_idx)
-                        && self.symbol_has_array_like_heritage(base_sym_id, visited)
+                        && self.symbol_has_array_like_heritage(base_sym_id, walk_state)
                     {
-                        visited.pop();
+                        walk_state.leave_path(sym_id);
                         return true;
                     }
                 }
             }
         }
 
-        visited.pop();
+        walk_state.leave_path(sym_id);
         false
     }
 

--- a/crates/tsz-checker/src/types/utilities/heritage_walk_state.rs
+++ b/crates/tsz-checker/src/types/utilities/heritage_walk_state.rs
@@ -1,0 +1,31 @@
+//! Visit state for checker-owned heritage symbol walks.
+
+use tsz_binder::SymbolId;
+
+#[derive(Default)]
+pub(crate) struct HeritageSymbolWalkState {
+    visited: Vec<SymbolId>,
+}
+
+impl HeritageSymbolWalkState {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn mark_seen(&mut self, sym_id: SymbolId) -> bool {
+        if self.visited.contains(&sym_id) {
+            return false;
+        }
+        self.visited.push(sym_id);
+        true
+    }
+
+    pub(crate) fn enter_path(&mut self, sym_id: SymbolId) -> bool {
+        self.mark_seen(sym_id)
+    }
+
+    pub(crate) fn leave_path(&mut self, sym_id: SymbolId) {
+        let popped = self.visited.pop();
+        debug_assert_eq!(popped, Some(sym_id));
+    }
+}

--- a/crates/tsz-checker/src/types/utilities/mod.rs
+++ b/crates/tsz-checker/src/types/utilities/mod.rs
@@ -10,5 +10,6 @@ pub(crate) mod cycle_guard;
 pub(crate) mod element_indexable;
 pub(crate) mod enum_utils;
 pub(crate) mod enum_utils_readonly;
+pub(crate) mod heritage_walk_state;
 pub(crate) mod overlap_relation_helpers;
 pub(crate) mod return_type;


### PR DESCRIPTION
Goal: green

## Summary
- Add `HeritageSymbolWalkState` as the checker-owned visit state for declaration heritage symbol walks.
- Route recursive generic heritage constraint walks through the named state instead of raw `Vec<SymbolId>` plumbing.
- Route array-like heritage classification through the same state while preserving the old path-stack unwind behavior.
- Add a focused source-scan guard so these walks do not regress to raw symbol vectors.

Structural rule: when checker walks binder heritage symbols for recursive constraints or array-like classification, traversal termination is owned by a checker walk-state helper; solver/query-boundary relation semantics remain unchanged.

Owner layer: checker type utilities and generic-checker heritage helpers.

Adjacent matrix: recursive heritage generic display/inference witnesses, structural heritage lookup guard, recursive heritage relation-boundary guard, array-like constraint guard, and array-like conformance witness.

Fallback/perf: revisiting a heritage symbol keeps the previous false fallback; array-like path exits still unwind the active stack. This wraps the previous vector state rather than adding new semantic work.

## Verification
- `cargo fmt --all -- --check && git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib heritage_symbol_walks_use_named_visit_state heritage_type_name_resolution_uses_structural_lookup recursive_heritage_property_conflicts_use_relation_outcome_boundary`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test recursive_generic_interface_application_display_tests recursive_heritage_generic_instance_source_displays_bare_type_argument recursive_heritage_display_independent_of_binder_names recursive_heritage_assignment_between_related_interfaces_keeps_arguments concrete_recursive_heritage_instance_displays_concrete_argument`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test conformance_issues_errors test_array_like_length_only_assignment_does_not_emit_ts2322`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `python3 scripts/arch/arch_guard.py --json`
- `scripts/arch/check-checker-boundaries.sh`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --lib --test recursive_generic_interface_application_display_tests --test conformance_issues_errors --test spread_rest_tests -- -D warnings`
- Baseline note: `scripts/safe-run.sh cargo nextest run -p tsz-checker --test spread_rest_tests test_array_like_rest_rejects_aggregate_rest_arguments` is red on this branch and fresh `origin/main` `e8d6ca93f0` with the same `[1]`/missing-global diagnostics, so it is not used as branch regression evidence.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high