### PR TITLE
refactor(solver): name relation complexity overflow path (#14351)

### DIFF
--- a/crates/tsz-solver/src/recursion.rs
+++ b/crates/tsz-solver/src/recursion.rs
@@ -520,6 +520,16 @@ impl<K: Hash + Eq + Copy> RecursionGuard<K> {
         };
     }
 
+    /// Manually mark the iteration/work budget as exceeded.
+    ///
+    /// Use this for relation-complexity limits that correspond to TS2859
+    /// rather than stack-depth limits. This preserves the broad `is_exceeded`
+    /// signal while keeping [`Self::iteration_exceeded`] true for diagnostics.
+    #[inline]
+    pub const fn mark_iteration_exceeded(&mut self) {
+        self.limit_state = RecursionLimitState::IterationExceeded;
+    }
+
     /// Clear the depth-`exceeded` flag while preserving `visiting` / `depth` /
     /// `iterations` and the `iteration_exceeded` flag.
     ///

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -1285,7 +1285,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
                     || target_union_contains_source
                     || source_union_contains_target;
                 if !trivially_related {
-                    self.subtype.guard.mark_exceeded();
+                    self.subtype.mark_relation_complexity_exceeded();
                     return false;
                 }
             }

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -842,6 +842,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.guard.iteration_exceeded()
     }
 
+    /// Record an externally detected relation-complexity overflow.
+    ///
+    /// This is the TS2859 path: callers already proved the relation cross
+    /// product exceeds the work budget, so the subtype checker owns the sticky
+    /// iteration verdict instead of exposing its raw recursion guard.
+    pub(crate) const fn mark_relation_complexity_exceeded(&mut self) {
+        self.guard.mark_iteration_exceeded();
+    }
+
     /// Run `f` with subtype flags configured for tsc's `isTypeIdenticalTo`
     /// identity checking (TS2403 and related redeclaration/identity paths).
     ///

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -350,6 +350,8 @@ fn narrowing_engine_keeps_request_stage_boundary() {
 #[test]
 fn relation_queries_keep_overflow_flags_on_relation_result() {
     let relation_queries_rs = read_solver_source("relations/relation_queries.rs");
+    let compat_rs = read_solver_source("relations/compat.rs");
+    let subtype_core_rs = read_solver_source("relations/subtype/core.rs");
 
     assert!(
         relation_queries_rs.contains("pub struct RelationResult")
@@ -364,6 +366,13 @@ fn relation_queries_keep_overflow_flags_on_relation_result() {
                 .contains("let (related, depth_exceeded, iteration_exceeded) = match kind"),
         "relation query dispatch must keep related/depth/iteration verdicts bundled \
          as RelationResult instead of passing around anonymous overflow tuples"
+    );
+    assert!(
+        compat_rs.contains("mark_relation_complexity_exceeded()")
+            && !compat_rs.contains("subtype.guard.mark_exceeded()")
+            && subtype_core_rs.contains("fn mark_relation_complexity_exceeded("),
+        "TS2859 relation complexity overflow must be recorded through the subtype-owned \
+         complexity verdict helper instead of CompatChecker mutating the raw recursion guard"
     );
 
     let conditional_phases_rs =

--- a/crates/tsz-solver/tests/recursion_tests.rs
+++ b/crates/tsz-solver/tests/recursion_tests.rs
@@ -1134,6 +1134,19 @@ fn iteration_exceeded_flag_not_set_after_depth_overflow() {
 }
 
 #[test]
+fn explicit_iteration_overflow_marks_iteration_exceeded() {
+    let mut guard = RecursionGuard::<u32>::new(100, 100);
+
+    guard.mark_iteration_exceeded();
+
+    assert!(guard.is_exceeded());
+    assert!(
+        guard.iteration_exceeded(),
+        "explicit relation-complexity overflow should preserve the TS2859 iteration verdict"
+    );
+}
+
+#[test]
 fn iteration_exceeded_flag_sticky_like_exceeded() {
     // Once set, stays set until reset().
     let mut guard = RecursionGuard::new(100, 1);

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -273,6 +273,17 @@ FILE_LINE_LIMIT_CHECKS = [
         + QUERY_BOUNDARY_COMMON_LINE_GREEN_HEADROOM,
     ),
     (
+        "Solver diagnostics formatter boundary: format/mod.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-solver"
+        / "src"
+        / "diagnostics"
+        / "format"
+        / "mod.rs",
+        2012,
+    ),
+    (
         "Emitter transform boundary: class_es5_ir.rs must not grow",
         ROOT / "crates" / "tsz-emitter" / "src" / "transforms" / "class_es5_ir.rs",
         2101,


### PR DESCRIPTION
Goal: green

## Summary
- route the TS2859 relation cross-product overflow through `SubtypeChecker::mark_relation_complexity_exceeded()` instead of letting `CompatChecker` mutate the raw subtype recursion guard
- add `RecursionGuard::mark_iteration_exceeded()` so externally detected relation work-budget overflow preserves the iteration/complexity verdict instead of looking like depth overflow
- add focused architecture/recursion coverage plus the fresh-main diagnostics formatter line-count ratchet required by `test_arch_guard.py`

## Structural Rule
When a relation comparison exceeds the TS2859 constituent cross-product work budget and is not trivially related, `tsc` reports excessive comparison complexity; `tsz` records that as a solver relations/subtype iteration verdict. `CompatChecker` detects the cross-product condition, but the subtype relation owner records the sticky overflow state.

## Owner Layer
Solver relations/subtype owns the relation complexity verdict. The generic recursion guard owns the depth-vs-iteration state bit, and `CompatChecker` stays at the compatibility-policy call site without reaching into `SubtypeChecker.guard`.

## Adjacent Matrix
- depth overflow: `mark_exceeded()` remains depth-only and existing recursion tests keep `iteration_exceeded()` false
- explicit relation complexity overflow: new `mark_iteration_exceeded()` keeps `iteration_exceeded()` true for TS2859 diagnostics
- trivial large union relation fallback remains unchanged because the overflow path still runs after the existing trivial-related check
- architecture guard prevents the TS2859 path from regressing to raw `subtype.guard.mark_exceeded()` mutation

## Verification
- red: `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards relation_queries_keep_overflow_flags_on_relation_result` failed before implementation
- red: `scripts/safe-run.sh cargo nextest run -p tsz-solver recursion::tests::explicit_iteration_overflow_marks_iteration_exceeded` failed to compile before implementation
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards relation_queries_keep_overflow_flags_on_relation_result`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver explicit_iteration_overflow_marks_iteration_exceeded`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver recursion::tests`
- `cargo fmt --all --check`
- `python3 scripts/arch/arch_guard.py`
- `python3 scripts/arch/test_arch_guard.py`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-solver --all-targets -- -D warnings`

Known fresh-main baseline: `scripts/safe-run.sh cargo nextest run -p tsz-solver --test architecture_guards` currently fails `evaluation_engine_keeps_request_stage_boundary` on `origin/main`; #15181 owns that independent fix. This PR's new relation-overflow architecture guard passes in focused form.

## Provenance
Machine: m4
Assistant: codex
Model: GPT-5
Effort: high
